### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,21 @@
 # Preloop Open Source - CI Pipeline
 # Runs unit tests on pull requests and pushes to main
-# For full integration tests, see GitLab CI
+# Builds and pushes Docker images on releases and main branch
 
 name: CI
 
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
 
 env:
   PYTHON_VERSION: "3.11"
   NODE_VERSION: "22"
+  REGISTRY_GHCR: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   # ==========================================================================
@@ -30,23 +33,33 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install dependencies
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install Python dependencies
         run: |
           pip install -U pip pre-commit ruff
           pip install -e ".[dev]"
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
 
       - name: Run pre-commit
         run: pre-commit run --all-files
 
       - name: Run ruff
-        run: ruff check
+        run: ruff check .
 
   test-backend:
     name: Backend Tests
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: pgvector/pgvector:pg13
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_DB: test_db
           POSTGRES_USER: test_user
@@ -61,6 +74,7 @@ jobs:
 
     env:
       DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
+      OPENAI_API_KEY: mock_key
       ANTHROPIC_API_KEY: mock_key
 
     steps:
@@ -81,34 +95,33 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -U pip pytest pytest-cov loguru
+          pip install -U pip pytest pytest-cov pytest-asyncio loguru
           pip install -e ".[dev]"
 
       - name: Initialize database
-        run: python ./scripts/init_db.py --force
+        run: python scripts/init_db.py --force
 
       - name: Run tests
         run: |
           pytest -v \
-            --ignore tests/integration \
-            --cov=backend/preloop/models \
-            --cov=backend/preloop/sync \
+            --ignore=backend/tests/integration \
             --cov=backend/preloop \
             --cov-report=xml \
-            --junitxml=test-results.xml \
-            backend/
+            --junitxml=test-results.xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        if: github.event_name != 'pull_request'
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results
+          name: backend-test-results
           path: test-results.xml
 
   # ==========================================================================
@@ -138,38 +151,97 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
       - name: Run tests
         run: npm run test
 
   # ==========================================================================
-  # Build Check (ensures Docker builds work)
+  # Build and Push Docker Images
   # ==========================================================================
 
-  build-check:
-    name: Build Check
+  build-and-push:
+    name: Build & Push Docker Images
     runs-on: ubuntu-latest
     needs: [lint, test-backend, test-frontend]
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build backend image
-        uses: docker/build-push-action@v5
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request' && vars.PUSH_TO_DOCKERHUB == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata for backend image
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
+            ${{ vars.PUSH_TO_DOCKERHUB == 'true' && format('{0}/preloop', vars.DOCKERHUB_ORG) || '' }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
-          tags: preloop:test
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-backend.outputs.tags }}
+          labels: ${{ steps.meta-backend.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build frontend image
-        uses: docker/build-push-action@v5
+      - name: Extract metadata for frontend image
+        id: meta-frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_GHCR }}/frontend
+            ${{ vars.PUSH_TO_DOCKERHUB == 'true' && format('{0}/frontend', vars.DOCKERHUB_ORG) || '' }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
         with:
           context: ./frontend
-          push: false
-          tags: preloop-frontend:test
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-frontend.outputs.tags }}
+          labels: ${{ steps.meta-frontend.outputs.labels }}
           build-args: |
             BRAND=preloop
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,8 +224,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.REGISTRY_GHCR }}/frontend
-            ${{ vars.PUSH_TO_DOCKERHUB == 'true' && format('{0}/frontend', vars.DOCKERHUB_ORG) || '' }}
+            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}/console
+            ${{ vars.PUSH_TO_DOCKERHUB == 'true' && format('{0}/console', vars.DOCKERHUB_ORG) || '' }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Run tests
         run: |
           pytest -v \
+            --ignore tests/integration \
             --cov=backend/preloop/models \
             --cov=backend/preloop/sync \
             --cov=backend/preloop \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -423,8 +423,8 @@ test:coverage:
     - helm upgrade --install ${ENV_NAME} ./helm/preloop
       --namespace ${NAMESPACE}
       --set image.tag=${CI_COMMIT_SHA}
-      --set spacelit.tag=${CI_COMMIT_SHA}
-      --set spacelit.repository=${CI_REGISTRY_IMAGE_FRONTEND}
+      --set console.tag=${CI_COMMIT_SHA}
+      --set console.repository=${CI_REGISTRY_IMAGE_FRONTEND}
       --set config.openai.apiKey=${OPENAI_API_KEY}
       --set config.anthropic.apiKey=${ANTHROPIC_API_KEY}
       --set config.smtp.host=${SMTP_HOST}

--- a/README.md
+++ b/README.md
@@ -6,15 +6,9 @@
 
 ## Overview
 
-Preloop is an open-source, event-driven automation platform with built-in human-in-the-loop safety. AI agents respond to events across your tools automatically. When agents call sensitive operations, Preloop intercepts the request and routes it for human approval—no infrastructure changes required.
+Preloop is an open-source, event-driven automation platform with built-in human-in-the-loop safety. AI agents respond to events across your tools automatically. When agents call sensitive operations, Preloop intercepts the request and routes it for human approval.
 
-> **Looking for Enterprise features?** Preloop Enterprise Edition adds RBAC, team-based approvals, advanced audit logging, and more. See [Enterprise Features](#enterprise-features) below.
-
-### Open Source vs Enterprise (important)
-
-- **Open Source**: single-user approvals with **email + mobile app notifications**.
-- **Enterprise**: adds **advanced conditions (CEL)**, **team-based approvals (quorum)**, **escalation**, and **Slack & Mattermost** notifications.
-- **Mobile & Watch apps**: the iOS/Watch and Android apps can be used with **self-hosted / open-source** Preloop deployments.
+Preloop acts as an MCP proxy and can be integrated in existing workflows without any infrastructure changes.
 
 ## Key Features
 
@@ -35,6 +29,14 @@ Preloop is an open-source, event-driven automation platform with built-in human-
 - **Duplicate Detection**: Automated detection of duplicate and overlapping issues
 - **Compliance Metrics**: Evaluate issue compliance and get improvement recommendations
 - **Web UI**: Modern interface built with Lit, Vite, and Shoelace Web Components
+
+> **Looking for Enterprise features?** Preloop Enterprise Edition adds RBAC, team-based approvals, advanced audit logging, and more. See [Enterprise Features](#enterprise-features) below.
+
+### Open Source vs Enterprise (important)
+
+- **Open Source**: single-user approvals with **email + mobile app notifications**.
+- **Enterprise**: adds **advanced conditions (CEL)**, **team-based approvals (quorum)**, **escalation**, and **Slack & Mattermost** notifications.
+- **Mobile & Watch apps**: the iOS/Watch and Android apps can be used with **self-hosted / open-source** Preloop deployments.
 
 ## Supported Issue Trackers
 
@@ -567,4 +569,4 @@ Contributions are welcome! Please see our [Contributing Guidelines](CONTRIBUTING
 
 Preloop is open source software licensed under the [Apache License 2.0](LICENSE).
 
-Copyright (c) 2025 Spacecode AI Inc.
+Copyright (c) 2026 Spacecode AI Inc.

--- a/backend/tests/test_issue_compliance_schema.py
+++ b/backend/tests/test_issue_compliance_schema.py
@@ -235,7 +235,7 @@ class TestIssueComplianceResultResponse:
 
     def test_from_attributes_config(self):
         """Test that from_attributes is enabled."""
-        assert IssueComplianceResultResponse.Config.from_attributes is True
+        assert IssueComplianceResultResponse.model_config.get("from_attributes") is True
 
 
 class TestComplianceSuggestionResponse:

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-SpaceLit is a modern web application frontend for Preloop, built with:
+Preloop Console is a modern web application frontend for Preloop, built with:
 - **Lit** (Web Components framework)
 - **TypeScript** for type safety
 - **Vaadin components** for UI (Vaadin router, forms, layouts)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-stage build: Build app, then serve with nginx
 
 # Stage 1: Build the application
-FROM node:18-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,7 +1,7 @@
 # Development Dockerfile
 # Runs Vite dev server with hot module replacement for live debugging
 
-FROM node:18-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/frontend/README.Docker.md
+++ b/frontend/README.Docker.md
@@ -1,6 +1,6 @@
-# Docker Setup for SpaceLit
+# Docker Setup for Preloop Console
 
-This document provides comprehensive Docker support for SpaceLit with multiple environments and easy API switching.
+This document provides comprehensive Docker support for Preloop Console with multiple environments and easy API switching.
 
 ## Quick Start
 
@@ -161,17 +161,17 @@ For production deployment:
 
 1. **Build the image**:
    ```bash
-   docker build -t spacelit:v1.0.0 .
+   docker build -t console:v1.0.0 .
    ```
 
 2. **Tag for registry**:
    ```bash
-   docker tag spacelit:v1.0.0 your-registry.com/spacelit:v1.0.0
+   docker tag console:v1.0.0 your-registry.com/console:v1.0.0
    ```
 
 3. **Push to registry**:
    ```bash
-   docker push your-registry.com/spacelit:v1.0.0
+   docker push your-registry.com/console:v1.0.0
    ```
 
 4. **Deploy with environment variables**:
@@ -180,5 +180,5 @@ For production deployment:
      -p 80:80 \
      -e API_URL=https://your-api.example.com \
      -e MOCK_API=false \
-     your-registry.com/spacelit:v1.0.0
+     your-registry.com/console:v1.0.0
    ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,10 +1,10 @@
-# SpaceLit
+# Preloop Console
 
-This directory contains the new Preloop frontend, a modern web application built with Lit, Vite, and TypeScript. It follows the Material v3 design system using Material Web Components.
+This directory contains the new Preloop frontend, a modern web application built with Lit, Vite, and TypeScript. It uses Shoelace Web Components for UI.
 
 ## Description
 
-This frontend is a single-page application (SPA) that provides a rich, interactive user experience for managing issue trackers through the Preloop API. It is designed to be fast, responsive, and maintainable.
+This frontend is a single-page application (SPA) that provides a rich, interactive user experience for managing MCP servers, issue trackers, and more through the Preloop API. It is designed to be fast, responsive, and maintainable.
 
 ## Development
 

--- a/frontend/docker-compose.dev.yml
+++ b/frontend/docker-compose.dev.yml
@@ -16,7 +16,7 @@ services:
       - NODE_ENV=development
       - VITE_API_URL=http://localhost:8000
     networks:
-      - spacelit-dev-network
+      - console-dev-network
 
   # Mock API for development
   mock-api:
@@ -27,8 +27,8 @@ services:
       - ./docker/mock-api:/usr/share/nginx/html
       - ./docker/mock-api.conf:/etc/nginx/conf.d/default.conf
     networks:
-      - spacelit-dev-network
+      - console-dev-network
 
 networks:
-  spacelit-dev-network:
+  console-dev-network:
     driver: bridge

--- a/frontend/docker-compose.mock.yml
+++ b/frontend/docker-compose.mock.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - mock-api
     networks:
-      - spacelit-mock-network
+      - console-mock-network
 
   # Mock API Server
   mock-api:
@@ -26,8 +26,8 @@ services:
       - ./docker/mock-api:/usr/share/nginx/html
       - ./docker/mock-api.conf:/etc/nginx/conf.d/default.conf
     networks:
-      - spacelit-mock-network
+      - console-mock-network
 
 networks:
-  spacelit-mock-network:
+  console-mock-network:
     driver: bridge

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - backend
     networks:
-      - spacelit-network
+      - console-network
 
   # Real API Backend (placeholder - replace with actual backend)
   backend:
@@ -25,7 +25,7 @@ services:
     volumes:
       - ./docker/mock-api.conf:/etc/nginx/conf.d/default.conf
     networks:
-      - spacelit-network
+      - console-network
 
   # Mock API Server (for testing without real backend)
   mock-api:
@@ -36,8 +36,8 @@ services:
       - ./docker/mock-api:/usr/share/nginx/html
       - ./docker/mock-api.conf:/etc/nginx/conf.d/default.conf
     networks:
-      - spacelit-network
+      - console-network
 
 networks:
-  spacelit-network:
+  console-network:
     driver: bridge

--- a/frontend/docker-run.sh
+++ b/frontend/docker-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SpaceLit Docker Management Script
+# Preloop Console Docker Management Script
 # Usage: ./docker-run.sh [command] [options]
 
 set -e
@@ -16,7 +16,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 print_usage() {
-    echo -e "${BLUE}SpaceLit Docker Management${NC}"
+    echo -e "${BLUE}Preloop Console Docker Management${NC}"
     echo ""
     echo -e "${YELLOW}Usage:${NC} ./docker-run.sh [command] [options]"
     echo ""
@@ -61,14 +61,14 @@ run_mock() {
 
 build_image() {
     echo -e "${GREEN}Building production Docker image...${NC}"
-    docker build -t spacelit:latest .
-    echo -e "${GREEN}Image built successfully: spacelit:latest${NC}"
+    docker build -t console:latest .
+    echo -e "${GREEN}Image built successfully: console:latest${NC}"
 }
 
 run_tests() {
     echo -e "${GREEN}Running tests in container...${NC}"
-    docker build -f Dockerfile.dev -t spacelit:test .
-    docker run --rm spacelit:test npm test
+    docker build -f Dockerfile.dev -t console:test .
+    docker run --rm console:test npm test
 }
 
 stop_containers() {
@@ -82,7 +82,7 @@ clean_up() {
     echo -e "${YELLOW}Cleaning up containers and images...${NC}"
     stop_containers
     docker system prune -f
-    docker image rm spacelit:latest spacelit:test 2>/dev/null || true
+    docker image rm console:latest console:test 2>/dev/null || true
     echo -e "${GREEN}Cleanup complete${NC}"
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "spacelit",
-  "version": "1.0.0",
+  "name": "preloop",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "spacelit",
-      "version": "1.0.0",
+      "name": "preloop",
+      "version": "0.8.0",
       "dependencies": {
         "@sentry/browser": "^10.5.0",
         "@shoelace-style/shoelace": "^2.20.1",
@@ -67,6 +67,7 @@
       "resolved": "https://registry.npmjs.org/@arcgis/components-utils/-/components-utils-4.33.9.tgz",
       "integrity": "sha512-cOwYSelayx5vGu0z2BUctZJMOsFM4yd5evYznw6V5u8cigTAKQGG6d6yRxxgTGbJJSnGisbF5+qOuybh3hO+zQ==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.1"
       }
@@ -76,6 +77,7 @@
       "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.33.8.tgz",
       "integrity": "sha512-nxdYn/XlTmKyWgh0XrousPP1pxNuQuQ90V8UDZoxOqeEU8Khm1T2awcUtauZNdHCk4vnopJEtbJ8FLO7FUGyDA==",
       "license": "SEE LICENSE IN copyright.txt",
+      "peer": true,
       "dependencies": {
         "@esri/arcgis-html-sanitizer": "~4.1.0",
         "@esri/calcite-components": "^3.2.1",
@@ -90,6 +92,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.7.9.tgz",
       "integrity": "sha512-B/xpWRl1P0KthZ4ZXeZj9jZEhvd1eDZs+CF2pdfg0Ib1cxHnwGMTBzydwuevcCFEdY0V0+jBQwbsYnMVSrJ6cg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -102,6 +105,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.7.9.tgz",
       "integrity": "sha512-a6V80JeUy940KvHrs6hKwAHbCCpsRWh8ITbrQXq9NksZSkjLlPz5Evfv6QEDxBpbni8WcEVXfan44t46oIPAiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -119,6 +123,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.9.tgz",
       "integrity": "sha512-fBIxWHxJt4xTTpne5gmp/54rEPfpLUjWDgkXXgpSWYWaoMYRLcKGNCDJ45adh8s8d+Nvs5qT/eOoOOOupRGerw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -132,6 +137,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.7.9.tgz",
       "integrity": "sha512-HRjd5DvFluj3UrbDD2YZ15hp20hOAXVIbFdj70PINPW8waeRZOBMZwGpXCPauGbrzFgvGsLTVAESJjMYsiEnZA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -145,6 +151,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.7.9.tgz",
       "integrity": "sha512-pxj3QGKTEcDHdEbABdsrCsPfHQQ8v0EpYCZhB2FkyXP5Q79oCG/tjT5lp/Gm9m67OTY1GeLDy6fbBwYp7satbA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -164,6 +171,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.9.tgz",
       "integrity": "sha512-dzTPRzDpqEoxLcNCvzl0mdAo3Da5hMgOAouFlV/MZdYTq7Axalno/6DfhBjbLa2JWMT00ihckuyCB+moFWBYKw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -178,6 +186,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.7.9.tgz",
       "integrity": "sha512-1DGZsxyYi6hWbcwHL6MpAxhO/fqAZzgq+1Rnxsq1KgEQC+1vrJx5a0uULDEnfqBnTmhcBUzfGsvdsSWtVwZw5A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.7.9",
@@ -192,6 +201,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.7.9.tgz",
       "integrity": "sha512-T2mcBv4a7gyMnzpCI4ILoEO+AfIvx2X6NLXHOj75Nd1FyPoukz2GVCEDH7Z4DJq1eVz2qr2gcu8ijS/vAd4U/Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "lit": "^3.0.0"
       }
@@ -201,6 +211,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.7.9.tgz",
       "integrity": "sha512-iXwryWdYYo7pG0mrvQneWReSMj3blIhiuAUvv6dflXiX6+sovt0AIgATJb9YiX/vmV9UpGXL6z+HT8cpLr33FA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -219,6 +230,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.9.tgz",
       "integrity": "sha512-codiq+QRpp9B5Q4IvX5CYTbO0RMn9TxFagJrIGm4ESgxtkMN6FAuKY5tCoft4w0Kd+X1Ov1Rcj+h5lkMzmo65Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.7.9",
@@ -231,6 +243,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.7.9.tgz",
       "integrity": "sha512-pxOy+xT878zXZjnIl7+1Zf0L1UWhXgfHxeg4GTkEfnCFj/inL8gcsavJMwzp9NIKDLx9xS22MRK1ozrcjFFlTg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.7.9",
@@ -242,6 +255,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.9.tgz",
       "integrity": "sha512-bPKsVo7Kkm7jeKecz0l2kalOj8w18Ue2OvIvdTQKvUuGhUnpGcK8wwyIz4CE74uc1g1XlM/qmPdplngD3SxC0g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
@@ -252,6 +266,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -264,6 +279,7 @@
       "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-4.33.9.tgz",
       "integrity": "sha512-Om37zxqnai4dVqxpwnDUMVwmHpZTawfIGY7R01iErm7BSJ14rLnFpadn8i37ybp0tg8Thl09lBLhMBQX0GmO2Q==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
       "dependencies": {
         "@arcgis/components-utils": "4.33.9",
         "@lit-labs/ssr": "^3.2.2",
@@ -351,7 +367,6 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.1.12.tgz",
       "integrity": "sha512-41u5ZBnpIUzUQ+S8u/8JBWN9BHTerRUcOv+1QmjWsp8noNWZN69cvOy3/AaaPA8UgSEycdnv+y8GGIMspBLHZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@luma.gl/constants": "^9.1.5",
         "@luma.gl/shadertools": "^9.1.5",
@@ -428,7 +443,6 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.1.12.tgz",
       "integrity": "sha512-N9ZCHgn0CCekOCYmXYG/JHqFJLLeS5/HN1dh+N4a1EyLk0bPhN7CfTJ9ypEK9fQvyiX1sdVgu1bkGWo3eazf9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@loaders.gl/core": "^4.2.0",
         "@loaders.gl/images": "^4.2.0",
@@ -454,7 +468,6 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.1.12.tgz",
       "integrity": "sha512-NIgHQRd0PNyZlwGMt4N5H3GRsTnzXMaZtuBi0O3EkwqULKftReomk/IrMNvAaokm/Hr9myY0NPu5lusJdLexTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@luma.gl/constants": "^9.1.5",
         "@luma.gl/shadertools": "^9.1.5",
@@ -471,7 +484,6 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.1.12.tgz",
       "integrity": "sha512-5I1rTmWAuqDeC6QfajuNkf4TgkSrZQhqCwfz/0QohfSPKEeP9A1B0fu6pYJvxj83qfZOxNLyzZqwwxqeboJ2nw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@loaders.gl/3d-tiles": "^4.2.0",
         "@loaders.gl/gis": "^4.2.0",
@@ -533,7 +545,6 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.1.12.tgz",
       "integrity": "sha512-szRPS7W3jCMp3jPjQYleIJGE9nkcMIXbUGi7Wc/4reU1WLayo8wvDnRbyyW/TaU6TTUPuI/K5raCnG+xoj67KQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@loaders.gl/images": "^4.2.0",
         "@loaders.gl/schema": "^4.2.0",
@@ -570,7 +581,6 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.1.12.tgz",
       "integrity": "sha512-SOwN4bpYL+rNRsuD2KweJ6BsA2w7PlzAFjUe3P84XqhSBhawVRSMrmiEFW0L0BnvoJOCWftR4hpF6M8lOUpENw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@loaders.gl/gltf": "^4.2.0",
         "@luma.gl/gltf": "^9.1.5",
@@ -599,7 +609,6 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/widgets/-/widgets-9.1.12.tgz",
       "integrity": "sha512-/bDO3u3N7nLDehLsWCeMNzAFuOd/PKndffeSsYI8DhJpN4H1qH9E5S13gxu65HXDD8+6+ApNN4Z1bWlmTpSp+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "preact": "^10.17.0"
       },
@@ -1047,6 +1056,7 @@
       "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-4.1.0.tgz",
       "integrity": "sha512-einEveDJ/k1180NOp78PB/4Hje9eBy3dyOGLLtLn6bSkizpUfCwuYBIXOA7Y3F/k/BsTQXgKqUVwQ0eiscWMdA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "xss": "1.0.13"
       },
@@ -1059,6 +1069,7 @@
       "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-3.2.1.tgz",
       "integrity": "sha512-NRBW/bhT4sQM5RAZF7W8/VymaOLgIzaR6yTZFI270Ig4NiQ4DRexjdeo/SwDMBlswFtBw5iya+/h+fAur2+Hlg==",
       "license": "SEE LICENSE.md",
+      "peer": true,
       "dependencies": {
         "@arcgis/components-utils": "^4.33.0-next.121",
         "@arcgis/lumina": "^4.33.0-next.121",
@@ -1082,6 +1093,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -1094,6 +1106,7 @@
       "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.2.0.tgz",
       "integrity": "sha512-GS41gUt1tgnqG+U1a6yDRiKOHmuLST2uyOI7+cJ83JtLJ7CGduH9K6RERabTE2vRYbudaebI8jZgKNSNOHdGzw==",
       "license": "SEE LICENSE.md",
+      "peer": true,
       "bin": {
         "spriter": "bin/spriter.js"
       }
@@ -1121,8 +1134,7 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@hapi/bourne": {
       "version": "3.0.0",
@@ -1135,7 +1147,8 @@
       "version": "1.10.27",
       "resolved": "https://registry.npmjs.org/@interactjs/types/-/types-1.10.27.tgz",
       "integrity": "sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -1176,6 +1189,7 @@
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-3.3.1.tgz",
       "integrity": "sha512-JlF1PempxvzrGEpRFrF+Ki0MHzR3HA51SK8Zv0cFpW9p0bPW4k0FeCwrElCu371UEpXF7RcaE2wgYaE1az0XKg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-client": "^1.1.7",
         "@lit-labs/ssr-dom-shim": "^1.3.0",
@@ -1198,6 +1212,7 @@
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.7.tgz",
       "integrity": "sha512-VvqhY/iif3FHrlhkzEPsuX/7h/NqnfxLwVf0p8ghNIlKegRyRqgeaJevZ57s/u/LiFyKgqksRP5n+LmNvpxN+A==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.0.4",
         "lit": "^3.1.2",
@@ -1214,13 +1229,15 @@
       "version": "16.18.126",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
       "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@lit-labs/ssr/node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -1233,6 +1250,7 @@
       "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.5.tgz",
       "integrity": "sha512-57KyQD9of4RlBXkOIF1N40/BLY1j+1wLB5wRmB207+VtwNIRfXbanLsB6BsnFYXrycOUIp2d8gqTNGwuW1lE9Q==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^1.6.2 || ^2.1.0"
       }
@@ -1315,7 +1333,6 @@
       "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.3.4.tgz",
       "integrity": "sha512-cG0C5fMZ1jyW6WCsf4LoHGvaIAJCEVA/ioqKoYRwoSfXkOf+17KupK1OUQyUCw5XoRn+oWA1FulJQOYlXnb9Gw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@loaders.gl/loader-utils": "4.3.4",
         "@loaders.gl/schema": "4.3.4",
@@ -1574,7 +1591,6 @@
       "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.1.9.tgz",
       "integrity": "sha512-1i9N7+I/UbFjx3axSMlc3/NufA+C2iBv/7mw51gRE/ypQPgvFmY/QqXBVZRe+nthF+OhlUMhO19TBndzYFTWhA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@math.gl/types": "^4.1.0",
         "@probe.gl/env": "^4.0.8",
@@ -1588,7 +1604,6 @@
       "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.1.9.tgz",
       "integrity": "sha512-n1GLK1sUMFkWxdb+aZYn6ZBFltFEMi7X+6ZPxn2pBsNT6oeF4AyvH5AyqhOpvHvUnCLDt3Zsf1UIfx3MI//YSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@math.gl/core": "^4.1.0",
         "@math.gl/types": "^4.1.0",
@@ -1621,7 +1636,6 @@
       "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.1.9.tgz",
       "integrity": "sha512-Uqp2xfgIEunRMLXTeCJ4uEMlWcUGcYMZGJ8GAOrAeDzn4bMKVRKmZDC71vkuTctnaodM3UdrI9W6s1sJlrXsxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@math.gl/core": "^4.1.0",
         "@math.gl/types": "^4.1.0",
@@ -1636,7 +1650,6 @@
       "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.1.9.tgz",
       "integrity": "sha512-jecHjhNSWkXH0v62rM6G5fIIkOmsrND27099iKgdutFvHIvd4QS4UzGWEEa9AEPlP0rTLqXkA6y6YL7f42ZkVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@luma.gl/constants": "9.1.9",
         "@math.gl/types": "^4.1.0",
@@ -1837,6 +1850,7 @@
       "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.3.0.tgz",
       "integrity": "sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^7.0.0"
       }
@@ -1846,6 +1860,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -3204,7 +3219,8 @@
       "version": "1.15.8",
       "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.8.tgz",
       "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -4517,6 +4533,7 @@
       "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.63.tgz",
       "integrity": "sha512-B02i6QDMUQ4c+5F9LmliBGA+jFsiEHIlF0eLQ6rWLaQOD3YwI6vyWwGkVCNJnVVguE2xYyr9fAwSD/3valm1/Q==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "bun": ">=0.7.0",
         "deno": ">=1.0.0",
@@ -5361,6 +5378,7 @@
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.0.tgz",
       "integrity": "sha512-16BlyiuyLq3MLxpRWyOTiWsO3ii/eLQLJUQXBSNcxMBBSnyt1ee9YUdaozQp03ifwm5woztEZGDbk9RGVuCsdw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^3.0.1",
         "color-string": "^2.0.0"
@@ -5394,6 +5412,7 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.0.1.tgz",
       "integrity": "sha512-5z9FbYTZPAo8iKsNEqRNv+OlpBbDcoE+SY9GjLfDUHEfcNNV7tS9eSAlFHEaub/r5tBL9LtskAeq1l9SaoZ5tQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^2.0.0"
       },
@@ -5406,6 +5425,7 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
       "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       }
@@ -5415,6 +5435,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
       "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^2.0.0"
       },
@@ -5427,6 +5448,7 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
       "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       }
@@ -5671,13 +5693,15 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cwise": {
       "version": "1.0.10",
@@ -5727,7 +5751,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6128,7 +6151,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6463,8 +6485,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -6599,6 +6620,7 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
       "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -6612,6 +6634,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -7006,6 +7029,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -7051,6 +7075,7 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
       "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -7060,6 +7085,7 @@
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -7258,7 +7284,8 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/h3-js": {
       "version": "4.2.1",
@@ -7516,6 +7543,7 @@
       "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
       "integrity": "sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@interactjs/types": "1.10.27"
       }
@@ -8683,6 +8711,7 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
       "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9528,6 +9557,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -9537,6 +9567,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -9555,6 +9586,7 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -10438,7 +10470,6 @@
       "integrity": "sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10564,7 +10595,8 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -10811,7 +10843,8 @@
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
       "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/source-map": {
       "version": "0.7.4",
@@ -11130,7 +11163,8 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/table-layout": {
       "version": "4.1.1",
@@ -11161,6 +11195,7 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
       "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11237,6 +11272,7 @@
       "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.10.4.tgz",
       "integrity": "sha512-AnkJYrbb7uPkDCEqGeVJiawZNiwVlSkkeX4jZg1gTEguClhyX+/Ezn07KB6DT29tG3UN418ldmS/W6KqGOTDjg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.12.0"
       }
@@ -11603,7 +11639,6 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -11673,6 +11708,7 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -11805,6 +11841,7 @@
       "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
       "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commander": "^2.20.3",
         "cssfilter": "0.0.10"
@@ -11820,7 +11857,8 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/xtend": {
       "version": "2.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "spacelit",
-  "version": "1.0.0",
-  "description": "SpaceLit frontend rewrite",
+  "name": "preloop",
+  "version": "0.8.0",
+  "description": "Preloop console frontend",
   "main": "src/main.ts",
   "scripts": {
     "start": "npm run dev",

--- a/frontend/src/services/README.md
+++ b/frontend/src/services/README.md
@@ -1,6 +1,6 @@
 # Unified WebSocket Services
 
-This directory contains the unified WebSocket infrastructure for SpaceLit.
+This directory contains the unified WebSocket infrastructure for Preloop Console.
 
 ## Overview
 

--- a/helm/preloop/README.md
+++ b/helm/preloop/README.md
@@ -105,10 +105,10 @@ Resources are configured per-component to allow fine-grained control:
 | `api.resources.requests.memory`   | API server memory request          | `256Mi`       |
 | `api.resources.limits.cpu`        | API server CPU limit               | `1`           |
 | `api.resources.limits.memory`     | API server memory limit            | `1Gi`         |
-| `spacelit.resources.requests.cpu` | Frontend (nginx) CPU request       | `50m`         |
-| `spacelit.resources.requests.memory` | Frontend memory request         | `64Mi`        |
-| `spacelit.resources.limits.cpu`   | Frontend CPU limit                 | `200m`        |
-| `spacelit.resources.limits.memory` | Frontend memory limit             | `256Mi`       |
+| `console.resources.requests.cpu` | Frontend (nginx) CPU request       | `50m`         |
+| `console.resources.requests.memory` | Frontend memory request         | `64Mi`        |
+| `console.resources.limits.cpu`   | Frontend CPU limit                 | `200m`        |
+| `console.resources.limits.memory` | Frontend memory limit             | `256Mi`       |
 | `worker.resources.requests.cpu`   | Worker CPU request                 | `200m`        |
 | `worker.resources.requests.memory` | Worker memory request             | `256Mi`       |
 | `worker.resources.limits.cpu`     | Worker CPU limit                   | `1`           |

--- a/helm/preloop/templates/ingress.yaml
+++ b/helm/preloop/templates/ingress.yaml
@@ -41,11 +41,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}-spacelit
+                name: {{ $fullName }}-console
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ $fullName }}-spacelit
+              serviceName: {{ $fullName }}-console
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}

--- a/helm/preloop/templates/service.yaml
+++ b/helm/preloop/templates/service.yaml
@@ -13,4 +13,4 @@ spec:
       name: http
   selector:
     {{- include "preloop.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: spacelit
+    app.kubernetes.io/component: console

--- a/helm/preloop/templates/spacelit-deployment.yaml
+++ b/helm/preloop/templates/spacelit-deployment.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "preloop.fullname" . }}-spacelit
+  name: {{ include "preloop.fullname" . }}-console
   labels:
     {{- include "preloop.labels" . | nindent 4 }}
-    app.kubernetes.io/component: spacelit
-    app: spacelit
+    app.kubernetes.io/component: console
+    app: console
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -13,7 +13,7 @@ spec:
   selector:
     matchLabels:
       {{- include "preloop.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: spacelit
+      app.kubernetes.io/component: console
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       labels:
         {{- include "preloop.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: spacelit
+        app.kubernetes.io/component: console
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -32,9 +32,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: spacelit
-          image: "{{ .Values.spacelit.repository }}:{{ .Values.spacelit.tag }}"
-          imagePullPolicy: {{ .Values.spacelit.pullPolicy }}
+        - name: console
+          image: "{{ .Values.console.repository }}:{{ .Values.console.tag }}"
+          imagePullPolicy: {{ .Values.console.pullPolicy }}
           ports:
             - name: http
               containerPort: 80
@@ -43,7 +43,7 @@ spec:
             - name: nginx-config
               mountPath: /etc/nginx/templates
           resources:
-            {{- toYaml .Values.spacelit.resources | nindent 12 }}
+            {{- toYaml .Values.console.resources | nindent 12 }}
       volumes:
         - name: nginx-config
           configMap:

--- a/helm/preloop/templates/spacelit-service.yaml
+++ b/helm/preloop/templates/spacelit-service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "preloop.fullname" . }}-spacelit
+  name: {{ include "preloop.fullname" . }}-console
   labels:
     {{- include "preloop.labels" . | nindent 4 }}
-    app.kubernetes.io/component: spacelit
+    app.kubernetes.io/component: console
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -14,4 +14,4 @@ spec:
       name: http
   selector:
     {{- include "preloop.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: spacelit
+    app.kubernetes.io/component: console

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -30,11 +30,11 @@ worker:
       cpu: "1"
       memory: "1Gi"
 
-spacelit:
-  repository: registry.spacecode.ai/spacecode/spacelit
+console:
+  repository: registry.spacecode.ai/spacecode/console
   tag: "latest"
   pullPolicy: Always
-  # SpaceLit frontend resources (nginx - lightweight)
+  # Preloop Console frontend resources (nginx - lightweight)
   resources:
     requests:
       cpu: "50m"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes CI/CD and standardizes frontend naming.
> 
> - **CI (GitHub Actions):** Adds Node setup, Playwright install, upgrades Postgres to `pg16`, includes `pytest-asyncio`, ignores integration tests in unit job, enables Codecov upload (non-PR), and introduces multi-arch Docker build/publish for backend and frontend to GHCR (optional Docker Hub) with metadata and semver/sha tags.
> - **GitLab CI:** Deployment helm args updated from `spacelit.*` to `console.*` for frontend image/tag.
> - **Frontend:** Renames SpaceLit to Preloop Console across docs/scripts, switches Docker images and compose network names, bumps Node base images to `22`, updates package name/version, and aligns Docker README/invocations (`console:*`).
> - **Helm chart:** Replaces `spacelit` with `console` in deployment/service/ingress templates and values; README reflects new resource keys.
> - **Backend tests:** Adjusts Pydantic v2 config access (`model_config.from_attributes`).
> - **Docs/README:** Messaging tweaks and year update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cfd523ce984269f020d25b742f216af1720a121. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->