### PR TITLE
Validate GitHub token permissions, add missing webhook events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY_GHCR }}/preloop/preloop
             ${{ vars.PUSH_TO_DOCKERHUB == 'true' && format('{0}/preloop', vars.DOCKERHUB_ORG) || '' }}
           tags: |
             type=ref,event=branch
@@ -224,7 +224,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}/console
+            ${{ env.REGISTRY_GHCR }}/preloop/console
             ${{ vars.PUSH_TO_DOCKERHUB == 'true' && format('{0}/console', vars.DOCKERHUB_ORG) || '' }}
           tags: |
             type=ref,event=branch

--- a/backend/preloop/api/endpoints/flows.py
+++ b/backend/preloop/api/endpoints/flows.py
@@ -110,6 +110,7 @@ def clone_preset(
         raise HTTPException(status_code=404, detail="Preset not found")
 
     # Build dict excluding fields we want to override or that aren't in FlowCreate
+    # Note: is_enabled is excluded so cloned flows start enabled (presets are disabled)
     preset_dict = {
         k: v
         for k, v in preset.__dict__.items()
@@ -121,6 +122,7 @@ def clone_preset(
             "updated_at",
             "name",
             "is_preset",
+            "is_enabled",
             "account_id",
         ]
     }
@@ -140,6 +142,7 @@ def clone_preset(
         **preset_dict,
         name=final_name,
         is_preset=False,
+        is_enabled=True,  # Cloned flows start enabled
         account_id=str(current_user.account_id),
     )
     cloned_flow = crud_flow.create(

--- a/backend/preloop/api/endpoints/mcp.py
+++ b/backend/preloop/api/endpoints/mcp.py
@@ -935,8 +935,8 @@ async def add_comment(target: str, comment: str) -> "AddCommentResponse":
                 # Remove gitlab host and get project path (everything between host and /-/)
                 project_path = "/".join(url_path[1:]).rstrip("/-")
                 logger.info(f"Detected GitLab MR: {project_path}#{pr_mr_number}")
-    # Parse slug format for PRs/MRs: owner/repo#123
-    elif "/" in target and "#" in target:
+    # Parse slug format for PRs/MRs: owner/repo#123 or repo#123
+    elif "#" in target:
         slug_parts = target.split("#")
         pr_mr_number = slug_parts[1]
         project_path = slug_parts[0]
@@ -1156,7 +1156,7 @@ async def get_pull_request(pull_request: str) -> "PullRequestResponse":
         tracker = trackers[0]
         from preloop.models.crud import crud_organization
 
-        organizations = crud_organization.get_multi_by_tracker(
+        organizations = crud_organization.get_for_tracker(
             db, tracker_id=tracker.id, account_id=current_user.account_id
         )
         if not organizations:
@@ -1276,7 +1276,7 @@ async def get_merge_request(merge_request: str) -> "MergeRequestResponse":
         tracker = trackers[0]
         from preloop.models.crud import crud_organization
 
-        organizations = crud_organization.get_multi_by_tracker(
+        organizations = crud_organization.get_for_tracker(
             db, tracker_id=tracker.id, account_id=current_user.account_id
         )
         if not organizations:
@@ -1414,7 +1414,7 @@ async def update_pull_request(
         tracker = trackers[0]
         from preloop.models.crud import crud_organization
 
-        organizations = crud_organization.get_multi_by_tracker(
+        organizations = crud_organization.get_for_tracker(
             db, tracker_id=tracker.id, account_id=current_user.account_id
         )
         if not organizations:
@@ -1562,7 +1562,7 @@ async def update_merge_request(
         tracker = trackers[0]
         from preloop.models.crud import crud_organization
 
-        organizations = crud_organization.get_multi_by_tracker(
+        organizations = crud_organization.get_for_tracker(
             db, tracker_id=tracker.id, account_id=current_user.account_id
         )
         if not organizations:

--- a/backend/preloop/api/endpoints/trackers.py
+++ b/backend/preloop/api/endpoints/trackers.py
@@ -1,10 +1,10 @@
 """Trackers router for registering and managing issue trackers."""
 
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
-from pydantic import UUID4
+from pydantic import UUID4, BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -19,11 +19,17 @@ from preloop.schemas.tracker import (
 from preloop.schemas.tracker import (
     ProjectIdentifier,
 )  # Corrected import location
+
+
 from preloop.sync.trackers import create_tracker_client
 from preloop.utils.email import send_tracker_registered_email
 from preloop.sync.services.event_bus import event_bus_service
 from preloop.models.db.session import get_db_session
+
+
 from preloop.models.models.tracker import Tracker, TrackerType, TrackerScopeRule
+
+
 from preloop.models.crud import (
     crud_account,
     crud_tracker,
@@ -35,6 +41,18 @@ from preloop.utils.permissions import require_permission
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+class TrackerCreateResponse(BaseModel):
+    """Response model for tracker creation."""
+
+    id: str
+    warnings: Optional[List[str]] = None
+
+    class Config:
+        """Pydantic config."""
+
+        from_attributes = True
 
 
 @router.post("/trackers/debug")
@@ -49,14 +67,18 @@ async def debug_tracker_request(request: Request):
         return {"error": str(e)}
 
 
-@router.post("/trackers", status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/trackers",
+    status_code=status.HTTP_201_CREATED,
+    response_model=TrackerCreateResponse,
+)
 @require_permission("create_trackers")
 async def register_tracker(
     request: Request,
     background_tasks: BackgroundTasks,
     current_user: AuthUserResponse = Depends(get_current_active_user),
     db: Session = Depends(get_db_session),
-) -> Dict[str, str]:
+) -> TrackerCreateResponse:
     """Register a new issue tracker.
 
     Args:
@@ -81,7 +103,7 @@ async def register_tracker(
         url_str = data.get("url")
         api_key = data.get("api_key")
         config = data.get("config")
-        scope_rules_data = data.get("scope_rules", [])
+        scope_rules_data = data.get("scope_rules") or []
 
         # Validate required fields
         if not name or not tracker_type_str or not api_key:
@@ -146,11 +168,12 @@ async def register_tracker(
                     rule.get("scope_type") == "ORGANIZATION"
                     and rule.get("rule_type") == "INCLUDE"
                 ):
-                    org_identifiers.append(rule.get("identifier"))
+                    identifier = rule.get("identifier")
+                    if identifier:  # Only append valid identifiers
+                        org_identifiers.append(identifier)
 
-            # Validate token permissions (check first org if any)
-            first_org = org_identifiers[0] if org_identifiers else None
-            permission_result = await client.validate_token_permissions(first_org)
+            # First, validate basic token permissions (scopes) without org-specific checks
+            permission_result = await client.validate_token_permissions(None)
 
             if not permission_result["valid"]:
                 raise HTTPException(
@@ -158,8 +181,21 @@ async def register_tracker(
                     detail=f"GitHub token validation failed: {', '.join(permission_result['errors'])}",
                 )
 
-            # Collect warnings to return with the response
+            # Collect basic scope warnings
             permission_warnings = permission_result.get("warnings", [])
+
+            # Now validate admin access for each organization in scope rules
+            for org_id in org_identifiers:
+                org_result = await client.validate_token_permissions(org_id)
+                # Add org-specific warnings (skip duplicate scope warnings)
+                for warning in org_result.get("warnings", []):
+                    if warning not in permission_warnings:
+                        permission_warnings.append(warning)
+                # Add any org-specific errors as warnings (don't fail registration)
+                for error in org_result.get("errors", []):
+                    if error not in permission_warnings:
+                        permission_warnings.append(error)
+
             if permission_warnings:
                 logger.warning(
                     f"GitHub token permission warnings for tracker '{name}': {permission_warnings}"

--- a/backend/preloop/api/endpoints/trackers.py
+++ b/backend/preloop/api/endpoints/trackers.py
@@ -133,6 +133,38 @@ async def register_tracker(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Failed to connect to tracker: {connection_result.message}",
             )
+
+        # For GitHub trackers, validate token permissions and warn about missing scopes
+        permission_warnings = []
+        if tracker_type == TrackerType.GITHUB and hasattr(
+            client, "validate_token_permissions"
+        ):
+            # Extract organization identifiers from scope rules to check admin access
+            org_identifiers = []
+            for rule in scope_rules_data:
+                if (
+                    rule.get("scope_type") == "ORGANIZATION"
+                    and rule.get("rule_type") == "INCLUDE"
+                ):
+                    org_identifiers.append(rule.get("identifier"))
+
+            # Validate token permissions (check first org if any)
+            first_org = org_identifiers[0] if org_identifiers else None
+            permission_result = await client.validate_token_permissions(first_org)
+
+            if not permission_result["valid"]:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"GitHub token validation failed: {', '.join(permission_result['errors'])}",
+                )
+
+            # Collect warnings to return with the response
+            permission_warnings = permission_result.get("warnings", [])
+            if permission_warnings:
+                logger.warning(
+                    f"GitHub token permission warnings for tracker '{name}': {permission_warnings}"
+                )
+
     except HTTPException:
         raise
     except Exception as e:
@@ -224,7 +256,11 @@ async def register_tracker(
         # Send NATS event
         await event_bus_service.publish_task("poll_tracker", str(new_tracker.id))
 
-        return {"id": str(new_tracker.id)}  # Return the tracker ID as string
+        # Build response with warnings if any
+        response = {"id": str(new_tracker.id)}
+        if permission_warnings:
+            response["warnings"] = permission_warnings
+        return response
 
     except IntegrityError as e:
         db.rollback()

--- a/backend/preloop/services/flow_trigger_service.py
+++ b/backend/preloop/services/flow_trigger_service.py
@@ -186,7 +186,10 @@ class FlowTriggerService:
             flows_to_trigger = []
             for flow in matching_flows:
                 if not flow.is_enabled:
-                    logger.info(f"Skipping disabled flow '{flow.name}' ({flow.id})")
+                    logger.warning(
+                        f"Skipping disabled flow '{flow.name}' ({flow.id}). "
+                        f"To enable this flow, set is_enabled=true via the API or UI."
+                    )
                     continue
 
                 if not self._matches_trigger_config(flow, event_data):

--- a/backend/preloop/sync/event_normalizer.py
+++ b/backend/preloop/sync/event_normalizer.py
@@ -116,6 +116,12 @@ def normalize_event_type(
                         normalized = "pull_request_closed"
                     elif action == "reopened":
                         normalized = "pull_request_reopened"
+                    elif action == "review_requested":
+                        normalized = "pull_request_review_requested"
+                    elif action == "synchronize":
+                        normalized = "pull_request_synchronized"
+                    elif action == "ready_for_review":
+                        normalized = "pull_request_ready_for_review"
                 elif normalized == "comment_created":
                     if action == "created":
                         pass  # Keep as comment_created
@@ -269,6 +275,19 @@ def extract_filter_fields(
                 filter_fields["reviewer"] = [
                     r.get("login") for r in requested_reviewers
                 ]
+
+            # For review_requested action, also check top-level requested_reviewer
+            # This is the specific reviewer that was just added (not in the PR object)
+            if action == "review_requested":
+                top_level_reviewer = payload.get("requested_reviewer", {})
+                if top_level_reviewer:
+                    reviewer_login = top_level_reviewer.get("login")
+                    if reviewer_login:
+                        # Ensure reviewer list includes the just-added reviewer
+                        if "reviewer" not in filter_fields:
+                            filter_fields["reviewer"] = []
+                        if reviewer_login not in filter_fields["reviewer"]:
+                            filter_fields["reviewer"].append(reviewer_login)
 
             # Labels
             labels = pr.get("labels", [])

--- a/backend/preloop/sync/trackers/base.py
+++ b/backend/preloop/sync/trackers/base.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 class BaseTracker(ABC):
     """Base class for all tracker implementations."""
 
+    # Subclasses should override this
+    tracker_type: str = "unknown"
+
     def __init__(
         self, tracker_id: str, api_key: str, connection_details: Dict[str, Any]
     ):

--- a/backend/preloop/sync/trackers/github.py
+++ b/backend/preloop/sync/trackers/github.py
@@ -47,6 +47,7 @@ from preloop.models.crud import crud_organization, crud_project, crud_webhook
 class GitHubTracker(BaseTracker):
     """GitHub tracker implementation."""
 
+    tracker_type: str = "github"
     API_BASE_URL = "https://api.github.com"
 
     def __init__(
@@ -418,6 +419,7 @@ class GitHubTracker(BaseTracker):
                         # or a login/slug. The membership API requires the login, so we need
                         # to resolve numeric IDs to logins first.
                         org_login = org_identifier
+                        org_lookup_failed = False
                         if org_identifier.isdigit():
                             # Numeric ID - need to look up the org login
                             org_lookup_url = (
@@ -430,52 +432,64 @@ class GitHubTracker(BaseTracker):
                                 org_data = org_lookup_response.json()
                                 org_login = org_data.get("login", org_identifier)
                             else:
-                                # Can't resolve org ID, warn but continue
+                                # Can't resolve org ID - skip membership check to avoid
+                                # misleading "not a member" errors when we just can't
+                                # resolve the numeric ID to a slug
+                                org_lookup_failed = True
                                 logger.warning(
                                     f"Could not resolve org ID {org_identifier} to login: "
                                     f"{org_lookup_response.status_code}"
                                 )
+                                result["is_org_admin"] = None
+                                result["warnings"].append(
+                                    f"Could not verify admin status for organization ID '{org_identifier}'. "
+                                    "The token may be missing 'read:org' scope or the organization "
+                                    "may not be accessible. Webhook registration may fail if you "
+                                    "are not an organization admin."
+                                )
 
-                        membership_url = f"{self.API_BASE_URL}/orgs/{org_login}/memberships/{username}"
-                        membership_response = await client.get(
-                            membership_url, headers=self.headers
-                        )
+                        # Only proceed with membership check if we resolved the org
+                        if not org_lookup_failed:
+                            membership_url = f"{self.API_BASE_URL}/orgs/{org_login}/memberships/{username}"
+                            membership_response = await client.get(
+                                membership_url, headers=self.headers
+                            )
 
-                        if membership_response.status_code == 200:
-                            membership_data = membership_response.json()
-                            role = membership_data.get("role")
-                            state = membership_data.get("state")
+                            if membership_response.status_code == 200:
+                                membership_data = membership_response.json()
+                                role = membership_data.get("role")
+                                state = membership_data.get("state")
 
-                            if state != "active":
+                                if state != "active":
+                                    result["is_org_admin"] = False
+                                    result["warnings"].append(
+                                        f"Your membership in organization '{org_login}' is pending. "
+                                        "Webhook registration may fail until membership is active."
+                                    )
+                                elif role == "admin":
+                                    result["is_org_admin"] = True
+                                else:
+                                    result["is_org_admin"] = False
+                                    result["warnings"].append(
+                                        f"You are not an admin of organization '{org_login}'. "
+                                        "Webhook registration requires organization admin access. "
+                                        "Contact an organization owner to register webhooks, or use a Fine-Grained Token with webhook permissions."
+                                    )
+                            elif membership_response.status_code == 404:
                                 result["is_org_admin"] = False
                                 result["warnings"].append(
-                                    f"Your membership in organization '{org_login}' is pending. "
-                                    "Webhook registration may fail until membership is active."
+                                    f"You are not a member of organization '{org_login}'. "
+                                    "Webhook registration will fail."
                                 )
-                            elif role == "admin":
-                                result["is_org_admin"] = True
-                            else:
-                                result["is_org_admin"] = False
+                            elif membership_response.status_code == 403:
+                                # User doesn't have permission to view membership
+                                # This can happen with Fine-Grained tokens
+                                result["is_org_admin"] = None
                                 result["warnings"].append(
-                                    f"You are not an admin of organization '{org_login}'. "
-                                    "Webhook registration requires organization admin access. "
-                                    "Contact an organization owner to register webhooks, or use a Fine-Grained Token with webhook permissions."
+                                    f"Cannot verify admin status for organization '{org_login}'. "
+                                    "If using a Fine-Grained Personal Access Token, ensure it has "
+                                    "'Organization webhooks' write permission."
                                 )
-                        elif membership_response.status_code == 404:
-                            result["is_org_admin"] = False
-                            result["warnings"].append(
-                                f"You are not a member of organization '{org_login}'. "
-                                "Webhook registration will fail."
-                            )
-                        elif membership_response.status_code == 403:
-                            # User doesn't have permission to view membership
-                            # This can happen with Fine-Grained tokens
-                            result["is_org_admin"] = None
-                            result["warnings"].append(
-                                f"Cannot verify admin status for organization '{org_login}'. "
-                                "If using a Fine-Grained Personal Access Token, ensure it has "
-                                "'Organization webhooks' write permission."
-                            )
                     except Exception as e:
                         logger.warning(
                             f"Error checking org membership for {org_login}: {e}"

--- a/backend/preloop/sync/trackers/github.py
+++ b/backend/preloop/sync/trackers/github.py
@@ -368,6 +368,14 @@ class GitHubTracker(BaseTracker):
                     result["errors"].append("Invalid or expired GitHub token")
                     return result
 
+                # Handle other error responses (403, 404, 500, etc.)
+                if response.status_code >= 400:
+                    result["valid"] = False
+                    result["errors"].append(
+                        f"GitHub API error: {response.status_code} - {response.text[:200]}"
+                    )
+                    return result
+
                 # Extract scopes from X-OAuth-Scopes header
                 oauth_scopes_header = response.headers.get("X-OAuth-Scopes", "")
                 scopes = [
@@ -406,7 +414,29 @@ class GitHubTracker(BaseTracker):
                         user_data = response.json()
                         username = user_data.get("login")
 
-                        membership_url = f"{self.API_BASE_URL}/orgs/{org_identifier}/memberships/{username}"
+                        # The org_identifier might be a numeric ID (from transform_organization)
+                        # or a login/slug. The membership API requires the login, so we need
+                        # to resolve numeric IDs to logins first.
+                        org_login = org_identifier
+                        if org_identifier.isdigit():
+                            # Numeric ID - need to look up the org login
+                            org_lookup_url = (
+                                f"{self.API_BASE_URL}/organizations/{org_identifier}"
+                            )
+                            org_lookup_response = await client.get(
+                                org_lookup_url, headers=self.headers
+                            )
+                            if org_lookup_response.status_code == 200:
+                                org_data = org_lookup_response.json()
+                                org_login = org_data.get("login", org_identifier)
+                            else:
+                                # Can't resolve org ID, warn but continue
+                                logger.warning(
+                                    f"Could not resolve org ID {org_identifier} to login: "
+                                    f"{org_lookup_response.status_code}"
+                                )
+
+                        membership_url = f"{self.API_BASE_URL}/orgs/{org_login}/memberships/{username}"
                         membership_response = await client.get(
                             membership_url, headers=self.headers
                         )
@@ -419,7 +449,7 @@ class GitHubTracker(BaseTracker):
                             if state != "active":
                                 result["is_org_admin"] = False
                                 result["warnings"].append(
-                                    f"Your membership in organization '{org_identifier}' is pending. "
+                                    f"Your membership in organization '{org_login}' is pending. "
                                     "Webhook registration may fail until membership is active."
                                 )
                             elif role == "admin":
@@ -427,14 +457,14 @@ class GitHubTracker(BaseTracker):
                             else:
                                 result["is_org_admin"] = False
                                 result["warnings"].append(
-                                    f"You are not an admin of organization '{org_identifier}'. "
+                                    f"You are not an admin of organization '{org_login}'. "
                                     "Webhook registration requires organization admin access. "
                                     "Contact an organization owner to register webhooks, or use a Fine-Grained Token with webhook permissions."
                                 )
                         elif membership_response.status_code == 404:
                             result["is_org_admin"] = False
                             result["warnings"].append(
-                                f"You are not a member of organization '{org_identifier}'. "
+                                f"You are not a member of organization '{org_login}'. "
                                 "Webhook registration will fail."
                             )
                         elif membership_response.status_code == 403:
@@ -442,13 +472,13 @@ class GitHubTracker(BaseTracker):
                             # This can happen with Fine-Grained tokens
                             result["is_org_admin"] = None
                             result["warnings"].append(
-                                f"Cannot verify admin status for organization '{org_identifier}'. "
+                                f"Cannot verify admin status for organization '{org_login}'. "
                                 "If using a Fine-Grained Personal Access Token, ensure it has "
                                 "'Organization webhooks' write permission."
                             )
                     except Exception as e:
                         logger.warning(
-                            f"Error checking org membership for {org_identifier}: {e}"
+                            f"Error checking org membership for {org_login}: {e}"
                         )
                         result["is_org_admin"] = None
 

--- a/backend/preloop/sync/trackers/github.py
+++ b/backend/preloop/sync/trackers/github.py
@@ -333,6 +333,131 @@ class GitHubTracker(BaseTracker):
         ) as e:
             return TrackerConnection(connected=False, message=str(e))
 
+    async def validate_token_permissions(
+        self, org_identifier: str | None = None
+    ) -> dict:
+        """
+        Validate that the GitHub token has the required permissions.
+
+        This checks:
+        1. Token scopes from the X-OAuth-Scopes header
+        2. If org_identifier is provided, checks if user is an admin of that org
+
+        Args:
+            org_identifier: Optional organization name to check admin access for.
+
+        Returns:
+            Dict with 'valid' (bool), 'scopes' (list), 'warnings' (list), and 'errors' (list)
+        """
+        result = {
+            "valid": True,
+            "scopes": [],
+            "warnings": [],
+            "errors": [],
+            "is_org_admin": None,
+        }
+
+        try:
+            # Make a request to /user to get the token scopes from response headers
+            async with httpx.AsyncClient() as client:
+                url = f"{self.API_BASE_URL}/user"
+                response = await client.get(url, headers=self.headers)
+
+                if response.status_code == HTTP_STATUS_UNAUTHORIZED:
+                    result["valid"] = False
+                    result["errors"].append("Invalid or expired GitHub token")
+                    return result
+
+                # Extract scopes from X-OAuth-Scopes header
+                oauth_scopes_header = response.headers.get("X-OAuth-Scopes", "")
+                scopes = [
+                    s.strip() for s in oauth_scopes_header.split(",") if s.strip()
+                ]
+                result["scopes"] = scopes
+
+                # Check for required scopes for webhook registration
+                # admin:org_hook or admin:org includes org hook permissions
+                has_org_hook_scope = any(
+                    scope in scopes
+                    for scope in ["admin:org_hook", "admin:org", "write:org_hook"]
+                )
+
+                if not has_org_hook_scope:
+                    result["warnings"].append(
+                        "Token is missing 'admin:org_hook' scope. "
+                        "Webhook registration for organizations will fail. "
+                        "Please regenerate the token with 'admin:org_hook' or 'admin:org' scope."
+                    )
+
+                # Check for repo scope (needed for reading repositories)
+                has_repo_scope = any(
+                    scope in scopes for scope in ["repo", "public_repo"]
+                )
+                if not has_repo_scope:
+                    result["warnings"].append(
+                        "Token is missing 'repo' scope. "
+                        "Access to private repositories will be limited."
+                    )
+
+                # If org_identifier provided, check if user is admin of that org
+                if org_identifier and org_identifier != "personal":
+                    try:
+                        # Get user's membership in the organization
+                        user_data = response.json()
+                        username = user_data.get("login")
+
+                        membership_url = f"{self.API_BASE_URL}/orgs/{org_identifier}/memberships/{username}"
+                        membership_response = await client.get(
+                            membership_url, headers=self.headers
+                        )
+
+                        if membership_response.status_code == 200:
+                            membership_data = membership_response.json()
+                            role = membership_data.get("role")
+                            state = membership_data.get("state")
+
+                            if state != "active":
+                                result["is_org_admin"] = False
+                                result["warnings"].append(
+                                    f"Your membership in organization '{org_identifier}' is pending. "
+                                    "Webhook registration may fail until membership is active."
+                                )
+                            elif role == "admin":
+                                result["is_org_admin"] = True
+                            else:
+                                result["is_org_admin"] = False
+                                result["warnings"].append(
+                                    f"You are not an admin of organization '{org_identifier}'. "
+                                    "Webhook registration requires organization admin access. "
+                                    "Contact an organization owner to register webhooks, or use a Fine-Grained Token with webhook permissions."
+                                )
+                        elif membership_response.status_code == 404:
+                            result["is_org_admin"] = False
+                            result["warnings"].append(
+                                f"You are not a member of organization '{org_identifier}'. "
+                                "Webhook registration will fail."
+                            )
+                        elif membership_response.status_code == 403:
+                            # User doesn't have permission to view membership
+                            # This can happen with Fine-Grained tokens
+                            result["is_org_admin"] = None
+                            result["warnings"].append(
+                                f"Cannot verify admin status for organization '{org_identifier}'. "
+                                "If using a Fine-Grained Personal Access Token, ensure it has "
+                                "'Organization webhooks' write permission."
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            f"Error checking org membership for {org_identifier}: {e}"
+                        )
+                        result["is_org_admin"] = None
+
+        except Exception as e:
+            result["valid"] = False
+            result["errors"].append(f"Failed to validate token: {str(e)}")
+
+        return result
+
     async def get_project_metadata(self, project_key: str) -> ProjectMetadata:
         """Get metadata about a GitHub project.
 
@@ -905,6 +1030,9 @@ class GitHubTracker(BaseTracker):
         events = [
             "issues",
             "issue_comment",
+            "pull_request",
+            "pull_request_review",
+            "pull_request_review_comment",
             "discussion",
             "project",
             "repository",

--- a/backend/preloop/sync/trackers/github.py
+++ b/backend/preloop/sync/trackers/github.py
@@ -492,7 +492,7 @@ class GitHubTracker(BaseTracker):
                                 )
                     except Exception as e:
                         logger.warning(
-                            f"Error checking org membership for {org_login}: {e}"
+                            f"Error checking org membership for {org_identifier}: {e}"
                         )
                         result["is_org_admin"] = None
 

--- a/backend/preloop/sync/trackers/gitlab.py
+++ b/backend/preloop/sync/trackers/gitlab.py
@@ -47,6 +47,8 @@ from preloop.schemas.tracker_models import (
 class GitLabTracker(BaseTracker):
     """GitLab tracker implementation using python-gitlab."""
 
+    tracker_type: str = "gitlab"
+
     def __init__(
         self, tracker_id: str, api_key: str, connection_details: Dict[str, Any]
     ):

--- a/backend/preloop/sync/trackers/jira.py
+++ b/backend/preloop/sync/trackers/jira.py
@@ -60,6 +60,8 @@ DEFAULT_JIRA_WEBHOOK_EVENTS = [
 class JiraTracker(BaseTracker):
     """Jira tracker implementation."""
 
+    tracker_type: str = "jira"
+
     def __init__(
         self, tracker_id: str, api_key: str, connection_details: Dict[str, Any]
     ):

--- a/backend/tests/sync/trackers/test_github.py
+++ b/backend/tests/sync/trackers/test_github.py
@@ -1003,3 +1003,156 @@ class TestGitHubTrackerIssueOperations(IsolatedAsyncioTestCase):
 
         # Assert - should return empty list on error
         self.assertEqual(result, [])
+
+
+@pytest.mark.asyncio
+class TestGitHubTrackerTokenValidation(unittest.IsolatedAsyncioTestCase):
+    """Tests for GitHub token permission validation."""
+
+    @patch("preloop.sync.trackers.github.httpx.AsyncClient")
+    async def test_validate_token_permissions_valid_token_with_all_scopes(
+        self, mock_client_class
+    ):
+        """Test validation with a token that has all required scopes."""
+        from unittest.mock import AsyncMock
+
+        # Setup mock response with all required scopes
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"X-OAuth-Scopes": "repo, admin:org_hook, user"}
+        mock_response.json.return_value = {"login": "testuser"}
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_class.return_value = mock_client
+
+        # Create tracker and validate
+        tracker = GitHubTracker(str(uuid4()), "test-token", {})
+        result = await tracker.validate_token_permissions()
+
+        # Assert
+        self.assertTrue(result["valid"])
+        self.assertIn("repo", result["scopes"])
+        self.assertIn("admin:org_hook", result["scopes"])
+        self.assertEqual(len(result["warnings"]), 0)
+        self.assertEqual(len(result["errors"]), 0)
+
+    @patch("preloop.sync.trackers.github.httpx.AsyncClient")
+    async def test_validate_token_permissions_missing_org_hook_scope(
+        self, mock_client_class
+    ):
+        """Test validation warns when admin:org_hook scope is missing."""
+        from unittest.mock import AsyncMock
+
+        # Setup mock response without org_hook scope
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"X-OAuth-Scopes": "repo, user"}
+        mock_response.json.return_value = {"login": "testuser"}
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_class.return_value = mock_client
+
+        # Create tracker and validate
+        tracker = GitHubTracker(str(uuid4()), "test-token", {})
+        result = await tracker.validate_token_permissions()
+
+        # Assert - should be valid but with warning
+        self.assertTrue(result["valid"])
+        self.assertTrue(
+            any("admin:org_hook" in w for w in result["warnings"]),
+            "Should warn about missing admin:org_hook scope",
+        )
+
+    @patch("preloop.sync.trackers.github.httpx.AsyncClient")
+    async def test_validate_token_permissions_invalid_token(self, mock_client_class):
+        """Test validation fails with invalid token."""
+        from unittest.mock import AsyncMock
+
+        # Setup mock response for unauthorized
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_class.return_value = mock_client
+
+        # Create tracker and validate
+        tracker = GitHubTracker(str(uuid4()), "invalid-token", {})
+        result = await tracker.validate_token_permissions()
+
+        # Assert - should not be valid
+        self.assertFalse(result["valid"])
+        self.assertTrue(len(result["errors"]) > 0)
+
+    @patch("preloop.sync.trackers.github.httpx.AsyncClient")
+    async def test_validate_token_permissions_with_org_admin_check(
+        self, mock_client_class
+    ):
+        """Test validation checks org admin status when org_identifier provided."""
+        from unittest.mock import AsyncMock
+
+        # Setup mock responses
+        user_response = MagicMock()
+        user_response.status_code = 200
+        user_response.headers = {"X-OAuth-Scopes": "repo, admin:org_hook"}
+        user_response.json.return_value = {"login": "testuser"}
+
+        membership_response = MagicMock()
+        membership_response.status_code = 200
+        membership_response.json.return_value = {"role": "admin", "state": "active"}
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [user_response, membership_response]
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_class.return_value = mock_client
+
+        # Create tracker and validate with org
+        tracker = GitHubTracker(str(uuid4()), "test-token", {})
+        result = await tracker.validate_token_permissions(org_identifier="test-org")
+
+        # Assert - should be valid and user is admin
+        self.assertTrue(result["valid"])
+        self.assertTrue(result["is_org_admin"])
+        self.assertEqual(len(result["warnings"]), 0)
+
+    @patch("preloop.sync.trackers.github.httpx.AsyncClient")
+    async def test_validate_token_permissions_non_admin_user(self, mock_client_class):
+        """Test validation warns when user is not an org admin."""
+        from unittest.mock import AsyncMock
+
+        # Setup mock responses
+        user_response = MagicMock()
+        user_response.status_code = 200
+        user_response.headers = {"X-OAuth-Scopes": "repo, admin:org_hook"}
+        user_response.json.return_value = {"login": "testuser"}
+
+        membership_response = MagicMock()
+        membership_response.status_code = 200
+        membership_response.json.return_value = {"role": "member", "state": "active"}
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [user_response, membership_response]
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_class.return_value = mock_client
+
+        # Create tracker and validate with org
+        tracker = GitHubTracker(str(uuid4()), "test-token", {})
+        result = await tracker.validate_token_permissions(org_identifier="test-org")
+
+        # Assert - should be valid but not admin with warning
+        self.assertTrue(result["valid"])
+        self.assertFalse(result["is_org_admin"])
+        self.assertTrue(
+            any("not an admin" in w for w in result["warnings"]),
+            "Should warn that user is not an admin",
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-    image: ghcr.io/preloop/preloop:latest
+    image: ghcr.io/preloop/console:latest
     restart: unless-stopped
     depends_on:
       - api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: registry.spacecode.ai/spacecode/preloop:latest
+    image: ghcr.io/preloop/preloop:latest
     restart: unless-stopped
     depends_on:
       - postgres
@@ -51,7 +51,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: registry.spacecode.ai/spacecode/preloop:latest
+    image: ghcr.io/preloop/preloop:latest
     restart: unless-stopped
     depends_on:
       - postgres
@@ -75,7 +75,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: registry.spacecode.ai/spacecode/preloop:latest
+    image: ghcr.io/preloop/preloop:latest
     restart: unless-stopped
     depends_on:
       - postgres
@@ -94,6 +94,17 @@ services:
     volumes:
       - .:/app
     command: preloop-sync worker
+
+  console:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    image: ghcr.io/preloop/preloop:latest
+    restart: unless-stopped
+    depends_on:
+      - api
+    ports:
+      - "3000:80"
 
 volumes:
   postgres-data:

--- a/frontend/src/components/add-tracker-modal.ts
+++ b/frontend/src/components/add-tracker-modal.ts
@@ -12,6 +12,7 @@ import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
 import '@shoelace-style/shoelace/dist/components/tree/tree.js';
 import '@shoelace-style/shoelace/dist/components/tree-item/tree-item.js';
+import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 
 @customElement('add-tracker-modal')
 export class AddTrackerModal extends LitElement {
@@ -67,6 +68,9 @@ export class AddTrackerModal extends LitElement {
 
   @state()
   private errorMessage = '';
+
+  @state()
+  private warningMessages: string[] = [];
 
   static styles = css`
     .error {
@@ -135,6 +139,17 @@ export class AddTrackerModal extends LitElement {
         @sl-request-close=${() => this.closeModal()}
       >
         ${this.step === 1 ? this.renderStep1() : this.renderStep2()}
+        ${this.warningMessages.length > 0
+          ? html`
+              <sl-alert variant="warning" open style="margin-top: 1rem;">
+                <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+                <strong>Warnings:</strong>
+                <ul style="margin: 0.5rem 0 0 0; padding-left: 1.5rem;">
+                  ${this.warningMessages.map((w) => html`<li>${w}</li>`)}
+                </ul>
+              </sl-alert>
+            `
+          : ''}
         ${this.errorMessage
           ? html`<p class="error">${this.errorMessage}</p>`
           : ''}
@@ -144,6 +159,14 @@ export class AddTrackerModal extends LitElement {
   }
 
   renderFooterButtons() {
+    // Show "Done" button after successful save with warnings
+    if (this.warningMessages.length > 0) {
+      return html`
+        <sl-button variant="primary" @click=${() => this.closeModal(true)}>
+          Done
+        </sl-button>
+      `;
+    }
     if (this.step === 1) {
       return html`
         <sl-button @click=${() => this.closeModal()}>Cancel</sl-button>
@@ -521,29 +544,36 @@ export class AddTrackerModal extends LitElement {
     };
 
     try {
+      let response;
       if (this.tracker) {
-        const updatedTracker = await this._api.updateTracker(
-          this.tracker.id,
-          trackerData
-        );
+        response = await this._api.updateTracker(this.tracker.id, trackerData);
         this.dispatchEvent(
           new CustomEvent('tracker-updated', {
-            detail: { tracker: updatedTracker },
+            detail: { tracker: response },
           })
         );
       } else {
-        const newTracker = await this._api.addTracker(trackerData);
+        response = await this._api.addTracker(trackerData);
         this.dispatchEvent(
           new CustomEvent('tracker-added', {
-            detail: { tracker: newTracker },
+            detail: { tracker: response },
           })
         );
       }
+
+      // Check for warnings in response and display them before closing
+      if (response?.warnings && response.warnings.length > 0) {
+        this.warningMessages = response.warnings;
+        this.isLoading = false;
+        // Don't close modal yet - let user see the warnings
+        return;
+      }
+
+      this.closeModal(true);
     } catch (error: any) {
       this.errorMessage = error.message;
     } finally {
       this.isLoading = false;
-      this.closeModal(true);
     }
   }
 

--- a/frontend/src/components/add-tracker-modal.ts
+++ b/frontend/src/components/add-tracker-modal.ts
@@ -126,6 +126,9 @@ export class AddTrackerModal extends LitElement {
     }
   }
   firstUpdated() {
+    // Reset state when modal is shown
+    this.warningMessages = [];
+    this.errorMessage = '';
     this.shadowRoot?.querySelector('sl-dialog')?.show();
     setTimeout(() => {
       const input = this.shadowRoot?.querySelector<SlInput>('sl-input');
@@ -547,28 +550,29 @@ export class AddTrackerModal extends LitElement {
       let response;
       if (this.tracker) {
         response = await this._api.updateTracker(this.tracker.id, trackerData);
-        this.dispatchEvent(
-          new CustomEvent('tracker-updated', {
-            detail: { tracker: response },
-          })
-        );
       } else {
         response = await this._api.addTracker(trackerData);
-        this.dispatchEvent(
-          new CustomEvent('tracker-added', {
-            detail: { tracker: response },
-          })
-        );
       }
 
       // Check for warnings in response and display them before closing
       if (response?.warnings && response.warnings.length > 0) {
         this.warningMessages = response.warnings;
         this.isLoading = false;
-        // Don't close modal yet - let user see the warnings
+        // Dispatch event but don't close modal yet - let user see the warnings
+        this.dispatchEvent(
+          new CustomEvent(this.tracker ? 'tracker-updated' : 'tracker-added', {
+            detail: { tracker: response, hasWarnings: true },
+          })
+        );
         return;
       }
 
+      // No warnings - dispatch event and close
+      this.dispatchEvent(
+        new CustomEvent(this.tracker ? 'tracker-updated' : 'tracker-added', {
+          detail: { tracker: response },
+        })
+      );
       this.closeModal(true);
     } catch (error: any) {
       this.errorMessage = error.message;

--- a/frontend/src/views/authed/dashboard-view.ts
+++ b/frontend/src/views/authed/dashboard-view.ts
@@ -796,13 +796,17 @@ export class DashboardView extends AuthedElement {
       }
       /* Analytics card styles */
       .analytics-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
         gap: var(--sl-spacing-large);
         margin-top: var(--sl-spacing-medium);
       }
       .analytics-stat {
         text-align: center;
+        display: flex;
+        flex-direction: column;
+        min-width: 30%;
       }
       .analytics-value {
         font-size: 2.5rem;

--- a/frontend/src/views/authed/flow-view.ts
+++ b/frontend/src/views/authed/flow-view.ts
@@ -2200,7 +2200,10 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre
   }
 
   private async handleTrackerAdded(event: CustomEvent) {
-    this.isAddingTracker = false;
+    // Don't close modal if there are warnings to display
+    if (!event.detail?.hasWarnings) {
+      this.isAddingTracker = false;
+    }
     // Reload trackers list
     this.trackers = await getTrackers();
 

--- a/frontend/src/views/authed/flow-view.ts
+++ b/frontend/src/views/authed/flow-view.ts
@@ -226,6 +226,9 @@ export class FlowView extends LitElement {
   private showTestRunModal = false;
 
   @state()
+  private formError: string | null = null;
+
+  @state()
   private testRunPlaceholders: Record<string, string> = {};
 
   private organizationPollingInterval?: number;
@@ -546,12 +549,40 @@ export class FlowView extends LitElement {
               <strong>Agent Type:</strong>
               <sl-badge>${this.flow.agent_type}</sl-badge>
 
+              ${this.flow.ai_model_id
+                ? html`
+                    <strong>AI Model:</strong>
+                    <span>${this.getModelName(this.flow.ai_model_id)}</span>
+                  `
+                : ''}
+
               <strong>Trigger:</strong>
               <span>
                 ${this.flow.trigger_event_source === 'webhook'
                   ? 'Webhook'
-                  : `${this.flow.trigger_event_source} - ${this.flow.trigger_event_type}`}
+                  : `${this.getTrackerName(this.flow.trigger_event_source)} - ${this.flow.trigger_event_type}`}
               </span>
+
+              ${this.flow.trigger_organization_id
+                ? html`
+                    <strong>Organization:</strong>
+                    <span
+                      >${this.getOrganizationName(
+                        this.flow.trigger_organization_id
+                      )}</span
+                    >
+                  `
+                : ''}
+              ${this.flow.trigger_project_id
+                ? html`
+                    <strong>Project:</strong>
+                    <span
+                      >${this.getProjectName(
+                        this.flow.trigger_project_id
+                      )}</span
+                    >
+                  `
+                : ''}
 
               <strong>Status:</strong>
               <sl-badge
@@ -575,6 +606,21 @@ export class FlowView extends LitElement {
             </div>
           </sl-card>
 
+          ${this.flow.prompt_template
+            ? html`
+                <sl-card>
+                  <div slot="header">
+                    <sl-icon name="chat-left-text"></sl-icon>
+                    Prompt Template
+                  </div>
+                  <pre
+                    style="white-space: pre-wrap; word-wrap: break-word; font-family: var(--sl-font-mono); font-size: var(--sl-font-size-small); background: var(--sl-color-neutral-50); padding: var(--sl-spacing-medium); border-radius: var(--sl-border-radius-medium); margin: 0; max-height: 300px; overflow-y: auto;"
+                  >
+${this.flow.prompt_template}</pre
+                  >
+                </sl-card>
+              `
+            : ''}
           ${this.flow.trigger_event_source === 'webhook' &&
           this.flow.webhook_config
             ? html`
@@ -998,6 +1044,19 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre
 
   renderForm() {
     return html`
+      ${this.formError
+        ? html`
+            <sl-alert
+              variant="danger"
+              open
+              closable
+              @sl-after-hide=${() => (this.formError = null)}
+            >
+              <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
+              ${this.formError}
+            </sl-alert>
+          `
+        : ''}
       <form @submit=${this.handleSubmit}>
         <sl-card>
           <sl-input
@@ -1454,6 +1513,7 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre
 
   async handleSubmit(e: Event) {
     e.preventDefault();
+    this.formError = null;
 
     // Build payload with required fields
     const payload: any = {
@@ -1492,13 +1552,26 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre
       }
     }
 
-    if (this.isNew) {
-      const newFlow = await createFlow(payload);
-      Router.go(`/console/flows/${newFlow.id}`);
-    } else {
-      await updateFlow(this.flowId!, payload);
-      // Redirect to flow view after successful update
-      Router.go(`/console/flows/${this.flowId}`);
+    try {
+      if (this.isNew) {
+        const newFlow = await createFlow(payload);
+        Router.go(`/console/flows/${newFlow.id}`);
+      } else {
+        await updateFlow(this.flowId!, payload);
+        // Redirect to flow view after successful update
+        Router.go(`/console/flows/${this.flowId}`);
+      }
+    } catch (error: any) {
+      // Extract error message from API response
+      let errorMessage = 'Failed to save flow. Please try again.';
+      if (error?.response?.data?.detail) {
+        errorMessage = error.response.data.detail;
+      } else if (error?.message) {
+        errorMessage = error.message;
+      }
+      this.formError = errorMessage;
+      // Scroll to top to show error
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   }
   startPollingOrganizations(trackerId: string) {
@@ -1835,6 +1908,29 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre
     return this.trackers.filter(
       (t) => t.tracker_type === 'github' || t.tracker_type === 'gitlab'
     );
+  }
+
+  getModelName(modelId: string): string {
+    const model = this.models.find((m: any) => m.id === modelId);
+    return model?.name || modelId;
+  }
+
+  getTrackerName(trackerId: string | undefined): string {
+    if (!trackerId) return 'Unknown';
+    const tracker = this.trackers.find((t: any) => t.id === trackerId);
+    return tracker?.name || trackerId;
+  }
+
+  getOrganizationName(orgId: string | undefined): string {
+    if (!orgId) return 'Unknown';
+    const org = this.organizations.find((o: any) => o.id === orgId);
+    return org?.name || orgId;
+  }
+
+  getProjectName(projectId: string | undefined): string {
+    if (!projectId) return 'Unknown';
+    const project = this.projects.find((p: any) => p.id === projectId);
+    return project?.name || projectId;
   }
 
   handleGitCloneToggle(enabled: boolean) {

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -439,7 +439,7 @@ export class FlowsView extends LitElement {
           <div class="flow-footer-actions">
             <sl-button
               size="small"
-              href=${router.urlForPath(`/console/flows/${flow.id}?edit=true`)}
+              href=${`/console/flows/${flow.id}?edit=true`}
               @click=${(e: Event) => e.stopPropagation()}
             >
               <sl-icon slot="prefix" name="pencil"></sl-icon>

--- a/frontend/src/views/authed/trackers-view.ts
+++ b/frontend/src/views/authed/trackers-view.ts
@@ -29,13 +29,19 @@ export class TrackersView extends LitElement {
     this.editingTracker = null;
   }
 
-  private async _handleTrackerAdded() {
-    this.isAddingTracker = false;
+  private async _handleTrackerAdded(event: CustomEvent) {
+    // Don't close modal if there are warnings to display
+    if (!event.detail?.hasWarnings) {
+      this.isAddingTracker = false;
+    }
     await this.trackerListElement?.fetchTrackers();
   }
 
-  private async _handleTrackerUpdated() {
-    this.editingTracker = null;
+  private async _handleTrackerUpdated(event: CustomEvent) {
+    // Don't close modal if there are warnings to display
+    if (!event.detail?.hasWarnings) {
+      this.editingTracker = null;
+    }
     await this.trackerListElement?.fetchTrackers();
   }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -568,10 +568,7 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties:
-                  type: string
-                type: object
-                title: Response Register Tracker Api V1 Trackers Post
+                $ref: '#/components/schemas/TrackerCreateResponse'
       security:
       - bearerAuth: []
   /api/v1/trackers/{tracker_id}:
@@ -7276,6 +7273,23 @@ components:
       type: object
       title: ToolConfigurationUpdate
       description: Schema for updating tool configuration.
+    TrackerCreateResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        warnings:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Warnings
+      type: object
+      required:
+      - id
+      title: TrackerCreateResponse
+      description: Response model for tracker creation.
     TrackerResponse:
       properties:
         name:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Tracker registration (API/UI):** Validates GitHub token scopes and org admin access; returns `warnings` via new `TrackerCreateResponse` and surfaces them in the console without auto-closing the modal. Updates OpenAPI accordingly.
> - **GitHub/GitLab integration:** Adds `tracker_type` to base/subclasses; GitHub gains `validate_token_permissions` and registers additional PR-related webhook events. Normalizer maps new PR actions (review requested, synchronize, ready for review) and captures the specific requested reviewer.
> - **MCP endpoints:** More permissive PR/MR slug parsing and switch to `crud_organization.get_for_tracker` in multiple calls.
> - **Flows:** Cloned presets now start with `is_enabled=true`; trigger service logs clearer messaging for disabled flows; UI shows AI model, tracker/org/project names, optional prompt template, and better error handling.
> - **Build/runtime:** CI and docker-compose retag images to `ghcr.io/preloop/*` and add a `console` service.
> - **Tests:** New unit tests cover GitHub token permission validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbf2fe10da8eb43e4f12ceb6e81d349731ca9e10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->