### PR TITLE
Add OAuth support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -261,6 +261,11 @@ test:unit:preloop-endpoints-mcp-servers:
   variables:
     TEST_PATHS: "backend/tests/endpoints/test_mcp_servers.py"
 
+test:unit:preloop-endpoints-oauth-consent:
+  extends: .test:unit:template
+  variables:
+    TEST_PATHS: "backend/tests/endpoints/test_oauth_consent.py"
+
 test:unit:preloop-endpoints-tools:
   extends: .test:unit:template
   variables:
@@ -363,6 +368,7 @@ test:coverage:
     - test:unit:preloop-endpoints-webhooks
     - test:unit:preloop-endpoints-mcp
     - test:unit:preloop-endpoints-mcp-servers
+    - test:unit:preloop-endpoints-oauth-consent
     - test:unit:preloop-endpoints-tools
     - test:unit:preloop-endpoints-api-keys
     - test:unit:preloop-endpoints-approval-requests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -266,6 +266,11 @@ test:unit:preloop-endpoints-oauth-consent:
   variables:
     TEST_PATHS: "backend/tests/endpoints/test_oauth_consent.py"
 
+test:unit:preloop-endpoints-oauth-server:
+  extends: .test:unit:template
+  variables:
+    TEST_PATHS: "backend/tests/endpoints/test_oauth_server.py"
+
 test:unit:preloop-endpoints-tools:
   extends: .test:unit:template
   variables:
@@ -369,6 +374,7 @@ test:coverage:
     - test:unit:preloop-endpoints-mcp
     - test:unit:preloop-endpoints-mcp-servers
     - test:unit:preloop-endpoints-oauth-consent
+    - test:unit:preloop-endpoints-oauth-server
     - test:unit:preloop-endpoints-tools
     - test:unit:preloop-endpoints-api-keys
     - test:unit:preloop-endpoints-approval-requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **OAuth Sign-in/Sign-up**: Authenticate users via external OAuth providers (GitHub, Google, GitLab)
+  - Plugin-based architecture: `plugins/oauth_signin/` with per-provider implementations
+  - Auto-links OAuth identity to existing accounts by verified email
+  - GitHub/GitLab sign-ups prompt for tracker installation after sign-in
+  - Stripe checkout integration for new users when billing is enabled
+  - Gated by `mcpOauth.enabled=true` Helm value; configure via `GOOGLE_OAUTH_CLIENT_ID/SECRET`, `GITLAB_OAUTH_CLIENT_ID/SECRET`, `GITHUB_APP_*` env vars
+- **MCP OAuth 2.1 Authorization Server**: Full OAuth 2.1 server for MCP client authentication
+  - Dynamic Client Registration (RFC 7591) at `POST /oauth/register`
+  - Authorization Code + PKCE flow for MCP clients (Claude Desktop, etc.)
+  - JWT token flow for CLI authentication (no PKCE)
+  - Token revocation at `POST /oauth/revoke`
+  - Discovery via `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource`
+
+### Security
+
+- **OAuth consent validation**: Validate `client_id` exists and `redirect_uri` is registered before issuing authorization codes
+- **XSS prevention**: HTML-escape all user-controlled values in OAuth consent page template
+- **PKCE enforcement**: Require `code_verifier` when authorization code was created with `code_challenge`
+- **Token delivery**: Use URL fragments instead of query parameters for OAuth callback tokens to prevent leakage via browser history, server logs, and Referrer headers
+- **Redirect URI validation**: Verify `redirect_uri` at token exchange matches the original authorization request
+
+### Fixed
+
+- **OAuth refresh tokens**: MCP clients can now refresh opaque OAuth tokens (previously only JWT refresh worked)
+- **Codex custom models**: Properly generate `~/.codex/config.toml` with `model_provider`, `base_url`, `env_key`, and `wire_api` for non-OpenAI models
+
 - **Policy-as-Code**: Define and manage policies declaratively via YAML files
   - `POST /api/v1/policies/import`: Import policy from YAML with validation and diff preview
   - `GET /api/v1/policies/export`: Export current configuration as YAML

--- a/README.md
+++ b/README.md
@@ -266,6 +266,56 @@ For enhanced GitHub integration including PR status checks and bot reactions:
 
 These are optional and only needed if you're using a GitHub App for authentication or advanced features like reaction management on PRs.
 
+#### OAuth Sign-In (Enterprise)
+
+Enable OAuth sign-in/sign-up via GitHub, Google, and/or GitLab. Users can authenticate with their existing provider accounts instead of creating a Preloop-specific password.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GOOGLE_OAUTH_CLIENT_ID` | | Google OAuth 2.0 client ID |
+| `GOOGLE_OAUTH_CLIENT_SECRET` | | Google OAuth 2.0 client secret |
+| `GITLAB_OAUTH_CLIENT_ID` | | GitLab OAuth client ID |
+| `GITLAB_OAUTH_CLIENT_SECRET` | | GitLab OAuth client secret |
+| `GITLAB_OAUTH_BASE_URL` | `https://gitlab.com` | GitLab instance URL (for self-hosted) |
+
+GitHub OAuth sign-in reuses the GitHub App credentials above. Enable via Helm values:
+
+```yaml
+mcpOauth:
+  enabled: true
+googleOauth:
+  enabled: true
+  clientId: "your-google-client-id"
+  clientSecret: "your-google-client-secret"
+gitlabOauth:
+  enabled: true
+  clientId: "your-gitlab-client-id"
+  clientSecret: "your-gitlab-client-secret"
+```
+
+**Supported flows:**
+- **GitHub**: Sign-in + automatic tracker setup prompt
+- **Google**: Sign-in only (no tracker created)
+- **GitLab**: Sign-in + automatic tracker setup prompt
+
+#### MCP OAuth 2.1 Server
+
+Preloop includes a built-in OAuth 2.1 Authorization Server for MCP client authentication (e.g., Claude Desktop). This is enabled automatically when `mcpOauth.enabled=true`.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PRELOOP_URL` | `http://localhost:8000` | Public URL of your Preloop instance (used for OAuth discovery endpoints) |
+
+**Discovery endpoints:**
+- `GET /.well-known/oauth-authorization-server` — RFC 8414 metadata
+- `GET /.well-known/oauth-protected-resource` — RFC 9728 metadata
+
+**OAuth endpoints:**
+- `POST /oauth/register` — Dynamic Client Registration (RFC 7591)
+- `GET /oauth/authorize` — Authorization endpoint (redirects to consent page)
+- `POST /oauth/token` — Token exchange (Authorization Code + PKCE for MCP, JWT for CLI)
+- `POST /oauth/revoke` — Token revocation
+
 ### Docker Setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Preloop is a comprehensive MCP firewall that gives you complete control over wha
 
 ## Why Preloop?
 
-AI coding agents like Claude Code, Cursor, and Cline are transforming how we build software. But with great power comes great risk:
+AI agents like Claude Code, Cursor, and OpenClaw are transforming how we work. But with great power comes great risk:
 
 - **Accidental deletions.** One wrong command and your production database is gone.
 - **Leaked secrets.** API keys pushed to public repos before anyone notices.

--- a/backend/preloop/agents/codex.py
+++ b/backend/preloop/agents/codex.py
@@ -283,6 +283,8 @@ class CodexAgent(ContainerAgentExecutor):
             or execution_context.get("model_identifier")
             or "gpt-4"
         )
+        model_provider = execution_context.get("model_provider", "openai").lower()
+        model_endpoint = execution_context.get("model_endpoint", "")
 
         # Escape prompt for shell - must escape:
         # - Double quotes (for string delimiter)
@@ -359,31 +361,12 @@ fi
 # Configure Codex CLI authentication
 mkdir -p ~/.codex
 
-# Create auth.json with OpenAI API key
-# Use unquoted heredoc to allow variable substitution (safer than sed with special chars)
-cat > ~/.codex/auth.json << EOF
-{{
-  "OPENAI_API_KEY": "$OPENAI_API_KEY"
-}}
-EOF
-
-# Create config.toml with model and MCP server configuration
-# Use unquoted heredoc to allow variable substitution
-# Note: MCP_TOOL_TIMEOUT_SEC will be substituted at runtime
-cat > ~/.codex/config.toml << EOF
-model = "{model}"
-
-rmcp_client = true
-
-[mcp_servers.preloop]
-url = "$PRELOOP_MCP_URL"
-bearer_token_env_var = "PRELOOP_API_TOKEN"
-tool_timeout_sec = $MCP_TOOL_TIMEOUT_SEC
-EOF
+{self._build_codex_auth_config(model, model_provider, model_endpoint)}
 
 # Debug: Show config files (with API key masked)
 echo "=== Codex Configuration ==="
 echo "Model: {model}"
+echo "Provider: {model_provider}"
 echo "MCP Server: $PRELOOP_MCP_URL"
 echo "=========================="
 
@@ -470,6 +453,82 @@ exit $CODEX_EXIT_CODE
         # Call parent implementation which will use the args and env
         return await super()._start_kubernetes_pod(execution_context)
 
+    def _build_codex_auth_config(
+        self, model: str, model_provider: str, model_endpoint: str
+    ) -> str:
+        """
+        Build the auth.json and config.toml shell script block for Codex CLI.
+
+        For OpenAI models, generates a standard config.
+        For custom models, generates a custom_provider section with base_url,
+        env_key, and wire_api so Codex knows how to reach the provider.
+
+        Args:
+            model: Model identifier (e.g., "gpt-4", "claude-sonnet-4-20250514")
+            model_provider: Provider name (e.g., "openai", "anthropic")
+            model_endpoint: API base URL for custom providers
+
+        Returns:
+            Shell script block to write auth.json and config.toml
+        """
+        is_custom = model_provider and model_provider != "openai"
+
+        if is_custom:
+            # Custom provider: generate provider-specific config
+            provider_key = model_provider.replace("-", "_").replace(" ", "_")
+            env_key = f"{model_provider.upper().replace('-', '_')}_API_KEY"
+            # Use 'chat' wire_api for most providers (OpenAI-compatible chat/completions)
+            wire_api = "responses" if model_provider == "openai" else "chat"
+
+            auth_block = f"""# Create auth.json with provider API key
+cat > ~/.codex/auth.json << EOF
+{{
+  "{env_key}": "${env_key}",
+  "OPENAI_API_KEY": "$OPENAI_API_KEY"
+}}
+EOF
+
+# Create config.toml with custom model provider and MCP server configuration
+cat > ~/.codex/config.toml << EOF
+model_provider = "{provider_key}"
+model = "{model}"
+
+[model_providers.{provider_key}]
+name = "{model_provider.title()}"
+base_url = "{model_endpoint}"
+env_key = "{env_key}"
+wire_api = "{wire_api}"
+
+rmcp_client = true
+
+[mcp_servers.preloop]
+url = "$PRELOOP_MCP_URL"
+bearer_token_env_var = "PRELOOP_API_TOKEN"
+tool_timeout_sec = $MCP_TOOL_TIMEOUT_SEC
+EOF"""
+        else:
+            # Standard OpenAI config
+            auth_block = f"""# Create auth.json with OpenAI API key
+cat > ~/.codex/auth.json << EOF
+{{
+  "OPENAI_API_KEY": "$OPENAI_API_KEY"
+}}
+EOF
+
+# Create config.toml with model and MCP server configuration
+cat > ~/.codex/config.toml << EOF
+model = "{model}"
+
+rmcp_client = true
+
+[mcp_servers.preloop]
+url = "$PRELOOP_MCP_URL"
+bearer_token_env_var = "PRELOOP_API_TOKEN"
+tool_timeout_sec = $MCP_TOOL_TIMEOUT_SEC
+EOF"""
+
+        return auth_block
+
     async def _prepare_environment(
         self, execution_context: Dict[str, Any]
     ) -> Dict[str, str]:
@@ -484,9 +543,17 @@ exit $CODEX_EXIT_CODE
         """
         env = {}
 
-        # Add OpenAI API key
+        # Add API key - use provider-specific env var for custom models
+        model_provider = execution_context.get("model_provider", "openai").lower()
         if "model_api_key" in execution_context:
-            env["OPENAI_API_KEY"] = execution_context["model_api_key"]
+            if model_provider == "openai" or not model_provider:
+                env["OPENAI_API_KEY"] = execution_context["model_api_key"]
+            else:
+                # Custom provider: set both the custom env var and OPENAI_API_KEY
+                # (OPENAI_API_KEY is still needed as a fallback for codex internals)
+                custom_env_key = f"{model_provider.upper()}_API_KEY"
+                env[custom_env_key] = execution_context["model_api_key"]
+                env["OPENAI_API_KEY"] = execution_context["model_api_key"]
 
         # Set home directory for config storage
         # Note: This is overridden to /home/agent in Kubernetes mode

--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -629,6 +629,18 @@ def create_app() -> FastAPI:
 
     app.openapi = custom_openapi
 
+    # OAuth consent page (login form for CLI and MCP OAuth flows)
+    from preloop.api.endpoints.oauth_consent import router as oauth_consent_router
+
+    app.include_router(oauth_consent_router)
+    logger.info("OAuth consent routes registered")
+
+    # OAuth server endpoints (authorize, token, register, well-known metadata)
+    from preloop.api.endpoints.oauth_server import router as oauth_server_router
+
+    app.include_router(oauth_server_router)
+    logger.info("OAuth server routes registered")
+
     # Setup MCP routes with DynamicMCPServer (MUST be before SPA mount)
     setup_mcp_routes(app)
     logger.info("MCP routes configured with DynamicMCPServer")

--- a/backend/preloop/api/endpoints/oauth_consent.py
+++ b/backend/preloop/api/endpoints/oauth_consent.py
@@ -10,6 +10,7 @@ Routes:
     POST /mcp/authorize/consent  - Authenticates user and issues auth code
 """
 
+import html
 import logging
 import os
 from pathlib import Path
@@ -28,18 +29,77 @@ router = APIRouter(tags=["OAuth Consent"], include_in_schema=False)
 _TEMPLATE_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
 
 
+# Known CLI client_id — allowed to use http://localhost redirect URIs
+_CLI_CLIENT_ID = "cli"
+
+
 def _render_template(template_name: str, context: dict) -> str:
-    """Simple template rendering using string replacement.
+    """Template rendering with auto HTML-escaping for XSS prevention.
 
     Uses Jinja2-style {{ variable }} placeholders.
+    All values are HTML-escaped to prevent XSS attacks from user-controlled
+    inputs (client_name, redirect_uri, state, error, etc.).
+
+    Values under keys ending with '_json' are JSON-encoded (for <script> blocks)
+    instead of HTML-escaped.
     """
     template_path = _TEMPLATE_DIR / template_name
     template = template_path.read_text()
 
     for key, value in context.items():
-        template = template.replace("{{ " + key + " }}", str(value or ""))
+        safe_value = html.escape(str(value or ""))
+        template = template.replace("{{ " + key + " }}", safe_value)
 
     return template
+
+
+def _validate_client_and_redirect(client_id: str, redirect_uri: str) -> dict:
+    """Validate that client_id exists and redirect_uri is registered.
+
+    Returns dict with 'error' (str or None) and 'client_name'.
+    """
+    from preloop.models.crud.oauth_mcp_client import crud_oauth_mcp_client
+
+    # CLI client gets special treatment — allow localhost redirects
+    if client_id == _CLI_CLIENT_ID:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(redirect_uri)
+        if parsed.hostname not in ("localhost", "127.0.0.1", "[::1]"):
+            return {
+                "error": "Invalid redirect_uri for CLI client (must be localhost)",
+                "client_name": "CLI",
+            }
+        return {"error": None, "client_name": "Preloop CLI"}
+
+    # Look up registered client
+    db = next(get_db_session())
+    try:
+        db_client = crud_oauth_mcp_client.get_by_client_id(db, client_id=client_id)
+        if not db_client:
+            logger.warning(f"OAuth consent: unknown client_id={client_id}")
+            return {"error": "Unknown client_id", "client_name": ""}
+
+        client_name = db_client.client_name or "MCP Client"
+
+        # Verify redirect_uri is registered for this client
+        registered_uris = db_client.redirect_uris or []
+        if redirect_uri not in registered_uris:
+            logger.warning(
+                f"OAuth consent: unregistered redirect_uri={redirect_uri} "
+                f"for client_id={client_id}"
+            )
+            return {
+                "error": "redirect_uri is not registered for this client",
+                "client_name": client_name,
+            }
+
+        return {"error": None, "client_name": client_name}
+    except Exception as e:
+        logger.error(f"OAuth consent validation error: {e}", exc_info=True)
+        return {"error": "Internal error validating client", "client_name": ""}
+    finally:
+        db.close()
 
 
 @router.get("/mcp/authorize/consent")
@@ -58,20 +118,14 @@ async def consent_page(
     authorization flow. The user must enter their Preloop credentials to
     approve the authorization.
     """
-    # Look up client name for display
-    client_name = "MCP Client"
-    try:
-        from preloop.models.crud.oauth_mcp_client import crud_oauth_mcp_client
-
-        db = next(get_db_session())
-        try:
-            db_client = crud_oauth_mcp_client.get_by_client_id(db, client_id=client_id)
-            if db_client and db_client.client_name:
-                client_name = db_client.client_name
-        finally:
-            db.close()
-    except Exception:
-        pass
+    # Validate client_id and redirect_uri
+    validation = _validate_client_and_redirect(client_id, redirect_uri)
+    if validation["error"]:
+        return HTMLResponse(
+            content=f"<h1>OAuth Error</h1><p>{html.escape(validation['error'])}</p>",
+            status_code=400,
+        )
+    client_name = validation["client_name"]
 
     context = {
         "client_id": client_id,
@@ -85,8 +139,8 @@ async def consent_page(
         "error": "",
     }
 
-    html = _render_template("oauth_authorize.html", context)
-    return HTMLResponse(content=html)
+    html_content = _render_template("oauth_authorize.html", context)
+    return HTMLResponse(content=html_content)
 
 
 @router.post("/mcp/authorize/consent")
@@ -108,6 +162,14 @@ async def consent_submit(
     """
     from preloop.api.auth.jwt import verify_password
     from preloop.models.crud import crud_user
+
+    # Re-validate client_id + redirect_uri on POST (defense in depth)
+    validation = _validate_client_and_redirect(client_id, redirect_uri)
+    if validation["error"]:
+        return HTMLResponse(
+            content=f"<h1>OAuth Error</h1><p>{html.escape(validation['error'])}</p>",
+            status_code=400,
+        )
 
     db = next(get_db_session())
     try:
@@ -218,8 +280,8 @@ def _render_error_response(
         "resource": resource,
         "error": error,
     }
-    html = _render_template("oauth_authorize.html", context)
-    return HTMLResponse(content=html)
+    html_content = _render_template("oauth_authorize.html", context)
+    return HTMLResponse(content=html_content)
 
 
 # Singleton provider instance

--- a/backend/preloop/api/endpoints/oauth_consent.py
+++ b/backend/preloop/api/endpoints/oauth_consent.py
@@ -1,0 +1,245 @@
+"""OAuth consent page handler for MCP OAuth authorization flow.
+
+This module provides the login/consent endpoints that are displayed to the user
+during the OAuth authorization code flow. The MCP OAuth AS redirects the user
+here, they log in with their Preloop credentials, and are redirected back to
+the MCP client with an authorization code.
+
+Routes:
+    GET  /mcp/authorize/consent  - Renders the login/consent form
+    POST /mcp/authorize/consent  - Authenticates user and issues auth code
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, Form
+from fastapi.responses import HTMLResponse, RedirectResponse
+from mcp.server.auth.provider import construct_redirect_uri
+
+from preloop.models.db.session import get_db_session
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["OAuth Consent"], include_in_schema=False)
+
+# Template directory
+_TEMPLATE_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
+
+
+def _render_template(template_name: str, context: dict) -> str:
+    """Simple template rendering using string replacement.
+
+    Uses Jinja2-style {{ variable }} placeholders.
+    """
+    template_path = _TEMPLATE_DIR / template_name
+    template = template_path.read_text()
+
+    for key, value in context.items():
+        template = template.replace("{{ " + key + " }}", str(value or ""))
+
+    return template
+
+
+@router.get("/mcp/authorize/consent")
+async def consent_page(
+    client_id: str,
+    redirect_uri: str,
+    code_challenge: str,
+    state: str = "",
+    scopes: str = "",
+    redirect_uri_provided_explicitly: str = "true",
+    resource: str = "",
+):
+    """Render the OAuth login/consent page.
+
+    This page is shown to the user when an MCP client initiates an OAuth
+    authorization flow. The user must enter their Preloop credentials to
+    approve the authorization.
+    """
+    # Look up client name for display
+    client_name = "MCP Client"
+    try:
+        from preloop.models.crud.oauth_mcp_client import crud_oauth_mcp_client
+
+        db = next(get_db_session())
+        try:
+            db_client = crud_oauth_mcp_client.get_by_client_id(db, client_id=client_id)
+            if db_client and db_client.client_name:
+                client_name = db_client.client_name
+        finally:
+            db.close()
+    except Exception:
+        pass
+
+    context = {
+        "client_id": client_id,
+        "client_name": client_name,
+        "redirect_uri": redirect_uri,
+        "code_challenge": code_challenge,
+        "state": state,
+        "scopes": scopes,
+        "redirect_uri_provided_explicitly": redirect_uri_provided_explicitly,
+        "resource": resource,
+        "error": "",
+    }
+
+    html = _render_template("oauth_authorize.html", context)
+    return HTMLResponse(content=html)
+
+
+@router.post("/mcp/authorize/consent")
+async def consent_submit(
+    client_id: str = Form(...),
+    redirect_uri: str = Form(...),
+    code_challenge: str = Form(...),
+    state: str = Form(""),
+    scopes: str = Form(""),
+    redirect_uri_provided_explicitly: str = Form("true"),
+    resource: str = Form(""),
+    username: str = Form(...),
+    password: str = Form(...),
+):
+    """Handle login form submission and issue an authorization code.
+
+    Authenticates the user with their Preloop credentials, creates an
+    authorization code, and redirects back to the MCP client.
+    """
+    from preloop.api.auth.jwt import verify_password
+    from preloop.models.crud import crud_user
+
+    db = next(get_db_session())
+    try:
+        # Authenticate user — try username first, then email
+        user = crud_user.get_by_username(db, username=username)
+        if not user:
+            user = crud_user.get_by_email(db, email=username)
+        if not user or not user.hashed_password:
+            return _render_error_response(
+                "Invalid username or password",
+                client_id=client_id,
+                redirect_uri=redirect_uri,
+                code_challenge=code_challenge,
+                state=state,
+                scopes=scopes,
+                redirect_uri_provided_explicitly=redirect_uri_provided_explicitly,
+                resource=resource,
+            )
+
+        if not verify_password(password, user.hashed_password):
+            return _render_error_response(
+                "Invalid username or password",
+                client_id=client_id,
+                redirect_uri=redirect_uri,
+                code_challenge=code_challenge,
+                state=state,
+                scopes=scopes,
+                redirect_uri_provided_explicitly=redirect_uri_provided_explicitly,
+                resource=resource,
+            )
+
+        if not user.is_active:
+            return _render_error_response(
+                "Account is deactivated",
+                client_id=client_id,
+                redirect_uri=redirect_uri,
+                code_challenge=code_challenge,
+                state=state,
+                scopes=scopes,
+                redirect_uri_provided_explicitly=redirect_uri_provided_explicitly,
+                resource=resource,
+            )
+
+        # Get the OAuth provider instance
+        provider = _get_oauth_provider()
+        if not provider:
+            return _render_error_response(
+                "OAuth not configured",
+                client_id=client_id,
+                redirect_uri=redirect_uri,
+                code_challenge=code_challenge,
+                state=state,
+                scopes=scopes,
+                redirect_uri_provided_explicitly=redirect_uri_provided_explicitly,
+                resource=resource,
+            )
+
+        # Create authorization code
+        scope_list = scopes.split() if scopes else []
+        code = provider.create_authorization_code_for_user(
+            client_id=client_id,
+            user_id=user.id,
+            account_id=user.account_id,
+            redirect_uri=redirect_uri,
+            redirect_uri_provided_explicitly=(
+                redirect_uri_provided_explicitly == "true"
+            ),
+            code_challenge=code_challenge,
+            scopes=scope_list,
+            resource=resource or None,
+        )
+
+        # Redirect back to client with authorization code
+        redirect_url = construct_redirect_uri(
+            redirect_uri,
+            code=code,
+            state=state if state else None,
+        )
+
+        logger.info(f"OAuth consent granted: user={user.username}, client={client_id}")
+
+        return RedirectResponse(url=redirect_url, status_code=302)
+
+    finally:
+        db.close()
+
+
+def _render_error_response(
+    error: str,
+    *,
+    client_id: str,
+    redirect_uri: str,
+    code_challenge: str,
+    state: str,
+    scopes: str,
+    redirect_uri_provided_explicitly: str,
+    resource: str,
+) -> HTMLResponse:
+    """Re-render the consent page with an error message."""
+    context = {
+        "client_id": client_id,
+        "client_name": "MCP Client",
+        "redirect_uri": redirect_uri,
+        "code_challenge": code_challenge,
+        "state": state,
+        "scopes": scopes,
+        "redirect_uri_provided_explicitly": redirect_uri_provided_explicitly,
+        "resource": resource,
+        "error": error,
+    }
+    html = _render_template("oauth_authorize.html", context)
+    return HTMLResponse(content=html)
+
+
+# Singleton provider instance
+_oauth_provider_instance = None
+
+
+def _get_oauth_provider():
+    """Get the shared PreloopOAuthProvider instance."""
+    global _oauth_provider_instance
+    if _oauth_provider_instance is None:
+        from preloop.services.oauth_provider import PreloopOAuthProvider
+
+        base_url = os.getenv("PRELOOP_URL", "http://localhost:8000")
+        _oauth_provider_instance = PreloopOAuthProvider(
+            base_url=f"{base_url.rstrip('/')}/mcp",
+            issuer_url=f"{base_url.rstrip('/')}/mcp",
+        )
+    return _oauth_provider_instance
+
+
+def get_oauth_provider():
+    """Public accessor for the shared OAuth provider instance."""
+    return _get_oauth_provider()

--- a/backend/preloop/api/endpoints/oauth_consent.py
+++ b/backend/preloop/api/endpoints/oauth_consent.py
@@ -46,7 +46,7 @@ def _render_template(template_name: str, context: dict) -> str:
 async def consent_page(
     client_id: str,
     redirect_uri: str,
-    code_challenge: str,
+    code_challenge: str = "",
     state: str = "",
     scopes: str = "",
     redirect_uri_provided_explicitly: str = "true",
@@ -93,7 +93,7 @@ async def consent_page(
 async def consent_submit(
     client_id: str = Form(...),
     redirect_uri: str = Form(...),
-    code_challenge: str = Form(...),
+    code_challenge: str = Form(""),
     state: str = Form(""),
     scopes: str = Form(""),
     redirect_uri_provided_explicitly: str = Form("true"),

--- a/backend/preloop/api/endpoints/oauth_consent.py
+++ b/backend/preloop/api/endpoints/oauth_consent.py
@@ -11,6 +11,7 @@ Routes:
 """
 
 import html
+import json
 import logging
 import os
 from pathlib import Path
@@ -47,7 +48,15 @@ def _render_template(template_name: str, context: dict) -> str:
     template = template_path.read_text()
 
     for key, value in context.items():
-        safe_value = html.escape(str(value or ""))
+        str_value = str(value or "")
+        if key.endswith("_json"):
+            # JSON-encode for safe embedding inside <script> blocks.
+            # Replace < and > to prevent </script> breakout.
+            safe_value = (
+                json.dumps(str_value).replace("<", "\\u003c").replace(">", "\\u003e")
+            )
+        else:
+            safe_value = html.escape(str_value)
         template = template.replace("{{ " + key + " }}", safe_value)
 
     return template
@@ -137,6 +146,10 @@ async def consent_page(
         "redirect_uri_provided_explicitly": redirect_uri_provided_explicitly,
         "resource": resource,
         "error": "",
+        # JSON-encoded variants for safe use inside <script> blocks
+        "redirect_uri_json": redirect_uri,
+        "state_json": state,
+        "error_json": "",
     }
 
     html_content = _render_template("oauth_authorize.html", context)
@@ -279,6 +292,10 @@ def _render_error_response(
         "redirect_uri_provided_explicitly": redirect_uri_provided_explicitly,
         "resource": resource,
         "error": error,
+        # JSON-encoded variants for safe use inside <script> blocks
+        "redirect_uri_json": redirect_uri,
+        "state_json": state,
+        "error_json": error,
     }
     html_content = _render_template("oauth_authorize.html", context)
     return HTMLResponse(content=html_content)

--- a/backend/preloop/api/endpoints/oauth_server.py
+++ b/backend/preloop/api/endpoints/oauth_server.py
@@ -1,0 +1,428 @@
+"""OAuth Authorization Server endpoints for CLI and MCP client authentication.
+
+Provides:
+    GET  /oauth/authorize  — Redirects to the login/consent page
+    POST /oauth/token      — Exchanges authorization code for tokens
+    POST /oauth/register   — Dynamic client registration (MCP clients)
+    POST /oauth/revoke     — Token revocation
+
+The CLI uses /oauth/authorize + /oauth/token (no PKCE).
+MCP clients (Claude Desktop) discover these via /.well-known metadata.
+"""
+
+import logging
+import os
+import time
+from typing import Optional
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Form, HTTPException, Query, status
+from fastapi.responses import JSONResponse, RedirectResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["OAuth Server"], include_in_schema=False)
+
+
+# ---------------------------------------------------------------------------
+# Well-known metadata endpoints (MCP OAuth discovery)
+# ---------------------------------------------------------------------------
+
+
+class AuthorizationServerMetadata(BaseModel):
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    registration_endpoint: Optional[str] = None
+    revocation_endpoint: Optional[str] = None
+    response_types_supported: list[str] = ["code"]
+    grant_types_supported: list[str] = ["authorization_code", "refresh_token"]
+    token_endpoint_auth_methods_supported: list[str] = ["client_secret_post", "none"]
+    code_challenge_methods_supported: list[str] = ["S256"]
+
+
+@router.get("/.well-known/oauth-authorization-server")
+async def oauth_authorization_server_metadata():
+    """Return OAuth Authorization Server Metadata (RFC 8414)."""
+    base_url = os.getenv("PRELOOP_URL", "http://localhost:8000").rstrip("/")
+
+    return AuthorizationServerMetadata(
+        issuer=base_url,
+        authorization_endpoint=f"{base_url}/oauth/authorize",
+        token_endpoint=f"{base_url}/oauth/token",
+        registration_endpoint=f"{base_url}/oauth/register",
+        revocation_endpoint=f"{base_url}/oauth/revoke",
+    )
+
+
+@router.get("/.well-known/oauth-protected-resource/{path:path}")
+async def oauth_protected_resource_metadata_with_path(path: str):
+    """Return OAuth Protected Resource Metadata (RFC 9728) for a specific path.
+
+    MCP clients look for this at:
+      /.well-known/oauth-protected-resource/{mcp_server_path}
+    e.g. /.well-known/oauth-protected-resource/mcp/v1
+    """
+    base_url = os.getenv("PRELOOP_URL", "http://localhost:8000").rstrip("/")
+
+    return {
+        "resource": f"{base_url}/{path}",
+        "authorization_servers": [base_url],
+    }
+
+
+@router.get("/.well-known/oauth-protected-resource")
+async def oauth_protected_resource_metadata():
+    """Return OAuth Protected Resource Metadata (RFC 9728) for root."""
+    base_url = os.getenv("PRELOOP_URL", "http://localhost:8000").rstrip("/")
+
+    return {
+        "resource": f"{base_url}/mcp",
+        "authorization_servers": [base_url],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Authorization endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get("/oauth/authorize")
+async def authorize(
+    response_type: str = Query("code"),
+    client_id: str = Query(""),
+    redirect_uri: str = Query(...),
+    state: str = Query(""),
+    code_challenge: str = Query(""),
+    code_challenge_method: str = Query(""),
+    scope: str = Query(""),
+):
+    """OAuth authorization endpoint — redirects to the login/consent page.
+
+    Both the CLI and MCP clients hit this endpoint. It redirects to the
+    consent page where the user authenticates with their Preloop credentials.
+    """
+    # Use "cli" as default client_id for the CLI tool
+    effective_client_id = client_id or "cli"
+
+    # Build redirect to the consent page
+    params = {
+        "client_id": effective_client_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "scopes": scope,
+        "redirect_uri_provided_explicitly": "true",
+    }
+    if code_challenge:
+        params["code_challenge"] = code_challenge
+
+    consent_url = f"/mcp/authorize/consent?{urlencode(params)}"
+    return RedirectResponse(url=consent_url, status_code=302)
+
+
+# ---------------------------------------------------------------------------
+# Token endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("/oauth/token")
+async def token_exchange(
+    grant_type: str = Form(...),
+    code: str = Form(""),
+    redirect_uri: str = Form(""),
+    client_id: str = Form(""),
+    client_secret: str = Form(""),
+    code_verifier: str = Form(""),
+    refresh_token: str = Form(""),
+):
+    """Exchange an authorization code for access/refresh tokens.
+
+    Supports both:
+    - CLI flow (no PKCE): returns JWT tokens usable with the REST API
+    - MCP flow (with PKCE): returns opaque OAuth tokens
+    """
+    if grant_type == "authorization_code":
+        return await _handle_authorization_code(
+            code=code,
+            redirect_uri=redirect_uri,
+            client_id=client_id,
+            code_verifier=code_verifier,
+        )
+    elif grant_type == "refresh_token":
+        return await _handle_refresh_token(
+            refresh_token_str=refresh_token,
+            client_id=client_id,
+        )
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported grant_type: {grant_type}",
+        )
+
+
+async def _handle_authorization_code(
+    code: str, redirect_uri: str, client_id: str, code_verifier: str
+):
+    """Exchange authorization code for tokens."""
+    from preloop.models.crud.oauth_mcp_token import crud_oauth_mcp_auth_code
+    from preloop.models.db.session import get_db_session
+
+    db = next(get_db_session())
+    try:
+        # Look up the auth code
+        effective_client_id = client_id or "cli"
+        db_code = crud_oauth_mcp_auth_code.get_by_code(
+            db, code=code, client_id=effective_client_id
+        )
+
+        if not db_code:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid authorization code",
+            )
+
+        if db_code.is_used:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Authorization code already used",
+            )
+
+        if db_code.expires_at < time.time():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Authorization code expired",
+            )
+
+        # Mark code as used
+        crud_oauth_mcp_auth_code.mark_used(db, obj=db_code)
+
+        # Decide token type based on whether PKCE was used
+        has_pkce = bool(db_code.code_challenge)
+
+        if has_pkce and code_verifier:
+            # MCP flow: verify PKCE and issue opaque OAuth tokens
+            import hashlib
+            import base64
+
+            expected = (
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(code_verifier.encode()).digest()
+                )
+                .rstrip(b"=")
+                .decode()
+            )
+
+            if expected != db_code.code_challenge:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Invalid code_verifier (PKCE validation failed)",
+                )
+
+            return await _issue_opaque_tokens(db, db_code)
+        else:
+            # CLI flow: issue JWT tokens
+            return await _issue_jwt_tokens(db, db_code)
+
+    finally:
+        db.close()
+
+
+async def _issue_jwt_tokens(db, db_code):
+    """Issue JWT access/refresh tokens for CLI usage."""
+    from datetime import timedelta
+
+    from preloop.api.auth.jwt import create_access_token, ACCESS_TOKEN_EXPIRE_MINUTES
+    from preloop.models.crud import crud_user
+
+    user = crud_user.get(db, id=str(db_code.user_id))
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User not found",
+        )
+
+    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        data={"sub": str(user.id), "scopes": []},
+        expires_delta=access_token_expires,
+    )
+
+    refresh_token_expires = timedelta(days=7)
+    refresh_token = create_access_token(
+        data={"sub": str(user.id), "scopes": [], "refresh": True},
+        expires_delta=refresh_token_expires,
+    )
+
+    return JSONResponse(
+        {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "token_type": "bearer",
+            "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        }
+    )
+
+
+async def _issue_opaque_tokens(db, db_code):
+    """Issue opaque OAuth tokens for MCP clients."""
+    from preloop.models.crud.oauth_mcp_token import (
+        crud_oauth_mcp_access_token,
+        crud_oauth_mcp_refresh_token,
+        generate_token,
+    )
+
+    now = int(time.time())
+    access_token_str = generate_token(32)
+    refresh_token_str = generate_token(32)
+
+    crud_oauth_mcp_access_token.create(
+        db,
+        token=access_token_str,
+        client_id=db_code.client_id,
+        user_id=db_code.user_id,
+        account_id=db_code.account_id,
+        scopes=db_code.scopes or [],
+        expires_at=now + 3600,
+        resource=db_code.resource,
+    )
+
+    crud_oauth_mcp_refresh_token.create(
+        db,
+        token=refresh_token_str,
+        client_id=db_code.client_id,
+        user_id=db_code.user_id,
+        account_id=db_code.account_id,
+        scopes=db_code.scopes or [],
+        expires_at=now + 2592000,  # 30 days
+    )
+
+    return JSONResponse(
+        {
+            "access_token": access_token_str,
+            "refresh_token": refresh_token_str,
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+    )
+
+
+async def _handle_refresh_token(refresh_token_str: str, client_id: str):
+    """Exchange a refresh token for new tokens."""
+    from datetime import timedelta
+
+    from preloop.api.auth.jwt import (
+        create_access_token,
+        decode_token,
+        ACCESS_TOKEN_EXPIRE_MINUTES,
+    )
+
+    # Try JWT refresh token (the standard path for CLI)
+    try:
+        token_data = decode_token(refresh_token_str)
+        if token_data.refresh and token_data.sub:
+            access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+            access_token = create_access_token(
+                data={"sub": token_data.sub, "scopes": token_data.scopes or []},
+                expires_delta=access_token_expires,
+            )
+            refresh_token_expires = timedelta(days=7)
+            new_refresh = create_access_token(
+                data={
+                    "sub": token_data.sub,
+                    "scopes": token_data.scopes or [],
+                    "refresh": True,
+                },
+                expires_delta=refresh_token_expires,
+            )
+            return JSONResponse(
+                {
+                    "access_token": access_token,
+                    "refresh_token": new_refresh,
+                    "token_type": "bearer",
+                    "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+                }
+            )
+    except Exception:
+        pass
+
+    raise HTTPException(status_code=400, detail="Invalid refresh token")
+
+
+# ---------------------------------------------------------------------------
+# Dynamic Client Registration (for MCP clients)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/oauth/register")
+async def register_client(request_body: dict):
+    """Register an OAuth client dynamically (RFC 7591).
+
+    MCP clients (like Claude Desktop) call this to register before
+    starting the authorization flow.
+    """
+    from preloop.api.endpoints.oauth_consent import get_oauth_provider
+
+    provider = get_oauth_provider()
+    if not provider:
+        raise HTTPException(status_code=501, detail="OAuth not configured")
+
+    from mcp.shared.auth import OAuthClientInformationFull
+
+    client_info = OAuthClientInformationFull(
+        client_id="pending",
+        redirect_uris=request_body.get("redirect_uris", []),
+        grant_types=request_body.get(
+            "grant_types", ["authorization_code", "refresh_token"]
+        ),
+        response_types=request_body.get("response_types", ["code"]),
+        token_endpoint_auth_method=request_body.get(
+            "token_endpoint_auth_method", "none"
+        ),
+        client_name=request_body.get("client_name"),
+        client_uri=request_body.get("client_uri"),
+        scope=request_body.get("scope"),
+        contacts=request_body.get("contacts"),
+        software_id=request_body.get("software_id"),
+        software_version=request_body.get("software_version"),
+    )
+
+    await provider.register_client(client_info)
+
+    return JSONResponse(
+        {
+            "client_id": client_info.client_id,
+            "client_secret": client_info.client_secret,
+            "client_id_issued_at": client_info.client_id_issued_at,
+            "client_secret_expires_at": client_info.client_secret_expires_at,
+            "redirect_uris": [str(u) for u in (client_info.redirect_uris or [])],
+            "grant_types": client_info.grant_types,
+            "response_types": client_info.response_types,
+            "token_endpoint_auth_method": client_info.token_endpoint_auth_method,
+            "client_name": client_info.client_name,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token Revocation
+# ---------------------------------------------------------------------------
+
+
+@router.post("/oauth/revoke")
+async def revoke_token(token: str = Form(...)):
+    """Revoke an access or refresh token."""
+    from preloop.api.endpoints.oauth_consent import get_oauth_provider
+
+    provider = get_oauth_provider()
+    if not provider:
+        raise HTTPException(status_code=501, detail="OAuth not configured")
+
+    # Try to load as access token first, then refresh token
+    access_token = await provider.load_access_token(token)
+    if access_token:
+        await provider.revoke_token(access_token)
+        return JSONResponse({"status": "revoked"})
+
+    # Not found — still return success per RFC 7009
+    return JSONResponse({"status": "revoked"})

--- a/backend/preloop/api/endpoints/oauth_server.py
+++ b/backend/preloop/api/endpoints/oauth_server.py
@@ -194,14 +194,31 @@ async def _handle_authorization_code(
                 detail="Authorization code expired",
             )
 
+        # Validate redirect_uri matches what was stored in the auth code
+        if (
+            db_code.redirect_uri
+            and redirect_uri
+            and db_code.redirect_uri != redirect_uri
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="redirect_uri does not match the authorization request",
+            )
+
         # Mark code as used
         crud_oauth_mcp_auth_code.mark_used(db, obj=db_code)
 
         # Decide token type based on whether PKCE was used
         has_pkce = bool(db_code.code_challenge)
 
-        if has_pkce and code_verifier:
-            # MCP flow: verify PKCE and issue opaque OAuth tokens
+        if has_pkce:
+            # PKCE was used — code_verifier is REQUIRED
+            if not code_verifier:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="code_verifier is required when PKCE was used",
+                )
+
             import hashlib
             import base64
 
@@ -219,9 +236,10 @@ async def _handle_authorization_code(
                     detail="Invalid code_verifier (PKCE validation failed)",
                 )
 
+            # MCP flow: issue opaque OAuth tokens
             return await _issue_opaque_tokens(db, db_code)
         else:
-            # CLI flow: issue JWT tokens
+            # No PKCE (CLI flow): issue JWT tokens
             return await _issue_jwt_tokens(db, db_code)
 
     finally:
@@ -308,17 +326,84 @@ async def _issue_opaque_tokens(db, db_code):
 
 
 async def _handle_refresh_token(refresh_token_str: str, client_id: str):
-    """Exchange a refresh token for new tokens."""
-    from datetime import timedelta
+    """Exchange a refresh token for new tokens.
 
-    from preloop.api.auth.jwt import (
-        create_access_token,
-        decode_token,
-        ACCESS_TOKEN_EXPIRE_MINUTES,
-    )
-
-    # Try JWT refresh token (the standard path for CLI)
+    Supports both:
+    - Opaque OAuth refresh tokens (MCP clients) — looked up in DB
+    - JWT refresh tokens (CLI) — decoded and reissued
+    """
+    # 1. Try opaque OAuth refresh token (MCP clients)
     try:
+        from preloop.models.crud.oauth_mcp_token import (
+            crud_oauth_mcp_refresh_token,
+            crud_oauth_mcp_access_token,
+            generate_token,
+        )
+        from preloop.models.db.session import get_db_session
+
+        db = next(get_db_session())
+        try:
+            db_refresh = crud_oauth_mcp_refresh_token.get_by_token(
+                db, token=refresh_token_str
+            )
+            if db_refresh and not db_refresh.is_revoked:
+                if db_refresh.expires_at and db_refresh.expires_at < int(time.time()):
+                    raise HTTPException(status_code=400, detail="Refresh token expired")
+
+                # Revoke the old refresh token (rotation)
+                crud_oauth_mcp_refresh_token.revoke(db, obj=db_refresh)
+
+                # Issue new opaque tokens
+                now = int(time.time())
+                new_access = generate_token(32)
+                new_refresh = generate_token(32)
+
+                crud_oauth_mcp_access_token.create(
+                    db,
+                    token=new_access,
+                    client_id=db_refresh.client_id,
+                    user_id=db_refresh.user_id,
+                    account_id=db_refresh.account_id,
+                    scopes=db_refresh.scopes or [],
+                    expires_at=now + 3600,
+                    resource=None,
+                )
+
+                crud_oauth_mcp_refresh_token.create(
+                    db,
+                    token=new_refresh,
+                    client_id=db_refresh.client_id,
+                    user_id=db_refresh.user_id,
+                    account_id=db_refresh.account_id,
+                    scopes=db_refresh.scopes or [],
+                    expires_at=now + 2592000,  # 30 days
+                )
+
+                return JSONResponse(
+                    {
+                        "access_token": new_access,
+                        "refresh_token": new_refresh,
+                        "token_type": "Bearer",
+                        "expires_in": 3600,
+                    }
+                )
+        finally:
+            db.close()
+    except HTTPException:
+        raise
+    except Exception:
+        pass
+
+    # 2. Try JWT refresh token (CLI path)
+    try:
+        from datetime import timedelta
+
+        from preloop.api.auth.jwt import (
+            create_access_token,
+            decode_token,
+            ACCESS_TOKEN_EXPIRE_MINUTES,
+        )
+
         token_data = decode_token(refresh_token_str)
         if token_data.refresh and token_data.sub:
             access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)

--- a/backend/preloop/api/endpoints/oauth_server.py
+++ b/backend/preloop/api/endpoints/oauth_server.py
@@ -194,16 +194,20 @@ async def _handle_authorization_code(
                 detail="Authorization code expired",
             )
 
-        # Validate redirect_uri matches what was stored in the auth code
-        if (
-            db_code.redirect_uri
-            and redirect_uri
-            and db_code.redirect_uri != redirect_uri
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="redirect_uri does not match the authorization request",
-            )
+        # Validate redirect_uri matches what was stored in the auth code.
+        # Per RFC 6749 §4.1.3: if redirect_uri was included in the
+        # authorization request, it MUST be required here and match exactly.
+        if db_code.redirect_uri:
+            if not redirect_uri:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="redirect_uri is required (it was included in the authorization request)",
+                )
+            if db_code.redirect_uri != redirect_uri:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="redirect_uri does not match the authorization request",
+                )
 
         # Mark code as used
         crud_oauth_mcp_auth_code.mark_used(db, obj=db_code)
@@ -503,11 +507,27 @@ async def revoke_token(token: str = Form(...)):
     if not provider:
         raise HTTPException(status_code=501, detail="OAuth not configured")
 
-    # Try to load as access token first, then refresh token
+    # Try to revoke as access token first
     access_token = await provider.load_access_token(token)
     if access_token:
         await provider.revoke_token(access_token)
         return JSONResponse({"status": "revoked"})
+
+    # Try to revoke as refresh token
+    try:
+        from preloop.models.crud.oauth_mcp_token import crud_oauth_mcp_refresh_token
+        from preloop.models.db.session import get_db_session
+
+        db = next(get_db_session())
+        try:
+            db_refresh = crud_oauth_mcp_refresh_token.get_by_token(db, token=token)
+            if db_refresh and not db_refresh.is_revoked:
+                crud_oauth_mcp_refresh_token.revoke(db, obj=db_refresh)
+                return JSONResponse({"status": "revoked"})
+        finally:
+            db.close()
+    except Exception:
+        pass
 
     # Not found — still return success per RFC 7009
     return JSONResponse({"status": "revoked"})

--- a/backend/preloop/config.py
+++ b/backend/preloop/config.py
@@ -81,6 +81,28 @@ class GitHubAppSettings(BaseModel):
         )
 
 
+class GoogleOAuthSettings(BaseModel):
+    """Google OAuth configuration for sign-in/sign-up."""
+
+    client_id: str = Field("", description="Google OAuth Client ID")
+    client_secret: str = Field("", description="Google OAuth Client Secret")
+
+
+class GitLabOAuthSettings(BaseModel):
+    """GitLab OAuth configuration for sign-in/sign-up.
+
+    Works with GitLab.com by default. For self-hosted GitLab, set
+    GITLAB_OAUTH_BASE_URL to your instance URL (e.g. https://gitlab.example.com).
+    """
+
+    client_id: str = Field("", description="GitLab OAuth Application ID")
+    client_secret: str = Field("", description="GitLab OAuth Application Secret")
+    base_url: str = Field(
+        "https://gitlab.com",
+        description="GitLab instance URL (for self-hosted)",
+    )
+
+
 class Settings(BaseSettings):
     """Application settings."""
 
@@ -110,6 +132,14 @@ class Settings(BaseSettings):
     github_app: GitHubAppSettings = Field(
         default_factory=GitHubAppSettings,
         description="GitHub App OAuth settings (SaaS only)",
+    )
+    google_oauth: GoogleOAuthSettings = Field(
+        default_factory=GoogleOAuthSettings,
+        description="Google OAuth settings for sign-in/sign-up",
+    )
+    gitlab_oauth: GitLabOAuthSettings = Field(
+        default_factory=GitLabOAuthSettings,
+        description="GitLab OAuth settings for sign-in/sign-up",
     )
 
     model_config = SettingsConfigDict(
@@ -205,6 +235,19 @@ class Settings(BaseSettings):
             slug=os.getenv("GITHUB_APP_SLUG", ""),
         )
 
+        # Google OAuth settings
+        google_oauth = GoogleOAuthSettings(
+            client_id=os.getenv("GOOGLE_OAUTH_CLIENT_ID", ""),
+            client_secret=os.getenv("GOOGLE_OAUTH_CLIENT_SECRET", ""),
+        )
+
+        # GitLab OAuth settings
+        gitlab_oauth = GitLabOAuthSettings(
+            client_id=os.getenv("GITLAB_OAUTH_CLIENT_ID", ""),
+            client_secret=os.getenv("GITLAB_OAUTH_CLIENT_SECRET", ""),
+            base_url=os.getenv("GITLAB_OAUTH_BASE_URL", "https://gitlab.com"),
+        )
+
         return cls(
             app_name=os.getenv("APP_NAME", "Preloop"),
             environment=os.getenv("ENVIRONMENT", "development"),
@@ -217,6 +260,8 @@ class Settings(BaseSettings):
             security=security,
             server=server,
             github_app=github_app,
+            google_oauth=google_oauth,
+            gitlab_oauth=gitlab_oauth,
             stripe_secret_key=stripe_secret_key,
             stripe_webhook_secret=stripe_webhook_secret,
         )

--- a/backend/preloop/models/alembic/versions/20260213_add_oauth_mcp_tables.py
+++ b/backend/preloop/models/alembic/versions/20260213_add_oauth_mcp_tables.py
@@ -1,0 +1,258 @@
+"""add_oauth_mcp_tables
+
+Revision ID: 9a5b2c3d4e9m
+Revises: 9a5b2c3d4e9k
+Create Date: 2026-02-13
+
+Adds tables for MCP OAuth 2.1 Authorization Server:
+- oauth_mcp_client: Dynamically registered OAuth clients (RFC 7591)
+- oauth_mcp_authorization_code: Authorization codes (short-lived)
+- oauth_mcp_access_token: Issued access tokens (hashed)
+- oauth_mcp_refresh_token: Issued refresh tokens (hashed)
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9a5b2c3d4e9m"
+down_revision: Union[str, None] = "9a5b2c3d4e9k"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create OAuth MCP tables."""
+
+    # oauth_mcp_client — Dynamic Client Registration
+    op.create_table(
+        "oauth_mcp_client",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("client_id", sa.String(255), nullable=False),
+        sa.Column("client_secret_hash", sa.String(255), nullable=True),
+        sa.Column(
+            "client_secret_expires_at", sa.Integer(), nullable=True, server_default="0"
+        ),
+        sa.Column(
+            "redirect_uris", postgresql.JSON(astext_type=sa.Text()), nullable=False
+        ),
+        sa.Column(
+            "grant_types",
+            postgresql.JSON(astext_type=sa.Text()),
+            nullable=False,
+            server_default='["authorization_code", "refresh_token"]',
+        ),
+        sa.Column(
+            "response_types",
+            postgresql.JSON(astext_type=sa.Text()),
+            nullable=False,
+            server_default='["code"]',
+        ),
+        sa.Column(
+            "token_endpoint_auth_method",
+            sa.String(50),
+            nullable=False,
+            server_default="client_secret_post",
+        ),
+        sa.Column("client_name", sa.String(255), nullable=True),
+        sa.Column("scope", sa.Text(), nullable=True),
+        sa.Column("client_uri", sa.String(2048), nullable=True),
+        sa.Column("logo_uri", sa.String(2048), nullable=True),
+        sa.Column("contacts", postgresql.JSON(astext_type=sa.Text()), nullable=True),
+        sa.Column("software_id", sa.String(255), nullable=True),
+        sa.Column("software_version", sa.String(255), nullable=True),
+        sa.Column("client_id_issued_at", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_oauth_mcp_client_id", "oauth_mcp_client", ["id"], unique=False)
+    op.create_index(
+        "ix_oauth_mcp_client_client_id", "oauth_mcp_client", ["client_id"], unique=True
+    )
+
+    # oauth_mcp_authorization_code
+    op.create_table(
+        "oauth_mcp_authorization_code",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("code_hash", sa.String(255), nullable=False),
+        sa.Column("client_id", sa.String(255), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("account_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("redirect_uri", sa.String(2048), nullable=False),
+        sa.Column(
+            "redirect_uri_provided_explicitly",
+            sa.Boolean(),
+            nullable=False,
+            server_default="true",
+        ),
+        sa.Column("code_challenge", sa.String(255), nullable=False),
+        sa.Column(
+            "scopes",
+            postgresql.JSON(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+        sa.Column("expires_at", sa.Float(), nullable=False),
+        sa.Column("resource", sa.String(2048), nullable=True),
+        sa.Column("is_used", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["account_id"], ["account.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_oauth_mcp_auth_code_id",
+        "oauth_mcp_authorization_code",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_oauth_mcp_auth_code_hash",
+        "oauth_mcp_authorization_code",
+        ["code_hash"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_oauth_mcp_auth_code_client_id",
+        "oauth_mcp_authorization_code",
+        ["client_id"],
+        unique=False,
+    )
+
+    # oauth_mcp_access_token
+    op.create_table(
+        "oauth_mcp_access_token",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("token_hash", sa.String(255), nullable=False),
+        sa.Column("client_id", sa.String(255), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("account_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "scopes",
+            postgresql.JSON(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+        sa.Column("expires_at", sa.Integer(), nullable=True),
+        sa.Column("resource", sa.String(2048), nullable=True),
+        sa.Column("is_revoked", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["account_id"], ["account.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_oauth_mcp_access_token_id", "oauth_mcp_access_token", ["id"], unique=False
+    )
+    op.create_index(
+        "ix_oauth_mcp_access_token_hash",
+        "oauth_mcp_access_token",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_oauth_mcp_access_token_client_id",
+        "oauth_mcp_access_token",
+        ["client_id"],
+        unique=False,
+    )
+
+    # oauth_mcp_refresh_token
+    op.create_table(
+        "oauth_mcp_refresh_token",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("token_hash", sa.String(255), nullable=False),
+        sa.Column("client_id", sa.String(255), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("account_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "scopes",
+            postgresql.JSON(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+        sa.Column("expires_at", sa.Integer(), nullable=True),
+        sa.Column("is_revoked", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["account_id"], ["account.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_oauth_mcp_refresh_token_id", "oauth_mcp_refresh_token", ["id"], unique=False
+    )
+    op.create_index(
+        "ix_oauth_mcp_refresh_token_hash",
+        "oauth_mcp_refresh_token",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_oauth_mcp_refresh_token_client_id",
+        "oauth_mcp_refresh_token",
+        ["client_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop OAuth MCP tables."""
+
+    # Drop refresh token table
+    op.drop_index(
+        "ix_oauth_mcp_refresh_token_client_id", table_name="oauth_mcp_refresh_token"
+    )
+    op.drop_index(
+        "ix_oauth_mcp_refresh_token_hash", table_name="oauth_mcp_refresh_token"
+    )
+    op.drop_index("ix_oauth_mcp_refresh_token_id", table_name="oauth_mcp_refresh_token")
+    op.drop_table("oauth_mcp_refresh_token")
+
+    # Drop access token table
+    op.drop_index(
+        "ix_oauth_mcp_access_token_client_id", table_name="oauth_mcp_access_token"
+    )
+    op.drop_index("ix_oauth_mcp_access_token_hash", table_name="oauth_mcp_access_token")
+    op.drop_index("ix_oauth_mcp_access_token_id", table_name="oauth_mcp_access_token")
+    op.drop_table("oauth_mcp_access_token")
+
+    # Drop authorization code table
+    op.drop_index(
+        "ix_oauth_mcp_auth_code_client_id", table_name="oauth_mcp_authorization_code"
+    )
+    op.drop_index(
+        "ix_oauth_mcp_auth_code_hash", table_name="oauth_mcp_authorization_code"
+    )
+    op.drop_index(
+        "ix_oauth_mcp_auth_code_id", table_name="oauth_mcp_authorization_code"
+    )
+    op.drop_table("oauth_mcp_authorization_code")
+
+    # Drop client table
+    op.drop_index("ix_oauth_mcp_client_client_id", table_name="oauth_mcp_client")
+    op.drop_index("ix_oauth_mcp_client_id", table_name="oauth_mcp_client")
+    op.drop_table("oauth_mcp_client")

--- a/backend/preloop/models/alembic/versions/20260213_add_oauth_mcp_tables.py
+++ b/backend/preloop/models/alembic/versions/20260213_add_oauth_mcp_tables.py
@@ -1,7 +1,7 @@
 """add_oauth_mcp_tables
 
-Revision ID: 9a5b2c3d4e9m
-Revises: 9a5b2c3d4e9k
+Revision ID: 9a5b2c3d4e9o
+Revises: 9a5b2c3d4e9m
 Create Date: 2026-02-13
 
 Adds tables for MCP OAuth 2.1 Authorization Server:
@@ -19,8 +19,8 @@ from sqlalchemy.dialects import postgresql
 
 
 # revision identifiers, used by Alembic.
-revision: str = "9a5b2c3d4e9m"
-down_revision: Union[str, None] = "9a5b2c3d4e9k"
+revision: str = "9a5b2c3d4e9o"
+down_revision: Union[str, None] = "9a5b2c3d4e9m"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/preloop/models/crud/oauth_mcp_client.py
+++ b/backend/preloop/models/crud/oauth_mcp_client.py
@@ -1,0 +1,76 @@
+"""CRUD operations for OAuthMCPClient model."""
+
+import hashlib
+import secrets
+import time
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from ..models.oauth_mcp_client import OAuthMCPClient
+from .base import CRUDBase
+
+
+class CRUDOAuthMCPClient(CRUDBase[OAuthMCPClient]):
+    """CRUD operations for OAuth MCP clients (Dynamic Client Registration)."""
+
+    @staticmethod
+    def generate_client_id() -> str:
+        """Generate a unique client ID."""
+        return f"preloop_{secrets.token_urlsafe(24)}"
+
+    @staticmethod
+    def generate_client_secret() -> str:
+        """Generate a client secret."""
+        return secrets.token_urlsafe(48)
+
+    @staticmethod
+    def hash_secret(secret: str) -> str:
+        """Hash a client secret using SHA-256."""
+        return hashlib.sha256(secret.encode()).hexdigest()
+
+    def get_by_client_id(
+        self, db: Session, *, client_id: str
+    ) -> Optional[OAuthMCPClient]:
+        """Get a client by its OAuth client_id."""
+        return db.query(self.model).filter(self.model.client_id == client_id).first()
+
+    def verify_client_secret(
+        self, db_client: OAuthMCPClient, client_secret: str
+    ) -> bool:
+        """Verify a client secret against the stored hash."""
+        if not db_client.client_secret_hash:
+            return False
+        return db_client.client_secret_hash == self.hash_secret(client_secret)
+
+    def delete_by_client_id(
+        self, db: Session, *, client_id: str
+    ) -> Optional[OAuthMCPClient]:
+        """Delete a client by its OAuth client_id."""
+        obj = self.get_by_client_id(db, client_id=client_id)
+        if obj:
+            db.delete(obj)
+            db.commit()
+        return obj
+
+    def cleanup_expired(self, db: Session) -> int:
+        """Delete clients whose secrets have expired. Returns count deleted."""
+        now = int(time.time())
+        expired = (
+            db.query(self.model)
+            .filter(
+                self.model.client_secret_expires_at.isnot(None),
+                self.model.client_secret_expires_at > 0,
+                self.model.client_secret_expires_at < now,
+            )
+            .all()
+        )
+        count = len(expired)
+        for client in expired:
+            db.delete(client)
+        if count:
+            db.commit()
+        return count
+
+
+crud_oauth_mcp_client = CRUDOAuthMCPClient(OAuthMCPClient)

--- a/backend/preloop/models/crud/oauth_mcp_token.py
+++ b/backend/preloop/models/crud/oauth_mcp_token.py
@@ -1,0 +1,293 @@
+"""CRUD operations for OAuth MCP token models (auth codes, access tokens, refresh tokens)."""
+
+import hashlib
+import secrets
+import time
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ..models.oauth_mcp_token import (
+    OAuthMCPAccessToken,
+    OAuthMCPAuthorizationCode,
+    OAuthMCPRefreshToken,
+)
+
+
+def _hash_token(token: str) -> str:
+    """Hash a token using SHA-256."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def generate_token(nbytes: int = 32) -> str:
+    """Generate a cryptographically secure random token."""
+    return secrets.token_urlsafe(nbytes)
+
+
+def generate_authorization_code() -> str:
+    """Generate an authorization code with >= 160 bits of entropy (RFC 6749 §10.10)."""
+    return secrets.token_urlsafe(24)  # 192 bits
+
+
+# --- Authorization Code CRUD ---
+
+
+class CRUDOAuthMCPAuthorizationCode:
+    """CRUD for OAuth MCP authorization codes."""
+
+    def create(
+        self,
+        db: Session,
+        *,
+        code: str,
+        client_id: str,
+        user_id: UUID,
+        account_id: UUID,
+        redirect_uri: str,
+        redirect_uri_provided_explicitly: bool,
+        code_challenge: str,
+        scopes: list[str],
+        expires_at: float,
+        resource: Optional[str] = None,
+    ) -> OAuthMCPAuthorizationCode:
+        """Store an authorization code (hashed)."""
+        obj = OAuthMCPAuthorizationCode(
+            code_hash=_hash_token(code),
+            client_id=client_id,
+            user_id=user_id,
+            account_id=account_id,
+            redirect_uri=redirect_uri,
+            redirect_uri_provided_explicitly=redirect_uri_provided_explicitly,
+            code_challenge=code_challenge,
+            scopes=scopes,
+            expires_at=expires_at,
+            resource=resource,
+            is_used=False,
+        )
+        db.add(obj)
+        db.commit()
+        db.refresh(obj)
+        return obj
+
+    def get_by_code(
+        self, db: Session, *, code: str, client_id: str
+    ) -> Optional[OAuthMCPAuthorizationCode]:
+        """Look up an authorization code by its hash and client_id."""
+        return (
+            db.query(OAuthMCPAuthorizationCode)
+            .filter(
+                OAuthMCPAuthorizationCode.code_hash == _hash_token(code),
+                OAuthMCPAuthorizationCode.client_id == client_id,
+            )
+            .first()
+        )
+
+    def mark_used(self, db: Session, *, obj: OAuthMCPAuthorizationCode) -> None:
+        """Mark an authorization code as consumed."""
+        obj.is_used = True
+        db.add(obj)
+        db.commit()
+
+    def delete_expired(self, db: Session) -> int:
+        """Delete expired or used authorization codes. Returns count deleted."""
+        now = time.time()
+        expired = (
+            db.query(OAuthMCPAuthorizationCode)
+            .filter(
+                (OAuthMCPAuthorizationCode.expires_at < now)
+                | (OAuthMCPAuthorizationCode.is_used == True)  # noqa: E712
+            )
+            .all()
+        )
+        count = len(expired)
+        for obj in expired:
+            db.delete(obj)
+        if count:
+            db.commit()
+        return count
+
+
+# --- Access Token CRUD ---
+
+
+class CRUDOAuthMCPAccessToken:
+    """CRUD for OAuth MCP access tokens."""
+
+    def create(
+        self,
+        db: Session,
+        *,
+        token: str,
+        client_id: str,
+        user_id: UUID,
+        account_id: UUID,
+        scopes: list[str],
+        expires_at: Optional[int] = None,
+        resource: Optional[str] = None,
+    ) -> OAuthMCPAccessToken:
+        """Store an access token (hashed)."""
+        obj = OAuthMCPAccessToken(
+            token_hash=_hash_token(token),
+            client_id=client_id,
+            user_id=user_id,
+            account_id=account_id,
+            scopes=scopes,
+            expires_at=expires_at,
+            resource=resource,
+            is_revoked=False,
+        )
+        db.add(obj)
+        db.commit()
+        db.refresh(obj)
+        return obj
+
+    def get_by_token(self, db: Session, *, token: str) -> Optional[OAuthMCPAccessToken]:
+        """Look up an access token by its hash."""
+        return (
+            db.query(OAuthMCPAccessToken)
+            .filter(OAuthMCPAccessToken.token_hash == _hash_token(token))
+            .first()
+        )
+
+    def revoke(self, db: Session, *, obj: OAuthMCPAccessToken) -> None:
+        """Revoke an access token."""
+        obj.is_revoked = True
+        db.add(obj)
+        db.commit()
+
+    def revoke_by_user_and_client(
+        self, db: Session, *, user_id: UUID, client_id: str
+    ) -> int:
+        """Revoke all access tokens for a user+client pair. Returns count."""
+        tokens = (
+            db.query(OAuthMCPAccessToken)
+            .filter(
+                OAuthMCPAccessToken.user_id == user_id,
+                OAuthMCPAccessToken.client_id == client_id,
+                OAuthMCPAccessToken.is_revoked == False,  # noqa: E712
+            )
+            .all()
+        )
+        for t in tokens:
+            t.is_revoked = True
+            db.add(t)
+        if tokens:
+            db.commit()
+        return len(tokens)
+
+    def delete_expired_and_revoked(self, db: Session) -> int:
+        """Delete expired or revoked access tokens. Returns count deleted."""
+        now = int(time.time())
+        stale = (
+            db.query(OAuthMCPAccessToken)
+            .filter(
+                (OAuthMCPAccessToken.is_revoked == True)  # noqa: E712
+                | (
+                    OAuthMCPAccessToken.expires_at.isnot(None)
+                    & (OAuthMCPAccessToken.expires_at < now)
+                )
+            )
+            .all()
+        )
+        count = len(stale)
+        for obj in stale:
+            db.delete(obj)
+        if count:
+            db.commit()
+        return count
+
+
+# --- Refresh Token CRUD ---
+
+
+class CRUDOAuthMCPRefreshToken:
+    """CRUD for OAuth MCP refresh tokens."""
+
+    def create(
+        self,
+        db: Session,
+        *,
+        token: str,
+        client_id: str,
+        user_id: UUID,
+        account_id: UUID,
+        scopes: list[str],
+        expires_at: Optional[int] = None,
+    ) -> OAuthMCPRefreshToken:
+        """Store a refresh token (hashed)."""
+        obj = OAuthMCPRefreshToken(
+            token_hash=_hash_token(token),
+            client_id=client_id,
+            user_id=user_id,
+            account_id=account_id,
+            scopes=scopes,
+            expires_at=expires_at,
+            is_revoked=False,
+        )
+        db.add(obj)
+        db.commit()
+        db.refresh(obj)
+        return obj
+
+    def get_by_token(
+        self, db: Session, *, token: str
+    ) -> Optional[OAuthMCPRefreshToken]:
+        """Look up a refresh token by its hash."""
+        return (
+            db.query(OAuthMCPRefreshToken)
+            .filter(OAuthMCPRefreshToken.token_hash == _hash_token(token))
+            .first()
+        )
+
+    def revoke(self, db: Session, *, obj: OAuthMCPRefreshToken) -> None:
+        """Revoke a refresh token."""
+        obj.is_revoked = True
+        db.add(obj)
+        db.commit()
+
+    def revoke_by_user_and_client(
+        self, db: Session, *, user_id: UUID, client_id: str
+    ) -> int:
+        """Revoke all refresh tokens for a user+client pair. Returns count."""
+        tokens = (
+            db.query(OAuthMCPRefreshToken)
+            .filter(
+                OAuthMCPRefreshToken.user_id == user_id,
+                OAuthMCPRefreshToken.client_id == client_id,
+                OAuthMCPRefreshToken.is_revoked == False,  # noqa: E712
+            )
+            .all()
+        )
+        for t in tokens:
+            t.is_revoked = True
+            db.add(t)
+        if tokens:
+            db.commit()
+        return len(tokens)
+
+    def delete_expired_and_revoked(self, db: Session) -> int:
+        """Delete expired or revoked refresh tokens. Returns count deleted."""
+        now = int(time.time())
+        stale = (
+            db.query(OAuthMCPRefreshToken)
+            .filter(
+                (OAuthMCPRefreshToken.is_revoked == True)  # noqa: E712
+                | (
+                    OAuthMCPRefreshToken.expires_at.isnot(None)
+                    & (OAuthMCPRefreshToken.expires_at < now)
+                )
+            )
+            .all()
+        )
+        count = len(stale)
+        for obj in stale:
+            db.delete(obj)
+        if count:
+            db.commit()
+        return count
+
+
+crud_oauth_mcp_auth_code = CRUDOAuthMCPAuthorizationCode()
+crud_oauth_mcp_access_token = CRUDOAuthMCPAccessToken()
+crud_oauth_mcp_refresh_token = CRUDOAuthMCPRefreshToken()

--- a/backend/preloop/models/models/account.py
+++ b/backend/preloop/models/models/account.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     from .tool_configuration import ToolConfiguration
     from .mcp_server import MCPServer
     from .approval_request import ApprovalRequest
-    from .tool_approval_condition import ToolApprovalCondition
     from .tool_access_rule import ToolAccessRule
     from .team import Team
     from .user import User
@@ -132,9 +131,6 @@ class Account(Base):
     )
     approval_requests: Mapped[List["ApprovalRequest"]] = relationship(
         "ApprovalRequest", back_populates="account", cascade="all, delete-orphan"
-    )
-    tool_approval_conditions: Mapped[List["ToolApprovalCondition"]] = relationship(
-        "ToolApprovalCondition", back_populates="account", cascade="all, delete-orphan"
     )
     tool_access_rules: Mapped[List["ToolAccessRule"]] = relationship(
         "ToolAccessRule", back_populates="account", cascade="all, delete-orphan"

--- a/backend/preloop/models/models/oauth_mcp_client.py
+++ b/backend/preloop/models/models/oauth_mcp_client.py
@@ -1,0 +1,65 @@
+"""OAuth MCP Client model for Dynamic Client Registration (RFC 7591)."""
+
+from typing import Optional
+
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import JSON
+
+from .base import Base
+
+
+class OAuthMCPClient(Base):
+    """Stores dynamically registered MCP OAuth clients.
+
+    Each MCP client (e.g., Claude Desktop, CLI) registers itself via
+    POST /mcp/register and receives a client_id + client_secret.
+
+    Attributes:
+        id: UUID primary key (inherited from Base).
+        client_id: Unique OAuth client identifier (generated on registration).
+        client_secret_hash: SHA-256 hash of the client secret.
+        client_secret_expires_at: When the client secret expires (0 = never).
+        redirect_uris: JSON array of registered redirect URIs.
+        grant_types: JSON array of allowed grant types.
+        response_types: JSON array of allowed response types.
+        token_endpoint_auth_method: Auth method for the token endpoint.
+        client_name: Human-readable client name.
+        scope: Space-separated list of allowed scopes.
+        client_uri: URL of the client's home page.
+        logo_uri: URL of the client's logo.
+        contacts: JSON array of contact emails.
+        software_id: Unique identifier for the client software.
+        software_version: Version of the client software.
+        client_id_issued_at: Unix timestamp when client_id was issued.
+    """
+
+    __tablename__ = "oauth_mcp_client"
+
+    client_id: Mapped[str] = mapped_column(
+        String(255), unique=True, nullable=False, index=True
+    )
+    client_secret_hash: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True
+    )
+    client_secret_expires_at: Mapped[Optional[int]] = mapped_column(
+        nullable=True, default=0
+    )
+    redirect_uris: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    grant_types: Mapped[list] = mapped_column(
+        JSON, nullable=False, default=lambda: ["authorization_code", "refresh_token"]
+    )
+    response_types: Mapped[list] = mapped_column(
+        JSON, nullable=False, default=lambda: ["code"]
+    )
+    token_endpoint_auth_method: Mapped[str] = mapped_column(
+        String(50), nullable=False, default="client_secret_post"
+    )
+    client_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    scope: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    client_uri: Mapped[Optional[str]] = mapped_column(String(2048), nullable=True)
+    logo_uri: Mapped[Optional[str]] = mapped_column(String(2048), nullable=True)
+    contacts: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
+    software_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    software_version: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    client_id_issued_at: Mapped[Optional[int]] = mapped_column(nullable=True)

--- a/backend/preloop/models/models/oauth_mcp_token.py
+++ b/backend/preloop/models/models/oauth_mcp_token.py
@@ -1,0 +1,134 @@
+"""OAuth MCP token models for authorization codes, access tokens, and refresh tokens."""
+
+import uuid
+from typing import Optional
+
+from sqlalchemy import Float, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import JSON
+
+from .base import Base
+
+
+class OAuthMCPAuthorizationCode(Base):
+    """Stores OAuth authorization codes (short-lived, consumed on token exchange).
+
+    Authorization codes are generated during the /authorize flow and exchanged
+    for access + refresh tokens via POST /token.
+
+    Attributes:
+        code_hash: SHA-256 hash of the authorization code.
+        client_id: The OAuth client that requested the code.
+        user_id: The Preloop user who authorized.
+        account_id: The Preloop account of the user.
+        redirect_uri: The redirect URI for this code.
+        redirect_uri_provided_explicitly: Whether redirect_uri was explicitly provided.
+        code_challenge: PKCE code challenge (S256).
+        scopes: JSON array of requested scopes.
+        expires_at: Unix timestamp when the code expires.
+        resource: RFC 8707 resource indicator.
+        is_used: Whether the code has been consumed.
+    """
+
+    __tablename__ = "oauth_mcp_authorization_code"
+
+    code_hash: Mapped[str] = mapped_column(
+        String(255), unique=True, nullable=False, index=True
+    )
+    client_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("account.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    redirect_uri: Mapped[str] = mapped_column(String(2048), nullable=False)
+    redirect_uri_provided_explicitly: Mapped[bool] = mapped_column(
+        nullable=False, default=True
+    )
+    code_challenge: Mapped[str] = mapped_column(String(255), nullable=False)
+    scopes: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    expires_at: Mapped[float] = mapped_column(Float, nullable=False)
+    resource: Mapped[Optional[str]] = mapped_column(String(2048), nullable=True)
+    is_used: Mapped[bool] = mapped_column(nullable=False, default=False)
+
+
+class OAuthMCPAccessToken(Base):
+    """Stores issued OAuth access tokens.
+
+    Access tokens are looked up by their SHA-256 hash for verification.
+    They are linked to the Preloop user/account for context extraction.
+
+    Attributes:
+        token_hash: SHA-256 hash of the access token.
+        client_id: The OAuth client this token was issued to.
+        user_id: The Preloop user this token represents.
+        account_id: The Preloop account of the user.
+        scopes: JSON array of granted scopes.
+        expires_at: Unix timestamp when the token expires (None = no expiry).
+        resource: RFC 8707 resource indicator.
+        is_revoked: Whether the token has been revoked.
+    """
+
+    __tablename__ = "oauth_mcp_access_token"
+
+    token_hash: Mapped[str] = mapped_column(
+        String(255), unique=True, nullable=False, index=True
+    )
+    client_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("account.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    scopes: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    expires_at: Mapped[Optional[int]] = mapped_column(nullable=True)
+    resource: Mapped[Optional[str]] = mapped_column(String(2048), nullable=True)
+    is_revoked: Mapped[bool] = mapped_column(nullable=False, default=False)
+
+
+class OAuthMCPRefreshToken(Base):
+    """Stores issued OAuth refresh tokens.
+
+    Refresh tokens are used to obtain new access tokens without re-authorization.
+    They are rotated on each use (old token invalidated, new one issued).
+
+    Attributes:
+        token_hash: SHA-256 hash of the refresh token.
+        client_id: The OAuth client this token was issued to.
+        user_id: The Preloop user this token represents.
+        account_id: The Preloop account of the user.
+        scopes: JSON array of granted scopes.
+        expires_at: Unix timestamp when the token expires (None = no expiry).
+        is_revoked: Whether the token has been revoked.
+    """
+
+    __tablename__ = "oauth_mcp_refresh_token"
+
+    token_hash: Mapped[str] = mapped_column(
+        String(255), unique=True, nullable=False, index=True
+    )
+    client_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("account.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    scopes: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    expires_at: Mapped[Optional[int]] = mapped_column(nullable=True)
+    is_revoked: Mapped[bool] = mapped_column(nullable=False, default=False)

--- a/backend/preloop/models/models/tool_approval_condition.py
+++ b/backend/preloop/models/models/tool_approval_condition.py
@@ -5,14 +5,13 @@ from typing import TYPE_CHECKING, Dict, Optional
 
 from sqlalchemy import ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import Boolean, JSON
 
 from .base import Base
 
 if TYPE_CHECKING:
-    from .account import Account
-    from .tool_configuration import ToolConfiguration
+    pass
 
 
 class ToolApprovalCondition(Base):
@@ -109,14 +108,9 @@ class ToolApprovalCondition(Base):
     # Note: created_at and updated_at are inherited from Base class
 
     # Relationships
-    account: Mapped["Account"] = relationship(
-        "Account", back_populates="tool_approval_conditions"
-    )
-    tool_configuration: Mapped["ToolConfiguration"] = relationship(
-        "ToolConfiguration",
-        back_populates="approval_condition",
-        uselist=False,  # 1:1 relationship
-    )
+    # NOTE: Relationships removed — the tool_approval_conditions table was dropped
+    # by migration 20260201_policy_engine_enhancements and replaced by tool_access_rules.
+    # This model is kept only for backward compatibility with existing CRUD/endpoint code.
 
     def __repr__(self) -> str:
         """String representation."""

--- a/backend/preloop/models/models/tool_configuration.py
+++ b/backend/preloop/models/models/tool_configuration.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from .account import Account
     from .mcp_server import MCPServer
     from .approval_request import ApprovalRequest
-    from .tool_approval_condition import ToolApprovalCondition
     from .tool_access_rule import ToolAccessRule
 
 
@@ -115,12 +114,6 @@ class ToolConfiguration(Base):
     approval_requests: Mapped[list["ApprovalRequest"]] = relationship(
         "ApprovalRequest",
         back_populates="tool_configuration",
-        cascade="all, delete-orphan",
-    )
-    approval_condition: Mapped[Optional["ToolApprovalCondition"]] = relationship(
-        "ToolApprovalCondition",
-        back_populates="tool_configuration",
-        uselist=False,  # 1:1 relationship
         cascade="all, delete-orphan",
     )
     access_rules: Mapped[list["ToolAccessRule"]] = relationship(

--- a/backend/preloop/plugins/base.py
+++ b/backend/preloop/plugins/base.py
@@ -312,9 +312,13 @@ class PluginManager:
 
             # Let each plugin declare its own features
             plugin_features = plugin.get_features()
-            for feature_name, enabled in plugin_features.items():
-                if enabled:
-                    features["features"][feature_name] = True
+            for feature_name, value in plugin_features.items():
+                if value is True or value is False:
+                    if value:
+                        features["features"][feature_name] = True
+                elif value:
+                    # Preserve non-boolean values (e.g. lists) as-is
+                    features["features"][feature_name] = value
 
         return features
 

--- a/backend/preloop/services/dynamic_fastmcp_http.py
+++ b/backend/preloop/services/dynamic_fastmcp_http.py
@@ -4,11 +4,14 @@ This module sets up FastMCP's StreamableHTTP transport with middleware that inje
 authenticated user context for per-request tool filtering.
 """
 
+import json
 import logging
+import os
 from contextvars import ContextVar
 from typing import Optional
 
 from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.responses import Response
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from preloop.services.dynamic_fastmcp import (
@@ -32,6 +35,9 @@ class UserContextMiddleware:
     This middleware runs for each request and extracts the authenticated user's
     context, storing it in a context variable that the DynamicFastMCP server
     can access during tool listing and execution.
+
+    Returns 401 Unauthorized when no valid auth token is provided, which
+    triggers OAuth discovery in MCP clients (e.g. Claude Desktop).
     """
 
     def __init__(self, app: ASGIApp):
@@ -53,7 +59,32 @@ class UserContextMiddleware:
                 f"has_tracker={user_context.has_tracker}"
             )
         else:
-            logger.warning("No user context extracted from scope")
+            logger.warning("No user context available, returning 401")
+            # Return 401 to trigger OAuth discovery in MCP clients
+            base_url = os.getenv("PRELOOP_URL", "http://localhost:8000").rstrip("/")
+            resource_metadata_url = (
+                f"{base_url}/.well-known/oauth-protected-resource/mcp"
+            )
+            response = Response(
+                content=json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "error": {
+                            "code": -32001,
+                            "message": "Authentication required. Provide Authorization: Bearer <token> header.",
+                        },
+                    }
+                ),
+                status_code=401,
+                media_type="application/json",
+                headers={
+                    "WWW-Authenticate": (
+                        f'Bearer resource_metadata="{resource_metadata_url}"'
+                    ),
+                },
+            )
+            await response(scope, receive, send)
+            return
 
         # Store in context variable for this request's async context
         token = _current_user_context.set(user_context)
@@ -96,17 +127,17 @@ def setup_dynamic_mcp_http(mcp: DynamicFastMCP):
     logger.info("Registered user context provider with DynamicFastMCP")
 
     # Get FastMCP's built-in HTTP app with StreamableHTTP transport
-    # path="/v1" means it will serve on /v1 within the mounted app
-    # So mounting at /mcp makes it available at /mcp/v1
+    # path="/" means it will serve at the mount root
+    # So mounting at /mcp makes it available at /mcp
     # NOTE: json_response must be None (not True) to allow SSE streaming for progress
     # NOTE: stateless_http=True prevents session state issues on server restart
     base_app = mcp.http_app(
-        path="/v1",
+        path="/",
         transport="streamable-http",
         json_response=None,  # Allow SSE streaming for progress notifications
         stateless_http=True,  # Don't maintain session state (allows clean reconnections)
     )
-    logger.info("Got FastMCP's http_app with streamable-http transport for path /v1")
+    logger.info("Got FastMCP's http_app with streamable-http transport for path /")
 
     # Wrap with our middleware layers
     # Layer 1: User context middleware (extracts and stores user context)

--- a/backend/preloop/services/mcp_http.py
+++ b/backend/preloop/services/mcp_http.py
@@ -521,10 +521,13 @@ def setup_mcp_routes(app: FastAPI):
     else:
         logger.warning("Could not find MCP app with lifespan")
 
-    # Mount the MCP app at /mcp
+    # Mount the MCP app at /mcp/v1 (backward compat) AND /mcp (primary)
+    # /mcp/v1 must be mounted first since FastAPI matches mounts by prefix
+    # length (longer prefix wins)
+    app.mount("/mcp/v1", mcp_app)
     app.mount("/mcp", mcp_app)
 
-    logger.info("MCP StreamableHTTP transport mounted at /mcp")
+    logger.info("MCP StreamableHTTP transport mounted at /mcp and /mcp/v1")
 
 
 def get_mcp_lifespan_manager():

--- a/backend/preloop/services/oauth_provider.py
+++ b/backend/preloop/services/oauth_provider.py
@@ -1,0 +1,558 @@
+"""Preloop OAuth Authorization Server Provider for MCP.
+
+Implements FastMCP's OAuthProvider interface so that MCP clients (Claude Desktop,
+CLI, etc.) can authenticate via the standard OAuth 2.1 authorization code flow
+with PKCE.
+
+Also falls back to existing Bearer token (API key / JWT) validation for
+backward compatibility.
+"""
+
+import logging
+import time
+from typing import Optional
+from urllib.parse import urlencode
+
+from mcp.server.auth.provider import (
+    AuthorizationCode,
+    AuthorizationParams,
+    RefreshToken,
+    TokenError,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+from fastmcp.server.auth.auth import AccessToken, OAuthProvider
+
+from preloop.models.crud.oauth_mcp_client import crud_oauth_mcp_client
+from preloop.models.crud.oauth_mcp_token import (
+    crud_oauth_mcp_access_token,
+    crud_oauth_mcp_auth_code,
+    crud_oauth_mcp_refresh_token,
+    generate_authorization_code,
+    generate_token,
+)
+
+logger = logging.getLogger(__name__)
+
+# Token expiry defaults (seconds)
+ACCESS_TOKEN_EXPIRY = 3600  # 1 hour
+REFRESH_TOKEN_EXPIRY = 2592000  # 30 days
+AUTH_CODE_EXPIRY = 300  # 5 minutes
+
+
+def _get_db():
+    """Get a database session (caller must close)."""
+    from preloop.models.db.session import get_session_factory
+
+    factory = get_session_factory()
+    return factory()
+
+
+class PreloopOAuthProvider(OAuthProvider):
+    """OAuth 2.1 Authorization Server for the Preloop MCP server.
+
+    Implements the full OAuth flow:
+    - Dynamic Client Registration (POST /register)
+    - Authorization (GET /authorize → login/consent page → redirect with code)
+    - Token exchange (POST /token)
+    - Token refresh (POST /token with grant_type=refresh_token)
+    - Token revocation (POST /revoke)
+    - Token verification (Bearer token in requests)
+
+    Also supports backward-compatible Bearer token auth (API keys and JWTs)
+    by falling back to Preloop's existing auth system when the token is not
+    found in the OAuth token store.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        issuer_url: Optional[str] = None,
+        access_token_expiry: int = ACCESS_TOKEN_EXPIRY,
+        refresh_token_expiry: int = REFRESH_TOKEN_EXPIRY,
+    ):
+        from mcp.server.auth.settings import (
+            ClientRegistrationOptions,
+            RevocationOptions,
+        )
+
+        self._access_token_expiry = access_token_expiry
+        self._refresh_token_expiry = refresh_token_expiry
+
+        super().__init__(
+            base_url=base_url,
+            issuer_url=issuer_url or base_url,
+            client_registration_options=ClientRegistrationOptions(
+                enabled=True,
+                valid_scopes=[],
+            ),
+            revocation_options=RevocationOptions(
+                enabled=True,
+            ),
+            required_scopes=[],
+        )
+
+    # -------------------------------------------------------------------------
+    # Dynamic Client Registration (RFC 7591)
+    # -------------------------------------------------------------------------
+
+    async def get_client(self, client_id: str) -> Optional[OAuthClientInformationFull]:
+        """Retrieve registered client by client_id."""
+        db = _get_db()
+        try:
+            db_client = crud_oauth_mcp_client.get_by_client_id(db, client_id=client_id)
+            if not db_client:
+                return None
+            return OAuthClientInformationFull(
+                client_id=db_client.client_id,
+                client_secret=None,  # Never expose secret
+                client_id_issued_at=db_client.client_id_issued_at,
+                client_secret_expires_at=db_client.client_secret_expires_at or 0,
+                redirect_uris=db_client.redirect_uris,
+                grant_types=db_client.grant_types,
+                response_types=db_client.response_types,
+                token_endpoint_auth_method=db_client.token_endpoint_auth_method,
+                client_name=db_client.client_name,
+                scope=db_client.scope,
+            )
+        finally:
+            db.close()
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        """Register a new OAuth client via Dynamic Client Registration."""
+        db = _get_db()
+        try:
+            now = int(time.time())
+
+            # Generate credentials
+            new_client_id = crud_oauth_mcp_client.generate_client_id()
+            new_client_secret = crud_oauth_mcp_client.generate_client_secret()
+            secret_hash = crud_oauth_mcp_client.hash_secret(new_client_secret)
+
+            # Store in DB
+            crud_oauth_mcp_client.create(
+                db,
+                obj_in={
+                    "client_id": new_client_id,
+                    "client_secret_hash": secret_hash,
+                    "client_secret_expires_at": 0,  # Never expires
+                    "redirect_uris": [
+                        str(u) for u in (client_info.redirect_uris or [])
+                    ],
+                    "grant_types": client_info.grant_types
+                    or ["authorization_code", "refresh_token"],
+                    "response_types": client_info.response_types or ["code"],
+                    "token_endpoint_auth_method": client_info.token_endpoint_auth_method
+                    or "client_secret_post",
+                    "client_name": client_info.client_name,
+                    "scope": client_info.scope,
+                    "client_uri": str(client_info.client_uri)
+                    if client_info.client_uri
+                    else None,
+                    "logo_uri": str(client_info.logo_uri)
+                    if client_info.logo_uri
+                    else None,
+                    "contacts": client_info.contacts,
+                    "software_id": client_info.software_id,
+                    "software_version": client_info.software_version,
+                    "client_id_issued_at": now,
+                },
+            )
+
+            # Mutate the passed-in object so the SDK returns credentials to the client
+            client_info.client_id = new_client_id
+            client_info.client_secret = new_client_secret
+            client_info.client_id_issued_at = now
+            client_info.client_secret_expires_at = 0
+
+            logger.info(
+                f"Registered OAuth MCP client: {new_client_id} ({client_info.client_name})"
+            )
+        finally:
+            db.close()
+
+    # -------------------------------------------------------------------------
+    # Authorization
+    # -------------------------------------------------------------------------
+
+    async def authorize(
+        self, client: OAuthClientInformationFull, params: AuthorizationParams
+    ) -> str:
+        """Redirect user to the Preloop login/consent page.
+
+        Returns a URL that the MCP SDK will redirect the user's browser to.
+        The login page will authenticate the user and redirect back to the
+        client's redirect_uri with an authorization code.
+        """
+        assert self.base_url is not None
+
+        # Build URL to our login/consent page (mounted at root, not under /mcp)
+        # base_url is e.g. "http://localhost:8000/mcp" — strip /mcp to get root
+        base = str(self.base_url).rstrip("/")
+        if base.endswith("/mcp"):
+            root_url = base[: -len("/mcp")]
+        else:
+            root_url = base
+
+        query_params = {
+            "client_id": client.client_id,
+            "redirect_uri": str(params.redirect_uri),
+            "code_challenge": params.code_challenge,
+            "scopes": " ".join(params.scopes) if params.scopes else "",
+        }
+        if params.state:
+            query_params["state"] = params.state
+        if params.redirect_uri_provided_explicitly:
+            query_params["redirect_uri_provided_explicitly"] = "true"
+        if params.resource:
+            query_params["resource"] = params.resource
+
+        authorize_url = f"{root_url}/mcp/authorize/consent?{urlencode(query_params)}"
+        return authorize_url
+
+    # -------------------------------------------------------------------------
+    # Authorization Code Exchange
+    # -------------------------------------------------------------------------
+
+    async def load_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: str
+    ) -> Optional[AuthorizationCode]:
+        """Load an authorization code from the database."""
+        db = _get_db()
+        try:
+            db_code = crud_oauth_mcp_auth_code.get_by_code(
+                db, code=authorization_code, client_id=client.client_id
+            )
+            if not db_code:
+                return None
+
+            # Check expiry
+            if db_code.expires_at < time.time():
+                logger.warning(
+                    f"Authorization code expired for client {client.client_id}"
+                )
+                return None
+
+            # Check if already used
+            if db_code.is_used:
+                logger.warning(
+                    f"Authorization code already used for client {client.client_id}"
+                )
+                return None
+
+            return AuthorizationCode(
+                code=authorization_code,
+                scopes=db_code.scopes or [],
+                expires_at=db_code.expires_at,
+                client_id=db_code.client_id,
+                code_challenge=db_code.code_challenge,
+                redirect_uri=db_code.redirect_uri,
+                redirect_uri_provided_explicitly=db_code.redirect_uri_provided_explicitly,
+                resource=db_code.resource,
+            )
+        finally:
+            db.close()
+
+    async def exchange_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: AuthorizationCode
+    ) -> OAuthToken:
+        """Exchange an authorization code for access + refresh tokens."""
+        db = _get_db()
+        try:
+            # Mark code as used
+            db_code = crud_oauth_mcp_auth_code.get_by_code(
+                db, code=authorization_code.code, client_id=client.client_id
+            )
+            if not db_code:
+                raise TokenError(
+                    error="invalid_grant",
+                    error_description="Authorization code not found",
+                )
+
+            if db_code.is_used:
+                raise TokenError(
+                    error="invalid_grant",
+                    error_description="Authorization code already used",
+                )
+
+            crud_oauth_mcp_auth_code.mark_used(db, obj=db_code)
+
+            # Generate tokens
+            access_token_str = generate_token(32)
+            refresh_token_str = generate_token(32)
+            now = int(time.time())
+
+            # Store access token
+            crud_oauth_mcp_access_token.create(
+                db,
+                token=access_token_str,
+                client_id=client.client_id,
+                user_id=db_code.user_id,
+                account_id=db_code.account_id,
+                scopes=db_code.scopes or [],
+                expires_at=now + self._access_token_expiry,
+                resource=db_code.resource,
+            )
+
+            # Store refresh token
+            crud_oauth_mcp_refresh_token.create(
+                db,
+                token=refresh_token_str,
+                client_id=client.client_id,
+                user_id=db_code.user_id,
+                account_id=db_code.account_id,
+                scopes=db_code.scopes or [],
+                expires_at=now + self._refresh_token_expiry,
+            )
+
+            logger.info(
+                f"Exchanged auth code for tokens: client={client.client_id}, "
+                f"user={db_code.user_id}"
+            )
+
+            return OAuthToken(
+                access_token=access_token_str,
+                token_type="Bearer",
+                expires_in=self._access_token_expiry,
+                scope=" ".join(db_code.scopes) if db_code.scopes else None,
+                refresh_token=refresh_token_str,
+            )
+        finally:
+            db.close()
+
+    # -------------------------------------------------------------------------
+    # Refresh Token
+    # -------------------------------------------------------------------------
+
+    async def load_refresh_token(
+        self, client: OAuthClientInformationFull, refresh_token: str
+    ) -> Optional[RefreshToken]:
+        """Load a refresh token from the database."""
+        db = _get_db()
+        try:
+            db_token = crud_oauth_mcp_refresh_token.get_by_token(
+                db, token=refresh_token
+            )
+            if not db_token:
+                return None
+
+            if db_token.is_revoked:
+                return None
+
+            if db_token.client_id != client.client_id:
+                return None
+
+            if db_token.expires_at and db_token.expires_at < int(time.time()):
+                return None
+
+            return RefreshToken(
+                token=refresh_token,
+                client_id=db_token.client_id,
+                scopes=db_token.scopes or [],
+                expires_at=db_token.expires_at,
+            )
+        finally:
+            db.close()
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        """Exchange a refresh token for new access + refresh tokens (rotation)."""
+        db = _get_db()
+        try:
+            # Look up the old refresh token to get user info
+            db_old_refresh = crud_oauth_mcp_refresh_token.get_by_token(
+                db, token=refresh_token.token
+            )
+            if not db_old_refresh:
+                raise TokenError(
+                    error="invalid_grant", error_description="Refresh token not found"
+                )
+
+            user_id = db_old_refresh.user_id
+            account_id = db_old_refresh.account_id
+
+            # Revoke old refresh token (rotation)
+            crud_oauth_mcp_refresh_token.revoke(db, obj=db_old_refresh)
+
+            # Generate new tokens
+            new_access_token_str = generate_token(32)
+            new_refresh_token_str = generate_token(32)
+            now = int(time.time())
+
+            effective_scopes = scopes if scopes else (refresh_token.scopes or [])
+
+            # Store new access token
+            crud_oauth_mcp_access_token.create(
+                db,
+                token=new_access_token_str,
+                client_id=client.client_id,
+                user_id=user_id,
+                account_id=account_id,
+                scopes=effective_scopes,
+                expires_at=now + self._access_token_expiry,
+            )
+
+            # Store new refresh token
+            crud_oauth_mcp_refresh_token.create(
+                db,
+                token=new_refresh_token_str,
+                client_id=client.client_id,
+                user_id=user_id,
+                account_id=account_id,
+                scopes=effective_scopes,
+                expires_at=now + self._refresh_token_expiry,
+            )
+
+            logger.info(f"Rotated tokens for client={client.client_id}, user={user_id}")
+
+            return OAuthToken(
+                access_token=new_access_token_str,
+                token_type="Bearer",
+                expires_in=self._access_token_expiry,
+                scope=" ".join(effective_scopes) if effective_scopes else None,
+                refresh_token=new_refresh_token_str,
+            )
+        finally:
+            db.close()
+
+    # -------------------------------------------------------------------------
+    # Access Token Verification (called on every MCP request)
+    # -------------------------------------------------------------------------
+
+    async def load_access_token(self, token: str) -> Optional[AccessToken]:
+        """Verify an access token — checks OAuth tokens first, then falls back
+        to legacy API key / JWT validation for backward compatibility."""
+        db = _get_db()
+        try:
+            # 1. Try OAuth token store
+            db_token = crud_oauth_mcp_access_token.get_by_token(db, token=token)
+            if db_token and not db_token.is_revoked:
+                # Check expiry
+                if db_token.expires_at and db_token.expires_at < int(time.time()):
+                    return None
+
+                # Load user for attaching to AccessToken
+                from preloop.models.crud import crud_user
+
+                user = crud_user.get(db, id=str(db_token.user_id))
+                if not user:
+                    return None
+
+                access_token = AccessToken(
+                    token=token,
+                    client_id=db_token.client_id,
+                    scopes=db_token.scopes or [],
+                    expires_at=db_token.expires_at,
+                    resource=db_token.resource,
+                )
+                # Attach user info for downstream middleware
+                object.__setattr__(access_token, "user", user)
+                return access_token
+
+            # 2. Fall back to legacy Bearer token (API key / JWT)
+            from preloop.api.auth.jwt import get_user_from_token_if_valid
+
+            user = await get_user_from_token_if_valid(token, db)
+            if user:
+                access_token = AccessToken(
+                    token=token,
+                    client_id=str(user.id),
+                    scopes=[],
+                    expires_at=None,
+                )
+                object.__setattr__(access_token, "user", user)
+
+                # Also attach API key object if applicable
+                if token and "." not in token:  # API keys don't have dots (JWTs do)
+                    from preloop.models.crud import crud_api_key
+
+                    api_key_obj = crud_api_key.get_by_key(db, key=token)
+                    if api_key_obj:
+                        object.__setattr__(access_token, "api_key", api_key_obj)
+
+                return access_token
+
+            return None
+        finally:
+            db.close()
+
+    # -------------------------------------------------------------------------
+    # Token Revocation
+    # -------------------------------------------------------------------------
+
+    async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
+        """Revoke an access or refresh token and its counterpart."""
+        db = _get_db()
+        try:
+            if isinstance(token, AccessToken):
+                db_access = crud_oauth_mcp_access_token.get_by_token(
+                    db, token=token.token
+                )
+                if db_access:
+                    crud_oauth_mcp_access_token.revoke(db, obj=db_access)
+                    # Also revoke associated refresh tokens
+                    crud_oauth_mcp_refresh_token.revoke_by_user_and_client(
+                        db, user_id=db_access.user_id, client_id=db_access.client_id
+                    )
+            elif isinstance(token, RefreshToken):
+                db_refresh = crud_oauth_mcp_refresh_token.get_by_token(
+                    db, token=token.token
+                )
+                if db_refresh:
+                    crud_oauth_mcp_refresh_token.revoke(db, obj=db_refresh)
+                    # Also revoke associated access tokens
+                    crud_oauth_mcp_access_token.revoke_by_user_and_client(
+                        db, user_id=db_refresh.user_id, client_id=db_refresh.client_id
+                    )
+        finally:
+            db.close()
+
+    # -------------------------------------------------------------------------
+    # Helper: Create authorization code (called by consent page handler)
+    # -------------------------------------------------------------------------
+
+    def create_authorization_code_for_user(
+        self,
+        *,
+        client_id: str,
+        user_id,
+        account_id,
+        redirect_uri: str,
+        redirect_uri_provided_explicitly: bool,
+        code_challenge: str,
+        scopes: list[str],
+        resource: Optional[str] = None,
+    ) -> str:
+        """Create and store an authorization code for a user who has consented.
+
+        This is called by the consent page handler after the user logs in
+        and approves the authorization request.
+
+        Returns the raw authorization code (to be included in the redirect).
+        """
+        db = _get_db()
+        try:
+            code = generate_authorization_code()
+            crud_oauth_mcp_auth_code.create(
+                db,
+                code=code,
+                client_id=client_id,
+                user_id=user_id,
+                account_id=account_id,
+                redirect_uri=redirect_uri,
+                redirect_uri_provided_explicitly=redirect_uri_provided_explicitly,
+                code_challenge=code_challenge,
+                scopes=scopes,
+                expires_at=time.time() + AUTH_CODE_EXPIRY,
+                resource=resource,
+            )
+            logger.info(
+                f"Created authorization code for user={user_id}, client={client_id}"
+            )
+            return code
+        finally:
+            db.close()

--- a/backend/preloop/templates/oauth_authorize.html
+++ b/backend/preloop/templates/oauth_authorize.html
@@ -149,7 +149,7 @@
 
         <div class="client-info">
             <div class="label">Application requesting access</div>
-            <div class="name" id="clientName">{{ client_name or 'MCP Client' }}</div>
+            <div class="name" id="clientName">{{ client_name }}</div>
             <div class="scope-note">This application will be able to access your Preloop account tools and data.</div>
         </div>
 
@@ -182,8 +182,8 @@
 
     <script>
         function handleDeny() {
-            const redirectUri = '{{ redirect_uri }}';
-            const state = '{{ state }}';
+            const redirectUri = {{ redirect_uri_json }};
+            const state = {{ state_json }};
             let denyUrl = redirectUri + '?error=access_denied&error_description=User+denied+the+request';
             if (state) {
                 denyUrl += '&state=' + encodeURIComponent(state);
@@ -192,7 +192,7 @@
         }
 
         // Show server-side error if present
-        const serverError = '{{ error }}';
+        const serverError = {{ error_json }};
         if (serverError) {
             const errEl = document.getElementById('errorMsg');
             errEl.textContent = serverError;

--- a/backend/preloop/templates/oauth_authorize.html
+++ b/backend/preloop/templates/oauth_authorize.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Preloop - Authorize Application</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%);
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            color: #e2e8f0;
+        }
+        .container {
+            background: #1e293b;
+            border: 1px solid #334155;
+            border-radius: 16px;
+            padding: 40px;
+            width: 100%;
+            max-width: 420px;
+            box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+        }
+        .logo {
+            text-align: center;
+            margin-bottom: 24px;
+        }
+        .logo h1 {
+            font-size: 28px;
+            font-weight: 700;
+            color: #f8fafc;
+            letter-spacing: -0.5px;
+        }
+        .logo .subtitle {
+            font-size: 14px;
+            color: #94a3b8;
+            margin-top: 4px;
+        }
+        .client-info {
+            background: #0f172a;
+            border: 1px solid #334155;
+            border-radius: 10px;
+            padding: 16px;
+            margin-bottom: 24px;
+            text-align: center;
+        }
+        .client-info .label {
+            font-size: 12px;
+            color: #64748b;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 4px;
+        }
+        .client-info .name {
+            font-size: 16px;
+            font-weight: 600;
+            color: #e2e8f0;
+        }
+        .client-info .scope-note {
+            font-size: 13px;
+            color: #94a3b8;
+            margin-top: 8px;
+        }
+        .form-group {
+            margin-bottom: 16px;
+        }
+        .form-group label {
+            display: block;
+            font-size: 14px;
+            font-weight: 500;
+            color: #cbd5e1;
+            margin-bottom: 6px;
+        }
+        .form-group input {
+            width: 100%;
+            padding: 10px 14px;
+            background: #0f172a;
+            border: 1px solid #334155;
+            border-radius: 8px;
+            color: #f8fafc;
+            font-size: 15px;
+            transition: border-color 0.2s;
+        }
+        .form-group input:focus {
+            outline: none;
+            border-color: #6366f1;
+            box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+        }
+        .btn {
+            width: 100%;
+            padding: 12px;
+            border: none;
+            border-radius: 8px;
+            font-size: 15px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        .btn-primary {
+            background: #6366f1;
+            color: white;
+            margin-bottom: 10px;
+        }
+        .btn-primary:hover { background: #4f46e5; }
+        .btn-secondary {
+            background: transparent;
+            color: #94a3b8;
+            border: 1px solid #334155;
+        }
+        .btn-secondary:hover { background: #334155; color: #e2e8f0; }
+        .error {
+            background: #450a0a;
+            border: 1px solid #7f1d1d;
+            color: #fca5a5;
+            padding: 10px 14px;
+            border-radius: 8px;
+            font-size: 14px;
+            margin-bottom: 16px;
+            display: none;
+        }
+        .divider {
+            text-align: center;
+            color: #475569;
+            font-size: 13px;
+            margin: 16px 0;
+            position: relative;
+        }
+        .divider::before, .divider::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            width: 40%;
+            height: 1px;
+            background: #334155;
+        }
+        .divider::before { left: 0; }
+        .divider::after { right: 0; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="logo">
+            <h1>Preloop</h1>
+            <p class="subtitle">Authorize Application</p>
+        </div>
+
+        <div class="client-info">
+            <div class="label">Application requesting access</div>
+            <div class="name" id="clientName">{{ client_name or 'MCP Client' }}</div>
+            <div class="scope-note">This application will be able to access your Preloop account tools and data.</div>
+        </div>
+
+        <div class="error" id="errorMsg"></div>
+
+        <form id="authForm" method="POST" action="/mcp/authorize/consent">
+            <!-- Hidden fields carrying OAuth params -->
+            <input type="hidden" name="client_id" value="{{ client_id }}">
+            <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
+            <input type="hidden" name="code_challenge" value="{{ code_challenge }}">
+            <input type="hidden" name="state" value="{{ state }}">
+            <input type="hidden" name="scopes" value="{{ scopes }}">
+            <input type="hidden" name="redirect_uri_provided_explicitly" value="{{ redirect_uri_provided_explicitly }}">
+            <input type="hidden" name="resource" value="{{ resource }}">
+
+            <div class="form-group">
+                <label for="username">Username or Email</label>
+                <input type="text" id="username" name="username" required autocomplete="username" autofocus>
+            </div>
+
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required autocomplete="current-password">
+            </div>
+
+            <button type="submit" class="btn btn-primary">Authorize</button>
+            <button type="button" class="btn btn-secondary" onclick="handleDeny()">Deny</button>
+        </form>
+    </div>
+
+    <script>
+        function handleDeny() {
+            const redirectUri = '{{ redirect_uri }}';
+            const state = '{{ state }}';
+            let denyUrl = redirectUri + '?error=access_denied&error_description=User+denied+the+request';
+            if (state) {
+                denyUrl += '&state=' + encodeURIComponent(state);
+            }
+            window.location.href = denyUrl;
+        }
+
+        // Show server-side error if present
+        const serverError = '{{ error }}';
+        if (serverError) {
+            const errEl = document.getElementById('errorMsg');
+            errEl.textContent = serverError;
+            errEl.style.display = 'block';
+        }
+    </script>
+</body>
+</html>

--- a/backend/tests/endpoints/test_oauth_consent.py
+++ b/backend/tests/endpoints/test_oauth_consent.py
@@ -1,0 +1,326 @@
+"""Tests for OAuth consent page endpoints (GET + POST /mcp/authorize/consent)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from preloop.api.endpoints.oauth_consent import router, _render_template
+
+
+# ---------------------------------------------------------------------------
+# App setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_provider_singleton():
+    """Reset the module-level singleton before each test."""
+    import preloop.api.endpoints.oauth_consent as mod
+
+    mod._oauth_provider_instance = None
+    yield
+    mod._oauth_provider_instance = None
+
+
+@pytest.fixture
+def app():
+    """Create a test FastAPI app with the consent router."""
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# _render_template
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTemplate:
+    """Tests for the simple template renderer."""
+
+    def test_replaces_variables(self, tmp_path):
+        template = tmp_path / "test.html"
+        template.write_text("<p>{{ name }} - {{ value }}</p>")
+
+        with patch("preloop.api.endpoints.oauth_consent._TEMPLATE_DIR", tmp_path):
+            result = _render_template("test.html", {"name": "hello", "value": "world"})
+
+        assert result == "<p>hello - world</p>"
+
+    def test_handles_none_values(self, tmp_path):
+        template = tmp_path / "test.html"
+        template.write_text("<p>{{ maybe }}</p>")
+
+        with patch("preloop.api.endpoints.oauth_consent._TEMPLATE_DIR", tmp_path):
+            result = _render_template("test.html", {"maybe": None})
+
+        assert result == "<p></p>"
+
+
+# ---------------------------------------------------------------------------
+# GET /mcp/authorize/consent
+# ---------------------------------------------------------------------------
+
+
+class TestConsentPageGet:
+    """Tests for the GET consent page endpoint."""
+
+    def test_renders_html(self, client):
+        with (
+            patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
+            patch(
+                "preloop.api.endpoints.oauth_consent._render_template",
+                return_value="<html>OK</html>",
+            ),
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+
+            # Patch the inner crud import
+            with patch(
+                "preloop.api.endpoints.oauth_consent.crud_oauth_mcp_client",
+                create=True,
+            ) as mock_crud:
+                mock_crud.get_by_client_id.return_value = None
+
+                response = client.get(
+                    "/mcp/authorize/consent",
+                    params={
+                        "client_id": "c1",
+                        "redirect_uri": "http://localhost/cb",
+                        "code_challenge": "ch123",
+                    },
+                )
+
+        assert response.status_code == 200
+        assert "OK" in response.text
+
+    def test_passes_params_to_template(self, client):
+        rendered_contexts = []
+
+        def capture_render(template_name, context):
+            rendered_contexts.append(context)
+            return "<html>test</html>"
+
+        with (
+            patch(
+                "preloop.api.endpoints.oauth_consent._render_template",
+                side_effect=capture_render,
+            ),
+            patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+
+            with patch(
+                "preloop.api.endpoints.oauth_consent.crud_oauth_mcp_client",
+                create=True,
+            ) as mock_crud:
+                mock_crud.get_by_client_id.return_value = None
+
+                client.get(
+                    "/mcp/authorize/consent",
+                    params={
+                        "client_id": "test_client",
+                        "redirect_uri": "http://example.com/cb",
+                        "code_challenge": "ch",
+                        "state": "state_abc",
+                        "scopes": "read write",
+                    },
+                )
+
+        assert len(rendered_contexts) == 1
+        ctx = rendered_contexts[0]
+        assert ctx["client_id"] == "test_client"
+        assert ctx["redirect_uri"] == "http://example.com/cb"
+        assert ctx["state"] == "state_abc"
+        assert ctx["scopes"] == "read write"
+        assert ctx["error"] == ""
+
+    def test_missing_required_params(self, client):
+        response = client.get("/mcp/authorize/consent")
+        assert response.status_code == 422  # Validation error
+
+
+# ---------------------------------------------------------------------------
+# POST /mcp/authorize/consent
+# ---------------------------------------------------------------------------
+
+
+class TestConsentPagePost:
+    """Tests for the POST consent submission endpoint."""
+
+    def test_successful_login_redirects(self, client):
+        user = MagicMock()
+        user.id = uuid4()
+        user.account_id = uuid4()
+        user.username = "testuser"
+        user.hashed_password = "hashed"
+        user.is_active = True
+
+        mock_provider = MagicMock()
+        mock_provider.create_authorization_code_for_user.return_value = "auth_code_xyz"
+
+        with (
+            patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
+            patch("preloop.models.crud.crud_user") as mock_crud_user,
+            patch("preloop.api.auth.jwt.verify_password", return_value=True),
+            patch(
+                "preloop.api.endpoints.oauth_consent._get_oauth_provider",
+                return_value=mock_provider,
+            ),
+            patch(
+                "preloop.api.endpoints.oauth_consent.construct_redirect_uri",
+                return_value="http://localhost/cb?code=auth_code_xyz",
+            ),
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+            mock_crud_user.get_by_username.return_value = user
+
+            response = client.post(
+                "/mcp/authorize/consent",
+                data={
+                    "client_id": "c1",
+                    "redirect_uri": "http://localhost/cb",
+                    "code_challenge": "ch",
+                    "username": "testuser",
+                    "password": "pass123",
+                },
+                follow_redirects=False,
+            )
+
+        assert response.status_code == 302
+        assert "code=auth_code_xyz" in response.headers["location"]
+
+    def test_invalid_credentials_renders_error(self, client):
+        with (
+            patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
+            patch("preloop.models.crud.crud_user") as mock_crud_user,
+            patch(
+                "preloop.api.endpoints.oauth_consent._render_template",
+                return_value="<html>error</html>",
+            ),
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+            mock_crud_user.get_by_username.return_value = None
+            mock_crud_user.get_by_email.return_value = None
+
+            response = client.post(
+                "/mcp/authorize/consent",
+                data={
+                    "client_id": "c1",
+                    "redirect_uri": "http://localhost/cb",
+                    "code_challenge": "ch",
+                    "username": "nobody",
+                    "password": "wrong",
+                },
+            )
+
+        assert response.status_code == 200
+        assert "error" in response.text
+
+    def test_wrong_password_renders_error(self, client):
+        user = MagicMock()
+        user.hashed_password = "hashed"
+
+        with (
+            patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
+            patch("preloop.models.crud.crud_user") as mock_crud_user,
+            patch("preloop.api.auth.jwt.verify_password", return_value=False),
+            patch(
+                "preloop.api.endpoints.oauth_consent._render_template",
+                return_value="<html>bad pass</html>",
+            ),
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+            mock_crud_user.get_by_username.return_value = user
+
+            response = client.post(
+                "/mcp/authorize/consent",
+                data={
+                    "client_id": "c1",
+                    "redirect_uri": "http://localhost/cb",
+                    "code_challenge": "ch",
+                    "username": "user",
+                    "password": "wrong",
+                },
+            )
+
+        assert response.status_code == 200
+
+    def test_inactive_user_renders_error(self, client):
+        user = MagicMock()
+        user.hashed_password = "hashed"
+        user.is_active = False
+
+        with (
+            patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
+            patch("preloop.models.crud.crud_user") as mock_crud_user,
+            patch("preloop.api.auth.jwt.verify_password", return_value=True),
+            patch(
+                "preloop.api.endpoints.oauth_consent._render_template",
+                return_value="<html>deactivated</html>",
+            ),
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+            mock_crud_user.get_by_username.return_value = user
+
+            response = client.post(
+                "/mcp/authorize/consent",
+                data={
+                    "client_id": "c1",
+                    "redirect_uri": "http://localhost/cb",
+                    "code_challenge": "ch",
+                    "username": "user",
+                    "password": "pass",
+                },
+            )
+
+        assert response.status_code == 200
+
+    def test_oauth_not_configured_renders_error(self, client):
+        user = MagicMock()
+        user.hashed_password = "hashed"
+        user.is_active = True
+
+        with (
+            patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
+            patch("preloop.models.crud.crud_user") as mock_crud_user,
+            patch("preloop.api.auth.jwt.verify_password", return_value=True),
+            patch(
+                "preloop.api.endpoints.oauth_consent._get_oauth_provider",
+                return_value=None,
+            ),
+            patch(
+                "preloop.api.endpoints.oauth_consent._render_template",
+                return_value="<html>not configured</html>",
+            ),
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+            mock_crud_user.get_by_username.return_value = user
+
+            response = client.post(
+                "/mcp/authorize/consent",
+                data={
+                    "client_id": "c1",
+                    "redirect_uri": "http://localhost/cb",
+                    "code_challenge": "ch",
+                    "username": "user",
+                    "password": "pass",
+                },
+            )
+
+        assert response.status_code == 200

--- a/backend/tests/endpoints/test_oauth_consent.py
+++ b/backend/tests/endpoints/test_oauth_consent.py
@@ -75,30 +75,23 @@ class TestConsentPageGet:
 
     def test_renders_html(self, client):
         with (
-            patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
+            patch(
+                "preloop.api.endpoints.oauth_consent._validate_client_and_redirect",
+                return_value={"error": None, "client_name": "Test Client"},
+            ),
             patch(
                 "preloop.api.endpoints.oauth_consent._render_template",
                 return_value="<html>OK</html>",
             ),
         ):
-            mock_db = MagicMock()
-            mock_gen.return_value = iter([mock_db])
-
-            # Patch the inner crud import
-            with patch(
-                "preloop.api.endpoints.oauth_consent.crud_oauth_mcp_client",
-                create=True,
-            ) as mock_crud:
-                mock_crud.get_by_client_id.return_value = None
-
-                response = client.get(
-                    "/mcp/authorize/consent",
-                    params={
-                        "client_id": "c1",
-                        "redirect_uri": "http://localhost/cb",
-                        "code_challenge": "ch123",
-                    },
-                )
+            response = client.get(
+                "/mcp/authorize/consent",
+                params={
+                    "client_id": "c1",
+                    "redirect_uri": "http://localhost/cb",
+                    "code_challenge": "ch123",
+                },
+            )
 
         assert response.status_code == 200
         assert "OK" in response.text
@@ -112,30 +105,24 @@ class TestConsentPageGet:
 
         with (
             patch(
+                "preloop.api.endpoints.oauth_consent._validate_client_and_redirect",
+                return_value={"error": None, "client_name": "Test Client"},
+            ),
+            patch(
                 "preloop.api.endpoints.oauth_consent._render_template",
                 side_effect=capture_render,
             ),
-            patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
         ):
-            mock_db = MagicMock()
-            mock_gen.return_value = iter([mock_db])
-
-            with patch(
-                "preloop.api.endpoints.oauth_consent.crud_oauth_mcp_client",
-                create=True,
-            ) as mock_crud:
-                mock_crud.get_by_client_id.return_value = None
-
-                client.get(
-                    "/mcp/authorize/consent",
-                    params={
-                        "client_id": "test_client",
-                        "redirect_uri": "http://example.com/cb",
-                        "code_challenge": "ch",
-                        "state": "state_abc",
-                        "scopes": "read write",
-                    },
-                )
+            client.get(
+                "/mcp/authorize/consent",
+                params={
+                    "client_id": "test_client",
+                    "redirect_uri": "http://example.com/cb",
+                    "code_challenge": "ch",
+                    "state": "state_abc",
+                    "scopes": "read write",
+                },
+            )
 
         assert len(rendered_contexts) == 1
         ctx = rendered_contexts[0]
@@ -170,6 +157,10 @@ class TestConsentPagePost:
         mock_provider.create_authorization_code_for_user.return_value = "auth_code_xyz"
 
         with (
+            patch(
+                "preloop.api.endpoints.oauth_consent._validate_client_and_redirect",
+                return_value={"error": None, "client_name": "Test Client"},
+            ),
             patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
             patch("preloop.models.crud.crud_user") as mock_crud_user,
             patch("preloop.api.auth.jwt.verify_password", return_value=True),
@@ -203,6 +194,10 @@ class TestConsentPagePost:
 
     def test_invalid_credentials_renders_error(self, client):
         with (
+            patch(
+                "preloop.api.endpoints.oauth_consent._validate_client_and_redirect",
+                return_value={"error": None, "client_name": "Test Client"},
+            ),
             patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
             patch("preloop.models.crud.crud_user") as mock_crud_user,
             patch(
@@ -234,6 +229,10 @@ class TestConsentPagePost:
         user.hashed_password = "hashed"
 
         with (
+            patch(
+                "preloop.api.endpoints.oauth_consent._validate_client_and_redirect",
+                return_value={"error": None, "client_name": "Test Client"},
+            ),
             patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
             patch("preloop.models.crud.crud_user") as mock_crud_user,
             patch("preloop.api.auth.jwt.verify_password", return_value=False),
@@ -265,6 +264,10 @@ class TestConsentPagePost:
         user.is_active = False
 
         with (
+            patch(
+                "preloop.api.endpoints.oauth_consent._validate_client_and_redirect",
+                return_value={"error": None, "client_name": "Test Client"},
+            ),
             patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
             patch("preloop.models.crud.crud_user") as mock_crud_user,
             patch("preloop.api.auth.jwt.verify_password", return_value=True),
@@ -296,6 +299,10 @@ class TestConsentPagePost:
         user.is_active = True
 
         with (
+            patch(
+                "preloop.api.endpoints.oauth_consent._validate_client_and_redirect",
+                return_value={"error": None, "client_name": "Test Client"},
+            ),
             patch("preloop.api.endpoints.oauth_consent.get_db_session") as mock_gen,
             patch("preloop.models.crud.crud_user") as mock_crud_user,
             patch("preloop.api.auth.jwt.verify_password", return_value=True),

--- a/backend/tests/endpoints/test_oauth_consent.py
+++ b/backend/tests/endpoints/test_oauth_consent.py
@@ -55,6 +55,44 @@ class TestRenderTemplate:
 
         assert result == "<p>hello - world</p>"
 
+    def test_json_keys_are_json_encoded(self, tmp_path):
+        """Values under keys ending in _json should be JSON-encoded, not HTML-escaped."""
+        template = tmp_path / "test.html"
+        template.write_text("<script>const v = {{ val_json }};</script>")
+
+        with patch("preloop.api.endpoints.oauth_consent._TEMPLATE_DIR", tmp_path):
+            result = _render_template("test.html", {"val_json": 'he said "hi"'})
+
+        # json.dumps produces '"he said \\"hi\\""' — a valid JS string literal
+        assert '"he said \\"hi\\""' in result
+
+    def test_json_keys_escape_script_tags(self, tmp_path):
+        """JSON-encoded values must escape < and > to prevent </script> breakout."""
+        template = tmp_path / "test.html"
+        template.write_text("<script>const v = {{ xss_json }};</script>")
+
+        with patch("preloop.api.endpoints.oauth_consent._TEMPLATE_DIR", tmp_path):
+            result = _render_template(
+                "test.html", {"xss_json": "</script><img src=x onerror=alert(1)>"}
+            )
+
+        assert "</script>" not in result.split("<script>")[1].split("</script>")[0]
+        assert "\\u003c" in result
+        assert "\\u003e" in result
+
+    def test_html_escapes_regular_values(self, tmp_path):
+        """Non-_json values must be HTML-escaped."""
+        template = tmp_path / "test.html"
+        template.write_text("<p>{{ name }}</p>")
+
+        with patch("preloop.api.endpoints.oauth_consent._TEMPLATE_DIR", tmp_path):
+            result = _render_template(
+                "test.html", {"name": "<script>alert(1)</script>"}
+            )
+
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
+
     def test_handles_none_values(self, tmp_path):
         template = tmp_path / "test.html"
         template.write_text("<p>{{ maybe }}</p>")
@@ -95,6 +133,40 @@ class TestConsentPageGet:
 
         assert response.status_code == 200
         assert "OK" in response.text
+
+    def test_context_includes_json_variants(self, client):
+        """Context passed to _render_template should include _json keys for script safety."""
+        rendered_contexts = []
+
+        def capture_render(template_name, context):
+            rendered_contexts.append(context)
+            return "<html>test</html>"
+
+        with (
+            patch(
+                "preloop.api.endpoints.oauth_consent._validate_client_and_redirect",
+                return_value={"error": None, "client_name": "Test Client"},
+            ),
+            patch(
+                "preloop.api.endpoints.oauth_consent._render_template",
+                side_effect=capture_render,
+            ),
+        ):
+            client.get(
+                "/mcp/authorize/consent",
+                params={
+                    "client_id": "c1",
+                    "redirect_uri": "http://localhost/cb",
+                    "state": "s1",
+                },
+            )
+
+        ctx = rendered_contexts[0]
+        assert "redirect_uri_json" in ctx
+        assert "state_json" in ctx
+        assert "error_json" in ctx
+        assert ctx["redirect_uri_json"] == "http://localhost/cb"
+        assert ctx["state_json"] == "s1"
 
     def test_passes_params_to_template(self, client):
         rendered_contexts = []

--- a/backend/tests/endpoints/test_oauth_server.py
+++ b/backend/tests/endpoints/test_oauth_server.py
@@ -1,0 +1,221 @@
+"""Tests for OAuth server endpoints (/oauth/token, /oauth/revoke)."""
+
+import time
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from preloop.api.endpoints.oauth_server import router
+
+
+# ---------------------------------------------------------------------------
+# App setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# POST /oauth/token — redirect_uri enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestTokenExchangeRedirectUri:
+    """Tests for redirect_uri enforcement during authorization code exchange."""
+
+    def _make_db_code(self, redirect_uri="http://localhost/cb", code_challenge=""):
+        code = MagicMock()
+        code.is_used = False
+        code.expires_at = time.time() + 600
+        code.redirect_uri = redirect_uri
+        code.code_challenge = code_challenge
+        code.client_id = "test_client"
+        code.user_id = uuid4()
+        code.account_id = uuid4()
+        code.scopes = []
+        code.resource = None
+        return code
+
+    def test_rejects_missing_redirect_uri_when_stored(self, client):
+        """If auth code has a redirect_uri, token request MUST include it."""
+        db_code = self._make_db_code(redirect_uri="http://localhost/cb")
+
+        with (
+            patch("preloop.models.db.session.get_db_session") as mock_gen,
+            patch(
+                "preloop.models.crud.oauth_mcp_token.crud_oauth_mcp_auth_code"
+            ) as mock_crud,
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+            mock_crud.get_by_code.return_value = db_code
+
+            response = client.post(
+                "/oauth/token",
+                data={
+                    "grant_type": "authorization_code",
+                    "code": "test_code",
+                    "client_id": "test_client",
+                    "redirect_uri": "",  # empty — should be rejected
+                },
+            )
+
+        assert response.status_code == 400
+        assert "redirect_uri is required" in response.json()["detail"]
+
+    def test_rejects_mismatched_redirect_uri(self, client):
+        """redirect_uri must exactly match the one stored in the auth code."""
+        db_code = self._make_db_code(redirect_uri="http://localhost/cb")
+
+        with (
+            patch("preloop.models.db.session.get_db_session") as mock_gen,
+            patch(
+                "preloop.models.crud.oauth_mcp_token.crud_oauth_mcp_auth_code"
+            ) as mock_crud,
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+            mock_crud.get_by_code.return_value = db_code
+
+            response = client.post(
+                "/oauth/token",
+                data={
+                    "grant_type": "authorization_code",
+                    "code": "test_code",
+                    "client_id": "test_client",
+                    "redirect_uri": "http://evil.com/steal",
+                },
+            )
+
+        assert response.status_code == 400
+        assert "does not match" in response.json()["detail"]
+
+    def test_allows_matching_redirect_uri(self, client):
+        """Matching redirect_uri should pass validation and proceed to token issuance."""
+        db_code = self._make_db_code(
+            redirect_uri="http://localhost/cb", code_challenge=""
+        )
+
+        with (
+            patch("preloop.models.db.session.get_db_session") as mock_gen,
+            patch(
+                "preloop.models.crud.oauth_mcp_token.crud_oauth_mcp_auth_code"
+            ) as mock_crud,
+            patch(
+                "preloop.api.endpoints.oauth_server._issue_jwt_tokens",
+                new_callable=AsyncMock,
+                return_value={"access_token": "t", "token_type": "bearer"},
+            ),
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+            mock_crud.get_by_code.return_value = db_code
+
+            response = client.post(
+                "/oauth/token",
+                data={
+                    "grant_type": "authorization_code",
+                    "code": "test_code",
+                    "client_id": "test_client",
+                    "redirect_uri": "http://localhost/cb",
+                },
+            )
+
+        # Should not be a 400 — it passed redirect_uri validation
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /oauth/revoke — refresh token revocation
+# ---------------------------------------------------------------------------
+
+
+class TestTokenRevocation:
+    """Tests for token revocation endpoint."""
+
+    def test_revokes_access_token(self, client):
+        """Access tokens should be revoked via the provider."""
+        mock_provider = MagicMock()
+        mock_token = MagicMock()
+        mock_provider.load_access_token = AsyncMock(return_value=mock_token)
+        mock_provider.revoke_token = AsyncMock()
+
+        with patch(
+            "preloop.api.endpoints.oauth_consent.get_oauth_provider",
+            return_value=mock_provider,
+        ):
+            response = client.post("/oauth/revoke", data={"token": "access_tok"})
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "revoked"
+        mock_provider.revoke_token.assert_called_once_with(mock_token)
+
+    def test_revokes_refresh_token(self, client):
+        """Refresh tokens should be revoked when access token lookup fails."""
+        mock_provider = MagicMock()
+        mock_provider.load_access_token = AsyncMock(return_value=None)
+
+        mock_db_refresh = MagicMock()
+        mock_db_refresh.is_revoked = False
+        mock_crud = MagicMock()
+        mock_crud.get_by_token.return_value = mock_db_refresh
+
+        with (
+            patch(
+                "preloop.api.endpoints.oauth_consent.get_oauth_provider",
+                return_value=mock_provider,
+            ),
+            patch(
+                "preloop.models.crud.oauth_mcp_token.crud_oauth_mcp_refresh_token",
+                mock_crud,
+            ),
+            patch("preloop.models.db.session.get_db_session") as mock_gen,
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+
+            response = client.post("/oauth/revoke", data={"token": "refresh_tok"})
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "revoked"
+        mock_crud.revoke.assert_called_once_with(mock_db, obj=mock_db_refresh)
+
+    def test_unknown_token_returns_success(self, client):
+        """Per RFC 7009, revocation of an unknown token should still return success."""
+        mock_provider = MagicMock()
+        mock_provider.load_access_token = AsyncMock(return_value=None)
+
+        mock_crud = MagicMock()
+        mock_crud.get_by_token.return_value = None
+
+        with (
+            patch(
+                "preloop.api.endpoints.oauth_consent.get_oauth_provider",
+                return_value=mock_provider,
+            ),
+            patch(
+                "preloop.models.crud.oauth_mcp_token.crud_oauth_mcp_refresh_token",
+                mock_crud,
+            ),
+            patch("preloop.models.db.session.get_db_session") as mock_gen,
+        ):
+            mock_db = MagicMock()
+            mock_gen.return_value = iter([mock_db])
+
+            response = client.post("/oauth/revoke", data={"token": "unknown_tok"})
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "revoked"

--- a/backend/tests/models/crud/test_oauth_mcp_client_crud.py
+++ b/backend/tests/models/crud/test_oauth_mcp_client_crud.py
@@ -1,0 +1,211 @@
+"""Tests for OAuth MCP client CRUD operations (Dynamic Client Registration)."""
+
+import hashlib
+
+import pytest
+from unittest.mock import MagicMock
+
+from sqlalchemy.orm import Session
+
+from preloop.models.crud.oauth_mcp_client import (
+    CRUDOAuthMCPClient,
+    crud_oauth_mcp_client,
+)
+from preloop.models.models.oauth_mcp_client import OAuthMCPClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    """Fixture for a mock database session."""
+    session = MagicMock(spec=Session)
+    return session
+
+
+@pytest.fixture
+def crud_client():
+    return CRUDOAuthMCPClient(OAuthMCPClient)
+
+
+# ---------------------------------------------------------------------------
+# Static helpers
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateClientId:
+    """Tests for generate_client_id."""
+
+    def test_prefix(self):
+        cid = CRUDOAuthMCPClient.generate_client_id()
+        assert cid.startswith("preloop_")
+
+    def test_unique(self):
+        ids = {CRUDOAuthMCPClient.generate_client_id() for _ in range(20)}
+        assert len(ids) == 20
+
+    def test_sufficient_length(self):
+        # 24 bytes → 32 chars base64url + "preloop_" prefix
+        cid = CRUDOAuthMCPClient.generate_client_id()
+        assert len(cid) > 30
+
+
+class TestGenerateClientSecret:
+    """Tests for generate_client_secret."""
+
+    def test_returns_string(self):
+        secret = CRUDOAuthMCPClient.generate_client_secret()
+        assert isinstance(secret, str)
+
+    def test_unique(self):
+        secrets = {CRUDOAuthMCPClient.generate_client_secret() for _ in range(20)}
+        assert len(secrets) == 20
+
+    def test_sufficient_length(self):
+        # 48 bytes → 64 chars base64url
+        secret = CRUDOAuthMCPClient.generate_client_secret()
+        assert len(secret) >= 60
+
+
+class TestHashSecret:
+    """Tests for hash_secret."""
+
+    def test_returns_sha256_hex(self):
+        secret = "test-secret"
+        expected = hashlib.sha256(secret.encode()).hexdigest()
+        assert CRUDOAuthMCPClient.hash_secret(secret) == expected
+
+    def test_deterministic(self):
+        assert CRUDOAuthMCPClient.hash_secret("x") == CRUDOAuthMCPClient.hash_secret(
+            "x"
+        )
+
+    def test_different_inputs(self):
+        assert CRUDOAuthMCPClient.hash_secret("a") != CRUDOAuthMCPClient.hash_secret(
+            "b"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CRUD methods
+# ---------------------------------------------------------------------------
+
+
+class TestGetByClientId:
+    """Tests for get_by_client_id."""
+
+    def test_found(self, crud_client, mock_db):
+        mock_obj = MagicMock(spec=OAuthMCPClient)
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = mock_obj
+
+        result = crud_client.get_by_client_id(mock_db, client_id="preloop_abc")
+        assert result is mock_obj
+
+    def test_not_found(self, crud_client, mock_db):
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = None
+
+        result = crud_client.get_by_client_id(mock_db, client_id="missing")
+        assert result is None
+
+
+class TestVerifyClientSecret:
+    """Tests for verify_client_secret."""
+
+    def test_correct_secret(self, crud_client):
+        secret = "my-secret"
+        db_client = MagicMock(spec=OAuthMCPClient)
+        db_client.client_secret_hash = CRUDOAuthMCPClient.hash_secret(secret)
+
+        assert crud_client.verify_client_secret(db_client, secret) is True
+
+    def test_wrong_secret(self, crud_client):
+        db_client = MagicMock(spec=OAuthMCPClient)
+        db_client.client_secret_hash = CRUDOAuthMCPClient.hash_secret("correct")
+
+        assert crud_client.verify_client_secret(db_client, "wrong") is False
+
+    def test_no_secret_hash(self, crud_client):
+        db_client = MagicMock(spec=OAuthMCPClient)
+        db_client.client_secret_hash = None
+
+        assert crud_client.verify_client_secret(db_client, "any") is False
+
+
+class TestDeleteByClientId:
+    """Tests for delete_by_client_id."""
+
+    def test_delete_existing(self, crud_client, mock_db):
+        mock_obj = MagicMock(spec=OAuthMCPClient)
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = mock_obj
+
+        result = crud_client.delete_by_client_id(mock_db, client_id="preloop_abc")
+        assert result is mock_obj
+        mock_db.delete.assert_called_once_with(mock_obj)
+        mock_db.commit.assert_called_once()
+
+    def test_delete_nonexistent(self, crud_client, mock_db):
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = None
+
+        result = crud_client.delete_by_client_id(mock_db, client_id="missing")
+        assert result is None
+        mock_db.delete.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+
+class TestCleanupExpired:
+    """Tests for cleanup_expired."""
+
+    def test_cleanup_deletes_expired(self, crud_client, mock_db):
+        expired1 = MagicMock()
+        expired2 = MagicMock()
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = [expired1, expired2]
+
+        count = crud_client.cleanup_expired(mock_db)
+        assert count == 2
+        assert mock_db.delete.call_count == 2
+        mock_db.commit.assert_called_once()
+
+    def test_cleanup_none_expired(self, crud_client, mock_db):
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = []
+
+        count = crud_client.cleanup_expired(mock_db)
+        assert count == 0
+        mock_db.delete.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+
+class TestSingleton:
+    """Test module-level singleton."""
+
+    def test_exists(self):
+        assert crud_oauth_mcp_client is not None
+        assert isinstance(crud_oauth_mcp_client, CRUDOAuthMCPClient)
+
+    def test_model(self):
+        assert crud_oauth_mcp_client.model == OAuthMCPClient

--- a/backend/tests/models/crud/test_oauth_mcp_token_crud.py
+++ b/backend/tests/models/crud/test_oauth_mcp_token_crud.py
@@ -1,0 +1,452 @@
+"""Tests for OAuth MCP token CRUD operations (auth codes, access tokens, refresh tokens)."""
+
+import hashlib
+import time
+
+import pytest
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from preloop.models.crud.oauth_mcp_token import (
+    CRUDOAuthMCPAuthorizationCode,
+    CRUDOAuthMCPAccessToken,
+    CRUDOAuthMCPRefreshToken,
+    _hash_token,
+    generate_token,
+    generate_authorization_code,
+    crud_oauth_mcp_auth_code,
+    crud_oauth_mcp_access_token,
+    crud_oauth_mcp_refresh_token,
+)
+from preloop.models.models.oauth_mcp_token import (
+    OAuthMCPAuthorizationCode,
+    OAuthMCPAccessToken,
+    OAuthMCPRefreshToken,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    """Fixture for a mock database session."""
+    session = MagicMock(spec=Session)
+    return session
+
+
+@pytest.fixture
+def crud_auth_code():
+    return CRUDOAuthMCPAuthorizationCode()
+
+
+@pytest.fixture
+def crud_access():
+    return CRUDOAuthMCPAccessToken()
+
+
+@pytest.fixture
+def crud_refresh():
+    return CRUDOAuthMCPRefreshToken()
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestHashToken:
+    """Tests for the _hash_token helper."""
+
+    def test_returns_sha256_hex(self):
+        token = "test-token-abc"
+        expected = hashlib.sha256(token.encode()).hexdigest()
+        assert _hash_token(token) == expected
+
+    def test_deterministic(self):
+        assert _hash_token("same") == _hash_token("same")
+
+    def test_different_tokens_different_hashes(self):
+        assert _hash_token("token-a") != _hash_token("token-b")
+
+
+class TestGenerateToken:
+    """Tests for the generate_token helper."""
+
+    def test_returns_string(self):
+        assert isinstance(generate_token(), str)
+
+    def test_unique(self):
+        tokens = {generate_token() for _ in range(20)}
+        assert len(tokens) == 20
+
+    def test_custom_length(self):
+        short = generate_token(8)
+        long = generate_token(64)
+        assert len(short) < len(long)
+
+
+class TestGenerateAuthorizationCode:
+    """Tests for the generate_authorization_code helper."""
+
+    def test_returns_string(self):
+        assert isinstance(generate_authorization_code(), str)
+
+    def test_sufficient_entropy(self):
+        # 24 bytes → 192 bits, base64url ≈ 32 chars
+        code = generate_authorization_code()
+        assert len(code) >= 30
+
+    def test_unique(self):
+        codes = {generate_authorization_code() for _ in range(20)}
+        assert len(codes) == 20
+
+
+# ---------------------------------------------------------------------------
+# Authorization Code CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestCRUDAuthorizationCode:
+    """Tests for CRUDOAuthMCPAuthorizationCode."""
+
+    def test_create_stores_hashed_code(self, crud_auth_code, mock_db):
+        user_id = uuid4()
+        account_id = uuid4()
+        code = "raw-code-abc"
+
+        crud_auth_code.create(
+            mock_db,
+            code=code,
+            client_id="client_1",
+            user_id=user_id,
+            account_id=account_id,
+            redirect_uri="http://localhost/callback",
+            redirect_uri_provided_explicitly=True,
+            code_challenge="challenge123",
+            scopes=["read"],
+            expires_at=time.time() + 300,
+        )
+
+        mock_db.add.assert_called_once()
+        obj = mock_db.add.call_args[0][0]
+        assert isinstance(obj, OAuthMCPAuthorizationCode)
+        assert obj.code_hash == _hash_token(code)
+        assert obj.client_id == "client_1"
+        assert obj.user_id == user_id
+        assert obj.is_used is False
+        mock_db.commit.assert_called_once()
+        mock_db.refresh.assert_called_once_with(obj)
+
+    def test_create_with_resource(self, crud_auth_code, mock_db):
+        crud_auth_code.create(
+            mock_db,
+            code="code",
+            client_id="c",
+            user_id=uuid4(),
+            account_id=uuid4(),
+            redirect_uri="http://x",
+            redirect_uri_provided_explicitly=False,
+            code_challenge="ch",
+            scopes=[],
+            expires_at=time.time() + 300,
+            resource="urn:example:resource",
+        )
+        obj = mock_db.add.call_args[0][0]
+        assert obj.resource == "urn:example:resource"
+        assert obj.redirect_uri_provided_explicitly is False
+
+    def test_get_by_code_found(self, crud_auth_code, mock_db):
+        mock_obj = MagicMock(spec=OAuthMCPAuthorizationCode)
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = mock_obj
+
+        result = crud_auth_code.get_by_code(mock_db, code="abc", client_id="c1")
+        assert result is mock_obj
+
+    def test_get_by_code_not_found(self, crud_auth_code, mock_db):
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = None
+
+        result = crud_auth_code.get_by_code(mock_db, code="missing", client_id="c1")
+        assert result is None
+
+    def test_mark_used(self, crud_auth_code, mock_db):
+        obj = MagicMock(spec=OAuthMCPAuthorizationCode)
+        obj.is_used = False
+        crud_auth_code.mark_used(mock_db, obj=obj)
+        assert obj.is_used is True
+        mock_db.add.assert_called_once_with(obj)
+        mock_db.commit.assert_called_once()
+
+    def test_delete_expired(self, crud_auth_code, mock_db):
+        expired1 = MagicMock()
+        expired2 = MagicMock()
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = [expired1, expired2]
+
+        count = crud_auth_code.delete_expired(mock_db)
+        assert count == 2
+        assert mock_db.delete.call_count == 2
+        mock_db.commit.assert_called_once()
+
+    def test_delete_expired_none(self, crud_auth_code, mock_db):
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = []
+
+        count = crud_auth_code.delete_expired(mock_db)
+        assert count == 0
+        mock_db.delete.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Access Token CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestCRUDAccessToken:
+    """Tests for CRUDOAuthMCPAccessToken."""
+
+    def test_create_stores_hashed_token(self, crud_access, mock_db):
+        user_id = uuid4()
+        account_id = uuid4()
+        token = "raw-access-token"
+
+        crud_access.create(
+            mock_db,
+            token=token,
+            client_id="client_1",
+            user_id=user_id,
+            account_id=account_id,
+            scopes=["read", "write"],
+            expires_at=int(time.time()) + 3600,
+        )
+
+        obj = mock_db.add.call_args[0][0]
+        assert isinstance(obj, OAuthMCPAccessToken)
+        assert obj.token_hash == _hash_token(token)
+        assert obj.scopes == ["read", "write"]
+        assert obj.is_revoked is False
+        mock_db.commit.assert_called_once()
+
+    def test_create_with_resource(self, crud_access, mock_db):
+        crud_access.create(
+            mock_db,
+            token="t",
+            client_id="c",
+            user_id=uuid4(),
+            account_id=uuid4(),
+            scopes=[],
+            resource="urn:example",
+        )
+        obj = mock_db.add.call_args[0][0]
+        assert obj.resource == "urn:example"
+
+    def test_get_by_token_found(self, crud_access, mock_db):
+        mock_obj = MagicMock(spec=OAuthMCPAccessToken)
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = mock_obj
+
+        result = crud_access.get_by_token(mock_db, token="abc")
+        assert result is mock_obj
+
+    def test_get_by_token_not_found(self, crud_access, mock_db):
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = None
+
+        result = crud_access.get_by_token(mock_db, token="missing")
+        assert result is None
+
+    def test_revoke(self, crud_access, mock_db):
+        obj = MagicMock(spec=OAuthMCPAccessToken)
+        obj.is_revoked = False
+        crud_access.revoke(mock_db, obj=obj)
+        assert obj.is_revoked is True
+        mock_db.add.assert_called_once_with(obj)
+        mock_db.commit.assert_called_once()
+
+    def test_revoke_by_user_and_client(self, crud_access, mock_db):
+        user_id = uuid4()
+        t1 = MagicMock(is_revoked=False)
+        t2 = MagicMock(is_revoked=False)
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = [t1, t2]
+
+        count = crud_access.revoke_by_user_and_client(
+            mock_db, user_id=user_id, client_id="c1"
+        )
+        assert count == 2
+        assert t1.is_revoked is True
+        assert t2.is_revoked is True
+        mock_db.commit.assert_called_once()
+
+    def test_revoke_by_user_and_client_no_tokens(self, crud_access, mock_db):
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = []
+
+        count = crud_access.revoke_by_user_and_client(
+            mock_db, user_id=uuid4(), client_id="c1"
+        )
+        assert count == 0
+        mock_db.commit.assert_not_called()
+
+    def test_delete_expired_and_revoked(self, crud_access, mock_db):
+        stale1 = MagicMock()
+        stale2 = MagicMock()
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = [stale1, stale2]
+
+        count = crud_access.delete_expired_and_revoked(mock_db)
+        assert count == 2
+        assert mock_db.delete.call_count == 2
+        mock_db.commit.assert_called_once()
+
+    def test_delete_expired_and_revoked_none(self, crud_access, mock_db):
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = []
+
+        count = crud_access.delete_expired_and_revoked(mock_db)
+        assert count == 0
+        mock_db.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Refresh Token CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestCRUDRefreshToken:
+    """Tests for CRUDOAuthMCPRefreshToken."""
+
+    def test_create_stores_hashed_token(self, crud_refresh, mock_db):
+        user_id = uuid4()
+        account_id = uuid4()
+        token = "raw-refresh-token"
+
+        crud_refresh.create(
+            mock_db,
+            token=token,
+            client_id="client_1",
+            user_id=user_id,
+            account_id=account_id,
+            scopes=["read"],
+            expires_at=int(time.time()) + 2592000,
+        )
+
+        obj = mock_db.add.call_args[0][0]
+        assert isinstance(obj, OAuthMCPRefreshToken)
+        assert obj.token_hash == _hash_token(token)
+        assert obj.is_revoked is False
+        mock_db.commit.assert_called_once()
+
+    def test_get_by_token_found(self, crud_refresh, mock_db):
+        mock_obj = MagicMock(spec=OAuthMCPRefreshToken)
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = mock_obj
+
+        result = crud_refresh.get_by_token(mock_db, token="abc")
+        assert result is mock_obj
+
+    def test_get_by_token_not_found(self, crud_refresh, mock_db):
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = None
+
+        result = crud_refresh.get_by_token(mock_db, token="missing")
+        assert result is None
+
+    def test_revoke(self, crud_refresh, mock_db):
+        obj = MagicMock(spec=OAuthMCPRefreshToken)
+        obj.is_revoked = False
+        crud_refresh.revoke(mock_db, obj=obj)
+        assert obj.is_revoked is True
+        mock_db.add.assert_called_once_with(obj)
+        mock_db.commit.assert_called_once()
+
+    def test_revoke_by_user_and_client(self, crud_refresh, mock_db):
+        user_id = uuid4()
+        t1 = MagicMock(is_revoked=False)
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = [t1]
+
+        count = crud_refresh.revoke_by_user_and_client(
+            mock_db, user_id=user_id, client_id="c1"
+        )
+        assert count == 1
+        assert t1.is_revoked is True
+        mock_db.commit.assert_called_once()
+
+    def test_revoke_by_user_and_client_no_tokens(self, crud_refresh, mock_db):
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = []
+
+        count = crud_refresh.revoke_by_user_and_client(
+            mock_db, user_id=uuid4(), client_id="c1"
+        )
+        assert count == 0
+        mock_db.commit.assert_not_called()
+
+    def test_delete_expired_and_revoked(self, crud_refresh, mock_db):
+        stale1 = MagicMock()
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.all.return_value = [stale1]
+
+        count = crud_refresh.delete_expired_and_revoked(mock_db)
+        assert count == 1
+        mock_db.delete.assert_called_once_with(stale1)
+        mock_db.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Singleton instances
+# ---------------------------------------------------------------------------
+
+
+class TestSingletons:
+    """Test module-level singleton CRUD instances."""
+
+    def test_auth_code_singleton(self):
+        assert crud_oauth_mcp_auth_code is not None
+        assert isinstance(crud_oauth_mcp_auth_code, CRUDOAuthMCPAuthorizationCode)
+
+    def test_access_token_singleton(self):
+        assert crud_oauth_mcp_access_token is not None
+        assert isinstance(crud_oauth_mcp_access_token, CRUDOAuthMCPAccessToken)
+
+    def test_refresh_token_singleton(self):
+        assert crud_oauth_mcp_refresh_token is not None
+        assert isinstance(crud_oauth_mcp_refresh_token, CRUDOAuthMCPRefreshToken)

--- a/backend/tests/services/test_approval_helper.py
+++ b/backend/tests/services/test_approval_helper.py
@@ -168,16 +168,14 @@ class TestRequireApprovalPolicyErrors:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=None)
 
         mock_db.execute = AsyncMock(
-            side_effect=[mock_config_result, mock_condition_result, mock_policy_result]
+            side_effect=[mock_config_result, mock_rules_result, mock_policy_result]
         )
 
         with patch(
@@ -213,10 +211,8 @@ class TestRequireApprovalSuccess:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -233,7 +229,7 @@ class TestRequireApprovalSuccess:
         # Set up execute to return different results
         execute_calls = [
             mock_config_result,  # First: get tool config
-            mock_condition_result,  # Second: get approval condition
+            mock_rules_result,  # Second: get approval condition
             mock_policy_result,  # Third: get approval policy
             mock_approval_result,  # Fourth: check approval status
         ]
@@ -284,10 +280,8 @@ class TestRequireApprovalSuccess:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -299,7 +293,7 @@ class TestRequireApprovalSuccess:
 
         execute_calls = [
             mock_config_result,
-            mock_condition_result,
+            mock_rules_result,
             mock_policy_result,
             mock_approval_result,
         ]
@@ -347,10 +341,8 @@ class TestRequireApprovalSuccess:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -362,7 +354,7 @@ class TestRequireApprovalSuccess:
 
         execute_calls = [
             mock_config_result,
-            mock_condition_result,
+            mock_rules_result,
             mock_policy_result,
             mock_approval_result,
         ]
@@ -413,10 +405,8 @@ class TestRequireApprovalDeclined:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -428,7 +418,7 @@ class TestRequireApprovalDeclined:
 
         execute_calls = [
             mock_config_result,
-            mock_condition_result,
+            mock_rules_result,
             mock_policy_result,
             mock_approval_result,
         ]
@@ -476,10 +466,8 @@ class TestRequireApprovalDeclined:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -491,7 +479,7 @@ class TestRequireApprovalDeclined:
 
         execute_calls = [
             mock_config_result,
-            mock_condition_result,
+            mock_rules_result,
             mock_policy_result,
             mock_approval_result,
         ]
@@ -541,10 +529,8 @@ class TestRequireApprovalCancelled:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -556,7 +542,7 @@ class TestRequireApprovalCancelled:
 
         execute_calls = [
             mock_config_result,
-            mock_condition_result,
+            mock_rules_result,
             mock_policy_result,
             mock_approval_result,
         ]
@@ -610,10 +596,8 @@ class TestRequireApprovalTimeout:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -627,7 +611,7 @@ class TestRequireApprovalTimeout:
         # Need multiple approval results for polling loop
         execute_calls = [
             mock_config_result,  # First: get tool config
-            mock_condition_result,  # Second: get approval condition
+            mock_rules_result,  # Second: get approval condition
             mock_policy_result,  # Third: get approval policy
             mock_approval_result,  # Fourth: first poll
             mock_approval_result,  # Fifth: second poll
@@ -684,10 +668,8 @@ class TestRequireApprovalEdgeCases:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -698,7 +680,7 @@ class TestRequireApprovalEdgeCases:
 
         execute_calls = [
             mock_config_result,
-            mock_condition_result,
+            mock_rules_result,
             mock_policy_result,
             mock_approval_result,
         ]
@@ -753,10 +735,8 @@ class TestRequireApprovalEdgeCases:
         mock_config_result = MagicMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = MagicMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = MagicMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -777,7 +757,7 @@ class TestRequireApprovalEdgeCases:
         # Provide enough execute calls for config, condition, policy, and multiple polls
         execute_calls = [
             mock_config_result,  # get tool config
-            mock_condition_result,  # get approval condition
+            mock_rules_result,  # get approval condition
             mock_policy_result,  # get approval policy
             mock_approval_result1,  # first poll - unknown_status
         ]
@@ -824,16 +804,14 @@ class TestRequireApprovalEdgeCases:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
 
         mock_db.execute = AsyncMock(
-            side_effect=[mock_config_result, mock_condition_result, mock_policy_result]
+            side_effect=[mock_config_result, mock_rules_result, mock_policy_result]
         )
 
         # Approval service raises error
@@ -908,10 +886,8 @@ class TestRequireApprovalProgressReporting:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -923,7 +899,7 @@ class TestRequireApprovalProgressReporting:
 
         execute_calls = [
             mock_config_result,
-            mock_condition_result,
+            mock_rules_result,
             mock_policy_result,
             mock_approval_result,
         ]
@@ -980,10 +956,8 @@ class TestRequireApprovalProgressReporting:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -995,7 +969,7 @@ class TestRequireApprovalProgressReporting:
 
         execute_calls = [
             mock_config_result,
-            mock_condition_result,
+            mock_rules_result,
             mock_policy_result,
             mock_approval_result,
         ]
@@ -1043,10 +1017,8 @@ class TestRequireApprovalProgressReporting:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -1058,7 +1030,7 @@ class TestRequireApprovalProgressReporting:
 
         execute_calls = [
             mock_config_result,
-            mock_condition_result,
+            mock_rules_result,
             mock_policy_result,
             mock_approval_result,
         ]
@@ -1116,10 +1088,8 @@ class TestRequireApprovalProgressReporting:
         mock_config_result = AsyncMock()
         mock_config_result.scalar_one_or_none = MagicMock(return_value=tool_config)
 
-        mock_condition_result = AsyncMock()
-        mock_condition_result.scalar_one_or_none = MagicMock(
-            return_value=approval_condition
-        )
+        mock_rules_result = MagicMock()
+        mock_rules_result.scalars = MagicMock(return_value=iter([]))
 
         mock_policy_result = AsyncMock()
         mock_policy_result.scalar_one_or_none = MagicMock(return_value=approval_policy)
@@ -1131,7 +1101,7 @@ class TestRequireApprovalProgressReporting:
 
         execute_calls = [
             mock_config_result,
-            mock_condition_result,
+            mock_rules_result,
             mock_policy_result,
             mock_approval_result,
         ]

--- a/backend/tests/services/test_oauth_provider.py
+++ b/backend/tests/services/test_oauth_provider.py
@@ -1,0 +1,842 @@
+"""Tests for PreloopOAuthProvider (MCP OAuth 2.1 Authorization Server)."""
+
+import time
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from mcp.server.auth.provider import (
+    AuthorizationCode,
+    AuthorizationParams,
+    RefreshToken,
+    TokenError,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+from preloop.services.oauth_provider import (
+    PreloopOAuthProvider,
+    ACCESS_TOKEN_EXPIRY,
+    REFRESH_TOKEN_EXPIRY,
+    AUTH_CODE_EXPIRY,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    return db
+
+
+@pytest.fixture
+def provider():
+    """Create a PreloopOAuthProvider with test URLs."""
+    with patch("preloop.services.oauth_provider._get_db") as _:
+        p = PreloopOAuthProvider(
+            base_url="http://localhost:8000/mcp",
+            issuer_url="http://localhost:8000/mcp",
+        )
+    return p
+
+
+@pytest.fixture
+def mock_client():
+    """A mock registered OAuth client."""
+    return OAuthClientInformationFull(
+        client_id="preloop_test123",
+        client_secret=None,
+        redirect_uris=["http://localhost:3000/callback"],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        token_endpoint_auth_method="client_secret_post",
+        client_name="Test MCP Client",
+        scope="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_client
+# ---------------------------------------------------------------------------
+
+
+class TestGetClient:
+    """Tests for get_client method."""
+
+    @pytest.mark.asyncio
+    async def test_get_client_found(self, provider, mock_db):
+        db_client = MagicMock()
+        db_client.client_id = "preloop_abc"
+        db_client.client_id_issued_at = 1000
+        db_client.client_secret_expires_at = 0
+        db_client.redirect_uris = ["http://localhost/cb"]
+        db_client.grant_types = ["authorization_code"]
+        db_client.response_types = ["code"]
+        db_client.token_endpoint_auth_method = "client_secret_post"
+        db_client.client_name = "Test"
+        db_client.scope = ""
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch("preloop.services.oauth_provider.crud_oauth_mcp_client") as mock_crud,
+        ):
+            mock_crud.get_by_client_id.return_value = db_client
+            result = await provider.get_client("preloop_abc")
+
+        assert result is not None
+        assert result.client_id == "preloop_abc"
+        assert result.client_secret is None  # Never exposed
+        assert result.client_name == "Test"
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_client_not_found(self, provider, mock_db):
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch("preloop.services.oauth_provider.crud_oauth_mcp_client") as mock_crud,
+        ):
+            mock_crud.get_by_client_id.return_value = None
+            result = await provider.get_client("missing")
+
+        assert result is None
+        mock_db.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# register_client
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterClient:
+    """Tests for register_client method."""
+
+    @pytest.mark.asyncio
+    async def test_register_client_mutates_info(self, provider, mock_db):
+        client_info = OAuthClientInformationFull(
+            client_id="placeholder",
+            redirect_uris=["http://localhost/cb"],
+            client_name="New Client",
+        )
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch("preloop.services.oauth_provider.crud_oauth_mcp_client") as mock_crud,
+        ):
+            mock_crud.generate_client_id.return_value = "preloop_new123"
+            mock_crud.generate_client_secret.return_value = "secret_abc"
+            mock_crud.hash_secret.return_value = "hashed_secret"
+            mock_crud.create.return_value = MagicMock()
+
+            await provider.register_client(client_info)
+
+        # Verify the client_info was mutated with generated credentials
+        assert client_info.client_id == "preloop_new123"
+        assert client_info.client_secret == "secret_abc"
+        assert client_info.client_secret_expires_at == 0
+        assert client_info.client_id_issued_at is not None
+        mock_crud.create.assert_called_once()
+        mock_db.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# authorize
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorize:
+    """Tests for authorize method."""
+
+    @pytest.mark.asyncio
+    async def test_authorize_returns_consent_url(self, provider, mock_client):
+        params = AuthorizationParams(
+            client_id=mock_client.client_id,
+            redirect_uri="http://localhost:3000/callback",
+            state="state123",
+            scopes=["read", "write"],
+            code_challenge="challenge_abc",
+            code_challenge_method="S256",
+            redirect_uri_provided_explicitly=True,
+        )
+
+        url = await provider.authorize(mock_client, params)
+
+        assert url.startswith("http://localhost:8000/mcp/authorize/consent?")
+        assert "client_id=preloop_test123" in url
+        assert "code_challenge=challenge_abc" in url
+        assert "state=state123" in url
+        assert "scopes=read+write" in url
+
+    @pytest.mark.asyncio
+    async def test_authorize_strips_double_mcp(self, provider, mock_client):
+        """Verify that base_url ending in /mcp doesn't produce /mcp/mcp."""
+        params = AuthorizationParams(
+            client_id=mock_client.client_id,
+            redirect_uri="http://localhost:3000/callback",
+            state="s",
+            scopes=[],
+            code_challenge="ch",
+            code_challenge_method="S256",
+            redirect_uri_provided_explicitly=True,
+        )
+
+        url = await provider.authorize(mock_client, params)
+        assert "/mcp/mcp/" not in url
+        assert "/mcp/authorize/consent" in url
+
+    @pytest.mark.asyncio
+    async def test_authorize_empty_state(self, provider, mock_client):
+        params = AuthorizationParams(
+            client_id=mock_client.client_id,
+            redirect_uri="http://localhost:3000/callback",
+            state="",
+            scopes=[],
+            code_challenge="ch",
+            code_challenge_method="S256",
+            redirect_uri_provided_explicitly=True,
+        )
+
+        url = await provider.authorize(mock_client, params)
+        # Should still produce a valid URL
+        assert "/mcp/authorize/consent" in url
+
+
+# ---------------------------------------------------------------------------
+# load_authorization_code
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAuthorizationCode:
+    """Tests for load_authorization_code method."""
+
+    @pytest.mark.asyncio
+    async def test_load_valid_code(self, provider, mock_db, mock_client):
+        db_code = MagicMock()
+        db_code.expires_at = time.time() + 300
+        db_code.is_used = False
+        db_code.scopes = ["read"]
+        db_code.client_id = mock_client.client_id
+        db_code.code_challenge = "ch"
+        db_code.redirect_uri = "http://localhost/cb"
+        db_code.redirect_uri_provided_explicitly = True
+        db_code.resource = None
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_auth_code"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_code.return_value = db_code
+            result = await provider.load_authorization_code(mock_client, "raw-code")
+
+        assert result is not None
+        assert isinstance(result, AuthorizationCode)
+        assert result.code == "raw-code"
+        assert result.scopes == ["read"]
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_load_expired_code(self, provider, mock_db, mock_client):
+        db_code = MagicMock()
+        db_code.expires_at = time.time() - 10  # Expired
+        db_code.is_used = False
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_auth_code"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_code.return_value = db_code
+            result = await provider.load_authorization_code(mock_client, "expired-code")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_load_used_code(self, provider, mock_db, mock_client):
+        db_code = MagicMock()
+        db_code.expires_at = time.time() + 300
+        db_code.is_used = True
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_auth_code"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_code.return_value = db_code
+            result = await provider.load_authorization_code(mock_client, "used-code")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_load_missing_code(self, provider, mock_db, mock_client):
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_auth_code"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_code.return_value = None
+            result = await provider.load_authorization_code(mock_client, "nope")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# exchange_authorization_code
+# ---------------------------------------------------------------------------
+
+
+class TestExchangeAuthorizationCode:
+    """Tests for exchange_authorization_code method."""
+
+    @pytest.mark.asyncio
+    async def test_exchange_success(self, provider, mock_db, mock_client):
+        db_code = MagicMock()
+        db_code.is_used = False
+        db_code.user_id = uuid4()
+        db_code.account_id = uuid4()
+        db_code.scopes = ["read"]
+        db_code.resource = None
+
+        auth_code = AuthorizationCode(
+            code="raw-code",
+            scopes=["read"],
+            expires_at=time.time() + 300,
+            client_id=mock_client.client_id,
+            code_challenge="ch",
+            redirect_uri="http://localhost/cb",
+            redirect_uri_provided_explicitly=True,
+        )
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_auth_code"
+            ) as mock_code_crud,
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_access_token"
+            ) as mock_at_crud,
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_refresh_token"
+            ) as mock_rt_crud,
+            patch("preloop.services.oauth_provider.generate_token") as mock_gen,
+        ):
+            mock_code_crud.get_by_code.return_value = db_code
+            mock_gen.side_effect = ["access_tok", "refresh_tok"]
+
+            result = await provider.exchange_authorization_code(mock_client, auth_code)
+
+        assert isinstance(result, OAuthToken)
+        assert result.access_token == "access_tok"
+        assert result.refresh_token == "refresh_tok"
+        assert result.token_type == "Bearer"
+        assert result.expires_in == ACCESS_TOKEN_EXPIRY
+        mock_code_crud.mark_used.assert_called_once()
+        mock_at_crud.create.assert_called_once()
+        mock_rt_crud.create.assert_called_once()
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_not_found(self, provider, mock_db, mock_client):
+        auth_code = AuthorizationCode(
+            code="missing",
+            scopes=[],
+            expires_at=time.time() + 300,
+            client_id=mock_client.client_id,
+            code_challenge="ch",
+            redirect_uri="http://localhost/cb",
+            redirect_uri_provided_explicitly=True,
+        )
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_auth_code"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_code.return_value = None
+
+            with pytest.raises(TokenError) as exc_info:
+                await provider.exchange_authorization_code(mock_client, auth_code)
+
+        assert "not found" in str(exc_info.value.error_description).lower()
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_already_used(self, provider, mock_db, mock_client):
+        db_code = MagicMock()
+        db_code.is_used = True
+
+        auth_code = AuthorizationCode(
+            code="used",
+            scopes=[],
+            expires_at=time.time() + 300,
+            client_id=mock_client.client_id,
+            code_challenge="ch",
+            redirect_uri="http://localhost/cb",
+            redirect_uri_provided_explicitly=True,
+        )
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_auth_code"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_code.return_value = db_code
+
+            with pytest.raises(TokenError) as exc_info:
+                await provider.exchange_authorization_code(mock_client, auth_code)
+
+        assert "already used" in str(exc_info.value.error_description).lower()
+
+
+# ---------------------------------------------------------------------------
+# load_refresh_token
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRefreshToken:
+    """Tests for load_refresh_token method."""
+
+    @pytest.mark.asyncio
+    async def test_load_valid_refresh(self, provider, mock_db, mock_client):
+        db_token = MagicMock()
+        db_token.is_revoked = False
+        db_token.client_id = mock_client.client_id
+        db_token.scopes = ["read"]
+        db_token.expires_at = int(time.time()) + 86400
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_refresh_token"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_token.return_value = db_token
+            result = await provider.load_refresh_token(mock_client, "refresh_tok")
+
+        assert result is not None
+        assert isinstance(result, RefreshToken)
+        assert result.token == "refresh_tok"
+
+    @pytest.mark.asyncio
+    async def test_load_revoked_refresh(self, provider, mock_db, mock_client):
+        db_token = MagicMock()
+        db_token.is_revoked = True
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_refresh_token"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_token.return_value = db_token
+            result = await provider.load_refresh_token(mock_client, "revoked")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_load_wrong_client(self, provider, mock_db, mock_client):
+        db_token = MagicMock()
+        db_token.is_revoked = False
+        db_token.client_id = "different_client"
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_refresh_token"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_token.return_value = db_token
+            result = await provider.load_refresh_token(mock_client, "tok")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_load_expired_refresh(self, provider, mock_db, mock_client):
+        db_token = MagicMock()
+        db_token.is_revoked = False
+        db_token.client_id = mock_client.client_id
+        db_token.expires_at = int(time.time()) - 10
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_refresh_token"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_token.return_value = db_token
+            result = await provider.load_refresh_token(mock_client, "expired")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_load_missing_refresh(self, provider, mock_db, mock_client):
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_refresh_token"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_token.return_value = None
+            result = await provider.load_refresh_token(mock_client, "nope")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# exchange_refresh_token
+# ---------------------------------------------------------------------------
+
+
+class TestExchangeRefreshToken:
+    """Tests for exchange_refresh_token (token rotation)."""
+
+    @pytest.mark.asyncio
+    async def test_rotation_success(self, provider, mock_db, mock_client):
+        user_id = uuid4()
+        account_id = uuid4()
+        db_old_refresh = MagicMock()
+        db_old_refresh.user_id = user_id
+        db_old_refresh.account_id = account_id
+
+        refresh = RefreshToken(
+            token="old_refresh",
+            client_id=mock_client.client_id,
+            scopes=["read"],
+            expires_at=int(time.time()) + 86400,
+        )
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_refresh_token"
+            ) as mock_rt,
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_access_token"
+            ) as mock_at,
+            patch("preloop.services.oauth_provider.generate_token") as mock_gen,
+        ):
+            mock_rt.get_by_token.return_value = db_old_refresh
+            mock_gen.side_effect = ["new_access", "new_refresh"]
+
+            result = await provider.exchange_refresh_token(mock_client, refresh, [])
+
+        assert isinstance(result, OAuthToken)
+        assert result.access_token == "new_access"
+        assert result.refresh_token == "new_refresh"
+        # Old refresh token should be revoked
+        mock_rt.revoke.assert_called_once_with(mock_db, obj=db_old_refresh)
+        mock_at.create.assert_called_once()
+        mock_rt.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rotation_not_found(self, provider, mock_db, mock_client):
+        refresh = RefreshToken(
+            token="missing",
+            client_id=mock_client.client_id,
+            scopes=[],
+        )
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_refresh_token"
+            ) as mock_rt,
+        ):
+            mock_rt.get_by_token.return_value = None
+
+            with pytest.raises(TokenError):
+                await provider.exchange_refresh_token(mock_client, refresh, [])
+
+    @pytest.mark.asyncio
+    async def test_rotation_uses_provided_scopes(self, provider, mock_db, mock_client):
+        db_old = MagicMock()
+        db_old.user_id = uuid4()
+        db_old.account_id = uuid4()
+
+        refresh = RefreshToken(
+            token="tok",
+            client_id=mock_client.client_id,
+            scopes=["old_scope"],
+        )
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_refresh_token"
+            ) as mock_rt,
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_access_token"
+            ) as mock_at,
+            patch("preloop.services.oauth_provider.generate_token") as mock_gen,
+        ):
+            mock_rt.get_by_token.return_value = db_old
+            mock_gen.side_effect = ["at", "rt"]
+
+            result = await provider.exchange_refresh_token(
+                mock_client, refresh, ["new_scope"]
+            )
+
+        assert result.scope == "new_scope"
+        # Verify new tokens created with new scopes
+        at_call_kwargs = mock_at.create.call_args[1]
+        assert at_call_kwargs["scopes"] == ["new_scope"]
+
+
+# ---------------------------------------------------------------------------
+# load_access_token
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAccessToken:
+    """Tests for load_access_token (token verification + legacy fallback)."""
+
+    @pytest.mark.asyncio
+    async def test_valid_oauth_token(self, provider, mock_db):
+        user = MagicMock()
+        user.id = uuid4()
+
+        db_token = MagicMock()
+        db_token.is_revoked = False
+        db_token.expires_at = int(time.time()) + 3600
+        db_token.client_id = "client_1"
+        db_token.scopes = ["read"]
+        db_token.resource = None
+        db_token.user_id = user.id
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_access_token"
+            ) as mock_crud,
+            patch("preloop.models.crud.crud_user") as mock_user_crud,
+        ):
+            mock_crud.get_by_token.return_value = db_token
+            mock_user_crud.get.return_value = user
+
+            result = await provider.load_access_token("valid_token")
+
+        assert result is not None
+        assert result.token == "valid_token"
+        assert result.client_id == "client_1"
+        assert result.scopes == ["read"]
+
+    @pytest.mark.asyncio
+    async def test_revoked_token_falls_back(self, provider, mock_db):
+        db_token = MagicMock()
+        db_token.is_revoked = True
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_access_token"
+            ) as mock_crud,
+            patch(
+                "preloop.api.auth.jwt.get_user_from_token_if_valid",
+                new_callable=AsyncMock,
+            ) as mock_legacy,
+        ):
+            mock_crud.get_by_token.return_value = db_token
+            mock_legacy.return_value = None
+
+            result = await provider.load_access_token("revoked")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_expired_token_returns_none(self, provider, mock_db):
+        db_token = MagicMock()
+        db_token.is_revoked = False
+        db_token.expires_at = int(time.time()) - 10  # Expired
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_access_token"
+            ) as mock_crud,
+            patch(
+                "preloop.api.auth.jwt.get_user_from_token_if_valid",
+                new_callable=AsyncMock,
+            ) as mock_legacy,
+        ):
+            mock_crud.get_by_token.return_value = db_token
+            mock_legacy.return_value = None
+
+            result = await provider.load_access_token("expired")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_legacy_jwt_fallback(self, provider, mock_db):
+        user = MagicMock()
+        user.id = uuid4()
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_access_token"
+            ) as mock_crud,
+            patch(
+                "preloop.api.auth.jwt.get_user_from_token_if_valid",
+                new_callable=AsyncMock,
+            ) as mock_legacy,
+        ):
+            mock_crud.get_by_token.return_value = None
+            mock_legacy.return_value = user
+
+            result = await provider.load_access_token("jwt.token.here")
+
+        assert result is not None
+        assert result.client_id == str(user.id)
+
+    @pytest.mark.asyncio
+    async def test_no_token_no_fallback(self, provider, mock_db):
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_access_token"
+            ) as mock_crud,
+            patch(
+                "preloop.api.auth.jwt.get_user_from_token_if_valid",
+                new_callable=AsyncMock,
+            ) as mock_legacy,
+        ):
+            mock_crud.get_by_token.return_value = None
+            mock_legacy.return_value = None
+
+            result = await provider.load_access_token("unknown")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# revoke_token
+# ---------------------------------------------------------------------------
+
+
+class TestRevokeToken:
+    """Tests for revoke_token method."""
+
+    @pytest.mark.asyncio
+    async def test_revoke_access_token(self, provider, mock_db):
+        from fastmcp.server.auth.auth import AccessToken
+
+        access = AccessToken(
+            token="at_123",
+            client_id="c1",
+            scopes=[],
+        )
+
+        db_access = MagicMock()
+        db_access.user_id = uuid4()
+        db_access.client_id = "c1"
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_access_token"
+            ) as mock_at,
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_refresh_token"
+            ) as mock_rt,
+        ):
+            mock_at.get_by_token.return_value = db_access
+
+            await provider.revoke_token(access)
+
+        mock_at.revoke.assert_called_once_with(mock_db, obj=db_access)
+        mock_rt.revoke_by_user_and_client.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_revoke_refresh_token(self, provider, mock_db):
+        refresh = RefreshToken(
+            token="rt_123",
+            client_id="c1",
+            scopes=[],
+        )
+
+        db_refresh = MagicMock()
+        db_refresh.user_id = uuid4()
+        db_refresh.client_id = "c1"
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_access_token"
+            ) as mock_at,
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_refresh_token"
+            ) as mock_rt,
+        ):
+            mock_rt.get_by_token.return_value = db_refresh
+
+            await provider.revoke_token(refresh)
+
+        mock_rt.revoke.assert_called_once_with(mock_db, obj=db_refresh)
+        mock_at.revoke_by_user_and_client.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# create_authorization_code_for_user
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAuthorizationCodeForUser:
+    """Tests for the helper used by the consent page handler."""
+
+    def test_creates_and_returns_code(self, provider, mock_db):
+        user_id = uuid4()
+        account_id = uuid4()
+
+        with (
+            patch("preloop.services.oauth_provider._get_db", return_value=mock_db),
+            patch(
+                "preloop.services.oauth_provider.crud_oauth_mcp_auth_code"
+            ) as mock_crud,
+            patch(
+                "preloop.services.oauth_provider.generate_authorization_code",
+                return_value="test_code",
+            ),
+        ):
+            code = provider.create_authorization_code_for_user(
+                client_id="c1",
+                user_id=user_id,
+                account_id=account_id,
+                redirect_uri="http://localhost/cb",
+                redirect_uri_provided_explicitly=True,
+                code_challenge="challenge",
+                scopes=["read"],
+            )
+
+        assert code == "test_code"
+        mock_crud.create.assert_called_once()
+        create_kwargs = mock_crud.create.call_args[1]
+        assert create_kwargs["code"] == "test_code"
+        assert create_kwargs["client_id"] == "c1"
+        assert create_kwargs["user_id"] == user_id
+        mock_db.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestDefaults:
+    """Verify default expiry constants."""
+
+    def test_access_token_expiry(self):
+        assert ACCESS_TOKEN_EXPIRY == 3600
+
+    def test_refresh_token_expiry(self):
+        assert REFRESH_TOKEN_EXPIRY == 2592000
+
+    def test_auth_code_expiry(self):
+        assert AUTH_CODE_EXPIRY == 300

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1795,7 +1795,7 @@ export interface FeaturesResponse {
     description: string;
   }>;
   features: {
-    [key: string]: boolean;
+    [key: string]: boolean | string[];
   };
 }
 

--- a/frontend/src/components/add-tracker-modal.ts
+++ b/frontend/src/components/add-tracker-modal.ts
@@ -179,10 +179,17 @@ export class AddTrackerModal extends LitElement {
     this.warningMessages = [];
     this.errorMessage = '';
     this.shadowRoot?.querySelector('sl-dialog')?.show();
-    setTimeout(() => {
-      const input = this.shadowRoot?.querySelector<SlInput>('sl-input');
-      input?.focus();
-    }, 100);
+
+    // Auto-trigger tracker creation when coming from GitHub App OAuth callback
+    if (this.githubInstallationId && !this.tracker) {
+      // Small delay to let the dialog render, then auto-save
+      setTimeout(() => this.testConnection(), 200);
+    } else {
+      setTimeout(() => {
+        const input = this.shadowRoot?.querySelector<SlInput>('sl-input');
+        input?.focus();
+      }, 100);
+    }
   }
   render() {
     return html`

--- a/frontend/src/components/app-header.ts
+++ b/frontend/src/components/app-header.ts
@@ -32,6 +32,9 @@ export class AppHeader extends LitElement {
   private billingEnabled = false;
 
   @state()
+  private oauthSigninEnabled = false;
+
+  @state()
   private registrationEnabled = true;
 
   static styles = css`
@@ -119,11 +122,13 @@ export class AppHeader extends LitElement {
     try {
       const features = await getFeatures();
       this.billingEnabled = features.features['billing'] === true;
+      this.oauthSigninEnabled = features.features['oauth_signin'] === true;
       // Registration is enabled by default, unless explicitly disabled
       this.registrationEnabled = features.features['registration'] !== false;
     } catch (error) {
       console.error('Failed to check billing feature:', error);
       this.billingEnabled = false;
+      this.oauthSigninEnabled = false;
       this.registrationEnabled = true;
     }
   }
@@ -132,13 +137,19 @@ export class AppHeader extends LitElement {
     e.preventDefault();
     this.isMenuOpen = false; // Close mobile menu
 
-    if (!this.billingEnabled) {
-      // No billing, use regular registration
+    // If OAuth is available, go to register page where users choose OAuth or email
+    if (this.oauthSigninEnabled) {
       Router.go('/register');
       return;
     }
 
-    // Billing enabled - redirect to Stripe checkout
+    if (!this.billingEnabled) {
+      // No billing and no OAuth — regular registration (OSS)
+      Router.go('/register');
+      return;
+    }
+
+    // Billing enabled (no OAuth) — redirect to Stripe checkout
     try {
       const response = await fetch('/api/v1/billing/create-checkout-session', {
         method: 'POST',
@@ -158,12 +169,10 @@ export class AppHeader extends LitElement {
       if (result.action === 'redirect' && result.url) {
         window.location.href = result.url;
       } else {
-        // Fallback to register if no URL
         Router.go('/register');
       }
     } catch (error) {
       console.error('Checkout error:', error);
-      // Fallback to register on error
       Router.go('/register');
     }
   }

--- a/frontend/src/components/approval-policy-dialog.ts
+++ b/frontend/src/components/approval-policy-dialog.ts
@@ -69,7 +69,8 @@ export class ApprovalPolicyDialog extends LitElement {
   @property({ type: Boolean }) open = false;
   @property({ type: Object }) policy: ApprovalPolicy | null = null;
   @property({ type: Array }) existingPolicies: ApprovalPolicy[] = [];
-  @property({ type: Object }) features: { [key: string]: boolean } = {};
+  @property({ type: Object }) features: { [key: string]: boolean | string[] } =
+    {};
 
   /**
    * Check if advanced approvals feature is enabled (EE only).

--- a/frontend/src/components/lit-app.ts
+++ b/frontend/src/components/lit-app.ts
@@ -262,7 +262,80 @@ export class LitApp extends LitElement {
         path: '/console',
         component: 'console-shell',
         action: () => {
-          // This is where you would add authentication checks
+          // Handle OAuth callback tokens from URL params
+          const params = new URLSearchParams(window.location.search);
+          const accessToken = params.get('access_token');
+          const refreshToken = params.get('refresh_token');
+
+          if (accessToken) {
+            localStorage.setItem('accessToken', accessToken);
+            if (refreshToken) {
+              localStorage.setItem('refreshToken', refreshToken);
+            }
+
+            // Store onboarding hints for the dashboard
+            if (params.get('new_user')) {
+              sessionStorage.setItem('oauth_new_user', '1');
+            }
+            if (params.get('setup_tracker')) {
+              sessionStorage.setItem(
+                'oauth_setup_tracker',
+                params.get('setup_tracker')!
+              );
+            }
+
+            // Clean tokens from URL
+            const cleanUrl = new URL(window.location.href);
+            cleanUrl.search = '';
+            window.history.replaceState({}, '', cleanUrl.pathname);
+
+            // Notify components of auth change
+            window.dispatchEvent(
+              new CustomEvent('auth-change', {
+                bubbles: true,
+                composed: true,
+              })
+            );
+
+            // Redirect to Stripe checkout if billing is pending for new OAuth users
+            if (params.get('checkout_pending')) {
+              fetch('/api/v1/billing/create-checkout-session', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Authorization: `Bearer ${accessToken}`,
+                },
+                body: JSON.stringify({
+                  plan_id: 'teams',
+                  interval: 'month',
+                }),
+              })
+                .then((res) => res.json())
+                .then((data) => {
+                  if (data.url && data.action === 'redirect') {
+                    window.location.href = data.url;
+                  }
+                })
+                .catch((err) => {
+                  console.error('Failed to create checkout session:', err);
+                });
+            } else if (params.get('setup_tracker') === 'github') {
+              // No billing — go straight to GitHub App installation
+              this._autoStartGitHubAppInstall(accessToken);
+            }
+          }
+
+          // After returning from Stripe, check if GitHub tracker setup is still pending
+          if (
+            !accessToken &&
+            !window.location.pathname.includes('/trackers') &&
+            sessionStorage.getItem('oauth_setup_tracker') === 'github'
+          ) {
+            const token = localStorage.getItem('accessToken');
+            if (token) {
+              this._autoStartGitHubAppInstall(token);
+            }
+          }
         },
         children: [
           { path: '', component: 'dashboard-view' },
@@ -323,6 +396,34 @@ export class LitApp extends LitElement {
         ],
       },
     ]);
+  }
+
+  /**
+   * Auto-redirect to GitHub App installation page for new OAuth users.
+   * Called after OAuth sign-in (or after Stripe checkout returns).
+   */
+  private _autoStartGitHubAppInstall(token: string) {
+    // Clear the flag to prevent redirect loops
+    sessionStorage.removeItem('oauth_setup_tracker');
+    sessionStorage.removeItem('oauth_new_user');
+
+    fetch('/api/v1/auth/github/authorize', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error('GitHub App not configured');
+        return res.json();
+      })
+      .then((data) => {
+        if (data.authorization_url) {
+          sessionStorage.setItem('github_oauth_state', data.state);
+          window.location.href = data.authorization_url;
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to start GitHub App install:', err);
+        // Fall back — user can add tracker manually from the trackers page
+      });
   }
 
   render() {

--- a/frontend/src/components/lit-app.ts
+++ b/frontend/src/components/lit-app.ts
@@ -262,19 +262,14 @@ export class LitApp extends LitElement {
         path: '/console',
         component: 'console-shell',
         action: () => {
-          // Handle OAuth callback tokens from URL fragment (preferred, avoids
-          // browser history / server logs / Referrer leakage) or query params
-          // (legacy fallback).
-          const fragmentParams = new URLSearchParams(
+          // Handle OAuth callback tokens from URL fragment only.
+          // Fragment-based delivery prevents tokens from appearing in browser
+          // history, server access logs, and Referrer headers.
+          const params = new URLSearchParams(
             window.location.hash.startsWith('#')
               ? window.location.hash.substring(1)
               : ''
           );
-          const queryParams = new URLSearchParams(window.location.search);
-          // Prefer fragment, fall back to query
-          const params = fragmentParams.get('access_token')
-            ? fragmentParams
-            : queryParams;
           const accessToken = params.get('access_token');
           const refreshToken = params.get('refresh_token');
 
@@ -295,9 +290,8 @@ export class LitApp extends LitElement {
               );
             }
 
-            // Clean tokens from URL (both search and hash)
+            // Clean tokens from URL fragment
             const cleanUrl = new URL(window.location.href);
-            cleanUrl.search = '';
             cleanUrl.hash = '';
             window.history.replaceState({}, '', cleanUrl.pathname);
 

--- a/frontend/src/components/lit-app.ts
+++ b/frontend/src/components/lit-app.ts
@@ -262,8 +262,19 @@ export class LitApp extends LitElement {
         path: '/console',
         component: 'console-shell',
         action: () => {
-          // Handle OAuth callback tokens from URL params
-          const params = new URLSearchParams(window.location.search);
+          // Handle OAuth callback tokens from URL fragment (preferred, avoids
+          // browser history / server logs / Referrer leakage) or query params
+          // (legacy fallback).
+          const fragmentParams = new URLSearchParams(
+            window.location.hash.startsWith('#')
+              ? window.location.hash.substring(1)
+              : ''
+          );
+          const queryParams = new URLSearchParams(window.location.search);
+          // Prefer fragment, fall back to query
+          const params = fragmentParams.get('access_token')
+            ? fragmentParams
+            : queryParams;
           const accessToken = params.get('access_token');
           const refreshToken = params.get('refresh_token');
 
@@ -284,9 +295,10 @@ export class LitApp extends LitElement {
               );
             }
 
-            // Clean tokens from URL
+            // Clean tokens from URL (both search and hash)
             const cleanUrl = new URL(window.location.href);
             cleanUrl.search = '';
+            cleanUrl.hash = '';
             window.history.replaceState({}, '', cleanUrl.pathname);
 
             // Notify components of auth change

--- a/frontend/src/components/tool-card.ts
+++ b/frontend/src/components/tool-card.ts
@@ -86,7 +86,7 @@ export class ToolCard extends LitElement {
   policies: ApprovalPolicy[] = [];
 
   @property({ type: Object })
-  features: { [key: string]: boolean } = {};
+  features: { [key: string]: boolean | string[] } = {};
 
   @state()
   private showPreloopDialog = false;

--- a/frontend/src/components/tool-list-item.ts
+++ b/frontend/src/components/tool-list-item.ts
@@ -27,7 +27,8 @@ export class ToolListItem extends LitElement {
   @property({ type: Object }) tool!: Tool;
   @property({ type: Array }) accessRules: AccessRuleSummary[] = [];
   @property({ type: Array }) policies: ApprovalPolicy[] = [];
-  @property({ type: Object }) features: { [key: string]: boolean } = {};
+  @property({ type: Object }) features: { [key: string]: boolean | string[] } =
+    {};
   @property({ type: Boolean }) expanded = false;
 
   @state() private _showRuleEditor = false;

--- a/frontend/src/components/tool-rule-editor.ts
+++ b/frontend/src/components/tool-rule-editor.ts
@@ -37,7 +37,8 @@ export class ToolRuleEditor extends LitElement {
   @property({ type: Object }) rule: AccessRule | null = null;
   @property({ type: String }) toolName = '';
   @property({ type: Array }) policies: ApprovalPolicy[] = [];
-  @property({ type: Object }) features: { [key: string]: boolean } = {};
+  @property({ type: Object }) features: { [key: string]: boolean | string[] } =
+    {};
   @property({ type: Object }) toolSchema: any = null;
 
   @state() private _action: 'allow' | 'deny' | 'require_approval' = 'deny';

--- a/frontend/src/utils/ide-configs.ts
+++ b/frontend/src/utils/ide-configs.ts
@@ -1,7 +1,7 @@
 import type { IdeConfig } from '../components/ide-setup-tabs';
 
 export function getIdeConfigs(): IdeConfig[] {
-  const mcpUrl = `${window.location.origin}/mcp/v1`;
+  const mcpUrl = `${window.location.origin}/mcp`;
   const envVarName = 'PRELOOP_API_KEY';
 
   return [

--- a/frontend/src/views/authed/dashboard-view.ts
+++ b/frontend/src/views/authed/dashboard-view.ts
@@ -141,6 +141,12 @@ export class DashboardView extends AuthedElement {
   private welcomeCardDismissed = false;
 
   @state()
+  private oauthSetupTracker: string | null = null;
+
+  @state()
+  private trackerSetupLoading = false;
+
+  @state()
   private dismissedExecutions: Set<string> = new Set();
 
   @state()
@@ -159,6 +165,12 @@ export class DashboardView extends AuthedElement {
     this.loadDismissedState();
     this.fetchDashboardData();
     this.connectToFlowUpdates();
+
+    // Check if a new OAuth user needs to connect a tracker
+    const setupTracker = sessionStorage.getItem('oauth_setup_tracker');
+    if (setupTracker) {
+      this.oauthSetupTracker = setupTracker;
+    }
   }
 
   private loadDismissedState() {
@@ -789,6 +801,98 @@ export class DashboardView extends AuthedElement {
     `,
   ];
 
+  private dismissTrackerSetup() {
+    this.oauthSetupTracker = null;
+    sessionStorage.removeItem('oauth_setup_tracker');
+    sessionStorage.removeItem('oauth_new_user');
+  }
+
+  private async startTrackerSetup() {
+    if (!this.oauthSetupTracker) return;
+
+    if (this.oauthSetupTracker === 'github') {
+      // Start the GitHub App OAuth flow for tracker connection
+      this.trackerSetupLoading = true;
+      try {
+        const { authorization_url, state } = await api.getGitHubAuthUrl();
+        sessionStorage.setItem('github_oauth_state', state);
+        // Clear the setup tracker hint — the trackers-view will handle the callback
+        sessionStorage.removeItem('oauth_setup_tracker');
+        sessionStorage.removeItem('oauth_new_user');
+        window.location.href = authorization_url;
+      } catch (error: any) {
+        console.error('Failed to start GitHub tracker setup:', error);
+        // Fall back to manual tracker setup
+        sessionStorage.removeItem('oauth_setup_tracker');
+        sessionStorage.removeItem('oauth_new_user');
+        window.location.href = '/console/trackers';
+      } finally {
+        this.trackerSetupLoading = false;
+      }
+    } else {
+      // For non-GitHub providers, navigate to trackers page
+      sessionStorage.removeItem('oauth_setup_tracker');
+      sessionStorage.removeItem('oauth_new_user');
+      window.location.href = '/console/trackers';
+    }
+  }
+
+  private renderTrackerSetupBanner() {
+    if (!this.oauthSetupTracker) return '';
+
+    const providerName =
+      this.oauthSetupTracker.charAt(0).toUpperCase() +
+      this.oauthSetupTracker.slice(1);
+    const isGitHub = this.oauthSetupTracker === 'github';
+
+    return html`
+      <sl-alert variant="primary" open class="tracker-setup-banner">
+        <sl-icon
+          slot="icon"
+          name="${isGitHub ? 'github' : 'link-45deg'}"
+        ></sl-icon>
+        <div
+          style="display: flex; align-items: center; justify-content: space-between; width: 100%;"
+        >
+          <div>
+            <strong>Connect your ${providerName} projects</strong>
+            <br />
+            <span
+              style="font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-600);"
+            >
+              ${isGitHub
+                ? 'Install the Preloop GitHub App to enable issue tracking, compliance checks, and automated flows for your repositories.'
+                : `Connect your ${providerName} account to enable issue tracking and automated flows.`}
+            </span>
+          </div>
+          <div
+            style="display: flex; gap: var(--sl-spacing-small); flex-shrink: 0; margin-left: var(--sl-spacing-medium);"
+          >
+            <sl-button
+              variant="primary"
+              size="small"
+              @click=${this.startTrackerSetup}
+              .loading=${this.trackerSetupLoading}
+            >
+              <sl-icon
+                slot="prefix"
+                name="${isGitHub ? 'github' : 'link-45deg'}"
+              ></sl-icon>
+              Connect ${providerName}
+            </sl-button>
+            <sl-button
+              variant="text"
+              size="small"
+              @click=${this.dismissTrackerSetup}
+            >
+              Later
+            </sl-button>
+          </div>
+        </div>
+      </sl-alert>
+    `;
+  }
+
   private renderWelcomeCard() {
     if (this.welcomeCardDismissed) {
       return '';
@@ -971,6 +1075,9 @@ export class DashboardView extends AuthedElement {
       <div class="column-layout dashboard extra-wide">
         <!-- Main Column -->
         <div class="main-column">
+          <!-- OAuth Tracker Setup Banner -->
+          ${this.renderTrackerSetupBanner()}
+
           <!-- Welcome Card -->
           ${this.renderWelcomeCard()}
 

--- a/frontend/src/views/authed/dashboard-view.ts
+++ b/frontend/src/views/authed/dashboard-view.ts
@@ -1383,9 +1383,27 @@ export class DashboardView extends AuthedElement {
                     <div class="status-indicator"></div>
                     <div class="server-details">
                       <span class="server-endpoint"
-                        >${window.location.origin}/mcp/v1</span
+                        >${window.location.origin}/mcp</span
                       >
                     </div>
+                    <sl-tooltip content="Copy URL">
+                      <sl-icon-button
+                        name="clipboard"
+                        style="font-size: 1rem;"
+                        @click=${() => {
+                          navigator.clipboard.writeText(
+                            `${window.location.origin}/mcp`
+                          );
+                          this.dispatchEvent(
+                            new CustomEvent('show-toast', {
+                              bubbles: true,
+                              composed: true,
+                              detail: { message: 'MCP URL copied!' },
+                            })
+                          );
+                        }}
+                      ></sl-icon-button>
+                    </sl-tooltip>
                     <a href="/console/settings/api-keys" class="capsule-link">
                       Manage Keys
                     </a>

--- a/frontend/src/views/authed/flow-view.ts
+++ b/frontend/src/views/authed/flow-view.ts
@@ -994,10 +994,19 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre
   }
 
   renderPresets() {
+    const sortedPresets = [...this.presets].sort((a, b) => {
+      const aIsPR = a.name?.toLowerCase().includes('pull request reviewer')
+        ? 0
+        : 1;
+      const bIsPR = b.name?.toLowerCase().includes('pull request reviewer')
+        ? 0
+        : 1;
+      return aIsPR - bIsPR;
+    });
     return html`
       <h2>Select a Preset</h2>
       <div class="form-grid">
-        ${this.presets.map(
+        ${sortedPresets.map(
           (preset) => html`
             <sl-card
               class="preset-card"
@@ -1046,7 +1055,70 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre
     // New flows should be enabled by default (presets are stored as disabled)
     this.flow.is_enabled = true;
 
+    // Auto-populate fields to reduce friction for new users
+    this._autoPopulatePresetFields();
+
     this.creationMode = 'scratch';
+  }
+
+  private async _autoPopulatePresetFields() {
+    // Auto-select the most recently added tracker (last in the list)
+    if (this.trackers.length > 0 && !this.flow.trigger_event_source) {
+      const tracker = this.trackers[this.trackers.length - 1];
+      this.flow.trigger_event_source = tracker.id;
+      this.triggerType = 'tracker';
+
+      // Auto-select PR/MR events based on tracker type
+      if (tracker.tracker_type === 'github') {
+        this.flow.trigger_event_types = [
+          'pull_request_opened',
+          'pull_request_updated',
+        ];
+      } else if (tracker.tracker_type === 'gitlab') {
+        this.flow.trigger_event_types = [
+          'merge_request_opened',
+          'merge_request_updated',
+        ];
+      }
+
+      // Load organizations for this tracker
+      const allOrganizations = await listOrganizations();
+      this.organizations = allOrganizations.filter(
+        (org: any) => org.tracker_id === tracker.id
+      );
+
+      if (this.organizations.length > 0) {
+        // Auto-select the first organization
+        const org = this.organizations[0];
+        this.flow.trigger_organization_id = org.id;
+
+        // Load and auto-select all projects for this organization
+        const allProjects = await listProjects();
+        this.projects = allProjects;
+        const orgProjects = allProjects.filter(
+          (proj: any) => proj.organization_id === org.id
+        );
+        if (orgProjects.length > 0) {
+          this.flow.trigger_project_ids = orgProjects.map(
+            (proj: any) => proj.id
+          );
+        }
+      } else {
+        // Start polling for organizations (they may still be syncing)
+        this.startPollingOrganizations(tracker.id);
+      }
+    }
+
+    // Auto-select the most recently added compatible AI model
+    if (!this.flow.ai_model_id) {
+      const compatibleModels = this.getCompatibleModels();
+      if (compatibleModels.length > 0) {
+        this.flow.ai_model_id =
+          compatibleModels[compatibleModels.length - 1].id;
+      }
+    }
+
+    this.requestUpdate();
   }
 
   /**

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -232,7 +232,7 @@ export class FlowsView extends LitElement {
         getFlowExecutions(),
       ]);
       this.flows = flows;
-      this.presets = presets;
+      this.presets = this.sortPresets(presets);
       this.executions = executions;
 
       if (this.flows.length === 0) {
@@ -597,5 +597,17 @@ export class FlowsView extends LitElement {
 
   private togglePresets() {
     this.showPresets = !this.showPresets;
+  }
+
+  private sortPresets(presets: Flow[]): Flow[] {
+    return [...presets].sort((a, b) => {
+      const aIsPR = a.name?.toLowerCase().includes('pull request reviewer')
+        ? 0
+        : 1;
+      const bIsPR = b.name?.toLowerCase().includes('pull request reviewer')
+        ? 0
+        : 1;
+      return aIsPR - bIsPR;
+    });
   }
 }

--- a/frontend/src/views/authed/policies-view.ts
+++ b/frontend/src/views/authed/policies-view.ts
@@ -125,7 +125,7 @@ export class PoliciesView extends LitElement {
   @state() private _approvalPolicies: ApprovalPolicy[] = [];
   @state() private _loading = false;
   @state() private _error: string | null = null;
-  @state() private _features: { [key: string]: boolean } = {};
+  @state() private _features: { [key: string]: boolean | string[] } = {};
 
   // Access policies state
   @state() private _toolAccessRules: ToolAccessRule[] = [];

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -68,7 +68,7 @@ export class ToolsView extends LitElement {
   @state() private editingMCPServer: MCPServer | null = null;
   @state() private currentUser: { id: string } | null = null;
   @state() private showSetupDialog = false;
-  @state() private features: { [key: string]: boolean } = {};
+  @state() private features: { [key: string]: boolean | string[] } = {};
   @state() private expandedTools: Set<string> = new Set();
   @state() private collapsedGroups: Set<string> = new Set();
   @state() private filterText = '';
@@ -105,7 +105,6 @@ export class ToolsView extends LitElement {
         display: flex;
         justify-content: space-between;
         align-items: flex-start;
-        margin-bottom: var(--sl-spacing-large);
         gap: var(--sl-spacing-large);
       }
 
@@ -266,6 +265,7 @@ export class ToolsView extends LitElement {
       .policy-row {
         display: flex;
         justify-content: flex-end;
+        margin-bottom: 0.6em;
       }
 
       .filter-bar {
@@ -1253,7 +1253,7 @@ export class ToolsView extends LitElement {
           @click=${() => this._openPolicyDialog(null)}
         >
           <sl-icon name="plus-lg" style="font-size: 0.7rem;"></sl-icon>
-          New Policy
+          New
         </span>
       </div>
     `;
@@ -1433,18 +1433,19 @@ export class ToolsView extends LitElement {
             ? html`<div class="loading-indicator">
                 <sl-spinner></sl-spinner>
               </div>`
-            : html`
-                ${this._renderTopSection()} ${this._renderFilterBar()}
-                ${groups.length === 0
-                  ? html`<div class="empty-state">
-                      <sl-icon
-                        name="tools"
-                        style="font-size: 2rem; color: var(--sl-color-neutral-400);"
-                      ></sl-icon>
-                      <p>No tools found. Add an MCP server to get started.</p>
-                    </div>`
-                  : groups.map((group) => this._renderToolGroup(group))}
-              `}
+            : html` ${this._renderTopSection()}
+                <div class="tool-groups">
+                  ${this._renderFilterBar()}
+                  ${groups.length === 0
+                    ? html`<div class="empty-state">
+                        <sl-icon
+                          name="tools"
+                          style="font-size: 2rem; color: var(--sl-color-neutral-400);"
+                        ></sl-icon>
+                        <p>No tools found. Add an MCP server to get started.</p>
+                      </div>`
+                    : groups.map((group) => this._renderToolGroup(group))}
+                </div>`}
         </div>
         <div class="side-column"></div>
       </div>

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -1024,7 +1024,7 @@ export class ToolsView extends LitElement {
 
   private _renderTopSection() {
     const apiUrl = window.location.origin;
-    const mcpUrl = `${apiUrl}/mcp/v1`;
+    const mcpUrl = `${apiUrl}/mcp`;
     const stats = this._getStats();
 
     // Helper: renders a single table cell with label left, number right, full-cell hover
@@ -1118,6 +1118,22 @@ export class ToolsView extends LitElement {
             <div class="info-row">
               <span class="info-label">URL:</span>
               <code class="info-value" title=${mcpUrl}>${mcpUrl}</code>
+              <sl-tooltip content="Copy URL">
+                <sl-icon-button
+                  name="clipboard"
+                  style="font-size: 1rem;"
+                  @click=${() => {
+                    navigator.clipboard.writeText(mcpUrl);
+                    this.dispatchEvent(
+                      new CustomEvent('show-toast', {
+                        bubbles: true,
+                        composed: true,
+                        detail: { message: 'MCP URL copied!' },
+                      })
+                    );
+                  }}
+                ></sl-icon-button>
+              </sl-tooltip>
             </div>
             <div class="info-row">
               <span class="info-label">Auth:</span>

--- a/frontend/src/views/public/landing-view.ts
+++ b/frontend/src/views/public/landing-view.ts
@@ -45,6 +45,7 @@ export class LandingView extends LitElement {
   @state() private _extendedDescription = '';
   @state() private _featuresLayout: 'carousel' | 'grid' = 'grid';
   @state() private _billingEnabled = false;
+  @state() private _oauthSigninEnabled = false;
   @state() private _productHunt: {
     enabled: boolean;
     post_id: string;
@@ -72,17 +73,25 @@ export class LandingView extends LitElement {
     try {
       const features = await getFeatures();
       this._billingEnabled = features.features['billing'] === true;
+      this._oauthSigninEnabled = features.features['oauth_signin'] === true;
     } catch (error) {
       console.error('Failed to check billing feature:', error);
       this._billingEnabled = false;
+      this._oauthSigninEnabled = false;
     }
   }
 
   private async _handleSignup(e: Event) {
     e.preventDefault();
 
+    // If OAuth is available, go to register page where users choose OAuth or email
+    if (this._oauthSigninEnabled) {
+      window.location.href = '/register';
+      return;
+    }
+
     if (!this._billingEnabled) {
-      // No billing, use regular registration
+      // No billing and no OAuth — regular registration (OSS)
       window.location.href = '/register';
       return;
     }
@@ -107,12 +116,10 @@ export class LandingView extends LitElement {
       if (result.action === 'redirect' && result.url) {
         window.location.href = result.url;
       } else {
-        // Fallback to register if no URL
         window.location.href = '/register';
       }
     } catch (error) {
       console.error('Checkout error:', error);
-      // Fallback to register on error
       window.location.href = '/register';
     }
   }
@@ -766,7 +773,7 @@ export class LandingView extends LitElement {
                 </sl-tooltip>
                 <sl-tooltip content="Discord">
                   <img
-                    src="images/logos/discord-logo.svg"
+                    src="/images/logos/discord-logo.svg"
                     alt="Discord Logo"
                     class="discord-logo tool-logo"
                   />

--- a/frontend/src/views/public/login-view.ts
+++ b/frontend/src/views/public/login-view.ts
@@ -1,12 +1,19 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { Router } from '@vaadin/router';
-import { post } from '../../api';
+import { post, getFeatures } from '../../api';
 import { formStyles } from '../../styles/form-styles';
 import { getBrandConfig } from '../../brand-config';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '../../components/logo-component';
+
+const OAUTH_PROVIDER_CONFIG: Record<string, { label: string; icon: string }> = {
+  github: { label: 'GitHub', icon: 'github' },
+  google: { label: 'Google', icon: 'google' },
+  gitlab: { label: 'GitLab', icon: 'gitlab' },
+};
 
 @customElement('login-view')
 export class LoginView extends LitElement {
@@ -15,6 +22,9 @@ export class LoginView extends LitElement {
 
   @state()
   private successMessage = '';
+
+  @state()
+  private oauthProviders: string[] = [];
 
   static styles = [
     formStyles,
@@ -28,6 +38,47 @@ export class LoginView extends LitElement {
         border-radius: 0.25rem;
         text-align: center;
       }
+
+      .oauth-section {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .oauth-button {
+        width: 100%;
+      }
+
+      .oauth-button::part(base) {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+      }
+
+      .divider {
+        display: flex;
+        align-items: center;
+        margin: 1.5rem 0;
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-small);
+      }
+
+      .divider::before,
+      .divider::after {
+        content: '';
+        flex: 1;
+        border-bottom: 1px solid var(--sl-color-neutral-300);
+      }
+
+      .divider::before {
+        margin-right: 0.75rem;
+      }
+
+      .divider::after {
+        margin-left: 0.75rem;
+      }
     `,
   ];
 
@@ -40,6 +91,17 @@ export class LoginView extends LitElement {
       const url = new URL(window.location.href);
       url.searchParams.delete('registered');
       window.history.replaceState({}, document.title, url.pathname);
+    }
+    this._checkFeatures();
+  }
+
+  private async _checkFeatures() {
+    try {
+      const features = await getFeatures();
+      const providers = features.features['oauth_providers'];
+      this.oauthProviders = Array.isArray(providers) ? providers : [];
+    } catch (error) {
+      this.oauthProviders = [];
     }
   }
 
@@ -70,7 +132,6 @@ export class LoginView extends LitElement {
         Router.go('/console');
       }
     } catch (error) {
-      // Extract the error message from the Error object
       if (error instanceof Error) {
         this.error = error.message;
       } else {
@@ -78,6 +139,33 @@ export class LoginView extends LitElement {
       }
       console.error('Sign in failed', error);
     }
+  }
+
+  private _renderOAuthButtons() {
+    if (this.oauthProviders.length === 0) return nothing;
+
+    return html`
+      <div class="oauth-section">
+        ${this.oauthProviders.map((provider) => {
+          const config = OAUTH_PROVIDER_CONFIG[provider];
+          if (!config) return nothing;
+          return html`
+            <sl-button
+              class="oauth-button"
+              variant="default"
+              size="large"
+              @click=${() => {
+                window.location.href = `/api/v1/auth/oauth/${provider}/authorize`;
+              }}
+            >
+              <sl-icon name="${config.icon}" slot="prefix"></sl-icon>
+              Sign in with ${config.label}
+            </sl-button>
+          `;
+        })}
+      </div>
+      <div class="divider">or sign in with email</div>
+    `;
   }
 
   render() {
@@ -96,6 +184,7 @@ export class LoginView extends LitElement {
           ${this.error
             ? html`<div class="error-message">${this.error}</div>`
             : ''}
+          ${this._renderOAuthButtons()}
           <form @submit=${this.handleLogin}>
             <div class="form-group">
               <sl-input

--- a/frontend/src/views/public/pricing-view.ts
+++ b/frontend/src/views/public/pricing-view.ts
@@ -19,6 +19,7 @@ interface Plan {
 export class PublicPricingView extends LitElement {
   @state() private _interval: 'month' | 'year' = 'year';
   @state() private _billingEnabled = false;
+  @state() private _oauthSigninEnabled = false;
 
   // Hardcoded plans - Open Source, Teams, and Enterprise
   private _plans: Plan[] = [
@@ -81,9 +82,11 @@ export class PublicPricingView extends LitElement {
     try {
       const features = await getFeatures();
       this._billingEnabled = features.features['billing'] === true;
+      this._oauthSigninEnabled = features.features['oauth_signin'] === true;
     } catch (error) {
       console.error('Failed to check billing feature:', error);
       this._billingEnabled = false;
+      this._oauthSigninEnabled = false;
     }
   }
 
@@ -103,8 +106,14 @@ export class PublicPricingView extends LitElement {
     }
 
     if (planId === 'teams') {
+      // If OAuth is available, go to register page where users choose OAuth or email
+      if (this._oauthSigninEnabled) {
+        window.location.href = '/register';
+        return;
+      }
+
       if (!this._billingEnabled) {
-        // No billing, use regular registration
+        // No billing and no OAuth — regular registration (OSS)
         window.location.href = '/register';
         return;
       }
@@ -132,12 +141,10 @@ export class PublicPricingView extends LitElement {
         if (result.action === 'redirect' && result.url) {
           window.location.href = result.url;
         } else {
-          // Fallback to register if no URL
           window.location.href = '/register';
         }
       } catch (error) {
         console.error('Checkout error:', error);
-        // Fallback to register on error
         window.location.href = '/register';
       }
     }

--- a/frontend/src/views/public/register-view.ts
+++ b/frontend/src/views/public/register-view.ts
@@ -1,20 +1,89 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { Router } from '@vaadin/router';
-import { post } from '../../api';
+import { post, getFeatures } from '../../api';
 import { formStyles } from '../../styles/form-styles';
 import { getBrandConfig } from '../../brand-config';
 
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '../../components/logo-component';
+
+const OAUTH_PROVIDER_CONFIG: Record<string, { label: string; icon: string }> = {
+  github: { label: 'GitHub', icon: 'github' },
+  google: { label: 'Google', icon: 'google' },
+  gitlab: { label: 'GitLab', icon: 'gitlab' },
+};
 
 @customElement('register-view')
 export class RegisterView extends LitElement {
   @state()
   private error = '';
 
-  static styles = [formStyles];
+  @state()
+  private oauthProviders: string[] = [];
+
+  static styles = [
+    formStyles,
+    css`
+      .oauth-section {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .oauth-button {
+        width: 100%;
+      }
+
+      .oauth-button::part(base) {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+      }
+
+      .divider {
+        display: flex;
+        align-items: center;
+        margin: 1.5rem 0;
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-small);
+      }
+
+      .divider::before,
+      .divider::after {
+        content: '';
+        flex: 1;
+        border-bottom: 1px solid var(--sl-color-neutral-300);
+      }
+
+      .divider::before {
+        margin-right: 0.75rem;
+      }
+
+      .divider::after {
+        margin-left: 0.75rem;
+      }
+    `,
+  ];
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._checkFeatures();
+  }
+
+  private async _checkFeatures() {
+    try {
+      const features = await getFeatures();
+      const providers = features.features['oauth_providers'];
+      this.oauthProviders = Array.isArray(providers) ? providers : [];
+    } catch (error) {
+      this.oauthProviders = [];
+    }
+  }
 
   private async handleRegister(event: SubmitEvent) {
     event.preventDefault();
@@ -32,15 +101,40 @@ export class RegisterView extends LitElement {
       });
       Router.go('/login?registered=true');
     } catch (error) {
-      // Extract the error message from the Error object
       if (error instanceof Error) {
-        debugger;
         this.error = error.message;
       } else {
         this.error = 'Failed to create an account';
       }
       console.error('Create account failed', error);
     }
+  }
+
+  private _renderOAuthButtons() {
+    if (this.oauthProviders.length === 0) return nothing;
+
+    return html`
+      <div class="oauth-section">
+        ${this.oauthProviders.map((provider) => {
+          const config = OAUTH_PROVIDER_CONFIG[provider];
+          if (!config) return nothing;
+          return html`
+            <sl-button
+              class="oauth-button"
+              variant="default"
+              size="large"
+              @click=${() => {
+                window.location.href = `/api/v1/auth/oauth/${provider}/authorize`;
+              }}
+            >
+              <sl-icon name="${config.icon}" slot="prefix"></sl-icon>
+              Sign up with ${config.label}
+            </sl-button>
+          `;
+        })}
+      </div>
+      <div class="divider">or sign up with email</div>
+    `;
   }
 
   render() {
@@ -56,6 +150,7 @@ export class RegisterView extends LitElement {
           ${this.error
             ? html`<div class="error-message">${this.error}</div>`
             : ''}
+          ${this._renderOAuthButtons()}
           <form @submit=${this.handleRegister}>
             <div class="form-group">
               <sl-input

--- a/helm/preloop/Chart.yaml
+++ b/helm/preloop/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v2
 name: preloop
-description: A Helm chart for Preloop - An event-driven automation platform with built-in human-in-the-loop safety
+description: A Helm chart for Preloop - The policy engine for AI agents with approval workflows and audit trails
 
 # A chart can be either an 'application' or a 'library' chart.
 type: application
 
 # Chart version
-version: 0.1.0
+version: 0.8.0
 
 # Application version
-appVersion: "0.1.0"
+appVersion: "0.8.0"
 
 # Keywords for the chart
 keywords:

--- a/helm/preloop/templates/api-deployment.yaml
+++ b/helm/preloop/templates/api-deployment.yaml
@@ -176,6 +176,26 @@ spec:
             - name: GITHUB_APP_SLUG
               value: {{ .Values.githubApp.slug | quote }}
             {{- end }}
+            {{- if .Values.googleOauth.enabled }}
+            - name: GOOGLE_OAUTH_CLIENT_ID
+              value: {{ .Values.googleOauth.clientId | quote }}
+            - name: GOOGLE_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "preloop.fullname" . }}
+                  key: google-oauth-client-secret
+            {{- end }}
+            {{- if .Values.gitlabOauth.enabled }}
+            - name: GITLAB_OAUTH_CLIENT_ID
+              value: {{ .Values.gitlabOauth.clientId | quote }}
+            - name: GITLAB_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "preloop.fullname" . }}
+                  key: gitlab-oauth-client-secret
+            - name: GITLAB_OAUTH_BASE_URL
+              value: {{ .Values.gitlabOauth.baseUrl | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8000

--- a/helm/preloop/templates/postgresql.yaml
+++ b/helm/preloop/templates/postgresql.yaml
@@ -9,6 +9,30 @@ spec:
   instances: {{ .Values.database.cnpg.instances }}
   imageName: {{ .Values.database.cnpg.imageName }}
   primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: restart
+
+  # HA: replication slots for reliable WAL streaming to replicas
+  {{- if gt (int .Values.database.cnpg.instances) 1 }}
+  replicationSlots:
+    highAvailability:
+      enabled: true
+      slotPrefix: _cnpg_
+    synchronizeReplicas:
+      enabled: true
+    updateInterval: 30
+  {{- end }}
+
+  # Pod scheduling — prefer spreading replicas across nodes
+  affinity:
+    podAntiAffinityType: preferred
+
+  # Graceful shutdown/failover timeouts
+  failoverDelay: 0
+  switchoverDelay: 3600
+  smartShutdownTimeout: 180
+  startDelay: 3600
+  stopDelay: 1800
+  enablePDB: true
   postgresql:
     parameters:
       {{- range $key, $value := .Values.database.cnpg.parameters }}
@@ -28,17 +52,23 @@ spec:
       log_line_prefix: {{ .Values.database.cnpg.logging.log_line_prefix | quote }}
       {{- end }}
       {{- if .Values.database.cnpg.queryAnalysis.enabled }}
-      # Note: shared_preload_libraries is managed by CNPG operator automatically
-      # when extensions are created. pg_stat_statements is auto-loaded.
-      # auto_explain requires shared_preload_libraries which CNPG controls,
-      # so we only configure pg_stat_statements parameters here.
       pg_stat_statements.track: "all"
       pg_stat_statements.max: "10000"
       {{- end }}
-  # Enable extensions
-  {{- if or .Values.database.cnpg.pgvector.enabled .Values.database.cnpg.queryAnalysis.enabled }}
+    {{- if .Values.database.cnpg.queryAnalysis.enabled }}
+    shared_preload_libraries:
+      - pg_stat_statements
+    {{- end }}
+  # User management
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: {{ include "preloop.fullname" . }}-db-superuser
   bootstrap:
     initdb:
+      database: {{ .Values.database.cnpg.bootstrap.initdb.database }}
+      owner: {{ .Values.database.cnpg.bootstrap.initdb.owner }}
+      secret:
+        name: {{ .Release.Name }}-db-user
       postInitSQL:
         {{- if .Values.database.cnpg.pgvector.enabled }}
         - CREATE EXTENSION IF NOT EXISTS vector;
@@ -46,25 +76,30 @@ spec:
         {{- if .Values.database.cnpg.queryAnalysis.enabled }}
         - CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
         {{- end }}
-        - ALTER USER {{ .Values.database.cnpg.auth.username }} WITH PASSWORD '{{ .Values.database.cnpg.auth.password }}';
-  {{- end }}
 
-  # User management
-  enableSuperuserAccess: true
-  superuserSecret:
-    name: {{ include "preloop.fullname" . }}-db-superuser
-  bootstrap:
-    initdb:
-      postInitTemplateSQL: {{ .Values.database.cnpg.bootstrap.initdb.postInitTemplateSQL }}
-      database: {{ .Values.database.cnpg.bootstrap.initdb.database }}
-      owner: {{ .Values.database.cnpg.bootstrap.initdb.owner }}
-      secret:
-        name: {{ .Release.Name }}-db-user
-    # recovery:
-    #   database: {{ .Values.database.cnpg.auth.database }}
-    #   owner: {{ .Values.database.cnpg.auth.username }}
-    #   secret:
-    #     name: {{ include "preloop.fullname" . }}-db-user
+  # Monitoring
+  monitoring:
+    enablePodMonitor: {{ .Values.database.cnpg.monitoring.enablePodMonitor | default false }}
+    disableDefaultQueries: false
+
+  {{- if .Values.database.cnpg.backup.enabled }}
+  # Continuous backup to object storage
+  backup:
+    barmanObjectStore:
+      destinationPath: {{ .Values.database.cnpg.backup.destinationPath }}
+      {{- if .Values.database.cnpg.backup.s3Credentials }}
+      s3Credentials:
+        accessKeyId:
+          name: {{ .Values.database.cnpg.backup.s3Credentials.secretName }}
+          key: {{ .Values.database.cnpg.backup.s3Credentials.accessKeyIdKey | default "ACCESS_KEY_ID" }}
+        secretAccessKey:
+          name: {{ .Values.database.cnpg.backup.s3Credentials.secretName }}
+          key: {{ .Values.database.cnpg.backup.s3Credentials.secretAccessKeyKey | default "SECRET_ACCESS_KEY" }}
+      {{- end }}
+      wal:
+        compression: {{ .Values.database.cnpg.backup.walCompression | default "gzip" }}
+    retentionPolicy: {{ .Values.database.cnpg.backup.retentionPolicy | default "30d" | quote }}
+  {{- end }}
 
   # Storage configuration
   storage:

--- a/helm/preloop/templates/secret.yaml
+++ b/helm/preloop/templates/secret.yaml
@@ -30,3 +30,9 @@ data:
   github-app-private-key: {{ .Values.githubApp.privateKey | default "" | b64enc | quote }}
   github-app-webhook-secret: {{ .Values.githubApp.webhookSecret | default "" | b64enc | quote }}
   {{- end }}
+  {{- if .Values.googleOauth.enabled }}
+  google-oauth-client-secret: {{ .Values.googleOauth.clientSecret | default "" | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.gitlabOauth.enabled }}
+  gitlab-oauth-client-secret: {{ .Values.gitlabOauth.clientSecret | default "" | b64enc | quote }}
+  {{- end }}

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -178,7 +178,7 @@ database:
   # CloudNativePG configuration (if enabled is true and external is false)
   cnpg:
     name: ""
-    instances: 1
+    instances: 1  # Set to 2+ for HA (primary + replicas). Requires adequate storage and nodes.
     imageName: registry.spacecode.ai/spacecode/pgvector:16
     auth:
       username: postgres
@@ -216,11 +216,22 @@ database:
       maintenance_work_mem: "256MB"  # For VACUUM, CREATE INDEX
       random_page_cost: "1.1"        # SSD storage (default 4.0 is for HDD)
       effective_io_concurrency: "200" # SSD
-    # Query analysis - enable pg_stat_statements for slow query detection
-    # Note: auto_explain requires shared_preload_libraries which CNPG manages,
-    # so only pg_stat_statements is supported here.
+    # Query analysis - enables pg_stat_statements via shared_preload_libraries
     queryAnalysis:
       enabled: false  # Set to true in production for query performance insights
+    # Monitoring - expose PostgreSQL metrics to Prometheus via PodMonitor
+    monitoring:
+      enablePodMonitor: false  # Set to true if Prometheus is deployed
+    # Continuous backup to object storage (WAL archiving + base backups)
+    backup:
+      enabled: false  # Set to true in production
+      destinationPath: ""  # e.g. s3://bucket/cnpg/preloop-prod
+      retentionPolicy: "30d"
+      walCompression: "gzip"
+      s3Credentials:
+        secretName: ""  # K8s secret containing ACCESS_KEY_ID and SECRET_ACCESS_KEY
+        accessKeyIdKey: "ACCESS_KEY_ID"
+        secretAccessKeyKey: "SECRET_ACCESS_KEY"
     # Slow query logging - enable to monitor query performance
     logging:
       enabled: false  # Set to true to enable slow query logging
@@ -302,6 +313,27 @@ githubApp:
   webhookSecret: ""
   # GitHub App slug (e.g., "preloop" or "preloop-staging")
   slug: ""
+
+# Google OAuth configuration (Enterprise Edition only)
+# Enables "Sign in with Google" on login/register pages
+googleOauth:
+  enabled: false
+  # Google OAuth Client ID (from Google Cloud Console)
+  clientId: ""
+  # Google OAuth Client Secret
+  clientSecret: ""
+
+# GitLab OAuth configuration (Enterprise Edition only)
+# Enables "Sign in with GitLab" on login/register pages
+# Supports GitLab.com (default) and self-hosted GitLab instances
+gitlabOauth:
+  enabled: false
+  # GitLab OAuth Application ID
+  clientId: ""
+  # GitLab OAuth Application Secret
+  clientSecret: ""
+  # GitLab instance URL (for self-hosted; defaults to https://gitlab.com)
+  baseUrl: "https://gitlab.com"
 
 # Apple Push Notification Service (APNS) configuration
 apns:


### PR DESCRIPTION
<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> OAuth adds an auth server, consent UI, and sign-in integrations, touching core auth paths; changes are substantial but issues are addressed/acknowledged.
>
> **Overview**
> Adds an OAuth 2.1 authorization server for MCP clients, consent/login UI, OAuth sign-in wiring, and token refresh/revocation handling. Updates discovery metadata, configuration, tests, and documentation for the new OAuth flows.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 9206854. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
