### PR TITLE
feat(security): redact sensitive data from logs and audit surfaces

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -546,7 +546,7 @@ The system is designed to be containerized using Docker, enabling easy deploymen
 - [x] Password hashing with industry-standard algorithms
 - [x] Input validation for all parameters via Pydantic models
 - [ ] Issue tracker credentials encrypted at rest (currently stored securely but not encrypted)
-- [ ] Sensitive data masked in logs
+- [x] Sensitive data masked in logs (see Redaction Policy below)
 - [ ] Rate limiting to prevent abuse (partial implementation exists)
 - [ ] 2FA/MFA support for user accounts
 - [ ] Session management and token revocation
@@ -554,6 +554,23 @@ The system is designed to be containerized using Docker, enabling easy deploymen
 
 > **Enterprise Security**: Preloop Enterprise Edition adds RBAC, comprehensive audit logging, and impersonation tracking for compliance requirements. Contact sales@preloop.ai for more information.
 
+### Redaction Policy
+
+Preloop redacts sensitive data before logging, persisting to audit surfaces, or sending notifications. The centralized redaction module (`preloop.utils.redaction`) provides:
+
+- **`redact_dict(data)`**: Recursively replaces values for sensitive field names (e.g. `password`, `api_key`, `token`, `secret`, `credential`) with `***REDACTED***`.
+- **`redact_for_log(data)`**: Produces a safe JSON string for log messages, with sensitive fields redacted and output truncated.
+
+**Redaction is applied in:**
+- MCP tool execution logs (tool arguments)
+- Approval flow logs and notifications (tool args, approval URLs)
+- Flow execution MCP usage logs (persisted to DB)
+- Audit trail (configuration changes, tool executions)
+- Approval request emails and Slack/Mattermost messages
+
+**Known exceptions:** Approval URLs are not logged in full (replaced with `[sent via notification]`). Progress tokens and request context metadata are not logged. Tracker credentials and AI model API keys are not logged when present in payloads.
+
+**Tests:** `tests/utils/test_redaction.py` asserts that representative secrets never appear in redacted output.
 
 ## Real-Time Communication
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Sensitive data redaction**: Centralized redaction of secrets and sensitive fields before logging, persisting to audit surfaces, or sending notifications. Tool arguments, approval payloads, and configuration changes are redacted in MCP execution logs, approval flows, flow execution logs, audit trail, and approval emails. See `preloop.utils.redaction` and ARCHITECTURE.md Redaction Policy.
+
 ## [0.8.0] - 2026-03-08
 
 ### Added

--- a/backend/preloop/api/endpoints/public_approval.py
+++ b/backend/preloop/api/endpoints/public_approval.py
@@ -67,11 +67,13 @@ def get_approval_request_public(
             status_code=404, detail="Approval request not found or invalid token"
         )
 
-    # Return public data only
+    # Return public data only (redact tool_args for display)
+    from preloop.utils.redaction import redact_dict
+
     return ApprovalRequestPublic(
         id=str(approval_request.id),
         tool_name=approval_request.tool_name,
-        tool_args=approval_request.tool_args,
+        tool_args=redact_dict(approval_request.tool_args or {}),
         agent_reasoning=approval_request.agent_reasoning,
         status=approval_request.status,
         requested_at=approval_request.requested_at.isoformat(),

--- a/backend/preloop/services/approval_helper.py
+++ b/backend/preloop/services/approval_helper.py
@@ -269,17 +269,19 @@ async def require_approval(
                 )
                 channels_display = ", ".join(notification_channels)
 
+                from preloop.utils.redaction import redact_for_log
+
                 logger.warning(
                     f"\n{'=' * 60}\n"
                     f"🚨 APPROVAL REQUIRED ({tool_source.upper()} Tool) 🚨\n"
                     f"{'=' * 60}\n"
                     f"Tool: {tool_name}\n"
-                    f"Arguments: {arguments}\n"
+                    f"Arguments: {redact_for_log(arguments)}\n"
                     f"Request ID: {approval_request.id}\n"
                     f"Notification sent via: {channels_display}\n"
                     f"Approval type: {workflow.approval_type}\n"
                     f"Timeout: {workflow.timeout_seconds or 300}s\n"
-                    f"Approval URL: {approval_url}\n"
+                    f"Approval URL: [sent via notification]\n"
                     f"{'=' * 60}\n"
                     f"⏳ Waiting for approval (polling every 2s)..."
                 )
@@ -373,13 +375,12 @@ async def require_approval(
                 # Send initial notification via Context (FastMCP streaming)
                 if ctx:
                     try:
-                        logger.info(f"Context object: {ctx}, type: {type(ctx)}")
-                        logger.info(
-                            f"Has report_progress: {hasattr(ctx, 'report_progress')}"
+                        logger.debug(
+                            f"Context: has report_progress={hasattr(ctx, 'report_progress')}"
                         )
                         # Report progress at 0% with status message
                         status_message = f"Approval request sent via {channels_display}"
-                        # Check if progressToken is available
+                        # Check if progressToken is available (do not log - sensitive)
                         progress_token = None
                         try:
                             progress_token = (
@@ -389,11 +390,6 @@ async def require_approval(
                             )
                         except Exception as e:
                             logger.error(f"Error getting progressToken: {e}")
-
-                        logger.info(f"   progressToken: {progress_token}")
-                        logger.info(
-                            f"   request_context.meta: {ctx.request_context.meta if hasattr(ctx, 'request_context') else 'N/A'}"
-                        )
 
                         # Only send progress notification if we have a valid progressToken
                         if progress_token is not None:

--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -148,7 +148,9 @@ class ApprovalService:
                 logger.warning("NATS not available for broadcasting approval update")
                 return
 
-            # Prepare update message
+            from preloop.utils.redaction import redact_dict
+
+            # Prepare update message (redact tool_args for broadcast/display)
             update_data = {
                 "type": f"approval_{event_type}",
                 "approval_request_id": str(approval_request.id),
@@ -157,7 +159,7 @@ class ApprovalService:
                 "approval_workflow_id": str(approval_request.approval_workflow_id),
                 "execution_id": approval_request.execution_id,
                 "tool_name": approval_request.tool_name,
-                "tool_args": approval_request.tool_args,
+                "tool_args": redact_dict(approval_request.tool_args or {}),
                 "agent_reasoning": approval_request.agent_reasoning,
                 "status": approval_request.status,
                 "requested_at": approval_request.requested_at.isoformat(),
@@ -250,6 +252,8 @@ class ApprovalService:
             corr_id = _correlation_id_var.get(None)
         except Exception:
             pass
+        from preloop.utils.redaction import redact_dict
+
         _log_approval_lifecycle_async(
             account_id=account_id,
             approval_id=approval_request.id,
@@ -259,7 +263,7 @@ class ApprovalService:
             correlation_id=corr_id,
             extra_details={
                 "approval_workflow_id": str(approval_workflow_id),
-                "tool_args": tool_args,
+                "tool_args": redact_dict(tool_args),
                 "timeout_seconds": timeout,
             },
         )
@@ -888,8 +892,11 @@ class ApprovalService:
             self.base_url, f"/approval/{approval_request.id}?token={token}"
         )
 
-        # Format tool arguments for display
-        tool_args_formatted = json.dumps(approval_request.tool_args, indent=2)
+        # Format tool arguments for display (redact sensitive fields)
+        from preloop.utils.redaction import redact_dict
+
+        tool_args_redacted = redact_dict(approval_request.tool_args or {})
+        tool_args_formatted = json.dumps(tool_args_redacted, indent=2)
 
         # Create message based on approval type
         if approval_workflow.approval_type in ["slack", "mattermost"]:
@@ -965,12 +972,12 @@ class ApprovalService:
                     },
                 )
         else:
-            # Generic webhook message
+            # Generic webhook message (redact tool_args for external webhooks)
             message = {
                 "type": "approval_request",
                 "request_id": str(approval_request.id),
                 "tool_name": approval_request.tool_name,
-                "tool_args": approval_request.tool_args,
+                "tool_args": tool_args_redacted,
                 "agent_reasoning": approval_request.agent_reasoning,
                 "status": approval_request.status,
                 "requested_at": approval_request.requested_at.isoformat(),
@@ -1040,6 +1047,8 @@ class ApprovalService:
         Returns:
             Created approval request (may be already resolved if AI-driven)
         """
+        # Store raw tool_args for execution; redact only for logging/notifications
+        # (see ARCHITECTURE.md Redaction Policy)
         # Create approval request first
         approval_request = await self.create_approval_request(
             account_id=account_id,
@@ -1377,11 +1386,13 @@ class ApprovalService:
                     f"{self.base_url}/approval/{approval_request.id}?token={token}"
                 )
 
-                # Send email
+                # Send email (redact tool_args for display)
+                from preloop.utils.redaction import redact_dict
+
                 await send_approval_request_email(
                     user_email=user.email,
                     tool_name=approval_request.tool_name,
-                    tool_args=approval_request.tool_args,
+                    tool_args=redact_dict(approval_request.tool_args or {}),
                     approval_url=approval_url,
                     agent_reasoning=approval_request.agent_reasoning,
                 )
@@ -1534,14 +1545,16 @@ class ApprovalService:
         # Default to "medium" for normal requests
         priority_str = getattr(approval_request, "priority", None) or "medium"
 
-        # Build notification payload with tool args for context
+        # Build notification payload (redact tool_args for push display)
+        from preloop.utils.redaction import redact_dict
+
         payload = NotificationPayloadBuilder.new_approval_request(
             request_id=str(approval_request.id),
             tool_name=approval_request.tool_name,
             priority=priority_str,
             expires_at=approval_request.expires_at,
             agent_reasoning=approval_request.agent_reasoning,
-            tool_args=approval_request.tool_args,
+            tool_args=redact_dict(approval_request.tool_args or {}),
         )
 
         apns_priority = 10 if priority_str in ["urgent", "high"] else 5
@@ -1959,14 +1972,16 @@ class ApprovalService:
                 "push_sent": 0,
             }
 
-        # Build escalation notification payload
+        # Build escalation notification payload (redact tool_args for display)
+        from preloop.utils.redaction import redact_dict
+
         payload = NotificationPayloadBuilder.new_approval_request(
             request_id=request_id,
             tool_name=tool_name,
             priority="high",  # Escalations are always high priority
             expires_at=approval_request.expires_at,
             agent_reasoning=f"ESCALATED: {approval_request.agent_reasoning or 'Original approvers did not respond'}",
-            tool_args=approval_request.tool_args,
+            tool_args=redact_dict(approval_request.tool_args or {}),
         )
 
         sent_count = 0

--- a/backend/preloop/services/approval_wrapper.py
+++ b/backend/preloop/services/approval_wrapper.py
@@ -172,16 +172,18 @@ def with_approval(tool_func: Callable) -> Callable:
                         else "webhook"
                     )
 
+                    from preloop.utils.redaction import redact_for_log
+
                     logger.warning(
                         f"\n{'=' * 60}\n"
                         f"🚨 APPROVAL REQUIRED 🚨\n"
                         f"{'=' * 60}\n"
                         f"Tool: {tool_name}\n"
-                        f"Arguments: {kwargs}\n"
+                        f"Arguments: {redact_for_log(kwargs)}\n"
                         f"Request ID: {approval_request.id}\n"
                         f"Notification sent to: {workflow.approval_type} ({notification_channel})\n"
                         f"Timeout: {workflow.timeout_seconds or 300}s\n"
-                        f"Approval URL: {approval_url}\n"
+                        f"Approval URL: [sent via notification]\n"
                         f"{'=' * 60}\n"
                         f"⏳ Waiting for approval (polling every 2s)..."
                     )

--- a/backend/preloop/services/dynamic_fastmcp.py
+++ b/backend/preloop/services/dynamic_fastmcp.py
@@ -787,6 +787,7 @@ async def {internal_name}({params_str}) -> str:
             # ── Audit: log tool execution ───────────────────────────────
             try:
                 from preloop.plugins.base import get_plugin_manager
+                from preloop.utils.redaction import redact_dict
 
                 plugin_manager = get_plugin_manager()
                 audit_service = plugin_manager.get_service("audit_service")
@@ -796,7 +797,7 @@ async def {internal_name}({params_str}) -> str:
                         account_id=uuid.UUID(user_context.account_id),
                         user_id=uuid.UUID(user_context.user_id),
                         tool_name=name,
-                        tool_args=arguments,
+                        tool_args=redact_dict(arguments),
                         result=exec_status,
                         duration_ms=elapsed_ms,
                         policy_decision=None,

--- a/backend/preloop/services/dynamic_mcp_server.py
+++ b/backend/preloop/services/dynamic_mcp_server.py
@@ -60,6 +60,8 @@ def _log_tool_execution_async(
 ) -> None:
     """Log a tool execution asynchronously (fire-and-forget)."""
     try:
+        from preloop.utils.redaction import redact_dict
+
         audit_service = _get_audit_service()
         if not audit_service:
             return
@@ -67,6 +69,9 @@ def _log_tool_execution_async(
         db_factory = _get_db_factory()
         if not db_factory:
             return
+
+        # Redact sensitive fields before audit
+        tool_args = redact_dict(tool_args)
 
         # Convert string IDs to UUIDs where needed
         user_uuid = None
@@ -313,9 +318,11 @@ class DynamicMCPServer:
                         )
                     ]
 
+                from preloop.utils.redaction import redact_for_log
+
                 logger.info(
                     f"Executing tool {name} for user {user_context.username} "
-                    f"with args: {arguments}"
+                    f"with args: {redact_for_log(arguments or {})}"
                 )
 
                 # Track execution time

--- a/backend/preloop/services/flow_execution_logger.py
+++ b/backend/preloop/services/flow_execution_logger.py
@@ -4,6 +4,8 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+from preloop.utils.redaction import redact_dict
+
 logger = logging.getLogger(__name__)
 
 
@@ -48,7 +50,7 @@ class FlowExecutionLogger:
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "server_name": server_name,
             "tool_name": tool_name,
-            "arguments": arguments,
+            "arguments": redact_dict(arguments),
             "status": status,
             "result_summary": result_summary,
             "error": error,

--- a/backend/preloop/services/mcp_http.py
+++ b/backend/preloop/services/mcp_http.py
@@ -516,9 +516,11 @@ async def mcp_http_streaming_endpoint(
                     media_type="application/json",
                 )
 
+            from preloop.utils.redaction import redact_for_log
+
             logger.info(
                 f"Executing tool {tool_name} for user {user_context['username']} "
-                f"with args: {tool_args}"
+                f"with args: {redact_for_log(tool_args)}"
             )
 
             # Call handler

--- a/backend/preloop/services/notification_service.py
+++ b/backend/preloop/services/notification_service.py
@@ -667,11 +667,13 @@ class NotificationService:
         token = approval_request.approval_token
         approval_url = f"{PRELOOP_URL}/approval/{approval_request.id}?token={token}"
 
+        from preloop.utils.redaction import redact_dict
+
         message = {
             "type": "approval_request",
             "request_id": str(approval_request.id),
             "tool_name": approval_request.tool_name,
-            "tool_args": approval_request.tool_args,
+            "tool_args": redact_dict(approval_request.tool_args or {}),
             "agent_reasoning": approval_request.agent_reasoning,
             "status": approval_request.status,
             "requested_at": approval_request.requested_at.isoformat(),
@@ -723,10 +725,13 @@ class NotificationService:
             Dict payload suitable for Slack or Mattermost incoming webhooks.
         """
         from preloop.utils.email import PRELOOP_URL
+        from preloop.utils.redaction import redact_dict
 
         token = approval_request.approval_token
         approval_url = f"{PRELOOP_URL}/approval/{approval_request.id}?token={token}"
-        tool_args_formatted = json.dumps(approval_request.tool_args, indent=2)
+        tool_args_formatted = json.dumps(
+            redact_dict(approval_request.tool_args or {}), indent=2
+        )
 
         message_text = f"⚠️ **Approval Required: {approval_request.tool_name}**\n\n"
         message_text += f"**Tool:** `{approval_request.tool_name}`\n"

--- a/backend/preloop/utils/audit.py
+++ b/backend/preloop/utils/audit.py
@@ -57,14 +57,16 @@ def log_config_change(
         return
 
     try:
+        from preloop.utils.redaction import redact_dict
+
         audit_service.log_configuration_change(
             db,
             account_id=user.account_id,
             user=user,
             config_type=config_type,
             action=action,
-            old_value=old_value,
-            new_value=new_value,
+            old_value=redact_dict(old_value) if old_value is not None else None,
+            new_value=redact_dict(new_value) if new_value is not None else None,
             request=request,
         )
     except Exception:

--- a/backend/preloop/utils/email.py
+++ b/backend/preloop/utils/email.py
@@ -419,9 +419,12 @@ async def send_approval_request_email(
     """
     subject = f"Tool Approval Required: {tool_name}"
 
-    # Format tool arguments for display
+    # Format tool arguments for display (redact sensitive fields)
     import json
 
+    from preloop.utils.redaction import redact_dict
+
+    tool_args = redact_dict(tool_args)
     tool_args_formatted = json.dumps(tool_args, indent=2)
 
     # Plain text version

--- a/backend/preloop/utils/redaction.py
+++ b/backend/preloop/utils/redaction.py
@@ -1,0 +1,134 @@
+"""Centralized redaction of sensitive data for logs and audit surfaces.
+
+This module provides helpers to prevent accidental leakage of secrets and
+sensitive user data through application logs, error traces, approval logs,
+and tool execution records.
+
+Redaction policy:
+- Field names matching SENSITIVE_FIELD_NAMES (case-insensitive) are replaced
+  with REDACTED_STRING in dicts and nested structures.
+- Use redact_dict() before logging or persisting dict-like data.
+- Use redact_for_log() for safe string representation in log messages.
+"""
+
+import json
+import re
+from typing import Any, Optional, Set
+
+REDACTED_STRING = "***REDACTED***"
+
+# Field names that should never appear in logs or audit payloads.
+# Matches case-insensitively.
+SENSITIVE_FIELD_NAMES: Set[str] = {
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "api-key",
+    "auth",
+    "authorization",
+    "credential",
+    "credentials",
+    "private_key",
+    "privatekey",
+    "access_token",
+    "accesstoken",
+    "refresh_token",
+    "refreshtoken",
+    "bearer",
+    "client_secret",
+    "clientsecret",
+    "webhook_secret",
+    "webhooksecret",
+    "jira_webhook_secret",
+    "device_token",
+    "devicetoken",
+    "progress_token",
+    "progresstoken",
+    "approval_token",
+    "approvaltoken",
+    "key",
+    "keys",
+}
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """Check if a dict key matches a sensitive field name."""
+    if not isinstance(key, str):
+        return False
+    key_lower = key.lower().strip()
+    # Exact match
+    if key_lower in SENSITIVE_FIELD_NAMES:
+        return True
+    # Suffix match for keys like "github_api_key", "oauth_client_secret"
+    for sensitive in SENSITIVE_FIELD_NAMES:
+        if key_lower.endswith(sensitive) or key_lower.startswith(sensitive):
+            return True
+    # Common patterns: *_token, *_secret, *_password, *_key
+    if re.search(r"(token|secret|password|api_key|credential)s?$", key_lower):
+        return True
+    return False
+
+
+def redact_dict(
+    data: Any,
+    field_names: Optional[Set[str]] = None,
+) -> Any:
+    """Recursively redact sensitive fields from a dict or list.
+
+    Replaces values for keys matching SENSITIVE_FIELD_NAMES (or field_names
+    if provided) with REDACTED_STRING. Nested dicts and lists are processed
+    recursively.
+
+    Args:
+        data: Dict, list, or scalar value to process.
+        field_names: Optional override for sensitive field names. If None,
+            uses SENSITIVE_FIELD_NAMES.
+
+    Returns:
+        A copy of data with sensitive values redacted. Scalars are returned
+        unchanged.
+    """
+    sensitive = field_names if field_names is not None else SENSITIVE_FIELD_NAMES
+
+    if isinstance(data, dict):
+        result = {}
+        for k, v in data.items():
+            key_sensitive = isinstance(k, str) and (
+                k.lower() in sensitive or _is_sensitive_key(k)
+            )
+            if key_sensitive:
+                result[k] = REDACTED_STRING
+            else:
+                result[k] = redact_dict(v, field_names=sensitive)
+        return result
+    elif isinstance(data, list):
+        return [redact_dict(item, field_names=sensitive) for item in data]
+    else:
+        return data
+
+
+def redact_for_log(data: Any, max_length: int = 500) -> str:
+    """Produce a safe string representation for logging.
+
+    Redacts sensitive fields and truncates long values to avoid leaking
+    secrets or flooding logs.
+
+    Args:
+        data: Value to serialize (typically dict or list).
+        max_length: Maximum length of the output string.
+
+    Returns:
+        JSON string with sensitive fields redacted, truncated if needed.
+    """
+    redacted = redact_dict(data)
+    try:
+        s = json.dumps(redacted, default=str)
+    except (TypeError, ValueError):
+        s = repr(redacted)
+    if len(s) > max_length:
+        s = s[: max_length - 20] + "...[truncated]"
+    return s

--- a/backend/tests/services/test_flow_execution_logger.py
+++ b/backend/tests/services/test_flow_execution_logger.py
@@ -1,6 +1,7 @@
 """Tests for FlowExecutionLogger service."""
 
 from preloop.services.flow_execution_logger import FlowExecutionLogger
+from preloop.utils.redaction import REDACTED_STRING
 
 
 class TestFlowExecutionLoggerInit:
@@ -69,6 +70,27 @@ class TestLogMCPToolCall:
         log_entry = logger.mcp_usage_logs[0]
         assert log_entry["status"] == "failed"
         assert log_entry["error"] == "Connection timeout"
+
+    def test_log_mcp_tool_call_redacts_sensitive_arguments(self):
+        """Test that sensitive arguments are redacted before storage."""
+        logger = FlowExecutionLogger()
+
+        logger.log_mcp_tool_call(
+            server_name="test-server",
+            tool_name="create_issue",
+            arguments={
+                "project": "my-org/repo",
+                "title": "Fix bug",
+                "api_key": "sk-secret-key-123",
+                "password": "super_secret",
+            },
+        )
+
+        log_entry = logger.mcp_usage_logs[0]
+        assert log_entry["arguments"]["project"] == "my-org/repo"
+        assert log_entry["arguments"]["title"] == "Fix bug"
+        assert log_entry["arguments"]["api_key"] == REDACTED_STRING
+        assert log_entry["arguments"]["password"] == REDACTED_STRING
 
     def test_log_multiple_mcp_tool_calls(self):
         """Test logging multiple MCP tool calls."""

--- a/backend/tests/utils/test_redaction.py
+++ b/backend/tests/utils/test_redaction.py
@@ -1,0 +1,140 @@
+"""Tests for preloop.utils.redaction module."""
+
+from preloop.utils.redaction import (
+    REDACTED_STRING,
+    redact_dict,
+    redact_for_log,
+    SENSITIVE_FIELD_NAMES,
+)
+
+
+class TestRedactDict:
+    """Tests for redact_dict function."""
+
+    def test_redacts_password(self) -> None:
+        """Password fields are redacted."""
+        data = {"username": "alice", "password": "secret123"}
+        result = redact_dict(data)
+        assert result["username"] == "alice"
+        assert result["password"] == REDACTED_STRING
+
+    def test_redacts_api_key(self) -> None:
+        """API key fields are redacted."""
+        data = {"project": "foo", "api_key": "sk-abc123xyz"}
+        result = redact_dict(data)
+        assert result["project"] == "foo"
+        assert result["api_key"] == REDACTED_STRING
+
+    def test_redacts_token(self) -> None:
+        """Token fields are redacted."""
+        data = {"user_id": "u1", "access_token": "eyJhbGciOiJIUzI1NiJ9"}
+        result = redact_dict(data)
+        assert result["user_id"] == "u1"
+        assert result["access_token"] == REDACTED_STRING
+
+    def test_redacts_nested_dict(self) -> None:
+        """Nested dicts are processed recursively."""
+        data = {
+            "outer": "ok",
+            "credentials": {
+                "username": "u",
+                "password": "p",
+                "nested": {"api_key": "key"},
+            },
+        }
+        result = redact_dict(data)
+        assert result["outer"] == "ok"
+        assert result["credentials"] == REDACTED_STRING
+
+    def test_redacts_list_of_dicts(self) -> None:
+        """Lists of dicts are processed."""
+        data = [{"name": "a", "secret": "s1"}, {"name": "b", "token": "t1"}]
+        result = redact_dict(data)
+        assert result[0]["name"] == "a"
+        assert result[0]["secret"] == REDACTED_STRING
+        assert result[1]["name"] == "b"
+        assert result[1]["token"] == REDACTED_STRING
+
+    def test_preserves_non_sensitive(self) -> None:
+        """Non-sensitive fields are preserved."""
+        data = {
+            "title": "Fix bug",
+            "description": "The issue is...",
+            "project": "my-org/repo",
+            "labels": ["bug", "urgent"],
+        }
+        result = redact_dict(data)
+        assert result == data
+
+    def test_redacts_suffix_patterns(self) -> None:
+        """Keys ending with _token, _secret, etc. are redacted."""
+        data = {
+            "github_api_key": "ghp_xxx",
+            "oauth_client_secret": "cs_yyy",
+            "webhook_secret": "wh_zzz",
+        }
+        result = redact_dict(data)
+        assert result["github_api_key"] == REDACTED_STRING
+        assert result["oauth_client_secret"] == REDACTED_STRING
+        assert result["webhook_secret"] == REDACTED_STRING
+
+    def test_returns_copy(self) -> None:
+        """Original dict is not mutated."""
+        data = {"password": "p"}
+        result = redact_dict(data)
+        assert data["password"] == "p"
+        assert result["password"] == REDACTED_STRING
+
+    def test_scalar_unchanged(self) -> None:
+        """Scalar values are returned unchanged."""
+        assert redact_dict("hello") == "hello"
+        assert redact_dict(42) == 42
+        assert redact_dict(None) is None
+
+
+class TestRedactForLog:
+    """Tests for redact_for_log function."""
+
+    def test_redacts_and_serializes(self) -> None:
+        """Produces JSON string with redacted values."""
+        data = {"command": "deploy", "api_key": "sk-xxx"}
+        s = redact_for_log(data)
+        assert "sk-xxx" not in s
+        assert REDACTED_STRING in s
+        assert "deploy" in s
+
+    def test_truncates_long_output(self) -> None:
+        """Long output is truncated."""
+        data = {"x": "a" * 1000}
+        s = redact_for_log(data, max_length=100)
+        assert len(s) <= 100
+        assert "[truncated]" in s
+
+    def test_secrets_never_in_output(self) -> None:
+        """Representative secrets never appear in output."""
+        secrets = [
+            {"password": "super_secret_123"},
+            {"api_key": "sk-abc123"},
+            {"access_token": "eyJhbGciOiJIUzI1NiJ9.xxx"},
+            {"client_secret": "cs_xyz789"},
+        ]
+        for data in secrets:
+            for key, value in data.items():
+                s = redact_for_log(data)
+                assert value not in s, f"Secret value leaked for key {key}"
+
+
+class TestSensitiveFieldNames:
+    """Tests for SENSITIVE_FIELD_NAMES coverage."""
+
+    def test_common_secret_fields_covered(self) -> None:
+        """Common secret-bearing field names are in the set."""
+        expected = {
+            "password",
+            "token",
+            "api_key",
+            "secret",
+            "credential",
+            "client_secret",
+        }
+        assert expected.issubset(SENSITIVE_FIELD_NAMES)


### PR DESCRIPTION
- Add centralized redaction module (preloop.utils.redaction)
- Redact tool args in MCP, approval, flow execution, and audit paths
- Redact tool_args in approval emails and notifications
- Add tests for redaction; document policy in ARCHITECTURE.md

Addresses https://github.com/preloop/preloop/issues/27

## Summary

-

## Testing

- [x] Backend tests
- [ ] Frontend tests
- [ ] Manual validation

## Checklist

- [ ] Docs updated if needed
- [x] Changelog updated if needed
- [x] No secrets included

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> The changes properly redact sensitive information from logs and notifications without breaking underlying tool execution functionality.
>
> **Overview**
> Adds centralized redaction helpers and applies them to MCP logging, approval flows, audits, and notification/email surfaces, plus tests and documentation updates. The previous issue regarding retaining raw tool arguments for execution has been fixed.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai). Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->