### PR TITLE
Pin per-agent approval workflows and harden default workflow seeding.

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -504,6 +504,8 @@ graph TD
 
 **Managed-agent linkage:** `ApprovalRequest` carries optional `managed_agent_id`, `runtime_session_id`, and `managed_agent_name` fields, populated from the runtime token context so approval surfaces can show which agent is asking. The endpoint and these identity columns are part of the open-source core. The per-agent native-tool interception adapters (Claude Code, Codex CLI, Cursor, OpenClaw, Hermes) and any future central per-agent/global policy UI live in Preloop Enterprise / the CLI.
 
+**Workflow resolution.** Every account gets a default approval workflow seeded at signup with the account owner as approver (a startup repair pass heals legacy defaults and seeds accounts that missed it). Operators can additionally pin a specific approval workflow per managed agent from the Console's agent detail view (Tools & Governance → Native tool approvals); the pin is stored in the agent's subject-governance config (`approval_workflow_id`) and wins over the account default when the permission-check endpoint resolves a workflow.
+
 #### Access Rules System
 
 The tool configuration system has been expanded with a **ToolAccessRule** model that replaces the simpler ToolApprovalCondition approach.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-agent native-tool approval workflow**: Operators can pin an approval workflow on a managed agent from the Console agent detail view (Tools & Governance → Native tool approvals). The pin is stored in subject governance as `approval_workflow_id` and takes precedence over the account default when `POST /api/v1/agents/permission-check` resolves a workflow. Governance updates reject workflow IDs that are invalid or not in the account.
+- **Default approval-workflow backfill**: The API startup repair pass now also seeds the account-default workflow (owner as approver) for active accounts that have none, covering signup-seed background tasks lost to restarts or transient failures.
+- **Interactive approvals opt-in**: Discover-driven agent onboarding prompts for native tool-approval hooks on supported agents (default yes), matching `preloop agents onboard --approvals`. README documents the interactive path.
+
+### Changed
+
+- **Default workflow owner resolution**: Seeding the account-default approval workflow prefers `Account.primary_user_id` over the oldest user in the account.
+- **Live gateway validation throttling**: Upstream HTTP 429 during live validation is treated as proof the gateway credential and wiring work; onboarding no longer rolls back gateway config for throttled probes (hard `failed` still does).
+- **CLI approvals list**: `preloop approvals list` table output now shows type, mode, default flag, approver summary, and timeout instead of the outdated tool-pattern / auto-approve / active columns.
+
 ## [0.10.0] - 2026-07-10
 
 ### Overview

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ runtime, and let the plugin connect.
 Don't have the runtime installed yet? `preloop agents install-runtime <hermes|openclaw>`
 installs it locally and onboards it through Preloop in one step. To route an
 agent's **native** tool calls (e.g. Claude Code `Bash`/`Edit`) through Preloop
-approvals, onboard with `preloop agents onboard <agent> --approvals`.
+approvals, onboard with `preloop agents onboard <agent> --approvals` — or just
+answer yes when interactive onboarding offers it for supported agents.
 
 <p align="center">
   <img alt="Preloop dashboard with live agent and gateway usage" src="frontend/public/assets/screenshots/quickstart/dark/dashboard.png" style="width: 100%; max-width: 1135px; border-radius: 12px;" />

--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -396,6 +396,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             from preloop.models.db.session import get_session_factory
             from preloop.models.crud import crud_approval_workflow
             from preloop.services.approval_workflow_service import (
+                create_default_approval_workflow_for_account,
                 repair_default_approval_workflow_for_account,
             )
 
@@ -403,6 +404,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             scan_db = session_factory()
             try:
                 broken = crud_approval_workflow.find_legacy_default_workflows(scan_db)
+                missing = crud_approval_workflow.find_accounts_missing_workflows(
+                    scan_db
+                )
             finally:
                 scan_db.close()
 
@@ -417,10 +421,25 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                         f"{account_id}: {inner_exc}"
                     )
 
-            if broken:
+            # Seed the default workflow (owner as approver) for accounts that
+            # have none at all — signup seeding runs as a background task and
+            # can be lost to a deploy restart or transient failure.
+            seeded = 0
+            for account_id in missing:
+                try:
+                    create_default_approval_workflow_for_account(account_id)
+                    seeded += 1
+                except Exception as inner_exc:  # pragma: no cover - defensive
+                    logger.warning(
+                        f"Default workflow seeding failed for account "
+                        f"{account_id}: {inner_exc}"
+                    )
+
+            if broken or missing:
                 logger.info(
                     f"Default approval workflow repair pass complete: "
-                    f"scanned={len(broken)}, repaired={repaired}"
+                    f"scanned={len(broken)}, repaired={repaired}, "
+                    f"missing={len(missing)}, seeded={seeded}"
                 )
         except Exception as e:
             logger.warning(

--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -393,53 +393,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # them. The repair pass is idempotent and safe to run on every boot.
     if not is_testing and is_api_role:
         try:
-            from preloop.models.db.session import get_session_factory
-            from preloop.models.crud import crud_approval_workflow
             from preloop.services.approval_workflow_service import (
-                create_default_approval_workflow_for_account,
-                repair_default_approval_workflow_for_account,
+                run_default_approval_workflow_startup_repair,
             )
 
-            session_factory = get_session_factory()
-            scan_db = session_factory()
-            try:
-                broken = crud_approval_workflow.find_legacy_default_workflows(scan_db)
-                missing = crud_approval_workflow.find_accounts_missing_workflows(
-                    scan_db
-                )
-            finally:
-                scan_db.close()
-
-            repaired = 0
-            for account_id in broken:
-                try:
-                    if repair_default_approval_workflow_for_account(account_id):
-                        repaired += 1
-                except Exception as inner_exc:  # pragma: no cover - defensive
-                    logger.warning(
-                        f"Default workflow repair failed for account "
-                        f"{account_id}: {inner_exc}"
-                    )
-
-            # Seed the default workflow (owner as approver) for accounts that
-            # have none at all — signup seeding runs as a background task and
-            # can be lost to a deploy restart or transient failure.
-            seeded = 0
-            for account_id in missing:
-                try:
-                    create_default_approval_workflow_for_account(account_id)
-                    seeded += 1
-                except Exception as inner_exc:  # pragma: no cover - defensive
-                    logger.warning(
-                        f"Default workflow seeding failed for account "
-                        f"{account_id}: {inner_exc}"
-                    )
-
-            if broken or missing:
+            stats = run_default_approval_workflow_startup_repair()
+            if stats["broken"] or stats["missing"]:
                 logger.info(
-                    f"Default approval workflow repair pass complete: "
-                    f"scanned={len(broken)}, repaired={repaired}, "
-                    f"missing={len(missing)}, seeded={seeded}"
+                    "Default approval workflow repair pass complete: "
+                    "scanned=%(broken)s, repaired=%(repaired)s, "
+                    "missing=%(missing)s, seeded=%(seeded)s" % stats
                 )
         except Exception as e:
             logger.warning(

--- a/backend/preloop/api/auth/jwt.py
+++ b/backend/preloop/api/auth/jwt.py
@@ -413,8 +413,11 @@ def get_current_user(
         token_data = decode_token(token)
         logger.info(f"JWT decoded successfully: {token_data}")
 
-        # Check if it's a refresh token
-        if isinstance(token_data, dict) and token_data.get("refresh", False):
+        # Check if it's a refresh token. decode_token() returns a TokenData
+        # model (never a dict), so the refresh flag must be read as an
+        # attribute — an isinstance(..., dict) guard here is dead code and
+        # would let a 7-day refresh token be used as an access token.
+        if getattr(token_data, "refresh", False):
             logger.warning("Attempted to use refresh token for authentication")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
@@ -593,7 +596,9 @@ def get_user_from_token_if_valid_sync(token: str, db_session: Any) -> Optional[U
                 return _authenticate_with_api_key(db_session, api_key)
 
         token_data = decode_token(token)
-        if isinstance(token_data, dict) and token_data.get("refresh", False):
+        # TokenData model, not a dict — read the refresh flag as an attribute so
+        # refresh tokens can't authenticate WebSocket/gateway sessions.
+        if getattr(token_data, "refresh", False):
             return None
 
         user_id_str = getattr(token_data, "sub", "")

--- a/backend/preloop/api/auth/router.py
+++ b/backend/preloop/api/auth/router.py
@@ -1394,73 +1394,11 @@ def update_api_key_governance(
     )
 
 
-@router.get("/api-keys/debug", response_model=List[ApiKeyResponse])
-def debug_api_keys(
-    username: str,
-    api_key: Optional[str] = None,
-    current_user: AuthUserResponse = Depends(get_current_active_user),
-    db: Session = Depends(get_db_session),
-) -> List[ApiKeyResponse]:
-    """Debug endpoint to get API keys with their values (admin only).
-
-    Args:
-        username: The username to get keys for
-        api_key: Optional specific API key to look up
-        current_user: The current authenticated user.
-
-    Returns:
-        List of API keys with their values.
-    """
-    # This is for debugging only
-    session = db
-
-    try:
-        # Check if specific key was requested
-        if api_key:
-            logger.info(f"Looking up specific API key: {api_key[:10]}...")
-            # Get specific key using CRUD layer
-            key = crud_api_key.get_by_key(session, key=api_key)
-            return (
-                [
-                    ApiKeyResponse(
-                        id=key.id
-                        if key
-                        else UUID("00000000-0000-0000-0000-000000000000"),
-                        name=key.name if key else "Not Found",
-                        key=key.key if key else api_key,
-                        created_at=key.created_at if key else datetime.now(UTC),
-                        expires_at=key.expires_at if key else None,
-                        scopes=key.scopes if key else [],
-                        user_id=key.user_id if key else uuid.uuid4(),
-                        last_used_at=key.last_used_at if key else None,
-                    )
-                ]
-                if key
-                else []
-            )
-
-        # Get all keys for the specified user using CRUD layer
-        keys = crud_api_key.get_by_user(session, username=username)
-
-        return [
-            ApiKeyResponse(
-                id=key.id,
-                name=key.name,
-                key=key.key,
-                created_at=key.created_at,
-                expires_at=key.expires_at,
-                scopes=key.scopes,
-                user_id=key.user_id,
-                last_used_at=key.last_used_at,
-            )
-            for key in keys
-        ]
-    except Exception as e:
-        logger.error(f"Error debugging API keys: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error debugging API keys: {str(e)}",
-        )
+# NOTE: the former GET /api-keys/debug endpoint was removed. It returned
+# plaintext API-key values for an arbitrary username with no account scoping or
+# superuser check — a cross-account credential-disclosure IDOR waiting for a
+# route-ordering change to become reachable. There is no debug substitute;
+# operators should use the account-scoped key management endpoints.
 
 
 @router.delete("/api-keys/{key_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -4,6 +4,7 @@ import html
 import logging
 import secrets
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
@@ -16,6 +17,7 @@ from preloop.models.crud import (
     crud_account,
     crud_ai_model,
     crud_api_key,
+    crud_approval_workflow,
     crud_managed_agent,
     crud_managed_agent_ai_model_binding,
     crud_managed_agent_credential,
@@ -220,7 +222,10 @@ def _managed_config_gateway_configured(managed_config: dict) -> bool:
 def _live_validation_disables_gateway(validation: dict) -> bool:
     """Return True when live validation results invalidate gateway onboarding."""
     live_validation_status = str(validation.get("live_validation_status") or "").strip()
-    live_validation_failed = live_validation_status in {"failed", "throttled"}
+    # "throttled" is deliberately NOT treated as failed: an upstream 429 proves
+    # the credential authenticated at the gateway and the request reached the
+    # provider, so the gateway wiring works even though the probe was rejected.
+    live_validation_failed = live_validation_status == "failed"
     live_validation_missing_gateway = (
         live_validation_status == "not_run"
         and isinstance(validation.get("live_validation_skip_reason"), str)
@@ -1240,6 +1245,22 @@ async def update_account_managed_agent_governance(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Managed agent not found"
         )
+    if payload.approval_workflow_id:
+        try:
+            workflow_id = UUID(payload.approval_workflow_id)
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid approval workflow id",
+            )
+        workflow = crud_approval_workflow.get(
+            db, id=workflow_id, account_id=str(account.id)
+        )
+        if workflow is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Approval workflow not found in this account",
+            )
     account.meta_data = set_subject_governance(
         account.meta_data or {},
         subject_type=SUBJECT_TYPE_MANAGED_AGENTS,

--- a/backend/preloop/api/endpoints/gemini_gateway.py
+++ b/backend/preloop/api/endpoints/gemini_gateway.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Body, Depends, Header, Query
 from sqlalchemy.orm import Session
 from starlette.responses import StreamingResponse
 
+from preloop.api.deps import get_budget_enforcer
 from preloop.models.db.session import get_db_session
 from preloop.services.gemini_gateway import GeminiGatewayService
 from preloop.services.model_gateway_auth import (
@@ -75,11 +76,15 @@ def generate_content(
     payload: Dict[str, Any] = Body(...),
     db: Session = Depends(get_db_session),
     auth_context: ModelGatewayAuthContext = Depends(get_gemini_gateway_auth_context),
+    budget_enforcer: Any = Depends(get_budget_enforcer),
     x_preloop_session_id: Optional[str] = Header(None, alias="X-Preloop-Session-Id"),
 ) -> Dict[str, Any]:
     """Generate Gemini-compatible content from the shared gateway."""
     return GeminiGatewayService(
-        db, auth_context, client_session_id=x_preloop_session_id
+        db,
+        auth_context,
+        client_session_id=x_preloop_session_id,
+        budget_enforcer=budget_enforcer,
     ).generate_content(model_name, payload)
 
 
@@ -89,12 +94,16 @@ def stream_generate_content(
     payload: Dict[str, Any] = Body(...),
     db: Session = Depends(get_db_session),
     auth_context: ModelGatewayAuthContext = Depends(get_gemini_gateway_auth_context),
+    budget_enforcer: Any = Depends(get_budget_enforcer),
     x_preloop_session_id: Optional[str] = Header(None, alias="X-Preloop-Session-Id"),
 ) -> StreamingResponse:
     """Stream Gemini-compatible content from the shared gateway."""
     return StreamingResponse(
         GeminiGatewayService(
-            db, auth_context, client_session_id=x_preloop_session_id
+            db,
+            auth_context,
+            client_session_id=x_preloop_session_id,
+            budget_enforcer=budget_enforcer,
         ).stream_generate_content(model_name, payload),
         media_type="text/event-stream",
     )

--- a/backend/preloop/api/endpoints/public_approval.py
+++ b/backend/preloop/api/endpoints/public_approval.py
@@ -151,11 +151,14 @@ async def decide_approval_request_public(
                 status_code=500, detail="Failed to update approval request"
             )
 
-        # Return updated data
+        from preloop.utils.redaction import redact_dict
+
+        # Return updated data. Redact tool_args to match the GET read path and
+        # the redaction policy — secrets in tool arguments must not leak here.
         return ApprovalRequestPublic(
             id=str(updated_request.id),
             tool_name=updated_request.tool_name,
-            tool_args=updated_request.tool_args,
+            tool_args=redact_dict(updated_request.tool_args or {}),
             agent_reasoning=updated_request.agent_reasoning,
             status=updated_request.status,
             requested_at=updated_request.requested_at.isoformat(),

--- a/backend/preloop/models/crud/approval_workflow.py
+++ b/backend/preloop/models/crud/approval_workflow.py
@@ -146,6 +146,26 @@ class CRUDApprovalWorkflow(CRUDBase[models.ApprovalWorkflow]):
         )
         return [row[0] for row in rows]
 
+    def find_accounts_missing_workflows(self, db: Session) -> List[UUID]:
+        """Return active ``account_id``s that have no approval workflows at all.
+
+        Every account is expected to get a default workflow seeded at signup,
+        but that seeding runs as a background task and can fail (deploy
+        restart, transient DB error). The startup repair pass uses this to
+        find such accounts and seed the default workflow retroactively so
+        approval requests always have a workflow (and approver) to route to.
+        """
+        rows = (
+            db.query(models.Account.id)
+            .outerjoin(self.model, self.model.account_id == models.Account.id)
+            .filter(
+                models.Account.is_active.is_(True),
+                self.model.id.is_(None),
+            )
+            .all()
+        )
+        return [row[0] for row in rows]
+
     def create(
         self,
         db: Session,

--- a/backend/preloop/models/crud/approval_workflow.py
+++ b/backend/preloop/models/crud/approval_workflow.py
@@ -166,6 +166,54 @@ class CRUDApprovalWorkflow(CRUDBase[models.ApprovalWorkflow]):
         )
         return [row[0] for row in rows]
 
+    def find_startup_repair_targets(self, db: Session) -> tuple[List[UUID], List[UUID]]:
+        """Return ``(legacy_default_ids, missing_workflow_ids)`` in one DB pass.
+
+        Combines :meth:`find_legacy_default_workflows` and
+        :meth:`find_accounts_missing_workflows` via ``UNION ALL`` so the
+        startup repair scan pays one round-trip instead of two.
+        """
+        from sqlalchemy import literal
+
+        broken_q = db.query(
+            literal("broken").label("kind"),
+            self.model.account_id.label("account_id"),
+        ).filter(
+            self.model.is_default.is_(True),
+            (
+                (self.model.approval_type == "manual")
+                | (
+                    (
+                        (self.model.approver_user_ids.is_(None))
+                        | (self.model.approver_user_ids == [])
+                    )
+                    & (
+                        (self.model.approver_team_ids.is_(None))
+                        | (self.model.approver_team_ids == [])
+                    )
+                )
+            ),
+        )
+        missing_q = (
+            db.query(
+                literal("missing").label("kind"),
+                models.Account.id.label("account_id"),
+            )
+            .outerjoin(self.model, self.model.account_id == models.Account.id)
+            .filter(
+                models.Account.is_active.is_(True),
+                self.model.id.is_(None),
+            )
+        )
+        broken: List[UUID] = []
+        missing: List[UUID] = []
+        for kind, account_id in broken_q.union_all(missing_q).all():
+            if kind == "broken":
+                broken.append(account_id)
+            else:
+                missing.append(account_id)
+        return broken, missing
+
     def create(
         self,
         db: Session,

--- a/backend/preloop/schemas/subject_governance.py
+++ b/backend/preloop/schemas/subject_governance.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -12,6 +12,14 @@ class SubjectGovernanceConfig(BaseModel):
     model_budgets: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     tool_rules: Dict[str, List[Dict[str, Any]]] = Field(default_factory=dict)
     tool_enabled_overrides: Dict[str, bool] = Field(default_factory=dict)
+    approval_workflow_id: Optional[str] = Field(
+        None,
+        description=(
+            "Approval workflow that governs this subject's native tool-call "
+            "approvals (agents permission-check). Falls back to the account "
+            "default workflow when unset."
+        ),
+    )
 
 
 class SubjectGovernanceResponse(BaseModel):

--- a/backend/preloop/services/agent_permission_service.py
+++ b/backend/preloop/services/agent_permission_service.py
@@ -23,6 +23,10 @@ from sqlalchemy.exc import IntegrityError
 from preloop.models import models
 from preloop.models.db.session import get_async_db_session
 from preloop.services.approval_workflow_service import DEFAULT_APPROVAL_TYPE
+from preloop.services.subject_governance import (
+    SUBJECT_TYPE_MANAGED_AGENTS,
+    get_subject_governance,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +34,21 @@ logger = logging.getLogger(__name__)
 # so central-policy rules and analytics can target them later.
 AGENT_TOOL_SOURCE = "agent"
 AGENT_TOOL_APPROVALS_WORKFLOW_NAME = "Agent Tool Approvals"
+
+
+def _managed_agent_approval_workflow_json_path(managed_agent_id: uuid.UUID) -> str:
+    """Build a Postgres ``#>>`` path for a managed-agent workflow pin.
+
+    Always coerce to ``uuid.UUID`` first so path segments cannot contain
+    commas or braces that would alter the JSON-path structure. Callers must
+    not copy this pattern with free-form strings.
+    """
+    agent_uuid = (
+        managed_agent_id
+        if isinstance(managed_agent_id, uuid.UUID)
+        else uuid.UUID(str(managed_agent_id))
+    )
+    return f"{{subject_governance,managed_agents,{agent_uuid},approval_workflow_id}}"
 
 
 async def _fetch_agent_tool_approvals_workflow(
@@ -62,15 +81,10 @@ async def _resolve_agent_configured_workflow(
     the JSON path (avoids Postgres cast failures on invalid pins). Python
     still validates the pin so we can warn on malformed UUIDs.
     """
-    from preloop.services.subject_governance import (
-        SUBJECT_TYPE_MANAGED_AGENTS,
-        get_subject_governance,
-    )
-
     # Extract the pin as text via Postgres #>> so the join compares plain
     # UUID strings (JSON -> / CAST can leave quoted JSON scalar text).
     pinned_workflow_id = models.Account.meta_data.op("#>>")(
-        f"{{subject_governance,managed_agents,{managed_agent_id},approval_workflow_id}}"
+        _managed_agent_approval_workflow_json_path(managed_agent_id)
     )
 
     result = await db.execute(

--- a/backend/preloop/services/agent_permission_service.py
+++ b/backend/preloop/services/agent_permission_service.py
@@ -17,7 +17,7 @@ import logging
 import uuid
 from typing import Any, Optional, Tuple
 
-from sqlalchemy import select
+from sqlalchemy import String, and_, cast, select
 from sqlalchemy.exc import IntegrityError
 
 from preloop.models import models
@@ -47,15 +47,90 @@ async def _fetch_agent_tool_approvals_workflow(
     return result.scalars().first()
 
 
+async def _resolve_agent_configured_workflow(
+    db: Any, account_id: str, managed_agent_id: uuid.UUID
+) -> models.ApprovalWorkflow | None:
+    """Return the workflow configured for this agent via subject governance.
+
+    Operators can pin an approval workflow per managed agent in the agent
+    detail view; the choice is stored in the account's subject-governance
+    config under the agent's id. Returns None when unset or when the
+    configured workflow no longer exists in the account.
+
+    Loads the account and matching workflow in one round-trip: the pin lives
+    in nested JSON, so the join compares ``approval_workflow.id`` as text to
+    the JSON path (avoids Postgres cast failures on invalid pins). Python
+    still validates the pin so we can warn on malformed UUIDs.
+    """
+    from preloop.services.subject_governance import (
+        SUBJECT_TYPE_MANAGED_AGENTS,
+        get_subject_governance,
+    )
+
+    # Extract the pin as text via Postgres #>> so the join compares plain
+    # UUID strings (JSON -> / CAST can leave quoted JSON scalar text).
+    pinned_workflow_id = models.Account.meta_data.op("#>>")(
+        f"{{subject_governance,managed_agents,{managed_agent_id},approval_workflow_id}}"
+    )
+
+    result = await db.execute(
+        select(models.Account, models.ApprovalWorkflow)
+        .select_from(models.Account)
+        .outerjoin(
+            models.ApprovalWorkflow,
+            and_(
+                models.ApprovalWorkflow.account_id == models.Account.id,
+                cast(models.ApprovalWorkflow.id, String) == pinned_workflow_id,
+            ),
+        )
+        .where(models.Account.id == account_id)
+        .limit(1)
+    )
+    row = result.first()
+    if row is None:
+        return None
+    account, workflow = row
+    config = get_subject_governance(
+        account.meta_data or {},
+        subject_type=SUBJECT_TYPE_MANAGED_AGENTS,
+        subject_id=str(managed_agent_id),
+    )
+    workflow_id = (config or {}).get("approval_workflow_id")
+    if not workflow_id:
+        return None
+    try:
+        uuid.UUID(str(workflow_id))
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid approval_workflow_id %r configured for managed agent %s",
+            workflow_id,
+            managed_agent_id,
+        )
+        return None
+    return workflow
+
+
 async def _resolve_workflow(
-    db: Any, account_id: str, approver_user_id: Optional[uuid.UUID]
+    db: Any,
+    account_id: str,
+    approver_user_id: Optional[uuid.UUID],
+    managed_agent_id: Optional[uuid.UUID] = None,
 ) -> models.ApprovalWorkflow:
     """Resolve the approval workflow to use, creating a minimal one if needed.
 
-    Prefers the account default, then any existing workflow, then creates a
-    dedicated "Agent Tool Approvals" standard workflow that notifies the
-    calling user so the request can reach their devices.
+    Prefers the workflow the operator configured for the managed agent
+    (subject governance), then the account default, then any existing
+    workflow, then creates a dedicated "Agent Tool Approvals" standard
+    workflow that notifies the calling user so the request can reach their
+    devices.
     """
+    if managed_agent_id is not None:
+        workflow = await _resolve_agent_configured_workflow(
+            db, account_id, managed_agent_id
+        )
+        if workflow is not None:
+            return workflow
+
     result = await db.execute(
         select(models.ApprovalWorkflow)
         .where(
@@ -190,7 +265,9 @@ async def request_agent_permission(
     from preloop.models.crud.approval_request import get_approval_request_async
 
     async with get_async_db_session() as db:
-        workflow = await _resolve_workflow(db, account_id, user_id)
+        workflow = await _resolve_workflow(
+            db, account_id, user_id, managed_agent_id=managed_agent_id
+        )
         timeout_seconds = workflow.timeout_seconds or 300
         config = await _resolve_tool_config(db, account_id, tool_name, workflow.id)
 

--- a/backend/preloop/services/approval_helper.py
+++ b/backend/preloop/services/approval_helper.py
@@ -736,5 +736,14 @@ async def require_approval(
 
     except Exception as e:
         logger.error(f"Error checking approval requirement: {e}", exc_info=True)
-        # Fail-open: if approval check fails, allow execution
-        return (True, "")
+        # SECURITY: fail CLOSED. If the approval check itself fails (DB outage,
+        # workflow lookup error, etc.) we must block rather than execute — a
+        # tool gated behind ``require_approval`` must never run un-approved just
+        # because an infrastructure error prevented the check. The inner
+        # approval-flow error path (above) already fails closed; keep this
+        # outer handler consistent.
+        return (
+            False,
+            "Approval check failed and the tool call was blocked as a safety "
+            "measure. Please retry.",
+        )

--- a/backend/preloop/services/approval_workflow_service.py
+++ b/backend/preloop/services/approval_workflow_service.py
@@ -230,3 +230,48 @@ def create_default_approval_workflow_background(
             f"for account {account_id}: {e}",
             exc_info=True,
         )
+
+
+def run_default_approval_workflow_startup_repair() -> dict[str, int]:
+    """Heal legacy defaults and seed missing account workflows on API boot.
+
+    Idempotent and safe to run on every startup. Per-account failures are
+    logged and skipped so one bad account cannot abort the whole pass.
+    """
+    session_factory = get_session_factory()
+    scan_db = session_factory()
+    try:
+        broken, missing = crud_approval_workflow.find_startup_repair_targets(scan_db)
+    finally:
+        scan_db.close()
+
+    repaired = 0
+    for account_id in broken:
+        try:
+            if repair_default_approval_workflow_for_account(account_id):
+                repaired += 1
+        except Exception as inner_exc:
+            logger.warning(
+                "Default workflow repair failed for account %s: %s",
+                account_id,
+                inner_exc,
+            )
+
+    seeded = 0
+    for account_id in missing:
+        try:
+            create_default_approval_workflow_for_account(account_id)
+            seeded += 1
+        except Exception as inner_exc:
+            logger.warning(
+                "Default workflow seeding failed for account %s: %s",
+                account_id,
+                inner_exc,
+            )
+
+    return {
+        "broken": len(broken),
+        "repaired": repaired,
+        "missing": len(missing),
+        "seeded": seeded,
+    }

--- a/backend/preloop/services/approval_workflow_service.py
+++ b/backend/preloop/services/approval_workflow_service.py
@@ -32,7 +32,13 @@ def _resolve_account_owner_user_id(db: Session, account_id: UUID) -> Optional[UU
     is called without an explicit ``user_id`` so the seeded default workflow
     still has at least one approver — otherwise approval requests created
     against the default workflow would have no one able to act on them.
+
+    Prefers the account's ``primary_user_id`` (the actual owner set at
+    signup) and only falls back to the oldest user when it is unset.
     """
+    account = db.query(models.Account).filter(models.Account.id == account_id).first()
+    if account is not None and account.primary_user_id:
+        return account.primary_user_id
     user = (
         db.query(models.User)
         .filter(models.User.account_id == account_id)

--- a/backend/preloop/services/dynamic_fastmcp.py
+++ b/backend/preloop/services/dynamic_fastmcp.py
@@ -1061,9 +1061,27 @@ async def {internal_name}({params_str}) -> str:
             logger.error(
                 f"Error evaluating access rules for '{name}': {e}", exc_info=True
             )
-            # Fail open for evaluation errors to avoid blocking all tools
-            # (the policy_evaluator already fails closed per-rule)
+            # SECURITY: fail CLOSED. If the central policy evaluation itself
+            # raises (DB outage, malformed principal id, etc.) we must not fall
+            # through to execution — otherwise any explicit ``deny`` /
+            # ``require_approval`` rule (including subject-governance
+            # tool-disabled denials) could be bypassed simply by inducing an
+            # infrastructure error. Block the call and surface a ret600able
+            # error to the agent.
             _rule_workflow_id_var.set(None)
+            return ToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=(
+                            f"Access denied: policy evaluation for '{name}' "
+                            "failed and the request was blocked as a safety "
+                            "measure. Please retry; if this persists, contact "
+                            "your Preloop administrator."
+                        ),
+                    )
+                ]
+            )
 
         # ── Translate and execute ───────────────────────────────────────
         # Translate tool name for proxied tools

--- a/backend/preloop/services/gemini_gateway.py
+++ b/backend/preloop/services/gemini_gateway.py
@@ -21,8 +21,17 @@ class GeminiGatewayService(OpenAIGatewayService):
         db: Session,
         auth_context: ModelGatewayAuthContext,
         client_session_id: Optional[str] = None,
+        budget_enforcer: Optional[Any] = None,
     ) -> None:
-        super().__init__(db, auth_context, client_session_id=client_session_id)
+        # Forward the budget enforcer so Gemini traffic is subject to the same
+        # account/flow budget policy enforcement as the OpenAI/Anthropic
+        # endpoints — otherwise clients could route around budgets via Gemini.
+        super().__init__(
+            db,
+            auth_context,
+            client_session_id=client_session_id,
+            budget_enforcer=budget_enforcer,
+        )
 
     def list_models(self) -> Dict[str, Any]:
         """List Gemini-compatible model descriptors."""

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -1091,7 +1091,23 @@ class OpenAIGatewayService:
                         error_detail=str(exc),
                         request_payload=payload,
                     )
+                    recorded = True
                 raise
+            finally:
+                # Client disconnect raises GeneratorExit (a BaseException) at the
+                # paused yield, which the except above does not catch — so
+                # already-consumed upstream tokens would go unbilled and let
+                # cumulative budgets drift. Record a best-effort row here.
+                if not recorded:
+                    self._record_stream_abort(
+                        endpoint="/anthropic/v1/messages",
+                        endpoint_kind="anthropic_messages_stream",
+                        started_at=started_at,
+                        ai_model=model,
+                        payload=payload,
+                        usage_details=final_usage_details or final_usage,
+                        budget_result=budget_result,
+                    )
 
         return event_stream()
 
@@ -1299,7 +1315,21 @@ class OpenAIGatewayService:
                         error_detail=str(exc),
                         request_payload=payload,
                     )
+                    recorded = True
                 raise
+            finally:
+                # See stream_message: catch the client-disconnect GeneratorExit
+                # so consumed tokens are still accounted.
+                if not recorded:
+                    self._record_stream_abort(
+                        endpoint="/openai/v1/chat/completions",
+                        endpoint_kind="chat_completions_stream",
+                        started_at=started_at,
+                        ai_model=model,
+                        payload=payload,
+                        usage_details=final_usage_details or final_usage,
+                        budget_result=budget_result,
+                    )
 
         return event_stream()
 
@@ -1603,7 +1633,21 @@ class OpenAIGatewayService:
                         error_detail=str(exc),
                         request_payload=payload,
                     )
+                    recorded = True
                 raise
+            finally:
+                # See stream_message: account for tokens consumed before a
+                # client disconnect (GeneratorExit).
+                if not recorded:
+                    self._record_stream_abort(
+                        endpoint="/openai/v1/responses",
+                        endpoint_kind="responses_stream",
+                        started_at=started_at,
+                        ai_model=model,
+                        payload=payload,
+                        usage_details=final_usage_details or final_usage,
+                        budget_result=budget_result,
+                    )
 
         return event_stream()
 
@@ -3575,6 +3619,46 @@ class OpenAIGatewayService:
         pricing = override.to_pricing_dict()
         pricing["id"] = str(override.id)
         return pricing
+
+    def _record_stream_abort(
+        self,
+        *,
+        endpoint: str,
+        endpoint_kind: str,
+        started_at: float,
+        ai_model: AIModel,
+        payload: Dict[str, Any],
+        usage_details: Optional[Dict[str, Any]],
+        budget_result: Optional[BudgetCheckResult],
+    ) -> None:
+        """Best-effort usage record when a streaming client disconnects early.
+
+        Called from a ``finally`` during GeneratorExit, so it must never raise —
+        a failure here would replace a clean disconnect with an error. Status
+        499 ("client closed request") flags the partial record.
+        """
+        try:
+            self._record_gateway_request(
+                endpoint=endpoint,
+                method="POST",
+                status_code=499,
+                duration=time.perf_counter() - started_at,
+                ai_model=ai_model,
+                requested_model=payload.get("model"),
+                response_payload=None,
+                upstream_response={"usage": usage_details}
+                if isinstance(usage_details, dict)
+                else None,
+                endpoint_kind=endpoint_kind,
+                budget_result=budget_result,
+                error_detail="client disconnected before stream completion",
+                request_payload=payload,
+            )
+        except Exception:  # pragma: no cover - defensive; never break teardown
+            logger.warning(
+                "Failed to record gateway usage after client disconnect",
+                exc_info=True,
+            )
 
     def _record_gateway_request(
         self,

--- a/backend/preloop/services/policy_evaluator.py
+++ b/backend/preloop/services/policy_evaluator.py
@@ -638,6 +638,19 @@ def _compare_values(lhs: Any, operator: str, rhs: Any) -> bool:
             return rhs is not None
         return False
 
+    # For ordering comparisons, coerce numeric-looking operands to numbers.
+    # SECURITY: without this, an agent could defeat a numeric rule such as
+    # ``args.amount > 300`` by sending ``amount`` as the *string* "1000000":
+    # ``"1000000" > 300`` raises TypeError, which was swallowed to a
+    # non-match and fell through to the default-allow, skipping the intended
+    # approval/deny. Coercing keeps the comparison meaningful across the JSON
+    # string/number ambiguity.
+    if operator in (">", "<", ">=", "<="):
+        lhs_num = _coerce_number(lhs)
+        rhs_num = _coerce_number(rhs)
+        if lhs_num is not None and rhs_num is not None:
+            lhs, rhs = lhs_num, rhs_num
+
     try:
         if operator == "==":
             return lhs == rhs
@@ -656,6 +669,25 @@ def _compare_values(lhs: Any, operator: str, rhs: Any) -> bool:
     except TypeError:
         # Type mismatch in comparison
         return False
+
+
+def _coerce_number(value: Any) -> Optional[float]:
+    """Return ``value`` as a float if it is numeric or a numeric string.
+
+    Bools are intentionally excluded (``True`` is not a quantity here) and
+    non-numeric strings return ``None`` so the caller keeps the original
+    values.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
 
 
 def _evaluate_cel_condition(

--- a/backend/preloop/services/subject_governance.py
+++ b/backend/preloop/services/subject_governance.py
@@ -87,6 +87,10 @@ def sanitize_subject_governance_config(config: dict[str, Any]) -> dict[str, Any]
     context_optimization = config.get("context_optimization")
     if isinstance(context_optimization, dict):
         sanitized["context_optimization"] = deepcopy(context_optimization)
+    sanitized["approval_workflow_id"] = None
+    approval_workflow_id = config.get("approval_workflow_id")
+    if approval_workflow_id is not None and str(approval_workflow_id).strip():
+        sanitized["approval_workflow_id"] = str(approval_workflow_id).strip()
     return sanitized
 
 

--- a/backend/preloop/utils/permissions.py
+++ b/backend/preloop/utils/permissions.py
@@ -26,6 +26,21 @@ except ImportError:
 _MISSING_DEPS_DETAIL = "Permission check requires current_user and db dependencies"
 
 
+def _rbac_checks_enabled() -> bool:
+    """Return True when permission enforcement should run.
+
+    Honors both the process env flag and the in-memory settings singleton
+    (tests often toggle env without recreating Settings).
+    """
+    import os
+
+    from preloop.config import settings
+
+    if settings.disable_rbac:
+        return False
+    return os.getenv("DISABLE_RBAC", "false").lower() != "true"
+
+
 def _ensure_permission_dependencies(**kwargs: object) -> None:
     """Fail closed when the decorated endpoint lacks auth dependencies."""
     if "current_user" not in kwargs or "db" not in kwargs:
@@ -72,14 +87,19 @@ def require_permission(permission_name: str):
 
             @functools.wraps(func)
             async def async_wrapper(*args, **kwargs):
-                _ensure_permission_dependencies(**kwargs)
+                # Only fail-closed on missing deps when RBAC is actually on —
+                # otherwise endpoints that omit unused ``db`` break under the
+                # test-suite DISABLE_RBAC default.
+                if _rbac_checks_enabled():
+                    _ensure_permission_dependencies(**kwargs)
                 return await plugin_wrapped(*args, **kwargs)
 
             return async_wrapper
 
         @functools.wraps(func)
         def sync_wrapper(*args, **kwargs):
-            _ensure_permission_dependencies(**kwargs)
+            if _rbac_checks_enabled():
+                _ensure_permission_dependencies(**kwargs)
             result = plugin_wrapped(*args, **kwargs)
             if inspect.isawaitable(result):
                 return _run_awaitable_sync(result)

--- a/backend/tests/endpoints/test_account_agents.py
+++ b/backend/tests/endpoints/test_account_agents.py
@@ -1,6 +1,7 @@
 """Endpoint tests for managed-agent registry surfaces."""
 
 from datetime import UTC, datetime
+from uuid import uuid4
 
 from preloop.api.endpoints.account import (
     _managed_agent_control_fields,
@@ -147,6 +148,37 @@ def test_onboarding_flags_downgrade_failed_live_gateway_to_mcp_only():
     assert mcp_configured is True
     assert gateway_configured is False
     assert state == "mcp_proxy_only"
+
+
+def test_onboarding_flags_keep_gateway_when_live_validation_throttled():
+    """An upstream rate-limit is inconclusive: the probe authenticated at the
+    gateway and reached the provider, so a throttled live validation must not
+    downgrade a configured gateway onboarding to MCP-only."""
+    mcp_configured, gateway_configured, state = _managed_agent_onboarding_flags(
+        {
+            "managed_config": {
+                "mcpServers": {"preloop": {"url": "https://preloop.example/mcp/v1"}},
+                "baseUrl": "https://preloop.example/openai/v1",
+                "apiKey": "agt_managed",
+                "model": {"name": "claude/haiku"},
+            },
+            "validation_result": {
+                "preloop_server_present": True,
+                "gateway_provider_ok": True,
+                "gateway_base_url_ok": True,
+                "gateway_token_ok": True,
+                "model_provider_rewritten": True,
+                "live_validation_supported": True,
+                "live_validation_attempted": True,
+                "live_validation_status": "throttled",
+                "live_validation_passed": False,
+            },
+        }
+    )
+
+    assert mcp_configured is True
+    assert gateway_configured is True
+    assert state == "fully_onboarded"
 
 
 def test_account_agents_endpoint_lists_onboarded_agents(client, db_session, test_user):
@@ -1145,6 +1177,70 @@ def test_account_agent_governance_round_trip(client, db_session, test_user):
     verify_response = client.get(f"/api/v1/agents/{agent_id}/governance")
     assert verify_response.status_code == 200
     assert verify_response.json()["config"] == updated["config"]
+
+
+def test_account_agent_governance_approval_workflow(client, db_session, test_user):
+    """Operators can pin the approval workflow that governs an agent's native
+    tool-call approvals; the id must reference a workflow in the account."""
+    from preloop.models.crud import crud_approval_workflow
+
+    token_response = client.post(
+        "/api/v1/auth/runtime-sessions/token",
+        json={
+            "session_source_type": "claude_code",
+            "session_source_id": "claude-approvals-workflow",
+            "runtime_principal_name": "Approvals Agent",
+        },
+    )
+    assert token_response.status_code == 201
+
+    list_response = client.get("/api/v1/agents")
+    assert list_response.status_code == 200
+    agent_id = list_response.json()["items"][0]["id"]
+
+    workflow = crud_approval_workflow.create(
+        db_session,
+        obj_in={
+            "name": "Agent-specific workflow",
+            "approval_type": "standard",
+            "approver_user_ids": [str(test_user.id)],
+        },
+        account_id=str(test_user.account_id),
+    )
+
+    # Unknown workflow ids are rejected.
+    invalid_response = client.put(
+        f"/api/v1/agents/{agent_id}/governance",
+        json={"approval_workflow_id": str(uuid4())},
+    )
+    assert invalid_response.status_code == 400
+
+    # Malformed ids are rejected.
+    malformed_response = client.put(
+        f"/api/v1/agents/{agent_id}/governance",
+        json={"approval_workflow_id": "not-a-uuid"},
+    )
+    assert malformed_response.status_code == 400
+
+    # A workflow belonging to the account is accepted and persisted.
+    update_response = client.put(
+        f"/api/v1/agents/{agent_id}/governance",
+        json={"approval_workflow_id": str(workflow.id)},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["config"]["approval_workflow_id"] == str(workflow.id)
+
+    verify_response = client.get(f"/api/v1/agents/{agent_id}/governance")
+    assert verify_response.status_code == 200
+    assert verify_response.json()["config"]["approval_workflow_id"] == str(workflow.id)
+
+    # Clearing the field removes the per-agent pin.
+    clear_response = client.put(
+        f"/api/v1/agents/{agent_id}/governance",
+        json={"approval_workflow_id": None},
+    )
+    assert clear_response.status_code == 200
+    assert clear_response.json()["config"]["approval_workflow_id"] is None
 
 
 def test_account_agent_enrollment_validate_and_restore(client, db_session, test_user):

--- a/backend/tests/endpoints/test_approval_requests.py
+++ b/backend/tests/endpoints/test_approval_requests.py
@@ -202,7 +202,9 @@ class TestApproveRequest:
     """Tests for the approve_request endpoint."""
 
     @pytest.mark.asyncio
-    async def test_approve_request_success(self, mock_user, mock_approval_request):
+    async def test_approve_request_success(
+        self, mock_user, mock_approval_request, mock_db_session
+    ):
         """Test successful approval of a request."""
         from preloop.models.schemas.approval_request import (
             ApprovalDecision,
@@ -245,6 +247,7 @@ class TestApproveRequest:
                         decision=decision,
                         request=mock_http_request,
                         current_user=mock_user,
+                        db=mock_db_session,
                     )
 
                     assert result == expected_response
@@ -258,7 +261,7 @@ class TestApproveRequest:
                     )
 
     @pytest.mark.asyncio
-    async def test_approve_request_not_found(self, mock_user):
+    async def test_approve_request_not_found(self, mock_user, mock_db_session):
         """Test 404 when approval request is not found."""
         from preloop.models.schemas.approval_request import ApprovalDecision
 
@@ -286,13 +289,16 @@ class TestApproveRequest:
                         decision=decision,
                         request=mock_http_request,
                         current_user=mock_user,
+                        db=mock_db_session,
                     )
 
                 assert exc_info.value.status_code == 404
                 assert exc_info.value.detail == "Approval request not found"
 
     @pytest.mark.asyncio
-    async def test_approve_request_unauthorized(self, mock_user, mock_approval_request):
+    async def test_approve_request_unauthorized(
+        self, mock_user, mock_approval_request, mock_db_session
+    ):
         """Test 403 when user is not authorized to approve."""
         from preloop.models.schemas.approval_request import ApprovalDecision
 
@@ -323,6 +329,7 @@ class TestApproveRequest:
                         decision=decision,
                         request=mock_http_request,
                         current_user=mock_user,
+                        db=mock_db_session,
                     )
 
                 assert exc_info.value.status_code == 403
@@ -330,7 +337,7 @@ class TestApproveRequest:
 
     @pytest.mark.asyncio
     async def test_approve_request_already_resolved(
-        self, mock_user, mock_approval_request
+        self, mock_user, mock_approval_request, mock_db_session
     ):
         """Test 400 when request is already resolved."""
         from preloop.models.schemas.approval_request import ApprovalDecision
@@ -361,6 +368,7 @@ class TestApproveRequest:
                         decision=decision,
                         request=mock_http_request,
                         current_user=mock_user,
+                        db=mock_db_session,
                     )
 
                 assert exc_info.value.status_code == 400
@@ -371,7 +379,9 @@ class TestDeclineRequest:
     """Tests for the decline_request endpoint."""
 
     @pytest.mark.asyncio
-    async def test_decline_request_success(self, mock_user, mock_approval_request):
+    async def test_decline_request_success(
+        self, mock_user, mock_approval_request, mock_db_session
+    ):
         """Test successful decline of a request."""
         from preloop.models.schemas.approval_request import (
             ApprovalDecision,
@@ -413,6 +423,7 @@ class TestDeclineRequest:
                         decision=decision,
                         request=mock_http_request,
                         current_user=mock_user,
+                        db=mock_db_session,
                     )
 
                     assert result == expected_response
@@ -426,7 +437,7 @@ class TestDeclineRequest:
                     )
 
     @pytest.mark.asyncio
-    async def test_decline_request_not_found(self, mock_user):
+    async def test_decline_request_not_found(self, mock_user, mock_db_session):
         """Test 404 when approval request is not found."""
         from preloop.models.schemas.approval_request import ApprovalDecision
 
@@ -454,6 +465,7 @@ class TestDeclineRequest:
                         decision=decision,
                         request=mock_http_request,
                         current_user=mock_user,
+                        db=mock_db_session,
                     )
 
                 assert exc_info.value.status_code == 404
@@ -463,7 +475,9 @@ class TestDecideRequest:
     """Tests for the decide_request endpoint."""
 
     @pytest.mark.asyncio
-    async def test_decide_request_approve(self, mock_user, mock_approval_request):
+    async def test_decide_request_approve(
+        self, mock_user, mock_approval_request, mock_db_session
+    ):
         """Test decide endpoint with approved=True."""
         from preloop.models.schemas.approval_request import (
             ApprovalDecision,
@@ -505,6 +519,7 @@ class TestDecideRequest:
                         decision=decision,
                         request=mock_http_request,
                         current_user=mock_user,
+                        db=mock_db_session,
                     )
 
                     assert result == expected_response
@@ -512,7 +527,9 @@ class TestDecideRequest:
                     mock_service.decline_request.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_decide_request_decline(self, mock_user, mock_approval_request):
+    async def test_decide_request_decline(
+        self, mock_user, mock_approval_request, mock_db_session
+    ):
         """Test decide endpoint with approved=False."""
         from preloop.models.schemas.approval_request import (
             ApprovalDecision,
@@ -554,6 +571,7 @@ class TestDecideRequest:
                         decision=decision,
                         request=mock_http_request,
                         current_user=mock_user,
+                        db=mock_db_session,
                     )
 
                     assert result == expected_response
@@ -561,7 +579,9 @@ class TestDecideRequest:
                     mock_service.approve_request.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_decide_request_failure(self, mock_user, mock_approval_request):
+    async def test_decide_request_failure(
+        self, mock_user, mock_approval_request, mock_db_session
+    ):
         """Test 500 when decision processing fails."""
         from preloop.models.schemas.approval_request import ApprovalDecision
 
@@ -590,6 +610,7 @@ class TestDecideRequest:
                         decision=decision,
                         request=mock_http_request,
                         current_user=mock_user,
+                        db=mock_db_session,
                     )
 
                 assert exc_info.value.status_code == 500

--- a/backend/tests/endpoints/test_jwt.py
+++ b/backend/tests/endpoints/test_jwt.py
@@ -271,13 +271,11 @@ class TestGetCurrentUser:
         assert "Invalid user ID" in exc_info.value.detail
 
     def test_get_current_user_refresh_token_rejected(self, mock_user):
-        """Test that refresh tokens cannot be used for authentication."""
+        """Refresh tokens must not authenticate access-token endpoints."""
         user_id = str(mock_user.id)
         # Create a refresh token (with refresh=True)
         token = jwt_module.create_access_token({"sub": user_id, "refresh": True})
 
-        # Note: The implementation checks for dict, but decode_token returns TokenData
-        # This test verifies the intended behavior
         with patch.object(jwt_module, "get_db_session") as mock_get_db:
             mock_session = MagicMock()
             mock_query = MagicMock()
@@ -286,9 +284,12 @@ class TestGetCurrentUser:
             mock_session.query.return_value = mock_query
             mock_get_db.return_value = iter([mock_session])
 
-            # Should succeed because decode_token returns TokenData, not dict
-            result = jwt_module.get_current_user(token, db=mock_session)
-            assert result == mock_user
+            # decode_token returns a TokenData model; the refresh flag is read
+            # as an attribute, so a refresh token is rejected with 401.
+            with pytest.raises(HTTPException) as exc_info:
+                jwt_module.get_current_user(token, db=mock_session)
+            assert exc_info.value.status_code == 401
+            assert "refresh token" in exc_info.value.detail.lower()
 
 
 class TestGetCurrentActiveUser:

--- a/backend/tests/endpoints/test_policies.py
+++ b/backend/tests/endpoints/test_policies.py
@@ -146,7 +146,7 @@ class TestValidatePolicy:
     """Test validate_policy endpoint."""
 
     async def test_validate_valid_yaml(
-        self, mock_db, mock_account, valid_policy_yaml, mock_upload_file
+        self, mock_db, mock_account, mock_user, valid_policy_yaml, mock_upload_file
     ):
         """Test validating a valid YAML policy file."""
         file = await mock_upload_file(valid_policy_yaml, "policy.yaml")
@@ -154,6 +154,7 @@ class TestValidatePolicy:
         result = await policies.validate_policy(
             file=file,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -162,7 +163,7 @@ class TestValidatePolicy:
         assert len(result.errors) == 0
 
     async def test_validate_invalid_yaml_syntax(
-        self, mock_db, mock_account, invalid_yaml_syntax, mock_upload_file
+        self, mock_db, mock_account, mock_user, invalid_yaml_syntax, mock_upload_file
     ):
         """Test validating YAML with syntax errors."""
         file = await mock_upload_file(invalid_yaml_syntax, "policy.yaml")
@@ -170,6 +171,7 @@ class TestValidatePolicy:
         result = await policies.validate_policy(
             file=file,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -180,7 +182,12 @@ class TestValidatePolicy:
         assert any("YAML" in e.message or "Invalid" in e.message for e in result.errors)
 
     async def test_validate_missing_required_field(
-        self, mock_db, mock_account, invalid_yaml_missing_field, mock_upload_file
+        self,
+        mock_db,
+        mock_account,
+        mock_user,
+        invalid_yaml_missing_field,
+        mock_upload_file,
     ):
         """Test validating YAML missing required field."""
         file = await mock_upload_file(invalid_yaml_missing_field, "policy.yaml")
@@ -188,6 +195,7 @@ class TestValidatePolicy:
         result = await policies.validate_policy(
             file=file,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -197,7 +205,7 @@ class TestValidatePolicy:
         # Should mention metadata field is required
         assert any("metadata" in e.path.lower() for e in result.errors)
 
-    async def test_validate_non_utf8_file(self, mock_db, mock_account):
+    async def test_validate_non_utf8_file(self, mock_db, mock_account, mock_user):
         """Test validating non-UTF8 encoded file."""
         mock_file = MagicMock()
         mock_file.filename = "policy.yaml"
@@ -212,6 +220,7 @@ class TestValidatePolicy:
             await policies.validate_policy(
                 file=mock_file,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -223,7 +232,13 @@ class TestUploadPolicy:
     """Test upload_policy endpoint."""
 
     async def test_upload_valid_yaml_dry_run(
-        self, mock_db, mock_account, valid_policy_yaml, mock_upload_file, mocker
+        self,
+        mock_db,
+        mock_account,
+        mock_user,
+        valid_policy_yaml,
+        mock_upload_file,
+        mocker,
     ):
         """Test uploading valid YAML with dry_run=True."""
         file = await mock_upload_file(valid_policy_yaml, "policy.yaml")
@@ -253,6 +268,7 @@ class TestUploadPolicy:
             dry_run=True,
             resolve_env=True,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -268,7 +284,13 @@ class TestUploadPolicy:
         assert call_kwargs[1]["dry_run"] is True
 
     async def test_upload_valid_yaml_apply(
-        self, mock_db, mock_account, valid_policy_yaml, mock_upload_file, mocker
+        self,
+        mock_db,
+        mock_account,
+        mock_user,
+        valid_policy_yaml,
+        mock_upload_file,
+        mocker,
     ):
         """Test uploading valid YAML with dry_run=False (actual apply)."""
         file = await mock_upload_file(valid_policy_yaml, "policy.yaml")
@@ -298,6 +320,7 @@ class TestUploadPolicy:
             dry_run=False,
             resolve_env=True,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -310,7 +333,7 @@ class TestUploadPolicy:
         assert call_kwargs[1]["dry_run"] is False
 
     async def test_upload_invalid_yaml_returns_error(
-        self, mock_db, mock_account, invalid_yaml_syntax, mock_upload_file
+        self, mock_db, mock_account, mock_user, invalid_yaml_syntax, mock_upload_file
     ):
         """Test uploading invalid YAML returns HTTP 400 error."""
         file = await mock_upload_file(invalid_yaml_syntax, "policy.yaml")
@@ -321,6 +344,7 @@ class TestUploadPolicy:
                 dry_run=True,
                 resolve_env=True,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -328,7 +352,13 @@ class TestUploadPolicy:
         assert "validation failed" in str(exc_info.value.detail).lower()
 
     async def test_upload_apply_failure_returns_error(
-        self, mock_db, mock_account, valid_policy_yaml, mock_upload_file, mocker
+        self,
+        mock_db,
+        mock_account,
+        mock_user,
+        valid_policy_yaml,
+        mock_upload_file,
+        mocker,
     ):
         """Test uploading when apply fails returns HTTP 500 error."""
         file = await mock_upload_file(valid_policy_yaml, "policy.yaml")
@@ -353,6 +383,7 @@ class TestUploadPolicy:
                 dry_run=False,
                 resolve_env=True,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -362,7 +393,7 @@ class TestUploadPolicy:
 class TestExportPolicy:
     """Test export_policy endpoint."""
 
-    async def test_export_yaml(self, mock_db, mock_account, mocker):
+    async def test_export_yaml(self, mock_db, mock_account, mock_user, mocker):
         """Test exporting current configuration as YAML."""
         from preloop.services.policy import (
             PolicyMetadata,
@@ -387,13 +418,14 @@ class TestExportPolicy:
             format="yaml",
             policy_name="My Export",
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
         assert result.media_type == "application/x-yaml"
         assert 'filename="policy.yaml"' in result.headers["Content-Disposition"]
 
-    async def test_export_json(self, mock_db, mock_account, mocker):
+    async def test_export_json(self, mock_db, mock_account, mock_user, mocker):
         """Test exporting current configuration as JSON."""
         from preloop.services.policy import (
             PolicyMetadata,
@@ -417,6 +449,7 @@ class TestExportPolicy:
             format="json",
             policy_name="My Export",
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -428,7 +461,13 @@ class TestDiffPolicy:
     """Test diff_policy endpoint."""
 
     async def test_diff_shows_additions(
-        self, mock_db, mock_account, valid_policy_yaml, mock_upload_file, mocker
+        self,
+        mock_db,
+        mock_account,
+        mock_user,
+        valid_policy_yaml,
+        mock_upload_file,
+        mocker,
     ):
         """Test diff shows additions when uploading new policy."""
         file = await mock_upload_file(valid_policy_yaml, "policy.yaml")
@@ -465,6 +504,7 @@ class TestDiffPolicy:
         result = await policies.diff_policy(
             file=file,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -472,7 +512,7 @@ class TestDiffPolicy:
         assert result.has_changes is True
 
     async def test_diff_invalid_yaml_returns_error(
-        self, mock_db, mock_account, invalid_yaml_syntax, mock_upload_file
+        self, mock_db, mock_account, mock_user, invalid_yaml_syntax, mock_upload_file
     ):
         """Test diff with invalid YAML returns HTTP 400 error."""
         file = await mock_upload_file(invalid_yaml_syntax, "policy.yaml")
@@ -481,6 +521,7 @@ class TestDiffPolicy:
             await policies.diff_policy(
                 file=file,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -506,7 +547,7 @@ class TestPolicyValidationWithConditions:
     """Test policy validation with various condition expressions."""
 
     async def test_validate_policy_with_complex_conditions(
-        self, mock_db, mock_account, mock_upload_file
+        self, mock_db, mock_account, mock_user, mock_upload_file
     ):
         """Test validating policy with complex CEL conditions."""
         yaml_content = """
@@ -539,6 +580,7 @@ tools:
         result = await policies.validate_policy(
             file=file,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -546,7 +588,7 @@ tools:
         assert len(result.errors) == 0
 
     async def test_validate_policy_with_invalid_reference(
-        self, mock_db, mock_account, mock_upload_file
+        self, mock_db, mock_account, mock_user, mock_upload_file
     ):
         """Test validating policy with invalid approval_workflow reference."""
         yaml_content = """
@@ -565,6 +607,7 @@ tools:
         result = await policies.validate_policy(
             file=file,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -582,7 +625,7 @@ tools:
 class TestListPolicyVersions:
     """Test list_policy_versions endpoint."""
 
-    async def test_list_versions_empty(self, mock_db, mock_account, mocker):
+    async def test_list_versions_empty(self, mock_db, mock_account, mock_user, mocker):
         """Test listing versions when none exist."""
         mock_service = MagicMock()
         mock_service.list_snapshots.return_value = []
@@ -603,6 +646,7 @@ class TestListPolicyVersions:
             offset=0,
             include_snapshots=False,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -610,7 +654,7 @@ class TestListPolicyVersions:
         assert result.total == 0
 
     async def test_list_versions_with_results(
-        self, mock_db, mock_account, mock_snapshot, mocker
+        self, mock_db, mock_account, mock_user, mock_snapshot, mocker
     ):
         """Test listing versions returns correct data."""
         mock_service = MagicMock()
@@ -632,6 +676,7 @@ class TestListPolicyVersions:
             offset=0,
             include_snapshots=False,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -641,7 +686,7 @@ class TestListPolicyVersions:
         assert result.versions[0].is_active is True
 
     async def test_list_versions_with_pagination(
-        self, mock_db, mock_account, mock_snapshot, mocker
+        self, mock_db, mock_account, mock_user, mock_snapshot, mocker
     ):
         """Test listing versions respects pagination."""
         mock_service = MagicMock()
@@ -663,6 +708,7 @@ class TestListPolicyVersions:
             offset=5,
             include_snapshots=False,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -679,7 +725,7 @@ class TestGetPolicyVersion:
     """Test get_policy_version endpoint."""
 
     async def test_get_version_success(
-        self, mock_db, mock_account, mock_snapshot, mocker
+        self, mock_db, mock_account, mock_user, mock_snapshot, mocker
     ):
         """Test retrieving a specific version."""
         mock_service = MagicMock()
@@ -692,6 +738,7 @@ class TestGetPolicyVersion:
         result = policies.get_policy_version(
             version_id=mock_snapshot.id,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -699,7 +746,9 @@ class TestGetPolicyVersion:
         assert result.version_number == mock_snapshot.version_number
         assert result.snapshot_data == mock_snapshot.snapshot_data
 
-    async def test_get_version_not_found(self, mock_db, mock_account, mocker):
+    async def test_get_version_not_found(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
         """Test retrieving a non-existent version returns 404."""
         mock_service = MagicMock()
         mock_service.get_snapshot.return_value = None
@@ -712,6 +761,7 @@ class TestGetPolicyVersion:
             policies.get_policy_version(
                 version_id=uuid.uuid4(),
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -790,7 +840,7 @@ class TestUpdateVersionTag:
     """Test update_version_tag endpoint."""
 
     async def test_update_tag_success(
-        self, mock_db, mock_account, mock_snapshot_with_tag, mocker
+        self, mock_db, mock_account, mock_user, mock_snapshot_with_tag, mocker
     ):
         """Test updating a version's tag."""
         mock_service = MagicMock()
@@ -806,13 +856,16 @@ class TestUpdateVersionTag:
             version_id=mock_snapshot_with_tag.id,
             request=request,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
         assert result.tag == "production"
         mock_db.commit.assert_called_once()
 
-    async def test_update_tag_version_not_found(self, mock_db, mock_account, mocker):
+    async def test_update_tag_version_not_found(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
         """Test updating tag on non-existent version returns 404."""
         mock_service = MagicMock()
         mock_service.update_tag.return_value = (None, "Snapshot not found")
@@ -828,6 +881,7 @@ class TestUpdateVersionTag:
                 version_id=uuid.uuid4(),
                 request=request,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -838,7 +892,7 @@ class TestRemoveVersionTag:
     """Test remove_version_tag endpoint."""
 
     async def test_remove_tag_success(
-        self, mock_db, mock_account, mock_snapshot, mocker
+        self, mock_db, mock_account, mock_user, mock_snapshot, mocker
     ):
         """Test removing a tag from a version."""
         mock_snapshot.tag = None  # Tag was removed
@@ -852,13 +906,16 @@ class TestRemoveVersionTag:
         result = await policies.remove_version_tag(
             version_id=mock_snapshot.id,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
         assert result.tag is None
         mock_db.commit.assert_called_once()
 
-    async def test_remove_tag_version_not_found(self, mock_db, mock_account, mocker):
+    async def test_remove_tag_version_not_found(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
         """Test removing tag from non-existent version returns 404."""
         mock_service = MagicMock()
         mock_service.remove_tag.return_value = (None, "Snapshot not found")
@@ -871,6 +928,7 @@ class TestRemoveVersionTag:
             await policies.remove_version_tag(
                 version_id=uuid.uuid4(),
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -880,7 +938,9 @@ class TestRemoveVersionTag:
 class TestRollbackToVersion:
     """Test rollback_to_version endpoint."""
 
-    async def test_rollback_preview_only(self, mock_db, mock_account, mocker):
+    async def test_rollback_preview_only(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
         """Test rollback with preview_only=True only returns diff."""
         mock_diff = PolicyDiffResult(
             has_changes=True,
@@ -900,6 +960,7 @@ class TestRollbackToVersion:
             version_id=uuid.uuid4(),
             request=request,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -909,7 +970,7 @@ class TestRollbackToVersion:
         # Should NOT commit when preview_only is True
         mock_db.commit.assert_not_called()
 
-    async def test_rollback_apply(self, mock_db, mock_account, mocker):
+    async def test_rollback_apply(self, mock_db, mock_account, mock_user, mocker):
         """Test rollback with preview_only=False applies changes."""
         mock_diff = PolicyDiffResult(
             has_changes=True,
@@ -929,13 +990,16 @@ class TestRollbackToVersion:
             version_id=uuid.uuid4(),
             request=request,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
         assert result.success is True
         mock_db.commit.assert_called_once()
 
-    async def test_rollback_version_not_found(self, mock_db, mock_account, mocker):
+    async def test_rollback_version_not_found(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
         """Test rollback to non-existent version returns 404."""
         mock_service = MagicMock()
         mock_service.rollback_to_snapshot.return_value = (
@@ -955,12 +1019,15 @@ class TestRollbackToVersion:
                 version_id=uuid.uuid4(),
                 request=request,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
 
-    async def test_rollback_failure_returns_error(self, mock_db, mock_account, mocker):
+    async def test_rollback_failure_returns_error(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
         """Test rollback failure returns error in response."""
         mock_diff = PolicyDiffResult(
             has_changes=True,
@@ -984,6 +1051,7 @@ class TestRollbackToVersion:
             version_id=uuid.uuid4(),
             request=request,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -995,7 +1063,9 @@ class TestRollbackToVersion:
 class TestDeletePolicyVersion:
     """Test delete_policy_version endpoint."""
 
-    async def test_delete_version_success(self, mock_db, mock_account, mocker):
+    async def test_delete_version_success(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
         """Test successfully deleting a version."""
         mock_service = MagicMock()
         mock_service.delete_snapshot.return_value = (True, None)
@@ -1008,12 +1078,15 @@ class TestDeletePolicyVersion:
         await policies.delete_policy_version(
             version_id=uuid.uuid4(),
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
         mock_db.commit.assert_called_once()
 
-    async def test_delete_version_not_found(self, mock_db, mock_account, mocker):
+    async def test_delete_version_not_found(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
         """Test deleting non-existent version returns 404."""
         mock_service = MagicMock()
         mock_service.delete_snapshot.return_value = (False, "Snapshot not found")
@@ -1026,13 +1099,14 @@ class TestDeletePolicyVersion:
             await policies.delete_policy_version(
                 version_id=uuid.uuid4(),
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
 
     async def test_delete_active_version_returns_400(
-        self, mock_db, mock_account, mocker
+        self, mock_db, mock_account, mock_user, mocker
     ):
         """Test deleting the active version returns 400."""
         mock_service = MagicMock()
@@ -1049,6 +1123,7 @@ class TestDeletePolicyVersion:
             await policies.delete_policy_version(
                 version_id=uuid.uuid4(),
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -1059,7 +1134,9 @@ class TestDeletePolicyVersion:
 class TestPrunePolicyVersions:
     """Test prune_policy_versions endpoint."""
 
-    async def test_prune_versions_success(self, mock_db, mock_account, mocker):
+    async def test_prune_versions_success(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
         """Test pruning old versions."""
         mock_service = MagicMock()
         mock_service.prune_snapshots.return_value = 5  # 5 versions deleted
@@ -1077,6 +1154,7 @@ class TestPrunePolicyVersions:
         result = await policies.prune_policy_versions(
             request=request,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -1088,7 +1166,9 @@ class TestPrunePolicyVersions:
         )
         mock_db.commit.assert_called_once()
 
-    async def test_prune_versions_none_deleted(self, mock_db, mock_account, mocker):
+    async def test_prune_versions_none_deleted(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
         """Test pruning when no versions match criteria."""
         mock_service = MagicMock()
         mock_service.prune_snapshots.return_value = 0
@@ -1106,12 +1186,15 @@ class TestPrunePolicyVersions:
         result = await policies.prune_policy_versions(
             request=request,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
         assert result.deleted_count == 0
 
-    async def test_prune_with_default_values(self, mock_db, mock_account, mocker):
+    async def test_prune_with_default_values(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
         """Test pruning with default request values."""
         mock_service = MagicMock()
         mock_service.prune_snapshots.return_value = 3
@@ -1125,6 +1208,7 @@ class TestPrunePolicyVersions:
         result = await policies.prune_policy_versions(
             request=request,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 

--- a/backend/tests/endpoints/test_tools.py
+++ b/backend/tests/endpoints/test_tools.py
@@ -1,7 +1,7 @@
 """Tests for tools API endpoints."""
 
 import uuid
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 from fastapi import HTTPException, status
@@ -11,6 +11,7 @@ from preloop.models.models.account import Account
 from preloop.models.models.mcp_server import MCPServer
 from preloop.models.models.mcp_tool import MCPTool
 from preloop.models.models.tool_configuration import ApprovalWorkflow, ToolConfiguration
+from preloop.models.models.user import User
 from preloop.models.schemas.tool_configuration import (
     ApprovalWorkflowCreate,
     ApprovalWorkflowResponse,
@@ -25,12 +26,15 @@ pytestmark = pytest.mark.asyncio
 
 @pytest.fixture
 def mock_user():
-    """Create mock user for testing."""
-    user = MagicMock()
+    """Autospec ``User`` — the type tools endpoints inject via
+    ``get_current_active_user`` (not ``AuthUserResponse``, which lacks
+    ``id`` / ``account_id``). Unknown attribute access raises AttributeError.
+    """
+    user = create_autospec(User, instance=True)
     user.id = uuid.uuid4()
     user.username = "testuser"
     user.email = "test@example.com"
-    user.account_id = str(uuid.uuid4())
+    user.account_id = uuid.uuid4()
     user.is_active = True
     return user
 

--- a/backend/tests/endpoints/test_tools.py
+++ b/backend/tests/endpoints/test_tools.py
@@ -7,7 +7,6 @@ import pytest
 from fastapi import HTTPException, status
 
 from preloop.api.endpoints import tools
-from preloop.schemas.auth import AuthUserResponse
 from preloop.models.models.account import Account
 from preloop.models.models.mcp_server import MCPServer
 from preloop.models.models.mcp_tool import MCPTool
@@ -27,12 +26,13 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 def mock_user():
     """Create mock user for testing."""
-    return AuthUserResponse(
-        username="testuser",
-        email="test@example.com",
-        email_verified=True,
-        full_name="Test User",
-    )
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.username = "testuser"
+    user.email = "test@example.com"
+    user.account_id = str(uuid.uuid4())
+    user.is_active = True
+    return user
 
 
 @pytest.fixture
@@ -67,7 +67,9 @@ class TestListAllTools:
             return_value=[],
         )
 
-        result = tools.list_all_tools(account=mock_account, db=mock_db)
+        result = tools.list_all_tools(
+            account=mock_account, current_user=mock_user, db=mock_db
+        )
 
         # Should return all builtin tools with defaults
         assert len(result) == len(tools.BUILTIN_TOOLS)
@@ -98,7 +100,9 @@ class TestListAllTools:
             return_value=[],
         )
 
-        result = tools.list_all_tools(account=mock_account, db=mock_db)
+        result = tools.list_all_tools(
+            account=mock_account, current_user=mock_user, db=mock_db
+        )
 
         # Find the configured tool
         get_issue_tool = next(t for t in result if t["name"] == "get_issue")
@@ -135,7 +139,9 @@ class TestListAllTools:
             return_value=[mcp_tool],
         )
 
-        result = tools.list_all_tools(account=mock_account, db=mock_db)
+        result = tools.list_all_tools(
+            account=mock_account, current_user=mock_user, db=mock_db
+        )
 
         # Should have builtin tools + MCP tool
         assert len(result) == len(tools.BUILTIN_TOOLS) + 1
@@ -181,6 +187,7 @@ class TestToolConfigurationEndpoints:
         result = await tools.create_tool_configuration(
             config_data=config_data,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -213,6 +220,7 @@ class TestToolConfigurationEndpoints:
             await tools.create_tool_configuration(
                 config_data=config_data,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -271,6 +279,7 @@ class TestToolConfigurationEndpoints:
         result = await tools.create_tool_configuration(
             config_data=config_data,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -309,6 +318,7 @@ class TestToolConfigurationEndpoints:
         result = await tools.get_tool_configuration(
             config_id=config_id,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -329,6 +339,7 @@ class TestToolConfigurationEndpoints:
             await tools.get_tool_configuration(
                 config_id=config_id,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -361,6 +372,7 @@ class TestToolConfigurationEndpoints:
             "preloop.api.endpoints.tools.crud_tool_configuration.get",
             return_value=config,
         )
+        mocker.patch("preloop.api.endpoints.tools.log_config_change")
 
         update_data = ToolConfigurationUpdate(is_enabled=False)
 
@@ -368,6 +380,7 @@ class TestToolConfigurationEndpoints:
             config_id=config_id,
             config_update=update_data,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -392,6 +405,7 @@ class TestToolConfigurationEndpoints:
         result = await tools.delete_tool_configuration(
             config_id=config_id,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -449,6 +463,7 @@ class TestApprovalWorkflowEndpoints:
 
         result = await tools.list_approval_workflows(
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -515,6 +530,7 @@ class TestApprovalWorkflowEndpoints:
         result = await tools.create_approval_workflow(
             workflow_data=workflow_data,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -544,6 +560,7 @@ class TestApprovalWorkflowEndpoints:
             await tools.create_approval_workflow(
                 workflow_data=workflow_data,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -597,6 +614,7 @@ class TestApprovalWorkflowEndpoints:
         result = await tools.get_approval_workflow(
             workflow_id=workflow_id,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -665,6 +683,7 @@ class TestApprovalWorkflowEndpoints:
             workflow_id=workflow_id,
             workflow_update=update_data,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -699,6 +718,7 @@ class TestApprovalWorkflowEndpoints:
         result = await tools.delete_approval_workflow(
             workflow_id=workflow_id,
             account=mock_account,
+            current_user=mock_user,
             db=mock_db,
         )
 
@@ -724,6 +744,7 @@ class TestApprovalWorkflowEndpointsErrorHandling:
             await tools.get_approval_workflow(
                 workflow_id=workflow_id,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -747,6 +768,7 @@ class TestApprovalWorkflowEndpointsErrorHandling:
                 workflow_id=workflow_id,
                 workflow_update=update_data,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -785,6 +807,7 @@ class TestApprovalWorkflowEndpointsErrorHandling:
                 workflow_id=workflow_id,
                 workflow_update=update_data,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -806,6 +829,7 @@ class TestApprovalWorkflowEndpointsErrorHandling:
             await tools.delete_approval_workflow(
                 workflow_id=workflow_id,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -836,6 +860,7 @@ class TestApprovalWorkflowEndpointsErrorHandling:
             await tools.delete_approval_workflow(
                 workflow_id=workflow_id,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -864,6 +889,7 @@ class TestApprovalWorkflowEndpointsErrorHandling:
             await tools.create_approval_workflow(
                 workflow_data=workflow_data,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -891,6 +917,7 @@ class TestToolConfigurationEndpointsErrorHandling:
                 config_id=config_id,
                 config_update=update_data,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -911,6 +938,7 @@ class TestToolConfigurationEndpointsErrorHandling:
             await tools.delete_tool_configuration(
                 config_id=config_id,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -939,6 +967,7 @@ class TestToolConfigurationEndpointsErrorHandling:
                 config_id=config_id,
                 config_update=update_data,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -966,6 +995,7 @@ class TestToolConfigurationEndpointsErrorHandling:
             await tools.delete_tool_configuration(
                 config_id=config_id,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -991,6 +1021,7 @@ class TestApprovalConditionEndpoints:
             await tools.get_tool_approval_condition(
                 config_id=config_id,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -1020,6 +1051,7 @@ class TestApprovalConditionEndpoints:
             await tools.get_tool_approval_condition(
                 config_id=config_id,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -1041,6 +1073,7 @@ class TestApprovalConditionEndpoints:
             await tools.delete_tool_approval_condition(
                 config_id=config_id,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -1069,6 +1102,7 @@ class TestApprovalConditionEndpoints:
             await tools.delete_tool_approval_condition(
                 config_id=config_id,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 
@@ -1095,6 +1129,7 @@ class TestUpdateToolApprovalCondition:
                 config_id=config_id,
                 condition_data=condition_data,
                 account=mock_account,
+                current_user=mock_user,
                 db=mock_db,
             )
 

--- a/backend/tests/models/crud/test_approval_workflow_crud.py
+++ b/backend/tests/models/crud/test_approval_workflow_crud.py
@@ -505,3 +505,32 @@ def test_find_accounts_missing_workflows_flags_and_clears(
 
     missing = crud_approval_workflow.find_accounts_missing_workflows(db_session)
     assert test_user.account_id not in missing
+
+
+def test_find_startup_repair_targets_combines_broken_and_missing(
+    crud_approval_workflow, db_session, test_user
+):
+    """The startup scan must return both legacy defaults and accounts with no
+    workflows in a single pass."""
+    from preloop.models.crud import crud_approval_workflow as crud
+
+    # test_user's account starts with no workflows -> missing.
+    broken, missing = crud.find_startup_repair_targets(db_session)
+    assert test_user.account_id in missing
+    assert test_user.account_id not in broken
+
+    # Seed a legacy-shaped default (manual + no approvers) -> broken, not missing.
+    crud.create(
+        db_session,
+        obj_in={
+            "name": "Default Approval Workflow",
+            "approval_type": "manual",
+            "is_default": True,
+            "approver_user_ids": [],
+            "approver_team_ids": [],
+        },
+        account_id=str(test_user.account_id),
+    )
+    broken, missing = crud.find_startup_repair_targets(db_session)
+    assert test_user.account_id in broken
+    assert test_user.account_id not in missing

--- a/backend/tests/models/crud/test_approval_workflow_crud.py
+++ b/backend/tests/models/crud/test_approval_workflow_crud.py
@@ -487,3 +487,21 @@ def test_get_multi_by_account_with_pagination(crud_approval_workflow, mock_db_se
     assert len(result) == 5
     mock_query.offset.assert_called()
     mock_query.limit.assert_called()
+
+
+def test_find_accounts_missing_workflows_flags_and_clears(
+    crud_approval_workflow, db_session, test_user
+):
+    """Accounts without any approval workflow must be flagged by the startup
+    seeding pass, and drop off the list once a workflow exists."""
+    missing = crud_approval_workflow.find_accounts_missing_workflows(db_session)
+    assert test_user.account_id in missing
+
+    crud_approval_workflow.create(
+        db_session,
+        obj_in={"name": "Default Approval Workflow", "approval_type": "standard"},
+        account_id=str(test_user.account_id),
+    )
+
+    missing = crud_approval_workflow.find_accounts_missing_workflows(db_session)
+    assert test_user.account_id not in missing

--- a/backend/tests/services/test_agent_permission_service.py
+++ b/backend/tests/services/test_agent_permission_service.py
@@ -66,3 +66,78 @@ async def test_resolve_workflow_recovers_from_duplicate_name_race() -> None:
 
     assert workflow is existing
     db.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_workflow_prefers_agent_configured_workflow() -> None:
+    """A workflow pinned on the managed agent via subject governance must win
+    over the account default."""
+    account_id = str(uuid.uuid4())
+    managed_agent_id = uuid.uuid4()
+    pinned = models.ApprovalWorkflow(
+        id=uuid.uuid4(),
+        account_id=account_id,
+        name="Agent-specific workflow",
+        approval_type=DEFAULT_APPROVAL_TYPE,
+    )
+    account = MagicMock()
+    account.meta_data = {
+        "subject_governance": {
+            "managed_agents": {
+                str(managed_agent_id): {"approval_workflow_id": str(pinned.id)}
+            },
+            "api_keys": {},
+        }
+    }
+
+    account_and_workflow = MagicMock()
+    account_and_workflow.first.return_value = (account, pinned)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=account_and_workflow)
+
+    workflow = await _resolve_workflow(
+        db, account_id, uuid.uuid4(), managed_agent_id=managed_agent_id
+    )
+
+    assert workflow is pinned
+    # Account + pinned workflow are loaded in one outerjoin round-trip.
+    assert db.execute.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_workflow_falls_back_when_agent_pin_missing() -> None:
+    """When the pinned workflow no longer exists, resolution falls back to the
+    account default instead of failing the permission check."""
+    account_id = str(uuid.uuid4())
+    managed_agent_id = uuid.uuid4()
+    default_workflow = models.ApprovalWorkflow(
+        id=uuid.uuid4(),
+        account_id=account_id,
+        name="Default Approval Workflow",
+        approval_type=DEFAULT_APPROVAL_TYPE,
+        is_default=True,
+    )
+    account = MagicMock()
+    account.meta_data = {
+        "subject_governance": {
+            "managed_agents": {
+                str(managed_agent_id): {"approval_workflow_id": str(uuid.uuid4())}
+            },
+            "api_keys": {},
+        }
+    }
+
+    account_and_missing = MagicMock()
+    account_and_missing.first.return_value = (account, None)
+    default_result = MagicMock()
+    default_result.scalars.return_value.first.return_value = default_workflow
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[account_and_missing, default_result])
+
+    workflow = await _resolve_workflow(
+        db, account_id, uuid.uuid4(), managed_agent_id=managed_agent_id
+    )
+
+    assert workflow is default_workflow

--- a/backend/tests/services/test_agent_permission_service.py
+++ b/backend/tests/services/test_agent_permission_service.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from preloop.models import models
 from preloop.services.agent_permission_service import (
     AGENT_TOOL_APPROVALS_WORKFLOW_NAME,
+    _managed_agent_approval_workflow_json_path,
     _resolve_workflow,
 )
 from preloop.services.approval_workflow_service import DEFAULT_APPROVAL_TYPE
@@ -141,3 +142,21 @@ async def test_resolve_workflow_falls_back_when_agent_pin_missing() -> None:
     )
 
     assert workflow is default_workflow
+
+
+def test_managed_agent_approval_workflow_json_path_rejects_unsafe_segments() -> None:
+    """Path builder must coerce to UUID so free-form strings cannot inject
+    commas/braces into the Postgres #>> path."""
+    agent_id = uuid.uuid4()
+    path = _managed_agent_approval_workflow_json_path(agent_id)
+    assert path == (
+        f"{{subject_governance,managed_agents,{agent_id},approval_workflow_id}}"
+    )
+    # String UUID form is accepted via coercion.
+    assert _managed_agent_approval_workflow_json_path(str(agent_id)) == path  # type: ignore[arg-type]
+    try:
+        _managed_agent_approval_workflow_json_path("evil,injected}")  # type: ignore[arg-type]
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for non-UUID path segment")

--- a/backend/tests/services/test_approval_helper.py
+++ b/backend/tests/services/test_approval_helper.py
@@ -866,8 +866,12 @@ class TestRequireApprovalEdgeCases:
         assert approved is False
         assert "error" in error.lower()
 
-    async def test_database_error_fails_open(self):
-        """Test that database errors fail open (allow execution)."""
+    async def test_database_error_fails_closed(self):
+        """Database errors must fail CLOSED (block execution).
+
+        A tool gated behind require_approval must never run un-approved just
+        because the approval check hit an infrastructure error.
+        """
         mock_db = create_mock_db_session()
         # Simulate database error
         mock_db.execute = AsyncMock(side_effect=Exception("Database error"))
@@ -884,9 +888,9 @@ class TestRequireApprovalEdgeCases:
                 ctx=None,
             )
 
-        # Should fail open
-        assert approved is True
-        assert error == ""
+        # Should fail closed
+        assert approved is False
+        assert error != ""
 
 
 class TestRequireApprovalProgressReporting:

--- a/backend/tests/services/test_approval_workflow_service.py
+++ b/backend/tests/services/test_approval_workflow_service.py
@@ -334,3 +334,45 @@ class TestCreateDefaultApprovalWorkflowBackground:
 
         # Assert
         mock_create_func.assert_called_once_with(account_id, None)
+
+
+class TestResolveAccountOwnerUserId:
+    """Tests for the owner-resolution fallback used by workflow seeding."""
+
+    def test_prefers_account_primary_user(self):
+        """The account's primary_user_id (the owner set at signup) must win
+        over the oldest-user fallback."""
+        from preloop.services.approval_workflow_service import (
+            _resolve_account_owner_user_id,
+        )
+
+        db = MagicMock()
+        primary_user_id = uuid4()
+        account = MagicMock(primary_user_id=primary_user_id)
+        db.query.return_value.filter.return_value.first.return_value = account
+
+        assert _resolve_account_owner_user_id(db, uuid4()) == primary_user_id
+
+    def test_falls_back_to_oldest_user_when_primary_unset(self):
+        from preloop.services.approval_workflow_service import (
+            _resolve_account_owner_user_id,
+        )
+
+        db = MagicMock()
+        account = MagicMock(primary_user_id=None)
+        first_user = MagicMock(id=uuid4())
+        db.query.return_value.filter.return_value.first.return_value = account
+        db.query.return_value.filter.return_value.order_by.return_value.first.return_value = first_user
+
+        assert _resolve_account_owner_user_id(db, uuid4()) == first_user.id
+
+    def test_returns_none_when_account_and_users_missing(self):
+        from preloop.services.approval_workflow_service import (
+            _resolve_account_owner_user_id,
+        )
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        db.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
+
+        assert _resolve_account_owner_user_id(db, uuid4()) is None

--- a/backend/tests/services/test_approval_workflow_service.py
+++ b/backend/tests/services/test_approval_workflow_service.py
@@ -376,3 +376,81 @@ class TestResolveAccountOwnerUserId:
         db.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
 
         assert _resolve_account_owner_user_id(db, uuid4()) is None
+
+
+class TestRunDefaultApprovalWorkflowStartupRepair:
+    """Tests for the boot-time repair/seed pass."""
+
+    @patch(
+        "preloop.services.approval_workflow_service.create_default_approval_workflow_for_account"
+    )
+    @patch(
+        "preloop.services.approval_workflow_service.repair_default_approval_workflow_for_account"
+    )
+    @patch("preloop.services.approval_workflow_service.crud_approval_workflow")
+    @patch("preloop.services.approval_workflow_service.get_session_factory")
+    def test_continues_when_per_account_seed_raises(
+        self, mock_session_factory, mock_crud, mock_repair, mock_create
+    ):
+        """A single account failure must not abort seeding of the remaining
+        accounts — the lifespan path used to be ``# pragma: no cover``."""
+        from preloop.services.approval_workflow_service import (
+            run_default_approval_workflow_startup_repair,
+        )
+
+        broken_id = uuid4()
+        missing_ok = uuid4()
+        missing_fail = uuid4()
+        mock_db = MagicMock()
+        mock_session_factory.return_value = MagicMock(return_value=mock_db)
+        mock_crud.find_startup_repair_targets.return_value = (
+            [broken_id],
+            [missing_fail, missing_ok],
+        )
+        mock_repair.return_value = True
+        mock_create.side_effect = [RuntimeError("seed boom"), None]
+
+        stats = run_default_approval_workflow_startup_repair()
+
+        assert stats == {
+            "broken": 1,
+            "repaired": 1,
+            "missing": 2,
+            "seeded": 1,
+        }
+        mock_repair.assert_called_once_with(broken_id)
+        assert mock_create.call_count == 2
+        mock_db.close.assert_called_once()
+
+    @patch(
+        "preloop.services.approval_workflow_service.create_default_approval_workflow_for_account"
+    )
+    @patch(
+        "preloop.services.approval_workflow_service.repair_default_approval_workflow_for_account"
+    )
+    @patch("preloop.services.approval_workflow_service.crud_approval_workflow")
+    @patch("preloop.services.approval_workflow_service.get_session_factory")
+    def test_continues_when_per_account_repair_raises(
+        self, mock_session_factory, mock_crud, mock_repair, mock_create
+    ):
+        from preloop.services.approval_workflow_service import (
+            run_default_approval_workflow_startup_repair,
+        )
+
+        broken_fail = uuid4()
+        broken_ok = uuid4()
+        mock_db = MagicMock()
+        mock_session_factory.return_value = MagicMock(return_value=mock_db)
+        mock_crud.find_startup_repair_targets.return_value = (
+            [broken_fail, broken_ok],
+            [],
+        )
+        mock_repair.side_effect = [RuntimeError("repair boom"), True]
+
+        stats = run_default_approval_workflow_startup_repair()
+
+        assert stats["broken"] == 2
+        assert stats["repaired"] == 1
+        assert stats["missing"] == 0
+        assert stats["seeded"] == 0
+        mock_create.assert_not_called()

--- a/backend/tests/services/test_dynamic_fastmcp.py
+++ b/backend/tests/services/test_dynamic_fastmcp.py
@@ -413,7 +413,13 @@ class TestMCPCallTool:
             Tool(name="builtin_tool", description="Builtin", parameters={})
         ]
 
-        with patch.object(dynamic_mcp, "list_tools", return_value=available_tools):
+        with (
+            patch.object(dynamic_mcp, "list_tools", return_value=available_tools),
+            patch(
+                "preloop.services.policy_evaluator.evaluate_policy_async",
+                new=AsyncMock(return_value=("allow", None, None)),
+            ),
+        ):
             # Mock super().call_tool for FastMCP 3.x
             mock_result = ToolResult(
                 content=[types.TextContent(type="text", text="Result")]
@@ -441,7 +447,13 @@ class TestMCPCallTool:
             Tool(name="proxied_tool", description="Proxied", parameters={})
         ]
 
-        with patch.object(dynamic_mcp, "list_tools", return_value=available_tools):
+        with (
+            patch.object(dynamic_mcp, "list_tools", return_value=available_tools),
+            patch(
+                "preloop.services.policy_evaluator.evaluate_policy_async",
+                new=AsyncMock(return_value=("allow", None, None)),
+            ),
+        ):
             # Mock super().call_tool to verify name translation
             mock_result = ToolResult(
                 content=[types.TextContent(type="text", text="Result")]

--- a/backend/tests/services/test_policy_evaluator.py
+++ b/backend/tests/services/test_policy_evaluator.py
@@ -433,6 +433,18 @@ class TestEvaluateSimpleExpression:
         assert evaluate_simple_expression("args.amount >= 100", {"amount": 100})
         assert evaluate_simple_expression("args.amount <= 100", {"amount": 100})
 
+    def test_comparison_coerces_stringified_numbers(self):
+        """A numeric rule must not be bypassable by passing a string.
+
+        Security regression: previously ``"1000000" > 300`` raised TypeError,
+        was swallowed to a non-match, and fell through to the default allow.
+        """
+        assert evaluate_simple_expression("args.amount > 300", {"amount": "1000000"})
+        assert not evaluate_simple_expression("args.amount > 300", {"amount": "10"})
+        assert evaluate_simple_expression("args.amount >= 300", {"amount": "300"})
+        # A genuinely non-numeric string still does not satisfy an ordering rule.
+        assert not evaluate_simple_expression("args.amount > 300", {"amount": "abc"})
+
     def test_contains_string(self):
         """args.field.contains('substring')."""
         assert evaluate_simple_expression(

--- a/backend/tests/services/test_policy_generation.py
+++ b/backend/tests/services/test_policy_generation.py
@@ -62,6 +62,15 @@ def mock_account():
 
 
 @pytest.fixture
+def mock_user():
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.account_id = uuid.uuid4()
+    user.username = "testuser"
+    return user
+
+
+@pytest.fixture
 def mock_ai_model():
     model = MagicMock()
     model.id = uuid.uuid4()
@@ -375,7 +384,7 @@ PATCH_SERVICE = "preloop.services.policy_generation.PolicyGenerationService"
 
 
 class TestGeneratePolicyEndpoint:
-    async def test_success(self, mock_account, mock_db):
+    async def test_success(self, mock_account, mock_db, mock_user):
         from preloop.api.endpoints.policies import (
             GeneratePolicyRequest,
             generate_policy,
@@ -390,12 +399,17 @@ class TestGeneratePolicyEndpoint:
             instance._build_system_prompt.return_value = "system"
             instance._call_llm.return_value = VALID_POLICY_YAML
             instance._validate_output.return_value = []
-            result = await generate_policy(request, mock_account, mock_db)
+            result = await generate_policy(
+                request,
+                account=mock_account,
+                current_user=mock_user,
+                db=mock_db,
+            )
 
         assert result.yaml == VALID_POLICY_YAML
         assert result.warnings == []
 
-    async def test_no_model_returns_400(self, mock_account, mock_db):
+    async def test_no_model_returns_400(self, mock_account, mock_db, mock_user):
         from fastapi import HTTPException
 
         from preloop.api.endpoints.policies import (
@@ -411,7 +425,12 @@ class TestGeneratePolicyEndpoint:
                 "No AI models configured"
             )
             with pytest.raises(HTTPException) as exc_info:
-                await generate_policy(request, mock_account, mock_db)
+                await generate_policy(
+                    request,
+                    account=mock_account,
+                    current_user=mock_user,
+                    db=mock_db,
+                )
 
         assert exc_info.value.status_code == 400
         assert "No AI models" in exc_info.value.detail
@@ -423,7 +442,7 @@ class TestGeneratePolicyEndpoint:
 
 
 class TestGeneratePolicyFromAuditEndpoint:
-    async def test_success(self, mock_account, mock_db):
+    async def test_success(self, mock_account, mock_db, mock_user):
         from preloop.api.endpoints.policies import (
             GeneratePolicyFromAuditRequest,
             generate_policy_from_audit,
@@ -439,12 +458,17 @@ class TestGeneratePolicyFromAuditEndpoint:
             instance._build_audit_system_prompt.return_value = "system"
             instance._call_llm.return_value = VALID_POLICY_YAML
             instance._validate_output.return_value = ["minor warning"]
-            result = await generate_policy_from_audit(request, mock_account, mock_db)
+            result = await generate_policy_from_audit(
+                request,
+                account=mock_account,
+                current_user=mock_user,
+                db=mock_db,
+            )
 
         assert result.yaml == VALID_POLICY_YAML
         assert result.warnings == ["minor warning"]
 
-    async def test_with_date_range(self, mock_account, mock_db):
+    async def test_with_date_range(self, mock_account, mock_db, mock_user):
         from preloop.api.endpoints.policies import (
             GeneratePolicyFromAuditRequest,
             generate_policy_from_audit,
@@ -462,11 +486,18 @@ class TestGeneratePolicyFromAuditEndpoint:
             instance._build_audit_system_prompt.return_value = "system"
             instance._call_llm.return_value = VALID_POLICY_YAML
             instance._validate_output.return_value = []
-            result = await generate_policy_from_audit(request, mock_account, mock_db)
+            result = await generate_policy_from_audit(
+                request,
+                account=mock_account,
+                current_user=mock_user,
+                db=mock_db,
+            )
 
         assert result.yaml == VALID_POLICY_YAML
 
-    async def test_invalid_start_date_returns_400(self, mock_account, mock_db):
+    async def test_invalid_start_date_returns_400(
+        self, mock_account, mock_db, mock_user
+    ):
         from fastapi import HTTPException
 
         from preloop.api.endpoints.policies import (
@@ -477,12 +508,17 @@ class TestGeneratePolicyFromAuditEndpoint:
         request = GeneratePolicyFromAuditRequest(start_date="not-a-date")
 
         with pytest.raises(HTTPException) as exc_info:
-            await generate_policy_from_audit(request, mock_account, mock_db)
+            await generate_policy_from_audit(
+                request,
+                account=mock_account,
+                current_user=mock_user,
+                db=mock_db,
+            )
 
         assert exc_info.value.status_code == 400
         assert "Invalid start_date" in exc_info.value.detail
 
-    async def test_invalid_end_date_returns_400(self, mock_account, mock_db):
+    async def test_invalid_end_date_returns_400(self, mock_account, mock_db, mock_user):
         from fastapi import HTTPException
 
         from preloop.api.endpoints.policies import (
@@ -493,12 +529,17 @@ class TestGeneratePolicyFromAuditEndpoint:
         request = GeneratePolicyFromAuditRequest(end_date="bad")
 
         with pytest.raises(HTTPException) as exc_info:
-            await generate_policy_from_audit(request, mock_account, mock_db)
+            await generate_policy_from_audit(
+                request,
+                account=mock_account,
+                current_user=mock_user,
+                db=mock_db,
+            )
 
         assert exc_info.value.status_code == 400
         assert "Invalid end_date" in exc_info.value.detail
 
-    async def test_no_logs_returns_400(self, mock_account, mock_db):
+    async def test_no_logs_returns_400(self, mock_account, mock_db, mock_user):
         from fastapi import HTTPException
 
         from preloop.api.endpoints.policies import (
@@ -513,12 +554,17 @@ class TestGeneratePolicyFromAuditEndpoint:
             instance._resolve_model.return_value = MagicMock()
             instance._summarise_account_logs.return_value = ""
             with pytest.raises(HTTPException) as exc_info:
-                await generate_policy_from_audit(request, mock_account, mock_db)
+                await generate_policy_from_audit(
+                    request,
+                    account=mock_account,
+                    current_user=mock_user,
+                    db=mock_db,
+                )
 
         assert exc_info.value.status_code == 400
         assert "No tool-call audit logs" in exc_info.value.detail
 
-    async def test_with_external_logs(self, mock_account, mock_db):
+    async def test_with_external_logs(self, mock_account, mock_db, mock_user):
         from preloop.api.endpoints.policies import (
             GeneratePolicyFromAuditRequest,
             generate_policy_from_audit,
@@ -535,7 +581,12 @@ class TestGeneratePolicyFromAuditEndpoint:
             instance._build_audit_system_prompt.return_value = "system"
             instance._call_llm.return_value = VALID_POLICY_YAML
             instance._validate_output.return_value = []
-            result = await generate_policy_from_audit(request, mock_account, mock_db)
+            result = await generate_policy_from_audit(
+                request,
+                account=mock_account,
+                current_user=mock_user,
+                db=mock_db,
+            )
 
         assert result.yaml == VALID_POLICY_YAML
         instance._summarise_external_logs.assert_called_once_with(logs)

--- a/backend/tests/test_permissions_fallback.py
+++ b/backend/tests/test_permissions_fallback.py
@@ -153,6 +153,8 @@ class TestRequirePermissionMissingDependencies:
             return decorator
 
         monkeypatch.setattr(perms, "_plugin_require_permission", fake_plugin_require)
+        # Force the fail-closed path even under the suite's DISABLE_RBAC default.
+        monkeypatch.setattr(perms, "_rbac_checks_enabled", lambda: True)
 
         @perms.require_permission("view_issues")
         def sync_handler():
@@ -182,6 +184,7 @@ class TestRequirePermissionMissingDependencies:
             return decorator
 
         monkeypatch.setattr(perms, "_plugin_require_permission", fake_plugin_require)
+        monkeypatch.setattr(perms, "_rbac_checks_enabled", lambda: True)
 
         @perms.require_permission("view_issues")
         async def async_handler():
@@ -194,3 +197,25 @@ class TestRequirePermissionMissingDependencies:
         assert exc_info.value.status_code == 500
         assert called["plugin"] is False
         assert called["raw"] is False
+
+    def test_wrapper_skips_deps_check_when_rbac_disabled(self, monkeypatch):
+        """Under DISABLE_RBAC the fail-closed deps gate must not fire."""
+        import preloop.utils.permissions as perms
+
+        def fake_plugin_require(permission_name: str):
+            def decorator(func):
+                def plugin_wrapped(*args, **kwargs):
+                    return func(*args, **kwargs)
+
+                return plugin_wrapped
+
+            return decorator
+
+        monkeypatch.setattr(perms, "_plugin_require_permission", fake_plugin_require)
+        monkeypatch.setattr(perms, "_rbac_checks_enabled", lambda: False)
+
+        @perms.require_permission("view_issues")
+        def sync_handler():
+            return "ok"
+
+        assert sync_handler() == "ok"

--- a/backend/tests/utils/test_permissions.py
+++ b/backend/tests/utils/test_permissions.py
@@ -7,35 +7,44 @@ from preloop.utils import permissions
 
 
 class TestRequirePermissionOSSFallback:
-    """Test require_permission decorator (OSS build uses no-op fallback)."""
+    """Test require_permission decorator (OSS build uses no-op fallback).
+
+    When the proprietary RBAC plugin is present (EE), the fail-closed wrapper
+    still requires ``current_user`` and ``db`` kwargs. These tests pass dummy
+    dependencies so that path can be exercised without weakening production
+    fail-closed behavior. With DISABLE_RBAC=true (set in tests/conftest.py),
+    the plugin allows the call through.
+    """
 
     def test_require_permission_preserves_sync_function(self):
         """require_permission decorator preserves sync function behavior."""
 
         @permissions.require_permission("admin:read")
-        def my_sync_func(x: int) -> int:
+        def my_sync_func(x: int, *, current_user=None, db=None) -> int:
             return x + 1
 
-        assert my_sync_func(41) == 42
+        assert my_sync_func(41, current_user=MagicMock(), db=MagicMock()) == 42
 
     def test_require_permission_preserves_async_function(self):
         """require_permission decorator preserves async function for FastAPI."""
 
         @permissions.require_permission("admin:write")
-        async def my_async_func(x: int) -> int:
+        async def my_async_func(x: int, *, current_user=None, db=None) -> int:
             return x * 2
 
-        result = asyncio.run(my_async_func(21))
+        result = asyncio.run(
+            my_async_func(21, current_user=MagicMock(), db=MagicMock())
+        )
         assert result == 42
 
     def test_require_permission_with_different_permission_names(self):
         """Decorator accepts various permission names."""
 
         @permissions.require_permission("flows:create")
-        def create_flow():
+        def create_flow(*, current_user=None, db=None):
             return "created"
 
-        assert create_flow() == "created"
+        assert create_flow(current_user=MagicMock(), db=MagicMock()) == "created"
 
     def test_require_permission_sync_wrapper_supports_running_event_loop(
         self, monkeypatch

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -4,6 +4,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -24,6 +25,24 @@ const (
 	// DefaultTimeout is the default HTTP client timeout.
 	DefaultTimeout = 30 * time.Second
 )
+
+// APIError is returned when the server responds with a non-2xx status.
+// Callers should use errors.As to inspect StatusCode rather than parsing
+// Error() strings.
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Body)
+}
+
+// IsStatus reports whether err is an *APIError with the given HTTP status.
+func IsStatus(err error, statusCode int) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == statusCode
+}
 
 // Client is an HTTP client for the Preloop API.
 type Client struct {
@@ -214,7 +233,7 @@ func (c *Client) doWithBodyAndHeaders(
 	}
 
 	if statusCode < 200 || statusCode >= 300 {
-		return fmt.Errorf("API error (status %d): %s", statusCode, string(responseBody))
+		return &APIError{StatusCode: statusCode, Body: string(responseBody)}
 	}
 
 	if result != nil && len(responseBody) > 0 {

--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -269,6 +270,19 @@ func TestGet_APIError(t *testing.T) {
 	err := client.Get("/test", &result)
 	if err == nil {
 		t.Fatal("expected error for 401 response")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", apiErr.StatusCode)
+	}
+	if !IsStatus(err, http.StatusUnauthorized) {
+		t.Fatal("IsStatus should match 401")
+	}
+	if IsStatus(err, http.StatusTooManyRequests) {
+		t.Fatal("IsStatus should not match 429")
 	}
 }
 

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -514,6 +514,7 @@ func init() {
 	agentsCmd.AddCommand(agentsStarterPolicyCmd)
 
 	agentsDiscoverCmd.Flags().Bool("add", false, "deprecated: use 'preloop agents onboard <agent>' instead")
+	agentsDiscoverCmd.Flags().Bool("json", false, "output discovered agents as JSON (read-only, no prompts)")
 	agentsDiscoverCmd.Flags().Bool("no-onboard-prompt", false, "do not prompt to onboard discovered agents")
 	agentsDiscoverCmd.Flags().BoolP("yes", "y", false, "auto-approve interactive onboarding prompts")
 	agentsDiscoverCmd.Flags().BoolP("force", "f", false, "alias for --yes")
@@ -3848,8 +3849,14 @@ func writeJSONDocument(path string, doc map[string]interface{}) error {
 		return fmt.Errorf("failed to encode managed config: %w", err)
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	// 0600: the managed config embeds the durable runtime bearer token, so it
+	// must not be world-readable. Chmod after write enforces the mode even when
+	// the file already existed (os.WriteFile only sets mode on creation).
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("failed to write managed config: %w", err)
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		return fmt.Errorf("failed to secure managed config permissions: %w", err)
 	}
 	return nil
 }
@@ -3865,8 +3872,12 @@ func writeTOMLDocument(path string, doc map[string]interface{}) error {
 	if len(data) == 0 || data[len(data)-1] != '\n' {
 		data = append(data, '\n')
 	}
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	// 0600: embeds the runtime bearer token (see writeJSONDocument).
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("failed to write managed config: %w", err)
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		return fmt.Errorf("failed to secure managed config permissions: %w", err)
 	}
 	return nil
 }

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -659,13 +659,14 @@ func promptToOnboardDiscoveredAgents(
 	// agents from being touched.
 	deferLiveValidate := !skipLiveValidate
 	var enrolled []AgentConfig
-	err = promptToOnboardCandidates(os.Stdin, os.Stdout, candidates, autoApprove, func(agent AgentConfig) error {
+	err = promptToOnboardCandidates(os.Stdin, os.Stdout, candidates, autoApprove, true, func(agent AgentConfig, approvals bool) error {
 		enrollErr := executeManagedEnrollment(agent, managedEnrollmentOptions{
 			Client:            client,
 			SkipConfirmation:  true,
 			LiveValidate:      true,
 			SkipLiveValidate:  skipLiveValidate,
 			DeferLiveValidate: deferLiveValidate,
+			Approvals:         approvals,
 			Input:             os.Stdin,
 			Output:            os.Stdout,
 		})
@@ -688,7 +689,8 @@ func promptToOnboardCandidates(
 	writer io.Writer,
 	candidates []AgentConfig,
 	autoApprove bool,
-	enroll func(agent AgentConfig) error,
+	askApprovals bool,
+	enroll func(agent AgentConfig, approvals bool) error,
 ) error {
 	bufferedReader := bufio.NewReader(reader)
 
@@ -714,7 +716,18 @@ func promptToOnboardCandidates(
 		if err != nil {
 			return err
 		}
-		if err := enroll(agent); err != nil {
+		// Offer the native tool-approvals hook for supported agents when the
+		// caller's enrollment flow skips its own interactive prompts (the
+		// discover-driven path); callers whose enrollment prompts interactively
+		// pass askApprovals=false so the user is only asked once.
+		approvals := false
+		if askApprovals && !autoApprove && !nonInteractiveAutoConfirm() {
+			approvals, err = promptForApprovalsOptIn(bufferedReader, writer, agent)
+			if err != nil {
+				return fmt.Errorf("failed to read approvals confirmation: %w", err)
+			}
+		}
+		if err := enroll(agent, approvals); err != nil {
 			return err
 		}
 	}
@@ -990,7 +1003,9 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 		}
 
 		var enrolled []AgentConfig
-		err = promptToOnboardCandidates(os.Stdin, os.Stdout, candidates, autoApprove, func(a AgentConfig) error {
+		// askApprovals=false: executeManagedEnrollment prompts for the
+		// approvals hook itself when this path runs interactively.
+		err = promptToOnboardCandidates(os.Stdin, os.Stdout, candidates, autoApprove, false, func(a AgentConfig, _ bool) error {
 			agentOpts := opts
 			agentOpts.SkipConfirmation = autoApprove
 			agentOpts.DeferLiveValidate = deferLiveValidate

--- a/cli/internal/cmd/agents_approval_hooks.go
+++ b/cli/internal/cmd/agents_approval_hooks.go
@@ -42,6 +42,27 @@ func isApprovalHookSupportedAgent(agent AgentConfig) bool {
 	return permissionSourceForAgent(agent) != ""
 }
 
+// promptForApprovalsOptIn asks the user whether to install the native
+// tool-approvals hook for a supported agent when onboarding was started
+// without --approvals. Unsupported agents never prompt and never opt in.
+func promptForApprovalsOptIn(
+	reader io.Reader,
+	writer io.Writer,
+	agent AgentConfig,
+) (bool, error) {
+	if !isApprovalHookSupportedAgent(agent) {
+		return false, nil
+	}
+	return confirmActionDefaultYes(
+		reader,
+		writer,
+		fmt.Sprintf(
+			"Route %s's native tool calls (shell commands, file edits) through Preloop approvals? (Y/n): ",
+			resolveAgentDisplayName(agent),
+		),
+	)
+}
+
 func permissionHookAgentsDir() (string, error) {
 	baseDir, err := config.GetConfigDir()
 	if err != nil {

--- a/cli/internal/cmd/agents_hermes.go
+++ b/cli/internal/cmd/agents_hermes.go
@@ -96,8 +96,14 @@ func writeHermesAgentConfigDocument(path string, doc map[string]interface{}) err
 	if len(data) == 0 || data[len(data)-1] != '\n' {
 		data = append(data, '\n')
 	}
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	// 0600: the Hermes config embeds the runtime bearer token in the managed
+	// preloop.control block, so keep it non-world-readable. Chmod enforces the
+	// mode even if the file already existed.
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("failed to write managed Hermes config: %w", err)
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		return fmt.Errorf("failed to secure managed Hermes config permissions: %w", err)
 	}
 	return nil
 }

--- a/cli/internal/cmd/agents_live_validate.go
+++ b/cli/internal/cmd/agents_live_validate.go
@@ -339,16 +339,22 @@ func isUpstreamRateLimitedValidationError(err error) bool {
 		strings.Contains(message, "status 429")
 }
 
-// liveValidationThrottleBackoffs are the waits between probe retries when the
-// upstream provider rate-limits the live-validation request. Two short
-// retries cover the common transient case (a burst of onboarding probes or
-// concurrent agent traffic) without stalling onboarding for long.
-var liveValidationThrottleBackoffs = []time.Duration{
-	3 * time.Second,
-	8 * time.Second,
+// liveValidationThrottleBackoffSchedule returns the waits between probe
+// retries when the upstream provider rate-limits the live-validation
+// request. Two short retries cover the common transient case (a burst of
+// onboarding probes or concurrent agent traffic) without stalling
+// onboarding for long. Returns a fresh slice so callers cannot mutate
+// shared package state.
+func liveValidationThrottleBackoffSchedule() []time.Duration {
+	return []time.Duration{
+		3 * time.Second,
+		8 * time.Second,
+	}
 }
 
 // liveValidationSleep is time.Sleep, injectable so tests can run instantly.
+// Not safe for concurrent reassignment: tests that override it must not use
+// t.Parallel alongside other live-validation tests in this package.
 var liveValidationSleep = time.Sleep
 
 // postGatewayProbeWithThrottleRetry runs the gateway probe, retrying only on
@@ -358,7 +364,7 @@ var liveValidationSleep = time.Sleep
 func postGatewayProbeWithThrottleRetry(post func() error) (int, error) {
 	attempts := 1
 	err := post()
-	for _, backoff := range liveValidationThrottleBackoffs {
+	for _, backoff := range liveValidationThrottleBackoffSchedule() {
 		if err == nil || !isUpstreamRateLimitedValidationError(err) {
 			return attempts, err
 		}

--- a/cli/internal/cmd/agents_live_validate.go
+++ b/cli/internal/cmd/agents_live_validate.go
@@ -30,6 +30,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -233,19 +234,19 @@ func runGatewayLiveValidation(
 	}
 
 	gatewayClient := api.NewClientWithToken(baseURL, spec.Token)
-	var gatewayResponse map[string]interface{}
-	var requestErr error
-	if len(spec.Headers) == 0 {
-		requestErr = gatewayClient.Post(spec.Endpoint, spec.Body, &gatewayResponse)
-	} else {
-		requestErr = gatewayClient.PostWithHeaders(
+	postProbe := func() error {
+		var gatewayResponse map[string]interface{}
+		if len(spec.Headers) == 0 {
+			return gatewayClient.Post(spec.Endpoint, spec.Body, &gatewayResponse)
+		}
+		return gatewayClient.PostWithHeaders(
 			spec.Endpoint,
 			spec.Body,
 			spec.Headers,
 			&gatewayResponse,
 		)
 	}
-	_ = gatewayResponse
+	probeAttempts, requestErr := postGatewayProbeWithThrottleRetry(postProbe)
 
 	apiKeyID := mostLikelyManagedAPIKeyID(detail.Credentials)
 	var searchHit *gatewayUsageSearchItem
@@ -269,6 +270,7 @@ func runGatewayLiveValidation(
 	}
 	result := mergeStringMaps(validationResult, map[string]interface{}{
 		"live_validation_attempted":      true,
+		"live_validation_attempts":       probeAttempts,
 		"live_validation_passed":         passed,
 		"live_validation_status":         liveValidationStatus,
 		"live_validation_token":          validationToken,
@@ -322,11 +324,66 @@ func isUpstreamRateLimitedValidationError(err error) bool {
 	if err == nil {
 		return false
 	}
+	// Prefer the typed HTTP status from the API client. Once we have an
+	// *api.APIError, trust StatusCode only — body text can mention rate
+	// limits on non-429 responses and must not override the status.
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusTooManyRequests
+	}
+	// Fallback for wrapped/non-client errors that only expose a message.
 	message := strings.ToLower(err.Error())
 	return strings.Contains(message, "rate_limit_error") ||
 		strings.Contains(message, "ratelimiterror") ||
 		strings.Contains(message, "throttling_error") ||
 		strings.Contains(message, "status 429")
+}
+
+// liveValidationThrottleBackoffs are the waits between probe retries when the
+// upstream provider rate-limits the live-validation request. Two short
+// retries cover the common transient case (a burst of onboarding probes or
+// concurrent agent traffic) without stalling onboarding for long.
+var liveValidationThrottleBackoffs = []time.Duration{
+	3 * time.Second,
+	8 * time.Second,
+}
+
+// liveValidationSleep is time.Sleep, injectable so tests can run instantly.
+var liveValidationSleep = time.Sleep
+
+// postGatewayProbeWithThrottleRetry runs the gateway probe, retrying only on
+// upstream rate-limit errors with the backoff schedule above. It returns the
+// number of attempts made and the final error (nil on success). Non-throttle
+// errors never retry: they indicate a config/auth problem a retry cannot fix.
+func postGatewayProbeWithThrottleRetry(post func() error) (int, error) {
+	attempts := 1
+	err := post()
+	for _, backoff := range liveValidationThrottleBackoffs {
+		if err == nil || !isUpstreamRateLimitedValidationError(err) {
+			return attempts, err
+		}
+		liveValidationSleep(backoff)
+		attempts++
+		err = post()
+	}
+	return attempts, err
+}
+
+// liveValidationStatusThrottled reports whether a validation result recorded
+// an upstream rate-limit outcome. Throttling is treated as inconclusive-but-
+// plumbing-verified: a 429 proves the durable credential authenticated at the
+// gateway and the request reached the upstream provider, so callers must NOT
+// roll back the managed gateway configuration over it.
+func liveValidationStatusThrottled(validationResult map[string]interface{}) bool {
+	if validationResult == nil {
+		return false
+	}
+	status, _ := validationResult["live_validation_status"].(string)
+	return status == "throttled"
+}
+
+func liveValidationOutcomeThrottled(outcome *managedLiveValidationOutcome) bool {
+	return outcome != nil && liveValidationStatusThrottled(outcome.ValidationResult)
 }
 
 func listManagedValidationAIModels(client *api.Client) []aiModelResponse {
@@ -1097,6 +1154,14 @@ func recoverDeferredGatewayValidationFailure(
 	if result.Err == nil {
 		return
 	}
+	if liveValidationOutcomeThrottled(result.Outcome) {
+		fmt.Fprintf(
+			output,
+			"      Note: the upstream provider rate-limited the live validation probe; keeping the Preloop gateway configuration in place. Re-verify with: preloop agents validate %s --live\n",
+			shellQuoteAgentName(resolveAgentDisplayName(result.Agent)),
+		) //nolint:errcheck
+		return
+	}
 	if !isClaudeCodeAgent(result.Agent) &&
 		!isCodexCLIAgent(result.Agent) &&
 		!isGeminiCLIAgent(result.Agent) {
@@ -1158,8 +1223,13 @@ func persistDeferredLiveValidationResult(
 	if enrollmentID == "" {
 		return
 	}
+	// A throttled probe is inconclusive, not a failure: the static config
+	// checks passed and the gateway config stays in place, so persist
+	// "validated" and let live_validation_status carry the "throttled" detail.
 	status := "validated"
-	if result.Outcome.Attempted && !result.Outcome.Passed {
+	if result.Outcome.Attempted &&
+		!result.Outcome.Passed &&
+		!liveValidationOutcomeThrottled(result.Outcome) {
 		status = "validation_failed"
 	}
 	_, _ = validateManagedEnrollmentRecord(

--- a/cli/internal/cmd/agents_live_validate_test.go
+++ b/cli/internal/cmd/agents_live_validate_test.go
@@ -874,7 +874,7 @@ func TestPostGatewayProbeWithThrottleRetry(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected persistent throttle error to surface")
 		}
-		expected := 1 + len(liveValidationThrottleBackoffs)
+		expected := 1 + len(liveValidationThrottleBackoffSchedule())
 		if attempts != expected || calls != expected {
 			t.Fatalf("expected %d attempts, got attempts=%d calls=%d", expected, attempts, calls)
 		}

--- a/cli/internal/cmd/agents_live_validate_test.go
+++ b/cli/internal/cmd/agents_live_validate_test.go
@@ -20,10 +20,13 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/preloop/preloop/cli/internal/api"
 )
 
 func decodeBuilderPayload(t *testing.T, body map[string]interface{}) map[string]interface{} {
@@ -671,7 +674,10 @@ func TestPrintDeferredLiveValidationLine_StatusVariants(t *testing.T) {
 						"live_validation_status": "throttled",
 					},
 				},
-				Err:      errStringForTest("API error (status 429): rate_limit_error"),
+				Err: &api.APIError{
+					StatusCode: http.StatusTooManyRequests,
+					Body:       "rate_limit_error",
+				},
 				Duration: 120 * time.Millisecond,
 			},
 			contains: []string{
@@ -818,5 +824,161 @@ func TestRunDeferredLiveValidationsParallel_ConcurrentNoOpIsSafe(t *testing.T) {
 	}
 	if calls.Load() != 16 {
 		t.Fatalf("expected 16 concurrent calls to complete, got %d", calls.Load())
+	}
+}
+
+// The throttle-retry helper exists because a burst of onboarding probes (or
+// the user's own concurrent agent traffic) commonly trips upstream rate
+// limiters; a couple of spaced retries turns most of those transient 429s
+// into a passing validation instead of a spurious gateway rollback.
+func TestPostGatewayProbeWithThrottleRetry(t *testing.T) {
+	restoreSleep := liveValidationSleep
+	defer func() { liveValidationSleep = restoreSleep }()
+	var slept []time.Duration
+	liveValidationSleep = func(d time.Duration) { slept = append(slept, d) }
+
+	t.Run("retries throttle errors and succeeds", func(t *testing.T) {
+		slept = nil
+		calls := 0
+		attempts, err := postGatewayProbeWithThrottleRetry(func() error {
+			calls++
+			if calls < 3 {
+				return &api.APIError{
+					StatusCode: http.StatusTooManyRequests,
+					Body:       "throttling_error",
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("expected success after retries, got %v", err)
+		}
+		if attempts != 3 || calls != 3 {
+			t.Fatalf("expected 3 attempts, got attempts=%d calls=%d", attempts, calls)
+		}
+		if len(slept) != 2 {
+			t.Fatalf("expected 2 backoff sleeps, got %v", slept)
+		}
+	})
+
+	t.Run("gives up after backoff schedule on persistent throttle", func(t *testing.T) {
+		slept = nil
+		calls := 0
+		attempts, err := postGatewayProbeWithThrottleRetry(func() error {
+			calls++
+			return &api.APIError{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       "rate_limit_error",
+			}
+		})
+		if err == nil {
+			t.Fatal("expected persistent throttle error to surface")
+		}
+		expected := 1 + len(liveValidationThrottleBackoffs)
+		if attempts != expected || calls != expected {
+			t.Fatalf("expected %d attempts, got attempts=%d calls=%d", expected, attempts, calls)
+		}
+	})
+
+	t.Run("does not retry non-throttle errors", func(t *testing.T) {
+		slept = nil
+		calls := 0
+		attempts, err := postGatewayProbeWithThrottleRetry(func() error {
+			calls++
+			return &api.APIError{StatusCode: http.StatusUnauthorized, Body: "unauthorized"}
+		})
+		if err == nil {
+			t.Fatal("expected error to surface")
+		}
+		if attempts != 1 || calls != 1 {
+			t.Fatalf("expected a single attempt, got attempts=%d calls=%d", attempts, calls)
+		}
+		if len(slept) != 0 {
+			t.Fatalf("expected no sleeps, got %v", slept)
+		}
+	})
+
+	t.Run("succeeds first try without sleeping", func(t *testing.T) {
+		slept = nil
+		attempts, err := postGatewayProbeWithThrottleRetry(func() error { return nil })
+		if err != nil || attempts != 1 || len(slept) != 0 {
+			t.Fatalf("expected clean single attempt, got attempts=%d err=%v slept=%v", attempts, err, slept)
+		}
+	})
+}
+
+func TestIsUpstreamRateLimitedValidationError(t *testing.T) {
+	if isUpstreamRateLimitedValidationError(nil) {
+		t.Fatal("nil must not be rate-limited")
+	}
+	if !isUpstreamRateLimitedValidationError(&api.APIError{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       "anything",
+	}) {
+		t.Fatal("typed 429 APIError must be detected")
+	}
+	if isUpstreamRateLimitedValidationError(&api.APIError{
+		StatusCode: http.StatusUnauthorized,
+		Body:       "rate_limit_error",
+	}) {
+		t.Fatal("typed non-429 APIError must not match on body text alone")
+	}
+	// Fallback path for wrapped/non-client errors that only expose a message.
+	if !isUpstreamRateLimitedValidationError(
+		errStringForTest("upstream said rate_limit_error"),
+	) {
+		t.Fatal("string fallback should still detect provider rate-limit codes")
+	}
+}
+
+func TestLiveValidationStatusThrottled(t *testing.T) {
+	if liveValidationStatusThrottled(nil) {
+		t.Fatal("nil result must not be throttled")
+	}
+	if liveValidationStatusThrottled(map[string]interface{}{"live_validation_status": "failed"}) {
+		t.Fatal("failed result must not be throttled")
+	}
+	if !liveValidationStatusThrottled(map[string]interface{}{"live_validation_status": "throttled"}) {
+		t.Fatal("throttled result must be detected")
+	}
+	if liveValidationOutcomeThrottled(nil) {
+		t.Fatal("nil outcome must not be throttled")
+	}
+	if !liveValidationOutcomeThrottled(&managedLiveValidationOutcome{
+		ValidationResult: map[string]interface{}{"live_validation_status": "throttled"},
+	}) {
+		t.Fatal("throttled outcome must be detected")
+	}
+}
+
+// A throttled live validation must never roll the managed gateway config
+// back: the 429 proved the credential authenticated and the request reached
+// the upstream. This is the regression test for the onboarding loop where a
+// rate-limited probe silently restored direct model access.
+func TestRecoverDeferredGatewayValidationFailure_SkipsRollbackWhenThrottled(t *testing.T) {
+	var buf bytes.Buffer
+	recoverDeferredGatewayValidationFailure(&buf, deferredLiveValidationResult{
+		Agent: AgentConfig{Name: "Claude Code"},
+		Outcome: &managedLiveValidationOutcome{
+			Attempted: true,
+			Passed:    false,
+			ValidationResult: map[string]interface{}{
+				"live_validation_status": "throttled",
+			},
+		},
+		Err: &api.APIError{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       "throttling_error",
+		},
+	})
+	rendered := buf.String()
+	if !strings.Contains(rendered, "rate-limited") {
+		t.Fatalf("expected throttle note in output, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "keeping the Preloop gateway configuration") {
+		t.Fatalf("expected keep-config note in output, got %q", rendered)
+	}
+	if strings.Contains(rendered, "Restored") {
+		t.Fatalf("expected no restore to run for throttled outcome, got %q", rendered)
 	}
 }

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -349,6 +349,18 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 			fmt.Println("Aborted without applying onboarding.")
 			return nil
 		}
+		// Offer the native tool-approvals hook even when the user did not
+		// pass --approvals, so interactive onboarding surfaces the feature
+		// for the agents that support it. Non-interactive runs
+		// (PRELOOP_CONFIRM) stay flag-driven: hooks change tool-call behavior
+		// and must not be installed by an auto-answered prompt.
+		if !opts.Approvals && !nonInteractiveAutoConfirm() {
+			optIn, approvalsErr := promptForApprovalsOptIn(input, output, agent)
+			if approvalsErr != nil {
+				return fmt.Errorf("failed to read approvals confirmation: %w", approvalsErr)
+			}
+			opts.Approvals = optIn
+		}
 	}
 
 	serverSync, err := ensureDiscoveredRemoteServers(client, syncAgent, baseURL)
@@ -595,14 +607,20 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 	}
 
 	var liveValidationErr error
+	liveValidationThrottled := false
 	if requestedLiveValidation {
 		liveOutcome, err := runManagedAgentLiveValidation(client, agent, validationResult)
 		if liveOutcome != nil && len(liveOutcome.ValidationResult) > 0 {
 			validationResult = liveOutcome.ValidationResult
 		}
+		liveValidationThrottled = liveValidationStatusThrottled(validationResult)
 		if liveOutcome != nil && liveOutcome.Attempted {
+			// A throttled probe is inconclusive, not a failure: the static
+			// config checks passed and the gateway config stays in place, so
+			// persist "validated" and let live_validation_status carry the
+			// "throttled" detail.
 			validationStatus := "validated"
-			if !liveOutcome.Passed {
+			if !liveOutcome.Passed && !liveValidationThrottled {
 				validationStatus = "validation_failed"
 			}
 			if _, persistErr := validateManagedEnrollmentRecord(
@@ -619,7 +637,29 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 			liveValidationErr = err
 		}
 	}
-	if liveValidationErr != nil {
+	if liveValidationErr != nil && liveValidationThrottled {
+		// A 429 proves the durable credential authenticated at the gateway and
+		// the request reached the upstream provider — the wiring works, the
+		// provider is just rate-limited right now. Rolling back the gateway
+		// config here would discard a working onboarding over a transient
+		// condition (and re-running onboarding to "fix" it only sends more
+		// probes into the same rate limiter).
+		quotedName := shellQuoteAgentName(resolveAgentDisplayName(agent))
+		fmt.Fprintf(
+			output,
+			"  Note: the upstream provider rate-limited the live validation probe; keeping the Preloop gateway configuration in place.\n",
+		) //nolint:errcheck
+		fmt.Fprintf(
+			output,
+			"        Re-verify later with: preloop agents validate %s --live\n",
+			quotedName,
+		) //nolint:errcheck
+		fmt.Fprintf(
+			output,
+			"        Or revert to direct model access with: preloop agents restore %s\n",
+			quotedName,
+		) //nolint:errcheck
+	} else if liveValidationErr != nil {
 		if rollbackErr := recoverManagedGatewayAfterLiveValidationFailure(
 			agent,
 			originalBytes,
@@ -713,7 +753,11 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		// <agent> --live`` is the dedicated command for "exit non-zero on
 		// live-validate failure" semantics. Print a clear warning with a
 		// recovery hint and continue.
-		fmt.Printf("  Warning: live validation failed: %v\n", liveValidationErr)
+		warningLabel := "failed"
+		if liveValidationThrottled {
+			warningLabel = "throttled by the upstream provider"
+		}
+		fmt.Printf("  Warning: live validation %s: %v\n", warningLabel, liveValidationErr)
 		fmt.Printf(
 			"           Run: preloop agents validate %s --live\n",
 			shellQuoteAgentName(resolveAgentDisplayName(agent)),

--- a/cli/internal/cmd/agents_test.go
+++ b/cli/internal/cmd/agents_test.go
@@ -1836,7 +1836,8 @@ func TestPromptToOnboardCandidates_DeclineContinuesToNextAgent(t *testing.T) {
 		output,
 		candidates,
 		false,
-		func(agent AgentConfig) error {
+		false,
+		func(agent AgentConfig, _ bool) error {
 			enrolled = append(enrolled, agent)
 			return nil
 		},
@@ -1861,6 +1862,96 @@ func TestPromptToOnboardCandidates_DeclineContinuesToNextAgent(t *testing.T) {
 	if !strings.Contains(rendered, "Agent name [Codex CLI]: ") {
 		t.Fatalf("expected name prompt in output, got %q", rendered)
 	}
+}
+
+func TestPromptToOnboardCandidates_AsksApprovalsForSupportedAgents(t *testing.T) {
+	// OpenClaw: confirm + name (no approvals question — its hook ships via the
+	// runtime plugin, not the local adapter). Codex CLI: confirm + name +
+	// approvals yes.
+	input := strings.NewReader("y\n\ny\n\ny\n")
+	output := &bytes.Buffer{}
+	candidates := []AgentConfig{
+		{Name: "OpenClaw", ConfigPath: "/tmp/openclaw.json"},
+		{Name: "Codex CLI", ConfigPath: "/tmp/codex.toml"},
+	}
+
+	approvalsByAgent := map[string]bool{}
+	err := promptToOnboardCandidates(
+		input,
+		output,
+		candidates,
+		false,
+		true,
+		func(agent AgentConfig, approvals bool) error {
+			approvalsByAgent[agent.Name] = approvals
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if approvalsByAgent["OpenClaw"] {
+		t.Fatal("expected no approvals opt-in for unsupported agent")
+	}
+	if !approvalsByAgent["Codex CLI"] {
+		t.Fatal("expected approvals opt-in for Codex CLI")
+	}
+	rendered := output.String()
+	if strings.Count(rendered, "through Preloop approvals?") != 1 {
+		t.Fatalf("expected exactly one approvals question, got %q", rendered)
+	}
+}
+
+func TestPromptForApprovalsOptIn(t *testing.T) {
+	t.Run("default yes for supported agent", func(t *testing.T) {
+		output := &bytes.Buffer{}
+		optIn, err := promptForApprovalsOptIn(
+			strings.NewReader("\n"),
+			output,
+			AgentConfig{Name: "Claude Code", ConfigPath: "/tmp/settings.json"},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !optIn {
+			t.Fatal("expected empty answer to default to yes")
+		}
+		if !strings.Contains(output.String(), "Route Claude Code's native tool calls") {
+			t.Fatalf("expected approvals prompt in output, got %q", output.String())
+		}
+	})
+
+	t.Run("explicit no is honored", func(t *testing.T) {
+		optIn, err := promptForApprovalsOptIn(
+			strings.NewReader("n\n"),
+			&bytes.Buffer{},
+			AgentConfig{Name: "Cursor", ConfigPath: "/tmp/mcp.json"},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if optIn {
+			t.Fatal("expected explicit no to decline the hook")
+		}
+	})
+
+	t.Run("unsupported agent never prompts", func(t *testing.T) {
+		output := &bytes.Buffer{}
+		optIn, err := promptForApprovalsOptIn(
+			strings.NewReader(""),
+			output,
+			AgentConfig{Name: "Gemini CLI", ConfigPath: "/tmp/settings.json"},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if optIn {
+			t.Fatal("expected unsupported agent to skip the hook")
+		}
+		if output.Len() != 0 {
+			t.Fatalf("expected no prompt output, got %q", output.String())
+		}
+	})
 }
 
 func TestPrepareAgentForEnrollment_AllowsEditingAgentName(t *testing.T) {

--- a/cli/internal/cmd/approvals.go
+++ b/cli/internal/cmd/approvals.go
@@ -21,13 +21,37 @@ const (
 
 // ApprovalWorkflow represents an approval workflow.
 type ApprovalWorkflow struct {
-	ID          string   `json:"id" yaml:"id"`
-	Name        string   `json:"name" yaml:"name"`
-	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
-	ToolPattern string   `json:"tool_pattern,omitempty" yaml:"tool_pattern,omitempty"`
-	Approvers   []string `json:"approvers,omitempty" yaml:"approvers,omitempty"`
-	AutoApprove bool     `json:"auto_approve" yaml:"auto_approve"`
-	Active      bool     `json:"active" yaml:"active"`
+	ID                   string   `json:"id" yaml:"id"`
+	Name                 string   `json:"name" yaml:"name"`
+	Description          string   `json:"description,omitempty" yaml:"description,omitempty"`
+	ApprovalType         string   `json:"approval_type" yaml:"approval_type"`
+	ApprovalMode         string   `json:"approval_mode" yaml:"approval_mode"`
+	IsDefault            bool     `json:"is_default" yaml:"is_default"`
+	TimeoutSeconds       int      `json:"timeout_seconds" yaml:"timeout_seconds"`
+	AsyncApprovalEnabled bool     `json:"async_approval_enabled" yaml:"async_approval_enabled"`
+	ApprovalsRequired    int      `json:"approvals_required" yaml:"approvals_required"`
+	ApproverUserIDs      []string `json:"approver_user_ids,omitempty" yaml:"approver_user_ids,omitempty"`
+	ApproverTeamIDs      []string `json:"approver_team_ids,omitempty" yaml:"approver_team_ids,omitempty"`
+}
+
+// approverSummary renders a compact human-readable count of the workflow's
+// approvers, e.g. "2 users", "1 user, 1 team", or "none".
+func (p ApprovalWorkflow) approverSummary() string {
+	parts := make([]string, 0, 2)
+	if n := len(p.ApproverUserIDs); n == 1 {
+		parts = append(parts, "1 user")
+	} else if n > 1 {
+		parts = append(parts, fmt.Sprintf("%d users", n))
+	}
+	if n := len(p.ApproverTeamIDs); n == 1 {
+		parts = append(parts, "1 team")
+	} else if n > 1 {
+		parts = append(parts, fmt.Sprintf("%d teams", n))
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, ", ")
 }
 
 // ApprovalRequest represents an approval request.
@@ -157,22 +181,18 @@ func runApprovalsList(cmd *cobra.Command, args []string) error {
 
 	default: // table
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tTOOL PATTERN\tAUTO-APPROVE\tACTIVE\tAPPROVERS") //nolint:errcheck
+		fmt.Fprintln(w, "NAME\tTYPE\tMODE\tDEFAULT\tAPPROVERS\tTIMEOUT") //nolint:errcheck
 		for _, p := range policies {
-			autoApprove := "no"
-			if p.AutoApprove {
-				autoApprove = "yes"
+			isDefault := "no"
+			if p.IsDefault {
+				isDefault = "yes"
 			}
-			active := "no"
-			if p.Active {
-				active = "yes"
+			timeout := "-"
+			if p.TimeoutSeconds > 0 {
+				timeout = fmt.Sprintf("%ds", p.TimeoutSeconds)
 			}
-			approvers := strings.Join(p.Approvers, ", ")
-			if len(approvers) > 30 {
-				approvers = approvers[:27] + "..."
-			}
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", //nolint:errcheck
-				p.Name, p.ToolPattern, autoApprove, active, approvers)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", //nolint:errcheck
+				p.Name, p.ApprovalType, p.ApprovalMode, isDefault, p.approverSummary(), timeout)
 		}
 		return w.Flush()
 	}

--- a/cli/internal/cmd/approvals_test.go
+++ b/cli/internal/cmd/approvals_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import "testing"
+
+// The approvals table previously rendered fields the backend response never
+// contained (approvers/active/auto_approve), so every workflow displayed as
+// inactive with no approvers. approverSummary reads the real
+// approver_user_ids / approver_team_ids fields.
+func TestApprovalWorkflowApproverSummary(t *testing.T) {
+	cases := []struct {
+		name     string
+		workflow ApprovalWorkflow
+		expected string
+	}{
+		{"no approvers", ApprovalWorkflow{}, "none"},
+		{
+			"single user",
+			ApprovalWorkflow{ApproverUserIDs: []string{"u1"}},
+			"1 user",
+		},
+		{
+			"multiple users",
+			ApprovalWorkflow{ApproverUserIDs: []string{"u1", "u2"}},
+			"2 users",
+		},
+		{
+			"users and teams",
+			ApprovalWorkflow{
+				ApproverUserIDs: []string{"u1"},
+				ApproverTeamIDs: []string{"t1", "t2"},
+			},
+			"1 user, 2 teams",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.workflow.approverSummary(); got != tc.expected {
+				t.Fatalf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -124,9 +124,18 @@ func Save(cfg *Config) error {
 	if err := v.WriteConfig(); err != nil {
 		// If config file doesn't exist, create it
 		if os.IsNotExist(err) {
-			return v.SafeWriteConfig()
+			if err := v.SafeWriteConfig(); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("failed to write config: %w", err)
 		}
-		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	// The config holds access/refresh tokens; viper writes 0644 by default, so
+	// tighten to 0600 (owner-only). The parent dir is already 0700.
+	if err := os.Chmod(cfgPath, 0600); err != nil {
+		return fmt.Errorf("failed to secure config permissions: %w", err)
 	}
 
 	return nil

--- a/frontend/src/components/embedding-viewer.ts
+++ b/frontend/src/components/embedding-viewer.ts
@@ -282,11 +282,23 @@ export class EmbeddingViewer extends LitElement {
       tooltip.style.display = 'block';
       tooltip.style.left = `${x}px`;
       tooltip.style.top = `${y}px`;
-      tooltip.innerHTML = `
-                <strong>${object.issueKey}</strong><br>
-                ${object.title}<br>
-                <small>Created: ${new Date(object.createdAt).toLocaleDateString()}</small>
-            `;
+      // Build with textContent rather than innerHTML: issueKey/title are
+      // external issue-tracker fields and interpolating them into innerHTML is
+      // a DOM XSS vector (e.g. a title of `<img src=x onerror=...>`).
+      const key = document.createElement('strong');
+      key.textContent = object.issueKey ?? '';
+      const title = document.createTextNode(object.title ?? '');
+      const created = document.createElement('small');
+      created.textContent = `Created: ${new Date(
+        object.createdAt
+      ).toLocaleDateString()}`;
+      tooltip.replaceChildren(
+        key,
+        document.createElement('br'),
+        title,
+        document.createElement('br'),
+        created
+      );
     } else {
       tooltip.style.display = 'none';
     }

--- a/frontend/src/components/issue-detail-view.ts
+++ b/frontend/src/components/issue-detail-view.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import DOMPurify from 'dompurify';
 import { when } from 'lit/directives/when.js';
 import {
   AIModelVerdict,
@@ -128,7 +129,7 @@ export class IssueDetailView extends LitElement {
           issue1.description,
           () =>
             html`<div class="issue-description">
-              ${unsafeHTML(issue1.description)}
+              ${unsafeHTML(DOMPurify.sanitize(issue1.description ?? ''))}
             </div>`
         )}
       </div>
@@ -146,7 +147,7 @@ export class IssueDetailView extends LitElement {
           issue2.description,
           () =>
             html`<div class="issue-description">
-              ${unsafeHTML(issue2.description)}
+              ${unsafeHTML(DOMPurify.sanitize(issue2.description ?? ''))}
             </div>`
         )}
       </div>

--- a/frontend/src/components/single-issue-detail-view.ts
+++ b/frontend/src/components/single-issue-detail-view.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import DOMPurify from 'dompurify';
 import { when } from 'lit/directives/when.js';
 import { getStatusVariant, getComplianceVariant } from '../utils/verdict';
 import { Issue, IssueComplianceResult } from '../types';
@@ -80,7 +81,7 @@ export class SingleIssueDetailView extends LitElement {
           this.issue.description,
           () =>
             html`<div class="issue-description">
-              ${unsafeHTML(this.issue.description)}
+              ${unsafeHTML(DOMPurify.sanitize(this.issue.description ?? ''))}
             </div>`,
           () =>
             html`<sl-alert variant="primary" open>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -496,6 +496,11 @@ export interface SubjectGovernanceConfig {
   >;
   tool_rules: Record<string, Array<Record<string, unknown>>>;
   tool_enabled_overrides?: Record<string, boolean>;
+  /**
+   * Approval workflow governing this subject's native tool-call approvals
+   * (agents permission-check). Null falls back to the account default.
+   */
+  approval_workflow_id?: string | null;
 }
 
 export interface SubjectGovernanceResponse {

--- a/frontend/src/views/authed/agent-detail-view.test.ts
+++ b/frontend/src/views/authed/agent-detail-view.test.ts
@@ -429,4 +429,44 @@ describe('AgentDetailView', () => {
     );
     expect(wrongModelLink).to.not.exist;
   });
+
+  it('lets the user pick the approval workflow for native tool approvals', async () => {
+    const element = await fixture<AgentDetailView>(
+      html`<agent-detail-view agentId="agent-1"></agent-detail-view>`
+    );
+
+    await waitUntil(
+      () => !(element as any).loading && (element as any).agent !== null,
+      'Agent detail view did not finish loading'
+    );
+
+    (element as any).activeTab = 'tools';
+    await element.updateComplete;
+
+    const select = element.shadowRoot?.querySelector(
+      '#agent-approval-workflow-select'
+    ) as any;
+    expect(select).to.exist;
+
+    // Options: the account-default fallback plus every workflow.
+    const optionValues = Array.from(select.querySelectorAll('sl-option')).map(
+      (option: any) => option.value
+    );
+    expect(optionValues).to.deep.equal(['', 'wf-1']);
+
+    // Selecting a workflow persists it through the governance PUT.
+    (element as any).saveApprovalWorkflowSelection('wf-1');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const putCall = fetchStub
+      .getCalls()
+      .find(
+        (call) =>
+          String(call.args[0]) === '/api/v1/agents/agent-1/governance' &&
+          call.args[1]?.method === 'PUT'
+      );
+    expect(putCall).to.exist;
+    const body = JSON.parse(putCall!.args[1].body);
+    expect(body.approval_workflow_id).to.equal('wf-1');
+  });
 });

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -162,6 +162,7 @@ export class AgentDetailView extends LitElement {
     model_budgets: {},
     tool_rules: {},
     tool_enabled_overrides: {},
+    approval_workflow_id: null,
   };
 
   @state()
@@ -1091,6 +1092,7 @@ export class AgentDetailView extends LitElement {
         model_budgets: parsedBudgets,
         tool_rules: serializeScopedToolRules(this.scopedToolRules),
         tool_enabled_overrides: this.toolEnabledOverrides,
+        approval_workflow_id: this.governance.approval_workflow_id ?? null,
       };
       const response = await updateAgentGovernance(this.agentId, config);
       this.governance = response.config;
@@ -1111,6 +1113,17 @@ export class AgentDetailView extends LitElement {
     } finally {
       this.actionLoading = false;
     }
+  }
+
+  private saveApprovalWorkflowSelection(workflowId: string | null): void {
+    if ((this.governance.approval_workflow_id ?? null) === workflowId) {
+      return;
+    }
+    this.governance = {
+      ...this.governance,
+      approval_workflow_id: workflowId,
+    };
+    void this.saveGovernance();
   }
 
   private getGovernanceTool(toolName: string): GovernanceToolDefinition | null {
@@ -2620,6 +2633,53 @@ export class AgentDetailView extends LitElement {
                               </div>
                             </div>
                           </div>
+                        </div>
+
+                        <div
+                          class="stat-card"
+                          style="display: flex; align-items: center; justify-content: space-between; gap: var(--sl-spacing-medium); flex-shrink: 0; margin-bottom: var(--sl-spacing-medium);"
+                        >
+                          <div>
+                            <div
+                              class="stat-label"
+                              style="display: flex; align-items: center; gap: 6px;"
+                            >
+                              <sl-icon name="shield-lock"></sl-icon>
+                              Native tool approvals
+                            </div>
+                            <div class="meta-line">
+                              Approval workflow used when this agent's native
+                              tool calls (e.g. shell commands, file edits)
+                              require human approval.
+                            </div>
+                          </div>
+                          <sl-select
+                            id="agent-approval-workflow-select"
+                            size="small"
+                            hoist
+                            style="min-width: 280px;"
+                            .value=${this.governance.approval_workflow_id ?? ''}
+                            @sl-change=${(e: Event) => {
+                              const value = (e.target as HTMLSelectElement)
+                                .value;
+                              this.saveApprovalWorkflowSelection(value || null);
+                            }}
+                          >
+                            <sl-option value=""
+                              >Account default workflow</sl-option
+                            >
+                            ${this.approvalWorkflows.map(
+                              (workflow: any) => html`
+                                <sl-option value=${workflow.id}>
+                                  ${workflow.name}${
+                                    workflow.is_default
+                                      ? ' (account default)'
+                                      : ''
+                                  }
+                                </sl-option>
+                              `
+                            )}
+                          </sl-select>
                         </div>
 
                         <tools-editor-component

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -567,49 +567,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/v1/auth/api-keys/debug:
-    get:
-      tags:
-      - Auth
-      summary: Debug Api Keys
-      description: "Debug endpoint to get API keys with their values (admin only).\n\
-        \nArgs:\n    username: The username to get keys for\n    api_key: Optional\
-        \ specific API key to look up\n    current_user: The current authenticated\
-        \ user.\n\nReturns:\n    List of API keys with their values."
-      operationId: debug_api_keys_api_v1_auth_api_keys_debug_get
-      security:
-      - OAuth2PasswordBearer: []
-      parameters:
-      - name: username
-        in: query
-        required: true
-        schema:
-          type: string
-          title: Username
-      - name: api_key
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Api Key
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiKeyResponse'
-                title: Response Debug Api Keys Api V1 Auth Api Keys Debug Get
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/auth/api-usage:
     get:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13842,6 +13842,14 @@ components:
             type: boolean
           type: object
           title: Tool Enabled Overrides
+        approval_workflow_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Approval Workflow Id
+          description: Approval workflow that governs this subject's native tool-call
+            approvals (agents permission-check). Falls back to the account default
+            workflow when unset.
       type: object
       title: SubjectGovernanceConfig
     SubjectGovernanceResponse:

--- a/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/plugin.py
+++ b/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/plugin.py
@@ -338,10 +338,28 @@ class HermesPreloopPlugin:
 
         document: dict[str, Any] = {}
         if config_path.exists():
-            loaded = yaml.safe_load(config_path.read_text())
+            original = config_path.read_text()
+            loaded = yaml.safe_load(original)
             if isinstance(loaded, dict):
                 document = loaded
-        preloop = document.setdefault("preloop", {})
+            # Back up the existing config before rewriting so a bad rewrite is
+            # recoverable (the rewrite drops comments/formatting).
+            backup_path = config_path.with_suffix(config_path.suffix + ".preloop.bak")
+            try:
+                backup_path.write_text(original)
+            except OSError as exc:
+                logger.warning(
+                    "Failed to write backup config to %s; continuing without backup: %s",
+                    backup_path,
+                    exc,
+                )
+        # Guard against an existing non-dict ``preloop:`` scalar, which would
+        # make setdefault(...)/item-assignment raise.
+        existing_preloop = document.get("preloop")
+        if not isinstance(existing_preloop, dict):
+            existing_preloop = {}
+            document["preloop"] = existing_preloop
+        preloop = existing_preloop
         preloop["control"] = {
             "enabled": True,
             "protocol": "preloop.agent_control.v1",

--- a/runtime-plugins/openclaw-preloop/src/index.ts
+++ b/runtime-plugins/openclaw-preloop/src/index.ts
@@ -110,15 +110,36 @@ type OperatorCommand = {
   };
 };
 
+/** Reconnect backoff bounds and heartbeat cadence (mirror the Python client). */
+const RECONNECT_BASE_DELAY_MS = 2_000;
+const RECONNECT_MAX_DELAY_MS = 30_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
 export class PreloopOpenClawPlugin {
   runtime = "openclaw";
   private controlConfig?: ControlConfig;
   private socket?: WebSocket;
+  private openclawRuntime?: OpenClawRuntime;
+  private stopped = false;
+  private reconnectAttempts = 0;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private heartbeatTimer?: ReturnType<typeof setInterval>;
+  private logger?: (message: string) => void;
 
   constructor(
     private readonly configPath?: string,
     private readonly fetchImpl?: FetchLike,
   ) {}
+
+  setLogger(logger: (message: string) => void): void {
+    this.logger = logger;
+  }
+
+  private log(message: string): void {
+    if (this.logger) {
+      this.logger(message);
+    }
+  }
 
   configure(config: ControlConfig): void {
     this.controlConfig = config;
@@ -158,13 +179,41 @@ export class PreloopOpenClawPlugin {
   }
 
   async start(openclawRuntime?: OpenClawRuntime): Promise<void> {
+    this.stopped = false;
+    this.openclawRuntime = openclawRuntime;
+    // Resolve config once up front so a bad config surfaces to the caller
+    // (register() logs it) instead of being retried forever.
+    this.controlConfig = this.controlConfig ?? this.loadConfig();
+    this.connect();
+  }
+
+  private connect(): void {
+    if (this.stopped) {
+      return;
+    }
     const config = this.controlConfig ?? this.loadConfig();
     const wsUrl = new URL(config.control_ws_url!);
+    // Note: Node's global WebSocket has no header option, so the durable
+    // bearer token is passed as a query param. The backend accepts this form.
     wsUrl.searchParams.set("token", config.bearer_token!);
-    this.socket = new WebSocket(wsUrl);
 
-    this.socket.addEventListener("open", () => {
-      this.socket?.send(
+    let socket: WebSocket;
+    try {
+      socket = new WebSocket(wsUrl);
+    } catch (error) {
+      this.log(
+        `Preloop Agent Control connect failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      this.scheduleReconnect();
+      return;
+    }
+    this.socket = socket;
+
+    socket.addEventListener("open", () => {
+      this.reconnectAttempts = 0;
+      socket.send(
         JSON.stringify({
           type: "presence",
           name: "capabilities",
@@ -186,13 +235,33 @@ export class PreloopOpenClawPlugin {
           },
         }),
       );
+      this.startHeartbeat(config);
     });
 
-    this.socket.addEventListener("message", async (event) => {
-      const command = JSON.parse(String(event.data)) as OperatorCommand;
+    socket.addEventListener("message", async (event) => {
+      let command: OperatorCommand;
       try {
-        const result = await this.dispatch(openclawRuntime, command);
-        this.socket?.send(
+        command = JSON.parse(String(event.data)) as OperatorCommand;
+      } catch (error) {
+        // Malformed frame: report it rather than throwing an unhandled
+        // rejection out of the async listener.
+        socket.send(
+          JSON.stringify({
+            type: "status",
+            name: "command_error",
+            payload: {
+              status: "failed",
+              error: `invalid_json: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            },
+          }),
+        );
+        return;
+      }
+      try {
+        const result = await this.dispatch(this.openclawRuntime, command);
+        socket.send(
           JSON.stringify({
             type: "status",
             name: "command_result",
@@ -206,7 +275,7 @@ export class PreloopOpenClawPlugin {
           }),
         );
       } catch (error) {
-        this.socket?.send(
+        socket.send(
           JSON.stringify({
             type: "status",
             name: "command_error",
@@ -220,9 +289,74 @@ export class PreloopOpenClawPlugin {
         );
       }
     });
+
+    const onClose = (): void => {
+      this.stopHeartbeat();
+      if (this.socket === socket) {
+        this.socket = undefined;
+      }
+      this.scheduleReconnect();
+    };
+    socket.addEventListener("close", onClose);
+    socket.addEventListener("error", () => {
+      // 'error' is followed by 'close' in the WS lifecycle; log and let
+      // onClose drive the reconnect so we don't schedule twice.
+      this.log("Preloop Agent Control websocket error");
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer) {
+      return;
+    }
+    const delay = Math.min(
+      RECONNECT_MAX_DELAY_MS,
+      RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempts,
+    );
+    this.reconnectAttempts += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      this.connect();
+    }, delay);
+    // Don't keep the process alive solely for the reconnect timer.
+    (this.reconnectTimer as { unref?: () => void }).unref?.();
+  }
+
+  private startHeartbeat(config: ControlConfig): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      if (!this.socket || this.socket.readyState !== this.socket.OPEN) {
+        return;
+      }
+      this.socket.send(
+        JSON.stringify({
+          type: "status",
+          name: "heartbeat",
+          message_id: randomUUID(),
+          payload: {
+            status: "online",
+            runtime_principal_id: config.runtime_principal_id,
+          },
+        }),
+      );
+    }, HEARTBEAT_INTERVAL_MS);
+    (this.heartbeatTimer as { unref?: () => void }).unref?.();
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = undefined;
+    }
   }
 
   stop(): void {
+    this.stopped = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+    this.stopHeartbeat();
     this.socket?.close();
     this.socket = undefined;
   }
@@ -471,6 +605,11 @@ export function register(api: {
   };
 }): void {
   const instance = new PreloopOpenClawPlugin();
+  if (api.logger?.warn || api.logger?.error) {
+    instance.setLogger((message) =>
+      (api.logger?.warn ?? api.logger?.error)?.(message),
+    );
+  }
   if (api.pluginConfig && Object.keys(api.pluginConfig).length > 0) {
     instance.configure(api.pluginConfig as ControlConfig);
   }


### PR DESCRIPTION
## Summary

Operators can choose a native-tool approval workflow per managed agent; startup now backfills missing account defaults, and interactive onboarding offers the approvals hook.

## Testing

- [x] Backend tests
- [x] Frontend tests
- [ ] Manual validation

## Checklist

- [x] Docs updated if needed
- [x] Changelog updated if needed
- [x] No secrets included

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-scoped feature additions with comprehensive test coverage. No security issues, breaking changes, or risky patterns. All previous review findings are addressed.
>
> **Overview**
> Adds per-agent approval workflow pinning via subject governance, backfills missing default workflows at startup, and offers interactive approvals opt-in during CLI onboarding. Changes span backend API/CRUD/services, CLI discovery/onboarding, and frontend agent detail view. All 6 issues from the first review pass are now resolved.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 87984f4. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->