### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/backend/preloop/models/models/flow_execution.py
+++ b/backend/preloop/models/models/flow_execution.py
@@ -24,7 +24,9 @@ class FlowExecution(Base):
     status = Column(
         String, nullable=False, default="PENDING", index=True
     )  # PENDING, INITIALIZING, RUNNING, etc.
-    start_time = Column(DateTime, default=datetime.now(UTC), nullable=False, index=True)
+    start_time = Column(
+        DateTime, default=lambda: datetime.now(UTC), nullable=False, index=True
+    )
     end_time = Column(DateTime, nullable=True)
     resolved_input_prompt = Column(Text, nullable=True)
     model_output_summary = Column(Text, nullable=True)
@@ -66,11 +68,11 @@ class FlowExecution(Base):
         DateTime(timezone=True), nullable=True, index=True
     )
 
-    created_at = Column(DateTime, default=datetime.now(UTC), nullable=False)
+    created_at = Column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
     updated_at = Column(
         DateTime,
-        default=datetime.now(UTC),
-        onupdate=datetime.now(UTC),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
         nullable=False,
     )
 


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/preloop/preloop/security/quality/ai-findings)._

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Trivial, well-understood fix: wraps `datetime.now(UTC)` in `lambda` closures so SQLAlchemy evaluates timestamps at row-insert/update time instead of module-import time, matching existing patterns in the codebase.
>
> **Overview**
> This PR corrects the `default` and `onupdate` arguments on `FlowExecution.start_time`, `created_at`, and `updated_at` columns. Without the `lambda`, every row would receive the server-startup timestamp rather than the actual creation/update time.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 5986710. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->