### PR TITLE
CLI: make agents discover/onboard resilient to per-agent failures

### DIFF
--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -438,6 +438,8 @@ func printAgentOnboardingSummary(w io.Writer, outcomes []agentOnboardingOutcome)
 	}
 	fmt.Fprintln(w, "\nOnboarding summary:") //nolint:errcheck
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintf(tw, "  Agent\tStatus\tReason\n") //nolint:errcheck
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
 	missingExecutable := false
 	for _, outcome := range outcomes {
 		reason := outcome.Reason

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -54,6 +55,7 @@ type agentSpec struct {
 	Name                string
 	ConfigPaths         []string // relative to $HOME
 	DetectionPaths      []string // optional install markers relative to $HOME
+	DetectionCommands   []string // optional executables on PATH that mark an install
 	BootstrapConfigPath string   // optional synthesized config path relative to $HOME
 	Parser              func(path string) (map[string]MCPDef, error)
 }
@@ -62,7 +64,14 @@ var agentSpecs = []agentSpec{
 	{
 		Name:        "Claude Code",
 		ConfigPaths: []string{".claude/settings.json", ".claude/mcp-servers.json"},
-		Parser:      parseClaudeConfig,
+		// Fresh or lightly-used installs write only ~/.claude.json (and put
+		// the `claude` binary on PATH) before any settings.json exists, so
+		// treat both as install markers. Onboarding then bootstraps the
+		// canonical ~/.claude/settings.json.
+		DetectionPaths:      []string{".claude.json"},
+		DetectionCommands:   []string{"claude"},
+		BootstrapConfigPath: ".claude/settings.json",
+		Parser:              parseClaudeConfig,
 	},
 	{
 		Name:        "Claude Desktop",
@@ -224,6 +233,15 @@ Supported agents: Claude Code, Cursor, Windsurf, VSCode/Copilot,
                   Gemini CLI, OpenCode, Codex CLI, OpenClaw, Hermes,
                   Antigravity, Devin.
 
+When the post-scan onboarding prompts run, an error onboarding one agent does
+not stop the remaining agents; a per-agent summary (onboarded / partial /
+failed) is printed at the end. A missing agent binary downgrades that agent to
+"partial" (MCP and model routing configured, managed launcher skipped) instead
+of failing it.
+
+Exit codes: 0 when at least one attempted agent onboarded (fully or
+partially), non-zero only when every attempted agent failed.
+
 Examples:
   preloop agents discover
   preloop agents discover --json`,
@@ -239,7 +257,17 @@ credential for it, back up the local config, and add a managed Preloop MCP serve
 entry to the selected agent configuration.
 
 This is the mutating companion to 'preloop agents discover'. Use --dry-run to
-preview the planned config and account changes without writing anything.`,
+preview the planned config and account changes without writing anything.
+
+A missing agent binary does not fail onboarding: the MCP and model routing
+configuration still applies and the managed launcher step is skipped with a
+warning ("partial" onboarding).
+
+Exit codes: when onboarding multiple agents (no agent argument, or --all), an
+error for one agent does not stop the others; the command exits 0 when at
+least one attempted agent onboarded (fully or partially) and non-zero only
+when every attempted agent failed. With a single agent argument, a partial
+onboarding still exits 0.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runAgentsEnroll,
 }
@@ -342,6 +370,124 @@ type mcpServerResponse struct {
 type agentOnboardingFailure struct {
 	Agent AgentConfig
 	Err   error
+}
+
+// Batch onboarding statuses reported in the end-of-run summary. "partial"
+// means the MCP/model configuration applied but an optional step (the
+// managed launcher) was skipped, e.g. because the agent binary is missing.
+const (
+	agentOnboardingStatusOnboarded = "onboarded"
+	agentOnboardingStatusPartial   = "partial"
+	agentOnboardingStatusFailed    = "failed"
+)
+
+// agentOnboardingOutcome records how a single agent fared during a batch
+// onboarding run (the discover-driven prompt loop or `onboard` without args).
+type agentOnboardingOutcome struct {
+	Agent  AgentConfig
+	Status string
+	// Reason is a one-line explanation for partial/failed outcomes.
+	Reason string
+	// MissingExecutable is true when the outcome stems from an agent binary
+	// that could not be found on PATH (drives the WSL hint).
+	MissingExecutable bool
+}
+
+// classifyAgentOnboardingOutcome converts an enrollment result into a summary
+// outcome: nil is a full onboarding, a managedLauncherSkippedError is a
+// partial onboarding, anything else is a failure.
+func classifyAgentOnboardingOutcome(agent AgentConfig, err error) agentOnboardingOutcome {
+	if err == nil {
+		return agentOnboardingOutcome{
+			Agent:  agent,
+			Status: agentOnboardingStatusOnboarded,
+		}
+	}
+	var skipErr *managedLauncherSkippedError
+	if errors.As(err, &skipErr) {
+		return agentOnboardingOutcome{
+			Agent:             agent,
+			Status:            agentOnboardingStatusPartial,
+			Reason:            skipErr.Error(),
+			MissingExecutable: true,
+		}
+	}
+	return agentOnboardingOutcome{
+		Agent:             agent,
+		Status:            agentOnboardingStatusFailed,
+		Reason:            firstErrorLine(err),
+		MissingExecutable: errors.Is(err, exec.ErrNotFound),
+	}
+}
+
+// firstErrorLine keeps summary reasons to a single line.
+func firstErrorLine(err error) string {
+	if err == nil {
+		return ""
+	}
+	line, _, _ := strings.Cut(err.Error(), "\n")
+	return strings.TrimSpace(line)
+}
+
+// printAgentOnboardingSummary prints the per-agent summary table for a batch
+// onboarding run, plus the WSL PATH hint when a missing executable was seen
+// inside a WSL environment.
+func printAgentOnboardingSummary(w io.Writer, outcomes []agentOnboardingOutcome) {
+	if len(outcomes) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "\nOnboarding summary:") //nolint:errcheck
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	missingExecutable := false
+	for _, outcome := range outcomes {
+		reason := outcome.Reason
+		if reason == "" {
+			reason = "-"
+		}
+		fmt.Fprintf( //nolint:errcheck
+			tw,
+			"  %s\t%s\t%s\n",
+			resolveAgentDisplayName(outcome.Agent),
+			outcome.Status,
+			reason,
+		)
+		if outcome.MissingExecutable {
+			missingExecutable = true
+		}
+	}
+	tw.Flush() //nolint:errcheck
+	if missingExecutable {
+		if hint := wslMissingExecutableHint(); hint != "" {
+			fmt.Fprintf(w, "  Hint: %s\n", hint) //nolint:errcheck
+		}
+	}
+}
+
+// agentOnboardingSummaryError implements the batch onboarding exit-code
+// convention documented in the discover/onboard help: exit 0 when at least
+// one attempted agent onboarded (fully or partially, and trivially when
+// nothing was attempted), non-zero only when every attempted agent failed.
+func agentOnboardingSummaryError(outcomes []agentOnboardingOutcome) error {
+	if len(outcomes) == 0 {
+		return nil
+	}
+	for _, outcome := range outcomes {
+		if outcome.Status != agentOnboardingStatusFailed {
+			return nil
+		}
+	}
+	return fmt.Errorf("failed to onboard all %d attempted agent(s)", len(outcomes))
+}
+
+// ignoreLauncherSkipped converts the partial-success launcher-skip marker to
+// nil for single-agent flows: the enrollment applied and the warning has
+// already been printed, so the command must exit 0.
+func ignoreLauncherSkipped(err error) error {
+	var skipErr *managedLauncherSkippedError
+	if errors.As(err, &skipErr) {
+		return nil
+	}
+	return err
 }
 
 type flowSummaryResponse struct {
@@ -659,9 +805,8 @@ func promptToOnboardDiscoveredAgents(
 	// take ~5s) and a slow upstream for one agent never blocks subsequent
 	// agents from being touched.
 	deferLiveValidate := !skipLiveValidate
-	var enrolled []AgentConfig
-	err = promptToOnboardCandidates(os.Stdin, os.Stdout, candidates, autoApprove, true, func(agent AgentConfig, approvals bool) error {
-		enrollErr := executeManagedEnrollment(agent, managedEnrollmentOptions{
+	outcomes, err := promptToOnboardCandidates(os.Stdin, os.Stdout, candidates, autoApprove, true, func(agent AgentConfig, approvals bool) error {
+		return executeManagedEnrollment(agent, managedEnrollmentOptions{
 			Client:            client,
 			SkipConfirmation:  true,
 			LiveValidate:      true,
@@ -671,20 +816,31 @@ func promptToOnboardDiscoveredAgents(
 			Input:             os.Stdin,
 			Output:            os.Stdout,
 		})
-		if enrollErr == nil {
-			enrolled = append(enrolled, agent)
-		}
-		return enrollErr
 	})
 	if err != nil {
 		return err
 	}
+	// Fully and partially onboarded agents both have live enrollments worth
+	// validating; only failed agents are excluded.
+	var enrolled []AgentConfig
+	for _, outcome := range outcomes {
+		if outcome.Status != agentOnboardingStatusFailed {
+			enrolled = append(enrolled, outcome.Agent)
+		}
+	}
 	if deferLiveValidate && len(enrolled) > 0 {
 		runDeferredLiveValidationsParallel(client, enrolled, os.Stdout)
 	}
-	return nil
+	printAgentOnboardingSummary(os.Stdout, outcomes)
+	return agentOnboardingSummaryError(outcomes)
 }
 
+// promptToOnboardCandidates walks the candidate agents, prompting per agent
+// unless autoApprove is set, and enrolls each approved agent. An error from
+// one agent's enrollment is recorded as a failed/partial outcome and the loop
+// continues with the remaining agents; only prompt I/O failures abort the
+// loop. The returned outcomes cover every attempted agent (skipped agents are
+// not included).
 func promptToOnboardCandidates(
 	reader io.Reader,
 	writer io.Writer,
@@ -692,8 +848,9 @@ func promptToOnboardCandidates(
 	autoApprove bool,
 	askApprovals bool,
 	enroll func(agent AgentConfig, approvals bool) error,
-) error {
+) ([]agentOnboardingOutcome, error) {
 	bufferedReader := bufio.NewReader(reader)
+	var outcomes []agentOnboardingOutcome
 
 	for _, agent := range candidates {
 		if !autoApprove {
@@ -707,7 +864,7 @@ func promptToOnboardCandidates(
 				fmt.Sprintf("%s %s (%s) into managed Preloop access now? (Y/n): ", action, agent.Name, resolveAgentDisplayName(agent)),
 			)
 			if err != nil {
-				return fmt.Errorf("failed to read onboarding confirmation: %w", err)
+				return outcomes, fmt.Errorf("failed to read onboarding confirmation: %w", err)
 			}
 			if !confirmed {
 				continue
@@ -715,7 +872,7 @@ func promptToOnboardCandidates(
 		}
 		agent, err := prepareAgentForEnrollment(bufferedReader, writer, agent, autoApprove)
 		if err != nil {
-			return err
+			return outcomes, err
 		}
 		// Offer the native tool-approvals hook for supported agents when the
 		// caller's enrollment flow skips its own interactive prompts (the
@@ -738,16 +895,30 @@ func promptToOnboardCandidates(
 			} else {
 				approvals, err = promptForApprovalsOptIn(bufferedReader, writer, agent)
 				if err != nil {
-					return fmt.Errorf("failed to read approvals confirmation: %w", err)
+					return outcomes, fmt.Errorf("failed to read approvals confirmation: %w", err)
 				}
 			}
 		}
-		if err := enroll(agent, approvals); err != nil {
-			return err
+		outcome := classifyAgentOnboardingOutcome(agent, enroll(agent, approvals))
+		if outcome.Status == agentOnboardingStatusFailed {
+			// Keep the batch going: one broken agent environment must not
+			// block the remaining agents from being onboarded.
+			fmt.Fprintf( //nolint:errcheck
+				writer,
+				"  Error onboarding %s: %s\n",
+				resolveAgentDisplayName(agent),
+				outcome.Reason,
+			)
+			if outcome.MissingExecutable {
+				if hint := wslMissingExecutableHint(); hint != "" {
+					fmt.Fprintf(writer, "  %s\n", hint) //nolint:errcheck
+				}
+			}
 		}
+		outcomes = append(outcomes, outcome)
 	}
 
-	return nil
+	return outcomes, nil
 }
 
 func onboardCandidatesBestEffort(
@@ -782,6 +953,12 @@ func onboardCandidatesBestEffort(
 		agentOpts.SkipConfirmation = true
 		agentOpts.DeferLiveValidate = deferLiveValidate
 		if err := enroll(prepared, agentOpts); err != nil {
+			// A skipped managed launcher is a partial success (MCP and
+			// model routing applied); count the agent as enrolled.
+			if ignoreLauncherSkipped(err) == nil {
+				enrolled = append(enrolled, prepared)
+				continue
+			}
 			failures = append(failures, agentOnboardingFailure{
 				Agent: prepared,
 				Err:   err,
@@ -802,6 +979,7 @@ func printAgentOnboardingFailures(
 		return
 	}
 	fmt.Fprintln(writer, "\nSome agents could not be onboarded:") //nolint:errcheck
+	missingExecutable := false
 	for _, failure := range failures {
 		fmt.Fprintf( //nolint:errcheck
 			writer,
@@ -809,6 +987,14 @@ func printAgentOnboardingFailures(
 			resolveAgentDisplayName(failure.Agent),
 			failure.Err,
 		)
+		if errors.Is(failure.Err, exec.ErrNotFound) {
+			missingExecutable = true
+		}
+	}
+	if missingExecutable {
+		if hint := wslMissingExecutableHint(); hint != "" {
+			fmt.Fprintf(writer, "  %s\n", hint) //nolint:errcheck
+		}
 	}
 	fmt.Fprintln( //nolint:errcheck
 		writer,
@@ -1017,26 +1203,28 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		var enrolled []AgentConfig
 		// askApprovals=false: executeManagedEnrollment prompts for the
 		// approvals hook itself when this path runs interactively.
-		err = promptToOnboardCandidates(os.Stdin, os.Stdout, candidates, autoApprove, false, func(a AgentConfig, _ bool) error {
+		outcomes, err := promptToOnboardCandidates(os.Stdin, os.Stdout, candidates, autoApprove, false, func(a AgentConfig, _ bool) error {
 			agentOpts := opts
 			agentOpts.SkipConfirmation = autoApprove
 			agentOpts.DeferLiveValidate = deferLiveValidate
-			if enrollErr := executeManagedEnrollment(a, agentOpts); enrollErr != nil {
-				return enrollErr
-			}
-			enrolled = append(enrolled, a)
-			return nil
+			return executeManagedEnrollment(a, agentOpts)
 		})
 		if err != nil {
 			return err
 		}
+		var enrolled []AgentConfig
+		for _, outcome := range outcomes {
+			if outcome.Status != agentOnboardingStatusFailed {
+				enrolled = append(enrolled, outcome.Agent)
+			}
+		}
 		if deferLiveValidate && len(enrolled) > 0 {
 			runDeferredLiveValidationsParallel(client, enrolled, os.Stdout)
 		}
-		return nil
+		printAgentOnboardingSummary(os.Stdout, outcomes)
+		return agentOnboardingSummaryError(outcomes)
 	}
 
 	agent, err := findDiscoveredAgent(discovered, args[0])
@@ -1044,7 +1232,9 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return executeManagedEnrollment(agent, opts)
+	// A skipped managed launcher (missing agent binary) is a partial success:
+	// the warning has been printed and the command exits 0.
+	return ignoreLauncherSkipped(executeManagedEnrollment(agent, opts))
 }
 
 func ensureAgentControlOnboarding(
@@ -1078,7 +1268,7 @@ func ensureAgentControlOnboarding(
 		agentOpts.AutoApprove = true
 		agentOpts.SkipConfirmation = true
 		agentOpts.DeferLiveValidate = false
-		if err := executeManagedEnrollment(agent, agentOpts); err != nil {
+		if err := ignoreLauncherSkipped(executeManagedEnrollment(agent, agentOpts)); err != nil {
 			return err
 		}
 	}
@@ -2711,13 +2901,20 @@ func discoverAgents(w io.Writer, printWarnings bool) ([]AgentConfig, error) {
 }
 
 func detectInstalledAgent(home string, spec agentSpec) (string, bool) {
-	if strings.TrimSpace(spec.BootstrapConfigPath) == "" || len(spec.DetectionPaths) == 0 {
+	if strings.TrimSpace(spec.BootstrapConfigPath) == "" ||
+		(len(spec.DetectionPaths) == 0 && len(spec.DetectionCommands) == 0) {
 		return "", false
 	}
+	bootstrapPath := expandAgentConfigPath(home, filepath.Join(home, spec.BootstrapConfigPath))
 	for _, relativePath := range spec.DetectionPaths {
 		fullPath := expandAgentConfigPath(home, filepath.Join(home, relativePath))
 		if _, err := os.Stat(fullPath); err == nil {
-			return expandAgentConfigPath(home, filepath.Join(home, spec.BootstrapConfigPath)), true
+			return bootstrapPath, true
+		}
+	}
+	for _, command := range spec.DetectionCommands {
+		if _, err := exec.LookPath(command); err == nil {
+			return bootstrapPath, true
 		}
 	}
 	return "", false

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -550,8 +551,18 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 	if err := syncClaudeCodeManagedMCPServer(agent, baseURL, credentialResp.Token); err != nil {
 		return err
 	}
+	var launcherSkipped *managedLauncherSkippedError
 	if err := syncManagedAgentRuntimeArtifacts(agent, baseURL, credentialResp.Token); err != nil {
-		return err
+		if !errors.As(err, &launcherSkipped) {
+			return err
+		}
+		// A missing agent binary must not fail the onboarding: the MCP and
+		// model-routing configuration above already applied, so finish the
+		// enrollment, warn, and report the agent as partially onboarded.
+		fmt.Fprintf(output, "  Warning: %s\n", launcherSkipped.Error()) //nolint:errcheck
+		if hint := wslMissingExecutableHint(); hint != "" {
+			fmt.Fprintf(output, "           %s\n", hint) //nolint:errcheck
+		}
 	}
 	if opts.Approvals && isApprovalHookSupportedAgent(agent) {
 		if err := installApprovalHooks(agent, baseURL, credentialResp.Token, output); err != nil {
@@ -791,6 +802,12 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 			"           Run: preloop agents validate %s --live\n",
 			shellQuoteAgentName(resolveAgentDisplayName(agent)),
 		)
+	}
+	if launcherSkipped != nil {
+		// Surface the skip to callers as a typed marker so batch onboarding
+		// records the agent as "partial"; single-agent callers convert it to
+		// a zero exit via ignoreLauncherSkipped.
+		return launcherSkipped
 	}
 	return nil
 }
@@ -5174,6 +5191,61 @@ func isYAMLConfigPath(path string) bool {
 
 const preloopManagedLauncherMarker = "# preloop-managed-wrapper"
 
+// managedLauncherSkippedError marks an enrollment that completed every
+// MCP/model configuration step but skipped writing the managed launcher
+// because the agent executable could not be found on PATH. Callers must
+// treat it as a partial success ("partial" in onboarding summaries and exit
+// code 0), never as a failed onboarding.
+type managedLauncherSkippedError struct {
+	CommandName string
+}
+
+func (e *managedLauncherSkippedError) Error() string {
+	return fmt.Sprintf(
+		"%s binary not found in PATH — launcher skipped; MCP and model routing configured",
+		e.CommandName,
+	)
+}
+
+// Unwrap keeps errors.Is(err, exec.ErrNotFound) working so missing-executable
+// classification (e.g. the WSL hint) sees through the skip marker.
+func (e *managedLauncherSkippedError) Unwrap() error {
+	return exec.ErrNotFound
+}
+
+// wslMissingExecutableHintText explains why an agent installed on the Windows
+// side of a WSL machine is invisible to PATH lookups inside the distro.
+const wslMissingExecutableHintText = "Running under WSL: agents installed on Windows are not on the WSL PATH — " +
+	"install the agent inside WSL or add its Windows install dir to PATH."
+
+// wslMissingExecutableHint returns the WSL PATH hint when the CLI is running
+// under WSL, and "" everywhere else.
+func wslMissingExecutableHint() string {
+	if isWSLEnvironment() {
+		return wslMissingExecutableHintText
+	}
+	return ""
+}
+
+func isWSLEnvironment() bool {
+	return detectWSLEnvironment(os.Getenv, "/proc/version")
+}
+
+// detectWSLEnvironment reports whether the process appears to run inside a
+// WSL distribution: either the WSL interop environment variables are set or
+// the kernel version string mentions Microsoft.
+func detectWSLEnvironment(getenv func(string) string, procVersionPath string) bool {
+	if strings.TrimSpace(getenv("WSL_DISTRO_NAME")) != "" ||
+		strings.TrimSpace(getenv("WSL_INTEROP")) != "" {
+		return true
+	}
+	data, err := os.ReadFile(procVersionPath)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(data)), "microsoft")
+}
+
 func syncManagedAgentRuntimeArtifacts(agent AgentConfig, baseURL, token string) error {
 	switch strings.ToLower(strings.TrimSpace(agent.Name)) {
 	case "gemini cli":
@@ -5228,6 +5300,11 @@ func syncManagedAgentLauncher(commandName, envFileName string, exports map[strin
 	}
 	originalPath, err := resolveManagedAgentExecutablePath(commandName, launcherPath)
 	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			// Missing agent binary (e.g. installed Windows-side on a WSL
+			// machine): degrade gracefully instead of failing onboarding.
+			return &managedLauncherSkippedError{CommandName: commandName}
+		}
 		return fmt.Errorf("failed to locate %s executable for managed launcher: %w", commandName, err)
 	}
 	if existing, err := os.ReadFile(launcherPath); err == nil {

--- a/cli/internal/cmd/agents_resilience_test.go
+++ b/cli/internal/cmd/agents_resilience_test.go
@@ -1,0 +1,413 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPromptToOnboardCandidatesContinuesOnError(t *testing.T) {
+	candidates := []AgentConfig{
+		{Name: "Codex CLI", DisplayName: "Codex CLI", ConfigPath: "/tmp/codex/config.toml"},
+		{Name: "Claude Code", DisplayName: "Claude Code", ConfigPath: "/tmp/claude/settings.json"},
+		{Name: "Gemini CLI", DisplayName: "Gemini CLI", ConfigPath: "/tmp/gemini/settings.json"},
+	}
+
+	tests := []struct {
+		name             string
+		enrollErrors     map[string]error
+		expectedStatuses map[string]string
+		expectSummaryErr bool
+	}{
+		{
+			name: "one agent errors, remaining agents still onboard",
+			enrollErrors: map[string]error{
+				"Codex CLI": fmt.Errorf("failed to bootstrap managed agent identity: boom"),
+			},
+			expectedStatuses: map[string]string{
+				"Codex CLI":   agentOnboardingStatusFailed,
+				"Claude Code": agentOnboardingStatusOnboarded,
+				"Gemini CLI":  agentOnboardingStatusOnboarded,
+			},
+			expectSummaryErr: false,
+		},
+		{
+			name: "all agents fail",
+			enrollErrors: map[string]error{
+				"Codex CLI":   fmt.Errorf("boom codex"),
+				"Claude Code": fmt.Errorf("boom claude"),
+				"Gemini CLI":  fmt.Errorf("boom gemini"),
+			},
+			expectedStatuses: map[string]string{
+				"Codex CLI":   agentOnboardingStatusFailed,
+				"Claude Code": agentOnboardingStatusFailed,
+				"Gemini CLI":  agentOnboardingStatusFailed,
+			},
+			expectSummaryErr: true,
+		},
+		{
+			name: "missing launcher binary degrades to partial",
+			enrollErrors: map[string]error{
+				"Codex CLI": &managedLauncherSkippedError{CommandName: "codex"},
+			},
+			expectedStatuses: map[string]string{
+				"Codex CLI":   agentOnboardingStatusPartial,
+				"Claude Code": agentOnboardingStatusOnboarded,
+				"Gemini CLI":  agentOnboardingStatusOnboarded,
+			},
+			expectSummaryErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attempted []string
+			var output bytes.Buffer
+			outcomes, err := promptToOnboardCandidates(
+				bytes.NewBuffer(nil),
+				&output,
+				candidates,
+				true,  // autoApprove: skip interactive prompts
+				false, // askApprovals
+				func(agent AgentConfig, _ bool) error {
+					attempted = append(attempted, agent.Name)
+					return tt.enrollErrors[agent.Name]
+				},
+			)
+			if err != nil {
+				t.Fatalf("expected no loop-level error, got %v", err)
+			}
+			if got := strings.Join(attempted, ","); got != "Codex CLI,Claude Code,Gemini CLI" {
+				t.Fatalf("expected all candidates attempted in order, got %v", attempted)
+			}
+			if len(outcomes) != len(candidates) {
+				t.Fatalf("expected %d outcomes, got %d", len(candidates), len(outcomes))
+			}
+			for _, outcome := range outcomes {
+				expected := tt.expectedStatuses[outcome.Agent.Name]
+				if outcome.Status != expected {
+					t.Fatalf(
+						"expected %s status %q, got %q (reason %q)",
+						outcome.Agent.Name,
+						expected,
+						outcome.Status,
+						outcome.Reason,
+					)
+				}
+				if outcome.Status != agentOnboardingStatusOnboarded && outcome.Reason == "" {
+					t.Fatalf("expected a one-line reason for %s", outcome.Agent.Name)
+				}
+			}
+			summaryErr := agentOnboardingSummaryError(outcomes)
+			if tt.expectSummaryErr && summaryErr == nil {
+				t.Fatal("expected non-nil summary error when all agents failed")
+			}
+			if !tt.expectSummaryErr && summaryErr != nil {
+				t.Fatalf("expected nil summary error, got %v", summaryErr)
+			}
+		})
+	}
+}
+
+func TestAgentOnboardingSummaryErrorExitCodeConvention(t *testing.T) {
+	agent := AgentConfig{Name: "Codex CLI", DisplayName: "Codex CLI"}
+	tests := []struct {
+		name      string
+		statuses  []string
+		expectErr bool
+	}{
+		{name: "nothing attempted", statuses: nil, expectErr: false},
+		{name: "all onboarded", statuses: []string{agentOnboardingStatusOnboarded}, expectErr: false},
+		{name: "partial counts as success", statuses: []string{agentOnboardingStatusPartial, agentOnboardingStatusFailed}, expectErr: false},
+		{name: "one success among failures", statuses: []string{agentOnboardingStatusFailed, agentOnboardingStatusOnboarded}, expectErr: false},
+		{name: "all failed", statuses: []string{agentOnboardingStatusFailed, agentOnboardingStatusFailed}, expectErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var outcomes []agentOnboardingOutcome
+			for _, status := range tt.statuses {
+				outcomes = append(outcomes, agentOnboardingOutcome{Agent: agent, Status: status})
+			}
+			err := agentOnboardingSummaryError(outcomes)
+			if tt.expectErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.expectErr && err != nil {
+				t.Fatalf("expected nil, got %v", err)
+			}
+		})
+	}
+}
+
+func TestDetectWSLEnvironment(t *testing.T) {
+	writeProcVersion := func(t *testing.T, content string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "version")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write proc version fixture: %v", err)
+		}
+		return path
+	}
+
+	tests := []struct {
+		name        string
+		env         map[string]string
+		procVersion string // "" means the file does not exist
+		expected    bool
+	}{
+		{
+			name:     "WSL_DISTRO_NAME set",
+			env:      map[string]string{"WSL_DISTRO_NAME": "Ubuntu"},
+			expected: true,
+		},
+		{
+			name:     "WSL_INTEROP set",
+			env:      map[string]string{"WSL_INTEROP": "/run/WSL/8_interop"},
+			expected: true,
+		},
+		{
+			name:        "proc version mentions Microsoft",
+			procVersion: "Linux version 5.15.167.4-microsoft-standard-WSL2 (root@..)",
+			expected:    true,
+		},
+		{
+			name:        "plain linux kernel",
+			procVersion: "Linux version 6.8.0-45-generic (buildd@lcy02)",
+			expected:    false,
+		},
+		{
+			name:     "no markers at all",
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getenv := func(key string) string { return tt.env[key] }
+			procPath := filepath.Join(t.TempDir(), "missing")
+			if tt.procVersion != "" {
+				procPath = writeProcVersion(t, tt.procVersion)
+			}
+			if got := detectWSLEnvironment(getenv, procPath); got != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestPrintAgentOnboardingSummaryIncludesWSLHintForMissingExecutables(t *testing.T) {
+	t.Setenv("WSL_DISTRO_NAME", "Ubuntu")
+
+	outcomes := []agentOnboardingOutcome{
+		{
+			Agent:  AgentConfig{Name: "Claude Code", DisplayName: "Claude Code"},
+			Status: agentOnboardingStatusOnboarded,
+		},
+		{
+			Agent:             AgentConfig{Name: "Codex CLI", DisplayName: "Codex CLI"},
+			Status:            agentOnboardingStatusPartial,
+			Reason:            (&managedLauncherSkippedError{CommandName: "codex"}).Error(),
+			MissingExecutable: true,
+		},
+	}
+
+	var output bytes.Buffer
+	printAgentOnboardingSummary(&output, outcomes)
+	report := output.String()
+	for _, expected := range []string{
+		"Onboarding summary:",
+		"Claude Code",
+		"onboarded",
+		"partial",
+		"codex binary not found in PATH — launcher skipped; MCP and model routing configured",
+		"Running under WSL: agents installed on Windows are not on the WSL PATH",
+	} {
+		if !strings.Contains(report, expected) {
+			t.Fatalf("expected summary to contain %q, got:\n%s", expected, report)
+		}
+	}
+}
+
+func TestPrintAgentOnboardingSummarySkipsWSLHintOutsideWSL(t *testing.T) {
+	t.Setenv("WSL_DISTRO_NAME", "")
+	t.Setenv("WSL_INTEROP", "")
+	if isWSLEnvironment() {
+		t.Skip("test host is a real WSL environment")
+	}
+
+	outcomes := []agentOnboardingOutcome{
+		{
+			Agent:             AgentConfig{Name: "Codex CLI", DisplayName: "Codex CLI"},
+			Status:            agentOnboardingStatusPartial,
+			Reason:            (&managedLauncherSkippedError{CommandName: "codex"}).Error(),
+			MissingExecutable: true,
+		},
+	}
+
+	var output bytes.Buffer
+	printAgentOnboardingSummary(&output, outcomes)
+	if strings.Contains(output.String(), "Running under WSL") {
+		t.Fatalf("did not expect WSL hint outside WSL, got:\n%s", output.String())
+	}
+}
+
+func TestDiscoverAgentsClaudeCodeMarkers(t *testing.T) {
+	tests := []struct {
+		name               string
+		settingsJSON       bool // ~/.claude/settings.json
+		claudeJSON         bool // ~/.claude.json
+		binaryOnPath       bool // `claude` executable on PATH
+		expectDiscovered   bool
+		expectConfigSuffix string
+	}{
+		{
+			name:               "settings.json only",
+			settingsJSON:       true,
+			expectDiscovered:   true,
+			expectConfigSuffix: filepath.Join(".claude", "settings.json"),
+		},
+		{
+			name:               ".claude.json only",
+			claudeJSON:         true,
+			expectDiscovered:   true,
+			expectConfigSuffix: filepath.Join(".claude", "settings.json"),
+		},
+		{
+			name:               "settings.json and .claude.json",
+			settingsJSON:       true,
+			claudeJSON:         true,
+			expectDiscovered:   true,
+			expectConfigSuffix: filepath.Join(".claude", "settings.json"),
+		},
+		{
+			name:               "claude binary on PATH only",
+			binaryOnPath:       true,
+			expectDiscovered:   true,
+			expectConfigSuffix: filepath.Join(".claude", "settings.json"),
+		},
+		{
+			name:             "no markers",
+			expectDiscovered: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			pathDir := t.TempDir()
+			t.Setenv("PATH", pathDir)
+
+			if tt.settingsJSON {
+				settingsPath := filepath.Join(home, ".claude", "settings.json")
+				if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+					t.Fatalf("failed to create .claude dir: %v", err)
+				}
+				if err := os.WriteFile(settingsPath, []byte(`{"mcpServers":{}}`), 0644); err != nil {
+					t.Fatalf("failed to write settings.json: %v", err)
+				}
+			}
+			if tt.claudeJSON {
+				claudeJSONPath := filepath.Join(home, ".claude.json")
+				if err := os.WriteFile(claudeJSONPath, []byte(`{"numStartups":1}`), 0644); err != nil {
+					t.Fatalf("failed to write .claude.json: %v", err)
+				}
+			}
+			if tt.binaryOnPath {
+				binaryPath := filepath.Join(pathDir, "claude")
+				if err := os.WriteFile(binaryPath, []byte("#!/usr/bin/env bash\n"), 0755); err != nil {
+					t.Fatalf("failed to write claude binary: %v", err)
+				}
+			}
+
+			discovered, err := discoverAgents(bytes.NewBuffer(nil), false)
+			if err != nil {
+				t.Fatalf("discoverAgents failed: %v", err)
+			}
+			var claude *AgentConfig
+			for i := range discovered {
+				if discovered[i].Name == "Claude Code" {
+					claude = &discovered[i]
+					break
+				}
+			}
+			if !tt.expectDiscovered {
+				if claude != nil {
+					t.Fatalf("did not expect Claude Code to be discovered, got %+v", *claude)
+				}
+				return
+			}
+			if claude == nil {
+				t.Fatalf("expected Claude Code to be discovered, got %+v", discovered)
+			}
+			expectedPath := filepath.Join(home, tt.expectConfigSuffix)
+			if claude.ConfigPath != expectedPath {
+				t.Fatalf("expected config path %q, got %q", expectedPath, claude.ConfigPath)
+			}
+		})
+	}
+}
+
+func TestRuntimeErrorsDoNotPrintUsage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Pre-seed the version check cache so PersistentPreRun does not hit the
+	// network during the test.
+	configDir := filepath.Join(home, ".preloop")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	stamp := time.Now().UTC().Format(time.RFC3339)
+	if err := os.WriteFile(filepath.Join(configDir, "last_version_check"), []byte(stamp), 0644); err != nil {
+		t.Fatalf("failed to seed version check cache: %v", err)
+	}
+
+	// The flag-error case runs first: PersistentPreRun sets SilenceUsage on
+	// the executed command, and the field is sticky across Execute calls.
+	t.Run("genuine flag error still prints usage", func(t *testing.T) {
+		var out, errOut bytes.Buffer
+		rootCmd.SetOut(&out)
+		rootCmd.SetErr(&errOut)
+		defer func() {
+			rootCmd.SetOut(nil)
+			rootCmd.SetErr(nil)
+			rootCmd.SilenceUsage = false
+			agentsDiscoverCmd.SilenceUsage = false
+		}()
+
+		rootCmd.SetArgs([]string{"agents", "discover", "--definitely-not-a-flag"})
+		if err := rootCmd.Execute(); err == nil {
+			t.Fatal("expected unknown flag error")
+		}
+		combined := out.String() + errOut.String()
+		if !strings.Contains(combined, "Usage:") {
+			t.Fatalf("flag error should print usage, got:\n%s", combined)
+		}
+	})
+
+	t.Run("runtime error suppresses usage dump", func(t *testing.T) {
+		var out, errOut bytes.Buffer
+		rootCmd.SetOut(&out)
+		rootCmd.SetErr(&errOut)
+		defer func() {
+			rootCmd.SetOut(nil)
+			rootCmd.SetErr(nil)
+			rootCmd.SilenceUsage = false
+			agentsDiscoverCmd.SilenceUsage = false
+			_ = agentsDiscoverCmd.Flags().Set("add", "false")
+		}()
+
+		// --add returns a runtime error from RunE before any discovery I/O.
+		rootCmd.SetArgs([]string{"agents", "discover", "--add"})
+		if err := rootCmd.Execute(); err == nil {
+			t.Fatal("expected runtime error from discover --add")
+		}
+		combined := out.String() + errOut.String()
+		if strings.Contains(combined, "Usage:") {
+			t.Fatalf("runtime error must not print usage, got:\n%s", combined)
+		}
+	})
+}

--- a/cli/internal/cmd/agents_runtime_install.go
+++ b/cli/internal/cmd/agents_runtime_install.go
@@ -172,7 +172,9 @@ func runAgentsInstallRuntime(cmd *cobra.Command, args []string) error {
 		LiveValidate:     liveValidate,
 		SkipLiveValidate: skipLiveValidate,
 	}
-	return executeManagedEnrollment(agent, opts)
+	// A skipped managed launcher (missing agent binary) is a partial success:
+	// the warning has been printed and the command exits 0.
+	return ignoreLauncherSkipped(executeManagedEnrollment(agent, opts))
 }
 
 func runRuntimeInstallCommand(command []string, writer io.Writer) error {

--- a/cli/internal/cmd/agents_test.go
+++ b/cli/internal/cmd/agents_test.go
@@ -1831,7 +1831,7 @@ func TestPromptToOnboardCandidates_DeclineContinuesToNextAgent(t *testing.T) {
 	}
 
 	var enrolled []AgentConfig
-	err := promptToOnboardCandidates(
+	_, err := promptToOnboardCandidates(
 		input,
 		output,
 		candidates,
@@ -1876,7 +1876,7 @@ func TestPromptToOnboardCandidates_AsksApprovalsForSupportedAgents(t *testing.T)
 	}
 
 	approvalsByAgent := map[string]bool{}
-	err := promptToOnboardCandidates(
+	_, err := promptToOnboardCandidates(
 		input,
 		output,
 		candidates,

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -48,6 +48,12 @@ API URL priority:        --url flag   > PRELOOP_URL env var   > ~/.preloop/confi
 		// arguments); merged into the daily check-in and reset on success.
 		telemetry.Increment(topLevelCommandName(cmd))
 
+		// Flag parsing and argument validation have already run by the time
+		// this hook fires, so genuine usage mistakes still print the usage
+		// text. From here on any error is a runtime failure and must not
+		// dump the full usage/flags help after the error message.
+		silenceUsageForRuntimeErrors(cmd)
+
 		// Check for updates on each invocation (cached daily)
 		if err := version.CheckForUpdate(); err != nil {
 			// Silently ignore update check errors
@@ -74,6 +80,15 @@ func topLevelCommandName(cmd *cobra.Command) string {
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() error {
 	return rootCmd.Execute()
+}
+
+// silenceUsageForRuntimeErrors marks the executing command so that errors
+// returned from its Run function print only the error, not the usage/flags
+// dump. It must be called from a hook that runs after flag parsing and
+// argument validation (e.g. PersistentPreRun) so genuine flag/argument
+// errors keep printing usage.
+func silenceUsageForRuntimeErrors(cmd *cobra.Command) {
+	cmd.SilenceUsage = true
 }
 
 func init() {


### PR DESCRIPTION
## Problem
A failure onboarding one agent aborted the entire `preloop agents discover` run: remaining agents were never onboarded, and the runtime error printed the full usage/flags dump. Observed in the field on WSL: Codex CLI's config lived in the Linux home but the binary was installed Windows-side (invisible to WSL's PATH) — the launcher error killed the run before Claude Code got its turn. Separately, Claude Code installs that only have `~/.claude.json` (fresh/lightly-used) were never discovered at all.

## Changes
- Per-agent isolation: discover/onboard continues past per-agent errors and prints an end-of-run summary table (`onboarded / partial / failed` + reason). Exit code: 0 if at least one agent onboarded (partial counts), non-zero only if all failed — documented in `--help`.
- Missing agent executable no longer fails that agent: MCP + model routing complete, managed-launcher integration is skipped with a warning; agent is reported as `partial`.
- WSL detection + hint: "agents installed on Windows are not on the WSL PATH — install the agent inside WSL or add its Windows install dir to PATH."
- Runtime errors no longer print the cobra usage dump (usage still prints for genuine flag/argument errors).
- Claude Code discovery extended: `~/.claude.json` and the `claude` binary on PATH are now discovery signals (previously only `~/.claude/settings.json`).

## Testing
`go vet ./...` clean; `go test ./...` green. New table-driven tests: continue-on-error matrix (one fails / all fail / launcher-missing→partial), exit-code convention, WSL detection and hint, Claude Code marker-file matrix, usage-suppression vs genuine flag error (end-to-end through rootCmd.Execute).

## Known follow-up (not in this PR)
`onboard --all`'s control-onboarding path can still abort mid-loop on a non-launcher error — narrower cousin of the same class, left out to keep the diff right-sized.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Critical Risk**
> Follow-up commit `f69709e5` introduced a compile error (`agents.go:442: no new variables on left side of :=`) when applying the column-header fix. Must be fixed before the next build.

> **Overview**
> Makes CLI agent discovery/onboarding resilient to per-agent failures: continues past individual agent errors, prints a summary table, degrades gracefully when agent binaries are missing (especially on WSL), suppresses usage dumps for runtime errors, and extends Claude Code detection.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit f69709e5. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->