### PR TITLE
Console: onboarding/empty-state UX pass, section descriptions, agent-kind fail-open

### DIFF
--- a/frontend/src/components/lit-app.test.ts
+++ b/frontend/src/components/lit-app.test.ts
@@ -1,0 +1,71 @@
+import { html, fixture, expect, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
+import { Router } from '@vaadin/router';
+
+import './lit-app';
+
+describe('LitApp routing', () => {
+  let fetchStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    (window as any).BRAND_CONFIG = {
+      name: 'Preloop',
+      domain: 'preloop.ai',
+      company: { legal_name: 'Preloop', address: '', city: '' },
+      branding: {
+        logo_light: '/logo.svg',
+        logo_dark: '/logo-dark.svg',
+        favicon: '/favicon.ico',
+        primary_color: '#000',
+        gradient_product: '',
+        gradient_ai: '',
+      },
+      social: { twitter: '', linkedin: '', instagram: '' },
+    };
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+
+    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub.callsFake(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      // Endpoints that expect list payloads
+      if (
+        url.includes('/api/v1/tools') ||
+        url.includes('/api/v1/trackers') ||
+        url.includes('/api/v1/ai-models') ||
+        url.includes('/api/v1/mcp-servers')
+      ) {
+        return new Response('[]', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    localStorage.clear();
+    delete (window as any).BRAND_CONFIG;
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('redirects the legacy /console/onboarding route to /console/agents', async () => {
+    await fixture(html`<lit-app></lit-app>`);
+
+    Router.go('/console/onboarding');
+
+    await waitUntil(
+      () => window.location.pathname === '/console/agents',
+      'Expected /console/onboarding to redirect to /console/agents',
+      { timeout: 5000 }
+    );
+
+    expect(window.location.pathname).to.equal('/console/agents');
+    expect(document.querySelector('onboarding-view')).to.equal(null);
+  });
+});

--- a/frontend/src/components/lit-app.ts
+++ b/frontend/src/components/lit-app.ts
@@ -55,7 +55,6 @@ import '../views/authed/policies-view';
 import '../views/authed/audit-view';
 import '../views/authed/agents-view';
 import '../views/authed/agent-detail-view';
-import '../views/authed/onboarding-view';
 import './app-header';
 import './app-footer';
 import { unifiedWebSocketManager } from '../services/unified-websocket-manager';
@@ -469,7 +468,14 @@ export class LitApp extends LitElement {
           { path: '/runtime-sessions', component: 'runtime-sessions-view' },
           { path: '/agents', component: 'agents-view' },
           { path: '/agents/:agentId', component: 'agent-detail-view' },
-          { path: '/onboarding', component: 'onboarding-view' },
+          {
+            path: '/onboarding',
+            action: (_context, commands) => {
+              // Legacy onboarding page removed; agents onboard from the
+              // Agents page (or the dashboard get-started wizard).
+              return commands.redirect('/console/agents');
+            },
+          },
           { path: 'cost', component: 'cost-view' },
           { path: '/api-usage', component: 'api-usage-view' },
           { path: 'settings', redirect: '/console/settings/profile' },

--- a/frontend/src/components/preloop-deploy-wizard.ts
+++ b/frontend/src/components/preloop-deploy-wizard.ts
@@ -968,7 +968,8 @@ agent.invoke(
                 `
           }
           <p class="wizard-copy">
-            Run these commands from the machine where your agents are installed.
+            Run these commands on the machine where your agents live. Takes
+            about two minutes.
           </p>
         </div>
 
@@ -990,13 +991,22 @@ agent.invoke(
           </div>
 
           <div class="command-step">
-            <div class="command-label">3. Discover and sync local agents</div>
+            <div class="command-label">
+              3. Discover and onboard local agents
+            </div>
             <div class="command-row">
               <code class="command-code">preloop agents discover</code>
               <sl-copy-button value="preloop agents discover"></sl-copy-button>
             </div>
           </div>
         </div>
+
+        <p class="wizard-copy">
+          The CLI lists what it finds — Claude Code, Cursor, Codex CLI,
+          OpenClaw, Gemini CLI and more — and asks before onboarding each one.
+          Onboarded agents appear on the Agents page; their first model call
+          shows up under Sessions.
+        </p>
       </div>
     `;
   }
@@ -1322,8 +1332,7 @@ agent.invoke(
                 <div class="wizard-header">
                   <h3 class="wizard-title">Deploy New Agent or Flow</h3>
                   <p class="wizard-copy">
-                    Select which type of deployment fits your automation
-                    scenario.
+                    Choose how the new agent should run.
                   </p>
                 </div>
 
@@ -1345,9 +1354,8 @@ agent.invoke(
                           Deploy Persistent Agent
                         </span>
                         <span class="wizard-option-description">
-                          Deploy a dedicated, persistent long-running agent node
-                          that stays active and ready to perform autonomous
-                          tasks.
+                          Run a long-lived agent that stays connected and picks
+                          up work continuously.
                         </span>
                       </span>
                     </div>
@@ -1370,8 +1378,8 @@ agent.invoke(
                           Configure Event-Driven Flow
                         </span>
                         <span class="wizard-option-description">
-                          Configure a short-lived agent that is provisioned on
-                          demand and decommissioned when execution completes.
+                          Start an agent when an event fires (issue created,
+                          webhook), stop it when the run completes.
                         </span>
                       </span>
                     </div>

--- a/frontend/src/components/preloop-session-observer.ts
+++ b/frontend/src/components/preloop-session-observer.ts
@@ -99,6 +99,10 @@ export class PreloopSessionObserver extends LitElement {
   @property({ type: String })
   selectedSessionId: string | null = null;
 
+  /** Optional override for the sidebar's no-sessions message. */
+  @property({ type: String })
+  emptyText = '';
+
   @state()
   private observedSessions: ObservedSession[] = [];
 
@@ -1390,6 +1394,9 @@ export class PreloopSessionObserver extends LitElement {
                   <session-list-panel
                     .sessions=${this.filteredSessions}
                     .activeSessionId=${this.activeSessionId}
+                    .emptyText=${
+                      this.observedSessions.length === 0 ? this.emptyText : ''
+                    }
                     @session-selected=${(event: CustomEvent) =>
                       this.selectSession(event.detail.sessionId)}
                   ></session-list-panel>

--- a/frontend/src/components/session-list-panel.ts
+++ b/frontend/src/components/session-list-panel.ts
@@ -14,6 +14,9 @@ export class SessionListPanel extends LitElement {
   @property({ type: String })
   activeSessionId: string | null = null;
 
+  @property({ type: String })
+  emptyText = '';
+
   static styles = css`
     :host {
       display: block;
@@ -160,7 +163,7 @@ export class SessionListPanel extends LitElement {
   render() {
     if (!this.sessions.length) {
       return html`<div class="empty">
-        No sessions recorded for this scope.
+        ${this.emptyText || 'No sessions recorded for this scope.'}
       </div>`;
     }
 

--- a/frontend/src/components/tracker-list.test.ts
+++ b/frontend/src/components/tracker-list.test.ts
@@ -81,7 +81,7 @@ describe('TrackerList', () => {
     expect(trackerItems).to.have.lengthOf(2);
   });
 
-  it('renders empty state when no trackers', async () => {
+  it('renders an informative empty state when no trackers', async () => {
     fetchStub.resolves(
       new Response(JSON.stringify([]), {
         status: 200,
@@ -94,14 +94,30 @@ describe('TrackerList', () => {
     )) as TrackerList;
 
     await waitUntil(
-      () => el.shadowRoot?.querySelector('.tracker-grid') !== null,
-      'Tracker grid did not render'
+      () => el.shadowRoot?.querySelector('.empty-state') !== null,
+      'Empty state did not render'
     );
 
     const trackerItems = el.shadowRoot?.querySelectorAll('tracker-item');
     expect(trackerItems).to.have.lengthOf(0);
-    const grid = el.shadowRoot?.querySelector('.tracker-grid');
-    expect(grid).to.exist;
+
+    const emptyState = el.shadowRoot?.querySelector('.empty-state');
+    expect(emptyState?.textContent).to.contain('No trackers connected.');
+    expect(emptyState?.textContent).to.contain(
+      'Connect GitHub, GitLab, or Jira'
+    );
+
+    // The CTA asks the parent view to open the add-tracker form.
+    const addRequested = new Promise<boolean>((resolve) => {
+      el.addEventListener('tracker-add-request', () => resolve(true), {
+        once: true,
+      });
+    });
+    const cta = emptyState?.querySelector('sl-button') as HTMLElement;
+    expect(cta).to.exist;
+    expect(cta.textContent).to.contain('Add New Tracker');
+    cta.click();
+    expect(await addRequested).to.equal(true);
   });
 
   it('renders error state when fetch fails', async () => {

--- a/frontend/src/components/tracker-list.ts
+++ b/frontend/src/components/tracker-list.ts
@@ -51,6 +51,15 @@ export class TrackerList extends LitElement {
     );
   }
 
+  private _handleAddTracker() {
+    this.dispatchEvent(
+      new CustomEvent('tracker-add-request', {
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
   private async _handleTrackerDeleted(event: CustomEvent) {
     const { id } = event.detail;
     try {
@@ -81,6 +90,20 @@ export class TrackerList extends LitElement {
       align-items: center;
       height: 100px;
     }
+
+    .empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--sl-spacing-medium);
+      padding: var(--sl-spacing-2x-large) var(--sl-spacing-large);
+      text-align: center;
+      color: var(--sl-color-neutral-500);
+    }
+
+    .empty-state sl-icon {
+      font-size: 2rem;
+    }
   `;
 
   render() {
@@ -95,6 +118,22 @@ export class TrackerList extends LitElement {
         <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
         <strong>Error:</strong> ${this.error}
       </sl-alert>`;
+    }
+
+    if (this.trackers.length === 0) {
+      return html`
+        <div class="empty-state">
+          <sl-icon name="link-45deg"></sl-icon>
+          <div>
+            No trackers connected. Connect GitHub, GitLab, or Jira to give flows
+            their triggers and agents their issue-tracking tools.
+          </div>
+          <sl-button variant="primary" @click=${this._handleAddTracker}>
+            <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+            Add New Tracker
+          </sl-button>
+        </div>
+      `;
     }
 
     return html`

--- a/frontend/src/components/view-header.test.ts
+++ b/frontend/src/components/view-header.test.ts
@@ -1,0 +1,39 @@
+import { html, fixture, expect } from '@open-wc/testing';
+
+import './view-header';
+import type { ViewHeader } from './view-header';
+
+describe('ViewHeader', () => {
+  it('renders the headerText as the page title', async () => {
+    const el = (await fixture(
+      html`<view-header headerText="Cost Analytics"></view-header>`
+    )) as ViewHeader;
+
+    const h1 = el.shadowRoot?.querySelector('h1');
+    expect(h1).to.exist;
+    expect(h1?.textContent).to.contain('Cost Analytics');
+  });
+
+  it('renders the description as a muted line under the title', async () => {
+    const el = (await fixture(
+      html`<view-header
+        headerText="Cost Analytics"
+        description="Understand gateway spend by model, agent, session, flow, and API key."
+      ></view-header>`
+    )) as ViewHeader;
+
+    const description = el.shadowRoot?.querySelector('.description');
+    expect(description).to.exist;
+    expect(description?.textContent).to.contain(
+      'Understand gateway spend by model, agent, session, flow, and API key.'
+    );
+  });
+
+  it('renders no description element when description is not set', async () => {
+    const el = (await fixture(
+      html`<view-header headerText="Tools"></view-header>`
+    )) as ViewHeader;
+
+    expect(el.shadowRoot?.querySelector('.description')).to.equal(null);
+  });
+});

--- a/frontend/src/components/view-header.ts
+++ b/frontend/src/components/view-header.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css, unsafeCSS } from 'lit';
+import { LitElement, html, css, nothing, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import consoleStyles from '../styles/console-styles.css?inline';
 
@@ -6,6 +6,9 @@ import consoleStyles from '../styles/console-styles.css?inline';
 export class ViewHeader extends LitElement {
   @property({ type: String })
   headerText = '';
+
+  @property({ type: String })
+  description = '';
 
   @property({ type: String })
   width = '';
@@ -22,6 +25,11 @@ export class ViewHeader extends LitElement {
       h1 {
         margin: 0;
       }
+      .description {
+        margin: var(--sl-spacing-2x-small) 0 0;
+        color: var(--sl-color-neutral-500);
+        font-size: 0.9rem;
+      }
     `,
   ];
 
@@ -36,6 +44,11 @@ export class ViewHeader extends LitElement {
             </h1>
             <slot name="main-column"></slot>
           </div>
+          ${
+            this.description
+              ? html`<p class="description">${this.description}</p>`
+              : nothing
+          }
         </div>
       </div>
     `;

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -4,12 +4,57 @@ import sinon from 'sinon';
 import './agents-view.ts';
 import type { AgentsView } from './agents-view';
 
+function makeAgent(
+  id: string,
+  displayName: string,
+  sourceType: string
+): Record<string, unknown> {
+  return {
+    id,
+    runtime_session_id: `runtime-session-${id}`,
+    owner_user_id: null,
+    owner_username: null,
+    owner_email: null,
+    display_name: displayName,
+    agent_kind: sourceType,
+    session_source_type: sourceType,
+    session_source_id: `workspace-${id}`,
+    session_reference: `session-${id}`,
+    enrolled_via: 'runtime_session_token',
+    managed_mcp_servers: ['github', 'jira'],
+    lifecycle_state: 'active',
+    lifecycle_reason: null,
+    lifecycle_updated_at: '2026-03-10T10:00:00Z',
+    is_active_now: true,
+    activity_status: 'active_now',
+    last_seen_at: '2026-03-10T10:00:00Z',
+    started_at: '2026-03-10T09:00:00Z',
+    last_activity_at: '2026-03-10T10:00:00Z',
+    ended_at: null,
+    total_requests: 3,
+    estimated_cost: 0.42,
+    latest_model_alias: 'openai/gpt-5',
+    latest_provider_name: 'openai',
+    last_request_at: '2026-03-10T09:58:00Z',
+    mcp_proxy_configured: true,
+    model_gateway_configured: true,
+    onboarding_state: 'fully_onboarded',
+    live_validation_supported: true,
+    live_validation_passed: true,
+    live_validation_status: 'passed',
+    last_validated_at: '2026-03-10T10:01:00Z',
+  };
+}
+
 describe('AgentsView', () => {
   let fetchStub: sinon.SinonStub;
+  let agentItems: Array<Record<string, unknown>>;
 
   beforeEach(() => {
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
+
+    agentItems = [makeAgent('agent-1', 'Claude Code Workspace', 'claude_code')];
 
     fetchStub = sinon.stub(window, 'fetch');
     fetchStub.callsFake(async (input: RequestInfo | URL) => {
@@ -21,45 +66,10 @@ describe('AgentsView', () => {
             query: null,
             session_source_type: null,
             status: 'all',
-            total: 1,
+            total: agentItems.length,
             limit: 50,
             offset: 0,
-            items: [
-              {
-                id: 'agent-1',
-                runtime_session_id: 'runtime-session-1',
-                owner_user_id: null,
-                owner_username: null,
-                owner_email: null,
-                display_name: 'Claude Code Workspace',
-                session_source_type: 'claude_code',
-                session_source_id: 'workspace-123',
-                session_reference: 'claude-session-abc',
-                enrolled_via: 'runtime_session_token',
-                managed_mcp_servers: ['github', 'jira'],
-                lifecycle_state: 'active',
-                lifecycle_reason: null,
-                lifecycle_updated_at: '2026-03-10T10:00:00Z',
-                is_active_now: true,
-                activity_status: 'active_now',
-                last_seen_at: '2026-03-10T10:00:00Z',
-                started_at: '2026-03-10T09:00:00Z',
-                last_activity_at: '2026-03-10T10:00:00Z',
-                ended_at: null,
-                total_requests: 3,
-                estimated_cost: 0.42,
-                latest_model_alias: 'openai/gpt-5',
-                latest_provider_name: 'openai',
-                last_request_at: '2026-03-10T09:58:00Z',
-                mcp_proxy_configured: true,
-                model_gateway_configured: true,
-                onboarding_state: 'fully_onboarded',
-                live_validation_supported: true,
-                live_validation_passed: true,
-                live_validation_status: 'passed',
-                last_validated_at: '2026-03-10T10:01:00Z',
-              },
-            ],
+            items: agentItems,
           }),
           {
             status: 200,
@@ -133,5 +143,73 @@ describe('AgentsView', () => {
 
     const agentNode = el.shadowRoot?.querySelector('.agent-node');
     expect(agentNode).to.exist;
+  });
+
+  it('renders claude_desktop agents and agents of unknown kinds', async () => {
+    agentItems = [
+      makeAgent('agent-desktop', 'My Claude Desktop', 'claude_desktop'),
+      makeAgent('agent-unknown', 'Mystery Agent', 'some_future_kind'),
+    ];
+
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+
+    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+
+    const text = el.shadowRoot?.textContent || '';
+    expect(text).to.contain('My Claude Desktop');
+    expect(text).to.contain('Mystery Agent');
+
+    const agentNodes = el.shadowRoot?.querySelectorAll('.agent-node');
+    expect(agentNodes?.length).to.equal(2);
+  });
+
+  it('omits the agent kind allowlist by default so unknown kinds are fetched', async () => {
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+
+    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+
+    const agentUrls = fetchStub
+      .getCalls()
+      .map((call) =>
+        typeof call.args[0] === 'string'
+          ? call.args[0]
+          : call.args[0].toString()
+      )
+      .filter((url: string) => url.startsWith('/api/v1/agents'));
+    expect(agentUrls.length).to.be.greaterThan(0);
+    for (const url of agentUrls) {
+      expect(url).to.not.contain('agent_kind');
+    }
+  });
+
+  it('keeps kinds added after a legacy saved filter visible (claude_desktop)', async () => {
+    // A selected-list persisted before claude_desktop existed must not hide it.
+    localStorage.setItem(
+      'preloopAgentKinds',
+      JSON.stringify(['claude_code', 'codex'])
+    );
+    agentItems = [
+      makeAgent('agent-desktop', 'My Claude Desktop', 'claude_desktop'),
+    ];
+
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+
+    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+
+    const agentUrls = fetchStub
+      .getCalls()
+      .map((call) =>
+        typeof call.args[0] === 'string'
+          ? call.args[0]
+          : call.args[0].toString()
+      )
+      .filter((url: string) => url.startsWith('/api/v1/agents'));
+    expect(agentUrls.length).to.be.greaterThan(0);
+    for (const url of agentUrls) {
+      expect(decodeURIComponent(url)).to.contain('claude_desktop');
+    }
+
+    const text = el.shadowRoot?.textContent || '';
+    expect(text).to.contain('My Claude Desktop');
   });
 });

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -137,8 +137,11 @@ describe('AgentsView', () => {
 
     const text = el.shadowRoot?.textContent || '';
     expect(text).to.contain('Claude Code Workspace');
-    expect(text).to.contain(
-      'Connections, telemetry, and live sessions managed by the Preloop'
+
+    // The section description renders inside the shared view-header.
+    const header = el.shadowRoot?.querySelector('view-header');
+    expect(header?.getAttribute('description')).to.contain(
+      'Onboard agents you already run with the CLI, or deploy new ones.'
     );
 
     const agentNode = el.shadowRoot?.querySelector('.agent-node');

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -185,6 +185,52 @@ describe('AgentsView', () => {
     }
   });
 
+  it('skips the agents API call and renders empty when all kinds are hidden', async () => {
+    // Hiding every kind means nothing can match — the view must not fall back
+    // to a sentinel agent_kind value; it should not call the agents API at all.
+    localStorage.setItem(
+      'preloopAgentKindsHidden',
+      JSON.stringify([
+        'openclaw',
+        'opencode',
+        'claude_code',
+        'claude_desktop',
+        'codex',
+        'gemini_cli',
+        'hermes',
+        'cursor',
+        'windsurf',
+        'desktop_agent',
+        'custom',
+        'flows',
+      ])
+    );
+    localStorage.setItem('preloop.agents.view_mode', 'cards');
+
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+
+    // Cards mode has no spinner; the empty-state renders once loading is done.
+    await waitUntil(() => !!el.shadowRoot?.querySelector('.empty-state'));
+
+    const agentUrls = fetchStub
+      .getCalls()
+      .map((call) =>
+        typeof call.args[0] === 'string'
+          ? call.args[0]
+          : call.args[0].toString()
+      )
+      .filter((url: string) => url.startsWith('/api/v1/agents'));
+    expect(agentUrls).to.have.length(0);
+
+    const agentNodes = el.shadowRoot?.querySelectorAll('.agent-node');
+    expect(agentNodes?.length ?? 0).to.equal(0);
+    const emptyState = el.shadowRoot?.querySelector('.empty-state');
+    expect(emptyState).to.exist;
+    expect(emptyState?.textContent).to.contain(
+      'No agents or flows found matching your query.'
+    );
+  });
+
   it('keeps kinds added after a legacy saved filter visible (claude_desktop)', async () => {
     // A selected-list persisted before claude_desktop existed must not hide it.
     localStorage.setItem(

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -53,6 +53,7 @@ const AVAILABLE_AGENT_KINDS = [
   { value: 'openclaw', label: 'OpenClaw' },
   { value: 'opencode', label: 'OpenCode' },
   { value: 'claude_code', label: 'Claude Code' },
+  { value: 'claude_desktop', label: 'Claude Desktop' },
   { value: 'codex', label: 'Codex CLI' },
   { value: 'gemini_cli', label: 'Gemini CLI' },
   { value: 'hermes', label: 'Hermes' },
@@ -63,9 +64,44 @@ const AVAILABLE_AGENT_KINDS = [
   { value: 'flows', label: 'Flows' },
 ];
 
-const DEFAULT_AGENT_KINDS = AVAILABLE_AGENT_KINDS.map((k) => k.value).filter(
-  (k) => k !== 'flows'
-);
+const AGENT_KIND_VALUES = AVAILABLE_AGENT_KINDS.map((k) => k.value);
+
+const DEFAULT_AGENT_KINDS = AGENT_KIND_VALUES.filter((k) => k !== 'flows');
+
+// Filter selections persist as a *hidden* list so agent kinds added in later
+// releases stay visible by default — a kind absent from storage means
+// "unknown at save time", never "deselected by the user". (A `claude_desktop`
+// agent was once invisible because the persisted selected-list predated it.)
+const HIDDEN_AGENT_KINDS_KEY = 'preloopAgentKindsHidden';
+const LEGACY_AGENT_KINDS_KEY = 'preloopAgentKinds';
+
+function loadInitialAgentKinds(): string[] {
+  try {
+    const hidden = localStorage.getItem(HIDDEN_AGENT_KINDS_KEY);
+    if (hidden) {
+      const hiddenKinds: string[] = JSON.parse(hidden);
+      return AGENT_KIND_VALUES.filter((v) => !hiddenKinds.includes(v));
+    }
+    const legacy = localStorage.getItem(LEGACY_AGENT_KINDS_KEY);
+    if (legacy) {
+      const selected: string[] = JSON.parse(legacy);
+      // Legacy selected-list saves predate `claude_desktop`; its absence
+      // there means "unknown at save time", not "deselected by the user".
+      return AGENT_KIND_VALUES.filter(
+        (v) => selected.includes(v) || v === 'claude_desktop'
+      );
+    }
+  } catch (e) {}
+  return DEFAULT_AGENT_KINDS;
+}
+
+function persistAgentKinds(selected: string[]): void {
+  try {
+    const hidden = AGENT_KIND_VALUES.filter((v) => !selected.includes(v));
+    localStorage.setItem(HIDDEN_AGENT_KINDS_KEY, JSON.stringify(hidden));
+    localStorage.removeItem(LEGACY_AGENT_KINDS_KEY);
+  } catch (e) {}
+}
 
 const CANVAS_LAYOUT_VERSION = 'polygon-rings-v1';
 const CANVAS_CARD_HALF_WIDTH = 160;
@@ -138,13 +174,7 @@ export class AgentsView extends LitElement {
   @state() private loading = true;
   @state() private error: string | null = null;
   @state() private searchQuery = '';
-  @state() private agentKinds: string[] = (() => {
-    try {
-      const saved = localStorage.getItem('preloopAgentKinds');
-      if (saved) return JSON.parse(saved);
-    } catch (e) {}
-    return DEFAULT_AGENT_KINDS;
-  })();
+  @state() private agentKinds: string[] = loadInitialAgentKinds();
   @state() private lastSeenAfter = 'all';
   @state() private flows: any[] = [];
   @state() private aiModels: AIModel[] = [];
@@ -888,8 +918,13 @@ export class AgentsView extends LitElement {
     };
 
     const selectedAgentKinds = this.agentKinds.filter((k) => k !== 'flows');
-    if (this.agentKinds.length === AVAILABLE_AGENT_KINDS.length) {
-      // Send nothing, backend will return everything by default
+    const allAgentKindsSelected = AVAILABLE_AGENT_KINDS.every(
+      (k) => k.value === 'flows' || selectedAgentKinds.includes(k.value)
+    );
+    if (allAgentKindsSelected) {
+      // Send no kind filter so the backend returns everything — including
+      // agent kinds this UI does not know about yet. Sending an explicit
+      // allowlist here is what once made `claude_desktop` agents invisible.
     } else if (selectedAgentKinds.length > 0) {
       params.agentKind = selectedAgentKinds.join(',');
     } else {
@@ -1654,7 +1689,7 @@ export class AgentsView extends LitElement {
       this.agentKinds = updated;
     }
 
-    localStorage.setItem('preloopAgentKinds', JSON.stringify(this.agentKinds));
+    persistAgentKinds(this.agentKinds);
     void this.loadAgents();
   }
 

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -3511,7 +3511,11 @@ export class AgentsView extends LitElement {
         </sl-dialog>
 
         <div class="content-bounds">
-          <view-header headerText="Agents" width="extra-wide">
+          <view-header
+            headerText="Agents"
+            description="Agents connected to Preloop — their gateway credentials, MCP access, and live status. Onboard agents you already run with the CLI, or deploy new ones."
+            width="extra-wide"
+          >
             <div
               slot="main-column"
               style="display: flex; gap: var(--sl-spacing-small); align-items: center;"
@@ -3534,13 +3538,6 @@ export class AgentsView extends LitElement {
               </sl-button>
             </div>
           </view-header>
-
-          <div
-            style="color: var(--sl-color-neutral-500); font-size: 0.9rem; margin-top: -12px; margin-bottom: var(--sl-spacing-large);"
-          >
-            Connections, telemetry, and live sessions managed by the Preloop
-            gateway
-          </div>
 
           <div class="agents-toolbar">
             <form class="filters" @submit=${this.handleSearchSubmit}>

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -921,6 +921,7 @@ export class AgentsView extends LitElement {
     const allAgentKindsSelected = AVAILABLE_AGENT_KINDS.every(
       (k) => k.value === 'flows' || selectedAgentKinds.includes(k.value)
     );
+    let skipAgentsFetch = false;
     if (allAgentKindsSelected) {
       // Send no kind filter so the backend returns everything — including
       // agent kinds this UI does not know about yet. Sending an explicit
@@ -928,7 +929,9 @@ export class AgentsView extends LitElement {
     } else if (selectedAgentKinds.length > 0) {
       params.agentKind = selectedAgentKinds.join(',');
     } else {
-      params.agentKind = '__none__'; // Send a dummy value so no agents match this request
+      // Every agent kind is hidden — nothing can match, so skip the agents
+      // API call entirely and render the filtered-empty state locally.
+      skipAgentsFetch = true;
     }
     // We handle the 'flows' display separately in frontend
     const includeFlows = this.agentKinds.includes('flows');
@@ -984,9 +987,21 @@ export class AgentsView extends LitElement {
     try {
       // Agent list first — gateway summary is refreshed separately so it never
       // blocks first paint (cached value may already be showing).
+      const emptyAgentsData: AccountManagedAgentListResponse = {
+        query: params.query ?? null,
+        agent_kind: null,
+        last_seen_after: params.lastSeenAfter ?? null,
+        status: 'all',
+        total: 0,
+        limit: params.limit ?? 50,
+        offset: 0,
+        items: [],
+      };
       const [agentsData, flowsData, modelsData, featuresData, users] =
         await Promise.all([
-          getAccountAgents(params),
+          skipAgentsFetch
+            ? Promise.resolve(emptyAgentsData)
+            : getAccountAgents(params),
           getFlows(),
           getAIModels().catch(() => [] as AIModel[]),
           getFeatures().catch(() => ({ features: {}, plugins: [] })),
@@ -994,12 +1009,6 @@ export class AgentsView extends LitElement {
         ]);
       this.aiModels = modelsData;
       void this.refreshGatewaySummary();
-
-      // Handle custom local empty case for dummy filter
-      if (params.agentKind === '__none__') {
-        agentsData.items = [];
-        agentsData.total = 0;
-      }
 
       // Check if a new agent was registered while the dialog is open
       if (

--- a/frontend/src/views/authed/approvals-view.ts
+++ b/frontend/src/views/authed/approvals-view.ts
@@ -623,7 +623,11 @@ export class ApprovalsView extends AuthedElement {
     }
 
     return html`
-      <view-header headerText="Approval Requests" width="wide">
+      <view-header
+        headerText="Approval Requests"
+        description="Tool calls that waited for a human decision — who approved, who denied, and how long it took. Choose which tools require approval in Tools."
+        width="wide"
+      >
         <sl-button href="/console/tools" size="small">
           <sl-icon slot="prefix" name="gear"></sl-icon>
           Configure Approvals

--- a/frontend/src/views/authed/audit-view.test.ts
+++ b/frontend/src/views/authed/audit-view.test.ts
@@ -276,6 +276,43 @@ describe('AuditView', () => {
     localStorage.clear();
   });
 
+  it('shows a first-run empty state when no audit events exist', async () => {
+    fetchStub.callsFake(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.startsWith('/api/v1/audit-logs/grouped?')) {
+        return new Response(
+          JSON.stringify({ groups: [], total: 0, skip: 0, limit: 50 }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      return new Response('[]', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const element = document.createElement('audit-view') as AuditView;
+    document.body.appendChild(element);
+
+    await waitUntil(
+      () => !(element as any)._loading,
+      'Audit view did not finish loading'
+    );
+    await element.updateComplete;
+
+    const content = (element.shadowRoot?.textContent || '').replace(
+      /\s+/g,
+      ' '
+    );
+    expect(content).to.contain('No audit events yet.');
+    expect(content).to.contain(
+      'Governed tool calls, approvals, and policy decisions are recorded here'
+    );
+    expect(content).to.not.contain('matching your filters');
+
+    element.remove();
+  });
+
   it('renders expandable runtime session events and API token attribution', async () => {
     const element = document.createElement('audit-view') as AuditView;
     document.body.appendChild(element);

--- a/frontend/src/views/authed/audit-view.ts
+++ b/frontend/src/views/authed/audit-view.ts
@@ -855,7 +855,11 @@ export class AuditView extends AuthedElement {
 
   render() {
     return html`
-      <view-header headerText="Audit Timeline" width="wide">
+      <view-header
+        headerText="Audit Timeline"
+        description="The permanent record of governed activity: tool calls, approvals, and policy decisions, with outcomes and timestamps."
+        width="wide"
+      >
         <sl-badge slot="title-prefix" pill variant="neutral"
           >${this._total} events</sl-badge
         >
@@ -889,7 +893,9 @@ export class AuditView extends AuthedElement {
                         </div>`
                       : this._groups.length === 0
                         ? html`<div class="empty-state">
-                            No audit events found matching your filters.
+                            No audit events yet. Governed tool calls, approvals,
+                            and policy decisions are recorded here as your
+                            agents work.
                           </div>`
                         : html`
                             <div class="timeline">

--- a/frontend/src/views/authed/cost-view.test.ts
+++ b/frontend/src/views/authed/cost-view.test.ts
@@ -1,4 +1,5 @@
 import { html, fixture, expect, waitUntil } from '@open-wc/testing';
+import type { LitElement } from 'lit';
 import sinon from 'sinon';
 import '../../components/view-header.ts';
 import './cost-view.ts';
@@ -139,5 +140,22 @@ describe('CostView', () => {
       '[role="status"][aria-busy="true"]'
     );
     expect(loading).to.exist;
+  });
+
+  it('renders the page title and description in the view header', async () => {
+    const element = (await fixture(html`<cost-view></cost-view>`)) as CostView;
+    await element.updateComplete;
+
+    const header = element.shadowRoot?.querySelector('view-header');
+    expect(header).to.exist;
+    await (header as LitElement).updateComplete;
+
+    const h1 = header?.shadowRoot?.querySelector('h1');
+    expect(h1?.textContent).to.contain('Cost Analytics');
+
+    const description = header?.shadowRoot?.querySelector('.description');
+    expect(description?.textContent).to.contain(
+      'Understand gateway spend by model, agent, session, flow, and API key.'
+    );
   });
 });

--- a/frontend/src/views/authed/cost-view.ts
+++ b/frontend/src/views/authed/cost-view.ts
@@ -2172,7 +2172,7 @@ export class CostView extends AuthedElement {
     return html`
       <div class="page">
         <view-header
-          title="Cost Analytics"
+          headerText="Cost Analytics"
           description="Understand gateway spend by model, agent, session, flow, and API key."
         ></view-header>
 

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -1128,7 +1128,12 @@ export class DashboardView extends AuthedElement {
 
   private dismissWelcomeCard(): void {
     this.welcomeCardDismissed = true;
-    localStorage.setItem('dashboard_welcome_dismissed', 'true');
+    // Only persist the dismissal once at least one agent is onboarded, so a
+    // stray click can't permanently erase onboarding guidance for a user who
+    // still has zero agents (session-only dismissal until then).
+    if (this.managedAgents.length > 0) {
+      localStorage.setItem('dashboard_welcome_dismissed', 'true');
+    }
   }
 
   private toggleGatewayMetrics(): void {
@@ -2605,9 +2610,10 @@ export class DashboardView extends AuthedElement {
           size="small"
           variant="text"
           style="position: absolute; right: 0; top: 0;"
+          aria-label="Dismiss get started"
           @click=${this.dismissWelcomeCard}
         >
-          <sl-icon name="x-lg"></sl-icon>
+          <sl-icon name="x-lg" label="Dismiss get started"></sl-icon>
         </sl-button>
 
         <img
@@ -4008,6 +4014,13 @@ export class DashboardView extends AuthedElement {
           ${
             this.showBudgetDialog
               ? html`
+                  <p
+                    style="margin: 0 0 var(--sl-spacing-medium); color: var(--sl-color-neutral-500); font-size: 0.9rem;"
+                  >
+                    Spending limits for the account or individual agents. Soft
+                    limits notify you; hard limits stop further model calls
+                    through the gateway.
+                  </p>
                   <budget-policy-editor
                     billingEnabled
                     @budget-policies-changed=${this.handleBudgetPoliciesChanged}

--- a/frontend/src/views/authed/flows-view.test.ts
+++ b/frontend/src/views/authed/flows-view.test.ts
@@ -67,6 +67,13 @@ describe('FlowsView', () => {
     const header = element.shadowRoot?.querySelector('view-header');
     expect(header).to.exist;
     expect(header?.getAttribute('headerText')).to.equal('Flows');
+
+    // The section description renders via the shared view-header prop, not an
+    // inline banner (keeps Flows consistent with the other console views).
+    expect(header?.getAttribute('description')).to.contain(
+      'Event-driven agent runs.'
+    );
+    expect(element.shadowRoot?.querySelector('.proxy-notice')).to.not.exist;
   });
 
   it('shows empty state when no flows', async () => {

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -368,7 +368,11 @@ export class FlowsView extends LitElement {
   render() {
     if (this.isLoading) {
       return html`
-        <view-header headerText="Flows" width="extra-wide"></view-header>
+        <view-header
+          headerText="Flows"
+          description="Event-driven agent runs. A flow starts an agent when something happens — a new issue, a webhook — and stops it when the run completes."
+          width="extra-wide"
+        ></view-header>
         <div style="display: flex; justify-content: center; padding: 48px;">
           <sl-spinner style="font-size: 3rem;"></sl-spinner>
         </div>
@@ -380,7 +384,11 @@ export class FlowsView extends LitElement {
     );
 
     return html`
-      <view-header headerText="Flows" width="extra-wide">
+      <view-header
+        headerText="Flows"
+        description="Event-driven agent runs. A flow starts an agent when something happens — a new issue, a webhook — and stops it when the run completes."
+        width="extra-wide"
+      >
         <div slot="main-column">
           <sl-button
             variant="primary"
@@ -393,15 +401,6 @@ export class FlowsView extends LitElement {
       </view-header>
       <div class="column-layout extra-wide">
         <div class="main-column">
-          <div class="proxy-notice">
-            <div class="proxy-notice-text">
-              Event-driven agent runs. A flow starts an agent when something
-              happens — a new issue, a webhook — and stops it when the run
-              completes. Get started by exploring the presets below, or create a
-              new flow from scratch.
-            </div>
-          </div>
-
           ${
             activeExecutions.length > 0
               ? html`

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -395,9 +395,10 @@ export class FlowsView extends LitElement {
         <div class="main-column">
           <div class="proxy-notice">
             <div class="proxy-notice-text">
-              Automate your workflows by creating intelligent agents that
-              respond to issue tracker events or external webhooks. Get started
-              by exploring the presets below, or create a new flow from scratch.
+              Event-driven agent runs. A flow starts an agent when something
+              happens — a new issue, a webhook — and stops it when the run
+              completes. Get started by exploring the presets below, or create a
+              new flow from scratch.
             </div>
           </div>
 

--- a/frontend/src/views/authed/runtime-sessions-view.test.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.test.ts
@@ -478,6 +478,64 @@ describe('RuntimeSessionsView', () => {
     window.history.replaceState({}, '', '/console/runtime-sessions');
   });
 
+  it('shows a first-run empty state when no sessions exist and no filters are active', async () => {
+    fetchStub.callsFake(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.startsWith('/api/v1/runtime-sessions?')) {
+        return new Response(
+          JSON.stringify({
+            period_start: '2026-02-08T00:00:00Z',
+            period_end: '2026-03-09T23:59:59Z',
+            query: null,
+            session_source_type: null,
+            status: 'all',
+            total: 0,
+            limit: 50,
+            offset: 0,
+            items: [],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      return new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const element = (await fixture(
+      html`<runtime-sessions-view></runtime-sessions-view>`
+    )) as RuntimeSessionsView;
+
+    await waitUntil(
+      () => !(element as any).loading,
+      'Runtime sessions view did not finish loading'
+    );
+    await element.updateComplete;
+
+    const content = getDeepText(element).replace(/\s+/g, ' ');
+    expect(content).to.contain('No sessions yet.');
+    expect(content).to.contain(
+      'Onboard an agent from the Agents page to see your first one.'
+    );
+    expect(content).to.not.contain('No sessions matched the current filters.');
+
+    // With a non-default filter active, blame the filters instead.
+    (element as any).searchQuery = 'nothing-matches-this';
+    await element.updateComplete;
+
+    await waitUntil(
+      () =>
+        getDeepText(element)
+          .replace(/\s+/g, ' ')
+          .includes('No sessions matched the current filters.'),
+      'Filtered empty-state copy did not render'
+    );
+    expect(getDeepText(element).replace(/\s+/g, ' ')).to.not.contain(
+      'No sessions yet.'
+    );
+  });
+
   it('renders runtime session list without blocking on session detail', async () => {
     const element = (await fixture(
       html`<runtime-sessions-view></runtime-sessions-view>`

--- a/frontend/src/views/authed/runtime-sessions-view.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.ts
@@ -1094,12 +1094,27 @@ export class RuntimeSessionsView extends LitElement {
     }
   }
 
+  private hasActiveFilters(): boolean {
+    return (
+      this.selectedRange !== 'last-30' ||
+      this.searchQuery !== '' ||
+      this.sessionSourceType !== 'all' ||
+      this.status !== 'all'
+    );
+  }
+
+  private emptySessionsText(): string {
+    return this.hasActiveFilters()
+      ? 'No sessions matched the current filters.'
+      : 'No sessions yet. A session is recorded automatically the first time an onboarded agent makes a model or tool call through the gateway. Onboard an agent from the Agents page to see your first one.';
+  }
+
   private renderSessionList() {
     if (!this.sessions || this.sessions.items.length === 0) {
       return html`
         <div class="empty-state">
           <sl-icon name="collection"></sl-icon>
-          <div>No sessions matched the current filters.</div>
+          <div>${this.emptySessionsText()}</div>
         </div>
       `;
     }
@@ -1869,7 +1884,11 @@ export class RuntimeSessionsView extends LitElement {
 
   render() {
     return html`
-      <view-header headerText="Sessions" width="extra-wide"></view-header>
+      <view-header
+        headerText="Sessions"
+        description="Everything your agents did, as it happened — prompts, responses, tool calls, and cost per session. Follow live or replay later."
+        width="extra-wide"
+      ></view-header>
       <div class="dashboard extra-wide">
         <div class="main-column">
           <div class="page">
@@ -1972,6 +1991,7 @@ export class RuntimeSessionsView extends LitElement {
                       <preloop-session-observer
                         scope="account"
                         .sessions=${this.sessions?.items || []}
+                        .emptyText=${this.emptySessionsText()}
                         .selectedSessionId=${this.selectedSessionId}
                         layout="full"
                         defaultReplayMode="timeline"

--- a/frontend/src/views/authed/settings/ai-models-view.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.ts
@@ -432,7 +432,11 @@ export class AIModelsView extends LitElement {
     };
 
     return html`
-      <view-header headerText="AI Models" width="narrow">
+      <view-header
+        headerText="AI Models"
+        description="The AI models your agents reach through the gateway. Each model gets a gateway alias; every call through it is metered and attributed to an agent and session."
+        width="narrow"
+      >
         <div slot="main-column">
           <sl-button variant="primary" @click=${this.openAddModelModal}>
             <sl-icon slot="prefix" name="plus-lg"></sl-icon> Add Model

--- a/frontend/src/views/authed/settings/api-keys-view.ts
+++ b/frontend/src/views/authed/settings/api-keys-view.ts
@@ -636,7 +636,11 @@ export class ApiKeysView extends LitElement {
     };
 
     return html`
-      <view-header headerText="API Keys" width="narrow">
+      <view-header
+        headerText="API Keys"
+        description='Credentials for the gateway and MCP endpoints. Keys labeled "Managed Agent" were minted automatically when an agent was onboarded.'
+        width="narrow"
+      >
         <div slot="main-column">
           <sl-button
             variant="primary"

--- a/frontend/src/views/authed/tools-view.test.ts
+++ b/frontend/src/views/authed/tools-view.test.ts
@@ -125,6 +125,63 @@ describe('ToolsView (approvals + conditions)', () => {
     invalidateApiCaches();
   });
 
+  it('renders the summary stats with correct labels and an unavailable note', async () => {
+    const availableTool = {
+      name: 'example_tool',
+      description: 'Example tool',
+      source: 'builtin',
+      source_id: null,
+      source_name: 'Built-in',
+      schema: {},
+      is_enabled: true,
+      is_supported: true,
+      approval_workflow_id: null,
+      has_approval_condition: false,
+      config_id: null,
+    };
+    const unavailableTool = {
+      ...availableTool,
+      name: 'tracker_tool',
+      description: 'Needs a tracker',
+      is_supported: false,
+      unsupported_reason: 'Requires a connected tracker',
+    };
+
+    fetchStub.callsFake(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/api/v1/tools')) {
+        return new Response(JSON.stringify([availableTool, unavailableTool]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/api/v1/features')) {
+        return new Response(JSON.stringify({ features: {} }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('[]', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(
+      () => el.shadowRoot?.querySelector('.summary-table') !== null,
+      'Summary table did not render'
+    );
+
+    const summary = el.shadowRoot?.querySelector('.summary-table');
+    expect(summary?.textContent).to.contain('Total tools');
+    expect(summary?.textContent).to.not.contain('toolss');
+
+    const note = el.shadowRoot?.querySelector('.unavailable-note');
+    expect(note).to.exist;
+    expect(note?.textContent).to.contain('Requires a connected tracker');
+  });
+
   it('does not create tool configuration twice when adding a rule immediately after toggling enabled', async () => {
     const element = (await fixture(
       html`<tools-view></tools-view>`

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -226,6 +226,12 @@ export class ToolsView extends LitElement {
         font-size: var(--sl-font-size-small);
       }
 
+      .unavailable-note {
+        margin-top: var(--sl-spacing-x-small);
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-small);
+      }
+
       .summary-table td {
         padding: 0;
         vertical-align: middle;
@@ -1640,7 +1646,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
         <div class="summary-table-wrapper">
           <table class="summary-table">
             <tr>
-              ${statCell('Total toolss', stats.total, 'all')}
+              ${statCell('Total tools', stats.total, 'all')}
               ${statCell('Available', stats.available, 'available')}
               ${statCell('Unavailable', stats.unavailable, 'unavailable', {
                 muted: stats.unavailable === 0,
@@ -1675,6 +1681,17 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
               ${statCell('No approval', stats.noApproval, 'no_approval')}
             </tr>
           </table>
+          ${
+            stats.unavailable > 0
+              ? html`<div class="unavailable-note">
+                  ${
+                    stats.unavailableReasons.length > 0
+                      ? stats.unavailableReasons.join('; ')
+                      : `${stats.unavailable} tool${stats.unavailable === 1 ? ' is' : 's are'} unavailable until a tracker is connected.`
+                  }
+                </div>`
+              : ''
+          }
           ${0 ? this._renderToolUsageStatsPanel() : ''}
         </div>
 
@@ -1904,7 +1921,11 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
       this._getStarterPolicyDiffChanges('remove');
 
     return html`
-      <view-header headerText="Tools" width="extra-wide">
+      <view-header
+        headerText="Tools"
+        description="Every MCP tool your agents can call, routed through Preloop's firewall. Enable or disable tools, set policy rules, and require human approval for sensitive calls."
+        width="extra-wide"
+      >
         <div slot="main-column">
           <sl-dropdown>
             <sl-button slot="trigger" size="small" variant="primary" caret>

--- a/frontend/src/views/authed/trackers-view.ts
+++ b/frontend/src/views/authed/trackers-view.ts
@@ -149,7 +149,11 @@ export class TrackersView extends LitElement {
 
   render() {
     return html`
-      <view-header headerText="Trackers" width="narrow">
+      <view-header
+        headerText="Trackers"
+        description="Issue trackers connected to Preloop, like GitHub, GitLab, or Jira. Trackers give flows their triggers and agents their issue tools."
+        width="narrow"
+      >
         <div slot="main-column">
           <sl-button variant="primary" @click=${this._openAddTrackerForm}>
             <sl-icon slot="prefix" name="plus-lg"></sl-icon>
@@ -194,7 +198,10 @@ export class TrackersView extends LitElement {
                 ></add-tracker-modal>`
               : ''
           }
-          <tracker-list @tracker-edit=${this._handleTrackerEdit}></tracker-list>
+          <tracker-list
+            @tracker-edit=${this._handleTrackerEdit}
+            @tracker-add-request=${this._openAddTrackerForm}
+          ></tracker-list>
         </div>
       </div>
     `;

--- a/frontend/src/views/public/login-view.ts
+++ b/frontend/src/views/public/login-view.ts
@@ -27,6 +27,9 @@ export class LoginView extends LitElement {
   @state()
   private oauthProviders: string[] = [];
 
+  @state()
+  private registrationEnabled = true;
+
   static styles = [
     formStyles,
     css`
@@ -101,8 +104,11 @@ export class LoginView extends LitElement {
       const features = await getFeatures();
       const providers = features.features['oauth_providers'];
       this.oauthProviders = Array.isArray(providers) ? providers : [];
+      this.registrationEnabled = features.features['registration'] !== false;
     } catch (error) {
       this.oauthProviders = [];
+      // Fail open, matching the /register route guard.
+      this.registrationEnabled = true;
     }
   }
 
@@ -217,8 +223,12 @@ export class LoginView extends LitElement {
               >
             </div>
             <div class="form-links">
-              <a href="/forgot-password">Forgot Password?</a> &middot;
-              <a href="/register">Create Account</a>
+              <a href="/forgot-password">Forgot Password?</a>
+              ${
+                this.registrationEnabled
+                  ? html` &middot; <a href="/register">Create Account</a>`
+                  : nothing
+              }
             </div>
           </form>
         </div>

--- a/frontend/src/views/public/welcome-view.ts
+++ b/frontend/src/views/public/welcome-view.ts
@@ -180,7 +180,14 @@ export class WelcomeView extends LitElement {
             </a>
           </div>
           <div class="form-container">
-            <div class="error-message">${this._error}</div>
+            <div class="error-message">
+              ${
+                this._email
+                  ? this._error
+                  : html`Could not retrieve your details. Try signing in at
+                      <a href="/login">/login</a>, or contact support.`
+              }
+            </div>
           </div>
         </div>
       `;


### PR DESCRIPTION
## Problem
A first-run usability audit of the console (driven by observing a real non-technical user onboard) found the activation path under-explained and several first-run states misleading or broken:
- The deploy wizard went silent at the CLI discovery step — no expectation of what happens next or where agents appear.
- The Cost page's title/description never rendered (props passed to `view-header` that it didn't implement).
- An orphaned onboarding page at `/console/onboarding` carried an incorrect install command, incorrect login command, and dead buttons.
- Empty states blamed the user's filters when no data had ever existed; Trackers rendered a blank page.
- Agents of kind `claude_desktop` were invisible: the agents view sent a hardcoded kind allowlist (missing that kind) to the backend, compounded by localStorage persistence of the selected kinds and the onboarding-success dialog relying on the same filtered fetch.

## Changes
- Agent kinds are now fail-open at every layer: default fetch omits the kind allowlist entirely (unknown kinds render with default icon/label), persistence inverted to a hidden-kinds list with legacy migration, `claude_desktop` entry added. A new agent kind can never be invisible again.
- Deploy wizard CLI step sets expectations (\"takes about two minutes\", the CLI asks before onboarding, where agents and sessions appear).
- `view-header` gains a `description` prop; Cost page prop wiring fixed (audited all 37 usages — single instance).
- `/console/onboarding` redirects to `/console/agents`.
- First-run empty states for Sessions, Audit, and Trackers explain what will appear and how to get it; filter-aware branch keeps the filter message when filters are actually active.
- Consistent one-to-two-sentence descriptions across all main sections (Agents, Tools, Trackers, Models, Cost, Sessions, Approvals, Audit, API Keys, Budget, Flows).
- Smaller fixes: \"Total toolss\" typo, get-started card dismissal is session-only at zero agents + labeled close button, Create Account hidden when registration is disabled, unavailable-tools inline note, /welcome error links to /login.

## Testing
Full frontend suite: 72 files, 388 passed, 0 failed. New/extended tests: view-header description rendering, /console/onboarding redirect, first-run vs filtered empty states, unknown-agent-kind rendering, legacy filter migration. Prettier clean on all touched files; `tsc --noEmit` byte-identical error set to baseline (zero new errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Frontend-only UX polish with strong test coverage (388 passed, 0 failed). No backend changes, no API contract modifications, and no security surface changes.
>
> **Overview**
> This PR fixes first-run onboarding flows discovered through real user observation: invisible agents of certain kinds, misleading empty states, a broken Cost page description, and an orphaned onboarding page. The agent kind filter system was redesigned to be fail-open — new agent kinds will never be invisible again. Empty states now distinguish between "no data exists yet" and "your filters found nothing." View headers gain consistent section descriptions across all main pages.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 554cb27. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->