### PR TITLE
Honor PRELOOP_DISABLE_TELEMETRY in the CLI and all test tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Use the Lit.dev framework for frontend code. If you create new web components en
 - **Docstrings**: Google-style with type annotations, document params, returns, raises
 - **Async**: Use async for I/O-bound operations, run_async utility for sync contexts
 - **Testing**: All code changes should have corresponding tests. Use red/green TDD when possible.
+- **Test telemetry**: ALL test scripts, rigs, and scripted runs must set `PRELOOP_DISABLE_TELEMETRY=true` (CLI, installers, and instance `.env`) so test traffic never pollutes funnel/adoption telemetry.
 
 ## Pre-commit Hooks
 The project uses pre-commit hooks to ensure code quality. These hooks run automatically before each commit and include:

--- a/backend/preloop/services/instance_service.py
+++ b/backend/preloop/services/instance_service.py
@@ -27,17 +27,22 @@ DISABLE_TELEMETRY_ENV = "PRELOOP_DISABLE_TELEMETRY"
 DISABLE_VERSION_CHECK_ENV = "DISABLE_VERSION_CHECK"
 
 
+# Truthy values for the opt-out variables: true/1/t/yes, case-insensitive,
+# surrounding whitespace ignored. Must stay aligned with the Go CLI's parsing
+# in cli/internal/telemetry/optout.go — one variable, one parsing rule.
+_TRUTHY_VALUES = ("true", "1", "t", "yes")
+
+
 def is_telemetry_disabled() -> bool:
     """Check if telemetry is disabled via environment variables.
 
     Accepts both PRELOOP_DISABLE_TELEMETRY and DISABLE_VERSION_CHECK for
     backwards compatibility with documentation.
     """
-    return os.getenv(DISABLE_TELEMETRY_ENV, "").lower() in (
-        "true",
-        "1",
-        "yes",
-    ) or os.getenv(DISABLE_VERSION_CHECK_ENV, "").lower() in ("true", "1", "yes")
+    return (
+        os.getenv(DISABLE_TELEMETRY_ENV, "").strip().lower() in _TRUTHY_VALUES
+        or os.getenv(DISABLE_VERSION_CHECK_ENV, "").strip().lower() in _TRUTHY_VALUES
+    )
 
 
 # Version check interval (default: 24 hours)

--- a/backend/tests/services/test_telemetry_optout.py
+++ b/backend/tests/services/test_telemetry_optout.py
@@ -52,6 +52,46 @@ class TestTelemetryOptOut:
 
             assert instance_service.is_telemetry_disabled() is True
 
+    def test_is_telemetry_disabled_with_t_value(self):
+        """Telemetry should be disabled with 't' (aligned with the Go CLI)."""
+        with patch.dict("os.environ", {"PRELOOP_DISABLE_TELEMETRY": "t"}):
+            import importlib
+            import preloop.services.instance_service as instance_service
+
+            importlib.reload(instance_service)
+
+            assert instance_service.is_telemetry_disabled() is True
+
+    def test_is_telemetry_disabled_with_uppercase_t_value(self):
+        """Telemetry should be disabled with 'T' (case-insensitive)."""
+        with patch.dict("os.environ", {"PRELOOP_DISABLE_TELEMETRY": "T"}):
+            import importlib
+            import preloop.services.instance_service as instance_service
+
+            importlib.reload(instance_service)
+
+            assert instance_service.is_telemetry_disabled() is True
+
+    def test_is_telemetry_disabled_with_whitespace_padded_value(self):
+        """Telemetry should be disabled with a whitespace-padded value."""
+        with patch.dict("os.environ", {"PRELOOP_DISABLE_TELEMETRY": "  true  "}):
+            import importlib
+            import preloop.services.instance_service as instance_service
+
+            importlib.reload(instance_service)
+
+            assert instance_service.is_telemetry_disabled() is True
+
+    def test_is_telemetry_disabled_legacy_env_with_t_value(self):
+        """DISABLE_VERSION_CHECK should accept the same truthy set."""
+        with patch.dict("os.environ", {"DISABLE_VERSION_CHECK": " T "}, clear=False):
+            import importlib
+            import preloop.services.instance_service as instance_service
+
+            importlib.reload(instance_service)
+
+            assert instance_service.is_telemetry_disabled() is True
+
     def test_telemetry_enabled_by_default(self):
         """Telemetry should be enabled when env vars are not set."""
         with patch.dict("os.environ", {}, clear=True):

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -439,7 +439,6 @@ func printAgentOnboardingSummary(w io.Writer, outcomes []agentOnboardingOutcome)
 	fmt.Fprintln(w, "\nOnboarding summary:") //nolint:errcheck
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
 	fmt.Fprintf(tw, "  Agent\tStatus\tReason\n") //nolint:errcheck
-	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
 	missingExecutable := false
 	for _, outcome := range outcomes {
 		reason := outcome.Reason

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -41,7 +41,11 @@ Use this CLI to:
 Get started by running 'preloop login --token <your-token>' to authenticate.
 
 Authentication priority: --token flag > PRELOOP_TOKEN env var > ~/.preloop/config.yaml
-API URL priority:        --url flag   > PRELOOP_URL env var   > ~/.preloop/config.yaml`,
+API URL priority:        --url flag   > PRELOOP_URL env var   > ~/.preloop/config.yaml
+
+Set PRELOOP_DISABLE_TELEMETRY=true to disable all adoption telemetry (the
+daily version check-in and conversion events). Update notifications are
+suppressed too, as they depend on the check-in response.`,
 
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// Count top-level command-category usage locally (names only, never

--- a/cli/internal/telemetry/counters.go
+++ b/cli/internal/telemetry/counters.go
@@ -49,6 +49,9 @@ func Load() map[string]int {
 // Increment bumps the counter for a command category. Failures are silent —
 // telemetry must never affect CLI behavior.
 func Increment(category string) {
+	if Disabled() {
+		return
+	}
 	if category == "" {
 		return
 	}

--- a/cli/internal/telemetry/counters_test.go
+++ b/cli/internal/telemetry/counters_test.go
@@ -13,6 +13,8 @@ func useTempConfigDir(t *testing.T) string {
 	t.Setenv("PRELOOP_CONFIG_DIR", dir)
 	// Fallback for config implementations keyed off HOME.
 	t.Setenv("HOME", dir)
+	// Hermetic: a developer's telemetry opt-out must not skip Increment here.
+	clearOptOutEnv(t)
 	return dir
 }
 

--- a/cli/internal/telemetry/events.go
+++ b/cli/internal/telemetry/events.go
@@ -22,6 +22,9 @@ const eventsBatchPath = "/api/v1/events/batch"
 // to the same server the CLI is authenticated against (same origin by
 // construction).
 func SendConversion(baseURL, accessToken, cliVersion, event string) {
+	if Disabled() {
+		return
+	}
 	if baseURL == "" || event == "" {
 		return
 	}

--- a/cli/internal/telemetry/optout.go
+++ b/cli/internal/telemetry/optout.go
@@ -1,0 +1,42 @@
+package telemetry
+
+import (
+	"os"
+	"strings"
+)
+
+// Environment variables that disable all adoption telemetry from the CLI:
+// the daily version check-in POST, conversion events, and local usage
+// counters. They mirror the server-side opt-out honored by
+// backend/preloop/services/instance_service.py so one variable silences
+// both halves of the product (e.g. in test rigs and CI).
+const (
+	// DisableTelemetryEnv is the primary opt-out variable.
+	DisableTelemetryEnv = "PRELOOP_DISABLE_TELEMETRY"
+
+	// DisableVersionCheckEnv is accepted as a legacy alias for backwards
+	// compatibility with documentation (same as the backend).
+	DisableVersionCheckEnv = "DISABLE_VERSION_CHECK"
+)
+
+// Disabled reports whether telemetry is disabled via environment variables.
+//
+// Note: when telemetry is disabled the CLI performs no version check at all,
+// so local update notifications are suppressed too — the notification is a
+// by-product of the check-in response and there is no offline source for it.
+// This is deliberate: the variable exists for scripted/test runs that must
+// leave zero footprint in adoption data.
+func Disabled() bool {
+	return envTruthy(os.Getenv(DisableTelemetryEnv)) ||
+		envTruthy(os.Getenv(DisableVersionCheckEnv))
+}
+
+// envTruthy matches the backend's truthy parsing spirit: true/1/t/yes,
+// case-insensitive, surrounding whitespace ignored.
+func envTruthy(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true", "1", "t", "yes":
+		return true
+	}
+	return false
+}

--- a/cli/internal/telemetry/optout_test.go
+++ b/cli/internal/telemetry/optout_test.go
@@ -1,0 +1,92 @@
+package telemetry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// clearOptOutEnv removes both opt-out variables for the duration of a test
+// (t.Setenv registers cleanup restoring the original values).
+func clearOptOutEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(DisableTelemetryEnv, "")
+	t.Setenv(DisableVersionCheckEnv, "")
+}
+
+func TestDisabledEnvParsing(t *testing.T) {
+	cases := []struct {
+		name  string
+		env   string
+		value string
+		want  bool
+	}{
+		{"unset", "", "", false},
+		{"true", DisableTelemetryEnv, "true", true},
+		{"TRUE", DisableTelemetryEnv, "TRUE", true},
+		{"True", DisableTelemetryEnv, "True", true},
+		{"one", DisableTelemetryEnv, "1", true},
+		{"t", DisableTelemetryEnv, "t", true},
+		{"T", DisableTelemetryEnv, "T", true},
+		{"yes", DisableTelemetryEnv, "yes", true},
+		{"YES", DisableTelemetryEnv, "YES", true},
+		{"whitespace-padded", DisableTelemetryEnv, "  true  ", true},
+		{"false", DisableTelemetryEnv, "false", false},
+		{"zero", DisableTelemetryEnv, "0", false},
+		{"no", DisableTelemetryEnv, "no", false},
+		{"empty", DisableTelemetryEnv, "", false},
+		{"garbage", DisableTelemetryEnv, "yeah-nah", false},
+		{"legacy-true", DisableVersionCheckEnv, "true", true},
+		{"legacy-1", DisableVersionCheckEnv, "1", true},
+		{"legacy-yes", DisableVersionCheckEnv, "YES", true},
+		{"legacy-false", DisableVersionCheckEnv, "false", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			clearOptOutEnv(t)
+			if c.env != "" {
+				t.Setenv(c.env, c.value)
+			}
+			if got := Disabled(); got != c.want {
+				t.Errorf("Disabled() with %s=%q = %v, want %v",
+					c.env, c.value, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSendConversionSkippedWhenTelemetryDisabled(t *testing.T) {
+	clearOptOutEnv(t)
+	t.Setenv("HOME", t.TempDir())
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			requests++
+		}))
+	defer server.Close()
+
+	t.Setenv(DisableTelemetryEnv, "true")
+	SendConversion(server.URL, "token", "0.0.0-test", "Login")
+	if requests != 0 {
+		t.Fatalf("expected no HTTP calls with telemetry disabled, got %d", requests)
+	}
+
+	// Sanity: with the variable unset the same call does reach the server.
+	t.Setenv(DisableTelemetryEnv, "")
+	SendConversion(server.URL, "token", "0.0.0-test", "Login")
+	if requests != 1 {
+		t.Fatalf("expected exactly 1 HTTP call with telemetry enabled, got %d", requests)
+	}
+}
+
+func TestIncrementSkippedWhenTelemetryDisabled(t *testing.T) {
+	clearOptOutEnv(t)
+	t.Setenv("HOME", t.TempDir())
+
+	t.Setenv(DisableTelemetryEnv, "1")
+	Increment("agents")
+	if counters := Load(); len(counters) != 0 {
+		t.Fatalf("expected no counters recorded with telemetry disabled, got %v", counters)
+	}
+}

--- a/cli/internal/version/check.go
+++ b/cli/internal/version/check.go
@@ -88,7 +88,15 @@ type VersionInfo struct {
 // CheckForUpdate checks for a new version if a day has passed since the last
 // check. A brand-new install (client id created this run) checks immediately
 // so first-run adoption is visible without waiting a day.
+//
+// When telemetry is disabled (PRELOOP_DISABLE_TELEMETRY / DISABLE_VERSION_CHECK)
+// no check-in POST happens at all; update notifications are suppressed as a
+// consequence, since they are derived from the check-in response. Scripted
+// and test runs must leave zero footprint in adoption data.
 func CheckForUpdate() error {
+	if telemetry.Disabled() {
+		return nil
+	}
 	_, firstRun, _ := config.GetOrCreateClientIDWithNew()
 	if !firstRun && !shouldCheck() {
 		return nil
@@ -326,7 +334,15 @@ func displayUpdatePrompt(info *VersionInfo) {
 }
 
 // ForceCheck forces a version check regardless of the last check time.
+// Even a forced check respects the telemetry opt-out: the check-in POST is
+// the telemetry, so there is no way to check without emitting it.
 func ForceCheck() (*VersionInfo, error) {
+	if telemetry.Disabled() {
+		return nil, fmt.Errorf(
+			"update check skipped: telemetry disabled via %s",
+			telemetry.DisableTelemetryEnv,
+		)
+	}
 	info, err := fetchVersionInfo()
 	if err != nil {
 		return nil, err

--- a/cli/internal/version/check_test.go
+++ b/cli/internal/version/check_test.go
@@ -177,8 +177,13 @@ func TestForceCheckRefusesWhenTelemetryDisabled(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv(telemetry.DisableVersionCheckEnv, "yes")
 
-	if _, err := ForceCheck(); err == nil {
+	_, err := ForceCheck()
+	if err == nil {
 		t.Fatal("ForceCheck must return an error when telemetry is disabled")
+	}
+	if !strings.Contains(err.Error(), telemetry.DisableTelemetryEnv) {
+		t.Errorf("error must name the env var %s, got: %v",
+			telemetry.DisableTelemetryEnv, err)
 	}
 	if requests != 0 {
 		t.Fatalf("expected no HTTP calls with telemetry disabled, got %d", requests)

--- a/cli/internal/version/check_test.go
+++ b/cli/internal/version/check_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/preloop/preloop/cli/internal/telemetry"
 )
 
 func TestTokenFingerprint(t *testing.T) {
@@ -129,6 +131,57 @@ func TestFetchVersionInfoFallsBackToLegacyEndpoint(t *testing.T) {
 	}
 	if len(paths) != 2 || !strings.HasSuffix(paths[1], LegacyVersionPath) {
 		t.Errorf("expected rich attempt then legacy fallback, got %v", paths)
+	}
+}
+
+func TestCheckForUpdateSkipsWhenTelemetryDisabled(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			requests++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"latest_version": "9.9.9",
+			})
+		}))
+	defer server.Close()
+
+	oldOrigin := VersionCheckOrigin
+	VersionCheckOrigin = server.URL
+	defer func() { VersionCheckOrigin = oldOrigin }()
+
+	// Fresh HOME: without the opt-out this would be a first run, which
+	// checks in immediately — the strictest possible setting.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(telemetry.DisableTelemetryEnv, "true")
+
+	if err := CheckForUpdate(); err != nil {
+		t.Fatalf("CheckForUpdate must be a silent no-op when disabled: %v", err)
+	}
+	if requests != 0 {
+		t.Fatalf("expected no HTTP calls with telemetry disabled, got %d", requests)
+	}
+}
+
+func TestForceCheckRefusesWhenTelemetryDisabled(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			requests++
+		}))
+	defer server.Close()
+
+	oldOrigin := VersionCheckOrigin
+	VersionCheckOrigin = server.URL
+	defer func() { VersionCheckOrigin = oldOrigin }()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(telemetry.DisableVersionCheckEnv, "yes")
+
+	if _, err := ForceCheck(); err == nil {
+		t.Fatal("ForceCheck must return an error when telemetry is disabled")
+	}
+	if requests != 0 {
+		t.Fatalf("expected no HTTP calls with telemetry disabled, got %d", requests)
 	}
 }
 

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -78,6 +78,9 @@ services:
       # Public signup. Set false to close registration (invite-only); the
       # install script does this once the first user exists.
       REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-true}
+      # Opt out of adoption telemetry (the daily version check-in to
+      # preloop.ai). Test/CI installs must always set this to true.
+      PRELOOP_DISABLE_TELEMETRY: ${PRELOOP_DISABLE_TELEMETRY:-}
       FLOW_EXECUTION_WORKER_ENABLED: ${FLOW_EXECUTION_WORKER_ENABLED:-false}
       # SMTP — required for approval emails, invitations and password resets.
       # Configure interactively via scripts/install-oss.sh or edit .env.

--- a/scripts/e2e-rig/README.md
+++ b/scripts/e2e-rig/README.md
@@ -14,6 +14,10 @@ real pty with pexpect into asciicast v2 and rendered with agg + ffmpeg
 (never vhs — it stalls), and every run is stitched into one continuous
 `<run-id>-oss-full-run.mp4` with per-step title cards.
 
+The rig always sets `PRELOOP_DISABLE_TELEMETRY=true` — locally, on every ssh
+command, in the CLI installer invocation, and in the installed instance's
+`.env` — to keep test runs out of adoption data.
+
 Relationship to the release smoke test: CI's release gate
 (`scripts/release_smoke_test.sh`, run by `.github/workflows/release.yml`)
 verifies that a tagged release installs and comes up healthy. This rig is

--- a/scripts/e2e-rig/lib/capture.py
+++ b/scripts/e2e-rig/lib/capture.py
@@ -99,13 +99,10 @@ def drain(child: pexpect.spawn) -> None:
         while True:
             if not child.read_nonblocking(4096, timeout=0):
                 break
-except pexpect.TIMEOUT:
-    pass  # Non-blocking drain: no output available (expected)
-except pexpect.EOF:
-    pass  # Child process ended (caller handles)
-        pass
+    except pexpect.TIMEOUT:
+        pass  # Non-blocking drain: no output available (expected)
     except pexpect.EOF:
-        pass
+        pass  # Child process ended (caller handles)
 
 
 def human_type(child: pexpect.spawn, text: str, cps: float = 24.0) -> None:
@@ -121,6 +118,9 @@ def spawn_shell(rec: CastRecorder, ssh_host: str | None = None) -> pexpect.spawn
     bootstrap = (
         f"export PS1='{PROMPT}' PS2='' TERM=xterm-256color; "
         "export PATH=$HOME/.local/bin:$HOME/.opencode/bin:$PATH; "
+        # Off-camera telemetry opt-out: every CLI command recorded in this
+        # shell must stay out of adoption data (rig standing rule).
+        "export PRELOOP_DISABLE_TELEMETRY=true; "
         "exec bash --norc --noprofile"
     )
     if ssh_host:

--- a/scripts/e2e-rig/lib/common.sh
+++ b/scripts/e2e-rig/lib/common.sh
@@ -10,6 +10,11 @@ set -euo pipefail
 RIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export RIG_DIR
 
+# STANDING RULE: the rig always sets PRELOOP_DISABLE_TELEMETRY so test runs
+# never pollute funnel/adoption data. Exported here for every module (local
+# CLI/tool invocations) and injected into every remote command by rig_ssh.
+export PRELOOP_DISABLE_TELEMETRY=true
+
 rig_log() {
   printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$*"
 }
@@ -37,7 +42,10 @@ rig_skip() {
 # for credentials) and timeouts are uniform. Remote command is a single string
 # run by the login shell.
 rig_ssh() {
-  ssh -o BatchMode=yes -o ConnectTimeout=15 "$RIG_HOST" "$@"
+  # Every remote command carries the telemetry opt-out so CLI/installer runs
+  # on the target host never emit adoption telemetry.
+  ssh -o BatchMode=yes -o ConnectTimeout=15 "$RIG_HOST" \
+    "export PRELOOP_DISABLE_TELEMETRY=true; $*"
 }
 
 rig_scp_from() {
@@ -131,5 +139,6 @@ rig_compose_args_remote() {
 COMPOSE_ARGS="-f docker-compose.yaml"
 [ -f docker-compose.auth.yaml ] && COMPOSE_ARGS="$COMPOSE_ARGS -f docker-compose.auth.yaml"
 [ -f docker-compose.tls.yaml ] && COMPOSE_ARGS="$COMPOSE_ARGS -f docker-compose.tls.yaml"
+[ -f docker-compose.rig-telemetry.yaml ] && COMPOSE_ARGS="$COMPOSE_ARGS -f docker-compose.rig-telemetry.yaml"
 EOF
 }

--- a/scripts/e2e-rig/lib/common.sh
+++ b/scripts/e2e-rig/lib/common.sh
@@ -44,6 +44,7 @@ rig_skip() {
 rig_ssh() {
   # Every remote command carries the telemetry opt-out so CLI/installer runs
   # on the target host never emit adoption telemetry.
+  # Note: rig_ssh expects a single command string, not multiple args.
   ssh -o BatchMode=yes -o ConnectTimeout=15 "$RIG_HOST" \
     "export PRELOOP_DISABLE_TELEMETRY=true; $*"
 }

--- a/scripts/e2e-rig/modules/05-install-preloop.sh
+++ b/scripts/e2e-rig/modules/05-install-preloop.sh
@@ -31,6 +31,7 @@ rig_log "installing Preloop OSS ${RIG_RELEASE} at ${RIG_URL} (installer: $INSTAL
 # gracefully and has_tty simply returns false.
 set +e
 rig_ssh "curl -fsSL '$INSTALLER_URL' -o /tmp/preloop-install-oss.sh &&
+         PRELOOP_DISABLE_TELEMETRY=true \
          PRELOOP_VERSION='$RIG_RELEASE' \
          PRELOOP_URL='$RIG_URL' \
          PRELOOP_SKIP_SMTP=1 \
@@ -39,6 +40,29 @@ rig_ssh "curl -fsSL '$INSTALLER_URL' -o /tmp/preloop-install-oss.sh &&
 status=${PIPESTATUS[0]}
 set -e
 [ "$status" -eq 0 ] || rig_die "installer exited $status (see $LOG)"
+
+# Server-side phone-home off: the test instance must never show up in
+# adoption data. The var goes into the instance .env, and — because the
+# pinned release's compose file may not map it into the api container — a
+# small rig overlay injects it into the api service (the only role that
+# phones home; see backend/preloop/services/instance_service.py).
+# rig_compose_args_remote picks the overlay up for all later compose calls.
+rig_ssh "
+  set -e
+  cd $RIG_INSTANCE_DIR
+  grep -q '^PRELOOP_DISABLE_TELEMETRY=' .env 2>/dev/null \
+    || printf 'PRELOOP_DISABLE_TELEMETRY=true\n' >> .env
+  printf '%s\n' \
+    '# Written by the e2e rig: test instances must not send adoption telemetry.' \
+    'services:' \
+    '  api:' \
+    '    environment:' \
+    '      PRELOOP_DISABLE_TELEMETRY: \${PRELOOP_DISABLE_TELEMETRY:-true}' \
+    > docker-compose.rig-telemetry.yaml
+  $(rig_compose_args_remote)
+  docker compose \$COMPOSE_ARGS up -d api
+" | tee -a "$LOG"
+rig_note "telemetry opt-out applied: PRELOOP_DISABLE_TELEMETRY=true in instance .env + api overlay"
 
 # TODO(remove-after-#65): installer workaround — HTTPS fixup for the
 # pre-existing-cert path described above. PR #65 (approved, unmerged) makes

--- a/scripts/e2e-rig/modules/08-cli-onboard.py
+++ b/scripts/e2e-rig/modules/08-cli-onboard.py
@@ -27,8 +27,11 @@ CLI_CONFIG_FILE = "$HOME/.preloop/config.yaml"
 
 
 def ssh(cmd: str, check: bool = True) -> subprocess.CompletedProcess:
+    # Telemetry opt-out on every remote command: test runs must never
+    # pollute adoption data (standing rule, see scripts/e2e-rig/README.md).
     return subprocess.run(
-        ["ssh", "-o", "BatchMode=yes", HOST, cmd],
+        ["ssh", "-o", "BatchMode=yes", HOST,
+         f"export PRELOOP_DISABLE_TELEMETRY=true; {cmd}"],
         capture_output=True,
         text=True,
         check=check,
@@ -83,6 +86,7 @@ def main() -> None:
         installer = (
             f"curl -fsSL https://github.com/preloop/preloop/releases/download/"
             f"v{CLI_VERSION}/install-cli.sh -o /tmp/install-cli.sh && "
+            f"PRELOOP_DISABLE_TELEMETRY=true "
             f"PRELOOP_VERSION={CLI_VERSION} PRELOOP_URL={URL} sh /tmp/install-cli.sh"
         )
         # The installer prompts to sign in; we decline — the login was staged

--- a/scripts/e2e-rig/modules/08-cli-onboard.py
+++ b/scripts/e2e-rig/modules/08-cli-onboard.py
@@ -30,8 +30,13 @@ def ssh(cmd: str, check: bool = True) -> subprocess.CompletedProcess:
     # Telemetry opt-out on every remote command: test runs must never
     # pollute adoption data (standing rule, see scripts/e2e-rig/README.md).
     return subprocess.run(
-        ["ssh", "-o", "BatchMode=yes", HOST,
-         f"export PRELOOP_DISABLE_TELEMETRY=true; {cmd}"],
+        [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            HOST,
+            f"export PRELOOP_DISABLE_TELEMETRY=true; {cmd}",
+        ],
         capture_output=True,
         text=True,
         check=check,

--- a/scripts/release_smoke_test.sh
+++ b/scripts/release_smoke_test.sh
@@ -23,6 +23,12 @@
 
 set -eu
 
+# Standing rule: test tooling must never pollute funnel/adoption telemetry.
+# Exported for any CLI use in this shell, and written into the stack's .env
+# below so the instance's server-side phone-home is off too.
+PRELOOP_DISABLE_TELEMETRY=true
+export PRELOOP_DISABLE_TELEMETRY
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
@@ -104,6 +110,7 @@ cat > "$WORK_DIR/.env" <<EOF
 PRELOOP_VERSION=${PRELOOP_VERSION}
 SECRET_KEY=$(generate_secret)
 POSTGRES_PASSWORD=$(generate_secret)
+PRELOOP_DISABLE_TELEMETRY=true
 EOF
 
 log "Pulling images..."


### PR DESCRIPTION
## Why

Test tooling and scripted runs must not pollute adoption telemetry. The server side already honors `PRELOOP_DISABLE_TELEMETRY` (with `DISABLE_VERSION_CHECK` as a legacy alias), but the Go CLI did not: its daily version check-in POST fired regardless, so scripted/CI runs showed up as adoption traffic.

## What

**CLI now honors the existing server-side opt-out var**
- `telemetry.Disabled()` accepts `PRELOOP_DISABLE_TELEMETRY` / `DISABLE_VERSION_CHECK` with values `true`/`1`/`t`/`yes`, case-insensitive — same parsing spirit as the backend.
- When set: no check-in POST, no conversion events, no local usage counters. Update notifications are suppressed too, since they derive from the check-in response (documented in `preloop --help`).
- `ForceCheck` refuses with an explicit error rather than silently checking in.
- Table-driven env parsing tests + httptest-backed tests proving zero HTTP requests when the var is set.

**e2e rig (`scripts/e2e-rig/`)**
- `lib/common.sh` exports the var for all modules and `rig_ssh` injects it into every remote command.
- Module 05 carries it on the installer invocation, writes it into the installed instance's `.env`, and adds a compose overlay so the api container of pinned releases gets it (server-side phone-home off).
- Module 08 carries it on its ssh helper and the CLI installer line; recorded shells export it in the off-camera bootstrap.

**Release gate**
- `scripts/release_smoke_test.sh` exports the var and writes it into the smoke stack's `.env`; `docker-compose.release.yaml` maps `PRELOOP_DISABLE_TELEMETRY` into the api service environment.

**Build fixes** (pre-existing on main, blocking the vet/compile gates)
- Duplicated `tabwriter.NewWriter` line in `cli/internal/cmd/agents.go` (package did not compile).
- Mangled try/except in `scripts/e2e-rig/lib/capture.py` (file did not parse).

**Docs**: standing rule recorded in `scripts/e2e-rig/README.md` and `AGENTS.md`.

## Verification

- `go vet ./...` and `go test` on `internal/telemetry`, `internal/version`, `internal/cmd` — all pass.
- `bash -n` / `sh -n` on all touched shell files; `py_compile` on touched Python files.
- Rig unit tests: `pytest scripts/e2e-rig/tests` — 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-structured telemetry opt-out gating for the CLI with comprehensive test coverage. All 3 review findings have been addressed (truthy parsing aligned, error assertion added, comment added). No security or data-leak concerns.
>
> **Overview**
> This PR adds `PRELOOP_DISABLE_TELEMETRY` / `DISABLE_VERSION_CHECK` env var support to the Go CLI, gating the daily check-in POST, conversion events, and local usage counters. It also wires the e2e rig and release smoke test to always set the opt-out. Includes two build fixes (duplicate tabwriter line, mangled Python try/except).
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit f9973b9. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->