### PR TITLE
Fold in parallel telemetry/version-tracking work (follow-up to #69)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,9 @@ PRODUCT_TEAM_EMAIL="product@preloop.ai"
 # Telemetry and Version Check
 # PRELOOP_DISABLE_TELEMETRY=false  # Set to true to disable version check telemetry
 # VERSION_CHECK_INTERVAL=86400  # Seconds between version checks (default: 24 hours)
+# PRELOOP_HOSTED=false  # Set to true ONLY on the hosted preloop.ai deployment:
+                        # it is the version-check tracker itself, so it never
+                        # persists update state or shows the update banner
 
 # Startup Options
 # SKIP_EXECUTION_RECOVERY=false  # Set to true to skip recovering orphaned executions on startup

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ plans/
 node_modules
 runtime-plugins/**/dist/
 .gstack/
+
+# Claude
+.claude/

--- a/backend/preloop/__init__.py
+++ b/backend/preloop/__init__.py
@@ -1,3 +1,33 @@
 """Preloop - Automation Platform with Human Approval Layer"""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _package_version
+from pathlib import Path
+
+
+def _resolve_version(default: str = "0.8.0") -> str:
+    """Resolve the installed Preloop version.
+
+    Mirrors ``preloop.config._load_release_version`` (importlib.metadata with
+    a VERSION-file fallback for Docker/local dev) but deliberately avoids
+    importing ``preloop.config`` here: that module pulls in pydantic settings
+    and would create a circular import for anything doing
+    ``from preloop import __version__``.
+    """
+    try:
+        return _package_version("preloop")
+    except PackageNotFoundError:
+        pass
+
+    version_file = Path(__file__).resolve().parents[2] / "VERSION"
+    try:
+        v = version_file.read_text(encoding="utf-8").strip()
+        if v:
+            return v
+    except OSError:
+        pass
+
+    return default
+
+
+__version__ = _resolve_version()

--- a/backend/preloop/models/crud/cli_client.py
+++ b/backend/preloop/models/crud/cli_client.py
@@ -10,6 +10,16 @@ from sqlalchemy.orm import Session
 from ..models.cli_client import CliClient
 from .base import CRUDBase
 
+# Columns accepted by get_all_paginated's sort_by parameter ("version" and
+# "os" map to the cli_version/os columns).
+CLI_CLIENT_SORT_FIELDS = (
+    "last_seen",
+    "first_seen",
+    "version",
+    "os",
+    "country",
+)
+
 
 class CRUDCliClient(CRUDBase[CliClient]):
     """CRUD operations for CLI clients (version-check telemetry)."""
@@ -24,16 +34,21 @@ class CRUDCliClient(CRUDBase[CliClient]):
         *,
         preloop_url: Optional[str] = None,
         active_within_days: Optional[int] = None,
+        sort_by: str = "last_seen",
+        sort_order: str = "desc",
         skip: int = 0,
         limit: int = 100,
     ) -> List[CliClient]:
-        """List clients, most recently seen first.
+        """List clients with server-side sorting (default: most recent first).
 
         Args:
             db: Database session
             preloop_url: Filter to clients configured against one server URL.
             active_within_days: Only clients whose last version check is
                 within this many days.
+            sort_by: One of CLI_CLIENT_SORT_FIELDS. Unknown values fall back
+                to last_seen.
+            sort_order: "asc" or "desc" (default). NULL sort keys always last.
             skip: Number of records to skip.
             limit: Maximum number of records to return.
         """
@@ -43,9 +58,19 @@ class CRUDCliClient(CRUDBase[CliClient]):
         if active_within_days is not None:
             cutoff = datetime.now(timezone.utc) - timedelta(days=active_within_days)
             query = query.filter(CliClient.last_seen >= cutoff)
-        return (
-            query.order_by(CliClient.last_seen.desc()).offset(skip).limit(limit).all()
+
+        if sort_by not in CLI_CLIENT_SORT_FIELDS:
+            sort_by = "last_seen"
+        sort_col = (
+            CliClient.cli_version
+            if sort_by == "version"
+            else getattr(CliClient, sort_by)
         )
+        ordering = sort_col.asc() if sort_order == "asc" else sort_col.desc()
+        if sort_by in ("os", "country"):  # nullable sort columns
+            ordering = ordering.nulls_last()
+        # Stable tiebreaker so pagination never duplicates/skips rows.
+        return query.order_by(ordering, CliClient.id).offset(skip).limit(limit).all()
 
     def get_with_coordinates(self, db: Session) -> List[CliClient]:
         """Clients that have lat/lon coordinates (for the admin map)."""

--- a/backend/preloop/models/crud/instance.py
+++ b/backend/preloop/models/crud/instance.py
@@ -9,6 +9,15 @@ from sqlalchemy.orm import Session
 from .base import CRUDBase
 from ..models.instance import Instance
 
+# Columns accepted by get_all_paginated's sort_by parameter.
+INSTANCE_SORT_FIELDS = (
+    "last_seen",
+    "first_seen",
+    "version",
+    "edition",
+    "country",
+)
+
 
 class CRUDInstance(CRUDBase[Instance]):
     """CRUD operations for Instance model."""
@@ -100,15 +109,20 @@ class CRUDInstance(CRUDBase[Instance]):
         *,
         active_only: bool = False,
         edition: Optional[str] = None,
+        sort_by: str = "last_seen",
+        sort_order: str = "desc",
         skip: int = 0,
         limit: int = 100,
     ) -> List[Instance]:
-        """Get all instances with optional filters.
+        """Get all instances with optional filters and server-side sorting.
 
         Args:
             db: Database session
             active_only: Whether to only return active instances
             edition: Edition to filter by
+            sort_by: One of INSTANCE_SORT_FIELDS. Unknown values fall back
+                to last_seen.
+            sort_order: "asc" or "desc" (default). NULL sort keys always last.
             skip: Number of records to skip
             limit: Maximum number of records to return
 
@@ -120,7 +134,15 @@ class CRUDInstance(CRUDBase[Instance]):
             query = query.filter(Instance.is_active == True)  # noqa: E712
         if edition:
             query = query.filter(Instance.edition == edition)
-        return query.order_by(Instance.last_seen.desc()).offset(skip).limit(limit).all()
+
+        if sort_by not in INSTANCE_SORT_FIELDS:
+            sort_by = "last_seen"
+        sort_col = getattr(Instance, sort_by)
+        ordering = sort_col.asc() if sort_order == "asc" else sort_col.desc()
+        if sort_by == "country":  # only nullable sort column
+            ordering = ordering.nulls_last()
+        # Stable tiebreaker so pagination never duplicates/skips rows.
+        return query.order_by(ordering, Instance.id).offset(skip).limit(limit).all()
 
     def count_total(self, db: Session) -> int:
         """Count total instances.

--- a/backend/preloop/models/models/instance.py
+++ b/backend/preloop/models/models/instance.py
@@ -117,7 +117,6 @@ class Instance(Base):
         index=True,
         comment="Whether instance is considered active",
     )
-
     # Additional metadata
     metadata_: Mapped[Optional[Dict[str, Any]]] = mapped_column(
         "metadata",

--- a/backend/preloop/schemas/installers.py
+++ b/backend/preloop/schemas/installers.py
@@ -16,6 +16,12 @@ class InstallerDownloadStats(BaseModel):
     """Summary statistics for installer script downloads and CLI activity."""
 
     audit_enabled: bool
+    # Account UUID whose audit log stores installer_download events
+    # (the INSTALLER_AUDIT_ACCOUNT_ID setting; superuser-only endpoint).
+    audit_account_id: str | None = None
+    # When auditing is disabled: the calling admin's own account id, offered
+    # as a copy-paste candidate for INSTALLER_AUDIT_ACCOUNT_ID.
+    suggested_account_id: str | None = None
     days: int
     total_downloads: int
     downloads_last_24h: int

--- a/backend/preloop/services/instance_service.py
+++ b/backend/preloop/services/instance_service.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 import httpx
 
-from preloop import __version__
+from preloop.config import SERVER_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +26,9 @@ VERSION_CHECK_URL = "https://preloop.ai/api/v1/version"
 DISABLE_TELEMETRY_ENV = "PRELOOP_DISABLE_TELEMETRY"
 DISABLE_VERSION_CHECK_ENV = "DISABLE_VERSION_CHECK"
 
+# Set on the hosted preloop.ai deployment itself: it IS the version-check
+# tracker, so it must never show itself an "update available" banner.
+HOSTED_ENV = "PRELOOP_HOSTED"
 
 # Truthy values for the opt-out variables: true/1/t/yes, case-insensitive,
 # surrounding whitespace ignored. Must stay aligned with the Go CLI's parsing
@@ -43,6 +46,49 @@ def is_telemetry_disabled() -> bool:
         os.getenv(DISABLE_TELEMETRY_ENV, "").strip().lower() in _TRUTHY_VALUES
         or os.getenv(DISABLE_VERSION_CHECK_ENV, "").strip().lower() in _TRUTHY_VALUES
     )
+
+
+def is_hosted_instance() -> bool:
+    """True when this deployment is the hosted preloop.ai service itself."""
+    return os.getenv(HOSTED_ENV, "").strip().lower() in _TRUTHY_VALUES
+
+
+def _parse_semver(value: object) -> Optional[tuple]:
+    """Parse a dotted version into an int tuple; None when unparseable.
+
+    Accepts an optional leading ``v`` and ignores pre-release/build suffixes
+    on each component (``1.0.0-rc1`` -> ``(1, 0, 0)``). Anything without
+    numeric components (or not a string) is unparseable.
+    """
+    if not isinstance(value, str):
+        return None
+    v = value.strip().lstrip("v")
+    if not v:
+        return None
+    parts = []
+    for part in v.split("."):
+        head = part.split("-")[0].split("+")[0]
+        if not head.isdigit():
+            return None
+        parts.append(int(head))
+    return tuple(parts)
+
+
+def is_newer_version(candidate: object, current: str) -> bool:
+    """True only when ``candidate`` is a valid version STRICTLY newer.
+
+    Unparseable candidates (or currents) are never "newer" — a garbage or
+    hardcoded latest-version value from the tracker must not light up the
+    update banner.
+    """
+    parsed_candidate = _parse_semver(candidate)
+    parsed_current = _parse_semver(current)
+    if parsed_candidate is None or parsed_current is None:
+        return False
+    width = max(len(parsed_candidate), len(parsed_current))
+    parsed_candidate += (0,) * (width - len(parsed_candidate))
+    parsed_current += (0,) * (width - len(parsed_current))
+    return parsed_candidate > parsed_current
 
 
 # Version check interval (default: 24 hours)
@@ -74,11 +120,12 @@ def get_or_create_instance() -> Optional["Instance"]:
 
             if instance:
                 # Update version if it changed
-                if instance.version != __version__:
+                if instance.version != SERVER_VERSION:
                     logger.info(
-                        f"Updating instance version from {instance.version} to {__version__}"
+                        f"Updating instance version from {instance.version} "
+                        f"to {SERVER_VERSION}"
                     )
-                    instance.version = __version__
+                    instance.version = SERVER_VERSION
                     instance.last_seen = datetime.now(timezone.utc)
                     db.commit()
                     db.refresh(instance)
@@ -88,7 +135,7 @@ def get_or_create_instance() -> Optional["Instance"]:
             edition = "enterprise" if _is_enterprise() else "oss"
             instance = Instance(
                 instance_uuid=uuid.uuid4(),
-                version=__version__,
+                version=SERVER_VERSION,
                 edition=edition,
                 first_seen=datetime.now(timezone.utc),
                 last_seen=datetime.now(timezone.utc),
@@ -182,9 +229,22 @@ def _persist_version_check_result(data: dict) -> None:
     Written to ``Instance.metadata_["version_check"]`` so the update status
     survives restarts and can be read by ``GET /api/v1/version`` for the
     admin update banner.
+
+    The hosted preloop.ai deployment never persists update state (it IS the
+    tracker), and the persisted ``update_available`` is recomputed locally:
+    a "latest" version that is not strictly newer than this server's own
+    version must never be stored as an available update.
     """
+    if is_hosted_instance():
+        return
+
     from preloop.models.db.session import get_db_session
     from preloop.models.models import Instance
+
+    latest_version = data.get("current_version")
+    update_available = bool(data.get("update_available")) and is_newer_version(
+        latest_version, SERVER_VERSION
+    )
 
     try:
         db = next(get_db_session())
@@ -195,8 +255,8 @@ def _persist_version_check_result(data: dict) -> None:
             row.metadata_ = {
                 **(row.metadata_ or {}),
                 "version_check": {
-                    "latest_version": data.get("current_version"),
-                    "update_available": bool(data.get("update_available")),
+                    "latest_version": latest_version,
+                    "update_available": update_available,
                     "update_url": data.get("update_url"),
                     "changelog_url": data.get("changelog_url"),
                     "checked_at": datetime.now(timezone.utc).isoformat(),
@@ -224,7 +284,8 @@ def get_local_update_status() -> dict:
         "changelog_url": None,
         "checked_at": None,
     }
-    if is_telemetry_disabled():
+    if is_telemetry_disabled() or is_hosted_instance():
+        # Hosted preloop.ai IS the update tracker: never surface a banner.
         return empty
     from preloop.models.db.session import get_db_session
     from preloop.models.models import Instance
@@ -236,7 +297,14 @@ def get_local_update_status() -> dict:
             if row is None or not row.metadata_:
                 return empty
             check = row.metadata_.get("version_check") or {}
-            return {**empty, **check}
+            status = {**empty, **check}
+            # Never trust the persisted boolean: recompute against this
+            # server's version so a stale/bogus "latest" (e.g. a hardcoded
+            # 1.0.0 from an old tracker deploy) cannot show an update.
+            status["update_available"] = is_newer_version(
+                status.get("latest_version"), SERVER_VERSION
+            )
+            return status
         finally:
             db.close()
     except Exception as e:

--- a/backend/tests/services/test_instance_service.py
+++ b/backend/tests/services/test_instance_service.py
@@ -21,6 +21,7 @@ def _reset_module_state(monkeypatch):
     """Reset env vars and module globals that leak across telemetry tests."""
     monkeypatch.delenv("PRELOOP_DISABLE_TELEMETRY", raising=False)
     monkeypatch.delenv("DISABLE_VERSION_CHECK", raising=False)
+    monkeypatch.delenv("PRELOOP_HOSTED", raising=False)
     instance_service._current_instance = None
     instance_service._version_check_task = None
     yield
@@ -179,6 +180,139 @@ async def test_send_version_check_defaults_metadata_to_empty(monkeypatch):
         await send_version_check(instance)
     payload = mock_client.post.call_args.kwargs["json"]
     assert payload["metadata"] == {}
+
+
+# --- version comparison ----------------------------------------------------
+
+
+class TestIsNewerVersion:
+    def test_strictly_newer(self):
+        assert instance_service.is_newer_version("1.0.0", "0.11.1") is True
+        assert instance_service.is_newer_version("0.11.2", "0.11.1") is True
+
+    def test_equal_is_not_newer(self):
+        assert instance_service.is_newer_version("0.11.1", "0.11.1") is False
+
+    def test_older_is_not_newer(self):
+        assert instance_service.is_newer_version("0.10.0", "0.11.1") is False
+
+    def test_v_prefix_and_padding(self):
+        assert instance_service.is_newer_version("v1.0", "0.11.1") is True
+        assert instance_service.is_newer_version("1.0", "1.0.0") is False
+
+    def test_unparseable_candidate_is_not_newer(self):
+        assert instance_service.is_newer_version("banana", "0.11.1") is False
+        assert instance_service.is_newer_version("", "0.11.1") is False
+        assert instance_service.is_newer_version(None, "0.11.1") is False
+
+    def test_prerelease_suffix_ignored(self):
+        assert instance_service.is_newer_version("1.0.0-rc1", "0.11.1") is True
+
+
+# --- hosted kill switch -----------------------------------------------------
+
+
+class TestHostedInstance:
+    @pytest.mark.parametrize("value", ["true", "1", "yes", "TRUE"])
+    def test_hosted_env_truthy(self, monkeypatch, value):
+        monkeypatch.setenv("PRELOOP_HOSTED", value)
+        assert instance_service.is_hosted_instance() is True
+
+    def test_not_hosted_by_default(self):
+        assert instance_service.is_hosted_instance() is False
+
+    def test_status_empty_when_hosted(self, monkeypatch):
+        """Hosted preloop.ai must never report an update to its own console."""
+        monkeypatch.setenv("PRELOOP_HOSTED", "1")
+        status = instance_service.get_local_update_status()
+        assert status["update_available"] is False
+        assert status["latest_version"] is None
+
+    def test_persist_skipped_when_hosted(self, monkeypatch):
+        monkeypatch.setenv("PRELOOP_HOSTED", "1")
+        with patch(
+            "preloop.models.db.session.get_db_session",
+            side_effect=AssertionError("must not touch the DB when hosted"),
+        ):
+            instance_service._persist_version_check_result(
+                {"update_available": True, "current_version": "99.0.0"}
+            )
+
+
+# --- update status recompute ------------------------------------------------
+
+
+def _mock_db_with_row(row):
+    db = MagicMock()
+    db.query.return_value.first.return_value = row
+    return db
+
+
+class TestGetLocalUpdateStatus:
+    def _status_with_persisted(self, monkeypatch, version_check):
+        row = SimpleNamespace(metadata_={"version_check": version_check})
+        db = _mock_db_with_row(row)
+        with patch(
+            "preloop.models.db.session.get_db_session",
+            return_value=iter([db]),
+        ):
+            return instance_service.get_local_update_status()
+
+    def test_recomputes_stale_persisted_boolean(self, monkeypatch):
+        """A persisted update_available=True with a non-newer latest is healed."""
+        monkeypatch.setattr(instance_service, "SERVER_VERSION", "1.0.0")
+        status = self._status_with_persisted(
+            monkeypatch,
+            {"update_available": True, "latest_version": "1.0.0"},
+        )
+        assert status["update_available"] is False
+
+    def test_reports_update_for_strictly_newer(self, monkeypatch):
+        monkeypatch.setattr(instance_service, "SERVER_VERSION", "0.11.1")
+        status = self._status_with_persisted(
+            monkeypatch,
+            {"update_available": True, "latest_version": "0.12.0"},
+        )
+        assert status["update_available"] is True
+        assert status["latest_version"] == "0.12.0"
+
+    def test_unparseable_latest_is_not_an_update(self, monkeypatch):
+        monkeypatch.setattr(instance_service, "SERVER_VERSION", "0.11.1")
+        status = self._status_with_persisted(
+            monkeypatch,
+            {"update_available": True, "latest_version": "not-a-version"},
+        )
+        assert status["update_available"] is False
+
+
+class TestPersistVersionCheckResult:
+    def test_does_not_persist_update_for_non_newer_version(self, monkeypatch):
+        """Self-heal: current_version <= SERVER_VERSION is never an update."""
+        monkeypatch.setattr(instance_service, "SERVER_VERSION", "1.0.0")
+        row = SimpleNamespace(metadata_={})
+        db = _mock_db_with_row(row)
+        with patch(
+            "preloop.models.db.session.get_db_session",
+            return_value=iter([db]),
+        ):
+            instance_service._persist_version_check_result(
+                {"update_available": True, "current_version": "1.0.0"}
+            )
+        assert row.metadata_["version_check"]["update_available"] is False
+        assert row.metadata_["version_check"]["latest_version"] == "1.0.0"
+
+    def test_persists_update_for_newer_version(self, monkeypatch):
+        monkeypatch.setattr(instance_service, "SERVER_VERSION", "0.11.1")
+        row = SimpleNamespace(metadata_={})
+        db = _mock_db_with_row(row)
+        with patch(
+            "preloop.models.db.session.get_db_session",
+            return_value=iter([db]),
+        ):
+            instance_service._persist_version_check_result(
+                {"update_available": True, "current_version": "0.12.0"}
+            )
+        assert row.metadata_["version_check"]["update_available"] is True
 
 
 # --- stop_version_checker --------------------------------------------------

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -1,9 +1,20 @@
 """Test the package version."""
 
 import preloop
+from preloop.config import SERVER_VERSION
 
 
 def test_version():
     """Test that the version is a string."""
     assert isinstance(preloop.__version__, str)
     assert preloop.__version__ != ""
+
+
+def test_version_matches_server_version():
+    """preloop.__version__ must resolve like config.SERVER_VERSION.
+
+    Guards against the historical bug where __init__.py hardcoded "0.1.0"
+    and every self-hosted install reported itself as v0.1.0 to the tracker.
+    """
+    assert preloop.__version__ == SERVER_VERSION
+    assert preloop.__version__ != "0.1.0"

--- a/cli/internal/telemetry/optout.go
+++ b/cli/internal/telemetry/optout.go
@@ -24,8 +24,9 @@ const (
 // Note: when telemetry is disabled the CLI performs no version check at all,
 // so local update notifications are suppressed too — the notification is a
 // by-product of the check-in response and there is no offline source for it.
-// This is deliberate: the variable exists for scripted/test runs that must
-// leave zero footprint in adoption data.
+// This is deliberate: the variable exists for scripted/test runs and
+// internal installs that must never appear in instance tracking or
+// adoption funnels.
 func Disabled() bool {
 	return envTruthy(os.Getenv(DisableTelemetryEnv)) ||
 		envTruthy(os.Getenv(DisableVersionCheckEnv))

--- a/helm/preloop/templates/api-deployment.yaml
+++ b/helm/preloop/templates/api-deployment.yaml
@@ -66,6 +66,14 @@ spec:
             - name: SKIP_EXECUTION_RECOVERY
               value: "true"
             {{- end }}
+            {{- if .Values.environment.hosted }}
+            - name: PRELOOP_HOSTED
+              value: "1"
+            {{- end }}
+            {{- if .Values.environment.releasesRepo }}
+            - name: PRELOOP_RELEASES_REPO
+              value: {{ .Values.environment.releasesRepo | quote }}
+            {{- end }}
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -212,6 +212,14 @@ environment:
   preloopUrl: "https://preloop.ai"
   debug: false
   modelGatewayCaptureContent: true
+  # Set true ONLY on the hosted preloop.ai deployment: it is the version-check
+  # tracker itself, so it must never persist update state or show the console
+  # "update available" banner (rendered as PRELOOP_HOSTED=1 on the API).
+  hosted: false
+  # GitHub repo ("owner/name") whose latest release the hosted version-check
+  # endpoint reports to self-hosted instances (PRELOOP_RELEASES_REPO). Leave
+  # empty on self-hosted installs.
+  releasesRepo: ""
   # Cap glibc malloc arenas for the Python services (api/gateway). Without a
   # cap, glibc creates up to 8 arenas per core; on many-core nodes with
   # transparent huge pages set to [always] this inflates RSS by hundreds of

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Preloop API
   description: REST API for Preloop issue tracking management
-  version: 0.1.0
+  version: 0.11.1
 paths:
   /api/v1/auth/register:
     post:

--- a/runtime-plugins/hermes-preloop/preloop-plugin.json
+++ b/runtime-plugins/hermes-preloop/preloop-plugin.json
@@ -2,7 +2,7 @@
   "name": "preloop-hermes-plugin",
   "displayName": "Preloop",
   "description": "Expose Hermes to Preloop for discovery, status, Agent Control, voice-transcript delivery, and native tool-call approval on mobile/watch.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "runtime": "hermes",
   "license": "Apache-2.0",
   "homepage": "https://preloop.ai",
@@ -27,10 +27,16 @@
   "capabilities": {
     "tool_approval": true
   },
-  "hooks": ["pre_tool_call"],
+  "hooks": [
+    "pre_tool_call"
+  ],
   "configSchema": {
     "path": "preloop.control",
-    "required": ["control_ws_url", "bearer_token", "runtime_principal_id"]
+    "required": [
+      "control_ws_url",
+      "bearer_token",
+      "runtime_principal_id"
+    ]
   },
   "verification": {
     "command": "preloop-hermes-plugin verify --config ~/.hermes/config.yaml"

--- a/runtime-plugins/hermes-preloop/pyproject.toml
+++ b/runtime-plugins/hermes-preloop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "preloop-hermes-plugin"
-version = "0.1.0"
+version = "0.1.1"
 description = "Preloop exposure and Agent Control plugin for Hermes"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Follow-up to #69, which merged while this work was in flight. This folds in the parallel telemetry/version-tracking changes that were developed alongside the opt-out branch.

## What

**Version reporting fix**
- `backend/preloop/__init__.py`: `__version__` now resolves via `importlib.metadata` with a `VERSION`-file fallback instead of a hardcoded `"0.1.0"` — every self-hosted install previously reported itself as v0.1.0 to the tracker. `openapi.yaml` regenerated accordingly.
- `instance_service.py` reports `config.SERVER_VERSION`; new test guards `preloop.__version__ == SERVER_VERSION`.

**Hosted kill switch + update-banner hardening**
- New `PRELOOP_HOSTED` env (helm: `environment.hosted`): the hosted preloop.ai deployment is the version-check tracker itself, so it never persists update state or shows the console update banner.
- `update_available` is recomputed with strict semver comparison (`is_newer_version`) on both persist and read — a stale or bogus "latest" from the tracker can never light up the banner. Unparseable versions are never "newer".
- Truthy parsing for all these env vars keeps the contract agreed in #69 review: `true/1/t/yes`, case-insensitive, whitespace-trimmed, identical in Go and Python.

**Admin/console support**
- Server-side sorting for instance and CLI-client listings (whitelisted sort fields, NULLs last, stable id tiebreaker for pagination).
- `InstallerDownloadStats` exposes `audit_account_id` / `suggested_account_id` (superuser-only endpoint).

**Plumbing**
- helm: `environment.hosted` → `PRELOOP_HOSTED=1`, `environment.releasesRepo` → `PRELOOP_RELEASES_REPO` on the API deployment.
- `.env.example` documents `PRELOOP_HOSTED`; `.gitignore` adds `.claude/`.
- `runtime-plugins/hermes-preloop`: 0.1.1 version bumps.

## Verification
- Backend: `test_instance_service.py`, `test_telemetry_optout.py`, `test_version.py` — 49 passed.
- Go: `go vet ./...` clean, `go test` green on `internal/telemetry`, `internal/version`, `internal/cmd`.
- Helm: `helm template` renders the API deployment with and without `environment.hosted`/`releasesRepo` set.
- pre-commit clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-tested telemetry hardening and version-reporting fix with no security concerns. Thorough test coverage across Python and Go.
>
> **Overview**
> Fixes version self-reporting (was hardcoded 0.1.0), adds PRELOOP_HOSTED kill switch for the hosted tracker, implements strict semver-based update-banner hardening with recomputation on both persist and read, adds server-side sorting for admin listings, and bumps hermes-preloop plugin to 0.1.1.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fb958f6. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->