### PR TITLE
CLI: pre-onboard auth probe, support-level honesty, stale OpenClaw plugin cleanup

### DIFF
--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -27,16 +27,24 @@ import (
 
 // AgentConfig describes a discovered AI agent MCP configuration.
 type AgentConfig struct {
-	Name                 string            `json:"name"`
-	DisplayName          string            `json:"display_name,omitempty"`
-	RuntimePrincipalID   string            `json:"runtime_principal_id,omitempty"`
-	ConfigPath           string            `json:"config_path"`
-	MCPServers           map[string]MCPDef `json:"mcp_servers,omitempty"`
-	IsOnboarded          bool              `json:"is_onboarded,omitempty"`
-	OnboardingState      string            `json:"onboarding_state,omitempty"`
-	ConfigDrift          bool              `json:"config_drift,omitempty"`
-	ReonboardRecommended bool              `json:"reonboard_recommended,omitempty"`
-	DriftReasons         []string          `json:"drift_reasons,omitempty"`
+	Name               string            `json:"name"`
+	DisplayName        string            `json:"display_name,omitempty"`
+	RuntimePrincipalID string            `json:"runtime_principal_id,omitempty"`
+	ConfigPath         string            `json:"config_path"`
+	MCPServers         map[string]MCPDef `json:"mcp_servers,omitempty"`
+	IsOnboarded        bool              `json:"is_onboarded,omitempty"`
+	OnboardingState    string            `json:"onboarding_state,omitempty"`
+	// AuthState is the pre-onboarding readiness probe result
+	// (ready / not_logged_in / unknown) — see detectAgentAuthState.
+	AuthState  string `json:"auth_state,omitempty"`
+	AuthDetail string `json:"auth_detail,omitempty"`
+	// SupportLevel is the per-agent-type capability: "full" (MCP + model
+	// routing) or "mcp-only" (model traffic not routable for this agent
+	// type) — see supportLevelForAgent.
+	SupportLevel         string   `json:"support_level,omitempty"`
+	ConfigDrift          bool     `json:"config_drift,omitempty"`
+	ReonboardRecommended bool     `json:"reonboard_recommended,omitempty"`
+	DriftReasons         []string `json:"drift_reasons,omitempty"`
 }
 
 // MCPDef is a minimal MCP server definition read from an agent config.
@@ -195,21 +203,37 @@ func isDevinAgent(agent AgentConfig) bool {
 // a vendor backend that cannot be redirected (Antigravity, Devin). Returns
 // "" for agents that do support gateway routing.
 func mcpOnlyAgentModelNote(agent AgentConfig) string {
+	// Every mcp-only note leads with the shared support-level phrase so the
+	// onboarding output matches the discovery listing and summary table:
+	// this is a support level of the agent type, not an incomplete
+	// onboarding.
 	switch {
 	case strings.EqualFold(strings.TrimSpace(agent.Name), "cursor"):
-		return "Cursor tool calls are governed through Preloop's MCP firewall. " +
-			"Cursor only accepts a custom model base URL via its in-app Settings → Models " +
-			"(global, chat-only, no config-file hook), so Preloop does not rewrite model " +
-			"traffic automatically. To route model spend through Preloop, set the OpenAI " +
-			"base URL override in Cursor settings to your Preloop gateway URL manually."
+		return mcpOnlySupportLabel + ": Cursor tool calls are governed through " +
+			"Preloop's MCP firewall. Cursor only accepts a custom model base URL via " +
+			"its in-app Settings → Models (global, chat-only, no config-file hook), " +
+			"so Preloop does not rewrite model traffic automatically. To route model " +
+			"spend through Preloop, set the OpenAI base URL override in Cursor " +
+			"settings to your Preloop gateway URL manually."
+	case strings.EqualFold(strings.TrimSpace(agent.Name), "claude desktop"):
+		return mcpOnlySupportLabel + ": Claude Desktop tool calls are governed " +
+			"through Preloop's MCP firewall. Claude Desktop's model traffic is fixed " +
+			"to Anthropic's backend by design and cannot be repointed, so MCP-level " +
+			"governance is the complete onboarding for this agent type."
 	case isAntigravityAgent(agent):
-		return "Antigravity tool calls are governed through Preloop's MCP firewall. " +
-			"Antigravity is locked to Google-hosted models with no BYO key or custom base " +
-			"URL, so model traffic cannot be routed through the Preloop gateway."
+		return mcpOnlySupportLabel + ": Antigravity tool calls are governed through " +
+			"Preloop's MCP firewall. Antigravity is locked to Google-hosted models " +
+			"with no BYO key or custom base URL, so model traffic cannot be routed " +
+			"through the Preloop gateway."
 	case isDevinAgent(agent):
-		return "Devin tool calls are governed through Preloop's MCP firewall. " +
-			"Devin runs all inference in Cognition's cloud and does not support third-party " +
-			"LLM endpoints, so model traffic cannot be routed through the Preloop gateway."
+		return mcpOnlySupportLabel + ": Devin tool calls are governed through " +
+			"Preloop's MCP firewall. Devin runs all inference in Cognition's cloud " +
+			"and does not support third-party LLM endpoints, so model traffic cannot " +
+			"be routed through the Preloop gateway."
+	case supportLevelForAgent(agent) == agentSupportLevelMCPOnly:
+		return mcpOnlySupportLabel + ": tool calls are governed through Preloop's " +
+			"MCP firewall; this agent type exposes no hook for rewriting model " +
+			"traffic."
 	default:
 		return ""
 	}
@@ -232,6 +256,14 @@ MCP server configurations without mutating local files or your Preloop account.
 Supported agents: Claude Code, Cursor, Windsurf, VSCode/Copilot,
                   Gemini CLI, OpenCode, Codex CLI, OpenClaw, Hermes,
                   Antigravity, Devin.
+
+Each listed agent shows a pre-onboarding readiness probe:
+  Auth     Ready / Not logged in / Unknown, detected from the agent's local
+           auth artifacts. A not-logged-in agent can still be onboarded; live
+           validation will fail until the agent logs in.
+  Support  Full (MCP firewall + model routing), or MCP-governed when the
+           agent type offers no way to route model traffic (a support level,
+           not a failure).
 
 When the post-scan onboarding prompts run, an error onboarding one agent does
 not stop the remaining agents; a per-agent summary (onboarded / partial /
@@ -401,6 +433,10 @@ func classifyAgentOnboardingOutcome(agent AgentConfig, err error) agentOnboardin
 		return agentOnboardingOutcome{
 			Agent:  agent,
 			Status: agentOnboardingStatusOnboarded,
+			// Successful onboardings still surface a pending agent-side
+			// login or an mcp-only support level in the Reason column so
+			// the summary is honest about what "onboarded" covers.
+			Reason: successSummaryReason(agent),
 		}
 	}
 	var skipErr *managedLauncherSkippedError
@@ -737,6 +773,8 @@ func runAgentsDiscover(cmd *cobra.Command, args []string) error {
 		fmt.Printf("     Agent Name: %s\n", resolveAgentDisplayName(agent))
 		fmt.Printf("     Runtime principal: %s\n", runtimePrincipalIDForAgent(agent))
 		fmt.Printf("     Config: %s\n", agent.ConfigPath)
+		fmt.Printf("     Auth: %s\n", agentAuthListingLabel(agent))
+		fmt.Printf("     Support: %s\n", agentSupportListingLabel(agent))
 		if agent.IsOnboarded {
 			fmt.Printf(
 				"     Managed: yes (%s)\n",
@@ -808,7 +846,10 @@ func promptToOnboardDiscoveredAgents(
 	deferLiveValidate := !skipLiveValidate
 	outcomes, err := promptToOnboardCandidates(os.Stdin, os.Stdout, candidates, autoApprove, true, func(agent AgentConfig, approvals bool) error {
 		return executeManagedEnrollment(agent, managedEnrollmentOptions{
-			Client:            client,
+			Client: client,
+			// AutoApprove carries the -y flag so per-agent sub-prompts
+			// (e.g. stale OpenClaw plugin cleanup) auto-accept under -y.
+			AutoApprove:       autoApprove,
 			SkipConfirmation:  true,
 			LiveValidate:      true,
 			SkipLiveValidate:  skipLiveValidate,
@@ -2885,7 +2926,9 @@ func discoverAgents(w io.Writer, printWarnings bool) ([]AgentConfig, error) {
 				ConfigPath: fullPath,
 				MCPServers: servers,
 			})
-			discovered[len(discovered)-1] = normalizeDiscoveredAgent(discovered[len(discovered)-1])
+			discovered[len(discovered)-1] = withDetectedAuthState(
+				normalizeDiscoveredAgent(discovered[len(discovered)-1]),
+			)
 			discoveredSpec = true
 			break
 		}
@@ -2893,11 +2936,11 @@ func discoverAgents(w io.Writer, printWarnings bool) ([]AgentConfig, error) {
 			continue
 		}
 		if fallbackPath, ok := detectInstalledAgent(home, spec); ok {
-			discovered = append(discovered, normalizeDiscoveredAgent(AgentConfig{
+			discovered = append(discovered, withDetectedAuthState(normalizeDiscoveredAgent(AgentConfig{
 				Name:       spec.Name,
 				ConfigPath: fallbackPath,
 				MCPServers: map[string]MCPDef{},
-			}))
+			})))
 		}
 	}
 	return discovered, nil

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -38,6 +38,196 @@ const (
 	openClawPreloopPluginID   = "preloop-plugin"
 )
 
+// canonicalOpenClawPluginPackage is the published npm package for the Preloop
+// OpenClaw runtime plugin. Earlier package names (below) are superseded by it.
+const canonicalOpenClawPluginPackage = "@preloop-ai/openclaw-plugin"
+
+// staleOpenClawPluginNames are earlier Preloop plugin package names that
+// OpenClaw can no longer resolve, superseded by
+// canonicalOpenClawPluginPackage. A plugins entry that tries to LOAD one of
+// these (loader keys like enabled/source/package) makes OpenClaw print a
+// scary "unknown plugin" warning on every startup. Note the distinction from
+// the CLI's own config stash: `plugins.entries.<id> = {"config": {...}}`
+// carries only Preloop control metadata (which the current plugin still reads
+// under legacy ids for backward compatibility) and is never stale.
+var staleOpenClawPluginNames = []string{
+	openClawPreloopPluginID, // "preloop-plugin"
+	"openclaw-plugin",
+	"@preloop/openclaw-plugin",
+}
+
+// detectStaleOpenClawPluginEntries returns the sorted ids of plugins entries
+// in the OpenClaw document that reference a known-stale Preloop plugin name:
+// either an entry under a stale id with loader keys, or an entry whose
+// source/package field points at a stale package.
+func detectStaleOpenClawPluginEntries(agent AgentConfig, doc map[string]interface{}) []string {
+	if !isOpenClawAgent(agent) || doc == nil {
+		return nil
+	}
+	plugins, ok := asObjectMap(doc["plugins"])
+	if !ok {
+		return nil
+	}
+	entries, ok := asObjectMap(plugins["entries"])
+	if !ok {
+		return nil
+	}
+	stale := map[string]bool{}
+	for id, raw := range entries {
+		entry, ok := asObjectMap(raw)
+		if !ok {
+			continue
+		}
+		if !openClawPluginEntryHasLoaderKeys(entry) {
+			// Pure {"config": {...}} stash written by this CLI — not stale.
+			continue
+		}
+		if isStaleOpenClawPluginName(id) {
+			stale[id] = true
+			continue
+		}
+		for _, field := range []string{"source", "package", "path", "url"} {
+			if isStaleOpenClawPluginName(lookupString(entry, field)) {
+				stale[id] = true
+				break
+			}
+		}
+	}
+	ids := make([]string, 0, len(stale))
+	for id := range stale {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// openClawPluginEntryHasLoaderKeys reports whether the entry carries anything
+// beyond the CLI-managed "config" stash (i.e. it asks OpenClaw to load a
+// plugin by this entry's name).
+func openClawPluginEntryHasLoaderKeys(entry map[string]interface{}) bool {
+	for key := range entry {
+		if key != "config" {
+			return true
+		}
+	}
+	return false
+}
+
+// isStaleOpenClawPluginName matches a plugin id or package reference against
+// the known-stale names, tolerating npm:/file: style prefixes.
+func isStaleOpenClawPluginName(name string) bool {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return false
+	}
+	for _, prefix := range []string{"npm:", "pkg:"} {
+		trimmed = strings.TrimPrefix(trimmed, prefix)
+	}
+	for _, staleName := range staleOpenClawPluginNames {
+		if strings.EqualFold(trimmed, staleName) {
+			return true
+		}
+	}
+	return false
+}
+
+// removeStaleOpenClawPluginEntries deletes the given plugin entry ids from
+// the document. Only the in-memory managed document is touched; the on-disk
+// config is preserved by the standard pre-onboarding backup.
+func removeStaleOpenClawPluginEntries(doc map[string]interface{}, ids []string) {
+	plugins, ok := asObjectMap(doc["plugins"])
+	if !ok {
+		return
+	}
+	entries, ok := asObjectMap(plugins["entries"])
+	if !ok {
+		return
+	}
+	for _, id := range ids {
+		delete(entries, id)
+	}
+}
+
+func staleOpenClawPluginEntriesNote(ids []string) string {
+	return fmt.Sprintf(
+		"Stale OpenClaw plugin entr%s detected (%s — superseded by %s); onboarding will offer to remove %s.",
+		pluralEntrySuffix(ids),
+		strings.Join(ids, ", "),
+		canonicalOpenClawPluginPackage,
+		pluralItPronoun(ids),
+	)
+}
+
+func pluralEntrySuffix(ids []string) string {
+	if len(ids) == 1 {
+		return "y"
+	}
+	return "ies"
+}
+
+func pluralItPronoun(ids []string) string {
+	if len(ids) == 1 {
+		return "it"
+	}
+	return "them"
+}
+
+// maybeRemoveStaleOpenClawPluginEntries offers to drop plugins entries that
+// reference superseded Preloop plugin package names before the managed config
+// is written. Auto-accepts under -y / PRELOOP_CONFIRM; preserves the entries
+// when the user declines. The pre-onboarding backup keeps the original config
+// either way.
+func maybeRemoveStaleOpenClawPluginEntries(
+	plan managedMCPEnrollmentPlan,
+	agent AgentConfig,
+	opts managedEnrollmentOptions,
+	input io.Reader,
+	output io.Writer,
+) (managedMCPEnrollmentPlan, error) {
+	staleIDs := detectStaleOpenClawPluginEntries(agent, plan.ManagedDocument)
+	if len(staleIDs) == 0 {
+		return plan, nil
+	}
+	joined := strings.Join(staleIDs, ", ")
+	remove := opts.AutoApprove || nonInteractiveAutoConfirm()
+	if remove {
+		fmt.Fprintf( //nolint:errcheck
+			output,
+			"  Removing stale OpenClaw plugin entr%s %s (superseded by %s); the pre-onboarding backup keeps the original config.\n",
+			pluralEntrySuffix(staleIDs),
+			joined,
+			canonicalOpenClawPluginPackage,
+		)
+	} else {
+		confirmed, err := confirmActionDefaultYes(
+			input,
+			output,
+			fmt.Sprintf(
+				"Remove stale OpenClaw plugin entr%s %s (superseded by %s)? The config backup keeps the original. (Y/n): ",
+				pluralEntrySuffix(staleIDs),
+				joined,
+				canonicalOpenClawPluginPackage,
+			),
+		)
+		if err != nil {
+			return plan, fmt.Errorf("failed to read stale plugin cleanup confirmation: %w", err)
+		}
+		remove = confirmed
+	}
+	if !remove {
+		fmt.Fprintf( //nolint:errcheck
+			output,
+			"  Keeping stale plugin entr%s %s; OpenClaw may warn about %s at startup.\n",
+			pluralEntrySuffix(staleIDs),
+			joined,
+			pluralItPronoun(staleIDs),
+		)
+		return plan, nil
+	}
+	removeStaleOpenClawPluginEntries(plan.ManagedDocument, staleIDs)
+	return refreshManagedPlanSnapshots(plan)
+}
+
 var openClawEnvPattern = regexp.MustCompile(`^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$`)
 var opencodeEnvPattern = regexp.MustCompile(`^\{env:([A-Za-z_][A-Za-z0-9_]*)\}$`)
 var opencodeBearerEnvPattern = regexp.MustCompile(`^[Bb]earer\s+\{env:([A-Za-z_][A-Za-z0-9_]*)\}$`)
@@ -277,6 +467,14 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		}
 	}
 
+	// Pre-onboarding readiness: when the agent itself is not logged in,
+	// onboarding still proceeds (the MCP/model config is written), but say so
+	// once up front so a later live-validation failure reads as "log the
+	// agent in", not as a Preloop bug.
+	if !opts.DryRun {
+		printAgentAuthPreflightNotice(output, agent)
+	}
+
 	syncAgent := prepareAgentForRemoteServerSync(agent, baseURL)
 
 	plan, err := buildManagedMCPEnrollmentPlan(
@@ -286,6 +484,9 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 	)
 	if err != nil {
 		return err
+	}
+	if staleEntries := detectStaleOpenClawPluginEntries(agent, plan.ManagedDocument); len(staleEntries) > 0 {
+		plan.Notes = append(plan.Notes, staleOpenClawPluginEntriesNote(staleEntries))
 	}
 	if supportsManagedGateway(agent) {
 		upstream, upstreamErr := resolveManagedGatewayUpstream(agent)
@@ -445,6 +646,10 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		baseURL,
 		credentialResp.Token,
 	)
+	if err != nil {
+		return err
+	}
+	plan, err = maybeRemoveStaleOpenClawPluginEntries(plan, agent, opts, input, output)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/cmd/agents_preflight.go
+++ b/cli/internal/cmd/agents_preflight.go
@@ -1,0 +1,360 @@
+package cmd
+
+// Pre-onboarding readiness probes.
+//
+// Before an agent is onboarded, `preloop agents discover` shows two cheap,
+// read-only facts per agent so users know what onboarding can and cannot do:
+//
+//  1. Auth state — whether the agent itself is logged in to its model
+//     provider (Ready / Not logged in / Unknown). Onboarding an agent that is
+//     not logged in still works (the MCP/model config is written), but live
+//     validation will fail until the user logs the agent in, and the output
+//     says so explicitly instead of looking like a Preloop bug.
+//  2. Support level — whether Preloop can route the agent's model traffic
+//     through the managed gateway ("full") or only govern its tool calls
+//     through the MCP firewall ("mcp-only"). MCP-only is a property of the
+//     agent type, not an onboarding failure, and is rendered as such.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// agentSupportLevel describes how far Preloop governance can reach for an
+// agent type.
+type agentSupportLevel string
+
+const (
+	// agentSupportLevelFull: MCP firewall plus model-traffic routing through
+	// the managed gateway.
+	agentSupportLevelFull agentSupportLevel = "full"
+	// agentSupportLevelMCPOnly: tool calls are governed through the MCP
+	// firewall, but the agent type offers no hook to repoint model traffic
+	// (by design of the agent, not an onboarding failure).
+	agentSupportLevelMCPOnly agentSupportLevel = "mcp-only"
+)
+
+// mcpOnlySupportLabel is the single user-facing phrase for the mcp-only
+// support level, used verbatim in the discovery listing, onboarding output,
+// and the batch summary so the three surfaces never disagree.
+const mcpOnlySupportLabel = "MCP-governed (model routing unavailable for this agent type)"
+
+const fullSupportLabel = "Full (MCP firewall + model routing)"
+
+// supportLevelForAgent maps an agent to its support level. OpenClaw is not in
+// supportsManagedGateway (it uses its own multi-model binding sync) but its
+// model traffic is fully routable, so it counts as full.
+func supportLevelForAgent(agent AgentConfig) agentSupportLevel {
+	if supportsManagedGateway(agent) || isOpenClawAgent(agent) {
+		return agentSupportLevelFull
+	}
+	return agentSupportLevelMCPOnly
+}
+
+// agentSupportListingLabel renders the support level for the discovery
+// listing.
+func agentSupportListingLabel(agent AgentConfig) string {
+	if supportLevelForAgent(agent) == agentSupportLevelFull {
+		return fullSupportLabel
+	}
+	return mcpOnlySupportLabel
+}
+
+// isOpenClawAgent reports whether the agent is OpenClaw.
+func isOpenClawAgent(agent AgentConfig) bool {
+	return strings.EqualFold(strings.TrimSpace(agent.Name), "openclaw")
+}
+
+// agentAuthState is the pre-onboarding auth readiness of a discovered agent.
+type agentAuthState string
+
+const (
+	agentAuthStateReady       agentAuthState = "ready"
+	agentAuthStateNotLoggedIn agentAuthState = "not_logged_in"
+	agentAuthStateUnknown     agentAuthState = "unknown"
+)
+
+// claudeKeychainPresenceProbe reports whether a Claude Code credential entry
+// exists in the OS keychain. Overridable in tests. The default is a
+// metadata-only lookup (no -w flag), so the secret is never read and macOS
+// does not raise an authorization prompt.
+var claudeKeychainPresenceProbe = defaultClaudeKeychainPresenceProbe
+
+func defaultClaudeKeychainPresenceProbe() bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	for _, service := range []string{"Claude Code-credentials", "Claude Code"} {
+		if exec.Command("security", "find-generic-password", "-s", service).Run() == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// codexKeychainPresenceProbe reports whether a Codex CLI OAuth entry exists
+// in the OS keychain (service "Codex Auth"). Overridable in tests;
+// metadata-only lookup for the same reasons as the Claude probe.
+var codexKeychainPresenceProbe = defaultCodexKeychainPresenceProbe
+
+func defaultCodexKeychainPresenceProbe() bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	return exec.Command("security", "find-generic-password", "-s", "Codex Auth").Run() == nil
+}
+
+// detectAgentAuthState inspects the agent's on-disk auth artifacts and
+// returns its auth state plus a short human-readable detail. The checks are
+// intentionally cheap (stat/read of small local files, metadata-only keychain
+// lookups) so they can run for every agent during discovery.
+//
+// Detection matrix:
+//
+//	Claude Code    ~/.claude/.credentials.json token blob, ~/.claude.json
+//	               primaryApiKey, ANTHROPIC_* env, or keychain service
+//	               presence                          → ready / not_logged_in
+//	Codex CLI      $CODEX_HOME/auth.json shape (OPENAI_API_KEY or
+//	               tokens.access_token+refresh_token), keychain fallback
+//	                                                 → ready / not_logged_in / unknown
+//	OpenCode       ~/.local/share/opencode/auth.json provider profiles
+//	                                                 → ready / not_logged_in / unknown
+//	OpenClaw       models.providers auth in its config (inline API key or
+//	               ambient/env auth)                 → ready / not_logged_in / unknown
+//	Cursor,        config presence only; their auth lives server-side and is
+//	Claude Desktop not locally inspectable           → unknown
+//	anything else                                    → unknown
+func detectAgentAuthState(agent AgentConfig) (agentAuthState, string) {
+	switch strings.ToLower(strings.TrimSpace(agent.Name)) {
+	case "claude code":
+		return detectClaudeCodeAuthState()
+	case "codex cli":
+		return detectCodexAuthState()
+	case "opencode":
+		return detectOpenCodeAuthState()
+	case "openclaw":
+		return detectOpenClawAuthState(agent)
+	default:
+		return agentAuthStateUnknown, "auth state is not locally inspectable for this agent type"
+	}
+}
+
+// withDetectedAuthState stamps the detected auth state onto the agent.
+func withDetectedAuthState(agent AgentConfig) AgentConfig {
+	state, detail := detectAgentAuthState(agent)
+	agent.AuthState = string(state)
+	agent.AuthDetail = detail
+	agent.SupportLevel = string(supportLevelForAgent(agent))
+	return agent
+}
+
+func detectClaudeCodeAuthState() (agentAuthState, string) {
+	for _, envKey := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"} {
+		if strings.TrimSpace(os.Getenv(envKey)) != "" {
+			return agentAuthStateReady, envKey + " is set"
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return agentAuthStateUnknown, "could not resolve home directory"
+	}
+	credentialsPath := filepath.Join(home, ".claude", ".credentials.json")
+	if data, readErr := os.ReadFile(credentialsPath); readErr == nil {
+		if extractClaudeTokenFromCredentialBlob(string(data)) != "" {
+			return agentAuthStateReady, "credential file present (~/.claude/.credentials.json)"
+		}
+		return agentAuthStateNotLoggedIn, "credential file exists but holds no usable token"
+	}
+	if resolveClaudePrimaryAPIKey() != "" {
+		return agentAuthStateReady, "API key configured in ~/.claude.json"
+	}
+	if claudeKeychainPresenceProbe() {
+		return agentAuthStateReady, "OS keychain entry present (service: Claude Code-credentials)"
+	}
+	return agentAuthStateNotLoggedIn, "no credential file, keychain entry, or API key found"
+}
+
+func detectCodexAuthState() (agentAuthState, string) {
+	path := resolveCodexAuthPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if codexKeychainPresenceProbe() {
+				return agentAuthStateReady, "OS keychain entry present (service: Codex Auth)"
+			}
+			return agentAuthStateNotLoggedIn, "no auth.json found"
+		}
+		return agentAuthStateUnknown, fmt.Sprintf("could not read %s", path)
+	}
+	var document map[string]interface{}
+	if err := json.Unmarshal(data, &document); err != nil {
+		return agentAuthStateUnknown, fmt.Sprintf("could not parse %s", path)
+	}
+	if apiKey, ok := document["OPENAI_API_KEY"].(string); ok && strings.TrimSpace(apiKey) != "" {
+		return agentAuthStateReady, "API key present in auth.json"
+	}
+	if tokens, ok := asObjectMap(document["tokens"]); ok {
+		access := strings.TrimSpace(lookupString(tokens, "access_token"))
+		refresh := strings.TrimSpace(lookupString(tokens, "refresh_token"))
+		if access != "" && refresh != "" {
+			return agentAuthStateReady, "ChatGPT OAuth tokens present in auth.json"
+		}
+	}
+	return agentAuthStateNotLoggedIn, "auth.json holds no usable credentials"
+}
+
+func detectOpenCodeAuthState() (agentAuthState, string) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return agentAuthStateUnknown, "could not resolve home directory"
+	}
+	path := filepath.Join(home, ".local", "share", "opencode", "auth.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return agentAuthStateNotLoggedIn, "no auth profiles found"
+		}
+		return agentAuthStateUnknown, fmt.Sprintf("could not read %s", path)
+	}
+	var profiles map[string]json.RawMessage
+	if err := json.Unmarshal(data, &profiles); err != nil {
+		return agentAuthStateUnknown, fmt.Sprintf("could not parse %s", path)
+	}
+	if len(profiles) == 0 {
+		return agentAuthStateNotLoggedIn, "auth.json holds no provider profiles"
+	}
+	providers := make([]string, 0, len(profiles))
+	for provider := range profiles {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+	return agentAuthStateReady, "auth profiles present for " + strings.Join(providers, ", ")
+}
+
+func detectOpenClawAuthState(agent AgentConfig) (agentAuthState, string) {
+	configPath := strings.TrimSpace(agent.ConfigPath)
+	if configPath == "" {
+		return agentAuthStateUnknown, "no OpenClaw config path"
+	}
+	if _, err := os.Stat(configPath); err != nil {
+		return agentAuthStateNotLoggedIn, "no OpenClaw config with provider auth found"
+	}
+	parsed, err := parseOpenClawConfig(configPath)
+	if err != nil {
+		return agentAuthStateUnknown, "could not parse OpenClaw config"
+	}
+	authedProviders := []string{}
+	for _, model := range parsed.ConfiguredModels {
+		if !model.UsesAmbientAuth && strings.TrimSpace(model.ProviderAPIKey) == "" {
+			continue
+		}
+		provider := strings.TrimSpace(model.ProviderID)
+		if provider == "" {
+			provider = strings.TrimSpace(model.ModelAlias)
+		}
+		if provider != "" {
+			authedProviders = append(authedProviders, provider)
+		}
+	}
+	if len(authedProviders) > 0 {
+		sort.Strings(authedProviders)
+		return agentAuthStateReady, "provider auth configured (" + strings.Join(authedProviders, ", ") + ")"
+	}
+	if len(parsed.ConfiguredModels) == 0 {
+		return agentAuthStateNotLoggedIn, "no model provider entries in config"
+	}
+	return agentAuthStateNotLoggedIn, "model provider entries hold no API key or ambient auth"
+}
+
+// agentLoginCommand returns the agent-native login command used in the
+// not-logged-in guidance, or "" when the agent type has no local login flow.
+func agentLoginCommand(agent AgentConfig) string {
+	switch strings.ToLower(strings.TrimSpace(agent.Name)) {
+	case "claude code":
+		return "claude /login"
+	case "codex cli":
+		return "codex login"
+	case "opencode":
+		return "opencode auth login"
+	case "openclaw":
+		return "openclaw onboard"
+	default:
+		return ""
+	}
+}
+
+// agentAuthListingLabel renders the auth state for the discovery listing.
+func agentAuthListingLabel(agent AgentConfig) string {
+	switch agentAuthState(strings.TrimSpace(agent.AuthState)) {
+	case agentAuthStateReady:
+		return "Ready"
+	case agentAuthStateNotLoggedIn:
+		if loginCmd := agentLoginCommand(agent); loginCmd != "" {
+			return fmt.Sprintf("Not logged in (run `%s`)", loginCmd)
+		}
+		return "Not logged in"
+	default:
+		return "Unknown"
+	}
+}
+
+// resolvedAgentAuthState returns the agent's stamped auth state, detecting it
+// on the spot when the agent did not pass through discovery stamping.
+func resolvedAgentAuthState(agent AgentConfig) agentAuthState {
+	if state := strings.TrimSpace(agent.AuthState); state != "" {
+		return agentAuthState(state)
+	}
+	state, _ := detectAgentAuthState(agent)
+	return state
+}
+
+// printAgentAuthPreflightNotice prints the single not-logged-in guidance line
+// during onboarding. Onboarding proceeds either way — the MCP/model config is
+// written now — but live validation cannot pass until the agent logs in, and
+// this line says so before the failure can be mistaken for a Preloop bug.
+func printAgentAuthPreflightNotice(writer io.Writer, agent AgentConfig) {
+	if resolvedAgentAuthState(agent) != agentAuthStateNotLoggedIn {
+		return
+	}
+	name := resolveAgentDisplayName(agent)
+	loginCmd := agentLoginCommand(agent)
+	if loginCmd == "" {
+		loginCmd = "the agent's login flow"
+	} else {
+		loginCmd = "`" + loginCmd + "`"
+	}
+	fmt.Fprintf( //nolint:errcheck
+		writer,
+		"  %s: not logged in — MCP/model config will be written now; run %s then `preloop agents validate '%s' --live`\n",
+		name,
+		loginCmd,
+		name,
+	)
+}
+
+// successSummaryReason fills the summary Reason column for successfully
+// onboarded agents that still need a caveat: a pending agent-side login, or
+// an mcp-only support level (informational, not a failure).
+func successSummaryReason(agent AgentConfig) string {
+	if resolvedAgentAuthState(agent) == agentAuthStateNotLoggedIn {
+		if loginCmd := agentLoginCommand(agent); loginCmd != "" {
+			return fmt.Sprintf(
+				"not logged in — run `%s`, then `preloop agents validate %s --live`",
+				loginCmd,
+				shellQuoteAgentName(resolveAgentDisplayName(agent)),
+			)
+		}
+		return "not logged in — log the agent in, then re-run live validation"
+	}
+	if supportLevelForAgent(agent) == agentSupportLevelMCPOnly {
+		return mcpOnlySupportLabel
+	}
+	return ""
+}

--- a/cli/internal/cmd/agents_preflight_test.go
+++ b/cli/internal/cmd/agents_preflight_test.go
@@ -1,0 +1,654 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// setPreflightTestEnv isolates auth-state detection from the developer's
+// machine: fresh HOME, no ambient Anthropic/Codex credentials, no keychain,
+// no PRELOOP_CONFIRM auto-answers.
+func setPreflightTestEnv(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("PRELOOP_CONFIRM", "")
+
+	originalClaudeProbe := claudeKeychainPresenceProbe
+	originalCodexProbe := codexKeychainPresenceProbe
+	claudeKeychainPresenceProbe = func() bool { return false }
+	codexKeychainPresenceProbe = func() bool { return false }
+	t.Cleanup(func() {
+		claudeKeychainPresenceProbe = originalClaudeProbe
+		codexKeychainPresenceProbe = originalCodexProbe
+	})
+	return home
+}
+
+func writePreflightFixture(t *testing.T, path string, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("failed to create fixture dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("failed to write fixture %s: %v", path, err)
+	}
+}
+
+const openClawAuthedConfigFixture = `{
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "bedrock/anthropic.claude-opus-4-6-2025-11-01-v1:0"
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "bedrock": {
+        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+        "apiKey": "ABSKQ-preflight-test",
+        "auth": "api-key",
+        "api": "bedrock-converse-stream",
+        "models": [
+          {"id": "anthropic.claude-opus-4-6-2025-11-01-v1:0", "name": "Claude Opus 4.6 (Bedrock)"}
+        ]
+      }
+    }
+  }
+}`
+
+func TestDetectAgentAuthStateMatrix(t *testing.T) {
+	tests := []struct {
+		name          string
+		agent         AgentConfig
+		setup         func(t *testing.T, home string) AgentConfig
+		claudeProbe   bool
+		codexProbe    bool
+		expectedState agentAuthState
+	}{
+		{
+			name:  "claude code with oauth credentials file is ready",
+			agent: AgentConfig{Name: "Claude Code"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				writePreflightFixture(
+					t,
+					filepath.Join(home, ".claude", ".credentials.json"),
+					`{"claudeAiOauth": {"accessToken": "tok-live", "refreshToken": "tok-refresh"}}`,
+				)
+				return AgentConfig{Name: "Claude Code"}
+			},
+			expectedState: agentAuthStateReady,
+		},
+		{
+			name:  "claude code credentials file without token is not logged in",
+			agent: AgentConfig{Name: "Claude Code"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				writePreflightFixture(
+					t,
+					filepath.Join(home, ".claude", ".credentials.json"),
+					`{}`,
+				)
+				return AgentConfig{Name: "Claude Code"}
+			},
+			expectedState: agentAuthStateNotLoggedIn,
+		},
+		{
+			name:  "claude code with primary api key in claude.json is ready",
+			agent: AgentConfig{Name: "Claude Code"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				writePreflightFixture(
+					t,
+					filepath.Join(home, ".claude.json"),
+					`{"primaryApiKey": "sk-ant-test"}`,
+				)
+				return AgentConfig{Name: "Claude Code"}
+			},
+			expectedState: agentAuthStateReady,
+		},
+		{
+			name:          "claude code with keychain entry only is ready",
+			agent:         AgentConfig{Name: "Claude Code"},
+			claudeProbe:   true,
+			expectedState: agentAuthStateReady,
+		},
+		{
+			name:          "claude code with no artifacts is not logged in",
+			agent:         AgentConfig{Name: "Claude Code"},
+			expectedState: agentAuthStateNotLoggedIn,
+		},
+		{
+			name:  "claude code with anthropic api key env is ready",
+			agent: AgentConfig{Name: "Claude Code"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				t.Setenv("ANTHROPIC_API_KEY", "sk-ant-env")
+				return AgentConfig{Name: "Claude Code"}
+			},
+			expectedState: agentAuthStateReady,
+		},
+		{
+			name:          "codex without auth.json is not logged in",
+			agent:         AgentConfig{Name: "Codex CLI"},
+			expectedState: agentAuthStateNotLoggedIn,
+		},
+		{
+			name:          "codex without auth.json but keychain entry is ready",
+			agent:         AgentConfig{Name: "Codex CLI"},
+			codexProbe:    true,
+			expectedState: agentAuthStateReady,
+		},
+		{
+			name:  "codex logged-out auth.json shape is not logged in",
+			agent: AgentConfig{Name: "Codex CLI"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				writePreflightFixture(
+					t,
+					filepath.Join(home, ".codex", "auth.json"),
+					`{"OPENAI_API_KEY": null, "tokens": null}`,
+				)
+				return AgentConfig{Name: "Codex CLI"}
+			},
+			expectedState: agentAuthStateNotLoggedIn,
+		},
+		{
+			name:  "codex api key auth.json is ready",
+			agent: AgentConfig{Name: "Codex CLI"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				writePreflightFixture(
+					t,
+					filepath.Join(home, ".codex", "auth.json"),
+					`{"OPENAI_API_KEY": "sk-test"}`,
+				)
+				return AgentConfig{Name: "Codex CLI"}
+			},
+			expectedState: agentAuthStateReady,
+		},
+		{
+			name:  "codex chatgpt oauth tokens are ready",
+			agent: AgentConfig{Name: "Codex CLI"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				writePreflightFixture(
+					t,
+					filepath.Join(home, ".codex", "auth.json"),
+					`{"tokens": {"access_token": "a", "refresh_token": "r", "account_id": "acct"}, "last_refresh": "2026-07-17T00:00:00Z"}`,
+				)
+				return AgentConfig{Name: "Codex CLI"}
+			},
+			expectedState: agentAuthStateReady,
+		},
+		{
+			name:  "codex malformed auth.json is unknown",
+			agent: AgentConfig{Name: "Codex CLI"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				writePreflightFixture(
+					t,
+					filepath.Join(home, ".codex", "auth.json"),
+					`{not json`,
+				)
+				return AgentConfig{Name: "Codex CLI"}
+			},
+			expectedState: agentAuthStateUnknown,
+		},
+		{
+			name:          "opencode without auth.json is not logged in",
+			agent:         AgentConfig{Name: "OpenCode"},
+			expectedState: agentAuthStateNotLoggedIn,
+		},
+		{
+			name:  "opencode empty auth.json is not logged in",
+			agent: AgentConfig{Name: "OpenCode"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				writePreflightFixture(
+					t,
+					filepath.Join(home, ".local", "share", "opencode", "auth.json"),
+					`{}`,
+				)
+				return AgentConfig{Name: "OpenCode"}
+			},
+			expectedState: agentAuthStateNotLoggedIn,
+		},
+		{
+			name:  "opencode with provider auth profile is ready",
+			agent: AgentConfig{Name: "OpenCode"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				writePreflightFixture(
+					t,
+					filepath.Join(home, ".local", "share", "opencode", "auth.json"),
+					`{"anthropic": {"type": "oauth", "access": "a", "refresh": "r"}}`,
+				)
+				return AgentConfig{Name: "OpenCode"}
+			},
+			expectedState: agentAuthStateReady,
+		},
+		{
+			name:  "opencode malformed auth.json is unknown",
+			agent: AgentConfig{Name: "OpenCode"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				writePreflightFixture(
+					t,
+					filepath.Join(home, ".local", "share", "opencode", "auth.json"),
+					`nope`,
+				)
+				return AgentConfig{Name: "OpenCode"}
+			},
+			expectedState: agentAuthStateUnknown,
+		},
+		{
+			name:  "openclaw with provider api key is ready",
+			agent: AgentConfig{Name: "OpenClaw"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				configPath := filepath.Join(home, ".openclaw", "openclaw.json")
+				writePreflightFixture(t, configPath, openClawAuthedConfigFixture)
+				return AgentConfig{Name: "OpenClaw", ConfigPath: configPath}
+			},
+			expectedState: agentAuthStateReady,
+		},
+		{
+			name:  "openclaw without provider entries is not logged in",
+			agent: AgentConfig{Name: "OpenClaw"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				configPath := filepath.Join(home, ".openclaw", "openclaw.json")
+				writePreflightFixture(t, configPath, `{"mcp": {"servers": {}}}`)
+				return AgentConfig{Name: "OpenClaw", ConfigPath: configPath}
+			},
+			expectedState: agentAuthStateNotLoggedIn,
+		},
+		{
+			name: "openclaw with missing config file is not logged in",
+			setup: func(t *testing.T, home string) AgentConfig {
+				return AgentConfig{
+					Name:       "OpenClaw",
+					ConfigPath: filepath.Join(home, ".openclaw", "openclaw.json"),
+				}
+			},
+			expectedState: agentAuthStateNotLoggedIn,
+		},
+		{
+			name:  "openclaw with unparseable config is unknown",
+			agent: AgentConfig{Name: "OpenClaw"},
+			setup: func(t *testing.T, home string) AgentConfig {
+				configPath := filepath.Join(home, ".openclaw", "openclaw.json")
+				writePreflightFixture(t, configPath, `{{{`)
+				return AgentConfig{Name: "OpenClaw", ConfigPath: configPath}
+			},
+			expectedState: agentAuthStateUnknown,
+		},
+		{
+			name:          "cursor is unknown by design",
+			agent:         AgentConfig{Name: "Cursor", ConfigPath: "/tmp/mcp.json"},
+			expectedState: agentAuthStateUnknown,
+		},
+		{
+			name:          "claude desktop is unknown by design",
+			agent:         AgentConfig{Name: "Claude Desktop", ConfigPath: "/tmp/claude_desktop_config.json"},
+			expectedState: agentAuthStateUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := setPreflightTestEnv(t)
+			claudeKeychainPresenceProbe = func() bool { return tt.claudeProbe }
+			codexKeychainPresenceProbe = func() bool { return tt.codexProbe }
+			agent := tt.agent
+			if tt.setup != nil {
+				agent = tt.setup(t, home)
+			}
+			state, detail := detectAgentAuthState(agent)
+			if state != tt.expectedState {
+				t.Fatalf(
+					"detectAgentAuthState(%s) = %q (%s), expected %q",
+					agent.Name,
+					state,
+					detail,
+					tt.expectedState,
+				)
+			}
+			if strings.TrimSpace(detail) == "" {
+				t.Fatal("expected a non-empty auth detail")
+			}
+		})
+	}
+}
+
+func TestSupportLevelForAgentMatrix(t *testing.T) {
+	fullAgents := []string{"Claude Code", "Codex CLI", "OpenCode", "Gemini CLI", "Hermes", "OpenClaw"}
+	mcpOnlyAgents := []string{"Cursor", "Claude Desktop", "Windsurf", "VSCode / Copilot", "Antigravity", "Devin"}
+	for _, name := range fullAgents {
+		if level := supportLevelForAgent(AgentConfig{Name: name}); level != agentSupportLevelFull {
+			t.Fatalf("expected %s to be full support, got %q", name, level)
+		}
+	}
+	for _, name := range mcpOnlyAgents {
+		if level := supportLevelForAgent(AgentConfig{Name: name}); level != agentSupportLevelMCPOnly {
+			t.Fatalf("expected %s to be mcp-only, got %q", name, level)
+		}
+	}
+}
+
+func TestAgentSupportListingLabel(t *testing.T) {
+	if label := agentSupportListingLabel(AgentConfig{Name: "Claude Desktop"}); label != mcpOnlySupportLabel {
+		t.Fatalf("expected mcp-only label for Claude Desktop, got %q", label)
+	}
+	if label := agentSupportListingLabel(AgentConfig{Name: "Codex CLI"}); label != fullSupportLabel {
+		t.Fatalf("expected full label for Codex CLI, got %q", label)
+	}
+}
+
+func TestAgentAuthListingLabel(t *testing.T) {
+	tests := []struct {
+		agent    AgentConfig
+		expected string
+	}{
+		{AgentConfig{Name: "Codex CLI", AuthState: string(agentAuthStateReady)}, "Ready"},
+		{AgentConfig{Name: "Codex CLI", AuthState: string(agentAuthStateNotLoggedIn)}, "Not logged in (run `codex login`)"},
+		{AgentConfig{Name: "Claude Desktop", AuthState: string(agentAuthStateUnknown)}, "Unknown"},
+		{AgentConfig{Name: "Cursor"}, "Unknown"},
+	}
+	for _, tt := range tests {
+		if label := agentAuthListingLabel(tt.agent); label != tt.expected {
+			t.Fatalf("agentAuthListingLabel(%s/%s) = %q, expected %q", tt.agent.Name, tt.agent.AuthState, label, tt.expected)
+		}
+	}
+}
+
+func TestPrintAgentAuthPreflightNotice(t *testing.T) {
+	var buffer bytes.Buffer
+	printAgentAuthPreflightNotice(&buffer, AgentConfig{
+		Name:      "Codex CLI",
+		AuthState: string(agentAuthStateNotLoggedIn),
+	})
+	output := buffer.String()
+	expected := "Codex CLI: not logged in — MCP/model config will be written now; " +
+		"run `codex login` then `preloop agents validate 'Codex CLI' --live`"
+	if !strings.Contains(output, expected) {
+		t.Fatalf("expected notice %q, got %q", expected, output)
+	}
+	if strings.Count(output, "\n") != 1 {
+		t.Fatalf("expected exactly one notice line, got %q", output)
+	}
+
+	buffer.Reset()
+	printAgentAuthPreflightNotice(&buffer, AgentConfig{
+		Name:      "Codex CLI",
+		AuthState: string(agentAuthStateReady),
+	})
+	if buffer.Len() != 0 {
+		t.Fatalf("expected no notice for a ready agent, got %q", buffer.String())
+	}
+}
+
+func TestClassifySuccessfulOnboardingReflectsAuthAndSupport(t *testing.T) {
+	notLoggedIn := classifyAgentOnboardingOutcome(AgentConfig{
+		Name:      "Codex CLI",
+		AuthState: string(agentAuthStateNotLoggedIn),
+	}, nil)
+	if notLoggedIn.Status != agentOnboardingStatusOnboarded {
+		t.Fatalf("expected onboarded status, got %q", notLoggedIn.Status)
+	}
+	if !strings.Contains(notLoggedIn.Reason, "not logged in") ||
+		!strings.Contains(notLoggedIn.Reason, "codex login") {
+		t.Fatalf("expected not-logged-in reason with login command, got %q", notLoggedIn.Reason)
+	}
+
+	mcpOnly := classifyAgentOnboardingOutcome(AgentConfig{
+		Name:      "Claude Desktop",
+		AuthState: string(agentAuthStateUnknown),
+	}, nil)
+	if mcpOnly.Reason != mcpOnlySupportLabel {
+		t.Fatalf("expected mcp-only support reason, got %q", mcpOnly.Reason)
+	}
+
+	ready := classifyAgentOnboardingOutcome(AgentConfig{
+		Name:      "Codex CLI",
+		AuthState: string(agentAuthStateReady),
+	}, nil)
+	if ready.Reason != "" {
+		t.Fatalf("expected empty reason for a ready full-support agent, got %q", ready.Reason)
+	}
+}
+
+func TestPrintAgentOnboardingSummaryShowsSupportLevelReason(t *testing.T) {
+	var buffer bytes.Buffer
+	printAgentOnboardingSummary(&buffer, []agentOnboardingOutcome{
+		classifyAgentOnboardingOutcome(AgentConfig{
+			Name:      "Claude Desktop",
+			AuthState: string(agentAuthStateUnknown),
+		}, nil),
+	})
+	if !strings.Contains(buffer.String(), mcpOnlySupportLabel) {
+		t.Fatalf("expected summary to include %q, got %q", mcpOnlySupportLabel, buffer.String())
+	}
+}
+
+func TestMCPOnlyAgentModelNoteLeadsWithSupportLabel(t *testing.T) {
+	for _, name := range []string{"Cursor", "Claude Desktop", "Antigravity", "Devin", "Windsurf"} {
+		note := mcpOnlyAgentModelNote(AgentConfig{Name: name})
+		if !strings.HasPrefix(note, mcpOnlySupportLabel) {
+			t.Fatalf("expected %s note to lead with the support label, got %q", name, note)
+		}
+	}
+	for _, name := range []string{"Claude Code", "Codex CLI", "OpenClaw"} {
+		if note := mcpOnlyAgentModelNote(AgentConfig{Name: name}); note != "" {
+			t.Fatalf("expected no mcp-only note for %s, got %q", name, note)
+		}
+	}
+}
+
+func staleOpenClawFixtureDocument() map[string]interface{} {
+	return map[string]interface{}{
+		"agents": map[string]interface{}{
+			"defaults": map[string]interface{}{
+				"model": map[string]interface{}{"primary": "anthropic/claude-opus-4-6"},
+			},
+		},
+		"plugins": map[string]interface{}{
+			"entries": map[string]interface{}{
+				"preloop-plugin": map[string]interface{}{
+					"enabled": true,
+					"source":  "npm:preloop-plugin",
+				},
+				"unrelated-plugin": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+		},
+	}
+}
+
+func TestDetectStaleOpenClawPluginEntries(t *testing.T) {
+	openclaw := AgentConfig{Name: "OpenClaw"}
+
+	stale := detectStaleOpenClawPluginEntries(openclaw, staleOpenClawFixtureDocument())
+	if !reflect.DeepEqual(stale, []string{"preloop-plugin"}) {
+		t.Fatalf("expected [preloop-plugin], got %v", stale)
+	}
+
+	// The CLI's own config stash under a legacy id is not a loader entry and
+	// must never be flagged.
+	configStash := map[string]interface{}{
+		"plugins": map[string]interface{}{
+			"entries": map[string]interface{}{
+				"preloop-plugin": map[string]interface{}{
+					"config": map[string]interface{}{"control_ws_url": "wss://example"},
+				},
+			},
+		},
+	}
+	if stale := detectStaleOpenClawPluginEntries(openclaw, configStash); len(stale) != 0 {
+		t.Fatalf("expected config stash to be preserved, got %v", stale)
+	}
+
+	// An entry under a non-stale id whose source references a stale package
+	// is flagged too.
+	renamed := map[string]interface{}{
+		"plugins": map[string]interface{}{
+			"entries": map[string]interface{}{
+				"my-preloop": map[string]interface{}{
+					"enabled": true,
+					"source":  "npm:@preloop/openclaw-plugin",
+				},
+			},
+		},
+	}
+	if stale := detectStaleOpenClawPluginEntries(openclaw, renamed); !reflect.DeepEqual(stale, []string{"my-preloop"}) {
+		t.Fatalf("expected [my-preloop], got %v", stale)
+	}
+
+	// The canonical package is never stale.
+	canonical := map[string]interface{}{
+		"plugins": map[string]interface{}{
+			"entries": map[string]interface{}{
+				canonicalOpenClawPluginPackage: map[string]interface{}{"enabled": true},
+			},
+		},
+	}
+	if stale := detectStaleOpenClawPluginEntries(openclaw, canonical); len(stale) != 0 {
+		t.Fatalf("expected canonical plugin entry to be kept, got %v", stale)
+	}
+
+	// Non-OpenClaw agents are never touched.
+	if stale := detectStaleOpenClawPluginEntries(AgentConfig{Name: "Codex CLI"}, staleOpenClawFixtureDocument()); len(stale) != 0 {
+		t.Fatalf("expected no detection for non-OpenClaw agent, got %v", stale)
+	}
+}
+
+func staleCleanupTestPlan(t *testing.T) (managedMCPEnrollmentPlan, string, []byte) {
+	t.Helper()
+	home := setPreflightTestEnv(t)
+	configPath := filepath.Join(home, ".openclaw", "openclaw.json")
+	originalConfig := `{
+  "plugins": {
+    "entries": {
+      "preloop-plugin": {"enabled": true, "source": "npm:preloop-plugin"},
+      "unrelated-plugin": {"enabled": true}
+    }
+  }
+}`
+	writePreflightFixture(t, configPath, originalConfig)
+	return managedMCPEnrollmentPlan{
+		Agent:           AgentConfig{Name: "OpenClaw", ConfigPath: configPath},
+		ManagedDocument: staleOpenClawFixtureDocument(),
+	}, configPath, []byte(originalConfig)
+}
+
+func pluginEntriesFromDocument(t *testing.T, doc map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	plugins, ok := asObjectMap(doc["plugins"])
+	if !ok {
+		t.Fatal("expected plugins object in managed document")
+	}
+	entries, ok := asObjectMap(plugins["entries"])
+	if !ok {
+		t.Fatal("expected plugins.entries object in managed document")
+	}
+	return entries
+}
+
+func TestMaybeRemoveStaleOpenClawPluginEntriesAutoYes(t *testing.T) {
+	plan, configPath, originalConfig := staleCleanupTestPlan(t)
+	var output bytes.Buffer
+
+	updated, err := maybeRemoveStaleOpenClawPluginEntries(
+		plan,
+		plan.Agent,
+		managedEnrollmentOptions{AutoApprove: true},
+		strings.NewReader(""),
+		&output,
+	)
+	if err != nil {
+		t.Fatalf("maybeRemoveStaleOpenClawPluginEntries returned error: %v", err)
+	}
+
+	entries := pluginEntriesFromDocument(t, updated.ManagedDocument)
+	if _, exists := entries["preloop-plugin"]; exists {
+		t.Fatal("expected stale preloop-plugin entry to be removed under -y")
+	}
+	if _, exists := entries["unrelated-plugin"]; !exists {
+		t.Fatal("expected unrelated plugin entry to survive cleanup")
+	}
+	if !strings.Contains(output.String(), "Removing stale OpenClaw plugin entry preloop-plugin") {
+		t.Fatalf("expected removal message, got %q", output.String())
+	}
+	if !strings.Contains(output.String(), canonicalOpenClawPluginPackage) {
+		t.Fatalf("expected message to mention the superseding package, got %q", output.String())
+	}
+
+	// The backup source — the on-disk config — is untouched by cleanup.
+	onDisk, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to re-read config: %v", err)
+	}
+	if !bytes.Equal(onDisk, originalConfig) {
+		t.Fatal("expected the on-disk config (backup source) to remain unchanged")
+	}
+}
+
+func TestMaybeRemoveStaleOpenClawPluginEntriesPromptAccepted(t *testing.T) {
+	plan, _, _ := staleCleanupTestPlan(t)
+	var output bytes.Buffer
+
+	updated, err := maybeRemoveStaleOpenClawPluginEntries(
+		plan,
+		plan.Agent,
+		managedEnrollmentOptions{},
+		strings.NewReader("y\n"),
+		&output,
+	)
+	if err != nil {
+		t.Fatalf("maybeRemoveStaleOpenClawPluginEntries returned error: %v", err)
+	}
+	entries := pluginEntriesFromDocument(t, updated.ManagedDocument)
+	if _, exists := entries["preloop-plugin"]; exists {
+		t.Fatal("expected stale entry to be removed after accepting the prompt")
+	}
+	if !strings.Contains(output.String(), "Remove stale OpenClaw plugin entry preloop-plugin") {
+		t.Fatalf("expected cleanup prompt, got %q", output.String())
+	}
+}
+
+func TestMaybeRemoveStaleOpenClawPluginEntriesDeclined(t *testing.T) {
+	plan, configPath, originalConfig := staleCleanupTestPlan(t)
+	var output bytes.Buffer
+
+	updated, err := maybeRemoveStaleOpenClawPluginEntries(
+		plan,
+		plan.Agent,
+		managedEnrollmentOptions{},
+		strings.NewReader("n\n"),
+		&output,
+	)
+	if err != nil {
+		t.Fatalf("maybeRemoveStaleOpenClawPluginEntries returned error: %v", err)
+	}
+	entries := pluginEntriesFromDocument(t, updated.ManagedDocument)
+	if _, exists := entries["preloop-plugin"]; !exists {
+		t.Fatal("expected stale entry to be preserved when the user declines")
+	}
+	if !strings.Contains(output.String(), "Keeping stale plugin entry") {
+		t.Fatalf("expected decline message, got %q", output.String())
+	}
+	onDisk, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to re-read config: %v", err)
+	}
+	if !bytes.Equal(onDisk, originalConfig) {
+		t.Fatal("expected the on-disk config to remain unchanged on decline")
+	}
+}
+
+func TestStaleOpenClawPluginEntriesNote(t *testing.T) {
+	note := staleOpenClawPluginEntriesNote([]string{"preloop-plugin"})
+	if !strings.Contains(note, "preloop-plugin") ||
+		!strings.Contains(note, canonicalOpenClawPluginPackage) {
+		t.Fatalf("expected note to name the stale entry and its replacement, got %q", note)
+	}
+}


### PR DESCRIPTION
## What

Three onboarding-clarity improvements to `preloop agents discover` / `onboard`, driven by watching real first-run sessions:

### 1. Pre-onboard readiness probe (auth state)
Discovery now cheaply detects each agent's auth state from its local artifacts and shows it in the listing **before** any onboarding prompt:

| Agent type | Artifact checked | States |
|---|---|---|
| Claude Code | `~/.claude/.credentials.json` token blob, `~/.claude.json` `primaryApiKey`, `ANTHROPIC_*` env, keychain service presence (metadata-only, no secret read) | Ready / Not logged in |
| Codex CLI | `$CODEX_HOME/auth.json` shape (`OPENAI_API_KEY` or `tokens.access_token` + `refresh_token`), keychain fallback | Ready / Not logged in / Unknown |
| OpenCode | `~/.local/share/opencode/auth.json` provider profiles | Ready / Not logged in / Unknown |
| OpenClaw | provider auth in its config (inline API key or ambient/env auth) | Ready / Not logged in / Unknown |
| Cursor, Claude Desktop | config presence only (auth lives server-side) | Unknown |
| everything else | — | Unknown |

Onboarding a not-logged-in agent still proceeds, with one clear line:

```
<agent>: not logged in — MCP/model config will be written now; run <login cmd> then `preloop agents validate '<agent>' --live`
```

and the batch-summary Reason column carries the same guidance — so a failed live validation reads as \"log the agent in\", not as a Preloop bug.

### 2. Support-level honesty
New per-agent-type capability: **full** (MCP firewall + model routing) vs **mcp-only** (model traffic not routable for that agent type). Claude Desktop, Cursor, Windsurf, VSCode/Copilot, Antigravity, and Devin now say `MCP-governed (model routing unavailable for this agent type)` — the exact same phrase — in the discovery listing, onboarding output, and summary. It is presented as a support level, never as an incomplete onboarding. Also exposed as `support_level` / `auth_state` in `discover --json`.

### 3. Stale OpenClaw plugin entry cleanup
Onboarding OpenClaw detects `plugins.entries` that try to load superseded Preloop plugin package names (`preloop-plugin`, `openclaw-plugin`, `@preloop/openclaw-plugin` — replaced by `@preloop-ai/openclaw-plugin`), which cause a scary unknown-plugin warning on every OpenClaw startup. The CLI offers to remove them (prompt; auto-yes under `-y`), the existing pre-onboarding backup keeps the original config, and the CLI's own `{\"config\": ...}` stash entries are never touched.

## Tests

- Table-driven auth-detection matrix with per-agent fixture files and overridable keychain probes
- Support-level rendering (listing label, onboarding note, summary Reason)
- Stale-entry cleanup: removed under `-y`, removed on prompt accept, preserved on decline, on-disk config (backup source) untouched
- `gofmt` clean, `go vet ./...` and `go test ./...` green

## Follow-ups (not in this PR)

- Cursor model base-URL override (needs design: Cursor only accepts an override via in-app Settings → Models; no config-file hook)
- Optional live no-op probe (`validate --probe`-style connectivity check that makes no billable model request)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-tested CLI improvements with conservative auth probing (metadata-only, no secret reads) and safe config mutation (backup-preserving cleanup). All 22 new tests pass, `go vet` clean, no security concerns.
>
> **Overview**
> Adds pre-onboard auth readiness probes, per-agent support-level honesty (full vs MCP-only), and stale OpenClaw plugin entry cleanup to the `preloop agents discover`/`onboard` flow. Discovery now shows auth state before any onboarding prompt, MCP-only agents show a consistent support-level label, and superseded plugin entries are safely removed with backup preservation.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 50bdb5c. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)