### PR TITLE
fix(console): raise /api nginx proxy timeouts to 300s for long LLM requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Console nginx no longer 504s long-running API requests: the `/api/` proxy
+  timeouts (console image and helm chart nginx configmap) were raised from 60s
+  to 300s. LLM-powered cost optimization suggestions
+  (`POST /api/v1/billing/cost/runtime-sessions/{id}/optimizations`) and replay
+  verification legitimately take ~90s on slower BYOK models; the browser got a
+  504 while the backend finished and cached the result, so a retry succeeded
+  instantly and the feature read as broken. Static-asset serving is unchanged.
+  The durable fix — running these analyses as async jobs with polling/SSE — is
+  tracked as a follow-up.
+
 ## [0.12.2] - 2026-07-18
 
 ## [0.12.1] - 2026-07-17

--- a/frontend/docker/nginx.conf.template
+++ b/frontend/docker/nginx.conf.template
@@ -35,8 +35,11 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
         proxy_connect_timeout 10s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        # LLM-powered analysis (cost optimization suggestions) and replay
+        # verification legitimately run ~90s on slower models; 60s here 504s the
+        # browser while the backend finishes. Durable fix is async jobs + polling.
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
 
         # CORS headers for API requests
         add_header 'Access-Control-Allow-Origin' '*' always;

--- a/helm/preloop/templates/configmap-nginx.yaml
+++ b/helm/preloop/templates/configmap-nginx.yaml
@@ -67,8 +67,12 @@ data:
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_cache_bypass $http_upgrade;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
+            # LLM-powered analysis (cost optimization suggestions) and replay
+            # verification legitimately run ~90s on slower models; 60s here 504s
+            # the browser while the backend finishes. Durable fix is async jobs
+            # + polling.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
 
             # CORS headers for API requests
             add_header 'Access-Control-Allow-Origin' '*' always;


### PR DESCRIPTION
## Problem

LLM-powered cost optimization suggestions (`POST /api/v1/billing/cost/runtime-sessions/{id}/optimizations`) and replay verification legitimately take ~90s on slower BYOK models. The console's nginx proxies `/api` with 60s `proxy_read_timeout`/`proxy_send_timeout`, so the browser gets a 504 while the backend finishes and caches the result. Re-clicking then returns an instant cached success — which makes the feature read as broken.

## Fix

Raise `proxy_read_timeout` / `proxy_send_timeout` to **300s for the `/api/` location only** (static-asset and other locations unchanged), everywhere the console/proxy config ships from this repo:

- `frontend/docker/nginx.conf.template` — the console image's nginx (used by the release compose `console` service and the frontend compose files)
- `helm/preloop/templates/configmap-nginx.yaml` — the helm chart's frontend nginx configmap (the exact-match `/api/v1/agents/permission-check` block keeps its longer 1860s timeout)

Layers checked and intentionally unchanged:

- The installer's TLS-terminating proxy (`tls/http.conf` / `https.conf` → `active.conf` in `scripts/install-oss.sh`) already uses `proxy_read_timeout 3600s` on its catch-all `location /`, so it never caps below 300s.
- The API runs plain uvicorn, which imposes no per-request timeout, and the endpoint sets none — confirmed by the observed behavior (backend completes and caches after the client 504).

## Verification

Built the console image from the updated template, brought up the `console` service via `docker-compose.release.yaml` (telemetry disabled), and inspected the rendered config inside the container:

```
$ grep -A1 'Durable fix' /etc/nginx/conf.d/default.conf
        proxy_send_timeout 300s;
        proxy_read_timeout 300s;
$ nginx -t
nginx: configuration file /etc/nginx/nginx.conf test is successful
```

`helm template` renders the configmap with 300s in `/api/` and 1860s preserved for the permission-check block. Compose project and volumes fully torn down afterwards.

## Follow-up

The proper fix — running suggestion generation and replay verification as async jobs with polling/SSE instead of one long synchronous request — is tracked as a follow-up and deliberately not part of this change.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only change: nginx proxy timeouts raised from 60s → 300s for `/api/` only. Both docker and helm paths updated consistently.
>
> **Overview**
> Fixes 504 Gateway Timeout errors for long-running LLM-powered API requests (~90s) by increasing the console nginx proxy timeouts for the `/api/` location. Static asset serving and the permission-check endpoint's 1860s timeout are unchanged.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit `main`. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->