### PR TITLE
Time-boxed approval bypasses for approval and notification fatigue

### DIFF
--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -31,6 +31,7 @@ from preloop.api.endpoints import (
     agent_permission,
     anthropic_gateway,
     audio,
+    approval_bypass,
     approval_requests,
     comments,
     cost,
@@ -854,6 +855,12 @@ def create_app() -> FastAPI:
             approval_requests.router,
             prefix="/api/v1",
             tags=["Approval Requests"],
+            dependencies=[Depends(get_current_active_user)],
+        )
+        app.include_router(
+            approval_bypass.router,
+            prefix="/api/v1",
+            tags=["Approval Bypasses"],
             dependencies=[Depends(get_current_active_user)],
         )
         app.include_router(

--- a/backend/preloop/api/endpoints/__init__.py
+++ b/backend/preloop/api/endpoints/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "agent_control",
     "anthropic_gateway",
     "audio",
+    "approval_bypass",
     "approval_requests",
     "comments",
     "cost",

--- a/backend/preloop/api/endpoints/approval_bypass.py
+++ b/backend/preloop/api/endpoints/approval_bypass.py
@@ -1,0 +1,250 @@
+"""API endpoints for time-boxed approval bypasses.
+
+These endpoints are the escape hatch for approval and notification fatigue: an
+onboarded agent generating approval requests faster than a human can act, with
+push, watch, and email all firing at once.
+
+Design constraints encoded here:
+
+* Every bypass expires. ``duration_minutes`` is required and bounded, so there
+  is no request shape that means "forever".
+* A bypass is created by an authenticated user and always applies to *that*
+  user. You cannot open a hole in somebody else's gating.
+* Creating and revoking are both cheap and idempotent-ish, because the person
+  using them is in a hurry and probably on a phone.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timedelta
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from preloop.api.auth import get_current_active_user
+from preloop.models.crud import crud_approval_bypass
+from preloop.models.db.session import get_db_session
+from preloop.models.models.approval_bypass import (
+    ApprovalBypass,
+    ApprovalBypassMode,
+)
+from preloop.models.models.user import User
+from preloop.schemas.approval_bypass import (
+    ApprovalBypassCreate,
+    ApprovalBypassResponse,
+    ApprovalBypassStatus,
+)
+from preloop.utils.permissions import require_permission
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/approval-bypasses",
+    tags=["approval_bypasses"],
+)
+
+
+@router.get("/status", response_model=ApprovalBypassStatus)
+def get_bypass_status(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+) -> ApprovalBypassStatus:
+    """Report whether any bypass is currently in force for this user.
+
+    Console and mobile poll this to drive the persistent warning banner. It is
+    intentionally readable by any authenticated user without a special
+    permission: knowing that governance is currently relaxed is not privileged
+    information, and hiding it would defeat the point.
+
+    Args:
+        current_user: Current authenticated user.
+        db: Database session.
+
+    Returns:
+        Aggregate bypass status for banner rendering.
+    """
+    active = [
+        b
+        for b in crud_approval_bypass.list_active_for_account(
+            db, account_id=current_user.account_id
+        )
+        if b.user_id == current_user.id
+    ]
+    responses = [ApprovalBypassResponse.model_validate(b) for b in active]
+    return ApprovalBypassStatus(
+        active=bool(responses),
+        auto_approve_active=any(
+            b.mode == ApprovalBypassMode.AUTO_APPROVE for b in active
+        ),
+        bypasses=responses,
+    )
+
+
+@router.get("", response_model=List[ApprovalBypassResponse])
+@require_permission("view_approvals")
+def list_bypasses(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+) -> List[ApprovalBypass]:
+    """List every active bypass in the account.
+
+    Account-wide visibility is deliberate: if a teammate has relaxed gating,
+    everyone governing the same fleet should be able to see it.
+
+    Args:
+        current_user: Current authenticated user.
+        db: Database session.
+
+    Returns:
+        Active bypasses, soonest-expiring last.
+    """
+    return crud_approval_bypass.list_active_for_account(
+        db, account_id=current_user.account_id
+    )
+
+
+@router.post("", response_model=ApprovalBypassResponse, status_code=201)
+@require_permission("view_approvals")
+def create_bypass(
+    payload: ApprovalBypassCreate,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+) -> ApprovalBypass:
+    """Open a time-boxed bypass for the calling user.
+
+    The bypass always targets ``current_user``; there is no parameter to target
+    somebody else. Duration is validated by the schema against the hard cap, so
+    an unbounded bypass cannot be constructed.
+
+    Args:
+        payload: Mode, duration, optional agent scope and reason.
+        current_user: Current authenticated user (the bypass subject).
+        db: Database session.
+
+    Returns:
+        The created bypass.
+
+    Raises:
+        HTTPException: If the duration is outside the permitted range.
+    """
+    expires_at = datetime.utcnow() + timedelta(minutes=payload.duration_minutes)
+
+    bypass = ApprovalBypass(
+        id=uuid.uuid4(),
+        account_id=current_user.account_id,
+        user_id=current_user.id,
+        managed_agent_id=payload.managed_agent_id,
+        mode=payload.mode,
+        reason=payload.reason,
+        created_by_user_id=current_user.id,
+        created_via=payload.created_via,
+        expires_at=expires_at,
+        auto_approved_count=0,
+    )
+    db.add(bypass)
+    db.commit()
+    db.refresh(bypass)
+
+    # Log loudly. A governance bypass being opened is a security-relevant
+    # event and should be greppable in the server log without a DB query.
+    logger.warning(
+        "APPROVAL BYPASS OPENED: mode=%s user=%s account=%s scope=%s "
+        "expires_at=%s via=%s reason=%r",
+        bypass.mode,
+        bypass.user_id,
+        bypass.account_id,
+        bypass.managed_agent_id or "account-wide",
+        bypass.expires_at.isoformat(),
+        bypass.created_via,
+        bypass.reason,
+    )
+    return bypass
+
+
+@router.delete("/{bypass_id}", response_model=ApprovalBypassResponse)
+@require_permission("view_approvals")
+def revoke_bypass(
+    bypass_id: uuid.UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+) -> ApprovalBypass:
+    """End a bypass early.
+
+    Any user who can view approvals in the account may revoke a bypass, even
+    one they did not create. Re-tightening a control is always safe, so it
+    should never be blocked on ownership.
+
+    Args:
+        bypass_id: The bypass to revoke.
+        current_user: Current authenticated user.
+        db: Database session.
+
+    Returns:
+        The revoked bypass.
+
+    Raises:
+        HTTPException: If the bypass is not found in this account.
+    """
+    existing = crud_approval_bypass.get(
+        db, id=str(bypass_id), account_id=str(current_user.account_id)
+    )
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Approval bypass not found")
+
+    revoked = crud_approval_bypass.revoke(
+        db, bypass_id=bypass_id, revoked_by_user_id=current_user.id
+    )
+    if revoked is None:  # pragma: no cover - defensive
+        raise HTTPException(status_code=404, detail="Approval bypass not found")
+
+    logger.warning(
+        "APPROVAL BYPASS REVOKED: id=%s mode=%s by=%s auto_approved_count=%s",
+        revoked.id,
+        revoked.mode,
+        current_user.id,
+        revoked.auto_approved_count,
+    )
+    return revoked
+
+
+@router.post("/revoke-all", response_model=List[ApprovalBypassResponse])
+@require_permission("view_approvals")
+def revoke_all_bypasses(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+) -> List[ApprovalBypass]:
+    """Revoke every active bypass in the account — the 'panic off' button.
+
+    Exists so that restoring full governance is always a single unambiguous
+    action, with no list to scroll and no per-item taps, from any surface.
+
+    Args:
+        current_user: Current authenticated user.
+        db: Database session.
+
+    Returns:
+        The bypasses that were revoked.
+    """
+    active = crud_approval_bypass.list_active_for_account(
+        db, account_id=current_user.account_id
+    )
+    revoked: List[ApprovalBypass] = []
+    for bypass in active:
+        result = crud_approval_bypass.revoke(
+            db,
+            bypass_id=bypass.id,
+            revoked_by_user_id=current_user.id,
+            commit=False,
+        )
+        if result is not None:
+            revoked.append(result)
+    db.commit()
+
+    logger.warning(
+        "ALL APPROVAL BYPASSES REVOKED: account=%s count=%s by=%s",
+        current_user.account_id,
+        len(revoked),
+        current_user.id,
+    )
+    return revoked

--- a/backend/preloop/models/alembic/versions/20260718_add_approval_bypass.py
+++ b/backend/preloop/models/alembic/versions/20260718_add_approval_bypass.py
@@ -1,0 +1,159 @@
+"""Add time-boxed approval bypasses and auto-approval markers.
+
+Revision ID: 20260718_approval_bypass
+Revises: 20260714_growth_analytics
+Create Date: 2026-07-18
+
+Adds:
+* ``approval_bypass`` — time-boxed, attributable suppressions of approval
+  gating (``auto_approve``) or of notification fan-out only
+  (``mute_notifications``).
+* ``approval_request.auto_approved_reason`` / ``auto_approval_bypass_id`` —
+  markers so a request auto-approved under a bypass is permanently
+  distinguishable from a human decision and from an AI decision.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "20260718_approval_bypass"
+down_revision = "20260714_growth_analytics"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the approval_bypass table and approval-request markers."""
+    approval_bypass_mode = sa.Enum(
+        "mute_notifications",
+        "auto_approve",
+        name="approval_bypass_mode",
+    )
+    approval_bypass_mode.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "approval_bypass",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "account_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("account.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("managed_agent_id", UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "mode",
+            approval_bypass_mode,
+            nullable=False,
+        ),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column(
+            "created_by_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("created_via", sa.String(length=32), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "revoked_by_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "auto_approved_count",
+            sa.Integer(),
+            server_default="0",
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_approval_bypass_id", "approval_bypass", ["id"], unique=False)
+    op.create_index("ix_approval_bypass_account_id", "approval_bypass", ["account_id"])
+    op.create_index("ix_approval_bypass_user_id", "approval_bypass", ["user_id"])
+    op.create_index(
+        "ix_approval_bypass_managed_agent_id",
+        "approval_bypass",
+        ["managed_agent_id"],
+    )
+    op.create_index("ix_approval_bypass_mode", "approval_bypass", ["mode"])
+    op.create_index("ix_approval_bypass_expires_at", "approval_bypass", ["expires_at"])
+    op.create_index(
+        "ix_approval_bypass_lookup",
+        "approval_bypass",
+        ["account_id", "user_id", "expires_at"],
+    )
+
+    op.add_column(
+        "approval_request",
+        sa.Column("auto_approved_reason", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "approval_request",
+        sa.Column(
+            "auto_approval_bypass_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("approval_bypass.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_approval_request_auto_approved_reason",
+        "approval_request",
+        ["auto_approved_reason"],
+    )
+    op.create_index(
+        "ix_approval_request_auto_approval_bypass_id",
+        "approval_request",
+        ["auto_approval_bypass_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the approval_bypass table and approval-request markers."""
+    op.drop_index(
+        "ix_approval_request_auto_approval_bypass_id",
+        table_name="approval_request",
+    )
+    op.drop_index(
+        "ix_approval_request_auto_approved_reason", table_name="approval_request"
+    )
+    op.drop_column("approval_request", "auto_approval_bypass_id")
+    op.drop_column("approval_request", "auto_approved_reason")
+
+    op.drop_index("ix_approval_bypass_lookup", table_name="approval_bypass")
+    op.drop_index("ix_approval_bypass_expires_at", table_name="approval_bypass")
+    op.drop_index("ix_approval_bypass_mode", table_name="approval_bypass")
+    op.drop_index("ix_approval_bypass_managed_agent_id", table_name="approval_bypass")
+    op.drop_index("ix_approval_bypass_user_id", table_name="approval_bypass")
+    op.drop_index("ix_approval_bypass_account_id", table_name="approval_bypass")
+    op.drop_index("ix_approval_bypass_id", table_name="approval_bypass")
+    op.drop_table("approval_bypass")
+
+    sa.Enum(name="approval_bypass_mode").drop(op.get_bind(), checkfirst=True)

--- a/backend/preloop/models/crud/__init__.py
+++ b/backend/preloop/models/crud/__init__.py
@@ -68,6 +68,12 @@ from .tool_configuration import CRUDToolConfiguration
 from .mcp_server import CRUDMCPServer
 from .mcp_tool import CRUDMCPTool
 from .approval_workflow import CRUDApprovalWorkflow
+from .approval_bypass import (
+    CRUDApprovalBypass,
+    crud_approval_bypass,
+    get_active_bypass_async,
+    record_bypass_use_async,
+)
 from .approval_request import CRUDApprovalRequest, crud_approval_request
 from .tool_access_rule import CRUDToolAccessRule
 from .gateway_usage_search_document import CRUDGatewayUsageSearchDocument
@@ -258,6 +264,10 @@ __all__ = [
     "crud_mcp_tool",
     "crud_approval_workflow",
     "crud_approval_request",
+    "CRUDApprovalBypass",
+    "crud_approval_bypass",
+    "get_active_bypass_async",
+    "record_bypass_use_async",
     "crud_tool_access_rule",
     "plan",
     "subscription",

--- a/backend/preloop/models/crud/approval_bypass.py
+++ b/backend/preloop/models/crud/approval_bypass.py
@@ -1,0 +1,193 @@
+"""CRUD operations for ApprovalBypass model.
+
+Resolution rule used by :func:`get_active_bypass_async`: when several bypasses
+could apply, the **strongest** one wins, and among equals the one expiring
+latest. Agent-scoped and account-wide bypasses are both considered, because a
+user who has muted everything account-wide should not keep getting buzzed by
+one agent that happens to have no agent-scoped row.
+"""
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy import or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.orm import Session
+
+from ..models.approval_bypass import ApprovalBypass, ApprovalBypassMode
+from .base import CRUDBase
+
+#: Strength ordering. ``auto_approve`` subsumes ``mute_notifications``: it also
+#: suppresses notifications, so it must win when both are in force.
+_MODE_STRENGTH = {
+    ApprovalBypassMode.MUTE_NOTIFICATIONS: 1,
+    ApprovalBypassMode.AUTO_APPROVE: 2,
+}
+
+
+class CRUDApprovalBypass(CRUDBase[ApprovalBypass]):
+    """CRUD operations for ApprovalBypass model."""
+
+    def get_active_for_user(
+        self,
+        db: Session,
+        *,
+        account_id: UUID,
+        user_id: UUID,
+        managed_agent_id: Optional[UUID] = None,
+        now: Optional[datetime] = None,
+    ) -> Optional[ApprovalBypass]:
+        """Return the strongest active bypass for a user/agent pair.
+
+        Args:
+            db: Sync database session.
+            account_id: Owning account.
+            user_id: User whose approvals may be bypassed.
+            managed_agent_id: Agent raising the request, if known.
+            now: Reference time; defaults to :func:`datetime.utcnow`.
+
+        Returns:
+            The winning :class:`ApprovalBypass`, or None when none applies.
+        """
+        reference = now or datetime.utcnow()
+        candidates = (
+            db.query(self.model)
+            .filter(
+                self.model.account_id == account_id,
+                self.model.user_id == user_id,
+                self.model.revoked_at.is_(None),
+                self.model.expires_at > reference,
+                or_(
+                    self.model.managed_agent_id.is_(None),
+                    self.model.managed_agent_id == managed_agent_id,
+                )
+                if managed_agent_id is not None
+                else self.model.managed_agent_id.is_(None),
+            )
+            .all()
+        )
+        return _strongest(candidates)
+
+    def list_active_for_account(
+        self,
+        db: Session,
+        *,
+        account_id: UUID,
+        now: Optional[datetime] = None,
+    ) -> List[ApprovalBypass]:
+        """List every active bypass in an account, newest expiry first."""
+        reference = now or datetime.utcnow()
+        return (
+            db.query(self.model)
+            .filter(
+                self.model.account_id == account_id,
+                self.model.revoked_at.is_(None),
+                self.model.expires_at > reference,
+            )
+            .order_by(self.model.expires_at.desc())
+            .all()
+        )
+
+    def revoke(
+        self,
+        db: Session,
+        *,
+        bypass_id: UUID,
+        revoked_by_user_id: UUID,
+        now: Optional[datetime] = None,
+        commit: bool = True,
+    ) -> Optional[ApprovalBypass]:
+        """End a bypass early, preserving the record that it existed."""
+        bypass = db.query(self.model).filter(self.model.id == bypass_id).first()
+        if bypass is None:
+            return None
+        if bypass.revoked_at is None:
+            bypass.revoked_at = now or datetime.utcnow()
+            bypass.revoked_by_user_id = revoked_by_user_id
+            if commit:
+                db.commit()
+                db.refresh(bypass)
+        return bypass
+
+
+crud_approval_bypass = CRUDApprovalBypass(ApprovalBypass)
+
+
+def _strongest(candidates: List[ApprovalBypass]) -> Optional[ApprovalBypass]:
+    """Pick the strongest bypass, tie-broken by latest expiry.
+
+    Args:
+        candidates: Active bypasses that all apply to the same request.
+
+    Returns:
+        The winning bypass, or None when the list is empty.
+    """
+    if not candidates:
+        return None
+    return max(
+        candidates,
+        key=lambda b: (_MODE_STRENGTH.get(b.mode, 0), b.expires_at),
+    )
+
+
+async def get_active_bypass_async(
+    db: AsyncSession,
+    *,
+    account_id: UUID,
+    user_id: UUID,
+    managed_agent_id: Optional[UUID] = None,
+    now: Optional[datetime] = None,
+) -> Optional[ApprovalBypass]:
+    """Async variant of :meth:`CRUDApprovalBypass.get_active_for_user`.
+
+    Args:
+        db: Async database session.
+        account_id: Owning account.
+        user_id: User whose approvals may be bypassed.
+        managed_agent_id: Agent raising the request, if known.
+        now: Reference time; defaults to :func:`datetime.utcnow`.
+
+    Returns:
+        The winning :class:`ApprovalBypass`, or None when none applies.
+    """
+    reference = now or datetime.utcnow()
+    scope_filter = (
+        or_(
+            ApprovalBypass.managed_agent_id.is_(None),
+            ApprovalBypass.managed_agent_id == managed_agent_id,
+        )
+        if managed_agent_id is not None
+        else ApprovalBypass.managed_agent_id.is_(None)
+    )
+    result = await db.execute(
+        select(ApprovalBypass).where(
+            ApprovalBypass.account_id == account_id,
+            ApprovalBypass.user_id == user_id,
+            ApprovalBypass.revoked_at.is_(None),
+            ApprovalBypass.expires_at > reference,
+            scope_filter,
+        )
+    )
+    return _strongest(list(result.scalars().all()))
+
+
+async def record_bypass_use_async(
+    db: AsyncSession,
+    *,
+    bypass_id: UUID,
+) -> None:
+    """Increment the auto-approval counter on a bypass.
+
+    Args:
+        db: Async database session.
+        bypass_id: Bypass that auto-approved a request.
+    """
+    result = await db.execute(
+        select(ApprovalBypass).where(ApprovalBypass.id == bypass_id)
+    )
+    bypass = result.scalars().first()
+    if bypass is not None:
+        bypass.auto_approved_count = (bypass.auto_approved_count or 0) + 1
+        await db.commit()

--- a/backend/preloop/models/models/__init__.py
+++ b/backend/preloop/models/models/__init__.py
@@ -33,6 +33,12 @@ from .provider_billing import ProviderBillingConnection, ProviderBillingSnapshot
 from .tool_configuration import ToolConfiguration, ApprovalWorkflow
 from .mcp_server import MCPServer
 from .mcp_tool import MCPTool
+from .approval_bypass import (
+    ApprovalBypass,
+    ApprovalBypassMode,
+    DEFAULT_BYPASS_DURATION,
+    MAX_BYPASS_DURATION,
+)
 from .approval_request import ApprovalRequest, ApprovalRequestStatus
 from .approval_event import ApprovalEvent
 from .tool_access_rule import ToolAccessRule
@@ -108,6 +114,10 @@ __all__ = [
     "ApprovalWorkflow",
     "MCPServer",
     "MCPTool",
+    "ApprovalBypass",
+    "ApprovalBypassMode",
+    "DEFAULT_BYPASS_DURATION",
+    "MAX_BYPASS_DURATION",
     "ApprovalRequest",
     "ApprovalRequestStatus",
     "ApprovalEvent",

--- a/backend/preloop/models/models/__init__.py
+++ b/backend/preloop/models/models/__init__.py
@@ -39,7 +39,11 @@ from .approval_bypass import (
     DEFAULT_BYPASS_DURATION,
     MAX_BYPASS_DURATION,
 )
-from .approval_request import ApprovalRequest, ApprovalRequestStatus
+from .approval_request import (
+    ApprovalRequest,
+    ApprovalRequestStatus,
+    AutoApprovedReason,
+)
 from .approval_event import ApprovalEvent
 from .tool_access_rule import ToolAccessRule
 from .notification_preferences import NotificationPreferences
@@ -120,6 +124,7 @@ __all__ = [
     "MAX_BYPASS_DURATION",
     "ApprovalRequest",
     "ApprovalRequestStatus",
+    "AutoApprovedReason",
     "ApprovalEvent",
     "ToolAccessRule",
     "NotificationPreferences",

--- a/backend/preloop/models/models/approval_bypass.py
+++ b/backend/preloop/models/models/approval_bypass.py
@@ -1,0 +1,202 @@
+"""Time-boxed approval bypasses ("panic switch" for approval/notification fatigue).
+
+An :class:`ApprovalBypass` is a deliberate, *expiring* relaxation of approval
+gating for one user, optionally narrowed to a single managed agent.
+
+Two independent modes exist because notification fatigue and approval fatigue
+are different problems:
+
+``mute_notifications``
+    Approval requests are still created and still **block** the agent. Only the
+    outbound notification fan-out (push/email/webhook) is suppressed. The user
+    stops being buzzed but keeps full control; they decide from the console or
+    the app when they choose to look.
+
+``auto_approve``
+    Approval requests are created, recorded, and **immediately auto-approved**
+    without notifying anyone. This is the governance bypass — the equivalent of
+    ``--dangerously-skip-permissions``. It is the escape hatch for a runaway
+    agent, not a normal operating mode.
+
+Safety properties, all deliberate:
+
+* **Always time-boxed.** ``expires_at`` is NOT NULL and is capped by
+  :data:`MAX_BYPASS_DURATION`. A bypass cannot be created that never ends, so
+  it cannot be silently forgotten — the single largest risk of an indefinite
+  "skip permissions" toggle.
+* **Always attributable.** ``created_by_user_id`` and ``reason`` record who
+  opened the hole and why.
+* **Always recorded.** Requests auto-approved under a bypass are still
+  persisted as :class:`ApprovalRequest` rows carrying
+  ``auto_approved_reason='bypass'`` and ``auto_approval_bypass_id``, so the
+  audit trail shows exactly what ran unsupervised and under whose authority.
+  Suppressing the *notification* solves the actual pain; suppressing the
+  *record* would only destroy evidence.
+* **Revocable.** ``revoked_at`` ends a bypass early without deleting the
+  history of it having existed.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text
+from sqlalchemy import Enum as SQLEnum
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from .account import Account
+    from .user import User
+
+
+class ApprovalBypassMode(str):
+    """Mode of an approval bypass."""
+
+    #: Suppress notifications only; approvals still block the agent.
+    MUTE_NOTIFICATIONS = "mute_notifications"
+    #: Auto-approve and suppress notifications. Governance bypass.
+    AUTO_APPROVE = "auto_approve"
+
+
+#: Longest bypass that may be created in a single call. Deliberately short:
+#: a bypass is an escape hatch from a runaway agent, not a configuration mode.
+#: Re-arming is cheap and forces a conscious re-decision.
+MAX_BYPASS_DURATION = timedelta(hours=8)
+
+#: Default when the caller does not specify. One hour is long enough to finish
+#: whatever the agent is doing, short enough that forgetting it is not a
+#: security incident.
+DEFAULT_BYPASS_DURATION = timedelta(hours=1)
+
+
+class ApprovalBypass(Base):
+    """A time-boxed suppression of approval gating and/or notifications."""
+
+    __tablename__ = "approval_bypass"
+    __table_args__ = (
+        Index(
+            "ix_approval_bypass_lookup",
+            "account_id",
+            "user_id",
+            "expires_at",
+        ),
+    )
+
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("account.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Account this bypass belongs to",
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="User whose approval requests are bypassed",
+    )
+
+    managed_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=True,
+        index=True,
+        comment=(
+            "Managed agent this bypass is scoped to. NULL means account-wide "
+            "for this user (the 'global switch')."
+        ),
+    )
+
+    mode: Mapped[str] = mapped_column(
+        SQLEnum(
+            "mute_notifications",
+            "auto_approve",
+            name="approval_bypass_mode",
+        ),
+        nullable=False,
+        index=True,
+        comment="'mute_notifications' (still blocks) or 'auto_approve' (bypass)",
+    )
+
+    reason: Mapped[Optional[str]] = mapped_column(
+        Text,
+        nullable=True,
+        comment="Operator-supplied justification for opening the bypass",
+    )
+
+    created_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+        comment="User who created the bypass (for attribution)",
+    )
+
+    created_via: Mapped[Optional[str]] = mapped_column(
+        String(32),
+        nullable=True,
+        comment="Originating surface: console|mobile|watch|api|cli",
+    )
+
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        index=True,
+        comment="When the bypass automatically ends. NOT NULL by design.",
+    )
+
+    revoked_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime,
+        nullable=True,
+        comment="When the bypass was ended early, if it was",
+    )
+
+    revoked_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="User who revoked the bypass early",
+    )
+
+    #: Number of approval requests auto-approved under this bypass. Maintained
+    #: incrementally so the console can show "47 calls ran unsupervised"
+    #: without an aggregate query on every render.
+    auto_approved_count: Mapped[int] = mapped_column(
+        nullable=False,
+        default=0,
+        server_default="0",
+        comment="How many approval requests this bypass auto-approved",
+    )
+
+    account: Mapped["Account"] = relationship("Account")
+    user: Mapped["User"] = relationship("User", foreign_keys=[user_id])
+    created_by: Mapped["User"] = relationship("User", foreign_keys=[created_by_user_id])
+
+    def is_active(self, now: Optional[datetime] = None) -> bool:
+        """Whether this bypass is currently in force.
+
+        Args:
+            now: Reference time; defaults to :func:`datetime.utcnow`.
+
+        Returns:
+            True when the bypass is neither revoked nor expired.
+        """
+        reference = now or datetime.utcnow()
+        if self.revoked_at is not None:
+            return False
+        return self.expires_at > reference
+
+    def __repr__(self) -> str:
+        """String representation."""
+        scope = (
+            f"agent={self.managed_agent_id}"
+            if self.managed_agent_id
+            else "account-wide"
+        )
+        return (
+            f"<ApprovalBypass(id={self.id}, mode={self.mode}, {scope}, "
+            f"user={self.user_id}, expires_at={self.expires_at})>"
+        )

--- a/backend/preloop/models/models/approval_request.py
+++ b/backend/preloop/models/models/approval_request.py
@@ -28,6 +28,27 @@ class ApprovalRequestStatus(str):
     CANCELLED = "cancelled"
 
 
+class AutoApprovedReason(str):
+    """Why a request was approved without a human looking at it.
+
+    Every value here means "no person judged this call". Surfaces must render
+    these distinctly from human decisions, and statistics must never count
+    them as approvals (see ``ApprovalRequestResponse.decided_by_human``).
+    """
+
+    #: A time-boxed :class:`ApprovalBypass` was in force. Carries a
+    #: non-NULL ``auto_approval_bypass_id`` pointing at the authorizing row.
+    BYPASS = "bypass"
+
+    #: The managed agent's subject-governance config sets
+    #: ``native_tool_approvals: "off"``. This is a *standing configured*
+    #: bypass rather than a time-boxed one, so ``auto_approval_bypass_id``
+    #: is NULL: no ApprovalBypass row authorizes it, the account's own
+    #: governance config does. Recorded identically in every other respect
+    #: so the audit trail still shows what ran unsupervised.
+    NATIVE_TOOL_APPROVALS_OFF = "native_tool_approvals_off"
+
+
 class ApprovalRequest(Base):
     """Approval request for tool execution.
 

--- a/backend/preloop/models/models/approval_request.py
+++ b/backend/preloop/models/models/approval_request.py
@@ -234,6 +234,26 @@ class ApprovalRequest(Base):
         comment="AI's reasoning for the approval/denial decision",
     )
 
+    # Bypass tracking. Set when the request was resolved without a human because
+    # a time-boxed ApprovalBypass was in force. Kept distinct from decided_by_ai:
+    # an AI *judged* the call, a bypass merely *skipped* judging it. Surfaces
+    # must render these differently and must never count them as human
+    # approvals in approval-rate statistics.
+    auto_approved_reason: Mapped[Optional[str]] = mapped_column(
+        String(64),
+        nullable=True,
+        index=True,
+        comment="Why this request was auto-approved without a human (e.g. 'bypass')",
+    )
+
+    auto_approval_bypass_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("approval_bypass.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+        comment="The ApprovalBypass that auto-approved this request",
+    )
+
     # Relationships
     account: Mapped["Account"] = relationship(
         "Account", back_populates="approval_requests"

--- a/backend/preloop/models/schemas/approval_request.py
+++ b/backend/preloop/models/schemas/approval_request.py
@@ -50,6 +50,9 @@ class ApprovalRequestUpdate(BaseModel):
     ai_model: Optional[str] = None
     ai_confidence: Optional[float] = None
     ai_reasoning: Optional[str] = None
+    # Bypass tracking (auto-approved without a human under a time-boxed bypass)
+    auto_approved_reason: Optional[str] = None
+    auto_approval_bypass_id: Optional[UUID] = None
 
 
 class ApprovalRequestResponse(ApprovalRequestBase):
@@ -77,6 +80,28 @@ class ApprovalRequestResponse(ApprovalRequestBase):
     ai_model: Optional[str] = None
     ai_confidence: Optional[float] = None
     ai_reasoning: Optional[str] = None
+    # Bypass tracking. Set when a time-boxed ApprovalBypass resolved this
+    # request instead of a human. Surfaces MUST render these distinctly and
+    # MUST NOT count them as human approvals in approval-rate stats.
+    auto_approved_reason: Optional[str] = None
+    auto_approval_bypass_id: Optional[UUID] = None
+
+    @computed_field
+    def was_bypassed(self) -> bool:
+        """True when a bypass auto-approved this request without a human."""
+        return self.auto_approved_reason is not None
+
+    @computed_field
+    def decided_by_human(self) -> bool:
+        """True only when a person actually made this decision.
+
+        The single field every statistic should filter on. A request is a human
+        decision only if it reached a terminal decided state without an AI
+        judging it and without a bypass skipping it.
+        """
+        if self.status not in ("approved", "declined"):
+            return False
+        return not self.decided_by_ai and self.auto_approved_reason is None
 
     # Computed fields for backward compatibility
     @computed_field

--- a/backend/preloop/schemas/approval_bypass.py
+++ b/backend/preloop/schemas/approval_bypass.py
@@ -1,0 +1,106 @@
+"""Pydantic schemas for time-boxed approval bypasses."""
+
+from datetime import datetime
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+
+from preloop.models.models.approval_bypass import MAX_BYPASS_DURATION
+
+BypassMode = Literal["mute_notifications", "auto_approve"]
+
+#: Durations offered as one-tap presets. Kept short and few so the choice is
+#: instant for someone whose phone is buzzing.
+BYPASS_DURATION_PRESETS_MINUTES = (15, 60, 240, 480)
+
+MAX_BYPASS_MINUTES = int(MAX_BYPASS_DURATION.total_seconds() // 60)
+
+
+class ApprovalBypassCreate(BaseModel):
+    """Request body for opening a bypass.
+
+    ``duration_minutes`` is required and bounded — there is deliberately no way
+    to express "forever". An indefinite bypass is the failure mode this feature
+    exists to prevent.
+    """
+
+    mode: BypassMode = Field(
+        ...,
+        description=(
+            "'mute_notifications' silences alerts but still blocks the agent; "
+            "'auto_approve' also approves automatically (governance bypass)"
+        ),
+    )
+    duration_minutes: int = Field(
+        ...,
+        ge=1,
+        le=MAX_BYPASS_MINUTES,
+        description=f"How long the bypass lasts (1-{MAX_BYPASS_MINUTES} minutes)",
+    )
+    managed_agent_id: Optional[UUID] = Field(
+        None,
+        description="Scope to one agent. Omit for an account-wide bypass.",
+    )
+    reason: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Why the bypass was opened (recorded for audit)",
+    )
+    created_via: Optional[str] = Field(
+        None,
+        description="Originating surface: console|mobile|watch|api|cli",
+    )
+
+
+class ApprovalBypassResponse(BaseModel):
+    """A bypass as returned to console and mobile surfaces."""
+
+    id: UUID
+    account_id: UUID
+    user_id: UUID
+    managed_agent_id: Optional[UUID] = None
+    mode: str
+    reason: Optional[str] = None
+    created_by_user_id: UUID
+    created_via: Optional[str] = None
+    created_at: datetime
+    expires_at: datetime
+    revoked_at: Optional[datetime] = None
+    revoked_by_user_id: Optional[UUID] = None
+    auto_approved_count: int = 0
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @computed_field
+    def is_account_wide(self) -> bool:
+        """True when this bypass applies to every agent for the user."""
+        return self.managed_agent_id is None
+
+    @computed_field
+    def suppresses_approvals(self) -> bool:
+        """True when agents are auto-approved rather than merely unmuted."""
+        return self.mode == "auto_approve"
+
+
+class ApprovalBypassStatus(BaseModel):
+    """Aggregate 'is anything bypassed right now?' answer for banners.
+
+    Console and mobile poll this to decide whether to show the persistent
+    warning banner, so it is intentionally cheap and shaped for direct
+    rendering.
+    """
+
+    active: bool = Field(..., description="Whether any bypass is currently in force")
+    auto_approve_active: bool = Field(
+        ...,
+        description="Whether any active bypass is auto-approving (unsupervised)",
+    )
+    bypasses: list[ApprovalBypassResponse] = Field(default_factory=list)
+
+    @computed_field
+    def soonest_expiry(self) -> Optional[datetime]:
+        """Earliest expiry among active bypasses, for a countdown."""
+        if not self.bypasses:
+            return None
+        return min(b.expires_at for b in self.bypasses)

--- a/backend/preloop/schemas/subject_governance.py
+++ b/backend/preloop/schemas/subject_governance.py
@@ -27,9 +27,13 @@ class SubjectGovernanceConfig(BaseModel):
         None,
         description=(
             "Whether native tool-call approvals (agents permission-check) are "
-            'enforced for this subject. "off" makes the server auto-allow '
-            "escalated (ask) calls instead of asking a human; absent/None "
-            'means "enforce".'
+            'enforced for this subject. "off" makes the server auto-approve '
+            "escalated (ask) calls instead of asking a human; the calls are "
+            "still recorded as approval requests marked "
+            "auto_approved_reason='native_tool_approvals_off' and audited with "
+            "no approver, so the audit trail stays complete. Unlike a "
+            "time-boxed approval bypass this setting does not expire; it stays "
+            'off until changed. Absent/None means "enforce".'
         ),
     )
 

--- a/backend/preloop/services/agent_permission_service.py
+++ b/backend/preloop/services/agent_permission_service.py
@@ -287,9 +287,13 @@ async def request_agent_permission(
 
     Escalation can be disabled per agent: when the managed agent's
     subject-governance config sets ``native_tool_approvals`` to ``"off"``,
-    escalated (ask) calls are allowed immediately without creating an
-    approval request. Explicit client ``allow``/``deny`` decisions are
-    unaffected by that switch.
+    escalated (ask) calls are approved immediately without asking a human.
+    They are still **recorded**: an approval request row is created and
+    resolved with ``auto_approved_reason='native_tool_approvals_off'`` and
+    audited under the ``[BYPASS]`` prefix with no approver, so the audit trail
+    shows what ran unsupervised. Only the notification and the human gate are
+    skipped. Explicit client ``allow``/``deny`` decisions are unaffected by
+    that switch.
 
     Args:
         base_url: Preloop base URL for approval links and notifications.
@@ -320,12 +324,55 @@ async def request_agent_permission(
     from preloop.models.crud.approval_request import get_approval_request_async
 
     async with get_async_db_session() as db:
-        if managed_agent_id is not None and await _native_tool_approvals_disabled(
-            db, account_id, managed_agent_id
-        ):
+        approvals_off = managed_agent_id is not None and (
+            await _native_tool_approvals_disabled(db, account_id, managed_agent_id)
+        )
+        if approvals_off:
             logger.info(
                 "Native tool approvals are disabled for managed agent %s "
-                "(account %s); auto-allowing tool %s without an approval request",
+                "(account %s); recording an auto-approved request for tool %s",
+                managed_agent_id,
+                account_id,
+                tool_name,
+            )
+
+        try:
+            workflow = await _resolve_workflow(
+                db, account_id, user_id, managed_agent_id=managed_agent_id
+            )
+            timeout_seconds = workflow.timeout_seconds or 300
+            config = await _resolve_tool_config(db, account_id, tool_name, workflow.id)
+
+            service = ApprovalService(db, base_url)
+            approval = await service.create_and_notify(
+                account_id=account_id,
+                tool_configuration_id=config.id,
+                approval_workflow=workflow,
+                tool_name=tool_name,
+                tool_args=tool_input or {},
+                agent_reasoning=agent_reasoning,
+                execution_id=None,
+                user_id=user_id,
+                managed_agent_id=managed_agent_id,
+                runtime_session_id=runtime_session_id,
+                managed_agent_name=managed_agent_name,
+                standing_bypass_reason=(
+                    models.AutoApprovedReason.NATIVE_TOOL_APPROVALS_OFF
+                    if approvals_off
+                    else None
+                ),
+            )
+        except Exception:
+            # The recording path must never become a new way to block an agent
+            # whose operator explicitly switched approvals off. Losing the audit
+            # row is bad; silently gating a tool call the operator said should
+            # not be gated is worse, and would read as a regression. Enforced
+            # agents still fail closed by propagating.
+            if not approvals_off:
+                raise
+            logger.exception(
+                "Failed to record the auto-approved request for managed agent %s "
+                "(account %s, tool %s); allowing per governance config",
                 managed_agent_id,
                 account_id,
                 tool_name,
@@ -336,26 +383,6 @@ async def request_agent_permission(
                 None,
             )
 
-        workflow = await _resolve_workflow(
-            db, account_id, user_id, managed_agent_id=managed_agent_id
-        )
-        timeout_seconds = workflow.timeout_seconds or 300
-        config = await _resolve_tool_config(db, account_id, tool_name, workflow.id)
-
-        service = ApprovalService(db, base_url)
-        approval = await service.create_and_notify(
-            account_id=account_id,
-            tool_configuration_id=config.id,
-            approval_workflow=workflow,
-            tool_name=tool_name,
-            tool_args=tool_input or {},
-            agent_reasoning=agent_reasoning,
-            execution_id=None,
-            user_id=user_id,
-            managed_agent_id=managed_agent_id,
-            runtime_session_id=runtime_session_id,
-            managed_agent_name=managed_agent_name,
-        )
         request_id = str(approval.id)
         status = approval.status
         comment = approval.approver_comment

--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -12,7 +12,11 @@ from urllib.parse import urljoin
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from preloop.models.models import ApprovalRequest, ApprovalWorkflow
+from preloop.models.models import (
+    ApprovalRequest,
+    ApprovalWorkflow,
+    AutoApprovedReason,
+)
 from preloop.models.schemas.approval_request import (
     ApprovalRequestUpdate,
 )
@@ -1040,13 +1044,7 @@ class ApprovalService:
         approval_request: ApprovalRequest,
         bypass: ApprovalBypass,
     ) -> ApprovalRequest:
-        """Approve a request under a bypass, recording it as unsupervised.
-
-        The request row is kept — deliberately. Suppressing the notification is
-        what relieves the user; suppressing the record would only destroy the
-        evidence of what ran while nobody was watching, which is the opposite
-        of what a governance product should do. The row is marked so no
-        surface can mistake it for a human decision.
+        """Approve a request under a time-boxed bypass.
 
         Args:
             approval_request: The pending request to resolve.
@@ -1060,14 +1058,52 @@ class ApprovalService:
             f"Auto-approved without review: an approval bypass for {scope} is "
             f"active until {bypass.expires_at.isoformat()}Z"
         )
+        return await self._auto_approve_without_review(
+            approval_request,
+            reason_code=AutoApprovedReason.BYPASS,
+            reason=reason,
+            bypass=bypass,
+        )
 
+    async def _auto_approve_without_review(
+        self,
+        approval_request: ApprovalRequest,
+        *,
+        reason_code: str,
+        reason: str,
+        bypass: Optional[ApprovalBypass] = None,
+    ) -> ApprovalRequest:
+        """Approve a request with no human involved, recording it as such.
+
+        Shared by every "nobody looked at this" path: time-boxed bypasses and
+        the standing ``native_tool_approvals: "off"`` governance setting.
+
+        The request row is kept — deliberately. Suppressing the notification is
+        what relieves the user; suppressing the record would only destroy the
+        evidence of what ran while nobody was watching, which is the opposite
+        of what a governance product should do. The row is marked so no
+        surface can mistake it for a human decision.
+
+        Args:
+            approval_request: The pending request to resolve.
+            reason_code: An :class:`AutoApprovedReason` value stored in
+                ``auto_approved_reason``; this is what makes the request
+                machine-identifiable as unsupervised.
+            reason: Human-readable explanation shown to operators.
+            bypass: The authorizing bypass, when a time-boxed one exists.
+                None for standing configured bypasses, which are authorized by
+                the account's governance config rather than by a bypass row.
+
+        Returns:
+            The updated, approved approval request.
+        """
         update = ApprovalRequestUpdate(
             status="approved",
             approver_comment=reason,
             resolved_at=datetime.utcnow(),
             decided_by_ai=False,
-            auto_approved_reason="bypass",
-            auto_approval_bypass_id=bypass.id,
+            auto_approved_reason=reason_code,
+            auto_approval_bypass_id=bypass.id if bypass is not None else None,
         )
         updated_request = await self.update_approval_request(
             approval_request.id, update
@@ -1075,12 +1111,13 @@ class ApprovalService:
         if updated_request is None:  # pragma: no cover - defensive
             return approval_request
 
-        try:
-            await record_bypass_use_async(self.db, bypass_id=bypass.id)
-        except Exception as exc:  # pragma: no cover - counter is advisory
-            logger.warning(
-                "Failed to increment bypass %s usage counter: %s", bypass.id, exc
-            )
+        if bypass is not None:
+            try:
+                await record_bypass_use_async(self.db, bypass_id=bypass.id)
+            except Exception as exc:  # pragma: no cover - counter is advisory
+                logger.warning(
+                    "Failed to increment bypass %s usage counter: %s", bypass.id, exc
+                )
 
         await self._broadcast_approval_update(updated_request, "approved")
 
@@ -1097,9 +1134,11 @@ class ApprovalService:
         )
 
         logger.info(
-            "Approval request %s auto-approved under bypass %s (tool=%s, agent=%s)",
+            "Approval request %s auto-approved without review "
+            "(reason=%s, bypass=%s, tool=%s, agent=%s)",
             updated_request.id,
-            bypass.id,
+            reason_code,
+            bypass.id if bypass is not None else None,
             updated_request.tool_name,
             updated_request.managed_agent_id,
         )
@@ -1384,6 +1423,7 @@ class ApprovalService:
         managed_agent_id: Optional[uuid.UUID] = None,
         runtime_session_id: Optional[uuid.UUID] = None,
         managed_agent_name: Optional[str] = None,
+        standing_bypass_reason: Optional[str] = None,
     ) -> ApprovalRequest:
         """Create approval request and send notifications through configured channels.
 
@@ -1399,6 +1439,12 @@ class ApprovalService:
             agent_reasoning: Agent's reasoning for the tool call
             execution_id: Flow execution ID (if applicable)
             user_id: ID of the user who initiated the tool call
+            standing_bypass_reason: When set, the caller has already established
+                that a standing governance setting disables approval for this
+                request (currently only ``native_tool_approvals: "off"``). The
+                request is still created and recorded, then immediately
+                auto-approved without notifying anyone. Must be an
+                :class:`AutoApprovedReason` value.
 
         Returns:
             Created approval request (may be already resolved if AI-driven)
@@ -1448,6 +1494,23 @@ class ApprovalService:
                 approval_request.id,
                 summary_error,
                 exc_info=True,
+            )
+
+        # Standing configured bypass. The operator has turned approvals off for
+        # this subject in governance config, which is a durable setting rather
+        # than a time-boxed escape hatch — so it is deliberately NOT expressed
+        # as an ApprovalBypass row (those are always time-boxed, and inventing
+        # a never-expiring one would make that guarantee a lie). The request is
+        # still created, recorded and audited; only the notification and the
+        # human gate are skipped.
+        if standing_bypass_reason:
+            return await self._auto_approve_without_review(
+                approval_request,
+                reason_code=standing_bypass_reason,
+                reason=(
+                    "Auto-approved without review: native tool approvals are "
+                    "switched off for this agent in Preloop's governance settings"
+                ),
             )
 
         # Time-boxed bypass check. Runs BEFORE the AI branch: the operator has

--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -20,6 +20,11 @@ from preloop.models.crud.approval_request import (
     get_approval_request_async,
     get_approval_request_for_update_async,
 )
+from preloop.models.crud.approval_bypass import (
+    get_active_bypass_async,
+    record_bypass_use_async,
+)
+from preloop.models.models.approval_bypass import ApprovalBypass, ApprovalBypassMode
 from preloop.sync.services.event_bus import get_task_publisher
 from preloop.services.ai_approval_service import get_ai_approval_service
 
@@ -956,6 +961,150 @@ class ApprovalService:
 
         return (max(total, 1), is_exact)
 
+    async def _resolve_bypass(
+        self,
+        approval_workflow: ApprovalWorkflow,
+        account_id: str,
+        managed_agent_id: Optional[uuid.UUID],
+        required_mode: str,
+    ) -> Optional[ApprovalBypass]:
+        """Return an active bypass covering *every* approver, or None.
+
+        The unanimity rule is deliberate and is the main safety property here.
+        A bypass belongs to one user. If a workflow requires several approvers,
+        one of them muting their phone must not disable the gate for everybody
+        else — that would let a single person silently revoke a control other
+        people are relying on. So the bypass only takes effect when every
+        approver on the workflow has an active bypass of at least the required
+        strength. In the common single-approver case (an individual governing
+        their own agents, which is the case this feature was built for) that
+        reduces to "the one approver muted it".
+
+        When no approvers can be resolved the request is treated as *not*
+        bypassed. Failing closed is the only safe direction here.
+
+        Args:
+            approval_workflow: Workflow whose approvers gate the request.
+            account_id: Owning account.
+            managed_agent_id: Agent raising the request, if known.
+            required_mode: Minimum strength; ``auto_approve`` matches only
+                auto-approve bypasses, ``mute_notifications`` matches either.
+
+        Returns:
+            The bypass to attribute the decision to, or None.
+        """
+        try:
+            approver_user_ids = await self._get_all_approver_user_ids(approval_workflow)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "Could not resolve approvers for bypass check on workflow %s: %s; "
+                "failing closed (no bypass applied)",
+                approval_workflow.id,
+                exc,
+            )
+            return None
+
+        if not approver_user_ids:
+            return None
+
+        try:
+            account_uuid = uuid.UUID(str(account_id))
+        except (ValueError, AttributeError, TypeError):
+            logger.warning(
+                "Invalid account_id %r for bypass check; failing closed", account_id
+            )
+            return None
+
+        winning: Optional[ApprovalBypass] = None
+        for approver_id in approver_user_ids:
+            bypass = await get_active_bypass_async(
+                self.db,
+                account_id=account_uuid,
+                user_id=approver_id,
+                managed_agent_id=managed_agent_id,
+            )
+            if bypass is None:
+                return None
+            if (
+                required_mode == ApprovalBypassMode.AUTO_APPROVE
+                and bypass.mode != ApprovalBypassMode.AUTO_APPROVE
+            ):
+                return None
+            if winning is None:
+                winning = bypass
+
+        return winning
+
+    async def _auto_approve_via_bypass(
+        self,
+        approval_request: ApprovalRequest,
+        bypass: ApprovalBypass,
+    ) -> ApprovalRequest:
+        """Approve a request under a bypass, recording it as unsupervised.
+
+        The request row is kept — deliberately. Suppressing the notification is
+        what relieves the user; suppressing the record would only destroy the
+        evidence of what ran while nobody was watching, which is the opposite
+        of what a governance product should do. The row is marked so no
+        surface can mistake it for a human decision.
+
+        Args:
+            approval_request: The pending request to resolve.
+            bypass: The bypass authorizing the auto-approval.
+
+        Returns:
+            The updated, approved approval request.
+        """
+        scope = "all agents" if bypass.managed_agent_id is None else "this agent"
+        reason = (
+            f"Auto-approved without review: an approval bypass for {scope} is "
+            f"active until {bypass.expires_at.isoformat()}Z"
+        )
+
+        update = ApprovalRequestUpdate(
+            status="approved",
+            approver_comment=reason,
+            resolved_at=datetime.utcnow(),
+            decided_by_ai=False,
+            auto_approved_reason="bypass",
+            auto_approval_bypass_id=bypass.id,
+        )
+        updated_request = await self.update_approval_request(
+            approval_request.id, update
+        )
+        if updated_request is None:  # pragma: no cover - defensive
+            return approval_request
+
+        try:
+            await record_bypass_use_async(self.db, bypass_id=bypass.id)
+        except Exception as exc:  # pragma: no cover - counter is advisory
+            logger.warning(
+                "Failed to increment bypass %s usage counter: %s", bypass.id, exc
+            )
+
+        await self._broadcast_approval_update(updated_request, "approved")
+
+        # Audit with no approver_id: nobody approved this. The [BYPASS] prefix
+        # mirrors the [AI] convention so the audit timeline is scannable.
+        _log_approval_lifecycle_async(
+            account_id=str(updated_request.account_id),
+            approval_id=updated_request.id,
+            event="approved",
+            tool_name=updated_request.tool_name,
+            approver_id=None,
+            reason=f"[BYPASS] {reason}",
+            execution_id=updated_request.execution_id,
+        )
+
+        logger.info(
+            "Approval request %s auto-approved under bypass %s (tool=%s, agent=%s)",
+            updated_request.id,
+            bypass.id,
+            updated_request.tool_name,
+            updated_request.managed_agent_id,
+        )
+        return updated_request
+
     async def _auto_approve_request(
         self,
         request_id: uuid.UUID,
@@ -1301,6 +1450,30 @@ class ApprovalService:
                 exc_info=True,
             )
 
+        # Time-boxed bypass check. Runs BEFORE the AI branch: the operator has
+        # made an explicit, expiring, recorded decision to stop being asked, and
+        # that outranks (and is far cheaper than) an LLM evaluation.
+        try:
+            bypass = await self._resolve_bypass(
+                approval_workflow,
+                account_id,
+                managed_agent_id,
+                required_mode=ApprovalBypassMode.AUTO_APPROVE,
+            )
+        except Exception as bypass_error:  # pragma: no cover - defensive
+            # Fail closed: an error resolving the bypass must never silently
+            # turn into an auto-approval.
+            logger.error(
+                "Bypass resolution failed for %s: %s; enforcing approval",
+                approval_request.id,
+                bypass_error,
+                exc_info=True,
+            )
+            bypass = None
+
+        if bypass is not None:
+            return await self._auto_approve_via_bypass(approval_request, bypass)
+
         # Check if this is an AI-driven approval workflow
         if approval_workflow.approval_mode == "ai_driven":
             # Evaluate using AI
@@ -1475,6 +1648,40 @@ class ApprovalService:
         except (TypeError, AttributeError):
             # In tests, requested_at might be a mock - just continue
             pass
+
+        # Notification mute. Distinct from auto-approval: the request stays
+        # pending and keeps blocking the agent, we simply stop buzzing people.
+        # This is the control for "I am being spammed but I still want the
+        # gate", and it is the safer of the two escape hatches.
+        try:
+            mute = await self._resolve_bypass(
+                approval_workflow,
+                str(approval_request.account_id),
+                approval_request.managed_agent_id,
+                required_mode=ApprovalBypassMode.MUTE_NOTIFICATIONS,
+            )
+        except Exception as mute_error:  # pragma: no cover - defensive
+            logger.warning(
+                "Mute resolution failed for %s: %s; notifying normally",
+                approval_request.id,
+                mute_error,
+            )
+            mute = None
+
+        if mute is not None:
+            logger.info(
+                "Suppressing notifications for approval request %s under bypass "
+                "%s (mode=%s); the request still requires approval",
+                approval_request.id,
+                mute.id,
+                mute.mode,
+            )
+            return {
+                "skipped": True,
+                "reason": "notifications_muted",
+                "bypass_id": str(mute.id),
+                "expires_at": mute.expires_at.isoformat(),
+            }
 
         # Recover correlation_id from the originating MCP context so the audit
         # entries we emit below land in the same timeline group.

--- a/backend/tests/services/test_agent_permission_service.py
+++ b/backend/tests/services/test_agent_permission_service.py
@@ -167,29 +167,142 @@ def test_managed_agent_approval_workflow_pin_rejects_unsafe_segments() -> None:
         raise AssertionError("expected ValueError for non-UUID path segment")
 
 
-@pytest.mark.asyncio
-async def test_request_agent_permission_disabled_short_circuits_allow() -> None:
-    """native_tool_approvals="off" → immediate allow, no approval row created.
+def _governance_off_db(default_workflow: models.ApprovalWorkflow) -> AsyncMock:
+    """An async DB mock whose governance lookup reports approvals switched off."""
+    account = MagicMock()
+    account.meta_data = {}
 
-    The switch only affects escalated (ask) calls; the immediate allow carries
-    the documented reason and no ApprovalRequest is created or notified.
-    """
-    db = AsyncMock()
     setting_result = MagicMock()
     setting_result.scalar.return_value = "off"
-    db.execute = AsyncMock(return_value=setting_result)
+    account_and_workflow = MagicMock()
+    account_and_workflow.first.return_value = (account, None)
+    default_result = MagicMock()
+    default_result.scalars.return_value.first.return_value = default_workflow
+
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[setting_result, account_and_workflow, default_result]
+    )
+    return db
+
+
+@pytest.mark.asyncio
+async def test_request_agent_permission_disabled_records_auto_approval() -> None:
+    """native_tool_approvals="off" → allowed, but *recorded*, never silent.
+
+    This is the core of the migration away from the old invisible
+    short-circuit. The call must still produce an ApprovalRequest carrying
+    ``auto_approved_reason='native_tool_approvals_off'`` so the audit trail
+    shows what ran unsupervised; only the human gate and the notification are
+    skipped.
+    """
+    account_id = str(uuid.uuid4())
+    managed_agent_id = uuid.uuid4()
+    default_workflow = models.ApprovalWorkflow(
+        id=uuid.uuid4(),
+        account_id=account_id,
+        name="Default Approval Workflow",
+        approval_type=DEFAULT_APPROVAL_TYPE,
+        is_default=True,
+        timeout_seconds=300,
+    )
+    db = _governance_off_db(default_workflow)
+
+    tool_config = MagicMock()
+    tool_config.id = uuid.uuid4()
+
+    approval = MagicMock()
+    approval.id = uuid.uuid4()
+    approval.status = "approved"
+    approval.approver_comment = "Auto-approved without review"
 
     with (
         patch(
             "preloop.services.agent_permission_service.get_async_db_session"
         ) as mock_get_session,
         patch("preloop.services.approval_service.ApprovalService") as mock_service_cls,
+        patch(
+            "preloop.models.crud.tool_configuration."
+            "get_tool_config_by_name_and_source_async",
+            new=AsyncMock(return_value=tool_config),
+        ),
     ):
         mock_get_session.return_value.__aenter__.return_value = db
+        mock_service = AsyncMock()
+        mock_service.create_and_notify = AsyncMock(return_value=approval)
+        mock_service_cls.return_value = mock_service
+
+        decision, _reason, request_id = await request_agent_permission(
+            base_url="http://localhost",
+            account_id=account_id,
+            user_id=uuid.uuid4(),
+            managed_agent_id=managed_agent_id,
+            runtime_session_id=None,
+            managed_agent_name="Claude Code",
+            source="claude_code",
+            tool_name="Bash",
+            tool_input={"command": "ls"},
+            agent_reasoning=None,
+            client_decision=None,
+        )
+
+    # The agent is still allowed to proceed, exactly as before the migration.
+    assert decision == "allow"
+    # ...but now there is a request id, i.e. a record, where there was None.
+    assert request_id == str(approval.id)
+
+    mock_service.create_and_notify.assert_awaited_once()
+    kwargs = mock_service.create_and_notify.await_args.kwargs
+    assert (
+        kwargs["standing_bypass_reason"]
+        == models.AutoApprovedReason.NATIVE_TOOL_APPROVALS_OFF
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_agent_permission_disabled_allows_when_recording_fails() -> None:
+    """A recording failure must not start gating an agent set to "off".
+
+    The operator explicitly disabled approvals for this agent. Losing the audit
+    row is bad, but silently blocking a tool call they said should not be
+    blocked would be a regression, so this path fails *open* — and only this
+    path: enforced agents still propagate the error.
+    """
+    account_id = str(uuid.uuid4())
+    default_workflow = models.ApprovalWorkflow(
+        id=uuid.uuid4(),
+        account_id=account_id,
+        name="Default Approval Workflow",
+        approval_type=DEFAULT_APPROVAL_TYPE,
+        is_default=True,
+        timeout_seconds=300,
+    )
+    db = _governance_off_db(default_workflow)
+
+    tool_config = MagicMock()
+    tool_config.id = uuid.uuid4()
+
+    with (
+        patch(
+            "preloop.services.agent_permission_service.get_async_db_session"
+        ) as mock_get_session,
+        patch("preloop.services.approval_service.ApprovalService") as mock_service_cls,
+        patch(
+            "preloop.models.crud.tool_configuration."
+            "get_tool_config_by_name_and_source_async",
+            new=AsyncMock(return_value=tool_config),
+        ),
+    ):
+        mock_get_session.return_value.__aenter__.return_value = db
+        mock_service = AsyncMock()
+        mock_service.create_and_notify = AsyncMock(
+            side_effect=RuntimeError("database is on fire")
+        )
+        mock_service_cls.return_value = mock_service
 
         decision, reason, request_id = await request_agent_permission(
             base_url="http://localhost",
-            account_id=str(uuid.uuid4()),
+            account_id=account_id,
             user_id=uuid.uuid4(),
             managed_agent_id=uuid.uuid4(),
             runtime_session_id=None,
@@ -204,10 +317,68 @@ async def test_request_agent_permission_disabled_short_circuits_allow() -> None:
     assert decision == "allow"
     assert reason == "Native tool approvals are disabled for this agent in Preloop"
     assert request_id is None
-    # Only the governance lookup ran; no ApprovalRequest was created.
-    mock_service_cls.assert_not_called()
-    db.add.assert_not_called()
-    assert db.execute.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_request_agent_permission_enforced_propagates_recording_failure() -> None:
+    """An enforced agent must fail closed when the approval cannot be created."""
+    account_id = str(uuid.uuid4())
+    default_workflow = models.ApprovalWorkflow(
+        id=uuid.uuid4(),
+        account_id=account_id,
+        name="Default Approval Workflow",
+        approval_type=DEFAULT_APPROVAL_TYPE,
+        is_default=True,
+        timeout_seconds=300,
+    )
+    account = MagicMock()
+    account.meta_data = {}
+    setting_result = MagicMock()
+    setting_result.scalar.return_value = None
+    account_and_workflow = MagicMock()
+    account_and_workflow.first.return_value = (account, None)
+    default_result = MagicMock()
+    default_result.scalars.return_value.first.return_value = default_workflow
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[setting_result, account_and_workflow, default_result]
+    )
+
+    tool_config = MagicMock()
+    tool_config.id = uuid.uuid4()
+
+    with (
+        patch(
+            "preloop.services.agent_permission_service.get_async_db_session"
+        ) as mock_get_session,
+        patch("preloop.services.approval_service.ApprovalService") as mock_service_cls,
+        patch(
+            "preloop.models.crud.tool_configuration."
+            "get_tool_config_by_name_and_source_async",
+            new=AsyncMock(return_value=tool_config),
+        ),
+        pytest.raises(RuntimeError, match="database is on fire"),
+    ):
+        mock_get_session.return_value.__aenter__.return_value = db
+        mock_service = AsyncMock()
+        mock_service.create_and_notify = AsyncMock(
+            side_effect=RuntimeError("database is on fire")
+        )
+        mock_service_cls.return_value = mock_service
+
+        await request_agent_permission(
+            base_url="http://localhost",
+            account_id=account_id,
+            user_id=uuid.uuid4(),
+            managed_agent_id=uuid.uuid4(),
+            runtime_session_id=None,
+            managed_agent_name="Claude Code",
+            source="claude_code",
+            tool_name="Bash",
+            tool_input={"command": "ls"},
+            agent_reasoning=None,
+            client_decision=None,
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_approval_bypass.py
+++ b/backend/tests/services/test_approval_bypass.py
@@ -1,0 +1,526 @@
+"""Tests for time-boxed approval bypasses.
+
+These tests are deliberately weighted toward the *safety* properties rather
+than the happy path, because this feature intentionally disables the product's
+core guarantee. The invariants under test:
+
+1. A bypass never applies unless every approver has one (no unilateral
+   disarming of a shared control).
+2. An expired or revoked bypass has no effect.
+3. A ``mute_notifications`` bypass never auto-approves.
+4. Auto-approved requests are **recorded** and are permanently distinguishable
+   from human decisions.
+5. Any failure while resolving a bypass fails closed (approval still required).
+"""
+
+import uuid
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from preloop.models.models import ApprovalRequest, ApprovalWorkflow
+from preloop.models.models.approval_bypass import (
+    ApprovalBypass,
+    ApprovalBypassMode,
+    DEFAULT_BYPASS_DURATION,
+    MAX_BYPASS_DURATION,
+)
+from preloop.models.crud.approval_bypass import _strongest
+from preloop.models.schemas.approval_request import ApprovalRequestResponse
+from preloop.services.approval_service import ApprovalService
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def mock_db():
+    """Create mock async database session."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def approval_service(mock_db):
+    """Create ApprovalService with a mocked database."""
+    return ApprovalService(mock_db, "https://app.test.com")
+
+
+@pytest.fixture
+def workflow():
+    """Approval workflow with a single approver."""
+    wf = MagicMock(spec=ApprovalWorkflow)
+    wf.id = uuid.uuid4()
+    wf.approval_type = "slack"
+    wf.timeout_seconds = 300
+    wf.approval_config = {}
+    wf.approval_mode = "human"
+    return wf
+
+
+@pytest.fixture
+def account_id():
+    """Account id as the service receives it (a string)."""
+    return str(uuid.uuid4())
+
+
+def make_bypass(
+    *,
+    mode=ApprovalBypassMode.AUTO_APPROVE,
+    expires_in=timedelta(hours=1),
+    revoked=False,
+    managed_agent_id=None,
+    user_id=None,
+    account_id=None,
+):
+    """Build an ApprovalBypass instance for tests."""
+    bypass = ApprovalBypass(
+        id=uuid.uuid4(),
+        account_id=account_id or uuid.uuid4(),
+        user_id=user_id or uuid.uuid4(),
+        managed_agent_id=managed_agent_id,
+        mode=mode,
+        created_by_user_id=user_id or uuid.uuid4(),
+        expires_at=datetime.utcnow() + expires_in,
+        auto_approved_count=0,
+    )
+    if revoked:
+        bypass.revoked_at = datetime.utcnow()
+    return bypass
+
+
+# --------------------------------------------------------------------------
+# Model-level invariants
+# --------------------------------------------------------------------------
+
+
+class TestBypassModel:
+    """Invariants on the ApprovalBypass model itself."""
+
+    async def test_active_bypass_is_active(self):
+        """A fresh, unrevoked bypass is in force."""
+        assert make_bypass().is_active() is True
+
+    async def test_expired_bypass_is_not_active(self):
+        """An expired bypass stops applying without anyone intervening.
+
+        This is the whole point of time-boxing: forgetting is harmless.
+        """
+        assert make_bypass(expires_in=timedelta(seconds=-1)).is_active() is False
+
+    async def test_revoked_bypass_is_not_active(self):
+        """A revoked bypass stops applying even before its expiry."""
+        assert make_bypass(revoked=True).is_active() is False
+
+    async def test_default_duration_is_bounded_and_short(self):
+        """The default is an hour and the cap is not open-ended."""
+        assert DEFAULT_BYPASS_DURATION == timedelta(hours=1)
+        assert MAX_BYPASS_DURATION <= timedelta(hours=24)
+
+    async def test_auto_approve_outranks_mute(self):
+        """When both modes are active the stronger one wins."""
+        mute = make_bypass(mode=ApprovalBypassMode.MUTE_NOTIFICATIONS)
+        auto = make_bypass(mode=ApprovalBypassMode.AUTO_APPROVE)
+        assert _strongest([mute, auto]) is auto
+        assert _strongest([auto, mute]) is auto
+
+    async def test_strongest_of_empty_is_none(self):
+        """No candidates means no bypass."""
+        assert _strongest([]) is None
+
+
+# --------------------------------------------------------------------------
+# Resolution: who a bypass applies to
+# --------------------------------------------------------------------------
+
+
+class TestBypassResolution:
+    """_resolve_bypass must fail closed and must require unanimity."""
+
+    async def test_no_approvers_means_no_bypass(
+        self, approval_service, workflow, account_id
+    ):
+        """A workflow with no resolvable approvers is never bypassed."""
+        approval_service._get_all_approver_user_ids = AsyncMock(return_value=[])
+        result = await approval_service._resolve_bypass(
+            workflow, account_id, None, ApprovalBypassMode.AUTO_APPROVE
+        )
+        assert result is None
+
+    async def test_approver_lookup_failure_fails_closed(
+        self, approval_service, workflow, account_id
+    ):
+        """If approvers cannot be resolved, enforce approval rather than skip it."""
+        approval_service._get_all_approver_user_ids = AsyncMock(
+            side_effect=RuntimeError("db down")
+        )
+        result = await approval_service._resolve_bypass(
+            workflow, account_id, None, ApprovalBypassMode.AUTO_APPROVE
+        )
+        assert result is None
+
+    async def test_invalid_account_id_fails_closed(self, approval_service, workflow):
+        """A malformed account id must not be interpreted as 'bypass everything'."""
+        approval_service._get_all_approver_user_ids = AsyncMock(
+            return_value=[uuid.uuid4()]
+        )
+        result = await approval_service._resolve_bypass(
+            workflow, "not-a-uuid", None, ApprovalBypassMode.AUTO_APPROVE
+        )
+        assert result is None
+
+    async def test_single_approver_with_bypass_resolves(
+        self, approval_service, workflow, account_id
+    ):
+        """The common case: one approver who muted their own agents."""
+        approver = uuid.uuid4()
+        approval_service._get_all_approver_user_ids = AsyncMock(return_value=[approver])
+        bypass = make_bypass(user_id=approver)
+
+        with patch(
+            "preloop.services.approval_service.get_active_bypass_async",
+            AsyncMock(return_value=bypass),
+        ):
+            result = await approval_service._resolve_bypass(
+                workflow, account_id, None, ApprovalBypassMode.AUTO_APPROVE
+            )
+
+        assert result is bypass
+
+    async def test_partial_coverage_does_not_bypass(
+        self, approval_service, workflow, account_id
+    ):
+        """One approver's bypass must not disable the gate for the others.
+
+        This is the key multi-user safety property: a bypass is a personal
+        escape hatch, not a way to unilaterally revoke a shared control.
+        """
+        approver_a, approver_b = uuid.uuid4(), uuid.uuid4()
+        approval_service._get_all_approver_user_ids = AsyncMock(
+            return_value=[approver_a, approver_b]
+        )
+        bypass_a = make_bypass(user_id=approver_a)
+
+        async def _lookup(db, *, account_id, user_id, managed_agent_id=None, now=None):
+            return bypass_a if user_id == approver_a else None
+
+        with patch(
+            "preloop.services.approval_service.get_active_bypass_async",
+            AsyncMock(side_effect=_lookup),
+        ):
+            result = await approval_service._resolve_bypass(
+                workflow, account_id, None, ApprovalBypassMode.AUTO_APPROVE
+            )
+
+        assert result is None
+
+    async def test_mute_bypass_does_not_satisfy_auto_approve(
+        self, approval_service, workflow, account_id
+    ):
+        """Muting notifications must never silently become auto-approval.
+
+        These are separate controls precisely so a user can quiet their phone
+        without surrendering the gate.
+        """
+        approver = uuid.uuid4()
+        approval_service._get_all_approver_user_ids = AsyncMock(return_value=[approver])
+        mute = make_bypass(user_id=approver, mode=ApprovalBypassMode.MUTE_NOTIFICATIONS)
+
+        with patch(
+            "preloop.services.approval_service.get_active_bypass_async",
+            AsyncMock(return_value=mute),
+        ):
+            result = await approval_service._resolve_bypass(
+                workflow, account_id, None, ApprovalBypassMode.AUTO_APPROVE
+            )
+
+        assert result is None
+
+    async def test_auto_approve_satisfies_mute_requirement(
+        self, approval_service, workflow, account_id
+    ):
+        """auto_approve subsumes muting, so it satisfies a mute check."""
+        approver = uuid.uuid4()
+        approval_service._get_all_approver_user_ids = AsyncMock(return_value=[approver])
+        auto = make_bypass(user_id=approver, mode=ApprovalBypassMode.AUTO_APPROVE)
+
+        with patch(
+            "preloop.services.approval_service.get_active_bypass_async",
+            AsyncMock(return_value=auto),
+        ):
+            result = await approval_service._resolve_bypass(
+                workflow, account_id, None, ApprovalBypassMode.MUTE_NOTIFICATIONS
+            )
+
+        assert result is auto
+
+
+# --------------------------------------------------------------------------
+# Auto-approval is RECORDED and distinguishable
+# --------------------------------------------------------------------------
+
+
+class TestAutoApproveViaBypass:
+    """A bypassed approval must leave a clearly-marked audit record."""
+
+    @pytest.fixture
+    def pending_request(self, account_id):
+        """A pending approval request."""
+        req = MagicMock(spec=ApprovalRequest)
+        req.id = uuid.uuid4()
+        req.account_id = uuid.UUID(account_id)
+        req.tool_name = "Bash"
+        req.execution_id = None
+        req.managed_agent_id = None
+        req.status = "pending"
+        return req
+
+    async def test_records_bypass_markers(self, approval_service, pending_request):
+        """The row is updated with auto_approved_reason and the bypass id."""
+        bypass = make_bypass()
+        updated = MagicMock(spec=ApprovalRequest)
+        updated.id = pending_request.id
+        updated.account_id = pending_request.account_id
+        updated.tool_name = "Bash"
+        updated.execution_id = None
+        updated.managed_agent_id = None
+
+        approval_service.update_approval_request = AsyncMock(return_value=updated)
+        approval_service._broadcast_approval_update = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.approval_service.record_bypass_use_async",
+                AsyncMock(),
+            ),
+            patch(
+                "preloop.services.approval_service._log_approval_lifecycle_async"
+            ) as mock_log,
+        ):
+            result = await approval_service._auto_approve_via_bypass(
+                pending_request, bypass
+            )
+
+        assert result is updated
+        update_arg = approval_service.update_approval_request.call_args[0][1]
+        assert update_arg.status == "approved"
+        assert update_arg.auto_approved_reason == "bypass"
+        assert update_arg.auto_approval_bypass_id == bypass.id
+        # Crucially NOT marked as an AI decision - an AI judged nothing here.
+        assert update_arg.decided_by_ai is False
+
+        # Audit entry has no human approver and is tagged [BYPASS].
+        audit_kwargs = mock_log.call_args.kwargs
+        assert audit_kwargs["approver_id"] is None
+        assert audit_kwargs["reason"].startswith("[BYPASS]")
+
+    async def test_increments_usage_counter(self, approval_service, pending_request):
+        """Each auto-approval is counted so the console can show the blast radius."""
+        bypass = make_bypass()
+        updated = MagicMock(spec=ApprovalRequest)
+        updated.id = pending_request.id
+        updated.account_id = pending_request.account_id
+        updated.tool_name = "Bash"
+        updated.execution_id = None
+        updated.managed_agent_id = None
+
+        approval_service.update_approval_request = AsyncMock(return_value=updated)
+        approval_service._broadcast_approval_update = AsyncMock()
+        record_mock = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.approval_service.record_bypass_use_async", record_mock
+            ),
+            patch("preloop.services.approval_service._log_approval_lifecycle_async"),
+        ):
+            await approval_service._auto_approve_via_bypass(pending_request, bypass)
+
+        record_mock.assert_awaited_once()
+        assert record_mock.await_args.kwargs["bypass_id"] == bypass.id
+
+    async def test_comment_names_the_expiry(self, approval_service, pending_request):
+        """The recorded comment says when the bypass ends, not just that it exists."""
+        bypass = make_bypass()
+        updated = MagicMock(spec=ApprovalRequest)
+        updated.id = pending_request.id
+        updated.account_id = pending_request.account_id
+        updated.tool_name = "Bash"
+        updated.execution_id = None
+        updated.managed_agent_id = None
+
+        approval_service.update_approval_request = AsyncMock(return_value=updated)
+        approval_service._broadcast_approval_update = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.approval_service.record_bypass_use_async", AsyncMock()
+            ),
+            patch("preloop.services.approval_service._log_approval_lifecycle_async"),
+        ):
+            await approval_service._auto_approve_via_bypass(pending_request, bypass)
+
+        comment = approval_service.update_approval_request.call_args[0][1]
+        assert bypass.expires_at.isoformat() in comment.approver_comment
+        assert "without review" in comment.approver_comment
+
+
+# --------------------------------------------------------------------------
+# Statistics must never count a bypass as a human approval
+# --------------------------------------------------------------------------
+
+
+class TestStatisticsDistinction:
+    """decided_by_human is the field every stat surface must filter on."""
+
+    def _response(self, **overrides):
+        """Build an ApprovalRequestResponse with sane defaults."""
+        payload = {
+            "id": uuid.uuid4(),
+            "account_id": uuid.uuid4(),
+            "tool_configuration_id": uuid.uuid4(),
+            "approval_workflow_id": uuid.uuid4(),
+            "tool_name": "Bash",
+            "tool_args": {},
+            "status": "approved",
+            "requested_at": datetime.utcnow(),
+            "resolved_at": datetime.utcnow(),
+            "expires_at": None,
+            "approver_comment": None,
+            "webhook_posted_at": None,
+            "webhook_error": None,
+        }
+        payload.update(overrides)
+        return ApprovalRequestResponse(**payload)
+
+    async def test_human_approval_counts_as_human(self):
+        """A plain human approval is counted."""
+        resp = self._response()
+        assert resp.decided_by_human is True
+        assert resp.was_bypassed is False
+
+    async def test_bypassed_approval_is_not_human(self):
+        """A bypassed approval must never inflate the approval rate."""
+        resp = self._response(auto_approved_reason="bypass")
+        assert resp.decided_by_human is False
+        assert resp.was_bypassed is True
+
+    async def test_ai_approval_is_not_human(self):
+        """AI decisions were already non-human; that stays true."""
+        resp = self._response(decided_by_ai=True)
+        assert resp.decided_by_human is False
+        assert resp.was_bypassed is False
+
+    async def test_pending_request_is_not_a_decision(self):
+        """Pending requests are not decisions of any kind."""
+        resp = self._response(status="pending", resolved_at=None)
+        assert resp.decided_by_human is False
+
+
+# --------------------------------------------------------------------------
+# create_and_notify wiring
+# --------------------------------------------------------------------------
+
+
+class TestCreateAndNotifyIntegration:
+    """The bypass must short-circuit before notifications are sent."""
+
+    async def test_bypass_suppresses_notifications_and_approves(
+        self, approval_service, workflow, account_id
+    ):
+        """No notification is dispatched when auto-approving under a bypass."""
+        created = MagicMock(spec=ApprovalRequest)
+        created.id = uuid.uuid4()
+        created.account_id = uuid.UUID(account_id)
+        created.tool_name = "Bash"
+        created.execution_id = None
+        created.managed_agent_id = None
+        created.status = "pending"
+
+        approved = MagicMock(spec=ApprovalRequest)
+        approved.status = "approved"
+
+        bypass = make_bypass()
+
+        approval_service.create_approval_request = AsyncMock(return_value=created)
+        approval_service._resolve_bypass = AsyncMock(return_value=bypass)
+        approval_service._auto_approve_via_bypass = AsyncMock(return_value=approved)
+        approval_service.send_notifications = AsyncMock()
+        approval_service.update_approval_request = AsyncMock(return_value=created)
+
+        with patch(
+            "preloop.services.approval_summary.generate_approval_summary",
+            AsyncMock(return_value=None),
+        ):
+            result = await approval_service.create_and_notify(
+                account_id=account_id,
+                tool_configuration_id=uuid.uuid4(),
+                approval_workflow=workflow,
+                tool_name="Bash",
+                tool_args={"command": "ls"},
+            )
+
+        assert result is approved
+        approval_service.send_notifications.assert_not_called()
+        approval_service._auto_approve_via_bypass.assert_awaited_once()
+
+    async def test_bypass_error_falls_back_to_normal_approval(
+        self, approval_service, workflow, account_id
+    ):
+        """A crash in bypass resolution must not auto-approve anything."""
+        created = MagicMock(spec=ApprovalRequest)
+        created.id = uuid.uuid4()
+        created.account_id = uuid.UUID(account_id)
+        created.tool_name = "Bash"
+        created.execution_id = None
+        created.managed_agent_id = None
+        created.status = "pending"
+
+        approval_service.create_approval_request = AsyncMock(return_value=created)
+        approval_service._resolve_bypass = AsyncMock(side_effect=RuntimeError("boom"))
+        approval_service._auto_approve_via_bypass = AsyncMock()
+        approval_service.send_notifications = AsyncMock()
+        approval_service.update_approval_request = AsyncMock(return_value=created)
+
+        with patch(
+            "preloop.services.approval_summary.generate_approval_summary",
+            AsyncMock(return_value=None),
+        ):
+            result = await approval_service.create_and_notify(
+                account_id=account_id,
+                tool_configuration_id=uuid.uuid4(),
+                approval_workflow=workflow,
+                tool_name="Bash",
+                tool_args={"command": "ls"},
+            )
+
+        approval_service._auto_approve_via_bypass.assert_not_called()
+        approval_service.send_notifications.assert_awaited_once()
+        assert result is created
+
+
+class TestSendNotificationsMute:
+    """send_notifications honors a mute without resolving the request."""
+
+    async def test_mute_skips_all_channels(self, approval_service, workflow):
+        """Muted approvals send nothing but stay pending."""
+        req = MagicMock(spec=ApprovalRequest)
+        req.id = uuid.uuid4()
+        req.account_id = uuid.uuid4()
+        req.managed_agent_id = None
+        req.requested_at = datetime.utcnow()
+        req.status = "pending"
+
+        mute = make_bypass(mode=ApprovalBypassMode.MUTE_NOTIFICATIONS)
+        approval_service._resolve_bypass = AsyncMock(return_value=mute)
+        approval_service._send_email_notification = AsyncMock()
+        approval_service._send_push_notification = AsyncMock()
+
+        result = await approval_service.send_notifications(req, workflow)
+
+        assert result["skipped"] is True
+        assert result["reason"] == "notifications_muted"
+        assert result["bypass_id"] == str(mute.id)
+        approval_service._send_email_notification.assert_not_called()
+        approval_service._send_push_notification.assert_not_called()
+        # The request itself is untouched - it still blocks the agent.
+        assert req.status == "pending"

--- a/backend/tests/services/test_approval_bypass.py
+++ b/backend/tests/services/test_approval_bypass.py
@@ -19,7 +19,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from preloop.models.models import ApprovalRequest, ApprovalWorkflow
+from preloop.models.models import (
+    ApprovalRequest,
+    ApprovalWorkflow,
+    AutoApprovedReason,
+)
 from preloop.models.models.approval_bypass import (
     ApprovalBypass,
     ApprovalBypassMode,
@@ -404,6 +408,19 @@ class TestStatisticsDistinction:
         assert resp.decided_by_human is False
         assert resp.was_bypassed is True
 
+    async def test_standing_bypass_approval_is_not_human(self):
+        """A ``native_tool_approvals: "off"`` approval is not human review either.
+
+        The statistics filter keys off ``auto_approved_reason`` being set at
+        all, not off the literal ``"bypass"``, so the standing reason code is
+        excluded from approval rates for free. This test pins that.
+        """
+        resp = self._response(
+            auto_approved_reason=AutoApprovedReason.NATIVE_TOOL_APPROVALS_OFF
+        )
+        assert resp.decided_by_human is False
+        assert resp.was_bypassed is True
+
     async def test_ai_approval_is_not_human(self):
         """AI decisions were already non-human; that stays true."""
         resp = self._response(decided_by_ai=True)
@@ -462,6 +479,67 @@ class TestCreateAndNotifyIntegration:
         assert result is approved
         approval_service.send_notifications.assert_not_called()
         approval_service._auto_approve_via_bypass.assert_awaited_once()
+
+    async def test_standing_bypass_records_and_suppresses_notification(
+        self, approval_service, workflow, account_id
+    ):
+        """``native_tool_approvals: "off"`` is recorded, audited, and silent.
+
+        This is the migration of the old invisible short-circuit in
+        agent_permission_service. The request must be marked with its own
+        reason code, carry NO bypass id (no ApprovalBypass row authorizes it),
+        be audited with no approver under [BYPASS], and notify nobody.
+        """
+        created = MagicMock(spec=ApprovalRequest)
+        created.id = uuid.uuid4()
+        created.account_id = uuid.UUID(account_id)
+        created.tool_name = "Bash"
+        created.execution_id = None
+        created.managed_agent_id = None
+        created.status = "pending"
+
+        approval_service.create_approval_request = AsyncMock(return_value=created)
+        approval_service.update_approval_request = AsyncMock(return_value=created)
+        approval_service._broadcast_approval_update = AsyncMock()
+        approval_service.send_notifications = AsyncMock()
+        # Must not consult time-boxed bypasses at all: this is a standing one.
+        approval_service._resolve_bypass = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.approval_summary.generate_approval_summary",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "preloop.services.approval_service._log_approval_lifecycle_async"
+            ) as mock_log,
+        ):
+            await approval_service.create_and_notify(
+                account_id=account_id,
+                tool_configuration_id=uuid.uuid4(),
+                approval_workflow=workflow,
+                tool_name="Bash",
+                tool_args={"command": "ls"},
+                standing_bypass_reason=(AutoApprovedReason.NATIVE_TOOL_APPROVALS_OFF),
+            )
+
+        approval_service.send_notifications.assert_not_called()
+        approval_service._resolve_bypass.assert_not_called()
+
+        update_arg = approval_service.update_approval_request.call_args[0][1]
+        assert update_arg.status == "approved"
+        assert (
+            update_arg.auto_approved_reason
+            == AutoApprovedReason.NATIVE_TOOL_APPROVALS_OFF
+        )
+        # No ApprovalBypass row authorized this - the governance config did.
+        assert update_arg.auto_approval_bypass_id is None
+        # An AI judged nothing here either.
+        assert update_arg.decided_by_ai is False
+
+        audit_kwargs = mock_log.call_args.kwargs
+        assert audit_kwargs["approver_id"] is None
+        assert audit_kwargs["reason"].startswith("[BYPASS]")
 
     async def test_bypass_error_falls_back_to_normal_approval(
         self, approval_service, workflow, account_id

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,9 @@ import { Router } from '@vaadin/router';
 import { DEFAULT_SIMILARITY_THRESHOLD } from './config';
 import { PermissionError, permissionErrorFromResponse } from './permissions';
 import type {
+  ApprovalBypass,
+  ApprovalBypassMode,
+  ApprovalBypassStatus,
   FetchIssuesListParams,
   SearchIssuesParams,
   SearchIssuesResponse,
@@ -3867,4 +3870,82 @@ export async function deleteBudgetPolicy(id: string): Promise<void> {
     method: 'DELETE',
   });
   if (!response.ok) throw new Error('Failed to delete budget policy');
+}
+
+// --- Approval bypasses (approval / notification fatigue escape hatch) -------
+
+/**
+ * Fetch the calling user's current bypass state.
+ *
+ * Drives the console warning banner. Deliberately cheap so it can be polled.
+ */
+export async function getApprovalBypassStatus(): Promise<ApprovalBypassStatus> {
+  const response = await fetchWithAuth('/api/v1/approval-bypasses/status');
+  if (!response.ok) {
+    throw new Error('Failed to fetch approval bypass status');
+  }
+  return response.json();
+}
+
+/** List every active bypass in the account (including teammates'). */
+export async function listApprovalBypasses(): Promise<ApprovalBypass[]> {
+  const response = await fetchWithAuth('/api/v1/approval-bypasses');
+  if (!response.ok) {
+    throw new Error('Failed to fetch approval bypasses');
+  }
+  return response.json();
+}
+
+/**
+ * Open a time-boxed bypass for the current user.
+ *
+ * `durationMinutes` is required and server-capped - there is intentionally no
+ * way to express an indefinite bypass.
+ */
+export async function createApprovalBypass(params: {
+  mode: ApprovalBypassMode;
+  durationMinutes: number;
+  managedAgentId?: string | null;
+  reason?: string | null;
+}): Promise<ApprovalBypass> {
+  const response = await fetchWithAuth('/api/v1/approval-bypasses', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      mode: params.mode,
+      duration_minutes: params.durationMinutes,
+      managed_agent_id: params.managedAgentId ?? null,
+      reason: params.reason ?? null,
+      created_via: 'console',
+    }),
+  });
+  if (!response.ok) {
+    throw new Error('Failed to create approval bypass');
+  }
+  return response.json();
+}
+
+/** End a single bypass early. */
+export async function revokeApprovalBypass(
+  bypassId: string
+): Promise<ApprovalBypass> {
+  const response = await fetchWithAuth(
+    `/api/v1/approval-bypasses/${bypassId}`,
+    { method: 'DELETE' }
+  );
+  if (!response.ok) {
+    throw new Error('Failed to revoke approval bypass');
+  }
+  return response.json();
+}
+
+/** Revoke every active bypass in the account - the "panic off" button. */
+export async function revokeAllApprovalBypasses(): Promise<ApprovalBypass[]> {
+  const response = await fetchWithAuth('/api/v1/approval-bypasses/revoke-all', {
+    method: 'POST',
+  });
+  if (!response.ok) {
+    throw new Error('Failed to revoke approval bypasses');
+  }
+  return response.json();
 }

--- a/frontend/src/components/approval-bypass-banner.ts
+++ b/frontend/src/components/approval-bypass-banner.ts
@@ -1,0 +1,211 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { getApprovalBypassStatus, revokeAllApprovalBypasses } from '../api';
+import type { ApprovalBypassStatus } from '../types';
+
+/**
+ * Persistent warning banner shown whenever approval gating is relaxed.
+ *
+ * Design intent: a bypass must be impossible to forget. The banner is
+ * unmissable, states plainly what is switched off, counts down to expiry, and
+ * carries a one-click "Restore approvals" action so re-tightening is never
+ * more than a single tap away.
+ *
+ * Colors follow DESIGN.md semantic states: pending/warning amber `#F2A93B`
+ * for a muted-but-still-gating bypass, denied/error red `#FF5D5D` accents when
+ * approvals are actually being skipped. A bypass is a warning condition and is
+ * never rendered in neutral chrome.
+ */
+@customElement('approval-bypass-banner')
+export class ApprovalBypassBanner extends LitElement {
+  @state()
+  private status: ApprovalBypassStatus | null = null;
+
+  @state()
+  private revoking = false;
+
+  /** Ticks once a second so the countdown stays honest. */
+  @state()
+  private now = Date.now();
+
+  private pollTimer?: number;
+  private tickTimer?: number;
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .banner {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: 4px;
+      border-left: 4px solid #f2a93b;
+      background: rgba(242, 169, 59, 0.12);
+      color: #e6edf3;
+      font-size: 14px;
+      line-height: 1.4;
+    }
+
+    /* Approvals are actually being skipped - the more severe state. */
+    .banner.bypassing {
+      border-left-color: #ff5d5d;
+      background: rgba(255, 93, 93, 0.12);
+    }
+
+    .icon {
+      flex-shrink: 0;
+      font-size: 18px;
+      line-height: 1;
+    }
+
+    .text {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .title {
+      font-weight: 600;
+    }
+
+    .detail {
+      opacity: 0.85;
+      font-size: 13px;
+    }
+
+    button {
+      flex-shrink: 0;
+      background: #0284c7;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: opacity 150ms ease-out;
+    }
+
+    button:hover:not(:disabled) {
+      opacity: 0.9;
+    }
+
+    button:disabled {
+      opacity: 0.6;
+      cursor: default;
+    }
+
+    @media (prefers-color-scheme: light) {
+      .banner {
+        color: #1c2128;
+      }
+    }
+  `;
+
+  connectedCallback() {
+    super.connectedCallback();
+    void this.refresh();
+    // Poll so a bypass opened from the phone shows up in an open console tab.
+    this.pollTimer = window.setInterval(() => void this.refresh(), 30000);
+    this.tickTimer = window.setInterval(() => {
+      this.now = Date.now();
+    }, 1000);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this.pollTimer) window.clearInterval(this.pollTimer);
+    if (this.tickTimer) window.clearInterval(this.tickTimer);
+  }
+
+  /** Reload bypass status, failing silently (the banner is advisory chrome). */
+  private async refresh() {
+    try {
+      this.status = await getApprovalBypassStatus();
+    } catch {
+      this.status = null;
+    }
+  }
+
+  private async handleRestore() {
+    this.revoking = true;
+    try {
+      await revokeAllApprovalBypasses();
+      await this.refresh();
+      this.dispatchEvent(
+        new CustomEvent('bypasses-revoked', {
+          bubbles: true,
+          composed: true,
+        })
+      );
+    } catch {
+      // Leave the banner up; the bypass is still active and must stay visible.
+    } finally {
+      this.revoking = false;
+    }
+  }
+
+  /** Human-readable time remaining until the soonest expiry. */
+  private countdown(): string {
+    const expiry = this.status?.soonest_expiry;
+    if (!expiry) return '';
+    const msLeft = new Date(`${expiry}Z`).getTime() - this.now;
+    if (msLeft <= 0) return 'expiring now';
+    const minutes = Math.floor(msLeft / 60000);
+    if (minutes < 1) return 'less than a minute left';
+    if (minutes < 60) return `${minutes} min left`;
+    const hours = Math.floor(minutes / 60);
+    const remainder = minutes % 60;
+    return remainder > 0 ? `${hours}h ${remainder}m left` : `${hours}h left`;
+  }
+
+  render() {
+    if (!this.status?.active) return html``;
+
+    const bypassing = this.status.auto_approve_active;
+    const autoApproved = this.status.bypasses.reduce(
+      (sum, b) => sum + (b.auto_approved_count ?? 0),
+      0
+    );
+
+    return html`
+      <div class="banner ${bypassing ? 'bypassing' : ''}" role="alert">
+        <span class="icon" aria-hidden="true">${bypassing ? '⚠' : '🔕'}</span>
+        <div class="text">
+          <div class="title">
+            ${
+              bypassing
+                ? 'Approvals are being auto-approved without review'
+                : 'Approval notifications are muted'
+            }
+          </div>
+          <div class="detail">
+            ${
+              bypassing
+                ? html`${autoApproved} tool
+                  ${autoApproved === 1 ? 'call has' : 'calls have'} run
+                  unsupervised. ${this.countdown()}.`
+                : html`Agents are still blocked waiting for you.
+                  ${this.countdown()}.`
+            }
+          </div>
+        </div>
+        <button
+          @click=${this.handleRestore}
+          ?disabled=${this.revoking}
+          part="restore"
+        >
+          ${this.revoking ? 'Restoring…' : 'Restore approvals'}
+        </button>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'approval-bypass-banner': ApprovalBypassBanner;
+  }
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1197,6 +1197,58 @@ export interface ApprovalRequest {
   question?: string | null;
   question_options?: string[] | null;
   allow_free_text?: boolean;
+  /** True when an AI judged this request rather than a person. */
+  decided_by_ai?: boolean;
+  /**
+   * Set when a time-boxed bypass auto-approved this request without any human
+   * review (currently always `'bypass'`). Surfaces must render these
+   * distinctly from human decisions.
+   */
+  auto_approved_reason?: string | null;
+  auto_approval_bypass_id?: string | null;
+  /** Convenience mirror of `auto_approved_reason !== null`. */
+  was_bypassed?: boolean;
+  /**
+   * True only when a person actually made this decision. Every approval
+   * statistic must filter on this — counting bypassed calls as approvals
+   * would overstate how much human oversight actually happened.
+   */
+  decided_by_human?: boolean;
+}
+
+/** Mode of a time-boxed approval bypass. */
+export type ApprovalBypassMode = 'mute_notifications' | 'auto_approve';
+
+/**
+ * A deliberate, expiring relaxation of approval gating.
+ *
+ * `mute_notifications` silences alerts while approvals still block the agent;
+ * `auto_approve` also approves automatically and is a governance bypass.
+ */
+export interface ApprovalBypass {
+  id: string;
+  account_id: string;
+  user_id: string;
+  managed_agent_id: string | null;
+  mode: ApprovalBypassMode;
+  reason: string | null;
+  created_by_user_id: string;
+  created_via: string | null;
+  created_at: string;
+  expires_at: string;
+  revoked_at: string | null;
+  revoked_by_user_id: string | null;
+  auto_approved_count: number;
+  is_account_wide?: boolean;
+  suppresses_approvals?: boolean;
+}
+
+/** Aggregate bypass state used to drive the console warning banner. */
+export interface ApprovalBypassStatus {
+  active: boolean;
+  auto_approve_active: boolean;
+  bypasses: ApprovalBypass[];
+  soonest_expiry?: string | null;
 }
 
 /**

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -2752,10 +2752,14 @@ export class AgentDetailView extends LitElement {
                                       name="exclamation-triangle"
                                     ></sl-icon>
                                     Approvals are bypassed server-side: Preloop
-                                    now auto-allows this agent's escalated tool
-                                    calls. The local hook installed at
-                                    onboarding still adds a network round-trip
-                                    to Preloop on every tool call.
+                                    now auto-approves this agent's escalated
+                                    tool calls without asking anyone. They are
+                                    still recorded in Approvals, marked
+                                    auto-approved and excluded from your
+                                    approval stats, so you keep the audit trail.
+                                    The local hook installed at onboarding still
+                                    adds a network round-trip to Preloop on
+                                    every tool call.
                                     <sl-details
                                       summary="How to fully disable the hook locally"
                                       style="margin-top: var(--sl-spacing-small);"

--- a/frontend/src/views/authed/approvals-view.ts
+++ b/frontend/src/views/authed/approvals-view.ts
@@ -32,7 +32,10 @@ interface ApprovalStats {
   expired: number;
   cancelled: number;
   avgResponseTimeMinutes: number;
+  /** Percentage of HUMAN decisions that were approvals. Excludes bypassed/AI. */
   approvalRate: number;
+  /** Requests auto-approved by a time-boxed bypass, with no human review. */
+  autoApprovedByBypass: number;
 }
 
 @customElement('approvals-view')
@@ -56,6 +59,7 @@ export class ApprovalsView extends AuthedElement {
     cancelled: 0,
     avgResponseTimeMinutes: 0,
     approvalRate: 0,
+    autoApprovedByBypass: 0,
   };
 
   @state()
@@ -393,9 +397,27 @@ export class ApprovalsView extends AuthedElement {
     const avgResponseTimeMinutes =
       resolvedCount > 0 ? Math.round(totalResponseTime / resolvedCount) : 0;
 
-    // Approval rate (approved / (approved + declined))
-    const decidedCount = approved + declined;
-    const approvalRate = decidedCount > 0 ? (approved / decidedCount) * 100 : 0;
+    // Approval rate counts HUMAN decisions only. Requests auto-approved by a
+    // bypass (or decided by AI) never reached a person, so folding them in
+    // would overstate how much oversight actually happened - the opposite of
+    // what this number is for.
+    const humanApproved = requests.filter(
+      (r) =>
+        r.status === 'approved' && !r.auto_approved_reason && !r.decided_by_ai
+    ).length;
+    const humanDeclined = requests.filter(
+      (r) =>
+        r.status === 'declined' && !r.auto_approved_reason && !r.decided_by_ai
+    ).length;
+    const decidedCount = humanApproved + humanDeclined;
+    const approvalRate =
+      decidedCount > 0 ? (humanApproved / decidedCount) * 100 : 0;
+
+    // Surfaced separately so an operator can see the unsupervised volume
+    // rather than having it silently blended into "approved".
+    const autoApprovedByBypass = requests.filter(
+      (r) => !!r.auto_approved_reason
+    ).length;
 
     this.stats = {
       total,
@@ -406,6 +428,7 @@ export class ApprovalsView extends AuthedElement {
       cancelled,
       avgResponseTimeMinutes,
       approvalRate,
+      autoApprovedByBypass,
     };
   }
 
@@ -828,6 +851,21 @@ export class ApprovalsView extends AuthedElement {
                                       : request.status
                                   }
                                 </sl-tag>
+                                ${
+                                  request.auto_approved_reason
+                                    ? html`<sl-tooltip
+                                        content="Auto-approved by a time-boxed bypass. No person reviewed this call."
+                                      >
+                                        <sl-tag size="small" variant="warning">
+                                          <sl-icon
+                                            name="exclamation-triangle"
+                                            style="margin-right: 4px;"
+                                          ></sl-icon>
+                                          not reviewed
+                                        </sl-tag>
+                                      </sl-tooltip>`
+                                    : ''
+                                }
                               </div>
                               ${
                                 request.summary

--- a/frontend/src/views/authed/console-shell.ts
+++ b/frontend/src/views/authed/console-shell.ts
@@ -17,6 +17,7 @@ import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '../../components/logo-component';
 import '../../components/global-notice';
 import '../../components/console-header';
+import '../../components/approval-bypass-banner';
 import consoleStyles from '../../styles/console-styles.css?inline';
 import {
   getFeatures,
@@ -713,6 +714,9 @@ export class ConsoleShell extends LitElement {
               @click=${this._handleSidebarToggle}
             ></sl-icon-button>
           </console-header>
+          <!-- Sits directly under the header so a relaxed governance state is
+               visible on every console page, not just the approvals view. -->
+          <approval-bypass-banner></approval-bypass-banner>
           <div
             class="main-content ${this._fullBleed ? 'full-bleed' : ''}"
             @request-full-bleed=${(e: CustomEvent) =>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15050,8 +15050,12 @@ components:
           - type: 'null'
           title: Native Tool Approvals
           description: Whether native tool-call approvals (agents permission-check)
-            are enforced for this subject. "off" makes the server auto-allow escalated
-            (ask) calls instead of asking a human; absent/None means "enforce".
+            are enforced for this subject. "off" makes the server auto-approve escalated
+            (ask) calls instead of asking a human; the calls are still recorded as
+            approval requests marked auto_approved_reason='native_tool_approvals_off'
+            and audited with no approver, so the audit trail stays complete. Unlike
+            a time-boxed approval bypass this setting does not expire; it stays off
+            until changed. Absent/None means "enforce".
       type: object
       title: SubjectGovernanceConfig
     SubjectGovernanceResponse:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3672,6 +3672,149 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/approval-bypasses/status:
+    get:
+      tags:
+      - Approval Bypasses
+      - approval_bypasses
+      summary: Get Bypass Status
+      description: "Report whether any bypass is currently in force for this user.\n\
+        \nConsole and mobile poll this to drive the persistent warning banner. It\
+        \ is\nintentionally readable by any authenticated user without a special\n\
+        permission: knowing that governance is currently relaxed is not privileged\n\
+        information, and hiding it would defeat the point.\n\nArgs:\n    current_user:\
+        \ Current authenticated user.\n    db: Database session.\n\nReturns:\n   \
+        \ Aggregate bypass status for banner rendering."
+      operationId: get_bypass_status_api_v1_approval_bypasses_status_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalBypassStatus'
+      security:
+      - bearerAuth: []
+  /api/v1/approval-bypasses:
+    get:
+      tags:
+      - Approval Bypasses
+      - approval_bypasses
+      summary: List Bypasses
+      description: "List every active bypass in the account.\n\nAccount-wide visibility\
+        \ is deliberate: if a teammate has relaxed gating,\neveryone governing the\
+        \ same fleet should be able to see it.\n\nArgs:\n    current_user: Current\
+        \ authenticated user.\n    db: Database session.\n\nReturns:\n    Active bypasses,\
+        \ soonest-expiring last."
+      operationId: list_bypasses_api_v1_approval_bypasses_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ApprovalBypassResponse'
+                type: array
+                title: Response List Bypasses Api V1 Approval Bypasses Get
+      security:
+      - bearerAuth: []
+    post:
+      tags:
+      - Approval Bypasses
+      - approval_bypasses
+      summary: Create Bypass
+      description: "Open a time-boxed bypass for the calling user.\n\nThe bypass always\
+        \ targets ``current_user``; there is no parameter to target\nsomebody else.\
+        \ Duration is validated by the schema against the hard cap, so\nan unbounded\
+        \ bypass cannot be constructed.\n\nArgs:\n    payload: Mode, duration, optional\
+        \ agent scope and reason.\n    current_user: Current authenticated user (the\
+        \ bypass subject).\n    db: Database session.\n\nReturns:\n    The created\
+        \ bypass.\n\nRaises:\n    HTTPException: If the duration is outside the permitted\
+        \ range."
+      operationId: create_bypass_api_v1_approval_bypasses_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApprovalBypassCreate'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalBypassResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /api/v1/approval-bypasses/{bypass_id}:
+    delete:
+      tags:
+      - Approval Bypasses
+      - approval_bypasses
+      summary: Revoke Bypass
+      description: "End a bypass early.\n\nAny user who can view approvals in the\
+        \ account may revoke a bypass, even\none they did not create. Re-tightening\
+        \ a control is always safe, so it\nshould never be blocked on ownership.\n\
+        \nArgs:\n    bypass_id: The bypass to revoke.\n    current_user: Current authenticated\
+        \ user.\n    db: Database session.\n\nReturns:\n    The revoked bypass.\n\n\
+        Raises:\n    HTTPException: If the bypass is not found in this account."
+      operationId: revoke_bypass_api_v1_approval_bypasses__bypass_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: bypass_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Bypass Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalBypassResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/approval-bypasses/revoke-all:
+    post:
+      tags:
+      - Approval Bypasses
+      - approval_bypasses
+      summary: Revoke All Bypasses
+      description: "Revoke every active bypass in the account — the 'panic off' button.\n\
+        \nExists so that restoring full governance is always a single unambiguous\n\
+        action, with no list to scroll and no per-item taps, from any surface.\n\n\
+        Args:\n    current_user: Current authenticated user.\n    db: Database session.\n\
+        \nReturns:\n    The bypasses that were revoked."
+      operationId: revoke_all_bypasses_api_v1_approval_bypasses_revoke_all_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ApprovalBypassResponse'
+                type: array
+                title: Response Revoke All Bypasses Api V1 Approval Bypasses Revoke
+                  All Post
+      security:
+      - bearerAuth: []
   /api/v1/notification-preferences/me:
     get:
       tags:
@@ -8579,6 +8722,176 @@ components:
       - requests_by_endpoint
       title: ApiUsageStatistics
       description: Model for API usage statistics.
+    ApprovalBypassCreate:
+      properties:
+        mode:
+          type: string
+          enum:
+          - mute_notifications
+          - auto_approve
+          title: Mode
+          description: '''mute_notifications'' silences alerts but still blocks the
+            agent; ''auto_approve'' also approves automatically (governance bypass)'
+        duration_minutes:
+          type: integer
+          maximum: 480.0
+          minimum: 1.0
+          title: Duration Minutes
+          description: How long the bypass lasts (1-480 minutes)
+        managed_agent_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Managed Agent Id
+          description: Scope to one agent. Omit for an account-wide bypass.
+        reason:
+          anyOf:
+          - type: string
+            maxLength: 500
+          - type: 'null'
+          title: Reason
+          description: Why the bypass was opened (recorded for audit)
+        created_via:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Created Via
+          description: 'Originating surface: console|mobile|watch|api|cli'
+      type: object
+      required:
+      - mode
+      - duration_minutes
+      title: ApprovalBypassCreate
+      description: 'Request body for opening a bypass.
+
+
+        ``duration_minutes`` is required and bounded — there is deliberately no way
+
+        to express "forever". An indefinite bypass is the failure mode this feature
+
+        exists to prevent.'
+    ApprovalBypassResponse:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        account_id:
+          type: string
+          format: uuid
+          title: Account Id
+        user_id:
+          type: string
+          format: uuid
+          title: User Id
+        managed_agent_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Managed Agent Id
+        mode:
+          type: string
+          title: Mode
+        reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reason
+        created_by_user_id:
+          type: string
+          format: uuid
+          title: Created By User Id
+        created_via:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Created Via
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        expires_at:
+          type: string
+          format: date-time
+          title: Expires At
+        revoked_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Revoked At
+        revoked_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Revoked By User Id
+        auto_approved_count:
+          type: integer
+          title: Auto Approved Count
+          default: 0
+        is_account_wide:
+          type: boolean
+          title: Is Account Wide
+          description: True when this bypass applies to every agent for the user.
+          readOnly: true
+        suppresses_approvals:
+          type: boolean
+          title: Suppresses Approvals
+          description: True when agents are auto-approved rather than merely unmuted.
+          readOnly: true
+      type: object
+      required:
+      - id
+      - account_id
+      - user_id
+      - mode
+      - created_by_user_id
+      - created_at
+      - expires_at
+      - is_account_wide
+      - suppresses_approvals
+      title: ApprovalBypassResponse
+      description: A bypass as returned to console and mobile surfaces.
+    ApprovalBypassStatus:
+      properties:
+        active:
+          type: boolean
+          title: Active
+          description: Whether any bypass is currently in force
+        auto_approve_active:
+          type: boolean
+          title: Auto Approve Active
+          description: Whether any active bypass is auto-approving (unsupervised)
+        bypasses:
+          items:
+            $ref: '#/components/schemas/ApprovalBypassResponse'
+          type: array
+          title: Bypasses
+        soonest_expiry:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Soonest Expiry
+          description: Earliest expiry among active bypasses, for a countdown.
+          readOnly: true
+      type: object
+      required:
+      - active
+      - auto_approve_active
+      - soonest_expiry
+      title: ApprovalBypassStatus
+      description: 'Aggregate ''is anything bypassed right now?'' answer for banners.
+
+
+        Console and mobile poll this to decide whether to show the persistent
+
+        warning banner, so it is intentionally cheap and shaped for direct
+
+        rendering.'
     ApprovalDecision:
       properties:
         approved:
@@ -8728,6 +9041,34 @@ components:
           - type: string
           - type: 'null'
           title: Ai Reasoning
+        auto_approved_reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Auto Approved Reason
+        auto_approval_bypass_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Auto Approval Bypass Id
+        was_bypassed:
+          type: boolean
+          title: Was Bypassed
+          description: True when a bypass auto-approved this request without a human.
+          readOnly: true
+        decided_by_human:
+          type: boolean
+          title: Decided By Human
+          description: 'True only when a person actually made this decision.
+
+
+            The single field every statistic should filter on. A request is a human
+
+            decision only if it reached a terminal decided state without an AI
+
+            judging it and without a bypass skipping it.'
+          readOnly: true
         approval_policy_id:
           type: string
           title: Approval Policy Id
@@ -8771,6 +9112,8 @@ components:
       - approver_comment
       - webhook_posted_at
       - webhook_error
+      - was_bypassed
+      - decided_by_human
       - approval_policy_id
       - is_question
       - question


### PR DESCRIPTION
Targets `launch-week-hardening` (PR #78), not `main` — rebase to `main` once that lands.

## The problem

An onboarded Cursor agent generated approval requests faster than a human could act on them, with no fast escape hatch. Phone, watch, and email all fired several times per minute, and there was no way to stop it short of offboarding the agent.

## Design decisions worth reviewing

**Bypassed requests are recorded, not skipped.** The tempting shortcut is to not persist them at all. But the symptom is notification spam, and rows don't buzz phones — the fan-out does. Skipping persistence buys nothing the user can feel while destroying the only evidence of what ran unsupervised, in a product that sells audit trails, during exactly the window you'd later want to reconstruct. So: record it, auto-approve it, mark `auto_approved_reason='bypass'` with the bypass id, audit with `approver_id=None` under a `[BYPASS]` prefix, and suppress only the notification.

**Time-boxed, never indefinite.** `expires_at` is `NOT NULL`, 1h default, 8h cap. No request shape means "forever". An indefinite toggle fails silently and without bound — you forget, and governance is off for weeks. An expiring one degrades safely: forgetting costs at most the window, and re-arming forces a conscious re-decision.

**Two controls, not one.** `mute_notifications` keeps approvals blocking and suppresses only alerts — right for "I'm being spammed but I still want the gate", and what the UI offers first. `auto_approve` is the actual bypass.

**Unanimity.** A bypass applies only when every approver on the workflow has one. One person muting their phone must not silently disarm a control their teammates rely on.

**Fails closed.** Any error resolving a bypass enforces approval.

**Never counted as human approvals.** New `decided_by_human` field; console approval rate excludes bypassed and AI decisions. `decided_by_ai` was deliberately not reused — an AI *judged* the call, a bypass *skipped judging it*.

## Surfaces

Amber banner (`#F2A93B`) on every console page while active, red (`#FF5D5D`) when approvals are actually being skipped, with countdown and one-click restore. Bypassed rows carry a "not reviewed" tag. `revoke-all` is a panic-off. Bypass creation logs at WARNING.

## Not in this PR

Mobile. It needs `GET/POST /api/v1/approval-bypasses`, `/status`, `/revoke-all`, and — highest value — **a "Mute 1h" action on the push notification itself**, since the phone is what is buzzing. Those apps are on a separate release cycle.

**This means `auto_approve` is only reachable from the console today**, so the motivating scenario is not fully solved until the mobile action lands. `mute_notifications` is the part that is ready to be useful now.

## Related, found while building this

Three unrecorded auto-approve paths already exist: `native_tool_approvals: "off"` (`agent_permission_service.py:323`, indefinite and unlogged), `_bypass_approval_var` (`dynamic_fastmcp.py:56`), and the client-policy short-circuit. Migrating the first onto this model is a behavior change on an existing switch and is left for a follow-up.

23 new tests; 3954 backend passing; ruff clean; mypy unchanged.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-designed escape hatch with strong safety properties: time-boxed (8h cap), unanimity-gated, fails-closed, and audit-recorded. Bypassed approvals are permanently distinguishable from human decisions. Three low-severity notes persist (concurrency advisory, type annotation, ARCHITECTURE.md gap) — none blocking.
>
> **Review Status**: ✅ Approved (second pass — all open issues are LOW severity)
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai). Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->