### PR TITLE
Multi-model per provider key + deterministic model resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **One provider key can now back several models.** After a provider key
+  validates, the add-model dialog offers the rest of that provider's models
+  under "Also add", creating an `AIModel` row per selection that reuses the
+  single stored credential. Deleting one of them leaves the key in place for
+  the others; deleting the last one removes it.
+
+### Fixed
+
+- **Model resolution was nondeterministic when several models shared an
+  identifier suffix.** The gateway matched a requested model against an
+  unordered query and returned on the first suffix match, so a bare
+  `claude-sonnet-4-5` could resolve to `anthropic/…` on one request and
+  `bedrock/…` on the next — a different `ai_model_id`, and therefore different
+  pricing, between otherwise identical requests. A suffix match on an earlier
+  row could also beat an exact match on a later one. Exact alias matches now
+  always win, and the candidate list is ordered deterministically
+  (account-owned models before system defaults, then oldest first). This was
+  latent while accounts held one model each; multi-model keys make it
+  reachable.
+
 ## [0.12.4] - 2026-07-18
 
 ### Fixed

--- a/backend/preloop/models/crud/ai_model.py
+++ b/backend/preloop/models/crud/ai_model.py
@@ -44,13 +44,43 @@ class CRUDAIModel(CRUDBase[AIModel]):
         secret_name: str,
         existing_secret_id=None,
     ) -> None:
-        """Resolve incoming credential fields into a SecretReference."""
+        """Resolve incoming credential fields into a SecretReference.
+
+        When ``obj_data`` already carries a ``credentials_secret_id`` and no new
+        credential material, the existing secret is reused as-is. This is what lets
+        several models share one provider key. The secret is verified to belong to
+        ``account_id`` first, so a caller cannot attach another account's key.
+
+        Raises:
+            ValueError: If the referenced secret does not exist or belongs to a
+                different account.
+        """
         api_key = obj_data.pop("api_key", None) if "api_key" in obj_data else None
         credential_type = obj_data.pop("credential_type", None)
         credential_payload = obj_data.pop("credential_payload", None)
         credentials_backend_type = obj_data.pop("credentials_backend_type", None)
         credentials_external_ref = obj_data.pop("credentials_external_ref", None)
         credentials_meta_data = obj_data.pop("credentials_meta_data", None)
+
+        reuse_secret_id = obj_data.get("credentials_secret_id")
+        has_new_credential_material = bool(
+            api_key
+            or credential_type
+            or credential_payload is not None
+            or credentials_backend_type
+            or credentials_external_ref
+            or credentials_meta_data
+        )
+        if reuse_secret_id is not None and not has_new_credential_material:
+            secret_ref = crud_secret_reference.get(db, id=reuse_secret_id)
+            if secret_ref is None:
+                raise ValueError("Referenced credential secret does not exist")
+            if str(secret_ref.account_id) != str(account_id):
+                raise ValueError(
+                    "Referenced credential secret belongs to a different account"
+                )
+            obj_data["api_key"] = None
+            return
 
         if api_key:
             secret_ref = get_secret_service().create_local_secret_reference(
@@ -252,13 +282,24 @@ class CRUDAIModel(CRUDBase[AIModel]):
     def get_all_for_account(
         self, db: Session, *, account_id: uuid.UUID | str
     ) -> list[AIModel]:
-        """Get all configured AIModels available to the account, including system defaults."""
+        """Get all configured AIModels available to the account, including system defaults.
+
+        Results are ordered deterministically: account-owned models before system
+        defaults, then oldest-first by ``created_at``, with ``id`` as a final
+        tiebreak. Model resolution and therefore pricing depend on this ordering
+        being stable across requests, so it must not be removed.
+        """
         return (
             db.query(self.model)
             .filter(
                 or_(
                     self.model.account_id == account_id, self.model.account_id.is_(None)
                 )
+            )
+            .order_by(
+                self.model.account_id.is_(None).asc(),
+                self.model.created_at.asc(),
+                self.model.id.asc(),
             )
             .all()
         )

--- a/backend/preloop/schemas/ai_model.py
+++ b/backend/preloop/schemas/ai_model.py
@@ -71,6 +71,15 @@ class AIModelBase(BaseModel):
 class AIModelCreate(AIModelBase):
     """Schema for creating a new AIModel entry."""
 
+    credentials_secret_id: Optional[uuid.UUID] = Field(
+        None,
+        description=(
+            "Reuse an existing SecretReference instead of minting a new one. Used to "
+            "create several models that share a single provider key. The secret must "
+            "already belong to the caller's account."
+        ),
+    )
+
     @model_validator(mode="after")
     def validate_credentials(self):
         has_inline_payload = (
@@ -84,6 +93,12 @@ class AIModelCreate(AIModelBase):
                 self.credentials_meta_data,
             )
         )
+        if self.credentials_secret_id is not None and (
+            self.api_key or has_inline_payload or has_external
+        ):
+            raise ValueError(
+                "credentials_secret_id cannot be combined with new credential material"
+            )
         if self.api_key and (has_external or has_inline_payload):
             raise ValueError("api_key cannot be combined with other credential fields")
         if has_inline_payload and has_external:

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -1786,9 +1786,25 @@ class OpenAIGatewayService:
                     default_gateway_model = ai_model
 
         if requested_model:
+            # Resolution must be deterministic: the resolved row decides which
+            # ai_model_id the request is billed and priced against. Two rules,
+            # in order:
+            #   1. An exact alias match always wins, regardless of position.
+            #   2. Otherwise the first provider-suffix match wins, in the stable
+            #      order given by get_all_for_account (account models before
+            #      system defaults, then oldest-first).
+            # Without (1) a suffix match on an earlier row would beat an exact
+            # match on a later one; without the stable ordering behind (2) a bare
+            # "claude-sonnet-4-5" could resolve to anthropic/... on one request
+            # and bedrock/... on the next, silently changing the price.
+            suffix_match: Optional[AIModel] = None
             for ai_model, alias in gateway_enabled_models:
-                if alias == requested_model or alias.endswith(f"/{requested_model}"):
+                if alias == requested_model:
                     return ai_model
+                if suffix_match is None and alias.endswith(f"/{requested_model}"):
+                    suffix_match = ai_model
+            if suffix_match is not None:
+                return suffix_match
             raise ModelGatewayAPIError(
                 provider=provider,
                 status_code=404,

--- a/backend/tests/endpoints/test_ai_models.py
+++ b/backend/tests/endpoints/test_ai_models.py
@@ -220,3 +220,45 @@ def test_ai_model_schema_rejects_mixed_inline_and_external_credentials():
     assert "api_key cannot be combined with other credential fields" in str(
         update_error.value
     )
+
+
+def test_ai_model_schema_accepts_reused_credentials_secret_id():
+    """Reusing an existing secret is the supported multi-model-per-key path."""
+    secret_id = uuid.uuid4()
+
+    model = AIModelCreate(
+        name="Claude Haiku",
+        provider_name="anthropic",
+        model_identifier="claude-haiku-4-5",
+        credentials_secret_id=secret_id,
+    )
+
+    assert model.credentials_secret_id == secret_id
+    assert model.api_key is None
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"api_key": "inline-key"},
+        {"credential_type": "oauth_openai_codex", "credential_payload": {}},
+        {
+            "credentials_backend_type": "vault_kv_v2",
+            "credentials_external_ref": "providers/anthropic/team-a",
+        },
+    ],
+)
+def test_ai_model_schema_rejects_secret_reuse_with_new_credentials(extra):
+    """Reusing a secret and supplying new credential material is contradictory."""
+    with pytest.raises(ValidationError) as error:
+        AIModelCreate(
+            name="Confused Model",
+            provider_name="anthropic",
+            model_identifier="claude-haiku-4-5",
+            credentials_secret_id=uuid.uuid4(),
+            **extra,
+        )
+
+    assert "credentials_secret_id cannot be combined with new credential material" in (
+        str(error.value)
+    )

--- a/backend/tests/models/test_ai_model.py
+++ b/backend/tests/models/test_ai_model.py
@@ -527,3 +527,196 @@ def test_normalize_model_kind_fields_does_not_mutate_caller_dict():
     assert normalized["meta_data"]["service_kind"] == "stt"
     assert normalized["meta_data"]["region"] == "us"
     assert original_meta["region"] == "us"
+
+
+def test_create_models_sharing_one_credentials_secret(
+    db_session: Session, create_account
+):
+    """One provider key should back several models via credentials_secret_id."""
+    account: Account = create_account()
+
+    first = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Sonnet",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "one-anthropic-key",
+        },
+        account_id=account.id,
+    )
+    shared_secret_id = first.credentials_secret_id
+    assert shared_secret_id is not None
+
+    second = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Haiku",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-haiku-4-5",
+            "credentials_secret_id": shared_secret_id,
+        },
+        account_id=account.id,
+    )
+
+    assert second.credentials_secret_id == shared_secret_id
+    assert second.api_key is None
+    # Reuse must not mint a second secret for the same key.
+    secrets = (
+        db_session.query(SecretReference)
+        .filter(SecretReference.account_id == account.id)
+        .all()
+    )
+    assert len(secrets) == 1
+
+
+def test_shared_secret_survives_until_last_model_is_deleted(
+    db_session: Session, create_account
+):
+    """Deleting one of N shared models keeps the key; the last deletion reaps it."""
+    account: Account = create_account()
+
+    first = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Model A",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "one-anthropic-key",
+        },
+        account_id=account.id,
+    )
+    shared_secret_id = first.credentials_secret_id
+    second = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Model B",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-haiku-4-5",
+            "credentials_secret_id": shared_secret_id,
+        },
+        account_id=account.id,
+    )
+    third = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Model C",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-opus-4-1",
+            "credentials_secret_id": shared_secret_id,
+        },
+        account_id=account.id,
+    )
+
+    crud_ai_model.remove(db=db_session, id=first.id)
+    assert db_session.get(SecretReference, shared_secret_id) is not None
+    assert crud_ai_model.get(db=db_session, id=second.id) is not None
+    assert crud_ai_model.get(db=db_session, id=third.id) is not None
+
+    crud_ai_model.remove(db=db_session, id=second.id)
+    assert db_session.get(SecretReference, shared_secret_id) is not None
+
+    crud_ai_model.remove(db=db_session, id=third.id)
+    assert db_session.get(SecretReference, shared_secret_id) is None
+
+
+def test_cannot_attach_secret_belonging_to_another_account(
+    db_session: Session, create_account
+):
+    """A model must not be able to borrow another account's provider key."""
+    owner: Account = create_account()
+    intruder: Account = create_account()
+
+    owned = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Owner Model",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "owner-key",
+        },
+        account_id=owner.id,
+    )
+
+    try:
+        crud_ai_model.create_with_account(
+            db=db_session,
+            obj_in={
+                "name": "Stolen",
+                "provider_name": "anthropic",
+                "model_identifier": "claude-haiku-4-5",
+                "credentials_secret_id": owned.credentials_secret_id,
+            },
+            account_id=intruder.id,
+        )
+    except ValueError as exc:
+        assert "different account" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for cross-account secret reuse")
+
+
+def test_get_all_for_account_is_deterministically_ordered(
+    db_session: Session, create_account
+):
+    """Ordering must be stable: account models first, then oldest-first.
+
+    Model resolution walks this list, so an unordered query makes pricing
+    nondeterministic when several models share an identifier suffix.
+    """
+    account: Account = create_account()
+
+    system_default = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "System Default",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+        },
+        account_id=None,
+    )
+    owned_first = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Owned First",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-haiku-4-5",
+        },
+        account_id=account.id,
+    )
+    owned_second = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Owned Second",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-opus-4-1",
+        },
+        account_id=account.id,
+    )
+
+    created = {owned_first.id, owned_second.id, system_default.id}
+
+    def ordering() -> list:
+        # Other tests may leave system-default rows behind, so compare only the
+        # rows this test created while preserving their relative order.
+        return [
+            model.id
+            for model in crud_ai_model.get_all_for_account(
+                db=db_session, account_id=account.id
+            )
+            if model.id in created
+        ]
+
+    observed = ordering()
+
+    # Account-owned models must sort ahead of system defaults.
+    assert observed[-1] == system_default.id
+    assert set(observed[:2]) == {owned_first.id, owned_second.id}
+
+    # These rows share a created_at (same transaction), so id.asc() is the
+    # tiebreak. The point is that the order is fixed and explainable, not that
+    # any particular model wins an inherently ambiguous tie.
+    assert observed[:2] == sorted([owned_first.id, owned_second.id])
+
+    # Repeated calls must agree — this is what pricing stability depends on.
+    for _ in range(3):
+        assert ordering() == observed

--- a/backend/tests/services/test_openai_gateway.py
+++ b/backend/tests/services/test_openai_gateway.py
@@ -2077,3 +2077,81 @@ def test_build_openai_codex_payload_passes_through_responses_api_tools():
     )
 
     assert upstream["tools"] == already_flat
+
+
+def _gateway_model(name: str, alias: str) -> SimpleNamespace:
+    """Build a gateway-enabled AIModel stand-in with an explicit alias."""
+    return SimpleNamespace(
+        id=name,
+        name=name,
+        provider_name="anthropic",
+        model_identifier=alias,
+        api_endpoint=None,
+        is_default=False,
+        model_parameters=None,
+        meta_data={"gateway": {"enabled": True, "model_alias": alias}},
+    )
+
+
+def _resolver_service(models):
+    auth_context = ModelGatewayAuthContext(
+        token="token",
+        user=SimpleNamespace(id="user-1", account_id="account-1"),
+    )
+    service = OpenAIGatewayService(MagicMock(), auth_context)
+    service._get_account_models = lambda: list(models)  # type: ignore[method-assign]
+    return service
+
+
+def test_resolve_requested_model_prefers_exact_match_over_earlier_suffix_match():
+    """An exact alias match must win even when a suffix match comes first.
+
+    Red under the old resolver: it returned on the first suffix match, so the
+    exact row was never reached and the request was priced against the wrong model.
+    """
+    suffix_row = _gateway_model("suffix", "anthropic/claude-sonnet-4-5")
+    exact_row = _gateway_model("exact", "claude-sonnet-4-5")
+    service = _resolver_service([suffix_row, exact_row])
+
+    resolved = service._resolve_requested_model(
+        "claude-sonnet-4-5", provider="anthropic"
+    )
+
+    assert resolved is exact_row
+
+
+def test_resolve_requested_model_exact_match_wins_regardless_of_position():
+    """The exact-match rule must not depend on list position."""
+    exact_row = _gateway_model("exact", "claude-sonnet-4-5")
+    suffix_row = _gateway_model("suffix", "anthropic/claude-sonnet-4-5")
+
+    for ordering in ([suffix_row, exact_row], [exact_row, suffix_row]):
+        service = _resolver_service(ordering)
+        resolved = service._resolve_requested_model(
+            "claude-sonnet-4-5", provider="anthropic"
+        )
+        assert resolved is exact_row
+
+
+def test_resolve_requested_model_suffix_match_is_stable_and_repeatable():
+    """With only suffix candidates, the first in the given order wins, every time."""
+    first = _gateway_model("first", "anthropic/claude-sonnet-4-5")
+    second = _gateway_model("second", "bedrock/claude-sonnet-4-5")
+    service = _resolver_service([first, second])
+
+    resolved = [
+        service._resolve_requested_model("claude-sonnet-4-5", provider="anthropic")
+        for _ in range(5)
+    ]
+
+    assert all(row is first for row in resolved)
+
+
+def test_resolve_requested_model_unknown_model_still_404s():
+    """Unknown models must keep raising a loud 404 rather than falling back."""
+    service = _resolver_service([_gateway_model("only", "anthropic/claude-opus-4-1")])
+
+    with pytest.raises(ModelGatewayAPIError) as excinfo:
+        service._resolve_requested_model("gpt-5", provider="anthropic")
+
+    assert excinfo.value.status_code == 404

--- a/frontend/src/components/add-ai-model-modal.test.ts
+++ b/frontend/src/components/add-ai-model-modal.test.ts
@@ -1,0 +1,175 @@
+import { html, fixture, expect } from '@open-wc/testing';
+import sinon, { SinonSandbox, SinonStub } from 'sinon';
+import './add-ai-model-modal.ts';
+import { AddAIModelModal } from './add-ai-model-modal';
+
+const SECRET_ID = '11111111-1111-1111-1111-111111111111';
+
+/** Payloads POSTed to the model-create endpoint, in call order. */
+function createdModelPayloads(fetchStub: SinonStub): any[] {
+  return fetchStub
+    .getCalls()
+    .filter(
+      (call) =>
+        String(call.args[0]).includes('/api/v1/ai-models') &&
+        (call.args[1]?.method ?? 'GET') === 'POST'
+    )
+    .map((call) => JSON.parse(String(call.args[1].body)));
+}
+
+describe('AddAIModelModal multi-model per key', () => {
+  let element: AddAIModelModal;
+  let sandbox: SinonSandbox;
+  let fetchStub: SinonStub;
+
+  beforeEach(async () => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    sandbox = sinon.createSandbox();
+
+    fetchStub = sandbox.stub(window, 'fetch');
+    // Every create returns the same secret id, mimicking the server minting one
+    // secret for the primary model and reusing it for the rest.
+    fetchStub.callsFake(async (url: any, init: any) => {
+      const target = String(url);
+      if (target.includes('available-models')) {
+        return new Response(
+          JSON.stringify(['claude-sonnet-4-5', 'claude-haiku-4-5'])
+        );
+      }
+      if (target.includes('/api/v1/ai-models') && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body));
+        return new Response(
+          JSON.stringify({
+            id: `id-${body.model_identifier}`,
+            ...body,
+            credentials_secret_id: SECRET_ID,
+          }),
+          { status: 201 }
+        );
+      }
+      return new Response(JSON.stringify([]));
+    });
+
+    element = await fixture(html`<add-ai-model-modal></add-ai-model-modal>`);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    localStorage.clear();
+  });
+
+  /** Put the form into a submittable create-mode state. */
+  const primeForm = async (additional: string[]) => {
+    element.open = true;
+    await element.updateComplete;
+    (element as any)._currentModel = {
+      name: 'Claude Sonnet',
+      provider_name: 'anthropic',
+      model_identifier: 'claude-sonnet-4-5',
+      model_kind: 'llm',
+      api_endpoint: 'https://api.anthropic.com',
+      api_key: 'one-anthropic-key',
+    };
+    (element as any)._modelSuggestions = [
+      'claude-sonnet-4-5',
+      'claude-haiku-4-5',
+    ];
+    (element as any)._additionalModelIds = additional;
+    (element as any)._syncFormFromDom = () => {};
+    await element.updateComplete;
+  };
+
+  it('creates only the primary model when no extras are selected', async () => {
+    await primeForm([]);
+
+    await (element as any)._handleFormSubmit(new Event('submit'));
+
+    const payloads = createdModelPayloads(fetchStub);
+    expect(payloads).to.have.lengthOf(1);
+    expect(payloads[0].model_identifier).to.equal('claude-sonnet-4-5');
+  });
+
+  it('creates extra models that reuse the primary key secret', async () => {
+    await primeForm(['claude-haiku-4-5']);
+
+    await (element as any)._handleFormSubmit(new Event('submit'));
+
+    const payloads = createdModelPayloads(fetchStub);
+    expect(payloads).to.have.lengthOf(2);
+
+    // The primary mints the secret: it sends the raw key, not a secret id.
+    expect(payloads[0].model_identifier).to.equal('claude-sonnet-4-5');
+    expect(payloads[0].api_key).to.equal('one-anthropic-key');
+    expect(payloads[0].credentials_secret_id).to.be.undefined;
+
+    // The extra reuses that secret and never re-sends the key.
+    expect(payloads[1].model_identifier).to.equal('claude-haiku-4-5');
+    expect(payloads[1].credentials_secret_id).to.equal(SECRET_ID);
+    expect(payloads[1].api_key).to.be.undefined;
+    expect(payloads[1].is_default).to.equal(false);
+  });
+
+  it('gives each extra model its own gateway alias', async () => {
+    await primeForm(['claude-haiku-4-5']);
+
+    await (element as any)._handleFormSubmit(new Event('submit'));
+
+    const payloads = createdModelPayloads(fetchStub);
+    // A shared alias would make the models indistinguishable to the resolver.
+    expect(payloads[0].meta_data.gateway.model_alias).to.equal(
+      'anthropic/claude-sonnet-4-5'
+    );
+    expect(payloads[1].meta_data.gateway.model_alias).to.equal(
+      'anthropic/claude-haiku-4-5'
+    );
+  });
+
+  it('never offers the primary model as an extra', async () => {
+    await primeForm([]);
+
+    expect((element as any)._additionalModelChoices).to.deep.equal([
+      'claude-haiku-4-5',
+    ]);
+  });
+
+  it('drops the newly chosen primary from an existing extras selection', async () => {
+    await primeForm(['claude-haiku-4-5']);
+
+    (element as any)._handleModelNameChange({
+      target: { value: 'claude-haiku-4-5' },
+    });
+
+    expect((element as any)._additionalModelIds).to.deep.equal([]);
+  });
+
+  it('reports partial success when an extra model fails to create', async () => {
+    await primeForm(['claude-haiku-4-5']);
+    fetchStub.callsFake(async (url: any, init: any) => {
+      const target = String(url);
+      if (target.includes('/api/v1/ai-models') && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body));
+        if (body.model_identifier === 'claude-haiku-4-5') {
+          return new Response(JSON.stringify({ detail: 'nope' }), {
+            status: 400,
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            id: 'id-primary',
+            ...body,
+            credentials_secret_id: SECRET_ID,
+          }),
+          { status: 201 }
+        );
+      }
+      return new Response(JSON.stringify([]));
+    });
+
+    await (element as any)._handleFormSubmit(new Event('submit'));
+
+    // The primary succeeded, so this must not read as a total failure.
+    expect((element as any)._formError).to.contain('claude-haiku-4-5');
+    expect((element as any)._formError).to.contain('claude-sonnet-4-5');
+  });
+});

--- a/frontend/src/components/add-ai-model-modal.ts
+++ b/frontend/src/components/add-ai-model-modal.ts
@@ -91,6 +91,11 @@ export class AddAIModelModal extends LitElement {
   @state() private _isOtherModel = false;
   @state() private _isFetchingModels = false;
   @state() private _modelsFetchError: string | null = null;
+  /**
+   * Extra models to create alongside the primary one, all sharing the single
+   * provider key entered on this form. Create-mode only.
+   */
+  @state() private _additionalModelIds: string[] = [];
   /** When true, register this model for Preloop gateway routing (requires upstream API key). */
   @state() private _preloopGatewayEnabled = true;
 
@@ -148,6 +153,7 @@ export class AddAIModelModal extends LitElement {
     }
     this._modelSuggestions = [];
     this._isOtherModel = false;
+    this._additionalModelIds = [];
     this._formError = null;
     this._isSubmitting = false;
     this._isFetchingModels = false;
@@ -155,15 +161,23 @@ export class AddAIModelModal extends LitElement {
   }
 
   /** Merge gateway routing metadata; gateway.enabled only when upstream credentials exist. */
-  private _buildMetaDataForSubmit(): Record<string, unknown> {
+  /**
+   * @param modelIdOverride Build the gateway alias for this model id instead of
+   *   the primary one. Used when creating extra models that share one key —
+   *   each needs its own alias or they would all resolve to the same entry.
+   */
+  private _buildMetaDataForSubmit(
+    modelIdOverride?: string
+  ): Record<string, unknown> {
     const existing =
       this._isEditing &&
+      !modelIdOverride &&
       this.model?.meta_data &&
       typeof this.model.meta_data === 'object'
         ? { ...this.model.meta_data }
         : {};
     const provider = this._currentModel.provider_name;
-    const modelId = this._currentModel.model_identifier;
+    const modelId = modelIdOverride ?? this._currentModel.model_identifier;
     const modelKind = this._currentModel.model_kind || 'llm';
     const baseMeta = {
       ...existing,
@@ -245,6 +259,7 @@ export class AddAIModelModal extends LitElement {
 
     this._modelSuggestions = [];
     this._isOtherModel = false;
+    this._additionalModelIds = [];
     this._modelsFetchError = null;
     this.requestUpdate();
     if (this._selectedServiceKind !== 'llm') {
@@ -291,6 +306,7 @@ export class AddAIModelModal extends LitElement {
     }
     this._modelSuggestions = [];
     this._isOtherModel = false;
+    this._additionalModelIds = [];
     this._modelsFetchError = null;
     this.requestUpdate();
     if (providerSupported && modelKind !== 'llm') {
@@ -346,10 +362,71 @@ export class AddAIModelModal extends LitElement {
       this._isOtherModel = false;
       this._currentModel.model_identifier = selectedValue;
     }
+    // The primary model must never also appear in the extras list, or we would
+    // try to create it twice.
+    this._additionalModelIds = this._additionalModelIds.filter(
+      (id) => id !== this._currentModel.model_identifier
+    );
   }
 
   private _handleCustomModelInput(e: Event) {
     this._currentModel.model_identifier = (e.target as SlInput).value;
+  }
+
+  private _handleAdditionalModelsChange(e: Event) {
+    const value = (e.target as SlSelect).value;
+    this._additionalModelIds = Array.isArray(value) ? [...value] : [];
+  }
+
+  /**
+   * Models offered as extras: everything discovered for this provider except
+   * the one already chosen as primary.
+   */
+  private get _additionalModelChoices(): string[] {
+    const primary = this._currentModel.model_identifier;
+    return this._modelSuggestions.filter((id) => id !== primary);
+  }
+
+  /**
+   * Create the extra selected models, each reusing the primary model's secret
+   * so a single provider key backs all of them.
+   *
+   * A failure here must not look like a total failure: the primary model was
+   * already created successfully, so we surface a partial-success message
+   * rather than throwing.
+   */
+  private async _createAdditionalModels(primary: AIModel): Promise<AIModel[]> {
+    const secretId = primary.credentials_secret_id;
+    if (!this._additionalModelIds.length || !secretId) return [];
+
+    const created: AIModel[] = [];
+    const failed: string[] = [];
+
+    for (const modelId of this._additionalModelIds) {
+      try {
+        created.push(
+          await createAIModel({
+            name: modelId,
+            description: this._currentModel.description,
+            provider_name: this._currentModel.provider_name,
+            model_identifier: modelId,
+            model_kind: this._currentModel.model_kind,
+            api_endpoint: this._currentModel.api_endpoint,
+            credentials_secret_id: secretId,
+            is_default: false,
+            meta_data: this._buildMetaDataForSubmit(modelId),
+          })
+        );
+      } catch (error) {
+        console.error(`Failed to create additional model ${modelId}:`, error);
+        failed.push(modelId);
+      }
+    }
+
+    if (failed.length) {
+      this._formError = `Added ${primary.model_identifier}, but these could not be added: ${failed.join(', ')}. You can add them separately.`;
+    }
+    return created;
   }
 
   // ── submit ───────────────────────────────────────────
@@ -399,9 +476,10 @@ export class AddAIModelModal extends LitElement {
         );
       } else {
         const created = await createAIModel(payload);
+        const extraModels = await this._createAdditionalModels(created);
         this.dispatchEvent(
           new CustomEvent('model-created', {
-            detail: { model: created },
+            detail: { model: created, additionalModels: extraModels },
             bubbles: true,
             composed: true,
           })
@@ -640,6 +718,29 @@ export class AddAIModelModal extends LitElement {
                         @sl-input=${this._handleCustomModelInput}
                         ?disabled=${this._isSubmitting}
                       ></sl-input>
+                    `
+                  )}
+                  ${when(
+                    !this._isEditing &&
+                      !this._isOtherModel &&
+                      this._additionalModelChoices.length > 0,
+                    () => html`
+                      <sl-select
+                        class="full-width"
+                        label="Also add (optional)"
+                        multiple
+                        clearable
+                        .value=${this._additionalModelIds}
+                        @sl-change=${this._handleAdditionalModelsChange}
+                        ?disabled=${this._isSubmitting}
+                        help-text="Add more models from this provider. They all reuse the same API key you entered above."
+                      >
+                        ${repeat(
+                          this._additionalModelChoices,
+                          (s) => s,
+                          (s) => html`<sl-option value="${s}">${s}</sl-option>`
+                        )}
+                      </sl-select>
                     `
                   )}
                 `

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7442,6 +7442,15 @@ components:
           - type: 'null'
           title: Meta Data
           description: Optional, for custom fields, labels, etc.
+        credentials_secret_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Credentials Secret Id
+          description: Reuse an existing SecretReference instead of minting a new
+            one. Used to create several models that share a single provider key. The
+            secret must already belong to the caller's account.
       type: object
       required:
       - name


### PR DESCRIPTION
**Ships this release.** Safe to merge during launch week.

Base is `launch-week-hardening` (#78), not `main` — rebase to `main` once #78 lands. Mirrors how #81 was done.

## What this does

Adding a provider key created exactly one model. Using Haiku *and* Sonnet from one Anthropic key meant entering that key twice and storing it twice.

...

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-scoped feature with proper security (account-bound secret reuse) and a critical non-deterministic resolution fix. 12 new tests, no regressions, no schema changes.
>
> **Overview**
> Enables one provider key to back multiple AI models via `credentials_secret_id` reuse. Simultaneously fixes nondeterministic model resolution by adding exact-match precedence and stable query ordering — the multi-model feature would have made unpredictable pricing reachable without this fix. Deletion semantics (ref-counting) already existed and are now tested.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 4083143. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->