### PR TITLE
Claude model-family env core for /model switching (post-launch)

### DIFF
--- a/cli/internal/cmd/agents_model_family.go
+++ b/cli/internal/cmd/agents_model_family.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// claudeModelFamily is one of the model families Claude Code's `/model` picker
+// knows about natively. Claude Code resolves a family selector (e.g. "sonnet")
+// through the matching ANTHROPIC_DEFAULT_<FAMILY>_MODEL environment variable,
+// which is why populating those keys is what makes `/model` switching work
+// against a custom gateway.
+type claudeModelFamily struct {
+	// selector is the bare name Claude Code uses ("opus", "sonnet", "haiku").
+	selector string
+	// envKey is the variable Claude Code reads to resolve that selector.
+	envKey string
+	// aliasMarkers identify the family from a gateway alias.
+	aliasMarkers []string
+}
+
+// claudeModelFamilies is ordered most- to least-capable. The order is only used
+// to make output deterministic; it implies no preference.
+var claudeModelFamilies = []claudeModelFamily{
+	{selector: "opus", envKey: "ANTHROPIC_DEFAULT_OPUS_MODEL", aliasMarkers: []string{"claude-opus", "/opus"}},
+	{selector: "sonnet", envKey: "ANTHROPIC_DEFAULT_SONNET_MODEL", aliasMarkers: []string{"claude-sonnet", "/sonnet"}},
+	{selector: "haiku", envKey: "ANTHROPIC_DEFAULT_HAIKU_MODEL", aliasMarkers: []string{"claude-haiku", "/haiku"}},
+}
+
+// claudeFamilyForAlias reports which family a gateway alias belongs to.
+//
+// It returns an empty family and false for aliases outside the three known
+// families (a bare custom model, a non-Anthropic provider, and so on). Those
+// are reachable only through ANTHROPIC_CUSTOM_MODEL_OPTION, not through the
+// family selectors.
+func claudeFamilyForAlias(alias string) (claudeModelFamily, bool) {
+	lower := strings.ToLower(strings.TrimSpace(alias))
+	if lower == "" {
+		return claudeModelFamily{}, false
+	}
+	for _, family := range claudeModelFamilies {
+		for _, marker := range family.aliasMarkers {
+			if strings.Contains(lower, marker) {
+				return family, true
+			}
+		}
+	}
+	return claudeModelFamily{}, false
+}
+
+// claudeFamilyModelEnv builds the ANTHROPIC_DEFAULT_*_MODEL environment entries
+// for every family represented in aliases.
+//
+// This is the core of making `/model` work against the Preloop gateway. Onboard
+// currently writes the keys for the single family it pinned and deletes the
+// other two, so a Sonnet-onboarded agent has no ANTHROPIC_DEFAULT_OPUS_MODEL
+// and no ANTHROPIC_DEFAULT_HAIKU_MODEL. Switching to Opus in `/model` then sends
+// Claude Code's built-in Opus identifier, which is not in the account registry,
+// and the gateway answers 404. The same gap is why a subagent pinned to a
+// different family cannot reach the gateway either.
+//
+// When several aliases map to one family the first wins, so the caller controls
+// precedence by ordering its input; the result is otherwise independent of input
+// order. Aliases outside the known families are ignored — they are addressable
+// via ANTHROPIC_CUSTOM_MODEL_OPTION instead.
+//
+// This function is deliberately pure: it reads no config and writes no files, so
+// it can be tested exhaustively before anything is wired into the onboarding
+// path.
+func claudeFamilyModelEnv(aliases []string) map[string]string {
+	env := make(map[string]string)
+	for _, alias := range aliases {
+		alias = strings.TrimSpace(alias)
+		family, ok := claudeFamilyForAlias(alias)
+		if !ok {
+			continue
+		}
+		if _, exists := env[family.envKey]; exists {
+			// First alias for a family wins; caller ordering decides.
+			continue
+		}
+		env[family.envKey] = alias
+		env[family.envKey+"_NAME"] = "Preloop " + alias
+	}
+	return env
+}
+
+// claudeStaleFamilyEnvKeys lists the family env keys that must be removed
+// because the account has no model for that family.
+//
+// Replacing clearClaudePinnedModelEnv's unconditional wipe with this is the
+// behavioral change: keys are cleared only when they would otherwise point at a
+// model the gateway cannot serve. Leaving a stale key in place would be worse
+// than deleting it — `/model` would offer an entry that 404s.
+func claudeStaleFamilyEnvKeys(aliases []string) []string {
+	present := claudeFamilyModelEnv(aliases)
+	var stale []string
+	for _, family := range claudeModelFamilies {
+		if _, ok := present[family.envKey]; ok {
+			continue
+		}
+		stale = append(stale,
+			family.envKey,
+			family.envKey+"_NAME",
+			family.envKey+"_DESCRIPTION",
+			family.envKey+"_SUPPORTED_CAPABILITIES",
+		)
+	}
+	sort.Strings(stale)
+	return stale
+}
+
+// describeClaudeFamilyCoverage renders a human-readable summary of which
+// families `/model` will be able to reach, for onboarding output.
+func describeClaudeFamilyCoverage(aliases []string) string {
+	env := claudeFamilyModelEnv(aliases)
+	if len(env) == 0 {
+		return "No Claude model families available; /model switching will not be routed through Preloop."
+	}
+	var parts []string
+	for _, family := range claudeModelFamilies {
+		if alias, ok := env[family.envKey]; ok {
+			parts = append(parts, fmt.Sprintf("%s -> %s", family.selector, alias))
+		}
+	}
+	return "Preloop will serve /model selections: " + strings.Join(parts, ", ")
+}

--- a/cli/internal/cmd/agents_model_family.go
+++ b/cli/internal/cmd/agents_model_family.go
@@ -22,7 +22,14 @@ type claudeModelFamily struct {
 
 // claudeModelFamilies is ordered most- to least-capable. The order is only used
 // to make output deterministic; it implies no preference.
-var claudeModelFamilies = []claudeModelFamily{
+// After wiring, claudePinnedModelSelection can delegate:
+func claudePinnedModelSelection(modelAlias string) (string, string) {
+	family, ok := claudeFamilyForAlias(modelAlias)
+	if !ok {
+		return "", ""
+	}
+	return family.selector, family.envKey
+}
 	{selector: "opus", envKey: "ANTHROPIC_DEFAULT_OPUS_MODEL", aliasMarkers: []string{"claude-opus", "/opus"}},
 	{selector: "sonnet", envKey: "ANTHROPIC_DEFAULT_SONNET_MODEL", aliasMarkers: []string{"claude-sonnet", "/sonnet"}},
 	{selector: "haiku", envKey: "ANTHROPIC_DEFAULT_HAIKU_MODEL", aliasMarkers: []string{"claude-haiku", "/haiku"}},

--- a/cli/internal/cmd/agents_model_family_test.go
+++ b/cli/internal/cmd/agents_model_family_test.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestClaudeFamilyForAlias(t *testing.T) {
+	cases := []struct {
+		name     string
+		alias    string
+		selector string
+		ok       bool
+	}{
+		{"prefixed opus", "anthropic/claude-opus-4-1", "opus", true},
+		{"prefixed sonnet", "anthropic/claude-sonnet-4-5", "sonnet", true},
+		{"prefixed haiku", "anthropic/claude-haiku-4-5", "haiku", true},
+		{"bare sonnet", "claude-sonnet-4-5", "sonnet", true},
+		{"slash selector", "bedrock/sonnet", "sonnet", true},
+		{"mixed case", "Anthropic/Claude-Opus-4-1", "opus", true},
+		{"padded", "  anthropic/claude-haiku-4-5  ", "haiku", true},
+		{"non-family model", "openai/gpt-5", "", false},
+		{"custom model", "anthropic/my-finetune", "", false},
+		{"empty", "", "", false},
+		{"whitespace only", "   ", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			family, ok := claudeFamilyForAlias(tc.alias)
+			if ok != tc.ok {
+				t.Fatalf("claudeFamilyForAlias(%q) ok = %v, want %v", tc.alias, ok, tc.ok)
+			}
+			if family.selector != tc.selector {
+				t.Fatalf("claudeFamilyForAlias(%q) selector = %q, want %q", tc.alias, family.selector, tc.selector)
+			}
+		})
+	}
+}
+
+// The behaviour this whole change exists for: an account holding all three
+// families must produce all three env keys, so /model can reach each one.
+func TestClaudeFamilyModelEnvCoversEveryFamily(t *testing.T) {
+	env := claudeFamilyModelEnv([]string{
+		"anthropic/claude-opus-4-1",
+		"anthropic/claude-sonnet-4-5",
+		"anthropic/claude-haiku-4-5",
+	})
+
+	want := map[string]string{
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":        "anthropic/claude-opus-4-1",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL_NAME":   "Preloop anthropic/claude-opus-4-1",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL":      "anthropic/claude-sonnet-4-5",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL_NAME": "Preloop anthropic/claude-sonnet-4-5",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":       "anthropic/claude-haiku-4-5",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME":  "Preloop anthropic/claude-haiku-4-5",
+	}
+	if !reflect.DeepEqual(env, want) {
+		t.Fatalf("claudeFamilyModelEnv() = %#v, want %#v", env, want)
+	}
+}
+
+// Today's onboarding writes one family and deletes the other two. This pins the
+// improvement: a Sonnet-onboarded agent that also owns Haiku keeps the Haiku key
+// instead of losing it, which is what fixes subagent-on-a-different-model.
+func TestClaudeFamilyModelEnvKeepsSiblingFamilies(t *testing.T) {
+	env := claudeFamilyModelEnv([]string{
+		"anthropic/claude-sonnet-4-5",
+		"anthropic/claude-haiku-4-5",
+	})
+
+	if env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] != "anthropic/claude-haiku-4-5" {
+		t.Fatalf("haiku key missing: %#v", env)
+	}
+	if env["ANTHROPIC_DEFAULT_SONNET_MODEL"] != "anthropic/claude-sonnet-4-5" {
+		t.Fatalf("sonnet key missing: %#v", env)
+	}
+	if _, ok := env["ANTHROPIC_DEFAULT_OPUS_MODEL"]; ok {
+		t.Fatalf("opus key must not be invented for a model the account lacks: %#v", env)
+	}
+}
+
+func TestClaudeFamilyModelEnvIgnoresUnknownAliases(t *testing.T) {
+	env := claudeFamilyModelEnv([]string{"openai/gpt-5", "anthropic/my-finetune", ""})
+	if len(env) != 0 {
+		t.Fatalf("expected no family keys, got %#v", env)
+	}
+}
+
+func TestClaudeFamilyModelEnvFirstAliasWinsPerFamily(t *testing.T) {
+	env := claudeFamilyModelEnv([]string{
+		"anthropic/claude-sonnet-4-5",
+		"bedrock/claude-sonnet-4-5",
+	})
+
+	if got := env["ANTHROPIC_DEFAULT_SONNET_MODEL"]; got != "anthropic/claude-sonnet-4-5" {
+		t.Fatalf("first alias should win, got %q", got)
+	}
+}
+
+// Independence from input order matters: the alias list comes from an account
+// query whose order the CLI does not control.
+func TestClaudeFamilyModelEnvIsOrderIndependentAcrossFamilies(t *testing.T) {
+	a := claudeFamilyModelEnv([]string{
+		"anthropic/claude-opus-4-1",
+		"anthropic/claude-haiku-4-5",
+	})
+	b := claudeFamilyModelEnv([]string{
+		"anthropic/claude-haiku-4-5",
+		"anthropic/claude-opus-4-1",
+	})
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("result depends on input order: %#v vs %#v", a, b)
+	}
+}
+
+// A key pointing at a model the gateway cannot serve is worse than no key: it
+// would appear in /model and then 404.
+func TestClaudeStaleFamilyEnvKeysClearsOnlyAbsentFamilies(t *testing.T) {
+	stale := claudeStaleFamilyEnvKeys([]string{"anthropic/claude-sonnet-4-5"})
+
+	want := []string{
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL_DESCRIPTION",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL_NAME",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES",
+	}
+	sort.Strings(want)
+	if !reflect.DeepEqual(stale, want) {
+		t.Fatalf("claudeStaleFamilyEnvKeys() = %#v, want %#v", stale, want)
+	}
+
+	for _, key := range stale {
+		if key == "ANTHROPIC_DEFAULT_SONNET_MODEL" {
+			t.Fatal("must never clear a family the account actually has")
+		}
+	}
+}
+
+func TestClaudeStaleFamilyEnvKeysClearsAllWhenNoFamiliesPresent(t *testing.T) {
+	stale := claudeStaleFamilyEnvKeys([]string{"openai/gpt-5"})
+	if len(stale) != 12 {
+		t.Fatalf("expected all 12 family keys stale, got %d: %#v", len(stale), stale)
+	}
+}
+
+func TestClaudeStaleFamilyEnvKeysEmptyWhenAllFamiliesPresent(t *testing.T) {
+	stale := claudeStaleFamilyEnvKeys([]string{
+		"anthropic/claude-opus-4-1",
+		"anthropic/claude-sonnet-4-5",
+		"anthropic/claude-haiku-4-5",
+	})
+	if len(stale) != 0 {
+		t.Fatalf("expected nothing stale, got %#v", stale)
+	}
+}
+
+// The new helper must agree with the existing pinning logic about which family
+// an alias belongs to, or onboarding and switching would disagree.
+func TestClaudeFamilyForAliasAgreesWithPinnedSelection(t *testing.T) {
+	for _, alias := range []string{
+		"anthropic/claude-opus-4-1",
+		"anthropic/claude-sonnet-4-5",
+		"anthropic/claude-haiku-4-5",
+		"openai/gpt-5",
+	} {
+		selector, envKey := claudePinnedModelSelection(alias)
+		family, ok := claudeFamilyForAlias(alias)
+		if ok != (envKey != "") {
+			t.Fatalf("alias %q: disagreement on family membership", alias)
+		}
+		if ok && (family.selector != selector || family.envKey != envKey) {
+			t.Fatalf("alias %q: got (%q,%q), pinned logic says (%q,%q)",
+				alias, family.selector, family.envKey, selector, envKey)
+		}
+	}
+}
+
+func TestDescribeClaudeFamilyCoverage(t *testing.T) {
+	got := describeClaudeFamilyCoverage([]string{
+		"anthropic/claude-sonnet-4-5",
+		"anthropic/claude-haiku-4-5",
+	})
+	want := "Preloop will serve /model selections: sonnet -> anthropic/claude-sonnet-4-5, haiku -> anthropic/claude-haiku-4-5"
+	if got != want {
+		t.Fatalf("describeClaudeFamilyCoverage() = %q, want %q", got, want)
+	}
+
+	if got := describeClaudeFamilyCoverage([]string{"openai/gpt-5"}); got == "" {
+		t.Fatal("expected an explanatory message when no families are available")
+	}
+}


### PR DESCRIPTION
## The problem

Switching a Claude Code agent's model requires offboard → change → reonboard. There is no `agents update` command; the registered subcommands are `discover, onboard, status, list, validate, install-plugin, restore, offboard, starter-policy`, and re-running `onboard` on an already-onboarded agent is a no-op for the model.

Onboard pins exactly one family. For a Sonnet agent, `applyClaudeManagedGateway` writes `ANTHROPIC_DEFAULT_SONNET_MODEL` and then `clearClaudePinnedModelEnv` **deletes the Opus and Haiku keys outright** (`agents.go:3675-3692`).

So selecting Opus in `/model` sends Claude Code's *built-in* Opus identifier, which is not in the account registry, and the gateway answers 404. The same missing `ANTHROPIC_DEFAULT_HAIKU_MODEL` is why a subagent on a different family cannot reach the gateway.

The good news the investigation turned on: **Claude Code's `/model` menu is driven by env keys Preloop already knows how to write.** Making three models visible does not require Claude Code to learn anything new — it requires Preloop to stop deleting two-thirds of the keys it already writes.

## What is in this PR

The pure, exhaustively-tested core — and deliberately nothing else:

| Function | Role |
|---|---|
| `claudeFamilyForAlias` | which family a gateway alias belongs to |
| `claudeFamilyModelEnv` | env entries for every family the account actually has |
| `claudeStaleFamilyEnvKeys` | only the families the account genuinely lacks |
| `describeClaudeFamilyCoverage` | operator-facing summary |

`claudeStaleFamilyEnvKeys` is the behavioral heart: keys are cleared **only** when they would otherwise point at a model the gateway cannot serve, instead of wiping two-thirds unconditionally. A stale key is worse than an absent one — `/model` would offer an entry that 404s.

## Why it is safe to sit here

**Nothing calls any of it.** `cli/internal/cmd/agents.go` is untouched — this PR adds two new files and changes no existing one. The onboarding path is byte-for-byte unchanged, and this commit cannot alter runtime behavior at all. Verified: `grep` finds no callers outside the new files; full `go test ./internal/cmd/` passes; `go vet` and `gofmt` clean.

## What is deliberately NOT here

- Threading an account-model lookup through the enrollment plan and calling this from `applyClaudeManagedGateway`.
- The `preloop agents set-model` / `agents update` command (needed for Codex, where the alias is pinned in `config.toml` and `/model` cannot reach it, and for non-family models).
- Live validation across Claude Code and Codex on a real host.

That work is 1-2 days plus live validation and it modifies the frozen path. Splitting the pure logic out now means the risky part shrinks to a call-site change against logic that is already proven, rather than one large change written under launch-week pressure. **I chose not to rush the wiring rather than land something half-validated on the onboarding path.**

## Tests

21 table-driven tests: family detection (prefixed, bare, mixed-case, padded, unknown, empty), multi-family coverage, sibling retention, order independence, first-alias-wins precedence, stale-key selection in all three configurations, and agreement with the existing `claudePinnedModelSelection` logic so onboarding and switching cannot disagree.

## Adjacent findings, not addressed here

- Offboard with no local backup state does **not** clear the pinned `ANTHROPIC_*` keys — it only removes the MCP server and approval hooks (`agents.go:2030-2038`). The agent is left pointed at the gateway with a revoked token.
- `GET /anthropic/v1/models` does not exist (OpenAI and Gemini both have one). Cheap and low-risk, but it buys nothing for Claude Code, which does not appear to query it.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Critical Risk**
> Post-merge commit `a6a8bd74` broke compilation by deleting the `var claudeModelFamilies` declaration and adding a duplicate function. Original PR (`167edab`) was clean.
>
> **Overview**
> Adds a model-family abstraction layer that will enable multi-model `/model` switching in Claude Code. The original PR is well-tested and isolated, but a suggestion application in the follow-up commit introduced a compilation error.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit a6a8bd74. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->