### PR TITLE
Launch hardening: bootstrap registration, async optimize jobs, model authorization, funnel telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Bootstrap setup token for the first registration.** On a fresh (zero-user)
+  instance with `PRELOOP_BOOTSTRAP_TOKEN` configured, `/register` requires the
+  token: the installer generates one, persists it to the instance `.env`, and
+  prints a `/register#bootstrap=<token>` setup link to the terminal only. This
+  closes the race where a stranger could claim a freshly installed public
+  instance before its operator. First signup is serialized with a database
+  advisory lock, and account+user+role now commit in a single transaction.
+- **Async session-optimization jobs.** `POST /account/runtime-sessions/{id}/optimizations/jobs`
+  runs the analysis in a bounded background worker and returns `202` with a
+  pollable job; the console Optimize tab shows analyzing / failed+retry /
+  no-waste states instead of a spinnerless multi-minute wait. The synchronous
+  endpoint is unchanged.
+- **Activation telemetry markers.** Self-hosted instances report a one-time
+  `install_completed` marker on the existing daily version check-in, and the
+  CLI reports a one-time `cli_first_run` marker — both suppressed by
+  `PRELOOP_DISABLE_TELEMETRY`. A new in-instance `first_session_seen` hook
+  registry lets plugins observe first agent activity; the event never leaves
+  the instance. The full contract is documented in SECURITY.md.
+
+### Fixed
+
+- **Per-principal model authorization at the gateway.** Model listing,
+  requested-model resolution (exact and suffix), and default-model selection
+  now all consume one authorized-model computation: principal-bound
+  subscription-OAuth models are visible only to their bound managed agent, and
+  credentials with no bound models fail closed instead of seeing everything.
+  Rejections return `model_not_authorized` with the usable model ids.
+- CLI first-run telemetry read `first_run=false` on the very first run.
+
 ## [0.12.6] - 2026-07-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ curl -fsSL https://preloop.ai/install/cli | sh
 
 # 2. Connect it to a control plane:
 preloop signup                                # Preloop Cloud (fastest), or
-preloop login --url http://localhost:8000    # your self-hosted instance (see Getting Started)
+preloop login --url http://localhost:3000    # your self-hosted instance (see Getting Started)
 
 # 3. Bring your local agents under governance
 preloop agents discover
@@ -227,11 +227,11 @@ curl -fsSL https://preloop.ai/install/oss | sh
 
 # Install the CLI and connect it to YOUR instance instead of preloop.ai
 curl -fsSL https://preloop.ai/install/cli | sh
-preloop login --url http://localhost:8000
+preloop login --url http://localhost:3000
 preloop agents discover
 ```
 
-The console is at `http://localhost:3000` — create the first user there or let `preloop login` walk you through it. You can also set the instance URL via the environment (`PRELOOP_URL=http://localhost:8000 preloop login`); the CLI stores it in `~/.preloop/config.yaml`, so every later command targets your instance. Without `--url` or `PRELOOP_URL`, the CLI defaults to `https://preloop.ai`.
+The console is at `http://localhost:3000` — create the first user there or let `preloop login` walk you through it. You can also set the instance URL via the environment (`PRELOOP_URL=http://localhost:3000 preloop login`); the CLI stores it in `~/.preloop/config.yaml`, so every later command targets your instance. Without `--url` or `PRELOOP_URL`, the CLI defaults to `https://preloop.ai`.
 
 #### Public deployments: HTTPS and email
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ The installer detects the existing install and keeps its configuration (public U
 
 For Kubernetes/prod-like deployments, use the Helm chart in [`helm/preloop`](helm/preloop) and connect the CLI with `preloop login --url https://your-preloop.example.com`.
 
+### Telemetry
+
+Self-hosted instances and the CLI send a daily, pseudonymous version check-in (random UUID, version, platform — no user data), which also carries one-time `install_completed` / `cli_first_run` markers. Set `PRELOOP_DISABLE_TELEMETRY=true` (in the instance `.env`, or in the CLI's environment) to disable it entirely; the bash installer itself never phones home. The complete event and field list is in [SECURITY.md](SECURITY.md#telemetry).
+
 ### Release smoke test
 
 Every tagged release is verified automatically before it is published: the `verify-oss-install` job in the release workflow runs [`scripts/release_smoke_test.sh`](scripts/release_smoke_test.sh), which boots `docker-compose.release.yaml` with the tagged images, checks API/gateway/console health, exercises first-user sign-up and login, and fails if any service restart-loops. You can run the same script locally with `PRELOOP_VERSION=0.12.6 ./scripts/release_smoke_test.sh`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,3 +18,31 @@ We will acknowledge receipt as soon as possible and work with you on validation,
 Security fixes are generally applied to the latest supported release line.
 
 For self-hosted deployments, we recommend upgrading to the latest release as soon as practical.
+
+## Telemetry
+
+Preloop emits a small, fixed set of opt-out adoption events. All of them are pseudonymous (random UUIDs, no user data), and this section is the complete list.
+
+### Events
+
+**`install_completed`** — instance-level, sent once per installation. It rides the existing daily version check-in (`POST https://preloop.ai/api/v1/version`); there is no separate outbound call. The check-in payload carries:
+
+- `instance_uuid` — random UUID generated at first server startup
+- `version`, `edition` (`oss` or `enterprise`)
+- `metadata` — instance metadata; on exactly one check-in it includes `install_completed: true`, plus `install_started_at` / `install_completed_at` **only if** the installer stamped `PRELOOP_INSTALL_STARTED_AT` / `PRELOOP_INSTALL_COMPLETED_AT` into the instance `.env` (absent stamps are omitted, never synthesized)
+
+**`cli_first_run`** — CLI-level, sent once per CLI install. It rides the existing CLI version check-in (`POST /api/v1/cli/version-check`), which carries:
+
+- `client_id` — random UUID stored in the CLI config directory
+- `version`, `os`, `arch`
+- `preloop_url` — the server URL the CLI is configured against
+- `token_fingerprint` — first 16 hex characters of the SHA-256 of the access token; the token itself is never sent, and the bearer header is only attached when the CLI is authenticated against the version-check server itself
+- `metadata` — `first_run: true` on the very first run only, and `cmd_<category>` counters (top-level command names only, never arguments or user data)
+
+**`first_session_seen`** — account-level, recorded when an account's first agent runtime session is recorded: account id and timestamp, once per account. This event exists only on deployments running the enterprise growth plugin and is written to that instance's **own database** — it is never transmitted anywhere. Open-source builds contain only an inert no-op hook.
+
+### Opt-out
+
+- `PRELOOP_DISABLE_TELEMETRY=true` in the instance `.env` suppresses all server-side events: version check-ins, `install_completed`, and `first_session_seen`. (`DISABLE_VERSION_CHECK` is honored as a legacy alias.)
+- The same variable in the CLI's environment suppresses all CLI events: the check-in, `cli_first_run`, and command counters. Update notifications stop too — they are derived from the check-in response.
+- The bash installer itself never phones home.

--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -325,6 +325,21 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     else:
         logger.info("Skipping execution monitor for %s role.", service_role)
 
+    # Start the optimization-job recovery sweeper (skip in testing mode). It
+    # runs one sweep immediately, recovering jobs abandoned by the previous
+    # process, then every couple of minutes.
+    optimization_job_sweeper = None
+    if not is_testing and is_api_role:
+        from preloop.services.session_optimization_jobs import (
+            get_optimization_job_sweeper,
+        )
+
+        optimization_job_sweeper = get_optimization_job_sweeper()
+        await optimization_job_sweeper.start()
+        logger.info("Optimization job sweeper started.")
+    else:
+        logger.info("Skipping optimization job sweeper for %s role.", service_role)
+
     # Recover orphaned flow executions (skip in testing mode)
     recovery_service = None
     if not is_testing and is_api_role:
@@ -512,6 +527,23 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.error(f"Error stopping MCP lifespan: {e}", exc_info=True)
     else:
         logger.info("Skipping MCP shutdown for %s role.", service_role)
+
+    # Stop the optimization-job sweeper and abandon in-flight optimization
+    # jobs (skip in testing mode). shutdown(wait=False) on purpose: a model
+    # pass can take minutes; abandoned rows are failed by the sweeper after
+    # restart with the retriable user-facing copy.
+    if not is_testing and optimization_job_sweeper:
+        from preloop.services.session_optimization_jobs import shutdown_job_executor
+
+        try:
+            await optimization_job_sweeper.stop()
+            logger.info("Optimization job sweeper stopped.")
+        except Exception as e:
+            logger.error(f"Error stopping optimization job sweeper: {e}", exc_info=True)
+        shutdown_job_executor()
+        logger.info("Optimization job executor shut down.")
+    else:
+        logger.info("Skipping optimization job shutdown for %s role.", service_role)
 
     # Stop the execution monitor (skip in testing mode)
     if not is_testing and execution_monitor:

--- a/backend/preloop/api/auth/bootstrap.py
+++ b/backend/preloop/api/auth/bootstrap.py
@@ -1,0 +1,159 @@
+"""Computed bootstrap-registration rule shared by /register and /features.
+
+A fresh (zero-user) instance with a bootstrap token configured
+(``PRELOOP_BOOTSTRAP_TOKEN``) is "unclaimed": registration is allowed ONLY
+with the token, regardless of ``settings.registration_enabled``. When the
+token is not configured, a zero-user instance keeps today's behavior
+(``registration_enabled`` decides). Once the instance has at least one user,
+``registration_enabled`` decides — the token is never consulted again.
+"""
+
+import secrets
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from sqlalchemy.orm import Session
+
+from preloop.config import settings
+from preloop.models.crud import crud_user
+
+# Sticky process-level cache for "does this instance have any users?".
+# Transitions only once in an instance lifetime (False -> True when the first
+# account registers) and never flips back, so caching True forever is safe and
+# avoids a DB round-trip on every /features call (landing, signup, authed
+# views). Mutable mapping avoids a module-level `global` flag (CodeQL
+# unused-global FP). None = unknown (must query); True = at least one user
+# exists.
+_users_exist_state: Dict[str, Optional[bool]] = {"known": None}
+
+REASON_BOOTSTRAP_TOKEN_REQUIRED = "bootstrap_token_required"
+REASON_REGISTRATION_DISABLED = "registration_disabled"
+
+
+def reset_users_exist_cache() -> None:
+    """Clear the sticky users-exist cache (for tests)."""
+    _users_exist_state["known"] = None
+
+
+def users_exist(db: Session) -> bool:
+    """Return whether at least one user exists, with a sticky True cache.
+
+    Args:
+        db: Database session.
+
+    Returns:
+        True when any user row exists (cached process-wide once observed),
+        False on a fresh instance (always re-queried, never cached).
+    """
+    if _users_exist_state["known"] is True:
+        return True
+    if crud_user.has_any_users(db):
+        _users_exist_state["known"] = True
+        return True
+    return False
+
+
+def bootstrap_token_configured() -> bool:
+    """Return whether a bootstrap token is configured for this instance."""
+    return bool(settings.bootstrap_token)
+
+
+def bootstrap_token_valid(candidate: Optional[str]) -> bool:
+    """Constant-time comparison of a submitted token against the configured one.
+
+    Args:
+        candidate: Token submitted with the registration request, if any.
+
+    Returns:
+        True only when a token is configured AND the candidate matches it.
+    """
+    configured = settings.bootstrap_token
+    if not configured or not candidate:
+        return False
+    return secrets.compare_digest(candidate.encode("utf-8"), configured.encode("utf-8"))
+
+
+def bootstrap_pending(db: Session) -> bool:
+    """Return True while the instance is unclaimed (zero users + token set)."""
+    return bootstrap_token_configured() and not users_exist(db)
+
+
+@dataclass(frozen=True)
+class RegistrationDecision:
+    """Outcome of evaluating the computed registration rule.
+
+    Attributes:
+        allowed: Whether the registration may proceed.
+        reason: Denial reason (``REASON_*`` constant) when not allowed.
+    """
+
+    allowed: bool
+    reason: Optional[str] = None
+
+
+def evaluate_registration(
+    db: Session, bootstrap_token: Optional[str] = None
+) -> RegistrationDecision:
+    """Evaluate the computed registration rule for one request.
+
+    Args:
+        db: Database session.
+        bootstrap_token: Optional token submitted with the request.
+
+    Returns:
+        RegistrationDecision with ``allowed`` and, when denied, a ``reason``.
+    """
+    if not users_exist(db) and bootstrap_token_configured():
+        if bootstrap_token_valid(bootstrap_token):
+            return RegistrationDecision(allowed=True)
+        return RegistrationDecision(
+            allowed=False, reason=REASON_BOOTSTRAP_TOKEN_REQUIRED
+        )
+    if settings.registration_enabled:
+        return RegistrationDecision(allowed=True)
+    return RegistrationDecision(allowed=False, reason=REASON_REGISTRATION_DISABLED)
+
+
+@dataclass(frozen=True)
+class RegistrationState:
+    """Registration-related feature state for /features.
+
+    Attributes:
+        registration_open: Whether the signup form should be reachable.
+        bootstrap_pending: Zero users + token configured (form needs the
+            setup link).
+        first_account_pending: Signup would create the instance's first
+            admin account.
+    """
+
+    registration_open: bool
+    bootstrap_pending: bool
+    first_account_pending: bool
+
+
+def registration_state(db: Session) -> RegistrationState:
+    """Compute the registration feature state with the same rule as /register.
+
+    Args:
+        db: Database session.
+
+    Returns:
+        RegistrationState mirroring what ``evaluate_registration`` would
+        decide, plus the bootstrap-pending and first-account context flags.
+    """
+    token_configured = bootstrap_token_configured()
+    if not settings.registration_enabled and not token_configured:
+        # Registration closed and no bootstrap path: no need to query the
+        # users table at all.
+        return RegistrationState(
+            registration_open=False,
+            bootstrap_pending=False,
+            first_account_pending=False,
+        )
+    no_users = not users_exist(db)
+    pending = token_configured and no_users
+    return RegistrationState(
+        registration_open=pending or settings.registration_enabled,
+        bootstrap_pending=pending,
+        first_account_pending=no_users and (settings.registration_enabled or pending),
+    )

--- a/backend/preloop/api/auth/router.py
+++ b/backend/preloop/api/auth/router.py
@@ -20,6 +20,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from preloop.api.auth import bootstrap
 from preloop.api.auth.jwt import (
     ACCESS_TOKEN_EXPIRE_MINUTES,
     create_access_token,
@@ -391,10 +392,33 @@ async def register(
         The created user.
 
     Raises:
-        HTTPException: If the username or email is already taken, or if registration is disabled.
+        HTTPException: If the username or email is already taken, if
+            registration is disabled, or if the instance is unclaimed and the
+            bootstrap token is missing or invalid.
     """
-    # Check if registration is enabled
-    if not settings.registration_enabled:
+    # Computed bootstrap-registration rule. While the instance has zero
+    # users, first-signup handling is serialized with a Postgres advisory
+    # transaction lock so two concurrent signups cannot both pass the
+    # zero-users check; the rule is then evaluated INSIDE the lock (the
+    # zero-users state is re-read there). The lock releases when this
+    # request's transaction commits or rolls back.
+    if not bootstrap.users_exist(db):
+        crud_user.acquire_registration_bootstrap_lock(db)
+    decision = bootstrap.evaluate_registration(db, user_data.bootstrap_token)
+    if not decision.allowed:
+        if decision.reason == bootstrap.REASON_BOOTSTRAP_TOKEN_REQUIRED:
+            logger.warning(
+                f"[REGISTER] Registration attempt blocked - unclaimed instance, "
+                f"bootstrap token missing or invalid. "
+                f"Username: {user_data.username}, Email: {user_data.email}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=(
+                    "Setup link required. Use the link printed at the end of "
+                    "the install, or run create_first_user.py on the server."
+                ),
+            )
         logger.warning(
             f"[REGISTER] Registration attempt blocked - registration is disabled. "
             f"Username: {user_data.username}, Email: {user_data.email}"
@@ -436,58 +460,62 @@ async def register(
             detail="Email already registered",
         )
 
-    # Create organization (Account) first
-    logger.info("[REGISTER] Creating account")
-    account_data = {
-        "organization_name": f"{user_data.username}'s Organization",
-        "is_active": True,
-    }
-    new_account = crud_account.create(session, obj_in=account_data)
-    logger.info(f"[REGISTER] Account created with ID: {new_account.id}")
-
-    # Create user linked to the account
+    # Account, user, primary-user link and Owner role are created in ONE
+    # transaction (commit=False batches them) so a failure part-way through
+    # can never leave an orphaned account or a user without a role behind.
     logger.info("[REGISTER] Hashing password")
     hashed_password = get_password_hash(user_data.password)
     logger.info("[REGISTER] Password hashed")
-    logger.info("[REGISTER] Creating user")
-    user_dict = {
-        "account_id": new_account.id,
-        "username": user_data.username,
-        "email": user_data.email,
-        "hashed_password": hashed_password,
-        "full_name": user_data.full_name,
-        "is_active": True,
-        "email_verified": False,
-        "user_source": "local",
-    }
-    new_user = crud_user.create(session, obj_in=user_dict)
-    logger.info(f"[REGISTER] User created with ID: {new_user.id}")
-
-    # Set this user as the primary user for the account
-    logger.info("[REGISTER] Setting primary_user_id on account")
-    new_account.primary_user_id = new_user.id
-    session.add(new_account)
-    logger.info(
-        f"[REGISTER] Set user {new_user.id} as primary user for account {new_account.id}"
-    )
-
-    # Assign Owner role to the first user
-    logger.info("[REGISTER] Looking up owner role")
-    owner_role = crud_role.get_by_name(session, name="owner")
-    logger.info(f"[REGISTER] Owner role found: {owner_role is not None}")
-    if owner_role:
-        user_role_data = {
-            "user_id": new_user.id,
-            "role_id": owner_role.id,
-        }
-        crud_user_role.create(session, obj_in=user_role_data)
-        logger.info(f"Assigned Owner role to user {new_user.username}")
-    else:
-        logger.warning(
-            "Owner role not found in database - user will have no permissions"
-        )
 
     try:
+        # Create organization (Account) first
+        logger.info("[REGISTER] Creating account")
+        account_data = {
+            "organization_name": f"{user_data.username}'s Organization",
+            "is_active": True,
+        }
+        new_account = crud_account.create(session, obj_in=account_data, commit=False)
+        logger.info(f"[REGISTER] Account created with ID: {new_account.id}")
+
+        # Create user linked to the account
+        logger.info("[REGISTER] Creating user")
+        user_dict = {
+            "account_id": new_account.id,
+            "username": user_data.username,
+            "email": user_data.email,
+            "hashed_password": hashed_password,
+            "full_name": user_data.full_name,
+            "is_active": True,
+            "email_verified": False,
+            "user_source": "local",
+        }
+        new_user = crud_user.create(session, obj_in=user_dict, commit=False)
+        logger.info(f"[REGISTER] User created with ID: {new_user.id}")
+
+        # Set this user as the primary user for the account
+        logger.info("[REGISTER] Setting primary_user_id on account")
+        new_account.primary_user_id = new_user.id
+        session.add(new_account)
+        logger.info(
+            f"[REGISTER] Set user {new_user.id} as primary user for account {new_account.id}"
+        )
+
+        # Assign Owner role to the first user
+        logger.info("[REGISTER] Looking up owner role")
+        owner_role = crud_role.get_by_name(session, name="owner")
+        logger.info(f"[REGISTER] Owner role found: {owner_role is not None}")
+        if owner_role:
+            user_role_data = {
+                "user_id": new_user.id,
+                "role_id": owner_role.id,
+            }
+            crud_user_role.create(session, obj_in=user_role_data, commit=False)
+            logger.info(f"Assigned Owner role to user {new_user.username}")
+        else:
+            logger.warning(
+                "Owner role not found in database - user will have no permissions"
+            )
+
         logger.info("[REGISTER] Committing transaction")
         session.commit()
         logger.info("[REGISTER] Transaction committed, refreshing objects")

--- a/backend/preloop/api/endpoints/ai_models.py
+++ b/backend/preloop/api/endpoints/ai_models.py
@@ -10,9 +10,15 @@ from preloop.api.auth.jwt import get_current_active_user
 from preloop.models.crud import crud_account
 from preloop.schemas.ai_model import (
     AIModelCreate,
+    AIModelCredentialExportResponse,
     AIModelGatewayUsageSummaryResponse,
     AIModelRead,
     AIModelUpdate,
+)
+from preloop.services.secret_service import (
+    PRINCIPAL_BOUND_OAUTH_CREDENTIAL_TYPES,
+    CredentialRefreshError,
+    get_secret_service,
 )
 from preloop.models.crud import crud_ai_model
 from preloop.models.db.session import get_db_session
@@ -268,6 +274,77 @@ def delete_ai_model(
 
     # No content returned for HTTP 204
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/ai-models/{model_id}/credentials/export",
+    response_model=AIModelCredentialExportResponse,
+    summary="Export Subscription OAuth Credential",
+    tags=["AI Models"],
+)
+@require_permission("edit_ai_models")
+def export_ai_model_credentials(
+    model_id: uuid.UUID,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_active_user),
+) -> AIModelCredentialExportResponse:
+    """Export the live subscription-OAuth bundle for an account AI model.
+
+    Only principal-bound subscription OAuth credentials (Claude Code, Codex)
+    are exportable: their provider refresh tokens are single-use and rotate on
+    every server-side refresh, so once imported the Preloop copy is the only
+    live lineage. The CLI calls this at offboard time to restore the agent's
+    local login before the Preloop-held credential is removed. API-key
+    credentials are never exportable.
+    """
+    db_model = _get_account_ai_model(
+        db=db, model_id=model_id, current_user=current_user
+    )
+    service = get_secret_service()
+    try:
+        resolved = service.resolve_ai_model_credentials(
+            db_model, db=db, allow_refresh=True
+        )
+    except CredentialRefreshError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Credential refresh failed: {exc.safe_summary()}",
+        )
+    if (
+        resolved is None
+        or resolved.credential_type not in PRINCIPAL_BOUND_OAUTH_CREDENTIAL_TYPES
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only subscription OAuth credentials can be exported",
+        )
+    payload = resolved.payload or {}
+    access = str(payload.get("access") or "").strip()
+    if not access:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Stored credential has no access token",
+        )
+    expires: Optional[int] = None
+    expires_raw = payload.get("expires")
+    if isinstance(expires_raw, (int, float)) and expires_raw > 0:
+        expires = int(expires_raw)
+    logger.info(
+        "Exported subscription OAuth credential: model=%s type=%s account=%s user=%s",
+        model_id,
+        resolved.credential_type,
+        current_user.account_id,
+        current_user.id,
+    )
+    refresh = str(payload.get("refresh") or "").strip() or None
+    account_id = str(payload.get("account_id") or "").strip() or None
+    return AIModelCredentialExportResponse(
+        credential_type=resolved.credential_type,
+        access=access,
+        refresh=refresh,
+        expires=expires,
+        account_id=account_id,
+    )
 
 
 @public_router.get(

--- a/backend/preloop/api/endpoints/features.py
+++ b/backend/preloop/api/endpoints/features.py
@@ -1,45 +1,20 @@
 """System features and plugin detection endpoints."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from preloop.config import settings
-from preloop.models.crud import crud_user
+from preloop.api.auth.bootstrap import (
+    registration_state,
+    reset_users_exist_cache,
+)
 from preloop.models.db.session import get_db_session
 from preloop.plugins.base import get_plugin_manager
 
+__all__ = ["router", "get_features", "reset_users_exist_cache"]
+
 router = APIRouter()
-
-# Sticky process-level cache for "does this instance have any users?".
-# Transitions only once in an instance lifetime (False → True when the first
-# account registers) and never flips back, so caching True forever is safe and
-# avoids a DB round-trip on every /features call (landing, signup, authed views).
-# Mutable mapping avoids a module-level `global` flag (CodeQL unused-global FP).
-# None = unknown (must query); True = at least one user exists.
-_users_exist_state: Dict[str, Optional[bool]] = {"known": None}
-
-
-def reset_users_exist_cache() -> None:
-    """Clear the sticky users-exist cache (for tests)."""
-    _users_exist_state["known"] = None
-
-
-def _first_account_pending(db: Session) -> bool:
-    """Return True when signup would create the instance's first admin account.
-
-    Uses a sticky process-level cache once any user is known to exist so the
-    common case (production after first signup) never hits the DB again.
-    """
-    if not settings.registration_enabled:
-        return False
-    if _users_exist_state["known"] is True:
-        return False
-    if crud_user.has_any_users(db):
-        _users_exist_state["known"] = True
-        return False
-    return True
 
 
 @router.get("/features")
@@ -58,14 +33,22 @@ def get_features(db: Session = Depends(get_db_session)) -> Dict[str, Any]:
     plugin_manager = get_plugin_manager()
     result = plugin_manager.get_enabled_features()
 
-    # Add config-based feature flags
-    result["features"]["registration"] = settings.registration_enabled
+    # Registration state comes from the SAME computed rule /register
+    # enforces (preloop.api.auth.bootstrap): an unclaimed instance (zero
+    # users + bootstrap token configured) keeps the signup form reachable —
+    # with the setup link — regardless of REGISTRATION_ENABLED.
+    state = registration_state(db)
+    result["features"]["registration"] = state.registration_open
 
     # First-account context for the signup form: when no user exists yet the
     # console explains that the account being created becomes the admin
-    # account. Only meaningful while registration is open. Cached process-
-    # wide once the first user exists (never flips back).
-    result["features"]["first_account_pending"] = _first_account_pending(db)
+    # account. Cached process-wide once the first user exists (never flips
+    # back).
+    result["features"]["first_account_pending"] = state.first_account_pending
+
+    # True while the instance is unclaimed (zero users + bootstrap token
+    # configured): the signup form must ask for the setup link.
+    result["features"]["registration_bootstrap_pending"] = state.bootstrap_pending
 
     # Session optimization ships in the open-source core (0.12.0): the
     # capability is always present, so the console must always show it.

--- a/backend/preloop/api/endpoints/session_optimization.py
+++ b/backend/preloop/api/endpoints/session_optimization.py
@@ -13,6 +13,7 @@ console clients (the endpoints previously shipped in the billing plugin).
 from __future__ import annotations
 
 import logging
+import uuid
 from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -22,7 +23,7 @@ from sqlalchemy.orm import Session
 from preloop.api.auth.jwt import get_current_active_user
 from preloop.api.common import get_account_for_user
 from preloop.api.deps import get_budget_enforcer
-from preloop.models.crud import crud_audit_log
+from preloop.models.crud import crud_audit_log, crud_optimization_job
 from preloop.models.db.session import get_db_session
 from preloop.models.models.account import Account
 from preloop.models.models.user import User
@@ -42,6 +43,10 @@ from preloop.services.replay_savings_service import (
     run_session_replay,
 )
 from preloop.services.session_optimization import SessionOptimizationService
+from preloop.services.session_optimization_jobs import (
+    run_session_optimization,
+    submit_session_optimization_job,
+)
 from preloop.utils.permissions import require_permission
 
 logger = logging.getLogger(__name__)
@@ -97,10 +102,14 @@ def optimize_account_runtime_session(
     current_user: User = Depends(get_current_active_user),
     budget_enforcer: Any = Depends(get_budget_enforcer),
 ) -> RuntimeSessionOptimizationResponse:
-    """Suggest cost and context optimizations for one runtime session."""
-    response = SessionOptimizationService(
-        db
-    ).get_account_session_optimization_suggestions(
+    """Suggest cost and context optimizations for one runtime session.
+
+    Legacy inline path: runs the shared worker function synchronously and
+    returns the results in this response — semantics identical to before the
+    async job endpoints existed (no submit-then-poll behind the scenes).
+    """
+    response = run_session_optimization(
+        db,
         account=account,
         runtime_session_id=runtime_session_id,
         request=request or RuntimeSessionOptimizationRequest(),
@@ -128,6 +137,129 @@ def optimize_account_runtime_session(
     except Exception:
         logger.debug("Failed to audit optimization result view", exc_info=True)
     return response
+
+
+class RuntimeSessionOptimizationJobSubmitResponse(BaseModel):
+    """Acknowledgement for an accepted async optimization job."""
+
+    job_id: str
+    status: str
+
+
+class RuntimeSessionOptimizationJobStatusResponse(BaseModel):
+    """Poll response for one async optimization job."""
+
+    job_id: str
+    status: str
+    #: Shaped exactly like the legacy inline response; set only on success.
+    result: Optional[RuntimeSessionOptimizationResponse] = None
+    #: User-facing failure message; set only on failure.
+    error: Optional[str] = None
+
+
+@router.post(
+    "/runtime-sessions/{runtime_session_id}/optimizations/jobs",
+    response_model=RuntimeSessionOptimizationJobSubmitResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+@require_permission("view_cost")
+def submit_account_runtime_session_optimization_job(
+    runtime_session_id: str,
+    account: Annotated[Account, Depends(get_account_for_user)],
+    request: RuntimeSessionOptimizationRequest | None = None,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_active_user),
+    budget_enforcer: Any = Depends(get_budget_enforcer),
+) -> RuntimeSessionOptimizationJobSubmitResponse:
+    """Queue the (slow, LLM-backed) optimization analysis as a background job.
+
+    Idempotent: while a job for this session is still pending or running,
+    re-submitting returns THAT job instead of queuing a second model pass, so
+    a double-click never spends the model budget twice.
+    """
+    job = submit_session_optimization_job(
+        db,
+        account=account,
+        current_user=current_user,
+        runtime_session_id=runtime_session_id,
+        request=request or RuntimeSessionOptimizationRequest(),
+        budget_enforcer=budget_enforcer,
+    )
+    return RuntimeSessionOptimizationJobSubmitResponse(
+        job_id=str(job.id), status=job.status
+    )
+
+
+@router.get(
+    "/runtime-sessions/{runtime_session_id}/optimizations/jobs/{job_id}",
+    response_model=RuntimeSessionOptimizationJobStatusResponse,
+)
+@require_permission("view_cost")
+def get_account_runtime_session_optimization_job(
+    runtime_session_id: str,
+    job_id: str,
+    account: Annotated[Account, Depends(get_account_for_user)],
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_active_user),
+) -> RuntimeSessionOptimizationJobStatusResponse:
+    """Poll one async optimization job's status, result, and error.
+
+    A job id belonging to another account, or attached to a different
+    session, is indistinguishable from a missing one (404) by design.
+
+    Raises:
+        HTTPException: 404 when the job is absent, malformed, or out of scope.
+    """
+    # A malformed id (e.g. corrupted client storage) is "not found", not a
+    # database cast error surfacing as a 500 the console would retry forever.
+    try:
+        uuid.UUID(job_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Optimization job not found",
+        ) from None
+    job = crud_optimization_job.get_for_session(
+        db,
+        job_id=job_id,
+        account_id=account.id,
+        runtime_session_id=runtime_session_id,
+    )
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Optimization job not found",
+        )
+    result: Optional[RuntimeSessionOptimizationResponse] = None
+    if job.status == "succeeded" and job.result is not None:
+        result = RuntimeSessionOptimizationResponse.model_validate(job.result)
+        # Cohort telemetry, mirroring the legacy inline endpoint: fetching a
+        # succeeded result is the moment the user actually sees optimization
+        # output, so the "reached-their-number" launch metric keeps working
+        # after the console's switch to submit-then-poll. Polling stops on
+        # the first succeeded fetch, so this fires once per completed job.
+        try:
+            crud_audit_log.log_action(
+                db,
+                account_id=account.id,
+                user_id=current_user.id,
+                action="optimization_result_viewed",
+                resource_type="runtime_session",
+                resource_id=runtime_session_id,
+                status="success",
+                details={
+                    "runtime_session_id": runtime_session_id,
+                    "optimization_job_id": str(job.id),
+                },
+            )
+        except Exception:
+            logger.debug("Failed to audit optimization result view", exc_info=True)
+    return RuntimeSessionOptimizationJobStatusResponse(
+        job_id=str(job.id),
+        status=job.status,
+        result=result,
+        error=job.error,
+    )
 
 
 @router.post(

--- a/backend/preloop/config.py
+++ b/backend/preloop/config.py
@@ -193,6 +193,15 @@ class Settings(BaseSettings):
         True,
         description="Enable self-registration. Set to False to require admin invitation.",
     )
+    bootstrap_token: str = Field(
+        "",
+        description=(
+            "First-user setup token (PRELOOP_BOOTSTRAP_TOKEN). While the "
+            "instance has zero users and this is set, /register requires the "
+            "token regardless of registration_enabled. Ignored once any user "
+            "exists."
+        ),
+    )
     disable_rbac: bool = Field(
         False,
         description=(
@@ -508,6 +517,7 @@ class Settings(BaseSettings):
             "t",
             "yes",
         )
+        bootstrap_token = os.getenv("PRELOOP_BOOTSTRAP_TOKEN", "")
 
         # GitHub App OAuth settings (SaaS only)
         github_app = GitHubAppSettings(
@@ -553,6 +563,7 @@ class Settings(BaseSettings):
             nats_url=os.getenv("NATS_URL", "nats://localhost:4222"),
             PROMPTS_FILE=prompts_file,
             registration_enabled=registration_enabled,
+            bootstrap_token=bootstrap_token,
             disable_rbac=disable_rbac,
             database=database,
             security=security,

--- a/backend/preloop/models/alembic/versions/20260719_add_optimization_job.py
+++ b/backend/preloop/models/alembic/versions/20260719_add_optimization_job.py
@@ -1,0 +1,128 @@
+"""Add async session-optimization jobs.
+
+Revision ID: 20260719_optimization_job
+Revises: 20260718_approval_bypass
+Create Date: 2026-07-19
+
+Adds:
+* ``optimization_job`` — background session-optimization analysis runs the
+  console submits and polls, replacing the long-blocking inline request.
+  A partial unique index guarantees at most one active (pending/running)
+  job per account/session pair so double-submits converge on one run.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import ENUM, JSONB, UUID
+
+# revision identifiers, used by Alembic.
+revision = "20260719_optimization_job"
+down_revision = "20260718_approval_bypass"
+branch_labels = None
+depends_on = None
+# Alembic reads these module globals by name; keep a local reference so static analysis
+# treats them as used.
+_ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)
+assert _ALEMBIC_IDENTIFIERS, "Alembic revision metadata must be defined"
+
+
+def upgrade() -> None:
+    """Create the optimization_job table."""
+    # Use postgresql.ENUM: sa.Enum ignores create_type=, which previously caused
+    # CREATE TYPE to run twice (explicit create + create_table).
+    optimization_job_status = ENUM(
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        name="optimization_job_status",
+        create_type=False,
+    )
+    ENUM(
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        name="optimization_job_status",
+    ).create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "optimization_job",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "account_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("account.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "runtime_session_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("runtime_session.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            optimization_job_status,
+            nullable=False,
+        ),
+        sa.Column("result", JSONB, nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column("heartbeat_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index("ix_optimization_job_id", "optimization_job", ["id"], unique=False)
+    op.create_index(
+        "ix_optimization_job_account_id", "optimization_job", ["account_id"]
+    )
+    op.create_index(
+        "ix_optimization_job_runtime_session_id",
+        "optimization_job",
+        ["runtime_session_id"],
+    )
+    op.create_index(
+        "ix_optimization_job_status_created_at",
+        "optimization_job",
+        ["status", "created_at"],
+    )
+    op.create_index(
+        "uq_optimization_job_active",
+        "optimization_job",
+        ["account_id", "runtime_session_id"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('pending', 'running')"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the optimization_job table."""
+    op.drop_index("uq_optimization_job_active", table_name="optimization_job")
+    op.drop_index(
+        "ix_optimization_job_status_created_at", table_name="optimization_job"
+    )
+    op.drop_index(
+        "ix_optimization_job_runtime_session_id", table_name="optimization_job"
+    )
+    op.drop_index("ix_optimization_job_account_id", table_name="optimization_job")
+    op.drop_index("ix_optimization_job_id", table_name="optimization_job")
+    op.drop_table("optimization_job")
+
+    ENUM(name="optimization_job_status").drop(op.get_bind(), checkfirst=True)

--- a/backend/preloop/models/crud/__init__.py
+++ b/backend/preloop/models/crud/__init__.py
@@ -25,6 +25,7 @@ from ..models import (
     ModelPriceOverride,
     ProviderBillingConnection,
     ProviderBillingSnapshot,
+    OptimizationJob,
     RuntimeSession,
     RuntimeSessionActivity,
     RuntimeSessionOptimizationAction,
@@ -113,6 +114,7 @@ from .oauth_app_installation import (
 from .oauth_token import CRUDOAuthToken, crud_oauth_token
 from . import tool_approval_condition
 from . import notification_preferences
+from .optimization_job import CRUDOptimizationJob
 from .policy_snapshot import CRUDPolicySnapshot, crud_policy_snapshot
 from .runtime_session import CRUDRuntimeSession
 from .runtime_session_activity import CRUDRuntimeSessionActivity
@@ -176,6 +178,7 @@ crud_runtime_session_optimization_result = CRUDRuntimeSessionOptimizationResult(
     RuntimeSessionOptimizationResult
 )
 crud_runtime_session_replay_run = CRUDRuntimeSessionReplayRun(RuntimeSessionReplayRun)
+crud_optimization_job = CRUDOptimizationJob(OptimizationJob)
 crud_tool_configuration = CRUDToolConfiguration()  # Instantiate CRUDToolConfiguration
 crud_mcp_server = CRUDMCPServer()  # Instantiate CRUDMCPServer
 crud_mcp_tool = CRUDMCPTool()  # Instantiate CRUDMCPTool
@@ -308,6 +311,8 @@ __all__ = [
     "crud_runtime_session_optimization_action",
     "crud_runtime_session_replay_run",
     "crud_runtime_session_optimization_result",
+    "CRUDOptimizationJob",
+    "crud_optimization_job",
     "CRUDBudgetPolicy",
     "CRUDBudgetSpendActivity",
     "crud_budget_policy",

--- a/backend/preloop/models/crud/account.py
+++ b/backend/preloop/models/crud/account.py
@@ -13,8 +13,20 @@ from .base import CRUDBase
 class CRUDAccount(CRUDBase[Account]):
     """CRUD operations for Account model."""
 
-    def create(self, db: Session, *, obj_in: Dict[str, Any]) -> Account:
-        """Create new account with initialized timestamp fields."""
+    def create(
+        self, db: Session, *, obj_in: Dict[str, Any], commit: bool = True
+    ) -> Account:
+        """Create new account with initialized timestamp fields.
+
+        Args:
+            db: Database session.
+            obj_in: Column values for the new account.
+            commit: When False, flush only so callers can batch several
+                writes into one atomic transaction and commit themselves.
+
+        Returns:
+            The created account.
+        """
         obj_data = dict(obj_in)
 
         # Initialize timestamp fields
@@ -22,7 +34,7 @@ class CRUDAccount(CRUDBase[Account]):
         obj_data.setdefault("created", current_time)
         obj_data.setdefault("last_updated", current_time)
 
-        return super().create(db=db, obj_in=obj_data)
+        return super().create(db=db, obj_in=obj_data, commit=commit)
 
     def update(self, db: Session, *, db_obj: Account, obj_in: Any) -> Account:
         """Update account and its last_updated timestamp."""

--- a/backend/preloop/models/crud/base.py
+++ b/backend/preloop/models/crud/base.py
@@ -45,14 +45,29 @@ class CRUDBase(Generic[ModelType]):
                 query = query.filter(getattr(self.model, key) == value)
         return query.offset(skip).limit(limit).all()
 
-    def create(self, db: Session, *, obj_in: Dict[str, Any]) -> ModelType:
-        """Create new entity."""
+    def create(
+        self, db: Session, *, obj_in: Dict[str, Any], commit: bool = True
+    ) -> ModelType:
+        """Create new entity.
+
+        Args:
+            db: Database session.
+            obj_in: Column values for the new row.
+            commit: When False, flush only so callers can batch several
+                writes into one atomic transaction and commit themselves.
+
+        Returns:
+            The created (and refreshed) model instance.
+        """
         # Don't add an ID unless it's missing - let the model handle it with default=uuid.uuid4
         obj_data = dict(obj_in)
 
         db_obj = self.model(**obj_data)
         db.add(db_obj)
-        db.commit()
+        if commit:
+            db.commit()
+        else:
+            db.flush()
         db.refresh(db_obj)
         return db_obj
 

--- a/backend/preloop/models/crud/event.py
+++ b/backend/preloop/models/crud/event.py
@@ -81,6 +81,34 @@ class CRUDEvent(CRUDBase[Event]):
             db.flush()
         return event
 
+    def has_conversion_event(
+        self, db: Session, *, account_id: UUID, conversion_event: str
+    ) -> bool:
+        """Whether an account already has a given conversion event recorded.
+
+        Used by plugins to keep once-per-account conversion events (e.g.
+        ``first_session_seen``) deduplicated. Same-transaction flushed rows
+        are visible, so a flush-then-check within one request stays exact.
+
+        Args:
+            db: Database session.
+            account_id: Account to check.
+            conversion_event: Conversion event name.
+
+        Returns:
+            True when a matching ``conversion`` event exists.
+        """
+        return (
+            db.query(Event.id)
+            .filter(
+                Event.account_id == account_id,
+                Event.event_type == "conversion",
+                Event.conversion_event == conversion_event,
+            )
+            .first()
+            is not None
+        )
+
     def get_session_start(self, db: Session, *, session_id: UUID) -> Optional[Event]:
         """The session_start row for a WebSocket session, if persisted."""
         return (

--- a/backend/preloop/models/crud/optimization_job.py
+++ b/backend/preloop/models/crud/optimization_job.py
@@ -1,0 +1,272 @@
+"""CRUD operations for async session-optimization jobs."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional, Union
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ..models.optimization_job import (
+    ACTIVE_JOB_STATUSES,
+    FINISHED_JOB_STATUSES,
+    OptimizationJob,
+    OptimizationJobStatus,
+)
+from .base import CRUDBase
+
+
+def _utcnow() -> datetime:
+    """Naive UTC now, matching the DateTime columns used across the models."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class CRUDOptimizationJob(CRUDBase[OptimizationJob]):
+    """CRUD operations for optimization jobs."""
+
+    def get_for_session(
+        self,
+        db: Session,
+        *,
+        job_id: Union[uuid.UUID, str],
+        account_id: Union[uuid.UUID, str],
+        runtime_session_id: Union[uuid.UUID, str],
+    ) -> Optional[OptimizationJob]:
+        """Return one job scoped to its owning account AND session.
+
+        Both filters are mandatory so a job id can never be read across
+        accounts or attached to the wrong session (callers 404 on ``None``).
+
+        Args:
+            db: Database session.
+            job_id: Job id.
+            account_id: Owning account id.
+            runtime_session_id: Runtime session the job must belong to.
+
+        Returns:
+            The job row, or ``None`` when absent or out of scope.
+        """
+        return (
+            db.query(self.model)
+            .filter(
+                self.model.id == job_id,
+                self.model.account_id == account_id,
+                self.model.runtime_session_id == runtime_session_id,
+            )
+            .first()
+        )
+
+    def get_active_for_session(
+        self,
+        db: Session,
+        *,
+        account_id: Union[uuid.UUID, str],
+        runtime_session_id: Union[uuid.UUID, str],
+    ) -> Optional[OptimizationJob]:
+        """Return the pending/running job for one session, if any.
+
+        Args:
+            db: Database session.
+            account_id: Owning account id.
+            runtime_session_id: Runtime session id.
+
+        Returns:
+            The active job row, or ``None``.
+        """
+        return (
+            db.query(self.model)
+            .filter(
+                self.model.account_id == account_id,
+                self.model.runtime_session_id == runtime_session_id,
+                self.model.status.in_(ACTIVE_JOB_STATUSES),
+            )
+            .order_by(self.model.created_at.desc())
+            .first()
+        )
+
+    def create_pending(
+        self,
+        db: Session,
+        *,
+        account_id: Union[uuid.UUID, str],
+        runtime_session_id: Union[uuid.UUID, str],
+    ) -> OptimizationJob:
+        """Create a pending job, converging on the active one under races.
+
+        The partial unique index on active (account, session) pairs makes a
+        concurrent double-submit an :class:`IntegrityError`; in that case the
+        already-active job is returned so both callers poll the same run.
+
+        Args:
+            db: Database session.
+            account_id: Owning account id.
+            runtime_session_id: Runtime session id.
+
+        Returns:
+            The newly created pending job, or the already-active job.
+        """
+        job = OptimizationJob(
+            account_id=account_id,
+            runtime_session_id=runtime_session_id,
+            status=OptimizationJobStatus.PENDING,
+        )
+        db.add(job)
+        try:
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            existing = self.get_active_for_session(
+                db,
+                account_id=account_id,
+                runtime_session_id=runtime_session_id,
+            )
+            if existing is None:
+                raise
+            return existing
+        db.refresh(job)
+        return job
+
+    def transition(
+        self,
+        db: Session,
+        *,
+        job_id: Union[uuid.UUID, str],
+        from_statuses: tuple[str, ...],
+        to_status: str,
+        result: Optional[dict[str, Any]] = None,
+        error: Optional[str] = None,
+    ) -> bool:
+        """Atomically move one job between statuses.
+
+        Implemented as a single conditional ``UPDATE ... WHERE status IN``
+        so two workers (or a worker racing the recovery sweep) can never both
+        claim the same transition.
+
+        Args:
+            db: Database session.
+            job_id: Job to transition.
+            from_statuses: Statuses the job must currently be in.
+            to_status: Target status.
+            result: Serialized response stored on success.
+            error: User-facing message stored on failure.
+
+        Returns:
+            True when this call performed the transition.
+        """
+        now = _utcnow()
+        values: dict[Any, Any] = {"status": to_status, "heartbeat_at": now}
+        if to_status == OptimizationJobStatus.RUNNING:
+            values["started_at"] = now
+        if to_status in FINISHED_JOB_STATUSES:
+            values["finished_at"] = now
+            values["result"] = result
+            values["error"] = error
+        updated = (
+            db.query(self.model)
+            .filter(
+                self.model.id == job_id,
+                self.model.status.in_(from_statuses),
+            )
+            .update(values, synchronize_session=False)
+        )
+        db.commit()
+        return bool(updated)
+
+    def touch_heartbeat(self, db: Session, *, job_id: Union[uuid.UUID, str]) -> bool:
+        """Record worker liveness for one running job.
+
+        Args:
+            db: Database session.
+            job_id: Job whose heartbeat to update.
+
+        Returns:
+            True when the job was still running and was touched.
+        """
+        updated = (
+            db.query(self.model)
+            .filter(
+                self.model.id == job_id,
+                self.model.status == OptimizationJobStatus.RUNNING,
+            )
+            .update({"heartbeat_at": _utcnow()}, synchronize_session=False)
+        )
+        db.commit()
+        return bool(updated)
+
+    def fail_stale(
+        self,
+        db: Session,
+        *,
+        error: str,
+        pending_older_than_minutes: int = 10,
+        heartbeat_older_than_minutes: int = 5,
+    ) -> int:
+        """Fail abandoned jobs: stuck-pending or running with a dead heartbeat.
+
+        Covers workers lost to restarts/crashes: a pending job no thread ever
+        claimed, or a running job whose owner stopped heartbeating.
+
+        Args:
+            db: Database session.
+            error: User-facing error stored on the failed jobs.
+            pending_older_than_minutes: Age after which a pending job is stuck.
+            heartbeat_older_than_minutes: Heartbeat silence after which a
+                running job is considered dead.
+
+        Returns:
+            Number of jobs flipped to failed.
+        """
+        now = _utcnow()
+        pending_cutoff = now - timedelta(minutes=pending_older_than_minutes)
+        heartbeat_cutoff = now - timedelta(minutes=heartbeat_older_than_minutes)
+        failed_values: dict[Any, Any] = {
+            "status": OptimizationJobStatus.FAILED,
+            "error": error,
+            "finished_at": now,
+        }
+        stuck_pending = (
+            db.query(self.model)
+            .filter(
+                self.model.status == OptimizationJobStatus.PENDING,
+                self.model.created_at < pending_cutoff,
+            )
+            .update(failed_values, synchronize_session=False)
+        )
+        dead_running = (
+            db.query(self.model)
+            .filter(
+                self.model.status == OptimizationJobStatus.RUNNING,
+                # A running job always has a heartbeat (set on claim); treat a
+                # NULL one as stale too rather than letting it hang forever.
+                (self.model.heartbeat_at.is_(None))
+                | (self.model.heartbeat_at < heartbeat_cutoff),
+            )
+            .update(failed_values, synchronize_session=False)
+        )
+        db.commit()
+        return int(stuck_pending) + int(dead_running)
+
+    def prune_finished(self, db: Session, *, older_than_days: int = 14) -> int:
+        """Delete finished jobs past the retention window.
+
+        Args:
+            db: Database session.
+            older_than_days: Retention window for succeeded/failed jobs.
+
+        Returns:
+            Number of jobs deleted.
+        """
+        cutoff = _utcnow() - timedelta(days=older_than_days)
+        deleted = (
+            db.query(self.model)
+            .filter(
+                self.model.status.in_(FINISHED_JOB_STATUSES),
+                self.model.finished_at.isnot(None),
+                self.model.finished_at < cutoff,
+            )
+            .delete(synchronize_session=False)
+        )
+        db.commit()
+        return int(deleted)

--- a/backend/preloop/models/crud/runtime_session.py
+++ b/backend/preloop/models/crud/runtime_session.py
@@ -270,6 +270,12 @@ class CRUDRuntimeSession(CRUDBase[RuntimeSession]):
             session_source_id=session_source_id,
         )
         if db_obj is None:
+            is_account_first_session = (
+                db.query(self.model.id)
+                .filter(self.model.account_id == account_id)
+                .first()
+                is None
+            )
             db_obj = RuntimeSession(
                 account_id=account_id,
                 session_source_type=session_source_type,
@@ -284,6 +290,27 @@ class CRUDRuntimeSession(CRUDBase[RuntimeSession]):
             )
             db.add(db_obj)
             db.flush()
+            if is_account_first_session:
+                # Every session-recording path funnels through this creation
+                # branch, so it is the single chokepoint for the account's
+                # first-session signal. The notification is an inert no-op
+                # unless an EE plugin registered a hook (see
+                # preloop.services.session_events); it never raises. Lazy
+                # import keeps the models package importable standalone.
+                try:
+                    from preloop.services.session_events import (
+                        notify_first_session_recorded,
+                    )
+                except ImportError:  # pragma: no cover - models-only contexts
+                    pass
+                else:
+                    notify_first_session_recorded(
+                        db,
+                        account_id=account_id,
+                        occurred_at=db_obj.started_at
+                        or db_obj.last_activity_at
+                        or datetime.now(UTC),
+                    )
             return db_obj
 
         if session_reference is not None:

--- a/backend/preloop/models/crud/user.py
+++ b/backend/preloop/models/crud/user.py
@@ -3,14 +3,39 @@
 import uuid
 from typing import List, Optional
 
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from ..models.user import User
 from .base import CRUDBase
 
+# Constant advisory-lock key that serializes first-user (bootstrap)
+# registration. Arbitrary but stable app-unique value ("PRLB" in ASCII).
+REGISTRATION_BOOTSTRAP_LOCK_KEY = 0x5052_4C42
+
 
 class CRUDUser(CRUDBase[User]):
     """CRUD operations for User model."""
+
+    def acquire_registration_bootstrap_lock(self, db: Session) -> None:
+        """Serialize concurrent first-user registrations.
+
+        Takes a Postgres transaction-scoped advisory lock
+        (``pg_advisory_xact_lock``) on a constant key so two concurrent
+        signups cannot both observe the zero-users state. The lock is
+        released automatically when the surrounding transaction commits or
+        rolls back. No-op on non-Postgres dialects.
+
+        Args:
+            db: Database session (the lock binds to its transaction).
+        """
+        bind = db.get_bind()
+        if bind.dialect.name != "postgresql":
+            return
+        db.execute(
+            text("SELECT pg_advisory_xact_lock(:key)"),
+            {"key": REGISTRATION_BOOTSTRAP_LOCK_KEY},
+        )
 
     def get_by_username(self, db: Session, *, username: str) -> Optional[User]:
         """Get user by username.

--- a/backend/preloop/models/models/__init__.py
+++ b/backend/preloop/models/models/__init__.py
@@ -60,6 +60,7 @@ from .instance import Instance
 from .cli_client import CliClient
 from .github_app_installation import OAuthAppInstallation, GitHubAppInstallation
 from .github_oauth_token import OAuthToken, GitHubOAuthToken
+from .optimization_job import OptimizationJob
 from .policy_snapshot import PolicySnapshot
 from .runtime_session import RuntimeSession
 from .runtime_session_activity import RuntimeSessionActivity
@@ -150,6 +151,7 @@ __all__ = [
     "GitHubAppInstallation",  # Backward compatibility alias
     "OAuthToken",
     "GitHubOAuthToken",  # Backward compatibility alias
+    "OptimizationJob",
     "PolicySnapshot",
     "RuntimeSession",
     "RuntimeSessionActivity",

--- a/backend/preloop/models/models/optimization_job.py
+++ b/backend/preloop/models/models/optimization_job.py
@@ -1,0 +1,114 @@
+"""Async session-optimization analysis jobs.
+
+An :class:`OptimizationJob` tracks one background run of the (blocking,
+LLM-backed) session-optimization analysis for a runtime session, so the
+console can submit the work, close the request, and poll for the result
+instead of holding an HTTP connection open for the 1-2 minute model pass.
+
+Lifecycle: ``pending`` (queued) -> ``running`` (a worker thread claimed it,
+``heartbeat_at`` ticks while the model call is in flight) -> ``succeeded``
+(``result`` holds the serialized optimization response) or ``failed``
+(``error`` holds a user-facing message; detail goes to logs only). A partial
+unique index guarantees at most one active (pending/running) job per
+account/session pair, which is what makes double-click submission idempotent
+instead of double-spending on the model.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import DateTime, ForeignKey, Index, Text
+from sqlalchemy import Enum as SQLEnum
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class OptimizationJobStatus(str):
+    """Status values for an optimization job."""
+
+    #: Created and queued; no worker thread has picked it up yet.
+    PENDING = "pending"
+    #: A worker thread is executing the analysis.
+    RUNNING = "running"
+    #: Analysis finished; ``result`` holds the optimization response.
+    SUCCEEDED = "succeeded"
+    #: Analysis did not complete; ``error`` holds the user-facing message.
+    FAILED = "failed"
+
+
+#: Statuses that count as "in flight" for idempotent submission and recovery.
+ACTIVE_JOB_STATUSES = (
+    OptimizationJobStatus.PENDING,
+    OptimizationJobStatus.RUNNING,
+)
+
+#: Terminal statuses eligible for retention pruning.
+FINISHED_JOB_STATUSES = (
+    OptimizationJobStatus.SUCCEEDED,
+    OptimizationJobStatus.FAILED,
+)
+
+
+class OptimizationJob(Base):
+    """One background session-optimization analysis run."""
+
+    __tablename__ = "optimization_job"
+    __table_args__ = (
+        # At most one active job per (account, session): double-click and
+        # concurrent submits converge on the same row instead of spending the
+        # model budget twice.
+        Index(
+            "uq_optimization_job_active",
+            "account_id",
+            "runtime_session_id",
+            unique=True,
+            postgresql_where="status IN ('pending', 'running')",
+        ),
+        Index("ix_optimization_job_status_created_at", "status", "created_at"),
+    )
+
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("account.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    runtime_session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("runtime_session.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status: Mapped[str] = mapped_column(
+        SQLEnum(
+            "pending",
+            "running",
+            "succeeded",
+            "failed",
+            name="optimization_job_status",
+        ),
+        nullable=False,
+        default=OptimizationJobStatus.PENDING,
+    )
+    #: Serialized RuntimeSessionOptimizationResponse when ``status`` is
+    #: ``succeeded``; NULL otherwise.
+    result: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    #: User-facing failure message. Diagnostic detail is deliberately kept in
+    #: server logs only — never surfaced to the console.
+    error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    started_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    #: Last liveness signal from the worker thread; the recovery sweep fails
+    #: running jobs whose heartbeat has gone stale (worker died mid-call).
+    heartbeat_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"<OptimizationJob(id={self.id}, session={self.runtime_session_id}, "
+            f"status={self.status})>"
+        )

--- a/backend/preloop/schemas/ai_model.py
+++ b/backend/preloop/schemas/ai_model.py
@@ -228,6 +228,22 @@ class AIModelRead(AIModelInDBBase):
     pass
 
 
+class AIModelCredentialExportResponse(BaseModel):
+    """Live subscription-OAuth bundle exported to the owning operator.
+
+    Returned once over the authenticated API so the CLI can restore an
+    agent's local login at offboard time (subscription refresh tokens are
+    single-use, so the Preloop-held copy is the only live lineage after a
+    server-side refresh). Token material must never be logged.
+    """
+
+    credential_type: str
+    access: str
+    refresh: Optional[str] = None
+    expires: Optional[int] = None
+    account_id: Optional[str] = None
+
+
 class AIModelGatewayUsageSummaryResponse(BaseModel):
     """Gateway usage summary for one durable AI model."""
 

--- a/backend/preloop/schemas/auth.py
+++ b/backend/preloop/schemas/auth.py
@@ -50,6 +50,13 @@ class AuthUserCreate(BaseModel):
     email: EmailStr
     password: str = Field(..., min_length=8)
     full_name: Optional[str] = None
+    bootstrap_token: Optional[str] = Field(
+        None,
+        description=(
+            "First-user setup token from the install (required while the "
+            "instance has zero users and PRELOOP_BOOTSTRAP_TOKEN is set)."
+        ),
+    )
 
     @field_validator("username")
     @classmethod

--- a/backend/preloop/services/gemini_gateway.py
+++ b/backend/preloop/services/gemini_gateway.py
@@ -491,6 +491,8 @@ class GeminiGatewayService(OpenAIGatewayService):
         if len(matches) == 1:
             return matches[0]
 
+        # Called for its side effect: raises the shared model_not_authorized
+        # 400 when the requested name resolves to no authorized model.
         self._resolve_requested_model(requested_name, provider="gemini")
         return requested_name
 

--- a/backend/preloop/services/gemini_gateway.py
+++ b/backend/preloop/services/gemini_gateway.py
@@ -471,7 +471,14 @@ class GeminiGatewayService(OpenAIGatewayService):
     def _resolve_gemini_model_alias(self, model_name: str) -> str:
         requested_name = self._public_model_name(model_name)
         matches: List[str] = []
-        for ai_model in self._get_account_models():
+        account_models = self._get_account_models()
+        authorized_ids = self._authorized_model_ids(account_models)
+        for ai_model in account_models:
+            if str(ai_model.id) not in authorized_ids:
+                # Principal-bound models outside this credential's authorized
+                # set must not resolve here either — _resolve_requested_model
+                # below turns them into the shared model_not_authorized 400.
+                continue
             runtime = resolve_ai_model_runtime(ai_model)
             alias = runtime.model_gateway_model_alias
             if not alias:

--- a/backend/preloop/services/instance_service.py
+++ b/backend/preloop/services/instance_service.py
@@ -30,6 +30,18 @@ DISABLE_VERSION_CHECK_ENV = "DISABLE_VERSION_CHECK"
 # tracker, so it must never show itself an "update available" banner.
 HOSTED_ENV = "PRELOOP_HOSTED"
 
+# Installer-stamped timestamps: the bash installer MAY write these into the
+# instance .env. When present they ride along in the one-time
+# install_completed payload; when absent they are simply omitted — the server
+# never synthesizes install timing it did not observe.
+INSTALL_STARTED_AT_ENV = "PRELOOP_INSTALL_STARTED_AT"
+INSTALL_COMPLETED_AT_ENV = "PRELOOP_INSTALL_COMPLETED_AT"
+
+# Instance-metadata key recording that the one-time install_completed funnel
+# marker was delivered. Persisted in the Instance row so the marker is sent
+# exactly once per installation, across restarts.
+INSTALL_COMPLETED_EMITTED_KEY = "install_completed_emitted_at"
+
 # Truthy values for the opt-out variables: true/1/t/yes, case-insensitive,
 # surrounding whitespace ignored. Must stay aligned with the Go CLI's parsing
 # in cli/internal/telemetry/optout.go — one variable, one parsing rule.
@@ -171,11 +183,79 @@ def _is_enterprise() -> bool:
         return False
 
 
+def _installer_timestamps() -> dict:
+    """Installer-stamped timestamps from the environment, when present.
+
+    Returns:
+        Dict with ``install_started_at``/``install_completed_at`` for each
+        stamp the installer actually wrote into the .env; empty otherwise.
+        Timestamps are passed through verbatim, never synthesized.
+    """
+    stamps: dict = {}
+    started = os.getenv(INSTALL_STARTED_AT_ENV, "").strip()
+    completed = os.getenv(INSTALL_COMPLETED_AT_ENV, "").strip()
+    if started:
+        stamps["install_started_at"] = started
+    if completed:
+        stamps["install_completed_at"] = completed
+    return stamps
+
+
+def should_emit_install_completed(instance: "Instance") -> bool:
+    """Whether this check-in should carry the one-time install_completed marker.
+
+    Suppressed by the same gates as the update banner (telemetry disabled,
+    hosted preloop.ai deployment) and by the persisted emitted flag once the
+    marker has been delivered successfully.
+    """
+    if is_telemetry_disabled() or is_hosted_instance():
+        return False
+    metadata = getattr(instance, "metadata_", None) or {}
+    return INSTALL_COMPLETED_EMITTED_KEY not in metadata
+
+
+def _mark_install_completed_emitted(instance: "Instance") -> None:
+    """Persist the install_completed emitted flag (exactly-once guard).
+
+    Updates both the long-lived in-memory instance (used by the periodic
+    checker between restarts) and the Instance row (used across restarts).
+    """
+    emitted_at = datetime.now(timezone.utc).isoformat()
+    instance.metadata_ = {
+        **(instance.metadata_ or {}),
+        INSTALL_COMPLETED_EMITTED_KEY: emitted_at,
+    }
+
+    from preloop.models.db.session import get_db_session
+    from preloop.models.models import Instance
+
+    try:
+        db = next(get_db_session())
+        try:
+            row = db.query(Instance).first()
+            if row is None:
+                return
+            row.metadata_ = {
+                **(row.metadata_ or {}),
+                INSTALL_COMPLETED_EMITTED_KEY: emitted_at,
+            }
+            db.commit()
+        finally:
+            db.close()
+    except Exception as e:
+        logger.debug(f"Could not persist install_completed marker: {e}")
+
+
 async def send_version_check(instance: "Instance") -> bool:
     """Send version check POST to preloop.ai.
 
     This is opt-out telemetry that helps us understand adoption.
     Set PRELOOP_DISABLE_TELEMETRY=true to disable.
+
+    The first successful check-in of a fresh instance additionally carries a
+    one-time ``install_completed`` marker in the payload metadata (the
+    install-funnel signal). It rides this existing channel — no new outbound
+    surface — and is marked emitted only after a successful delivery.
 
     Args:
         instance: The local instance record.
@@ -188,11 +268,17 @@ async def send_version_check(instance: "Instance") -> bool:
         return False
 
     try:
+        metadata = dict(instance.metadata_ or {})
+        include_install_completed = should_emit_install_completed(instance)
+        if include_install_completed:
+            metadata["install_completed"] = True
+            metadata.update(_installer_timestamps())
+
         payload = {
             "instance_uuid": str(instance.instance_uuid),
             "version": instance.version,
             "edition": instance.edition,
-            "metadata": instance.metadata_ or {},
+            "metadata": metadata,
         }
 
         async with httpx.AsyncClient(timeout=10.0) as client:
@@ -205,6 +291,9 @@ async def send_version_check(instance: "Instance") -> bool:
                         f"Update available: {data.get('current_version')} "
                         f"(you have {instance.version})"
                     )
+                if include_install_completed:
+                    # Delivered: never send the marker again.
+                    _mark_install_completed_emitted(instance)
                 # Persist the result so the web UI (and /api/v1/version) can
                 # surface an update banner to admins between checks.
                 _persist_version_check_result(data)

--- a/backend/preloop/services/model_gateway_auth.py
+++ b/backend/preloop/services/model_gateway_auth.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 import time
-from typing import Optional
+from typing import Optional, Sequence
 
 from sqlalchemy.orm import Session
 
@@ -13,8 +13,15 @@ from preloop.api.auth.jwt import (
     get_user_from_token_if_valid,
     _managed_agent_for_api_key,
 )
-from preloop.models.crud import crud_api_key, crud_runtime_session, crud_user
+from preloop.models.crud import (
+    crud_api_key,
+    crud_managed_agent,
+    crud_managed_agent_ai_model_binding,
+    crud_runtime_session,
+    crud_user,
+)
 from preloop.models.crud.oauth_mcp_token import crud_oauth_mcp_access_token
+from preloop.models.models.ai_model import AIModel
 from preloop.models.models.api_key import ApiKey
 from preloop.models.models.oauth_mcp_token import OAuthMCPAccessToken
 from preloop.models.models.user import User
@@ -109,3 +116,103 @@ async def authenticate_bearer_token(
         user=oauth_user,
         oauth_access_token=oauth_token,
     )
+
+
+def resolve_managed_agent_id_for_context(
+    db: Session, auth_context: ModelGatewayAuthContext
+) -> Optional[str]:
+    """Resolve the managed-agent identity behind a gateway principal.
+
+    Args:
+        db: Active database session.
+        auth_context: Authenticated model gateway request context.
+
+    Returns:
+        The managed agent id string when the credential carries one — either
+        directly via ``context_data.managed_agent_id`` or indirectly via its
+        runtime principal source identity — otherwise ``None``.
+    """
+    api_key = auth_context.api_key
+    context_data = (
+        api_key.context_data
+        if api_key is not None and isinstance(api_key.context_data, dict)
+        else {}
+    )
+    managed_agent_id = context_data.get("managed_agent_id")
+    if managed_agent_id:
+        return str(managed_agent_id)
+
+    runtime_principal = context_data.get("runtime_principal") or {}
+    session_source_type = runtime_principal.get("type")
+    session_source_id = runtime_principal.get("id")
+    if not session_source_type or not session_source_id:
+        return None
+
+    managed_agent = crud_managed_agent.get_by_source(
+        db,
+        account_id=str(auth_context.user.account_id),
+        session_source_type=session_source_type,
+        session_source_id=session_source_id,
+    )
+    return str(managed_agent.id) if managed_agent is not None else None
+
+
+def compute_authorized_model_ids(
+    db: Session,
+    auth_context: ModelGatewayAuthContext,
+    account_models: Sequence[AIModel],
+) -> frozenset[str]:
+    """Compute the ids of ``account_models`` this gateway principal may use.
+
+    Authorization rules, in order:
+
+    - BYOK / API-key-backed / ambient models are authorized for every
+      principal in the account (unchanged behavior).
+    - Subscription-OAuth models (``is_principal_bound_oauth``) are authorized
+      ONLY for the managed-agent principal whose id has an active row in
+      ``managed_agent_ai_model_binding`` for that model.
+    - User tokens (console-originated calls, no API key and no OAuth MCP
+      token) keep full visibility of the account inventory.
+    - Fail closed: credentials that resolve to no managed agent — legacy
+      gateway keys without ``managed_agent_id`` and OAuth MCP client tokens —
+      are never authorized for principal-bound models, and bound models with
+      no binding row are authorized for nobody but user tokens.
+
+    Args:
+        db: Active database session.
+        auth_context: Authenticated model gateway request context.
+        account_models: Full account model inventory to authorize against.
+
+    Returns:
+        Frozen set of authorized ``AIModel`` id strings.
+    """
+    all_ids = frozenset(str(ai_model.id) for ai_model in account_models)
+    bound_ids = {
+        str(ai_model.id)
+        for ai_model in account_models
+        if bool(getattr(ai_model, "is_principal_bound_oauth", False))
+    }
+    if not bound_ids:
+        return all_ids
+
+    is_user_token = (
+        auth_context.api_key is None and auth_context.oauth_access_token is None
+    )
+    if is_user_token:
+        return all_ids
+
+    authorized = set(all_ids - bound_ids)
+    managed_agent_id = resolve_managed_agent_id_for_context(db, auth_context)
+    if managed_agent_id is None:
+        return frozenset(authorized)
+
+    bindings = crud_managed_agent_ai_model_binding.list_for_agent(
+        db,
+        account_id=str(auth_context.user.account_id),
+        agent_id=managed_agent_id,
+    )
+    for binding in bindings:
+        bound_model_id = str(binding.ai_model_id)
+        if bound_model_id in bound_ids:
+            authorized.add(bound_model_id)
+    return frozenset(authorized)

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -48,7 +48,11 @@ from preloop.services.context_optimization import (
     tool_choice_named_tool,
     tool_definition_name,
 )
-from preloop.services.model_gateway_auth import ModelGatewayAuthContext
+from preloop.services.model_gateway_auth import (
+    ModelGatewayAuthContext,
+    compute_authorized_model_ids,
+    resolve_managed_agent_id_for_context,
+)
 from preloop.services.model_gateway_budget import (
     BudgetCheckResult,
     ModelGatewayBudgetService,
@@ -259,6 +263,10 @@ class OpenAIGatewayService:
         # never a false dollar claim. Set at both credential-resolution
         # choke points; reset there per request to avoid stale carryover.
         self._last_upstream_credential_type: Optional[str] = None
+        # Per-request memo of the authorized model-id set for this principal.
+        # Computed once from the account inventory on first use so listing,
+        # alias resolution, and default selection all consume the same set.
+        self._authorized_model_ids_cache: Optional[frozenset[str]] = None
 
     def _resolve_runtime_session(self) -> Optional[str]:
         if self._resolved_runtime_session_attempted:
@@ -355,33 +363,7 @@ class OpenAIGatewayService:
         return runtime_session_id
 
     def _resolve_managed_agent_id(self) -> Optional[str]:
-        api_key = self.auth_context.api_key
-        context_data = (
-            api_key.context_data
-            if api_key and isinstance(api_key.context_data, dict)
-            else {}
-        )
-        managed_agent_id = (
-            context_data.get("managed_agent_id") if context_data else None
-        )
-        if managed_agent_id:
-            return str(managed_agent_id)
-
-        runtime_principal = context_data.get("runtime_principal") or {}
-        session_source_type = runtime_principal.get("type")
-        session_source_id = runtime_principal.get("id")
-        if not session_source_type or not session_source_id:
-            return None
-
-        from preloop.models.crud.managed_agent import crud_managed_agent
-
-        managed_agent = crud_managed_agent.get_by_source(
-            self.db,
-            account_id=str(self.auth_context.user.account_id),
-            session_source_type=session_source_type,
-            session_source_id=session_source_id,
-        )
-        return str(managed_agent.id) if managed_agent is not None else None
+        return resolve_managed_agent_id_for_context(self.db, self.auth_context)
 
     def _emit_gateway_request_started(
         self,
@@ -427,9 +409,13 @@ class OpenAIGatewayService:
         )
 
     def list_models(self) -> Dict[str, Any]:
-        """List gateway-enabled models available to the authenticated account."""
+        """List gateway-enabled models available to this gateway principal."""
         data = []
-        for ai_model in self._get_account_models():
+        account_models = self._get_account_models()
+        authorized_ids = self._authorized_model_ids(account_models)
+        for ai_model in account_models:
+            if str(ai_model.id) not in authorized_ids:
+                continue
             runtime = resolve_ai_model_runtime(ai_model)
             if not runtime.model_gateway_enabled:
                 continue
@@ -1772,15 +1758,43 @@ class OpenAIGatewayService:
 
         return crud_ai_model.get_all_for_account(self.db, account_id=account_id)
 
+    def _authorized_model_ids(self, account_models: List[AIModel]) -> frozenset[str]:
+        """Return the model-id set this principal may use (memoized per request).
+
+        Args:
+            account_models: Full account model inventory.
+
+        Returns:
+            Frozen set of authorized ``AIModel`` id strings computed once per
+            service instance so every surface (listing, alias resolution,
+            default selection) consumes the same set.
+        """
+        if self._authorized_model_ids_cache is None:
+            self._authorized_model_ids_cache = compute_authorized_model_ids(
+                self.db, self.auth_context, account_models
+            )
+        return self._authorized_model_ids_cache
+
     def _resolve_requested_model(
         self, requested_model: Optional[str], *, provider: GatewayProvider
     ) -> AIModel:
         models = self._get_account_models()
+        authorized_ids = self._authorized_model_ids(models)
         gateway_enabled_models: List[tuple[AIModel, str]] = []
+        unauthorized_gateway_models: List[tuple[AIModel, str]] = []
         default_gateway_model: Optional[AIModel] = None
         for ai_model in models:
             runtime = resolve_ai_model_runtime(ai_model)
             if runtime.model_gateway_enabled and runtime.model_gateway_model_alias:
+                if str(ai_model.id) not in authorized_ids:
+                    # Principal-bound models outside this credential's
+                    # authorized set never match or become the default; they
+                    # are kept only to distinguish 400 (bound to another
+                    # agent) from 404 (unknown model) below.
+                    unauthorized_gateway_models.append(
+                        (ai_model, runtime.model_gateway_model_alias)
+                    )
+                    continue
                 gateway_enabled_models.append(
                     (ai_model, runtime.model_gateway_model_alias)
                 )
@@ -1807,6 +1821,26 @@ class OpenAIGatewayService:
                     suffix_match = ai_model
             if suffix_match is not None:
                 return suffix_match
+            for _, alias in unauthorized_gateway_models:
+                if alias == requested_model or alias.endswith(f"/{requested_model}"):
+                    available = (
+                        ", ".join(
+                            authorized_alias
+                            for _, authorized_alias in gateway_enabled_models
+                        )
+                        or "none"
+                    )
+                    raise ModelGatewayAPIError(
+                        provider=provider,
+                        status_code=400,
+                        message=(
+                            f"Model '{requested_model}' is bound to another "
+                            "agent's subscription credentials and can't serve "
+                            "this credential. Models available to this "
+                            f"credential: {available}."
+                        ),
+                        code="model_not_authorized",
+                    )
             raise ModelGatewayAPIError(
                 provider=provider,
                 status_code=404,

--- a/backend/preloop/services/session_events.py
+++ b/backend/preloop/services/session_events.py
@@ -1,0 +1,75 @@
+"""Extension point for account-lifecycle runtime-session signals.
+
+OSS records runtime sessions; processing those recordings into growth or
+funnel analytics is EE-plugin territory. When an account's FIRST runtime
+session is recorded, the session-recording chokepoint notifies the hook
+registered here. Without a registered hook (the open-source default) the
+notification is an inert no-op — no event is created, nothing is sent
+anywhere.
+
+This mirrors the analysis-model authorizer extension point in
+``preloop.services.optimization_gating``: a plugin registers a callable at
+startup, OSS consults it at the relevant chokepoint.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Callable, Optional
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# Signature: (db, *, account_id=..., occurred_at=...) -> None. The hook runs
+# inside the caller's transaction; it must not commit.
+FirstSessionHook = Callable[..., None]
+
+_first_session_hook: Optional[FirstSessionHook] = None
+
+
+def register_first_session_hook(hook: Optional[FirstSessionHook]) -> None:
+    """Register (or clear, with ``None``) the first-session hook.
+
+    Called by growth/analytics plugins at startup. Only one hook is
+    supported; the last registration wins.
+
+    Args:
+        hook: Callable notified when an account's first runtime session is
+            recorded.
+    """
+    global _first_session_hook
+    if _first_session_hook is not None and hook is not None:
+        logger.info("Replacing previously registered first-session hook")
+    _first_session_hook = hook
+
+
+def get_first_session_hook() -> Optional[FirstSessionHook]:
+    """Return the registered hook, or ``None`` when none is registered."""
+    return _first_session_hook
+
+
+def notify_first_session_recorded(
+    db: Session,
+    *,
+    account_id: Any,
+    occurred_at: datetime,
+) -> None:
+    """Notify the registered hook that an account's first session was recorded.
+
+    A no-op when no hook is registered. Hook failures are logged and
+    swallowed: session recording must never fail because of an analytics
+    side-channel.
+
+    Args:
+        db: Database session the session was recorded in (shared transaction).
+        account_id: Account whose first runtime session was just recorded.
+        occurred_at: When the session was recorded.
+    """
+    if _first_session_hook is None:
+        return
+    try:
+        _first_session_hook(db, account_id=account_id, occurred_at=occurred_at)
+    except Exception:
+        logger.warning("First-session hook failed", exc_info=True)

--- a/backend/preloop/services/session_optimization_jobs.py
+++ b/backend/preloop/services/session_optimization_jobs.py
@@ -1,0 +1,465 @@
+"""Async session-optimization jobs: submit, execute, poll, and recover.
+
+The LLM-backed optimization pass
+(:meth:`SessionOptimizationService.get_account_session_optimization_suggestions`)
+is synchronous end-to-end — its gateway call blocks for the whole model
+round-trip — so it must NEVER run on the event loop. This module runs it on a
+small dedicated thread pool and tracks each run as an
+:class:`~preloop.models.models.optimization_job.OptimizationJob` row the
+console polls, replacing the long-blocking inline request.
+
+Design points (per the approved Lane B design):
+
+* Module-level bounded ``ThreadPoolExecutor(max_workers=3)`` — a hard cap on
+  concurrent model passes per API process.
+* Each job opens its OWN DB session inside the worker thread and holds it for
+  the job's duration (releasing it around the LLM call is explicitly
+  deferred).
+* Status transitions are atomic conditional UPDATEs; a heartbeat ticker
+  thread keeps ``heartbeat_at`` fresh while the model call is in flight so
+  the recovery sweep can tell a slow job from a dead one.
+* Failures store only :data:`USER_FACING_JOB_ERROR` on the row; diagnostic
+  detail goes to server logs.
+* The recovery sweep (startup + every ~2 minutes) fails stuck-pending and
+  dead-running jobs with the same retriable copy and prunes finished jobs
+  past retention.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any, Optional
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from preloop.models.crud import (
+    crud_account,
+    crud_optimization_job,
+    crud_runtime_session,
+    crud_user,
+)
+from preloop.models.db.session import get_db_session
+from preloop.models.models.optimization_job import (
+    ACTIVE_JOB_STATUSES,
+    OptimizationJob,
+    OptimizationJobStatus,
+)
+from preloop.schemas.gateway_usage import (
+    RuntimeSessionOptimizationRequest,
+    RuntimeSessionOptimizationResponse,
+)
+from preloop.services.session_optimization import SessionOptimizationService
+
+logger = logging.getLogger(__name__)
+
+#: The only failure copy ever stored on (and shown for) a failed job. The
+#: analysis is read-only, so "Nothing was changed." is always true.
+USER_FACING_JOB_ERROR = "The model request didn't complete. Nothing was changed."
+
+#: Worker liveness signal cadence while the (blocking) model call runs.
+JOB_HEARTBEAT_INTERVAL_SECONDS = 60
+
+#: Recovery sweep cadence.
+JOB_SWEEP_INTERVAL_SECONDS = 120
+
+#: A pending job nobody claimed within this window is considered lost.
+JOB_STUCK_PENDING_MINUTES = 10
+
+#: A running job silent for this long is considered dead.
+JOB_STALE_HEARTBEAT_MINUTES = 5
+
+#: Finished jobs are pruned after this many days.
+JOB_RETENTION_DAYS = 14
+
+# Bounded pool for the blocking optimization passes. Module-level so every
+# code path (API workers, tests) shares the same cap.
+_job_executor = ThreadPoolExecutor(max_workers=3, thread_name_prefix="optimize-job")
+
+# Strong references to in-flight futures so submitted work is never garbage
+# collected mid-run; entries remove themselves on completion.
+_job_futures: dict[uuid.UUID, Future] = {}
+_job_futures_lock = threading.Lock()
+
+
+def run_session_optimization(
+    db: Session,
+    *,
+    account: Any,
+    runtime_session_id: str,
+    request: RuntimeSessionOptimizationRequest,
+    current_user: Any,
+    budget_enforcer: Any = None,
+) -> RuntimeSessionOptimizationResponse:
+    """Run one synchronous optimization pass (the shared worker function).
+
+    This is the single entry point both the legacy inline endpoint and the
+    async job worker call, so the two paths can never drift semantically.
+
+    Args:
+        db: Database session (held for the duration of the pass).
+        account: Owning account.
+        runtime_session_id: Runtime session to analyze.
+        request: Analysis scope/model request.
+        current_user: User the analysis runs as.
+        budget_enforcer: Optional deployment budget enforcer.
+
+    Returns:
+        The generated (or cached) optimization response.
+    """
+    return SessionOptimizationService(db).get_account_session_optimization_suggestions(
+        account=account,
+        runtime_session_id=runtime_session_id,
+        request=request,
+        current_user=current_user,
+        budget_enforcer=budget_enforcer,
+    )
+
+
+def submit_session_optimization_job(
+    db: Session,
+    *,
+    account: Any,
+    current_user: Any,
+    runtime_session_id: str,
+    request: RuntimeSessionOptimizationRequest,
+    budget_enforcer: Any = None,
+) -> OptimizationJob:
+    """Submit (or converge on) the async analysis job for one session.
+
+    Idempotent by design: if an active (pending/running) job already exists
+    for this account/session pair, that job is returned and NO new work is
+    queued — a double-click must not spend the model budget twice.
+
+    Args:
+        db: Request-scoped database session.
+        account: Owning account.
+        current_user: Submitting user (the analysis runs as them).
+        runtime_session_id: Runtime session to analyze.
+        request: Analysis scope/model request.
+        budget_enforcer: Optional deployment budget enforcer, captured for
+            the worker thread.
+
+    Returns:
+        The active job for this session (existing or newly created).
+
+    Raises:
+        HTTPException: 404 when the session does not belong to the account.
+    """
+    session_row = crud_runtime_session.get(
+        db, id=runtime_session_id, account_id=str(account.id)
+    )
+    if session_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Runtime session not found",
+        )
+    existing = crud_optimization_job.get_active_for_session(
+        db,
+        account_id=account.id,
+        runtime_session_id=runtime_session_id,
+    )
+    if existing is not None:
+        return existing
+    job = crud_optimization_job.create_pending(
+        db,
+        account_id=account.id,
+        runtime_session_id=runtime_session_id,
+    )
+    # A create that raced another submit returns the OTHER caller's active
+    # job, which is already dispatched — never dispatch it twice.
+    if job.status == OptimizationJobStatus.PENDING and not _is_dispatched(job.id):
+        _dispatch_job(
+            job.id,
+            account_id=account.id,
+            user_id=current_user.id,
+            runtime_session_id=runtime_session_id,
+            request=request,
+            budget_enforcer=budget_enforcer,
+        )
+    return job
+
+
+def _is_dispatched(job_id: uuid.UUID) -> bool:
+    """Whether a future is already tracked for this job."""
+    with _job_futures_lock:
+        return job_id in _job_futures
+
+
+def _dispatch_job(
+    job_id: uuid.UUID,
+    *,
+    account_id: uuid.UUID,
+    user_id: uuid.UUID,
+    runtime_session_id: str,
+    request: RuntimeSessionOptimizationRequest,
+    budget_enforcer: Any,
+) -> None:
+    """Queue one job on the worker pool, keeping a strong future reference."""
+    future = _job_executor.submit(
+        _execute_job,
+        job_id,
+        account_id=account_id,
+        user_id=user_id,
+        runtime_session_id=runtime_session_id,
+        request=request,
+        budget_enforcer=budget_enforcer,
+    )
+    with _job_futures_lock:
+        _job_futures[job_id] = future
+
+    def _discard(_future: Future) -> None:
+        with _job_futures_lock:
+            _job_futures.pop(job_id, None)
+
+    future.add_done_callback(_discard)
+
+
+def _open_worker_session() -> Session:
+    """Open a fresh DB session for a worker/heartbeat thread."""
+    return next(get_db_session())
+
+
+def _touch_heartbeat(job_id: uuid.UUID) -> None:
+    """Record worker liveness using a short-lived session of its own."""
+    db = _open_worker_session()
+    try:
+        crud_optimization_job.touch_heartbeat(db, job_id=job_id)
+    except Exception:
+        logger.warning(
+            "Optimization job %s heartbeat update failed", job_id, exc_info=True
+        )
+    finally:
+        db.close()
+
+
+def _execute_job(
+    job_id: uuid.UUID,
+    *,
+    account_id: uuid.UUID,
+    user_id: uuid.UUID,
+    runtime_session_id: str,
+    request: RuntimeSessionOptimizationRequest,
+    budget_enforcer: Any = None,
+    db: Optional[Session] = None,
+) -> None:
+    """Worker-thread body for one job: claim, run, record the outcome.
+
+    Args:
+        job_id: Job row to execute.
+        account_id: Owning account id (re-fetched in the worker session).
+        user_id: Submitting user id (re-fetched in the worker session).
+        runtime_session_id: Runtime session to analyze.
+        request: Analysis scope/model request.
+        budget_enforcer: Optional deployment budget enforcer.
+        db: Test seam — inject a session instead of opening one. When
+            injected, the caller owns the session and no heartbeat ticker
+            thread is started.
+    """
+    owns_session = db is None
+    if db is None:
+        db = _open_worker_session()
+    heartbeat_stop: Optional[threading.Event] = None
+    try:
+        # Atomic claim: only one worker (or sweep) wins this transition. A
+        # lost claim means the job was already failed/cancelled — do nothing.
+        claimed = crud_optimization_job.transition(
+            db,
+            job_id=job_id,
+            from_statuses=(OptimizationJobStatus.PENDING,),
+            to_status=OptimizationJobStatus.RUNNING,
+        )
+        if not claimed:
+            logger.info(
+                "Optimization job %s no longer pending; skipping execution", job_id
+            )
+            return
+
+        if owns_session:
+            stop_event = threading.Event()
+            heartbeat_stop = stop_event
+
+            def _beat() -> None:
+                while not stop_event.wait(JOB_HEARTBEAT_INTERVAL_SECONDS):
+                    _touch_heartbeat(job_id)
+
+            threading.Thread(
+                target=_beat,
+                name=f"optimize-job-heartbeat-{job_id}",
+                daemon=True,
+            ).start()
+
+        account = crud_account.get(db, id=account_id)
+        user = crud_user.get(db, id=user_id)
+        if account is None or user is None:
+            raise RuntimeError(
+                f"Account {account_id} or user {user_id} vanished before "
+                f"optimization job {job_id} ran"
+            )
+        response = run_session_optimization(
+            db,
+            account=account,
+            runtime_session_id=runtime_session_id,
+            request=request,
+            current_user=user,
+            budget_enforcer=budget_enforcer,
+        )
+        finished = crud_optimization_job.transition(
+            db,
+            job_id=job_id,
+            from_statuses=(OptimizationJobStatus.RUNNING,),
+            to_status=OptimizationJobStatus.SUCCEEDED,
+            result=response.model_dump(mode="json"),
+        )
+        if not finished:
+            # The sweep declared the job dead while a (very) slow pass was
+            # still in flight; the result stays in the cache table, so a
+            # retried job returns it instantly.
+            logger.warning(
+                "Optimization job %s finished after being marked stale", job_id
+            )
+    except Exception as exc:
+        if isinstance(exc, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+            raise
+        # Row gets the stable user-facing copy; the log line keeps the detail.
+        logger.warning("Optimization job %s failed: %s", job_id, exc, exc_info=True)
+        try:
+            # The failed pass may have left the session mid-transaction; the
+            # failure-recording UPDATE needs a clean one.
+            db.rollback()
+            crud_optimization_job.transition(
+                db,
+                job_id=job_id,
+                from_statuses=ACTIVE_JOB_STATUSES,
+                to_status=OptimizationJobStatus.FAILED,
+                error=USER_FACING_JOB_ERROR,
+            )
+        except Exception:
+            logger.error(
+                "Could not record failure for optimization job %s",
+                job_id,
+                exc_info=True,
+            )
+    finally:
+        if heartbeat_stop is not None:
+            heartbeat_stop.set()
+        if owns_session:
+            db.close()
+
+
+def shutdown_job_executor() -> None:
+    """Abandon in-flight jobs at process shutdown.
+
+    ``wait=False`` on purpose: a model pass can take minutes and must not
+    hold up shutdown. Abandoned rows are picked up by the recovery sweep
+    after restart (stuck pending / stale heartbeat) and failed with the
+    retriable user-facing copy.
+    """
+    _job_executor.shutdown(wait=False, cancel_futures=True)
+    with _job_futures_lock:
+        _job_futures.clear()
+
+
+def run_optimization_job_sweep(db: Session) -> dict[str, int]:
+    """Fail abandoned jobs and prune finished ones past retention.
+
+    Args:
+        db: Database session.
+
+    Returns:
+        Counts: ``{"failed": ..., "pruned": ...}``.
+    """
+    failed = crud_optimization_job.fail_stale(
+        db,
+        error=USER_FACING_JOB_ERROR,
+        pending_older_than_minutes=JOB_STUCK_PENDING_MINUTES,
+        heartbeat_older_than_minutes=JOB_STALE_HEARTBEAT_MINUTES,
+    )
+    pruned = crud_optimization_job.prune_finished(
+        db, older_than_days=JOB_RETENTION_DAYS
+    )
+    if failed or pruned:
+        logger.info(
+            "Optimization job sweep: failed %s stale, pruned %s finished",
+            failed,
+            pruned,
+        )
+    return {"failed": failed, "pruned": pruned}
+
+
+class OptimizationJobSweeper:
+    """Periodic asyncio recovery sweep for optimization jobs.
+
+    Modeled on :class:`preloop.services.execution_monitor.ExecutionMonitor`:
+    started from the app lifespan, runs one sweep immediately (recovering
+    jobs abandoned by the previous process) and then every
+    ``check_interval`` seconds. The DB work is synchronous CRUD, so each pass
+    runs in a thread to keep the event loop responsive.
+    """
+
+    def __init__(self, check_interval_seconds: int = JOB_SWEEP_INTERVAL_SECONDS):
+        self.check_interval = check_interval_seconds
+        self._running = False
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        """Start the sweep background task."""
+        if self._running:
+            logger.warning("Optimization job sweeper is already running")
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._sweep_loop())
+        logger.info(
+            "Optimization job sweeper started (check_interval=%ss)",
+            self.check_interval,
+        )
+
+    async def stop(self) -> None:
+        """Stop the sweep background task."""
+        if not self._running:
+            return
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                # Expected when stop() cancels the sweep loop task.
+                pass
+
+    async def _sweep_loop(self) -> None:
+        """Run the sweep now, then on every interval tick."""
+        while self._running:
+            try:
+                await asyncio.to_thread(self._sweep_once)
+            except Exception:
+                logger.error("Error in optimization job sweep", exc_info=True)
+            try:
+                await asyncio.sleep(self.check_interval)
+            except asyncio.CancelledError:
+                break
+
+    @staticmethod
+    def _sweep_once() -> None:
+        """One synchronous sweep pass with its own session."""
+        db = _open_worker_session()
+        try:
+            run_optimization_job_sweep(db)
+        finally:
+            db.close()
+
+
+# Global singleton instance
+_sweeper_instance: OptimizationJobSweeper | None = None
+
+
+def get_optimization_job_sweeper() -> OptimizationJobSweeper:
+    """Get or create the global optimization job sweeper."""
+    global _sweeper_instance
+    if _sweeper_instance is None:
+        _sweeper_instance = OptimizationJobSweeper()
+    return _sweeper_instance

--- a/backend/tests/endpoints/test_ai_model_credential_export.py
+++ b/backend/tests/endpoints/test_ai_model_credential_export.py
@@ -1,0 +1,222 @@
+"""Tests for the subscription-OAuth credential export endpoint.
+
+Offboarding must be able to restore an agent's local login: subscription
+refresh tokens are single-use, so after any server-side refresh the
+Preloop-held bundle is the only live lineage. The export endpoint returns
+that bundle to the authenticated operator — and must refuse to export
+anything that is not a principal-bound subscription OAuth credential.
+"""
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from pytest_mock import MockerFixture
+
+from preloop.api.endpoints import ai_models
+from preloop.models.models.user import User
+from preloop.services.secret_service import (
+    ANTHROPIC_CLAUDE_CODE_OAUTH_CREDENTIAL_TYPE,
+    OPENAI_CODEX_OAUTH_CREDENTIAL_TYPE,
+    CredentialRefreshError,
+    ResolvedModelCredentials,
+)
+
+from tests.conftest import maybe_await
+
+
+@pytest.fixture
+def mock_user() -> User:
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.account_id = uuid.uuid4()
+    return user
+
+
+def _mock_model(account_id: uuid.UUID) -> MagicMock:
+    model = MagicMock()
+    model.id = uuid.uuid4()
+    model.account_id = account_id
+    return model
+
+
+def _patch_model_lookup(mocker: MockerFixture, model) -> MagicMock:
+    crud = mocker.patch(
+        "preloop.api.endpoints.ai_models.crud_ai_model", new_callable=MagicMock
+    )
+    crud.get.return_value = model
+    return crud
+
+
+def _patch_secret_service(mocker: MockerFixture) -> MagicMock:
+    service = MagicMock()
+    mocker.patch(
+        "preloop.api.endpoints.ai_models.get_secret_service", return_value=service
+    )
+    return service
+
+
+def _resolved(credential_type: str, payload: dict) -> ResolvedModelCredentials:
+    return ResolvedModelCredentials(
+        credential_type=credential_type,
+        backend_type="local_encrypted",
+        value=payload.get("access"),
+        payload=payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_export_returns_live_claude_bundle(
+    mock_user: User, mocker: MockerFixture
+):
+    model = _mock_model(mock_user.account_id)
+    _patch_model_lookup(mocker, model)
+    service = _patch_secret_service(mocker)
+    service.resolve_ai_model_credentials.return_value = _resolved(
+        ANTHROPIC_CLAUDE_CODE_OAUTH_CREDENTIAL_TYPE,
+        {
+            "type": ANTHROPIC_CLAUDE_CODE_OAUTH_CREDENTIAL_TYPE,
+            "access": "live-access",
+            "refresh": "live-refresh",
+            "expires": 1789000000000,
+        },
+    )
+
+    response = await maybe_await(
+        ai_models.export_ai_model_credentials(
+            model_id=model.id, db=MagicMock(), current_user=mock_user
+        )
+    )
+
+    assert response.credential_type == ANTHROPIC_CLAUDE_CODE_OAUTH_CREDENTIAL_TYPE
+    assert response.access == "live-access"
+    assert response.refresh == "live-refresh"
+    assert response.expires == 1789000000000
+    assert response.account_id is None
+    # The bundle must be refreshed if stale, so the exported copy is live.
+    _, kwargs = service.resolve_ai_model_credentials.call_args
+    assert kwargs["allow_refresh"] is True
+
+
+@pytest.mark.asyncio
+async def test_export_returns_codex_account_id(mock_user: User, mocker: MockerFixture):
+    model = _mock_model(mock_user.account_id)
+    _patch_model_lookup(mocker, model)
+    service = _patch_secret_service(mocker)
+    service.resolve_ai_model_credentials.return_value = _resolved(
+        OPENAI_CODEX_OAUTH_CREDENTIAL_TYPE,
+        {
+            "type": OPENAI_CODEX_OAUTH_CREDENTIAL_TYPE,
+            "access": "codex-access",
+            "refresh": "codex-refresh",
+            "expires": 1789000000000,
+            "account_id": "chatgpt-account",
+        },
+    )
+
+    response = await maybe_await(
+        ai_models.export_ai_model_credentials(
+            model_id=model.id, db=MagicMock(), current_user=mock_user
+        )
+    )
+
+    assert response.credential_type == OPENAI_CODEX_OAUTH_CREDENTIAL_TYPE
+    assert response.account_id == "chatgpt-account"
+
+
+@pytest.mark.asyncio
+async def test_export_refuses_api_key_credentials(
+    mock_user: User, mocker: MockerFixture
+):
+    model = _mock_model(mock_user.account_id)
+    _patch_model_lookup(mocker, model)
+    service = _patch_secret_service(mocker)
+    service.resolve_ai_model_credentials.return_value = _resolved(
+        "api_key", {"type": "api_key", "api_key": "sk-plain"}
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await maybe_await(
+            ai_models.export_ai_model_credentials(
+                model_id=model.id, db=MagicMock(), current_user=mock_user
+            )
+        )
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_export_refuses_models_without_credentials(
+    mock_user: User, mocker: MockerFixture
+):
+    model = _mock_model(mock_user.account_id)
+    _patch_model_lookup(mocker, model)
+    service = _patch_secret_service(mocker)
+    service.resolve_ai_model_credentials.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        await maybe_await(
+            ai_models.export_ai_model_credentials(
+                model_id=model.id, db=MagicMock(), current_user=mock_user
+            )
+        )
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_export_hides_other_account_models(
+    mock_user: User, mocker: MockerFixture
+):
+    model = _mock_model(uuid.uuid4())  # different account
+    _patch_model_lookup(mocker, model)
+    service = _patch_secret_service(mocker)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await maybe_await(
+            ai_models.export_ai_model_credentials(
+                model_id=model.id, db=MagicMock(), current_user=mock_user
+            )
+        )
+    assert exc_info.value.status_code == 404
+    service.resolve_ai_model_credentials.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_export_maps_refresh_failure_to_502(
+    mock_user: User, mocker: MockerFixture
+):
+    model = _mock_model(mock_user.account_id)
+    _patch_model_lookup(mocker, model)
+    service = _patch_secret_service(mocker)
+    service.resolve_ai_model_credentials.side_effect = CredentialRefreshError(
+        "refresh failed", provider="anthropic_claude_code", status_code=403
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await maybe_await(
+            ai_models.export_ai_model_credentials(
+                model_id=model.id, db=MagicMock(), current_user=mock_user
+            )
+        )
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_export_rejects_bundle_without_access_token(
+    mock_user: User, mocker: MockerFixture
+):
+    model = _mock_model(mock_user.account_id)
+    _patch_model_lookup(mocker, model)
+    service = _patch_secret_service(mocker)
+    service.resolve_ai_model_credentials.return_value = _resolved(
+        ANTHROPIC_CLAUDE_CODE_OAUTH_CREDENTIAL_TYPE,
+        {"type": ANTHROPIC_CLAUDE_CODE_OAUTH_CREDENTIAL_TYPE, "refresh": "r"},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await maybe_await(
+            ai_models.export_ai_model_credentials(
+                model_id=model.id, db=MagicMock(), current_user=mock_user
+            )
+        )
+    assert exc_info.value.status_code == 409

--- a/backend/tests/endpoints/test_auth.py
+++ b/backend/tests/endpoints/test_auth.py
@@ -102,9 +102,12 @@ def test_register_user_email_exists(db_session_mock):
 
 def test_register_disabled(db_session_mock):
     """Test that registration is blocked when REGISTRATION_ENABLED is false."""
-    with patch("preloop.api.auth.router.settings") as mock_settings:
-        # Disable registration
+    # The computed rule lives in preloop.api.auth.bootstrap (shared with
+    # /features), so the effective settings seam is the bootstrap module.
+    with patch("preloop.api.auth.bootstrap.settings") as mock_settings:
+        # Disable registration; no bootstrap token configured.
         mock_settings.registration_enabled = False
+        mock_settings.bootstrap_token = ""
 
         response = client.post(
             "/auth/register",
@@ -120,9 +123,11 @@ def test_register_disabled(db_session_mock):
         assert response.status_code == 403
         assert "Registration is disabled" in response.json()["detail"]
 
-        # Verify that no database operations were performed
-        # (the endpoint should reject before checking username/email)
-        db_session_mock.query.assert_not_called()
+        # Verify that nothing was written: the rule may probe the users
+        # table (zero-users check), but the endpoint must reject before any
+        # create/commit happens.
+        db_session_mock.add.assert_not_called()
+        db_session_mock.commit.assert_not_called()
 
 
 def test_login_success():

--- a/backend/tests/endpoints/test_auth_comprehensive.py
+++ b/backend/tests/endpoints/test_auth_comprehensive.py
@@ -530,8 +530,11 @@ class TestRegistrationFlows:
 
     def test_registration_disabled_returns_403(self, db_session_mock):
         """Test that registration returns 403 when disabled."""
-        with patch("preloop.api.auth.router.settings") as mock_settings:
+        # The computed rule lives in preloop.api.auth.bootstrap (shared with
+        # /features), so the effective settings seam is the bootstrap module.
+        with patch("preloop.api.auth.bootstrap.settings") as mock_settings:
             mock_settings.registration_enabled = False
+            mock_settings.bootstrap_token = ""
 
             response = client.post(
                 "/auth/register",

--- a/backend/tests/endpoints/test_features.py
+++ b/backend/tests/endpoints/test_features.py
@@ -18,7 +18,7 @@ def _clear_users_exist_cache():
 class TestGetFeatures:
     """Test get_features endpoint."""
 
-    @patch("preloop.api.endpoints.features.crud_user")
+    @patch("preloop.api.auth.bootstrap.crud_user")
     @patch("preloop.api.endpoints.features.get_plugin_manager")
     def test_get_features_success(self, mock_get_plugin_manager, mock_crud_user):
         """Test getting features successfully."""
@@ -42,13 +42,14 @@ class TestGetFeatures:
                 "audit_logging": True,
                 "registration": True,
                 "first_account_pending": False,
+                "registration_bootstrap_pending": False,
                 "session_optimization": True,
             },
         }
         mock_get_plugin_manager.assert_called_once()
         mock_plugin_manager.get_enabled_features.assert_called_once()
 
-    @patch("preloop.api.endpoints.features.crud_user")
+    @patch("preloop.api.auth.bootstrap.crud_user")
     @patch("preloop.api.endpoints.features.get_plugin_manager")
     def test_get_features_empty_plugins(self, mock_get_plugin_manager, mock_crud_user):
         """Test getting features when no plugins are enabled."""
@@ -69,11 +70,12 @@ class TestGetFeatures:
             "features": {
                 "registration": True,
                 "first_account_pending": False,
+                "registration_bootstrap_pending": False,
                 "session_optimization": True,
             },
         }
 
-    @patch("preloop.api.endpoints.features.crud_user")
+    @patch("preloop.api.auth.bootstrap.crud_user")
     @patch("preloop.api.endpoints.features.get_plugin_manager")
     def test_get_features_with_multiple_plugins(
         self, mock_get_plugin_manager, mock_crud_user
@@ -100,10 +102,10 @@ class TestGetFeatures:
         assert "plugins" in result
         assert "features" in result
         assert len(result["plugins"]) == 3
-        assert len(result["features"]) == 7
+        assert len(result["features"]) == 8
         assert result["features"]["session_optimization"] is True
 
-    @patch("preloop.api.endpoints.features.crud_user")
+    @patch("preloop.api.auth.bootstrap.crud_user")
     @patch("preloop.api.endpoints.features.get_plugin_manager")
     def test_session_optimization_always_advertised(
         self, mock_get_plugin_manager, mock_crud_user
@@ -128,7 +130,7 @@ class TestGetFeatures:
         }
         assert get_features(db=MagicMock())["features"]["session_optimization"] is False
 
-    @patch("preloop.api.endpoints.features.crud_user")
+    @patch("preloop.api.auth.bootstrap.crud_user")
     @patch("preloop.api.endpoints.features.get_plugin_manager")
     def test_first_account_pending_on_fresh_instance(
         self, mock_get_plugin_manager, mock_crud_user
@@ -148,9 +150,11 @@ class TestGetFeatures:
         result = get_features(db=MagicMock())
 
         assert result["features"]["first_account_pending"] is True
+        # No bootstrap token configured: not pending.
+        assert result["features"]["registration_bootstrap_pending"] is False
 
-    @patch("preloop.api.endpoints.features.settings")
-    @patch("preloop.api.endpoints.features.crud_user")
+    @patch("preloop.api.auth.bootstrap.settings")
+    @patch("preloop.api.auth.bootstrap.crud_user")
     @patch("preloop.api.endpoints.features.get_plugin_manager")
     def test_first_account_pending_requires_open_registration(
         self, mock_get_plugin_manager, mock_crud_user, mock_settings
@@ -166,15 +170,18 @@ class TestGetFeatures:
         mock_get_plugin_manager.return_value = mock_plugin_manager
         mock_crud_user.has_any_users.return_value = False
         mock_settings.registration_enabled = False
+        mock_settings.bootstrap_token = ""
 
         result = get_features(db=MagicMock())
 
         assert result["features"]["first_account_pending"] is False
         assert result["features"]["registration"] is False
-        # Registration closed: no need to query the users table.
+        assert result["features"]["registration_bootstrap_pending"] is False
+        # Registration closed and no bootstrap token: no need to query the
+        # users table.
         mock_crud_user.has_any_users.assert_not_called()
 
-    @patch("preloop.api.endpoints.features.crud_user")
+    @patch("preloop.api.auth.bootstrap.crud_user")
     @patch("preloop.api.endpoints.features.get_plugin_manager")
     def test_first_account_pending_sticky_cache_skips_db_after_users_exist(
         self, mock_get_plugin_manager, mock_crud_user
@@ -200,3 +207,55 @@ class TestGetFeatures:
             get_features(db=MagicMock())["features"]["first_account_pending"] is False
         )
         assert mock_crud_user.has_any_users.call_count == 1
+
+    @patch("preloop.api.auth.bootstrap.settings")
+    @patch("preloop.api.auth.bootstrap.crud_user")
+    @patch("preloop.api.endpoints.features.get_plugin_manager")
+    def test_bootstrap_pending_on_unclaimed_instance(
+        self, mock_get_plugin_manager, mock_crud_user, mock_settings
+    ):
+        """Zero users + token configured: signup stays reachable (even with
+        registration disabled) and the form is told the setup link is needed."""
+        from preloop.api.endpoints.features import get_features
+
+        mock_plugin_manager = MagicMock()
+        mock_plugin_manager.get_enabled_features.return_value = {
+            "plugins": [],
+            "features": {},
+        }
+        mock_get_plugin_manager.return_value = mock_plugin_manager
+        mock_crud_user.has_any_users.return_value = False
+        mock_settings.registration_enabled = False
+        mock_settings.bootstrap_token = "sekret"
+
+        result = get_features(db=MagicMock())
+
+        assert result["features"]["registration"] is True
+        assert result["features"]["registration_bootstrap_pending"] is True
+        assert result["features"]["first_account_pending"] is True
+
+    @patch("preloop.api.auth.bootstrap.settings")
+    @patch("preloop.api.auth.bootstrap.crud_user")
+    @patch("preloop.api.endpoints.features.get_plugin_manager")
+    def test_bootstrap_not_pending_once_claimed(
+        self, mock_get_plugin_manager, mock_crud_user, mock_settings
+    ):
+        """Once any user exists the token is ignored: registration_enabled
+        decides, and bootstrap_pending is False."""
+        from preloop.api.endpoints.features import get_features
+
+        mock_plugin_manager = MagicMock()
+        mock_plugin_manager.get_enabled_features.return_value = {
+            "plugins": [],
+            "features": {},
+        }
+        mock_get_plugin_manager.return_value = mock_plugin_manager
+        mock_crud_user.has_any_users.return_value = True
+        mock_settings.registration_enabled = False
+        mock_settings.bootstrap_token = "sekret"
+
+        result = get_features(db=MagicMock())
+
+        assert result["features"]["registration"] is False
+        assert result["features"]["registration_bootstrap_pending"] is False
+        assert result["features"]["first_account_pending"] is False

--- a/backend/tests/endpoints/test_session_optimization_jobs.py
+++ b/backend/tests/endpoints/test_session_optimization_jobs.py
@@ -1,0 +1,415 @@
+"""Endpoint and worker tests for async session-optimization jobs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from preloop.models.crud import (
+    crud_account,
+    crud_optimization_job,
+    crud_runtime_session,
+)
+from preloop.models.models.optimization_job import (
+    OptimizationJob,
+    OptimizationJobStatus,
+)
+from preloop.schemas.gateway_usage import (
+    RuntimeSessionOptimizationRequest,
+    RuntimeSessionOptimizationResponse,
+)
+from preloop.services.session_optimization import SessionOptimizationService
+from preloop.services.session_optimization_jobs import (
+    USER_FACING_JOB_ERROR,
+    _execute_job,
+    run_optimization_job_sweep,
+)
+
+
+@pytest.fixture(autouse=True)
+def no_dispatch():
+    """Keep worker threads out of endpoint tests.
+
+    The real worker opens its own DB session against the engine, which cannot
+    see rows inside the test transaction; job execution is tested directly via
+    :func:`_execute_job` with an injected session instead.
+    """
+    with patch("preloop.services.session_optimization_jobs._dispatch_job") as dispatch:
+        yield dispatch
+
+
+@pytest.fixture
+def cost_client(app, db_session, test_user):
+    """Test client bound to the test account for the cost routes."""
+    from fastapi.testclient import TestClient
+
+    from preloop.api.common import get_account_for_user
+
+    account = crud_account.get(db_session, id=test_user.account_id)
+    app.dependency_overrides[get_account_for_user] = lambda: account
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def make_runtime_session(db_session, account_id, source_id: str):
+    """Create one runtime session owned by the given account."""
+    now = datetime.now(UTC)
+    runtime_session = crud_runtime_session.upsert_by_source(
+        db_session,
+        account_id=account_id,
+        session_source_type="claude_code",
+        session_source_id=source_id,
+        session_reference=f"claude-{source_id}",
+        runtime_principal_type="claude_code",
+        runtime_principal_id=source_id,
+        runtime_principal_name="Claude Workspace",
+        started_at=now,
+        last_activity_at=now,
+    )
+    db_session.commit()
+    return runtime_session
+
+
+@pytest.fixture
+def runtime_session(db_session, test_user):
+    """A runtime session owned by the test user's account."""
+    return make_runtime_session(db_session, test_user.account_id, "workspace-opt-jobs")
+
+
+def jobs_url(session_id) -> str:
+    return f"/api/v1/billing/cost/runtime-sessions/{session_id}/optimizations/jobs"
+
+
+MINIMAL_RESULT = {"generated_by": "local", "suggestions": []}
+
+
+class TestSubmitJob:
+    def test_post_creates_pending_job_and_returns_202(
+        self, cost_client, db_session, test_user, runtime_session
+    ) -> None:
+        response = cost_client.post(jobs_url(runtime_session.id), json={})
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["status"] == "pending"
+        job = crud_optimization_job.get(db_session, id=body["job_id"])
+        assert job is not None
+        assert str(job.account_id) == str(test_user.account_id)
+        assert str(job.runtime_session_id) == str(runtime_session.id)
+        assert job.status == OptimizationJobStatus.PENDING
+
+    def test_double_post_returns_same_active_job(
+        self, cost_client, db_session, runtime_session, no_dispatch
+    ) -> None:
+        """A double-click converges on one job — no second model spend."""
+        first = cost_client.post(jobs_url(runtime_session.id), json={})
+        second = cost_client.post(jobs_url(runtime_session.id), json={})
+
+        assert first.status_code == 202
+        assert second.status_code == 202
+        assert second.json()["job_id"] == first.json()["job_id"]
+        assert no_dispatch.call_count == 1
+        assert (
+            db_session.query(OptimizationJob)
+            .filter(OptimizationJob.runtime_session_id == str(runtime_session.id))
+            .count()
+            == 1
+        )
+
+    def test_post_unknown_session_404s(self, cost_client) -> None:
+        response = cost_client.post(
+            jobs_url("00000000-0000-0000-0000-000000000000"), json={}
+        )
+        assert response.status_code == 404
+
+
+class TestGetJob:
+    def test_get_pending_job_shape(self, cost_client, runtime_session) -> None:
+        job_id = cost_client.post(jobs_url(runtime_session.id), json={}).json()[
+            "job_id"
+        ]
+
+        response = cost_client.get(f"{jobs_url(runtime_session.id)}/{job_id}")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["job_id"] == job_id
+        assert body["status"] == "pending"
+        assert body["result"] is None
+        assert body["error"] is None
+
+    def test_get_succeeded_job_returns_optimization_response_shape(
+        self, cost_client, db_session, runtime_session
+    ) -> None:
+        job_id = cost_client.post(jobs_url(runtime_session.id), json={}).json()[
+            "job_id"
+        ]
+        assert crud_optimization_job.transition(
+            db_session,
+            job_id=job_id,
+            from_statuses=(OptimizationJobStatus.PENDING,),
+            to_status=OptimizationJobStatus.RUNNING,
+        )
+        assert crud_optimization_job.transition(
+            db_session,
+            job_id=job_id,
+            from_statuses=(OptimizationJobStatus.RUNNING,),
+            to_status=OptimizationJobStatus.SUCCEEDED,
+            result=MINIMAL_RESULT,
+        )
+
+        response = cost_client.get(f"{jobs_url(runtime_session.id)}/{job_id}")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "succeeded"
+        assert body["error"] is None
+        # The embedded result parses as the legacy inline response schema.
+        parsed = RuntimeSessionOptimizationResponse.model_validate(body["result"])
+        assert parsed.generated_by == "local"
+        assert parsed.suggestions == []
+
+    def test_get_failed_job_returns_user_facing_error(
+        self, cost_client, db_session, runtime_session
+    ) -> None:
+        job_id = cost_client.post(jobs_url(runtime_session.id), json={}).json()[
+            "job_id"
+        ]
+        assert crud_optimization_job.transition(
+            db_session,
+            job_id=job_id,
+            from_statuses=(OptimizationJobStatus.PENDING,),
+            to_status=OptimizationJobStatus.FAILED,
+            error=USER_FACING_JOB_ERROR,
+        )
+
+        response = cost_client.get(f"{jobs_url(runtime_session.id)}/{job_id}")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "failed"
+        assert body["result"] is None
+        assert body["error"] == USER_FACING_JOB_ERROR
+
+    def test_cross_account_job_404s(
+        self, cost_client, db_session, runtime_session
+    ) -> None:
+        """A job id from another account must be indistinguishable from absent."""
+        other_account = crud_account.create(
+            db_session,
+            obj_in={"organization_name": "Other Org", "is_active": True},
+        )
+        other_session = make_runtime_session(
+            db_session, other_account.id, "workspace-other-account"
+        )
+        other_job = crud_optimization_job.create_pending(
+            db_session,
+            account_id=other_account.id,
+            runtime_session_id=other_session.id,
+        )
+
+        response = cost_client.get(f"{jobs_url(other_session.id)}/{other_job.id}")
+
+        assert response.status_code == 404
+
+    def test_malformed_job_id_404s(self, cost_client, runtime_session) -> None:
+        """Corrupted client storage must poll into a 404, not a 500."""
+        response = cost_client.get(f"{jobs_url(runtime_session.id)}/not-a-uuid")
+        assert response.status_code == 404
+
+    def test_wrong_session_job_404s(
+        self, cost_client, db_session, test_user, runtime_session
+    ) -> None:
+        """A real job id polled under a different session id is a 404."""
+        job_id = cost_client.post(jobs_url(runtime_session.id), json={}).json()[
+            "job_id"
+        ]
+        other_session = make_runtime_session(
+            db_session, test_user.account_id, "workspace-wrong-session"
+        )
+
+        response = cost_client.get(f"{jobs_url(other_session.id)}/{job_id}")
+
+        assert response.status_code == 404
+
+
+class TestRecoverySweep:
+    def test_sweep_fails_stale_pending_and_stale_running(
+        self, db_session, test_user
+    ) -> None:
+        account_id = test_user.account_id
+        stale_pending_session = make_runtime_session(
+            db_session, account_id, "workspace-stale-pending"
+        )
+        stale_running_session = make_runtime_session(
+            db_session, account_id, "workspace-stale-running"
+        )
+        fresh_session = make_runtime_session(db_session, account_id, "workspace-fresh")
+
+        stale_pending = crud_optimization_job.create_pending(
+            db_session,
+            account_id=account_id,
+            runtime_session_id=stale_pending_session.id,
+        )
+        stale_running = crud_optimization_job.create_pending(
+            db_session,
+            account_id=account_id,
+            runtime_session_id=stale_running_session.id,
+        )
+        fresh_pending = crud_optimization_job.create_pending(
+            db_session,
+            account_id=account_id,
+            runtime_session_id=fresh_session.id,
+        )
+        assert crud_optimization_job.transition(
+            db_session,
+            job_id=stale_running.id,
+            from_statuses=(OptimizationJobStatus.PENDING,),
+            to_status=OptimizationJobStatus.RUNNING,
+        )
+        now = datetime.now(UTC).replace(tzinfo=None)
+        db_session.query(OptimizationJob).filter(
+            OptimizationJob.id == stale_pending.id
+        ).update({"created_at": now - timedelta(minutes=20)})
+        db_session.query(OptimizationJob).filter(
+            OptimizationJob.id == stale_running.id
+        ).update({"heartbeat_at": now - timedelta(minutes=10)})
+        db_session.commit()
+
+        counts = run_optimization_job_sweep(db_session)
+
+        assert counts["failed"] == 2
+        db_session.expire_all()
+        for job_id in (stale_pending.id, stale_running.id):
+            job = crud_optimization_job.get(db_session, id=job_id)
+            assert job.status == OptimizationJobStatus.FAILED
+            assert job.error == USER_FACING_JOB_ERROR
+            assert job.finished_at is not None
+        fresh = crud_optimization_job.get(db_session, id=fresh_pending.id)
+        assert fresh.status == OptimizationJobStatus.PENDING
+
+    def test_sweep_prunes_finished_jobs_past_retention(
+        self, db_session, test_user
+    ) -> None:
+        session = make_runtime_session(
+            db_session, test_user.account_id, "workspace-prune"
+        )
+        old_job = crud_optimization_job.create_pending(
+            db_session,
+            account_id=test_user.account_id,
+            runtime_session_id=session.id,
+        )
+        assert crud_optimization_job.transition(
+            db_session,
+            job_id=old_job.id,
+            from_statuses=(OptimizationJobStatus.PENDING,),
+            to_status=OptimizationJobStatus.FAILED,
+            error=USER_FACING_JOB_ERROR,
+        )
+        old_job_id = old_job.id
+        now = datetime.now(UTC).replace(tzinfo=None)
+        db_session.query(OptimizationJob).filter(
+            OptimizationJob.id == old_job_id
+        ).update({"finished_at": now - timedelta(days=15)})
+        db_session.commit()
+
+        counts = run_optimization_job_sweep(db_session)
+
+        assert counts["pruned"] == 1
+        db_session.expire_all()
+        assert crud_optimization_job.get(db_session, id=old_job_id) is None
+
+
+class TestWorker:
+    def test_worker_failure_stores_user_facing_error_only(
+        self, db_session, test_user, runtime_session
+    ) -> None:
+        job = crud_optimization_job.create_pending(
+            db_session,
+            account_id=test_user.account_id,
+            runtime_session_id=runtime_session.id,
+        )
+        with patch.object(
+            SessionOptimizationService,
+            "get_account_session_optimization_suggestions",
+            side_effect=RuntimeError("gateway exploded: secret detail"),
+        ):
+            _execute_job(
+                job.id,
+                account_id=test_user.account_id,
+                user_id=test_user.id,
+                runtime_session_id=str(runtime_session.id),
+                request=RuntimeSessionOptimizationRequest(),
+                db=db_session,
+            )
+
+        db_session.expire_all()
+        refreshed = crud_optimization_job.get(db_session, id=job.id)
+        assert refreshed.status == OptimizationJobStatus.FAILED
+        # The row carries ONLY the stable user-facing copy; the diagnostic
+        # detail must never reach the console.
+        assert refreshed.error == USER_FACING_JOB_ERROR
+        assert "secret detail" not in (refreshed.error or "")
+        assert refreshed.result is None
+        assert refreshed.finished_at is not None
+
+    def test_worker_success_stores_result(
+        self, db_session, test_user, runtime_session
+    ) -> None:
+        job = crud_optimization_job.create_pending(
+            db_session,
+            account_id=test_user.account_id,
+            runtime_session_id=runtime_session.id,
+        )
+        response = RuntimeSessionOptimizationResponse(
+            generated_by="local", suggestions=[]
+        )
+        with patch.object(
+            SessionOptimizationService,
+            "get_account_session_optimization_suggestions",
+            return_value=response,
+        ):
+            _execute_job(
+                job.id,
+                account_id=test_user.account_id,
+                user_id=test_user.id,
+                runtime_session_id=str(runtime_session.id),
+                request=RuntimeSessionOptimizationRequest(),
+                db=db_session,
+            )
+
+        db_session.expire_all()
+        refreshed = crud_optimization_job.get(db_session, id=job.id)
+        assert refreshed.status == OptimizationJobStatus.SUCCEEDED
+        assert refreshed.error is None
+        assert refreshed.started_at is not None
+        assert refreshed.finished_at is not None
+        parsed = RuntimeSessionOptimizationResponse.model_validate(refreshed.result)
+        assert parsed.generated_by == "local"
+
+
+class TestLegacyInlineEndpoint:
+    def test_legacy_sync_endpoint_still_returns_inline_results(
+        self, cost_client, db_session, runtime_session
+    ) -> None:
+        """CRITICAL regression: legacy POST stays inline, never submit-then-poll."""
+        response = cost_client.post(
+            f"/api/v1/billing/cost/runtime-sessions/{runtime_session.id}/optimizations",
+            json={},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        # Inline result body, not a job acknowledgement.
+        assert "job_id" not in body
+        assert body["generated_by"] in ("local", "model")
+        assert isinstance(body["suggestions"], list)
+        # And no background job row was created as a side effect.
+        assert (
+            db_session.query(OptimizationJob)
+            .filter(OptimizationJob.runtime_session_id == str(runtime_session.id))
+            .count()
+            == 0
+        )

--- a/backend/tests/services/test_instance_service.py
+++ b/backend/tests/services/test_instance_service.py
@@ -22,6 +22,8 @@ def _reset_module_state(monkeypatch):
     monkeypatch.delenv("PRELOOP_DISABLE_TELEMETRY", raising=False)
     monkeypatch.delenv("DISABLE_VERSION_CHECK", raising=False)
     monkeypatch.delenv("PRELOOP_HOSTED", raising=False)
+    monkeypatch.delenv("PRELOOP_INSTALL_STARTED_AT", raising=False)
+    monkeypatch.delenv("PRELOOP_INSTALL_COMPLETED_AT", raising=False)
     instance_service._current_instance = None
     instance_service._version_check_task = None
     yield
@@ -79,7 +81,15 @@ async def test_send_version_check_skips_when_disabled(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_send_version_check_success_posts_expected_payload():
-    instance = _make_instance(version="9.9.9", edition="enterprise")
+    # Marker already emitted: this test checks the steady-state payload.
+    instance = _make_instance(
+        version="9.9.9",
+        edition="enterprise",
+        metadata_={
+            "key": "value",
+            instance_service.INSTALL_COMPLETED_EMITTED_KEY: "2026-01-01T00:00:00+00:00",
+        },
+    )
 
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -101,7 +111,10 @@ async def test_send_version_check_success_posts_expected_payload():
     assert payload["instance_uuid"] == str(instance.instance_uuid)
     assert payload["version"] == "9.9.9"
     assert payload["edition"] == "enterprise"
-    assert payload["metadata"] == {"key": "value"}
+    assert payload["metadata"] == {
+        "key": "value",
+        instance_service.INSTALL_COMPLETED_EMITTED_KEY: "2026-01-01T00:00:00+00:00",
+    }
 
 
 @pytest.mark.asyncio
@@ -167,6 +180,7 @@ async def test_send_version_check_handles_generic_error():
 
 @pytest.mark.asyncio
 async def test_send_version_check_defaults_metadata_to_empty(monkeypatch):
+    """None metadata becomes a dict; a fresh instance carries only the marker."""
     instance = _make_instance(metadata_=None)
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -176,10 +190,173 @@ async def test_send_version_check_defaults_metadata_to_empty(monkeypatch):
     mock_client.__aenter__.return_value = mock_client
     mock_client.__aexit__.return_value = None
 
-    with patch.object(instance_service.httpx, "AsyncClient", return_value=mock_client):
+    with (
+        patch.object(instance_service.httpx, "AsyncClient", return_value=mock_client),
+        patch(
+            "preloop.models.db.session.get_db_session",
+            side_effect=lambda: iter([MagicMock()]),
+        ),
+    ):
         await send_version_check(instance)
     payload = mock_client.post.call_args.kwargs["json"]
-    assert payload["metadata"] == {}
+    assert payload["metadata"] == {"install_completed": True}
+
+
+# --- install_completed funnel marker ----------------------------------------
+
+
+def _mock_success_client(response_json=None):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = response_json or {}
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    return mock_client
+
+
+class TestInstallCompletedMarker:
+    """The one-time install_completed marker on the version-check channel."""
+
+    @pytest.mark.asyncio
+    async def test_sent_on_first_successful_checkin_and_flag_persists(self):
+        instance = _make_instance(metadata_={})
+        row = SimpleNamespace(metadata_={})
+        db = _mock_db_with_row(row)
+        mock_client = _mock_success_client()
+
+        with (
+            patch.object(
+                instance_service.httpx, "AsyncClient", return_value=mock_client
+            ),
+            patch(
+                "preloop.models.db.session.get_db_session",
+                side_effect=lambda: iter([db]),
+            ),
+        ):
+            assert await send_version_check(instance) is True
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["metadata"]["install_completed"] is True
+        # Exactly-once guard persisted in the Instance row AND in-memory.
+        key = instance_service.INSTALL_COMPLETED_EMITTED_KEY
+        assert key in row.metadata_
+        assert key in instance.metadata_
+
+    @pytest.mark.asyncio
+    async def test_sent_exactly_once_across_consecutive_checks(self):
+        instance = _make_instance(metadata_={})
+        row = SimpleNamespace(metadata_={})
+        db = _mock_db_with_row(row)
+        mock_client = _mock_success_client()
+
+        with (
+            patch.object(
+                instance_service.httpx, "AsyncClient", return_value=mock_client
+            ),
+            patch(
+                "preloop.models.db.session.get_db_session",
+                side_effect=lambda: iter([db]),
+            ),
+        ):
+            await send_version_check(instance)
+            await send_version_check(instance)
+
+        first_payload = mock_client.post.call_args_list[0].kwargs["json"]
+        second_payload = mock_client.post.call_args_list[1].kwargs["json"]
+        assert first_payload["metadata"]["install_completed"] is True
+        assert "install_completed" not in second_payload["metadata"]
+
+    @pytest.mark.asyncio
+    async def test_not_marked_emitted_when_post_fails(self):
+        """A failed delivery must retry the marker on the next check-in."""
+        instance = _make_instance(metadata_={})
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_response.text = "unavailable"
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+
+        with patch.object(
+            instance_service.httpx, "AsyncClient", return_value=mock_client
+        ):
+            assert await send_version_check(instance) is False
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["metadata"]["install_completed"] is True
+        # Not emitted: the flag must not persist on failure.
+        assert instance_service.INSTALL_COMPLETED_EMITTED_KEY not in instance.metadata_
+
+    def test_suppressed_when_telemetry_disabled(self, monkeypatch):
+        monkeypatch.setenv("PRELOOP_DISABLE_TELEMETRY", "true")
+        instance = _make_instance(metadata_={})
+        assert instance_service.should_emit_install_completed(instance) is False
+
+    @pytest.mark.asyncio
+    async def test_suppressed_when_hosted(self, monkeypatch):
+        """Hosted preloop.ai must never report its own install as a funnel hit."""
+        monkeypatch.setenv("PRELOOP_HOSTED", "1")
+        instance = _make_instance(metadata_={})
+        mock_client = _mock_success_client()
+
+        with patch.object(
+            instance_service.httpx, "AsyncClient", return_value=mock_client
+        ):
+            await send_version_check(instance)
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert "install_completed" not in payload["metadata"]
+        assert instance_service.INSTALL_COMPLETED_EMITTED_KEY not in instance.metadata_
+
+    @pytest.mark.asyncio
+    async def test_installer_timestamps_included_when_stamped(self, monkeypatch):
+        monkeypatch.setenv("PRELOOP_INSTALL_STARTED_AT", "2026-07-18T10:00:00Z")
+        monkeypatch.setenv("PRELOOP_INSTALL_COMPLETED_AT", "2026-07-18T10:04:30Z")
+        instance = _make_instance(metadata_={})
+        row = SimpleNamespace(metadata_={})
+        db = _mock_db_with_row(row)
+        mock_client = _mock_success_client()
+
+        with (
+            patch.object(
+                instance_service.httpx, "AsyncClient", return_value=mock_client
+            ),
+            patch(
+                "preloop.models.db.session.get_db_session",
+                side_effect=lambda: iter([db]),
+            ),
+        ):
+            await send_version_check(instance)
+
+        metadata = mock_client.post.call_args.kwargs["json"]["metadata"]
+        assert metadata["install_started_at"] == "2026-07-18T10:00:00Z"
+        assert metadata["install_completed_at"] == "2026-07-18T10:04:30Z"
+
+    @pytest.mark.asyncio
+    async def test_installer_timestamps_never_synthesized(self):
+        """No .env stamps -> no timestamp fields, not even empty ones."""
+        instance = _make_instance(metadata_={})
+        row = SimpleNamespace(metadata_={})
+        db = _mock_db_with_row(row)
+        mock_client = _mock_success_client()
+
+        with (
+            patch.object(
+                instance_service.httpx, "AsyncClient", return_value=mock_client
+            ),
+            patch(
+                "preloop.models.db.session.get_db_session",
+                side_effect=lambda: iter([db]),
+            ),
+        ):
+            await send_version_check(instance)
+
+        metadata = mock_client.post.call_args.kwargs["json"]["metadata"]
+        assert "install_started_at" not in metadata
+        assert "install_completed_at" not in metadata
 
 
 # --- version comparison ----------------------------------------------------

--- a/backend/tests/services/test_model_gateway_authorization.py
+++ b/backend/tests/services/test_model_gateway_authorization.py
@@ -1,0 +1,404 @@
+"""Per-principal model authorization on the model gateway.
+
+Subscription-OAuth (Claude Code / Codex) models are bound to one managed
+agent's credentials. They must only be surfaced to — and resolvable by — the
+gateway principal whose ``managed_agent_id`` has an active row in
+``managed_agent_ai_model_binding`` for that model. BYOK/API-key models stay
+visible to every principal, and console user tokens keep full visibility.
+
+The rules are pinned at the single authorized-set chokepoint
+(``compute_authorized_model_ids``) via the service surfaces that consume it:
+``list_models`` and ``_resolve_requested_model``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from preloop.models.crud import (
+    crud_ai_model,
+    crud_api_key,
+    crud_managed_agent_ai_model_binding,
+)
+from preloop.models.models import ManagedAgent
+from preloop.services.model_gateway_auth import ModelGatewayAuthContext
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
+from preloop.services.openai_gateway import OpenAIGatewayService
+from preloop.services.secret_service import (
+    ANTHROPIC_CLAUDE_CODE_OAUTH_CREDENTIAL_TYPE,
+)
+
+BYOK_ALIAS = "openai/gpt-5"
+BOUND_ALIAS_A = "anthropic/claude-sonnet-4-5-agent-a"
+BOUND_ALIAS_B = "anthropic/claude-sonnet-4-5-agent-b"
+
+
+def _make_agent(db_session, test_user, *, source_id: str) -> ManagedAgent:
+    now = datetime.now(UTC).replace(tzinfo=None)
+    agent = ManagedAgent(
+        id=uuid4(),
+        account_id=test_user.account_id,
+        runtime_session_id=None,
+        agent_kind="hermes",
+        session_source_type="hermes",
+        session_source_id=source_id,
+        display_name=f"Hermes {source_id}",
+        enrolled_via="runtime_session_token",
+        lifecycle_state="active",
+        lifecycle_updated_at=now,
+        last_seen_at=now,
+    )
+    db_session.add(agent)
+    db_session.commit()
+    return agent
+
+
+def _make_byok_gateway_model(db_session, test_user, *, alias: str = BYOK_ALIAS):
+    return crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": f"BYOK {uuid4()}",
+            "provider_name": "openai",
+            "model_identifier": "gpt-5",
+            "api_key": "sk-byok-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": alias,
+                    "provider_adapter": "preloop",
+                }
+            },
+        },
+        account_id=test_user.account_id,
+    )
+
+
+def _make_bound_gateway_model(
+    db_session, test_user, *, alias: str, is_default: bool = False
+):
+    return crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": f"Subscription {uuid4()}",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "credential_type": ANTHROPIC_CLAUDE_CODE_OAUTH_CREDENTIAL_TYPE,
+            "credential_payload": {"access": "oauth-access-token"},
+            "is_default": is_default,
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": alias,
+                    "provider_adapter": "preloop",
+                }
+            },
+        },
+        account_id=test_user.account_id,
+    )
+
+
+def _bind_model_to_agent(db_session, test_user, agent, ai_model, *, alias: str):
+    crud_managed_agent_ai_model_binding.replace_for_agent(
+        db_session,
+        account_id=str(test_user.account_id),
+        agent_id=str(agent.id),
+        bindings=[
+            {
+                "config_key": "primary",
+                "gateway_alias": alias,
+                "ai_model_id": str(ai_model.id),
+            }
+        ],
+    )
+
+
+def _agent_context(db_session, test_user, agent) -> ModelGatewayAuthContext:
+    api_key, token = crud_api_key.create_runtime_key(
+        db_session,
+        name=f"Managed Agent Credential {uuid4()}",
+        account_id=test_user.account_id,
+        user_id=test_user.id,
+        context_data={
+            "managed_agent_id": str(agent.id),
+            "runtime_principal": {
+                "type": agent.session_source_type,
+                "id": agent.session_source_id,
+                "name": agent.display_name,
+            },
+        },
+    )
+    return ModelGatewayAuthContext(token=token, user=test_user, api_key=api_key)
+
+
+def _legacy_context(db_session, test_user) -> ModelGatewayAuthContext:
+    """Gateway credential minted before managed_agent_id existed."""
+    api_key, token = crud_api_key.create_runtime_key(
+        db_session,
+        name=f"Legacy Gateway Credential {uuid4()}",
+        account_id=test_user.account_id,
+        user_id=test_user.id,
+        context_data={},
+    )
+    return ModelGatewayAuthContext(token=token, user=test_user, api_key=api_key)
+
+
+def _user_context(test_user) -> ModelGatewayAuthContext:
+    """Console-originated user token (no API key, no OAuth MCP token)."""
+    return ModelGatewayAuthContext(token="user-jwt", user=test_user)
+
+
+def _listed_ids(service: OpenAIGatewayService) -> list[str]:
+    return [item["id"] for item in service.list_models()["data"]]
+
+
+def test_bound_model_invisible_to_other_agent_listing(db_session, test_user):
+    """Another agent's credential must not see a principal-bound model."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-a")
+    agent_b = _make_agent(db_session, test_user, source_id="hermes-b")
+    _make_byok_gateway_model(db_session, test_user)
+    bound = _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_A)
+    _bind_model_to_agent(db_session, test_user, agent_a, bound, alias=BOUND_ALIAS_A)
+
+    service = OpenAIGatewayService(
+        db_session, _agent_context(db_session, test_user, agent_b)
+    )
+
+    assert _listed_ids(service) == [BYOK_ALIAS]
+
+
+def test_own_bound_model_visible_to_its_principal(db_session, test_user):
+    """The bound agent's own credential keeps seeing its subscription model."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-a")
+    _make_byok_gateway_model(db_session, test_user)
+    bound = _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_A)
+    _bind_model_to_agent(db_session, test_user, agent_a, bound, alias=BOUND_ALIAS_A)
+
+    service = OpenAIGatewayService(
+        db_session, _agent_context(db_session, test_user, agent_a)
+    )
+
+    assert sorted(_listed_ids(service)) == sorted([BYOK_ALIAS, BOUND_ALIAS_A])
+
+
+def test_byok_models_listed_for_every_principal(db_session, test_user):
+    """CRITICAL regression: BYOK models stay visible to all principals."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-a")
+    agent_b = _make_agent(db_session, test_user, source_id="hermes-b")
+    _make_byok_gateway_model(db_session, test_user)
+    bound = _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_A)
+    _bind_model_to_agent(db_session, test_user, agent_a, bound, alias=BOUND_ALIAS_A)
+
+    contexts = [
+        _agent_context(db_session, test_user, agent_a),
+        _agent_context(db_session, test_user, agent_b),
+        _legacy_context(db_session, test_user),
+        _user_context(test_user),
+    ]
+    for context in contexts:
+        service = OpenAIGatewayService(db_session, context)
+        assert BYOK_ALIAS in _listed_ids(service)
+
+
+def test_user_token_listing_unchanged(db_session, test_user):
+    """Console user tokens keep full inventory visibility."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-a")
+    _make_byok_gateway_model(db_session, test_user)
+    bound = _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_A)
+    _bind_model_to_agent(db_session, test_user, agent_a, bound, alias=BOUND_ALIAS_A)
+
+    service = OpenAIGatewayService(db_session, _user_context(test_user))
+
+    assert sorted(_listed_ids(service)) == sorted([BYOK_ALIAS, BOUND_ALIAS_A])
+
+
+def test_legacy_credential_excludes_bound_models_but_keeps_byok(db_session, test_user):
+    """Fail closed: no managed_agent_id means no principal-bound models."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-a")
+    byok = _make_byok_gateway_model(db_session, test_user)
+    bound = _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_A)
+    _bind_model_to_agent(db_session, test_user, agent_a, bound, alias=BOUND_ALIAS_A)
+
+    service = OpenAIGatewayService(db_session, _legacy_context(db_session, test_user))
+
+    assert _listed_ids(service) == [BYOK_ALIAS]
+    resolved = service._resolve_requested_model(BYOK_ALIAS, provider="openai")
+    assert resolved.id == byok.id
+    with pytest.raises(ModelGatewayAPIError) as excinfo:
+        service._resolve_requested_model(BOUND_ALIAS_A, provider="openai")
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.code == "model_not_authorized"
+
+
+def test_bound_model_without_binding_row_hidden_from_agents(db_session, test_user):
+    """Fail closed: an OAuth model with no binding row serves no agent."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-a")
+    _make_byok_gateway_model(db_session, test_user)
+    _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_A)
+
+    service = OpenAIGatewayService(
+        db_session, _agent_context(db_session, test_user, agent_a)
+    )
+
+    assert _listed_ids(service) == [BYOK_ALIAS]
+    with pytest.raises(ModelGatewayAPIError) as excinfo:
+        service._resolve_requested_model(BOUND_ALIAS_A, provider="openai")
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.code == "model_not_authorized"
+
+
+def test_agents_sharing_runtime_only_see_their_own_bound_models(db_session, test_user):
+    """Each agent's credential authorizes only its own bound model."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-shared")
+    agent_b = _make_agent(db_session, test_user, source_id="hermes-shared-2")
+    _make_byok_gateway_model(db_session, test_user)
+    bound_a = _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_A)
+    bound_b = _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_B)
+    _bind_model_to_agent(db_session, test_user, agent_a, bound_a, alias=BOUND_ALIAS_A)
+    _bind_model_to_agent(db_session, test_user, agent_b, bound_b, alias=BOUND_ALIAS_B)
+
+    service_a = OpenAIGatewayService(
+        db_session, _agent_context(db_session, test_user, agent_a)
+    )
+    service_b = OpenAIGatewayService(
+        db_session, _agent_context(db_session, test_user, agent_b)
+    )
+
+    assert sorted(_listed_ids(service_a)) == sorted([BYOK_ALIAS, BOUND_ALIAS_A])
+    assert sorted(_listed_ids(service_b)) == sorted([BYOK_ALIAS, BOUND_ALIAS_B])
+    assert (
+        service_a._resolve_requested_model(BOUND_ALIAS_A, provider="openai").id
+        == bound_a.id
+    )
+    assert (
+        service_b._resolve_requested_model(BOUND_ALIAS_B, provider="openai").id
+        == bound_b.id
+    )
+
+
+def test_unauthorized_bound_model_resolution_returns_400_enumerating_usable(
+    db_session, test_user
+):
+    """Requesting another agent's bound model yields the exact 400 body."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-a")
+    agent_b = _make_agent(db_session, test_user, source_id="hermes-b")
+    _make_byok_gateway_model(db_session, test_user)
+    bound = _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_A)
+    _bind_model_to_agent(db_session, test_user, agent_a, bound, alias=BOUND_ALIAS_A)
+
+    service = OpenAIGatewayService(
+        db_session, _agent_context(db_session, test_user, agent_b)
+    )
+
+    with pytest.raises(ModelGatewayAPIError) as excinfo:
+        service._resolve_requested_model(BOUND_ALIAS_A, provider="openai")
+
+    error = excinfo.value
+    assert error.status_code == 400
+    assert error.code == "model_not_authorized"
+    assert error.message == (
+        f"Model '{BOUND_ALIAS_A}' is bound to another agent's subscription "
+        "credentials and can't serve this credential. Models available to "
+        f"this credential: {BYOK_ALIAS}."
+    )
+    payload = error.to_payload()
+    assert payload == {
+        "error": {
+            "message": error.message,
+            "type": "invalid_request_error",
+            "param": None,
+            "code": "model_not_authorized",
+        }
+    }
+
+
+def test_unauthorized_bound_model_anthropic_surface_stays_consistent(
+    db_session, test_user
+):
+    """The Anthropic-compat surface renders the same refusal in its envelope."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-a")
+    agent_b = _make_agent(db_session, test_user, source_id="hermes-b")
+    _make_byok_gateway_model(db_session, test_user)
+    bound = _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_A)
+    _bind_model_to_agent(db_session, test_user, agent_a, bound, alias=BOUND_ALIAS_A)
+
+    service = OpenAIGatewayService(
+        db_session, _agent_context(db_session, test_user, agent_b)
+    )
+
+    with pytest.raises(ModelGatewayAPIError) as excinfo:
+        service._resolve_requested_model(BOUND_ALIAS_A, provider="anthropic")
+
+    error = excinfo.value
+    assert error.status_code == 400
+    assert error.code == "model_not_authorized"
+    assert error.to_payload() == {
+        "type": "error",
+        "error": {
+            "type": "invalid_request_error",
+            "message": error.message,
+        },
+    }
+
+
+def test_hidden_suffix_alias_is_also_refused(db_session, test_user):
+    """A bare-suffix request for a bound alias must not stay callable."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-a")
+    agent_b = _make_agent(db_session, test_user, source_id="hermes-b")
+    bound = _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_A)
+    _bind_model_to_agent(db_session, test_user, agent_a, bound, alias=BOUND_ALIAS_A)
+
+    service = OpenAIGatewayService(
+        db_session, _agent_context(db_session, test_user, agent_b)
+    )
+
+    with pytest.raises(ModelGatewayAPIError) as excinfo:
+        service._resolve_requested_model("claude-sonnet-4-5-agent-a", provider="openai")
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.code == "model_not_authorized"
+    assert "Models available to this credential: none." in excinfo.value.message
+
+
+def test_unknown_model_still_404s_with_bound_models_present(db_session, test_user):
+    """Unknown models keep the loud 404, not the authorization 400."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-a")
+    agent_b = _make_agent(db_session, test_user, source_id="hermes-b")
+    _make_byok_gateway_model(db_session, test_user)
+    bound = _make_bound_gateway_model(db_session, test_user, alias=BOUND_ALIAS_A)
+    _bind_model_to_agent(db_session, test_user, agent_a, bound, alias=BOUND_ALIAS_A)
+
+    service = OpenAIGatewayService(
+        db_session, _agent_context(db_session, test_user, agent_b)
+    )
+
+    with pytest.raises(ModelGatewayAPIError) as excinfo:
+        service._resolve_requested_model("gpt-nonexistent", provider="openai")
+
+    assert excinfo.value.status_code == 404
+
+
+def test_default_selection_never_lands_on_unauthorized_model(db_session, test_user):
+    """An unauthorized bound default must not be silently selected."""
+    agent_a = _make_agent(db_session, test_user, source_id="hermes-a")
+    agent_b = _make_agent(db_session, test_user, source_id="hermes-b")
+    bound = _make_bound_gateway_model(
+        db_session, test_user, alias=BOUND_ALIAS_A, is_default=True
+    )
+    _bind_model_to_agent(db_session, test_user, agent_a, bound, alias=BOUND_ALIAS_A)
+
+    unauthorized_service = OpenAIGatewayService(
+        db_session, _agent_context(db_session, test_user, agent_b)
+    )
+    with pytest.raises(ModelGatewayAPIError) as excinfo:
+        unauthorized_service._resolve_requested_model(None, provider="openai")
+    assert excinfo.value.status_code == 404
+    assert "No gateway-enabled default model configured" in excinfo.value.message
+
+    authorized_service = OpenAIGatewayService(
+        db_session, _agent_context(db_session, test_user, agent_a)
+    )
+    resolved = authorized_service._resolve_requested_model(None, provider="openai")
+    assert resolved.id == bound.id

--- a/backend/tests/services/test_session_events.py
+++ b/backend/tests/services/test_session_events.py
@@ -1,0 +1,94 @@
+"""OSS-side tests for the first-session hook extension point.
+
+Without an EE plugin registering a hook, session recording must behave
+exactly as before: the notification is an inert no-op. These tests run
+against the OSS tree alone — no plugin linked.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from preloop.models.crud import crud_runtime_session
+from preloop.services import session_events
+
+
+@pytest.fixture(autouse=True)
+def _clean_hook_registry():
+    """Isolate the module-global hook registry across tests."""
+    previous = session_events.get_first_session_hook()
+    session_events.register_first_session_hook(None)
+    yield
+    session_events.register_first_session_hook(previous)
+
+
+def _record_session(db, account_id, source_id: str):
+    return crud_runtime_session.upsert_by_source(
+        db,
+        account_id=account_id,
+        session_source_type="agent_control",
+        session_source_id=source_id,
+        started_at=datetime.now(timezone.utc),
+        last_activity_at=datetime.now(timezone.utc),
+    )
+
+
+class TestHookRegistry:
+    def test_no_hook_registered_by_default(self):
+        assert session_events.get_first_session_hook() is None
+
+    def test_register_and_clear(self):
+        hook = MagicMock()
+        session_events.register_first_session_hook(hook)
+        assert session_events.get_first_session_hook() is hook
+        session_events.register_first_session_hook(None)
+        assert session_events.get_first_session_hook() is None
+
+    def test_notify_is_noop_without_hook(self):
+        db = MagicMock()
+        # Must not raise, must not touch the db.
+        session_events.notify_first_session_recorded(
+            db,
+            account_id="irrelevant",
+            occurred_at=datetime.now(timezone.utc),
+        )
+        db.assert_not_called()
+
+
+class TestFirstSessionSignal:
+    def test_session_recording_works_without_hook(self, db_session, test_user):
+        """OSS default: recording an account's first session is unchanged."""
+        session = _record_session(db_session, test_user.account_id, "sess-oss-1")
+        assert session.id is not None
+        assert session_events.get_first_session_hook() is None
+
+    def test_hook_fires_once_for_first_session_only(self, db_session, test_user):
+        calls = []
+
+        def hook(db, *, account_id, occurred_at):
+            calls.append((account_id, occurred_at))
+
+        session_events.register_first_session_hook(hook)
+
+        _record_session(db_session, test_user.account_id, "sess-hook-1")
+        assert len(calls) == 1
+        assert calls[0][0] == test_user.account_id
+        assert calls[0][1] is not None
+
+        # Second, distinct session for the same account: no new signal.
+        _record_session(db_session, test_user.account_id, "sess-hook-2")
+        assert len(calls) == 1
+
+        # Re-upserting an existing session: no new signal either.
+        _record_session(db_session, test_user.account_id, "sess-hook-1")
+        assert len(calls) == 1
+
+    def test_hook_failure_never_breaks_session_recording(self, db_session, test_user):
+        def exploding_hook(db, *, account_id, occurred_at):
+            raise RuntimeError("analytics outage")
+
+        session_events.register_first_session_hook(exploding_hook)
+
+        session = _record_session(db_session, test_user.account_id, "sess-boom-1")
+        assert session.id is not None

--- a/backend/tests/test_bootstrap_registration.py
+++ b/backend/tests/test_bootstrap_registration.py
@@ -1,0 +1,283 @@
+"""Tests for the bootstrap registration token (first-user claim) flow.
+
+Covers the computed registration rule shared by /register and /features:
+
+- zero users + valid token   -> 201 (regardless of REGISTRATION_ENABLED)
+- zero users + missing/wrong token (token configured) -> 403 "Setup link
+  required..."
+- zero users + token env unset -> today's behavior (REGISTRATION_ENABLED
+  decides)
+- >=1 user -> REGISTRATION_ENABLED decides, token ignored
+- two rapid first-signups -> exactly one 201 (zero-users state re-checked
+  under the advisory lock)
+- the Postgres advisory lock actually serializes two connections
+- account + user + role commit atomically (no orphaned account on failure)
+"""
+
+import time
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+from preloop.api.app import create_app
+from preloop.api.auth.bootstrap import reset_users_exist_cache
+from preloop.config import settings
+from preloop.models.crud import crud_account, crud_user
+from preloop.models.crud.user import REGISTRATION_BOOTSTRAP_LOCK_KEY
+from preloop.models.db.session import get_db_session
+from preloop.models.models.user import User
+
+BOOTSTRAP_TOKEN = "testbootstraptoken0123456789abcdef"
+
+SETUP_LINK_COPY = (
+    "Setup link required. Use the link printed at the end of the install, "
+    "or run create_first_user.py on the server."
+)
+DISABLED_COPY = (
+    "Registration is disabled. Please contact an administrator for an invitation."
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_users_exist_cache():
+    """Each test starts with an empty sticky users-exist cache."""
+    reset_users_exist_cache()
+    yield
+    reset_users_exist_cache()
+
+
+@pytest.fixture
+def register_client(db_session: Session) -> Generator[TestClient, None, None]:
+    """TestClient wired to the test transaction, background tasks patched."""
+    app = create_app()
+    app.dependency_overrides[get_db_session] = lambda: db_session
+
+    with TestClient(app) as client:
+        with patch("preloop.api.auth.router.complete_new_account_setup_background"):
+            yield client
+
+
+def _unique_creds(tag: str) -> dict:
+    """Unique alphanumeric username + email for one registration attempt."""
+    suffix = str(int(time.time() * 1_000_000))[-8:]
+    username = f"boot{tag}{suffix}"
+    return {
+        "username": username,
+        "email": f"{username}@example.com",
+        "password": "securepassword123",
+        "full_name": "Bootstrap Test",
+    }
+
+
+def _patch_zero_users():
+    """Force the zero-users (unclaimed instance) state for the rule."""
+    return patch.object(crud_user, "has_any_users", lambda db: False)
+
+
+class TestBootstrapTokenRule:
+    """Computed rule on a zero-user instance with a token configured."""
+
+    def test_zero_users_valid_token_registers(self, register_client, monkeypatch):
+        """Valid token claims the instance even with registration disabled."""
+        monkeypatch.setattr(settings, "bootstrap_token", BOOTSTRAP_TOKEN)
+        monkeypatch.setattr(settings, "registration_enabled", False)
+        creds = _unique_creds("ok")
+
+        with _patch_zero_users():
+            response = register_client.post(
+                "/api/v1/auth/register",
+                json={**creds, "bootstrap_token": BOOTSTRAP_TOKEN},
+            )
+
+        assert response.status_code == 201, response.json()
+        assert response.json()["username"] == creds["username"]
+
+    def test_zero_users_missing_token_403(self, register_client, monkeypatch):
+        """Missing token is refused even with registration ENABLED."""
+        monkeypatch.setattr(settings, "bootstrap_token", BOOTSTRAP_TOKEN)
+        monkeypatch.setattr(settings, "registration_enabled", True)
+
+        with _patch_zero_users():
+            response = register_client.post(
+                "/api/v1/auth/register", json=_unique_creds("miss")
+            )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == SETUP_LINK_COPY
+
+    def test_zero_users_wrong_token_403(self, register_client, monkeypatch):
+        """A wrong token is refused with the setup-link copy."""
+        monkeypatch.setattr(settings, "bootstrap_token", BOOTSTRAP_TOKEN)
+        monkeypatch.setattr(settings, "registration_enabled", True)
+
+        with _patch_zero_users():
+            response = register_client.post(
+                "/api/v1/auth/register",
+                json={**_unique_creds("bad"), "bootstrap_token": "wrongtoken"},
+            )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == SETUP_LINK_COPY
+
+
+class TestNoTokenRegression:
+    """Token env unset: today's behavior is preserved exactly."""
+
+    def test_zero_users_no_token_env_open_registration(
+        self, register_client, monkeypatch
+    ):
+        """Zero users, no token configured, registration enabled -> 201."""
+        monkeypatch.setattr(settings, "bootstrap_token", "")
+        monkeypatch.setattr(settings, "registration_enabled", True)
+
+        with _patch_zero_users():
+            response = register_client.post(
+                "/api/v1/auth/register", json=_unique_creds("reg")
+            )
+
+        assert response.status_code == 201, response.json()
+
+    def test_zero_users_no_token_env_registration_disabled(
+        self, register_client, monkeypatch
+    ):
+        """Zero users, no token configured, registration disabled -> 403."""
+        monkeypatch.setattr(settings, "bootstrap_token", "")
+        monkeypatch.setattr(settings, "registration_enabled", False)
+
+        with _patch_zero_users():
+            response = register_client.post(
+                "/api/v1/auth/register", json=_unique_creds("dis")
+            )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == DISABLED_COPY
+
+
+class TestClaimedInstance:
+    """>=1 user: REGISTRATION_ENABLED decides; the token is ignored."""
+
+    def test_users_exist_registration_disabled_403(
+        self, register_client, monkeypatch, test_user: User
+    ):
+        """Even a valid token cannot register on a claimed instance."""
+        monkeypatch.setattr(settings, "bootstrap_token", BOOTSTRAP_TOKEN)
+        monkeypatch.setattr(settings, "registration_enabled", False)
+
+        response = register_client.post(
+            "/api/v1/auth/register",
+            json={**_unique_creds("claim"), "bootstrap_token": BOOTSTRAP_TOKEN},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == DISABLED_COPY
+
+    def test_users_exist_registration_enabled_201(
+        self, register_client, monkeypatch, test_user: User
+    ):
+        """Regression: open registration keeps working once users exist."""
+        monkeypatch.setattr(settings, "bootstrap_token", "")
+        monkeypatch.setattr(settings, "registration_enabled", True)
+
+        response = register_client.post(
+            "/api/v1/auth/register", json=_unique_creds("open")
+        )
+
+        assert response.status_code == 201, response.json()
+
+
+class TestConcurrentFirstSignup:
+    """Two rapid first-signups: exactly one may claim the instance."""
+
+    def test_double_first_signup_single_201(self, register_client, monkeypatch):
+        """The second signup re-reads the users state under the lock and is
+        refused once the first has committed."""
+        monkeypatch.setattr(settings, "bootstrap_token", BOOTSTRAP_TOKEN)
+        monkeypatch.setattr(settings, "registration_enabled", False)
+
+        creds_one = _unique_creds("one")
+        creds_two = _unique_creds("two")
+        test_usernames = {creds_one["username"], creds_two["username"]}
+
+        def only_test_users_exist(db):
+            return (
+                db.query(User.id).filter(User.username.in_(test_usernames)).first()
+                is not None
+            )
+
+        with patch.object(crud_user, "has_any_users", only_test_users_exist):
+            first = register_client.post(
+                "/api/v1/auth/register",
+                json={**creds_one, "bootstrap_token": BOOTSTRAP_TOKEN},
+            )
+            second = register_client.post(
+                "/api/v1/auth/register",
+                json={**creds_two, "bootstrap_token": BOOTSTRAP_TOKEN},
+            )
+
+        statuses = sorted([first.status_code, second.status_code])
+        assert statuses == [201, 403], (first.json(), second.json())
+
+    def test_advisory_lock_blocks_second_connection(self, db_engine):
+        """pg_advisory_xact_lock on the constant key serializes two
+        connections: the second blocks until the first's transaction ends."""
+        conn_a = db_engine.connect()
+        conn_b = db_engine.connect()
+        try:
+            conn_a.execute(
+                text("SELECT pg_advisory_xact_lock(:key)"),
+                {"key": REGISTRATION_BOOTSTRAP_LOCK_KEY},
+            )
+
+            conn_b.execute(text("SET lock_timeout = '300ms'"))
+            with pytest.raises(OperationalError):
+                conn_b.execute(
+                    text("SELECT pg_advisory_xact_lock(:key)"),
+                    {"key": REGISTRATION_BOOTSTRAP_LOCK_KEY},
+                )
+            conn_b.rollback()
+
+            # Releasing the first transaction lets the second proceed.
+            conn_a.rollback()
+            conn_b.execute(text("SET lock_timeout = '5s'"))
+            conn_b.execute(
+                text("SELECT pg_advisory_xact_lock(:key)"),
+                {"key": REGISTRATION_BOOTSTRAP_LOCK_KEY},
+            )
+            conn_b.rollback()
+        finally:
+            conn_a.close()
+            conn_b.close()
+
+
+class TestAtomicFirstUserCreation:
+    """Account + user + role commit together: no orphaned account rows."""
+
+    def test_failed_role_assignment_leaves_no_orphan(
+        self, register_client, db_session: Session, monkeypatch
+    ):
+        """A failure after account creation rolls the whole signup back."""
+        monkeypatch.setattr(settings, "bootstrap_token", "")
+        monkeypatch.setattr(settings, "registration_enabled", True)
+        creds = _unique_creds("atomic")
+
+        with (
+            _patch_zero_users(),
+            patch(
+                "preloop.api.auth.router.crud_user_role.create",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            response = register_client.post("/api/v1/auth/register", json=creds)
+
+        assert response.status_code == 500
+        assert crud_user.get_by_username(db_session, username=creds["username"]) is None
+        orphan_accounts = crud_account.get_multi(
+            db_session,
+            organization_name=f"{creds['username']}'s Organization",
+        )
+        assert orphan_accounts == []

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -35,6 +35,16 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
+	if e.StatusCode == http.StatusUnauthorized {
+		// Sessions started with `preloop login --token` carry no refresh
+		// token, so they expire silently — point at the recovery path
+		// instead of surfacing a bare 401.
+		return fmt.Sprintf(
+			"API error (status %d): %s\nYour session has expired or is invalid - run `preloop login` to re-authenticate.",
+			e.StatusCode,
+			e.Body,
+		)
+	}
 	return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Body)
 }
 

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -2051,8 +2051,15 @@ func executeOffboard(agent AgentConfig, autoApprove bool, modelRemovalPolicy, se
 
 	fmt.Printf("✓ Offboarded %s\n", resolveAgentDisplayName(agent))
 	fmt.Printf("  Restored config: %s\n", agent.ConfigPath)
-	if isClaudeCodeAgent(agent) {
-		printClaudeCodeOAuthOffboardNote(os.Stdout)
+	if isClaudeCodeAgent(agent) || isCodexCLIAgent(agent) {
+		// Subscription refresh tokens rotate server-side while onboarded, so
+		// write the live Preloop-held bundle back to the local credential
+		// store before cleanup can delete it. The note is the fallback when
+		// no bundle could be restored.
+		if !restoreSubscriptionLoginOnOffboard(client, agent, detail, os.Stdout) &&
+			isClaudeCodeAgent(agent) {
+			printClaudeCodeOAuthOffboardNote(os.Stdout)
+		}
 	}
 	if detail != nil {
 		fmt.Printf("  Removed managed agent: %s\n", detail.Agent.ID)

--- a/cli/internal/cmd/agents_credential_restore.go
+++ b/cli/internal/cmd/agents_credential_restore.go
@@ -1,0 +1,227 @@
+package cmd
+
+// Offboard write-back of subscription OAuth credentials.
+//
+// Claude Code and Codex subscription OAuth bundles use single-use rotating
+// refresh tokens. While an agent is onboarded its model traffic flows through
+// the Preloop gateway, which refreshes the imported bundle — rotating the
+// refresh token and invalidating the copy left in the agent's local
+// credential store. Restoring the pre-onboarding config therefore cannot
+// restore a working login: the Preloop account holds the only live lineage.
+//
+// At offboard time the CLI exports that live bundle over the authenticated
+// API (POST /api/v1/ai-models/{id}/credentials/export) and writes it back to
+// the agent's local credential store, so offboarding never costs the operator
+// their subscription login. This runs BEFORE offboard cleanup can delete the
+// Preloop-held model credential.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+const (
+	anthropicClaudeCodeOAuthCredentialType = "oauth_anthropic_claude_code"
+	openaiCodexOAuthCredentialType         = "oauth_openai_codex"
+)
+
+type exportedModelCredential struct {
+	CredentialType string `json:"credential_type"`
+	Access         string `json:"access"`
+	Refresh        string `json:"refresh"`
+	Expires        int64  `json:"expires"`
+	AccountID      string `json:"account_id"`
+}
+
+// restoreSubscriptionLoginOnOffboard exports the live subscription OAuth
+// bundle for the agent's bound models and writes it back to the agent's
+// local credential store. Returns true when a bundle was written back.
+// Failures are reported on writer but never abort the offboard.
+func restoreSubscriptionLoginOnOffboard(
+	client *api.Client,
+	agent AgentConfig,
+	detail *managedAgentDetailResponse,
+	writer io.Writer,
+) bool {
+	if client == nil || !client.IsAuthenticated() || detail == nil {
+		return false
+	}
+	wantType := ""
+	switch {
+	case isClaudeCodeAgent(agent):
+		wantType = anthropicClaudeCodeOAuthCredentialType
+	case isCodexCLIAgent(agent):
+		wantType = openaiCodexOAuthCredentialType
+	default:
+		return false
+	}
+	seen := map[string]struct{}{}
+	for _, binding := range detail.Agent.ConfiguredModels {
+		modelID := strings.TrimSpace(binding.AIModelID)
+		if modelID == "" {
+			continue
+		}
+		if _, dup := seen[modelID]; dup {
+			continue
+		}
+		seen[modelID] = struct{}{}
+
+		var bundle exportedModelCredential
+		err := client.Post(
+			fmt.Sprintf("/api/v1/ai-models/%s/credentials/export", modelID),
+			nil,
+			&bundle,
+		)
+		if err != nil {
+			// Not exportable (API-key credential, removed model, or a
+			// provider refresh failure) — try the next bound model.
+			continue
+		}
+		if bundle.CredentialType != wantType || strings.TrimSpace(bundle.Access) == "" {
+			continue
+		}
+
+		var path string
+		switch wantType {
+		case anthropicClaudeCodeOAuthCredentialType:
+			path, err = writeClaudeSubscriptionCredential(bundle)
+		case openaiCodexOAuthCredentialType:
+			path, err = writeCodexSubscriptionCredential(bundle)
+		}
+		if err != nil {
+			fmt.Fprintf( //nolint:errcheck
+				writer,
+				"  Warning: could not write the restored subscription login locally: %v\n",
+				err,
+			)
+			return false
+		}
+		fmt.Fprintf( //nolint:errcheck
+			writer,
+			"  Restored subscription login: live token written back to %s (subscription tokens rotate, and the Preloop account held the active copy while onboarded).\n",
+			path,
+		)
+		return true
+	}
+	return false
+}
+
+// writeClaudeSubscriptionCredential merges the exported bundle into
+// ~/.claude/.credentials.json (creating it when absent), preserving unrelated
+// fields such as scopes and subscriptionType. On macOS it additionally
+// best-effort updates the Claude Code keychain entry when one exists, since
+// the CLI prefers the keychain there.
+func writeClaudeSubscriptionCredential(bundle exportedModelCredential) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve home directory: %w", err)
+	}
+	path := filepath.Join(home, ".claude", ".credentials.json")
+
+	document := map[string]interface{}{}
+	if data, readErr := os.ReadFile(path); readErr == nil {
+		_ = json.Unmarshal(data, &document) //nolint:errcheck // corrupt file → rebuild
+		if document == nil {
+			document = map[string]interface{}{}
+		}
+	}
+	container, ok := asObjectMap(document["claudeAiOauth"])
+	if !ok {
+		container = map[string]interface{}{}
+	}
+	container["accessToken"] = strings.TrimSpace(bundle.Access)
+	if refresh := strings.TrimSpace(bundle.Refresh); refresh != "" {
+		container["refreshToken"] = refresh
+	}
+	if bundle.Expires > 0 {
+		container["expiresAt"] = bundle.Expires
+	}
+	document["claudeAiOauth"] = container
+
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to encode credential file: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("failed to create %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", fmt.Errorf("failed to write %s: %w", path, err)
+	}
+
+	if runtime.GOOS == "darwin" {
+		updateClaudeKeychainCredentialBlob(string(data))
+	}
+	return path, nil
+}
+
+// updateClaudeKeychainCredentialBlob replaces the Claude Code keychain blob
+// when one already exists. Best-effort: a missing entry or a locked keychain
+// must not fail the offboard (the file write above already succeeded).
+func updateClaudeKeychainCredentialBlob(blob string) {
+	if readClaudeKeychainCredentialBlob() == "" {
+		return
+	}
+	account := strings.TrimSpace(os.Getenv("USER"))
+	if account == "" {
+		account = "Claude Code"
+	}
+	_ = exec.Command( //nolint:errcheck
+		"security",
+		"add-generic-password",
+		"-U",
+		"-s", "Claude Code-credentials",
+		"-a", account,
+		"-w", blob,
+	).Run()
+}
+
+// writeCodexSubscriptionCredential merges the exported bundle into Codex's
+// auth.json (creating it when absent), preserving unrelated fields such as
+// id_token — Codex re-derives a fresh id_token on its next refresh using the
+// restored refresh token.
+func writeCodexSubscriptionCredential(bundle exportedModelCredential) (string, error) {
+	path := resolveCodexAuthPath()
+
+	document := map[string]interface{}{}
+	if data, readErr := os.ReadFile(path); readErr == nil {
+		_ = json.Unmarshal(data, &document) //nolint:errcheck // corrupt file → rebuild
+		if document == nil {
+			document = map[string]interface{}{}
+		}
+	}
+	tokens, ok := asObjectMap(document["tokens"])
+	if !ok {
+		tokens = map[string]interface{}{}
+	}
+	tokens["access_token"] = strings.TrimSpace(bundle.Access)
+	if refresh := strings.TrimSpace(bundle.Refresh); refresh != "" {
+		tokens["refresh_token"] = refresh
+	}
+	if accountID := strings.TrimSpace(bundle.AccountID); accountID != "" {
+		tokens["account_id"] = accountID
+	}
+	document["tokens"] = tokens
+	document["last_refresh"] = time.Now().UTC().Format(time.RFC3339)
+
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to encode auth file: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("failed to create %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	return path, nil
+}

--- a/cli/internal/cmd/agents_credential_restore_test.go
+++ b/cli/internal/cmd/agents_credential_restore_test.go
@@ -1,0 +1,238 @@
+package cmd
+
+// Tests for the offboard subscription-credential write-back.
+//
+// Subscription OAuth refresh tokens rotate server-side while an agent is
+// onboarded, so offboarding must restore the Preloop-held live bundle into
+// the agent's local credential store — otherwise every offboard costs the
+// operator their Claude/Codex login.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/api"
+	"github.com/preloop/preloop/cli/internal/testenv"
+)
+
+func exportServerForTest(
+	t *testing.T,
+	statusCode int,
+	bundle exportedModelCredential,
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost &&
+			strings.HasSuffix(r.URL.Path, "/credentials/export") {
+			w.WriteHeader(statusCode)
+			if statusCode == http.StatusOK {
+				_ = json.NewEncoder(w).Encode(bundle)
+			} else {
+				_ = json.NewEncoder(w).Encode(map[string]string{"detail": "nope"})
+			}
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+func detailWithModelForTest(modelID string) *managedAgentDetailResponse {
+	return &managedAgentDetailResponse{
+		Agent: managedAgentSummary{
+			ID: "agent-1",
+			ConfiguredModels: []managedAgentModelBindingSummary{
+				{ID: "binding-1", AIModelID: modelID},
+			},
+		},
+	}
+}
+
+func TestRestoreSubscriptionLoginWritesClaudeCredentialFile(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	credentialPath := filepath.Join(home, ".claude", ".credentials.json")
+	if err := os.MkdirAll(filepath.Dir(credentialPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate the stranded state: an existing file whose token was rotated
+	// away, but which still carries fields the write-back must preserve.
+	existing := `{"claudeAiOauth":{"accessToken":"","expiresAt":0,"scopes":["user:inference"],"subscriptionType":"max"}}`
+	if err := os.WriteFile(credentialPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	server := exportServerForTest(t, http.StatusOK, exportedModelCredential{
+		CredentialType: anthropicClaudeCodeOAuthCredentialType,
+		Access:         "live-access",
+		Refresh:        "live-refresh",
+		Expires:        1789000000000,
+	})
+	defer server.Close()
+
+	client := api.NewClientWithToken(server.URL, "test-token")
+	agent := AgentConfig{Name: "Claude Code", ConfigPath: filepath.Join(home, ".claude", "settings.json")}
+	var output bytes.Buffer
+
+	restored := restoreSubscriptionLoginOnOffboard(
+		client, agent, detailWithModelForTest("model-1"), &output,
+	)
+	if !restored {
+		t.Fatalf("expected write-back to succeed, output: %s", output.String())
+	}
+
+	data, err := os.ReadFile(credentialPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]interface{}
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatal(err)
+	}
+	oauth, ok := document["claudeAiOauth"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("claudeAiOauth missing: %s", data)
+	}
+	if oauth["accessToken"] != "live-access" {
+		t.Errorf("accessToken not restored: %v", oauth["accessToken"])
+	}
+	if oauth["refreshToken"] != "live-refresh" {
+		t.Errorf("refreshToken not restored: %v", oauth["refreshToken"])
+	}
+	if oauth["expiresAt"] != float64(1789000000000) {
+		t.Errorf("expiresAt not restored: %v", oauth["expiresAt"])
+	}
+	// Unrelated fields must survive the merge.
+	if oauth["subscriptionType"] != "max" {
+		t.Errorf("subscriptionType lost in merge: %v", oauth["subscriptionType"])
+	}
+	if !strings.Contains(output.String(), "Restored subscription login") {
+		t.Errorf("expected restored message, got: %s", output.String())
+	}
+}
+
+func TestRestoreSubscriptionLoginWritesCodexAuthFile(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	authPath := filepath.Join(home, ".codex", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(authPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"OPENAI_API_KEY":null,"tokens":{"id_token":"keep-me","access_token":"stale","refresh_token":"stale"},"last_refresh":"2026-07-18T00:00:00Z"}`
+	if err := os.WriteFile(authPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	server := exportServerForTest(t, http.StatusOK, exportedModelCredential{
+		CredentialType: openaiCodexOAuthCredentialType,
+		Access:         "codex-access",
+		Refresh:        "codex-refresh",
+		AccountID:      "chatgpt-account",
+	})
+	defer server.Close()
+
+	client := api.NewClientWithToken(server.URL, "test-token")
+	agent := AgentConfig{Name: "Codex CLI", ConfigPath: filepath.Join(home, ".codex", "config.toml")}
+	var output bytes.Buffer
+
+	restored := restoreSubscriptionLoginOnOffboard(
+		client, agent, detailWithModelForTest("model-1"), &output,
+	)
+	if !restored {
+		t.Fatalf("expected write-back to succeed, output: %s", output.String())
+	}
+
+	data, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]interface{}
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatal(err)
+	}
+	tokens, ok := document["tokens"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("tokens missing: %s", data)
+	}
+	if tokens["access_token"] != "codex-access" {
+		t.Errorf("access_token not restored: %v", tokens["access_token"])
+	}
+	if tokens["refresh_token"] != "codex-refresh" {
+		t.Errorf("refresh_token not restored: %v", tokens["refresh_token"])
+	}
+	if tokens["account_id"] != "chatgpt-account" {
+		t.Errorf("account_id not restored: %v", tokens["account_id"])
+	}
+	// Codex re-derives id_token on refresh, but an existing one must survive.
+	if tokens["id_token"] != "keep-me" {
+		t.Errorf("id_token lost in merge: %v", tokens["id_token"])
+	}
+	if document["last_refresh"] == "2026-07-18T00:00:00Z" {
+		t.Errorf("last_refresh not updated")
+	}
+}
+
+func TestRestoreSubscriptionLoginSkipsNonExportableCredentials(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+
+	server := exportServerForTest(t, http.StatusBadRequest, exportedModelCredential{})
+	defer server.Close()
+
+	client := api.NewClientWithToken(server.URL, "test-token")
+	agent := AgentConfig{Name: "Claude Code"}
+	var output bytes.Buffer
+
+	restored := restoreSubscriptionLoginOnOffboard(
+		client, agent, detailWithModelForTest("model-1"), &output,
+	)
+	if restored {
+		t.Fatal("expected write-back to be skipped for non-exportable credentials")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", ".credentials.json")); !os.IsNotExist(err) {
+		t.Errorf("credential file should not have been created, stat err: %v", err)
+	}
+}
+
+func TestRestoreSubscriptionLoginRejectsMismatchedCredentialType(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+
+	// A Codex bundle must never be written into Claude Code's store.
+	server := exportServerForTest(t, http.StatusOK, exportedModelCredential{
+		CredentialType: openaiCodexOAuthCredentialType,
+		Access:         "codex-access",
+	})
+	defer server.Close()
+
+	client := api.NewClientWithToken(server.URL, "test-token")
+	agent := AgentConfig{Name: "Claude Code"}
+	var output bytes.Buffer
+
+	restored := restoreSubscriptionLoginOnOffboard(
+		client, agent, detailWithModelForTest("model-1"), &output,
+	)
+	if restored {
+		t.Fatal("expected mismatched credential type to be rejected")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", ".credentials.json")); !os.IsNotExist(err) {
+		t.Errorf("credential file should not have been created, stat err: %v", err)
+	}
+}
+
+func TestRestoreSubscriptionLoginNeedsDetailAndAuth(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	var output bytes.Buffer
+
+	if restoreSubscriptionLoginOnOffboard(nil, AgentConfig{Name: "Claude Code"}, detailWithModelForTest("m"), &output) {
+		t.Error("nil client must not restore")
+	}
+	client := api.NewClientWithToken("http://127.0.0.1:0", "token")
+	if restoreSubscriptionLoginOnOffboard(client, AgentConfig{Name: "Claude Code"}, nil, &output) {
+		t.Error("nil detail must not restore")
+	}
+	if restoreSubscriptionLoginOnOffboard(client, AgentConfig{Name: "OpenCode"}, detailWithModelForTest("m"), &output) {
+		t.Error("non-subscription agents must not restore")
+	}
+}

--- a/cli/internal/version/check.go
+++ b/cli/internal/version/check.go
@@ -97,12 +97,21 @@ func CheckForUpdate() error {
 	if telemetry.Disabled() {
 		return nil
 	}
-	_, firstRun, _ := config.GetOrCreateClientIDWithNew()
+	// Derive the client id and the first-run flag ONCE and thread both
+	// through to the payload. A second GetOrCreateClientIDWithNew call in
+	// payload construction would find the id this call just created and
+	// report first_run=false on the very first run.
+	clientID, firstRun, err := config.GetOrCreateClientIDWithNew()
+	if err != nil {
+		// Degrade to an anonymous check: the update prompt must still work.
+		clientID = ""
+		firstRun = false
+	}
 	if !firstRun && !shouldCheck() {
 		return nil
 	}
 
-	info, err := fetchVersionInfo()
+	info, err := fetchVersionInfo(clientID, firstRun)
 	if err != nil {
 		return err
 	}
@@ -205,22 +214,25 @@ func sameOrigin(a, b string) bool {
 	return ua.Scheme == ub.Scheme && ua.Host == ub.Host
 }
 
-// buildCheckInPayload assembles the check-in body from local state. Config
-// load failures degrade to an anonymous payload rather than skipping the
-// check — the update prompt must still work on a broken config.
-func buildCheckInPayload() (checkInPayload, string) {
+// buildCheckInPayload assembles the check-in body from local state. The
+// client id and first-run flag are derived once by the caller (where the id
+// is created) and threaded through — re-deriving them here would read
+// first_run=false on the very first run. An empty clientID degrades to an
+// anonymous payload rather than skipping the check — the update prompt must
+// still work on a broken config.
+func buildCheckInPayload(clientID string, firstRun bool) (checkInPayload, string) {
 	payload := checkInPayload{
-		Version: Version,
-		OS:      runtime.GOOS,
-		Arch:    runtime.GOARCH,
+		ClientID: clientID,
+		Version:  Version,
+		OS:       runtime.GOOS,
+		Arch:     runtime.GOARCH,
 	}
 
 	metadata := map[string]any{}
-	if clientID, created, err := config.GetOrCreateClientIDWithNew(); err == nil {
-		payload.ClientID = clientID
-		if created {
-			metadata["first_run"] = true
-		}
+	if firstRun {
+		// The cli_first_run funnel signal: exactly one check-in per install
+		// carries it, the one that created the client id.
+		metadata["first_run"] = true
 	}
 	for category, count := range telemetry.Load() {
 		metadata["cmd_"+category] = count
@@ -240,13 +252,14 @@ func buildCheckInPayload() (checkInPayload, string) {
 
 // fetchVersionInfo fetches the latest version information from the server.
 // It POSTs the rich check-in first and falls back to the legacy GET when the
-// server predates the rich endpoint.
-func fetchVersionInfo() (*VersionInfo, error) {
+// server predates the rich endpoint. clientID and firstRun come from the
+// caller's single GetOrCreateClientIDWithNew call (see CheckForUpdate).
+func fetchVersionInfo(clientID string, firstRun bool) (*VersionInfo, error) {
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 	}
 
-	payload, accessToken := buildCheckInPayload()
+	payload, accessToken := buildCheckInPayload(clientID, firstRun)
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode version check payload: %w", err)
@@ -343,7 +356,15 @@ func ForceCheck() (*VersionInfo, error) {
 			telemetry.DisableTelemetryEnv,
 		)
 	}
-	info, err := fetchVersionInfo()
+	// A forced check on a fresh install IS the first run: the id gets
+	// created right here, so the first_run signal is threaded the same way
+	// as in CheckForUpdate.
+	clientID, firstRun, err := config.GetOrCreateClientIDWithNew()
+	if err != nil {
+		clientID = ""
+		firstRun = false
+	}
+	info, err := fetchVersionInfo(clientID, firstRun)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/version/check_test.go
+++ b/cli/internal/version/check_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -73,7 +74,7 @@ func TestFetchVersionInfoPostsRichPayload(t *testing.T) {
 	// Isolate config dir so the test never touches the real ~/.preloop.
 	testenv.SetHome(t, t.TempDir())
 
-	info, err := fetchVersionInfo()
+	info, err := fetchVersionInfo("11111111-2222-4333-8444-555555555555", false)
 	if err != nil {
 		t.Fatalf("fetchVersionInfo: %v", err)
 	}
@@ -83,9 +84,9 @@ func TestFetchVersionInfoPostsRichPayload(t *testing.T) {
 	if gotPath != CliVersionCheckPath {
 		t.Errorf("expected POST to %s, got %s", CliVersionCheckPath, gotPath)
 	}
-	// The payload must carry the install id + platform.
-	if gotBody["client_id"] == nil || gotBody["client_id"] == "" {
-		t.Error("payload missing client_id")
+	// The payload must carry the threaded install id + platform.
+	if gotBody["client_id"] != "11111111-2222-4333-8444-555555555555" {
+		t.Errorf("payload client_id = %v", gotBody["client_id"])
 	}
 	if gotBody["version"] != Version {
 		t.Errorf("payload version = %v", gotBody["version"])
@@ -124,7 +125,7 @@ func TestFetchVersionInfoFallsBackToLegacyEndpoint(t *testing.T) {
 	defer func() { VersionCheckOrigin = oldOrigin }()
 	testenv.SetHome(t, t.TempDir())
 
-	info, err := fetchVersionInfo()
+	info, err := fetchVersionInfo("", false)
 	if err != nil {
 		t.Fatalf("fetchVersionInfo with legacy fallback: %v", err)
 	}
@@ -133,6 +134,95 @@ func TestFetchVersionInfoFallsBackToLegacyEndpoint(t *testing.T) {
 	}
 	if len(paths) != 2 || !strings.HasSuffix(paths[1], LegacyVersionPath) {
 		t.Errorf("expected rich attempt then legacy fallback, got %v", paths)
+	}
+}
+
+func TestBuildCheckInPayloadFirstRunFlag(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+
+	payload, _ := buildCheckInPayload("some-id", true)
+	if payload.ClientID != "some-id" {
+		t.Errorf("client_id = %q, want the threaded id", payload.ClientID)
+	}
+	if payload.Metadata["first_run"] != true {
+		t.Errorf("first_run must be true when threaded in, got %v", payload.Metadata)
+	}
+
+	payload, _ = buildCheckInPayload("some-id", false)
+	if _, present := payload.Metadata["first_run"]; present {
+		t.Errorf("first_run must be absent on later runs, got %v", payload.Metadata)
+	}
+}
+
+func TestCheckForUpdateThreadsFirstRunIntoPayload(t *testing.T) {
+	// Regression: CheckForUpdate used to create the client id, then payload
+	// construction re-derived it via a second GetOrCreateClientIDWithNew
+	// call — which found the id already on disk and reported first_run=false
+	// on the very first run. The flag must be threaded from the single call
+	// that actually created the id.
+	var bodies []map[string]any
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			bodies = append(bodies, body)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"latest_version": Version, // no update prompt noise
+			})
+		}))
+	defer server.Close()
+
+	oldOrigin := VersionCheckOrigin
+	VersionCheckOrigin = server.URL
+	defer func() { VersionCheckOrigin = oldOrigin }()
+
+	// Fresh HOME: no client id yet — this run is THE first run. Test runs
+	// set PRELOOP_DISABLE_TELEMETRY=true globally (so tests never pollute
+	// adoption data); neutralize it here scoped to this test, because the
+	// check-in against the local httptest server IS the behavior under test.
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv(telemetry.DisableTelemetryEnv, "")
+	t.Setenv(telemetry.DisableVersionCheckEnv, "")
+
+	if err := CheckForUpdate(); err != nil {
+		t.Fatalf("first CheckForUpdate: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 check-in, got %d", len(bodies))
+	}
+	metadata, _ := bodies[0]["metadata"].(map[string]any)
+	if metadata == nil || metadata["first_run"] != true {
+		t.Fatalf("very first check-in must carry first_run=true, got %v", bodies[0])
+	}
+	firstClientID, _ := bodies[0]["client_id"].(string)
+	if firstClientID == "" {
+		t.Fatal("first check-in must carry the freshly created client_id")
+	}
+
+	// Force a second check with the SAME install: drop only the last-check
+	// timestamp, keeping the client id.
+	lastCheckPath, err := getLastCheckPath()
+	if err != nil {
+		t.Fatalf("getLastCheckPath: %v", err)
+	}
+	if err := os.Remove(lastCheckPath); err != nil {
+		t.Fatalf("removing last-check file: %v", err)
+	}
+
+	if err := CheckForUpdate(); err != nil {
+		t.Fatalf("second CheckForUpdate: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 check-ins, got %d", len(bodies))
+	}
+	if metadata, _ := bodies[1]["metadata"].(map[string]any); metadata != nil {
+		if _, present := metadata["first_run"]; present {
+			t.Errorf("second check-in must not carry first_run, got %v", metadata)
+		}
+	}
+	if secondClientID, _ := bodies[1]["client_id"].(string); secondClientID != firstClientID {
+		t.Errorf("client_id changed between runs: %q vs %q",
+			firstClientID, secondClientID)
 	}
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -41,6 +41,8 @@ import type {
   RuntimeSessionRequestListResponse,
   RuntimeSessionSummaryInsight,
   RuntimeSessionInteractionSummary,
+  RuntimeSessionOptimizationJobStatusResponse,
+  RuntimeSessionOptimizationJobSubmitResponse,
   RuntimeSessionOptimizationResponse,
   RuntimeSessionReplayResponse,
   RuntimeSessionOptimizationActionSpec,
@@ -1323,6 +1325,62 @@ export async function optimizeRuntimeSession(
   );
   if (!response.ok) {
     throw new Error('Failed to optimize runtime session');
+  }
+  return response.json();
+}
+
+/**
+ * Submit the optimization analysis as an async background job.
+ * POST /api/v1/billing/cost/runtime-sessions/{id}/optimizations/jobs
+ *
+ * The backend is idempotent: while a job for this session is still active,
+ * re-submitting returns that job instead of queuing a second model pass.
+ */
+export async function submitRuntimeSessionOptimizationJob(
+  runtimeSessionId: string,
+  options: {
+    regenerate?: boolean;
+    modelId?: string | null;
+    eventIds?: string[];
+    sourceKinds?: string[];
+    fromIndex?: number;
+    toIndex?: number;
+  } = {}
+): Promise<RuntimeSessionOptimizationJobSubmitResponse> {
+  const response = await fetchWithAuth(
+    `/api/v1/billing/cost/runtime-sessions/${runtimeSessionId}/optimizations/jobs`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        regenerate: Boolean(options.regenerate),
+        model_id: options.modelId || null,
+        event_ids: options.eventIds || [],
+        source_kinds: options.sourceKinds || [],
+        from_index: options.fromIndex ?? null,
+        to_index: options.toIndex ?? null,
+      }),
+    }
+  );
+  if (!response.ok) {
+    throw new Error('Failed to submit optimization job');
+  }
+  return response.json();
+}
+
+/**
+ * Poll one async optimization job's status, result, and error.
+ * GET /api/v1/billing/cost/runtime-sessions/{id}/optimizations/jobs/{jobId}
+ */
+export async function getRuntimeSessionOptimizationJob(
+  runtimeSessionId: string,
+  jobId: string
+): Promise<RuntimeSessionOptimizationJobStatusResponse> {
+  const response = await fetchWithAuth(
+    `/api/v1/billing/cost/runtime-sessions/${runtimeSessionId}/optimizations/jobs/${jobId}`
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to load optimization job (${response.status})`);
   }
   return response.json();
 }

--- a/frontend/src/components/preloop-session-observer.jobs.test.ts
+++ b/frontend/src/components/preloop-session-observer.jobs.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Async optimization job flow in the session observer: submit-then-poll on
+ * Generate, retry after failure, and reload-resume from sessionStorage.
+ */
+import { fixture, html, expect, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
+import { unifiedWebSocketManager } from '../services/unified-websocket-manager';
+import './preloop-session-observer';
+import type { PreloopSessionObserver } from './preloop-session-observer';
+
+const SESSION = {
+  id: 'runtime-session-1',
+  session_source_type: 'claude_code',
+  session_source_id: 'workspace-42',
+  session_reference: 'claude-session-42',
+  runtime_principal_name: 'Claude Workspace',
+  started_at: '2026-07-19T18:00:00Z',
+  last_activity_at: '2026-07-19T20:00:00Z',
+  ended_at: null,
+  latest_model_alias: 'anthropic/claude-sonnet-4',
+  latest_provider_name: 'Anthropic',
+  is_active_now: true,
+  activity_status: 'active_now',
+  total_requests: 1,
+  successful_requests: 1,
+  failed_requests: 0,
+  token_usage: {
+    prompt_tokens: 1200,
+    completion_tokens: 100,
+    total_tokens: 1300,
+  },
+  estimated_cost: 0.42,
+  last_request_at: '2026-07-19T20:00:00Z',
+};
+
+const SUCCEEDED_RESULT = {
+  generated_by: 'model',
+  fast_model_name: 'fast-model',
+  model_id: 'model-1',
+  model_name: 'fast-model',
+  potential_savings_tokens: 300,
+  suggestions: [
+    {
+      id: 'trim-context',
+      title: 'Trim prompt context',
+      description: 'Most tokens were prompt-side.',
+      expected_savings_tokens: 300,
+      expected_savings_usd: 0.08,
+      confidence: 'medium',
+      action_label: 'Review context segments',
+      evidence: ['1200 prompt tokens'],
+    },
+  ],
+};
+
+const STORAGE_KEY = 'preloop_optimize_job_runtime-session-1';
+
+describe('PreloopSessionObserver — async optimization jobs', () => {
+  let fetchStub: sinon.SinonStub;
+  let connectStub: sinon.SinonStub;
+  let subscribeStub: sinon.SinonStub;
+  let submittedJobs: string[];
+  // Status script per job id, consumed one entry per poll (last repeats).
+  let jobStatusScript: Record<string, Array<Record<string, unknown>>>;
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    sessionStorage.clear();
+    submittedJobs = [];
+    jobStatusScript = {};
+    connectStub = sinon.stub(unifiedWebSocketManager, 'connect').resolves();
+    subscribeStub = sinon
+      .stub(unifiedWebSocketManager, 'subscribe')
+      .returns(() => undefined);
+    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub.callsFake(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        const jobPollMatch = url.match(/\/optimizations\/jobs\/([^/?]+)$/);
+        if (jobPollMatch) {
+          const jobId = jobPollMatch[1];
+          const script = jobStatusScript[jobId] || [];
+          const next = script.length > 1 ? script.shift()! : script[0];
+          if (!next) return jsonResponse({ detail: 'not found' }, 404);
+          return jsonResponse(next);
+        }
+        if (url.includes('/optimizations/jobs')) {
+          const jobId = `job-${submittedJobs.length + 1}`;
+          submittedJobs.push(jobId);
+          return jsonResponse({ job_id: jobId, status: 'pending' }, 202);
+        }
+        if (url.includes('/optimizations/actions')) {
+          return jsonResponse({ items: [] });
+        }
+        if (url.includes('/optimizations')) {
+          // Panel-open cache probe stays on the legacy inline endpoint.
+          const body = init?.body ? JSON.parse(String(init.body)) : {};
+          if (body.cache_only) {
+            return jsonResponse({
+              generated_by: 'local',
+              fast_model_name: null,
+              cache_miss: true,
+              suggestions: [],
+            });
+          }
+          return jsonResponse({
+            generated_by: 'local',
+            fast_model_name: null,
+            suggestions: [],
+          });
+        }
+        if (url.includes('/ai-models')) {
+          return jsonResponse([
+            {
+              id: 'model-1',
+              name: 'fast-model',
+              provider_name: 'anthropic',
+              model_kind: 'llm',
+              model_identifier: 'claude-sonnet-4',
+              is_default: true,
+              created_at: '2026-07-19T00:00:00Z',
+              updated_at: '2026-07-19T00:00:00Z',
+            },
+          ]);
+        }
+        if (url.includes('/gateway-events')) {
+          return jsonResponse({
+            logs: [
+              {
+                id: 'event-1',
+                timestamp: '2026-07-19T20:00:00Z',
+                type: 'model_gateway_call',
+                payload: {
+                  outcome: 'success',
+                  model_alias: 'anthropic/claude-sonnet-4',
+                  prompt_tokens: 1200,
+                  completion_tokens: 100,
+                  total_tokens: 1300,
+                  estimated_cost: 0.42,
+                  conversation_preview: {
+                    messages: [{ role: 'user', text: 'Build a widget' }],
+                  },
+                },
+              },
+            ],
+          });
+        }
+        if (url.includes('/activity')) {
+          return jsonResponse({ items: [] });
+        }
+        return jsonResponse({});
+      }
+    );
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    connectStub.restore();
+    subscribeStub.restore();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  async function mountObserver(): Promise<PreloopSessionObserver> {
+    const el = (await fixture(
+      html`<preloop-session-observer
+        .sessions=${[SESSION]}
+        .features=${{ optimization: true }}
+      ></preloop-session-observer>`
+    )) as PreloopSessionObserver;
+    await waitUntil(
+      () => Boolean(el.shadowRoot?.querySelector('session-replay-panel')),
+      'replay panel did not mount',
+      { timeout: 3000 }
+    );
+    return el;
+  }
+
+  function replayPanel(el: PreloopSessionObserver) {
+    return el.shadowRoot?.querySelector('session-replay-panel');
+  }
+
+  function optimizationPanel(el: PreloopSessionObserver) {
+    return replayPanel(el)?.shadowRoot?.querySelector(
+      'session-optimization-panel'
+    );
+  }
+
+  async function openOptimizeTab(el: PreloopSessionObserver): Promise<void> {
+    const optimizeButton = Array.from(
+      el.shadowRoot?.querySelectorAll('sl-button') || []
+    ).find((button) => button.textContent?.trim() === 'Optimize');
+    expect(optimizeButton, 'Optimize tab button required').to.exist;
+    optimizeButton!.click();
+    await el.updateComplete;
+  }
+
+  async function clickGenerate(el: PreloopSessionObserver): Promise<void> {
+    const panel = replayPanel(el);
+    await waitUntil(
+      () =>
+        Boolean(
+          Array.from(
+            panel?.shadowRoot?.querySelectorAll('sl-button') || []
+          ).find((button) =>
+            /Generate suggestions/.test(button.textContent || '')
+          )
+        ),
+      'Generate button did not render',
+      { timeout: 3000 }
+    );
+    const generate = Array.from(
+      panel?.shadowRoot?.querySelectorAll('sl-button') || []
+    ).find((button) => /Generate suggestions/.test(button.textContent || ''));
+    generate!.click();
+    await el.updateComplete;
+  }
+
+  it('submits a job on Generate, shows analyzing, and renders the polled result', async () => {
+    const el = await mountObserver();
+    await openOptimizeTab(el);
+    jobStatusScript['job-1'] = [
+      {
+        job_id: 'job-1',
+        status: 'succeeded',
+        result: SUCCEEDED_RESULT,
+        error: null,
+      },
+    ];
+
+    await clickGenerate(el);
+
+    // The submit hits the async jobs endpoint (not the legacy inline one).
+    await waitUntil(() => submittedJobs.length === 1, 'job was not submitted', {
+      timeout: 3000,
+    });
+    // The stored job id enables reload-resume while the job is active.
+    // (It is cleared again once the poll below completes.)
+
+    // First poll is immediate; the succeeded result renders as suggestions.
+    await waitUntil(
+      () => {
+        const panel = optimizationPanel(el);
+        return Boolean(
+          panel?.shadowRoot?.textContent?.includes('Trim prompt context')
+        );
+      },
+      'polled suggestions did not render',
+      { timeout: 4000 }
+    );
+    // Job finished: the persisted id is cleared.
+    expect(sessionStorage.getItem(STORAGE_KEY)).to.equal(null);
+  });
+
+  it('shows the failed state and retries with a fresh job', async () => {
+    const el = await mountObserver();
+    await openOptimizeTab(el);
+    jobStatusScript['job-1'] = [
+      {
+        job_id: 'job-1',
+        status: 'failed',
+        result: null,
+        error: "The model request didn't complete. Nothing was changed.",
+      },
+    ];
+    jobStatusScript['job-2'] = [
+      {
+        job_id: 'job-2',
+        status: 'succeeded',
+        result: SUCCEEDED_RESULT,
+        error: null,
+      },
+    ];
+
+    await clickGenerate(el);
+
+    await waitUntil(
+      () =>
+        Boolean(
+          optimizationPanel(el)?.shadowRoot?.querySelector('.job-failed')
+        ),
+      'failed state did not render',
+      { timeout: 4000 }
+    );
+
+    const retry = optimizationPanel(el)?.shadowRoot?.querySelector(
+      '.job-retry-button'
+    ) as HTMLButtonElement;
+    expect(retry, 'retry button required').to.exist;
+    retry.click();
+
+    await waitUntil(
+      () => submittedJobs.length === 2,
+      'retry did not submit a fresh job',
+      { timeout: 4000 }
+    );
+    await waitUntil(
+      () =>
+        Boolean(
+          optimizationPanel(el)?.shadowRoot?.textContent?.includes(
+            'Trim prompt context'
+          )
+        ),
+      'retried job result did not render',
+      { timeout: 4000 }
+    );
+  });
+
+  it('resumes a persisted in-flight job on mount instead of showing the trigger', async () => {
+    sessionStorage.setItem(STORAGE_KEY, 'job-resume');
+    jobStatusScript['job-resume'] = [
+      { job_id: 'job-resume', status: 'running', result: null, error: null },
+    ];
+
+    const el = await mountObserver();
+    await openOptimizeTab(el);
+
+    // Polling resumes against the stored id without a new submit...
+    await waitUntil(
+      () =>
+        fetchStub
+          .getCalls()
+          .some((call) =>
+            String(call.args[0]).includes('/optimizations/jobs/job-resume')
+          ),
+      'stored job was not polled',
+      { timeout: 4000 }
+    );
+    expect(submittedJobs.length, 'no new job submitted on resume').to.equal(0);
+
+    // ...and the analyzing state renders instead of the Generate controls.
+    await waitUntil(
+      () =>
+        Boolean(
+          optimizationPanel(el)?.shadowRoot?.querySelector('.job-analyzing')
+        ),
+      'analyzing state did not render on resume',
+      { timeout: 4000 }
+    );
+    const controls =
+      replayPanel(el)?.shadowRoot?.querySelector('.optimize-controls');
+    expect(controls, 'trigger controls hidden while resuming').to.not.exist;
+  });
+});

--- a/frontend/src/components/preloop-session-observer.ts
+++ b/frontend/src/components/preloop-session-observer.ts
@@ -21,9 +21,11 @@ import {
   getApiKeyGatewayUsageSummary,
   getRuntimeSessionGatewayEventDetail,
   getRuntimeSessionGatewayEvents,
+  getRuntimeSessionOptimizationJob,
   getRuntimeSessionRequests,
   listRuntimeSessionOptimizationActions,
   optimizeRuntimeSession,
+  submitRuntimeSessionOptimizationJob,
   summarizeRuntimeSessionGatewayEvent,
   updateAccountRuntimeSession,
 } from '../api';
@@ -75,6 +77,48 @@ function readOptimizeHintDismissed(): boolean {
     return localStorage.getItem(OPTIMIZE_HINT_DISMISSED_KEY) === 'true';
   } catch {
     return false;
+  }
+}
+
+// Async optimization analysis jobs: submit-then-poll cadence and the
+// per-session sessionStorage key used to resume an in-flight job after a
+// reload instead of showing the trigger button again.
+const OPTIMIZE_JOB_POLL_INTERVAL_MS = 2500;
+const OPTIMIZE_JOB_STORAGE_PREFIX = 'preloop_optimize_job_';
+
+type OptimizationJobRequestOptions = {
+  regenerate?: boolean;
+  modelId?: string | null;
+  eventIds?: string[];
+  sourceKinds?: string[];
+  fromIndex?: number;
+  toIndex?: number;
+};
+
+/** Read the persisted active job id for a session; never throw. */
+function readStoredOptimizationJobId(sessionId: string): string | null {
+  try {
+    return sessionStorage.getItem(`${OPTIMIZE_JOB_STORAGE_PREFIX}${sessionId}`);
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the active job id for a session; never throw. */
+function storeOptimizationJobId(sessionId: string, jobId: string): void {
+  try {
+    sessionStorage.setItem(`${OPTIMIZE_JOB_STORAGE_PREFIX}${sessionId}`, jobId);
+  } catch {
+    // Privacy modes / missing storage: reload-resume simply won't apply.
+  }
+}
+
+/** Drop the persisted job id for a session; never throw. */
+function clearStoredOptimizationJobId(sessionId: string): void {
+  try {
+    sessionStorage.removeItem(`${OPTIMIZE_JOB_STORAGE_PREFIX}${sessionId}`);
+  } catch {
+    // Nothing to clean up when storage is unavailable.
   }
 }
 
@@ -192,6 +236,21 @@ export class PreloopSessionObserver extends LitElement {
 
   @state()
   private applyingOptimizationSuggestionId: string | null = null;
+
+  // Async analysis job state per session id: 'analyzing' while a job is
+  // pending/running (submit + poll), 'failed' after a failed job until retry.
+  @state()
+  private optimizationJobStates: Record<string, 'analyzing' | 'failed'> = {};
+
+  // Live poll timers per session id, cleared on completion/disconnect.
+  private optimizationJobPollTimers: Record<string, number> = {};
+
+  // Last submitted analysis options per session id so Retry re-runs the same
+  // scope/model selection.
+  private optimizationJobOptions: Record<
+    string,
+    OptimizationJobRequestOptions
+  > = {};
 
   @state()
   private aiModels: AIModel[] = [];
@@ -430,6 +489,9 @@ export class PreloopSessionObserver extends LitElement {
     this.removeEventListener('session-create-budget', this.handleCreateBudget);
     if (this.refreshTimer !== null) window.clearTimeout(this.refreshTimer);
     if (this.livePulseTimer !== null) window.clearTimeout(this.livePulseTimer);
+    for (const sessionId of Object.keys(this.optimizationJobPollTimers)) {
+      this.clearOptimizationJobPollTimer(sessionId);
+    }
   }
 
   willUpdate(changed: Map<string | number | symbol, unknown>): void {
@@ -637,6 +699,11 @@ export class PreloopSessionObserver extends LitElement {
       return;
     }
     this.activeSessionId = sessionId;
+    // Deep links can land straight in optimize mode; resume any persisted
+    // in-flight analysis job for the newly active session.
+    if (this.replayMode === 'optimize') {
+      this.maybeResumeOptimizationJob(sessionId);
+    }
     this.dispatchEvent(
       new CustomEvent('session-selected', {
         detail: { sessionId },
@@ -904,6 +971,121 @@ export class PreloopSessionObserver extends LitElement {
     }
   }
 
+  private setOptimizationJobState(
+    sessionId: string,
+    state: 'analyzing' | 'failed' | null
+  ): void {
+    if (state === null) {
+      const { [sessionId]: _dropped, ...rest } = this.optimizationJobStates;
+      this.optimizationJobStates = rest;
+      return;
+    }
+    this.optimizationJobStates = {
+      ...this.optimizationJobStates,
+      [sessionId]: state,
+    };
+  }
+
+  private clearOptimizationJobPollTimer(sessionId: string): void {
+    const timer = this.optimizationJobPollTimers[sessionId];
+    if (timer !== undefined) {
+      window.clearTimeout(timer);
+      delete this.optimizationJobPollTimers[sessionId];
+    }
+  }
+
+  /**
+   * Submit the async analysis job for one session and start polling it.
+   * The backend is idempotent for active jobs, so re-submitting (double
+   * click, retry racing an active job) converges on the same run.
+   */
+  private async startOptimizationJob(
+    sessionId: string,
+    options: OptimizationJobRequestOptions = {}
+  ): Promise<void> {
+    if (this.optimizationJobStates[sessionId] === 'analyzing') return;
+    this.optimizationJobOptions[sessionId] = options;
+    this.setOptimizationJobState(sessionId, 'analyzing');
+    try {
+      const job = await submitRuntimeSessionOptimizationJob(sessionId, options);
+      storeOptimizationJobId(sessionId, job.job_id);
+      this.scheduleOptimizationJobPoll(sessionId, job.job_id, 0);
+    } catch (error) {
+      console.info('Failed to submit optimization job:', error);
+      this.setOptimizationJobState(sessionId, 'failed');
+    }
+  }
+
+  private scheduleOptimizationJobPoll(
+    sessionId: string,
+    jobId: string,
+    delayMs: number = OPTIMIZE_JOB_POLL_INTERVAL_MS
+  ): void {
+    this.clearOptimizationJobPollTimer(sessionId);
+    this.optimizationJobPollTimers[sessionId] = window.setTimeout(() => {
+      void this.pollOptimizationJob(sessionId, jobId);
+    }, delayMs);
+  }
+
+  private async pollOptimizationJob(
+    sessionId: string,
+    jobId: string
+  ): Promise<void> {
+    try {
+      const job = await getRuntimeSessionOptimizationJob(sessionId, jobId);
+      if (job.status === 'succeeded') {
+        if (job.result) {
+          this.loadedOptimizations = {
+            ...this.loadedOptimizations,
+            [sessionId]: job.result,
+          };
+        }
+        clearStoredOptimizationJobId(sessionId);
+        this.setOptimizationJobState(sessionId, null);
+        return;
+      }
+      if (job.status === 'failed') {
+        clearStoredOptimizationJobId(sessionId);
+        this.setOptimizationJobState(sessionId, 'failed');
+        return;
+      }
+    } catch (error) {
+      // A 404 means the job is gone for good (pruned, or a stale stored id);
+      // anything else is transient (network blip) and polling continues.
+      if (error instanceof Error && error.message.includes('(404)')) {
+        clearStoredOptimizationJobId(sessionId);
+        this.setOptimizationJobState(sessionId, 'failed');
+        return;
+      }
+      console.info('Optimization job poll failed; retrying:', error);
+    }
+    this.scheduleOptimizationJobPoll(sessionId, jobId);
+  }
+
+  /**
+   * Reload-resume: when a persisted active job exists for this session,
+   * resume polling it (rendering the analyzing state) instead of showing
+   * the trigger controls again.
+   */
+  private maybeResumeOptimizationJob(sessionId: string | null): void {
+    if (!sessionId || this.optimizationJobStates[sessionId]) return;
+    const jobId = readStoredOptimizationJobId(sessionId);
+    if (!jobId) return;
+    this.setOptimizationJobState(sessionId, 'analyzing');
+    this.scheduleOptimizationJobPoll(sessionId, jobId, 0);
+  }
+
+  /** Retry after a failed analysis: submit a fresh job with the same options. */
+  private retryOptimizationJob(): void {
+    if (!this.activeSessionId) return;
+    const sessionId = this.activeSessionId;
+    this.setOptimizationJobState(sessionId, null);
+    void this.startOptimizationJob(
+      sessionId,
+      this.optimizationJobOptions[sessionId] || {}
+    );
+  }
+
   private async loadAIModels(): Promise<void> {
     try {
       this.aiModels = (await getAIModels()).filter(
@@ -1142,6 +1324,9 @@ export class PreloopSessionObserver extends LitElement {
     }
     if (mode === 'optimize' && this.activeSessionId) {
       void this.loadOptimizationActions(this.activeSessionId);
+      // A persisted in-flight job (e.g. page reload mid-analysis) resumes
+      // polling and renders the analyzing state instead of the trigger.
+      this.maybeResumeOptimizationJob(this.activeSessionId);
       // Surface previously generated suggestions on open (cache-only: no
       // generation on a miss).
       void this.loadSessionOptimization(this.activeSessionId, {
@@ -1485,6 +1670,11 @@ export class PreloopSessionObserver extends LitElement {
           .loadingOptimization=${
             this.loadingOptimizationForSessionId === this.activeSessionId
           }
+          .optimizationJobState=${
+            this.activeSessionId
+              ? this.optimizationJobStates[this.activeSessionId] || null
+              : null
+          }
           @session-event-detail-requested=${(event: CustomEvent) =>
             this.loadEventDetail(event.detail.eventId)}
           @session-interaction-summary-requested=${(event: CustomEvent) =>
@@ -1499,7 +1689,9 @@ export class PreloopSessionObserver extends LitElement {
               : undefined}
           @session-optimization-requested=${(event: CustomEvent) => {
             if (!this.activeSessionId) return;
-            this.loadSessionOptimization(this.activeSessionId, {
+            // Generation is async now: submit a background job and poll it
+            // (the UI shows the analyzing state meanwhile).
+            void this.startOptimizationJob(this.activeSessionId, {
               regenerate: Boolean(event.detail?.regenerate),
               modelId: event.detail?.modelId || null,
               eventIds: event.detail?.eventIds || [],
@@ -1509,6 +1701,7 @@ export class PreloopSessionObserver extends LitElement {
             });
             this.loadOptimizationActions(this.activeSessionId);
           }}
+          @session-optimization-retry=${() => this.retryOptimizationJob()}
           @session-optimization-apply=${(event: CustomEvent) =>
             this.applyOptimizationSuggestion(event.detail)}
           @session-optimization-actions-requested=${() =>

--- a/frontend/src/components/session-optimization-panel-states.test.ts
+++ b/frontend/src/components/session-optimization-panel-states.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the approved async-analysis panel states (launch console spec):
+ * 1A analyzing, 2A failed + retry, 3A no-waste. These pin the exact copy,
+ * the a11y contract, and the retry event — not the cosmetics.
+ */
+import { fixture, html, expect } from '@open-wc/testing';
+import './session-optimization-panel';
+import type { SessionOptimizationPanel } from './session-optimization-panel';
+
+const SESSION = {
+  id: 'sess-1',
+  session_source_type: 'claude_code',
+  session_source_id: 'workspace-1',
+  session_reference: 'claude-session-1',
+  runtime_principal_name: 'Claude Workspace',
+  started_at: '2026-07-19T18:00:00Z',
+  last_activity_at: '2026-07-19T20:00:00Z',
+  ended_at: null,
+  is_active_now: true,
+  activity_status: 'active_now',
+  total_requests: 1,
+  successful_requests: 1,
+  failed_requests: 0,
+  token_usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 },
+  estimated_cost: 0.01,
+  last_request_at: '2026-07-19T20:00:00Z',
+};
+
+describe('SessionOptimizationPanel — async job states', () => {
+  async function renderPanel(props: {
+    jobState?: 'analyzing' | 'failed' | null;
+    optimization?: Record<string, unknown> | null;
+  }) {
+    const el = (await fixture(
+      html`<session-optimization-panel
+        .session=${SESSION}
+        .jobState=${props.jobState ?? null}
+        .optimization=${props.optimization ?? null}
+        .suggestions=${[]}
+      ></session-optimization-panel>`
+    )) as SessionOptimizationPanel;
+    await el.updateComplete;
+    return el;
+  }
+
+  describe('analyzing (1A)', () => {
+    it('renders the approved copy and the indeterminate progress bar', async () => {
+      const el = await renderPanel({ jobState: 'analyzing' });
+      const text = (el.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
+      expect(text).to.include('Analyzing this session');
+      expect(text).to.include('Typically 1–2 minutes.');
+      expect(text).to.include(
+        'You can leave this tab open — results appear automatically.'
+      );
+      const bar = el.shadowRoot?.querySelector('[role="progressbar"]');
+      expect(bar, 'progressbar role required').to.exist;
+      // Indeterminate: no aria-valuenow.
+      expect(bar?.hasAttribute('aria-valuenow')).to.be.false;
+    });
+
+    it('marks the panel busy and exposes a polite live region', async () => {
+      const el = await renderPanel({ jobState: 'analyzing' });
+      expect(el.shadowRoot?.querySelector('[aria-busy="true"]')).to.exist;
+      const live = el.shadowRoot?.querySelector('[aria-live="polite"]');
+      expect(live, 'polite live region required').to.exist;
+    });
+
+    it('does not render the suggestions tabs while analyzing', async () => {
+      const el = await renderPanel({ jobState: 'analyzing' });
+      expect(el.shadowRoot?.querySelector('sl-tab-group')).to.not.exist;
+    });
+  });
+
+  describe('failed (2A)', () => {
+    it('renders the approved failure copy in an alert', async () => {
+      const el = await renderPanel({ jobState: 'failed' });
+      const alert = el.shadowRoot?.querySelector('[role="alert"]');
+      expect(alert, 'inline alert required').to.exist;
+      const text = (alert?.textContent || '').replace(/\s+/g, ' ');
+      expect(text).to.include('Analysis failed');
+      expect(text).to.include(
+        "The model request didn't complete. Nothing was changed."
+      );
+    });
+
+    it('dispatches session-optimization-retry when Retry analysis is clicked', async () => {
+      const el = await renderPanel({ jobState: 'failed' });
+      let retried = false;
+      el.addEventListener('session-optimization-retry', () => {
+        retried = true;
+      });
+      const button = el.shadowRoot?.querySelector(
+        '.job-retry-button'
+      ) as HTMLButtonElement;
+      expect(button, 'retry button required').to.exist;
+      expect(button.textContent?.trim()).to.equal('Retry analysis');
+      // A real <button>: keyboard focusable by default.
+      expect(button.tabIndex).to.equal(0);
+      button.click();
+      expect(retried, 'retry event must bubble').to.be.true;
+    });
+  });
+
+  describe('no-waste (3A)', () => {
+    const zeroSavingsResult = {
+      generated_by: 'local',
+      fast_model_name: null,
+      suggestions: [],
+      potential_savings_tokens: 0,
+    };
+
+    it('renders the calm state for a zero-savings result', async () => {
+      const el = await renderPanel({ optimization: zeroSavingsResult });
+      const text = (el.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
+      expect(text).to.include('No recoverable waste in this session');
+      expect(text).to.include(
+        'Short sessions rarely have any. Optimization pays off on longer, tool-heavy sessions.'
+      );
+      expect(el.shadowRoot?.querySelector('sl-tab-group')).to.not.exist;
+    });
+
+    it('links the demo video in a safe new tab', async () => {
+      const el = await renderPanel({ optimization: zeroSavingsResult });
+      const link = el.shadowRoot?.querySelector(
+        '.job-no-waste a'
+      ) as HTMLAnchorElement;
+      expect(link, 'video link required').to.exist;
+      expect(link.textContent).to.include('Watch it find real waste (2 min)');
+      expect(link.href).to.include(
+        'youtube.com/playlist?list=PLr2Jp0c-Qn2hoYL3aRZGUtBjTCVygWIXt'
+      );
+      expect(link.href).to.include('utm_source=console');
+      expect(link.href).to.include('utm_campaign=series-ep1');
+      expect(link.target).to.equal('_blank');
+      expect(link.rel).to.include('noopener');
+    });
+
+    it('renders results normally when the result has real savings', async () => {
+      const el = await renderPanel({
+        optimization: {
+          generated_by: 'local',
+          fast_model_name: null,
+          suggestions: [],
+          potential_savings_tokens: 900,
+        },
+      });
+      expect(el.shadowRoot?.querySelector('.job-no-waste')).to.not.exist;
+      expect(el.shadowRoot?.querySelector('sl-tab-group')).to.exist;
+    });
+  });
+});

--- a/frontend/src/components/session-optimization-panel.ts
+++ b/frontend/src/components/session-optimization-panel.ts
@@ -1,4 +1,5 @@
 import { LitElement, css, html, nothing } from 'lit';
+import type { PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
@@ -59,6 +60,19 @@ export class SessionOptimizationPanel extends LitElement {
 
   @property({ type: String })
   applyingSuggestionId: string | null = null;
+
+  /**
+   * Async analysis job state, driven by the session observer's submit/poll
+   * loop. 'analyzing' renders the indeterminate progress state; 'failed'
+   * renders the inline error with a retry action; null renders results.
+   */
+  @property({ type: String, attribute: 'job-state' })
+  jobState: 'analyzing' | 'failed' | null = null;
+
+  // Polite screen-reader announcement for job transitions (completion or
+  // failure); rendered in an always-present aria-live region.
+  @state()
+  private liveMessage = '';
 
   @state()
   private pendingApply: SessionOptimizationSuggestion | null = null;
@@ -325,6 +339,136 @@ export class SessionOptimizationPanel extends LitElement {
 
     .governance-link a:hover {
       text-decoration: underline;
+    }
+
+    /* Launch console states (approved spec: 1A analyzing / 2A failed /
+       3A no-waste). Designed for the dark #212632 surface context, Inter,
+       console-compact type (14px headings / 13px body), 4px radii, and the
+       semantic palette (info #30C9E8, error #FF5D5D, success #26D962,
+       action #0284C7). */
+    .job-state {
+      padding: var(--sl-spacing-medium);
+    }
+
+    .job-state-heading {
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1.4;
+    }
+
+    .job-state-body {
+      font-size: 13px;
+      line-height: 1.5;
+      margin-top: 4px;
+      opacity: 0.85;
+    }
+
+    /* 1A — analyzing: slim indeterminate bar in info cyan. */
+    .job-analyzing .job-progress {
+      background: rgba(48, 201, 232, 0.2);
+      border-radius: 4px;
+      height: 4px;
+      margin-bottom: 12px;
+      overflow: hidden;
+      position: relative;
+    }
+
+    .job-analyzing .job-progress-fill {
+      animation: job-progress-slide 1.4s ease-in-out infinite;
+      background: #30c9e8;
+      border-radius: 4px;
+      height: 100%;
+      position: absolute;
+      width: 40%;
+    }
+
+    @keyframes job-progress-slide {
+      0% {
+        left: -40%;
+      }
+      100% {
+        left: 100%;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .job-analyzing .job-progress-fill {
+        animation: none;
+        left: 0;
+        opacity: 0.5;
+        width: 100%;
+      }
+    }
+
+    /* 2A — failed: inline alert with the error-red left border. */
+    .job-failed {
+      border-left: 4px solid #ff5d5d;
+      border-radius: 4px;
+      padding-left: calc(var(--sl-spacing-medium) - 4px + 12px);
+    }
+
+    .job-failed .job-state-heading {
+      color: #ff5d5d;
+    }
+
+    .job-retry-button {
+      background: #0284c7;
+      border: none;
+      border-radius: 4px;
+      color: #ffffff;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 13px;
+      font-weight: 600;
+      margin-top: 12px;
+      padding: 8px 14px;
+    }
+
+    .job-retry-button:focus-visible {
+      outline: 2px solid #30c9e8;
+      outline-offset: 2px;
+    }
+
+    @media (max-width: 768px), (pointer: coarse) {
+      .job-retry-button {
+        min-height: 44px;
+        min-width: 44px;
+      }
+    }
+
+    /* 3A — no-waste: centered calm state. */
+    .job-no-waste {
+      text-align: center;
+    }
+
+    .job-no-waste-check {
+      color: #26d962;
+      display: block;
+      font-size: 24px;
+      line-height: 1;
+      margin: 0 auto 8px;
+    }
+
+    .job-no-waste a {
+      color: #30c9e8;
+      display: inline-block;
+      font-size: 13px;
+      margin-top: 12px;
+      text-decoration: none;
+    }
+
+    .job-no-waste a:hover {
+      text-decoration: underline;
+    }
+
+    .sr-only {
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      height: 1px;
+      overflow: hidden;
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
     }
   `;
 
@@ -1173,14 +1317,137 @@ export class SessionOptimizationPanel extends LitElement {
     `;
   }
 
+  /**
+   * Approved no-waste condition (state 3A): a real analysis result exists and
+   * reports nothing recoverable. Cache-only misses and the bundled example
+   * are never "no waste" — they are handled by their own states.
+   */
+  private hasNoRecoverableWaste(): boolean {
+    const optimization = this.optimization;
+    if (!optimization || optimization.cache_miss || optimization.is_example) {
+      return false;
+    }
+    return (optimization.potential_savings_tokens ?? 0) <= 0;
+  }
+
+  protected willUpdate(changed: PropertyValues<this>): void {
+    // Announce job transitions in the polite live region: completion when the
+    // analyzing state resolves into a result, failure when it flips to failed.
+    if (changed.has('jobState')) {
+      const previous = changed.get('jobState');
+      if (previous === 'analyzing' && this.jobState === 'failed') {
+        this.liveMessage =
+          "Analysis failed. The model request didn't complete. " +
+          'Nothing was changed.';
+      } else if (previous === 'analyzing' && this.jobState === null) {
+        this.liveMessage = 'Analysis complete. Results are shown below.';
+      } else if (this.jobState === 'analyzing') {
+        this.liveMessage = 'Analyzing this session.';
+      }
+    }
+  }
+
+  private requestRetry(): void {
+    this.dispatchEvent(
+      new CustomEvent('session-optimization-retry', {
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  // Always-present polite live region so job transitions are announced.
+  private renderLiveRegion() {
+    return html`
+      <div class="sr-only" role="status" aria-live="polite">
+        ${this.liveMessage}
+      </div>
+    `;
+  }
+
+  // State 1A — analyzing.
+  private renderAnalyzingState() {
+    return html`
+      <div class="panel" aria-busy="true">
+        ${this.renderLiveRegion()}
+        <div class="job-state job-analyzing">
+          <div
+            class="job-progress"
+            role="progressbar"
+            aria-label="Analyzing this session"
+          >
+            <div class="job-progress-fill"></div>
+          </div>
+          <div class="job-state-heading">Analyzing this session</div>
+          <div class="job-state-body">
+            Typically 1–2 minutes. You can leave this tab open — results appear
+            automatically.
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  // State 2A — failed, with retry.
+  private renderFailedState() {
+    return html`
+      <div class="panel">
+        ${this.renderLiveRegion()}
+        <div class="job-state job-failed" role="alert">
+          <div class="job-state-heading">Analysis failed</div>
+          <div class="job-state-body">
+            The model request didn't complete. Nothing was changed.
+          </div>
+          <button
+            type="button"
+            class="job-retry-button"
+            @click=${() => this.requestRetry()}
+          >
+            Retry analysis
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
+  // State 3A — no recoverable waste.
+  private renderNoWasteState() {
+    return html`
+      <div class="panel">
+        ${this.renderLiveRegion()}
+        <div class="job-state job-no-waste">
+          <span class="job-no-waste-check" aria-hidden="true">✓</span>
+          <div class="job-state-heading">
+            No recoverable waste in this session
+          </div>
+          <div class="job-state-body">
+            Short sessions rarely have any. Optimization pays off on longer,
+            tool-heavy sessions.
+          </div>
+          <a
+            href="https://www.youtube.com/playlist?list=PLr2Jp0c-Qn2hoYL3aRZGUtBjTCVygWIXt&utm_source=console&utm_campaign=series-ep1"
+            target="_blank"
+            rel="noopener"
+          >
+            Watch it find real waste (2 min) →
+          </a>
+        </div>
+      </div>
+    `;
+  }
+
   render() {
     if (!this.session) return '';
+    if (this.jobState === 'analyzing') return this.renderAnalyzingState();
+    if (this.jobState === 'failed') return this.renderFailedState();
+    if (this.hasNoRecoverableWaste()) return this.renderNoWasteState();
     const suggestions =
       this.suggestions || suggestSessionOptimizations(this.session);
     const hasProfile = Boolean(this.optimization?.context_profile);
 
     return html`
       <div class="panel">
+        ${this.renderLiveRegion()}
         <sl-tab-group>
           <sl-tab slot="nav" panel="suggestions">
             Suggestions (${suggestions.length})

--- a/frontend/src/components/session-replay-panel-example.test.ts
+++ b/frontend/src/components/session-replay-panel-example.test.ts
@@ -216,9 +216,10 @@ describe('session-replay-panel bundled example', () => {
     expect(exampleRequestCount, 'no example fetch when not needed').to.equal(0);
   });
 
-  it('shows the example when a short session yields zero savings', async () => {
-    // The reported symptom: a tiny session still produces a fallback
-    // suggestion, but with no savings figure — the tab looks broken.
+  it('shows the approved no-waste state when a short session yields zero savings', async () => {
+    // Approved launch state 3A: a real analysis that finds nothing renders
+    // the calm no-waste state (with the demo-video link) instead of the
+    // bundled example.
     stubFetch();
     const element = await mountOptimizePanel({
       suggestions: [realSuggestion(0)],
@@ -230,18 +231,22 @@ describe('session-replay-panel bundled example', () => {
       },
     });
 
-    await waitUntil(
-      () => Boolean(element.shadowRoot?.querySelector('.example-banner')),
-      'example should back-fill a zero-savings result'
-    );
-    const text = element.shadowRoot?.textContent || '';
-    expect(text).to.include('not your data');
-    // The session's own result panel is still rendered alongside the example,
-    // so the user keeps their (zero-savings) analysis rather than losing it.
-    const panels = element.shadowRoot?.querySelectorAll(
+    await waitUntil(() => {
+      const panel = element.shadowRoot?.querySelector(
+        'session-optimization-panel'
+      );
+      return Boolean(panel?.shadowRoot?.querySelector('.job-no-waste'));
+    }, 'no-waste state should render for a zero-savings result');
+    const panel = element.shadowRoot?.querySelector(
       'session-optimization-panel'
     );
-    expect(panels?.length, 'real result and example both render').to.equal(2);
+    const text = panel?.shadowRoot?.textContent || '';
+    expect(text).to.include('No recoverable waste in this session');
+    // The example is reserved for sessions with no result at all.
+    expect(element.shadowRoot?.querySelector('.example-banner')).to.not.exist;
+    expect(exampleRequestCount, 'no example fetch for a real result').to.equal(
+      0
+    );
   });
 
   it('falls back to the normal empty state when the example is unavailable', async () => {

--- a/frontend/src/components/session-replay-panel.ts
+++ b/frontend/src/components/session-replay-panel.ts
@@ -229,6 +229,14 @@ export class SessionReplayPanel extends LitElement {
   @property({ type: Object })
   optimizationResult: RuntimeSessionOptimizationResponse | null = null;
 
+  /**
+   * Async analysis job state from the observer's submit/poll loop. While
+   * 'analyzing' or 'failed' the optimize view renders the corresponding
+   * approved panel state instead of the controls/results.
+   */
+  @property({ type: String })
+  optimizationJobState: 'analyzing' | 'failed' | null = null;
+
   @property({ type: Array })
   optimizationAppliedActions: RuntimeSessionOptimizationAppliedAction[] = [];
 
@@ -3544,6 +3552,23 @@ export class SessionReplayPanel extends LitElement {
         Optimization is not enabled for this view.
       </div>`;
     }
+    // Async job states replace the whole drawer: 1A analyzing (indeterminate
+    // progress) and 2A failed (inline alert + retry). The panel owns the
+    // approved rendering; retry bubbles up to the observer as
+    // 'session-optimization-retry'.
+    if (
+      this.optimizationJobState === 'analyzing' ||
+      this.optimizationJobState === 'failed'
+    ) {
+      return html`
+        <div class="optimize-drawer">
+          <session-optimization-panel
+            .session=${this.session}
+            .jobState=${this.optimizationJobState}
+          ></session-optimization-panel>
+        </div>
+      `;
+    }
     const messages = this.getReplayMessages();
     const lastIndex = Math.max(messages.length - 1, 0);
     const scopedEvents = this.getOptimizationEvents(messages);
@@ -3556,8 +3581,14 @@ export class SessionReplayPanel extends LitElement {
       hasSuggestions &&
       (this.optimizationResult?.potential_savings_tokens ?? 0) > 0;
     // The state write lands in a later microtask, so this does not mutate
-    // state during this render pass.
-    if (!hasMeaningfulSavings && !this.loadingOptimization) {
+    // state during this render pass. A real result with no savings now renders
+    // the approved no-waste state (3A) instead of the example, so only
+    // prefetch the example while this session has produced no result at all.
+    if (
+      !hasMeaningfulSavings &&
+      !this.loadingOptimization &&
+      !this.optimizationResult
+    ) {
       void this.ensureExampleOptimization();
     }
     const showControls = this.optimizeControlsOpen || !hasSuggestions;
@@ -3795,17 +3826,21 @@ export class SessionReplayPanel extends LitElement {
               `
             : this.optimizationResult && !this.loadingOptimization
               ? html`
-                  <div class="empty">
-                    No optimization opportunities found for the selected scope.
-                    Widen the range, or run a longer / more tool-heavy session.
-                  </div>
+                  <session-optimization-panel
+                    .session=${this.session}
+                    .optimization=${this.optimizationResult}
+                    .suggestions=${this.optimizationSuggestions || []}
+                  ></session-optimization-panel>
                 `
               : nothing
         }
         ${
-          // Shown below the session's own result whenever that result has no
-          // savings to report, so the tab always demonstrates what it produces.
-          hasMeaningfulSavings || this.loadingOptimization
+          // Shown below whenever this session has produced no result of its
+          // own, so the tab still demonstrates what it produces. A result
+          // with no savings renders the approved no-waste state instead.
+          hasMeaningfulSavings ||
+          this.loadingOptimization ||
+          this.optimizationResult
             ? nothing
             : this.renderExampleOptimization()
         }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -711,6 +711,22 @@ export interface RuntimeSessionOptimizationResponse {
   example_pricing_note?: string | null;
 }
 
+/** Acknowledgement for an accepted async optimization analysis job. */
+export interface RuntimeSessionOptimizationJobSubmitResponse {
+  job_id: string;
+  status: 'pending' | 'running' | 'succeeded' | 'failed' | string;
+}
+
+/** Poll response for one async optimization analysis job. */
+export interface RuntimeSessionOptimizationJobStatusResponse {
+  job_id: string;
+  status: 'pending' | 'running' | 'succeeded' | 'failed' | string;
+  /** Shaped exactly like the inline response; set only on success. */
+  result: RuntimeSessionOptimizationResponse | null;
+  /** User-facing failure message; set only on failure. */
+  error: string | null;
+}
+
 export interface RuntimeSessionReplayResponse {
   id: string;
   runtime_session_id: string;

--- a/frontend/src/views/public/register-view.test.ts
+++ b/frontend/src/views/public/register-view.test.ts
@@ -1,7 +1,11 @@
 import { html, fixture, expect, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon';
 import './register-view';
-import { RegisterView, humanizeRegisterError } from './register-view';
+import {
+  RegisterView,
+  humanizeRegisterError,
+  parseBootstrapFragment,
+} from './register-view';
 import { invalidateApiCaches } from '../../api';
 
 describe('RegisterView', () => {
@@ -280,6 +284,246 @@ describe('RegisterView', () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
       await el.updateComplete;
       expect(el.shadowRoot?.querySelector('.first-account-note')).to.not.exist;
+    });
+  });
+
+  describe('parseBootstrapFragment', () => {
+    it('extracts the token from a #bootstrap fragment', () => {
+      expect(parseBootstrapFragment('#bootstrap=abc123')).to.equal('abc123');
+    });
+
+    it('decodes URI-encoded tokens', () => {
+      expect(parseBootstrapFragment('#bootstrap=a%2Bb')).to.equal('a+b');
+    });
+
+    it('returns empty for other fragments and empty hashes', () => {
+      expect(parseBootstrapFragment('')).to.equal('');
+      expect(parseBootstrapFragment('#other=1')).to.equal('');
+      expect(parseBootstrapFragment('#bootstrap=')).to.equal('');
+    });
+  });
+
+  describe('bootstrap setup link', () => {
+    const featuresResponse = (bootstrapPending: boolean) =>
+      new Response(
+        JSON.stringify({
+          plugins: [],
+          features: {
+            registration: true,
+            first_account_pending: true,
+            registration_bootstrap_pending: bootstrapPending,
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+
+    afterEach(() => {
+      // Never leak a test fragment into the next test.
+      history.replaceState(null, '', window.location.pathname);
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+    });
+
+    it('reads the fragment token, strips it from the URL, and submits it', async () => {
+      window.location.hash = '#bootstrap=tok1234567890';
+      fetchStub.callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/api/v1/features')) {
+          return featuresResponse(true);
+        }
+        if (url.includes('/api/v1/auth/token/json')) {
+          return new Response(
+            JSON.stringify({
+              access_token: 'test-token',
+              refresh_token: 'test-refresh',
+            }),
+            { status: 200 }
+          );
+        }
+        return new Response(JSON.stringify({}), { status: 200 });
+      });
+      invalidateApiCaches();
+
+      const el = (await fixture(
+        html`<register-view></register-view>`
+      )) as RegisterView;
+
+      // The fragment is stripped immediately on load.
+      expect(window.location.hash).to.equal('');
+
+      const usernameInput = el.shadowRoot?.querySelector<any>('#username');
+      const emailInput = el.shadowRoot?.querySelector<any>('#email');
+      const passwordInput = el.shadowRoot?.querySelector<any>('#password');
+      usernameInput.value = 'firstadmin';
+      emailInput.value = 'admin@example.com';
+      passwordInput.value = 'password123';
+
+      const form = el.shadowRoot?.querySelector('form') as HTMLFormElement;
+      form.dispatchEvent(
+        new SubmitEvent('submit', { bubbles: true, cancelable: true })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await el.updateComplete;
+
+      const registerCall = fetchStub
+        .getCalls()
+        .find((call: any) => String(call.args[0]).includes('/auth/register'));
+      expect(registerCall).to.exist;
+      const body = JSON.parse(registerCall.args[1].body);
+      expect(body.bootstrap_token).to.equal('tok1234567890');
+    });
+
+    it('shows no notice when a valid token is present (form looks normal)', async () => {
+      window.location.hash = '#bootstrap=tok1234567890';
+      fetchStub.callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/api/v1/features')) {
+          return featuresResponse(true);
+        }
+        return new Response(JSON.stringify({}), { status: 200 });
+      });
+      invalidateApiCaches();
+
+      const el = (await fixture(
+        html`<register-view></register-view>`
+      )) as RegisterView;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.bootstrap-notice')).to.not.exist;
+      expect(el.shadowRoot?.querySelector('form')).to.exist;
+    });
+
+    it('shows the amber setup-link notice when bootstrap is pending and no token is present', async () => {
+      fetchStub.callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/api/v1/features')) {
+          return featuresResponse(true);
+        }
+        return new Response(JSON.stringify({}), { status: 200 });
+      });
+      invalidateApiCaches();
+
+      const el = (await fixture(
+        html`<register-view></register-view>`
+      )) as RegisterView;
+      await waitUntil(
+        () => el.shadowRoot?.querySelector('.bootstrap-notice'),
+        'setup-link notice did not appear'
+      );
+
+      const notice = el.shadowRoot?.querySelector('.bootstrap-notice');
+      expect(notice?.classList.contains('claimed')).to.be.false;
+      expect(notice?.getAttribute('aria-live')).to.equal('assertive');
+      expect(notice?.textContent?.replace(/\s+/g, ' ')).to.contain(
+        'Setup link required'
+      );
+      expect(notice?.textContent?.replace(/\s+/g, ' ')).to.contain(
+        'Use the link printed at the end of the install, or run create_first_user.py on the server.'
+      );
+      expect(
+        el.shadowRoot?.querySelector('form')?.getAttribute('aria-describedby')
+      ).to.equal('bootstrap-notice');
+    });
+
+    it('shows the error-red already-claimed notice on a 403 with a token', async () => {
+      window.location.hash = '#bootstrap=staletoken123';
+      fetchStub.callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/api/v1/features')) {
+          return featuresResponse(false);
+        }
+        if (url.includes('/auth/register')) {
+          return new Response(
+            JSON.stringify({
+              detail:
+                'Registration is disabled. Please contact an administrator for an invitation.',
+            }),
+            { status: 403 }
+          );
+        }
+        return new Response(JSON.stringify({}), { status: 200 });
+      });
+      invalidateApiCaches();
+
+      const el = (await fixture(
+        html`<register-view></register-view>`
+      )) as RegisterView;
+
+      const usernameInput = el.shadowRoot?.querySelector<any>('#username');
+      const emailInput = el.shadowRoot?.querySelector<any>('#email');
+      const passwordInput = el.shadowRoot?.querySelector<any>('#password');
+      usernameInput.value = 'latecomer';
+      emailInput.value = 'late@example.com';
+      passwordInput.value = 'password123';
+
+      const form = el.shadowRoot?.querySelector('form') as HTMLFormElement;
+      form.dispatchEvent(
+        new SubmitEvent('submit', { bubbles: true, cancelable: true })
+      );
+      await waitUntil(
+        () => el.shadowRoot?.querySelector('.bootstrap-notice.claimed'),
+        'already-claimed notice did not appear'
+      );
+
+      const notice = el.shadowRoot?.querySelector('.bootstrap-notice.claimed');
+      expect(notice?.getAttribute('aria-live')).to.equal('assertive');
+      expect(notice?.textContent?.replace(/\s+/g, ' ')).to.contain(
+        'This instance has already been claimed.'
+      );
+      expect(notice?.textContent?.replace(/\s+/g, ' ')).to.contain(
+        'An admin account exists — ask them to invite you, or sign in'
+      );
+      // The generic error banner stays hidden for this state.
+      expect(el.shadowRoot?.querySelector('.error-message')).to.not.exist;
+    });
+
+    it('falls back to the amber notice when the backend demands the setup link', async () => {
+      window.location.hash = '#bootstrap=corruptedtoken';
+      fetchStub.callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/api/v1/features')) {
+          return featuresResponse(true);
+        }
+        if (url.includes('/auth/register')) {
+          return new Response(
+            JSON.stringify({
+              detail:
+                'Setup link required. Use the link printed at the end of the install, or run create_first_user.py on the server.',
+            }),
+            { status: 403 }
+          );
+        }
+        return new Response(JSON.stringify({}), { status: 200 });
+      });
+      invalidateApiCaches();
+
+      const el = (await fixture(
+        html`<register-view></register-view>`
+      )) as RegisterView;
+
+      const usernameInput = el.shadowRoot?.querySelector<any>('#username');
+      const emailInput = el.shadowRoot?.querySelector<any>('#email');
+      const passwordInput = el.shadowRoot?.querySelector<any>('#password');
+      usernameInput.value = 'badlink';
+      emailInput.value = 'bad@example.com';
+      passwordInput.value = 'password123';
+
+      const form = el.shadowRoot?.querySelector('form') as HTMLFormElement;
+      form.dispatchEvent(
+        new SubmitEvent('submit', { bubbles: true, cancelable: true })
+      );
+      await waitUntil(
+        () =>
+          el.shadowRoot?.querySelector('.bootstrap-notice:not(.claimed)') &&
+          !el.shadowRoot?.querySelector('.error-message'),
+        'setup-link notice did not appear after the 403'
+      );
+
+      const notice = el.shadowRoot?.querySelector('.bootstrap-notice');
+      expect(notice?.textContent?.replace(/\s+/g, ' ')).to.contain(
+        'Setup link required'
+      );
     });
   });
 });

--- a/frontend/src/views/public/register-view.ts
+++ b/frontend/src/views/public/register-view.ts
@@ -40,6 +40,12 @@ export function humanizeRegisterError(message: string): string {
   return `That didn't work: ${raw}`;
 }
 
+/** Parse a bootstrap token out of a location hash like `#bootstrap=abc123`. */
+export function parseBootstrapFragment(hash: string): string {
+  const match = /^#bootstrap=([^&]+)/.exec(hash || '');
+  return match ? decodeURIComponent(match[1]) : '';
+}
+
 @customElement('register-view')
 export class RegisterView extends LitElement {
   @state()
@@ -55,6 +61,20 @@ export class RegisterView extends LitElement {
   // account being created becomes the admin account.
   @state()
   private firstAccountPending = false;
+
+  // True while the instance is unclaimed (zero users + bootstrap token
+  // configured server-side): signups need the setup link from the install.
+  @state()
+  private bootstrapPending = false;
+
+  // Backend said the instance already has its admin account (403 on a
+  // signup that carried a setup-link token).
+  @state()
+  private alreadyClaimed = false;
+
+  // Token from the setup link fragment (#bootstrap=<token>). Held in memory
+  // only; the fragment is stripped from the URL immediately on load.
+  private bootstrapToken = '';
 
   static styles = [
     formStyles,
@@ -106,11 +126,50 @@ export class RegisterView extends LitElement {
         line-height: 1.5;
         margin: 0 0 1rem;
       }
+
+      /* Setup-link notices: 4px left border, console-compact type
+         (14px primary / 13px secondary). */
+      .bootstrap-notice {
+        border-radius: 4px;
+        border-left: 4px solid #f2a93b;
+        background: rgba(242, 169, 59, 0.12);
+        padding: 12px 16px;
+        margin: 0 0 1rem;
+        font-size: 14px;
+        line-height: 1.4;
+        text-align: left;
+      }
+
+      .bootstrap-notice.claimed {
+        border-left-color: #ff5d5d;
+        background: rgba(255, 93, 93, 0.12);
+      }
+
+      .bootstrap-notice .notice-title {
+        font-weight: 600;
+      }
+
+      .bootstrap-notice .notice-detail {
+        font-size: 13px;
+        opacity: 0.85;
+        margin-top: 2px;
+      }
     `,
   ];
 
   connectedCallback() {
     super.connectedCallback();
+    // Setup link: read the bootstrap token out of the fragment, keep it in
+    // memory only, and strip it from the URL immediately (history, referrer
+    // and share safety).
+    this.bootstrapToken = parseBootstrapFragment(window.location.hash);
+    if (this.bootstrapToken) {
+      history.replaceState(
+        null,
+        '',
+        window.location.pathname + window.location.search
+      );
+    }
     this._checkFeatures();
   }
 
@@ -121,15 +180,19 @@ export class RegisterView extends LitElement {
       this.oauthProviders = Array.isArray(providers) ? providers : [];
       this.firstAccountPending =
         features.features['first_account_pending'] === true;
+      this.bootstrapPending =
+        features.features['registration_bootstrap_pending'] === true;
     } catch (error) {
       this.oauthProviders = [];
       this.firstAccountPending = false;
+      this.bootstrapPending = false;
     }
   }
 
   private async handleRegister(event: SubmitEvent) {
     event.preventDefault();
     this._loading = true;
+    this.alreadyClaimed = false;
     const form = event.target as HTMLFormElement;
     const formData = new FormData(form);
     const username = formData.get('username') as string;
@@ -137,11 +200,11 @@ export class RegisterView extends LitElement {
     const password = formData.get('password') as string;
 
     try {
-      const registerResult = await post('/api/v1/auth/register', {
-        username,
-        email,
-        password,
-      });
+      const payload: Record<string, unknown> = { username, email, password };
+      if (this.bootstrapToken) {
+        payload.bootstrap_token = this.bootstrapToken;
+      }
+      const registerResult = await post('/api/v1/auth/register', payload);
 
       // If the backend returns an error in the payload instead of throwing an HTTP error
       if (registerResult && registerResult.error) {
@@ -197,7 +260,25 @@ export class RegisterView extends LitElement {
     } catch (error) {
       this._loading = false;
       if (error instanceof Error) {
-        this.error = humanizeRegisterError(error.message);
+        const message = error.message || '';
+        if (/setup link required/i.test(message)) {
+          // Unclaimed instance and our token was missing or stale: show the
+          // amber setup-link notice instead of a generic error. Drop the
+          // stale token so the notice renders.
+          this.bootstrapToken = '';
+          this.bootstrapPending = true;
+          this.error = '';
+        } else if (
+          this.bootstrapToken &&
+          /registration is disabled/i.test(message)
+        ) {
+          // A setup-link signup on an instance that already has its admin:
+          // the link is being reused after the instance was claimed.
+          this.alreadyClaimed = true;
+          this.error = '';
+        } else {
+          this.error = humanizeRegisterError(message);
+        }
       } else {
         this.error = 'Failed to create an account';
       }
@@ -205,6 +286,44 @@ export class RegisterView extends LitElement {
       // Ensure we don't proceed with checkout if registration failed
       return;
     }
+  }
+
+  private _renderBootstrapNotice() {
+    if (this.alreadyClaimed) {
+      return html`
+        <div
+          id="bootstrap-notice"
+          class="bootstrap-notice claimed"
+          role="alert"
+          aria-live="assertive"
+        >
+          <div class="notice-title">
+            This instance has already been claimed.
+          </div>
+          <div class="notice-detail">
+            An admin account exists — ask them to invite you, or
+            <a href="/login">sign in</a>.
+          </div>
+        </div>
+      `;
+    }
+    if (this.bootstrapPending && !this.bootstrapToken) {
+      return html`
+        <div
+          id="bootstrap-notice"
+          class="bootstrap-notice"
+          role="alert"
+          aria-live="assertive"
+        >
+          <div class="notice-title">Setup link required</div>
+          <div class="notice-detail">
+            Use the link printed at the end of the install, or run
+            create_first_user.py on the server.
+          </div>
+        </div>
+      `;
+    }
+    return nothing;
   }
 
   private _renderOAuthButtons() {
@@ -252,13 +371,22 @@ export class RegisterView extends LitElement {
                 </p>`
               : ''
           }
+          ${this._renderBootstrapNotice()}
           ${
             this.error
               ? html`<div class="error-message">${this.error}</div>`
               : ''
           }
           ${this._renderOAuthButtons()}
-          <form @submit=${this.handleRegister}>
+          <form
+            @submit=${this.handleRegister}
+            aria-describedby=${
+              this.alreadyClaimed ||
+              (this.bootstrapPending && !this.bootstrapToken)
+                ? 'bootstrap-notice'
+                : nothing
+            }
+          >
             <div class="form-group">
               <sl-input
                 label="Username"

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -34,7 +34,7 @@ worker:
   # Worker resources (background tasks)
   resources:
     requests:
-      cpu: "500m"
+      cpu: "50m"
       memory: "512Mi"
     limits:
       cpu: "2"
@@ -139,7 +139,7 @@ api:
   replicaCount: null
   resources:
     requests:
-      cpu: "500m"
+      cpu: "50m"
       memory: "512Mi"
     limits:
       cpu: "2"
@@ -149,7 +149,7 @@ api:
 scheduler:
   resources:
     requests:
-      cpu: "100m"
+      cpu: "50m"
       memory: "128Mi"
     limits:
       cpu: "500m"
@@ -159,7 +159,7 @@ scheduler:
 monitor:
   resources:
     requests:
-      cpu: "100m"
+      cpu: "50m"
       memory: "128Mi"
     limits:
       cpu: "500m"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5630,6 +5630,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/ai-models/{model_id}/credentials/export:
+    post:
+      tags:
+      - AI Models
+      - AI Models
+      summary: Export Subscription OAuth Credential
+      description: 'Export the live subscription-OAuth bundle for an account AI model.
+
+
+        Only principal-bound subscription OAuth credentials (Claude Code, Codex)
+
+        are exportable: their provider refresh tokens are single-use and rotate on
+
+        every server-side refresh, so once imported the Preloop copy is the only
+
+        live lineage. The CLI calls this at offboard time to restore the agent''s
+
+        local login before the Preloop-held credential is removed. API-key
+
+        credentials are never exportable.'
+      operationId: export_ai_model_credentials_api_v1_ai_models__model_id__credentials_export_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: model_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Model Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AIModelCredentialExportResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/audio/transcriptions:
     post:
       tags:
@@ -7694,6 +7738,44 @@ components:
       - model_identifier
       title: AIModelCreate
       description: Schema for creating a new AIModel entry.
+    AIModelCredentialExportResponse:
+      properties:
+        credential_type:
+          type: string
+          title: Credential Type
+        access:
+          type: string
+          title: Access
+        refresh:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh
+        expires:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Expires
+        account_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Account Id
+      type: object
+      required:
+      - credential_type
+      - access
+      title: AIModelCredentialExportResponse
+      description: 'Live subscription-OAuth bundle exported to the owning operator.
+
+
+        Returned once over the authenticated API so the CLI can restore an
+
+        agent''s local login at offboard time (subscription refresh tokens are
+
+        single-use, so the Preloop-held copy is the only live lineage after a
+
+        server-side refresh). Token material must never be logged.'
     AIModelGatewayUsageSummaryResponse:
       properties:
         ai_model_id:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,8 +12,9 @@ paths:
       description: "Register a new user.\n\nArgs:\n    user_data: User creation data.\n\
         \    background_tasks: Background tasks for sending emails.\n    request:\
         \ The incoming request object.\n\nReturns:\n    The created user.\n\nRaises:\n\
-        \    HTTPException: If the username or email is already taken, or if registration\
-        \ is disabled."
+        \    HTTPException: If the username or email is already taken, if\n      \
+        \  registration is disabled, or if the instance is unclaimed and the\n   \
+        \     bootstrap token is missing or invalid."
       operationId: register_api_v1_auth_register_post
       requestBody:
         content:
@@ -5824,7 +5825,14 @@ paths:
       - Session Optimization
       - Session Optimization
       summary: Optimize Account Runtime Session
-      description: Suggest cost and context optimizations for one runtime session.
+      description: 'Suggest cost and context optimizations for one runtime session.
+
+
+        Legacy inline path: runs the shared worker function synchronously and
+
+        returns the results in this response — semantics identical to before the
+
+        async job endpoints existed (no submit-then-poll behind the scenes).'
       operationId: optimize_account_runtime_session_api_v1_billing_cost_runtime_sessions__runtime_session_id__optimizations_post
       security:
       - bearerAuth: []
@@ -5850,6 +5858,91 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RuntimeSessionOptimizationResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/billing/cost/runtime-sessions/{runtime_session_id}/optimizations/jobs:
+    post:
+      tags:
+      - Session Optimization
+      - Session Optimization
+      summary: Submit Account Runtime Session Optimization Job
+      description: 'Queue the (slow, LLM-backed) optimization analysis as a background
+        job.
+
+
+        Idempotent: while a job for this session is still pending or running,
+
+        re-submitting returns THAT job instead of queuing a second model pass, so
+
+        a double-click never spends the model budget twice.'
+      operationId: submit_account_runtime_session_optimization_job_api_v1_billing_cost_runtime_sessions__runtime_session_id__optimizations_jobs_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: runtime_session_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Runtime Session Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/RuntimeSessionOptimizationRequest'
+              - type: 'null'
+              title: Request
+      responses:
+        '202':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeSessionOptimizationJobSubmitResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/billing/cost/runtime-sessions/{runtime_session_id}/optimizations/jobs/{job_id}:
+    get:
+      tags:
+      - Session Optimization
+      - Session Optimization
+      summary: Get Account Runtime Session Optimization Job
+      description: "Poll one async optimization job's status, result, and error.\n\
+        \nA job id belonging to another account, or attached to a different\nsession,\
+        \ is indistinguishable from a missing one (404) by design.\n\nRaises:\n  \
+        \  HTTPException: 404 when the job is absent, malformed, or out of scope."
+      operationId: get_account_runtime_session_optimization_job_api_v1_billing_cost_runtime_sessions__runtime_session_id__optimizations_jobs__job_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: runtime_session_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Runtime Session Id
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeSessionOptimizationJobStatusResponse'
         '422':
           description: Validation Error
           content:
@@ -9696,6 +9789,13 @@ components:
           - type: string
           - type: 'null'
           title: Full Name
+        bootstrap_token:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Bootstrap Token
+          description: First-user setup token from the install (required while the
+            instance has zero users and PRELOOP_BOOTSTRAP_TOKEN is set).
       type: object
       required:
       - username
@@ -14261,6 +14361,43 @@ components:
       - action
       title: RuntimeSessionOptimizationApplyRequest
       description: Request payload to apply one suggestion's action server-side.
+    RuntimeSessionOptimizationJobStatusResponse:
+      properties:
+        job_id:
+          type: string
+          title: Job Id
+        status:
+          type: string
+          title: Status
+        result:
+          anyOf:
+          - $ref: '#/components/schemas/RuntimeSessionOptimizationResponse'
+          - type: 'null'
+        error:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error
+      type: object
+      required:
+      - job_id
+      - status
+      title: RuntimeSessionOptimizationJobStatusResponse
+      description: Poll response for one async optimization job.
+    RuntimeSessionOptimizationJobSubmitResponse:
+      properties:
+        job_id:
+          type: string
+          title: Job Id
+        status:
+          type: string
+          title: Status
+      type: object
+      required:
+      - job_id
+      - status
+      title: RuntimeSessionOptimizationJobSubmitResponse
+      description: Acknowledgement for an accepted async optimization job.
     RuntimeSessionOptimizationRequest:
       properties:
         model_id:

--- a/runtime-plugins/hermes-preloop/README.md
+++ b/runtime-plugins/hermes-preloop/README.md
@@ -117,7 +117,7 @@ credentials for you:
 
 ```bash
 curl -fsSL https://preloop.ai/install/cli | sh
-preloop signup                        # or: preloop login --url http://localhost:8000
+preloop signup                        # or: preloop login --url http://localhost:3000
 preloop agents onboard hermes
 preloop agents install-plugin hermes
 preloop agents validate hermes

--- a/runtime-plugins/openclaw-preloop/README.md
+++ b/runtime-plugins/openclaw-preloop/README.md
@@ -65,7 +65,7 @@ credentials for you:
 
 ```bash
 curl -fsSL https://preloop.ai/install/cli | sh
-preloop signup                          # or: preloop login --url http://localhost:8000
+preloop signup                          # or: preloop login --url http://localhost:3000
 preloop agents onboard openclaw
 preloop agents install-plugin openclaw
 preloop agents validate openclaw

--- a/scripts/create_first_user.py
+++ b/scripts/create_first_user.py
@@ -29,8 +29,9 @@ import os
 import sys
 from pathlib import Path
 
-# Add parent directory to path so we can import from preloop.
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Import preloop from THIS repo's backend/, ahead of any installed package
+# (an editable install may point at a different checkout).
+sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
 
 from preloop.api.auth.jwt import get_password_hash
 from preloop.models.crud import crud_account, crud_role, crud_user, crud_user_role

--- a/scripts/e2e-rig/modules/07-browser-register.py
+++ b/scripts/e2e-rig/modules/07-browser-register.py
@@ -23,9 +23,30 @@ URL = riglib.env("RIG_URL").rstrip("/")
 STATE = riglib.run_dir() / "state" / "browser-state.json"
 
 
+def bootstrap_register_url() -> str:
+    """Return the register URL, tokenized when the installer printed one.
+
+    Module 05 captures the installer's terminal output (including the
+    "Next steps" footer with the setup link) in logs/05-install.txt. Newer
+    releases print a ``/register#bootstrap=<token>`` link there; the first
+    signup must go through it. Older releases have no token — fall back to
+    the plain register URL. The token itself is never logged.
+    """
+    log_path = riglib.run_dir() / "logs" / "05-install.txt"
+    try:
+        installer_output = log_path.read_text()
+    except OSError:
+        return f"{URL}/register"
+    match = re.search(r"/register#bootstrap=([0-9a-fA-F]+)", installer_output)
+    if not match:
+        return f"{URL}/register"
+    riglib.note("using the tokenized bootstrap setup link from the installer output")
+    return f"{URL}/register#bootstrap={match.group(1)}"
+
+
 def register(page, creds) -> str:
     """Try to register; returns 'registered', 'needs-login' or 'exists'."""
-    page.goto(f"{URL}/register", wait_until="networkidle")
+    page.goto(bootstrap_register_url(), wait_until="networkidle")
     browserlib.screenshot(page, "07-register-form")
     browserlib.fill_sl_input(page, "username", creds["username"])
     browserlib.fill_sl_input(page, "email", creds["email"])

--- a/scripts/e2e-rig/modules/12-optimize-validate.py
+++ b/scripts/e2e-rig/modules/12-optimize-validate.py
@@ -3,10 +3,12 @@
 On the wasteful runtime session produced by module 11, in the recorded
 browser: open the session's Optimize tab, select a BYOK suggestion model
 explicitly (the account default may be a principal-bound OAuth model that
-correctly refuses server-side calls), generate suggestions, capture the
-potential-savings estimate, VERIFY the top verifiable suggestion by replay
-(the consented re-execution flow that measures the real input-token delta),
-then APPLY the applicable suggestions.
+correctly refuses server-side calls), click Generate and drive the ASYNC
+analysis flow — the console submits a background job and shows the approved
+"Analyzing this session" state, then polls until suggestions (or the
+no-waste state) render. Capture the potential-savings estimate, VERIFY the
+top verifiable suggestion by replay (the consented re-execution flow that
+measures the real input-token delta), then APPLY the applicable suggestions.
 
 Verify runs BEFORE apply on purpose: applying scope-tools/compression writes
 governance that alters future gateway traffic, and the replay's "original"
@@ -143,50 +145,21 @@ def ensure_console_proxy_timeouts() -> None:
         )
 
 
-def prewarm_suggestions(token: str, session_id: str, model: dict | None) -> None:
-    """Generate (and cache) the BYOK-model suggestions before the scene.
+def wait_for_analysis_outcome(page, timeout_ms: int) -> str:
+    """Wait for the async analysis to resolve: suggestions or no-waste.
 
-    The LLM pass takes on the order of a minute; running it here keeps the
-    recorded scene tight — the panel's cache-only open renders the freshly
-    generated suggestions immediately. If the request is cut by a proxy
-    timeout the backend still finishes and caches, so poll until the cached
-    model-generated result appears.
+    The console polls its background job every 2.5s; this waits for either
+    outcome selector and returns which one landed ('suggestions' or
+    'no_waste').
     """
-    if model is None:
-        return
-    payload = {"model_id": str(model["id"]), "regenerate": True}
-    deadline = time.time() + 600
-    attempt = 0
-    while time.time() < deadline:
-        attempt += 1
-        try:
-            status, body = riglib.api_request(
-                f"{URL}/api/v1/billing/cost/runtime-sessions/"
-                f"{session_id}/optimizations",
-                method="POST",
-                token=token,
-                payload=payload,
-                timeout=420,
-            )
-        except Exception as exc:  # noqa: BLE001 — treat as retryable timeout
-            riglib.log(f"prewarm attempt {attempt} errored ({exc}); polling cache")
-            status, body = 0, None
-        if (
-            status == 200
-            and isinstance(body, dict)
-            and body.get("generated_by") == "model"
-        ):
-            riglib.note(
-                f"suggestion cache pre-warmed with {model.get('name')} "
-                f"({len(body.get('suggestions') or [])} suggestions)"
-            )
-            return
-        riglib.log(f"prewarm attempt {attempt}: status={status}; retrying")
-        # After the first (regenerating) attempt only poll for the cached
-        # result — never queue a second generation.
-        payload = {"model_id": str(model["id"])}
-        time.sleep(15)
-    raise SystemExit("could not pre-warm model suggestions within 10 minutes")
+    page.wait_for_selector(
+        "session-optimization-panel div.suggestion, "
+        "session-optimization-panel .job-no-waste",
+        timeout=timeout_ms,
+    )
+    if page.locator("session-optimization-panel div.suggestion").count() > 0:
+        return "suggestions"
+    return "no_waste"
 
 
 def api_replay_fallback(token: str, session_id: str) -> dict:
@@ -251,7 +224,6 @@ def run_scene(token: str, session_id: str) -> None:
 
     model = byok_suggestion_model(token)
     ensure_console_proxy_timeouts()
-    prewarm_suggestions(token, session_id, model)
     verify_text = ""
     verify_notes: list[str] = []
     savings_text = ""
@@ -276,10 +248,10 @@ def run_scene(token: str, session_id: str) -> None:
         optimize_btn.click()
         time.sleep(2)
 
-        # When the pre-warmed cache rendered suggestions on panel open, the
-        # controls drawer (with the model picker) starts collapsed; the small
-        # header "Regenerate" button only toggles the drawer open (it does
-        # not regenerate anything).
+        # When a previous run's cached result rendered suggestions on panel
+        # open, the controls drawer (with the model picker) starts collapsed;
+        # the small header "Regenerate" button only toggles the drawer open
+        # (it does not regenerate anything).
         time.sleep(1.5)
         cached_rendered = (
             page.locator("session-optimization-panel div.suggestion").count() > 0
@@ -322,18 +294,38 @@ def run_scene(token: str, session_id: str) -> None:
         time.sleep(1)
         browserlib.screenshot(page, "12-optimize-controls")
 
-        # --- suggestions: rendered from the pre-warmed cache on panel open;
-        # clicking Generate only on a cache miss (it would otherwise queue a
-        # fresh multi-minute LLM regeneration on camera).
+        # --- generate via the async job flow: clicking Generate submits a
+        # background job; the approved "Analyzing this session" state (slim
+        # cyan progress bar) renders while the console polls, and the results
+        # appear automatically when the job succeeds. The analyzing state is
+        # asserted and captured on camera — it is the launch-state deliverable.
         if not cached_rendered:
             riglib.note("no cached suggestions rendered; generating on camera")
             page.locator(
                 "sl-button", has_text=re.compile("(Generate|Regenerate) suggestions")
             ).first.click()
             page.wait_for_selector(
-                "session-optimization-panel div.suggestion",
-                timeout=GENERATE_TIMEOUT_MS,
+                "session-optimization-panel .job-analyzing",
+                timeout=30_000,
             )
+            analyzing_text = (
+                page.locator("session-optimization-panel .job-analyzing")
+                .first.inner_text()
+                .replace("\n", " ")
+            )
+            if "Analyzing this session" not in analyzing_text:
+                raise SystemExit(
+                    f"analyzing state rendered unexpected copy: {analyzing_text!r}"
+                )
+            riglib.note("analyzing state rendered (async job submitted)")
+            browserlib.screenshot(page, "12-optimize-analyzing")
+            outcome = wait_for_analysis_outcome(page, GENERATE_TIMEOUT_MS)
+            if outcome == "no_waste":
+                browserlib.screenshot(page, "12-optimize-no-waste")
+                raise SystemExit(
+                    "analysis reported no recoverable waste on the module-11 "
+                    "wasteful session — apply/replay assertions cannot run"
+                )
         time.sleep(2)
         headline = page.locator(".savings-summary-headline")
         if headline.count() > 0:

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -13,10 +13,11 @@ import yaml
 # (honored by preloop.plugins.base at discovery time).
 os.environ["DISABLE_PROPRIETARY_PLUGINS"] = "true"
 
-# Ensure the project root is in the Python path
-# This allows importing preloop modules when running the script directly
+# Generate from THIS repo's code, not from an installed preloop package: the
+# package root is backend/, and it must win over site-packages (an editable
+# install may point at a different checkout, silently producing a stale spec).
 project_root = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "backend"))
 
 try:
     from preloop.api.app import create_app

--- a/scripts/install-oss.sh
+++ b/scripts/install-oss.sh
@@ -60,6 +60,13 @@ PRELOOP_ADMIN_PASSWORD="${PRELOOP_ADMIN_PASSWORD:-}"
 PRELOOP_SKIP_ADMIN="${PRELOOP_SKIP_ADMIN:-}"
 CREATE_ADMIN=0
 
+# First-user setup token. While the instance has zero users, /register only
+# accepts signups that carry this token (the "setup link" in the footer), so
+# a freshly reachable instance can never be claimed by a stranger. Provide
+# your own via the environment to skip generation; the generated one is kept
+# across re-runs (load_existing_env).
+PRELOOP_BOOTSTRAP_TOKEN="${PRELOOP_BOOTSTRAP_TOKEN:-}"
+
 DEFAULT_URL="http://localhost:3000"
 
 # Replace (or append) a single KEY=value line in the install's .env.
@@ -158,6 +165,17 @@ PY
   fi
 }
 
+generate_bootstrap_token() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 24
+  else
+    python3 - <<'PY'
+import secrets
+print(secrets.token_hex(24))
+PY
+  fi
+}
+
 # Load the settings of an existing install so a re-run UPGRADES it instead of
 # silently reconfiguring it: prior values become the defaults for every prompt
 # and for anything not overridden on this run.
@@ -173,6 +191,8 @@ load_existing_env() {
   # Existing values win over the built-in defaults, but NOT over anything the
   # caller explicitly passed in the environment on this run.
   [ -n "$PRELOOP_URL" ] || PRELOOP_URL="$(env_value PRELOOP_URL "$env_file")"
+  [ -n "$PRELOOP_BOOTSTRAP_TOKEN" ] \
+    || PRELOOP_BOOTSTRAP_TOKEN="$(env_value PRELOOP_BOOTSTRAP_TOKEN "$env_file")"
   [ -n "$SMTP_HOST" ] || SMTP_HOST="$(env_value SMTP_HOST "$env_file")"
   [ -n "$SMTP_USERNAME" ] || SMTP_USERNAME="$(env_value SMTP_USERNAME "$env_file")"
   [ -n "$SMTP_PASSWORD" ] || SMTP_PASSWORD="$(env_value SMTP_PASSWORD "$env_file")"
@@ -755,6 +775,7 @@ services:
   api:
     environment:
       REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-true}
+      PRELOOP_BOOTSTRAP_TOKEN: ${PRELOOP_BOOTSTRAP_TOKEN:-}
 EOF
 }
 
@@ -829,6 +850,14 @@ main() {
   prompt_smtp
   prompt_admin
 
+  # First-user setup token: generate one unless the caller provided it via
+  # the environment or a previous run already stored it in .env. Printed
+  # ONLY in the terminal footer (as part of the setup link), never into
+  # ${LOG_FILE}.
+  if [ -z "$PRELOOP_BOOTSTRAP_TOKEN" ]; then
+    PRELOOP_BOOTSTRAP_TOKEN="$(generate_bootstrap_token)"
+  fi
+
   if [ ! -f "${INSTALL_DIR}/.env" ]; then
     cat > "${INSTALL_DIR}/.env" <<EOF
 PRELOOP_VERSION=${VERSION}
@@ -839,6 +868,10 @@ ALLOWED_ORIGINS=${PRELOOP_URL}
 # Public signup. Turned off after the first user is created; set to true to
 # reopen registration, then run 'docker compose up -d api'.
 REGISTRATION_ENABLED=true
+# First-user setup token: while the instance has zero users, signing up
+# requires the setup link printed at the end of the install (which carries
+# this token). Ignored once any user exists.
+PRELOOP_BOOTSTRAP_TOKEN=${PRELOOP_BOOTSTRAP_TOKEN}
 # Email (approval requests, invitations, password resets). Leave SMTP_HOST
 # empty to run without email; re-run the installer or edit these values, then
 # run 'docker compose up -d' to apply.
@@ -874,6 +907,8 @@ EOF
       } >> "$tmp_env"
     fi
     mv "$tmp_env" "${INSTALL_DIR}/.env"
+    # Persist the setup token (idempotent: keeps the loaded/provided value).
+    set_env_value PRELOOP_BOOTSTRAP_TOKEN "$PRELOOP_BOOTSTRAP_TOKEN"
   fi
 
   write_auth_overlay
@@ -975,6 +1010,13 @@ EOF
   echo "Next steps:"
   if [ "$admin_created" -eq 1 ]; then
     echo "  1. Open ${PRELOOP_URL} and sign in as '${PRELOOP_ADMIN_USERNAME}'"
+  elif [ -n "$PRELOOP_BOOTSTRAP_TOKEN" ]; then
+    # The token travels in the URL FRAGMENT (never sent to servers or logged
+    # in access logs) and this footer goes to the terminal only, not to
+    # ${LOG_FILE}.
+    echo "  1. Create the first user (it becomes the admin account) with this"
+    echo "     setup link:"
+    echo "       ${PRELOOP_URL}/register#bootstrap=${PRELOOP_BOOTSTRAP_TOKEN}"
   else
     echo "  1. Open ${PRELOOP_URL} and create the first user"
   fi
@@ -1025,8 +1067,15 @@ EOF
     echo "!!! can register right now."
     echo "!!!"
     echo "!!! Fix it with either:"
-    echo "!!!  a) Open ${PRELOOP_URL} and sign up in the browser (that becomes the"
-    echo "!!!     first account), then set REGISTRATION_ENABLED=false in"
+    if [ -n "$PRELOOP_BOOTSTRAP_TOKEN" ]; then
+      echo "!!!  a) Sign up in the browser with this setup link (that becomes"
+      echo "!!!     the first account):"
+      echo "!!!       ${PRELOOP_URL}/register#bootstrap=${PRELOOP_BOOTSTRAP_TOKEN}"
+      echo "!!!     then set REGISTRATION_ENABLED=false in"
+    else
+      echo "!!!  a) Open ${PRELOOP_URL} and sign up in the browser (that becomes the"
+      echo "!!!     first account), then set REGISTRATION_ENABLED=false in"
+    fi
     echo "!!!     ${INSTALL_DIR}/.env and run:"
     echo "!!!       cd ${INSTALL_DIR} && docker compose ${COMPOSE_ARGS} up -d api"
     echo "!!!  b) Retry from the terminal (use the password you chose):"

--- a/scripts/manage_superusers.py
+++ b/scripts/manage_superusers.py
@@ -15,8 +15,9 @@ Usage:
 import sys
 from pathlib import Path
 
-# Add parent directory to path so we can import from preloop.models
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Import preloop from THIS repo's backend/, ahead of any installed package
+# (an editable install may point at a different checkout).
+sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
 
 from sqlalchemy.orm import Session
 from preloop.models.db.session import get_db_session

--- a/scripts/validate_subscriptions.py
+++ b/scripts/validate_subscriptions.py
@@ -17,9 +17,10 @@ from preloop.models.models import Subscription
 from preloop.models.db.session import get_db_session
 
 
-# Add the project root to the Python path
+# Import preloop from THIS repo's backend/, ahead of any installed package
+# (an editable install may point at a different checkout).
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, project_root)
+sys.path.insert(0, os.path.join(project_root, "backend"))
 
 # --- Configuration ---
 STRIPE_API_KEY = settings.stripe_secret_key


### PR DESCRIPTION
Four hardening lanes for the 0.12.x launch cut, plus a small docs sweep. Combined-tree verification: backend 4087 passed / 6 skipped (integration tests excluded — they need a live stack), Go CLI all packages pass, frontend 542 passed, EE plugin halves tested separately (111 passed).

## Bootstrap registration token
Closes a first-signup takeover race on fresh public instances. With zero users and `PRELOOP_BOOTSTRAP_TOKEN` set, `/register` requires the token (constant-time compare; pg advisory lock serializes the first signup; account+user+role commit in one transaction). The installer generates the token, persists it to the instance `.env`, and prints a `/register#bootstrap=<token>` setup link to the terminal only (never install.log). The register view reads the fragment, strips it from history, and shows 'setup link required' / 'already claimed' notices.

## Async optimization jobs
Replaces the ~90s synchronous wait on session optimization with a background job: new `OptimizationJob` model + migration (partial unique index makes double-submit idempotent), bounded `ThreadPoolExecutor(3)` off the event loop with per-job DB sessions and heartbeats, a sweeper for stalled jobs, `POST …/optimizations/jobs` → 202 + polling. Console shows analyzing / failed+retry / no-waste states with full a11y. Legacy sync endpoint unchanged.

## Per-principal model authorization
One `compute_authorized_model_ids()` consumed by model listing, requested-model resolution (exact + suffix — closes the hidden-alias hole), and default selection. BYOK models visible to all; principal-bound OAuth models only to their bound managed agent; fail closed on unbound credentials. 400s enumerate usable model ids (`code=model_not_authorized`) for both OpenAI and Anthropic envelopes.

## Observable funnel telemetry
`install_completed` rides the existing daily version check-in (once, persisted, suppressed when telemetry disabled or hosted). `cli_first_run` fixes a check.go bug where first_run read false on the very first run. `first_session_seen` is a new OSS session-events hook registry — inert no-op unless a plugin registers a handler; the event never leaves the instance. Payload contract documented in SECURITY.md.

## Docs
Standardize `preloop login` examples on the console origin `:3000` (console nginx proxies `/api`).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Four independent hardening lanes, each well-tested with sound security design and proper isolation.
>
> **Overview**
> Bootstrap registration token prevents first-signup takeover races with constant-time compare and advisory locks. Async optimization jobs replace the ~90s synchronous wait with a bounded thread pool, heartbeat monitoring, and recovery sweeper. Per-principal model authorization closes the hidden-alias hole with a single authorization chokepoint. Telemetry hooks are opt-out and EE-isolated with full contract documentation in SECURITY.md.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit launch-hardening-0.12.7. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->