### PR TITLE
Landing hero polish: neutral play affordance, calendar demo CTA, larger visual

### DIFF
--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -104,7 +104,7 @@ p.lead {
 /* Two-column hero: copy on the left, static product shot on the right. */
 .hero-inner.has-visual {
   align-items: center;
-  gap: 4rem;
+  gap: 3rem;
 }
 
 .hero-inner.has-visual .hero-content {
@@ -119,7 +119,7 @@ p.lead {
 }
 
 .hero-visual {
-  flex: 1.5 1 0;
+  flex: 1.75 1 0;
   min-width: 0;
   flex-shrink: 0;
   cursor: pointer;

--- a/frontend/src/views/public/landing-view.ts
+++ b/frontend/src/views/public/landing-view.ts
@@ -321,6 +321,10 @@ export class LandingView extends LitElement {
         transform: none;
       }
 
+      /* Deliberately NOT the product's sky primary: the button floats over a
+         real console screenshot, and a sky fill reads as part of the depicted
+         UI (it sat right above the gateway node in the shot). Dark translucent
+         chrome reads as a video affordance instead. */
       .hero-video-play {
         position: absolute;
         top: 50%;
@@ -332,9 +336,11 @@ export class LandingView extends LitElement {
         width: 4.5rem;
         height: 3.25rem;
         padding: 0;
-        background: #0284c7;
+        background: rgba(15, 18, 26, 0.72);
+        backdrop-filter: blur(4px);
+        -webkit-backdrop-filter: blur(4px);
         color: #ffffff;
-        border: none;
+        border: 1px solid rgba(255, 255, 255, 0.28);
         border-radius: 4px;
         cursor: pointer;
         box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
@@ -342,7 +348,7 @@ export class LandingView extends LitElement {
       }
 
       .hero-video-play:hover {
-        background: #0273ac;
+        background: rgba(15, 18, 26, 0.88);
       }
 
       .hero-video-play:focus-visible {
@@ -1825,7 +1831,7 @@ export class LandingView extends LitElement {
                       <sl-button
                         variant="text"
                         size="large"
-                        href="/request-demo"
+                        href=${this._ctaSecondaryUrl || '/request-demo'}
                         @click=${this._handleSecondaryCta}
                         data-track="cta_demo_footer"
                         >Request a Demo</sl-button


### PR DESCRIPTION
Three issues on the landing hero:

1. **Play button read as part of the depicted console UI** — it used the product's sky primary (`#0284c7`) and floated directly above the gateway node in the screenshot. Now dark translucent chrome (`rgba(15,18,26,.72)` + blur + hairline border), the standard video-affordance treatment, per DESIGN.md's quiet-chrome direction.
2. **Both demo CTAs now book the calendar** — the landing footer 'Request a Demo' used `/request-demo` (the form) while the hero 'Book a Demo' used the booking calendar; the footer CTA now reuses the brand's secondary-CTA URL with the form as fallback for brands without one.
3. **Hero balance** — the visual takes a modestly larger share (flex 1.5→1.75, gap 4rem→3rem) so the screenshot fills its column better against the taller copy side. 'Book a Demo' deliberately stays in the hero per DESIGN.md's locked action-pair rule.

Verified by rendering the EE-branded dev build and screenshotting before/after.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Three visual-only CSS/UI polish fixes with safe fallbacks — no API, data, or behavioral changes.
>
> **Overview**
> Restyles the hero video play button from sky-primary to dark translucent chrome (so it reads as a video affordance, not console UI), routes the footer demo CTA through the brand's secondary-CTA URL instead of hardcoded `/request-demo`, and modestly increases the hero visual's flex share for better column balance.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/landing-hero-polish. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->