### PR TITLE
Fall back to the npm tarball when OpenClaw's marketplace plugin install fails

### DIFF
--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -3840,6 +3840,27 @@ func installAgentControlRuntimePlugin(agent AgentConfig, writer io.Writer) map[s
 			message = err.Error()
 		}
 		pipInstalled := false
+		npmTarballInstalled := false
+		if runtimeSessionSourceTypeForAgent(agent.Name) == "openclaw" &&
+			strings.HasPrefix(strings.TrimSpace(installTarget), "@") {
+			// OpenClaw's ClawHub download path can fail client-side (the zip
+			// never lands: "ENOENT ... openclaw-plugin.zip") even when both
+			// registries serve the version. The same plugin ships on npm, and
+			// OpenClaw installs local tarballs fine — fetch the npm tarball
+			// and install that instead.
+			var npmError string
+			npmTarballInstalled, npmError = installOpenClawPluginViaNpmTarball(
+				installerPath, installTarget, writer,
+			)
+			if npmTarballInstalled {
+				result["control_plugin_installer"] = "openclaw+npm-tarball"
+				result["control_plugin_marketplace_install_error"] = message
+			} else if npmError != "" {
+				message = fmt.Sprintf(
+					"%s (npm tarball fallback also failed: %s)", message, npmError,
+				)
+			}
+		}
 		if runtimeSessionSourceTypeForAgent(agent.Name) == hermesSourceType {
 			// Hermes has no PyPI-backed plugin marketplace: `hermes plugins
 			// install` only accepts Git URLs or owner/repo shorthands, while the
@@ -3856,7 +3877,7 @@ func installAgentControlRuntimePlugin(agent AgentConfig, writer io.Writer) map[s
 				message = fmt.Sprintf("%s (pip fallback also failed: %s)", message, pipError)
 			}
 		}
-		if !pipInstalled {
+		if !pipInstalled && !npmTarballInstalled {
 			status, remediation := classifyRuntimePluginInstallFailure(installer, message)
 			result["control_plugin_install_status"] = status
 			result["control_plugin_install_error"] = message
@@ -3884,6 +3905,72 @@ func installAgentControlRuntimePlugin(agent AgentConfig, writer io.Writer) map[s
 		result = mergeStringMaps(result, ensureManagedAgentControlSidecar(agent, writer))
 	}
 	return result
+}
+
+// installOpenClawPluginViaNpmTarball downloads the plugin's npm tarball and
+// installs it as a local file. OpenClaw resolves bare package names through
+// ClawHub, whose client-side download path can fail (zip never written,
+// "ENOENT"); local-tarball installs use a separate, working code path. npm is
+// a safe dependency here — OpenClaw itself is installed via npm.
+// resolveNpmExecutable is a seam for tests: resolveRuntimeExecutable consults
+// fixed fallback paths beyond PATH, so tests cannot mask the real npm.
+var resolveNpmExecutable = func() (string, error) {
+	return resolveRuntimeExecutable("npm")
+}
+
+func installOpenClawPluginViaNpmTarball(
+	installerPath string,
+	installTarget string,
+	writer io.Writer,
+) (bool, string) {
+	npmPath, err := resolveNpmExecutable()
+	if err != nil {
+		return false, "npm not found for tarball fallback"
+	}
+	tmpDir, err := os.MkdirTemp("", "preloop-openclaw-plugin-")
+	if err != nil {
+		return false, fmt.Sprintf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck
+
+	if writer != nil {
+		fmt.Fprintf(
+			writer,
+			"  Marketplace install failed; fetching %s from npm and installing the tarball instead...\n",
+			installTarget,
+		) //nolint:errcheck
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	packCmd := exec.CommandContext(ctx, npmPath, "pack", installTarget)
+	packCmd.Dir = tmpDir
+	if packOut, packErr := packCmd.CombinedOutput(); packErr != nil {
+		message := strings.TrimSpace(string(packOut))
+		if message == "" {
+			message = packErr.Error()
+		}
+		return false, fmt.Sprintf("npm pack failed: %s", message)
+	}
+	tarballs, _ := filepath.Glob(filepath.Join(tmpDir, "*.tgz"))
+	if len(tarballs) != 1 {
+		return false, fmt.Sprintf(
+			"npm pack produced %d tarballs, expected exactly 1", len(tarballs),
+		)
+	}
+
+	installCtx, installCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer installCancel()
+	output, err := exec.CommandContext(
+		installCtx, installerPath, "plugins", "install", tarballs[0],
+	).CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return false, fmt.Sprintf("tarball install failed: %s", message)
+	}
+	return true, ""
 }
 
 func classifyRuntimePluginInstallFailure(installer string, message string) (string, string) {

--- a/cli/internal/cmd/agents_openclaw_npm_fallback_test.go
+++ b/cli/internal/cmd/agents_openclaw_npm_fallback_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+// Tests for the OpenClaw npm-tarball plugin-install fallback.
+//
+// OpenClaw resolves bare package names through ClawHub, whose client-side
+// download path can fail ("ENOENT ... openclaw-plugin.zip") even when both
+// registries serve the version. The fallback fetches the npm tarball and
+// installs it as a local file, which uses a separate, working code path.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeExecutableForTest(t *testing.T, path, script string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+func npmFallbackBinDir(t *testing.T) string {
+	t.Helper()
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("failed to create bin dir: %v", err)
+	}
+	return binDir
+}
+
+func stubNpmExecutable(t *testing.T, path string, err error) {
+	t.Helper()
+	original := resolveNpmExecutable
+	resolveNpmExecutable = func() (string, error) { return path, err }
+	t.Cleanup(func() { resolveNpmExecutable = original })
+}
+
+func TestNpmTarballFallbackInstallsPluginFromPack(t *testing.T) {
+	skipNoShebangOnWindows(t, "npm tarball fallback")
+	binDir := npmFallbackBinDir(t)
+	// Fake npm: `npm pack <target>` writes a tarball into the cwd.
+	writeExecutableForTest(t, filepath.Join(binDir, "npm"),
+		"#!/bin/sh\nif [ \"$1\" = \"pack\" ]; then touch preloop-ai-openclaw-plugin-0.2.0.tgz; echo preloop-ai-openclaw-plugin-0.2.0.tgz; exit 0; fi\nexit 1\n")
+	// Fake openclaw installer: succeeds only for a local .tgz path.
+	installerPath := filepath.Join(binDir, "openclaw")
+	writeExecutableForTest(t, installerPath,
+		"#!/bin/sh\ncase \"$3\" in *.tgz) echo \"Installed plugin: preloop-plugin\"; exit 0;; esac\nexit 1\n")
+	stubNpmExecutable(t, filepath.Join(binDir, "npm"), nil)
+
+	var output bytes.Buffer
+	installed, errMessage := installOpenClawPluginViaNpmTarball(
+		installerPath, "@preloop-ai/openclaw-plugin", &output,
+	)
+	if !installed {
+		t.Fatalf("expected fallback install to succeed, got error: %s", errMessage)
+	}
+	if !strings.Contains(output.String(), "installing the tarball instead") {
+		t.Errorf("expected fallback note in output, got: %s", output.String())
+	}
+}
+
+func TestNpmTarballFallbackReportsMissingNpm(t *testing.T) {
+	skipNoShebangOnWindows(t, "npm tarball fallback")
+	binDir := npmFallbackBinDir(t)
+	stubNpmExecutable(t, "", os.ErrNotExist)
+
+	installed, errMessage := installOpenClawPluginViaNpmTarball(
+		filepath.Join(binDir, "openclaw"), "@preloop-ai/openclaw-plugin", nil,
+	)
+	if installed {
+		t.Fatal("expected fallback to fail without npm")
+	}
+	if !strings.Contains(errMessage, "npm not found") {
+		t.Errorf("expected npm-not-found message, got: %s", errMessage)
+	}
+}
+
+func TestNpmTarballFallbackReportsTarballInstallFailure(t *testing.T) {
+	skipNoShebangOnWindows(t, "npm tarball fallback")
+	binDir := npmFallbackBinDir(t)
+	writeExecutableForTest(t, filepath.Join(binDir, "npm"),
+		"#!/bin/sh\nif [ \"$1\" = \"pack\" ]; then touch preloop-ai-openclaw-plugin-0.2.0.tgz; exit 0; fi\nexit 1\n")
+	installerPath := filepath.Join(binDir, "openclaw")
+	writeExecutableForTest(t, installerPath,
+		"#!/bin/sh\necho \"install exploded\" >&2\nexit 1\n")
+	stubNpmExecutable(t, filepath.Join(binDir, "npm"), nil)
+
+	installed, errMessage := installOpenClawPluginViaNpmTarball(
+		installerPath, "@preloop-ai/openclaw-plugin", nil,
+	)
+	if installed {
+		t.Fatal("expected fallback to fail when tarball install fails")
+	}
+	if !strings.Contains(errMessage, "tarball install failed") {
+		t.Errorf("expected tarball-install-failed message, got: %s", errMessage)
+	}
+}
+
+func TestNpmTarballFallbackFailsWhenPackProducesNothing(t *testing.T) {
+	skipNoShebangOnWindows(t, "npm tarball fallback")
+	binDir := npmFallbackBinDir(t)
+	writeExecutableForTest(t, filepath.Join(binDir, "npm"),
+		"#!/bin/sh\nexit 0\n")
+	stubNpmExecutable(t, filepath.Join(binDir, "npm"), nil)
+
+	installed, errMessage := installOpenClawPluginViaNpmTarball(
+		filepath.Join(binDir, "openclaw"), "@preloop-ai/openclaw-plugin", nil,
+	)
+	if installed {
+		t.Fatal("expected fallback to fail when npm pack yields no tarball")
+	}
+	if !strings.Contains(errMessage, "expected exactly 1") {
+		t.Errorf("expected tarball-count message, got: %s", errMessage)
+	}
+}


### PR DESCRIPTION
Split out of #89 per review (scope). OpenClaw resolves bare package names through ClawHub, whose client-side download path fails (`ENOENT … openclaw-plugin.zip`) even when both registries serve the version — verified live with 0.2.0 published and npm/ClawHub shasums matching (`6bb53d22…`). The same plugin ships on npm and OpenClaw installs local tarballs fine, so `preloop agents install-plugin` now runs `npm pack` and installs the tarball when the marketplace path errors, mirroring the existing Hermes pip fallback. Failure messages chain both errors; npm resolution is a test seam because the executable resolver consults fixed fallback paths beyond PATH. 4 Go tests; the tarball route itself verified end-to-end on a live VM.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-scoped fallback that mirrors an existing pattern. Adds `npm pack` + local tarball install when the OpenClaw marketplace download fails. All 4 Go tests pass.

> **Overview**
> This PR adds an npm tarball fallback for OpenClaw plugin installation. When ClawHub's client-side download path fails (the zip never lands), the CLI falls back to `npm pack` to fetch the tarball and installs it locally. The pattern mirrors the Hermes pip fallback. Error messages chain both failures for diagnostics.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit ac3e152. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
