### PR TITLE
Claude Code on Kimi K3: map all model selectors for non-Anthropic managed models

### DIFF
--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -3454,6 +3454,24 @@ func applyClaudeManagedGateway(plan managedMCPEnrollmentPlan, baseURL, token, mo
 		env[envKey+"_NAME"] = "Preloop " + modelAlias
 	} else {
 		env["ANTHROPIC_MODEL"] = modelAlias
+		// Non-family managed model (e.g. a Kimi K3 alias): Claude Code's
+		// background/fast-path requests resolve through the built-in
+		// claude-haiku-* family identifiers and subagents through
+		// CLAUDE_CODE_SUBAGENT_MODEL, none of which exist at the gateway
+		// for a non-Anthropic account model. Map every selector at the
+		// managed alias so those calls resolve instead of 404ing.
+		// clearClaudePinnedModelEnv above wipes these same keys first, so
+		// re-onboarding and model changes always refresh them.
+		for key, value := range claudeNonFamilyModelEnv(modelAlias) {
+			env[key] = value
+		}
+		plan.Notes = append(
+			plan.Notes,
+			fmt.Sprintf(
+				"All Claude Code model selectors (opus/sonnet/haiku, background, and subagent models) will resolve to %s through Preloop.",
+				modelAlias,
+			),
+		)
 	}
 	plan.ManagedModelAlias = modelAlias
 	plan.ManagedProviderName = "preloop"
@@ -3679,6 +3697,7 @@ func claudeManagedGatewayEnvKeys() []string {
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION",
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES",
+		claudeSubagentModelEnvKey,
 	}
 }
 
@@ -3696,6 +3715,7 @@ func clearClaudePinnedModelEnv(env map[string]interface{}) {
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION",
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES",
+		claudeSubagentModelEnvKey,
 	} {
 		delete(env, key)
 	}

--- a/cli/internal/cmd/agents_model_family.go
+++ b/cli/internal/cmd/agents_model_family.go
@@ -96,6 +96,49 @@ func claudeFamilyModelEnv(aliases []string) map[string]string {
 	return env
 }
 
+// claudeSubagentModelEnvKey is the variable Claude Code reads to pick the
+// model for subagent (Task tool) runs. It bypasses the family selectors, so a
+// non-family managed model must pin it explicitly or subagents fall back to
+// built-in claude-* identifiers the gateway cannot serve.
+const claudeSubagentModelEnvKey = "CLAUDE_CODE_SUBAGENT_MODEL"
+
+// claudeNonFamilyModelEnv builds the env entries that route every one of
+// Claude Code's model selectors at a managed alias OUTSIDE the known Claude
+// families (a Kimi K3 alias, any other OpenAI-compatible model, ...).
+//
+// Setting ANTHROPIC_MODEL alone is not enough for these models: Claude Code's
+// background/fast-path requests ask for its built-in claude-haiku-* family
+// identifiers, and subagents resolve CLAUDE_CODE_SUBAGENT_MODEL. Neither is in
+// the account registry when the managed model is not an Anthropic-family
+// model, so the gateway answers 404 model_not_authorized. Pointing all three
+// family selectors and the subagent override at the managed alias closes that
+// gap — the same mapping Moonshot documents for running Claude Code against
+// Kimi models.
+//
+// Aliases that DO belong to a Claude family return an empty map: for those the
+// pinned-selection path (claudePinnedModelSelection) already writes the one
+// correct family key, and inventing entries for the other families would
+// advertise models the account may not hold.
+//
+// Like claudeFamilyModelEnv, this is deliberately pure — no config reads, no
+// file writes — so it is exhaustively testable before being wired anywhere.
+func claudeNonFamilyModelEnv(modelAlias string) map[string]string {
+	alias := strings.TrimSpace(modelAlias)
+	if alias == "" {
+		return map[string]string{}
+	}
+	if _, isFamily := claudeFamilyForAlias(alias); isFamily {
+		return map[string]string{}
+	}
+	env := make(map[string]string, 2*len(claudeModelFamilies)+1)
+	for _, family := range claudeModelFamilies {
+		env[family.envKey] = alias
+		env[family.envKey+"_NAME"] = "Preloop " + alias
+	}
+	env[claudeSubagentModelEnvKey] = alias
+	return env
+}
+
 // claudeStaleFamilyEnvKeys lists the family env keys that must be removed
 // because the account has no model for that family.
 //

--- a/cli/internal/cmd/agents_model_family_test.go
+++ b/cli/internal/cmd/agents_model_family_test.go
@@ -115,6 +115,86 @@ func TestClaudeFamilyModelEnvIsOrderIndependentAcrossFamilies(t *testing.T) {
 	}
 }
 
+// The Kimi K3 case: a managed model outside the Claude families must map every
+// selector Claude Code can emit — the three family env vars plus the subagent
+// override — at the managed alias, or background/fast-path calls and subagents
+// request built-in claude-* identifiers the gateway rejects with 404.
+func TestClaudeNonFamilyModelEnvMapsEverySelector(t *testing.T) {
+	env := claudeNonFamilyModelEnv("moonshot/kimi-k3-0905")
+
+	want := map[string]string{
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":        "moonshot/kimi-k3-0905",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL_NAME":   "Preloop moonshot/kimi-k3-0905",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL":      "moonshot/kimi-k3-0905",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL_NAME": "Preloop moonshot/kimi-k3-0905",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":       "moonshot/kimi-k3-0905",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME":  "Preloop moonshot/kimi-k3-0905",
+		"CLAUDE_CODE_SUBAGENT_MODEL":          "moonshot/kimi-k3-0905",
+	}
+	if !reflect.DeepEqual(env, want) {
+		t.Fatalf("claudeNonFamilyModelEnv() = %#v, want %#v", env, want)
+	}
+}
+
+func TestClaudeNonFamilyModelEnvTrimsAlias(t *testing.T) {
+	env := claudeNonFamilyModelEnv("  moonshot/kimi-k3-0905  ")
+	if got := env["ANTHROPIC_DEFAULT_HAIKU_MODEL"]; got != "moonshot/kimi-k3-0905" {
+		t.Fatalf("expected trimmed alias, got %q", got)
+	}
+}
+
+// Family aliases must produce nothing: for those the pinned-selection path
+// writes the one correct family key, and inventing entries for the other
+// families would advertise models the account may not hold.
+func TestClaudeNonFamilyModelEnvEmptyForFamilyAliases(t *testing.T) {
+	for _, alias := range []string{
+		"anthropic/claude-opus-4-1",
+		"anthropic/claude-sonnet-4-5",
+		"amazon-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+	} {
+		if env := claudeNonFamilyModelEnv(alias); len(env) != 0 {
+			t.Fatalf("expected no entries for family alias %q, got %#v", alias, env)
+		}
+	}
+}
+
+func TestClaudeNonFamilyModelEnvEmptyForBlankAlias(t *testing.T) {
+	for _, alias := range []string{"", "   "} {
+		if env := claudeNonFamilyModelEnv(alias); len(env) != 0 {
+			t.Fatalf("expected no entries for blank alias %q, got %#v", alias, env)
+		}
+	}
+}
+
+// Re-onboarding refreshes by clear-then-set, so every key the non-family map
+// emits must be wiped by clearClaudePinnedModelEnv — anything it misses would
+// survive a model change and keep routing traffic at the old alias.
+func TestClearClaudePinnedModelEnvRemovesEveryNonFamilyKey(t *testing.T) {
+	env := map[string]interface{}{}
+	for key, value := range claudeNonFamilyModelEnv("moonshot/kimi-k3-0905") {
+		env[key] = value
+	}
+	clearClaudePinnedModelEnv(env)
+	if len(env) != 0 {
+		t.Fatalf("clearClaudePinnedModelEnv left non-family keys behind: %#v", env)
+	}
+}
+
+// Offboard's env restore (restoreClaudeGatewayEnvFromOriginal) walks
+// claudeManagedGatewayEnvKeys, so every key the non-family map emits must be
+// listed there — anything missing would be left behind after offboard.
+func TestClaudeManagedGatewayEnvKeysCoverEveryNonFamilyKey(t *testing.T) {
+	managed := map[string]bool{}
+	for _, key := range claudeManagedGatewayEnvKeys() {
+		managed[key] = true
+	}
+	for key := range claudeNonFamilyModelEnv("moonshot/kimi-k3-0905") {
+		if !managed[key] {
+			t.Fatalf("claudeManagedGatewayEnvKeys() is missing %q; offboard restore would leave it behind", key)
+		}
+	}
+}
+
 // A key pointing at a model the gateway cannot serve is worse than no key: it
 // would appear in /model and then 404.
 func TestClaudeStaleFamilyEnvKeysClearsOnlyAbsentFamilies(t *testing.T) {

--- a/cli/internal/cmd/agents_test.go
+++ b/cli/internal/cmd/agents_test.go
@@ -2816,6 +2816,227 @@ func TestApplyClaudeManagedGatewayConfiguresEnv(t *testing.T) {
 	if got := plan.ManagedDocument["model"]; got != "haiku" {
 		t.Fatalf("expected Claude settings model to stay on haiku, got %#v", got)
 	}
+	// Anthropic-family models keep the single-family pinning: the other
+	// family selectors and the subagent override must NOT be invented.
+	for _, key := range []string{
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"CLAUDE_CODE_SUBAGENT_MODEL",
+	} {
+		if _, exists := env[key]; exists {
+			t.Fatalf("did not expect %s for an Anthropic-family model: %#v", key, env)
+		}
+	}
+}
+
+// A managed model outside the Claude families (the Kimi K3 case) must map
+// every selector Claude Code can emit at the managed alias. ANTHROPIC_MODEL
+// alone only covers the main loop: background/fast-path calls request
+// built-in claude-haiku-* identifiers and subagents resolve
+// CLAUDE_CODE_SUBAGENT_MODEL, and the gateway 404s both unless they are
+// pointed at the managed alias too.
+func TestApplyClaudeManagedGatewayNonAnthropicModelMapsAllSelectors(t *testing.T) {
+	plan := managedMCPEnrollmentPlan{
+		ManagedDocument: map[string]interface{}{
+			"mcpServers": map[string]interface{}{
+				"preloop": map[string]interface{}{
+					"url": "https://preloop.example/mcp/v1",
+				},
+			},
+		},
+	}
+	plan, err := applyClaudeManagedGateway(
+		plan,
+		"https://preloop.example",
+		"claude-durable-token",
+		"moonshot/kimi-k3-0905",
+	)
+	if err != nil {
+		t.Fatalf("unexpected gateway apply error: %v", err)
+	}
+
+	env := plan.ManagedDocument["env"].(map[string]interface{})
+	if env["ANTHROPIC_MODEL"] != "moonshot/kimi-k3-0905" {
+		t.Fatalf("expected main model pinned to managed alias: %#v", env)
+	}
+	if env["ANTHROPIC_CUSTOM_MODEL_OPTION"] != "moonshot/kimi-k3-0905" {
+		t.Fatalf("expected custom model option pinned to managed alias: %#v", env)
+	}
+	for _, key := range []string{
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+		"CLAUDE_CODE_SUBAGENT_MODEL",
+	} {
+		if env[key] != "moonshot/kimi-k3-0905" {
+			t.Fatalf("expected %s pinned to managed alias, got %#v", key, env[key])
+		}
+	}
+	if _, exists := plan.ManagedDocument["model"]; exists {
+		t.Fatalf(
+			"did not expect a root model selection key for a non-family model, got %#v",
+			plan.ManagedDocument["model"],
+		)
+	}
+	if plan.ManagedModelAlias != "moonshot/kimi-k3-0905" {
+		t.Fatalf("unexpected managed model alias: %q", plan.ManagedModelAlias)
+	}
+}
+
+// Re-onboarding from a non-family model to an Anthropic-family model must not
+// leave the all-selector mapping behind: a stale CLAUDE_CODE_SUBAGENT_MODEL or
+// sibling-family key would keep routing part of the traffic at the old model.
+func TestApplyClaudeManagedGatewayReonboardToAnthropicClearsNonFamilySelectors(t *testing.T) {
+	plan := managedMCPEnrollmentPlan{
+		ManagedDocument: map[string]interface{}{},
+	}
+	plan, err := applyClaudeManagedGateway(
+		plan,
+		"https://preloop.example",
+		"claude-durable-token",
+		"moonshot/kimi-k3-0905",
+	)
+	if err != nil {
+		t.Fatalf("unexpected gateway apply error: %v", err)
+	}
+	plan, err = applyClaudeManagedGateway(
+		plan,
+		"https://preloop.example",
+		"claude-durable-token",
+		"anthropic/claude-sonnet-4-5",
+	)
+	if err != nil {
+		t.Fatalf("unexpected gateway re-apply error: %v", err)
+	}
+
+	env := plan.ManagedDocument["env"].(map[string]interface{})
+	if env["ANTHROPIC_MODEL"] != "sonnet" {
+		t.Fatalf("expected family selection key after re-onboard, got %#v", env["ANTHROPIC_MODEL"])
+	}
+	if env["ANTHROPIC_DEFAULT_SONNET_MODEL"] != "anthropic/claude-sonnet-4-5" {
+		t.Fatalf("expected sonnet family key after re-onboard: %#v", env)
+	}
+	for _, key := range []string{
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+		"CLAUDE_CODE_SUBAGENT_MODEL",
+	} {
+		if value, exists := env[key]; exists {
+			t.Fatalf("stale non-family selector %s survived re-onboard: %#v", key, value)
+		}
+	}
+}
+
+// Switching between two non-family models must refresh every selector — no
+// env key may still point at the previous alias.
+func TestApplyClaudeManagedGatewayReonboardBetweenNonFamilyModelsRefreshes(t *testing.T) {
+	plan := managedMCPEnrollmentPlan{
+		ManagedDocument: map[string]interface{}{},
+	}
+	plan, err := applyClaudeManagedGateway(
+		plan,
+		"https://preloop.example",
+		"claude-durable-token",
+		"moonshot/kimi-k3-0905",
+	)
+	if err != nil {
+		t.Fatalf("unexpected gateway apply error: %v", err)
+	}
+	plan, err = applyClaudeManagedGateway(
+		plan,
+		"https://preloop.example",
+		"claude-durable-token",
+		"openai/gpt-5.4",
+	)
+	if err != nil {
+		t.Fatalf("unexpected gateway re-apply error: %v", err)
+	}
+
+	env := plan.ManagedDocument["env"].(map[string]interface{})
+	for key, value := range env {
+		text, ok := value.(string)
+		if !ok {
+			continue
+		}
+		if strings.Contains(text, "kimi-k3") {
+			t.Fatalf("env key %s still points at the previous alias: %q", key, text)
+		}
+	}
+	for _, key := range []string{
+		"ANTHROPIC_MODEL",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+		"CLAUDE_CODE_SUBAGENT_MODEL",
+	} {
+		if env[key] != "openai/gpt-5.4" {
+			t.Fatalf("expected %s refreshed to new alias, got %#v", key, env[key])
+		}
+	}
+}
+
+// Offboard-style env restore must remove the all-selector mapping written for
+// a non-family model, mirroring how ANTHROPIC_MODEL itself is cleaned.
+func TestRestoreClaudeGatewayEnvFromOriginalRemovesNonFamilySelectors(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "settings.json")
+	original := []byte(`{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "sk-ant-oat01-local"
+  }
+}`)
+	if err := os.WriteFile(configPath, original, 0644); err != nil {
+		t.Fatalf("failed to write original config: %v", err)
+	}
+
+	agent := AgentConfig{Name: "Claude Code", ConfigPath: configPath}
+	plan := managedMCPEnrollmentPlan{
+		Agent: agent,
+		ManagedDocument: map[string]interface{}{
+			"env": map[string]interface{}{
+				"ANTHROPIC_AUTH_TOKEN": "sk-ant-oat01-local",
+			},
+		},
+	}
+	managed, err := applyClaudeManagedGateway(
+		plan,
+		"https://preloop.example",
+		"preloop-token",
+		"moonshot/kimi-k3-0905",
+	)
+	if err != nil {
+		t.Fatalf("applyClaudeManagedGateway returned error: %v", err)
+	}
+	if err := writeAgentConfigDocument(agent, managed.ManagedDocument); err != nil {
+		t.Fatalf("failed to write managed Claude config: %v", err)
+	}
+
+	if err := restoreClaudeGatewayEnvFromOriginal(agent, original, io.Discard); err != nil {
+		t.Fatalf("restoreClaudeGatewayEnvFromOriginal returned error: %v", err)
+	}
+
+	restored, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		t.Fatalf("failed to load restored config: %v", err)
+	}
+	env := restored["env"].(map[string]interface{})
+	if env["ANTHROPIC_AUTH_TOKEN"] != "sk-ant-oat01-local" {
+		t.Fatalf("expected original Claude auth restored, got %#v", env)
+	}
+	for _, key := range []string{
+		"ANTHROPIC_MODEL",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL_NAME",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL_NAME",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
+		"CLAUDE_CODE_SUBAGENT_MODEL",
+	} {
+		if value, exists := env[key]; exists {
+			t.Fatalf("expected %s removed by restore, got %#v", key, value)
+		}
+	}
 }
 
 func TestRestoreClaudeGatewayEnvFromOriginalRestoresLocalAuth(t *testing.T) {


### PR DESCRIPTION
# Claude Code on Kimi K3 (and any non-Anthropic model) via Preloop

## Problem

Onboarding Claude Code with a managed gateway model outside the Claude families (e.g. a Kimi K3 alias) only pinned `ANTHROPIC_MODEL`, so the MAIN model worked but:

- Background/fast-path calls request Claude Code's built-in `claude-haiku-*` identifiers → gateway 404 `model_not_authorized`.
- Subagents resolve `CLAUDE_CODE_SUBAGENT_MODEL`, which was never set → same 404.

The gap was already documented in-code at `claudeFamilyModelEnv` (`cli/internal/cmd/agents_model_family.go`); the tested pure helpers there were never wired into the settings.json env block onboarding writes.

## What changed

For a managed model that is NOT an Anthropic-family model, `applyClaudeManagedGateway` now writes all of:

| Env var | Value |
|---|---|
| `ANTHROPIC_MODEL` | managed alias (unchanged) |
| `ANTHROPIC_CUSTOM_MODEL_OPTION` (+`_NAME`) | managed alias (unchanged) |
| `ANTHROPIC_DEFAULT_OPUS_MODEL` (+`_NAME`) | managed alias (new) |
| `ANTHROPIC_DEFAULT_SONNET_MODEL` (+`_NAME`) | managed alias (new) |
| `ANTHROPIC_DEFAULT_HAIKU_MODEL` (+`_NAME`) | managed alias (new) |
| `CLAUDE_CODE_SUBAGENT_MODEL` | managed alias (new) |

This is the same mapping Moonshot's own Claude Code guide uses for Kimi models. Anthropic-family models keep the existing single-family pinning — no behavior change there.

Lifecycle:

- **Re-onboarding / model changes**: `clearClaudePinnedModelEnv` runs before every apply and now also wipes `CLAUDE_CODE_SUBAGENT_MODEL`, so switching kimi→sonnet or kimi→gpt leaves no stale selector behind.
- **Offboard**: settings.json is restored wholesale from the pre-onboarding backup, which removes all of these. The no-backup fallback path (`restoreClaudeGatewayEnvFromOriginal` via `claudeManagedGatewayEnvKeys`) now covers `CLAUDE_CODE_SUBAGENT_MODEL` too, mirroring how `ANTHROPIC_MODEL` is cleaned.
- **Live validation**: unaffected — the probe already resolves `ANTHROPIC_CUSTOM_MODEL_OPTION` first.

## Recipe: Claude Code on Kimi K3

1. **Add K3 as an AI model in Preloop** using Moonshot's OpenAI-compatible endpoint:
   - Provider base URL: `https://api.moonshot.ai/v1` (use `api.moonshot.cn` for the China platform)
   - API key: your Moonshot key
   - Model ID: the Kimi K3 model name from Moonshot's model list
2. **Onboard Claude Code**: `preloop agents onboard "Claude Code"` and select the K3 model when prompted for the managed gateway model.
3. That's it — settings.json now maps every Claude Code selector (main, opus/sonnet/haiku pickers, background/fast-path, subagents) to the K3 alias through the Preloop gateway. Onboarding output prints the coverage note.

### What works

- Main-loop chat, tool use, background/fast-path calls, and subagent (Task tool) runs all route through Preloop to K3.
- `/model` picker entries resolve to the managed alias instead of 404ing.
- Offboard restores the original settings.json exactly.

### Known caveats

- **Thinking deltas**: Kimi's Anthropic-compatible surface streams reasoning differently from Claude; extended-thinking display in Claude Code may be partial or absent depending on how the gateway transcodes thinking deltas.
- **`cache_control`**: Anthropic prompt-caching directives are not honored by Moonshot; requests still succeed, but there is no cache discount and cache-read metrics stay at zero.
- **Tool search**: Moonshot's guidance for Claude Code on Kimi is to set `ENABLE_TOOL_SEARCH=false` (deferred/searchable tool loading can confuse the model); consider exporting it in your shell or adding it to settings.json env until this is baked in.

## Tests

- `cli/internal/cmd/agents_model_family_test.go`: 6 new tests — exact selector map for a K3 alias, alias trimming, empty map for family/blank aliases, and two agreement tests guaranteeing every emitted key is covered by `clearClaudePinnedModelEnv` (re-onboard refresh) and `claudeManagedGatewayEnvKeys` (offboard restore).
- `cli/internal/cmd/agents_test.go`: 4 new tests — non-Anthropic onboarding writes all selectors; re-onboard kimi→sonnet clears them; re-onboard kimi→gpt refreshes every key with no stale alias anywhere in env; env restore removes them all. Existing Anthropic-family test extended to pin that the new keys are NOT invented for family models.
- Full suite: `go build ./... && go test ./...` green (all 8 packages); `gofmt -l` clean on changed files.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-tested, scoped change that follows existing patterns. Pure helpers + thorough lifecycle coverage.
>
> **Overview**
> Maps all Claude Code model selectors (opus/sonnet/haiku, background/fast-path, subagents) to the managed gateway alias for non-Anthropic models. Fixes 404 errors for background calls and subagents when using models like Kimi K3 through the Preloop gateway. 10 new/extended tests cover onboarding, re-onboarding, and offboard.
>
> <sup>Written by Preloop PR Reviewer for commit on `feat/claude-code-model-family-env`. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
