### PR TITLE
OpenClaw plugin trust gate (plugins.allow) + shared provider-prefix map

### DIFF
--- a/backend/preloop/services/litellm_routing.py
+++ b/backend/preloop/services/litellm_routing.py
@@ -44,6 +44,9 @@ PROVIDER_PREFIX: Dict[str, str] = {
     "mistral": "mistral",
     "openrouter": "openrouter",
     "azure": "azure",
+    "aws": "bedrock",
+    "vertex": "vertex_ai",
+    "vertex_ai": "vertex_ai",
 }
 
 

--- a/backend/preloop/services/model_pricing.py
+++ b/backend/preloop/services/model_pricing.py
@@ -10,23 +10,13 @@ from typing import Any, Dict, Iterable, Optional
 import litellm
 
 from preloop.models.models.ai_model import AIModel
+from preloop.services.litellm_routing import PROVIDER_PREFIX as _PROVIDER_PREFIX
 
 logger = logging.getLogger(__name__)
 
-_PROVIDER_PREFIX: Dict[str, str] = {
-    "openai": "openai",
-    "anthropic": "anthropic",
-    "google": "gemini",
-    "gemini": "gemini",
-    "qwen": "openai",
-    "deepseek": "deepseek",
-    "aws": "bedrock",
-    "bedrock": "bedrock",
-    "amazon-bedrock": "bedrock",
-    "azure": "azure",
-    "vertex": "vertex_ai",
-    "vertex_ai": "vertex_ai",
-}
+# _PROVIDER_PREFIX is the shared gateway-routing map (imported above). Pricing
+# only uses it to GENERATE candidate catalog keys alongside the unprefixed
+# identifier, so routing-oriented entries are harmless here.
 
 # Bedrock cross-region inference profiles prefix the model id with a region
 # marker that litellm's price map does not include.

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -1714,6 +1714,18 @@ func runAgentsInstallPlugin(cmd *cobra.Command, args []string) error {
 			err,
 		)
 	}
+	// OpenClaw's plugin trust gate (plugins.allow) must admit the plugin or
+	// the install registers nothing; ensure it before installing so the
+	// standalone command matches what onboarding writes.
+	if runtimeSessionSourceTypeForAgent(agentName) == "openclaw" {
+		if err := ensureOpenClawPluginAllowlistedOnDisk(agentName); err != nil {
+			fmt.Fprintf(
+				cmd.ErrOrStderr(),
+				"Warning: could not update OpenClaw's plugins.allow list: %v\n",
+				err,
+			)
+		}
+	}
 	command := exec.Command(executable, installArgs...)
 	output, err := command.CombinedOutput()
 	if len(output) > 0 {
@@ -1725,6 +1737,27 @@ func runAgentsInstallPlugin(cmd *cobra.Command, args []string) error {
 			message = err.Error()
 		}
 		agent := AgentConfig{Name: agentName}
+		if runtimeSessionSourceTypeForAgent(agent.Name) == "openclaw" {
+			// Same ClawHub client failure the onboarding path works around:
+			// fetch the npm tarball and install it as a local file.
+			if installed, npmError := installOpenClawPluginViaNpmTarball(
+				executable,
+				agentControlPluginInstallTarget(agent),
+				cmd.ErrOrStderr(),
+			); installed {
+				fmt.Fprintf(
+					cmd.OutOrStdout(),
+					"\nInstalled %s from the npm tarball. Run `preloop agents validate %s` to verify plugin load and control readiness.\n",
+					agentControlPluginPackageName(agent),
+					agentName,
+				)
+				return nil
+			} else if npmError != "" {
+				message = fmt.Sprintf(
+					"%s (npm tarball fallback also failed: %s)", message, npmError,
+				)
+			}
+		}
 		if runtimeSessionSourceTypeForAgent(agent.Name) == hermesSourceType {
 			// Hermes' `plugins install` only accepts Git URLs or owner/repo
 			// shorthands; the Preloop plugin ships on PyPI, so fall back to a

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -3604,10 +3604,95 @@ func applyAgentControlConfigToDocument(
 			openClawPreloopPluginID,
 		)
 		pluginEntry["config"] = control
+		ensureOpenClawPluginAllowlisted(doc)
 		return
 	}
 	preloop := ensureObjectPath(doc, "preloop")
 	preloop["control"] = control
+}
+
+// ensureOpenClawPluginAllowlisted makes OpenClaw's plugin trust gate
+// (plugins.allow, introduced in OpenClaw 2026.3.x) admit the Preloop plugin —
+// without it, the installed plugin fails to register and Agent Control never
+// verifies. Appending to an existing list is safe; when the list is ABSENT,
+// creating it flips OpenClaw from permissive mode into strict allowlist mode,
+// which would silently disable every OTHER plugin the user runs — so a fresh
+// list is seeded with all configured entry ids plus everything already
+// installed under the extensions directory.
+func ensureOpenClawPluginAllowlisted(doc map[string]interface{}) {
+	plugins := ensureObjectPath(doc, "plugins")
+	if list, ok := plugins["allow"].([]interface{}); ok {
+		for _, item := range list {
+			if id, ok := item.(string); ok && id == openClawPreloopPluginID {
+				return
+			}
+		}
+		plugins["allow"] = append(list, openClawPreloopPluginID)
+		return
+	}
+	seen := map[string]bool{openClawPreloopPluginID: true}
+	allow := []interface{}{}
+	appendID := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		allow = append(allow, id)
+	}
+	if entries, ok := asObjectMap(plugins["entries"]); ok {
+		ids := make([]string, 0, len(entries))
+		for id := range entries {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		for _, id := range ids {
+			appendID(id)
+		}
+	}
+	for _, id := range installedOpenClawExtensionIDs() {
+		appendID(id)
+	}
+	plugins["allow"] = append(allow, openClawPreloopPluginID)
+}
+
+// ensureOpenClawPluginAllowlistedOnDisk applies the allowlist rule to the
+// live openclaw.json for the standalone install-plugin command, which does
+// not run the onboarding config rewrite. No-op when nothing changes.
+func ensureOpenClawPluginAllowlistedOnDisk(agentName string) error {
+	agent := AgentConfig{Name: agentName}
+	doc, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		return err
+	}
+	before, _ := json.Marshal(doc["plugins"])
+	ensureOpenClawPluginAllowlisted(doc)
+	after, _ := json.Marshal(doc["plugins"])
+	if string(before) == string(after) {
+		return nil
+	}
+	return writeAgentConfigDocument(agent, doc)
+}
+
+// installedOpenClawExtensionIDs lists plugin ids already installed under
+// ~/.openclaw/extensions, so seeding a fresh allowlist keeps them loadable.
+func installedOpenClawExtensionIDs() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	dirEntries, err := os.ReadDir(filepath.Join(home, ".openclaw", "extensions"))
+	if err != nil {
+		return nil
+	}
+	ids := make([]string, 0, len(dirEntries))
+	for _, entry := range dirEntries {
+		if entry.IsDir() {
+			ids = append(ids, entry.Name())
+		}
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 func validateAgentControlConfig(
@@ -3980,6 +4065,12 @@ func classifyRuntimePluginInstallFailure(installer string, message string) (stri
 		strings.Contains(normalizedMessage, "invalid plugin identifier") {
 		return "runtime_marketplace_rejected_identifier",
 			"Hermes' `plugins install` only accepts Git URLs or owner/repo shorthands; the Preloop plugin is distributed on PyPI. Install it with `pip install preloop-hermes-plugin` using Hermes' Python environment, then restart Hermes."
+	}
+	if normalizedInstaller == "openclaw" &&
+		strings.Contains(normalizedMessage, "control_ws_url") &&
+		strings.Contains(normalizedMessage, "required property") {
+		return "runtime_plugin_config_missing",
+			"OpenClaw's Preloop plugin needs its Agent Control config before it can load. Run `preloop agents onboard openclaw` first, then retry the plugin install."
 	}
 	if normalizedInstaller == "openclaw" &&
 		(strings.Contains(normalizedMessage, "requires node") ||

--- a/cli/internal/cmd/agents_openclaw_allowlist_test.go
+++ b/cli/internal/cmd/agents_openclaw_allowlist_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+// Tests for OpenClaw's plugin trust-gate handling (plugins.allow).
+//
+// OpenClaw 2026.3.x requires non-bundled plugins to be allowlisted before
+// they register. Appending to an existing list is safe; creating a NEW list
+// flips OpenClaw into strict allowlist mode, which silently disables every
+// other plugin — so a fresh list must be seeded with everything the user
+// already has configured or installed.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/testenv"
+)
+
+func allowListStrings(t *testing.T, doc map[string]interface{}) []string {
+	t.Helper()
+	plugins, ok := asObjectMap(doc["plugins"])
+	if !ok {
+		t.Fatal("plugins block missing")
+	}
+	raw, ok := plugins["allow"].([]interface{})
+	if !ok {
+		t.Fatalf("plugins.allow missing or wrong type: %T", plugins["allow"])
+	}
+	ids := make([]string, 0, len(raw))
+	for _, item := range raw {
+		ids = append(ids, item.(string))
+	}
+	return ids
+}
+
+func TestAllowlistAppendsToExistingList(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	doc := map[string]interface{}{
+		"plugins": map[string]interface{}{
+			"allow": []interface{}{"acpx", "telegram"},
+		},
+	}
+	ensureOpenClawPluginAllowlisted(doc)
+	ids := allowListStrings(t, doc)
+	if strings.Join(ids, ",") != "acpx,telegram,preloop-plugin" {
+		t.Errorf("unexpected allow list: %v", ids)
+	}
+}
+
+func TestAllowlistIsIdempotent(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	doc := map[string]interface{}{
+		"plugins": map[string]interface{}{
+			"allow": []interface{}{"preloop-plugin"},
+		},
+	}
+	ensureOpenClawPluginAllowlisted(doc)
+	ids := allowListStrings(t, doc)
+	if len(ids) != 1 || ids[0] != "preloop-plugin" {
+		t.Errorf("expected unchanged single-entry list, got %v", ids)
+	}
+}
+
+func TestFreshAllowlistSeedsConfiguredAndInstalledPlugins(t *testing.T) {
+	// A new list must not disable the user's other plugins: seed from
+	// configured entries AND plugins already installed under extensions/.
+	home := testenv.SetHome(t, t.TempDir())
+	for _, ext := range []string{"community-widget", "acpx"} {
+		if err := os.MkdirAll(
+			filepath.Join(home, ".openclaw", "extensions", ext), 0o755,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	doc := map[string]interface{}{
+		"plugins": map[string]interface{}{
+			"entries": map[string]interface{}{
+				"acpx":     map[string]interface{}{},
+				"telegram": map[string]interface{}{},
+			},
+		},
+	}
+	ensureOpenClawPluginAllowlisted(doc)
+	ids := allowListStrings(t, doc)
+	if strings.Join(ids, ",") != "acpx,telegram,community-widget,preloop-plugin" {
+		t.Errorf("unexpected seeded allow list: %v", ids)
+	}
+}
+
+func TestClassifyMissingControlConfigSuggestsOnboarding(t *testing.T) {
+	status, remediation := classifyRuntimePluginInstallFailure(
+		"openclaw",
+		"Config invalid: plugins.entries.preloop-plugin.config.control_ws_url: invalid config: must have required property 'control_ws_url'",
+	)
+	if status != "runtime_plugin_config_missing" {
+		t.Errorf("unexpected status: %s", status)
+	}
+	if !strings.Contains(remediation, "preloop agents onboard openclaw") {
+		t.Errorf("remediation should point at onboarding, got: %s", remediation)
+	}
+}


### PR DESCRIPTION
Two post-0.12.8 fixes:

**OpenClaw plugin trust gate.** OpenClaw 2026.3.x requires non-bundled plugins to be listed in `plugins.allow` before they register — found on the live 0.12.8 verification run: the plugin installed (npm fallback worked) but Agent Control never verified until the allowlist admitted it. Onboarding's config rewrite and the standalone `install-plugin` command now ensure the allowlist. Critical subtlety, verified live: creating a NEW allow list flips OpenClaw into strict allowlist mode and silently disables every other plugin — a fresh list is therefore seeded with all configured entries plus everything installed under `extensions/`. The standalone `install-plugin` also gains the npm-tarball fallback the onboarding path already has, and a config-invalid failure now says 'run `preloop agents onboard openclaw` first' instead of dumping schema errors. With this + a gateway restart, the full Agent Control channel verified end-to-end on the test VM for the first time (`control_plugin_verified: yes`).

**Shared provider-prefix map.** `model_pricing.py` carried the last private `_PROVIDER_PREFIX` copy; it now imports the shared `litellm_routing` map (extended with its aws/vertex entries). Pricing semantics unchanged — the map only generates candidate catalog keys there.

4 new Go tests (allowlist append/idempotent/fresh-seed + onboard-first classification); full CLI and pricing/routing suites green.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-tested fixes to OpenClaw plugin trust gating and provider-prefix deduplication. No security concerns.
>
> **Overview**
> Ensures the OpenClaw plugins.allow trust gate admits the Preloop plugin (matching onboarding behavior in standalone installs), adds npm tarball fallback to the standalone install path, improves error messages, and consolidates the provider-prefix map. 4 new Go tests; no breaking changes.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/openclaw-plugin-allowlist. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->