### PR TITLE
CLI onboarding UX: single name prompt, stale-config detection, validate-first tiers, troubleshooting footer

### DIFF
--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -863,7 +863,7 @@ func promptToOnboardDiscoveredAgents(
 	// take ~5s) and a slow upstream for one agent never blocks subsequent
 	// agents from being touched.
 	deferLiveValidate := !skipLiveValidate
-	outcomes, err := promptToOnboardCandidates(os.Stdin, os.Stdout, candidates, autoApprove, true, func(agent AgentConfig, approvals bool) error {
+	outcomes, err := promptToOnboardCandidatesTiered(os.Stdin, os.Stdout, client, candidates, autoApprove, true, func(agent AgentConfig, approvals bool) error {
 		return executeManagedEnrollment(agent, managedEnrollmentOptions{
 			Client: client,
 			// AutoApprove carries the -y flag so per-agent sub-prompts
@@ -1259,14 +1259,31 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 					return nil
 				}
 			}
+			// Validate-first ordering: agents with verified model routing
+			// onboard first; the MCP-only/unverified tier follows its printed
+			// explanation. --all keeps onboarding everything.
+			verified, unverified, reasons := partitionCandidatesByModelRouting(client, candidates)
 			enrolled, failures := onboardCandidatesBestEffort(
 				os.Stdin,
 				os.Stdout,
-				candidates,
+				verified,
 				opts,
 				deferLiveValidate,
 				executeManagedEnrollment,
 			)
+			if len(unverified) > 0 {
+				printModelRoutingTierExplanation(os.Stdout, unverified, reasons, true)
+				secondTier, secondFailures := onboardCandidatesBestEffort(
+					os.Stdin,
+					os.Stdout,
+					unverified,
+					opts,
+					deferLiveValidate,
+					executeManagedEnrollment,
+				)
+				enrolled = append(enrolled, secondTier...)
+				failures = append(failures, secondFailures...)
+			}
 			if deferLiveValidate && len(enrolled) > 0 {
 				runDeferredLiveValidationsParallel(client, enrolled, os.Stdout)
 			}
@@ -1284,7 +1301,7 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 
 		// askApprovals=false: executeManagedEnrollment prompts for the
 		// approvals hook itself when this path runs interactively.
-		outcomes, err := promptToOnboardCandidates(os.Stdin, os.Stdout, candidates, autoApprove, false, func(a AgentConfig, _ bool) error {
+		outcomes, err := promptToOnboardCandidatesTiered(os.Stdin, os.Stdout, client, candidates, autoApprove, false, func(a AgentConfig, _ bool) error {
 			agentOpts := opts
 			agentOpts.SkipConfirmation = autoApprove
 			agentOpts.DeferLiveValidate = deferLiveValidate

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -41,7 +41,13 @@ type AgentConfig struct {
 	// SupportLevel is the per-agent-type capability: "full" (MCP + model
 	// routing) or "mcp-only" (model traffic not routable for this agent
 	// type) — see supportLevelForAgent.
-	SupportLevel         string   `json:"support_level,omitempty"`
+	SupportLevel string `json:"support_level,omitempty"`
+	// RuntimeState reports whether the agent's runtime (executable or app
+	// bundle) was actually found: present / missing / unknown — see
+	// detectAgentRuntimeState. "missing" flags a config-only leftover from
+	// an uninstalled agent; "unknown" is treated as present.
+	RuntimeState         string   `json:"runtime_state,omitempty"`
+	RuntimeDetail        string   `json:"runtime_detail,omitempty"`
 	ConfigDrift          bool     `json:"config_drift,omitempty"`
 	ReonboardRecommended bool     `json:"reonboard_recommended,omitempty"`
 	DriftReasons         []string `json:"drift_reasons,omitempty"`
@@ -774,6 +780,9 @@ func runAgentsDiscover(cmd *cobra.Command, args []string) error {
 		fmt.Printf("     Runtime principal: %s\n", runtimePrincipalIDForAgent(agent))
 		fmt.Printf("     Config: %s\n", agent.ConfigPath)
 		fmt.Printf("     Auth: %s\n", agentAuthListingLabel(agent))
+		if runtimeLabel := agentRuntimeListingLabel(agent); runtimeLabel != "" {
+			fmt.Printf("     Runtime: %s\n", runtimeLabel)
+		}
 		fmt.Printf("     Support: %s\n", agentSupportListingLabel(agent))
 		if agent.IsOnboarded {
 			fmt.Printf(
@@ -833,6 +842,16 @@ func promptToOnboardDiscoveredAgents(
 	}
 	if len(candidates) == 0 {
 		fmt.Println("All discovered agents are already onboarded or have local managed enrollment state.")
+		return nil
+	}
+
+	// Config-only agents (runtime uninstalled, config files left behind) are
+	// never onboarded by the discover-driven batch — neither under --yes nor
+	// via the interactive prompts. Explicit `preloop agents onboard <name>`
+	// still works, with a warning.
+	candidates, configOnly := splitRuntimeMissingCandidates(candidates)
+	printRuntimeMissingOnboardingSkips(os.Stdout, configOnly)
+	if len(candidates) == 0 {
 		return nil
 	}
 
@@ -1196,6 +1215,12 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+		// Batch onboarding (with or without --all/--yes) never touches
+		// config-only agents whose runtime is reliably missing; they need an
+		// explicit `preloop agents onboard <name>`.
+		var configOnly []AgentConfig
+		candidates, configOnly = splitRuntimeMissingCandidates(candidates)
+		printRuntimeMissingOnboardingSkips(os.Stdout, configOnly)
 		if len(candidates) == 0 {
 			if runAll {
 				if err := ensureAgentControlOnboarding(client, discovered, opts); err != nil {
@@ -1291,6 +1316,11 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Explicitly named config-only agents may still be onboarded, but say up
+	// front that the runtime is missing so the result is not mistaken for a
+	// working enrollment.
+	printRuntimeMissingOnboardingWarning(os.Stdout, agent)
 
 	// A skipped managed launcher (missing agent binary) is a partial success:
 	// the warning has been printed and the command exits 0.
@@ -2949,9 +2979,9 @@ func discoverAgents(w io.Writer, printWarnings bool) ([]AgentConfig, error) {
 				ConfigPath: fullPath,
 				MCPServers: servers,
 			})
-			discovered[len(discovered)-1] = withDetectedAuthState(
+			discovered[len(discovered)-1] = withDetectedRuntimeState(withDetectedAuthState(
 				normalizeDiscoveredAgent(discovered[len(discovered)-1]),
-			)
+			))
 			discoveredSpec = true
 			break
 		}
@@ -2959,11 +2989,11 @@ func discoverAgents(w io.Writer, printWarnings bool) ([]AgentConfig, error) {
 			continue
 		}
 		if fallbackPath, ok := detectInstalledAgent(home, spec); ok {
-			discovered = append(discovered, withDetectedAuthState(normalizeDiscoveredAgent(AgentConfig{
+			discovered = append(discovered, withDetectedRuntimeState(withDetectedAuthState(normalizeDiscoveredAgent(AgentConfig{
 				Name:       spec.Name,
 				ConfigPath: fallbackPath,
 				MCPServers: map[string]MCPDef{},
-			})))
+			}))))
 		}
 	}
 	return discovered, nil

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -482,6 +482,7 @@ func printAgentOnboardingSummary(w io.Writer, outcomes []agentOnboardingOutcome)
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
 	fmt.Fprintf(tw, "  Agent\tStatus\tReason\n") //nolint:errcheck
 	missingExecutable := false
+	anyFailed := false
 	for _, outcome := range outcomes {
 		reason := outcome.Reason
 		if reason == "" {
@@ -497,12 +498,18 @@ func printAgentOnboardingSummary(w io.Writer, outcomes []agentOnboardingOutcome)
 		if outcome.MissingExecutable {
 			missingExecutable = true
 		}
+		if outcome.Status == agentOnboardingStatusFailed {
+			anyFailed = true
+		}
 	}
 	tw.Flush() //nolint:errcheck
 	if missingExecutable {
 		if hint := wslMissingExecutableHint(); hint != "" {
 			fmt.Fprintf(w, "  Hint: %s\n", hint) //nolint:errcheck
 		}
+	}
+	if anyFailed {
+		printTroubleshootingFooter(w)
 	}
 }
 
@@ -1064,6 +1071,7 @@ func printAgentOnboardingFailures(
 		writer,
 		"Re-run `preloop agents onboard <agent> -y` after fixing the listed agent environment.",
 	)
+	printTroubleshootingFooter(writer)
 }
 
 // shouldPromptForEnrollmentName reports whether executeManagedEnrollment must
@@ -1341,7 +1349,11 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 
 	// A skipped managed launcher (missing agent binary) is a partial success:
 	// the warning has been printed and the command exits 0.
-	return ignoreLauncherSkipped(executeManagedEnrollment(agent, opts))
+	if err := ignoreLauncherSkipped(executeManagedEnrollment(agent, opts)); err != nil {
+		printTroubleshootingFooter(os.Stdout)
+		return err
+	}
+	return nil
 }
 
 func ensureAgentControlOnboarding(
@@ -1752,6 +1764,7 @@ func runAgentsValidate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  routing: %s\n", onboardingStateNote(onboardingStateFromValidation(result)))
 
 	if status != "validated" {
+		printTroubleshootingFooter(os.Stdout)
 		return fmt.Errorf("managed enrollment validation failed")
 	}
 	return nil

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -851,6 +851,7 @@ func promptToOnboardDiscoveredAgents(
 			// (e.g. stale OpenClaw plugin cleanup) auto-accept under -y.
 			AutoApprove:       autoApprove,
 			SkipConfirmation:  true,
+			AgentPrepared:     true,
 			LiveValidate:      true,
 			SkipLiveValidate:  skipLiveValidate,
 			DeferLiveValidate: deferLiveValidate,
@@ -994,6 +995,7 @@ func onboardCandidatesBestEffort(
 		agentOpts := opts
 		agentOpts.AutoApprove = true
 		agentOpts.SkipConfirmation = true
+		agentOpts.AgentPrepared = true
 		agentOpts.DeferLiveValidate = deferLiveValidate
 		if err := enroll(prepared, agentOpts); err != nil {
 			// A skipped managed launcher is a partial success (MCP and
@@ -1043,6 +1045,15 @@ func printAgentOnboardingFailures(
 		writer,
 		"Re-run `preloop agents onboard <agent> -y` after fixing the listed agent environment.",
 	)
+}
+
+// shouldPromptForEnrollmentName reports whether executeManagedEnrollment must
+// run its own prepareAgentForEnrollment (which prompts for the display name in
+// interactive runs). Callers that already prepared the agent — the discover
+// and `onboard` batch loops call prepareAgentForEnrollment before enrolling —
+// set AgentPrepared so the user is asked for the agent name exactly once.
+func shouldPromptForEnrollmentName(opts managedEnrollmentOptions) bool {
+	return !opts.SkipConfirmation && !opts.AutoApprove && !opts.AgentPrepared
 }
 
 func prepareAgentForEnrollment(
@@ -1252,6 +1263,11 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 			agentOpts := opts
 			agentOpts.SkipConfirmation = autoApprove
 			agentOpts.DeferLiveValidate = deferLiveValidate
+			// promptToOnboardCandidates already ran
+			// prepareAgentForEnrollment (name prompt) for this agent; the
+			// enrollment must keep its plan/apply confirmation but not ask
+			// for the agent name a second time.
+			agentOpts.AgentPrepared = true
 			return executeManagedEnrollment(a, agentOpts)
 		})
 		if err != nil {

--- a/cli/internal/cmd/agents_onboarding_tiers.go
+++ b/cli/internal/cmd/agents_onboarding_tiers.go
@@ -1,0 +1,153 @@
+package cmd
+
+// Validate-first onboarding tiers.
+//
+// Quick and interactive batch onboarding used to walk candidates in discovery
+// order, so an agent that could only be MCP-governed (or whose model
+// credential could not be resolved) was interleaved with agents whose model
+// routing works end to end. Onboarding now happens in two tiers:
+//
+//	Tier 1  agents whose model routing is verified to be workable: the agent
+//	        type supports gateway routing AND a model credential was resolved
+//	        locally (resolveManagedGatewayUpstream) or is already stored in
+//	        the Preloop account (serverHasReusableGatewayCredential). For
+//	        OpenClaw — which syncs its own multi-model bindings — the
+//	        existing auth-state probe stands in.
+//	Tier 2  everything else: MCP-only agent types, and gateway-capable agents
+//	        with no verifiable credential. These are onboarded after tier 1,
+//	        behind a printed explanation (interactive flows then ask
+//	        per-agent, --yes keeps onboarding them for backward
+//	        compatibility).
+//
+// This reuses the existing preflight/planning probes; no new validation path
+// is introduced. Live validation still runs after onboarding exactly as
+// before.
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+// agentModelRoutingVerified reports whether onboarding this agent can be
+// expected to yield working model routing, with a one-line reason when not.
+func agentModelRoutingVerified(client *api.Client, agent AgentConfig) (bool, string) {
+	if supportLevelForAgent(agent) != agentSupportLevelFull {
+		return false, mcpOnlySupportLabel
+	}
+	if isOpenClawAgent(agent) {
+		// OpenClaw routes through its own multi-model binding sync; the
+		// pre-onboarding auth probe already says whether provider
+		// credentials exist.
+		if resolvedAgentAuthState(agent) == agentAuthStateReady {
+			return true, ""
+		}
+		return false, "model routing supported, but no provider credentials are configured yet"
+	}
+	upstream, err := resolveManagedGatewayUpstream(agent)
+	if err != nil {
+		return false, "model routing supported, but resolving the local model credential failed: " + firstErrorLine(err)
+	}
+	if upstream != nil && upstream.CanRouteThroughGateway() {
+		return true, ""
+	}
+	if serverHasReusableGatewayCredential(client, agent, upstream) {
+		return true, ""
+	}
+	return false, "model routing supported, but no usable model credential was found locally"
+}
+
+// partitionCandidatesByModelRouting splits onboarding candidates into the
+// verified tier and the unverified tier; reasons is parallel to unverified.
+func partitionCandidatesByModelRouting(
+	client *api.Client,
+	candidates []AgentConfig,
+) (verified, unverified []AgentConfig, reasons []string) {
+	for _, agent := range candidates {
+		ok, reason := agentModelRoutingVerified(client, agent)
+		if ok {
+			verified = append(verified, agent)
+			continue
+		}
+		unverified = append(unverified, agent)
+		reasons = append(reasons, reason)
+	}
+	return verified, unverified, reasons
+}
+
+// printModelRoutingTierExplanation introduces the tier-2 group once per run,
+// before any of its agents are onboarded or prompted for.
+func printModelRoutingTierExplanation(
+	writer io.Writer,
+	unverified []AgentConfig,
+	reasons []string,
+	autoApprove bool,
+) {
+	if len(unverified) == 0 {
+		return
+	}
+	fmt.Fprintln( //nolint:errcheck
+		writer,
+		"\nThese agents can be governed for tool calls (MCP), but Preloop couldn't verify model routing for them:",
+	)
+	for i, agent := range unverified {
+		reason := ""
+		if i < len(reasons) {
+			reason = reasons[i]
+		}
+		if reason == "" {
+			reason = "model routing could not be verified"
+		}
+		fmt.Fprintf(writer, "  - %s: %s\n", resolveAgentDisplayName(agent), reason) //nolint:errcheck
+	}
+	if autoApprove {
+		fmt.Fprintln( //nolint:errcheck
+			writer,
+			"Onboarding them as well: MCP governance applies now; model traffic stays direct until routing can be verified.",
+		)
+		return
+	}
+	fmt.Fprintln( //nolint:errcheck
+		writer,
+		"Onboarding them still applies MCP governance now; model traffic stays direct until routing can be verified. Onboard anyway?",
+	)
+}
+
+// promptToOnboardCandidatesTiered wraps promptToOnboardCandidates with the
+// two-tier ordering: verified-model-routing agents first, then the
+// MCP-only/unverified tier behind its explanation. A single buffered reader is
+// shared across both passes so no interactive input is lost between them
+// (bufio.NewReader returns an existing *bufio.Reader unchanged).
+func promptToOnboardCandidatesTiered(
+	reader io.Reader,
+	writer io.Writer,
+	client *api.Client,
+	candidates []AgentConfig,
+	autoApprove bool,
+	askApprovals bool,
+	enroll func(agent AgentConfig, approvals bool) error,
+) ([]agentOnboardingOutcome, error) {
+	verified, unverified, reasons := partitionCandidatesByModelRouting(client, candidates)
+	bufferedReader := bufio.NewReader(reader)
+
+	if len(verified) > 0 && len(unverified) > 0 {
+		fmt.Fprintf( //nolint:errcheck
+			writer,
+			"Onboarding %d agent(s) with verified model routing first.\n",
+			len(verified),
+		)
+	}
+	outcomes, err := promptToOnboardCandidates(bufferedReader, writer, verified, autoApprove, askApprovals, enroll)
+	if err != nil {
+		return outcomes, err
+	}
+	if len(unverified) == 0 {
+		return outcomes, nil
+	}
+	printModelRoutingTierExplanation(writer, unverified, reasons, autoApprove)
+	secondTier, err := promptToOnboardCandidates(bufferedReader, writer, unverified, autoApprove, askApprovals, enroll)
+	outcomes = append(outcomes, secondTier...)
+	return outcomes, err
+}

--- a/cli/internal/cmd/agents_onboarding_tiers_test.go
+++ b/cli/internal/cmd/agents_onboarding_tiers_test.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAgentModelRoutingVerified(t *testing.T) {
+	t.Run("mcp-only agent type is never verified", func(t *testing.T) {
+		ok, reason := agentModelRoutingVerified(nil, AgentConfig{
+			Name:       "Cursor",
+			ConfigPath: "/tmp/mcp.json",
+		})
+		if ok {
+			t.Fatal("expected mcp-only agent to be unverified")
+		}
+		if reason != mcpOnlySupportLabel {
+			t.Fatalf("expected shared mcp-only label, got %q", reason)
+		}
+	})
+
+	t.Run("openclaw uses the auth-state probe", func(t *testing.T) {
+		ready, _ := agentModelRoutingVerified(nil, AgentConfig{
+			Name:       "OpenClaw",
+			ConfigPath: "/tmp/openclaw.json",
+			AuthState:  string(agentAuthStateReady),
+		})
+		if !ready {
+			t.Fatal("expected auth-ready OpenClaw to be verified")
+		}
+		notReady, reason := agentModelRoutingVerified(nil, AgentConfig{
+			Name:       "OpenClaw",
+			ConfigPath: "/tmp/openclaw.json",
+			AuthState:  string(agentAuthStateNotLoggedIn),
+		})
+		if notReady {
+			t.Fatal("expected OpenClaw without provider auth to be unverified")
+		}
+		if !strings.Contains(reason, "no provider credentials") {
+			t.Fatalf("expected credential reason, got %q", reason)
+		}
+	})
+
+	t.Run("gateway-capable agent without a resolvable credential is unverified", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+		ok, reason := agentModelRoutingVerified(nil, AgentConfig{
+			Name:       "Codex CLI",
+			ConfigPath: filepath.Join(home, ".codex", "config.toml"),
+		})
+		if ok {
+			t.Fatal("expected Codex CLI without config/credentials to be unverified")
+		}
+		if !strings.Contains(reason, "model routing supported") {
+			t.Fatalf("expected model-routing reason, got %q", reason)
+		}
+	})
+}
+
+func TestPartitionCandidatesByModelRouting(t *testing.T) {
+	candidates := []AgentConfig{
+		{Name: "Cursor", ConfigPath: "/tmp/mcp.json"},
+		{Name: "OpenClaw", ConfigPath: "/tmp/openclaw.json", AuthState: string(agentAuthStateReady)},
+	}
+	verified, unverified, reasons := partitionCandidatesByModelRouting(nil, candidates)
+	if len(verified) != 1 || verified[0].Name != "OpenClaw" {
+		t.Fatalf("expected OpenClaw in the verified tier, got %#v", verified)
+	}
+	if len(unverified) != 1 || unverified[0].Name != "Cursor" {
+		t.Fatalf("expected Cursor in the unverified tier, got %#v", unverified)
+	}
+	if len(reasons) != 1 || reasons[0] != mcpOnlySupportLabel {
+		t.Fatalf("expected parallel mcp-only reason, got %#v", reasons)
+	}
+}
+
+func TestPromptToOnboardCandidatesTiered_AutoApproveOrdersVerifiedFirst(t *testing.T) {
+	output := &bytes.Buffer{}
+	// Discovery order deliberately lists the MCP-only agent first.
+	candidates := []AgentConfig{
+		{Name: "Cursor", ConfigPath: "/tmp/mcp.json"},
+		{Name: "OpenClaw", ConfigPath: "/tmp/openclaw.json", AuthState: string(agentAuthStateReady)},
+	}
+
+	var enrolledOrder []string
+	outcomes, err := promptToOnboardCandidatesTiered(
+		strings.NewReader(""),
+		output,
+		nil,
+		candidates,
+		true,
+		false,
+		func(agent AgentConfig, _ bool) error {
+			enrolledOrder = append(enrolledOrder, agent.Name)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(outcomes) != 2 {
+		t.Fatalf("expected both agents onboarded under --yes, got %#v", outcomes)
+	}
+	if len(enrolledOrder) != 2 || enrolledOrder[0] != "OpenClaw" || enrolledOrder[1] != "Cursor" {
+		t.Fatalf("expected verified agent first, got %v", enrolledOrder)
+	}
+	rendered := output.String()
+	if !strings.Contains(rendered, "couldn't verify model routing") {
+		t.Fatalf("expected tier explanation, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "Cursor: "+mcpOnlySupportLabel) {
+		t.Fatalf("expected per-agent reason, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "Onboarding them as well") {
+		t.Fatalf("expected --yes continuation note, got %q", rendered)
+	}
+	// The explanation must precede the second-tier enrollment, i.e. appear
+	// after the first tier's heading.
+	if strings.Index(rendered, "verified model routing first") > strings.Index(rendered, "couldn't verify model routing") {
+		t.Fatalf("expected tier-1 heading before tier-2 explanation, got %q", rendered)
+	}
+}
+
+func TestPromptToOnboardCandidatesTiered_InteractiveTwoStepAsk(t *testing.T) {
+	output := &bytes.Buffer{}
+	candidates := []AgentConfig{
+		{Name: "Cursor", ConfigPath: "/tmp/mcp.json"},
+		{Name: "OpenClaw", ConfigPath: "/tmp/openclaw.json", AuthState: string(agentAuthStateReady)},
+	}
+
+	// OpenClaw (tier 1): confirm yes + keep default name. Cursor (tier 2):
+	// decline after the explanation.
+	input := strings.NewReader("y\n\nn\n")
+	var enrolledOrder []string
+	outcomes, err := promptToOnboardCandidatesTiered(
+		input,
+		output,
+		nil,
+		candidates,
+		false,
+		false,
+		func(agent AgentConfig, _ bool) error {
+			enrolledOrder = append(enrolledOrder, agent.Name)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(enrolledOrder) != 1 || enrolledOrder[0] != "OpenClaw" {
+		t.Fatalf("expected only the verified agent enrolled, got %v", enrolledOrder)
+	}
+	if len(outcomes) != 1 || outcomes[0].Agent.Name != "OpenClaw" {
+		t.Fatalf("expected a single OpenClaw outcome, got %#v", outcomes)
+	}
+	rendered := output.String()
+	if !strings.Contains(rendered, "couldn't verify model routing") ||
+		!strings.Contains(rendered, "Onboard anyway?") {
+		t.Fatalf("expected interactive tier-2 explanation, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "Onboard Cursor (Cursor) into managed Preloop access now?") {
+		t.Fatalf("expected tier-2 per-agent prompt after the explanation, got %q", rendered)
+	}
+}

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -290,9 +290,16 @@ type managedEnrollmentOptions struct {
 	// would-prompt tool calls to Preloop's mobile/watch approval flow. Off by
 	// default; enabled via `preloop agents onboard --approvals`.
 	Approvals bool
-	Tags      map[string]string
-	Input     io.Reader
-	Output    io.Writer
+	// AgentPrepared marks that the caller already ran
+	// prepareAgentForEnrollment on the agent (display name confirmed,
+	// runtime principal generated). executeManagedEnrollment must not run
+	// the name prompt again in that case: the discover/onboard batch loops
+	// prepare each agent before enrolling it, and re-preparing inside the
+	// enrollment made interactive onboarding ask for the agent name twice.
+	AgentPrepared bool
+	Tags          map[string]string
+	Input         io.Reader
+	Output        io.Writer
 }
 
 type managedLiveValidationOutcome struct {
@@ -460,7 +467,7 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 	}
 
 	agent = normalizeDiscoveredAgent(agent)
-	if !opts.SkipConfirmation && !opts.AutoApprove {
+	if shouldPromptForEnrollmentName(opts) {
 		agent, err = prepareAgentForEnrollment(bufio.NewReader(input), output, agent, false)
 		if err != nil {
 			return err

--- a/cli/internal/cmd/agents_runtime_presence.go
+++ b/cli/internal/cmd/agents_runtime_presence.go
@@ -1,0 +1,285 @@
+package cmd
+
+// Runtime-presence probes for discovered agents.
+//
+// Discovery is config-driven: an agent whose runtime was uninstalled but whose
+// config files were left behind (the classic case: Antigravity removed,
+// ~/.gemini/antigravity still present) used to look identical to an installed
+// agent, so discover offered to onboard it and quick flows (--yes) silently
+// did. These probes check whether the agent's runtime actually exists —
+// executable on PATH / known install locations for CLI agents, the
+// /Applications bundle for GUI apps on macOS — and classify each agent as:
+//
+//	present  runtime found; onboarding can work end to end.
+//	missing  config exists but the runtime was reliably not found
+//	         ("config found, runtime not installed"). Quick flows skip these;
+//	         explicit `preloop agents onboard <name>` still works with a
+//	         warning.
+//	unknown  presence is not reliably detectable for this agent type/platform
+//	         (e.g. GUI apps outside macOS, VS Code's many variants). Unknown
+//	         is treated as present everywhere — a working agent must never be
+//	         falsely excluded.
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type agentRuntimeState string
+
+const (
+	agentRuntimeStatePresent agentRuntimeState = "present"
+	agentRuntimeStateMissing agentRuntimeState = "missing"
+	agentRuntimeStateUnknown agentRuntimeState = "unknown"
+)
+
+// runtimeMissingListingLabel is the single user-facing phrase for a
+// config-only agent, shared by the discover listing, the quick-flow skip
+// notice, and the explicit-onboard warning so the surfaces never disagree.
+const runtimeMissingListingLabel = "config found, runtime not installed"
+
+// agentRuntimeProbeSpec describes how to look for one agent type's runtime.
+type agentRuntimeProbeSpec struct {
+	// commands are executables resolved via resolveRuntimeExecutable (PATH
+	// plus the known ~/.local/bin, pnpm, and nvm fallback locations).
+	commands []string
+	// appBundles are macOS .app bundle names probed under /Applications and
+	// ~/Applications. Only meaningful on darwin.
+	appBundles []string
+	// conclusiveOnDarwin / conclusiveElsewhere mark the probe reliable
+	// enough to report "missing" when nothing was found. GUI-app probes are
+	// only conclusive on macOS, where the /Applications convention holds;
+	// anywhere the probe is not conclusive a miss degrades to "unknown".
+	conclusiveOnDarwin  bool
+	conclusiveElsewhere bool
+}
+
+// agentRuntimeProbes maps the lowercased agent type name to its probe.
+// Agent types not listed here (and future ones) default to "unknown".
+var agentRuntimeProbes = map[string]agentRuntimeProbeSpec{
+	"claude code": {
+		commands:            []string{"claude"},
+		conclusiveOnDarwin:  true,
+		conclusiveElsewhere: true,
+	},
+	"claude desktop": {
+		appBundles:         []string{"Claude.app"},
+		conclusiveOnDarwin: true,
+	},
+	"cursor": {
+		commands:           []string{"cursor"},
+		appBundles:         []string{"Cursor.app"},
+		conclusiveOnDarwin: true,
+	},
+	"windsurf": {
+		commands:           []string{"windsurf"},
+		appBundles:         []string{"Windsurf.app"},
+		conclusiveOnDarwin: true,
+	},
+	// VS Code ships as many parseable-config variants (Code, Insiders,
+	// VSCodium, OSS builds); a miss is never conclusive.
+	"vscode / copilot": {
+		commands: []string{"code", "code-insiders", "codium"},
+		appBundles: []string{
+			"Visual Studio Code.app",
+			"Visual Studio Code - Insiders.app",
+			"VSCodium.app",
+		},
+	},
+	"gemini cli": {
+		commands:            []string{"gemini"},
+		conclusiveOnDarwin:  true,
+		conclusiveElsewhere: true,
+	},
+	"opencode": {
+		commands:            []string{"opencode"},
+		conclusiveOnDarwin:  true,
+		conclusiveElsewhere: true,
+	},
+	"codex cli": {
+		commands:            []string{"codex"},
+		conclusiveOnDarwin:  true,
+		conclusiveElsewhere: true,
+	},
+	"openclaw": {
+		commands:            []string{"openclaw"},
+		conclusiveOnDarwin:  true,
+		conclusiveElsewhere: true,
+	},
+	"hermes": {
+		commands:            []string{"hermes"},
+		conclusiveOnDarwin:  true,
+		conclusiveElsewhere: true,
+	},
+	// Antigravity: the IDE installs an /Applications bundle on macOS and the
+	// `antigravity` launcher (plus the `agy` CLI, also under ~/.local/bin,
+	// which resolveRuntimeExecutable probes) elsewhere.
+	"antigravity": {
+		commands:            []string{"agy", "antigravity"},
+		appBundles:          []string{"Antigravity.app"},
+		conclusiveOnDarwin:  true,
+		conclusiveElsewhere: true,
+	},
+	// Devin's local surface varies (CLI vs. desktop app); a miss is not
+	// conclusive.
+	"devin": {
+		commands:   []string{"devin"},
+		appBundles: []string{"Devin.app"},
+	},
+}
+
+// runtimeExecutableProbe resolves a runtime command. Overridable in tests.
+var runtimeExecutableProbe = resolveRuntimeExecutable
+
+// appBundleProbe reports whether a macOS app bundle exists, returning the
+// resolved path. Overridable in tests.
+var appBundleProbe = defaultAppBundleProbe
+
+func defaultAppBundleProbe(bundleName string) (string, bool) {
+	searchDirs := []string{"/Applications"}
+	if home, err := os.UserHomeDir(); err == nil {
+		searchDirs = append(searchDirs, filepath.Join(home, "Applications"))
+	}
+	for _, dir := range searchDirs {
+		candidate := filepath.Join(dir, bundleName)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+// detectAgentRuntimeState probes for the agent's runtime and returns its
+// state plus a short human-readable detail.
+func detectAgentRuntimeState(agent AgentConfig) (agentRuntimeState, string) {
+	spec, ok := agentRuntimeProbes[strings.ToLower(strings.TrimSpace(agent.Name))]
+	if !ok {
+		return agentRuntimeStateUnknown, "runtime presence is not detectable for this agent type"
+	}
+	for _, command := range spec.commands {
+		if path, err := runtimeExecutableProbe(command); err == nil {
+			return agentRuntimeStatePresent, fmt.Sprintf("%s found at %s", command, path)
+		}
+	}
+	if runtime.GOOS == "darwin" {
+		for _, bundle := range spec.appBundles {
+			if path, found := appBundleProbe(bundle); found {
+				return agentRuntimeStatePresent, fmt.Sprintf("app bundle found at %s", path)
+			}
+		}
+	}
+
+	conclusive := spec.conclusiveElsewhere
+	if runtime.GOOS == "darwin" {
+		conclusive = spec.conclusiveOnDarwin
+	}
+	if !conclusive {
+		return agentRuntimeStateUnknown, "runtime presence could not be reliably determined on this platform"
+	}
+	return agentRuntimeStateMissing, describeRuntimeProbeMiss(spec)
+}
+
+func describeRuntimeProbeMiss(spec agentRuntimeProbeSpec) string {
+	var looked []string
+	for _, command := range spec.commands {
+		looked = append(looked, "`"+command+"` on PATH or known install locations")
+	}
+	if runtime.GOOS == "darwin" {
+		for _, bundle := range spec.appBundles {
+			looked = append(looked, bundle+" in /Applications")
+		}
+	}
+	if len(looked) == 0 {
+		return "no runtime found"
+	}
+	return "looked for " + strings.Join(looked, ", ")
+}
+
+// withDetectedRuntimeState stamps the detected runtime state onto the agent.
+func withDetectedRuntimeState(agent AgentConfig) AgentConfig {
+	state, detail := detectAgentRuntimeState(agent)
+	agent.RuntimeState = string(state)
+	agent.RuntimeDetail = detail
+	return agent
+}
+
+// resolvedAgentRuntimeState returns the agent's stamped runtime state,
+// detecting it on the spot when the agent did not pass through discovery
+// stamping.
+func resolvedAgentRuntimeState(agent AgentConfig) agentRuntimeState {
+	if state := strings.TrimSpace(agent.RuntimeState); state != "" {
+		return agentRuntimeState(state)
+	}
+	state, _ := detectAgentRuntimeState(agent)
+	return state
+}
+
+// agentRuntimeMissing reports whether the agent is reliably config-only
+// (runtime uninstalled). Unknown is treated as present.
+func agentRuntimeMissing(agent AgentConfig) bool {
+	return resolvedAgentRuntimeState(agent) == agentRuntimeStateMissing
+}
+
+// agentRuntimeListingLabel renders the runtime state for the discovery
+// listing; empty when there is nothing worth flagging.
+func agentRuntimeListingLabel(agent AgentConfig) string {
+	if resolvedAgentRuntimeState(agent) != agentRuntimeStateMissing {
+		return ""
+	}
+	detail := strings.TrimSpace(agent.RuntimeDetail)
+	if detail == "" {
+		return runtimeMissingListingLabel
+	}
+	return fmt.Sprintf("%s (%s)", runtimeMissingListingLabel, detail)
+}
+
+// splitRuntimeMissingCandidates partitions onboarding candidates into usable
+// agents and config-only agents (runtime reliably missing).
+func splitRuntimeMissingCandidates(candidates []AgentConfig) (usable, configOnly []AgentConfig) {
+	for _, agent := range candidates {
+		if agentRuntimeMissing(agent) {
+			configOnly = append(configOnly, agent)
+			continue
+		}
+		usable = append(usable, agent)
+	}
+	return usable, configOnly
+}
+
+// printRuntimeMissingOnboardingSkips explains why config-only agents are left
+// out of a discover/onboard batch and how to onboard them deliberately.
+func printRuntimeMissingOnboardingSkips(writer io.Writer, configOnly []AgentConfig) {
+	for _, agent := range configOnly {
+		fmt.Fprintf( //nolint:errcheck
+			writer,
+			"  Skipping %s: %s — run `preloop agents onboard %s` to onboard it anyway.\n",
+			resolveAgentDisplayName(agent),
+			runtimeMissingListingLabel,
+			shellQuoteAgentName(resolveAgentDisplayName(agent)),
+		)
+	}
+}
+
+// printRuntimeMissingOnboardingWarning is the explicit-onboard warning for a
+// config-only agent: onboarding proceeds (managed config is written now), but
+// the agent cannot use it until its runtime is reinstalled.
+func printRuntimeMissingOnboardingWarning(writer io.Writer, agent AgentConfig) {
+	if !agentRuntimeMissing(agent) {
+		return
+	}
+	detail := strings.TrimSpace(agent.RuntimeDetail)
+	if detail == "" {
+		_, detail = detectAgentRuntimeState(agent)
+	}
+	fmt.Fprintf( //nolint:errcheck
+		writer,
+		"Warning: %s — %s. Onboarding will write the managed config now, but %s cannot use it until its runtime is reinstalled.\n",
+		runtimeMissingListingLabel,
+		detail,
+		resolveAgentDisplayName(agent),
+	)
+}

--- a/cli/internal/cmd/agents_runtime_presence_test.go
+++ b/cli/internal/cmd/agents_runtime_presence_test.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// stubRuntimeProbes overrides the executable and app-bundle probes for the
+// duration of the test. found maps command/bundle names to their fake paths;
+// anything absent is reported as not found.
+func stubRuntimeProbes(t *testing.T, found map[string]string) {
+	t.Helper()
+	originalExecutable := runtimeExecutableProbe
+	originalBundle := appBundleProbe
+	runtimeExecutableProbe = func(command string) (string, error) {
+		if path, ok := found[command]; ok {
+			return path, nil
+		}
+		return "", fmt.Errorf("executable file %q not found", command)
+	}
+	appBundleProbe = func(bundle string) (string, bool) {
+		path, ok := found[bundle]
+		return path, ok
+	}
+	t.Cleanup(func() {
+		runtimeExecutableProbe = originalExecutable
+		appBundleProbe = originalBundle
+	})
+}
+
+func TestDetectAgentRuntimeStateFindsExecutable(t *testing.T) {
+	stubRuntimeProbes(t, map[string]string{"claude": "/usr/local/bin/claude"})
+	state, detail := detectAgentRuntimeState(AgentConfig{Name: "Claude Code"})
+	if state != agentRuntimeStatePresent {
+		t.Fatalf("expected present, got %s (%s)", state, detail)
+	}
+	if !strings.Contains(detail, "/usr/local/bin/claude") {
+		t.Fatalf("expected resolved path in detail, got %q", detail)
+	}
+}
+
+func TestDetectAgentRuntimeStateMarksUninstalledCLIAgentMissing(t *testing.T) {
+	stubRuntimeProbes(t, nil)
+	// Antigravity is the reported case: config files left behind after the
+	// runtime was uninstalled.
+	state, detail := detectAgentRuntimeState(AgentConfig{Name: "Antigravity"})
+	if state != agentRuntimeStateMissing {
+		t.Fatalf("expected missing, got %s (%s)", state, detail)
+	}
+	if !strings.Contains(detail, "agy") {
+		t.Fatalf("expected searched locations in detail, got %q", detail)
+	}
+}
+
+func TestDetectAgentRuntimeStateGUIAppBundle(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("app bundle probing is darwin-only")
+	}
+	stubRuntimeProbes(t, map[string]string{"Claude.app": "/Applications/Claude.app"})
+	state, detail := detectAgentRuntimeState(AgentConfig{Name: "Claude Desktop"})
+	if state != agentRuntimeStatePresent {
+		t.Fatalf("expected present, got %s (%s)", state, detail)
+	}
+}
+
+func TestDetectAgentRuntimeStateGUIAppMissDependsOnPlatform(t *testing.T) {
+	stubRuntimeProbes(t, nil)
+	state, detail := detectAgentRuntimeState(AgentConfig{Name: "Claude Desktop"})
+	if runtime.GOOS == "darwin" {
+		if state != agentRuntimeStateMissing {
+			t.Fatalf("expected missing on darwin, got %s (%s)", state, detail)
+		}
+	} else if state != agentRuntimeStateUnknown {
+		t.Fatalf("expected unknown off darwin, got %s (%s)", state, detail)
+	}
+}
+
+func TestDetectAgentRuntimeStateUnreliableProbesReportUnknown(t *testing.T) {
+	stubRuntimeProbes(t, nil)
+	for _, name := range []string{"VSCode / Copilot", "Devin", "Some Future Agent"} {
+		state, detail := detectAgentRuntimeState(AgentConfig{Name: name})
+		if state != agentRuntimeStateUnknown {
+			t.Fatalf("expected unknown for %s, got %s (%s)", name, state, detail)
+		}
+	}
+}
+
+func TestSplitRuntimeMissingCandidatesTreatsUnknownAsUsable(t *testing.T) {
+	candidates := []AgentConfig{
+		{Name: "Claude Code", RuntimeState: string(agentRuntimeStatePresent)},
+		{Name: "Antigravity", RuntimeState: string(agentRuntimeStateMissing)},
+		{Name: "Devin", RuntimeState: string(agentRuntimeStateUnknown)},
+	}
+	usable, configOnly := splitRuntimeMissingCandidates(candidates)
+	if len(usable) != 2 || usable[0].Name != "Claude Code" || usable[1].Name != "Devin" {
+		t.Fatalf("expected present+unknown agents usable, got %#v", usable)
+	}
+	if len(configOnly) != 1 || configOnly[0].Name != "Antigravity" {
+		t.Fatalf("expected only the missing-runtime agent excluded, got %#v", configOnly)
+	}
+}
+
+func TestAgentRuntimeListingLabelOnlyFlagsMissing(t *testing.T) {
+	missing := AgentConfig{
+		Name:          "Antigravity",
+		RuntimeState:  string(agentRuntimeStateMissing),
+		RuntimeDetail: "looked for `agy` on PATH or known install locations",
+	}
+	label := agentRuntimeListingLabel(missing)
+	if !strings.Contains(label, runtimeMissingListingLabel) || !strings.Contains(label, "agy") {
+		t.Fatalf("expected missing label with detail, got %q", label)
+	}
+	present := AgentConfig{Name: "Claude Code", RuntimeState: string(agentRuntimeStatePresent)}
+	if got := agentRuntimeListingLabel(present); got != "" {
+		t.Fatalf("expected no runtime label for present agent, got %q", got)
+	}
+}
+
+func TestPrintRuntimeMissingOnboardingSkips(t *testing.T) {
+	output := &bytes.Buffer{}
+	printRuntimeMissingOnboardingSkips(output, []AgentConfig{
+		{Name: "Antigravity", RuntimeState: string(agentRuntimeStateMissing)},
+	})
+	rendered := output.String()
+	if !strings.Contains(rendered, "Skipping Antigravity: "+runtimeMissingListingLabel) {
+		t.Fatalf("expected skip notice, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "preloop agents onboard Antigravity") {
+		t.Fatalf("expected explicit onboarding hint, got %q", rendered)
+	}
+}
+
+func TestPrintRuntimeMissingOnboardingWarning(t *testing.T) {
+	output := &bytes.Buffer{}
+	printRuntimeMissingOnboardingWarning(output, AgentConfig{
+		Name:          "Antigravity",
+		RuntimeState:  string(agentRuntimeStateMissing),
+		RuntimeDetail: "looked for `agy` on PATH or known install locations",
+	})
+	rendered := output.String()
+	if !strings.Contains(rendered, runtimeMissingListingLabel) ||
+		!strings.Contains(rendered, "reinstalled") {
+		t.Fatalf("expected config-only warning, got %q", rendered)
+	}
+
+	quiet := &bytes.Buffer{}
+	printRuntimeMissingOnboardingWarning(quiet, AgentConfig{
+		Name:         "Claude Code",
+		RuntimeState: string(agentRuntimeStatePresent),
+	})
+	if quiet.Len() != 0 {
+		t.Fatalf("expected no warning for present runtime, got %q", quiet.String())
+	}
+}

--- a/cli/internal/cmd/agents_test.go
+++ b/cli/internal/cmd/agents_test.go
@@ -125,6 +125,41 @@ func TestPrintAgentOnboardingFailuresReportsRecordedFailures(t *testing.T) {
 	}
 }
 
+func TestFailureFootersPointAtTroubleshootingDocs(t *testing.T) {
+	t.Run("summary with a failed agent links the docs once", func(t *testing.T) {
+		var output bytes.Buffer
+		printAgentOnboardingSummary(&output, []agentOnboardingOutcome{
+			{Agent: AgentConfig{Name: "Codex CLI"}, Status: agentOnboardingStatusOnboarded},
+			{Agent: AgentConfig{Name: "Gemini CLI"}, Status: agentOnboardingStatusFailed, Reason: "boom"},
+		})
+		if strings.Count(output.String(), troubleshootingDocsURL) != 1 {
+			t.Fatalf("expected exactly one troubleshooting link, got:\n%s", output.String())
+		}
+	})
+
+	t.Run("fully successful summary stays clean", func(t *testing.T) {
+		var output bytes.Buffer
+		printAgentOnboardingSummary(&output, []agentOnboardingOutcome{
+			{Agent: AgentConfig{Name: "Codex CLI"}, Status: agentOnboardingStatusOnboarded},
+			{Agent: AgentConfig{Name: "Gemini CLI"}, Status: agentOnboardingStatusPartial, Reason: "launcher skipped"},
+		})
+		if strings.Contains(output.String(), troubleshootingDocsURL) {
+			t.Fatalf("expected no troubleshooting link without failures, got:\n%s", output.String())
+		}
+	})
+
+	t.Run("batch failure report links the docs once", func(t *testing.T) {
+		var output bytes.Buffer
+		printAgentOnboardingFailures(&output, []agentOnboardingFailure{
+			{Agent: AgentConfig{Name: "Codex CLI"}, Err: fmt.Errorf("boom")},
+			{Agent: AgentConfig{Name: "Gemini CLI"}, Err: fmt.Errorf("also boom")},
+		})
+		if strings.Count(output.String(), troubleshootingDocsURL) != 1 {
+			t.Fatalf("expected exactly one troubleshooting link, got:\n%s", output.String())
+		}
+	})
+}
+
 func TestResolveManagedAgentExecutablePathUsesNVMFallback(t *testing.T) {
 	skipManagedLauncherOnWindows(t, "resolving an agent binary from the nvm fallback path")
 	home := t.TempDir()

--- a/cli/internal/cmd/agents_test.go
+++ b/cli/internal/cmd/agents_test.go
@@ -1813,6 +1813,46 @@ func TestPromptForApprovalsOptIn(t *testing.T) {
 	})
 }
 
+func TestShouldPromptForEnrollmentName(t *testing.T) {
+	cases := []struct {
+		name string
+		opts managedEnrollmentOptions
+		want bool
+	}{
+		{
+			name: "interactive single-agent onboard prompts once",
+			opts: managedEnrollmentOptions{},
+			want: true,
+		},
+		{
+			name: "auto-approve never prompts",
+			opts: managedEnrollmentOptions{AutoApprove: true},
+			want: false,
+		},
+		{
+			name: "skip-confirmation never prompts",
+			opts: managedEnrollmentOptions{SkipConfirmation: true},
+			want: false,
+		},
+		{
+			// Regression: the discover/onboard batch loops prepare the agent
+			// (name prompt) before calling executeManagedEnrollment; the
+			// enrollment must not ask for the agent name a second time even
+			// when its own confirmation prompts stay interactive.
+			name: "already-prepared agent is not re-prompted",
+			opts: managedEnrollmentOptions{AgentPrepared: true},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldPromptForEnrollmentName(tc.opts); got != tc.want {
+				t.Fatalf("shouldPromptForEnrollmentName(%+v) = %v, want %v", tc.opts, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestPrepareAgentForEnrollment_AllowsEditingAgentName(t *testing.T) {
 	agent, err := prepareAgentForEnrollment(
 		bufio.NewReader(strings.NewReader("Octavia\n")),

--- a/cli/internal/cmd/urls.go
+++ b/cli/internal/cmd/urls.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/preloop/preloop/cli/internal/config"
@@ -13,4 +14,16 @@ func resolveConfiguredAPIURL() (string, error) {
 		return "", fmt.Errorf("failed to load config: %w", err)
 	}
 	return strings.TrimRight(cfg.APIURL, "/"), nil
+}
+
+// troubleshootingDocsURL is the docs page linked from onboarding/validation
+// failure output.
+const troubleshootingDocsURL = "https://docs.preloop.ai/troubleshooting/"
+
+// printTroubleshootingFooter prints the single line pointing at the
+// troubleshooting docs. It belongs at the end of a command's failure output —
+// the onboarding failure summaries and terminal failure paths call it at most
+// once per command run; it must not be attached to every individual error.
+func printTroubleshootingFooter(w io.Writer) {
+	fmt.Fprintf(w, "Troubleshooting guide: %s\n", troubleshootingDocsURL) //nolint:errcheck
 }


### PR DESCRIPTION
Four onboarding UX fixes reported by an external tester using `preloop signup` (Preloop Cloud) + `preloop agents discover`. One commit per fix.

## 1. Agent name asked twice (`9894c7c`)
Interactive `preloop agents onboard` (no args) prompted for the display name in `promptToOnboardCandidates` (via `prepareAgentForEnrollment`) and then a second time inside `executeManagedEnrollment`, which re-ran `prepareAgentForEnrollment` because `SkipConfirmation` stays false on the interactive path. New `managedEnrollmentOptions.AgentPrepared` flag + `shouldPromptForEnrollmentName` gate: batch loops that already prepared the agent suppress the in-enrollment prompt; the entered name threads through unchanged. Single-agent `onboard <name>` still asks once.

## 2. Stale-config agents offered for onboarding (`1895f40`)
Uninstalled agents with leftover config (the tester's Google Antigravity case) looked identical to installed ones. New per-agent runtime-presence probe table (`agents_runtime_presence.go`): executables via the existing `resolveRuntimeExecutable` PATH+fallback search, `/Applications` bundles for GUI apps on macOS; classification present / missing / unknown, where unreliable probes (VS Code variants, GUI apps off macOS, Devin, unknown agent types) report unknown and are treated as present. Config-only agents are flagged in discover output ("config found, runtime not installed"), skipped by all batch flows (interactive, `--yes`, `--all`) with a printed hint, and still explicitly onboardable with an upfront warning. Smoke-tested on a real machine: correctly caught two genuine config-only leftovers (OpenClaw, Windsurf) and recognized installed GUI apps.

## 3. Validate-first onboarding tiers (`597dad1`)
Batch onboarding now runs verified-model-routing agents first (reusing `supportLevelForAgent`, `resolveManagedGatewayUpstream`/`CanRouteThroughGateway`, `serverHasReusableGatewayCredential`, and the OpenClaw auth-state preflight — no new validation path). The MCP-only/unverified tier follows a printed explanation with per-agent reasons; interactive flows then ask per agent ("Onboard anyway?"), while `--yes`/`--all` keep onboarding everything, ordered working-first. Deferred live validation is unchanged.

## 4. Troubleshooting link on failure (`cba547e`)
`printTroubleshootingFooter` prints `https://docs.preloop.ai/troubleshooting/` once per command run: batch summary when any agent failed, `--all` failure report, single-agent onboard failure, and `agents validate` failure. Per-agent error lines stay footer-free.

## Testing
- `go build ./... && go test ./...` green (all packages)
- `gofmt -l` clean on changed files
- New tests: name-prompt gating, runtime-presence detection/partition/labels/warnings, tier partition + tiered prompting (auto-approve ordering and interactive two-step), troubleshooting footer once/absent.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI onboarding UX refinements only; no server-side changes, no new validation paths, no database or API contract changes. All additions are additive with well-tested safety guards (unknown runtime state treated as present, nil-safe credential checks).
>
> **Overview**
> Four tightly-scoped UX fixes for the CLI onboarding flow: eliminates a duplicate name prompt, detects stale config-only agents that should not be silently onboarded, orders batch onboarding by verified-model-routing tier, and adds a troubleshooting link on failure outputs. One inline nit about a misleading code comment.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 9894c7c..cba547e. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->