### PR TITLE
fix(cli): stdio mcp-remote bridge for Claude Desktop onboarding

### DIFF
--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -202,6 +202,11 @@ func isDevinAgent(agent AgentConfig) bool {
 	return strings.EqualFold(strings.TrimSpace(agent.Name), devinAgentName)
 }
 
+// isClaudeDesktopAgent reports whether the agent is the Claude Desktop app.
+func isClaudeDesktopAgent(agent AgentConfig) bool {
+	return strings.EqualFold(strings.TrimSpace(agent.Name), "claude desktop")
+}
+
 // mcpOnlyAgentModelNote returns a clear, agent-specific note explaining why
 // an agent is onboarded for tool-call governance only and its model traffic
 // is not routed through the Preloop gateway. These agents either expose no
@@ -642,7 +647,12 @@ type managedMCPEnrollmentPlan struct {
 	ManagedControlWSURL string
 	ManagedModelAlias   string
 	ManagedProviderName string
-	Notes               []string
+	// MCPConfigSkipped is set when the plan deliberately writes no managed
+	// Preloop MCP entry (currently only Claude Desktop when the npx/node
+	// runtime for the mcp-remote stdio bridge is missing). The reason and
+	// the user's options are carried in Notes.
+	MCPConfigSkipped bool
+	Notes            []string
 }
 
 type remoteServerSyncResult struct {
@@ -3205,7 +3215,11 @@ func printEnrollmentPlan(plan managedMCPEnrollmentPlan, dryRun bool) {
 	fmt.Printf("%s managed MCP onboarding for %s\n", mode, resolveAgentDisplayName(plan.Agent))
 	fmt.Printf("  Agent type: %s\n", plan.Agent.Name)
 	fmt.Printf("  Config: %s\n", plan.Agent.ConfigPath)
-	fmt.Printf("  Managed server: %s -> %s\n", plan.ManagedServerName, plan.ManagedServerURL)
+	if plan.MCPConfigSkipped {
+		fmt.Printf("  Managed server: skipped — npx/Node.js not found (see notes)\n")
+	} else {
+		fmt.Printf("  Managed server: %s -> %s\n", plan.ManagedServerName, plan.ManagedServerURL)
+	}
 	if plan.ManagedControlWSURL != "" {
 		fmt.Printf("  Agent Control config target: %s\n", plan.ManagedControlWSURL)
 		fmt.Println("  Agent Control runtime plugin: install/verify when supported")
@@ -3223,6 +3237,56 @@ func printEnrollmentPlan(plan managedMCPEnrollmentPlan, dryRun bool) {
 		// print via a dedicated helper so taint from companion return
 		// values in upstream resolvers does not flow into logging sinks.
 		fmt.Printf("  Note: %s\n", publicPlanNote(note))
+	}
+}
+
+// resolveClaudeDesktopBridgeRuntime is a package-level seam for tests (in the
+// style of resolveNpmExecutable). The managed Claude Desktop entry launches
+// the mcp-remote stdio bridge via npx, so onboarding must not write it when
+// the runtime is missing: Claude Desktop's config file cannot express a
+// remote url/headers server, and an entry whose command cannot start (or the
+// remote shape itself) can wedge the app's whole MCP subsystem.
+var resolveClaudeDesktopBridgeRuntime = func() error {
+	if _, err := resolveRuntimeExecutable("npx"); err != nil {
+		return fmt.Errorf("npx is not available on PATH: %w", err)
+	}
+	// npx ships with Node.js, but probe node too so a broken partial
+	// install does not produce a bridge entry that can never start.
+	if _, err := resolveRuntimeExecutable("node"); err != nil {
+		return fmt.Errorf("node is not available on PATH: %w", err)
+	}
+	return nil
+}
+
+// claudeDesktopBridgeSkippedNote explains why no Preloop MCP entry was
+// written for Claude Desktop and what the user can do about it.
+func claudeDesktopBridgeSkippedNote(mcpURL string) string {
+	return "Skipped writing the Preloop MCP entry for Claude Desktop: the entry " +
+		"runs the mcp-remote bridge via npx, and npx (Node.js) was not found on " +
+		"PATH. Claude Desktop's config file only supports stdio MCP servers, so " +
+		"a remote URL entry cannot be written instead. Your options: install " +
+		"Node.js (https://nodejs.org) and re-run onboarding, or add Preloop as a " +
+		"custom connector in Claude Desktop under Settings → Connectors using " +
+		"the MCP URL " + mcpURL + " (Preloop's MCP endpoint supports the OAuth " +
+		"flow MCP clients use)."
+}
+
+// stringArgsFromConfigValue coerces a config `args` value — []string when
+// freshly built, []interface{} after a JSON round-trip — into []string.
+func stringArgsFromConfigValue(value interface{}) []string {
+	switch typed := value.(type) {
+	case []string:
+		return typed
+	case []interface{}:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
 	}
 }
 
@@ -3248,7 +3312,20 @@ func buildManagedMCPEnrollmentPlan(agent AgentConfig, baseURL, token string) (ma
 		return managedMCPEnrollmentPlan{}, err
 	}
 	removedPreloopServers := prunePreloopOwnedMCPServersFromDocument(managedDoc)
-	container["preloop"] = adapter.BuildManagedServer(baseURL, token)
+	mcpConfigSkipped := false
+	if isClaudeDesktopAgent(agent) {
+		if runtimeErr := resolveClaudeDesktopBridgeRuntime(); runtimeErr != nil {
+			// Without npx/node the mcp-remote bridge cannot start, and no
+			// other shape is writable (Claude Desktop's config file cannot
+			// express remote servers). Write no Preloop entry at all — the
+			// prune above still cleans up any broken entry from an earlier
+			// onboard — and tell the user their options in the notes.
+			mcpConfigSkipped = true
+		}
+	}
+	if !mcpConfigSkipped {
+		container["preloop"] = adapter.BuildManagedServer(baseURL, token)
+	}
 	ensureLegacyCodexMCPServer(agent, managedDoc, baseURL, token)
 	if supportsAgentControlChannel(agent) {
 		applyAgentControlConfigToDocument(
@@ -3277,6 +3354,12 @@ func buildManagedMCPEnrollmentPlan(agent AgentConfig, baseURL, token string) (ma
 	sanitizeConfigSnapshot(sanitizedManaged)
 
 	notes := []string{}
+	if mcpConfigSkipped {
+		notes = append(
+			notes,
+			claudeDesktopBridgeSkippedNote(strings.TrimRight(baseURL, "/")+"/mcp/v1"),
+		)
+	}
 	if len(removedPreloopServers) > 0 {
 		notes = append(
 			notes,
@@ -3301,6 +3384,7 @@ func buildManagedMCPEnrollmentPlan(agent AgentConfig, baseURL, token string) (ma
 		ManagedServerName:   "preloop",
 		ManagedServerURL:    strings.TrimRight(baseURL, "/") + "/mcp/v1",
 		ManagedControlWSURL: controlWSURL,
+		MCPConfigSkipped:    mcpConfigSkipped,
 		Notes:               notes,
 	}, nil
 }
@@ -4364,6 +4448,30 @@ func (a genericManagedMCPAdapter) BuildManagedServer(baseURL, token string) map[
 				"Authorization": "Bearer " + token,
 			},
 		}
+	case "claude desktop":
+		// claude_desktop_config.json only supports stdio servers
+		// (command/args/env); remote HTTP servers are added through the
+		// app's Settings → Connectors UI, never through this file. A
+		// url/headers entry here is invalid and can wedge Claude Desktop's
+		// entire MCP subsystem (observed on older builds). Bridge to the
+		// remote endpoint with mcp-remote instead. The Authorization header
+		// is split into a space-free "Authorization:${AUTH_HEADER}" arg
+		// plus an env block because Claude Desktop mangles spaces inside
+		// args on some versions — this is the workaround documented in the
+		// mcp-remote README ("note no spaces around ':'").
+		return map[string]interface{}{
+			"command": "npx",
+			"args": []interface{}{
+				"-y",
+				"mcp-remote",
+				url,
+				"--header",
+				"Authorization:${AUTH_HEADER}",
+			},
+			"env": map[string]interface{}{
+				"AUTH_HEADER": "Bearer " + token,
+			},
+		}
 	default:
 		transport := "http-streaming"
 		if usesNestedMCPServers(a.agent) {
@@ -4440,6 +4548,54 @@ func (a genericManagedMCPAdapter) ValidateManagedConfig(doc map[string]interface
 				result["authorization_header_ok"] = true
 			}
 		}
+	}
+	if isClaudeDesktopAgent(a.agent) {
+		// The managed Claude Desktop entry is an mcp-remote stdio bridge
+		// (command/args/env), not a remote url/headers entry — Claude
+		// Desktop cannot read the remote shape from its config file at all.
+		// Validate the bridge shape and deliberately reject the legacy
+		// url/headers form this override replaces: preloop_url_ok requires
+		// the endpoint URL inside args, transport_ok requires npx +
+		// mcp-remote, and authorization_header_ok requires the --header
+		// Authorization arg (env-indirected or literal bearer).
+		command, _ := preloop["command"].(string)
+		args := stringArgsFromConfigValue(preloop["args"])
+		bridgeCommandOK := strings.EqualFold(
+			filepath.Base(strings.TrimSpace(command)),
+			"npx",
+		)
+		bridgeArgOK := false
+		bridgeURLOK := false
+		headerArg := ""
+		for i, arg := range args {
+			switch strings.TrimSpace(arg) {
+			case "mcp-remote":
+				bridgeArgOK = true
+			case expectedURL:
+				bridgeURLOK = true
+			case "--header":
+				if i+1 < len(args) {
+					headerArg = strings.TrimSpace(args[i+1])
+				}
+			}
+		}
+		bridgeAuthOK := false
+		if value, ok := strings.CutPrefix(headerArg, "Authorization:"); ok {
+			if strings.Contains(value, "${AUTH_HEADER}") {
+				if env, ok := asObjectMap(preloop["env"]); ok {
+					if raw, ok := env["AUTH_HEADER"].(string); ok &&
+						strings.HasPrefix(strings.TrimSpace(raw), "Bearer ") {
+						bridgeAuthOK = true
+					}
+				}
+			} else if strings.HasPrefix(strings.TrimSpace(value), "Bearer ") {
+				bridgeAuthOK = true
+			}
+		}
+		result["bridge_command_ok"] = bridgeCommandOK && bridgeArgOK
+		result["preloop_url_ok"] = bridgeURLOK
+		result["transport_ok"] = bridgeCommandOK && bridgeArgOK
+		result["authorization_header_ok"] = bridgeAuthOK
 	}
 	result["validation_passed"] =
 		result["preloop_server_present"] == true &&

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -546,7 +546,10 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		}
 	}
 
-	if note := mcpOnlyAgentModelNote(agent); note != "" {
+	// The MCP-only support note claims active MCP-firewall governance, which
+	// would contradict a skipped MCP-config step (Claude Desktop without
+	// npx) — the skip note in plan.Notes already explains that case.
+	if note := mcpOnlyAgentModelNote(agent); note != "" && !plan.MCPConfigSkipped {
 		plan.Notes = append(plan.Notes, note)
 	}
 
@@ -801,6 +804,14 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		validationResult,
 		defaultManagedLiveValidationResult(agent),
 	)
+	if plan.MCPConfigSkipped {
+		// The MCP-config step was deliberately skipped (Claude Desktop
+		// without npx/node for the mcp-remote bridge). Record it so the
+		// enrollment reads as "skipped, here is why", not as a silent
+		// validation failure.
+		validationResult["mcp_config_skipped"] = true
+		validationResult["mcp_config_skip_reason"] = "npx (Node.js) not found on PATH"
+	}
 
 	appliedAt := timeNowUTC()
 	enrollment, err := createManagedEnrollmentRecord(
@@ -984,6 +995,13 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 	onboardingState := onboardingStateFromValidation(validationResult)
 	fmt.Printf("  Onboarding mode: %s\n", onboardingStateLabel(onboardingState))
 	fmt.Printf("  Routing: %s\n", onboardingStateNote(onboardingState))
+	if plan.MCPConfigSkipped {
+		fmt.Printf("  MCP config: skipped\n")
+		fmt.Printf(
+			"  Note: %s\n",
+			publicPlanNote(claudeDesktopBridgeSkippedNote(plan.ManagedServerURL)),
+		)
+	}
 	if supportsAgentControlChannel(agent) {
 		fmt.Printf("  Agent Control config: %s\n", boolStatus(validationResult["control_config_written"]))
 		fmt.Printf("  Agent Control runtime plugin: %s\n", agentControlPluginStatus(validationResult))

--- a/cli/internal/cmd/agents_test.go
+++ b/cli/internal/cmd/agents_test.go
@@ -2626,6 +2626,166 @@ func TestManagedServerSchemaDevin(t *testing.T) {
 	}
 }
 
+// TestManagedServerSchemaClaudeDesktop asserts the Claude Desktop MCP entry
+// is an mcp-remote stdio bridge (command/args/env) — never a remote
+// url/headers entry, which claude_desktop_config.json cannot express and
+// which can wedge the app's MCP subsystem — and that a freshly built entry
+// round-trips through ValidateManagedConfig.
+func TestManagedServerSchemaClaudeDesktop(t *testing.T) {
+	adapter := managedMCPAdapterForAgent(AgentConfig{Name: "Claude Desktop"})
+	entry := adapter.BuildManagedServer("https://preloop.example", "durable-token")
+	if entry["command"] != "npx" {
+		t.Fatalf("expected npx bridge command for Claude Desktop, got %#v", entry)
+	}
+	for _, forbidden := range []string{"url", "transport", "headers"} {
+		if _, has := entry[forbidden]; has {
+			t.Fatalf("Claude Desktop entry must not carry %q (remote shape), got %#v", forbidden, entry)
+		}
+	}
+	args := stringArgsFromConfigValue(entry["args"])
+	expectedArgs := []string{
+		"-y",
+		"mcp-remote",
+		"https://preloop.example/mcp/v1",
+		"--header",
+		"Authorization:${AUTH_HEADER}",
+	}
+	if len(args) != len(expectedArgs) {
+		t.Fatalf("unexpected bridge args: %#v", args)
+	}
+	for i, expected := range expectedArgs {
+		if args[i] != expected {
+			t.Fatalf("bridge arg %d: expected %q, got %q (full: %#v)", i, expected, args[i], args)
+		}
+	}
+	// The Authorization value lives in env (spaces intact) while the arg
+	// stays space-free — the mcp-remote README workaround for Claude
+	// Desktop's arg-space mangling.
+	env, _ := entry["env"].(map[string]interface{})
+	if env["AUTH_HEADER"] != "Bearer durable-token" {
+		t.Fatalf("expected AUTH_HEADER env with bearer token, got %#v", entry)
+	}
+	result := adapter.ValidateManagedConfig(map[string]interface{}{
+		"mcpServers": map[string]interface{}{"preloop": entry},
+	}, "https://preloop.example")
+	if result["validation_passed"] != true {
+		t.Fatalf("expected claude desktop bridge validation to pass, got %+v", result)
+	}
+}
+
+// TestClaudeDesktopValidateAcceptsJSONRoundTrippedBridge ensures validation
+// still passes after the entry has been serialized to disk and reloaded
+// (args become []interface{}).
+func TestClaudeDesktopValidateAcceptsJSONRoundTrippedBridge(t *testing.T) {
+	adapter := managedMCPAdapterForAgent(AgentConfig{Name: "Claude Desktop"})
+	entry := adapter.BuildManagedServer("https://preloop.example", "durable-token")
+	raw, err := json.Marshal(map[string]interface{}{
+		"mcpServers": map[string]interface{}{"preloop": entry},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal document: %v", err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("failed to unmarshal document: %v", err)
+	}
+	result := adapter.ValidateManagedConfig(doc, "https://preloop.example")
+	if result["validation_passed"] != true {
+		t.Fatalf("expected round-tripped bridge validation to pass, got %+v", result)
+	}
+}
+
+// TestClaudeDesktopValidateRejectsLegacyRemoteShape ensures the remote
+// url/headers shape that bricked Claude Desktop is treated as invalid.
+func TestClaudeDesktopValidateRejectsLegacyRemoteShape(t *testing.T) {
+	adapter := managedMCPAdapterForAgent(AgentConfig{Name: "Claude Desktop"})
+	result := adapter.ValidateManagedConfig(map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"preloop": map[string]interface{}{
+				"url":       "https://preloop.example/mcp/v1",
+				"transport": "http",
+				"headers": map[string]interface{}{
+					"Authorization": "Bearer durable-token",
+				},
+			},
+		},
+	}, "https://preloop.example")
+	if result["validation_passed"] != false {
+		t.Fatalf("expected legacy remote shape to fail validation, got %+v", result)
+	}
+	if result["transport_ok"] != false {
+		t.Fatalf("expected transport_ok=false for legacy remote shape, got %+v", result)
+	}
+}
+
+// TestClaudeDesktopPlanWritesBridgeWhenNpxPresent asserts onboarding writes
+// the stdio bridge entry when the npx/node runtime resolves.
+func TestClaudeDesktopPlanWritesBridgeWhenNpxPresent(t *testing.T) {
+	original := resolveClaudeDesktopBridgeRuntime
+	t.Cleanup(func() { resolveClaudeDesktopBridgeRuntime = original })
+	resolveClaudeDesktopBridgeRuntime = func() error { return nil }
+
+	configPath := filepath.Join(t.TempDir(), "claude_desktop_config.json")
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers": {}}`), 0o600); err != nil {
+		t.Fatalf("failed to seed config: %v", err)
+	}
+	agent := AgentConfig{Name: "Claude Desktop", ConfigPath: configPath}
+	plan, err := buildManagedMCPEnrollmentPlan(agent, "https://preloop.example", "durable-token")
+	if err != nil {
+		t.Fatalf("failed to build plan: %v", err)
+	}
+	if plan.MCPConfigSkipped {
+		t.Fatalf("expected MCP config not to be skipped when npx resolves, plan: %+v", plan)
+	}
+	servers, _ := plan.ManagedDocument["mcpServers"].(map[string]interface{})
+	preloop, _ := servers["preloop"].(map[string]interface{})
+	if preloop == nil || preloop["command"] != "npx" {
+		t.Fatalf("expected npx bridge entry in managed document, got %#v", plan.ManagedDocument)
+	}
+}
+
+// TestClaudeDesktopPlanSkipsMCPEntryWhenNpxMissing asserts onboarding writes
+// NO Preloop entry when npx is unavailable (Claude Desktop cannot read a
+// remote fallback shape), prunes any broken entry left by an earlier
+// onboard, and tells the user their options.
+func TestClaudeDesktopPlanSkipsMCPEntryWhenNpxMissing(t *testing.T) {
+	original := resolveClaudeDesktopBridgeRuntime
+	t.Cleanup(func() { resolveClaudeDesktopBridgeRuntime = original })
+	resolveClaudeDesktopBridgeRuntime = func() error {
+		return fmt.Errorf("npx is not available on PATH")
+	}
+
+	configPath := filepath.Join(t.TempDir(), "claude_desktop_config.json")
+	// Seed with the broken remote-shaped entry an earlier CLI version wrote.
+	seed := `{"mcpServers": {"preloop": {"url": "https://old.example/mcp/v1", "transport": "http", "headers": {"Authorization": "Bearer stale"}}}}`
+	if err := os.WriteFile(configPath, []byte(seed), 0o600); err != nil {
+		t.Fatalf("failed to seed config: %v", err)
+	}
+	agent := AgentConfig{Name: "Claude Desktop", ConfigPath: configPath}
+	plan, err := buildManagedMCPEnrollmentPlan(agent, "https://preloop.example", "durable-token")
+	if err != nil {
+		t.Fatalf("failed to build plan: %v", err)
+	}
+	if !plan.MCPConfigSkipped {
+		t.Fatalf("expected MCP config to be skipped without npx, plan: %+v", plan)
+	}
+	servers, _ := plan.ManagedDocument["mcpServers"].(map[string]interface{})
+	if _, has := servers["preloop"]; has {
+		t.Fatalf("expected no preloop entry without npx, got %#v", plan.ManagedDocument)
+	}
+	foundOptionsNote := false
+	for _, note := range plan.Notes {
+		if strings.Contains(note, "Settings → Connectors") &&
+			strings.Contains(note, "Node.js") &&
+			strings.Contains(note, "https://preloop.example/mcp/v1") {
+			foundOptionsNote = true
+		}
+	}
+	if !foundOptionsNote {
+		t.Fatalf("expected a skip note listing user options, got %#v", plan.Notes)
+	}
+}
+
 // TestManagedServerSchemaCodex asserts the Codex MCP entry uses `url` +
 // http_headers (the format Codex actually reads) with no transport field and
 // no [auth] sub-table, and that no-token enrollment falls back to


### PR DESCRIPTION
## Problem

Onboarding wrote a remote-shaped MCP entry (`{url, transport, headers}`) into `claude_desktop_config.json`. Claude Desktop's config file only supports **stdio** servers (`command`/`args`/`env`) — remote servers are added via Settings → Connectors — and the invalid entry can wedge the app's whole MCP subsystem. This bricked an external tester's Claude Desktop (older build, Intel Mac) until they logged out/in.

## Fix (Claude Desktop only; other agents' shapes untouched)

- **Bridge entry**: `BuildManagedServer` now writes the mcp-remote stdio bridge:
  ```json
  {
    "command": "npx",
    "args": ["-y", "mcp-remote", "<url>", "--header", "Authorization:${AUTH_HEADER}"],
    "env": {"AUTH_HEADER": "Bearer <token>"}
  }
  ```
  The header is split into a space-free arg + `env` block, per the mcp-remote README workaround for Claude Desktop mangling spaces in args.
- **Preflight**: when `npx`/`node` is not resolvable, no Preloop entry is written at all (there is no valid fallback shape). The enrollment marks the MCP-config step skipped and tells the user their options: install Node.js and re-run, or add Preloop as a custom connector in Settings → Connectors using the MCP URL (the endpoint supports the MCP OAuth flow). The existing prune still removes any broken remote-shaped entry left by an earlier onboard, so re-running the CLI repairs bricked configs.
- **Validation**: `ValidateManagedConfig` validates the bridge shape for Claude Desktop and rejects the legacy remote shape.
- **Honest output**: onboarding no longer claims MCP-firewall governance when the step was skipped; skip reason is persisted in the enrollment validation result (`mcp_config_skipped`).

## Testing

- 5 new tests: bridge shape + round-trip validation, JSON-reloaded validation, legacy-shape rejection, preflight write and skip paths (via new `resolveClaudeDesktopBridgeRuntime` test seam).
- `go build ./... && go test ./...` green (350 tests in internal/cmd), `gofmt -l` clean.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-structured fix following existing patterns; only affects Claude Desktop onboarding path.
>
> **Overview**
> Replaces the invalid remote-shaped MCP entry in Claude Desktop config with an mcp-remote stdio bridge. Adds preflight checks for Node.js availability, updates validation, and provides clear fallback guidance.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/claude-desktop-mcp-bridge. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->