### PR TITLE
Compact overview dashboard layout

### DIFF
--- a/frontend/src/components/view-header.test.ts
+++ b/frontend/src/components/view-header.test.ts
@@ -36,4 +36,20 @@ describe('ViewHeader', () => {
 
     expect(el.shadowRoot?.querySelector('.description')).to.equal(null);
   });
+
+  it('supports compact metadata beside the page title', async () => {
+    const el = (await fixture(html`
+      <view-header headerText="Overview">
+        <span slot="title-suffix">Last updated just now</span>
+      </view-header>
+    `)) as ViewHeader;
+
+    const suffixSlot = el.shadowRoot?.querySelector<HTMLSlotElement>(
+      'slot[name="title-suffix"]'
+    );
+    expect(suffixSlot).to.exist;
+    expect(suffixSlot?.assignedElements()[0]?.textContent).to.contain(
+      'Last updated just now'
+    );
+  });
 });

--- a/frontend/src/components/view-header.ts
+++ b/frontend/src/components/view-header.ts
@@ -37,6 +37,11 @@ export class ViewHeader extends LitElement {
         color: var(--sl-color-neutral-500);
         font-size: 0.9rem;
       }
+      ::slotted([slot='title-suffix']) {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-small);
+        font-weight: 400;
+      }
     `,
   ];
 
@@ -47,7 +52,9 @@ export class ViewHeader extends LitElement {
           <slot name="top"></slot>
           <div class="header">
             <h1 style="display: flex; align-items: center; gap: 12px;">
-              <slot name="title-prefix"></slot>${this.headerText}
+              <slot name="title-prefix"></slot>${this.headerText}<slot
+                name="title-suffix"
+              ></slot>
             </h1>
             <slot name="main-column"></slot>
           </div>

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -280,10 +280,10 @@ export class DashboardView extends AuthedElement {
       .metrics-grid {
         display: grid;
         grid-template-columns: repeat(5, minmax(0, 1fr));
-        gap: var(--sl-spacing-large);
-        row-gap: var(--sl-spacing-2x-large);
+        gap: var(--sl-spacing-medium);
+        row-gap: var(--sl-spacing-large);
         align-items: start;
-        margin-bottom: var(--sl-spacing-2x-large);
+        margin-bottom: var(--sl-spacing-large);
       }
       .budget-track {
         position: relative;
@@ -646,7 +646,30 @@ export class DashboardView extends AuthedElement {
       .dashboard-stack {
         display: flex;
         flex-direction: column;
-        gap: var(--sl-spacing-large);
+        gap: var(--sl-spacing-medium);
+      }
+
+      .dashboard-pair {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--sl-spacing-medium);
+        align-items: stretch;
+      }
+
+      .dashboard-pair > * {
+        min-width: 0;
+      }
+
+      .dashboard-pair sl-card::part(base) {
+        height: 100%;
+      }
+
+      .dashboard-pair .empty-state {
+        min-height: 72px;
+        padding: var(--sl-spacing-medium);
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
 
       .summary-grid,
@@ -901,6 +924,10 @@ export class DashboardView extends AuthedElement {
         }
       }
       @media (max-width: 800px) {
+        .dashboard-pair {
+          grid-template-columns: 1fr;
+        }
+
         .card-header,
         .card-header-with-action,
         .row-main,
@@ -3966,9 +3993,9 @@ export class DashboardView extends AuthedElement {
 
     return html`
       <view-header headerText="Overview" width="extra-wide">
-        <div class="updated-at" slot="description">
+        <span class="updated-at" slot="title-suffix">
           Last updated ${this.formatLastUpdatedLabel()}
-        </div>
+        </span>
       </view-header>
       <div class="extra-wide" style="margin-bottom: var(--sl-spacing-large);">
         ${
@@ -3979,24 +4006,22 @@ export class DashboardView extends AuthedElement {
         ${this.renderWelcomeCard()}
       </div>
 
-      <div class="column-layout dashboard extra-wide">
-        <div class="main-column">
-          <div class="dashboard-stack">
-            ${this.renderPreloopGatewayCard()}
-            ${this.renderActiveExecutionsCard()}
-            ${this.renderRecentFlowExecutionsCard()}
+      <div class="dashboard-stack extra-wide">
+        ${this.renderPreloopGatewayCard()}
+        ${this.renderPendingApprovalsCard()}
 
-            <div
-              style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--sl-spacing-large); margin-top: var(--sl-spacing-large);"
-            >
-              ${this.renderGatewayFailuresCard()}
-              ${this.renderAuditExceptionsCard()}
-            </div>
-          </div>
+        <div class="dashboard-pair dashboard-pair--activity">
+          ${this.renderActiveExecutionsCard()}
+          ${this.renderRecentFlowExecutionsCard()}
         </div>
 
-        <div class="side-column">
-          ${this.renderPendingApprovalsCard()} ${this.renderBudgetHealthCard()}
+        <div class="dashboard-pair dashboard-pair--exceptions">
+          ${this.renderGatewayFailuresCard()}
+          ${this.renderAuditExceptionsCard()}
+        </div>
+
+        <div class="dashboard-pair dashboard-pair--insights">
+          ${this.renderBudgetHealthCard()}
           ${this.renderTopModelsCard()}
         </div>
         <mcp-setup-dialog

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -487,6 +487,17 @@ describe('DashboardView', () => {
 
     const header = element.shadowRoot?.querySelector('view-header');
     expect(header?.getAttribute('headerText')).to.equal('Overview');
+    expect(
+      header?.querySelector('[slot="title-suffix"]')?.textContent
+    ).to.contain('Last updated');
+    expect(
+      element.shadowRoot?.querySelector('.dashboard-pair--activity')?.children
+        .length
+    ).to.equal(2);
+    expect(
+      element.shadowRoot?.querySelector('.dashboard-pair--insights')?.children
+        .length
+    ).to.equal(2);
     expect(element.shadowRoot?.textContent).to.contain(
       'Recent Flow Executions'
     );


### PR DESCRIPTION
## What changed

- compacted the Overview gateway metrics and spacing
- moved the last-updated timestamp beside the page title
- arranged active agents and recent flow executions in a balanced desktop row
- arranged budget health and top models in a second balanced desktop row
- preserved responsive single-column stacking on smaller screens
- added component coverage for the new layout and title metadata slot

## Why

The Overview page required excessive scrolling and gave large empty states more visual weight than useful operational information. This layout keeps the existing behavior while bringing the primary dashboard content above the fold.

## Validation

- `npm run build` passes
- `git diff --check` passes
- focused browser tests were prepared but could not run because the Playwright Chromium download repeatedly timed out in the development environment
- repository-wide `tsc --noEmit` still reports existing unrelated baseline errors

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Frontend-only layout refactor with no API, security, or data changes. Well-tested with intentional test additions.
>
> **Overview**
> Compacts the Overview dashboard by replacing the two-column layout with stacked grid pairs, moving the last-updated timestamp inline with the page title via a new `title-suffix` slot on `view-header`. Responsive breakpoints are preserved. Two minor suggestions remain: a dead CSS rule and a test coverage gap.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 4099458. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->