### PR TITLE
Clarify agents list and relationship views

### DIFF
--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -144,8 +144,18 @@ describe('AgentsView', () => {
       'Onboard agents you already run with the CLI, or deploy new ones.'
     );
 
-    const agentNode = el.shadowRoot?.querySelector('.agent-node');
-    expect(agentNode).to.exist;
+    const agentCard = el.shadowRoot?.querySelector('.agent-card');
+    expect(agentCard).to.exist;
+    expect(agentCard?.getAttribute('role')).to.equal('link');
+
+    const controls = el.shadowRoot?.querySelector('.view-switcher-group');
+    expect(controls?.textContent).to.contain('1 agent');
+    expect(controls?.textContent).to.contain('Agents');
+    expect(controls?.textContent).to.contain('Relationships');
+    expect(controls?.querySelector('sl-icon[name="share"]')).to.not.exist;
+
+    expect(text).to.contain('Deploy new agent');
+    expect(text).to.contain('Onboard existing agent');
   });
 
   it('renders claude_desktop agents and agents of unknown kinds', async () => {
@@ -162,8 +172,8 @@ describe('AgentsView', () => {
     expect(text).to.contain('My Claude Desktop');
     expect(text).to.contain('Mystery Agent');
 
-    const agentNodes = el.shadowRoot?.querySelectorAll('.agent-node');
-    expect(agentNodes?.length).to.equal(2);
+    const agentCards = el.shadowRoot?.querySelectorAll('.agent-card');
+    expect(agentCards?.length).to.equal(2);
   });
 
   it('omits the agent kind allowlist by default so unknown kinds are fetched', async () => {

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -212,7 +212,7 @@ export class AgentsView extends LitElement {
   private hasAutoOpenedOnboarding = false;
 
   // Switcher state
-  @state() private currentView: 'cards' | 'canvas' = 'canvas';
+  @state() private currentView: 'cards' | 'canvas' = 'cards';
 
   // VM Provisioning state variables
   @state() private computeFeatureEnabled = false;
@@ -324,6 +324,14 @@ export class AgentsView extends LitElement {
       .view-switcher-group sl-radio-group {
         white-space: nowrap;
       }
+      .view-switcher-group sl-icon {
+        margin-right: var(--sl-spacing-x-small);
+      }
+      .results-count {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        white-space: nowrap;
+      }
       .toolbar-divider {
         width: 1px;
         height: 32px;
@@ -341,9 +349,13 @@ export class AgentsView extends LitElement {
       }
       .cards {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-        gap: var(--sl-spacing-large);
-        padding: 1rem 1rem 0 2rem;
+        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+        gap: var(--sl-spacing-medium);
+        padding: 0;
+        width: 100%;
+      }
+      .cards > .empty-state {
+        grid-column: 1 / -1;
       }
       .deploy-grid {
         display: grid;
@@ -360,7 +372,6 @@ export class AgentsView extends LitElement {
         height: 100%;
       }
       .agent-card {
-        max-width: 400px;
         cursor: pointer;
       }
       .agent-card:focus-visible::part(base) {
@@ -3624,14 +3635,14 @@ export class AgentsView extends LitElement {
                 }}
               >
                 <sl-icon slot="prefix" name="cloud-arrow-up"></sl-icon>
-                Deploy Agent
+                Deploy new agent
               </sl-button>
               <sl-button
                 variant="primary"
                 @click=${() => (this.showOnboardingDialog = true)}
               >
                 <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                Onboard Agents
+                Onboard existing agent
               </sl-button>
             </div>
           </view-header>
@@ -3693,6 +3704,7 @@ export class AgentsView extends LitElement {
               </sl-dropdown>
 
               <sl-select
+                aria-label="Last seen"
                 value=${this.lastSeenAfter}
                 @sl-change=${this.handleLastSeenAfterChange}
               >
@@ -3705,17 +3717,27 @@ export class AgentsView extends LitElement {
             </form>
 
             <div class="view-switcher-group">
+              <span class="results-count">
+                ${this.agents?.total || 0}
+                ${(this.agents?.total || 0) === 1 ? 'agent' : 'agents'}
+              </span>
               <span class="toolbar-divider" aria-hidden="true"></span>
               <sl-radio-group
+                label="Agent view"
                 value=${this.currentView}
                 @sl-change=${(e: any) => this.setCurrentView(e.target.value)}
                 size="small"
               >
-                <sl-radio-button value="cards" title="Cards View">
-                  <sl-icon name="grid"></sl-icon>
+                <sl-radio-button value="cards" title="Agents list">
+                  <sl-icon name="person-vcard"></sl-icon>
+                  Agents
                 </sl-radio-button>
-                <sl-radio-button value="canvas" title="Canvas View">
-                  <sl-icon name="share"></sl-icon>
+                <sl-radio-button
+                  value="canvas"
+                  title="Agent relationships"
+                >
+                  <sl-icon name="diagram-3"></sl-icon>
+                  Relationships
                 </sl-radio-button>
               </sl-radio-group>
             </div>
@@ -3733,7 +3755,7 @@ export class AgentsView extends LitElement {
           this.currentView === 'canvas'
             ? this.renderCanvas()
             : html`
-                <div class="cards">
+                <div class="cards content-bounds">
                   ${
                     (!this.agents ||
                       (this.agents.items.length === 0 &&


### PR DESCRIPTION
## What changed

- made compact agent cards the default Agents-page view
- replaced the ambiguous grid/share icon toggle with labeled **Agents** and **Relationships** controls
- used a person-card icon for agents and a connected-diagram icon for relationships
- added the visible agent result count
- clarified **Deploy new agent** and **Onboard existing agent** actions
- tightened card spacing and preserved the relationship canvas as an optional view
- added coverage for the default cards, labels, count, and action copy

## Why

The relationship canvas was the default even for a single agent, leaving most of the page empty. Its share-shaped icon also did not communicate agent relationships. The revised default is easier to scan and the explicit toggle labels make both views understandable.

## Validation

- `npm run build` passes
- `git diff --check` passes
- focused browser tests remain blocked by the unavailable Playwright Chromium binary in this environment
