### PR TITLE
fix(cli): OpenCode gateway onboarding resolution, rollback, and error UX

### DIFF
--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -32,10 +32,16 @@ const (
 type APIError struct {
 	StatusCode int
 	Body       string
+	// SuppressLoginHint omits the "run `preloop login`" recovery hint on 401
+	// responses. Set for clients that authenticate with non-session tokens
+	// (e.g. gateway probes using durable agent credentials), where a 401
+	// usually comes from the upstream model provider — telling the operator
+	// to re-run `preloop login` would be misleading.
+	SuppressLoginHint bool
 }
 
 func (e *APIError) Error() string {
-	if e.StatusCode == http.StatusUnauthorized {
+	if e.StatusCode == http.StatusUnauthorized && !e.SuppressLoginHint {
 		// Sessions started with `preloop login --token` carry no refresh
 		// token, so they expire silently — point at the recovery path
 		// instead of surfacing a bare 401.
@@ -46,6 +52,59 @@ func (e *APIError) Error() string {
 		)
 	}
 	return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Body)
+}
+
+// Time is a time.Time that tolerates the timestamp formats the Preloop
+// backend actually emits. Python/FastAPI serializes naive datetimes without
+// a timezone offset (e.g. "2026-07-25T22:09:24.940820"), which the stdlib
+// RFC 3339 parser rejects ('cannot parse "" as "Z07:00"'). Naive values are
+// interpreted as UTC, matching how the backend stores them.
+type Time struct {
+	time.Time
+}
+
+// apiTimeLayouts lists accepted formats, most specific first.
+var apiTimeLayouts = []string{
+	time.RFC3339Nano,
+	"2006-01-02T15:04:05.999999999", // naive datetime with fractional seconds
+	"2006-01-02T15:04:05",           // naive datetime
+	"2006-01-02",                    // date only
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (t *Time) UnmarshalJSON(data []byte) error {
+	raw := strings.Trim(strings.TrimSpace(string(data)), `"`)
+	if raw == "" || raw == "null" {
+		t.Time = time.Time{}
+		return nil
+	}
+	var lastErr error
+	for _, layout := range apiTimeLayouts {
+		parsed, err := time.Parse(layout, raw)
+		if err == nil {
+			t.Time = parsed.UTC()
+			return nil
+		}
+		lastErr = err
+	}
+	return fmt.Errorf("unrecognized timestamp %q: %w", raw, lastErr)
+}
+
+// MarshalJSON implements json.Marshaler, emitting RFC 3339 (or null when
+// zero) so round-trips always produce timezone-explicit values.
+func (t Time) MarshalJSON() ([]byte, error) {
+	if t.IsZero() {
+		return []byte("null"), nil
+	}
+	return json.Marshal(t.Time.Format(time.RFC3339Nano))
+}
+
+// MarshalYAML mirrors MarshalJSON for `--format yaml` output paths.
+func (t Time) MarshalYAML() (interface{}, error) {
+	if t.IsZero() {
+		return nil, nil
+	}
+	return t.Time.Format(time.RFC3339Nano), nil
 }
 
 // IsStatus reports whether err is an *APIError with the given HTTP status.
@@ -62,6 +121,11 @@ type Client struct {
 	refreshToken   string
 	refreshEnabled bool
 	persistTokens  bool
+	// gatewayProbe marks this client as authenticating with a durable
+	// gateway credential rather than the operator's login session. 401s
+	// from such clients originate at the model gateway / upstream provider
+	// and must not advise `preloop login` (see APIError.SuppressLoginHint).
+	gatewayProbe bool
 }
 
 // NewClient creates a new Preloop API client.
@@ -101,6 +165,17 @@ func NewClientWithToken(baseURL, token string) *Client {
 		},
 		token: token,
 	}
+}
+
+// NewGatewayProbeClient creates a client that authenticates with a durable
+// gateway credential (agent token) instead of the operator's login session.
+// Its 401 errors omit the `preloop login` recovery hint, because they almost
+// always reflect an upstream model-provider auth failure surfaced through the
+// gateway, not an expired CLI session.
+func NewGatewayProbeClient(baseURL, token string) *Client {
+	client := NewClientWithToken(baseURL, token)
+	client.gatewayProbe = true
+	return client
 }
 
 // Get performs a GET request to the specified path.
@@ -243,7 +318,11 @@ func (c *Client) doWithBodyAndHeaders(
 	}
 
 	if statusCode < 200 || statusCode >= 300 {
-		return &APIError{StatusCode: statusCode, Body: string(responseBody)}
+		return &APIError{
+			StatusCode:        statusCode,
+			Body:              string(responseBody),
+			SuppressLoginHint: c.gatewayProbe,
+		}
 	}
 
 	if result != nil && len(responseBody) > 0 {

--- a/cli/internal/api/time_naive_test.go
+++ b/cli/internal/api/time_naive_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAPITimeParsesNaiveAndRFC3339(t *testing.T) {
+	cases := []string{
+		`"2026-07-25T22:09:24.940820"`,
+		`"2026-07-25T22:09:24"`,
+		`"2026-07-25T22:09:24.940820Z"`,
+		`"2026-07-25T22:09:24+02:00"`,
+		`null`,
+		`""`,
+	}
+	for _, c := range cases {
+		var ts Time
+		if err := json.Unmarshal([]byte(c), &ts); err != nil {
+			t.Errorf("failed to parse %s: %v", c, err)
+		}
+	}
+	var ts Time
+	if err := json.Unmarshal([]byte(`"2026-07-25T22:09:24.940820"`), &ts); err != nil {
+		t.Fatal(err)
+	}
+	if ts.IsZero() || ts.Location().String() != "UTC" {
+		t.Errorf("naive timestamp should parse as UTC, got %v", ts)
+	}
+}

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -3941,6 +3941,57 @@ func recoverManagedGatewayAfterLiveValidationFailure(
 	if isGeminiCLIAgent(agent) {
 		return restoreGeminiGatewaySelectionFromOriginal(agent, originalBytes, writer)
 	}
+	if isOpenCodeAgent(agent) {
+		return restoreOpenCodeGatewaySelectionFromOriginal(agent, originalBytes, writer)
+	}
+	return nil
+}
+
+// restoreOpenCodeGatewaySelectionFromOriginal reverts the managed model
+// gateway pieces of an OpenCode config (the injected "preloop" provider and
+// the "preloop/<alias>" model pin) back to the pre-onboarding selection when
+// live validation fails. The managed MCP server entry is intentionally left
+// in place: MCP onboarding is validated separately and a model-side auth
+// failure says nothing about it.
+func restoreOpenCodeGatewaySelectionFromOriginal(
+	agent AgentConfig,
+	originalBytes []byte,
+	writer io.Writer,
+) error {
+	if !isOpenCodeAgent(agent) {
+		return nil
+	}
+	current, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		return err
+	}
+	original := map[string]interface{}{}
+	if len(bytes.TrimSpace(originalBytes)) > 0 {
+		if err := json.Unmarshal(originalBytes, &original); err != nil {
+			return fmt.Errorf("failed to parse original OpenCode config: %w", err)
+		}
+	}
+	if providers, ok := asObjectMap(current["provider"]); ok {
+		delete(providers, "preloop")
+		if len(providers) == 0 {
+			delete(current, "provider")
+		}
+	}
+	originalModel := strings.TrimSpace(lookupString(original, "model"))
+	if originalModel != "" && !strings.HasPrefix(strings.ToLower(originalModel), "preloop/") {
+		current["model"] = originalModel
+	} else {
+		delete(current, "model")
+	}
+	if err := writeAgentConfigDocument(agent, current); err != nil {
+		return err
+	}
+	if writer != nil {
+		fmt.Fprintf(
+			writer,
+			"  Note: Restored OpenCode's local model provider because Preloop gateway live validation failed. MCP remains onboarded; sign in with a working provider credential (opencode auth login) and rerun onboarding to enable model gateway routing.\n",
+		) //nolint:errcheck
+	}
 	return nil
 }
 
@@ -4066,6 +4117,10 @@ func isCodexCLIAgent(agent AgentConfig) bool {
 
 func isGeminiCLIAgent(agent AgentConfig) bool {
 	return strings.EqualFold(strings.TrimSpace(agent.Name), "Gemini CLI")
+}
+
+func isOpenCodeAgent(agent AgentConfig) bool {
+	return strings.EqualFold(strings.TrimSpace(agent.Name), "OpenCode")
 }
 
 // claudeFamilyEnvKeyVariants lists every env key Claude Code derives from one

--- a/cli/internal/cmd/agents_live_validate.go
+++ b/cli/internal/cmd/agents_live_validate.go
@@ -233,7 +233,7 @@ func runGatewayLiveValidation(
 		))
 	}
 
-	gatewayClient := api.NewClientWithToken(baseURL, spec.Token)
+	gatewayClient := api.NewGatewayProbeClient(baseURL, spec.Token)
 	postProbe := func() error {
 		var gatewayResponse map[string]interface{}
 		if len(spec.Headers) == 0 {
@@ -1256,7 +1256,8 @@ func recoverDeferredGatewayValidationFailure(
 	}
 	if !isClaudeCodeAgent(result.Agent) &&
 		!isCodexCLIAgent(result.Agent) &&
-		!isGeminiCLIAgent(result.Agent) {
+		!isGeminiCLIAgent(result.Agent) &&
+		!isOpenCodeAgent(result.Agent) {
 		return
 	}
 	state, err := loadLocalEnrollmentState(result.Agent)

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -231,7 +231,13 @@ func maybeRemoveStaleOpenClawPluginEntries(
 var openClawEnvPattern = regexp.MustCompile(`^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$`)
 var opencodeEnvPattern = regexp.MustCompile(`^\{env:([A-Za-z_][A-Za-z0-9_]*)\}$`)
 var opencodeBearerEnvPattern = regexp.MustCompile(`^[Bb]earer\s+\{env:([A-Za-z_][A-Za-z0-9_]*)\}$`)
-var managedGatewayLLMLogPattern = regexp.MustCompile(`service=llm providerID=([^\s]+) modelID=([^\s]+)`)
+// managedGatewayLLMLogPattern matches OpenCode's model-usage log lines across
+// log-format generations: older builds tagged LLM calls with ``service=llm``,
+// while 1.18+ logs streaming requests as ``message=stream`` — both carry
+// ``providerID=<provider> modelID=<model>`` pairs.
+var managedGatewayLLMLogPattern = regexp.MustCompile(
+	`(?:service=llm|message=stream) providerID=([^\s]+) modelID=([^\s]+)`,
+)
 
 const (
 	geminiAPIKeyServiceName   = "gemini-cli-api-key"
@@ -241,11 +247,17 @@ const (
 )
 
 var openCodeDefaultModelByProvider = map[string]string{
-	"zai": "glm-5-turbo",
+	"zai":             "glm-5-turbo",
+	"kimi-for-coding": "kimi-for-coding",
+	"moonshotai":      "kimi-k2.7-code",
+	"moonshotai-cn":   "kimi-k2.7-code",
 }
 
 var openCodeDefaultEndpointByProvider = map[string]string{
-	"zai": "https://api.z.ai/api/coding/paas/v4",
+	"zai":             "https://api.z.ai/api/coding/paas/v4",
+	"kimi-for-coding": "https://api.kimi.com/coding/v1",
+	"moonshotai":      "https://api.moonshot.ai/v1",
+	"moonshotai-cn":   "https://api.moonshot.cn/v1",
 }
 
 type managedEnrollmentOptions struct {
@@ -980,7 +992,8 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 			) //nolint:errcheck
 		} else if isClaudeCodeAgent(agent) ||
 			isCodexCLIAgent(agent) ||
-			isGeminiCLIAgent(agent) {
+			isGeminiCLIAgent(agent) ||
+			isOpenCodeAgent(agent) {
 			clearManagedGatewayValidationFlags(validationResult)
 			plan.ManagedModelAlias = ""
 			plan.ManagedProviderName = ""
@@ -1309,7 +1322,7 @@ func runCodexLiveValidation(
 	)
 	requestPayload := buildCodexLiveValidationPayload(managedModelAlias, prompt)
 
-	gatewayClient := api.NewClientWithToken(baseURL, token)
+	gatewayClient := api.NewGatewayProbeClient(baseURL, token)
 	var gatewayResponse map[string]interface{}
 	requestErr := gatewayClient.Post(
 		"/openai/v1/responses",

--- a/cli/internal/cmd/approvals.go
+++ b/cli/internal/cmd/approvals.go
@@ -61,9 +61,9 @@ type ApprovalRequest struct {
 	ToolInput   string    `json:"tool_input,omitempty" yaml:"tool_input,omitempty"`
 	Status      string    `json:"status" yaml:"status"`
 	RequestedBy string    `json:"requested_by,omitempty" yaml:"requested_by,omitempty"`
-	RequestedAt time.Time `json:"requested_at" yaml:"requested_at"`
+	RequestedAt api.Time  `json:"requested_at" yaml:"requested_at"`
 	ResolvedBy  string    `json:"resolved_by,omitempty" yaml:"resolved_by,omitempty"`
-	ResolvedAt  time.Time `json:"resolved_at,omitempty" yaml:"resolved_at,omitempty"`
+	ResolvedAt  api.Time  `json:"resolved_at,omitempty" yaml:"resolved_at,omitempty"`
 	Reason      string    `json:"reason,omitempty" yaml:"reason,omitempty"`
 	SessionID   string    `json:"session_id,omitempty" yaml:"session_id,omitempty"`
 }
@@ -238,7 +238,7 @@ func runApprovalsPending(cmd *cobra.Command, args []string) error {
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "ID\tTOOL\tREQUESTED BY\tAGE\tINPUT") //nolint:errcheck
 		for _, r := range requests {
-			age := formatDuration(time.Since(r.RequestedAt))
+			age := formatDuration(time.Since(r.RequestedAt.Time))
 			input := r.ToolInput
 			if len(input) > 40 {
 				input = input[:37] + "..."

--- a/cli/internal/cmd/auth_test.go
+++ b/cli/internal/cmd/auth_test.go
@@ -288,6 +288,37 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
+	// Scrub ambient agent/model env vars so upstream-resolution tests see a
+	// hermetic environment. When the test suite itself runs inside a managed
+	// agent session (e.g. Preloop-managed Claude Code exporting
+	// ANTHROPIC_BASE_URL=https://.../anthropic), resolvers like
+	// parseClaudeManagedGatewayUpstream read os.Getenv and correctly refuse
+	// to treat the managed gateway as an upstream — failing tests that
+	// expect detection. Tests that need these vars set them via t.Setenv.
+	scrubPrefixes := []string{"ANTHROPIC_", "CLAUDE_CODE_", "CLAUDE_"}
+	scrubExact := []string{
+		"AWS_BEARER_TOKEN_BEDROCK",
+		"GEMINI_API_KEY",
+		"GOOGLE_API_KEY",
+		"OPENAI_API_KEY",
+		"CLAUDECODE",
+	}
+	for _, entry := range os.Environ() {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		for _, prefix := range scrubPrefixes {
+			if strings.HasPrefix(key, prefix) {
+				_ = os.Unsetenv(key)
+				break
+			}
+		}
+	}
+	for _, key := range scrubExact {
+		_ = os.Unsetenv(key)
+	}
+
 	code := m.Run()
 
 	restoreHome()


### PR DESCRIPTION
## Summary

Fixes four issues found while onboarding OpenCode 1.18.5 (`preloop agents onboard opencode`):

1. **Upstream model inference broken for OpenCode 1.18+** — the resolver's log regex only matched the legacy `service=llm providerID=... modelID=...` format; OpenCode 1.18+ logs `message=stream providerID=... modelID=...`. Recent-model detection always failed and onboarding silently degraded to MCP-proxy-only even with a working recent session. Pattern now matches both generations.

2. **Missing Kimi/Moonshot provider defaults** — `kimi-for-coding`, `moonshotai`, and `moonshotai-cn` added to `openCodeDefaultModelByProvider` / `openCodeDefaultEndpointByProvider` so single-auth-profile users resolve to a gateway model without an explicit model config.

3. **No gateway rollback for OpenCode on live-validation failure** — Claude Code / Codex CLI / Gemini CLI revert their model-gateway config when the post-onboarding live probe fails, but OpenCode was left "Fully onboarded" with a 401-ing model route. Added `restoreOpenCodeGatewaySelectionFromOriginal` and wired OpenCode into both rollback call sites; MCP stays onboarded, enrollment persists `validation_failed`.

4. **Misleading 401 recovery hint** — a failed upstream-provider auth surfaced as `Your session has expired... run preloop login`. Gateway probes now use `api.NewGatewayProbeClient`, which suppresses the login hint (`APIError.SuppressLoginHint`) since those 401s originate at the model provider, not the operator's Preloop session.

Also:

- **`api.Time`**: `preloop approvals pending` failed to decode the backend's naive (timezone-less) Python datetimes (`parsing time "2026-07-25T22:09:24.940820" ... cannot parse "" as "Z07:00"`). New tolerant timestamp type (naive → UTC) used by `ApprovalRequest`, with regression test. Follow-up: backend should emit timezone-aware timestamps.
- **Test hermeticity**: `TestMain` now scrubs ambient `ANTHROPIC_*`/`CLAUDE_*`/provider-key env vars so `TestParseClaudeManagedGatewayUpstream*` pass when the suite itself runs inside a Preloop-managed agent session (the resolvers read `os.Getenv` and correctly refuse to treat the managed gateway as an upstream).

## Testing

- `go build ./...`, `go vet ./...` clean
- `go test ./...` passes on the committed tree (including previously env-flaky Claude upstream tests)
- Manually verified end-to-end: OpenCode 1.18.5 + Moonshot key → `Detected OpenCode's recent upstream model as moonshotai/kimi-k3` → fully onboarded, model traffic routed through the gateway
- `preloop approvals pending` now renders the pending table instead of the decode error

## Stack

Base of a 4-PR stack: this → gateway rollback parity (Hermes/OpenClaw) → ambiguous provider picker → agent format fixtures.

Mirrored from GitLab MR !35.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-scoped bug fixes with clean implementation. No security concerns, follows existing patterns, and includes appropriate regression tests.
>
> **Overview**
> Fixes OpenCode onboarding (regex compatibility, missing provider defaults, gateway rollback), misleading 401 hints via a new `NewGatewayProbeClient`, and a Python-naive-datetime parsing error in `preloop approvals pending`. All changes are surgical and backward-compatible.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit `HEAD`. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->