### PR TITLE
fix(cli): gateway rollback parity for Hermes and OpenClaw

### DIFF
--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -20,6 +20,7 @@ import (
 
 	toml "github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
+	json5 "github.com/yosuke-furukawa/json5/encoding/json5"
 
 	"github.com/preloop/preloop/cli/internal/api"
 	"github.com/preloop/preloop/cli/internal/config"
@@ -3943,6 +3944,142 @@ func recoverManagedGatewayAfterLiveValidationFailure(
 	}
 	if isOpenCodeAgent(agent) {
 		return restoreOpenCodeGatewaySelectionFromOriginal(agent, originalBytes, writer)
+	}
+	if isHermesAgent(agent) {
+		return restoreHermesGatewaySelectionFromOriginal(agent, originalBytes, writer)
+	}
+	if isOpenClawAgent(agent) {
+		return restoreOpenClawGatewaySelectionFromOriginal(agent, originalBytes, writer)
+	}
+	return nil
+}
+
+// restoreHermesGatewaySelectionFromOriginal reverts the managed model
+// gateway pieces of a Hermes config (the rewritten `model:` mapping pointing
+// provider/base_url/api_key at Preloop) back to the pre-onboarding selection
+// when live validation fails. The managed MCP configuration stays in place —
+// MCP onboarding is validated separately and a model-side auth failure says
+// nothing about it.
+func restoreHermesGatewaySelectionFromOriginal(
+	agent AgentConfig,
+	originalBytes []byte,
+	writer io.Writer,
+) error {
+	if !isHermesAgent(agent) {
+		return nil
+	}
+	current, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		return err
+	}
+	original := map[string]interface{}{}
+	if len(bytes.TrimSpace(originalBytes)) > 0 {
+		decoded, decodeErr := decodeHermesYAMLDocument(originalBytes)
+		if decodeErr != nil {
+			return fmt.Errorf("failed to parse original Hermes config: %w", decodeErr)
+		}
+		original = decoded
+	}
+	// The gateway apply only touches the `model` block (provider, base_url,
+	// api_key, default). Restore it wholesale from the pre-onboarding
+	// snapshot; when the original had none, drop the managed block entirely
+	// so Hermes falls back to its own defaults instead of a dead gateway.
+	if originalModel, exists := original["model"]; exists &&
+		!hermesModelBlockPointsAtPreloop(originalModel) {
+		current["model"] = originalModel
+	} else {
+		delete(current, "model")
+	}
+	if err := writeAgentConfigDocument(agent, current); err != nil {
+		return err
+	}
+	if writer != nil {
+		fmt.Fprintf(
+			writer,
+			"  Note: Restored Hermes' local model provider because Preloop gateway live validation failed. MCP remains onboarded; configure a working provider credential and rerun onboarding to enable model gateway routing.\n",
+		) //nolint:errcheck
+	}
+	return nil
+}
+
+// hermesModelBlockPointsAtPreloop reports whether a Hermes `model:` value
+// (string shorthand or structured mapping) already routes through Preloop —
+// e.g. a backup captured after a previous managed onboarding. Restoring such
+// a block would reinstate the failing gateway route, so callers drop it.
+func hermesModelBlockPointsAtPreloop(value interface{}) bool {
+	switch typed := value.(type) {
+	case string:
+		return looksManagedGatewayModelRef(strings.TrimSpace(typed)) &&
+			strings.TrimSpace(typed) != ""
+	case map[string]interface{}:
+		baseURL := strings.ToLower(strings.TrimSpace(lookupString(typed, "base_url")))
+		if strings.Contains(baseURL, "preloop") {
+			return true
+		}
+		defaultRef := strings.TrimSpace(lookupString(typed, "default"))
+		return defaultRef != "" && looksManagedGatewayModelRef(defaultRef)
+	default:
+		return false
+	}
+}
+
+// restoreOpenClawGatewaySelectionFromOriginal reverts the managed model
+// gateway pieces of an OpenClaw config (the injected models.providers.preloop
+// entry and the rewritten model selectors under `agents`) back to the
+// pre-onboarding selection when live validation fails. The managed MCP server
+// entry and agent-control config stay in place for the same reason as the
+// other agents: MCP onboarding is validated separately.
+func restoreOpenClawGatewaySelectionFromOriginal(
+	agent AgentConfig,
+	originalBytes []byte,
+	writer io.Writer,
+) error {
+	if !isOpenClawAgent(agent) {
+		return nil
+	}
+	current, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		return err
+	}
+	original := map[string]interface{}{}
+	if len(bytes.TrimSpace(originalBytes)) > 0 {
+		if err := json5.Unmarshal(originalBytes, &original); err != nil {
+			return fmt.Errorf("failed to parse original OpenClaw config: %w", err)
+		}
+	}
+	// The gateway apply touches exactly two subtrees: `models` (provider
+	// injection + provider-model rewrites) and `agents` (model selector
+	// rewrites to preloop/<alias>). Restore both wholesale from the
+	// pre-onboarding snapshot, or drop them when the original had none.
+	for _, key := range []string{"models", "agents"} {
+		if originalValue, exists := original[key]; exists {
+			current[key] = originalValue
+		} else {
+			delete(current, key)
+		}
+	}
+	// Defensive: if the restored `models` still carries a preloop provider
+	// (backup captured after a previous managed onboarding), strip it so we
+	// never reinstate the failing gateway route.
+	if models, ok := asObjectMap(current["models"]); ok {
+		if providers, ok := asObjectMap(models["providers"]); ok {
+			delete(providers, "preloop")
+			if len(providers) == 0 {
+				delete(models, "providers")
+			}
+		}
+		if len(models) == 0 {
+			delete(current, "models")
+		}
+	}
+	if err := writeAgentConfigDocument(agent, current); err != nil {
+		return err
+	}
+	if writer != nil {
+		fmt.Fprintf(
+			writer,
+			"  Note: Restored OpenClaw's local model provider because Preloop gateway live validation failed. MCP remains onboarded; configure a working provider credential and rerun onboarding to enable model gateway routing.\n",
+		) //nolint:errcheck
 	}
 	return nil
 }

--- a/cli/internal/cmd/agents_gateway_rollback_test.go
+++ b/cli/internal/cmd/agents_gateway_rollback_test.go
@@ -1,0 +1,260 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRestoreOpenCodeGatewaySelectionFromOriginalPreservesMCP(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	original := []byte(`{"model":"moonshotai/kimi-k3"}`)
+	if err := os.WriteFile(configPath, original, 0644); err != nil {
+		t.Fatalf("failed to seed OpenCode config: %v", err)
+	}
+	agent := AgentConfig{Name: "OpenCode", ConfigPath: configPath}
+	doc, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		t.Fatalf("failed to load OpenCode config: %v", err)
+	}
+	doc["model"] = "preloop/moonshotai/kimi-k3"
+	doc["provider"] = map[string]interface{}{
+		"preloop": map[string]interface{}{
+			"npm": "@ai-sdk/openai-compatible",
+			"options": map[string]interface{}{
+				"baseURL": "https://preloop.example/openai/v1",
+				"apiKey":  "durable-token",
+			},
+		},
+	}
+	doc["mcp"] = map[string]interface{}{
+		"preloop": map[string]interface{}{
+			"type": "remote",
+			"url":  "https://preloop.example/mcp/v1",
+		},
+	}
+	if err := writeAgentConfigDocument(agent, doc); err != nil {
+		t.Fatalf("failed to write managed OpenCode config: %v", err)
+	}
+
+	if err := restoreOpenCodeGatewaySelectionFromOriginal(agent, original, io.Discard); err != nil {
+		t.Fatalf("restoreOpenCodeGatewaySelectionFromOriginal returned error: %v", err)
+	}
+
+	restored, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		t.Fatalf("failed to load restored OpenCode config: %v", err)
+	}
+	if restored["model"] != "moonshotai/kimi-k3" {
+		t.Fatalf("expected original OpenCode model restored, got %#v", restored["model"])
+	}
+	if _, exists := restored["provider"]; exists {
+		t.Fatalf("expected injected preloop provider removed, got %#v", restored["provider"])
+	}
+	if _, ok := restored["mcp"].(map[string]interface{})["preloop"]; !ok {
+		t.Fatalf("expected Preloop MCP server to remain present, got %#v", restored)
+	}
+}
+
+func TestRestoreOpenCodeGatewaySelectionDropsContaminatedModelPin(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	// Backup captured after a previous managed onboarding: restoring its
+	// model pin verbatim would reinstate the failing gateway route.
+	original := []byte(`{"model":"preloop/moonshotai/kimi-k3"}`)
+	if err := os.WriteFile(configPath, original, 0644); err != nil {
+		t.Fatalf("failed to seed OpenCode config: %v", err)
+	}
+	agent := AgentConfig{Name: "OpenCode", ConfigPath: configPath}
+	doc, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		t.Fatalf("failed to load OpenCode config: %v", err)
+	}
+	doc["provider"] = map[string]interface{}{
+		"preloop": map[string]interface{}{"npm": "@ai-sdk/openai-compatible"},
+	}
+	if err := writeAgentConfigDocument(agent, doc); err != nil {
+		t.Fatalf("failed to write managed OpenCode config: %v", err)
+	}
+
+	if err := restoreOpenCodeGatewaySelectionFromOriginal(agent, original, io.Discard); err != nil {
+		t.Fatalf("restoreOpenCodeGatewaySelectionFromOriginal returned error: %v", err)
+	}
+
+	restored, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		t.Fatalf("failed to load restored OpenCode config: %v", err)
+	}
+	if _, exists := restored["model"]; exists {
+		t.Fatalf("expected contaminated preloop model pin dropped, got %#v", restored["model"])
+	}
+	if _, exists := restored["provider"]; exists {
+		t.Fatalf("expected injected preloop provider removed, got %#v", restored["provider"])
+	}
+}
+
+func TestRestoreHermesGatewaySelectionFromOriginalRestoresModelBlock(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	original := []byte("model:\n  default: gpt-5.4\n  provider: openai\n")
+	if err := os.WriteFile(configPath, original, 0600); err != nil {
+		t.Fatalf("failed to seed Hermes config: %v", err)
+	}
+	agent := AgentConfig{Name: "Hermes", ConfigPath: configPath}
+	doc, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		t.Fatalf("failed to load Hermes config: %v", err)
+	}
+	doc["model"] = map[string]interface{}{
+		"provider": "custom",
+		"base_url": "https://preloop.example/openai/v1",
+		"api_key":  "durable-token",
+		"default":  "preloop/openai/gpt-5.4",
+	}
+	doc["preloop"] = map[string]interface{}{
+		"control": map[string]interface{}{"ws_url": "wss://preloop.example/api/v1/agents/control/ws"},
+	}
+	if err := writeAgentConfigDocument(agent, doc); err != nil {
+		t.Fatalf("failed to write managed Hermes config: %v", err)
+	}
+
+	if err := restoreHermesGatewaySelectionFromOriginal(agent, original, io.Discard); err != nil {
+		t.Fatalf("restoreHermesGatewaySelectionFromOriginal returned error: %v", err)
+	}
+
+	restored, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		t.Fatalf("failed to load restored Hermes config: %v", err)
+	}
+	model, ok := restored["model"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected restored Hermes model block, got %#v", restored["model"])
+	}
+	if model["default"] != "gpt-5.4" || model["provider"] != "openai" {
+		t.Fatalf("expected original Hermes model selection restored, got %#v", model)
+	}
+	if _, exists := model["api_key"]; exists {
+		t.Fatalf("expected gateway api_key removed, got %#v", model)
+	}
+	if _, ok := restored["preloop"]; !ok {
+		t.Fatalf("expected managed preloop control block to remain, got %#v", restored)
+	}
+}
+
+func TestRestoreHermesGatewaySelectionDropsContaminatedModelBlock(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	original := []byte(
+		"model:\n  provider: custom\n  base_url: https://preloop.example/openai/v1\n  default: preloop/openai/gpt-5.4\n",
+	)
+	if err := os.WriteFile(configPath, original, 0600); err != nil {
+		t.Fatalf("failed to seed Hermes config: %v", err)
+	}
+	agent := AgentConfig{Name: "Hermes", ConfigPath: configPath}
+
+	if err := restoreHermesGatewaySelectionFromOriginal(agent, original, io.Discard); err != nil {
+		t.Fatalf("restoreHermesGatewaySelectionFromOriginal returned error: %v", err)
+	}
+
+	restored, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		t.Fatalf("failed to load restored Hermes config: %v", err)
+	}
+	if _, exists := restored["model"]; exists {
+		t.Fatalf("expected contaminated Hermes model block dropped, got %#v", restored["model"])
+	}
+}
+
+func TestRestoreOpenClawGatewaySelectionFromOriginalPreservesMCP(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "openclaw.json")
+	original := []byte(`{
+  "models": {
+    "providers": {
+      "anthropic": {"apiKey": "sk-ant-original"}
+    }
+  },
+  "agents": {
+    "defaults": {"model": "anthropic/claude-opus-4-6"}
+  }
+}`)
+	if err := os.WriteFile(configPath, original, 0644); err != nil {
+		t.Fatalf("failed to seed OpenClaw config: %v", err)
+	}
+	agent := AgentConfig{Name: "OpenClaw", ConfigPath: configPath}
+	doc, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		t.Fatalf("failed to load OpenClaw config: %v", err)
+	}
+	doc["models"] = map[string]interface{}{
+		"providers": map[string]interface{}{
+			"preloop": map[string]interface{}{
+				"baseUrl": "https://preloop.example/openai/v1",
+				"apiKey":  "durable-token",
+			},
+		},
+	}
+	doc["agents"] = map[string]interface{}{
+		"defaults": map[string]interface{}{"model": "preloop/anthropic/claude-opus-4-6"},
+	}
+	doc["mcp"] = map[string]interface{}{
+		"servers": map[string]interface{}{
+			"preloop": map[string]interface{}{"url": "https://preloop.example/mcp/v1"},
+		},
+	}
+	if err := writeAgentConfigDocument(agent, doc); err != nil {
+		t.Fatalf("failed to write managed OpenClaw config: %v", err)
+	}
+
+	if err := restoreOpenClawGatewaySelectionFromOriginal(agent, original, io.Discard); err != nil {
+		t.Fatalf("restoreOpenClawGatewaySelectionFromOriginal returned error: %v", err)
+	}
+
+	restored, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		t.Fatalf("failed to load restored OpenClaw config: %v", err)
+	}
+	providers, _ := asObjectMap(lookupValue(restored, "models", "providers"))
+	if _, exists := providers["preloop"]; exists {
+		t.Fatalf("expected injected preloop provider removed, got %#v", providers)
+	}
+	if _, exists := providers["anthropic"]; !exists {
+		t.Fatalf("expected original anthropic provider restored, got %#v", providers)
+	}
+	if model := lookupString(restored, "agents", "defaults", "model"); model != "anthropic/claude-opus-4-6" {
+		t.Fatalf("expected original OpenClaw model selector restored, got %#v", model)
+	}
+	if _, ok := asObjectMap(lookupValue(restored, "mcp", "servers", "preloop")); !ok {
+		t.Fatalf("expected Preloop MCP server to remain present, got %#v", restored)
+	}
+}
+
+func TestRestoreOpenClawGatewaySelectionStripsPreloopFromContaminatedBackup(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "openclaw.json")
+	original := []byte(`{
+  "models": {
+    "providers": {
+      "preloop": {"baseUrl": "https://preloop.example/openai/v1"}
+    }
+  }
+}`)
+	if err := os.WriteFile(configPath, original, 0644); err != nil {
+		t.Fatalf("failed to seed OpenClaw config: %v", err)
+	}
+	agent := AgentConfig{Name: "OpenClaw", ConfigPath: configPath}
+
+	if err := restoreOpenClawGatewaySelectionFromOriginal(agent, original, io.Discard); err != nil {
+		t.Fatalf("restoreOpenClawGatewaySelectionFromOriginal returned error: %v", err)
+	}
+
+	restored, err := loadAgentConfigDocument(agent)
+	if err != nil {
+		t.Fatalf("failed to load restored OpenClaw config: %v", err)
+	}
+	if _, exists := restored["models"]; exists {
+		t.Fatalf("expected contaminated preloop provider stripped, got %#v", restored["models"])
+	}
+}

--- a/cli/internal/cmd/agents_live_validate.go
+++ b/cli/internal/cmd/agents_live_validate.go
@@ -1257,7 +1257,9 @@ func recoverDeferredGatewayValidationFailure(
 	if !isClaudeCodeAgent(result.Agent) &&
 		!isCodexCLIAgent(result.Agent) &&
 		!isGeminiCLIAgent(result.Agent) &&
-		!isOpenCodeAgent(result.Agent) {
+		!isOpenCodeAgent(result.Agent) &&
+		!isHermesAgent(result.Agent) &&
+		!isOpenClawAgent(result.Agent) {
 		return
 	}
 	state, err := loadLocalEnrollmentState(result.Agent)

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -993,7 +993,9 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		} else if isClaudeCodeAgent(agent) ||
 			isCodexCLIAgent(agent) ||
 			isGeminiCLIAgent(agent) ||
-			isOpenCodeAgent(agent) {
+			isOpenCodeAgent(agent) ||
+			isHermesAgent(agent) ||
+			isOpenClawAgent(agent) {
 			clearManagedGatewayValidationFlags(validationResult)
 			plan.ManagedModelAlias = ""
 			plan.ManagedProviderName = ""


### PR DESCRIPTION
## Summary

**Stacked on #102** (structural gap #1 from its "known remaining gaps" list).

Claude Code, Codex CLI, Gemini CLI, and (as of #102) OpenCode all revert their managed model-gateway configuration when the post-onboarding live-validation probe fails, keeping MCP onboarded but restoring direct model access. **Hermes and OpenClaw were missing from that path** — a failed probe left them reported as "Fully onboarded" with a dead (e.g. 401-ing) model route.

## Changes

- `restoreHermesGatewaySelectionFromOriginal` — restores the pre-onboarding `model:` YAML block; drops the managed block when the backup has none or already points at Preloop (contaminated backup). Managed MCP + `preloop.control` config stays.
- `restoreOpenClawGatewaySelectionFromOriginal` — restores the `models` and `agents` subtrees from the pre-onboarding JSON5 snapshot; defensively strips any `preloop` provider from contaminated backups. Managed MCP server entry stays.
- Both agents wired into the two rollback gates (deferred validation in `agents_live_validate.go`, inline enrollment in `agents_openclaw.go`), so enrollment persists `validation_failed` and clears gateway flags like the other agents.
- New `agents_gateway_rollback_test.go`: happy-path + contaminated-backup restore tests for OpenCode, Hermes, and OpenClaw.

## Testing

- `go build ./...`, `go vet ./...` clean
- Full `./internal/api` + `./internal/cmd` suites pass on the committed tree

Mirrored from GitLab MR !36.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Parity fix adding Hermes and OpenClaw to the existing gateway rollback path. Well-tested, follows established patterns. Re-reviewed — no new issues found.
>
> **Overview**
> Adds `restoreHermesGatewaySelectionFromOriginal` and `restoreOpenClawGatewaySelectionFromOriginal` to revert managed model-gateway config when live validation fails, matching the existing behavior for Claude Code, Codex CLI, Gemini CLI, and OpenCode. Includes defensive contamination detection and 6 new tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit HEAD. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->