### PR TITLE
feat(cli): prompt for provider when gateway upstream resolution is ambiguous

### DIFF
--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -501,6 +501,30 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 
 	syncAgent := prepareAgentForRemoteServerSync(agent, baseURL)
 
+	// Resolve upstream ambiguity interactively before building the plan
+	// preview: when the agent's local state offers several credentialed
+	// providers and no way to pick one (e.g. OpenCode with multiple auth
+	// profiles and no configured or recently-used model), silently degrading
+	// to MCP-only hides the choice from the operator. Non-interactive runs
+	// (--yes / --dry-run / PRELOOP_CONFIRM) keep the degrade behavior; the
+	// preview note explains how to resolve it.
+	gatewayHints := managedGatewayResolutionHints{}
+	if supportsManagedGateway(agent) &&
+		!opts.DryRun &&
+		!opts.AutoApprove &&
+		!opts.SkipConfirmation &&
+		!nonInteractiveAutoConfirm() {
+		selectedProvider, promptErr := maybePromptForAmbiguousGatewayProvider(
+			agent,
+			bufio.NewReader(input),
+			output,
+		)
+		if promptErr != nil {
+			return promptErr
+		}
+		gatewayHints.PreferredProviderID = selectedProvider
+	}
+
 	plan, err := buildManagedMCPEnrollmentPlan(
 		agent,
 		baseURL,
@@ -513,7 +537,7 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		plan.Notes = append(plan.Notes, staleOpenClawPluginEntriesNote(staleEntries))
 	}
 	if supportsManagedGateway(agent) {
-		upstream, upstreamErr := resolveManagedGatewayUpstream(agent)
+		upstream, upstreamErr := resolveManagedGatewayUpstreamWithHints(agent, gatewayHints)
 		if upstreamErr != nil {
 			return upstreamErr
 		}
@@ -682,7 +706,7 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		return err
 	}
 	if supportsManagedGateway(agent) {
-		upstream, upstreamErr := resolveManagedGatewayUpstream(agent)
+		upstream, upstreamErr := resolveManagedGatewayUpstreamWithHints(agent, gatewayHints)
 		if upstreamErr != nil {
 			return upstreamErr
 		}
@@ -1609,10 +1633,26 @@ func shouldPreferCurrentConfigForGatewayResolution(agent AgentConfig, current ma
 	return !strings.EqualFold(providerID, "preloop") && !looksManagedGatewayModelRef(modelRef)
 }
 
+// managedGatewayResolutionHints carries operator-supplied disambiguation for
+// upstream resolution. Today the only hint is a preferred provider ID for
+// agents whose local state is ambiguous (e.g. OpenCode with several auth
+// profiles and no configured or recently-used model); resolvers ignore hints
+// they do not need.
+type managedGatewayResolutionHints struct {
+	PreferredProviderID string
+}
+
 func resolveManagedGatewayUpstream(agent AgentConfig) (*managedGatewayUpstream, error) {
+	return resolveManagedGatewayUpstreamWithHints(agent, managedGatewayResolutionHints{})
+}
+
+func resolveManagedGatewayUpstreamWithHints(
+	agent AgentConfig,
+	hints managedGatewayResolutionHints,
+) (*managedGatewayUpstream, error) {
 	switch strings.ToLower(strings.TrimSpace(agent.Name)) {
 	case "opencode":
-		return parseOpenCodeManagedGatewayUpstream(agent)
+		return parseOpenCodeManagedGatewayUpstreamWithHints(agent, hints)
 	case "gemini cli":
 		return parseGeminiManagedGatewayUpstream(agent)
 	case "claude code":
@@ -1656,7 +1696,120 @@ type openCodeAuthProfile struct {
 	Key  string `json:"key"`
 }
 
+// detectAmbiguousGatewayProviders returns the candidate provider IDs when the
+// agent's upstream resolution would fail purely because several credentialed
+// providers exist and nothing (configured model, recent-session model) picks
+// between them. It returns nil when resolution is not ambiguous — either it
+// succeeds on its own or it fails for a different reason (no credentials at
+// all, unparseable config, ...), where a provider prompt would not help.
+//
+// Today only OpenCode exhibits this shape (multiple auth.json profiles); other
+// agents either have a single credential source or encode the provider choice
+// in their config.
+func detectAmbiguousGatewayProviders(agent AgentConfig) []string {
+	if !strings.EqualFold(strings.TrimSpace(agent.Name), "OpenCode") {
+		return nil
+	}
+	upstream, err := parseOpenCodeManagedGatewayUpstream(agent)
+	if err != nil || upstream != nil {
+		// Resolution succeeds (or fails hard) without a hint; nothing to ask.
+		return nil
+	}
+	document, err := readAgentConfigForGatewayResolution(agent)
+	if err != nil {
+		return nil
+	}
+	if modelRef := strings.TrimSpace(lookupString(document, "model")); modelRef != "" &&
+		!strings.HasPrefix(strings.ToLower(modelRef), "preloop/") {
+		// A configured model exists, so the failure is not about provider
+		// choice.
+		return nil
+	}
+	authProfiles, err := loadOpenCodeAuthProfiles()
+	if err != nil || len(authProfiles) < 2 {
+		return nil
+	}
+	candidates := make([]string, 0, len(authProfiles))
+	for providerID, profile := range authProfiles {
+		if strings.TrimSpace(profile.Key) == "" {
+			continue
+		}
+		// Only offer providers we can actually resolve to a gateway model:
+		// either the config declares models for it or we ship a default.
+		providers, _ := asObjectMap(document["provider"])
+		if singleOpenCodeProviderModel(providers, providerID) == "" &&
+			openCodeDefaultModelByProvider[strings.ToLower(providerID)] == "" {
+			continue
+		}
+		candidates = append(candidates, providerID)
+	}
+	if len(candidates) < 2 {
+		return nil
+	}
+	sort.Strings(candidates)
+	return candidates
+}
+
+// maybePromptForAmbiguousGatewayProvider asks the operator to pick an upstream
+// provider when detectAmbiguousGatewayProviders reports a genuine tie. Returns
+// the selected provider ID, or "" when there is nothing to ask or the operator
+// declines (blank answer), in which case enrollment proceeds with the existing
+// degrade-to-MCP-only behavior.
+func maybePromptForAmbiguousGatewayProvider(
+	agent AgentConfig,
+	reader *bufio.Reader,
+	writer io.Writer,
+) (string, error) {
+	candidates := detectAmbiguousGatewayProviders(agent)
+	if len(candidates) == 0 {
+		return "", nil
+	}
+	fmt.Fprintf(
+		writer,
+		"%s has credentials for multiple model providers and no configured model:\n",
+		resolveAgentDisplayName(agent),
+	) //nolint:errcheck
+	for index, providerID := range candidates {
+		fmt.Fprintf(writer, "  %d) %s\n", index+1, providerID) //nolint:errcheck
+	}
+	answer, err := promptForTextInput(
+		reader,
+		writer,
+		fmt.Sprintf(
+			"Route model traffic through Preloop using which provider? [1-%d, blank to keep model traffic direct]: ",
+			len(candidates),
+		),
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to read provider selection: %w", err)
+	}
+	answer = strings.TrimSpace(answer)
+	if answer == "" {
+		return "", nil
+	}
+	if index, convErr := strconv.Atoi(answer); convErr == nil {
+		if index >= 1 && index <= len(candidates) {
+			return candidates[index-1], nil
+		}
+		return "", nil
+	}
+	// Accept the provider name itself as an answer too.
+	for _, providerID := range candidates {
+		if strings.EqualFold(providerID, answer) {
+			return providerID, nil
+		}
+	}
+	return "", nil
+}
+
 func parseOpenCodeManagedGatewayUpstream(agent AgentConfig) (*managedGatewayUpstream, error) {
+	return parseOpenCodeManagedGatewayUpstreamWithHints(agent, managedGatewayResolutionHints{})
+}
+
+func parseOpenCodeManagedGatewayUpstreamWithHints(
+	agent AgentConfig,
+	hints managedGatewayResolutionHints,
+) (*managedGatewayUpstream, error) {
 	document, err := readAgentConfigForGatewayResolution(agent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse OpenCode config: %w", err)
@@ -1692,6 +1845,17 @@ func parseOpenCodeManagedGatewayUpstream(agent AgentConfig) (*managedGatewayUpst
 	}
 	if providerID == "" {
 		providerID = singleOpenCodeAuthProvider(authProfiles)
+	}
+	if providerID == "" {
+		if preferred := strings.ToLower(strings.TrimSpace(hints.PreferredProviderID)); preferred != "" {
+			if _, ok := authProfiles[preferred]; ok {
+				providerID = preferred
+				notes = append(
+					notes,
+					fmt.Sprintf("Using operator-selected OpenCode provider %s.", providerID),
+				)
+			}
+		}
 	}
 	if modelID == "" {
 		modelID = singleOpenCodeProviderModel(providers, providerID)

--- a/cli/internal/cmd/agents_provider_picker_test.go
+++ b/cli/internal/cmd/agents_provider_picker_test.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/testenv"
+)
+
+// seedOpenCodeAmbiguousState writes an OpenCode config with no model pin and
+// an auth.json holding two credentialed providers that both map to gateway
+// defaults, so upstream resolution is genuinely ambiguous.
+func seedOpenCodeAmbiguousState(t *testing.T, home string) AgentConfig {
+	t.Helper()
+	configPath := filepath.Join(home, ".config", "opencode", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("failed to create opencode config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("failed to write opencode config: %v", err)
+	}
+	authPath := filepath.Join(home, ".local", "share", "opencode", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(authPath), 0o755); err != nil {
+		t.Fatalf("failed to create opencode auth dir: %v", err)
+	}
+	auth := map[string]openCodeAuthProfile{
+		"moonshotai": {Type: "api", Key: "sk-moonshot"},
+		"zai":        {Type: "api", Key: "sk-zai"},
+	}
+	data, err := json.Marshal(auth)
+	if err != nil {
+		t.Fatalf("failed to marshal auth profiles: %v", err)
+	}
+	if err := os.WriteFile(authPath, data, 0o600); err != nil {
+		t.Fatalf("failed to write opencode auth: %v", err)
+	}
+	return AgentConfig{Name: "OpenCode", ConfigPath: configPath}
+}
+
+func TestDetectAmbiguousGatewayProvidersOpenCode(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	agent := seedOpenCodeAmbiguousState(t, home)
+
+	candidates := detectAmbiguousGatewayProviders(agent)
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 ambiguous providers, got %#v", candidates)
+	}
+	if candidates[0] != "moonshotai" || candidates[1] != "zai" {
+		t.Fatalf("expected sorted [moonshotai zai], got %#v", candidates)
+	}
+}
+
+func TestDetectAmbiguousGatewayProvidersNotAmbiguousWithSingleProfile(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	agent := seedOpenCodeAmbiguousState(t, home)
+	authPath := filepath.Join(home, ".local", "share", "opencode", "auth.json")
+	if err := os.WriteFile(
+		authPath,
+		[]byte(`{"moonshotai":{"type":"api","key":"sk-moonshot"}}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("failed to rewrite auth profiles: %v", err)
+	}
+
+	if candidates := detectAmbiguousGatewayProviders(agent); candidates != nil {
+		t.Fatalf("expected no ambiguity with one profile, got %#v", candidates)
+	}
+}
+
+func TestDetectAmbiguousGatewayProvidersNotAmbiguousWithConfiguredModel(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	agent := seedOpenCodeAmbiguousState(t, home)
+	if err := os.WriteFile(
+		agent.ConfigPath,
+		[]byte(`{"model":"moonshotai/kimi-k3"}`),
+		0o644,
+	); err != nil {
+		t.Fatalf("failed to rewrite opencode config: %v", err)
+	}
+
+	if candidates := detectAmbiguousGatewayProviders(agent); candidates != nil {
+		t.Fatalf("expected no ambiguity with configured model, got %#v", candidates)
+	}
+}
+
+func TestMaybePromptForAmbiguousGatewayProviderSelectsByNumber(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	agent := seedOpenCodeAmbiguousState(t, home)
+
+	var out bytes.Buffer
+	selected, err := maybePromptForAmbiguousGatewayProvider(
+		agent,
+		bufio.NewReader(strings.NewReader("1\n")),
+		&out,
+	)
+	if err != nil {
+		t.Fatalf("unexpected prompt error: %v", err)
+	}
+	if selected != "moonshotai" {
+		t.Fatalf("expected moonshotai selected, got %q", selected)
+	}
+	if !strings.Contains(out.String(), "moonshotai") || !strings.Contains(out.String(), "zai") {
+		t.Fatalf("expected both providers listed in prompt, got %q", out.String())
+	}
+}
+
+func TestMaybePromptForAmbiguousGatewayProviderAcceptsName(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	agent := seedOpenCodeAmbiguousState(t, home)
+
+	selected, err := maybePromptForAmbiguousGatewayProvider(
+		agent,
+		bufio.NewReader(strings.NewReader("zai\n")),
+		&bytes.Buffer{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected prompt error: %v", err)
+	}
+	if selected != "zai" {
+		t.Fatalf("expected zai selected, got %q", selected)
+	}
+}
+
+func TestMaybePromptForAmbiguousGatewayProviderBlankKeepsDirect(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	agent := seedOpenCodeAmbiguousState(t, home)
+
+	selected, err := maybePromptForAmbiguousGatewayProvider(
+		agent,
+		bufio.NewReader(strings.NewReader("\n")),
+		&bytes.Buffer{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected prompt error: %v", err)
+	}
+	if selected != "" {
+		t.Fatalf("expected blank answer to keep direct routing, got %q", selected)
+	}
+}
+
+func TestParseOpenCodeUpstreamWithPreferredProviderHint(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	agent := seedOpenCodeAmbiguousState(t, home)
+
+	// Without a hint: ambiguous, no upstream.
+	upstream, err := parseOpenCodeManagedGatewayUpstream(agent)
+	if err != nil {
+		t.Fatalf("unexpected resolution error: %v", err)
+	}
+	if upstream != nil {
+		t.Fatalf("expected ambiguous resolution to yield nil upstream, got %#v", upstream)
+	}
+
+	// With the hint the selected provider resolves through its default model.
+	upstream, err = parseOpenCodeManagedGatewayUpstreamWithHints(
+		agent,
+		managedGatewayResolutionHints{PreferredProviderID: "moonshotai"},
+	)
+	if err != nil {
+		t.Fatalf("unexpected hinted resolution error: %v", err)
+	}
+	if upstream == nil {
+		t.Fatal("expected hinted resolution to yield an upstream")
+	}
+	if upstream.SourceProviderID != "moonshotai" {
+		t.Fatalf("expected moonshotai provider, got %#v", upstream.SourceProviderID)
+	}
+	if upstream.APIKey != "sk-moonshot" {
+		t.Fatalf("expected moonshotai key resolved, got %#v", upstream.APIKey)
+	}
+	if upstream.ManagedModelAlias == "" {
+		t.Fatalf("expected managed alias from provider default, got %#v", upstream)
+	}
+}


### PR DESCRIPTION
## Summary

**Stacked on #103 → #102** (structural gap #2 from #102's "known remaining gaps" list).

When an agent holds credentials for several model providers and nothing picks between them (no configured model, no recent-session model), onboarding **silently degraded to MCP-proxy-only** with only a "could not resolve" note — hiding the model gateway from operators who simply had two provider logins (exactly the state that surfaced during OpenCode testing: `kimi-for-coding` + `moonshotai` profiles in auth.json).

Interactive onboarding now asks:

```
OpenCode has credentials for multiple model providers and no configured model:
  1) moonshotai
  2) zai
Route model traffic through Preloop using which provider? [1-2, blank to keep model traffic direct]:
```

## Design

- `managedGatewayResolutionHints` threads an operator-selected provider through a new `resolveManagedGatewayUpstreamWithHints`; resolvers that don't need hints ignore them. Existing `resolveManagedGatewayUpstream` callers are unaffected.
- `detectAmbiguousGatewayProviders` fires **only on a genuine tie**: ≥2 credentialed profiles that all map to a resolvable gateway model, no configured/recent model, and un-hinted resolution returning nil. Any other failure mode (no credentials, parse errors, single profile) keeps the existing degrade-to-MCP-only behavior.
- Selection by number or provider name; **blank answer preserves previous behavior** (model traffic stays direct).
- Non-interactive paths unchanged: `--yes`, `--dry-run`, `PRELOOP_CONFIRM` never prompt.
- OpenCode is the only agent with this shape today (multiple auth.json profiles); the hint plumbing is agent-generic so Codex/Gemini/etc. can adopt it if they grow equivalent ambiguity.

## Testing

- 7 new tests: ambiguity detection (positive, single-profile negative, configured-model negative), prompt selection by number/name/blank, and hinted resolution end-to-end
- `go build ./...`, `go vet ./...` clean; full `./internal/api` + `./internal/cmd` suites pass

Mirrored from GitLab MR !37.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk** — Clean, backward-compatible feature with no security concerns, comprehensive tests, and conservative ambiguity detection gating.
>
> **Overview**
> Adds interactive provider selection during OpenCode onboarding when multiple auth profiles create ambiguity. Hint plumbing is agent-generic and preserves existing callers. Detection only fires on ≥2 resolvable providers with no configured/recent model.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit `feat/ambiguous-provider-picker`. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->