### PR TITLE
test(cli): version-pinned agent format fixtures for model resolvers

### DIFF
--- a/cli/internal/cmd/agents_format_fixtures_test.go
+++ b/cli/internal/cmd/agents_format_fixtures_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/testenv"
+)
+
+// These tests pin the CLI's recent-model resolvers to verbatim on-disk
+// format samples captured from real agent installations (see
+// testdata/agent-formats/README.md). The files the resolvers read are not
+// stable interfaces of the agents, and when a format changes the resolvers
+// fail *silently* — inference returns "", and onboarding degrades to
+// MCP-proxy-only with no error (this shipped: OpenCode 1.18 changed its LLM
+// log tag and gateway onboarding quietly stopped resolving). Fixtures turn
+// that drift into a test failure with a actionable name.
+
+func copyFixture(t *testing.T, fixtureRelPath, destPath string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "agent-formats", fixtureRelPath))
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", fixtureRelPath, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		t.Fatalf("failed to create fixture dest dir: %v", err)
+	}
+	if err := os.WriteFile(destPath, data, 0o644); err != nil {
+		t.Fatalf("failed to write fixture to %s: %v", destPath, err)
+	}
+}
+
+func TestOpenCodeRecentModelFormatFixtures(t *testing.T) {
+	cases := []struct {
+		name    string
+		fixture string
+		want    string
+	}{
+		{
+			// service=llm tag; last matching line wins (reverse scan).
+			name:    "legacy 1.17 service=llm",
+			fixture: "opencode/log@1.17.txt",
+			want:    "zai/glm-5-turbo",
+		},
+		{
+			// message=stream tag introduced in 1.18.
+			name:    "1.18.5 message=stream",
+			fixture: "opencode/log@1.18.5.txt",
+			want:    "moonshotai/kimi-k3",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			home := t.TempDir()
+			testenv.SetHome(t, home)
+			copyFixture(
+				t,
+				testCase.fixture,
+				filepath.Join(home, ".local", "share", "opencode", "log", "opencode.log"),
+			)
+			if got := resolveOpenCodeRecentModelRef(); got != testCase.want {
+				t.Fatalf(
+					"resolveOpenCodeRecentModelRef() = %q, want %q — OpenCode log format drift? See testdata/agent-formats/README.md",
+					got,
+					testCase.want,
+				)
+			}
+		})
+	}
+}
+
+func TestClaudeRecentModelFormatFixture(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	copyFixture(
+		t,
+		"claude-code/session@2.1.jsonl",
+		filepath.Join(home, ".claude", "projects", "-tmp-w", "session.jsonl"),
+	)
+	if got := resolveClaudeRecentModelRef(); got != "claude-opus-4-6" {
+		t.Fatalf(
+			"resolveClaudeRecentModelRef() = %q, want %q — Claude Code session format drift? See testdata/agent-formats/README.md",
+			got,
+			"claude-opus-4-6",
+		)
+	}
+}
+
+func TestCodexRecentModelFormatFixture(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	codexHome := filepath.Join(home, ".codex")
+	t.Setenv("CODEX_HOME", codexHome)
+	copyFixture(
+		t,
+		"codex-cli/session@0.46.jsonl",
+		filepath.Join(codexHome, "sessions", "2026", "07", "15", "rollout-2026-07-15T23-20-01-x.jsonl"),
+	)
+	// Codex rollouts store bare model IDs; provider resolution happens in
+	// the caller (config model_provider / ChatGPT auth mode → openai).
+	if got := resolveCodexRecentModelRef(); got != "gpt-5.6-sol" {
+		t.Fatalf(
+			"resolveCodexRecentModelRef() = %q, want %q — Codex session format drift? See testdata/agent-formats/README.md",
+			got,
+			"gpt-5.6-sol",
+		)
+	}
+}
+
+func TestGeminiRecentModelFormatFixture(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	copyFixture(
+		t,
+		"gemini-cli/chat@0.21.json",
+		filepath.Join(home, ".gemini", "tmp", "deadbeef", "chats", "session-1.json"),
+	)
+	if got := resolveGeminiRecentModelRef(); got != "gemini-3-pro-preview" {
+		t.Fatalf(
+			"resolveGeminiRecentModelRef() = %q, want %q — Gemini chat format drift? See testdata/agent-formats/README.md",
+			got,
+			"gemini-3-pro-preview",
+		)
+	}
+}

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -3248,6 +3248,15 @@ func resolveCodexRecentModelRef() string {
 			if strings.HasPrefix(strings.ToLower(trimmed), "preloop/") {
 				trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "preloop/"))
 			}
+			// Codex session rollouts store bare model IDs ("gpt-5.6-sol",
+			// no provider prefix; see testdata/agent-formats/codex-cli).
+			// Return bare refs as-is: the caller resolves the provider from
+			// config/auth mode (ChatGPT OAuth → openai). Running them
+			// through splitOpenClawModelRef here stamped its "anthropic"
+			// default onto GPT models and bypassed that fallback.
+			if !strings.Contains(trimmed, "/") {
+				return trimmed
+			}
 			if providerID, modelID := splitOpenClawModelRef(trimmed); providerID != "" && modelID != "" {
 				return providerID + "/" + modelID
 			}

--- a/cli/internal/cmd/testdata/agent-formats/README.md
+++ b/cli/internal/cmd/testdata/agent-formats/README.md
@@ -1,0 +1,18 @@
+# Agent format fixtures
+
+Version-pinned snapshots of the on-disk formats (logs, session files) that the
+CLI's upstream-model resolvers parse. Each fixture is a **verbatim sample**
+captured from a real agent installation, named `<format>@<agent-version>.<ext>`.
+
+Purpose: the resolvers infer an agent's recent upstream model from files the
+agents do not treat as stable interfaces. When an agent changes its format
+(e.g. OpenCode 1.18 switched LLM log lines from `service=llm` to
+`message=stream`), inference silently returns nothing and onboarding degrades
+to MCP-proxy-only without an error. These fixtures turn that silent drift into
+a CI failure.
+
+When adding support for a new agent version's format:
+1. Capture a sanitized sample (redact keys/tokens/paths) into this tree.
+2. Add a case to `agents_format_fixtures_test.go` asserting the resolver
+   extracts the expected provider/model.
+3. Keep the old version's fixture — resolvers must stay backward compatible.

--- a/cli/internal/cmd/testdata/agent-formats/claude-code/session@2.1.jsonl
+++ b/cli/internal/cmd/testdata/agent-formats/claude-code/session@2.1.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-07-20T10:00:00.000Z","type":"user","message":{"role":"user","content":"hello"}}
+{"timestamp":"2026-07-20T10:00:04.120Z","type":"assistant","message":{"role":"assistant","model":"claude-opus-4-6","content":[{"type":"text","text":"hi"}]}}
+{"timestamp":"2026-07-20T10:00:05.000Z","type":"assistant","message":{"role":"assistant","model":"<synthetic>","content":[]}}

--- a/cli/internal/cmd/testdata/agent-formats/codex-cli/session@0.46.jsonl
+++ b/cli/internal/cmd/testdata/agent-formats/codex-cli/session@0.46.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-07-15T23:20:01.000Z","type":"session_meta","payload":{"id":"019f67a6-a28e-7793-a199-fc940500e78f","cwd":"/tmp/w","collaboration_mode":{"mode":"default","settings":{"model":"gpt-5.6-sol","reasoning_effort":"high","developer_instructions":null}}}}
+{"timestamp":"2026-07-15T23:20:02.000Z","type":"turn_context","payload":{"model":"gpt-5.6-sol"}}

--- a/cli/internal/cmd/testdata/agent-formats/gemini-cli/chat@0.21.json
+++ b/cli/internal/cmd/testdata/agent-formats/gemini-cli/chat@0.21.json
@@ -1,0 +1,10 @@
+{
+  "sessionId": "b1946ac9-2f65-4a3e-a5d1-000000000000",
+  "projectHash": "deadbeef",
+  "startTime": "2026-07-19T12:00:00.000Z",
+  "lastUpdated": "2026-07-19T12:05:00.000Z",
+  "messages": [
+    {"id": "m1", "type": "user", "content": "hello", "timestamp": "2026-07-19T12:00:01.000Z"},
+    {"id": "m2", "type": "gemini", "content": "hi", "model": "gemini-3-pro-preview", "timestamp": "2026-07-19T12:00:04.000Z"}
+  ]
+}

--- a/cli/internal/cmd/testdata/agent-formats/opencode/log@1.17.txt
+++ b/cli/internal/cmd/testdata/agent-formats/opencode/log@1.17.txt
@@ -1,0 +1,3 @@
+timestamp=2026-05-11T09:14:02.101Z level=INFO run=aa11bb22 message=init count=42
+timestamp=2026-05-11T09:14:07.334Z level=INFO run=aa11bb22 service=llm providerID=anthropic modelID=claude-opus-4-6 session.id=ses_legacy001
+timestamp=2026-05-11T09:14:09.812Z level=INFO run=aa11bb22 service=llm providerID=zai modelID=glm-5-turbo session.id=ses_legacy001

--- a/cli/internal/cmd/testdata/agent-formats/opencode/log@1.18.5.txt
+++ b/cli/internal/cmd/testdata/agent-formats/opencode/log@1.18.5.txt
@@ -1,0 +1,3 @@
+timestamp=2026-07-26T14:06:17.321Z level=INFO run=7672b312 message=created id=ses_061408316ffevgismtsLGRYBrN slug=neon-falcon version=1.18.5 agent=build model.id=k3 model.providerID=kimi-for-coding model.variant=high
+timestamp=2026-07-26T14:06:17.343Z level=INFO run=7672b312 message=stream providerID=kimi-for-coding modelID=k3 session.id=ses_061408316ffevgismtsLGRYBrN small=true agent=title mode=primary
+timestamp=2026-07-26T14:08:39.044Z level=INFO run=7672b312 message=stream providerID=moonshotai modelID=kimi-k3 session.id=ses_061408316ffevgismtsLGRYBrN small=false agent=build mode=primary


### PR DESCRIPTION
## Summary

**Stacked on #104 → #103 → #102** (structural gap #3 from #102's "known remaining gaps" list).

The CLI's recent-model resolvers parse files (logs, session histories) that agents do **not** treat as stable interfaces. When a format changes, the resolvers fail silently — inference returns `""` and onboarding degrades to MCP-proxy-only with no error. This shipped for real: OpenCode 1.18 renamed its LLM log tag from `service=llm` to `message=stream` and gateway onboarding quietly stopped resolving recent models (fixed in #102).

This PR turns that silent drift into CI failures with actionable names.

## Changes

New `testdata/agent-formats/` tree with verbatim, sanitized fixtures pinned to the agent version they were captured from, plus `agents_format_fixtures_test.go` asserting each resolver extracts the expected model:

- **opencode**: `log@1.17` (`service=llm`) and `log@1.18.5` (`message=stream`) — both must keep passing (backward compatibility)
- **claude-code**: `session@2.1` projects jsonl (incl. `<synthetic>` filtering)
- **codex-cli**: `session@0.46` rollout jsonl (bare model IDs)
- **gemini-cli**: `chat@0.21` `tmp/<hash>/chats` json

A README documents the capture/redaction workflow for adding new versions.

## Bug found by the fixtures

Validating the Codex fixture against a real rollout exposed a live bug: `resolveCodexRecentModelRef` ran bare model IDs (`"gpt-5.6-sol"` — the actual on-disk shape) through `splitOpenClawModelRef`, whose fallback stamped provider **`anthropic`** onto GPT models and bypassed the caller's config/auth-mode provider resolution (ChatGPT OAuth → `openai`). Bare refs are now returned as-is for the caller to resolve. Existing `openai/`-prefixed session tests still pass.

## Testing

- `go build ./...`, `go vet ./...` clean
- Full `./internal/api` + `./internal/cmd` suites pass on the committed tree

Mirrored from GitLab MR !38.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Test-only PR with a minor, well-reasoned bug fix. Fixtures add regression coverage for silent agent format drift; the Codex fix is a targeted 5-line change with existing test coverage.
>
> **Overview**
> This PR adds version-pinned test fixtures for four agent formats (OpenCode, Claude Code, Codex CLI, Gemini CLI) and fixes a bug where bare Codex model IDs were incorrectly stamped with the `anthropic` provider. All 5 new fixture tests pass alongside existing suites.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 288df9a0. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->