### PR TITLE
Add SignPath Foundation code signing policy attribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -540,15 +540,19 @@ jobs:
             curl -fsSL https://preloop.ai/install/cli | sh
             ```
 
-            Windows (PowerShell — recommended):
+            ### Windows binaries
+
+            Free code signing provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
+
+            Download `preloop-windows-amd64.exe` or `preloop-windows-arm64.exe` from the assets below (Authenticode-signed), or install with PowerShell:
 
             ```powershell
             irm https://preloop.ai/install/cli.ps1 | iex
             ```
 
-            Or download a platform-specific `preloop-*` binary below and verify it against `SHA256SUMS`. Pin with `PRELOOP_VERSION=${{ steps.version.outputs.package_version }}`.
+            Verify against `SHA256SUMS`. Pin with `PRELOOP_VERSION=${{ steps.version.outputs.package_version }}`.
 
-            Windows Defender notes and SignPath setup: [docs/windows-cli.md](https://github.com/preloop/preloop/blob/main/docs/windows-cli.md)
+            Code signing policy: [docs/code-signing-policy.md](https://github.com/preloop/preloop/blob/main/docs/code-signing-policy.md). Defender notes: [docs/windows-cli.md](https://github.com/preloop/preloop/blob/main/docs/windows-cli.md).
 
             ## Install Open Source Edition
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **SignPath code signing policy** on the README and release notes (Windows
+  binary section), required for SignPath Foundation attribution
+  (`docs/code-signing-policy.md`).
+
 - **Windows PowerShell CLI installer** (`install-cli.ps1`) with
   `irm https://preloop.ai/install/cli.ps1 | iex`, release `SHA256SUMS`, and
   docs for Defender false-positive recovery (`docs/windows-cli.md`).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ Windows install, Defender false-positive recovery, `go install`, and
 code-signing / VirusTotal status: [docs/windows-cli.md](./docs/windows-cli.md),
 [docs/windows-code-signing.md](./docs/windows-code-signing.md).
 
+## Code signing policy
+
+Free code signing provided by [SignPath.io](https://about.signpath.io/),
+certificate by [SignPath Foundation](https://signpath.org/).
+
+Windows CLI release binaries (`preloop-windows-amd64.exe`,
+`preloop-windows-arm64.exe`) on
+[GitHub Releases](https://github.com/preloop/preloop/releases) are
+Authenticode-signed via SignPath. Full policy (roles, privacy):
+[docs/code-signing-policy.md](./docs/code-signing-policy.md).
+
 <p align="center">
   <img alt="Preloop onboarding local agents into the control plane" src="frontend/public/assets/screenshots/quickstart/dark/agents-onboarding.webp" style="width: 100%; max-width: 1135px; border-radius: 12px;" />
 </p>

--- a/docs/code-signing-policy.md
+++ b/docs/code-signing-policy.md
@@ -1,0 +1,38 @@
+# Code signing policy
+
+Free code signing provided by [SignPath.io](https://about.signpath.io/),
+certificate by [SignPath Foundation](https://signpath.org/).
+
+## What is signed
+
+Windows CLI release binaries published on
+[GitHub Releases](https://github.com/preloop/preloop/releases):
+
+- `preloop-windows-amd64.exe`
+- `preloop-windows-arm64.exe`
+
+These artifacts are built by GitHub Actions from this repository on version
+tags (`v*`) and submitted to SignPath for Authenticode signing before they are
+attached to the release. macOS and Linux CLI binaries are not Authenticode-signed.
+
+See also [windows-code-signing.md](./windows-code-signing.md) for CI wiring and
+maintainer setup.
+
+## Team roles
+
+Per [SignPath Foundation conditions for Open Source projects](https://signpath.org/terms.html):
+
+| Role | Members |
+|------|---------|
+| **Authors** | [preloop organization members](https://github.com/orgs/preloop/people) trusted to modify source in this repository |
+| **Reviewers** | [preloop organization members](https://github.com/orgs/preloop/people) who review pull requests |
+| **Approvers** | [preloop organization owners](https://github.com/orgs/preloop/people?query=role%3Aowner) who approve SignPath signing requests |
+
+## Privacy policy
+
+CLI and self-hosted instance telemetry (optional, opt-out) is documented in
+[SECURITY.md § Telemetry](../SECURITY.md#telemetry). Set
+`PRELOOP_DISABLE_TELEMETRY=true` to disable it.
+
+For Preloop Cloud / hosted services, see
+[https://preloop.ai/privacy](https://preloop.ai/privacy).

--- a/docs/windows-code-signing.md
+++ b/docs/windows-code-signing.md
@@ -1,5 +1,10 @@
 # Windows code signing (SignPath Foundation)
 
+> **Code signing policy (user-facing):** see
+> [code-signing-policy.md](./code-signing-policy.md).
+> Free code signing provided by [SignPath.io](https://about.signpath.io/),
+> certificate by [SignPath Foundation](https://signpath.org/).
+
 Preloop’s release workflow can Authenticode-sign Windows CLI binaries via
 [SignPath Foundation](https://signpath.org/) (free for open-source projects).
 Signing is **optional until credentials are configured**: releases still


### PR DESCRIPTION
## Summary
- Add `docs/code-signing-policy.md` with SignPath-required attribution, roles, and privacy links
- Surface **Code signing policy** on the README (home page requirement)
- Put the SignPath attribution in a **Windows binaries** section of every GitHub Release body (next to the Windows assets)

## Test plan
- [ ] README shows Code signing policy with exact SignPath wording
- [ ] Latest release notes updated (see below) so https://github.com/preloop/preloop/releases mentions SignPath

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes adding required SignPath Foundation attribution. No code, no logic, no security impact.
>
> **Overview**
> Adds a code-signing-policy.md document with SignPath attribution, team roles, and privacy links. Updates README, CHANGELOG, release notes template, and cross-references in windows-code-signing.md.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit docs/signpath-attribution. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->

Made with [Cursor](https://cursor.com)