### PR TITLE
fix: launch-week production error triage

### DIFF
--- a/backend/preloop/api/endpoints/mcp.py
+++ b/backend/preloop/api/endpoints/mcp.py
@@ -1401,16 +1401,28 @@ async def add_comment(
                             url=None,
                         )
 
-                    # GitLab inline diff comments require position data (base_sha, start_sha,
-                    # head_sha, new_path, new_line) which is not available in this context.
-                    # Return a clear error instead of silently creating a non-anchored discussion.
-                    raise HTTPException(
-                        status_code=501,
-                        detail="GitLab inline diff comments (path/line) are not yet supported. "
-                        "GitLab requires diff position data (base_sha, start_sha, head_sha) "
-                        "which is not available in this API. Use a general discussion instead "
-                        "by omitting path and line parameters, or use in_reply_to to reply "
-                        "to an existing discussion.",
+                    # GitLab inline diff comments require position data (base_sha,
+                    # start_sha, head_sha, new_path, new_line) which is not available
+                    # in this context. Degrade gracefully: create a general discussion
+                    # that references the file/line in the body text (same fallback
+                    # update_pull_request uses for review_comments).
+                    logger.info(
+                        f"GitLab inline comment on MR {target_id} at {path}:{line} "
+                        "falling back to general discussion (no diff position data)"
+                    )
+                    discussion_result = await tracker_client.create_mr_discussion(
+                        mr_iid=target_id,
+                        body=f"**{path}:{line}**\n\n{comment}",
+                    )
+                    return AddCommentResponse(
+                        comment_id=str(discussion_result.get("id", "")),
+                        status="created",
+                        message=(
+                            f"Added comment to MR {target_id} as a general discussion "
+                            f"referencing {path}:{line} (GitLab inline diff positioning "
+                            "requires diff position data which is not available)"
+                        ),
+                        url=None,
                     )
 
             # Regular PR/MR comment (not inline)

--- a/backend/preloop/api/endpoints/websockets.py
+++ b/backend/preloop/api/endpoints/websockets.py
@@ -384,15 +384,25 @@ async def unified_websocket(websocket: WebSocket):
             manager_connection_id = str(session.connection_id)
             manager.active_connections[manager_connection_id] = websocket
 
-        # Send initial handshake confirmation
-        await websocket.send_json(
-            {
-                "type": "handshake",
-                "session_id": session.id,
-                "authenticated": session.is_authenticated,
-                "message": "Connected to unified WebSocket",
-            }
-        )
+        # Send initial handshake confirmation. The client may already have
+        # disconnected between accept() and this send — uvloop then raises a
+        # bare RuntimeError ("unable to perform operation on <TCPTransport
+        # closed=True ...>"). Treat that as a normal early disconnect rather
+        # than an unexpected server error.
+        try:
+            await websocket.send_json(
+                {
+                    "type": "handshake",
+                    "session_id": session.id,
+                    "authenticated": session.is_authenticated,
+                    "message": "Connected to unified WebSocket",
+                }
+            )
+        except RuntimeError as e:
+            logger.info(
+                f"Session {session.id} disconnected before handshake completed: {e}"
+            )
+            return
 
         # Message loop
         while True:

--- a/backend/preloop/models/crud/embedding.py
+++ b/backend/preloop/models/crud/embedding.py
@@ -5,6 +5,7 @@ from datetime import datetime, UTC
 from typing import Dict, List, Optional, Tuple, Union
 
 from sqlalchemy import func, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..models.comment import Comment
@@ -288,15 +289,19 @@ class CRUDIssueEmbedding(CRUDBase[IssueEmbedding]):
                     text=text_to_embed, model=model, api_key=api_key
                 )
 
+                meta_data = {
+                    "source": source_entity_description,
+                    "text_processed": text_to_embed[:100] + "..."
+                    if len(text_to_embed) > 100
+                    else text_to_embed,
+                }
+
                 # Create or update embedding
                 if existing:
                     existing.embedding = embedding_vector
                     existing.meta_data = {
                         "updated_at": datetime.now(UTC).isoformat(),
-                        "source": source_entity_description,
-                        "text_processed": text_to_embed[:100] + "..."
-                        if len(text_to_embed) > 100
-                        else text_to_embed,
+                        **meta_data,
                     }
                     db.add(existing)
                     results[model.name] = f"updated_for_{source_entity_description}"
@@ -307,15 +312,35 @@ class CRUDIssueEmbedding(CRUDBase[IssueEmbedding]):
                         comment_id=comment_id,  # Pass comment_id
                         embedding_model_id=model.id,
                         embedding=embedding_vector,
-                        meta_data={
-                            "source": source_entity_description,
-                            "text_processed": text_to_embed[:100] + "..."
-                            if len(text_to_embed) > 100
-                            else text_to_embed,
-                        },
+                        meta_data=meta_data,
                     )
-                    db.add(new_embedding)
-                    results[model.name] = f"created_for_{source_entity_description}"
+                    # Flush inside a savepoint so a concurrent insert (e.g. two
+                    # webhook deliveries for the same comment racing through the
+                    # check-then-insert above) surfaces here as an IntegrityError
+                    # we can recover from, instead of blowing up the whole
+                    # transaction at commit time (uix_issue_embedding_model).
+                    try:
+                        with db.begin_nested():
+                            db.add(new_embedding)
+                            db.flush()
+                        results[model.name] = f"created_for_{source_entity_description}"
+                    except IntegrityError:
+                        # Row was inserted concurrently; update it instead.
+                        concurrent = query.first()
+                        if concurrent is not None:
+                            concurrent.embedding = embedding_vector
+                            concurrent.meta_data = {
+                                "updated_at": datetime.now(UTC).isoformat(),
+                                **meta_data,
+                            }
+                            db.add(concurrent)
+                            results[model.name] = (
+                                f"updated_for_{source_entity_description}"
+                            )
+                        else:
+                            results[model.name] = (
+                                f"already_exists_for_{source_entity_description}"
+                            )
             except Exception as e:
                 results[model.name] = f"error_for_{source_entity_description}: {str(e)}"
 

--- a/backend/preloop/sync/trackers/gitlab.py
+++ b/backend/preloop/sync/trackers/gitlab.py
@@ -1791,19 +1791,38 @@ class GitLabTracker(BaseTracker):
         try:
             project = await self._make_request(self.gl.projects.get, project_id)
             mr = await self._make_request(project.mergerequests.get, mr_iid)
-
-            # Unapprove the merge request
-            await self._make_request(mr.unapprove)
-
-            return {
-                "id": str(mr.id),
-                "iid": mr.iid,
-                "approved": False,
-            }
-
         except Exception as e:
             logger.error(f"Error unapproving merge request {mr_iid}: {e}")
             raise TrackerResponseError(f"Failed to unapprove merge request: {e}")
+
+        try:
+            # Unapprove the merge request
+            await self._make_request(mr.unapprove)
+        except Exception as e:
+            # GitLab returns 404 when there is no approval from the current
+            # user to revoke (or the approvals feature is unavailable on this
+            # plan/instance). Treat this as a successful no-op instead of
+            # failing the whole review flow.
+            if is_not_found_error(e):
+                logger.warning(
+                    f"Unapprove skipped for MR {mr_iid}: no approval to revoke "
+                    f"or approvals not available (404). Treating as no-op."
+                )
+                return {
+                    "id": str(mr.id),
+                    "iid": mr.iid,
+                    "approved": False,
+                    "skipped": True,
+                    "reason": "no approval to revoke (404)",
+                }
+            logger.error(f"Error unapproving merge request {mr_iid}: {e}")
+            raise TrackerResponseError(f"Failed to unapprove merge request: {e}")
+
+        return {
+            "id": str(mr.id),
+            "iid": mr.iid,
+            "approved": False,
+        }
 
     async def get_mr_discussions(
         self, mr_iid: str, filter_author: Optional[str] = None

--- a/backend/tests/endpoints/test_mcp.py
+++ b/backend/tests/endpoints/test_mcp.py
@@ -7,7 +7,6 @@ from datetime import datetime, timezone
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
-from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from preloop.api.endpoints import mcp
@@ -727,10 +726,11 @@ async def test_add_comment_inline_github_pr(db_session: Session, test_user: User
 @pytest.mark.asyncio
 async def test_add_comment_inline_gitlab_mr(db_session: Session, test_user: User):
     """
-    Tests that inline comments on GitLab MRs return 501 (not implemented).
+    Tests that inline comments on GitLab MRs degrade gracefully to a general
+    discussion referencing the file/line (GlitchTip issue 3274).
 
     GitLab inline diff comments require position data (base_sha, start_sha, head_sha)
-    which is not available through this API.
+    which is not available through this API, so we fall back instead of erroring.
     """
     tracker = Tracker(
         name="test-tracker",
@@ -777,20 +777,26 @@ async def test_add_comment_inline_gitlab_mr(db_session: Session, test_user: User
 
         mock_tracker = MagicMock()
         mock_tracker.tracker_type = "gitlab"
+        mock_tracker.create_mr_discussion = AsyncMock(return_value={"id": "disc-456"})
         mock_get_tracker.return_value = mock_tracker
 
-        # GitLab inline comments (with path/line) should return 501
-        with pytest.raises(HTTPException) as exc_info:
-            await mcp.add_comment(
-                target="https://gitlab.com/group/project/-/merge_requests/5",
-                comment="Consider refactoring this",
-                path="lib/utils.py",
-                line=100,
-            )
+        # GitLab inline comments (with path/line) fall back to a general
+        # discussion that references the file/line in the body.
+        response = await mcp.add_comment(
+            target="https://gitlab.com/group/project/-/merge_requests/5",
+            comment="Consider refactoring this",
+            path="lib/utils.py",
+            line=100,
+        )
 
-        assert exc_info.value.status_code == 501
-        assert "GitLab inline diff comments" in exc_info.value.detail
-        assert "not yet supported" in exc_info.value.detail
+    assert response.status == "created"
+    assert response.comment_id == "disc-456"
+    assert "lib/utils.py:100" in response.message
+    mock_tracker.create_mr_discussion.assert_called_once()
+    call_kwargs = mock_tracker.create_mr_discussion.call_args.kwargs
+    assert call_kwargs["mr_iid"] == "5"
+    assert "**lib/utils.py:100**" in call_kwargs["body"]
+    assert "Consider refactoring this" in call_kwargs["body"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/endpoints/test_websockets.py
+++ b/backend/tests/endpoints/test_websockets.py
@@ -310,3 +310,54 @@ class TestUnifiedWebSocket:
 
         # Verify session cleanup was called
         mock_session_manager.end_session.assert_called_once()
+
+    @patch("preloop.api.endpoints.websockets.handle_activity")
+    @patch("preloop.api.endpoints.websockets.session_manager")
+    @patch("preloop.api.endpoints.websockets.manager")
+    def test_unified_websocket_client_gone_before_handshake(
+        self,
+        mock_manager,
+        mock_session_manager,
+        mock_handle_activity,
+    ):
+        """If the client transport is already closed when the handshake is sent,
+        uvloop raises a bare RuntimeError ("unable to perform operation on
+        <TCPTransport closed=True ...>"). The endpoint must treat this as a
+        normal early disconnect and still run cleanup (GlitchTip issue 3275).
+        """
+        import asyncio
+
+        from preloop.api.endpoints.websockets import unified_websocket
+
+        # Session mocks
+        mock_session = MagicMock()
+        mock_session.id = "test-session-id"
+        mock_session.connection_id = "test-connection-id"
+        mock_session.is_authenticated = False
+        mock_session_manager.create_session = AsyncMock(return_value=mock_session)
+        mock_session_manager.end_session = AsyncMock()
+        mock_session_manager.sessions = {}
+
+        mock_manager.active_connections = {}
+        mock_manager.disconnect = MagicMock()
+
+        # WebSocket whose transport died between accept() and the handshake send
+        mock_websocket = MagicMock()
+        mock_websocket.accept = AsyncMock()
+        mock_websocket.close = AsyncMock()
+        mock_websocket.scope = {"state": {"user": None}}
+        mock_websocket.query_params = {"fingerprint": "test-fingerprint"}
+        mock_websocket.headers = {"user-agent": "test-agent"}
+        mock_websocket.client = MagicMock(host="127.0.0.1")
+        mock_websocket.send_json = AsyncMock(
+            side_effect=RuntimeError(
+                "unable to perform operation on <TCPTransport closed=True "
+                "reading=False 0xdeadbeef>; the handler is closed"
+            )
+        )
+
+        # Must not raise — early disconnect is a normal condition
+        asyncio.run(unified_websocket(mock_websocket))
+
+        # Cleanup still ran
+        mock_session_manager.end_session.assert_called_once_with("test-session-id")

--- a/backend/tests/endpoints/test_websockets.py
+++ b/backend/tests/endpoints/test_websockets.py
@@ -359,5 +359,7 @@ class TestUnifiedWebSocket:
         # Must not raise — early disconnect is a normal condition
         asyncio.run(unified_websocket(mock_websocket))
 
-        # Cleanup still ran
+        # Full cleanup chain ran despite the dead transport
         mock_session_manager.end_session.assert_called_once_with("test-session-id")
+        mock_manager.disconnect.assert_called_once_with("test-connection-id")
+        mock_websocket.close.assert_called_once()

--- a/backend/tests/models/test_embedding.py
+++ b/backend/tests/models/test_embedding.py
@@ -432,3 +432,62 @@ def test_similarity_search_with_embedding_type(
             embedding_type="another_invalid",
             limit=5,
         )
+
+
+def test_create_embeddings_concurrent_insert_race(
+    db_session, create_issue, create_comment, create_embedding_model, mocker
+):
+    """A concurrent insert between the existence check and our insert must not
+    blow up with IntegrityError (uix_issue_embedding_model) — it should fall
+    back to updating the concurrently-inserted row (GlitchTip issue 2526).
+    """
+    from preloop.models.models.issue import EmbeddingModel
+
+    issue = create_issue()
+    comment = create_comment(
+        issue_id=str(issue.id), external_id="902", body="Race condition comment."
+    )
+    model = create_embedding_model()
+
+    # Deactivate any other (seeded) embedding models so the simulated
+    # concurrent insert below races against exactly our model's row.
+    db_session.query(EmbeddingModel).filter(EmbeddingModel.id != model.id).update(
+        {"is_active": False}
+    )
+    db_session.flush()
+
+    mock_generate_embedding = mocker.patch(
+        "preloop.models.crud.crud_issue_embedding._generate_embedding_vector"
+    )
+
+    def _simulate_concurrent_insert(*args, **kwargs):
+        # Another webhook delivery wins the race: insert the row AFTER the
+        # existence check ran but BEFORE create_embeddings inserts its own.
+        competing = IssueEmbedding(
+            id=IssueEmbedding.generate_id(),
+            issue_id=issue.id,
+            comment_id=comment.id,
+            embedding_model_id=model.id,
+            embedding=[0.5] * model.dimensions,
+            meta_data={"source": "concurrent writer"},
+        )
+        db_session.add(competing)
+        db_session.flush()
+        return [0.1] * model.dimensions
+
+    mock_generate_embedding.side_effect = _simulate_concurrent_insert
+
+    result = crud_issue_embedding.create_embeddings(
+        db_session, issue_id=issue.id, comment_id=comment.id, force_update=False
+    )
+
+    # No "error_for_..." result: the duplicate insert was recovered by
+    # updating the concurrently-created row.
+    assert model.name in result
+    assert "error" not in result[model.name]
+    assert f"updated_for_comment {comment.id}" in result[model.name]
+
+    embeddings = crud_issue_embedding.get_for_comment(db_session, comment_id=comment.id)
+    embedding = embeddings[model.name]
+    # The recovered row now carries our vector, not the competing one.
+    assert embedding.embedding[0] == pytest.approx(0.1)

--- a/backend/tests/sync/trackers/test_gitlab_mr_review.py
+++ b/backend/tests/sync/trackers/test_gitlab_mr_review.py
@@ -121,6 +121,36 @@ class TestUnapproveMergeRequest(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Project ID not found", str(context.exception))
 
     @patch("preloop.sync.trackers.gitlab.gitlab.Gitlab")
+    async def test_unapprove_merge_request_404_is_noop(self, mock_gitlab_constructor):
+        """A 404 from the unapprove call (no approval to revoke, or approvals
+        unavailable on this plan) is treated as a successful no-op instead of
+        raising (GlitchTip issues 3270-3273)."""
+        import gitlab as gitlab_lib
+
+        mock_gl_instance = MagicMock()
+        mock_gitlab_constructor.return_value = mock_gl_instance
+        mock_gl_instance.auth.return_value = None
+
+        mock_project = MagicMock()
+        mock_gl_instance.projects.get.return_value = mock_project
+
+        mock_mr = MagicMock()
+        mock_mr.id = 12345
+        mock_mr.iid = 1
+        mock_mr.unapprove.side_effect = gitlab_lib.exceptions.GitlabHttpError(
+            "404 Not Found", response_code=404
+        )
+        mock_project.mergerequests.get.return_value = mock_mr
+
+        tracker = GitLabTracker("tracker-1", "api-key", {"project_id": "proj-1"})
+        result = await tracker.unapprove_merge_request("1")
+
+        self.assertEqual(result["id"], "12345")
+        self.assertEqual(result["iid"], 1)
+        self.assertFalse(result["approved"])
+        self.assertTrue(result["skipped"])
+
+    @patch("preloop.sync.trackers.gitlab.gitlab.Gitlab")
     async def test_unapprove_merge_request_api_error(self, mock_gitlab_constructor):
         """Test unapproval handles API errors."""
         mock_gl_instance = MagicMock()


### PR DESCRIPTION
## Summary

Triage of production errors observed in GlitchTip on the hosted instance during launch week. Three error classes fixed; the rest are filed as issues with evidence.

### 1. GitLab MR review flow degrades gracefully (GlitchTip 3270–3274)

The PR-reviewer flow failed hard on two GitLab limitations:

- **`unapprove` 404** — GitLab returns 404 from `POST .../unapprove` when there is no approval from the current user to revoke (or the approvals feature is unavailable on the plan/instance). This raised `TrackerResponseError` and failed the entire `request_changes` review. Now treated as a successful no-op (`skipped: true` in the result) with a warning log.
- **Inline comments 501** — `add_comment` with `path`/`line` on a GitLab MR raised HTTP 501 because GitLab requires diff position data (base_sha/start_sha/head_sha) that isn't available here. Now falls back to a general discussion referencing `path:line` in the body — the same fallback `update_pull_request` already used for `review_comments`.

### 2. Embedding creation survives concurrent webhook deliveries (GlitchTip 2526, 56 occurrences)

`create_embeddings` used check-then-insert; two webhook deliveries for the same comment racing through it caused `IntegrityError: duplicate key ... uix_issue_embedding_model` and rolled back the whole webhook transaction. The insert now runs inside a savepoint (`begin_nested`) and recovers from a concurrent insert by updating the winning row.

### 3. WebSocket handshake vs. vanished client (GlitchTip 3275)

If the client transport closes between `accept()` and the handshake `send_json`, uvloop raises a bare `RuntimeError` ("unable to perform operation on \<TCPTransport closed=True ...\>") which was logged as an unexpected server error. Now treated as a normal early disconnect: info log, full cleanup, no error event.

## Not fixed here (filed separately with GlitchTip evidence)

- OAuth code-exchange failures (3260–3262, ~128 each): confirmed **100% synthetic** — every event carries the `preloop-sso-probe/1` user agent and the probe's invalid code; endpoint already returns a clean 400 to callers. Log-noise fix belongs to the probe/EE side.
- `APIConnectionError` (3276) and `MidStreamFallbackError` (2992): upstream provider connection failures, low volume.
- Instance-tracker duplicate `instance_uuid` (2922): lives in EE plugin code.

## Tests

- New: unapprove-404-is-noop, GitLab inline-comment fallback, embedding concurrent-insert race, websocket client-gone-before-handshake.
- Ran: `tests/endpoints/test_mcp.py`, `tests/sync/trackers/`, `tests/models/test_embedding.py`, `tests/endpoints/test_websockets.py`, `tests/endpoints/test_embedding.py` → **265 passed**.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> This PR fixes three well-understood production error classes with targeted, well-tested changes. No API contract changes, no new dependencies, no schema migrations. The savepoint-based race fix in `create_embeddings` is the only change with subtle concurrency semantics and is covered by a dedicated test.

> **Overview**
> Production error triage from launch week: GitLab MR review degrades gracefully on 404/501 responses, embedding creation survives concurrent webhook inserts via savepoints, and WebSocket early-disconnect is handled as a normal condition. All fixes have corresponding regression tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 78ca515. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->