### PR TITLE
docs: verifiable trust badges + OpenSSF scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+# OpenSSF Scorecard supply-chain security analysis
+# https://github.com/ossf/scorecard-action
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 2 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to OpenSSF REST API for badge and public visibility.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # <img alt="Preloop Logo" src="frontend/public/assets/preloop-badge.png" style="height: 22px;" height="22px" /> Preloop - The Open-Source AI Agent Control Plane
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/preloop/preloop/ci.yml?branch=main&label=CI)](https://github.com/preloop/preloop/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/preloop/preloop)](https://github.com/preloop/preloop/releases/latest)
+[![PyPI](https://img.shields.io/pypi/v/preloop)](https://pypi.org/project/preloop/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 **Preloop is the open-source AI agent control plane.** It unifies an **MCP firewall** for tool access, an **AI model gateway** for cost, safety and attribution, **policy-as-code** with **human approvals**, **runtime session observability**, and **audit trails** - in a single self-hostable platform.
 
@@ -39,13 +42,16 @@ code-signing / VirusTotal status: [docs/windows-cli.md](./docs/windows-cli.md),
 
 ## Code signing policy
 
+Releases ship a `SHA256SUMS` asset and a VirusTotal scan of the Windows binaries; SignPath Authenticode signing is pending. See [docs/windows-cli.md](./docs/windows-cli.md) and [docs/windows-code-signing.md](./docs/windows-code-signing.md).
+
 Free code signing provided by [SignPath.io](https://about.signpath.io/),
 certificate by [SignPath Foundation](https://signpath.org/).
 
 Windows CLI release binaries (`preloop-windows-amd64.exe`,
 `preloop-windows-arm64.exe`) on
-[GitHub Releases](https://github.com/preloop/preloop/releases) are
-Authenticode-signed via SignPath. Full policy (roles, privacy):
+[GitHub Releases](https://github.com/preloop/preloop/releases) will be
+Authenticode-signed via SignPath once the signing policy is active. Full
+policy (roles, privacy):
 [docs/code-signing-policy.md](./docs/code-signing-policy.md).
 
 <p align="center">

--- a/docs/OPENSSF_BEST_PRACTICES.md
+++ b/docs/OPENSSF_BEST_PRACTICES.md
@@ -1,0 +1,87 @@
+# OpenSSF Best Practices Badge: Readiness Checklist
+
+Working notes for completing the questionnaire at
+[bestpractices.dev](https://www.bestpractices.dev/) (passing level).
+We do NOT claim the badge until the questionnaire is submitted and the site
+grants it. This file maps each passing criterion to current repo evidence so
+the questionnaire can be filled in quickly and honestly.
+
+Status legend: MET (evidence exists), PARTIAL (some evidence, gap noted),
+UNMET (honest gap, action listed).
+
+## Basics
+
+| Criterion | Status | Evidence / gap |
+|---|---|---|
+| Project website describes what the software does | MET | [README.md](../README.md), https://preloop.ai, https://docs.preloop.ai |
+| Contribution process documented | MET | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Contribution requirements (style, tests) | MET | CONTRIBUTING.md (code style), [TESTING.md](../TESTING.md) |
+| FLOSS license | MET | Apache-2.0, [LICENSE](../LICENSE), OSI approved |
+| License file at standard location | MET | `LICENSE` at repo root |
+| Basic documentation | MET | README, ARCHITECTURE.md, docs.preloop.ai |
+| HTTPS project sites | MET | GitHub, preloop.ai, docs.preloop.ai all HTTPS |
+| Discussion mechanism | MET | GitHub issues + Discord (linked from README) |
+| English supported | MET | All docs and issues in English |
+
+## Change control
+
+| Criterion | Status | Evidence / gap |
+|---|---|---|
+| Public version-controlled source repo | MET | https://github.com/preloop/preloop |
+| Interim versions available for review | MET | main branch, PRs public |
+| Unique version numbering | MET | SemVer tags `vX.Y.Z`, [VERSION](../VERSION) file |
+| Release notes per release | MET | [CHANGELOG.md](../CHANGELOG.md) (Keep a Changelog format, git-cliff) + GitHub release notes |
+| Release notes identify fixed vulnerabilities | PARTIAL | Process exists via CHANGELOG; no CVEs published yet, so untested. Note in RELEASING.md when first one lands. |
+
+## Reporting
+
+| Criterion | Status | Evidence / gap |
+|---|---|---|
+| Bug reporting process | MET | GitHub issues |
+| Bug tracker archive | MET | GitHub issues history |
+| Vulnerability reporting process published | MET | [SECURITY.md](../SECURITY.md), security@preloop.ai |
+| Private vulnerability reporting supported | MET | Email path in SECURITY.md; consider also enabling GitHub private vulnerability reporting in repo settings (small gap) |
+| Initial response to vulnerability reports <= 14 days | PARTIAL | Committed to in SECURITY.md ("acknowledge receipt as soon as possible"); no reports received yet to demonstrate track record |
+
+## Quality
+
+| Criterion | Status | Evidence / gap |
+|---|---|---|
+| Working build system | MET | pyproject.toml, cli/Makefile, Dockerfile, CI builds all of it |
+| Automated test suite | MET | pytest (backend), Web Test Runner (frontend), Go tests (CLI); run in [ci.yml](../.github/workflows/ci.yml) |
+| New functionality includes tests (policy) | PARTIAL | Practiced and enforced via coverage gate (`--cov-fail-under=60`, Codecov); make the policy explicit in CONTRIBUTING.md (one-line addition) |
+| Warning flags / linters enabled | MET | ruff + pre-commit in CI lint job |
+| Test coverage measured | MET | Codecov upload in CI; target 75%, floor 60% (TESTING.md) |
+
+## Security
+
+| Criterion | Status | Evidence / gap |
+|---|---|---|
+| Developers know secure design basics | MET | Security-focused product (policy engine, approvals, audit); ARCHITECTURE.md documents trust boundaries |
+| Crypto: published protocols only, no custom crypto | MET | Standard TLS, JWT, bcrypt via passlib (pyproject.toml); no homegrown crypto |
+| Crypto: FLOSS implementations | MET | Python/Go standard ecosystem libraries |
+| Secure delivery of releases | MET | HTTPS GitHub Releases; `SHA256SUMS` asset ships with every release; VirusTotal scan links appended to release notes for Windows binaries |
+| Signed releases | PARTIAL | Checksums yes; Authenticode via SignPath is wired in [release.yml](../.github/workflows/release.yml) but PENDING SignPath approval/secrets ([docs/windows-code-signing.md](./windows-code-signing.md)). No GPG/Sigstore signing of tarballs yet. Action: enable SignPath, consider Sigstore cosign for archives. |
+| No unpatched publicly known vulnerabilities (medium+) | MET | None known; dependency updates ongoing |
+| Static analysis applied | PARTIAL | ruff covers Python; add a dedicated security scanner (bandit or CodeQL) and Go staticcheck/gosec. OpenSSF Scorecard action now runs weekly ([scorecard.yml](../.github/workflows/scorecard.yml)). |
+| Dynamic analysis (suggested, not required) | UNMET | Not currently run; integration tests exercise real stack which partially covers this |
+
+## Honest gaps summary (do these before or while filling the questionnaire)
+
+1. SignPath Authenticode signing: pending approval; binaries currently publish
+   unsigned with checksums. Track in docs/windows-code-signing.md.
+2. No cryptographic signing of source archives (GPG/Sigstore). Optional for
+   passing level but strengthens "signed releases".
+3. Enable GitHub private vulnerability reporting to complement the email path.
+4. Add one line to CONTRIBUTING.md making tests-for-new-functionality an
+   explicit policy.
+5. Add CodeQL or bandit + gosec for dedicated security static analysis.
+6. No vulnerability-fix track record yet (no reports received); nothing to do,
+   just answer honestly.
+
+## How to claim the badge
+
+1. Sign in at https://www.bestpractices.dev/ with the project GitHub account.
+2. Register https://github.com/preloop/preloop.
+3. Fill the passing questionnaire using the table above (most answers are Met).
+4. Only after the site shows "passing" do we add the badge to README.md.


### PR DESCRIPTION
## What

- **README badges**: adds CI workflow status, latest GitHub release, and PyPI version badges next to the existing Python and license badges. Every shields.io URL and link target was verified to return HTTP 200 before commit.
- **Honesty fix**: the code signing section previously said Windows binaries *are* Authenticode-signed; SignPath is wired in the release workflow but still pending activation, so the wording now says signing is pending. Added one line stating releases ship `SHA256SUMS` plus a VirusTotal scan, linking [docs/windows-cli.md](docs/windows-cli.md) and [docs/windows-code-signing.md](docs/windows-code-signing.md).
- **OpenSSF Scorecard**: adds the standard [ossf/scorecard-action](https://github.com/ossf/scorecard-action) workflow (`.github/workflows/scorecard.yml`) running weekly and on pushes to main, with `publish_results: true` and SARIF upload to code scanning.
- **Best Practices prep**: adds [docs/OPENSSF_BEST_PRACTICES.md](docs/OPENSSF_BEST_PRACTICES.md), a checklist mapping bestpractices.dev passing criteria to current repo evidence with honest gaps listed (SignPath pending, no archive signing, no dedicated security static analysis yet). We do not claim the badge until the questionnaire is submitted and granted.

## Why

Keep README badges limited to verifiable signals (CI, releases, registries, license) rather than directory rankings; see #108.

## Notes

- No badge added for OpenSSF Best Practices or Scorecard yet; those come after results are published and the questionnaire is passed.
- Do not merge without founder review.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only changes plus a standard OpenSSF Scorecard CI workflow. No application code modified.

> **Overview**
> Adds verified README badges (CI, release, PyPI), corrects code-signing language to honestly reflect SignPath's pending status, introduces OpenSSF Scorecard weekly scanning, and ships a bestpractices.dev readiness checklist. All changes are documentation/config-only.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit feat/trust-badges. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->