### PR TITLE
fix: gateway SSE streams no longer die as silent empty HTTP 200 (#109)

### DIFF
--- a/backend/preloop/services/gemini_gateway.py
+++ b/backend/preloop/services/gemini_gateway.py
@@ -126,6 +126,21 @@ class GeminiGatewayService(OpenAIGatewayService):
                     final_usage = response.get("usage")
                     response_id = response.get("id")
                     model_version = response.get("model") or model_name
+                elif event_type == "error":
+                    # The upstream OpenAI-compatible stream failed mid-stream
+                    # (issue #109). Relay it as a Gemini-native error event and
+                    # stop without emitting the final STOP candidate.
+                    yield self._sse_event(
+                        {
+                            "error": {
+                                "code": 502,
+                                "message": parsed.get("message")
+                                or "Gateway upstream error",
+                                "status": "INTERNAL",
+                            }
+                        }
+                    )
+                    return
 
             final_payload: Dict[str, Any] = {
                 "candidates": [

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -11,6 +11,7 @@ import threading
 import time
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+from itertools import chain
 from typing import Any, Dict, Iterator, List, Optional, Protocol
 from urllib import error as urllib_error
 from urllib import request as urllib_request
@@ -847,11 +848,14 @@ class OpenAIGatewayService:
                     url=url, headers=headers, body=body
                 )
             else:
-                upstream_stream = self._call_litellm(
-                    model,
-                    messages=messages,
-                    payload=payload,
-                    stream=True,
+                upstream_stream = self._prefetch_upstream_stream(
+                    self._call_litellm(
+                        model,
+                        messages=messages,
+                        payload=payload,
+                        stream=True,
+                        provider="anthropic",
+                    ),
                     provider="anthropic",
                 )
         except ModelGatewayAPIError as exc:
@@ -1161,7 +1165,14 @@ class OpenAIGatewayService:
                         request_payload=payload,
                     )
                     recorded = True
-                raise
+                # Status 200 is already on the wire; emit an Anthropic-style
+                # SSE error event instead of truncating silently (issue #109).
+                logger.error(
+                    "Gateway anthropic-messages stream failed mid-stream: %s",
+                    exc,
+                    exc_info=True,
+                )
+                yield self._anthropic_stream_error_event(exc)
             finally:
                 # Client disconnect raises GeneratorExit (a BaseException) at the
                 # paused yield, which the except above does not catch — so
@@ -1233,11 +1244,14 @@ class OpenAIGatewayService:
                     started_at=started_at,
                     budget_result=budget_result,
                 )
-            upstream_stream = self._call_litellm(
-                model,
-                messages=messages,
-                payload=payload,
-                stream=True,
+            upstream_stream = self._prefetch_upstream_stream(
+                self._call_litellm(
+                    model,
+                    messages=messages,
+                    payload=payload,
+                    stream=True,
+                    provider="openai",
+                ),
                 provider="openai",
             )
         except ModelGatewayAPIError as exc:
@@ -1403,7 +1417,17 @@ class OpenAIGatewayService:
                         request_payload=payload,
                     )
                     recorded = True
-                raise
+                # The HTTP 200 status line is already committed once the ASGI
+                # layer starts the stream, so re-raising here would hand the
+                # client a silent, truncated body (issue #109). Emit a visible
+                # SSE error event instead so clients can distinguish an
+                # upstream failure from a network fault.
+                logger.error(
+                    "Gateway chat-completions stream failed mid-stream: %s",
+                    exc,
+                    exc_info=True,
+                )
+                yield self._openai_stream_error_event(exc)
             finally:
                 # See stream_message: catch the client-disconnect GeneratorExit
                 # so consumed tokens are still accounted.
@@ -1465,11 +1489,14 @@ class OpenAIGatewayService:
                     started_at=started_at,
                     budget_result=budget_result,
                 )
-            upstream_stream = self._call_litellm(
-                model,
-                messages=messages,
-                payload=payload,
-                stream=True,
+            upstream_stream = self._prefetch_upstream_stream(
+                self._call_litellm(
+                    model,
+                    messages=messages,
+                    payload=payload,
+                    stream=True,
+                    provider="openai",
+                ),
                 provider="openai",
             )
         except ModelGatewayAPIError as exc:
@@ -1725,7 +1752,14 @@ class OpenAIGatewayService:
                         request_payload=payload,
                     )
                     recorded = True
-                raise
+                # Status 200 is already on the wire; surface the failure as an
+                # SSE error event instead of silently truncating (issue #109).
+                logger.error(
+                    "Gateway responses stream failed mid-stream: %s",
+                    exc,
+                    exc_info=True,
+                )
+                yield self._responses_stream_error_event(exc)
             finally:
                 # See stream_message: account for tokens consumed before a
                 # client disconnect (GeneratorExit).
@@ -2709,8 +2743,18 @@ class OpenAIGatewayService:
             or resolve_ai_model_runtime(ai_model).model_gateway_model_alias
         )
 
-        def event_stream() -> Iterator[str]:
+        # Call the upstream BEFORE handing the generator to the ASGI layer so
+        # upstream failures surface as real error responses instead of empty
+        # HTTP 200 streams (issue #109); see _stream_openai_codex_chat_completion.
+        try:
             response_dict = self._create_openai_codex_response(ai_model, payload)
+        except ModelGatewayAPIError:
+            # Recorded by the caller's pre-stream error handler.
+            raise
+        except Exception as exc:
+            raise self._normalize_upstream_error("openai", exc) from exc
+
+        def event_stream() -> Iterator[str]:
             response_payload = self._build_responses_api_payload(
                 ai_model=ai_model,
                 requested_model=requested_model,
@@ -2833,7 +2877,14 @@ class OpenAIGatewayService:
                     error_detail=str(exc),
                     request_payload=payload,
                 )
-                raise
+                # Status 200 is already on the wire; emit an SSE error event
+                # instead of truncating silently (issue #109).
+                logger.error(
+                    "Gateway codex responses stream failed mid-stream: %s",
+                    exc,
+                    exc_info=True,
+                )
+                yield self._responses_stream_error_event(exc)
 
         return event_stream()
 
@@ -2861,22 +2912,34 @@ class OpenAIGatewayService:
             or resolve_ai_model_runtime(ai_model).model_gateway_model_alias
         )
 
+        # Call the upstream BEFORE handing the generator to the ASGI layer.
+        # StreamingResponse commits the HTTP 200 status line before pulling the
+        # first chunk, so an upstream failure raised inside the generator would
+        # reach the client as an empty 200 stream with no error event (issue
+        # #109: deterministic empty streams for tool-bearing requests when the
+        # Codex upstream rejected them). Raising here instead surfaces the real
+        # status code through the normal gateway error path.
+        try:
+            upstream_payload = self._build_openai_codex_payload_from_chat_completion(
+                payload=payload,
+                messages=messages,
+                ai_model=ai_model,
+            )
+            raw_codex_response = self._create_openai_codex_response(
+                ai_model, upstream_payload
+            )
+            response_dict = self._codex_response_to_chat_completion_dict(
+                raw_codex_response
+            )
+        except ModelGatewayAPIError:
+            # Recorded by the caller's pre-stream error handler.
+            raise
+        except Exception as exc:
+            raise self._normalize_upstream_error("openai", exc) from exc
+
         def event_stream() -> Iterator[str]:
             recorded = False
             try:
-                upstream_payload = (
-                    self._build_openai_codex_payload_from_chat_completion(
-                        payload=payload,
-                        messages=messages,
-                        ai_model=ai_model,
-                    )
-                )
-                raw_codex_response = self._create_openai_codex_response(
-                    ai_model, upstream_payload
-                )
-                response_dict = self._codex_response_to_chat_completion_dict(
-                    raw_codex_response
-                )
                 response_id = response_dict.get("id", f"chatcmpl_{int(time.time())}")
                 created_at = int(response_dict.get("created", time.time()))
                 message = (response_dict.get("choices") or [{}])[0].get("message") or {}
@@ -3004,29 +3067,18 @@ class OpenAIGatewayService:
                 )
                 recorded = True
                 yield self._sse_done()
-            except ModelGatewayAPIError as exc:
-                if not recorded:
-                    self._record_gateway_request(
-                        endpoint="/openai/v1/chat/completions",
-                        method="POST",
-                        status_code=exc.status_code,
-                        duration=time.perf_counter() - started_at,
-                        ai_model=ai_model,
-                        requested_model=payload.get("model"),
-                        response_payload=None,
-                        upstream_response=None,
-                        endpoint_kind="chat_completions_stream",
-                        budget_result=budget_result,
-                        error_detail=exc.message,
-                        request_payload=payload,
-                    )
-                raise
             except Exception as exc:
+                status_code = (
+                    exc.status_code if isinstance(exc, ModelGatewayAPIError) else 502
+                )
+                error_detail = (
+                    exc.message if isinstance(exc, ModelGatewayAPIError) else str(exc)
+                )
                 if not recorded:
                     self._record_gateway_request(
                         endpoint="/openai/v1/chat/completions",
                         method="POST",
-                        status_code=502,
+                        status_code=status_code,
                         duration=time.perf_counter() - started_at,
                         ai_model=ai_model,
                         requested_model=payload.get("model"),
@@ -3034,10 +3086,17 @@ class OpenAIGatewayService:
                         upstream_response=None,
                         endpoint_kind="chat_completions_stream",
                         budget_result=budget_result,
-                        error_detail=str(exc),
+                        error_detail=error_detail,
                         request_payload=payload,
                     )
-                raise
+                # Status 200 is already on the wire; emit an SSE error event
+                # instead of truncating silently (issue #109).
+                logger.error(
+                    "Gateway codex chat stream failed mid-stream: %s",
+                    exc,
+                    exc_info=True,
+                )
+                yield self._openai_stream_error_event(exc)
 
         return event_stream()
 
@@ -3549,7 +3608,14 @@ class OpenAIGatewayService:
                         request_payload=payload,
                     )
                     recorded = True
-                raise
+                # Status 200 is already on the wire; emit an Anthropic-style
+                # SSE error event instead of truncating silently (issue #109).
+                logger.error(
+                    "Gateway anthropic passthrough stream failed mid-stream: %s",
+                    exc,
+                    exc_info=True,
+                )
+                yield self._anthropic_stream_error_event(exc)
             finally:
                 # GeneratorExit (client disconnect) bypasses the except above;
                 # bill already-consumed upstream tokens best-effort.
@@ -3746,6 +3812,68 @@ class OpenAIGatewayService:
             return self.upstream_backend.completion(**kwargs)
         except Exception as exc:
             raise self._normalize_upstream_error(provider, exc) from exc
+
+    def _prefetch_upstream_stream(
+        self, upstream_stream: Any, *, provider: GatewayProvider
+    ) -> Iterator[Any]:
+        """Pull the first upstream chunk before SSE headers are committed.
+
+        ``StreamingResponse`` sends the HTTP 200 status line before iterating
+        the body, so any upstream failure raised on the FIRST chunk inside the
+        generator would surface to the client as an empty 200 stream (issue
+        #109). Fetching one chunk eagerly converts first-chunk failures into a
+        normal pre-stream ``ModelGatewayAPIError`` with a real status code.
+
+        Args:
+            upstream_stream: The stream returned by the upstream backend.
+            provider: Gateway provider used to shape normalized errors.
+
+        Returns:
+            An iterator yielding the prefetched chunk followed by the rest.
+
+        Raises:
+            ModelGatewayAPIError: When the first chunk cannot be obtained.
+        """
+        iterator = iter(upstream_stream)
+        try:
+            first_chunk = next(iterator)
+        except StopIteration:
+            return iter(())
+        except ModelGatewayAPIError:
+            raise
+        except Exception as exc:
+            raise self._normalize_upstream_error(provider, exc) from exc
+        return chain([first_chunk], iterator)
+
+    def _stream_error(
+        self, provider: GatewayProvider, exc: Exception
+    ) -> ModelGatewayAPIError:
+        """Coerce a mid-stream exception into a gateway error for SSE emission."""
+        if isinstance(exc, ModelGatewayAPIError):
+            return exc
+        return self._normalize_upstream_error(provider, exc)
+
+    def _openai_stream_error_event(self, exc: Exception) -> str:
+        """Render a mid-stream failure as an OpenAI-style SSE error event."""
+        return self._sse_event(self._stream_error("openai", exc).to_payload())
+
+    def _responses_stream_error_event(self, exc: Exception) -> str:
+        """Render a mid-stream failure as a Responses-API SSE error event."""
+        error = self._stream_error("openai", exc)
+        return self._sse_event(
+            {
+                "type": "error",
+                "code": error.code or error.error_type,
+                "message": error.message,
+                "param": error.param,
+            }
+        )
+
+    def _anthropic_stream_error_event(self, exc: Exception) -> str:
+        """Render a mid-stream failure as an Anthropic-style SSE error event."""
+        return self._anthropic_sse_event(
+            "error", self._stream_error("anthropic", exc).to_payload()
+        )
 
     def _capture_tools_meta(self, original_tools: Any) -> None:
         """Stash per-tool cost attribution for the usage row.

--- a/backend/tests/endpoints/test_anthropic_gateway.py
+++ b/backend/tests/endpoints/test_anthropic_gateway.py
@@ -256,3 +256,115 @@ def test_messages_endpoint_forwards_anthropic_headers_to_service(
     call_kwargs = mock_service.create_message.call_args.kwargs
     assert call_kwargs["anthropic_version"] == "2023-06-01"
     assert call_kwargs["anthropic_beta"] == "prompt-caching-2024-07-31"
+
+
+def test_messages_stream_first_chunk_failure_returns_error_status(
+    app, client, db_session, test_user
+):
+    """Regression for issue #109: first-chunk failures must not become
+    empty HTTP 200 SSE streams."""
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Gateway Model",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "anthropic/claude-sonnet-4-5",
+                    "provider_adapter": "preloop",
+                }
+            },
+        },
+        account_id=test_user.account_id,
+    )
+    app.dependency_overrides[get_anthropic_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token="runtime-token", user=test_user)
+    )
+
+    def _failing_stream():
+        raise Exception("upstream rejected the request")
+        yield  # pragma: no cover
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_failing_stream(),
+    ):
+        response = client.post(
+            "/anthropic/v1/messages",
+            headers={
+                "x-api-key": "ignored",
+                "anthropic-version": "2023-06-01",
+            },
+            json={
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 256,
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 502
+    body = response.json()
+    assert body["type"] == "error"
+    assert "upstream rejected the request" in body["error"]["message"]
+
+
+def test_messages_stream_midstream_failure_emits_sse_error_event(
+    app, client, db_session, test_user
+):
+    """Regression for issue #109: mid-stream failures must emit an
+    Anthropic-style SSE error event, not silently truncate."""
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Gateway Model",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "anthropic/claude-sonnet-4-5",
+                    "provider_adapter": "preloop",
+                }
+            },
+        },
+        account_id=test_user.account_id,
+    )
+    app.dependency_overrides[get_anthropic_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token="runtime-token", user=test_user)
+    )
+
+    def _exploding_stream():
+        yield {
+            "id": "msg_123",
+            "choices": [{"index": 0, "delta": {"content": "Hel"}}],
+        }
+        raise Exception("upstream connection reset")
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_exploding_stream(),
+    ):
+        response = client.post(
+            "/anthropic/v1/messages",
+            headers={
+                "x-api-key": "ignored",
+                "anthropic-version": "2023-06-01",
+            },
+            json={
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 256,
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert "event: message_start" in response.text
+    assert "event: error" in response.text
+    assert "upstream connection reset" in response.text
+    assert "event: message_stop" not in response.text

--- a/backend/tests/endpoints/test_gemini_gateway.py
+++ b/backend/tests/endpoints/test_gemini_gateway.py
@@ -527,3 +527,45 @@ def test_stream_generate_content_streams_gemini_sse(app, client, db_session, tes
         "candidatesTokenCount": 4,
         "totalTokenCount": 7,
     }
+
+
+def test_stream_generate_content_midstream_failure_emits_gemini_error_event(
+    app, client, db_session, test_user
+):
+    """Regression for issue #109: mid-stream upstream failures must surface as
+    a Gemini-native SSE error event, not a silently truncated stream."""
+    from preloop.api.endpoints.gemini_gateway import get_gemini_gateway_auth_context
+
+    _create_gateway_model(db_session, test_user.account_id)
+    app.dependency_overrides[get_gemini_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token="gateway-token", user=test_user)
+    )
+
+    def _exploding_stream():
+        yield {"choices": [{"delta": {"content": "Hel"}}]}
+        raise Exception("upstream connection reset")
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_exploding_stream(),
+    ):
+        response = client.post(
+            "/gemini/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse",
+            headers={"x-goog-api-key": "ignored"},
+            json={
+                "contents": [{"role": "user", "parts": [{"text": "Hello"}]}],
+            },
+        )
+
+    assert response.status_code == 200
+    payloads = _parse_sse_payloads(response.text)
+    assert payloads, f"expected SSE payloads, got: {response.text!r}"
+    error_payloads = [p for p in payloads if "error" in p]
+    assert error_payloads, f"expected a Gemini error event, got: {payloads!r}"
+    assert "upstream connection reset" in error_payloads[-1]["error"]["message"]
+    # The final STOP candidate must not be emitted after a failure.
+    assert not any(
+        candidate.get("finishReason") == "STOP"
+        for p in payloads
+        for candidate in p.get("candidates", [])
+    )

--- a/backend/tests/endpoints/test_openai_gateway.py
+++ b/backend/tests/endpoints/test_openai_gateway.py
@@ -524,3 +524,247 @@ def test_responses_endpoint_streams_sse(app, client, db_session, test_user):
     assert "response.created" in response.text
     assert "response.completed" in response.text
     assert "data: [DONE]" in response.text
+
+
+def _create_gateway_model(db_session, test_user):
+    """Create a gateway-enabled model for streaming regression tests."""
+    return crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Gateway Model",
+            "provider_name": "openai",
+            "model_identifier": "gpt-5",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "openai/gpt-5",
+                    "provider_adapter": "preloop",
+                }
+            },
+        },
+        account_id=test_user.account_id,
+    )
+
+
+def test_chat_completions_stream_with_tools_returns_chunks(
+    app, client, db_session, test_user
+):
+    """Regression for issue #109: tool-bearing streaming requests must stream.
+
+    A request with a tools array must forward the tools upstream and relay the
+    tool-call delta chunks plus [DONE] to the client.
+    """
+    _create_gateway_model(db_session, test_user)
+    app.dependency_overrides[get_model_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token="runtime-token", user=test_user)
+    )
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=iter(
+            [
+                {
+                    "id": "chatcmpl_tools",
+                    "created": 1710000000,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "get_time",
+                                            "arguments": "{}",
+                                        },
+                                    }
+                                ]
+                            },
+                        }
+                    ],
+                },
+                {
+                    "id": "chatcmpl_tools",
+                    "created": 1710000000,
+                    "choices": [
+                        {"index": 0, "delta": {}, "finish_reason": "tool_calls"}
+                    ],
+                    "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 2,
+                        "total_tokens": 7,
+                    },
+                },
+            ]
+        ),
+    ) as mock_completion:
+        response = client.post(
+            "/openai/v1/chat/completions",
+            headers={"Authorization": "Bearer ignored"},
+            json={
+                "model": "openai/gpt-5",
+                "messages": [{"role": "user", "content": "What time is it?"}],
+                "stream": True,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_time",
+                            "description": "Get the current time",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert len(response.text) > 0
+    assert "get_time" in response.text
+    assert "tool_calls" in response.text
+    assert "data: [DONE]" in response.text
+    # Tools were forwarded upstream, not dropped.
+    assert mock_completion.call_args.kwargs["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_time",
+                "description": "Get the current time",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def test_chat_completions_stream_first_chunk_failure_returns_error_status(
+    app, client, db_session, test_user
+):
+    """Regression for issue #109: a first-chunk upstream failure must be a
+    non-200 response, never an empty HTTP 200 SSE stream."""
+    _create_gateway_model(db_session, test_user)
+    app.dependency_overrides[get_model_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token="runtime-token", user=test_user)
+    )
+
+    def _failing_stream():
+        raise Exception("upstream rejected the tools payload")
+        yield  # pragma: no cover
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_failing_stream(),
+    ):
+        response = client.post(
+            "/openai/v1/chat/completions",
+            headers={"Authorization": "Bearer ignored"},
+            json={
+                "model": "openai/gpt-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {"name": "noop", "parameters": {"type": "object"}},
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 502
+    body = response.json()
+    assert body["error"]["type"] == "api_error"
+    assert "upstream rejected the tools payload" in body["error"]["message"]
+
+
+def test_chat_completions_stream_midstream_failure_emits_sse_error_event(
+    app, client, db_session, test_user
+):
+    """Regression for issue #109: a mid-stream upstream failure must emit a
+    visible SSE error event, never leave the client with a truncated body."""
+    _create_gateway_model(db_session, test_user)
+    app.dependency_overrides[get_model_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token="runtime-token", user=test_user)
+    )
+
+    def _exploding_stream():
+        yield {
+            "id": "chatcmpl_mid",
+            "created": 1710000000,
+            "choices": [{"index": 0, "delta": {"content": "Hel"}}],
+        }
+        raise Exception("upstream connection reset")
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_exploding_stream(),
+    ):
+        response = client.post(
+            "/openai/v1/chat/completions",
+            headers={"Authorization": "Bearer ignored"},
+            json={
+                "model": "openai/gpt-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    # The delta consumed before the failure is relayed...
+    assert "Hel" in response.text
+    # ...and the failure is surfaced as an explicit SSE error event.
+    error_events = [
+        json.loads(line[len("data: ") :])
+        for line in response.text.splitlines()
+        if line.startswith("data: ") and '"error"' in line
+    ]
+    assert error_events, f"expected an SSE error event, got: {response.text!r}"
+    assert "upstream connection reset" in error_events[-1]["error"]["message"]
+    assert error_events[-1]["error"]["type"] == "api_error"
+    # No [DONE] marker: the stream did not complete successfully.
+    assert "data: [DONE]" not in response.text
+
+
+def test_responses_stream_midstream_failure_emits_sse_error_event(
+    app, client, db_session, test_user
+):
+    """Responses-API streams must also surface mid-stream failures (issue #109)."""
+    _create_gateway_model(db_session, test_user)
+    app.dependency_overrides[get_model_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token="runtime-token", user=test_user)
+    )
+
+    def _exploding_stream():
+        yield {
+            "id": "chatcmpl_mid",
+            "created": 1710000000,
+            "choices": [{"index": 0, "delta": {"content": "Hel"}}],
+        }
+        raise Exception("upstream connection reset")
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_exploding_stream(),
+    ):
+        response = client.post(
+            "/openai/v1/responses",
+            headers={"Authorization": "Bearer ignored"},
+            json={
+                "model": "openai/gpt-5",
+                "input": "Hello",
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    error_events = [
+        json.loads(line[len("data: ") :])
+        for line in response.text.splitlines()
+        if line.startswith("data: ") and '"type": "error"' in line
+    ]
+    assert error_events, f"expected an SSE error event, got: {response.text!r}"
+    assert "upstream connection reset" in error_events[-1]["message"]
+    assert "data: [DONE]" not in response.text


### PR DESCRIPTION
Fixes #109.

## Symptom

`POST /openai/v1/chat/completions` with `stream: true` intermittently returned HTTP 200 with a completely empty body: 0 bytes, no SSE events, no `finish_reason`. With a `tools` array present the failure was deterministic (0/6 attempts in the S10 curl matrix on tuvok). Hermes surfaced it as `EmptyStreamError http_status=200 bytes=0 chunks=0` and could not complete onboarding.

## Root cause

Two layers, both variants of the same structural flaw: errors raised inside the SSE generator after the ASGI layer has already committed the HTTP 200 status line.

1. Pre-first-chunk failures inside the generator. `StreamingResponse` sends `http.response.start` (the 200) before pulling the first body chunk. The Codex OAuth fake-stream path (`_stream_openai_codex_chat_completion` and `_stream_openai_codex_response`) called the upstream INSIDE the generator, before the first `yield`. Any upstream rejection, including a rejected translated tools payload or the intermittent 502 "servers overloaded" seen at the same time in non-streaming requests, raised after the 200 was on the wire. Starlette's global handler cannot replace a committed status line, so the client saw exactly 0 bytes. This explains the deterministic tools failure: the request always reached the upstream call inside the generator, and the tool-bearing payload always failed there. The litellm paths had the same window in narrower form: `litellm.completion()` can return a lazy stream whose connection error only raises on first iteration.

2. Mid-stream failures re-raised. Every streaming `except` block recorded usage and then `raise`d. Once headers are sent, a re-raise just terminates the body: the client gets a truncated (often empty) 200 with no error event. This explains the intermittent no-tools failures during the upstream 502 weather.

## Fix

- Codex streaming paths now call the upstream BEFORE handing the generator to the ASGI layer, so failures surface as real non-200 gateway error responses through the normal `ModelGatewayAPIError` handler.
- New `_prefetch_upstream_stream()` eagerly pulls the first upstream chunk pre-stream on all three litellm streaming paths (openai chat completions, openai responses, anthropic messages), converting first-chunk failures into pre-stream errors with a real status code.
- Mid-stream failures now emit a provider-native SSE error event instead of silently truncating: OpenAI `{"error": ...}` payload for chat completions, Responses-API `{"type": "error", ...}` event, Anthropic `event: error`, and a Gemini-native error JSON relayed by the gemini wrapper. `[DONE]` / `message_stop` are not emitted after a failure, so clients can reliably detect the incomplete stream. Usage recording and stream-abort accounting are unchanged.

Invariant enforced: an SSE stream that dies MUST emit an SSE error event or a non-200. A silent empty 200 is never produced.

## Tests

New regression tests (verified to fail on the pre-fix code):
- streaming with a `tools` array returns chunks, relays tool-call deltas, forwards tools upstream, and ends with `[DONE]`
- first-chunk upstream failure returns non-200 with the provider error envelope (openai + anthropic)
- mid-stream upstream failure yields the already-streamed deltas plus a visible SSE error event and no `[DONE]` (openai chat, responses, anthropic, gemini)

`pytest` gateway subset: 188 passed (endpoints openai/anthropic/gemini/streaming-accuracy/usage-summary + services openai_gateway, tool_calls, attribution, errors, budget, usage, custom-provider routing). `ruff check` and `ruff format --check` clean.

## Notes for reviewers

- The 2/5 no-tools failures in the repro matrix line up with the upstream 502 weather at the same timestamp; the deterministic tools failure lines up with the Codex in-generator upstream call. Both are closed by this change regardless of which upstream misbehaves.
- nginx buffering was considered and ruled out as root cause: buffering cannot produce 0-byte 200s on some requests and 816-byte bodies on identical ones; the empty responses closed in ~0.6s.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-tested bug fix for silent empty HTTP 200 SSE streams. All changes are confined to gateway error-handling paths with no API surface changes.
>
> **Overview**
> Fixes streaming SSE failures that produced silent empty 200 responses. All 6 streaming paths now either error before the 200 status line is committed (prefetch + codex pre-gen changes) or emit a provider-native SSE error event mid-stream. 8 new regression tests cover first-chunk and mid-stream failures across OpenAI, Anthropic, Gemini, and tool-bearing requests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/gateway-empty-sse-stream. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->