### PR TITLE
fix: sanitize params on subscription-OAuth passthrough branches

### DIFF
--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -2131,10 +2131,81 @@ class OpenAIGatewayService:
             )
         return resolved
 
+    # Parameters the ChatGPT Codex backend accepts, measured empirically
+    # against ``chatgpt.com/backend-api/codex/responses`` (2026-07-30).
+    # The backend rejects EVERY other top-level key with HTTP 400
+    # ``{"detail": "Unsupported parameter: <name>"}``, including standard
+    # Responses-API tunables such as ``max_output_tokens``, ``temperature``
+    # and ``top_p``, so there is no translation target for token limits:
+    # they must be dropped. ``store`` must be present and exactly ``false``
+    # (absent or ``true`` both fail with "Store must be set to false").
+    _CODEX_SUPPORTED_PARAMS = frozenset(
+        {
+            "model",
+            "instructions",
+            "input",
+            "store",
+            "stream",
+            "tools",
+            "tool_choice",
+            "parallel_tool_calls",
+            "reasoning",
+            "include",
+            "prompt_cache_key",
+            "text",
+        }
+    )
+
+    def _sanitize_openai_codex_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Reduce a payload to the parameter set the Codex backend accepts.
+
+        The subscription-OAuth Codex backend is strict: any top-level key
+        outside ``_CODEX_SUPPORTED_PARAMS`` fails the whole request with
+        HTTP 400 ``Unsupported parameter: <name>`` (prod failure 2026-07-29
+        22:22 UTC: Hermes sent ``max_completion_tokens`` and every request
+        died; follow-up to issue #109). ``max_completion_tokens`` has no
+        accepted equivalent (``max_output_tokens`` and ``max_tokens`` are
+        rejected too), so unsupported tunables are dropped rather than
+        translated. The one translation we can do: ``reasoning_effort``
+        (chat-completions form) becomes ``reasoning: {"effort": ...}``.
+
+        Args:
+            payload: The candidate upstream payload (already deep-copied).
+
+        Returns:
+            The payload containing only supported keys, with ``store``
+            forced to ``False``.
+        """
+        sanitized: Dict[str, Any] = {}
+        dropped: List[str] = []
+        for key, value in payload.items():
+            if key in self._CODEX_SUPPORTED_PARAMS:
+                sanitized[key] = value
+                continue
+            if (
+                key == "reasoning_effort"
+                and isinstance(value, str)
+                and not isinstance(payload.get("reasoning"), dict)
+            ):
+                sanitized["reasoning"] = {"effort": value}
+                continue
+            dropped.append(key)
+        # Codex rejects requests without ``store: false`` (HTTP 400 "Store
+        # must be set to false"); force it regardless of client input.
+        sanitized["store"] = False
+        if dropped:
+            logger.debug(
+                "Dropped parameters unsupported by the OpenAI Codex backend: %s",
+                sorted(dropped),
+            )
+        return sanitized
+
     def _build_openai_codex_payload(
         self, ai_model: AIModel, payload: Dict[str, Any], *, stream: bool = False
     ) -> Dict[str, Any]:
-        upstream_payload = json.loads(json.dumps(payload))
+        upstream_payload = self._sanitize_openai_codex_payload(
+            json.loads(json.dumps(payload))
+        )
         upstream_payload["model"] = ai_model.model_identifier
         if stream:
             upstream_payload["stream"] = True
@@ -2277,15 +2348,42 @@ class OpenAIGatewayService:
             # flag; we must replicate it for chat-completion clients too.
             "store": False,
         }
-        for key in (
-            "temperature",
-            "top_p",
-            "max_output_tokens",
-            "max_completion_tokens",
-            "parallel_tool_calls",
-        ):
-            if payload.get(key) is not None:
-                upstream_payload[key] = payload[key]
+        # Only ``parallel_tool_calls`` survives among the chat-completions
+        # tunables: the Codex backend rejects ``temperature``, ``top_p``,
+        # ``max_completion_tokens``, ``max_output_tokens`` and ``max_tokens``
+        # outright with HTTP 400 ``Unsupported parameter`` (measured
+        # 2026-07-30; prod failure 2026-07-29 22:22 UTC when Hermes sent
+        # ``max_completion_tokens``). There is no accepted token-limit
+        # parameter to translate to, so they are dropped and logged.
+        if payload.get("parallel_tool_calls") is not None:
+            upstream_payload["parallel_tool_calls"] = payload["parallel_tool_calls"]
+        if isinstance(payload.get("reasoning"), dict):
+            upstream_payload["reasoning"] = payload["reasoning"]
+        elif isinstance(payload.get("reasoning_effort"), str):
+            # chat-completions ``reasoning_effort`` maps onto the accepted
+            # Responses-API ``reasoning.effort`` field.
+            upstream_payload["reasoning"] = {"effort": payload["reasoning_effort"]}
+        dropped = sorted(
+            key
+            for key in payload
+            if key not in self._CODEX_SUPPORTED_PARAMS
+            and key
+            not in {
+                # Consumed by this translation (or intentionally mapped).
+                "messages",
+                "reasoning_effort",
+                # Belong to the chat-completions envelope, not the upstream.
+                "stream",
+                "stream_options",
+            }
+            and payload.get(key) is not None
+        )
+        if dropped:
+            logger.debug(
+                "Dropped chat-completion parameters unsupported by the "
+                "OpenAI Codex backend: %s",
+                dropped,
+            )
 
         # Tools and tool_choice need shape translation: chat-completions nests
         # the function spec under a ``function`` key, while the Codex Responses
@@ -3293,6 +3391,77 @@ class OpenAIGatewayService:
                 return requested_tail
         return base_identifier
 
+    # OpenAI-protocol parameters that the Anthropic Messages API rejects
+    # with HTTP 400 ``invalid_request_error`` ("Extra inputs are not
+    # permitted") when forwarded verbatim. Clients speaking the OpenAI
+    # dialect (or generic SDKs with provider-agnostic knobs) leak these into
+    # Anthropic-protocol requests; one stray key fails the whole request.
+    # This is a denylist (not an allowlist) on purpose: the passthrough must
+    # keep forwarding unknown Anthropic-native fields verbatim so new
+    # Anthropic features work without a gateway release.
+    _ANTHROPIC_PASSTHROUGH_DROP_PARAMS = frozenset(
+        {
+            "frequency_penalty",
+            "presence_penalty",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "logit_bias",
+            "n",
+            "response_format",
+            "stop",
+            "user",
+            "stream_options",
+            "reasoning_effort",
+            "parallel_tool_calls",
+            "modalities",
+            "prediction",
+            "store",
+            "instructions",
+            "input",
+        }
+    )
+
+    def _sanitize_anthropic_passthrough_payload(
+        self, body: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Remove OpenAI-protocol strays before the OAuth passthrough.
+
+        Only top-level OpenAI-dialect keys are touched; ``system``,
+        ``messages``, ``tools`` and every nested ``cache_control`` marker
+        stay byte-identical (the whole point of the passthrough). The OpenAI
+        token-limit spellings (``max_completion_tokens``,
+        ``max_output_tokens``) are translated to Anthropic's ``max_tokens``
+        when the client did not send it; everything else on the denylist is
+        dropped and logged at debug level.
+
+        Args:
+            body: A shallow copy of the client payload (safe to mutate).
+
+        Returns:
+            The same dict, with stray keys removed.
+        """
+        dropped: List[str] = []
+        for alias in ("max_completion_tokens", "max_output_tokens"):
+            if alias not in body:
+                continue
+            value = body.pop(alias)
+            if body.get("max_tokens") is None and isinstance(value, int):
+                body["max_tokens"] = value
+            else:
+                dropped.append(alias)
+        for key in self._ANTHROPIC_PASSTHROUGH_DROP_PARAMS:
+            if key in body:
+                body.pop(key)
+                dropped.append(key)
+        if dropped:
+            logger.debug(
+                "Dropped parameters unsupported by the Anthropic Messages "
+                "API from the OAuth passthrough: %s",
+                sorted(dropped),
+            )
+        return body
+
     def _prepare_anthropic_passthrough(
         self,
         *,
@@ -3307,9 +3476,10 @@ class OpenAIGatewayService:
 
         The body is a shallow copy of the client payload: ``system``,
         ``messages``, ``tools`` and all nested ``cache_control`` blocks are
-        the client's own objects, forwarded untouched. Only ``model`` (the
-        account model's upstream identifier) and ``stream`` are set by
-        Preloop.
+        the client's own objects, forwarded untouched. Preloop sets
+        ``model`` (the account model's upstream identifier) and ``stream``,
+        and strips top-level OpenAI-dialect strays the upstream would 400
+        on (see ``_sanitize_anthropic_passthrough_payload``).
 
         Args:
             ai_model: The resolved gateway model.
@@ -3329,7 +3499,9 @@ class OpenAIGatewayService:
         payload = self._strip_anthropic_passthrough_tools(payload)
         self._capture_tools_meta(original_tools)
 
-        body: Dict[str, Any] = dict(payload)
+        body: Dict[str, Any] = self._sanitize_anthropic_passthrough_payload(
+            dict(payload)
+        )
         body["model"] = self._passthrough_upstream_model_ref(
             ai_model, payload.get("model")
         )

--- a/backend/tests/services/test_openai_gateway.py
+++ b/backend/tests/services/test_openai_gateway.py
@@ -1624,7 +1624,9 @@ def test_build_openai_codex_payload_from_chat_completion_extracts_system_message
 
     assert upstream["instructions"] == "You are a billing assistant."
     assert upstream["model"] == "openai/gpt-5.4"
-    assert upstream["temperature"] == 0.5
+    # Codex rejects ``temperature`` (HTTP 400 Unsupported parameter); it
+    # must NOT be forwarded.
+    assert "temperature" not in upstream
     # System message must NOT show up in input items.
     assert all(
         item.get("role") != "system"
@@ -1791,6 +1793,488 @@ def test_build_openai_codex_payload_overrides_model_with_ai_model_identifier():
         ai_model=ai_model,
     )
     assert upstream["model"] == "gpt-5-codex"
+
+
+def _codex_service() -> OpenAIGatewayService:
+    auth_context = ModelGatewayAuthContext(
+        token="token",
+        user=SimpleNamespace(id="user-1", account_id="account-1"),
+    )
+    return OpenAIGatewayService(MagicMock(), auth_context)
+
+
+def _codex_ai_model() -> SimpleNamespace:
+    return SimpleNamespace(
+        id="model-1",
+        provider_name="openai-codex",
+        model_identifier="gpt-5.6-sol",
+        api_endpoint="https://chatgpt.com/backend-api/codex",
+    )
+
+
+def test_build_openai_codex_payload_from_chat_completion_drops_rejected_tunables(
+    caplog,
+):
+    """The Codex backend 400s on ``max_completion_tokens`` (prod failure
+    2026-07-29 22:22 UTC, follow-up to #109) and on every other OpenAI
+    tunable; none of them may be forwarded, and the drop must be logged."""
+    service = _codex_service()
+    payload = {
+        "model": "openai/gpt-5.6-sol",
+        "max_completion_tokens": 1024,
+        "max_tokens": 512,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.1,
+        "seed": 42,
+        "stop": ["END"],
+        "user": "hermes",
+        "response_format": {"type": "text"},
+        "parallel_tool_calls": True,
+    }
+
+    with caplog.at_level("DEBUG", logger="preloop.services.openai_gateway"):
+        upstream = service._build_openai_codex_payload_from_chat_completion(
+            payload=payload,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    for rejected in (
+        "max_completion_tokens",
+        "max_tokens",
+        "max_output_tokens",
+        "temperature",
+        "top_p",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "stop",
+        "user",
+        "response_format",
+    ):
+        assert rejected not in upstream, rejected
+    # The one tunable Codex accepts must survive.
+    assert upstream["parallel_tool_calls"] is True
+    assert upstream["store"] is False
+    dropped_logs = [
+        record.message
+        for record in caplog.records
+        if "unsupported by the OpenAI Codex backend" in record.message
+    ]
+    assert dropped_logs, "dropped parameters must be logged at debug level"
+    assert "max_completion_tokens" in dropped_logs[0]
+
+
+def test_build_openai_codex_payload_from_chat_completion_maps_reasoning_effort():
+    """chat-completions ``reasoning_effort`` maps to the accepted
+    Responses-API ``reasoning.effort`` shape instead of being dropped."""
+    service = _codex_service()
+
+    upstream = service._build_openai_codex_payload_from_chat_completion(
+        payload={"model": "openai/gpt-5.6-sol", "reasoning_effort": "low"},
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert upstream["reasoning"] == {"effort": "low"}
+    assert "reasoning_effort" not in upstream
+
+
+def test_build_openai_codex_payload_sanitizes_responses_payload(caplog):
+    """The direct Responses-API codex path (``_build_openai_codex_payload``)
+    must strip rejected params too and force ``store: false``."""
+    service = _codex_service()
+    ai_model = _codex_ai_model()
+    payload = {
+        "model": "openai/gpt-5.6-sol",
+        "instructions": "Be terse.",
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hi"}],
+            }
+        ],
+        "max_output_tokens": 256,
+        "max_completion_tokens": 256,
+        "temperature": 0.3,
+        "metadata": {"k": "v"},
+        "truncation": "auto",
+        "store": True,
+        "reasoning": {"effort": "medium"},
+        "prompt_cache_key": "cache-1",
+    }
+
+    with caplog.at_level("DEBUG", logger="preloop.services.openai_gateway"):
+        upstream = service._build_openai_codex_payload(ai_model, payload, stream=True)
+
+    for rejected in (
+        "max_output_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "metadata",
+        "truncation",
+    ):
+        assert rejected not in upstream, rejected
+    assert upstream["model"] == "gpt-5.6-sol"
+    assert upstream["store"] is False
+    assert upstream["stream"] is True
+    assert upstream["instructions"] == "Be terse."
+    assert upstream["reasoning"] == {"effort": "medium"}
+    assert upstream["prompt_cache_key"] == "cache-1"
+    assert any(
+        "unsupported by the OpenAI Codex backend" in record.message
+        for record in caplog.records
+    )
+
+
+def test_create_chat_completion_codex_sanitizes_client_params():
+    """Non-streaming codex chat completions must not forward
+    ``max_completion_tokens`` upstream (the exact prod failure shape)."""
+    service = _codex_service()
+    ai_model = _codex_ai_model()
+
+    with (
+        patch.object(service, "_resolve_requested_model", return_value=ai_model),
+        patch.object(service, "_check_budget", return_value=None),
+        patch.object(service, "_record_gateway_request"),
+        patch.object(service, "_emit_gateway_request_started"),
+        patch.object(
+            service,
+            "_create_openai_codex_response",
+            return_value=_codex_responses_payload(),
+        ) as mock_create_codex,
+    ):
+        service.create_chat_completion(
+            {
+                "model": "preloop/openai/gpt-5.6-sol",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_completion_tokens": 4096,
+                "temperature": 0.2,
+            }
+        )
+
+    upstream_payload = mock_create_codex.call_args.args[1]
+    assert "max_completion_tokens" not in upstream_payload
+    assert "temperature" not in upstream_payload
+    assert upstream_payload["store"] is False
+
+
+def test_stream_chat_completion_codex_sanitizes_client_params():
+    """Streaming codex chat completions must not forward
+    ``max_completion_tokens`` upstream either."""
+    service = _codex_service()
+    ai_model = _codex_ai_model()
+
+    with (
+        patch.object(service, "_resolve_requested_model", return_value=ai_model),
+        patch.object(service, "_check_budget", return_value=None),
+        patch.object(service, "_record_gateway_request"),
+        patch.object(service, "_emit_gateway_request_started"),
+        patch.object(
+            service,
+            "_create_openai_codex_response",
+            return_value=_codex_responses_payload(),
+        ) as mock_create_codex,
+    ):
+        events = list(
+            service.stream_chat_completion(
+                {
+                    "model": "preloop/openai/gpt-5.6-sol",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": True,
+                    "max_completion_tokens": 4096,
+                    "top_p": 0.9,
+                }
+            )
+        )
+
+    assert events, "stream must still produce chunks"
+    upstream_payload = mock_create_codex.call_args.args[1]
+    assert "max_completion_tokens" not in upstream_payload
+    assert "top_p" not in upstream_payload
+    assert upstream_payload["store"] is False
+
+
+def test_create_openai_codex_response_sends_sanitized_body():
+    """The wire body sent to chatgpt.com/backend-api/codex must contain only
+    supported parameters (covers create_response and stream_response, which
+    both sanitize inside ``_create_openai_codex_response``)."""
+    service = _codex_service()
+    ai_model = _codex_ai_model()
+    credentials = SimpleNamespace(
+        value="oauth-token",
+        payload={"account_id": "acct-1"},
+    )
+    sse_body = (
+        b'data: {"type":"response.output_item.added","item":'
+        b'{"id":"msg_1","type":"message","role":"assistant"}}\n'
+        b"\n"
+        b'data: {"type":"response.output_text.done","item_id":"msg_1",'
+        b'"text":"OK"}\n'
+        b"\n"
+        b'data: {"type":"response.completed","response":{"id":"resp_1",'
+        b'"usage":{"input_tokens":1,"output_tokens":1}}}\n'
+        b"\n"
+    )
+
+    class _FakeResponse:
+        def __enter__(self):
+            return iter(sse_body.splitlines(keepends=True))
+
+        def __exit__(self, *args):
+            return False
+
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _FakeResponse()
+
+    with (
+        patch.object(
+            service, "_resolve_openai_codex_credentials", return_value=credentials
+        ),
+        patch(
+            "preloop.services.openai_gateway.urllib_request.urlopen",
+            side_effect=fake_urlopen,
+        ),
+    ):
+        service._create_openai_codex_response(
+            ai_model,
+            {
+                "model": "preloop/openai/gpt-5.6-sol",
+                "instructions": "Be terse.",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "hi"}],
+                    }
+                ],
+                "max_completion_tokens": 128,
+                "temperature": 0.5,
+            },
+        )
+
+    body = captured["body"]
+    assert "max_completion_tokens" not in body
+    assert "temperature" not in body
+    assert body["store"] is False
+    assert body["stream"] is True
+    assert body["model"] == "gpt-5.6-sol"
+
+
+def _anthropic_oauth_model() -> SimpleNamespace:
+    return SimpleNamespace(
+        id="model-a1",
+        provider_name="anthropic",
+        model_identifier="claude-fable-5",
+        api_endpoint=None,
+    )
+
+
+def test_prepare_anthropic_passthrough_translates_and_drops_openai_params(
+    caplog,
+):
+    """OpenAI-dialect strays must be removed before the OAuth passthrough:
+    one unknown top-level key 400s the whole Anthropic request. Token-limit
+    spellings translate to ``max_tokens``; Anthropic-native content
+    (system blocks, cache_control, tools) stays byte-identical."""
+    service = _codex_service()
+    ai_model = _anthropic_oauth_model()
+    system_blocks = [
+        {
+            "type": "text",
+            "text": "You are Claude Code",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+    messages = [{"role": "user", "content": "hi"}]
+    tools = [
+        {
+            "name": "get_time",
+            "description": "time",
+            "input_schema": {"type": "object", "properties": {}},
+        }
+    ]
+    payload = {
+        "model": "claude-fable-5",
+        "system": system_blocks,
+        "messages": messages,
+        "tools": tools,
+        "max_completion_tokens": 2048,
+        "frequency_penalty": 0.2,
+        "seed": 7,
+        "stream_options": {"include_usage": True},
+        "metadata": {"user_id": "u-1"},
+    }
+
+    with (
+        patch.object(
+            service, "_strip_anthropic_passthrough_tools", side_effect=lambda p: p
+        ),
+        patch.object(service, "_capture_tools_meta"),
+        caplog.at_level("DEBUG", logger="preloop.services.openai_gateway"),
+    ):
+        _url, _headers, body = service._prepare_anthropic_passthrough(
+            ai_model=ai_model,
+            payload=payload,
+            oauth_token="oauth-token",
+            anthropic_version="2023-06-01",
+            anthropic_beta=None,
+            stream=False,
+        )
+
+    # OpenAI token-limit spelling translated to the Anthropic one.
+    assert body["max_tokens"] == 2048
+    assert "max_completion_tokens" not in body
+    for stray in ("frequency_penalty", "seed", "stream_options"):
+        assert stray not in body, stray
+    # Anthropic-native fields forwarded verbatim (same objects, untouched).
+    assert body["system"] is system_blocks
+    assert body["messages"] is messages
+    assert body["tools"] is tools
+    # ``metadata`` is a real Anthropic Messages parameter; it must survive.
+    assert body["metadata"] == {"user_id": "u-1"}
+    assert body["stream"] is False
+    assert any(
+        "unsupported by the Anthropic Messages API" in record.message
+        for record in caplog.records
+    )
+
+
+def test_prepare_anthropic_passthrough_keeps_client_max_tokens():
+    """When the client already sent ``max_tokens``, the OpenAI spellings are
+    dropped rather than overwriting it."""
+    service = _codex_service()
+    ai_model = _anthropic_oauth_model()
+    payload = {
+        "model": "claude-fable-5",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 100,
+        "max_completion_tokens": 999,
+        "max_output_tokens": 888,
+    }
+
+    with (
+        patch.object(
+            service, "_strip_anthropic_passthrough_tools", side_effect=lambda p: p
+        ),
+        patch.object(service, "_capture_tools_meta"),
+    ):
+        _url, _headers, body = service._prepare_anthropic_passthrough(
+            ai_model=ai_model,
+            payload=payload,
+            oauth_token="oauth-token",
+            anthropic_version="2023-06-01",
+            anthropic_beta=None,
+            stream=True,
+        )
+
+    assert body["max_tokens"] == 100
+    assert "max_completion_tokens" not in body
+    assert "max_output_tokens" not in body
+    assert body["stream"] is True
+
+
+def test_create_message_passthrough_sends_sanitized_body():
+    """Non-streaming OAuth passthrough requests are sanitized end to end."""
+    service = _codex_service()
+    ai_model = _anthropic_oauth_model()
+
+    with (
+        patch.object(service, "_resolve_requested_model", return_value=ai_model),
+        patch.object(service, "_check_budget", return_value=None),
+        patch.object(service, "_record_gateway_request"),
+        patch.object(service, "_emit_gateway_request_started"),
+        patch.object(
+            service, "_anthropic_oauth_passthrough_token", return_value="oauth-token"
+        ),
+        patch.object(
+            service, "_strip_anthropic_passthrough_tools", side_effect=lambda p: p
+        ),
+        patch.object(service, "_capture_tools_meta"),
+        patch.object(
+            service,
+            "_anthropic_oauth_passthrough_complete",
+            return_value={
+                "id": "msg_1",
+                "content": [{"type": "text", "text": "OK"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        ) as mock_complete,
+    ):
+        service.create_message(
+            {
+                "model": "claude-fable-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_completion_tokens": 64,
+                "seed": 3,
+            },
+            anthropic_version="2023-06-01",
+        )
+
+    body = mock_complete.call_args.kwargs["body"]
+    assert body["max_tokens"] == 64
+    assert "max_completion_tokens" not in body
+    assert "seed" not in body
+
+
+def test_stream_message_passthrough_sends_sanitized_body():
+    """Streaming OAuth passthrough requests are sanitized end to end."""
+    service = _codex_service()
+    ai_model = _anthropic_oauth_model()
+
+    upstream_response = MagicMock()
+    upstream_response.iter_text.return_value = iter(
+        [
+            'data: {"type":"message_start","message":{"id":"msg_1",'
+            '"usage":{"input_tokens":1}}}\n\n',
+            'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
+            '"usage":{"output_tokens":1}}\n\n',
+        ]
+    )
+    upstream_client = MagicMock()
+
+    with (
+        patch.object(service, "_resolve_requested_model", return_value=ai_model),
+        patch.object(service, "_check_budget", return_value=None),
+        patch.object(service, "_record_gateway_request"),
+        patch.object(service, "_emit_gateway_request_started"),
+        patch.object(
+            service, "_anthropic_oauth_passthrough_token", return_value="oauth-token"
+        ),
+        patch.object(
+            service, "_strip_anthropic_passthrough_tools", side_effect=lambda p: p
+        ),
+        patch.object(service, "_capture_tools_meta"),
+        patch.object(
+            service,
+            "_open_anthropic_oauth_passthrough_stream",
+            return_value=(upstream_client, upstream_response),
+        ) as mock_open,
+    ):
+        events = list(
+            service.stream_message(
+                {
+                    "model": "claude-fable-5",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                    "max_output_tokens": 32,
+                    "frequency_penalty": 0.5,
+                },
+                anthropic_version="2023-06-01",
+            )
+        )
+
+    assert events, "passthrough stream must relay upstream chunks"
+    body = mock_open.call_args.kwargs["body"]
+    assert body["max_tokens"] == 32
+    assert "max_output_tokens" not in body
+    assert "frequency_penalty" not in body
+    assert body["stream"] is True
 
 
 def test_aggregate_codex_sse_stream_builds_assistant_message_from_streaming_events():


### PR DESCRIPTION
## Summary

Follow-up to #109 (PR #121). After the empty-SSE fix landed, the Codex OAuth passthrough surfaced its next failure mode in prod: requests routed over the ChatGPT/Codex subscription-OAuth branch fail with HTTP 400 `{"detail":"Unsupported parameter: max_completion_tokens"}` whenever the client includes `max_completion_tokens`. Hermes sends it on every request.

Evidence: prod `api_usage` 2026-07-29 22:22 UTC, runtime principal `loopbot-73322460ff8d`, requested_model `preloop/openai/gpt-5.6-sol`. Simple payloads without the param passed at 22:08 (200).

## What the Codex upstream actually accepts

Measured empirically against `chatgpt.com/backend-api/codex/responses` on 2026-07-30 (subscription OAuth, model `gpt-5.6-sol`):

- Accepted (200): `model`, `instructions`, `input`, `store: false` (required; absent or `true` both 400), `stream`, `tools`, `tool_choice`, `parallel_tool_calls`, `reasoning`, `include`, `prompt_cache_key`, `text`.
- Rejected (400 `Unsupported parameter`): `max_completion_tokens`, `max_output_tokens`, `max_tokens`, `temperature`, `top_p`, `frequency_penalty`, `presence_penalty`, `seed`, `logprobs`, `logit_bias`, `stop`, `n`, `user`, `response_format`, `reasoning_effort`, `metadata`, `previous_response_id`, `truncation`, plus any unknown key. `stream_options` 400s with an OpenAI-style unknown-parameter error.

Key finding: there is NO accepted token-limit parameter (`max_output_tokens` and `max_tokens` are rejected too), so `max_completion_tokens` cannot be translated. It has to be dropped.

## Changes

### Codex OAuth branch
- New `_sanitize_openai_codex_payload` with the measured allowlist, applied inside `_build_openai_codex_payload`, the single choke point for all four codex paths (chat completions and responses, streaming and non-streaming, since `_create_openai_codex_response` builds the wire body there).
- The chat-completions translation builder no longer copies `temperature`/`top_p`/`max_*` upstream; `parallel_tool_calls` survives, `reasoning_effort` maps to the accepted `reasoning: {"effort": ...}` shape.
- `store: false` is always forced.
- Every drop is logged at debug level.

### Anthropic Claude Code OAuth passthrough
`_prepare_anthropic_passthrough` forwarded the client payload verbatim, so one stray OpenAI-dialect key (Anthropic 400s unknown top-level fields with "Extra inputs are not permitted") failed the whole request. New `_sanitize_anthropic_passthrough_payload`:
- Denylist, not allowlist: unknown Anthropic-native fields keep flowing verbatim so new upstream features work without a gateway release.
- `max_completion_tokens`/`max_output_tokens` translate to Anthropic's `max_tokens` when the client did not send it; otherwise dropped.
- `system`, `messages`, `tools` and nested `cache_control` blocks stay byte-identical (tests assert object identity) to preserve the upstream's structural OAuth validation and prompt caching.
- Drops logged at debug level.

## Tests
- 10 new unit tests in `backend/tests/services/test_openai_gateway.py` covering streaming and non-streaming on both branches, including a wire-body test that intercepts `urllib.urlopen` for the codex path and end-to-end `create_message`/`stream_message` passthrough body assertions.
- All 10 fail on pre-fix code (verified via stash).
- Gateway subset green: 140 passed (openai/anthropic/gemini endpoint + service gateway files, streaming accuracy, usage summaries, budget, accounting). ruff check and format clean.
- Live validation: a Hermes-shaped payload (tools + `max_completion_tokens` + `temperature` + `top_p` + `stream_options`) run through the new builder POSTed to the real codex upstream returns 200/`response.created`; the same payload un-sanitized returns the prod 400.

## Follow-ups
- After merge + deploy: re-run Hermes traffic against `preloop/openai/gpt-5.6-sol` and confirm the 22:22 UTC failure shape is gone from `api_usage`.
- The Claude Code OAuth token on the dev machine could not be refreshed (403), so the Anthropic-side rejection list is based on Anthropic's documented strict-schema behavior rather than a live probe; the denylist is conservative and only touches OpenAI-dialect keys.
- Author: d-mo

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-understood fix with extensive test coverage; only strips/translates client-side parameters on the OAuth passthrough branches.

> **Overview**
> Adds sanitization layers to the Codex and Anthropic subscription-OAuth passthrough paths that drop or translate OpenAI-dialect parameters rejected by the upstream APIs, fixing a production 400 failure when Hermes sends `max_completion_tokens` through the Codex branch.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/codex-passthrough-param-sanitize. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->