### PR TITLE
Fix MCP scan error opacity/alert spam and enable zero-downtime rollouts

### DIFF
--- a/backend/preloop/services/mcp_client_pool.py
+++ b/backend/preloop/services/mcp_client_pool.py
@@ -271,28 +271,28 @@ class MCPClient:
             ):
                 result = await session.list_tools()
             return result.tools
-        except Exception as e:
-            logger.error(f"Error listing tools: {e}", exc_info=True)
-            raise
         except BaseException as e:
-            target_exc = e
-            if type(e).__name__ in ("ExceptionGroup", "BaseExceptionGroup"):
-                exceptions = getattr(e, "exceptions", [])
-                for exc in exceptions:
-                    if isinstance(exc, Exception):
-                        target_exc = exc
-                        break
+            # NOTE: ExceptionGroup (py3.11) subclasses Exception, so a plain
+            # `except Exception` would catch it first and re-raise verbatim as
+            # "unhandled errors in a TaskGroup (N sub-exceptions)", hiding the
+            # real cause (e.g. connection refused on an unreachable server).
+            # Unwrap to the meaningful leaf, mirroring call_tool().
+            target_exc = _unwrap_exception_group(e)
 
-            logger.error(f"Error listing tools: {target_exc}")
+            logger.error(
+                "Error listing tools on %s: %s", self.url, target_exc, exc_info=True
+            )
 
             if isinstance(target_exc, Exception):
-                raise target_exc
+                raise target_exc from None
 
             if "cancel scope" in str(target_exc).lower() or type(e).__name__ in (
                 "ExceptionGroup",
                 "BaseExceptionGroup",
             ):
-                raise ConnectionError(f"Operation aborted: {target_exc}")
+                raise ConnectionError(
+                    f"MCP server '{self.url}' is unavailable: {target_exc}"
+                ) from None
 
             raise e
 

--- a/backend/preloop/services/mcp_tool_discovery.py
+++ b/backend/preloop/services/mcp_tool_discovery.py
@@ -104,6 +104,7 @@ async def scan_mcp_server_tools(mcp_server_id: UUID, db: Session) -> List[MCPToo
 
     except Exception as e:
         # Update server with error status
+        was_healthy = mcp_server.status != "error"
         mcp_server.status = "error"
         mcp_server.last_error = str(e)
         db.commit()
@@ -112,6 +113,9 @@ async def scan_mcp_server_tools(mcp_server_id: UUID, db: Session) -> List[MCPToo
         try:
             from preloop.sync.tasks import notify_admins
 
+            if not was_healthy:
+                # Already known-unhealthy; avoid re-notifying on every rescan.
+                return crud_mcp_tool.get_by_server(db, server_id=mcp_server_id)
             notify_admins(
                 subject=f"MCP server scan failed: {mcp_server.name}",
                 message=(

--- a/backend/tests/services/test_mcp_client_pool.py
+++ b/backend/tests/services/test_mcp_client_pool.py
@@ -284,6 +284,37 @@ class TestMCPClientListTools:
         with pytest.raises(RuntimeError, match="not connected"):
             await client.list_tools()
 
+    async def test_list_tools_unwraps_exception_group_to_leaf(self):
+        """list_tools must surface the meaningful leaf cause of a TaskGroup
+        ExceptionGroup, not the opaque "unhandled errors in a TaskGroup"
+        wrapper (regression: prod admin alerts for unreachable servers)."""
+        client = MCPClient(url="http://localhost:8001/mcp")
+        client._connected = True
+
+        leaf = ConnectionRefusedError("All connection attempts failed")
+        nested = ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [ExceptionGroup("inner", [leaf])],
+        )
+
+        mock_streams, mock_session = mock_mcp_session()
+        mock_session.list_tools = AsyncMock(side_effect=nested)
+
+        with (
+            patch(
+                "preloop.services.mcp_client_pool.streamablehttp_client",
+                return_value=mock_streams,
+            ),
+            patch(
+                "preloop.services.mcp_client_pool.ClientSession",
+                return_value=mock_session,
+            ),
+        ):
+            with pytest.raises(
+                ConnectionRefusedError, match="All connection attempts failed"
+            ):
+                await client.list_tools()
+
     async def test_list_tools_error(self):
         """Test error handling in list_tools."""
         client = MCPClient(url="http://localhost:8001/mcp")

--- a/backend/tests/services/test_mcp_tool_discovery.py
+++ b/backend/tests/services/test_mcp_tool_discovery.py
@@ -211,6 +211,44 @@ class TestScanMCPServerTools:
         assert mock_db.commit.called
         mock_notify.assert_called_once()
 
+    async def test_scan_already_error_skips_notification(self, mocker):
+        """Rescanning an already-unhealthy server must not re-notify admins."""
+        mock_db = MagicMock()
+        server_id = uuid.uuid4()
+
+        mock_server = MagicMock(spec=MCPServer)
+        mock_server.id = server_id
+        mock_server.name = "Test Server"
+        mock_server.url = "http://test.com"
+        mock_server.auth_type = "none"
+        mock_server.auth_config = {}
+        mock_server.transport = "http"
+        mock_server.status = "error"  # already unhealthy
+
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_server
+        cached_tool = MagicMock(spec=MCPTool)
+        cached_tool.name = "cached_tool"
+
+        mock_client = AsyncMock()
+        mock_client.list_tools.side_effect = Exception("Connection failed")
+        mock_client_pool = MagicMock()
+        mock_client_pool.get_client = AsyncMock(return_value=mock_client)
+        mocker.patch(
+            "preloop.services.mcp_tool_discovery.get_mcp_client_pool",
+            return_value=mock_client_pool,
+        )
+        mock_notify = mocker.patch("preloop.sync.tasks.notify_admins")
+        mocker.patch(
+            "preloop.services.mcp_tool_discovery.crud_mcp_tool.get_by_server",
+            return_value=[cached_tool],
+        )
+
+        result = await scan_mcp_server_tools(server_id, mock_db)
+
+        assert result == [cached_tool]
+        assert mock_server.status == "error"
+        mock_notify.assert_not_called()
+
 
 class TestGetCachedToolsForServer:
     """Test get_cached_tools_for_server function."""

--- a/helm/preloop/templates/api-deployment.yaml
+++ b/helm/preloop/templates/api-deployment.yaml
@@ -10,6 +10,13 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.api.replicaCount | default .Values.replicaCount }}
   {{- end }}
+  # Zero-downtime rollouts: never take a serving pod down before its
+  # replacement is Ready (surge first, drain after).
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       {{- include "preloop.selectorLabels" . | nindent 6 }}
@@ -301,6 +308,12 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
+          # Delay SIGTERM so ingress/kube-proxy endpoint updates propagate
+          # before the server stops accepting; avoids 502s during rollouts.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "10"]
           livenessProbe:
             httpGet:
               path: /api/v1/ping

--- a/helm/preloop/templates/frontend-deployment.yaml
+++ b/helm/preloop/templates/frontend-deployment.yaml
@@ -10,6 +10,12 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  # Zero-downtime rollouts: surge a Ready replacement before draining.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       {{- include "preloop.selectorLabels" . | nindent 6 }}
@@ -44,6 +50,28 @@ spec:
               mountPath: /etc/nginx/templates
           resources:
             {{- toYaml .Values.console.resources | nindent 12 }}
+          # Without a readiness probe the rollout considers nginx Ready the
+          # instant the container starts, racing the config-template render.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
       volumes:
         - name: nginx-config
           configMap:

--- a/helm/preloop/templates/gateway-deployment.yaml
+++ b/helm/preloop/templates/gateway-deployment.yaml
@@ -10,6 +10,14 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  # Zero-downtime rollouts: never take a serving pod down before its
+  # replacement is Ready (surge first, drain after). Critical for the
+  # gateway, which often runs a single replica under HPA minReplicas=1.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       {{- include "preloop.selectorLabels" . | nindent 6 }}
@@ -217,6 +225,14 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
+          # Delay SIGTERM so ingress/kube-proxy endpoint updates propagate
+          # before the server stops accepting; avoids 502s during rollouts.
+          # Long-lived SSE/streaming requests then drain within the pod's
+          # termination grace period.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "10"]
           livenessProbe:
             httpGet:
               path: /api/v1/ping


### PR DESCRIPTION
## What

**Backend**
- `MCPClient.list_tools` now unwraps `ExceptionGroup` to the meaningful leaf exception (same treatment `call_tool` already got). Before, admin alerts read `Error: unhandled errors in a TaskGroup (1 sub-exception)` which hides the actual cause (observed on prod for server `mempalace` at `http://127.0.0.1:8766/mcp`, which is simply unreachable from Cloud because it is a localhost URL).
- Scan-failure admin notifications now fire only on the healthy → error transition. Previously every periodic rescan of a known-unhealthy server re-notified admins.

**Helm (zero-downtime deploys)**
- `strategy: RollingUpdate` with `maxUnavailable: 0`, `maxSurge: 1` on api, gateway, and console deployments. Defaults were 25%/25%; with 1-2 replicas that allows the only/half the serving pods to be killed before replacements are Ready — the source of gateway 502s seen during prod deploys.
- `preStop: sleep 10` (5s console) so endpoints controller/kube-proxy/ingress drop the pod from rotation before uvicorn gets SIGTERM.
- Console pod gains readiness/liveness probes; it had none, so it was Ready at container start.

## Verification
- `helm lint` clean; `helm template` renders `maxUnavailable: 0` on all three deployments.
- `py_compile` clean on both backend modules.

## Notes
- Gateway HPA `minReplicas: 1` still means a node failure is a brief outage; bumping prod values to `minReplicas: 2` is a values-file change on the deploy side, recommended.
- Long-lived SSE streams will be cut at pod termination grace expiry (90s default); clients reconnect.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> All previously flagged issues have been addressed with test coverage. Changes are internal bug fixes, notification-flow improvements, and Helm pod-lifecycle configuration.

> **Overview**
> Fixes opaque MCP scan errors by unwrapping ExceptionGroup to leaf exceptions, suppresses repeated admin alerts for known-unhealthy servers, and adds zero-downtime RollingUpdate config to Helm deployments with preStop hooks and console readiness probes.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit latest. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->