### PR TITLE
fix: stop aggressive session expiry, cap sliding sessions at 30 days

### DIFF
--- a/backend/preloop/api/auth/jwt.py
+++ b/backend/preloop/api/auth/jwt.py
@@ -6,7 +6,7 @@ import os
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, UTC
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
@@ -32,6 +32,12 @@ from preloop.config import settings
 SECRET_KEY: str = settings.security.secret_key
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "1440"))
+# Refresh tokens rotate on every /refresh call (sliding window). Each rotation
+# carries the original session start forward in the "sat" claim so the sliding
+# window can be capped: an active user is never logged out inside
+# MAX_SESSION_DAYS, and a stolen refresh token cannot be rotated forever.
+REFRESH_TOKEN_EXPIRE_DAYS = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", "7"))
+MAX_SESSION_DAYS = int(os.getenv("MAX_SESSION_DAYS", "30"))
 
 # Password context for hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -368,6 +374,35 @@ def create_access_token(
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
 
+def create_refresh_token(
+    sub: str,
+    scopes: Optional[List[str]] = None,
+    session_started_at: Optional[datetime] = None,
+) -> str:
+    """Create a JWT refresh token carrying the session start claim.
+
+    Args:
+        sub: Subject (user id) for the token.
+        scopes: OAuth scopes to carry through rotation.
+        session_started_at: When this login session originally started. On
+            first login this is now; on rotation the previous token's value is
+            carried forward so MAX_SESSION_DAYS caps the sliding window.
+
+    Returns:
+        Encoded JWT refresh token.
+    """
+    started = session_started_at or datetime.now(UTC)
+    return create_access_token(
+        data={
+            "sub": sub,
+            "scopes": scopes or [],
+            "refresh": True,
+            "sat": int(started.timestamp()),
+        },
+        expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+    )
+
+
 def decode_token(token: str) -> TokenData:
     """Decode a JWT token.
 
@@ -394,12 +429,14 @@ def decode_token(token: str) -> TokenData:
         scopes = payload.get("scopes", [])
         exp = payload.get("exp")
         refresh = payload.get("refresh", False)
+        sat = payload.get("sat")
 
         return TokenData(
             sub=sub,
             scopes=scopes,
             exp=datetime.fromtimestamp(exp) if exp else None,
             refresh=refresh,
+            session_started_at=(datetime.fromtimestamp(sat, tz=UTC) if sat else None),
         )
     except JWTError:
         raise HTTPException(

--- a/backend/preloop/api/auth/router.py
+++ b/backend/preloop/api/auth/router.py
@@ -23,7 +23,9 @@ from sqlalchemy.orm import Session
 from preloop.api.auth import bootstrap
 from preloop.api.auth.jwt import (
     ACCESS_TOKEN_EXPIRE_MINUTES,
+    MAX_SESSION_DAYS,
     create_access_token,
+    create_refresh_token,
     decode_token,
     get_current_active_user,
     get_password_hash,
@@ -732,11 +734,10 @@ async def login_form(
         expires_delta=access_token_expires,
     )
 
-    # Create refresh token with longer expiration
-    refresh_token_expires = timedelta(days=7)  # 7 days
-    refresh_token = create_access_token(
-        data={"sub": str(user.id), "scopes": form_data.scopes or [], "refresh": True},
-        expires_delta=refresh_token_expires,
+    # Create refresh token with longer expiration; a fresh login starts a new
+    # sliding session window (sat claim).
+    refresh_token = create_refresh_token(
+        sub=str(user.id), scopes=form_data.scopes or []
     )
 
     return {
@@ -782,12 +783,9 @@ async def login_json(
         expires_delta=access_token_expires,
     )
 
-    # Create refresh token with longer expiration
-    refresh_token_expires = timedelta(days=7)  # 7 days
-    refresh_token = create_access_token(
-        data={"sub": str(user.id), "scopes": [], "refresh": True},
-        expires_delta=refresh_token_expires,
-    )
+    # Create refresh token with longer expiration; a fresh login starts a new
+    # sliding session window (sat claim).
+    refresh_token = create_refresh_token(sub=str(user.id), scopes=[])
 
     return {
         "access_token": access_token,
@@ -820,6 +818,16 @@ async def refresh_token(
         # Decode and validate the refresh token
         token_data = decode_token(request.refresh_token)
 
+        # Check if it's a refresh token before touching the database: an
+        # access token presented here is always invalid, regardless of user
+        # state.
+        if not token_data.refresh:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid refresh token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
         # Parse user_id from token
         try:
             user_id = UUID(token_data.sub)
@@ -840,11 +848,17 @@ async def refresh_token(
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        # Check if it's a refresh token
-        if not token_data.refresh:
+        # Enforce the sliding-session cap: rotation extends the session by
+        # REFRESH_TOKEN_EXPIRE_DAYS each time, but the chain as a whole may
+        # not outlive MAX_SESSION_DAYS from the original login. Tokens minted
+        # before the sat claim existed have no session start; treat this
+        # rotation as the start of their session window.
+        session_started_at = token_data.session_started_at or datetime.now(UTC)
+        session_age = datetime.now(UTC) - session_started_at
+        if session_age > timedelta(days=MAX_SESSION_DAYS):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid refresh token",
+                detail="Session expired, please sign in again",
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
@@ -855,11 +869,12 @@ async def refresh_token(
             expires_delta=access_token_expires,
         )
 
-        # Create a new refresh token
-        refresh_token_expires = timedelta(days=7)  # 7 days
-        refresh_token = create_access_token(
-            data={"sub": token_data.sub, "scopes": token_data.scopes, "refresh": True},
-            expires_delta=refresh_token_expires,
+        # Rotate the refresh token, carrying the original session start
+        # forward so the 30-day cap survives rotation.
+        refresh_token = create_refresh_token(
+            sub=token_data.sub,
+            scopes=token_data.scopes,
+            session_started_at=session_started_at,
         )
 
         return {
@@ -868,6 +883,8 @@ async def refresh_token(
             "token_type": "bearer",
             "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # in seconds
         }
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -1619,11 +1636,7 @@ async def complete_onboarding(
         data={"sub": str(user.id), "scopes": []},
         expires_delta=access_token_expires,
     )
-    refresh_token_expires = timedelta(days=7)
-    refresh_token = create_access_token(
-        data={"sub": str(user.id), "scopes": [], "refresh": True},
-        expires_delta=refresh_token_expires,
-    )
+    refresh_token = create_refresh_token(sub=str(user.id), scopes=[])
 
     return {
         "access_token": access_token,

--- a/backend/preloop/schemas/auth.py
+++ b/backend/preloop/schemas/auth.py
@@ -23,6 +23,9 @@ class TokenData(BaseModel):
     scopes: List[str] = []
     exp: Optional[datetime] = None
     refresh: Optional[bool] = False
+    # When the login session originally started ("sat" claim). Carried through
+    # refresh-token rotations so the sliding session window can be capped.
+    session_started_at: Optional[datetime] = None
 
 
 class User(BaseModel):

--- a/backend/tests/endpoints/test_auth_comprehensive.py
+++ b/backend/tests/endpoints/test_auth_comprehensive.py
@@ -21,7 +21,9 @@ from sqlalchemy.orm import Session
 
 from preloop.api.auth.router import router as auth_router, authenticate_user
 from preloop.api.auth.jwt import (
+    MAX_SESSION_DAYS,
     create_access_token,
+    create_refresh_token,
     decode_token,
     verify_password,
     get_password_hash,
@@ -367,6 +369,94 @@ class TestTokenRefresh:
         assert "access_token" in data
         assert "refresh_token" in data
         assert data["token_type"] == "bearer"
+
+    def test_refresh_rotation_carries_session_start(self, db_session_mock, mock_user):
+        """The sat (session start) claim survives refresh-token rotation."""
+        started = datetime.now(timezone.utc) - timedelta(days=3)
+        refresh_token = create_refresh_token(
+            sub=str(mock_user.id), scopes=[], session_started_at=started
+        )
+
+        with patch("preloop.api.auth.router.crud_user") as mock_crud:
+            mock_crud.get.return_value = mock_user
+
+            response = client.post(
+                "/auth/refresh",
+                json={"refresh_token": refresh_token},
+            )
+
+        assert response.status_code == 200
+        rotated = decode_token(response.json()["refresh_token"])
+        assert rotated.session_started_at is not None
+        # Carried forward, not reset: still ~3 days old.
+        age = datetime.now(timezone.utc) - rotated.session_started_at
+        assert timedelta(days=2, hours=23) < age < timedelta(days=3, hours=1)
+
+    def test_refresh_rejected_after_session_cap(self, db_session_mock, mock_user):
+        """A refresh chain older than MAX_SESSION_DAYS is rejected with 401."""
+        started = datetime.now(timezone.utc) - timedelta(days=MAX_SESSION_DAYS + 1)
+        refresh_token = create_refresh_token(
+            sub=str(mock_user.id), scopes=[], session_started_at=started
+        )
+
+        with patch("preloop.api.auth.router.crud_user") as mock_crud:
+            mock_crud.get.return_value = mock_user
+
+            response = client.post(
+                "/auth/refresh",
+                json={"refresh_token": refresh_token},
+            )
+
+        assert response.status_code == 401
+        assert "Session expired" in response.json()["detail"]
+
+    def test_refresh_legacy_token_without_sat_still_works(
+        self, db_session_mock, mock_user
+    ):
+        """Refresh tokens minted before the sat claim existed still refresh.
+
+        Their rotated replacement gains a sat claim so the cap applies from
+        this rotation onward.
+        """
+        legacy_refresh = create_access_token(
+            data={"sub": str(mock_user.id), "scopes": [], "refresh": True},
+            expires_delta=timedelta(days=7),
+        )
+
+        with patch("preloop.api.auth.router.crud_user") as mock_crud:
+            mock_crud.get.return_value = mock_user
+
+            response = client.post(
+                "/auth/refresh",
+                json={"refresh_token": legacy_refresh},
+            )
+
+        assert response.status_code == 200
+        rotated = decode_token(response.json()["refresh_token"])
+        assert rotated.session_started_at is not None
+        # Session window started now for legacy chains.
+        age = datetime.now(timezone.utc) - rotated.session_started_at
+        assert age < timedelta(minutes=1)
+
+    def test_login_json_returns_refresh_token_with_sat(
+        self, db_session_mock, mock_user
+    ):
+        """Password login mints a refresh token that starts the session window."""
+        with patch(
+            "preloop.api.auth.router.authenticate_user",
+            return_value=mock_user,
+        ):
+            response = client.post(
+                "/auth/token/json",
+                json={"username": "testuser", "password": "password123"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "refresh_token" in data
+        token_data = decode_token(data["refresh_token"])
+        assert token_data.refresh is True
+        assert token_data.session_started_at is not None
 
     def test_refresh_token_not_refresh_type(self, db_session_mock):
         """Test refresh fails when using access token instead of refresh token."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       DEBUG: 'true'
       SECRET_KEY: development_secret_key_do_not_use_in_production
       JWT_ALGORITHM: HS256
-      ACCESS_TOKEN_EXPIRE_MINUTES: 60
+      ACCESS_TOKEN_EXPIRE_MINUTES: 1440
       LOG_LEVEL: DEBUG
       INIT_TEST_DATA: 'true'
       PRELOOP_SERVICE_ROLE: api
@@ -63,7 +63,7 @@ services:
       DEBUG: 'true'
       SECRET_KEY: development_secret_key_do_not_use_in_production
       JWT_ALGORITHM: HS256
-      ACCESS_TOKEN_EXPIRE_MINUTES: 60
+      ACCESS_TOKEN_EXPIRE_MINUTES: 1440
       LOG_LEVEL: DEBUG
       INIT_TEST_DATA: 'true'
       PRELOOP_SERVICE_ROLE: gateway
@@ -90,7 +90,7 @@ services:
       DEBUG: 'true'
       SECRET_KEY: development_secret_key_do_not_use_in_production
       JWT_ALGORITHM: HS256
-      ACCESS_TOKEN_EXPIRE_MINUTES: 60
+      ACCESS_TOKEN_EXPIRE_MINUTES: 1440
       LOG_LEVEL: DEBUG
       INIT_TEST_DATA: 'true'
     volumes:
@@ -114,7 +114,7 @@ services:
       DEBUG: 'true'
       SECRET_KEY: development_secret_key_do_not_use_in_production
       JWT_ALGORITHM: HS256
-      ACCESS_TOKEN_EXPIRE_MINUTES: 60
+      ACCESS_TOKEN_EXPIRE_MINUTES: 1440
       LOG_LEVEL: DEBUG
       INIT_TEST_DATA: 'true'
     volumes:

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -141,6 +141,103 @@ describe('api', () => {
       expect(threw).to.be.true;
       expect(routerGoStub).to.have.been.calledWith('/login');
     });
+
+    it('clears tokens when refresh is definitively rejected', async () => {
+      fetchStub.callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/api/v1/auth/refresh')) {
+          return new Response(
+            JSON.stringify({ detail: 'Invalid refresh token' }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        return new Response(JSON.stringify({}), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+
+      try {
+        await fetchWithAuth('/api/v1/test');
+      } catch {
+        // expected
+      }
+      expect(localStorage.getItem('accessToken')).to.be.null;
+      expect(localStorage.getItem('refreshToken')).to.be.null;
+    });
+
+    it('keeps session and retries once when refresh fails transiently', async () => {
+      let refreshCalls = 0;
+      fetchStub.callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/api/v1/auth/refresh')) {
+          refreshCalls++;
+          // Simulate a deploy blip: both refresh attempts return 502.
+          return new Response('Bad Gateway', { status: 502 });
+        }
+        return new Response(JSON.stringify({}), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+
+      const response = await fetchWithAuth('/api/v1/test');
+
+      // Transient failure: original 401 response is returned, session intact.
+      expect(response.status).to.equal(401);
+      expect(refreshCalls).to.equal(2); // initial attempt + one retry
+      expect(localStorage.getItem('accessToken')).to.equal('test-access-token');
+      expect(localStorage.getItem('refreshToken')).to.equal(
+        'test-refresh-token'
+      );
+      expect(routerGoStub).to.not.have.been.calledWith('/login');
+    });
+
+    it('recovers when the transient retry succeeds', async () => {
+      let refreshCalls = 0;
+      fetchStub.callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/api/v1/auth/refresh')) {
+          refreshCalls++;
+          if (refreshCalls === 1) {
+            return new Response('Bad Gateway', { status: 502 });
+          }
+          return new Response(
+            JSON.stringify({
+              access_token: 'recovered-access-token',
+              refresh_token: 'recovered-refresh-token',
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        const headers =
+          (fetchStub.lastCall?.args[1] as RequestInit | undefined)?.headers ??
+          null;
+        const auth =
+          headers instanceof Headers ? headers.get('Authorization') : null;
+        if (auth === 'Bearer recovered-access-token') {
+          return new Response(JSON.stringify({ data: 'ok' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({}), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+
+      const response = await fetchWithAuth('/api/v1/test');
+
+      expect(response.status).to.equal(200);
+      expect(refreshCalls).to.equal(2);
+      expect(localStorage.getItem('accessToken')).to.equal(
+        'recovered-access-token'
+      );
+      expect(localStorage.getItem('refreshToken')).to.equal(
+        'recovered-refresh-token'
+      );
+    });
   });
 
   describe('getFlowExecutions', () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -75,7 +75,14 @@ import type {
 } from './types';
 
 // Global refresh promise to prevent concurrent refresh requests
-let refreshPromise: Promise<string | null> | null = null;
+interface RefreshResult {
+  token: string | null;
+  // True when the refresh token was definitively rejected (401/403) and the
+  // session is over. False for transient failures (5xx, network) where the
+  // session must be preserved so a deploy blip does not log the user out.
+  terminal: boolean;
+}
+let refreshPromise: Promise<RefreshResult> | null = null;
 
 // Short-TTL in-memory caches with single-flight dedupe for hot auth/bootstrap
 // endpoints. Invalidated on logout / auth-change so navigations reuse results
@@ -148,31 +155,83 @@ export function extractErrorMessage(
   return defaultMessage;
 }
 
-async function refreshToken(): Promise<string | null> {
+async function attemptRefresh(refreshTokenValue: string): Promise<Response> {
+  return fetch(`/api/v1/auth/refresh`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ refresh_token: refreshTokenValue }),
+  });
+}
+
+function endSessionAndRedirect(): void {
+  localStorage.removeItem('accessToken');
+  localStorage.removeItem('refreshToken');
+
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('auth-change', { bubbles: true, composed: true })
+    );
+    if (
+      !window.location.pathname.startsWith('/login') &&
+      !window.location.pathname.startsWith('/register')
+    ) {
+      localStorage.setItem(
+        'loginRedirect',
+        window.location.pathname + window.location.search + window.location.hash
+      );
+    }
+  }
+
+  Router.go('/login');
+}
+
+async function refreshToken(): Promise<RefreshResult> {
   // If a refresh is already in progress, wait for it
   if (refreshPromise) {
     return refreshPromise;
   }
 
   // Start a new refresh
-  refreshPromise = (async () => {
+  refreshPromise = (async (): Promise<RefreshResult> => {
     try {
       const refreshTokenValue = localStorage.getItem('refreshToken');
       if (!refreshTokenValue) {
         console.error('No refresh token available');
-        return null;
+        endSessionAndRedirect();
+        return { token: null, terminal: true };
       }
 
-      const response = await fetch(`/api/v1/auth/refresh`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ refresh_token: refreshTokenValue }),
-      });
+      let response: Response | null = null;
+      try {
+        response = await attemptRefresh(refreshTokenValue);
+      } catch {
+        // Network error (offline, deploy blip). Retry once below.
+        response = null;
+      }
+
+      // Retry once on transient failure (network error or 5xx). Only a
+      // definitive 401/403 means the refresh token itself is dead.
+      if (!response || response.status >= 500) {
+        try {
+          response = await attemptRefresh(refreshTokenValue);
+        } catch {
+          response = null;
+        }
+      }
+
+      if (!response || response.status >= 500) {
+        // Still transient: keep the session. The next 401 will try again.
+        console.error('Token refresh failed transiently; keeping session');
+        return { token: null, terminal: false };
+      }
 
       if (!response.ok) {
-        throw new Error('Failed to refresh token');
+        // Definitive rejection (401/403/4xx): session is over.
+        console.error(`Token refresh rejected with status ${response.status}`);
+        endSessionAndRedirect();
+        return { token: null, terminal: true };
       }
 
       const data = await response.json();
@@ -186,32 +245,12 @@ async function refreshToken(): Promise<string | null> {
         );
       }
 
-      return data.access_token;
+      return { token: data.access_token, terminal: false };
     } catch (error) {
+      // Unexpected error (e.g. malformed JSON body). Treat as transient so a
+      // broken deploy cannot log everyone out.
       console.error('Error refreshing token:', error);
-      // Clear tokens and redirect to login
-      localStorage.removeItem('accessToken');
-      localStorage.removeItem('refreshToken');
-
-      if (typeof window !== 'undefined') {
-        window.dispatchEvent(
-          new CustomEvent('auth-change', { bubbles: true, composed: true })
-        );
-        if (
-          !window.location.pathname.startsWith('/login') &&
-          !window.location.pathname.startsWith('/register')
-        ) {
-          localStorage.setItem(
-            'loginRedirect',
-            window.location.pathname +
-              window.location.search +
-              window.location.hash
-          );
-        }
-      }
-
-      Router.go('/login');
-      return null;
+      return { token: null, terminal: false };
     } finally {
       // Clear the refresh promise so future requests can refresh again
       refreshPromise = null;
@@ -281,17 +320,19 @@ export async function fetchWithAuth(
       return fetch(url, options);
     }
 
-    const newAccessToken = await refreshToken();
-    if (newAccessToken) {
-      headers.set('Authorization', `Bearer ${newAccessToken}`);
+    const refreshResult = await refreshToken();
+    if (refreshResult.token) {
+      headers.set('Authorization', `Bearer ${refreshResult.token}`);
       options.headers = headers;
       // Retry the request with the new token
       response = await fetch(url, options);
-    } else {
-      // If refresh fails, the refreshToken function will handle redirection
-      Router.go('/login');
+    } else if (refreshResult.terminal) {
+      // Refresh token definitively rejected; refreshToken() already cleared
+      // storage and redirected to /login.
       throw new Error('Failed to refresh token, redirecting to login.');
     }
+    // Transient refresh failure: fall through and return the original 401
+    // response without destroying the session. The next request retries.
   }
 
   if (response.status === 429) {

--- a/frontend/src/views/public/login-view.ts
+++ b/frontend/src/views/public/login-view.ts
@@ -126,6 +126,11 @@ export class LoginView extends LitElement {
       });
 
       localStorage.setItem('accessToken', data.access_token);
+      // Without the refresh token in storage, refreshToken() cannot renew the
+      // session and the user is hard-logged-out when the access token expires.
+      if (data.refresh_token) {
+        localStorage.setItem('refreshToken', data.refresh_token);
+      }
       this.error = '';
       this.successMessage = '';
       // Returning-user conversion: distinguishes sign-ins from new signups.

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -242,7 +242,9 @@ environment:
   # JWT settings
   jwtSecret: "b6fe6fa9-cf7c-4798-8328-f778712062df"
   jwtAlgorithm: "HS256"
-  jwtExpireMinutes: 60
+  # Access token lifetime. 1440 (24h) matches the documented session design:
+  # 24h access token + 7 day rotating refresh token capped at 30 days.
+  jwtExpireMinutes: 1440
 
 # Configuration for external APIs
 config:


### PR DESCRIPTION
## Root cause

Users were re-prompted to log in after about an hour of active use. Three compounding causes, in order of impact:

1. Password login never stored the refresh token. `frontend/src/views/public/login-view.ts` saved only `data.access_token` from `/api/v1/auth/token/json` and silently dropped `data.refresh_token`. When the access token expired, `refreshToken()` in `api.ts` found nothing in localStorage and hard-logged the user out. The register, welcome, and OAuth-fragment paths all stored it; only the main sign-in form did not.

2. Deployed access-token lifetime was 60 minutes, not 24 hours. The code default is `ACCESS_TOKEN_EXPIRE_MINUTES=1440` (`jwt.py`), but `helm/preloop/values.yaml` set `jwtExpireMinutes: 60` (injected into all five deployments) and docker-compose set 60 as well. Combined with bug 1, every password session died at the 60 minute mark. That is the "after a while".

3. Any refresh failure was terminal. `refreshToken()` treated every non-ok response (including 502s and network blips during a deploy) as fatal: it cleared both tokens and redirected to /login. A single mid-deploy blip logged users out even when their refresh token was perfectly valid.

Checked and ruled out: `/refresh` is mounted without an auth dependency (cannot reject expired access tokens); rotation is stateless with no blacklist so two-tab races are safe (`fetchWithAuth` also re-reads localStorage before refreshing); the WebSocket manager waits for `auth-change` instead of logging out on `auth_error`.

## Fix

- `login-view.ts`: store `refresh_token` on password sign-in.
- `api.ts`: only clear tokens and redirect on a definitive 401/403 from `/refresh`. On 5xx/network failure, retry once; if still failing, keep the session and return the original 401 so the next request tries again.
- Sliding-session cap: refresh tokens now carry a `sat` (session started at) claim minted at login and carried through every rotation. `/refresh` rejects chains older than `MAX_SESSION_DAYS` (default 30). An active user is never logged out inside 30 days; an idle one still expires after `REFRESH_TOKEN_EXPIRE_DAYS` (default 7). Legacy refresh tokens without `sat` continue to work and gain the claim on their next rotation.
- `/refresh` hardening: validate the refresh flag before the DB lookup and re-raise HTTPExceptions instead of wrapping every error as "Invalid refresh token".
- Helm values and docker-compose: `ACCESS_TOKEN_EXPIRE_MINUTES` 60 -> 1440 to match the documented design.

New env knobs: `REFRESH_TOKEN_EXPIRE_DAYS` (7), `MAX_SESSION_DAYS` (30).

## Tests

- Backend (`test_auth_comprehensive.py`): sat carried through rotation; chain rejected past the 30-day cap; legacy tokens without sat still refresh and gain the claim; password login returns a refresh token with sat. 56 passed.
- Frontend (`api.test.ts`): definitive 401 clears tokens and redirects; transient 502 retries once, preserves both tokens, and does not redirect; recovery when the retry succeeds. 12 passed, plus login-view tests.

Note for deployers: the CLI OAuth token paths in `oauth_server.py` use their own `CLI_JWT_REFRESH_TOKEN_EXPIRE_DAYS` and are intentionally untouched.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk** — Targeted fix for session expiry with clean token-rotation design.
>
> **Overview**
> Fixes aggressive session expiry via three changes: storing the refresh token on password login, aligning deployed access-token lifetime to 24h (1440 min), and making refresh failures non-terminal for transient errors. Adds a `sat` claim to refresh tokens so sliding sessions are capped at 30 days. Extensive backend and frontend tests included.
>
> <sup>Reviewed by [Preloop PR Reviewer](https://preloop.ai) for PR #125. ✅ Approved.</sup>
<!-- /PRELOOP_SUMMARY -->