### PR TITLE
feat: WebAuthn passkey sign-in and registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Passkey (WebAuthn) sign-in and registration**: register passkeys in user
+  settings and sign in from the login page with discoverable credentials (no
+  username needed). Feature-flagged via `PASSKEYS_ENABLED` (default `true`);
+  relying party and origin overridable with `WEBAUTHN_RP_ID` and
+  `WEBAUTHN_ORIGIN`. Passkey logins are audit-logged and trigger the same
+  inactivity notifications as password logins.
+
+### Fixed
+
+- **Sessions no longer expire aggressively**: refresh failures caused by
+  transient errors (5xx, network) no longer clear tokens and force re-login;
+  only definitive 401/403 does. OAuth logins now store refresh tokens.
+  Active sessions slide up to a 30-day cap.
+
 ## [0.13.1] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ curl -fsSL https://preloop.ai/install/oss | \
 
 **Email is not optional in practice**: approval requests, invitations and password resets are delivered by email, so an instance without SMTP cannot notify approvers. Everything the installer writes lives in `~/.preloop-oss/.env` — edit it and run `docker compose up -d` to change any setting later.
 
+**Passkeys (WebAuthn)**: passkey sign-in is enabled by default; set `PASSKEYS_ENABLED=false` to turn it off. Behind a proxy or on a non-standard domain setup, pin the relying party and origin explicitly with `WEBAUTHN_RP_ID` (the registrable domain, e.g. `preloop.example.com`) and `WEBAUTHN_ORIGIN` (e.g. `https://preloop.example.com`); by default both are derived from the request. `WEBAUTHN_CHALLENGE_RATE_LIMIT` (default `30`) caps challenge requests per IP per minute.
+
 To install a pre-release (e.g. a release candidate), pin the version: `curl -fsSL https://preloop.ai/install/oss | PRELOOP_VERSION=0.13.1 sh` (the same works for the CLI installer).
 
 #### Upgrading

--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -843,6 +843,16 @@ def create_app() -> FastAPI:
 
         # Core API routers
         app.include_router(auth_router, prefix="/api/v1/auth", tags=["Auth"])
+        # WebAuthn passkey ceremonies. Mounted WITHOUT an auth dependency:
+        # the authentication ceremony must run before the user has a token.
+        # Endpoints that need a signed-in user declare it themselves.
+        from preloop.api.auth.webauthn_router import router as webauthn_router
+
+        app.include_router(
+            webauthn_router,
+            prefix="/api/v1/auth/webauthn",
+            tags=["Auth", "Passkeys"],
+        )
         app.include_router(
             account.router,
             prefix="/api/v1",

--- a/backend/preloop/api/auth/webauthn_router.py
+++ b/backend/preloop/api/auth/webauthn_router.py
@@ -119,9 +119,7 @@ def _check_challenge_rate_limit(request: Request) -> None:
     # Opportunistic cleanup so the map cannot grow unbounded across many IPs.
     if len(_rate_buckets) > 10_000:
         for stale_ip in [
-            k
-            for k, v in _rate_buckets.items()
-            if not v or v[-1] <= window_start
+            k for k, v in _rate_buckets.items() if not v or v[-1] <= window_start
         ]:
             _rate_buckets.pop(stale_ip, None)
 
@@ -411,9 +409,7 @@ def authentication_verify(
             detail="User not found or inactive",
         )
 
-    crud_webauthn_credential.touch(
-        db, obj=cred, sign_count=verification.new_sign_count
-    )
+    crud_webauthn_credential.touch(db, obj=cred, sign_count=verification.new_sign_count)
 
     # Audit and notification parity with password login (authenticate_user in
     # auth/router.py): update last_login, write a user.login audit event, and

--- a/backend/preloop/api/auth/webauthn_router.py
+++ b/backend/preloop/api/auth/webauthn_router.py
@@ -1,0 +1,425 @@
+"""WebAuthn passkey endpoints: registration and authentication ceremonies.
+
+Mounted under /api/v1/auth/webauthn/. Feature-flagged via PASSKEYS_ENABLED
+(default true).
+
+Scope (deliberately tight):
+- Single-device passkeys with discoverable (resident) credentials.
+- Registration from user settings (authenticated).
+- "Sign in with passkey" on the login page (unauthenticated ceremony).
+- No admin management UI.
+
+Challenge state is carried in a short-lived JWT signed with the server
+secret rather than server-side session storage, so the ceremony survives
+multi-replica deployments without shared state.
+"""
+
+import base64
+import json
+import logging
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from jose import JWTError, jwt
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from webauthn import (
+    generate_authentication_options,
+    generate_registration_options,
+    options_to_json,
+    verify_authentication_response,
+    verify_registration_response,
+)
+from webauthn.helpers import base64url_to_bytes
+from webauthn.helpers.exceptions import (
+    InvalidAuthenticationResponse,
+    InvalidRegistrationResponse,
+)
+from webauthn.helpers.structs import (
+    AuthenticatorSelectionCriteria,
+    PublicKeyCredentialDescriptor,
+    ResidentKeyRequirement,
+    UserVerificationRequirement,
+)
+
+from preloop.api.auth.jwt import (
+    ACCESS_TOKEN_EXPIRE_MINUTES,
+    ALGORITHM,
+    SECRET_KEY,
+    create_access_token,
+    create_refresh_token,
+    get_current_active_user,
+)
+from preloop.models.crud import crud_user, crud_webauthn_credential
+from preloop.models.db.session import get_db_session
+from preloop.models.models.user import User
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+CHALLENGE_TTL_SECONDS = 300
+
+
+def passkeys_enabled() -> bool:
+    """Whether passkey support is enabled (PASSKEYS_ENABLED, default true)."""
+    return os.getenv("PASSKEYS_ENABLED", "true").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _require_enabled() -> None:
+    if not passkeys_enabled():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Passkey support is disabled",
+        )
+
+
+def _rp_id(request: Request) -> str:
+    """Relying party ID: WEBAUTHN_RP_ID env override or the request host."""
+    configured = os.getenv("WEBAUTHN_RP_ID", "").strip()
+    if configured:
+        return configured
+    host = request.url.hostname or "localhost"
+    return host
+
+
+def _expected_origin(request: Request) -> str:
+    """Expected client origin: WEBAUTHN_ORIGIN env override or the Origin header."""
+    configured = os.getenv("WEBAUTHN_ORIGIN", "").strip()
+    if configured:
+        return configured
+    origin = request.headers.get("origin")
+    if origin:
+        return origin
+    scheme = request.url.scheme or "https"
+    host = request.url.hostname or "localhost"
+    port = request.url.port
+    if port and port not in (80, 443):
+        return f"{scheme}://{host}:{port}"
+    return f"{scheme}://{host}"
+
+
+def _issue_challenge_token(challenge: bytes, purpose: str, user_id: str = "") -> str:
+    """Sign the ceremony challenge into a short-lived stateless token."""
+    return jwt.encode(
+        {
+            "chal": base64.urlsafe_b64encode(challenge).decode().rstrip("="),
+            "purpose": purpose,
+            "user_id": user_id,
+            "exp": datetime.now(UTC) + timedelta(seconds=CHALLENGE_TTL_SECONDS),
+        },
+        SECRET_KEY,
+        algorithm=ALGORITHM,
+    )
+
+
+def _read_challenge_token(token: str, purpose: str) -> dict:
+    """Validate a challenge token and return its payload."""
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired passkey challenge",
+        )
+    if payload.get("purpose") != purpose:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Challenge token purpose mismatch",
+        )
+    padded = payload["chal"] + "=" * (-len(payload["chal"]) % 4)
+    payload["challenge_bytes"] = base64.urlsafe_b64decode(padded)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class RegistrationOptionsResponse(BaseModel):
+    """Options for navigator.credentials.create plus the challenge token."""
+
+    options: dict
+    challenge_token: str
+
+
+class RegistrationVerifyRequest(BaseModel):
+    """Authenticator response for the registration ceremony."""
+
+    credential: dict
+    challenge_token: str
+    name: Optional[str] = None
+
+
+class AuthenticationOptionsResponse(BaseModel):
+    """Options for navigator.credentials.get plus the challenge token."""
+
+    options: dict
+    challenge_token: str
+
+
+class AuthenticationVerifyRequest(BaseModel):
+    """Authenticator response for the authentication ceremony."""
+
+    credential: dict
+    challenge_token: str
+
+
+class PasskeySummary(BaseModel):
+    """Non-sensitive passkey metadata for the settings UI."""
+
+    id: uuid.UUID
+    name: str
+    created_at: datetime
+    last_used_at: Optional[datetime] = None
+
+
+# ---------------------------------------------------------------------------
+# Registration ceremony (authenticated)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/register/options",
+    response_model=RegistrationOptionsResponse,
+)
+def registration_options(
+    request: Request,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+) -> RegistrationOptionsResponse:
+    """Begin passkey registration for the signed-in user."""
+    _require_enabled()
+
+    existing = crud_webauthn_credential.list_for_user(db, user_id=current_user.id)
+    exclude: List[PublicKeyCredentialDescriptor] = [
+        PublicKeyCredentialDescriptor(id=base64url_to_bytes(cred.credential_id))
+        for cred in existing
+    ]
+
+    options = generate_registration_options(
+        rp_id=_rp_id(request),
+        rp_name="Preloop",
+        user_id=str(current_user.id).encode("utf-8"),
+        user_name=current_user.username,
+        user_display_name=current_user.full_name or current_user.username,
+        exclude_credentials=exclude,
+        authenticator_selection=AuthenticatorSelectionCriteria(
+            resident_key=ResidentKeyRequirement.REQUIRED,
+            user_verification=UserVerificationRequirement.PREFERRED,
+        ),
+    )
+
+    return RegistrationOptionsResponse(
+        options=json.loads(options_to_json(options)),
+        challenge_token=_issue_challenge_token(
+            options.challenge, "register", str(current_user.id)
+        ),
+    )
+
+
+@router.post("/register/verify", response_model=PasskeySummary)
+def registration_verify(
+    body: RegistrationVerifyRequest,
+    request: Request,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+) -> PasskeySummary:
+    """Complete passkey registration and store the credential."""
+    _require_enabled()
+
+    payload = _read_challenge_token(body.challenge_token, "register")
+    if payload.get("user_id") != str(current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Challenge was issued for a different user",
+        )
+
+    try:
+        verification = verify_registration_response(
+            credential=body.credential,
+            expected_challenge=payload["challenge_bytes"],
+            expected_rp_id=_rp_id(request),
+            expected_origin=_expected_origin(request),
+        )
+    except InvalidRegistrationResponse as e:
+        logger.warning(f"Passkey registration verification failed: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Passkey registration could not be verified",
+        )
+
+    credential_id_b64 = (
+        base64.urlsafe_b64encode(verification.credential_id).decode().rstrip("=")
+    )
+    if crud_webauthn_credential.get_by_credential_id(
+        db, credential_id=credential_id_b64
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This passkey is already registered",
+        )
+
+    transports = body.credential.get("response", {}).get("transports")
+    from preloop.models.models.webauthn_credential import WebAuthnCredential
+
+    cred = WebAuthnCredential(
+        user_id=current_user.id,
+        credential_id=credential_id_b64,
+        public_key=base64.urlsafe_b64encode(verification.credential_public_key)
+        .decode()
+        .rstrip("="),
+        sign_count=verification.sign_count,
+        transports=json.dumps(transports) if transports else None,
+        name=(body.name or "Passkey")[:100],
+        aaguid=str(verification.aaguid) if verification.aaguid else None,
+        is_active=True,
+    )
+    db.add(cred)
+    db.commit()
+    db.refresh(cred)
+
+    return PasskeySummary(
+        id=cred.id,
+        name=cred.name,
+        created_at=cred.created_at,
+        last_used_at=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Authentication ceremony (unauthenticated)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/authenticate/options",
+    response_model=AuthenticationOptionsResponse,
+)
+def authentication_options(request: Request) -> AuthenticationOptionsResponse:
+    """Begin passkey sign-in. Discoverable credentials: no username needed."""
+    _require_enabled()
+
+    options = generate_authentication_options(
+        rp_id=_rp_id(request),
+        user_verification=UserVerificationRequirement.PREFERRED,
+    )
+
+    return AuthenticationOptionsResponse(
+        options=json.loads(options_to_json(options)),
+        challenge_token=_issue_challenge_token(options.challenge, "authenticate"),
+    )
+
+
+@router.post("/authenticate/verify")
+def authentication_verify(
+    body: AuthenticationVerifyRequest,
+    request: Request,
+    db: Session = Depends(get_db_session),
+) -> dict:
+    """Complete passkey sign-in; returns access and refresh tokens."""
+    _require_enabled()
+
+    payload = _read_challenge_token(body.challenge_token, "authenticate")
+
+    raw_id = body.credential.get("rawId") or body.credential.get("id") or ""
+    credential_id_b64 = raw_id.rstrip("=")
+    cred = crud_webauthn_credential.get_by_credential_id(
+        db, credential_id=credential_id_b64
+    )
+    if cred is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unknown passkey",
+        )
+
+    public_key_padded = cred.public_key + "=" * (-len(cred.public_key) % 4)
+    try:
+        verification = verify_authentication_response(
+            credential=body.credential,
+            expected_challenge=payload["challenge_bytes"],
+            expected_rp_id=_rp_id(request),
+            expected_origin=_expected_origin(request),
+            credential_public_key=base64.urlsafe_b64decode(public_key_padded),
+            credential_current_sign_count=cred.sign_count,
+        )
+    except InvalidAuthenticationResponse as e:
+        logger.warning(f"Passkey authentication verification failed: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Passkey authentication failed",
+        )
+
+    user = crud_user.get(db, id=cred.user_id)
+    if user is None or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found or inactive",
+        )
+
+    crud_webauthn_credential.touch(
+        db, obj=cred, sign_count=verification.new_sign_count
+    )
+
+    access_token = create_access_token(
+        data={"sub": str(user.id), "scopes": []},
+        expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+    )
+    refresh_token = create_refresh_token(sub=str(user.id), scopes=[])
+
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+        "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Credential management (authenticated, settings UI)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/credentials", response_model=List[PasskeySummary])
+def list_credentials(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+) -> List[PasskeySummary]:
+    """List the signed-in user's passkeys."""
+    _require_enabled()
+    creds = crud_webauthn_credential.list_for_user(db, user_id=current_user.id)
+    return [
+        PasskeySummary(
+            id=c.id,
+            name=c.name,
+            created_at=c.created_at,
+            last_used_at=c.last_used_at,
+        )
+        for c in creds
+    ]
+
+
+@router.delete("/credentials/{credential_id}", status_code=204)
+def delete_credential(
+    credential_id: uuid.UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+) -> None:
+    """Remove one of the signed-in user's passkeys."""
+    _require_enabled()
+    cred = crud_webauthn_credential.get(db, id=credential_id)
+    if cred is None or cred.user_id != current_user.id or not cred.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Passkey not found",
+        )
+    crud_webauthn_credential.deactivate(db, obj=cred)

--- a/backend/preloop/api/auth/webauthn_router.py
+++ b/backend/preloop/api/auth/webauthn_router.py
@@ -53,9 +53,11 @@ from preloop.api.auth.jwt import (
     create_refresh_token,
     get_current_active_user,
 )
-from preloop.models.crud import crud_user, crud_webauthn_credential
+from preloop.models.crud import crud_audit_log, crud_user, crud_webauthn_credential
 from preloop.models.db.session import get_db_session
 from preloop.models.models.user import User
+from preloop.models.models.webauthn_credential import WebAuthnCredential
+from preloop.utils.request import get_client_ip
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +82,48 @@ def _require_enabled() -> None:
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Passkey support is disabled",
         )
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting for challenge generation
+# ---------------------------------------------------------------------------
+# The challenge endpoints sign a JWT per call, and /authenticate/options is
+# unauthenticated, so an anonymous caller could burn CPU on JWT signing and
+# option generation. Simple in-process sliding-window per-IP throttle; the
+# tokens are stateless so there is no storage to exhaust, only CPU to protect.
+# Multi-replica deployments get N x the budget, which is acceptable for this
+# purpose (protecting compute, not enforcing a strict global quota).
+
+_RATE_LIMIT_MAX_CALLS = int(os.getenv("WEBAUTHN_CHALLENGE_RATE_LIMIT", "30"))
+_RATE_LIMIT_WINDOW_SECONDS = 60
+_rate_buckets: dict[str, list[float]] = {}
+
+
+def _check_challenge_rate_limit(request: Request) -> None:
+    import time
+
+    ip = get_client_ip(request)
+    now = time.monotonic()
+    window_start = now - _RATE_LIMIT_WINDOW_SECONDS
+
+    bucket = [t for t in _rate_buckets.get(ip, []) if t > window_start]
+    if len(bucket) >= _RATE_LIMIT_MAX_CALLS:
+        _rate_buckets[ip] = bucket
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many passkey challenge requests; try again shortly",
+        )
+    bucket.append(now)
+    _rate_buckets[ip] = bucket
+
+    # Opportunistic cleanup so the map cannot grow unbounded across many IPs.
+    if len(_rate_buckets) > 10_000:
+        for stale_ip in [
+            k
+            for k, v in _rate_buckets.items()
+            if not v or v[-1] <= window_start
+        ]:
+            _rate_buckets.pop(stale_ip, None)
 
 
 def _rp_id(request: Request) -> str:
@@ -199,6 +243,7 @@ def registration_options(
 ) -> RegistrationOptionsResponse:
     """Begin passkey registration for the signed-in user."""
     _require_enabled()
+    _check_challenge_rate_limit(request)
 
     existing = crud_webauthn_credential.list_for_user(db, user_id=current_user.id)
     exclude: List[PublicKeyCredentialDescriptor] = [
@@ -270,7 +315,6 @@ def registration_verify(
         )
 
     transports = body.credential.get("response", {}).get("transports")
-    from preloop.models.models.webauthn_credential import WebAuthnCredential
 
     cred = WebAuthnCredential(
         user_id=current_user.id,
@@ -308,6 +352,7 @@ def registration_verify(
 def authentication_options(request: Request) -> AuthenticationOptionsResponse:
     """Begin passkey sign-in. Discoverable credentials: no username needed."""
     _require_enabled()
+    _check_challenge_rate_limit(request)
 
     options = generate_authentication_options(
         rp_id=_rp_id(request),
@@ -369,6 +414,59 @@ def authentication_verify(
     crud_webauthn_credential.touch(
         db, obj=cred, sign_count=verification.new_sign_count
     )
+
+    # Audit and notification parity with password login (authenticate_user in
+    # auth/router.py): update last_login, write a user.login audit event, and
+    # notify admins on login after prolonged inactivity.
+    import threading
+
+    from preloop.services.account_setup_service import (
+        notify_admins_user_login_after_inactivity,
+        should_notify_on_login,
+    )
+
+    source_ip = get_client_ip(request)
+    old_last_login = user.last_login
+    user.last_login = datetime.now(UTC)
+    db.commit()
+    db.refresh(user)
+
+    try:
+        crud_audit_log.log_action(
+            db,
+            account_id=user.account_id,
+            user_id=user.id,
+            action="user.login",
+            resource_type="user",
+            resource_id=str(user.id),
+            status="success",
+            ip_address=source_ip,
+            details={"method": "passkey", "credential_id": str(cred.id)},
+        )
+    except Exception:
+        logger.debug("Failed to audit passkey login", exc_info=True)
+
+    if (
+        should_notify_on_login(old_last_login, days_threshold=7)
+        and source_ip != "testclient"
+    ):
+        username_str = user.username
+        email_str = user.email
+
+        def send_login_notification():
+            try:
+                notify_admins_user_login_after_inactivity(
+                    username=username_str,
+                    email=email_str,
+                    last_login=old_last_login,
+                    source_ip=source_ip,
+                )
+            except Exception as e:
+                logger.error(f"Failed to send login notification: {e}")
+
+        thread = threading.Thread(target=send_login_notification)
+        thread.daemon = True
+        thread.start()
 
     access_token = create_access_token(
         data={"sub": str(user.id), "scopes": []},

--- a/backend/preloop/api/endpoints/features.py
+++ b/backend/preloop/api/endpoints/features.py
@@ -59,8 +59,13 @@ def get_features(db: Session = Depends(get_db_session)) -> Dict[str, Any]:
 
     # Passkey (WebAuthn) support: PASSKEYS_ENABLED env, default true. The
     # login page uses this to decide whether to render "Sign in with passkey".
-    from preloop.api.auth.webauthn_router import passkeys_enabled
+    # Import guarded so a missing/broken webauthn dependency degrades to
+    # "passkeys: false" instead of breaking the whole features endpoint.
+    try:
+        from preloop.api.auth.webauthn_router import passkeys_enabled
 
-    result["features"]["passkeys"] = passkeys_enabled()
+        result["features"]["passkeys"] = passkeys_enabled()
+    except Exception:
+        result["features"]["passkeys"] = False
 
     return result

--- a/backend/preloop/api/endpoints/features.py
+++ b/backend/preloop/api/endpoints/features.py
@@ -57,4 +57,10 @@ def get_features(db: Session = Depends(get_db_session)) -> Dict[str, Any]:
     # setdefault so a plugin that already set the flag keeps its value.
     result["features"].setdefault("session_optimization", True)
 
+    # Passkey (WebAuthn) support: PASSKEYS_ENABLED env, default true. The
+    # login page uses this to decide whether to render "Sign in with passkey".
+    from preloop.api.auth.webauthn_router import passkeys_enabled
+
+    result["features"]["passkeys"] = passkeys_enabled()
+
     return result

--- a/backend/preloop/models/alembic/versions/20260730_add_webauthn_credentials.py
+++ b/backend/preloop/models/alembic/versions/20260730_add_webauthn_credentials.py
@@ -1,0 +1,89 @@
+"""Add webauthn_credential table for passkey support.
+
+Revision ID: 20260730_webauthn_credentials
+Revises: 20260719_optimization_job
+Create Date: 2026-07-30
+
+Adds ``webauthn_credential``: one row per registered passkey authenticator.
+Scope is single-device passkeys with discoverable credentials; no admin
+management surface.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "20260730_webauthn_credentials"
+down_revision = "20260719_optimization_job"
+branch_labels = None
+depends_on = None
+# Alembic reads these module globals by name; keep a local reference so static
+# analysis treats them as used.
+_ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)
+assert _ALEMBIC_IDENTIFIERS, "Alembic revision metadata must be defined"
+
+
+def upgrade() -> None:
+    """Create the webauthn_credential table."""
+    op.create_table(
+        "webauthn_credential",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("credential_id", sa.Text(), nullable=False),
+        sa.Column("public_key", sa.Text(), nullable=False),
+        sa.Column(
+            "sign_count", sa.BigInteger(), nullable=False, server_default="0"
+        ),
+        sa.Column("transports", sa.Text(), nullable=True),
+        sa.Column(
+            "name",
+            sa.String(length=100),
+            nullable=False,
+            server_default="Passkey",
+        ),
+        sa.Column("aaguid", sa.String(length=64), nullable=True),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=False, server_default=sa.true()
+        ),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index(
+        "ix_webauthn_credential_user_id",
+        "webauthn_credential",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_webauthn_credential_credential_id",
+        "webauthn_credential",
+        ["credential_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Drop the webauthn_credential table."""
+    op.drop_index(
+        "ix_webauthn_credential_credential_id", table_name="webauthn_credential"
+    )
+    op.drop_index(
+        "ix_webauthn_credential_user_id", table_name="webauthn_credential"
+    )
+    op.drop_table("webauthn_credential")

--- a/backend/preloop/models/alembic/versions/20260730_add_webauthn_credentials.py
+++ b/backend/preloop/models/alembic/versions/20260730_add_webauthn_credentials.py
@@ -49,9 +49,7 @@ def upgrade() -> None:
         ),
         sa.Column("credential_id", sa.Text(), nullable=False),
         sa.Column("public_key", sa.Text(), nullable=False),
-        sa.Column(
-            "sign_count", sa.BigInteger(), nullable=False, server_default="0"
-        ),
+        sa.Column("sign_count", sa.BigInteger(), nullable=False, server_default="0"),
         sa.Column("transports", sa.Text(), nullable=True),
         sa.Column(
             "name",
@@ -60,9 +58,7 @@ def upgrade() -> None:
             server_default="Passkey",
         ),
         sa.Column("aaguid", sa.String(length=64), nullable=True),
-        sa.Column(
-            "is_active", sa.Boolean(), nullable=False, server_default=sa.true()
-        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
         sa.Column("last_used_at", sa.DateTime(), nullable=True),
     )
     op.create_index(
@@ -83,7 +79,5 @@ def downgrade() -> None:
     op.drop_index(
         "ix_webauthn_credential_credential_id", table_name="webauthn_credential"
     )
-    op.drop_index(
-        "ix_webauthn_credential_user_id", table_name="webauthn_credential"
-    )
+    op.drop_index("ix_webauthn_credential_user_id", table_name="webauthn_credential")
     op.drop_table("webauthn_credential")

--- a/backend/preloop/models/crud/__init__.py
+++ b/backend/preloop/models/crud/__init__.py
@@ -14,6 +14,7 @@ from ..models import (
     Organization,
     Project,
     TrackerScopeRule,
+    WebAuthnCredential,
     Webhook,
     IssueRelationship,
     IssueSet,
@@ -49,6 +50,7 @@ from .project import CRUDProject
 from .tracker import CRUDTracker, crud_tracker
 from .tracker_scope_rule import CRUDTrackerScopeRule
 from .ai_model import CRUDAIModel
+from .webauthn_credential import CRUDWebAuthnCredential
 from .webhook import CRUDWebhook
 from .issue_compliance_result import (
     CRUDIssueComplianceResult,
@@ -148,6 +150,7 @@ crud_api_usage = CRUDApiUsage(ApiUsage)
 crud_audit_log = CRUDAuditLog(AuditLog)
 crud_ai_model = CRUDAIModel(AIModel)
 # crud_comment is already instantiated in its own file
+crud_webauthn_credential = CRUDWebAuthnCredential(WebAuthnCredential)
 crud_webhook = CRUDWebhook(Webhook)
 crud_flow = CRUDFlow()  # Instantiate CRUDFlow
 crud_flow_execution = CRUDFlowExecution()  # Instantiate CRUDFlowExecution
@@ -247,6 +250,7 @@ __all__ = [
     "crud_comment",
     "crud_ai_model",
     "crud_secret_reference",
+    "crud_webauthn_credential",
     "crud_webhook",
     "crud_flow",
     "crud_flow_execution",

--- a/backend/preloop/models/crud/webauthn_credential.py
+++ b/backend/preloop/models/crud/webauthn_credential.py
@@ -1,0 +1,55 @@
+"""CRUD operations for WebAuthn passkey credentials."""
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from ..models.webauthn_credential import WebAuthnCredential
+from .base import CRUDBase
+
+
+class CRUDWebAuthnCredential(CRUDBase[WebAuthnCredential]):
+    """CRUD operations for WebAuthn credentials."""
+
+    def get_by_credential_id(
+        self, db: Session, *, credential_id: str
+    ) -> Optional[WebAuthnCredential]:
+        """Look up an active credential by its base64url credential ID."""
+        return (
+            db.query(self.model)
+            .filter(
+                self.model.credential_id == credential_id,
+                self.model.is_active.is_(True),
+            )
+            .first()
+        )
+
+    def list_for_user(self, db: Session, *, user_id) -> List[WebAuthnCredential]:
+        """List active credentials for a user."""
+        return (
+            db.query(self.model)
+            .filter(
+                self.model.user_id == user_id,
+                self.model.is_active.is_(True),
+            )
+            .order_by(self.model.created_at)
+            .all()
+        )
+
+    def touch(
+        self, db: Session, *, obj: WebAuthnCredential, sign_count: int
+    ) -> WebAuthnCredential:
+        """Record a successful authentication: update counter and timestamp."""
+        obj.sign_count = sign_count
+        obj.last_used_at = datetime.now(timezone.utc)
+        db.add(obj)
+        db.commit()
+        db.refresh(obj)
+        return obj
+
+    def deactivate(self, db: Session, *, obj: WebAuthnCredential) -> None:
+        """Soft-delete a credential."""
+        obj.is_active = False
+        db.add(obj)
+        db.commit()

--- a/backend/preloop/models/models/__init__.py
+++ b/backend/preloop/models/models/__init__.py
@@ -18,6 +18,7 @@ from .flow import Flow
 from .flow_execution import FlowExecution
 from .flow_execution_log import FlowExecutionLog
 from .gateway_usage_search_document import GatewayUsageSearchDocument
+from .webauthn_credential import WebAuthnCredential
 from .webhook import Webhook
 from .tracker_scope_rule import TrackerScopeRule
 from .issue_compliance_result import IssueComplianceResult
@@ -100,6 +101,7 @@ __all__ = [
     "FlowExecution",
     "FlowExecutionLog",
     "GatewayUsageSearchDocument",
+    "WebAuthnCredential",
     "Webhook",
     "TrackerScopeRule",
     "IssueComplianceResult",

--- a/backend/preloop/models/models/webauthn_credential.py
+++ b/backend/preloop/models/models/webauthn_credential.py
@@ -1,0 +1,62 @@
+"""WebAuthn passkey credential model."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import BigInteger, Boolean, DateTime, String, Text
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from .user import User
+
+
+class WebAuthnCredential(Base):
+    """A registered WebAuthn passkey credential.
+
+    One row per registered authenticator. Scope is intentionally tight
+    (single-device passkeys with discoverable credentials): no admin
+    management, no attestation trust chains, no backup-state tracking beyond
+    what the authenticator reports.
+
+    Attributes:
+        user_id: Owner of the credential.
+        credential_id: Base64url-encoded credential ID from the authenticator.
+        public_key: Base64url-encoded COSE public key.
+        sign_count: Signature counter for clone detection.
+        transports: JSON-encoded list of transports (e.g. ["internal"]).
+        name: User-friendly label shown in settings.
+        aaguid: Authenticator AAGUID (informational).
+        is_active: Soft-delete flag.
+        last_used_at: Last successful authentication with this credential.
+    """
+
+    __tablename__ = "webauthn_credential"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="The user this passkey belongs to",
+    )
+    credential_id: Mapped[str] = mapped_column(
+        Text, nullable=False, unique=True, index=True
+    )
+    public_key: Mapped[str] = mapped_column(Text, nullable=False)
+    sign_count: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    transports: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, default="Passkey")
+    aaguid: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    last_used_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    user: Mapped["User"] = relationship("User")
+
+    def __repr__(self) -> str:
+        """Return a string representation of the credential."""
+        return f"<WebAuthnCredential {self.name} for user {self.user_id}>"

--- a/backend/tests/endpoints/test_features.py
+++ b/backend/tests/endpoints/test_features.py
@@ -44,6 +44,7 @@ class TestGetFeatures:
                 "first_account_pending": False,
                 "registration_bootstrap_pending": False,
                 "session_optimization": True,
+                "passkeys": True,
             },
         }
         mock_get_plugin_manager.assert_called_once()
@@ -72,6 +73,7 @@ class TestGetFeatures:
                 "first_account_pending": False,
                 "registration_bootstrap_pending": False,
                 "session_optimization": True,
+                "passkeys": True,
             },
         }
 
@@ -102,7 +104,7 @@ class TestGetFeatures:
         assert "plugins" in result
         assert "features" in result
         assert len(result["plugins"]) == 3
-        assert len(result["features"]) == 8
+        assert len(result["features"]) == 9
         assert result["features"]["session_optimization"] is True
 
     @patch("preloop.api.auth.bootstrap.crud_user")

--- a/backend/tests/endpoints/test_webauthn_passkeys.py
+++ b/backend/tests/endpoints/test_webauthn_passkeys.py
@@ -34,11 +34,16 @@ def _b64url(data: bytes) -> str:
 
 @pytest.fixture
 def mock_user():
+    from datetime import UTC, datetime
+
     user = MagicMock(spec=User)
     user.id = uuid.uuid4()
+    user.account_id = uuid.uuid4()
     user.username = "testuser"
+    user.email = "testuser@example.com"
     user.full_name = "Test User"
     user.is_active = True
+    user.last_login = datetime.now(UTC)  # recent: no inactivity notification
     return user
 
 
@@ -372,6 +377,127 @@ class TestAuthenticationCeremony:
         )
         assert response.status_code == 400
         assert "Invalid or expired" in response.json()["detail"]
+
+
+class TestLoginParityAndRateLimit:
+    def test_verify_writes_audit_event(self, db_session_mock, mock_user):
+        """Passkey sign-ins must be visible in the audit trail (user.login)."""
+        challenge_token = _issue_challenge_token(b"auth-chal", "authenticate")
+
+        cred = MagicMock()
+        cred.id = uuid.uuid4()
+        cred.user_id = mock_user.id
+        cred.public_key = _b64url(b"public-key-bytes")
+        cred.sign_count = 5
+
+        verification = MagicMock()
+        verification.new_sign_count = 6
+
+        with (
+            patch(
+                "preloop.api.auth.webauthn_router.crud_webauthn_credential"
+            ) as mock_crud,
+            patch(
+                "preloop.api.auth.webauthn_router.verify_authentication_response",
+                return_value=verification,
+            ),
+            patch("preloop.api.auth.webauthn_router.crud_user") as mock_crud_user,
+            patch(
+                "preloop.api.auth.webauthn_router.crud_audit_log"
+            ) as mock_audit,
+        ):
+            mock_crud.get_by_credential_id.return_value = cred
+            mock_crud_user.get.return_value = mock_user
+
+            response = client.post(
+                "/auth/webauthn/authenticate/verify",
+                json={
+                    "credential": {"id": "abc", "rawId": _b64url(b"cred-id")},
+                    "challenge_token": challenge_token,
+                },
+            )
+
+        assert response.status_code == 200
+        mock_audit.log_action.assert_called_once()
+        kwargs = mock_audit.log_action.call_args.kwargs
+        assert kwargs["action"] == "user.login"
+        assert kwargs["user_id"] == mock_user.id
+        assert kwargs["details"]["method"] == "passkey"
+
+    def test_verify_notifies_after_inactivity(self, db_session_mock, mock_user):
+        """Inactivity notification parity with password login."""
+        from datetime import UTC, datetime, timedelta as td
+
+        mock_user.last_login = datetime.now(UTC) - td(days=30)
+        challenge_token = _issue_challenge_token(b"auth-chal", "authenticate")
+
+        cred = MagicMock()
+        cred.id = uuid.uuid4()
+        cred.user_id = mock_user.id
+        cred.public_key = _b64url(b"public-key-bytes")
+        cred.sign_count = 5
+
+        verification = MagicMock()
+        verification.new_sign_count = 6
+
+        with (
+            patch(
+                "preloop.api.auth.webauthn_router.crud_webauthn_credential"
+            ) as mock_crud,
+            patch(
+                "preloop.api.auth.webauthn_router.verify_authentication_response",
+                return_value=verification,
+            ),
+            patch("preloop.api.auth.webauthn_router.crud_user") as mock_crud_user,
+            patch(
+                "preloop.services.account_setup_service.notify_admins_user_login_after_inactivity"
+            ) as mock_notify,
+            # TestClient reports source_ip="testclient", which the parity code
+            # (matching password login) deliberately skips; use a real-looking IP.
+            patch(
+                "preloop.api.auth.webauthn_router.get_client_ip",
+                return_value="203.0.113.7",
+            ),
+        ):
+            mock_crud.get_by_credential_id.return_value = cred
+            mock_crud_user.get.return_value = mock_user
+
+            response = client.post(
+                "/auth/webauthn/authenticate/verify",
+                json={
+                    "credential": {"id": "abc", "rawId": _b64url(b"cred-id")},
+                    "challenge_token": challenge_token,
+                },
+            )
+
+        assert response.status_code == 200
+        # Notification runs in a daemon thread; give it a beat.
+        import time
+
+        for _ in range(20):
+            if mock_notify.called:
+                break
+            time.sleep(0.05)
+        mock_notify.assert_called_once()
+
+    def test_challenge_rate_limit(self, db_session_mock):
+        """Unauthenticated challenge endpoint throttles per IP."""
+        from preloop.api.auth import webauthn_router
+
+        original = webauthn_router._rate_buckets.copy()
+        webauthn_router._rate_buckets.clear()
+        try:
+            with patch.object(webauthn_router, "_RATE_LIMIT_MAX_CALLS", 3):
+                codes = [
+                    client.post("/auth/webauthn/authenticate/options").status_code
+                    for _ in range(5)
+                ]
+            assert codes[:3] == [200, 200, 200]
+            assert codes[3] == 429
+            assert codes[4] == 429
+        finally:
+            webauthn_router._rate_buckets.clear()
+            webauthn_router._rate_buckets.update(original)
 
 
 class TestCredentialManagement:

--- a/backend/tests/endpoints/test_webauthn_passkeys.py
+++ b/backend/tests/endpoints/test_webauthn_passkeys.py
@@ -1,0 +1,424 @@
+"""Tests for WebAuthn passkey ceremony endpoints.
+
+Ceremony verification is mocked (authenticator hardware cannot run in CI);
+these tests cover option generation, challenge-token integrity, credential
+storage/lookup, token issuance, the feature flag, and credential management.
+"""
+
+import base64
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from preloop.api.auth.jwt import decode_token, get_current_active_user
+from preloop.api.auth.webauthn_router import (
+    _issue_challenge_token,
+    _read_challenge_token,
+    router as webauthn_router,
+)
+from preloop.models.models.user import User
+
+app = FastAPI()
+app.include_router(webauthn_router, prefix="/auth/webauthn")
+client = TestClient(app)
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+@pytest.fixture
+def mock_user():
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.username = "testuser"
+    user.full_name = "Test User"
+    user.is_active = True
+    return user
+
+
+@pytest.fixture
+def db_session_mock():
+    from preloop.models.db.session import get_db_session
+
+    db_session = MagicMock(spec=Session)
+    app.dependency_overrides[get_db_session] = lambda: db_session
+    try:
+        yield db_session
+    finally:
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+@pytest.fixture
+def authed_user(mock_user):
+    app.dependency_overrides[get_current_active_user] = lambda: mock_user
+    try:
+        yield mock_user
+    finally:
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+class TestChallengeToken:
+    """The stateless challenge token that carries ceremony state."""
+
+    def test_roundtrip(self):
+        token = _issue_challenge_token(b"challenge-bytes", "register", "user-1")
+        payload = _read_challenge_token(token, "register")
+        assert payload["challenge_bytes"] == b"challenge-bytes"
+        assert payload["user_id"] == "user-1"
+
+    def test_purpose_mismatch_rejected(self):
+        from fastapi import HTTPException
+
+        token = _issue_challenge_token(b"x", "register")
+        with pytest.raises(HTTPException) as exc:
+            _read_challenge_token(token, "authenticate")
+        assert exc.value.status_code == 400
+
+    def test_garbage_token_rejected(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            _read_challenge_token("not-a-jwt", "register")
+        assert exc.value.status_code == 400
+
+
+class TestFeatureFlag:
+    def test_disabled_returns_404(self, db_session_mock):
+        with patch.dict("os.environ", {"PASSKEYS_ENABLED": "false"}):
+            response = client.post("/auth/webauthn/authenticate/options")
+        assert response.status_code == 404
+
+    def test_enabled_by_default(self, db_session_mock):
+        with patch.dict("os.environ", {}, clear=False):
+            response = client.post("/auth/webauthn/authenticate/options")
+        assert response.status_code == 200
+
+
+class TestRegistrationCeremony:
+    def test_options_include_challenge_and_exclusions(
+        self, db_session_mock, authed_user
+    ):
+        existing = MagicMock()
+        existing.credential_id = _b64url(b"existing-cred-id")
+        with patch(
+            "preloop.api.auth.webauthn_router.crud_webauthn_credential"
+        ) as mock_crud:
+            mock_crud.list_for_user.return_value = [existing]
+            response = client.post("/auth/webauthn/register/options")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "challenge" in data["options"]
+        assert data["challenge_token"]
+        assert data["options"]["rp"]["name"] == "Preloop"
+        # Discoverable credentials required
+        assert (
+            data["options"]["authenticatorSelection"]["residentKey"] == "required"
+        )
+        # Existing credential excluded from re-registration
+        assert len(data["options"]["excludeCredentials"]) == 1
+
+    def test_verify_stores_credential(self, db_session_mock, authed_user):
+        challenge_token = _issue_challenge_token(
+            b"chal", "register", str(authed_user.id)
+        )
+
+        verification = MagicMock()
+        verification.credential_id = b"new-cred-id"
+        verification.credential_public_key = b"public-key-bytes"
+        verification.sign_count = 0
+        verification.aaguid = "aaguid-value"
+
+        with (
+            patch(
+                "preloop.api.auth.webauthn_router.verify_registration_response",
+                return_value=verification,
+            ) as mock_verify,
+            patch(
+                "preloop.api.auth.webauthn_router.crud_webauthn_credential"
+            ) as mock_crud,
+        ):
+            mock_crud.get_by_credential_id.return_value = None
+
+            def fake_refresh(obj):
+                obj.id = uuid.uuid4()
+                obj.created_at = datetime.now(timezone.utc)
+
+            db_session_mock.refresh.side_effect = fake_refresh
+
+            response = client.post(
+                "/auth/webauthn/register/verify",
+                json={
+                    "credential": {
+                        "id": "abc",
+                        "response": {"transports": ["internal"]},
+                    },
+                    "challenge_token": challenge_token,
+                    "name": "My laptop",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "My laptop"
+        mock_verify.assert_called_once()
+        # Challenge bytes from the token were passed to verification
+        assert (
+            mock_verify.call_args.kwargs["expected_challenge"] == b"chal"
+        )
+        db_session_mock.add.assert_called_once()
+        stored = db_session_mock.add.call_args.args[0]
+        assert stored.credential_id == _b64url(b"new-cred-id")
+        assert stored.user_id == authed_user.id
+
+    def test_verify_rejects_challenge_for_other_user(
+        self, db_session_mock, authed_user
+    ):
+        challenge_token = _issue_challenge_token(
+            b"chal", "register", str(uuid.uuid4())
+        )
+        response = client.post(
+            "/auth/webauthn/register/verify",
+            json={
+                "credential": {"id": "abc", "response": {}},
+                "challenge_token": challenge_token,
+            },
+        )
+        assert response.status_code == 400
+        assert "different user" in response.json()["detail"]
+
+    def test_verify_rejects_invalid_attestation(self, db_session_mock, authed_user):
+        from webauthn.helpers.exceptions import InvalidRegistrationResponse
+
+        challenge_token = _issue_challenge_token(
+            b"chal", "register", str(authed_user.id)
+        )
+        with patch(
+            "preloop.api.auth.webauthn_router.verify_registration_response",
+            side_effect=InvalidRegistrationResponse("bad attestation"),
+        ):
+            response = client.post(
+                "/auth/webauthn/register/verify",
+                json={
+                    "credential": {"id": "abc", "response": {}},
+                    "challenge_token": challenge_token,
+                },
+            )
+        assert response.status_code == 400
+        assert "could not be verified" in response.json()["detail"]
+
+
+class TestAuthenticationCeremony:
+    def test_options_have_challenge(self, db_session_mock):
+        response = client.post("/auth/webauthn/authenticate/options")
+        assert response.status_code == 200
+        data = response.json()
+        assert "challenge" in data["options"]
+        assert data["challenge_token"]
+
+    def test_verify_issues_tokens(self, db_session_mock, mock_user):
+        challenge_token = _issue_challenge_token(b"auth-chal", "authenticate")
+
+        cred = MagicMock()
+        cred.user_id = mock_user.id
+        cred.public_key = _b64url(b"public-key-bytes")
+        cred.sign_count = 5
+
+        verification = MagicMock()
+        verification.new_sign_count = 6
+
+        with (
+            patch(
+                "preloop.api.auth.webauthn_router.crud_webauthn_credential"
+            ) as mock_crud,
+            patch(
+                "preloop.api.auth.webauthn_router.verify_authentication_response",
+                return_value=verification,
+            ) as mock_verify,
+            patch("preloop.api.auth.webauthn_router.crud_user") as mock_crud_user,
+        ):
+            mock_crud.get_by_credential_id.return_value = cred
+            mock_crud_user.get.return_value = mock_user
+
+            response = client.post(
+                "/auth/webauthn/authenticate/verify",
+                json={
+                    "credential": {"id": "abc", "rawId": _b64url(b"cred-id")},
+                    "challenge_token": challenge_token,
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["token_type"] == "bearer"
+        access = decode_token(data["access_token"])
+        assert access.sub == str(mock_user.id)
+        assert not access.refresh
+        refresh = decode_token(data["refresh_token"])
+        assert refresh.refresh is True
+        assert refresh.session_started_at is not None
+        # Sign counter updated for clone detection
+        mock_crud.touch.assert_called_once()
+        assert mock_crud.touch.call_args.kwargs["sign_count"] == 6
+        # Challenge from token passed to verification
+        assert (
+            mock_verify.call_args.kwargs["expected_challenge"] == b"auth-chal"
+        )
+
+    def test_verify_unknown_credential(self, db_session_mock):
+        challenge_token = _issue_challenge_token(b"auth-chal", "authenticate")
+        with patch(
+            "preloop.api.auth.webauthn_router.crud_webauthn_credential"
+        ) as mock_crud:
+            mock_crud.get_by_credential_id.return_value = None
+            response = client.post(
+                "/auth/webauthn/authenticate/verify",
+                json={
+                    "credential": {"id": "abc", "rawId": "unknown"},
+                    "challenge_token": challenge_token,
+                },
+            )
+        assert response.status_code == 401
+        assert "Unknown passkey" in response.json()["detail"]
+
+    def test_verify_rejects_bad_assertion(self, db_session_mock, mock_user):
+        from webauthn.helpers.exceptions import InvalidAuthenticationResponse
+
+        challenge_token = _issue_challenge_token(b"auth-chal", "authenticate")
+        cred = MagicMock()
+        cred.user_id = mock_user.id
+        cred.public_key = _b64url(b"public-key-bytes")
+        cred.sign_count = 5
+
+        with (
+            patch(
+                "preloop.api.auth.webauthn_router.crud_webauthn_credential"
+            ) as mock_crud,
+            patch(
+                "preloop.api.auth.webauthn_router.verify_authentication_response",
+                side_effect=InvalidAuthenticationResponse("bad signature"),
+            ),
+        ):
+            mock_crud.get_by_credential_id.return_value = cred
+            response = client.post(
+                "/auth/webauthn/authenticate/verify",
+                json={
+                    "credential": {"id": "abc", "rawId": _b64url(b"cred-id")},
+                    "challenge_token": challenge_token,
+                },
+            )
+        assert response.status_code == 401
+
+    def test_verify_rejects_inactive_user(self, db_session_mock, mock_user):
+        challenge_token = _issue_challenge_token(b"auth-chal", "authenticate")
+        mock_user.is_active = False
+        cred = MagicMock()
+        cred.user_id = mock_user.id
+        cred.public_key = _b64url(b"public-key-bytes")
+        cred.sign_count = 5
+
+        verification = MagicMock()
+        verification.new_sign_count = 6
+
+        with (
+            patch(
+                "preloop.api.auth.webauthn_router.crud_webauthn_credential"
+            ) as mock_crud,
+            patch(
+                "preloop.api.auth.webauthn_router.verify_authentication_response",
+                return_value=verification,
+            ),
+            patch("preloop.api.auth.webauthn_router.crud_user") as mock_crud_user,
+        ):
+            mock_crud.get_by_credential_id.return_value = cred
+            mock_crud_user.get.return_value = mock_user
+
+            response = client.post(
+                "/auth/webauthn/authenticate/verify",
+                json={
+                    "credential": {"id": "abc", "rawId": _b64url(b"cred-id")},
+                    "challenge_token": challenge_token,
+                },
+            )
+        assert response.status_code == 401
+
+    def test_stale_challenge_rejected(self, db_session_mock):
+        """An expired challenge token is rejected."""
+        from jose import jwt as jose_jwt
+
+        from preloop.api.auth.jwt import ALGORITHM, SECRET_KEY
+
+        expired = jose_jwt.encode(
+            {
+                "chal": _b64url(b"auth-chal"),
+                "purpose": "authenticate",
+                "user_id": "",
+                "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+            },
+            SECRET_KEY,
+            algorithm=ALGORITHM,
+        )
+        response = client.post(
+            "/auth/webauthn/authenticate/verify",
+            json={
+                "credential": {"id": "abc", "rawId": "x"},
+                "challenge_token": expired,
+            },
+        )
+        assert response.status_code == 400
+        assert "Invalid or expired" in response.json()["detail"]
+
+
+class TestCredentialManagement:
+    def test_list_credentials(self, db_session_mock, authed_user):
+        cred = MagicMock()
+        cred.id = uuid.uuid4()
+        cred.name = "My laptop"
+        cred.created_at = datetime.now(timezone.utc)
+        cred.last_used_at = None
+
+        with patch(
+            "preloop.api.auth.webauthn_router.crud_webauthn_credential"
+        ) as mock_crud:
+            mock_crud.list_for_user.return_value = [cred]
+            response = client.get("/auth/webauthn/credentials")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "My laptop"
+
+    def test_delete_own_credential(self, db_session_mock, authed_user):
+        cred = MagicMock()
+        cred.id = uuid.uuid4()
+        cred.user_id = authed_user.id
+        cred.is_active = True
+
+        with patch(
+            "preloop.api.auth.webauthn_router.crud_webauthn_credential"
+        ) as mock_crud:
+            mock_crud.get.return_value = cred
+            response = client.delete(f"/auth/webauthn/credentials/{cred.id}")
+
+        assert response.status_code == 204
+        mock_crud.deactivate.assert_called_once()
+
+    def test_delete_other_users_credential_404(self, db_session_mock, authed_user):
+        cred = MagicMock()
+        cred.id = uuid.uuid4()
+        cred.user_id = uuid.uuid4()  # someone else
+        cred.is_active = True
+
+        with patch(
+            "preloop.api.auth.webauthn_router.crud_webauthn_credential"
+        ) as mock_crud:
+            mock_crud.get.return_value = cred
+            response = client.delete(f"/auth/webauthn/credentials/{cred.id}")
+
+        assert response.status_code == 404
+        mock_crud.deactivate.assert_not_called()

--- a/backend/tests/endpoints/test_webauthn_passkeys.py
+++ b/backend/tests/endpoints/test_webauthn_passkeys.py
@@ -123,9 +123,7 @@ class TestRegistrationCeremony:
         assert data["challenge_token"]
         assert data["options"]["rp"]["name"] == "Preloop"
         # Discoverable credentials required
-        assert (
-            data["options"]["authenticatorSelection"]["residentKey"] == "required"
-        )
+        assert data["options"]["authenticatorSelection"]["residentKey"] == "required"
         # Existing credential excluded from re-registration
         assert len(data["options"]["excludeCredentials"]) == 1
 
@@ -173,9 +171,7 @@ class TestRegistrationCeremony:
         assert response.json()["name"] == "My laptop"
         mock_verify.assert_called_once()
         # Challenge bytes from the token were passed to verification
-        assert (
-            mock_verify.call_args.kwargs["expected_challenge"] == b"chal"
-        )
+        assert mock_verify.call_args.kwargs["expected_challenge"] == b"chal"
         db_session_mock.add.assert_called_once()
         stored = db_session_mock.add.call_args.args[0]
         assert stored.credential_id == _b64url(b"new-cred-id")
@@ -184,9 +180,7 @@ class TestRegistrationCeremony:
     def test_verify_rejects_challenge_for_other_user(
         self, db_session_mock, authed_user
     ):
-        challenge_token = _issue_challenge_token(
-            b"chal", "register", str(uuid.uuid4())
-        )
+        challenge_token = _issue_challenge_token(b"chal", "register", str(uuid.uuid4()))
         response = client.post(
             "/auth/webauthn/register/verify",
             json={
@@ -271,9 +265,7 @@ class TestAuthenticationCeremony:
         mock_crud.touch.assert_called_once()
         assert mock_crud.touch.call_args.kwargs["sign_count"] == 6
         # Challenge from token passed to verification
-        assert (
-            mock_verify.call_args.kwargs["expected_challenge"] == b"auth-chal"
-        )
+        assert mock_verify.call_args.kwargs["expected_challenge"] == b"auth-chal"
 
     def test_verify_unknown_credential(self, db_session_mock):
         challenge_token = _issue_challenge_token(b"auth-chal", "authenticate")
@@ -402,9 +394,7 @@ class TestLoginParityAndRateLimit:
                 return_value=verification,
             ),
             patch("preloop.api.auth.webauthn_router.crud_user") as mock_crud_user,
-            patch(
-                "preloop.api.auth.webauthn_router.crud_audit_log"
-            ) as mock_audit,
+            patch("preloop.api.auth.webauthn_router.crud_audit_log") as mock_audit,
         ):
             mock_crud.get_by_credential_id.return_value = cred
             mock_crud_user.get.return_value = mock_user

--- a/frontend/src/services/passkeys.ts
+++ b/frontend/src/services/passkeys.ts
@@ -44,7 +44,9 @@ function bufferToBase64url(buffer: ArrayBuffer): string {
 
 /* Convert the JSON options from the server into the binary shapes
  * navigator.credentials expects. */
-function prepareCreationOptions(options: any): PublicKeyCredentialCreationOptions {
+function prepareCreationOptions(
+  options: any
+): PublicKeyCredentialCreationOptions {
   return {
     ...options,
     challenge: base64urlToBuffer(options.challenge),
@@ -59,7 +61,9 @@ function prepareCreationOptions(options: any): PublicKeyCredentialCreationOption
   };
 }
 
-function prepareRequestOptions(options: any): PublicKeyCredentialRequestOptions {
+function prepareRequestOptions(
+  options: any
+): PublicKeyCredentialRequestOptions {
   return {
     ...options,
     challenge: base64urlToBuffer(options.challenge),

--- a/frontend/src/services/passkeys.ts
+++ b/frontend/src/services/passkeys.ts
@@ -1,0 +1,214 @@
+/**
+ * WebAuthn passkey ceremonies for the console.
+ *
+ * Registration (settings) and authentication (login page) against
+ * /api/v1/auth/webauthn/. Keeps scope tight: single-device passkeys with
+ * discoverable credentials.
+ */
+
+import { fetchWithAuth } from '../api';
+
+export interface PasskeySummary {
+  id: string;
+  name: string;
+  created_at: string;
+  last_used_at?: string | null;
+}
+
+export function passkeysSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    'PublicKeyCredential' in window &&
+    typeof navigator.credentials?.create === 'function'
+  );
+}
+
+function base64urlToBuffer(value: string): ArrayBuffer {
+  const padded = value.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(padded + '='.repeat((4 - (padded.length % 4)) % 4));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function bufferToBase64url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+/* Convert the JSON options from the server into the binary shapes
+ * navigator.credentials expects. */
+function prepareCreationOptions(options: any): PublicKeyCredentialCreationOptions {
+  return {
+    ...options,
+    challenge: base64urlToBuffer(options.challenge),
+    user: {
+      ...options.user,
+      id: base64urlToBuffer(options.user.id),
+    },
+    excludeCredentials: (options.excludeCredentials || []).map((c: any) => ({
+      ...c,
+      id: base64urlToBuffer(c.id),
+    })),
+  };
+}
+
+function prepareRequestOptions(options: any): PublicKeyCredentialRequestOptions {
+  return {
+    ...options,
+    challenge: base64urlToBuffer(options.challenge),
+    allowCredentials: (options.allowCredentials || []).map((c: any) => ({
+      ...c,
+      id: base64urlToBuffer(c.id),
+    })),
+  };
+}
+
+function serializeAttestation(credential: PublicKeyCredential): any {
+  const response = credential.response as AuthenticatorAttestationResponse;
+  return {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    response: {
+      clientDataJSON: bufferToBase64url(response.clientDataJSON),
+      attestationObject: bufferToBase64url(response.attestationObject),
+      transports:
+        typeof response.getTransports === 'function'
+          ? response.getTransports()
+          : [],
+    },
+    clientExtensionResults: credential.getClientExtensionResults(),
+  };
+}
+
+function serializeAssertion(credential: PublicKeyCredential): any {
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    response: {
+      clientDataJSON: bufferToBase64url(response.clientDataJSON),
+      authenticatorData: bufferToBase64url(response.authenticatorData),
+      signature: bufferToBase64url(response.signature),
+      userHandle: response.userHandle
+        ? bufferToBase64url(response.userHandle)
+        : null,
+    },
+    clientExtensionResults: credential.getClientExtensionResults(),
+  };
+}
+
+/** Register a new passkey for the signed-in user (settings page). */
+export async function registerPasskey(name?: string): Promise<PasskeySummary> {
+  const optionsResponse = await fetchWithAuth(
+    '/api/v1/auth/webauthn/register/options',
+    { method: 'POST' }
+  );
+  if (!optionsResponse.ok) {
+    throw new Error('Failed to start passkey registration');
+  }
+  const { options, challenge_token } = await optionsResponse.json();
+
+  const credential = (await navigator.credentials.create({
+    publicKey: prepareCreationOptions(options),
+  })) as PublicKeyCredential | null;
+  if (!credential) {
+    throw new Error('Passkey registration was cancelled');
+  }
+
+  const verifyResponse = await fetchWithAuth(
+    '/api/v1/auth/webauthn/register/verify',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        credential: serializeAttestation(credential),
+        challenge_token,
+        name: name || null,
+      }),
+    }
+  );
+  if (!verifyResponse.ok) {
+    const errorData = await verifyResponse.json().catch(() => ({}));
+    throw new Error(
+      typeof errorData.detail === 'string'
+        ? errorData.detail
+        : 'Failed to verify passkey registration'
+    );
+  }
+  return verifyResponse.json();
+}
+
+/**
+ * Sign in with a passkey (login page, unauthenticated). Returns the token
+ * payload; the caller stores tokens and navigates.
+ */
+export async function signInWithPasskey(): Promise<{
+  access_token: string;
+  refresh_token: string;
+}> {
+  const optionsResponse = await fetch(
+    '/api/v1/auth/webauthn/authenticate/options',
+    { method: 'POST' }
+  );
+  if (!optionsResponse.ok) {
+    throw new Error('Failed to start passkey sign-in');
+  }
+  const { options, challenge_token } = await optionsResponse.json();
+
+  const credential = (await navigator.credentials.get({
+    publicKey: prepareRequestOptions(options),
+  })) as PublicKeyCredential | null;
+  if (!credential) {
+    throw new Error('Passkey sign-in was cancelled');
+  }
+
+  const verifyResponse = await fetch(
+    '/api/v1/auth/webauthn/authenticate/verify',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        credential: serializeAssertion(credential),
+        challenge_token,
+      }),
+    }
+  );
+  if (!verifyResponse.ok) {
+    const errorData = await verifyResponse.json().catch(() => ({}));
+    throw new Error(
+      typeof errorData.detail === 'string'
+        ? errorData.detail
+        : 'Passkey sign-in failed'
+    );
+  }
+  return verifyResponse.json();
+}
+
+/** List the signed-in user's passkeys. */
+export async function listPasskeys(): Promise<PasskeySummary[]> {
+  const response = await fetchWithAuth('/api/v1/auth/webauthn/credentials');
+  if (!response.ok) {
+    throw new Error('Failed to fetch passkeys');
+  }
+  return response.json();
+}
+
+/** Remove a passkey by id. */
+export async function deletePasskey(id: string): Promise<void> {
+  const response = await fetchWithAuth(
+    `/api/v1/auth/webauthn/credentials/${id}`,
+    { method: 'DELETE' }
+  );
+  if (!response.ok) {
+    throw new Error('Failed to delete passkey');
+  }
+}

--- a/frontend/src/views/authed/settings/security-view.ts
+++ b/frontend/src/views/authed/settings/security-view.ts
@@ -1,6 +1,13 @@
 import { LitElement, html, css, unsafeCSS } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { changePassword } from '../../../api';
+import { changePassword, getFeatures } from '../../../api';
+import {
+  PasskeySummary,
+  deletePasskey,
+  listPasskeys,
+  passkeysSupported,
+  registerPasskey,
+} from '../../../services/passkeys';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import consoleStyles from '../../../styles/console-styles.css?inline';
@@ -18,6 +25,64 @@ export class SecurityView extends LitElement {
 
   @state()
   private changePasswordMessage = '';
+
+  @state()
+  private passkeys: PasskeySummary[] = [];
+
+  @state()
+  private passkeysEnabled = false;
+
+  @state()
+  private passkeyMessage = '';
+
+  @state()
+  private passkeyBusy = false;
+
+  connectedCallback() {
+    super.connectedCallback();
+    void this.loadPasskeys();
+  }
+
+  private async loadPasskeys() {
+    try {
+      const features = await getFeatures();
+      this.passkeysEnabled =
+        features.features['passkeys'] !== false && passkeysSupported();
+      if (this.passkeysEnabled) {
+        this.passkeys = await listPasskeys();
+      }
+    } catch {
+      // Passkey list failure must not break the security page.
+      this.passkeysEnabled = false;
+    }
+  }
+
+  private async handleAddPasskey() {
+    this.passkeyMessage = '';
+    this.passkeyBusy = true;
+    try {
+      await registerPasskey();
+      this.passkeys = await listPasskeys();
+      this.passkeyMessage = 'Passkey registered.';
+    } catch (error) {
+      this.passkeyMessage =
+        error instanceof Error ? error.message : 'Failed to register passkey.';
+    } finally {
+      this.passkeyBusy = false;
+    }
+  }
+
+  private async handleDeletePasskey(id: string) {
+    this.passkeyMessage = '';
+    try {
+      await deletePasskey(id);
+      this.passkeys = this.passkeys.filter((p) => p.id !== id);
+      this.passkeyMessage = 'Passkey removed.';
+    } catch (error) {
+      this.passkeyMessage =
+        error instanceof Error ? error.message : 'Failed to remove passkey.';
+    }
+  }
 
   async handleChangePassword(event: Event) {
     event.preventDefault();
@@ -102,6 +167,59 @@ export class SecurityView extends LitElement {
               </form>
             </div>
           </div>
+          ${this.passkeysEnabled
+            ? html`
+                <div class="card">
+                  <div class="card-header">
+                    <h3>Passkeys</h3>
+                  </div>
+                  <div class="card-body">
+                    <p>
+                      Sign in without a password using your device's screen
+                      lock, fingerprint, or security key.
+                    </p>
+                    ${this.passkeys.length > 0
+                      ? html`
+                          <ul class="passkey-list">
+                            ${this.passkeys.map(
+                              (passkey) => html`
+                                <li class="passkey-item">
+                                  <span>
+                                    ${passkey.name}
+                                    <small>
+                                      added
+                                      ${new Date(
+                                        passkey.created_at
+                                      ).toLocaleDateString()}
+                                    </small>
+                                  </span>
+                                  <sl-button
+                                    size="small"
+                                    variant="danger"
+                                    outline
+                                    @click="${() =>
+                                      this.handleDeletePasskey(passkey.id)}"
+                                    >Remove</sl-button
+                                  >
+                                </li>
+                              `
+                            )}
+                          </ul>
+                        `
+                      : html`<p><em>No passkeys registered yet.</em></p>`}
+                    <sl-button
+                      variant="primary"
+                      ?loading="${this.passkeyBusy}"
+                      @click="${this.handleAddPasskey}"
+                      >Add Passkey</sl-button
+                    >
+                    ${this.passkeyMessage
+                      ? html`<p>${this.passkeyMessage}</p>`
+                      : ''}
+                  </div>
+                </div>
+              `
+            : ''}
         </div>
         <div class="side-column"></div>
       </div>
@@ -127,6 +245,29 @@ export class SecurityView extends LitElement {
 
       sl-button {
         width: 12em;
+      }
+
+      .passkey-list {
+        list-style: none;
+        margin: 0 0 1rem 0;
+        padding: 0;
+      }
+
+      .passkey-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0;
+        border-bottom: 1px solid var(--sl-color-neutral-200);
+      }
+
+      .passkey-item sl-button {
+        width: auto;
+      }
+
+      .passkey-item small {
+        color: var(--sl-color-neutral-500);
+        margin-left: 0.5rem;
       }
     `,
   ];

--- a/frontend/src/views/authed/settings/security-view.ts
+++ b/frontend/src/views/authed/settings/security-view.ts
@@ -180,36 +180,36 @@ export class SecurityView extends LitElement {
                         lock, fingerprint, or security key.
                       </p>
                       ${
-                      this.passkeys.length > 0
-                        ? html`
-                            <ul class="passkey-list">
-                              ${this.passkeys.map(
-                              (passkey) => html`
-                                <li class="passkey-item">
-                                  <span>
-                                    ${passkey.name}
-                                    <small>
-                                      added
-                                      ${new Date(
-                                        passkey.created_at
-                                      ).toLocaleDateString()}
-                                    </small>
-                                  </span>
-                                  <sl-button
-                                    size="small"
-                                    variant="danger"
-                                    outline
-                                    @click="${() =>
-                                      this.handleDeletePasskey(passkey.id)}"
-                                    >Remove</sl-button
-                                  >
-                                </li>
-                              `
-                            )}
-                            </ul>
-                          `
-                        : html`<p><em>No passkeys registered yet.</em></p>`
-                    }
+                        this.passkeys.length > 0
+                          ? html`
+                              <ul class="passkey-list">
+                                ${this.passkeys.map(
+                                  (passkey) => html`
+                                    <li class="passkey-item">
+                                      <span>
+                                        ${passkey.name}
+                                        <small>
+                                          added
+                                          ${new Date(
+                                            passkey.created_at
+                                          ).toLocaleDateString()}
+                                        </small>
+                                      </span>
+                                      <sl-button
+                                        size="small"
+                                        variant="danger"
+                                        outline
+                                        @click="${() =>
+                                          this.handleDeletePasskey(passkey.id)}"
+                                        >Remove</sl-button
+                                      >
+                                    </li>
+                                  `
+                                )}
+                              </ul>
+                            `
+                          : html`<p><em>No passkeys registered yet.</em></p>`
+                      }
                       <sl-button
                         variant="primary"
                         ?loading="${this.passkeyBusy}"
@@ -217,10 +217,10 @@ export class SecurityView extends LitElement {
                         >Add Passkey</sl-button
                       >
                       ${
-                      this.passkeyMessage
-                        ? html`<p>${this.passkeyMessage}</p>`
-                        : ''
-                    }
+                        this.passkeyMessage
+                          ? html`<p>${this.passkeyMessage}</p>`
+                          : ''
+                      }
                     </div>
                   </div>
                 `

--- a/frontend/src/views/authed/settings/security-view.ts
+++ b/frontend/src/views/authed/settings/security-view.ts
@@ -167,21 +167,23 @@ export class SecurityView extends LitElement {
               </form>
             </div>
           </div>
-          ${this.passkeysEnabled
-            ? html`
-                <div class="card">
-                  <div class="card-header">
-                    <h3>Passkeys</h3>
-                  </div>
-                  <div class="card-body">
-                    <p>
-                      Sign in without a password using your device's screen
-                      lock, fingerprint, or security key.
-                    </p>
-                    ${this.passkeys.length > 0
-                      ? html`
-                          <ul class="passkey-list">
-                            ${this.passkeys.map(
+          ${
+            this.passkeysEnabled
+              ? html`
+                  <div class="card">
+                    <div class="card-header">
+                      <h3>Passkeys</h3>
+                    </div>
+                    <div class="card-body">
+                      <p>
+                        Sign in without a password using your device's screen
+                        lock, fingerprint, or security key.
+                      </p>
+                      ${
+                      this.passkeys.length > 0
+                        ? html`
+                            <ul class="passkey-list">
+                              ${this.passkeys.map(
                               (passkey) => html`
                                 <li class="passkey-item">
                                   <span>
@@ -204,22 +206,26 @@ export class SecurityView extends LitElement {
                                 </li>
                               `
                             )}
-                          </ul>
-                        `
-                      : html`<p><em>No passkeys registered yet.</em></p>`}
-                    <sl-button
-                      variant="primary"
-                      ?loading="${this.passkeyBusy}"
-                      @click="${this.handleAddPasskey}"
-                      >Add Passkey</sl-button
-                    >
-                    ${this.passkeyMessage
-                      ? html`<p>${this.passkeyMessage}</p>`
-                      : ''}
+                            </ul>
+                          `
+                        : html`<p><em>No passkeys registered yet.</em></p>`
+                    }
+                      <sl-button
+                        variant="primary"
+                        ?loading="${this.passkeyBusy}"
+                        @click="${this.handleAddPasskey}"
+                        >Add Passkey</sl-button
+                      >
+                      ${
+                      this.passkeyMessage
+                        ? html`<p>${this.passkeyMessage}</p>`
+                        : ''
+                    }
+                    </div>
                   </div>
-                </div>
-              `
-            : ''}
+                `
+              : ''
+          }
         </div>
         <div class="side-column"></div>
       </div>

--- a/frontend/src/views/public/login-view.ts
+++ b/frontend/src/views/public/login-view.ts
@@ -9,6 +9,10 @@ import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '../../components/logo-component';
 import { trackGoal } from '../../services/web-analytics';
+import {
+  passkeysSupported,
+  signInWithPasskey,
+} from '../../services/passkeys';
 
 const OAUTH_PROVIDER_CONFIG: Record<string, { label: string; icon: string }> = {
   github: { label: 'GitHub', icon: 'github' },
@@ -29,6 +33,9 @@ export class LoginView extends LitElement {
 
   @state()
   private registrationEnabled = true;
+
+  @state()
+  private passkeysEnabled = false;
 
   static styles = [
     formStyles,
@@ -105,10 +112,54 @@ export class LoginView extends LitElement {
       const providers = features.features['oauth_providers'];
       this.oauthProviders = Array.isArray(providers) ? providers : [];
       this.registrationEnabled = features.features['registration'] !== false;
+      this.passkeysEnabled =
+        features.features['passkeys'] !== false && passkeysSupported();
     } catch (error) {
       this.oauthProviders = [];
       // Fail open, matching the /register route guard.
       this.registrationEnabled = true;
+      this.passkeysEnabled = false;
+    }
+  }
+
+  private _navigateAfterLogin() {
+    const redirectPath = localStorage.getItem('loginRedirect');
+    if (redirectPath) {
+      localStorage.removeItem('loginRedirect');
+      if (redirectPath.startsWith('/admin')) {
+        // The admin dashboard is a separate SPA that the console's
+        // client-side router cannot reach; do a hard navigation.
+        window.location.href = redirectPath;
+      } else {
+        Router.go(redirectPath);
+      }
+    } else {
+      Router.go('/console');
+    }
+  }
+
+  private async handlePasskeySignIn() {
+    this.error = '';
+    try {
+      const data = await signInWithPasskey();
+      localStorage.setItem('accessToken', data.access_token);
+      if (data.refresh_token) {
+        localStorage.setItem('refreshToken', data.refresh_token);
+      }
+      trackGoal('Login');
+      window.dispatchEvent(
+        new CustomEvent('auth-change', { bubbles: true, composed: true })
+      );
+      this._navigateAfterLogin();
+    } catch (error) {
+      // A cancelled ceremony (user dismissed the prompt) is not an error
+      // worth showing.
+      const message =
+        error instanceof Error ? error.message : 'Passkey sign-in failed';
+      if (!message.includes('cancelled')) {
+        this.error = message;
+      }
+      console.error('Passkey sign in failed', error);
     }
   }
 
@@ -138,19 +189,7 @@ export class LoginView extends LitElement {
       window.dispatchEvent(
         new CustomEvent('auth-change', { bubbles: true, composed: true })
       );
-      const redirectPath = localStorage.getItem('loginRedirect');
-      if (redirectPath) {
-        localStorage.removeItem('loginRedirect');
-        if (redirectPath.startsWith('/admin')) {
-          // The admin dashboard is a separate SPA that the console's
-          // client-side router cannot reach; do a hard navigation.
-          window.location.href = redirectPath;
-        } else {
-          Router.go(redirectPath);
-        }
-      } else {
-        Router.go('/console');
-      }
+      this._navigateAfterLogin();
     } catch (error) {
       if (error instanceof Error) {
         this.error = error.message;
@@ -161,11 +200,28 @@ export class LoginView extends LitElement {
     }
   }
 
+  private _renderPasskeyButton() {
+    if (!this.passkeysEnabled) return nothing;
+    return html`
+      <sl-button
+        class="oauth-button"
+        variant="default"
+        size="large"
+        @click=${this.handlePasskeySignIn}
+      >
+        <sl-icon name="fingerprint" slot="prefix"></sl-icon>
+        Sign in with passkey
+      </sl-button>
+    `;
+  }
+
   private _renderOAuthButtons() {
-    if (this.oauthProviders.length === 0) return nothing;
+    if (this.oauthProviders.length === 0 && !this.passkeysEnabled)
+      return nothing;
 
     return html`
       <div class="oauth-section">
+        ${this._renderPasskeyButton()}
         ${this.oauthProviders.map((provider) => {
           const config = OAUTH_PROVIDER_CONFIG[provider];
           if (!config) return nothing;

--- a/frontend/src/views/public/login-view.ts
+++ b/frontend/src/views/public/login-view.ts
@@ -9,10 +9,7 @@ import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '../../components/logo-component';
 import { trackGoal } from '../../services/web-analytics';
-import {
-  passkeysSupported,
-  signInWithPasskey,
-} from '../../services/passkeys';
+import { passkeysSupported, signInWithPasskey } from '../../services/passkeys';
 
 const OAUTH_PROVIDER_CONFIG: Record<string, { label: string; icon: string }> = {
   github: { label: 'GitHub', icon: 'github' },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -642,6 +642,145 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/auth/webauthn/register/options:
+    post:
+      tags:
+      - Auth
+      - Passkeys
+      summary: Registration Options
+      description: Begin passkey registration for the signed-in user.
+      operationId: registration_options_api_v1_auth_webauthn_register_options_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegistrationOptionsResponse'
+      security:
+      - OAuth2PasswordBearer: []
+  /api/v1/auth/webauthn/register/verify:
+    post:
+      tags:
+      - Auth
+      - Passkeys
+      summary: Registration Verify
+      description: Complete passkey registration and store the credential.
+      operationId: registration_verify_api_v1_auth_webauthn_register_verify_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegistrationVerifyRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PasskeySummary'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - OAuth2PasswordBearer: []
+  /api/v1/auth/webauthn/authenticate/options:
+    post:
+      tags:
+      - Auth
+      - Passkeys
+      summary: Authentication Options
+      description: 'Begin passkey sign-in. Discoverable credentials: no username needed.'
+      operationId: authentication_options_api_v1_auth_webauthn_authenticate_options_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticationOptionsResponse'
+  /api/v1/auth/webauthn/authenticate/verify:
+    post:
+      tags:
+      - Auth
+      - Passkeys
+      summary: Authentication Verify
+      description: Complete passkey sign-in; returns access and refresh tokens.
+      operationId: authentication_verify_api_v1_auth_webauthn_authenticate_verify_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticationVerifyRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Authentication Verify Api V1 Auth Webauthn Authenticate
+                  Verify Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/auth/webauthn/credentials:
+    get:
+      tags:
+      - Auth
+      - Passkeys
+      summary: List Credentials
+      description: List the signed-in user's passkeys.
+      operationId: list_credentials_api_v1_auth_webauthn_credentials_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/PasskeySummary'
+                type: array
+                title: Response List Credentials Api V1 Auth Webauthn Credentials
+                  Get
+      security:
+      - OAuth2PasswordBearer: []
+  /api/v1/auth/webauthn/credentials/{credential_id}:
+    delete:
+      tags:
+      - Auth
+      - Passkeys
+      summary: Delete Credential
+      description: Remove one of the signed-in user's passkeys.
+      operationId: delete_credential_api_v1_auth_webauthn_credentials__credential_id__delete
+      security:
+      - OAuth2PasswordBearer: []
+      parameters:
+      - name: credential_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Credential Id
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/account/details:
     get:
       tags:
@@ -10023,6 +10162,36 @@ components:
       type: object
       title: AuthUserUpdate
       description: User update model.
+    AuthenticationOptionsResponse:
+      properties:
+        options:
+          additionalProperties: true
+          type: object
+          title: Options
+        challenge_token:
+          type: string
+          title: Challenge Token
+      type: object
+      required:
+      - options
+      - challenge_token
+      title: AuthenticationOptionsResponse
+      description: Options for navigator.credentials.get plus the challenge token.
+    AuthenticationVerifyRequest:
+      properties:
+        credential:
+          additionalProperties: true
+          type: object
+          title: Credential
+        challenge_token:
+          type: string
+          title: Challenge Token
+      type: object
+      required:
+      - credential
+      - challenge_token
+      title: AuthenticationVerifyRequest
+      description: Authenticator response for the authentication ceremony.
     Body_diff_policy_api_v1_policies_diff_post:
       properties:
         file:
@@ -13672,6 +13841,32 @@ components:
       type: object
       title: OrganizationUpdate
       description: Model for updating an organization.
+    PasskeySummary:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        last_used_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Used At
+      type: object
+      required:
+      - id
+      - name
+      - created_at
+      title: PasskeySummary
+      description: Non-sensitive passkey metadata for the settings UI.
     PasswordChangeRequest:
       properties:
         current_password:
@@ -14235,6 +14430,41 @@ components:
       - refresh_token
       title: RefreshRequest
       description: Model for token refresh requests.
+    RegistrationOptionsResponse:
+      properties:
+        options:
+          additionalProperties: true
+          type: object
+          title: Options
+        challenge_token:
+          type: string
+          title: Challenge Token
+      type: object
+      required:
+      - options
+      - challenge_token
+      title: RegistrationOptionsResponse
+      description: Options for navigator.credentials.create plus the challenge token.
+    RegistrationVerifyRequest:
+      properties:
+        credential:
+          additionalProperties: true
+          type: object
+          title: Credential
+        challenge_token:
+          type: string
+          title: Challenge Token
+        name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Name
+      type: object
+      required:
+      - credential
+      - challenge_token
+      title: RegistrationVerifyRequest
+      description: Authenticator response for the registration ceremony.
     RollbackRequest:
       properties:
         preview_only:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ dependencies = [
     # gateway streaming tests.
     "litellm>=1.81.13,<1.90",
     "boto3>=1.34.0",  # For AWS Bedrock support through litellm
+    "webauthn>=2.0.0",  # WebAuthn passkey registration/authentication ceremonies
 ]
 
 [project.urls]


### PR DESCRIPTION
Adds passkey support behind `PASSKEYS_ENABLED` (default true). Built on top of #125 (branched from `fix/session-expiry` because passkey sign-in issues refresh tokens through the new `create_refresh_token` helper with the sliding-session `sat` claim); those commits will drop out of this diff once #125 merges.

## Scope (deliberately tight)

- Single-device passkeys with discoverable (resident) credentials
- Register from user settings; "Sign in with passkey" on the login page
- No admin management UI

## Backend

- `webauthn_credential` table + Alembic migration (`20260730_webauthn_credentials`): one row per authenticator, soft-delete, unique credential ID, sign counter for clone detection
- Endpoints under `/api/v1/auth/webauthn/` using the `webauthn` PyPI lib:
  - `POST register/options` and `POST register/verify` (authenticated) with existing-credential exclusion and resident-key required
  - `POST authenticate/options` and `POST authenticate/verify` (unauthenticated ceremony) issuing standard access + refresh tokens on success
  - `GET/DELETE credentials` for the settings UI (owner-scoped)
- Ceremony challenge state travels in a short-lived (5 min) JWT signed with the server secret, so the flow works across replicas with no shared session storage; the token binds purpose (register vs authenticate) and, for registration, the user
- `WEBAUTHN_RP_ID` / `WEBAUTHN_ORIGIN` env overrides for deployments behind proxies; defaults derive from the request
- `/features` exposes a `passkeys` flag so the login page knows whether to render the button

## Frontend

- `services/passkeys.ts`: base64url conversions and both ceremonies around `navigator.credentials`
- Security settings page: add, list, and remove passkeys (hidden when the flag is off or the browser lacks WebAuthn)
- Login page: passkey button above the OAuth providers, gated on the feature flag and `passkeysSupported()`; cancelled prompts are not surfaced as errors

## Tests

18 backend tests (`test_webauthn_passkeys.py`) with mocked authenticator data: challenge-token roundtrip/purpose/expiry, registration option shape and exclusions, attestation verify success/failure, cross-user challenge rejection, authentication token issuance (including the refresh token's session claim), unknown credential, bad assertion, inactive user, stale challenge, feature flag 404, and credential list/delete ownership. Existing auth suites still pass (74 total). Frontend security-view and login-view tests pass; touched files are clean under `tsc`.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Well-scoped passkey implementation with solid test coverage. All 6 issues from the first review have been addressed — audit events, rate limiting, code style fixes, import guards, and README documentation are all present.
>
> **Overview**
> Adds WebAuthn passkey registration and sign-in behind `PASSKEYS_ENABLED` (default true). Uses stateless JWT challenge tokens for multi-replica compatibility. Frontend gates on feature flag and browser support, with cancelled prompts gracefully handled.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 881423fa. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->