### PR TITLE
docs: Cursor BYOK onboarding covers AI panel incl. Agent mode

### DIFF
--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -223,10 +223,12 @@ func mcpOnlyAgentModelNote(agent AgentConfig) string {
 	case strings.EqualFold(strings.TrimSpace(agent.Name), "cursor"):
 		return mcpOnlySupportLabel + ": Cursor tool calls are governed through " +
 			"Preloop's MCP firewall. Cursor only accepts a custom model base URL via " +
-			"its in-app Settings → Models (global, chat-only, no config-file hook), " +
-			"so Preloop does not rewrite model traffic automatically. To route model " +
-			"spend through Preloop, set the OpenAI base URL override in Cursor " +
-			"settings to your Preloop gateway URL manually."
+			"its in-app Settings → Models (global, no config-file hook), so Preloop " +
+			"does not rewrite model traffic automatically. Setting the OpenAI base " +
+			"URL override there to your Preloop gateway URL routes the AI panel's " +
+			"third-party model calls (Ask/Plan and Agent modes) through Preloop; " +
+			"Tab, inline edit, and Cursor-billed bundled models stay on Cursor's " +
+			"backend."
 	case strings.EqualFold(strings.TrimSpace(agent.Name), "claude desktop"):
 		return mcpOnlySupportLabel + ": Claude Desktop tool calls are governed " +
 			"through Preloop's MCP firewall. Claude Desktop's model traffic is fixed " +


### PR DESCRIPTION
## Summary

Updates the Cursor support messaging based on the Cursor full-onboarding research memo. Cursor's BYOK mechanism (OpenAI key slot plus Override OpenAI Base URL) routes the AI panel's third-party model calls through the Preloop gateway in Ask/Plan mode and in Agent mode, not just chat.

## Changes

- `cli/internal/cmd/agents.go`: the Cursor support note no longer describes the base-URL override as chat-only. It now states that the override routes the AI panel's third-party model calls (Ask/Plan and Agent modes) through Preloop, while Tab, inline edit, and Cursor-billed bundled models stay on Cursor's backend.

Companion docs MR (preloop-docs) upgrades the Cursor section of `guide/clients/other-mcp-clients.md` to a full BYOK walkthrough and aligns `guide/concepts/model-gateway.md` and the CLI support-levels table.

## Scope honesty

- Bundled models (Composer, Grok, Auto) never traverse the override: they error with it enabled, and Auto silently bypasses it.
- Cursor blocks localhost base URLs; the gateway needs a public HTTPS endpoint.
- Cursor's Anthropic key slot has no override; Claude models are served via /openai/v1 alias resolution.
- Teams/Enterprise: Cursor's Token Rate still applies to BYOK traffic, and admins can restrict personal API keys entirely.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only user-facing message update with no logic changes.
>
> **Overview**
> Updates the Cursor MCP-only model note to accurately describe BYOK behavior across Ask, Plan, and Agent modes. Single-file change with 6 added and 4 deleted lines.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit `docs/cursor-byok-onboarding`. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->