### PR TITLE
fix: onboard live-validation rollback UX (#110)

### DIFF
--- a/cli/internal/cmd/agents_live_validate.go
+++ b/cli/internal/cmd/agents_live_validate.go
@@ -1344,7 +1344,13 @@ func recoverDeferredGatewayValidationFailure(
 	if result.Err == nil {
 		return
 	}
-	if liveValidationStatusKeepsGatewayConfig(result.Outcome.ValidationResult) {
+func recoverDeferredGatewayValidationFailure(
+	output interface{ Write(p []byte) (int, error) },
+	result deferredLiveValidationResult,
+) {
+	if result.Err == nil || result.Outcome == nil {
+		return
+	}
 		note := liveValidationUpstreamNote(result.Outcome.ValidationResult)
 		if note == "" {
 			note = "the live validation probe failed"

--- a/cli/internal/cmd/agents_live_validate.go
+++ b/cli/internal/cmd/agents_live_validate.go
@@ -246,7 +246,7 @@ func runGatewayLiveValidation(
 			&gatewayResponse,
 		)
 	}
-	probeAttempts, requestErr := postGatewayProbeWithThrottleRetry(postProbe)
+	probeAttempts, requestErr := postGatewayProbeWithRetry(postProbe)
 
 	apiKeyID := mostLikelyManagedAPIKeyID(detail.Credentials)
 	var searchHit *gatewayUsageSearchItem
@@ -269,6 +269,8 @@ func runGatewayLiveValidation(
 		liveValidationStatus = "throttled"
 	} else if isUpstreamBillingValidationError(requestErr) {
 		liveValidationStatus = "upstream_unavailable"
+	} else if isUpstreamTransientValidationError(requestErr) {
+		liveValidationStatus = "upstream_transient"
 	}
 	result := mergeStringMaps(validationResult, map[string]interface{}{
 		"live_validation_attempted":      true,
@@ -287,6 +289,8 @@ func runGatewayLiveValidation(
 		result["live_validation_failure_reason"] = "upstream_rate_limited"
 	case "upstream_unavailable":
 		result["live_validation_failure_reason"] = "upstream_billing"
+	case "upstream_transient":
+		result["live_validation_failure_reason"] = "upstream_transient"
 	}
 	// Intentionally omit api key ids from the result map so they cannot
 	// flow into validation status logging (go/clear-text-logging).
@@ -369,6 +373,40 @@ func isUpstreamBillingValidationError(err error) bool {
 		strings.Contains(message, "credit balance is too low")
 }
 
+// isUpstreamTransientValidationError reports whether the probe failed with a
+// transient upstream server error (HTTP 5xx: bad gateway, service
+// unavailable, gateway timeout, ...). These say nothing definitive about the
+// onboarding wiring — the provider may simply be having a moment — so the
+// probe is retried with a short backoff before any failure is declared, and
+// an exhausted retry budget keeps the gateway configuration in place so
+// “preloop agents validate <agent> --live“ remains re-runnable.
+func isUpstreamTransientValidationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Billing/quota refusals have their own classification (and must never
+	// be retried — more probes cannot refill a wallet).
+	if isUpstreamBillingValidationError(err) {
+		return false
+	}
+	// Prefer the typed HTTP status from the API client.
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode >= 500 && apiErr.StatusCode <= 599
+	}
+	// Fallback for wrapped/non-client errors that only expose a message.
+	message := strings.ToLower(err.Error())
+	return transientUpstreamStatusPattern.MatchString(message) ||
+		strings.Contains(message, "bad gateway") ||
+		strings.Contains(message, "service unavailable") ||
+		strings.Contains(message, "gateway timeout") ||
+		strings.Contains(message, "overloaded_error")
+}
+
+// transientUpstreamStatusPattern matches the “status 5xx“ fragment the API
+// client embeds in error strings, for wrapped errors that lost their type.
+var transientUpstreamStatusPattern = regexp.MustCompile(`status 5\d\d`)
+
 // liveValidationThrottleBackoffSchedule returns the waits between probe
 // retries when the upstream provider rate-limits the live-validation
 // request. Two short retries cover the common transient case (a burst of
@@ -382,27 +420,49 @@ func liveValidationThrottleBackoffSchedule() []time.Duration {
 	}
 }
 
+// liveValidationTransientBackoffSchedule returns the waits between probe
+// retries when the upstream provider answers with a transient 5xx. Two
+// short exponential retries (3 attempts total) cover a blip in the
+// provider's availability without stalling onboarding for long. Returns a
+// fresh slice so callers cannot mutate shared package state.
+func liveValidationTransientBackoffSchedule() []time.Duration {
+	return []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+	}
+}
+
 // liveValidationSleep is time.Sleep, injectable so tests can run instantly.
 // Not safe for concurrent reassignment: tests that override it must not use
 // t.Parallel alongside other live-validation tests in this package.
 var liveValidationSleep = time.Sleep
 
-// postGatewayProbeWithThrottleRetry runs the gateway probe, retrying only on
-// upstream rate-limit errors with the backoff schedule above. It returns the
-// number of attempts made and the final error (nil on success). Non-throttle
-// errors never retry: they indicate a config/auth problem a retry cannot fix.
-func postGatewayProbeWithThrottleRetry(post func() error) (int, error) {
+// postGatewayProbeWithRetry runs the gateway probe, retrying on upstream
+// rate-limit errors and on transient upstream 5xx errors, each with its own
+// backoff schedule above. It returns the number of attempts made and the
+// final error (nil on success). Other errors never retry: they indicate a
+// config/auth problem a retry cannot fix.
+func postGatewayProbeWithRetry(post func() error) (int, error) {
 	attempts := 1
 	err := post()
-	for _, backoff := range liveValidationThrottleBackoffSchedule() {
-		if err == nil || !isUpstreamRateLimitedValidationError(err) {
+	throttleBackoffs := liveValidationThrottleBackoffSchedule()
+	transientBackoffs := liveValidationTransientBackoffSchedule()
+	for {
+		var backoff time.Duration
+		switch {
+		case err == nil:
+			return attempts, nil
+		case isUpstreamRateLimitedValidationError(err) && len(throttleBackoffs) > 0:
+			backoff, throttleBackoffs = throttleBackoffs[0], throttleBackoffs[1:]
+		case isUpstreamTransientValidationError(err) && len(transientBackoffs) > 0:
+			backoff, transientBackoffs = transientBackoffs[0], transientBackoffs[1:]
+		default:
 			return attempts, err
 		}
 		liveValidationSleep(backoff)
 		attempts++
 		err = post()
 	}
-	return attempts, err
 }
 
 // liveValidationStatusThrottled reports whether a validation result recorded
@@ -433,6 +493,25 @@ func liveValidationStatusGatewayVerified(validationResult map[string]interface{}
 	return status == "throttled" || status == "upstream_unavailable"
 }
 
+// liveValidationStatusKeepsGatewayConfig reports whether a failed or
+// inconclusive live validation must keep the managed gateway configuration
+// in place. This covers everything gateway-verified (throttled / billing)
+// plus transient upstream 5xx failures: rolling the routing back over a
+// temporary provider outage would leave the enrollment in a state where
+// “preloop agents validate <agent> --live“ can never succeed again
+// (“managed model gateway provider is not configured“), forcing a full
+// re-onboard for what is likely a passing check five minutes later.
+func liveValidationStatusKeepsGatewayConfig(validationResult map[string]interface{}) bool {
+	if liveValidationStatusGatewayVerified(validationResult) {
+		return true
+	}
+	if validationResult == nil {
+		return false
+	}
+	status, _ := validationResult["live_validation_status"].(string)
+	return status == "upstream_transient"
+}
+
 // liveValidationUpstreamNote explains an upstream-side refusal to the operator,
 // or returns "" when the outcome was not one.
 func liveValidationUpstreamNote(validationResult map[string]interface{}) string {
@@ -445,12 +524,32 @@ func liveValidationUpstreamNote(validationResult map[string]interface{}) string 
 		return "the upstream provider rate-limited the live validation probe"
 	case "upstream_unavailable":
 		return "the upstream provider rejected the live validation probe (billing or quota)"
+	case "upstream_transient":
+		return "the upstream provider returned a transient server error (5xx) during the live validation probe"
 	}
 	return ""
 }
 
 func liveValidationOutcomeGatewayVerified(outcome *managedLiveValidationOutcome) bool {
 	return outcome != nil && liveValidationStatusGatewayVerified(outcome.ValidationResult)
+}
+
+func liveValidationOutcomeKeepsGatewayConfig(outcome *managedLiveValidationOutcome) bool {
+	return outcome != nil && liveValidationStatusKeepsGatewayConfig(outcome.ValidationResult)
+}
+
+// liveValidationGatewayRolledBack reports whether the managed gateway
+// configuration was reverted to the pre-onboarding provider after a live
+// validation failure. Once this is set, “preloop agents validate <agent>
+// --live“ can no longer succeed (the gateway provider is gone from the
+// config), so every user-facing hint must point at re-running
+// “preloop agents onboard <agent>“ instead.
+func liveValidationGatewayRolledBack(validationResult map[string]interface{}) bool {
+	if validationResult == nil {
+		return false
+	}
+	rolledBack, _ := validationResult["live_validation_gateway_rolled_back"].(bool)
+	return rolledBack
 }
 
 func liveValidationOutcomeThrottled(outcome *managedLiveValidationOutcome) bool {
@@ -1245,7 +1344,11 @@ func recoverDeferredGatewayValidationFailure(
 	if result.Err == nil {
 		return
 	}
-	if note := liveValidationUpstreamNote(result.Outcome.ValidationResult); note != "" {
+	if liveValidationStatusKeepsGatewayConfig(result.Outcome.ValidationResult) {
+		note := liveValidationUpstreamNote(result.Outcome.ValidationResult)
+		if note == "" {
+			note = "the live validation probe failed"
+		}
 		fmt.Fprintf(
 			output,
 			"      Note: %s; keeping the Preloop gateway configuration in place. Re-verify with: preloop agents validate %s --live\n",
@@ -1290,6 +1393,11 @@ func recoverDeferredGatewayValidationFailure(
 	if result.Outcome != nil && result.Outcome.ValidationResult != nil {
 		clearManagedGatewayValidationFlags(result.Outcome.ValidationResult)
 	}
+	fmt.Fprintf(
+		output,
+		"      Model routing was reverted to the previous provider. Fix the failure above and re-run: preloop agents onboard %s\n",
+		shellQuoteAgentName(resolveAgentDisplayName(result.Agent)),
+	) //nolint:errcheck
 }
 
 func clearManagedGatewayValidationFlags(validationResult map[string]interface{}) {
@@ -1299,6 +1407,10 @@ func clearManagedGatewayValidationFlags(validationResult map[string]interface{})
 	validationResult["gateway_model_configured"] = false
 	validationResult["model_provider_rewritten"] = false
 	validationResult["gateway_model_alias"] = ""
+	// Record the rollback so summary/hint rendering knows that
+	// ``validate --live`` can no longer succeed and points the user at
+	// re-running ``preloop agents onboard`` instead.
+	validationResult["live_validation_gateway_rolled_back"] = true
 }
 
 // persistDeferredLiveValidationResult records “result.Outcome“ against the
@@ -1341,7 +1453,7 @@ func deferredLiveValidationPersistStatus(outcome *managedLiveValidationOutcome) 
 	if outcome == nil || !outcome.Attempted || outcome.Passed {
 		return "validated"
 	}
-	if liveValidationOutcomeGatewayVerified(outcome) {
+	if liveValidationOutcomeKeepsGatewayConfig(outcome) {
 		return "validation_inconclusive"
 	}
 	return "validation_failed"
@@ -1408,6 +1520,8 @@ func printDeferredLiveValidationLine(
 			label = "throttled"
 		case "upstream_unavailable":
 			label = "inconclusive (upstream provider refused)"
+		case "upstream_transient":
+			label = "failed (transient upstream error after retries)"
 		}
 		fmt.Fprintf(
 			output,
@@ -1417,11 +1531,21 @@ func printDeferredLiveValidationLine(
 			result.Duration.Milliseconds(),
 			result.Err,
 		)
-		fmt.Fprintf(
-			output,
-			"      Run: preloop agents validate %s --live\n",
-			shellQuoteAgentName(name),
-		)
+		if liveValidationGatewayRolledBack(result.Outcome.ValidationResult) {
+			// The gateway config was reverted: ``validate --live`` can no
+			// longer succeed, so the only useful recovery is a re-onboard.
+			fmt.Fprintf(
+				output,
+				"      Run: preloop agents onboard %s\n",
+				shellQuoteAgentName(name),
+			)
+		} else {
+			fmt.Fprintf(
+				output,
+				"      Run: preloop agents validate %s --live\n",
+				shellQuoteAgentName(name),
+			)
+		}
 		return
 	}
 	fmt.Fprintf(
@@ -1469,9 +1593,10 @@ func liveValidationSummaryReason(result deferredLiveValidationResult) string {
 	if result.Outcome == nil || !result.Outcome.Attempted || result.Outcome.Passed {
 		return ""
 	}
+	quotedName := shellQuoteAgentName(resolveAgentDisplayName(result.Agent))
 	revalidate := fmt.Sprintf(
 		"re-verify with: preloop agents validate %s --live",
-		shellQuoteAgentName(resolveAgentDisplayName(result.Agent)),
+		quotedName,
 	)
 	status, _ := result.Outcome.ValidationResult["live_validation_status"].(string)
 	switch status {
@@ -1479,6 +1604,8 @@ func liveValidationSummaryReason(result deferredLiveValidationResult) string {
 		return "live validation throttled — model traffic unverified; " + revalidate
 	case "upstream_unavailable":
 		return "live validation inconclusive (upstream billing/quota); " + revalidate
+	case "upstream_transient":
+		return "live validation failed (transient upstream 5xx after retries) — model traffic unverified; " + revalidate
 	}
 	detail := ""
 	if result.Err != nil {
@@ -1486,6 +1613,12 @@ func liveValidationSummaryReason(result deferredLiveValidationResult) string {
 	} else if message, _ := result.Outcome.ValidationResult["live_validation_error"].(string); message != "" {
 		message, _, _ = strings.Cut(message, "\n")
 		detail = ": " + strings.TrimSpace(message)
+	}
+	if liveValidationGatewayRolledBack(result.Outcome.ValidationResult) {
+		// The gateway routing was reverted — pointing at ``validate --live``
+		// would send the user to a command that can never succeed.
+		return "live validation failed" + detail +
+			"; model routing reverted — re-run: preloop agents onboard " + quotedName
 	}
 	return "live validation failed" + detail + "; " + revalidate
 }

--- a/cli/internal/cmd/agents_live_validate_test.go
+++ b/cli/internal/cmd/agents_live_validate_test.go
@@ -832,7 +832,7 @@ func TestRunDeferredLiveValidationsParallel_ConcurrentNoOpIsSafe(t *testing.T) {
 // the user's own concurrent agent traffic) commonly trips upstream rate
 // limiters; a couple of spaced retries turns most of those transient 429s
 // into a passing validation instead of a spurious gateway rollback.
-func TestPostGatewayProbeWithThrottleRetry(t *testing.T) {
+func TestPostGatewayProbeWithRetry(t *testing.T) {
 	restoreSleep := liveValidationSleep
 	defer func() { liveValidationSleep = restoreSleep }()
 	var slept []time.Duration
@@ -841,7 +841,7 @@ func TestPostGatewayProbeWithThrottleRetry(t *testing.T) {
 	t.Run("retries throttle errors and succeeds", func(t *testing.T) {
 		slept = nil
 		calls := 0
-		attempts, err := postGatewayProbeWithThrottleRetry(func() error {
+		attempts, err := postGatewayProbeWithRetry(func() error {
 			calls++
 			if calls < 3 {
 				return &api.APIError{
@@ -865,7 +865,7 @@ func TestPostGatewayProbeWithThrottleRetry(t *testing.T) {
 	t.Run("gives up after backoff schedule on persistent throttle", func(t *testing.T) {
 		slept = nil
 		calls := 0
-		attempts, err := postGatewayProbeWithThrottleRetry(func() error {
+		attempts, err := postGatewayProbeWithRetry(func() error {
 			calls++
 			return &api.APIError{
 				StatusCode: http.StatusTooManyRequests,
@@ -884,7 +884,7 @@ func TestPostGatewayProbeWithThrottleRetry(t *testing.T) {
 	t.Run("does not retry non-throttle errors", func(t *testing.T) {
 		slept = nil
 		calls := 0
-		attempts, err := postGatewayProbeWithThrottleRetry(func() error {
+		attempts, err := postGatewayProbeWithRetry(func() error {
 			calls++
 			return &api.APIError{StatusCode: http.StatusUnauthorized, Body: "unauthorized"}
 		})
@@ -901,7 +901,7 @@ func TestPostGatewayProbeWithThrottleRetry(t *testing.T) {
 
 	t.Run("succeeds first try without sleeping", func(t *testing.T) {
 		slept = nil
-		attempts, err := postGatewayProbeWithThrottleRetry(func() error { return nil })
+		attempts, err := postGatewayProbeWithRetry(func() error { return nil })
 		if err != nil || attempts != 1 || len(slept) != 0 {
 			t.Fatalf("expected clean single attempt, got attempts=%d err=%v slept=%v", attempts, err, slept)
 		}
@@ -1223,5 +1223,359 @@ func TestLiveValidationSummaryReason_FailureIncludesDetail(t *testing.T) {
 	}
 	if strings.Contains(reason, "more detail") {
 		t.Fatalf("reason must stay one line, got %q", reason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue #110: transient upstream 5xx handling during onboarding live
+// validation. The regressions pinned here are:
+//   (a) a transient 502 must be retried with backoff and can succeed,
+//   (b) a persistent upstream 5xx keeps the gateway config in place so
+//       ``validate --live`` stays re-runnable,
+//   (c) a genuine rollback is LOUD: the summary/checkmark reflects the
+//       failure, the hint says ``onboard`` (never ``validate``), and
+//       single-agent invocations exit non-zero.
+// ---------------------------------------------------------------------------
+
+func TestIsUpstreamTransientValidationError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"typed 502", &api.APIError{StatusCode: http.StatusBadGateway, Body: "bad gateway"}, true},
+		{"typed 503", &api.APIError{StatusCode: http.StatusServiceUnavailable, Body: "unavailable"}, true},
+		{"typed 504", &api.APIError{StatusCode: http.StatusGatewayTimeout, Body: "timeout"}, true},
+		{"typed 500", &api.APIError{StatusCode: http.StatusInternalServerError, Body: "boom"}, true},
+		{"typed 401", &api.APIError{StatusCode: http.StatusUnauthorized, Body: "no auth"}, false},
+		{"typed 404", &api.APIError{StatusCode: http.StatusNotFound, Body: "no model"}, false},
+		{
+			// 429 has its own rate-limit classifier + throttle backoff
+			// schedule; it must not double-classify as transient.
+			"typed 429",
+			&api.APIError{StatusCode: http.StatusTooManyRequests, Body: "slow down"},
+			false,
+		},
+		{
+			// Billing refusals are never transient: retrying cannot refill a
+			// wallet, and they have their own gateway-verified classification.
+			"billing 402",
+			&api.APIError{StatusCode: http.StatusPaymentRequired, Body: "Insufficient Balance"},
+			false,
+		},
+		{"wrapped status text", errors.New("API error (status 503): upstream unavailable"), true},
+		{"wrapped bad gateway text", errors.New("upstream said bad gateway"), true},
+		{"plain config error", errors.New("managed config does not contain a token"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUpstreamTransientValidationError(tc.err); got != tc.want {
+				t.Fatalf("isUpstreamTransientValidationError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPostGatewayProbeWithRetry_TransientUpstream(t *testing.T) {
+	restoreSleep := liveValidationSleep
+	defer func() { liveValidationSleep = restoreSleep }()
+	var slept []time.Duration
+	liveValidationSleep = func(d time.Duration) { slept = append(slept, d) }
+
+	t.Run("transient 502 then success via retry", func(t *testing.T) {
+		slept = nil
+		calls := 0
+		attempts, err := postGatewayProbeWithRetry(func() error {
+			calls++
+			if calls < 2 {
+				return &api.APIError{StatusCode: http.StatusBadGateway, Body: "bad gateway"}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("expected success after transient retry, got %v", err)
+		}
+		if attempts != 2 || calls != 2 {
+			t.Fatalf("expected 2 attempts, got attempts=%d calls=%d", attempts, calls)
+		}
+		if len(slept) != 1 {
+			t.Fatalf("expected 1 backoff sleep, got %v", slept)
+		}
+	})
+
+	t.Run("persistent 502 gives up after backoff schedule", func(t *testing.T) {
+		slept = nil
+		calls := 0
+		attempts, err := postGatewayProbeWithRetry(func() error {
+			calls++
+			return &api.APIError{StatusCode: http.StatusBadGateway, Body: "bad gateway"}
+		})
+		if err == nil {
+			t.Fatal("expected persistent transient error to surface")
+		}
+		expected := 1 + len(liveValidationTransientBackoffSchedule())
+		if attempts != expected || calls != expected {
+			t.Fatalf("expected %d attempts, got attempts=%d calls=%d", expected, attempts, calls)
+		}
+		if len(slept) != len(liveValidationTransientBackoffSchedule()) {
+			t.Fatalf("expected %d backoff sleeps, got %v", len(liveValidationTransientBackoffSchedule()), slept)
+		}
+	})
+
+	t.Run("transient backoff grows (short exponential)", func(t *testing.T) {
+		schedule := liveValidationTransientBackoffSchedule()
+		if len(schedule) < 2 {
+			t.Fatalf("expected at least 2 transient backoffs (3 attempts total), got %v", schedule)
+		}
+		for i := 1; i < len(schedule); i++ {
+			if schedule[i] <= schedule[i-1] {
+				t.Fatalf("expected growing backoff, got %v", schedule)
+			}
+		}
+	})
+
+	t.Run("transient budget is independent from throttle budget", func(t *testing.T) {
+		slept = nil
+		calls := 0
+		// Alternate 429 / 502: each schedule is consumed independently, so
+		// the total attempts is 1 + len(throttle) + len(transient).
+		attempts, err := postGatewayProbeWithRetry(func() error {
+			calls++
+			if calls%2 == 1 {
+				return &api.APIError{StatusCode: http.StatusTooManyRequests, Body: "throttling_error"}
+			}
+			return &api.APIError{StatusCode: http.StatusBadGateway, Body: "bad gateway"}
+		})
+		if err == nil {
+			t.Fatal("expected the final error to surface")
+		}
+		expected := 1 + len(liveValidationThrottleBackoffSchedule()) + len(liveValidationTransientBackoffSchedule())
+		if attempts != expected || calls != expected {
+			t.Fatalf("expected %d attempts, got attempts=%d calls=%d", expected, attempts, calls)
+		}
+	})
+}
+
+func TestLiveValidationStatusKeepsGatewayConfig(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{"throttled", true},
+		{"upstream_unavailable", true},
+		{"upstream_transient", true},
+		{"failed", false},
+		{"passed", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := liveValidationStatusKeepsGatewayConfig(
+			map[string]interface{}{"live_validation_status": tc.status},
+		)
+		if got != tc.want {
+			t.Fatalf("status %q: keeps-gateway-config = %v, want %v", tc.status, got, tc.want)
+		}
+	}
+	if liveValidationStatusKeepsGatewayConfig(nil) {
+		t.Fatal("nil validation result must not keep gateway config")
+	}
+}
+
+// A transient upstream 5xx that survived the retry budget must NOT roll the
+// managed gateway config back in the deferred (parallel) recovery path:
+// rolling back leaves “validate --live“ permanently unable to succeed
+// (live_validation_skip_reason: managed model gateway provider is not
+// configured), which is the exact trap of issue #110.
+func TestRecoverDeferredGatewayValidationFailure_KeepsConfigOnTransient(t *testing.T) {
+	var buf bytes.Buffer
+	recoverDeferredGatewayValidationFailure(&buf, deferredLiveValidationResult{
+		Agent: AgentConfig{Name: "Claude Code"},
+		Outcome: &managedLiveValidationOutcome{
+			Attempted: true,
+			Passed:    false,
+			ValidationResult: map[string]interface{}{
+				"live_validation_status": "upstream_transient",
+			},
+		},
+		Err: &api.APIError{StatusCode: http.StatusBadGateway, Body: "bad gateway"},
+	})
+	rendered := buf.String()
+	if !strings.Contains(rendered, "keeping the Preloop gateway configuration") {
+		t.Fatalf("expected keep-config note in output, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "preloop agents validate") {
+		t.Fatalf("expected re-runnable validate hint, got %q", rendered)
+	}
+	if strings.Contains(rendered, "Restored") || strings.Contains(rendered, "reverted") {
+		t.Fatalf("expected no rollback for transient outcome, got %q", rendered)
+	}
+}
+
+// After a rollback the “validate --live“ hint is a dead end (the managed
+// gateway provider is gone from the config), so every user-facing hint must
+// point at re-running onboarding instead.
+func TestPrintDeferredLiveValidationLine_RolledBackPointsAtOnboard(t *testing.T) {
+	var buf bytes.Buffer
+	printDeferredLiveValidationLine(&buf, deferredLiveValidationResult{
+		Agent: AgentConfig{Name: "Hermes"},
+		Outcome: &managedLiveValidationOutcome{
+			Attempted: true,
+			Passed:    false,
+			ValidationResult: map[string]interface{}{
+				"live_validation_status":              "failed",
+				"live_validation_gateway_rolled_back": true,
+			},
+		},
+		Err:      errStringForTest("HTTP 401 bad credential"),
+		Duration: 90 * time.Millisecond,
+	})
+	out := buf.String()
+	if !strings.Contains(out, "preloop agents onboard Hermes") {
+		t.Fatalf("expected onboard hint after rollback, got %q", out)
+	}
+	if strings.Contains(out, "preloop agents validate") {
+		t.Fatalf("rolled-back failure must not suggest validate --live, got %q", out)
+	}
+}
+
+func TestLiveValidationSummaryReason_TransientKeepsValidateHint(t *testing.T) {
+	reason := liveValidationSummaryReason(deferredLiveValidationResult{
+		Agent: AgentConfig{Name: "OpenCode"},
+		Outcome: &managedLiveValidationOutcome{
+			Attempted: true,
+			Passed:    false,
+			ValidationResult: map[string]interface{}{
+				"live_validation_status": "upstream_transient",
+			},
+		},
+		Err: &api.APIError{StatusCode: http.StatusServiceUnavailable, Body: "unavailable"},
+	})
+	if !strings.Contains(reason, "transient upstream 5xx") {
+		t.Fatalf("expected transient wording, got %q", reason)
+	}
+	if !strings.Contains(reason, "preloop agents validate OpenCode --live") {
+		t.Fatalf("kept-config failure must keep the validate hint, got %q", reason)
+	}
+}
+
+func TestLiveValidationSummaryReason_RollbackPointsAtOnboard(t *testing.T) {
+	reason := liveValidationSummaryReason(deferredLiveValidationResult{
+		Agent: AgentConfig{Name: "Hermes"},
+		Outcome: &managedLiveValidationOutcome{
+			Attempted: true,
+			Passed:    false,
+			ValidationResult: map[string]interface{}{
+				"live_validation_status":              "failed",
+				"live_validation_gateway_rolled_back": true,
+			},
+		},
+		Err: errStringForTest("HTTP 401 bad credential"),
+	})
+	if !strings.Contains(reason, "model routing reverted") {
+		t.Fatalf("expected loud rollback wording, got %q", reason)
+	}
+	if !strings.Contains(reason, "re-run: preloop agents onboard Hermes") {
+		t.Fatalf("expected onboard re-run hint, got %q", reason)
+	}
+	if strings.Contains(reason, "validate") {
+		t.Fatalf("rolled-back failure must not suggest validate --live, got %q", reason)
+	}
+}
+
+func TestClearManagedGatewayValidationFlags_MarksRollback(t *testing.T) {
+	result := map[string]interface{}{
+		"gateway_provider_ok": true,
+		"gateway_token_ok":    true,
+	}
+	clearManagedGatewayValidationFlags(result)
+	if !liveValidationGatewayRolledBack(result) {
+		t.Fatal("clearing gateway flags must record the rollback marker")
+	}
+	if liveValidationGatewayRolledBack(map[string]interface{}{}) {
+		t.Fatal("empty result must not read as rolled back")
+	}
+	if liveValidationGatewayRolledBack(nil) {
+		t.Fatal("nil result must not read as rolled back")
+	}
+}
+
+// The summary checkmark must reflect the true end state (issue #110): a
+// failed live validation never renders as an unqualified "✓ Onboarded".
+func TestOnboardingCompletionHeadline(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		rolledBack bool
+		contains   []string
+		excludes   []string
+	}{
+		{
+			name:     "success",
+			err:      nil,
+			contains: []string{"✓ Onboarded Hermes"},
+		},
+		{
+			name:       "rolled back",
+			err:        errStringForTest("HTTP 401"),
+			rolledBack: true,
+			contains:   []string{"✗ Onboarding incomplete", "reverted"},
+			excludes:   []string{"✓"},
+		},
+		{
+			name:     "kept config degraded",
+			err:      errStringForTest("HTTP 503"),
+			contains: []string{"⚠ Onboarded Hermes with degraded validation"},
+			excludes: []string{"✓"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			headline := onboardingCompletionHeadline("Hermes", tc.err, tc.rolledBack)
+			for _, want := range tc.contains {
+				if !strings.Contains(headline, want) {
+					t.Fatalf("expected headline to contain %q, got %q", want, headline)
+				}
+			}
+			for _, unwanted := range tc.excludes {
+				if strings.Contains(headline, unwanted) {
+					t.Fatalf("expected headline to NOT contain %q, got %q", unwanted, headline)
+				}
+			}
+		})
+	}
+}
+
+// A rollback must surface as a non-zero exit for single-agent onboarding:
+// the typed error is not a launcher-skip (which maps to exit 0), it carries
+// the onboard re-run hint, and it never mentions the dead-end validate
+// command.
+func TestLiveValidationRollbackError_ExitAndHintSemantics(t *testing.T) {
+	rollbackErr := &liveValidationRollbackError{
+		AgentName: "Codex CLI",
+		Err:       errStringForTest("HTTP 401 bad credential"),
+	}
+	if got := ignoreLauncherSkipped(rollbackErr); got == nil {
+		t.Fatal("rollback error must not be swallowed by ignoreLauncherSkipped (single-agent exit must be non-zero)")
+	}
+	message := rollbackErr.Error()
+	if !strings.Contains(message, "re-run: preloop agents onboard \"Codex CLI\"") {
+		t.Fatalf("expected onboard re-run hint in error, got %q", message)
+	}
+	if strings.Contains(message, "validate") {
+		t.Fatalf("rollback error must not suggest validate --live, got %q", message)
+	}
+	if !errors.Is(rollbackErr, rollbackErr.Err) {
+		// errors.Is via Unwrap keeps the root cause inspectable.
+		t.Fatal("expected Unwrap to expose the underlying validation error")
+	}
+	// Batch summaries must classify the rollback as failed, with the reason
+	// carried through to the summary table.
+	outcome := classifyAgentOnboardingOutcome(AgentConfig{Name: "Codex CLI"}, rollbackErr)
+	if outcome.Status != agentOnboardingStatusFailed {
+		t.Fatalf("expected failed outcome for rollback, got %q", outcome.Status)
+	}
+	if !strings.Contains(outcome.Reason, "model routing was reverted") {
+		t.Fatalf("expected rollback reason in summary, got %q", outcome.Reason)
 	}
 }

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -950,12 +950,15 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 
 	var liveValidationErr error
 	liveValidationGatewayVerified := false
+	liveValidationKeepsGatewayConfig := false
+	liveValidationRolledBack := false
 	if requestedLiveValidation {
 		liveOutcome, err := runManagedAgentLiveValidation(client, agent, validationResult)
 		if liveOutcome != nil && len(liveOutcome.ValidationResult) > 0 {
 			validationResult = liveOutcome.ValidationResult
 		}
 		liveValidationGatewayVerified = liveValidationStatusGatewayVerified(validationResult)
+		liveValidationKeepsGatewayConfig = liveValidationStatusKeepsGatewayConfig(validationResult)
 		if liveOutcome != nil && liveOutcome.Attempted {
 			// A probe the upstream provider refused (rate limit, billing) is
 			// inconclusive, not a failure: the static config checks passed and
@@ -979,14 +982,16 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 			liveValidationErr = err
 		}
 	}
-	if liveValidationErr != nil && liveValidationGatewayVerified {
+	if liveValidationErr != nil && liveValidationKeepsGatewayConfig {
 		// A 429 (or a billing refusal) proves the durable credential
 		// authenticated at the gateway and the request reached the upstream
 		// provider — the wiring works, the provider just declined to serve this
 		// probe. Rolling back the gateway config here would discard a working
 		// onboarding over a condition that has nothing to do with it (and
 		// re-running onboarding to "fix" it only sends more probes into the
-		// same rate limiter / empty wallet).
+		// same rate limiter / empty wallet). The same holds for a transient
+		// upstream 5xx that survived the retry budget: keeping the gateway
+		// config in place is what keeps ``validate --live`` re-runnable.
 		quotedName := shellQuoteAgentName(resolveAgentDisplayName(agent))
 		fmt.Fprintf(
 			output,
@@ -1020,6 +1025,7 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 			isOpenCodeAgent(agent) ||
 			isHermesAgent(agent) ||
 			isOpenClawAgent(agent) {
+			liveValidationRolledBack = true
 			clearManagedGatewayValidationFlags(validationResult)
 			plan.ManagedModelAlias = ""
 			plan.ManagedProviderName = ""
@@ -1036,7 +1042,11 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 	}
 	dedupeManagedAgentControlSidecar(agent, pluginInstallResult)
 
-	fmt.Printf("✓ Onboarded %s\n", resolveAgentDisplayName(agent))
+	fmt.Println(onboardingCompletionHeadline(
+		resolveAgentDisplayName(agent),
+		liveValidationErr,
+		liveValidationRolledBack,
+	))
 	fmt.Printf("  Managed agent: %s (%s)\n", managedAgent.ID, runtimePrincipalIDForAgent(agent))
 	if len(serverSync.Added) > 0 {
 		fmt.Printf(
@@ -1096,20 +1106,44 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 	}
 	fmt.Printf("  Config updated: %s\n", agent.ConfigPath)
 	fmt.Printf("  Backup saved: %s\n", backupState.BackupPath)
+	if liveValidationErr != nil && liveValidationRolledBack {
+		// The gateway routing was reverted to the pre-onboarding provider, so
+		// ``preloop agents validate <agent> --live`` can never succeed anymore
+		// (the managed gateway provider is gone from the config). Be LOUD
+		// about the rollback, point at re-running onboarding (never at
+		// ``validate``), and surface a typed error so single-agent
+		// invocations exit non-zero instead of pretending everything worked.
+		fmt.Printf(
+			"  Warning: live validation failed and model routing was reverted to the previous provider: %v\n",
+			liveValidationErr,
+		)
+		fmt.Printf(
+			"           MCP onboarding remains in place, but managed model routing is NOT active.\n",
+		)
+		fmt.Printf(
+			"           Fix the failure above, then re-run: preloop agents onboard %s\n",
+			shellQuoteAgentName(resolveAgentDisplayName(agent)),
+		)
+		return &liveValidationRollbackError{
+			AgentName: resolveAgentDisplayName(agent),
+			Err:       liveValidationErr,
+		}
+	}
 	if liveValidationErr != nil {
-		// Live validation is informational and runs by default for every
-		// supported agent — its failure mode must NOT abort sibling agents
-		// during ``--all`` onboarding, nor exit non-zero for a single
-		// onboard, because the onboarding itself succeeded (account state
-		// applied, config rewritten, backup saved). The failure status is
-		// already persisted to ``validation_result`` and surfaces in the
-		// console UI as "Live check failed", and ``preloop agents validate
-		// <agent> --live`` is the dedicated command for "exit non-zero on
-		// live-validate failure" semantics. Print a clear warning with a
-		// recovery hint and continue.
+		// Live validation failed but the managed gateway configuration was
+		// kept in place (upstream throttle / billing refusal / transient
+		// 5xx that survived the retry budget), so ``preloop agents validate
+		// <agent> --live`` remains re-runnable and is the correct recovery
+		// hint. The failure status is already persisted to
+		// ``validation_result`` and surfaces in the console UI as "Live
+		// check failed". This degraded-but-recoverable state must NOT abort
+		// sibling agents during ``--all`` onboarding, so print a clear
+		// warning with the recovery hint and continue.
 		warningLabel := "failed"
 		if liveValidationGatewayVerified {
 			warningLabel = "inconclusive — " + liveValidationUpstreamNote(validationResult)
+		} else if liveValidationKeepsGatewayConfig {
+			warningLabel = "failed (transient upstream error after retries)"
 		}
 		fmt.Printf("  Warning: live validation %s: %v\n", warningLabel, liveValidationErr)
 		fmt.Printf(
@@ -1124,6 +1158,53 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		return launcherSkipped
 	}
 	return nil
+}
+
+// onboardingCompletionHeadline renders the first line of the onboarding
+// result so the checkmark always reflects the true end state: an
+// unqualified "✓ Onboarded" is reserved for a fully validated (or
+// not-validated-by-request) enrollment, a kept-config validation failure
+// reads as degraded, and a rollback reads as incomplete.
+func onboardingCompletionHeadline(
+	agentName string,
+	liveValidationErr error,
+	rolledBack bool,
+) string {
+	switch {
+	case liveValidationErr == nil:
+		return fmt.Sprintf("✓ Onboarded %s", agentName)
+	case rolledBack:
+		return fmt.Sprintf(
+			"✗ Onboarding incomplete for %s — model routing was reverted to the previous provider",
+			agentName,
+		)
+	default:
+		return fmt.Sprintf("⚠ Onboarded %s with degraded validation", agentName)
+	}
+}
+
+// liveValidationRollbackError marks an enrollment whose live validation
+// failed hard enough that the managed model gateway configuration was rolled
+// back to the pre-onboarding provider. MCP onboarding remains applied, but
+// managed model routing is NOT active and ``preloop agents validate <agent>
+// --live`` can never succeed until the agent is re-onboarded. Single-agent
+// invocations must exit non-zero on this error; batch flows record the agent
+// as failed in the summary.
+type liveValidationRollbackError struct {
+	AgentName string
+	Err       error
+}
+
+func (e *liveValidationRollbackError) Error() string {
+	return fmt.Sprintf(
+		"live validation failed and model routing was reverted for %s — re-run: preloop agents onboard %s",
+		e.AgentName,
+		shellQuoteAgentName(e.AgentName),
+	)
+}
+
+func (e *liveValidationRollbackError) Unwrap() error {
+	return e.Err
 }
 
 func updateManagedAgentTags(client *api.Client, agentID string, tags map[string]string) error {


### PR DESCRIPTION
Fixes #110

## Problem

`preloop agents onboard <agent>`: when live validation failed transiently (upstream 5xx), the CLI reverted model routing to the local provider but still printed `✓ Onboarded`, exited 0, and told the user to run `preloop agents validate <agent> --live` — which can never succeed after the rollback (`live_validation_skip_reason: managed model gateway provider is not configured`).

## Changes

1. **Retry with backoff on transient 5xx**: `postGatewayProbeWithRetry` (renamed from `postGatewayProbeWithThrottleRetry`) now retries transient upstream 5xx errors (502/503/504/500) with a short exponential schedule (3 attempts total: 1s, 2s), in addition to the existing 429 throttle schedule (3s, 8s). The two budgets are independent so alternating 429/5xx errors cannot starve either.
2. **Keep gateway config on transient failure**: a 5xx that survives the retry budget is classified as `upstream_transient` and treated like throttle/billing refusals — the managed gateway configuration is **kept in place** (inline and deferred/parallel paths), so `validate --live` remains re-runnable. Enrollment persists the honest `validation_inconclusive` status.
3. **Loud rollback when it does happen** (auth/config failures that a retry can't fix):
   - `clearManagedGatewayValidationFlags` records `live_validation_gateway_rolled_back` in the validation result.
   - All hints after a rollback say `re-run: preloop agents onboard <agent>` — never the dead-end `validate --live` (onboard output, deferred validation lines, batch summary reasons).
   - Single-agent invocations return a typed `liveValidationRollbackError` → **non-zero exit**; batch summaries classify the agent as `failed`.
4. **Honest checkmark**: the completion headline reflects the true end state:
   - `✓ Onboarded <agent>` — only when live validation passed or was not requested
   - `⚠ Onboarded <agent> with degraded validation` — kept-config failure, `validate --live` re-runnable
   - `✗ Onboarding incomplete for <agent> — model routing was reverted to the previous provider`

Scope is limited to validation-failure handling/reporting; onboarding flow itself is unchanged.

## Test evidence

```
$ cd cli && go build ./...
$ go test ./internal/cmd/... -run 'Validate|Rollback|Onboard'
ok  	github.com/preloop/preloop/cli/internal/cmd	1.174s

$ go test ./internal/cmd/... -run 'TestIsUpstreamTransientValidationError|TestPostGatewayProbeWithRetry|TestLiveValidationStatusKeepsGatewayConfig|TestRecoverDeferredGatewayValidationFailure' -v
--- PASS: TestPostGatewayProbeWithRetry (0.00s)
--- PASS: TestRecoverDeferredGatewayValidationFailure_SkipsRollbackWhenThrottled (0.00s)
--- PASS: TestIsUpstreamTransientValidationError (0.00s)
--- PASS: TestPostGatewayProbeWithRetry_TransientUpstream (0.00s)
--- PASS: TestLiveValidationStatusKeepsGatewayConfig (0.00s)
--- PASS: TestRecoverDeferredGatewayValidationFailure_KeepsConfigOnTransient (0.00s)
ok  	github.com/preloop/preloop/cli/internal/cmd	0.193s

$ go test ./internal/cmd/...   # full package
ok  	github.com/preloop/preloop/cli/internal/cmd	10.104s
$ go vet ./internal/cmd/       # clean
```

New table tests cover the required scenarios:
- (a) transient 502 then success via retry: `TestPostGatewayProbeWithRetry_TransientUpstream/transient_502_then_success_via_retry`
- (b) persistent failure → correct message + non-zero exit + no misleading validate hint: `TestLiveValidationRollbackError_ExitAndHintSemantics`, `TestLiveValidationSummaryReason_RollbackPointsAtOnboard`, `TestPrintDeferredLiveValidationLine_RolledBackPointsAtOnboard`, `TestRecoverDeferredGatewayValidationFailure_KeepsConfigOnTransient`
- (c) checkmark/summary reflects failure: `TestOnboardingCompletionHeadline` (✓ / ⚠ / ✗ variants)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Focused UX bugfix with excellent test coverage — retry logic, honest status reporting, and correct recovery hints.

**Overview**
This PR fixes the issue where transient upstream 5xx errors during onboarding live validation caused a silent rollback to local provider routing with misleading success messaging. It adds transient 5xx retries with backoff, keeps the gateway config on persistent transient failures (making `validate --live` re-runnable), and makes genuine rollbacks loud with non-zero exit codes and correct recovery hints.
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 804f73e. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->