### PR TITLE
fix: install Hermes plugin into its venv, detect entrypoint installs

### DIFF
--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -1786,6 +1786,14 @@ func runAgentsValidate(cmd *cobra.Command, args []string) error {
 func runAgentsInstallPlugin(cmd *cobra.Command, args []string) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	agentName := strings.Join(args, " ")
+	if runtimeSessionSourceTypeForAgent(agentName) == hermesSourceType {
+		// Hermes' `plugins install` only accepts Git URLs or owner/repo
+		// shorthands, so the marketplace command can never install the
+		// PyPI-distributed Preloop plugin. The working path is a pip install
+		// into Hermes' own virtualenv followed by a plugin enable, so both
+		// --dry-run output and the real install go straight there.
+		return runAgentsInstallHermesPlugin(cmd, agentName, dryRun)
+	}
 	installCommand, installArgs, err := agentControlPluginInstallCommand(agentName)
 	if err != nil {
 		return err
@@ -1847,25 +1855,6 @@ func runAgentsInstallPlugin(cmd *cobra.Command, args []string) error {
 				)
 			}
 		}
-		if runtimeSessionSourceTypeForAgent(agent.Name) == hermesSourceType {
-			// Hermes' `plugins install` only accepts Git URLs or owner/repo
-			// shorthands; the Preloop plugin ships on PyPI, so fall back to a
-			// pip install into Hermes' Python environment.
-			if installed, pipError := installHermesPluginViaPip(
-				agentControlPluginInstallTarget(agent),
-				cmd.ErrOrStderr(),
-			); installed {
-				fmt.Fprintf(
-					cmd.OutOrStdout(),
-					"\nInstalled %s via pip. Run `preloop agents validate %s` to verify plugin load and control readiness.\n",
-					agentControlPluginPackageName(agent),
-					agentName,
-				)
-				return nil
-			} else if pipError != "" {
-				message = fmt.Sprintf("%s (pip fallback also failed: %s)", message, pipError)
-			}
-		}
 		_, remediation := classifyRuntimePluginInstallFailure(installCommand, message)
 		if remediation != "" {
 			return fmt.Errorf(
@@ -1880,6 +1869,41 @@ func runAgentsInstallPlugin(cmd *cobra.Command, args []string) error {
 		cmd.OutOrStdout(),
 		"\nInstalled %s. Run `preloop agents validate %s` to verify plugin load and control readiness.\n",
 		agentControlPluginPackageName(AgentConfig{Name: agentName}),
+		agentName,
+	)
+	return nil
+}
+
+// runAgentsInstallHermesPlugin installs the Preloop Hermes plugin directly via
+// pip into Hermes' virtualenv (discovered from the `Install directory:` line
+// of `hermes --version`). Hermes' marketplace installer cannot resolve PyPI
+// package names, and the system Python rejects installs on PEP 668
+// (externally-managed-environment) distributions, so the venv pip is the only
+// working path. On --dry-run this prints the actual working command.
+func runAgentsInstallHermesPlugin(cmd *cobra.Command, agentName string, dryRun bool) error {
+	agent := AgentConfig{Name: agentName}
+	installTarget := agentControlPluginInstallTarget(agent)
+	if installTarget == "" {
+		return fmt.Errorf(
+			"standalone Preloop runtime plugin target for %s was not found",
+			agentName,
+		)
+	}
+	if dryRun {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", hermesManualPluginInstallCommand(installTarget))
+		return nil
+	}
+	if installed, pipError := installHermesPluginViaPip(installTarget, cmd.ErrOrStderr()); !installed {
+		return fmt.Errorf(
+			"failed to install Preloop runtime plugin: %s\nManual fix: run `%s`, then restart Hermes (`hermes gateway restart`).",
+			pipError,
+			hermesManualPluginInstallCommand(installTarget),
+		)
+	}
+	fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"\nInstalled %s into Hermes' virtualenv via pip. Run `preloop agents validate %s` to verify plugin load and control readiness.\n",
+		agentControlPluginPackageName(agent),
 		agentName,
 	)
 	return nil

--- a/cli/internal/cmd/agents_hermes.go
+++ b/cli/internal/cmd/agents_hermes.go
@@ -732,49 +732,160 @@ func extractHermesCredentialPoolAuthBlob(
 	return nil
 }
 
+// hermesInstallDirVersionPrefix is the label Hermes prints in its
+// `hermes --version` banner ahead of the installation root, e.g.
+//
+//	Hermes Agent 1.2.3
+//	Install directory: /usr/local/lib/hermes-agent
+//
+// The virtualenv Hermes runs from (and loads `hermes_agent.plugins` entry
+// points from) lives at `<install-dir>/venv`, so this line is the most
+// reliable discovery signal for the interpreter pip installs must target.
+const hermesInstallDirVersionPrefix = "Install directory:"
+
+// hermesInstallDirFromVersionOutput extracts the install directory from
+// `hermes --version` output. Returns "" when the banner does not include one.
+func hermesInstallDirFromVersionOutput(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, hermesInstallDirVersionPrefix) {
+			return strings.TrimSpace(strings.TrimPrefix(line, hermesInstallDirVersionPrefix))
+		}
+	}
+	return ""
+}
+
+// hermesInstallDirFromVersionCommand runs `hermes --version` and parses the
+// reported install directory. Returns "" when hermes cannot be resolved or the
+// banner carries no install directory. CombinedOutput is used deliberately:
+// some Hermes builds print the banner on stderr, and even a failing invocation
+// may still emit the line we need.
+func hermesInstallDirFromVersionCommand() string {
+	hermesPath, err := resolveRuntimeExecutable("hermes")
+	if err != nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	output, _ := exec.CommandContext(ctx, hermesPath, "--version").CombinedOutput()
+	return hermesInstallDirFromVersionOutput(string(output))
+}
+
+// hermesVenvBinDirCandidates returns directories that may hold Hermes'
+// virtualenv executables (python, pip, plugin console scripts), most specific
+// first:
+//
+//  1. `<install-dir>/venv/bin` where install-dir comes from `hermes --version`
+//     (matches the running gateway process, whose cmdline is
+//     `<install-dir>/venv/bin/python -m hermes_cli.main gateway run`).
+//  2. The directory containing the hermes executable itself, but only when it
+//     actually is a virtualenv bin directory (pipx-style installs put hermes
+//     directly inside the venv bin). The `pyvenv.cfg` gate stops us from
+//     mistaking `/usr/bin` for a venv when hermes and the system python3
+//     happen to share a bin directory.
+//  3. The default `~/.hermes/hermes-agent/venv/bin` location.
+func hermesVenvBinDirCandidates() []string {
+	dirs := []string{}
+	if installDir := hermesInstallDirFromVersionCommand(); installDir != "" {
+		dirs = append(dirs, filepath.Join(installDir, "venv", "bin"))
+	}
+	if hermesPath, err := resolveRuntimeExecutable("hermes"); err == nil {
+		hermesBinDir := filepath.Dir(hermesPath)
+		if _, statErr := os.Stat(filepath.Join(filepath.Dir(hermesBinDir), "pyvenv.cfg")); statErr == nil {
+			dirs = append(dirs, hermesBinDir)
+		}
+	}
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(homeDir, ".hermes", "hermes-agent", "venv", "bin"))
+	}
+	return dirs
+}
+
+// findHermesVenvExecutable looks for the named executable inside Hermes'
+// virtualenv bin directories. Console scripts installed by pip (for example
+// `preloop-hermes-plugin`) land there rather than on PATH, so validation must
+// check these locations before concluding the plugin is missing.
+func findHermesVenvExecutable(command string) (string, bool) {
+	for _, dir := range hermesVenvBinDirCandidates() {
+		candidate := filepath.Join(dir, command)
+		if isExecutableRegularFile(candidate) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+// isExecutableRegularFile reports whether path is an executable regular file.
+func isExecutableRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir() && info.Mode().Perm()&0111 != 0
+}
+
 // hermesPipPythonCandidates returns Python interpreters that live inside
 // Hermes' own environment, most specific first. Hermes loads plugins from its
 // Python environment via the `hermes_agent.plugins` entry point, so pip
 // installs must target that interpreter rather than an arbitrary system one.
 func hermesPipPythonCandidates() []string {
 	candidates := []string{}
-	if hermesPath, err := resolveRuntimeExecutable("hermes"); err == nil {
-		binDir := filepath.Dir(hermesPath)
+	for _, dir := range hermesVenvBinDirCandidates() {
 		candidates = append(
 			candidates,
-			filepath.Join(binDir, "python3"),
-			filepath.Join(binDir, "python"),
-		)
-	}
-	if homeDir, err := os.UserHomeDir(); err == nil {
-		venvBin := filepath.Join(homeDir, ".hermes", "hermes-agent", "venv", "bin")
-		candidates = append(
-			candidates,
-			filepath.Join(venvBin, "python3"),
-			filepath.Join(venvBin, "python"),
+			filepath.Join(dir, "python3"),
+			filepath.Join(dir, "python"),
 		)
 	}
 	return candidates
 }
 
 // resolveHermesPipPython picks the interpreter used for pip-installing the
-// Preloop Hermes plugin: a python bundled with the Hermes install when
-// available, otherwise python3/python from PATH.
+// Preloop Hermes plugin. Only interpreters inside Hermes' own environment are
+// considered: installing into the system Python both fails PEP 668
+// (externally-managed-environment) on stock Debian and would not be visible to
+// Hermes' plugin loader anyway, so there is deliberately no PATH fallback.
 func resolveHermesPipPython() (string, error) {
 	for _, candidate := range hermesPipPythonCandidates() {
-		if info, err := os.Stat(candidate); err == nil && !info.IsDir() &&
-			info.Mode().Perm()&0111 != 0 {
+		if isExecutableRegularFile(candidate) {
 			return candidate, nil
 		}
 	}
-	for _, name := range []string{"python3", "python"} {
-		if path, err := exec.LookPath(name); err == nil {
-			return path, nil
+	return "", fmt.Errorf(
+		"could not locate Hermes' virtualenv Python interpreter (checked the `Install directory:` "+
+			"reported by `hermes --version`, the directory containing the hermes executable, and "+
+			"~/.hermes/hermes-agent/venv/bin). Hermes loads plugins from its own virtualenv, and the "+
+			"system Python rejects installs on PEP 668 (externally-managed-environment) systems, so "+
+			"no system interpreter is used. Install the plugin manually with: %s",
+		hermesManualPluginInstallCommand("preloop-hermes-plugin"),
+	)
+}
+
+// hermesVenvPipFallbackPath returns the best-known path to Hermes' venv pip
+// binary for use in copy-pasteable remediation commands. It never degrades to
+// a bare `pip`: when the venv cannot be located it returns the path where the
+// venv pip is expected to live so the user runs the right interpreter.
+func hermesVenvPipFallbackPath() string {
+	for _, candidate := range hermesPipPythonCandidates() {
+		if isExecutableRegularFile(candidate) {
+			return filepath.Join(filepath.Dir(candidate), "pip")
 		}
 	}
-	return "", fmt.Errorf(
-		"no Python interpreter found for installing the Hermes Preloop plugin " +
-			"(looked next to the hermes executable, in ~/.hermes/hermes-agent/venv/bin, and on PATH)",
+	if installDir := hermesInstallDirFromVersionCommand(); installDir != "" {
+		return filepath.Join(installDir, "venv", "bin", "pip")
+	}
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(homeDir, ".hermes", "hermes-agent", "venv", "bin", "pip")
+	}
+	return "<hermes-install-dir>/venv/bin/pip"
+}
+
+// hermesManualPluginInstallCommand renders the manual (and `--dry-run`)
+// install command for the Preloop Hermes plugin. `hermes plugins install`
+// only accepts Git URLs / owner-repo shorthands, so the working command is a
+// pip install into Hermes' virtualenv followed by a plugin enable.
+func hermesManualPluginInstallCommand(installTarget string) string {
+	return fmt.Sprintf(
+		"%s install --upgrade %s && hermes plugins enable preloop --allow-tool-override",
+		hermesVenvPipFallbackPath(),
+		installTarget,
 	)
 }
 
@@ -784,7 +895,9 @@ func resolveHermesPipPython() (string, error) {
 // channel is PyPI (`preloop-hermes-plugin`) plus the `hermes_agent.plugins`
 // entry point (see runtime-plugins/PUBLISHING.md). installTarget is either
 // the PyPI package name or a local plugin source directory; pip accepts both.
-// Returns (true, "") on success, otherwise (false, failure message).
+// After a successful install the plugin is enabled best-effort so Hermes
+// actually loads it. Returns (true, "") on success, otherwise
+// (false, failure message).
 func installHermesPluginViaPip(installTarget string, writer io.Writer) (bool, string) {
 	pythonPath, err := resolveHermesPipPython()
 	if err != nil {
@@ -810,7 +923,93 @@ func installHermesPluginViaPip(installTarget string, writer io.Writer) (bool, st
 		}
 		return false, message
 	}
+	enableHermesPreloopPlugin(writer)
 	return true, ""
+}
+
+// enableHermesPreloopPlugin best-effort enables the entry-point-installed
+// Preloop plugin so Hermes loads it. Newer Hermes builds require
+// `--allow-tool-override` because the plugin overrides tool dispatch; older
+// builds reject the flag, so we retry without it. Failures are non-fatal —
+// verification and the printed remediation cover the manual path.
+func enableHermesPreloopPlugin(writer io.Writer) bool {
+	hermesPath, err := resolveRuntimeExecutable("hermes")
+	if err != nil {
+		return false
+	}
+	for _, args := range [][]string{
+		{"plugins", "enable", "preloop", "--allow-tool-override"},
+		{"plugins", "enable", "preloop"},
+	} {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		_, runErr := exec.CommandContext(ctx, hermesPath, args...).CombinedOutput()
+		cancel()
+		if runErr == nil {
+			if writer != nil {
+				fmt.Fprintln(writer, "  Enabled the Preloop plugin in Hermes.") //nolint:errcheck
+			}
+			return true
+		}
+	}
+	if writer != nil {
+		fmt.Fprintln(
+			writer,
+			"  Warning: could not enable the Preloop plugin automatically. "+
+				"Run `hermes plugins enable preloop --allow-tool-override` manually, then restart Hermes.",
+		) //nolint:errcheck
+	}
+	return false
+}
+
+// hermesPluginsListPreloopStatus inspects `hermes plugins list` for the
+// Preloop plugin. Entry-point installs (pip into Hermes' venv) register the
+// plugin with Hermes itself even when no console script is discoverable, so
+// this is the authoritative fallback signal for "plugin installed". Returns
+// (installed, enabled).
+func hermesPluginsListPreloopStatus() (bool, bool) {
+	hermesPath, err := resolveRuntimeExecutable("hermes")
+	if err != nil {
+		return false, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, hermesPath, "plugins", "list").CombinedOutput()
+	if err != nil {
+		return false, false
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		lower := strings.ToLower(line)
+		if !strings.Contains(lower, "preloop") {
+			continue
+		}
+		if strings.Contains(lower, "disabled") {
+			return true, false
+		}
+		return true, true
+	}
+	return false, false
+}
+
+// verifyHermesEntryPointPlugin recognises a Preloop plugin installed through
+// the `hermes_agent.plugins` entry point (pip install into Hermes' venv) when
+// no console script is discoverable. Returns nil when Hermes does not report
+// the plugin at all so callers can fall through to the managed sidecar check.
+func verifyHermesEntryPointPlugin() map[string]interface{} {
+	installed, enabled := hermesPluginsListPreloopStatus()
+	if !installed {
+		return nil
+	}
+	result := map[string]interface{}{
+		"control_plugin_installed": true,
+		"control_plugin_verified":  enabled,
+	}
+	if enabled {
+		result["control_plugin_verification"] = "hermes_entry_point_plugin_enabled"
+	} else {
+		result["control_plugin_verification"] = "hermes_entry_point_plugin_disabled"
+		result["control_plugin_install_remediation"] = "Run `hermes plugins enable preloop --allow-tool-override`, then restart Hermes (`hermes gateway restart`)."
+	}
+	return result
 }
 
 // restartHermesGatewayAfterReconfig reloads the Hermes messaging gateway so MCP

--- a/cli/internal/cmd/agents_hermes_test.go
+++ b/cli/internal/cmd/agents_hermes_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/base64"
 	"io"
 	"os"
@@ -469,6 +470,11 @@ func TestInstallAgentControlRuntimePluginFallsBackToPipWhenHermesRejectsIdentifi
 		t.Fatalf("failed to write fake Hermes installer: %v", err)
 	}
 	// Fake python3 next to the hermes executable records the pip invocation.
+	// The interpreter next to hermes only counts as Hermes' environment when
+	// the parent directory is a real virtualenv, so mark it with pyvenv.cfg.
+	if err := os.WriteFile(filepath.Join(dir, "pyvenv.cfg"), []byte("home = /usr\n"), 0644); err != nil {
+		t.Fatalf("failed to write pyvenv.cfg: %v", err)
+	}
 	pipArgsFile := filepath.Join(dir, "pip-args.txt")
 	if err := os.WriteFile(
 		filepath.Join(binDir, "python3"),
@@ -512,6 +518,11 @@ func TestInstallAgentControlRuntimePluginFallsBackToPipWhenHermesRejectsIdentifi
 }
 
 func TestClassifyRuntimePluginInstallFailureHermesInvalidIdentifier(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	testenv.SetHome(t, home)
+	t.Setenv("PATH", filepath.Join(dir, "empty-path"))
+
 	status, remediation := classifyRuntimePluginInstallFailure(
 		"hermes",
 		"Agent Control plugin install failed: Error: Invalid plugin identifier: 'preloop-hermes-plugin'. Use a Git URL or owner/repo shorthand",
@@ -519,8 +530,262 @@ func TestClassifyRuntimePluginInstallFailureHermesInvalidIdentifier(t *testing.T
 	if status != "runtime_marketplace_rejected_identifier" {
 		t.Fatalf("unexpected status: %q", status)
 	}
-	if !strings.Contains(remediation, "pip install preloop-hermes-plugin") {
-		t.Fatalf("expected pip remediation, got %q", remediation)
+	// The remediation must be copy-pasteable with the full venv pip path —
+	// never a bare `pip install`, which hits the system interpreter and fails
+	// PEP 668 on stock Debian.
+	expectedPip := filepath.Join(home, ".hermes", "hermes-agent", "venv", "bin", "pip")
+	if !strings.Contains(remediation, expectedPip+" install --upgrade preloop-hermes-plugin") {
+		t.Fatalf("expected venv pip remediation with full path %q, got %q", expectedPip, remediation)
+	}
+	if !strings.Contains(remediation, "hermes plugins enable preloop --allow-tool-override") {
+		t.Fatalf("expected plugin enable step in remediation, got %q", remediation)
+	}
+}
+
+func TestHermesInstallDirFromVersionOutput(t *testing.T) {
+	output := "Hermes Agent 1.2.3\n  Install directory: /usr/local/lib/hermes-agent\nPython 3.11.2\n"
+	if got := hermesInstallDirFromVersionOutput(output); got != "/usr/local/lib/hermes-agent" {
+		t.Fatalf("expected install dir from version banner, got %q", got)
+	}
+	if got := hermesInstallDirFromVersionOutput("Hermes Agent 1.2.3\n"); got != "" {
+		t.Fatalf("expected empty install dir when banner lacks the line, got %q", got)
+	}
+	if got := hermesInstallDirFromVersionOutput(""); got != "" {
+		t.Fatalf("expected empty install dir for empty output, got %q", got)
+	}
+}
+
+func TestResolveHermesPipPythonDiscoversVenvFromVersionOutput(t *testing.T) {
+	skipNoShebangOnWindows(t, "Hermes venv discovery from `hermes --version` output")
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	testenv.SetHome(t, home)
+
+	// Simulate a stock Debian layout: hermes on PATH reports its install
+	// directory, and the venv python lives under <install-dir>/venv/bin.
+	installDir := filepath.Join(dir, "usr", "local", "lib", "hermes-agent")
+	venvBin := filepath.Join(installDir, "venv", "bin")
+	if err := os.MkdirAll(venvBin, 0755); err != nil {
+		t.Fatalf("failed to create venv bin dir: %v", err)
+	}
+	venvPython := filepath.Join(venvBin, "python3")
+	if err := os.WriteFile(venvPython, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("failed to write fake venv python: %v", err)
+	}
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("failed to create bin dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(binDir, "hermes"),
+		[]byte("#!/bin/sh\necho \"Hermes Agent 1.2.3\"\necho \"Install directory: "+installDir+"\"\n"),
+		0755,
+	); err != nil {
+		t.Fatalf("failed to write fake hermes: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	resolved, err := resolveHermesPipPython()
+	if err != nil {
+		t.Fatalf("unexpected python resolution error: %v", err)
+	}
+	if resolved != venvPython {
+		t.Fatalf("expected venv python %q from version banner, got %q", venvPython, resolved)
+	}
+}
+
+func TestResolveHermesPipPythonNeverFallsBackToSystemPython(t *testing.T) {
+	skipNoShebangOnWindows(t, "Hermes pip interpreter refusing system python")
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	testenv.SetHome(t, home)
+
+	// A system python3 is on PATH, but no Hermes venv exists anywhere. The
+	// resolver must fail with a copy-pasteable venv pip hint instead of
+	// returning the system interpreter (PEP 668 would reject the install).
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("failed to create bin dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(binDir, "python3"), []byte("#!/bin/sh\n"), 0755,
+	); err != nil {
+		t.Fatalf("failed to write fake system python: %v", err)
+	}
+	installDir := filepath.Join(dir, "usr", "local", "lib", "hermes-agent")
+	if err := os.WriteFile(
+		filepath.Join(binDir, "hermes"),
+		[]byte("#!/bin/sh\necho \"Install directory: "+installDir+"\"\n"),
+		0755,
+	); err != nil {
+		t.Fatalf("failed to write fake hermes: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	_, err := resolveHermesPipPython()
+	if err == nil {
+		t.Fatalf("expected resolution to fail rather than use the system python")
+	}
+	expectedPip := filepath.Join(installDir, "venv", "bin", "pip")
+	if !strings.Contains(err.Error(), expectedPip+" install --upgrade preloop-hermes-plugin") {
+		t.Fatalf("expected error to carry full venv pip path %q, got %q", expectedPip, err.Error())
+	}
+}
+
+func TestRunAgentsInstallPluginHermesDryRunPrintsVenvPipCommand(t *testing.T) {
+	skipManagedLauncherOnWindows(t, "Hermes install-plugin dry-run venv pip command")
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	testenv.SetHome(t, home)
+	t.Setenv("PATH", filepath.Join(dir, "empty-path"))
+	t.Setenv("PRELOOP_RUNTIME_PLUGINS_DIR", filepath.Join(dir, "runtime-plugins"))
+
+	cmd := agentsInstallPluginCmd
+	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+		t.Fatalf("failed to set dry-run flag: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Flags().Set("dry-run", "false")
+		cmd.SetOut(nil)
+	})
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+
+	if err := runAgentsInstallPlugin(cmd, []string{"hermes"}); err != nil {
+		t.Fatalf("dry run failed: %v", err)
+	}
+	printed := strings.TrimSpace(buf.String())
+	// The dry-run must print the actual working command: Hermes'
+	// `plugins install` rejects PyPI names, so the command is a venv pip
+	// install plus the plugin enable.
+	expectedPip := filepath.Join(home, ".hermes", "hermes-agent", "venv", "bin", "pip")
+	expected := expectedPip + " install --upgrade preloop-hermes-plugin && hermes plugins enable preloop --allow-tool-override"
+	if printed != expected {
+		t.Fatalf("unexpected dry-run command:\n  got:  %q\n  want: %q", printed, expected)
+	}
+	if strings.Contains(printed, "hermes plugins install") {
+		t.Fatalf("dry-run must not print the broken marketplace command, got %q", printed)
+	}
+}
+
+func TestVerifyAgentControlRuntimePluginDetectsHermesEntryPointInstall(t *testing.T) {
+	skipNoShebangOnWindows(t, "Hermes entry-point plugin detection via `hermes plugins list`")
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	testenv.SetHome(t, home)
+
+	// No `preloop-hermes-plugin` console script anywhere: the plugin was
+	// installed via `venv/bin/pip install preloop-hermes-plugin` and is only
+	// visible through Hermes' own plugin registry.
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("failed to create bin dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(binDir, "hermes"),
+		[]byte("#!/bin/sh\nif [ \"$1\" = plugins ] && [ \"$2\" = list ]; then\n"+
+			"  echo \"preloop    enabled    Preloop Agent Control\"\n  exit 0\nfi\n"+
+			"echo \"Hermes Agent 1.2.3\"\n"),
+		0755,
+	); err != nil {
+		t.Fatalf("failed to write fake hermes: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	result := verifyAgentControlRuntimePlugin(AgentConfig{
+		Name:       hermesAgentName,
+		ConfigPath: filepath.Join(home, ".hermes", "config.yaml"),
+	})
+	if result["control_plugin_installed"] != true {
+		t.Fatalf("expected entry-point plugin to be detected as installed, got %#v", result)
+	}
+	if result["control_plugin_verified"] != true {
+		t.Fatalf("expected enabled entry-point plugin to verify, got %#v", result)
+	}
+	if result["control_plugin_verification"] != "hermes_entry_point_plugin_enabled" {
+		t.Fatalf("unexpected verification detail: %#v", result)
+	}
+}
+
+func TestVerifyAgentControlRuntimePluginReportsDisabledHermesEntryPointInstall(t *testing.T) {
+	skipNoShebangOnWindows(t, "Hermes disabled entry-point plugin detection")
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	testenv.SetHome(t, home)
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("failed to create bin dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(binDir, "hermes"),
+		[]byte("#!/bin/sh\nif [ \"$1\" = plugins ] && [ \"$2\" = list ]; then\n"+
+			"  echo \"preloop    disabled    Preloop Agent Control\"\n  exit 0\nfi\n"+
+			"echo \"Hermes Agent 1.2.3\"\n"),
+		0755,
+	); err != nil {
+		t.Fatalf("failed to write fake hermes: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	result := verifyAgentControlRuntimePlugin(AgentConfig{
+		Name:       hermesAgentName,
+		ConfigPath: filepath.Join(home, ".hermes", "config.yaml"),
+	})
+	if result["control_plugin_installed"] != true {
+		t.Fatalf("expected disabled entry-point plugin to still count as installed, got %#v", result)
+	}
+	if result["control_plugin_verified"] != false {
+		t.Fatalf("expected disabled plugin to fail verification, got %#v", result)
+	}
+	remediation, _ := result["control_plugin_install_remediation"].(string)
+	if !strings.Contains(remediation, "hermes plugins enable preloop --allow-tool-override") {
+		t.Fatalf("expected enable remediation for disabled plugin, got %#v", result)
+	}
+}
+
+func TestVerifyAgentControlRuntimePluginFindsHermesVenvConsoleScript(t *testing.T) {
+	skipNoShebangOnWindows(t, "Hermes venv console-script verification")
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	testenv.SetHome(t, home)
+
+	// The plugin's console script lives only inside Hermes' venv bin
+	// (reported via `hermes --version`), not on PATH.
+	installDir := filepath.Join(dir, "opt", "hermes-agent")
+	venvBin := filepath.Join(installDir, "venv", "bin")
+	if err := os.MkdirAll(venvBin, 0755); err != nil {
+		t.Fatalf("failed to create venv bin dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(venvBin, "preloop-hermes-plugin"),
+		[]byte("#!/bin/sh\n[ \"$1\" = verify ] && [ \"$2\" = --config ]\n"),
+		0755,
+	); err != nil {
+		t.Fatalf("failed to write fake venv verifier: %v", err)
+	}
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("failed to create bin dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(binDir, "hermes"),
+		[]byte("#!/bin/sh\necho \"Install directory: "+installDir+"\"\n"),
+		0755,
+	); err != nil {
+		t.Fatalf("failed to write fake hermes: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	result := verifyAgentControlRuntimePlugin(AgentConfig{
+		Name:       hermesAgentName,
+		ConfigPath: filepath.Join(home, ".hermes", "config.yaml"),
+	})
+	if result["control_plugin_installed"] != true ||
+		result["control_plugin_verified"] != true ||
+		result["control_plugin_verification"] != "verified" {
+		t.Fatalf("expected venv console script to verify, got %#v", result)
 	}
 }
 

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -4359,7 +4359,10 @@ func classifyRuntimePluginInstallFailure(installer string, message string) (stri
 	if normalizedInstaller == "hermes" &&
 		strings.Contains(normalizedMessage, "invalid plugin identifier") {
 		return "runtime_marketplace_rejected_identifier",
-			"Hermes' `plugins install` only accepts Git URLs or owner/repo shorthands; the Preloop plugin is distributed on PyPI. Install it with `pip install preloop-hermes-plugin` using Hermes' Python environment, then restart Hermes."
+			fmt.Sprintf(
+				"Hermes' `plugins install` only accepts Git URLs or owner/repo shorthands; the Preloop plugin is distributed on PyPI and must be installed into Hermes' virtualenv (never the system Python, which rejects installs on PEP 668 systems). Run `%s`, then restart Hermes (`hermes gateway restart`).",
+				hermesManualPluginInstallCommand("preloop-hermes-plugin"),
+			)
 	}
 	if normalizedInstaller == "openclaw" &&
 		strings.Contains(normalizedMessage, "control_ws_url") &&
@@ -4451,7 +4454,23 @@ func verifyAgentControlRuntimePlugin(agent AgentConfig) map[string]interface{} {
 		return result
 	}
 	path, err := resolveRuntimeExecutable(command)
+	if err != nil && runtimeSessionSourceTypeForAgent(agent.Name) == hermesSourceType {
+		// pip installs into Hermes' virtualenv put the plugin's console script
+		// in <install-dir>/venv/bin, which is usually not on PATH. Check the
+		// venv before concluding the plugin is missing.
+		if venvPath, ok := findHermesVenvExecutable(command); ok {
+			path, err = venvPath, nil
+		}
+	}
 	if err != nil {
+		if runtimeSessionSourceTypeForAgent(agent.Name) == hermesSourceType {
+			// Entry-point installs register the plugin with Hermes itself even
+			// when no console script is discoverable; `hermes plugins list` is
+			// the authoritative signal in that case.
+			if entryPoint := verifyHermesEntryPointPlugin(); entryPoint != nil {
+				return mergeStringMaps(result, entryPoint)
+			}
+		}
 		return mergeStringMaps(result, managedAgentControlSidecarVerification(agent))
 	}
 	result["control_plugin_installed"] = true


### PR DESCRIPTION
## Summary

Fixes #111 — `preloop agents onboard hermes` / `preloop agents install-plugin hermes` failed on every path on stock Debian:

1. `hermes plugins install preloop-hermes-plugin` always fails ("Invalid plugin identifier": Hermes only accepts Git URLs / owner-repo shorthands).
2. The pip fallback used the system `/usr/bin/python3`, which fails PEP 668 (`externally-managed-environment`).
3. After a manual venv install, `preloop agents validate Hermes` still reported `control_plugin_installed: no`.

## Changes

- **Venv discovery**: parse the `Install directory:` line from `hermes --version` and target `<install-dir>/venv` for pip installs. Also considers the hermes-adjacent bin dir (only when `pyvenv.cfg` proves it's a venv — never `/usr/bin`) and the default `~/.hermes/hermes-agent/venv/bin`. The system interpreter is **never** used; the old PATH `python3` fallback is removed.
- **Copy-pasteable remediation**: when the venv can't be located, all errors/remediations print the full venv pip path (e.g. `/usr/local/lib/hermes-agent/venv/bin/pip install --upgrade preloop-hermes-plugin && hermes plugins enable preloop --allow-tool-override`), never a bare `pip install`.
- **`install-plugin hermes --dry-run`** now prints the actual working command (venv pip install + plugin enable) instead of the broken `hermes plugins install preloop-hermes-plugin`. The real run goes straight to pip (no doomed marketplace attempt) and then enables the plugin, passing `--allow-tool-override` and retrying without it for older Hermes builds.
- **Validation detects entrypoint installs**: `verifyAgentControlRuntimePlugin` now checks Hermes' venv bin for the plugin console script, and falls back to `hermes plugins list` (authoritative for `hermes_agent.plugins` entry-point installs). A listed-but-disabled plugin reports installed + an enable remediation, so Agent Control channel setup proceeds after a manual `venv/bin/pip install` + `hermes plugins enable preloop`.

## Test evidence

New tests (all mocked exec, per existing patterns):
- `TestHermesInstallDirFromVersionOutput` — parses `Install directory:` from version banner.
- `TestResolveHermesPipPythonDiscoversVenvFromVersionOutput` — venv discovery from `hermes --version` output.
- `TestResolveHermesPipPythonNeverFallsBackToSystemPython` — system python on PATH is rejected; error carries the full venv pip path.
- `TestRunAgentsInstallPluginHermesDryRunPrintsVenvPipCommand` — dry-run prints the corrected working command.
- `TestVerifyAgentControlRuntimePluginDetectsHermesEntryPointInstall` / `...ReportsDisabledHermesEntryPointInstall` — validate recognises entrypoint-installed plugins via `hermes plugins list` (incl. disabled → remediation).
- `TestVerifyAgentControlRuntimePluginFindsHermesVenvConsoleScript` — console script inside the venv (off PATH) verifies.
- Updated `TestClassifyRuntimePluginInstallFailureHermesInvalidIdentifier` to require the full venv pip path + `--allow-tool-override` in the remediation.

```
$ cd cli && go build ./... && go test ./internal/cmd/... -run 'Hermes|Plugin'
ok  github.com/preloop/preloop/cli/internal/cmd  5.4s   (54 tests)
$ go test ./...
ok  (all packages)
```

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Bug fix for Hermes plugin installation — well-contained Go changes with thorough test coverage (54 Hermes/Plugin tests pass).

> **Overview**
> Fixes #111 by replacing the broken `hermes plugins install` flow with direct venv pip installs, discovering Hermes' virtualenv via `hermes --version` output, and teaching validation to detect entrypoint-installed plugins. Never uses system Python to avoid PEP 668 failures; all remediations include copy-pasteable full venv pip paths.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 58f785f. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
