### PR TITLE
feat: ingest Cursor bundled-model usage into Cost analytics (#123)

### DIFF
--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -50,6 +50,7 @@ from preloop.api.endpoints import (
     session_optimization,
     tools,
     trackers,
+    usage_import,
     version,
     embedding as embedding_router,
     webhooks,
@@ -966,6 +967,12 @@ def create_app() -> FastAPI:
             cost.router,
             prefix="/api/v1",
             tags=["Cost Analytics"],
+            dependencies=[Depends(get_current_active_user)],
+        )
+        app.include_router(
+            usage_import.router,
+            prefix="/api/v1",
+            tags=["Usage Import"],
             dependencies=[Depends(get_current_active_user)],
         )
         app.include_router(

--- a/backend/preloop/api/common.py
+++ b/backend/preloop/api/common.py
@@ -429,6 +429,28 @@ def get_accessible_projects(
     return filtered_projects
 
 
+def get_account_or_404(db: Session, current_user: User) -> Account:
+    """Return the authenticated user's account or raise 404.
+
+    Shared by endpoints that treat a missing account row as a not-found
+    resource (e.g. cost analytics, usage import) rather than an auth error.
+
+    Args:
+        db: Database session.
+        current_user: Authenticated user.
+
+    Returns:
+        The user's Account.
+
+    Raises:
+        HTTPException: 404 when the account row does not exist.
+    """
+    account = crud_account.get(db=db, id=current_user.account_id)
+    if account is None:
+        raise HTTPException(status_code=404, detail="Account not found")
+    return account
+
+
 def get_account_for_user(
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db_session),

--- a/backend/preloop/api/endpoints/__init__.py
+++ b/backend/preloop/api/endpoints/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "search",
     "tools",
     "trackers",
+    "usage_import",
     "version",
     "webhooks",
     "flows",

--- a/backend/preloop/api/endpoints/cost.py
+++ b/backend/preloop/api/endpoints/cost.py
@@ -9,12 +9,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from preloop.api.auth.jwt import get_current_active_user
-from preloop.models.crud import crud_account
+from preloop.models.crud import crud_account, crud_api_usage
 from preloop.models.db.session import get_db_session
 from preloop.models.models.user import User
 from preloop.schemas.cost_analytics import (
     CostAnalyticsSummaryResponse,
     CostHealthResponse,
+    ImportedUsageByModel,
+    ImportedUsageSummary,
     PriceCatalogInfo,
 )
 from preloop.services.gateway_accounting_check import run_accounting_checks
@@ -68,6 +70,34 @@ def get_cost_summary(
         include_breakdown=True,
         exclude_retries=exclude_retries,
     )
+    # Imported (observed) spend is reported as a SEPARATE block, using the
+    # summary's normalized window: it is never added into estimated_cost or
+    # the budget figures (issue #123 — imported and gateway-metered spend
+    # must not silently mix).
+    imported_totals = crud_api_usage.get_imported_usage_summary(
+        db,
+        account_id=str(account.id),
+        start_date=summary.period_start,
+        end_date=summary.period_end,
+        runtime_principal_id=runtime_principal_id,
+    )
+    imported_usage = None
+    if imported_totals["event_count"]:
+        imported_usage = ImportedUsageSummary(
+            event_count=imported_totals["event_count"],
+            total_tokens=imported_totals["total_tokens"],
+            imported_cost=imported_totals["imported_cost"],
+            usage_by_model=[
+                ImportedUsageByModel(**row)
+                for row in crud_api_usage.get_imported_usage_by_model(
+                    db,
+                    account_id=str(account.id),
+                    start_date=summary.period_start,
+                    end_date=summary.period_end,
+                    runtime_principal_id=runtime_principal_id,
+                )
+            ],
+        )
     return CostAnalyticsSummaryResponse(
         period_start=summary.period_start,
         period_end=summary.period_end,
@@ -85,6 +115,7 @@ def get_cost_summary(
         usage_by_flow=summary.usage_by_flow,
         usage_by_session=summary.usage_by_session,
         usage_by_tool=summary.usage_by_tool,
+        imported_usage=imported_usage,
     )
 
 

--- a/backend/preloop/api/endpoints/cost.py
+++ b/backend/preloop/api/endpoints/cost.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from preloop.api.auth.jwt import get_current_active_user
-from preloop.models.crud import crud_account, crud_api_usage
+from preloop.api.common import get_account_or_404
+from preloop.models.crud import crud_api_usage
 from preloop.models.db.session import get_db_session
 from preloop.models.models.user import User
 from preloop.schemas.cost_analytics import (
@@ -37,13 +38,6 @@ def _price_catalog_info() -> Optional[PriceCatalogInfo]:
         return None
 
 
-def _get_account_or_404(db: Session, current_user: User) -> Any:
-    account = crud_account.get(db=db, id=current_user.account_id)
-    if account is None:
-        raise HTTPException(status_code=404, detail="Account not found")
-    return account
-
-
 @router.get("/summary", response_model=CostAnalyticsSummaryResponse)
 @require_permission("view_cost")
 def get_cost_summary(
@@ -61,7 +55,7 @@ def get_cost_summary(
     current_user: User = Depends(get_current_active_user),
 ) -> CostAnalyticsSummaryResponse:
     """Return the OSS cost overview using gateway usage and pricing metadata."""
-    account = _get_account_or_404(db, current_user)
+    account = get_account_or_404(db, current_user)
     summary = ModelGatewayUsageService(db).get_account_summary(
         account=account,
         start_date=start_date,
@@ -138,6 +132,6 @@ def get_cost_health(
     events are being written — so silent accounting breakage cannot go
     unnoticed.
     """
-    account = _get_account_or_404(db, current_user)
+    account = get_account_or_404(db, current_user)
     result = run_accounting_checks(db, account_id=str(account.id), window_hours=hours)
     return CostHealthResponse(**result)

--- a/backend/preloop/api/endpoints/usage_import.py
+++ b/backend/preloop/api/endpoints/usage_import.py
@@ -19,7 +19,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from sqlalchemy.orm import Session
 
 from preloop.api.auth.jwt import get_current_active_user
-from preloop.models.crud import crud_account
+from preloop.api.common import get_account_or_404
 from preloop.models.db.session import get_db_session
 from preloop.models.models.user import User
 from preloop.schemas.usage_import import (
@@ -41,11 +41,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/usage", tags=["Usage Import"])
 
 
-def _require_account(db: Session, current_user: User) -> None:
-    if crud_account.get(db=db, id=current_user.account_id) is None:
-        raise HTTPException(status_code=404, detail="Account not found")
-
-
 @router.post("/import", response_model=UsageImportResponse)
 @require_permission("import_usage")
 def import_usage_events(
@@ -60,7 +55,7 @@ def import_usage_events(
     ``usage_source='imported'``. Re-sending the same events is idempotent —
     duplicates are counted in ``skipped_duplicates``, never double-billed.
     """
-    _require_account(db, current_user)
+    get_account_or_404(db, current_user)
     try:
         agent = resolve_target_agent(
             db,
@@ -124,7 +119,7 @@ async def import_usage_csv(
     stored with tokens but no charged amount. Re-importing the same file is
     idempotent.
     """
-    _require_account(db, current_user)
+    get_account_or_404(db, current_user)
 
     parsed_column_map = None
     if column_map:

--- a/backend/preloop/api/endpoints/usage_import.py
+++ b/backend/preloop/api/endpoints/usage_import.py
@@ -40,6 +40,16 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/usage", tags=["Usage Import"])
 
+#: Chunk size for reading CSV uploads without buffering the whole body.
+_CSV_READ_CHUNK_BYTES = 1024 * 1024
+
+
+def _csv_too_large() -> HTTPException:
+    return HTTPException(
+        status_code=413,
+        detail=f"CSV exceeds the {MAX_CSV_BYTES // (1024 * 1024)} MiB limit",
+    )
+
 
 @router.post("/import", response_model=UsageImportResponse)
 @require_permission("import_usage")
@@ -62,17 +72,16 @@ def import_usage_events(
             account_id=str(current_user.account_id),
             agent_id=str(payload.agent_id) if payload.agent_id else None,
         )
+        imported, skipped = ingest_events(
+            db,
+            account_id=str(current_user.account_id),
+            user_id=str(current_user.id),
+            agent=agent,
+            events=payload.events,
+            source=payload.source,
+        )
     except UsageImportError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-
-    imported, skipped = ingest_events(
-        db,
-        account_id=str(current_user.account_id),
-        user_id=str(current_user.id),
-        agent=agent,
-        events=payload.events,
-        source=payload.source,
-    )
     logger.info(
         "Imported %d usage events (%d duplicates skipped) for agent %s "
         "(source=%s, account=%s)",
@@ -138,13 +147,23 @@ async def import_usage_csv(
                 detail="column_map must be a JSON object of string to string",
             )
 
-    content = await file.read()
-    if len(content) > MAX_CSV_BYTES:
-        raise HTTPException(
-            status_code=413,
-            detail=f"CSV exceeds the {MAX_CSV_BYTES // (1024 * 1024)} MiB limit",
-        )
+    # First line of defense: Starlette populates UploadFile.size from the
+    # multipart parsing, so an oversized upload is rejected without reading
+    # the body at all. The chunked read below is the backstop for uploads
+    # that arrive without a usable size, bounding memory to the cap.
+    if file.size is not None and file.size > MAX_CSV_BYTES:
+        raise _csv_too_large()
 
+    chunks: list[bytes] = []
+    received = 0
+    while chunk := await file.read(_CSV_READ_CHUNK_BYTES):
+        received += len(chunk)
+        if received > MAX_CSV_BYTES:
+            raise _csv_too_large()
+        chunks.append(chunk)
+    content = b"".join(chunks)
+
+    normalized_source = source.strip().lower() or "cursor"
     try:
         agent = resolve_target_agent(
             db,
@@ -152,18 +171,16 @@ async def import_usage_csv(
             agent_id=str(agent_id) if agent_id else None,
         )
         parse_result = parse_cursor_usage_csv(content, column_map=parsed_column_map)
+        imported, skipped = ingest_events(
+            db,
+            account_id=str(current_user.account_id),
+            user_id=str(current_user.id),
+            agent=agent,
+            events=parse_result.events,
+            source=normalized_source,
+        )
     except UsageImportError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-
-    normalized_source = source.strip().lower() or "cursor"
-    imported, skipped = ingest_events(
-        db,
-        account_id=str(current_user.account_id),
-        user_id=str(current_user.id),
-        agent=agent,
-        events=parse_result.events,
-        source=normalized_source,
-    )
     logger.info(
         "CSV import: %d rows parsed, %d imported, %d duplicates, %d skipped "
         "rows for agent %s (account=%s)",

--- a/backend/preloop/api/endpoints/usage_import.py
+++ b/backend/preloop/api/endpoints/usage_import.py
@@ -1,0 +1,191 @@
+"""Usage ingest endpoints: import externally observed spend (issue #123).
+
+Cursor's bundled models never traverse the Preloop model gateway, so their
+spend is invisible to Cost analytics. These endpoints accept that spend as
+normalized usage events (JSON) or as the Cursor dashboard Usage CSV export,
+attribute it to a managed agent, and record it with
+``usage_source='imported'`` so it is labeled apart from gateway-metered
+spend and never mixes into gateway budgets.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from sqlalchemy.orm import Session
+
+from preloop.api.auth.jwt import get_current_active_user
+from preloop.models.crud import crud_account
+from preloop.models.db.session import get_db_session
+from preloop.models.models.user import User
+from preloop.schemas.usage_import import (
+    UsageImportCsvResponse,
+    UsageImportRequest,
+    UsageImportResponse,
+)
+from preloop.services.usage_import import (
+    MAX_CSV_BYTES,
+    UsageImportError,
+    ingest_events,
+    parse_cursor_usage_csv,
+    resolve_target_agent,
+)
+from preloop.utils.permissions import require_permission
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/usage", tags=["Usage Import"])
+
+
+def _require_account(db: Session, current_user: User) -> None:
+    if crud_account.get(db=db, id=current_user.account_id) is None:
+        raise HTTPException(status_code=404, detail="Account not found")
+
+
+@router.post("/import", response_model=UsageImportResponse)
+@require_permission("import_usage")
+def import_usage_events(
+    payload: UsageImportRequest,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_active_user),
+) -> UsageImportResponse:
+    """Ingest a batch of normalized usage events into the cost ledger.
+
+    Events are attributed to the given managed agent (default: the account's
+    managed Cursor agent from onboarding) and recorded with
+    ``usage_source='imported'``. Re-sending the same events is idempotent —
+    duplicates are counted in ``skipped_duplicates``, never double-billed.
+    """
+    _require_account(db, current_user)
+    try:
+        agent = resolve_target_agent(
+            db,
+            account_id=str(current_user.account_id),
+            agent_id=str(payload.agent_id) if payload.agent_id else None,
+        )
+    except UsageImportError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    imported, skipped = ingest_events(
+        db,
+        account_id=str(current_user.account_id),
+        user_id=str(current_user.id),
+        agent=agent,
+        events=payload.events,
+        source=payload.source,
+    )
+    logger.info(
+        "Imported %d usage events (%d duplicates skipped) for agent %s "
+        "(source=%s, account=%s)",
+        imported,
+        skipped,
+        agent.id,
+        payload.source,
+        current_user.account_id,
+    )
+    return UsageImportResponse(
+        imported=imported,
+        skipped_duplicates=skipped,
+        agent_id=UUID(str(agent.id)),
+        agent_display_name=agent.display_name,
+        source=payload.source,
+    )
+
+
+@router.post("/import/csv", response_model=UsageImportCsvResponse)
+@require_permission("import_usage")
+async def import_usage_csv(
+    file: UploadFile = File(..., description="Cursor dashboard Usage CSV export"),
+    agent_id: Optional[UUID] = Form(default=None),
+    source: str = Form(default="cursor"),
+    column_map: Optional[str] = Form(
+        default=None,
+        description=(
+            "Optional JSON object mapping logical fields (date, model, cost, "
+            "kind, max_mode, input_with_cache_write, input_without_cache_write, "
+            "cache_read, output_tokens, total_tokens) to your export's exact "
+            "column headers, for CSV shapes the built-in matcher does not "
+            "recognize."
+        ),
+    ),
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_active_user),
+) -> UsageImportCsvResponse:
+    """Import a Cursor dashboard Usage CSV export into the cost ledger.
+
+    Parses the export (Date / Kind / Model / Max Mode / Input (w/ Cache
+    Write) / Input (w/o Cache Write) / Cache Read / Output Tokens / Total
+    Tokens / Cost), normalizes each row, and ingests it through the same
+    pipeline as ``POST /usage/import``. Rows whose Cost is "Included" are
+    stored with tokens but no charged amount. Re-importing the same file is
+    idempotent.
+    """
+    _require_account(db, current_user)
+
+    parsed_column_map = None
+    if column_map:
+        try:
+            parsed_column_map = json.loads(column_map)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=422, detail=f"column_map is not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(parsed_column_map, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in parsed_column_map.items()
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail="column_map must be a JSON object of string to string",
+            )
+
+    content = await file.read()
+    if len(content) > MAX_CSV_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"CSV exceeds the {MAX_CSV_BYTES // (1024 * 1024)} MiB limit",
+        )
+
+    try:
+        agent = resolve_target_agent(
+            db,
+            account_id=str(current_user.account_id),
+            agent_id=str(agent_id) if agent_id else None,
+        )
+        parse_result = parse_cursor_usage_csv(content, column_map=parsed_column_map)
+    except UsageImportError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    normalized_source = source.strip().lower() or "cursor"
+    imported, skipped = ingest_events(
+        db,
+        account_id=str(current_user.account_id),
+        user_id=str(current_user.id),
+        agent=agent,
+        events=parse_result.events,
+        source=normalized_source,
+    )
+    logger.info(
+        "CSV import: %d rows parsed, %d imported, %d duplicates, %d skipped "
+        "rows for agent %s (account=%s)",
+        parse_result.parsed_rows,
+        imported,
+        skipped,
+        parse_result.skipped_rows,
+        agent.id,
+        current_user.account_id,
+    )
+    return UsageImportCsvResponse(
+        imported=imported,
+        skipped_duplicates=skipped,
+        agent_id=UUID(str(agent.id)),
+        agent_display_name=agent.display_name,
+        source=normalized_source,
+        parsed_rows=parse_result.parsed_rows,
+        skipped_rows=parse_result.skipped_rows,
+        skipped_row_reasons=parse_result.skipped_row_reasons,
+    )

--- a/backend/preloop/models/alembic/versions/20260731_usage_source_imported.py
+++ b/backend/preloop/models/alembic/versions/20260731_usage_source_imported.py
@@ -1,0 +1,66 @@
+"""Allow 'imported' in api_usage cost_source / usage_source markers.
+
+Revision ID: 20260731_usage_imported
+Revises: 20260730_webauthn_credentials
+Create Date: 2026-07-31
+
+Usage ingest (issue #123) records spend observed outside the model gateway
+(e.g. Cursor bundled-model usage imported from the Cursor dashboard CSV or
+pushed through the ingest API). Those rows are labeled
+``usage_source='imported'`` / ``cost_source='imported'`` so gateway-metered
+and imported spend can never be silently mixed.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260731_usage_imported"
+down_revision: Union[str, None] = "20260730_webauthn_credentials"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+# Alembic reads these module globals by name; keep a local reference so static
+# analysis treats them as used.
+_ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)
+assert _ALEMBIC_IDENTIFIERS, "Alembic revision metadata must be defined"
+
+
+def upgrade() -> None:
+    """Extend the marker CHECK constraints with the 'imported' value."""
+    op.drop_constraint("ck_api_usage_cost_source", "api_usage", type_="check")
+    op.drop_constraint("ck_api_usage_usage_source", "api_usage", type_="check")
+    op.create_check_constraint(
+        "ck_api_usage_cost_source",
+        "api_usage",
+        "cost_source IS NULL OR cost_source IN "
+        "('override', 'model_config', 'catalog', 'subscription', 'unpriced', "
+        "'imported')",
+    )
+    op.create_check_constraint(
+        "ck_api_usage_usage_source",
+        "api_usage",
+        "usage_source IS NULL OR usage_source IN "
+        "('provider', 'estimated', 'partial', 'imported')",
+    )
+
+
+def downgrade() -> None:
+    """Restore the previous marker CHECK constraints (clearing 'imported')."""
+    op.execute("UPDATE api_usage SET cost_source = NULL WHERE cost_source = 'imported'")
+    op.execute(
+        "UPDATE api_usage SET usage_source = NULL WHERE usage_source = 'imported'"
+    )
+    op.drop_constraint("ck_api_usage_cost_source", "api_usage", type_="check")
+    op.drop_constraint("ck_api_usage_usage_source", "api_usage", type_="check")
+    op.create_check_constraint(
+        "ck_api_usage_cost_source",
+        "api_usage",
+        "cost_source IS NULL OR cost_source IN "
+        "('override', 'model_config', 'catalog', 'subscription', 'unpriced')",
+    )
+    op.create_check_constraint(
+        "ck_api_usage_usage_source",
+        "api_usage",
+        "usage_source IS NULL OR usage_source IN ('provider', 'estimated', 'partial')",
+    )

--- a/backend/preloop/models/alembic/versions/20260731_usage_source_imported.py
+++ b/backend/preloop/models/alembic/versions/20260731_usage_source_imported.py
@@ -14,6 +14,7 @@ and imported spend can never be silently mixed.
 from typing import Sequence, Union
 
 from alembic import op
+from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
 revision: str = "20260731_usage_imported"
@@ -27,7 +28,19 @@ assert _ALEMBIC_IDENTIFIERS, "Alembic revision metadata must be defined"
 
 
 def upgrade() -> None:
-    """Extend the marker CHECK constraints with the 'imported' value."""
+    """Extend the marker CHECK constraints and add the dedupe unique index."""
+    # DB-level dedupe for imported usage: a unique partial index on
+    # (account_id, meta_data->>'import_fingerprint') closes the TOCTOU race
+    # between the application's existence check and the insert under
+    # concurrent imports. NULL fingerprints are distinct, so rows imported
+    # without a fingerprint never conflict.
+    op.create_index(
+        "ix_api_usage_imported_fingerprint_uniq",
+        "api_usage",
+        ["account_id", text("(meta_data->>'import_fingerprint')")],
+        unique=True,
+        postgresql_where=text("action_type = 'imported_usage'"),
+    )
     op.drop_constraint("ck_api_usage_cost_source", "api_usage", type_="check")
     op.drop_constraint("ck_api_usage_usage_source", "api_usage", type_="check")
     op.create_check_constraint(
@@ -47,6 +60,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Restore the previous marker CHECK constraints (clearing 'imported')."""
+    op.execute("DROP INDEX IF EXISTS ix_api_usage_imported_fingerprint_uniq")
     op.execute("UPDATE api_usage SET cost_source = NULL WHERE cost_source = 'imported'")
     op.execute(
         "UPDATE api_usage SET usage_source = NULL WHERE usage_source = 'imported'"

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -1838,6 +1838,29 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
 
     IMPORTED_USAGE_ACTION_TYPE = "imported_usage"
 
+    #: Unique partial index enforcing per-account fingerprint dedupe in the DB.
+    IMPORTED_FINGERPRINT_INDEX = "ix_api_usage_imported_fingerprint_uniq"
+
+    def _imported_fingerprint_exists(
+        self, db: Session, *, account_id: str, import_fingerprint: str
+    ) -> bool:
+        """Return True when the account already has a row with this fingerprint.
+
+        This is a fast-path check only; the authoritative guard is the
+        unique partial index ``ix_api_usage_imported_fingerprint_uniq``,
+        which closes the check-then-insert race under concurrent imports.
+        """
+        exists = (
+            db.query(ApiUsage.id)
+            .filter(
+                ApiUsage.account_id == account_id,
+                ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,
+                ApiUsage.meta_data["import_fingerprint"].astext == import_fingerprint,
+            )
+            .first()
+        )
+        return exists is not None
+
     def log_imported_usage_event(
         self,
         db: Session,
@@ -1884,26 +1907,19 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             import_fingerprint: Stable dedupe key; when a row with the same
                 fingerprint already exists for the account, the event is
                 skipped and ``None`` is returned (re-importing the same CSV
-                must not double-count spend).
+                must not double-count spend). Enforced by the unique partial
+                index ``ix_api_usage_imported_fingerprint_uniq``, so two
+                concurrent imports of the same event cannot both land.
             meta_data: Extra keys merged into the stored ``meta_data``.
             commit: When False, flush only so callers can batch commits.
 
         Returns:
             The created row, or ``None`` when skipped as a duplicate.
         """
-        if import_fingerprint:
-            exists = (
-                db.query(ApiUsage.id)
-                .filter(
-                    ApiUsage.account_id == account_id,
-                    ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,
-                    ApiUsage.meta_data["import_fingerprint"].astext
-                    == import_fingerprint,
-                )
-                .first()
-            )
-            if exists is not None:
-                return None
+        if import_fingerprint and self._imported_fingerprint_exists(
+            db, account_id=account_id, import_fingerprint=import_fingerprint
+        ):
+            return None
 
         if total_tokens is None and (
             prompt_tokens is not None or completion_tokens is not None
@@ -1940,12 +1956,20 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             meta_data=merged_meta,
             timestamp=timestamp,
         )
-        db.add(db_obj)
+        # Insert inside a savepoint so a unique-index violation (a concurrent
+        # import of the same event committed between the fast-path check and
+        # this insert) skips just this row and leaves the batch usable.
+        try:
+            with db.begin_nested():
+                db.add(db_obj)
+                db.flush()
+        except IntegrityError as exc:
+            if self.IMPORTED_FINGERPRINT_INDEX not in str(exc.orig):
+                raise
+            return None
         if commit:
             db.commit()
             db.refresh(db_obj)
-        else:
-            db.flush()
         return db_obj
 
     def get_imported_usage_summary(

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -1826,5 +1826,235 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         )
         return float(value or 0.0)
 
+    # ------------------------------------------------------------------
+    # Imported (observed) usage — spend the gateway cannot see (issue #123)
+    # ------------------------------------------------------------------
+    #
+    # Imported rows use ``action_type='imported_usage'`` so every gateway
+    # aggregation above (summaries, budgets, spend caps, accounting health),
+    # which filters on ``action_type == 'model_gateway'``, is structurally
+    # unable to mix imported spend into gateway-metered spend. Budget-bucket
+    # accumulation is deliberately NOT performed for imported rows.
+
+    IMPORTED_USAGE_ACTION_TYPE = "imported_usage"
+
+    def log_imported_usage_event(
+        self,
+        db: Session,
+        *,
+        account_id: str,
+        user_id: Optional[str] = None,
+        timestamp: datetime,
+        model_alias: str,
+        source: str,
+        prompt_tokens: Optional[int] = None,
+        completion_tokens: Optional[int] = None,
+        total_tokens: Optional[int] = None,
+        cache_read_tokens: Optional[int] = None,
+        cache_creation_tokens: Optional[int] = None,
+        cost_usd: Optional[float] = None,
+        runtime_principal_type: Optional[str] = None,
+        runtime_principal_id: Optional[str] = None,
+        runtime_principal_name: Optional[str] = None,
+        import_fingerprint: Optional[str] = None,
+        meta_data: Optional[Dict[str, Any]] = None,
+        commit: bool = True,
+    ) -> Optional[ApiUsage]:
+        """Record one imported usage event in the cost ledger.
+
+        Args:
+            db: Database session.
+            account_id: Owning account id.
+            user_id: Importing user's id, for audit.
+            timestamp: When the usage occurred at the source vendor.
+            model_alias: Source-reported model name (e.g. ``composer``).
+            source: Origin label (e.g. ``cursor``); stored in
+                ``meta_data.import_source``.
+            prompt_tokens: Input tokens reported by the source.
+            completion_tokens: Output tokens reported by the source.
+            total_tokens: Total tokens; derived from prompt+completion when
+                absent.
+            cache_read_tokens: Cache-read tokens reported by the source.
+            cache_creation_tokens: Cache-write tokens reported by the source.
+            cost_usd: Amount the source vendor charged, in USD. Stored in
+                ``estimated_cost`` with ``cost_source='imported'``.
+            runtime_principal_type: Managed-agent principal type attribution.
+            runtime_principal_id: Managed-agent principal id attribution.
+            runtime_principal_name: Managed-agent display name attribution.
+            import_fingerprint: Stable dedupe key; when a row with the same
+                fingerprint already exists for the account, the event is
+                skipped and ``None`` is returned (re-importing the same CSV
+                must not double-count spend).
+            meta_data: Extra keys merged into the stored ``meta_data``.
+            commit: When False, flush only so callers can batch commits.
+
+        Returns:
+            The created row, or ``None`` when skipped as a duplicate.
+        """
+        if import_fingerprint:
+            exists = (
+                db.query(ApiUsage.id)
+                .filter(
+                    ApiUsage.account_id == account_id,
+                    ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,
+                    ApiUsage.meta_data["import_fingerprint"].astext
+                    == import_fingerprint,
+                )
+                .first()
+            )
+            if exists is not None:
+                return None
+
+        if total_tokens is None and (
+            prompt_tokens is not None or completion_tokens is not None
+        ):
+            total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
+
+        merged_meta: Dict[str, Any] = dict(meta_data or {})
+        merged_meta["import_source"] = source
+        if import_fingerprint:
+            merged_meta["import_fingerprint"] = import_fingerprint
+
+        db_obj = ApiUsage(
+            user_id=user_id,
+            account_id=account_id,
+            endpoint=f"/usage/import/{source}",
+            method="POST",
+            status_code=200,
+            duration=0.0,
+            action_type=self.IMPORTED_USAGE_ACTION_TYPE,
+            model_alias=model_alias,
+            provider_name=source,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
+            estimated_cost=cost_usd,
+            currency="USD" if cost_usd is not None else None,
+            cost_source="imported" if cost_usd is not None else None,
+            usage_source="imported",
+            runtime_principal_type=runtime_principal_type,
+            runtime_principal_id=runtime_principal_id,
+            runtime_principal_name=runtime_principal_name,
+            meta_data=merged_meta,
+            timestamp=timestamp,
+        )
+        db.add(db_obj)
+        if commit:
+            db.commit()
+            db.refresh(db_obj)
+        else:
+            db.flush()
+        return db_obj
+
+    def get_imported_usage_summary(
+        self,
+        db: Session,
+        *,
+        account_id: str,
+        start_date: datetime,
+        end_date: datetime,
+        runtime_principal_id: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Aggregate imported usage totals for an account in a window.
+
+        Args:
+            db: Database session.
+            account_id: Account whose imported usage is aggregated.
+            start_date: Inclusive lower bound on event timestamp.
+            end_date: Exclusive upper bound on event timestamp.
+            runtime_principal_id: Restrict to one managed-agent principal.
+            source: Restrict to one import source label (e.g. ``cursor``).
+
+        Returns:
+            Dict with ``event_count``, ``total_tokens``, ``imported_cost``.
+        """
+        query = db.query(
+            func.count(ApiUsage.id).label("event_count"),
+            func.coalesce(func.sum(ApiUsage.total_tokens), 0).label("total_tokens"),
+            func.coalesce(func.sum(ApiUsage.estimated_cost), 0.0).label(
+                "imported_cost"
+            ),
+        ).filter(
+            ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,
+            ApiUsage.account_id == account_id,
+            ApiUsage.timestamp >= start_date,
+            ApiUsage.timestamp < end_date,
+        )
+        if runtime_principal_id:
+            query = query.filter(ApiUsage.runtime_principal_id == runtime_principal_id)
+        if source:
+            query = query.filter(ApiUsage.meta_data["import_source"].astext == source)
+        row = query.one()
+        return {
+            "event_count": int(row.event_count or 0),
+            "total_tokens": int(row.total_tokens or 0),
+            "imported_cost": float(row.imported_cost or 0.0),
+        }
+
+    def get_imported_usage_by_model(
+        self,
+        db: Session,
+        *,
+        account_id: str,
+        start_date: datetime,
+        end_date: datetime,
+        runtime_principal_id: Optional[str] = None,
+        source: Optional[str] = None,
+        limit: Optional[int] = 20,
+    ) -> List[Dict[str, Any]]:
+        """Group imported usage by source-reported model.
+
+        Args:
+            db: Database session.
+            account_id: Account whose imported usage is aggregated.
+            start_date: Inclusive lower bound on event timestamp.
+            end_date: Exclusive upper bound on event timestamp.
+            runtime_principal_id: Restrict to one managed-agent principal.
+            source: Restrict to one import source label.
+            limit: Maximum grouped rows, ordered by event count descending.
+
+        Returns:
+            One dict per (model, source) group with counts, tokens, cost.
+        """
+        import_source = ApiUsage.meta_data["import_source"].astext
+        query = db.query(
+            ApiUsage.model_alias,
+            import_source.label("source"),
+            func.count(ApiUsage.id).label("request_count"),
+            func.coalesce(func.sum(ApiUsage.total_tokens), 0).label("total_tokens"),
+            func.coalesce(func.sum(ApiUsage.estimated_cost), 0.0).label(
+                "imported_cost"
+            ),
+            func.max(ApiUsage.timestamp).label("last_event_at"),
+        ).filter(
+            ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,
+            ApiUsage.account_id == account_id,
+            ApiUsage.timestamp >= start_date,
+            ApiUsage.timestamp < end_date,
+        )
+        if runtime_principal_id:
+            query = query.filter(ApiUsage.runtime_principal_id == runtime_principal_id)
+        if source:
+            query = query.filter(import_source == source)
+        query = query.group_by(ApiUsage.model_alias, import_source).order_by(
+            func.count(ApiUsage.id).desc()
+        )
+        if limit is not None:
+            query = query.limit(limit)
+        return [
+            {
+                "model_alias": row.model_alias,
+                "source": row.source,
+                "request_count": int(row.request_count or 0),
+                "total_tokens": int(row.total_tokens or 0),
+                "imported_cost": float(row.imported_cost or 0.0),
+                "last_event_at": row.last_event_at,
+            }
+            for row in query.all()
+        ]
+
 
 crud_api_usage = CRUDApiUsage(ApiUsage)

--- a/backend/preloop/models/crud/managed_agent.py
+++ b/backend/preloop/models/crud/managed_agent.py
@@ -295,6 +295,25 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
             .first()
         )
 
+    def list_by_kind(
+        self, db: Session, *, account_id: str, agent_kind: str
+    ) -> list[ManagedAgent]:
+        """Return the account's managed agents of one kind, newest first.
+
+        Used by the usage ingest API to resolve the default attribution
+        target (the managed Cursor agent from onboarding) when the caller
+        does not name an agent explicitly.
+        """
+        return (
+            db.query(self.model)
+            .filter(
+                self.model.account_id == account_id,
+                self.model.agent_kind == agent_kind,
+            )
+            .order_by(self.model.created_at.desc())
+            .all()
+        )
+
     def get_for_account(
         self, db: Session, *, account_id: str, agent_id: str
     ) -> Optional[ManagedAgent]:

--- a/backend/preloop/models/models/api_usage.py
+++ b/backend/preloop/models/models/api_usage.py
@@ -106,9 +106,9 @@ class ApiUsage(Base):
     estimated_cost: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     # ISO-4217 code of estimated_cost; NULL on legacy rows means USD.
     currency: Mapped[Optional[str]] = mapped_column(String(3), nullable=True)
-    # override | model_config | catalog | subscription | unpriced
+    # override | model_config | catalog | subscription | unpriced | imported
     cost_source: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
-    # provider | estimated | partial
+    # provider | estimated | partial | imported
     usage_source: Mapped[Optional[str]] = mapped_column(String(16), nullable=True)
     is_retry: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
     runtime_principal_type: Mapped[Optional[str]] = mapped_column(
@@ -147,12 +147,13 @@ class ApiUsage(Base):
     __table_args__ = (
         CheckConstraint(
             "cost_source IS NULL OR cost_source IN "
-            "('override', 'model_config', 'catalog', 'subscription', 'unpriced')",
+            "('override', 'model_config', 'catalog', 'subscription', 'unpriced', "
+            "'imported')",
             name="ck_api_usage_cost_source",
         ),
         CheckConstraint(
             "usage_source IS NULL OR usage_source IN "
-            "('provider', 'estimated', 'partial')",
+            "('provider', 'estimated', 'partial', 'imported')",
             name="ck_api_usage_usage_source",
         ),
         Index(

--- a/backend/preloop/models/models/api_usage.py
+++ b/backend/preloop/models/models/api_usage.py
@@ -6,7 +6,7 @@ from datetime import datetime
 # Use TYPE_CHECKING to avoid circular imports
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import CheckConstraint, ForeignKey, Index, func
+from sqlalchemy import CheckConstraint, ForeignKey, Index, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import Boolean, DateTime, Float, Integer, String
@@ -170,6 +170,18 @@ class ApiUsage(Base):
             "runtime_principal_id",
             "timestamp",
             postgresql_ops={"timestamp": "DESC"},
+        ),
+        # Imported-usage dedupe is enforced at the DB level: concurrent
+        # imports of the same event race past the application-level
+        # existence check under READ COMMITTED, so uniqueness of the
+        # fingerprint per account is the source of truth. NULL fingerprints
+        # are distinct, so fingerprint-less rows never conflict.
+        Index(
+            "ix_api_usage_imported_fingerprint_uniq",
+            "account_id",
+            text("(meta_data->>'import_fingerprint')"),
+            unique=True,
+            postgresql_where=text("action_type = 'imported_usage'"),
         ),
     )
 

--- a/backend/preloop/schemas/cost_analytics.py
+++ b/backend/preloop/schemas/cost_analytics.py
@@ -213,6 +213,31 @@ class PriceCatalogInfo(BaseModel):
     model_count: Optional[int] = None
 
 
+class ImportedUsageByModel(BaseModel):
+    """Imported (observed) usage aggregate grouped by source model."""
+
+    model_alias: Optional[str] = None
+    source: Optional[str] = None
+    request_count: int = 0
+    total_tokens: int = 0
+    imported_cost: float = 0.0
+    last_event_at: Optional[datetime] = None
+
+
+class ImportedUsageSummary(BaseModel):
+    """Spend ingested from outside the gateway (``usage_source='imported'``).
+
+    Kept as a separate block — never merged into ``estimated_cost`` or the
+    budget figures — so gateway-metered and imported spend cannot be
+    silently mixed.
+    """
+
+    event_count: int = 0
+    total_tokens: int = 0
+    imported_cost: float = 0.0
+    usage_by_model: List[ImportedUsageByModel] = Field(default_factory=list)
+
+
 class CostAnalyticsSummaryResponse(BaseModel):
     """Open-source cost overview response."""
 
@@ -232,6 +257,7 @@ class CostAnalyticsSummaryResponse(BaseModel):
     usage_by_flow: List[GatewayUsageByFlow] = Field(default_factory=list)
     usage_by_session: List[GatewayUsageBySession] = Field(default_factory=list)
     usage_by_tool: List[GatewayUsageByTool] = Field(default_factory=list)
+    imported_usage: Optional[ImportedUsageSummary] = None
 
 
 class RepriceRequest(BaseModel):

--- a/backend/preloop/schemas/usage_import.py
+++ b/backend/preloop/schemas/usage_import.py
@@ -58,6 +58,8 @@ class UsageImportEvent(BaseModel):
                 self.prompt_tokens,
                 self.completion_tokens,
                 self.total_tokens,
+                self.cache_read_tokens,
+                self.cache_creation_tokens,
             )
         )
         has_cost = self.charged_cents is not None or self.cost_usd is not None

--- a/backend/preloop/schemas/usage_import.py
+++ b/backend/preloop/schemas/usage_import.py
@@ -118,14 +118,3 @@ class UsageImportCsvResponse(UsageImportResponse):
     parsed_rows: int = 0
     skipped_rows: int = 0
     skipped_row_reasons: List[str] = Field(default_factory=list)
-
-
-class ImportedUsageByModel(BaseModel):
-    """Imported-usage aggregate grouped by model."""
-
-    model_alias: Optional[str] = None
-    source: Optional[str] = None
-    request_count: int = 0
-    total_tokens: int = 0
-    imported_cost: float = 0.0
-    last_event_at: Optional[datetime] = None

--- a/backend/preloop/schemas/usage_import.py
+++ b/backend/preloop/schemas/usage_import.py
@@ -1,0 +1,131 @@
+"""Schemas for the usage ingest API (issue #123).
+
+Normalized usage events observed OUTSIDE the model gateway (e.g. Cursor
+bundled-model spend exported from the Cursor dashboard) are ingested into the
+cost ledger with ``usage_source='imported'`` so they are visible in Cost
+analytics without ever mixing into gateway budget accounting.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+#: Hard cap on events per ingest request; callers must batch beyond this.
+MAX_EVENTS_PER_REQUEST = 5000
+
+
+class UsageImportEvent(BaseModel):
+    """One normalized usage event observed outside the model gateway."""
+
+    timestamp: datetime
+    model: str = Field(..., min_length=1, max_length=255)
+    prompt_tokens: Optional[int] = Field(default=None, ge=0)
+    completion_tokens: Optional[int] = Field(default=None, ge=0)
+    total_tokens: Optional[int] = Field(default=None, ge=0)
+    cache_read_tokens: Optional[int] = Field(default=None, ge=0)
+    cache_creation_tokens: Optional[int] = Field(default=None, ge=0)
+    charged_cents: Optional[float] = Field(
+        default=None,
+        ge=0,
+        description="Amount charged by the source vendor, in cents (USD).",
+    )
+    cost_usd: Optional[float] = Field(
+        default=None,
+        ge=0,
+        description="Amount charged in USD. Mutually exclusive with charged_cents.",
+    )
+    session_id: Optional[str] = Field(default=None, max_length=255)
+    kind: Optional[str] = Field(
+        default=None,
+        max_length=100,
+        description="Source billing category (e.g. 'Usage-based', 'Included').",
+    )
+    max_mode: Optional[bool] = None
+    meta: Optional[Dict[str, Any]] = None
+
+    @model_validator(mode="after")
+    def validate_measurement_present(self) -> "UsageImportEvent":
+        """Require at least one measurable quantity (tokens or money)."""
+        if self.charged_cents is not None and self.cost_usd is not None:
+            raise ValueError("Provide charged_cents or cost_usd, not both")
+        has_tokens = any(
+            value is not None
+            for value in (
+                self.prompt_tokens,
+                self.completion_tokens,
+                self.total_tokens,
+            )
+        )
+        has_cost = self.charged_cents is not None or self.cost_usd is not None
+        if not has_tokens and not has_cost:
+            raise ValueError("Event must carry token counts and/or a charged amount")
+        return self
+
+    def resolved_cost_usd(self) -> Optional[float]:
+        """Return the event's charged amount in USD, if any."""
+        if self.cost_usd is not None:
+            return float(self.cost_usd)
+        if self.charged_cents is not None:
+            return float(self.charged_cents) / 100.0
+        return None
+
+
+class UsageImportRequest(BaseModel):
+    """Batch of normalized usage events to ingest."""
+
+    events: List[UsageImportEvent] = Field(
+        ..., min_length=1, max_length=MAX_EVENTS_PER_REQUEST
+    )
+    agent_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "Managed agent to attribute the events to. When omitted, the "
+            "account's managed Cursor agent (from `preloop agents onboard "
+            "cursor`) is used if exactly resolvable."
+        ),
+    )
+    source: str = Field(
+        default="cursor",
+        min_length=1,
+        max_length=64,
+        description="Origin label stored on each row (e.g. 'cursor').",
+    )
+
+    @field_validator("source")
+    @classmethod
+    def normalize_source(cls, value: str) -> str:
+        """Normalize the source label for stable filtering."""
+        return value.strip().lower()
+
+
+class UsageImportResponse(BaseModel):
+    """Result of an ingest request."""
+
+    imported: int = 0
+    skipped_duplicates: int = 0
+    agent_id: Optional[UUID] = None
+    agent_display_name: Optional[str] = None
+    source: str = "cursor"
+
+
+class UsageImportCsvResponse(UsageImportResponse):
+    """Result of a CSV import, including rows the parser could not use."""
+
+    parsed_rows: int = 0
+    skipped_rows: int = 0
+    skipped_row_reasons: List[str] = Field(default_factory=list)
+
+
+class ImportedUsageByModel(BaseModel):
+    """Imported-usage aggregate grouped by model."""
+
+    model_alias: Optional[str] = None
+    source: Optional[str] = None
+    request_count: int = 0
+    total_tokens: int = 0
+    imported_cost: float = 0.0
+    last_event_at: Optional[datetime] = None

--- a/backend/preloop/services/usage_import.py
+++ b/backend/preloop/services/usage_import.py
@@ -41,6 +41,9 @@ DEFAULT_AGENT_KIND = "cursor"
 #: Hard cap on CSV size accepted by the import endpoint (10 MiB).
 MAX_CSV_BYTES = 10 * 1024 * 1024
 
+#: Hard cap on data rows per CSV import; larger exports must be split.
+MAX_CSV_ROWS = 10_000
+
 
 class UsageImportError(ValueError):
     """Raised when an ingest request cannot be attributed or parsed."""
@@ -158,10 +161,20 @@ def ingest_events(
     Returns:
         Tuple of (imported_count, skipped_duplicate_count). The write is
         committed once at the end so a batch is all-or-nothing.
+
+    Raises:
+        UsageImportError: When the agent has no ``session_source_id`` — the
+            fingerprint is scoped by it, so a missing value would silently
+            merge the dedupe scopes of unrelated agents.
     """
     imported = 0
     skipped = 0
     principal_id = agent.session_source_id
+    if not principal_id:
+        raise UsageImportError(
+            f"Managed agent {agent.id} has no session_source_id; imported "
+            "events cannot be fingerprinted for deduplication"
+        )
     for event in events:
         timestamp = event.timestamp
         if timestamp.tzinfo is not None:
@@ -320,6 +333,7 @@ def parse_cursor_usage_csv(
     *,
     column_map: Optional[Dict[str, str]] = None,
     max_skipped_reasons: int = 20,
+    max_rows: int = MAX_CSV_ROWS,
 ) -> CsvParseResult:
     """Parse a Cursor dashboard Usage CSV export into normalized events.
 
@@ -332,13 +346,17 @@ def parse_cursor_usage_csv(
             CSV header names, for export shapes the built-in matcher does
             not recognize.
         max_skipped_reasons: Cap on per-row skip reasons returned.
+        max_rows: Hard cap on data rows; parsing aborts beyond it so one
+            request cannot fan out into an unbounded number of events.
 
     Returns:
         CsvParseResult with normalized events and per-row skip accounting.
 
     Raises:
         UsageImportError: When the CSV has no parseable header (required
-            columns ``Date`` and ``Model`` not found).
+            columns ``Date`` and ``Model`` not found), or when it carries
+            more than ``max_rows`` data rows (split the export and import
+            in batches).
     """
     for key in column_map or {}:
         if key not in _CURSOR_LOGICAL_FIELDS:
@@ -388,6 +406,11 @@ def parse_cursor_usage_csv(
     for line_number, row in enumerate(reader, start=2):
         if not row or all(not value.strip() for value in row):
             continue
+        if result.parsed_rows >= max_rows:
+            raise UsageImportError(
+                f"CSV has more than {max_rows} data rows; split the export "
+                "and import it in batches"
+            )
         result.parsed_rows += 1
 
         timestamp = _parse_date(cell(row, "date"))

--- a/backend/preloop/services/usage_import.py
+++ b/backend/preloop/services/usage_import.py
@@ -1,0 +1,442 @@
+"""Usage ingest service: spend the model gateway cannot see (issue #123).
+
+Cursor's bundled models (Composer, Auto, ...) never traverse the Preloop
+model gateway, so their spend is invisible to Cost analytics. This service
+ingests normalized usage events — pushed through the API or parsed from the
+Cursor dashboard Usage CSV export — into the cost ledger as
+``action_type='imported_usage'`` rows labeled ``usage_source='imported'``.
+
+Design invariants:
+
+- Imported rows NEVER mix with gateway-metered spend: every gateway
+  aggregation filters on ``action_type == 'model_gateway'`` and budget-bucket
+  accumulation is not performed for imported rows.
+- Re-importing the same data is idempotent: each event carries a stable
+  fingerprint and duplicate fingerprints are skipped.
+- No reverse-engineered vendor auth: input is either the caller's own
+  normalized events or the CSV file the vendor's dashboard officially exports.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from preloop.models.crud import crud_api_usage, crud_managed_agent
+from preloop.models.models.managed_agent import ManagedAgent
+from preloop.schemas.usage_import import UsageImportEvent
+
+logger = logging.getLogger(__name__)
+
+#: Default agent kind resolved when the caller does not name an agent.
+DEFAULT_AGENT_KIND = "cursor"
+
+#: Hard cap on CSV size accepted by the import endpoint (10 MiB).
+MAX_CSV_BYTES = 10 * 1024 * 1024
+
+
+class UsageImportError(ValueError):
+    """Raised when an ingest request cannot be attributed or parsed."""
+
+
+@dataclass
+class CsvParseResult:
+    """Outcome of parsing a Cursor usage CSV export."""
+
+    events: List[UsageImportEvent] = field(default_factory=list)
+    parsed_rows: int = 0
+    skipped_rows: int = 0
+    skipped_row_reasons: List[str] = field(default_factory=list)
+
+
+def resolve_target_agent(
+    db: Session,
+    *,
+    account_id: str,
+    agent_id: Optional[str] = None,
+    default_agent_kind: str = DEFAULT_AGENT_KIND,
+) -> ManagedAgent:
+    """Resolve the managed agent imported events are attributed to.
+
+    Args:
+        db: Database session.
+        account_id: Owning account id.
+        agent_id: Explicit managed agent id, when the caller provided one.
+        default_agent_kind: Agent kind used for default resolution.
+
+    Returns:
+        The target ManagedAgent.
+
+    Raises:
+        UsageImportError: When the explicit agent does not exist in the
+            account, when no agent of the default kind exists, or when
+            several exist and the caller must disambiguate.
+    """
+    if agent_id:
+        agent = crud_managed_agent.get_for_account(
+            db, account_id=account_id, agent_id=str(agent_id)
+        )
+        if agent is None:
+            raise UsageImportError(f"Managed agent {agent_id} not found")
+        return agent
+
+    candidates = crud_managed_agent.list_by_kind(
+        db, account_id=account_id, agent_kind=default_agent_kind
+    )
+    if not candidates:
+        raise UsageImportError(
+            f"No managed '{default_agent_kind}' agent found. Onboard one with "
+            f"`preloop agents onboard {default_agent_kind}` or pass agent_id "
+            "explicitly."
+        )
+    if len(candidates) > 1:
+        ids = ", ".join(str(agent.id) for agent in candidates[:5])
+        raise UsageImportError(
+            f"Multiple managed '{default_agent_kind}' agents found ({ids}). "
+            "Pass agent_id to choose one."
+        )
+    return candidates[0]
+
+
+def event_fingerprint(
+    event: UsageImportEvent, *, source: str, agent_principal_id: str
+) -> str:
+    """Compute a stable dedupe fingerprint for one normalized event.
+
+    The fingerprint covers the fields that identify a usage row at the
+    source (timestamp, model, token counts, charged amount, session id) plus
+    the attribution target, so importing the same CSV twice — or replaying
+    the same API batch — cannot double-count spend, while two genuinely
+    distinct events that happen to share a timestamp+model still both land
+    if any measured quantity differs.
+    """
+    cost = event.resolved_cost_usd()
+    payload = "|".join(
+        [
+            source,
+            agent_principal_id,
+            event.timestamp.isoformat(),
+            event.model,
+            str(event.prompt_tokens),
+            str(event.completion_tokens),
+            str(event.total_tokens),
+            str(event.cache_read_tokens),
+            str(event.cache_creation_tokens),
+            f"{cost:.6f}" if cost is not None else "None",
+            event.session_id or "",
+        ]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def ingest_events(
+    db: Session,
+    *,
+    account_id: str,
+    user_id: Optional[str],
+    agent: ManagedAgent,
+    events: List[UsageImportEvent],
+    source: str,
+) -> Tuple[int, int]:
+    """Write normalized events into the cost ledger, deduplicated.
+
+    Args:
+        db: Database session.
+        account_id: Owning account id.
+        user_id: Importing user's id, for audit.
+        agent: Managed agent the events are attributed to.
+        events: Normalized usage events.
+        source: Origin label (e.g. ``cursor``).
+
+    Returns:
+        Tuple of (imported_count, skipped_duplicate_count). The write is
+        committed once at the end so a batch is all-or-nothing.
+    """
+    imported = 0
+    skipped = 0
+    principal_id = agent.session_source_id
+    for event in events:
+        timestamp = event.timestamp
+        if timestamp.tzinfo is not None:
+            timestamp = timestamp.astimezone(timezone.utc).replace(tzinfo=None)
+        meta: Dict[str, Any] = {"managed_agent_id": str(agent.id)}
+        if event.session_id:
+            meta["source_session_id"] = event.session_id
+        if event.kind:
+            meta["source_kind"] = event.kind
+        if event.max_mode is not None:
+            meta["max_mode"] = event.max_mode
+        if event.meta:
+            for key, value in event.meta.items():
+                meta.setdefault(key, value)
+        row = crud_api_usage.log_imported_usage_event(
+            db,
+            account_id=account_id,
+            user_id=user_id,
+            timestamp=timestamp,
+            model_alias=event.model,
+            source=source,
+            prompt_tokens=event.prompt_tokens,
+            completion_tokens=event.completion_tokens,
+            total_tokens=event.total_tokens,
+            cache_read_tokens=event.cache_read_tokens,
+            cache_creation_tokens=event.cache_creation_tokens,
+            cost_usd=event.resolved_cost_usd(),
+            runtime_principal_type=agent.session_source_type,
+            runtime_principal_id=principal_id,
+            runtime_principal_name=agent.display_name,
+            import_fingerprint=event_fingerprint(
+                event, source=source, agent_principal_id=principal_id
+            ),
+            meta_data=meta,
+            commit=False,
+        )
+        if row is None:
+            skipped += 1
+        else:
+            imported += 1
+    db.commit()
+    return imported, skipped
+
+
+# ---------------------------------------------------------------------------
+# Cursor dashboard Usage CSV export parsing
+# ---------------------------------------------------------------------------
+#
+# Observed header shape (Cursor dashboard → Usage → Export CSV; confirmed via
+# Cursor forum/staff posts and community parsers, 2026-07):
+#
+#   Date, [User,] Kind, Model, [Max Mode,] Input (w/ Cache Write),
+#   Input (w/o Cache Write), Cache Read, Output Tokens, Total Tokens, Cost
+#
+# "Max Mode" and "User" appear in newer/team exports. The Cost column may
+# contain "$1.23", "Included", "-", or empty. Header matching below is
+# case-insensitive and prefix-based, so column reordering and the known
+# variants parse without configuration; a custom ``column_map`` can override
+# any logical field for future shapes.
+
+_CURSOR_LOGICAL_FIELDS = (
+    "date",
+    "kind",
+    "model",
+    "max_mode",
+    "input_with_cache_write",
+    "input_without_cache_write",
+    "cache_read",
+    "output_tokens",
+    "total_tokens",
+    "cost",
+)
+
+_CURSOR_DATE_FORMATS = (
+    "%Y-%m-%dT%H:%M:%S.%f%z",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d",
+    "%m/%d/%Y",
+)
+
+
+def _match_cursor_header(header: str) -> Optional[str]:
+    """Map one raw CSV header to a logical field name, or None."""
+    normalized = header.strip().lower().lstrip("﻿")
+    if normalized == "date":
+        return "date"
+    if normalized == "kind" or normalized == "type":
+        return "kind"
+    if normalized == "model":
+        return "model"
+    if normalized == "max mode":
+        return "max_mode"
+    if normalized.startswith("input (w/ cache") or normalized.startswith(
+        "input (w/cache"
+    ):
+        return "input_with_cache_write"
+    if normalized.startswith("input (w/o cache"):
+        return "input_without_cache_write"
+    if normalized.startswith("cache read"):
+        return "cache_read"
+    if normalized.startswith("output"):
+        return "output_tokens"
+    if normalized.startswith("total"):
+        return "total_tokens"
+    if normalized == "cost" or normalized.startswith("cost to you"):
+        return "cost"
+    return None
+
+
+def _parse_int(value: str) -> Optional[int]:
+    """Parse a token count; tolerate separators and placeholder values."""
+    cleaned = value.strip().replace(",", "")
+    if not cleaned or cleaned in {"-", "N/A", "n/a"}:
+        return None
+    try:
+        return int(cleaned)
+    except ValueError:
+        return None
+
+
+def _parse_cost(value: str) -> Optional[float]:
+    """Parse a Cost cell; 'Included'/'-'/'' mean no charged amount."""
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    if cleaned.lower() in {"included", "-", "nan", "n/a", "free"}:
+        return None
+    cleaned = cleaned.replace("$", "").replace(",", "").strip()
+    try:
+        parsed = float(cleaned)
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _parse_date(value: str) -> Optional[datetime]:
+    """Parse the Date cell across formats Cursor has emitted."""
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    for fmt in _CURSOR_DATE_FORMATS:
+        try:
+            return datetime.strptime(cleaned, fmt)
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+
+def parse_cursor_usage_csv(
+    content: bytes,
+    *,
+    column_map: Optional[Dict[str, str]] = None,
+    max_skipped_reasons: int = 20,
+) -> CsvParseResult:
+    """Parse a Cursor dashboard Usage CSV export into normalized events.
+
+    Args:
+        content: Raw CSV bytes as exported from the Cursor dashboard.
+        column_map: Optional overrides mapping logical field names
+            (``date``, ``model``, ``cost``, ``kind``, ``max_mode``,
+            ``input_with_cache_write``, ``input_without_cache_write``,
+            ``cache_read``, ``output_tokens``, ``total_tokens``) to exact
+            CSV header names, for export shapes the built-in matcher does
+            not recognize.
+        max_skipped_reasons: Cap on per-row skip reasons returned.
+
+    Returns:
+        CsvParseResult with normalized events and per-row skip accounting.
+
+    Raises:
+        UsageImportError: When the CSV has no parseable header (required
+            columns ``Date`` and ``Model`` not found).
+    """
+    for key in column_map or {}:
+        if key not in _CURSOR_LOGICAL_FIELDS:
+            raise UsageImportError(f"Unknown column_map field: {key!r}")
+
+    try:
+        text = content.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise UsageImportError("CSV is not valid UTF-8") from exc
+
+    reader = csv.reader(io.StringIO(text))
+    try:
+        headers = next(reader)
+    except StopIteration:
+        raise UsageImportError("CSV is empty") from None
+
+    index: Dict[str, int] = {}
+    explicit = {
+        header.strip().lower(): logical
+        for logical, header in (column_map or {}).items()
+    }
+    for position, header in enumerate(headers):
+        logical = explicit.get(header.strip().lower()) or _match_cursor_header(header)
+        if logical and logical not in index:
+            index[logical] = position
+
+    if "date" not in index or "model" not in index:
+        raise UsageImportError(
+            "Unrecognized CSV header: required columns 'Date' and 'Model' not "
+            f"found in {headers!r}. Pass column_map to map your export's "
+            "columns onto the expected fields."
+        )
+
+    result = CsvParseResult()
+
+    def cell(row: List[str], logical: str) -> str:
+        position = index.get(logical)
+        if position is None or position >= len(row):
+            return ""
+        return row[position]
+
+    def skip(line_number: int, reason: str) -> None:
+        result.skipped_rows += 1
+        if len(result.skipped_row_reasons) < max_skipped_reasons:
+            result.skipped_row_reasons.append(f"line {line_number}: {reason}")
+
+    for line_number, row in enumerate(reader, start=2):
+        if not row or all(not value.strip() for value in row):
+            continue
+        result.parsed_rows += 1
+
+        timestamp = _parse_date(cell(row, "date"))
+        if timestamp is None:
+            skip(line_number, f"unparseable date {cell(row, 'date')!r}")
+            continue
+        model = cell(row, "model").strip()
+        if not model:
+            skip(line_number, "missing model")
+            continue
+
+        input_with = _parse_int(cell(row, "input_with_cache_write"))
+        input_without = _parse_int(cell(row, "input_without_cache_write"))
+        cache_read = _parse_int(cell(row, "cache_read"))
+        output_tokens = _parse_int(cell(row, "output_tokens"))
+        total_tokens = _parse_int(cell(row, "total_tokens"))
+        cost = _parse_cost(cell(row, "cost"))
+
+        # "Input (w/ Cache Write)" counts tokens that also wrote cache;
+        # the two input columns are disjoint slices of prompt tokens.
+        prompt_tokens = None
+        if input_with is not None or input_without is not None:
+            prompt_tokens = (input_with or 0) + (input_without or 0)
+
+        if (
+            prompt_tokens is None
+            and output_tokens is None
+            and (total_tokens is None and cost is None)
+        ):
+            skip(line_number, "row carries neither token counts nor a cost")
+            continue
+
+        kind = cell(row, "kind").strip() or None
+        max_mode_raw = cell(row, "max_mode").strip().lower()
+        max_mode = max_mode_raw in {"true", "yes", "1", "on"} if max_mode_raw else None
+
+        result.events.append(
+            UsageImportEvent(
+                timestamp=timestamp,
+                model=model,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=output_tokens,
+                total_tokens=total_tokens,
+                cache_creation_tokens=input_with,
+                cache_read_tokens=cache_read,
+                cost_usd=cost,
+                kind=kind,
+                max_mode=max_mode,
+            )
+        )
+
+    return result

--- a/backend/tests/endpoints/test_usage_import.py
+++ b/backend/tests/endpoints/test_usage_import.py
@@ -1,0 +1,320 @@
+"""Endpoint tests for the usage ingest API (issue #123).
+
+Covers POST /api/v1/usage/import (normalized JSON events) and
+POST /api/v1/usage/import/csv (Cursor dashboard Usage export), plus the
+integration contract with GET /api/v1/cost/summary: imported spend appears
+as a separate ``imported_usage`` block and never inflates the
+gateway-metered ``estimated_cost``.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from preloop.models.crud import crud_api_usage, crud_managed_agent
+
+IMPORT_URL = "/api/v1/usage/import"
+IMPORT_CSV_URL = "/api/v1/usage/import/csv"
+COST_SUMMARY_URL = "/api/v1/cost/summary"
+
+SAMPLE_CSV = (
+    "Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),"
+    "Cache Read,Output Tokens,Total Tokens,Cost\n"
+    "{date},Usage-based,claude-4.5-sonnet,No,1200,300,4500,850,6850,$0.42\n"
+    "{date},Included,composer,No,0,150,0,90,240,Included\n"
+)
+
+
+def _make_cursor_agent(db, account_id, *, source_id="cursor-ws-1", name="Cursor"):
+    """Register a managed Cursor agent like `preloop agents onboard cursor`."""
+    return crud_managed_agent.upsert_from_runtime_session(
+        db,
+        account_id=account_id,
+        runtime_session_id=None,
+        session_source_type="cursor",
+        session_source_id=source_id,
+        display_name=name,
+    )
+
+
+def _events_payload(**overrides):
+    """Build a minimal valid ingest payload."""
+    timestamp = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    payload = {
+        "events": [
+            {
+                "timestamp": timestamp,
+                "model": "composer",
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "cost_usd": 0.25,
+            },
+            {
+                "timestamp": timestamp,
+                "model": "claude-4.5-sonnet",
+                "total_tokens": 600,
+                "charged_cents": 125.0,
+                "session_id": "sess-1",
+            },
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestImportEvents:
+    """POST /api/v1/usage/import."""
+
+    def test_import_attributes_to_default_cursor_agent(
+        self, client, db_session, test_user
+    ):
+        """Events land on the account's managed Cursor agent by default."""
+        agent = _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        response = client.post(IMPORT_URL, json=_events_payload())
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["imported"] == 2
+        assert body["skipped_duplicates"] == 0
+        assert body["agent_id"] == str(agent.id)
+        assert body["agent_display_name"] == "Cursor"
+        assert body["source"] == "cursor"
+
+    def test_import_is_idempotent_on_replay(self, client, db_session, test_user):
+        """Re-sending the same batch skips every event as a duplicate."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        payload = _events_payload()
+
+        first = client.post(IMPORT_URL, json=payload).json()
+        second = client.post(IMPORT_URL, json=payload).json()
+
+        assert first["imported"] == 2
+        assert second["imported"] == 0
+        assert second["skipped_duplicates"] == 2
+
+    def test_import_without_cursor_agent_returns_422(
+        self, client, db_session, test_user
+    ):
+        """With no onboarded Cursor agent and no agent_id, ingest fails."""
+        response = client.post(IMPORT_URL, json=_events_payload())
+
+        assert response.status_code == 422
+        assert "onboard" in response.json()["detail"].lower()
+
+    def test_import_with_ambiguous_default_returns_422(
+        self, client, db_session, test_user
+    ):
+        """Several Cursor agents require an explicit agent_id."""
+        _make_cursor_agent(db_session, test_user.account_id, source_id="ws-1")
+        _make_cursor_agent(db_session, test_user.account_id, source_id="ws-2")
+        db_session.commit()
+
+        response = client.post(IMPORT_URL, json=_events_payload())
+
+        assert response.status_code == 422
+        assert "agent_id" in response.json()["detail"]
+
+    def test_import_with_explicit_agent_id(self, client, db_session, test_user):
+        """An explicit agent_id disambiguates between agents."""
+        _make_cursor_agent(db_session, test_user.account_id, source_id="ws-1")
+        chosen = _make_cursor_agent(
+            db_session, test_user.account_id, source_id="ws-2", name="Cursor B"
+        )
+        db_session.commit()
+
+        response = client.post(
+            IMPORT_URL, json=_events_payload(agent_id=str(chosen.id))
+        )
+
+        assert response.status_code == 200
+        assert response.json()["agent_id"] == str(chosen.id)
+
+    def test_import_rejects_foreign_account_agent(self, client, db_session, test_user):
+        """An agent belonging to another account is not addressable."""
+        from preloop.models.crud import crud_account
+
+        other = crud_account.create(
+            db_session, obj_in={"organization_name": "Other Org", "is_active": True}
+        )
+        foreign_agent = _make_cursor_agent(db_session, other.id)
+        db_session.commit()
+
+        response = client.post(
+            IMPORT_URL, json=_events_payload(agent_id=str(foreign_agent.id))
+        )
+
+        assert response.status_code == 422
+        assert "not found" in response.json()["detail"]
+
+    def test_import_rejects_event_without_measurement(
+        self, client, db_session, test_user
+    ):
+        """An event carrying neither tokens nor money fails validation."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        payload = {
+            "events": [
+                {
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "model": "composer",
+                }
+            ]
+        }
+        response = client.post(IMPORT_URL, json=payload)
+
+        assert response.status_code == 422
+
+    def test_import_rejects_empty_batch(self, client, db_session, test_user):
+        """An empty events list fails request validation."""
+        response = client.post(IMPORT_URL, json={"events": []})
+        assert response.status_code == 422
+
+
+class TestImportCsv:
+    """POST /api/v1/usage/import/csv."""
+
+    def _upload(self, client, csv_text, **form):
+        return client.post(
+            IMPORT_CSV_URL,
+            files={"file": ("usage.csv", csv_text.encode("utf-8"), "text/csv")},
+            data=form,
+        )
+
+    def test_csv_import_success(self, client, db_session, test_user):
+        """A canonical Cursor export imports every row."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        csv_text = SAMPLE_CSV.format(
+            date=(datetime.now(UTC) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S")
+        )
+
+        response = self._upload(client, csv_text)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["parsed_rows"] == 2
+        assert body["imported"] == 2
+        assert body["skipped_rows"] == 0
+        assert body["source"] == "cursor"
+
+    def test_csv_reimport_is_idempotent(self, client, db_session, test_user):
+        """Uploading the same file twice never double-counts spend."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        csv_text = SAMPLE_CSV.format(
+            date=(datetime.now(UTC) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S")
+        )
+
+        first = self._upload(client, csv_text).json()
+        second = self._upload(client, csv_text).json()
+
+        assert first["imported"] == 2
+        assert second["imported"] == 0
+        assert second["skipped_duplicates"] == 2
+
+    def test_csv_unrecognized_header_returns_422(self, client, db_session, test_user):
+        """A CSV without Date/Model columns is rejected with guidance."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        response = self._upload(client, "Foo,Bar\n1,2\n")
+
+        assert response.status_code == 422
+        assert "column_map" in response.json()["detail"]
+
+    def test_csv_with_column_map_override(self, client, db_session, test_user):
+        """column_map maps a foreign export shape onto logical fields."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        csv_text = "When,Which Model,Tokens,Charged\n2026-07-28,composer,42,$0.05\n"
+
+        response = self._upload(
+            client,
+            csv_text,
+            column_map=(
+                '{"date": "When", "model": "Which Model", '
+                '"total_tokens": "Tokens", "cost": "Charged"}'
+            ),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["imported"] == 1
+
+    def test_csv_invalid_column_map_json_returns_422(
+        self, client, db_session, test_user
+    ):
+        """A malformed column_map form field is rejected."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        response = self._upload(client, "Date,Model\n", column_map="{not json")
+
+        assert response.status_code == 422
+        assert "not valid JSON" in response.json()["detail"]
+
+
+class TestCostSummaryIntegration:
+    """Imported spend in GET /api/v1/cost/summary."""
+
+    def test_imported_spend_is_separate_from_gateway_cost(
+        self, client, db_session, test_user
+    ):
+        """Imported spend shows in its own block; gateway cost is untouched."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        crud_api_usage.log_gateway_request(
+            db_session,
+            endpoint="/openai/v1/responses",
+            method="POST",
+            status_code=200,
+            duration=0.1,
+            user_id=str(test_user.id),
+            account_id=str(test_user.account_id),
+            model_alias="openai/gpt-5",
+            provider_name="openai",
+            prompt_tokens=12,
+            completion_tokens=8,
+            total_tokens=20,
+            estimated_cost=0.05,
+        )
+        db_session.commit()
+
+        imported = client.post(IMPORT_URL, json=_events_payload())
+        assert imported.status_code == 200
+
+        body = client.get(COST_SUMMARY_URL).json()
+
+        # Gateway-metered figures unchanged by the import.
+        assert body["total_requests"] == 1
+        assert body["estimated_cost"] == 0.05
+        # Imported block reported separately.
+        block = body["imported_usage"]
+        assert block is not None
+        assert block["event_count"] == 2
+        assert block["imported_cost"] == 1.5  # 0.25 + 125 cents
+        models = {row["model_alias"] for row in block["usage_by_model"]}
+        assert models == {"composer", "claude-4.5-sonnet"}
+
+    def test_summary_without_imports_has_no_block(self, client, db_session, test_user):
+        """With no imported rows the block stays null (not a zero object)."""
+        body = client.get(COST_SUMMARY_URL).json()
+        assert body["imported_usage"] is None
+
+    def test_summary_principal_filter_scopes_imported_block(
+        self, client, db_session, test_user
+    ):
+        """runtime_principal_id filters imported spend like gateway spend."""
+        agent_a = _make_cursor_agent(db_session, test_user.account_id, source_id="ws-A")
+        agent_b = _make_cursor_agent(db_session, test_user.account_id, source_id="ws-B")
+        db_session.commit()
+
+        client.post(IMPORT_URL, json=_events_payload(agent_id=str(agent_a.id)))
+        client.post(IMPORT_URL, json=_events_payload(agent_id=str(agent_b.id)))
+
+        body = client.get(
+            COST_SUMMARY_URL,
+            params={"runtime_principal_id": agent_a.session_source_id},
+        ).json()
+
+        assert body["imported_usage"]["event_count"] == 2

--- a/backend/tests/endpoints/test_usage_import.py
+++ b/backend/tests/endpoints/test_usage_import.py
@@ -254,6 +254,46 @@ class TestImportCsv:
         assert response.status_code == 422
         assert "not valid JSON" in response.json()["detail"]
 
+    def test_csv_exceeding_size_limit_returns_413(
+        self, client, db_session, test_user, monkeypatch
+    ):
+        """An oversized upload is rejected without ingesting anything."""
+        import preloop.api.endpoints.usage_import as usage_import_endpoint
+
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        monkeypatch.setattr(usage_import_endpoint, "MAX_CSV_BYTES", 64)
+
+        oversized = "Date,Model,Total Tokens,Cost\n" + (
+            "2026-07-28,composer,10,$0.01\n" * 20
+        )
+        response = self._upload(client, oversized)
+
+        assert response.status_code == 413
+        assert "exceeds" in response.json()["detail"]
+
+    def test_csv_exceeding_row_limit_returns_422(
+        self, client, db_session, test_user, monkeypatch
+    ):
+        """A CSV with more data rows than the cap is rejected with guidance."""
+        import preloop.services.usage_import as usage_import_service
+
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        monkeypatch.setitem(
+            usage_import_service.parse_cursor_usage_csv.__kwdefaults__,
+            "max_rows",
+            2,
+        )
+
+        csv_text = "Date,Model,Total Tokens,Cost\n" + (
+            "2026-07-28,composer,10,$0.01\n" * 3
+        )
+        response = self._upload(client, csv_text)
+
+        assert response.status_code == 422
+        assert "data rows" in response.json()["detail"]
+
 
 class TestCostSummaryIntegration:
     """Imported spend in GET /api/v1/cost/summary."""

--- a/backend/tests/models/crud/test_imported_usage_crud.py
+++ b/backend/tests/models/crud/test_imported_usage_crud.py
@@ -104,6 +104,59 @@ def test_duplicate_fingerprint_is_skipped(db_session, create_account):
     assert summary["event_count"] == 1
 
 
+def test_db_index_closes_dedupe_race(db_session, create_account, monkeypatch):
+    """The unique partial index catches duplicates the fast-path check missed.
+
+    Simulates the TOCTOU interleaving: a concurrent import commits the same
+    fingerprint after this transaction's existence check ran. Disabling the
+    fast-path check forces the insert to hit the DB index, which must skip
+    the row (return None) instead of double-recording spend or breaking the
+    session/batch.
+    """
+    account = create_account()
+
+    first = _log_imported(
+        db_session, account_id=account.id, import_fingerprint="fp-race"
+    )
+    assert first is not None
+
+    monkeypatch.setattr(
+        crud_api_usage,
+        "_imported_fingerprint_exists",
+        lambda *args, **kwargs: False,
+    )
+    second = _log_imported(
+        db_session, account_id=account.id, import_fingerprint="fp-race"
+    )
+
+    assert second is None
+    # The session survives the caught unique violation: further writes and
+    # reads in the same batch still work.
+    third = _log_imported(
+        db_session, account_id=account.id, import_fingerprint="fp-race-other"
+    )
+    assert third is not None
+
+    summary = crud_api_usage.get_imported_usage_summary(
+        db_session,
+        account_id=str(account.id),
+        start_date=_utcnow_naive() - timedelta(hours=1),
+        end_date=_utcnow_naive() + timedelta(hours=1),
+    )
+    assert summary["event_count"] == 2
+
+
+def test_fingerprintless_rows_never_conflict(db_session, create_account):
+    """Rows without a fingerprint are exempt from the unique index (NULLs)."""
+    account = create_account()
+
+    first = _log_imported(db_session, account_id=account.id)
+    second = _log_imported(db_session, account_id=account.id)
+
+    assert first is not None
+    assert second is not None
+
+
 def test_same_fingerprint_in_other_account_still_lands(db_session, create_account):
     """Dedupe is account-scoped; another account may carry the same key."""
     account_a = create_account()

--- a/backend/tests/models/crud/test_imported_usage_crud.py
+++ b/backend/tests/models/crud/test_imported_usage_crud.py
@@ -1,0 +1,254 @@
+"""Real-DB tests for imported-usage ledger writes (issue #123).
+
+Pins the cost-ledger contract for spend observed outside the model gateway:
+
+  1. Imported events land as ``action_type='imported_usage'`` rows labeled
+     ``usage_source='imported'`` (and ``cost_source='imported'`` when priced).
+  2. Re-importing the same event (same fingerprint) never double-counts.
+  3. Imported aggregations are account-scoped and window/principal/source
+     filterable.
+  4. Gateway aggregations are structurally blind to imported rows, so
+     budgets and gateway spend can never silently mix in imported spend.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from preloop.models.crud import crud_api_usage
+
+
+def _utcnow_naive() -> datetime:
+    """Ledger timestamps are stored naive-UTC."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _log_imported(db, *, account_id, **overrides):
+    """Log one imported usage event with sensible defaults."""
+    params = dict(
+        account_id=str(account_id),
+        timestamp=_utcnow_naive(),
+        model_alias="composer",
+        source="cursor",
+        prompt_tokens=100,
+        completion_tokens=50,
+        cost_usd=0.25,
+    )
+    params.update(overrides)
+    return crud_api_usage.log_imported_usage_event(db, **params)
+
+
+def test_log_imported_usage_event_writes_labeled_ledger_row(
+    db_session, create_account, create_user
+):
+    """The row must carry the imported markers and source metadata."""
+    account = create_account()
+    user = create_user(account=account)
+
+    row = _log_imported(
+        db_session,
+        account_id=account.id,
+        user_id=str(user.id),
+        runtime_principal_type="cursor",
+        runtime_principal_id="cursor-ws-1",
+        runtime_principal_name="Cursor (laptop)",
+        import_fingerprint="fp-write-1",
+        meta_data={"source_kind": "Usage-based"},
+    )
+
+    assert row is not None
+    assert row.action_type == "imported_usage"
+    assert row.usage_source == "imported"
+    assert row.cost_source == "imported"
+    assert row.currency == "USD"
+    assert row.estimated_cost == 0.25
+    assert row.total_tokens == 150  # derived from prompt + completion
+    assert row.provider_name == "cursor"
+    assert row.runtime_principal_id == "cursor-ws-1"
+    assert row.meta_data["import_source"] == "cursor"
+    assert row.meta_data["import_fingerprint"] == "fp-write-1"
+    assert row.meta_data["source_kind"] == "Usage-based"
+
+
+def test_tokens_only_event_has_no_cost_markers(db_session, create_account):
+    """Unpriced (e.g. 'Included') events carry tokens but no cost labels."""
+    account = create_account()
+
+    row = _log_imported(db_session, account_id=account.id, cost_usd=None)
+
+    assert row is not None
+    assert row.estimated_cost is None
+    assert row.cost_source is None
+    assert row.currency is None
+    assert row.usage_source == "imported"
+
+
+def test_duplicate_fingerprint_is_skipped(db_session, create_account):
+    """Replaying an event with a known fingerprint must return None."""
+    account = create_account()
+
+    first = _log_imported(
+        db_session, account_id=account.id, import_fingerprint="fp-dupe"
+    )
+    second = _log_imported(
+        db_session, account_id=account.id, import_fingerprint="fp-dupe"
+    )
+
+    assert first is not None
+    assert second is None
+
+    summary = crud_api_usage.get_imported_usage_summary(
+        db_session,
+        account_id=str(account.id),
+        start_date=_utcnow_naive() - timedelta(hours=1),
+        end_date=_utcnow_naive() + timedelta(hours=1),
+    )
+    assert summary["event_count"] == 1
+
+
+def test_same_fingerprint_in_other_account_still_lands(db_session, create_account):
+    """Dedupe is account-scoped; another account may carry the same key."""
+    account_a = create_account()
+    account_b = create_account()
+
+    row_a = _log_imported(
+        db_session, account_id=account_a.id, import_fingerprint="fp-shared"
+    )
+    row_b = _log_imported(
+        db_session, account_id=account_b.id, import_fingerprint="fp-shared"
+    )
+
+    assert row_a is not None
+    assert row_b is not None
+
+
+def test_summary_is_account_scoped_and_windowed(db_session, create_account):
+    """Totals cover only the account's rows inside the requested window."""
+    account = create_account()
+    other = create_account()
+    now = _utcnow_naive()
+
+    _log_imported(db_session, account_id=account.id, cost_usd=0.30)
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        cost_usd=0.70,
+        timestamp=now - timedelta(days=40),  # outside window
+    )
+    _log_imported(db_session, account_id=other.id, cost_usd=9.99)
+
+    summary = crud_api_usage.get_imported_usage_summary(
+        db_session,
+        account_id=str(account.id),
+        start_date=now - timedelta(days=30),
+        end_date=now + timedelta(hours=1),
+    )
+
+    assert summary["event_count"] == 1
+    assert summary["imported_cost"] == 0.30
+    assert summary["total_tokens"] == 150
+
+
+def test_summary_filters_by_principal_and_source(db_session, create_account):
+    """runtime_principal_id and source restrict the aggregation."""
+    account = create_account()
+    now = _utcnow_naive()
+
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        runtime_principal_id="ws-A",
+        source="cursor",
+        cost_usd=0.10,
+    )
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        runtime_principal_id="ws-B",
+        source="windsurf",
+        cost_usd=0.20,
+    )
+
+    window = dict(
+        account_id=str(account.id),
+        start_date=now - timedelta(hours=1),
+        end_date=now + timedelta(hours=1),
+    )
+
+    by_principal = crud_api_usage.get_imported_usage_summary(
+        db_session, runtime_principal_id="ws-A", **window
+    )
+    assert by_principal["event_count"] == 1
+    assert by_principal["imported_cost"] == 0.10
+
+    by_source = crud_api_usage.get_imported_usage_summary(
+        db_session, source="windsurf", **window
+    )
+    assert by_source["event_count"] == 1
+    assert by_source["imported_cost"] == 0.20
+
+
+def test_by_model_grouping(db_session, create_account):
+    """Grouped rows report per-model counts, tokens, and cost."""
+    account = create_account()
+    now = _utcnow_naive()
+
+    _log_imported(
+        db_session, account_id=account.id, model_alias="composer", cost_usd=0.10
+    )
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        model_alias="composer",
+        cost_usd=0.15,
+        import_fingerprint="fp-model-2",
+    )
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        model_alias="claude-4.5-sonnet",
+        cost_usd=0.50,
+    )
+
+    rows = crud_api_usage.get_imported_usage_by_model(
+        db_session,
+        account_id=str(account.id),
+        start_date=now - timedelta(hours=1),
+        end_date=now + timedelta(hours=1),
+    )
+
+    assert [row["model_alias"] for row in rows] == [
+        "composer",
+        "claude-4.5-sonnet",
+    ]
+    composer = rows[0]
+    assert composer["request_count"] == 2
+    assert composer["imported_cost"] == 0.25
+    assert composer["source"] == "cursor"
+    assert composer["last_event_at"] is not None
+
+
+def test_gateway_aggregations_are_blind_to_imported_rows(
+    db_session, create_account, create_user
+):
+    """Imported spend must never surface in gateway-metered aggregations."""
+    account = create_account()
+    user = create_user(account=account)
+    now = _utcnow_naive()
+
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        user_id=str(user.id),
+        cost_usd=123.45,
+        total_tokens=99999,
+    )
+
+    gateway = crud_api_usage.get_gateway_usage_summary(
+        db_session,
+        account_id=str(account.id),
+        start_date=now - timedelta(hours=1),
+        end_date=now + timedelta(hours=1),
+    )
+
+    assert gateway["request_count"] == 0
+    assert gateway["estimated_cost"] == 0.0
+    assert gateway["total_tokens"] == 0

--- a/backend/tests/services/test_usage_import.py
+++ b/backend/tests/services/test_usage_import.py
@@ -7,14 +7,17 @@ No database required.
 """
 
 from datetime import datetime, timezone
+from unittest.mock import MagicMock
 
 import pytest
 from pydantic import ValidationError
 
+from preloop.models.models.managed_agent import ManagedAgent
 from preloop.schemas.usage_import import UsageImportEvent
 from preloop.services.usage_import import (
     UsageImportError,
     event_fingerprint,
+    ingest_events,
     parse_cursor_usage_csv,
 )
 
@@ -179,6 +182,33 @@ class TestParseCursorUsageCsv:
         with pytest.raises(UsageImportError, match="Unknown column_map field"):
             parse_cursor_usage_csv(CANONICAL_CSV, column_map={"nope": "Date"})
 
+    def test_row_limit_enforced(self):
+        """Parsing aborts once the data-row cap is exceeded."""
+        content = (
+            "Date,Model,Total Tokens,Cost\n"
+            "2026-07-28,m1,10,$0.01\n"
+            "2026-07-28,m2,10,$0.01\n"
+            "2026-07-28,m3,10,$0.01\n"
+        ).encode("utf-8")
+
+        with pytest.raises(UsageImportError, match="more than 2 data rows"):
+            parse_cursor_usage_csv(content, max_rows=2)
+
+    def test_row_limit_ignores_blank_rows(self):
+        """Blank filler lines do not count toward the row cap."""
+        content = (
+            "Date,Model,Total Tokens,Cost\n"
+            "\n"
+            "2026-07-28,m1,10,$0.01\n"
+            "\n"
+            "2026-07-28,m2,10,$0.01\n"
+        ).encode("utf-8")
+
+        result = parse_cursor_usage_csv(content, max_rows=2)
+
+        assert result.parsed_rows == 2
+        assert len(result.events) == 2
+
 
 class TestEventFingerprint:
     """The dedupe fingerprint contract."""
@@ -235,3 +265,39 @@ class TestUsageImportEventSchema:
         """Money without token counts is an acceptable measurement."""
         event = _event(total_tokens=None, cost_usd=0.5)
         assert event.resolved_cost_usd() == pytest.approx(0.5)
+
+    def test_cache_only_event_is_valid(self):
+        """Cache token counts alone are a valid measurement."""
+        read_only = _event(total_tokens=None, cache_read_tokens=4500)
+        assert read_only.cache_read_tokens == 4500
+
+        write_only = _event(total_tokens=None, cache_creation_tokens=1200)
+        assert write_only.cache_creation_tokens == 1200
+
+
+class TestIngestEventsGuards:
+    """Pre-write invariants enforced by ingest_events."""
+
+    def test_agent_without_principal_id_is_rejected(self):
+        """An agent lacking session_source_id cannot scope fingerprints.
+
+        The dedupe fingerprint is scoped by the agent's principal id; a
+        missing value would silently merge the dedupe scopes of unrelated
+        agents. The guard fires before any database access.
+        """
+        agent = ManagedAgent(
+            agent_kind="cursor",
+            session_source_type="cursor",
+            session_source_id="",
+            display_name="Broken Agent",
+        )
+
+        with pytest.raises(UsageImportError, match="session_source_id"):
+            ingest_events(
+                MagicMock(),
+                account_id="acct-1",
+                user_id="user-1",
+                agent=agent,
+                events=[_event()],
+                source="cursor",
+            )

--- a/backend/tests/services/test_usage_import.py
+++ b/backend/tests/services/test_usage_import.py
@@ -1,0 +1,237 @@
+"""Unit tests for the usage-import service (issue #123).
+
+Covers the Cursor dashboard Usage CSV parser (header matching, column_map
+overrides, cost/token cell normalization, per-row skip accounting), the
+event dedupe fingerprint, and the normalized-event schema validation.
+No database required.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from preloop.schemas.usage_import import UsageImportEvent
+from preloop.services.usage_import import (
+    UsageImportError,
+    event_fingerprint,
+    parse_cursor_usage_csv,
+)
+
+CANONICAL_CSV = (
+    "Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),"
+    "Cache Read,Output Tokens,Total Tokens,Cost\n"
+    "2026-07-28T09:15:00.000+00:00,Usage-based,claude-4.5-sonnet,No,1200,300,"
+    "4500,850,6850,$0.42\n"
+    "2026-07-28T10:02:00.000+00:00,Included,composer,No,0,150,0,90,240,Included\n"
+).encode("utf-8")
+
+
+def _event(**overrides) -> UsageImportEvent:
+    params = dict(
+        timestamp=datetime(2026, 7, 28, 9, 15, tzinfo=timezone.utc),
+        model="composer",
+        total_tokens=100,
+    )
+    params.update(overrides)
+    return UsageImportEvent(**params)
+
+
+class TestParseCursorUsageCsv:
+    """Parsing the Cursor dashboard Usage export."""
+
+    def test_parses_canonical_export(self):
+        """The documented header shape should parse every row."""
+        result = parse_cursor_usage_csv(CANONICAL_CSV)
+
+        assert result.parsed_rows == 2
+        assert result.skipped_rows == 0
+        assert len(result.events) == 2
+
+        paid = result.events[0]
+        assert paid.model == "claude-4.5-sonnet"
+        # Prompt tokens = both input slices; w/ cache write also counts as
+        # cache creation.
+        assert paid.prompt_tokens == 1500
+        assert paid.cache_creation_tokens == 1200
+        assert paid.cache_read_tokens == 4500
+        assert paid.completion_tokens == 850
+        assert paid.total_tokens == 6850
+        assert paid.cost_usd == pytest.approx(0.42)
+        assert paid.kind == "Usage-based"
+        assert paid.max_mode is False
+
+        included = result.events[1]
+        assert included.model == "composer"
+        assert included.resolved_cost_usd() is None
+        assert included.kind == "Included"
+        assert included.total_tokens == 240
+
+    def test_handles_bom_and_reordered_columns(self):
+        """A UTF-8 BOM and shuffled column order must not break matching."""
+        content = (
+            "\ufeffModel,Cost,Date,Total Tokens\ncomposer,$1.10,2026-07-28,300\n"
+        ).encode("utf-8")
+
+        result = parse_cursor_usage_csv(content)
+
+        assert len(result.events) == 1
+        event = result.events[0]
+        assert event.model == "composer"
+        assert event.cost_usd == pytest.approx(1.10)
+        assert event.total_tokens == 300
+
+    def test_ignores_unknown_columns_like_user(self):
+        """Team exports carry extra columns (e.g. User) that are ignored."""
+        content = (
+            "Date,User,Kind,Model,Total Tokens,Cost\n"
+            "2026-07-28,alex@example.com,Usage-based,composer,500,$0.10\n"
+        ).encode("utf-8")
+
+        result = parse_cursor_usage_csv(content)
+
+        assert len(result.events) == 1
+        assert result.events[0].model == "composer"
+
+    def test_cost_cell_variants(self):
+        """'Included', '-', empty, and separator-laden dollar values parse."""
+        content = (
+            "Date,Model,Total Tokens,Cost\n"
+            "2026-07-28,m1,10,Included\n"
+            "2026-07-28,m2,10,-\n"
+            "2026-07-28,m3,10,\n"
+            '2026-07-28,m4,10,"$1,234.56"\n'
+        ).encode("utf-8")
+
+        result = parse_cursor_usage_csv(content)
+
+        costs = [event.resolved_cost_usd() for event in result.events]
+        assert costs == [None, None, None, pytest.approx(1234.56)]
+
+    def test_skips_unusable_rows_with_reasons(self):
+        """Bad dates and missing models are skipped with line-level reasons."""
+        content = (
+            "Date,Model,Total Tokens,Cost\n"
+            "not-a-date,composer,10,$0.01\n"
+            "2026-07-28,,10,$0.01\n"
+            "2026-07-28,composer,10,$0.01\n"
+        ).encode("utf-8")
+
+        result = parse_cursor_usage_csv(content)
+
+        assert result.parsed_rows == 3
+        assert result.skipped_rows == 2
+        assert len(result.events) == 1
+        assert any("line 2" in reason for reason in result.skipped_row_reasons)
+        assert any("line 3" in reason for reason in result.skipped_row_reasons)
+
+    def test_row_without_tokens_or_cost_is_skipped(self):
+        """A row carrying neither tokens nor a charge is unusable."""
+        content = (
+            "Date,Model,Total Tokens,Cost\n2026-07-28,composer,,Included\n"
+        ).encode("utf-8")
+
+        result = parse_cursor_usage_csv(content)
+
+        assert result.skipped_rows == 1
+        assert result.events == []
+
+    def test_missing_required_columns_raises(self):
+        """Without Date and Model columns the CSV shape is unusable."""
+        content = b"Foo,Bar\n1,2\n"
+        with pytest.raises(UsageImportError, match="Date"):
+            parse_cursor_usage_csv(content)
+
+    def test_empty_csv_raises(self):
+        """An empty file has no header to match."""
+        with pytest.raises(UsageImportError, match="empty"):
+            parse_cursor_usage_csv(b"")
+
+    def test_non_utf8_raises(self):
+        """Invalid UTF-8 is rejected with a clear error."""
+        with pytest.raises(UsageImportError, match="UTF-8"):
+            parse_cursor_usage_csv(b"\xff\xfe\x00bad")
+
+    def test_column_map_override(self):
+        """column_map maps unrecognized headers onto logical fields."""
+        content = (
+            "When,Which Model,Tokens,Charged\n2026-07-28,composer,42,$0.05\n"
+        ).encode("utf-8")
+
+        result = parse_cursor_usage_csv(
+            content,
+            column_map={
+                "date": "When",
+                "model": "Which Model",
+                "total_tokens": "Tokens",
+                "cost": "Charged",
+            },
+        )
+
+        assert len(result.events) == 1
+        event = result.events[0]
+        assert event.model == "composer"
+        assert event.total_tokens == 42
+        assert event.cost_usd == pytest.approx(0.05)
+
+    def test_column_map_unknown_field_raises(self):
+        """Unknown logical field names in column_map are rejected."""
+        with pytest.raises(UsageImportError, match="Unknown column_map field"):
+            parse_cursor_usage_csv(CANONICAL_CSV, column_map={"nope": "Date"})
+
+
+class TestEventFingerprint:
+    """The dedupe fingerprint contract."""
+
+    def test_identical_events_share_fingerprint(self):
+        """Replaying the same event must produce the same fingerprint."""
+        first = event_fingerprint(_event(), source="cursor", agent_principal_id="ws-1")
+        second = event_fingerprint(_event(), source="cursor", agent_principal_id="ws-1")
+        assert first == second
+
+    def test_fingerprint_changes_with_measured_quantity(self):
+        """Two events differing in any measured field must both land."""
+        base = event_fingerprint(_event(), source="cursor", agent_principal_id="ws-1")
+        different = event_fingerprint(
+            _event(total_tokens=101), source="cursor", agent_principal_id="ws-1"
+        )
+        assert base != different
+
+    def test_fingerprint_scoped_by_source_and_agent(self):
+        """The same event imported under another source/agent is distinct."""
+        base = event_fingerprint(_event(), source="cursor", agent_principal_id="ws-1")
+        other_source = event_fingerprint(
+            _event(), source="windsurf", agent_principal_id="ws-1"
+        )
+        other_agent = event_fingerprint(
+            _event(), source="cursor", agent_principal_id="ws-2"
+        )
+        assert base != other_source
+        assert base != other_agent
+
+
+class TestUsageImportEventSchema:
+    """Validation rules on the normalized event schema."""
+
+    def test_event_requires_tokens_or_cost(self):
+        """An event with no measurable quantity is rejected."""
+        with pytest.raises(ValidationError, match="token counts and/or"):
+            UsageImportEvent(
+                timestamp=datetime(2026, 7, 28, tzinfo=timezone.utc),
+                model="composer",
+            )
+
+    def test_event_rejects_both_cost_fields(self):
+        """charged_cents and cost_usd are mutually exclusive."""
+        with pytest.raises(ValidationError, match="not both"):
+            _event(charged_cents=100.0, cost_usd=1.0)
+
+    def test_charged_cents_converts_to_usd(self):
+        """charged_cents is normalized to USD."""
+        event = _event(total_tokens=None, charged_cents=125.0)
+        assert event.resolved_cost_usd() == pytest.approx(1.25)
+
+    def test_cost_only_event_is_valid(self):
+        """Money without token counts is an acceptable measurement."""
+        event = _event(total_tokens=None, cost_usd=0.5)
+        assert event.resolved_cost_usd() == pytest.approx(0.5)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6019,6 +6019,86 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/usage/import:
+    post:
+      tags:
+      - Usage Import
+      - Usage Import
+      summary: Import Usage Events
+      description: 'Ingest a batch of normalized usage events into the cost ledger.
+
+
+        Events are attributed to the given managed agent (default: the account''s
+
+        managed Cursor agent from onboarding) and recorded with
+
+        ``usage_source=''imported''``. Re-sending the same events is idempotent —
+
+        duplicates are counted in ``skipped_duplicates``, never double-billed.'
+      operationId: import_usage_events_api_v1_usage_import_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsageImportRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageImportResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /api/v1/usage/import/csv:
+    post:
+      tags:
+      - Usage Import
+      - Usage Import
+      summary: Import Usage Csv
+      description: 'Import a Cursor dashboard Usage CSV export into the cost ledger.
+
+
+        Parses the export (Date / Kind / Model / Max Mode / Input (w/ Cache
+
+        Write) / Input (w/o Cache Write) / Cache Read / Output Tokens / Total
+
+        Tokens / Cost), normalizes each row, and ingests it through the same
+
+        pipeline as ``POST /usage/import``. Rows whose Cost is "Included" are
+
+        stored with tokens but no charged amount. Re-importing the same file is
+
+        idempotent.'
+      operationId: import_usage_csv_api_v1_usage_import_csv_post
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Body_import_usage_csv_api_v1_usage_import_csv_post'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageImportCsvResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
   /api/v1/billing/cost/runtime-sessions/example/optimization:
     get:
       tags:
@@ -10203,6 +10283,36 @@ components:
       required:
       - file
       title: Body_diff_policy_api_v1_policies_diff_post
+    Body_import_usage_csv_api_v1_usage_import_csv_post:
+      properties:
+        file:
+          type: string
+          contentMediaType: application/octet-stream
+          title: File
+          description: Cursor dashboard Usage CSV export
+        agent_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Agent Id
+        source:
+          type: string
+          title: Source
+          default: cursor
+        column_map:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Column Map
+          description: Optional JSON object mapping logical fields (date, model, cost,
+            kind, max_mode, input_with_cache_write, input_without_cache_write, cache_read,
+            output_tokens, total_tokens) to your export's exact column headers, for
+            CSV shapes the built-in matcher does not recognize.
+      type: object
+      required:
+      - file
+      title: Body_import_usage_csv_api_v1_usage_import_csv_post
     Body_login_form_api_v1_auth_token_post:
       properties:
         grant_type:
@@ -10521,6 +10631,10 @@ components:
             $ref: '#/components/schemas/GatewayUsageByTool'
           type: array
           title: Usage By Tool
+        imported_usage:
+          anyOf:
+          - $ref: '#/components/schemas/ImportedUsageSummary'
+          - type: 'null'
       type: object
       required:
       - period_start
@@ -12204,6 +12318,68 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
+    ImportedUsageByModel:
+      properties:
+        model_alias:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Model Alias
+        source:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source
+        request_count:
+          type: integer
+          title: Request Count
+          default: 0
+        total_tokens:
+          type: integer
+          title: Total Tokens
+          default: 0
+        imported_cost:
+          type: number
+          title: Imported Cost
+          default: 0.0
+        last_event_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Event At
+      type: object
+      title: ImportedUsageByModel
+      description: Imported (observed) usage aggregate grouped by source model.
+    ImportedUsageSummary:
+      properties:
+        event_count:
+          type: integer
+          title: Event Count
+          default: 0
+        total_tokens:
+          type: integer
+          title: Total Tokens
+          default: 0
+        imported_cost:
+          type: number
+          title: Imported Cost
+          default: 0.0
+        usage_by_model:
+          items:
+            $ref: '#/components/schemas/ImportedUsageByModel'
+          type: array
+          title: Usage By Model
+      type: object
+      title: ImportedUsageSummary
+      description: 'Spend ingested from outside the gateway (``usage_source=''imported''``).
+
+
+        Kept as a separate block — never merged into ``estimated_cost`` or the
+
+        budget figures — so gateway-metered and imported spend cannot be
+
+        silently mixed.'
     IssueCreate:
       properties:
         title:
@@ -16538,6 +16714,190 @@ components:
       - tag
       title: UpdateTagRequest
       description: Request to update a version's tag.
+    UsageImportCsvResponse:
+      properties:
+        imported:
+          type: integer
+          title: Imported
+          default: 0
+        skipped_duplicates:
+          type: integer
+          title: Skipped Duplicates
+          default: 0
+        agent_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Agent Id
+        agent_display_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Agent Display Name
+        source:
+          type: string
+          title: Source
+          default: cursor
+        parsed_rows:
+          type: integer
+          title: Parsed Rows
+          default: 0
+        skipped_rows:
+          type: integer
+          title: Skipped Rows
+          default: 0
+        skipped_row_reasons:
+          items:
+            type: string
+          type: array
+          title: Skipped Row Reasons
+      type: object
+      title: UsageImportCsvResponse
+      description: Result of a CSV import, including rows the parser could not use.
+    UsageImportEvent:
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          title: Timestamp
+        model:
+          type: string
+          maxLength: 255
+          minLength: 1
+          title: Model
+        prompt_tokens:
+          anyOf:
+          - type: integer
+            minimum: 0.0
+          - type: 'null'
+          title: Prompt Tokens
+        completion_tokens:
+          anyOf:
+          - type: integer
+            minimum: 0.0
+          - type: 'null'
+          title: Completion Tokens
+        total_tokens:
+          anyOf:
+          - type: integer
+            minimum: 0.0
+          - type: 'null'
+          title: Total Tokens
+        cache_read_tokens:
+          anyOf:
+          - type: integer
+            minimum: 0.0
+          - type: 'null'
+          title: Cache Read Tokens
+        cache_creation_tokens:
+          anyOf:
+          - type: integer
+            minimum: 0.0
+          - type: 'null'
+          title: Cache Creation Tokens
+        charged_cents:
+          anyOf:
+          - type: number
+            minimum: 0.0
+          - type: 'null'
+          title: Charged Cents
+          description: Amount charged by the source vendor, in cents (USD).
+        cost_usd:
+          anyOf:
+          - type: number
+            minimum: 0.0
+          - type: 'null'
+          title: Cost Usd
+          description: Amount charged in USD. Mutually exclusive with charged_cents.
+        session_id:
+          anyOf:
+          - type: string
+            maxLength: 255
+          - type: 'null'
+          title: Session Id
+        kind:
+          anyOf:
+          - type: string
+            maxLength: 100
+          - type: 'null'
+          title: Kind
+          description: Source billing category (e.g. 'Usage-based', 'Included').
+        max_mode:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Max Mode
+        meta:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Meta
+      type: object
+      required:
+      - timestamp
+      - model
+      title: UsageImportEvent
+      description: One normalized usage event observed outside the model gateway.
+    UsageImportRequest:
+      properties:
+        events:
+          items:
+            $ref: '#/components/schemas/UsageImportEvent'
+          type: array
+          maxItems: 5000
+          minItems: 1
+          title: Events
+        agent_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Agent Id
+          description: Managed agent to attribute the events to. When omitted, the
+            account's managed Cursor agent (from `preloop agents onboard cursor`)
+            is used if exactly resolvable.
+        source:
+          type: string
+          maxLength: 64
+          minLength: 1
+          title: Source
+          description: Origin label stored on each row (e.g. 'cursor').
+          default: cursor
+      type: object
+      required:
+      - events
+      title: UsageImportRequest
+      description: Batch of normalized usage events to ingest.
+    UsageImportResponse:
+      properties:
+        imported:
+          type: integer
+          title: Imported
+          default: 0
+        skipped_duplicates:
+          type: integer
+          title: Skipped Duplicates
+          default: 0
+        agent_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Agent Id
+        agent_display_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Agent Display Name
+        source:
+          type: string
+          title: Source
+          default: cursor
+      type: object
+      title: UsageImportResponse
+      description: Result of an ingest request.
     ValidationError:
       properties:
         loc:

--- a/scripts/init_system_roles.py
+++ b/scripts/init_system_roles.py
@@ -180,6 +180,12 @@ SYSTEM_PERMISSIONS: Dict[str, List[Dict[str, str]]] = {
             "name": "manage_budgets",
             "description": "Create and manage budget policies and limits",
         },
+        {
+            "name": "import_usage",
+            "description": (
+                "Import externally observed usage/spend into cost analytics"
+            ),
+        },
     ],
     "agents": [
         {


### PR DESCRIPTION
Closes #123.

## Summary

Cursor's bundled models (Composer, Auto) never traverse the Preloop model gateway, so their spend was invisible to Cost analytics. This PR adds the v1 scope agreed in the issue: ingest API first, CSV import on top.

- **`POST /api/v1/usage/import`** — authenticated ingest of normalized usage events (`timestamp`, `model`, tokens and/or `charged_cents`/`cost_usd`, optional `session_id`). Events are attributed to a managed agent — by default the managed Cursor agent from `preloop agents onboard cursor` — and recorded in the cost ledger (`api_usage`) as `action_type='imported_usage'` rows labeled `usage_source='imported'` / `cost_source='imported'`.
- **`POST /api/v1/usage/import/csv`** — the Cursor dashboard Usage CSV export as a supported input (`Date / Kind / Model / Max Mode / Input (w/ Cache Write) / Input (w/o Cache Write) / Cache Read / Output Tokens / Total Tokens / Cost`). Header matching is case-insensitive and order-independent; an optional `column_map` form field maps unrecognized export shapes onto the logical fields. Rows whose Cost is `Included` are stored with tokens but no charged amount.
- **Idempotency** — every event carries a dedupe fingerprint (source + agent + timestamp + model + measured quantities + session id). Re-importing the same CSV or replaying the same batch skips duplicates (`skipped_duplicates` in the response) and never double-counts spend.
- **Budgets never silently mix** — all gateway aggregations (summaries, budgets, spend caps, accounting health) filter on `action_type='model_gateway'`, so they are structurally blind to imported rows, and budget-bucket accumulation is not performed for imports. Imported spend surfaces in `GET /api/v1/cost/summary` as a separate `imported_usage` block (totals + per-model breakdown), never inside `estimated_cost`.
- **Migration & permissions** — alembic migration `20260731_usage_imported` extends the `api_usage` marker CHECK constraints with `'imported'`; new `import_usage` permission granted to owner/admin roles.
- No reverse-engineered vendor auth anywhere: input is either the caller's own normalized events or the CSV the Cursor dashboard officially exports.

## Testing a Cloud prototype

Push normalized events:

```bash
curl -sS -X POST \\"$PRELOOP_URL/api/v1/usage/import\\" \
  -H \\"Authorization: Bearer $PRELOOP_TOKEN\\" \
  -H \\"Content-Type: application/json\\" \
  -d '{
    \\"source\\": \\"cursor\\",
    \\"events\\": [
      {\\"timestamp\\": \\"2026-07-31T10:00:00Z\\", \\"model\\": \\"composer\\",
       \\"prompt_tokens\\": 1500, \\"completion_tokens\\": 850, \\"cost_usd\\": 0.42},
      {\\"timestamp\\": \\"2026-07-31T10:05:00Z\\", \\"model\\": \\"claude-4.5-sonnet\\",
       \\"total_tokens\\": 240, \\"charged_cents\\": 125, \\"session_id\\": \\"sess-1\\"}
    ]
  }'
```

Import the Cursor dashboard Usage export (Dashboard → Usage → Export CSV):

```bash
curl -sS -X POST \\"$PRELOOP_URL/api/v1/usage/import/csv\\" \
  -H \\"Authorization: Bearer $PRELOOP_TOKEN\\" \
  -F \\"file=@cursor-usage.csv\\"
```

Example CSV shape:

```csv
Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost
2026-07-28T09:15:00,Usage-based,claude-4.5-sonnet,No,1200,300,4500,850,6850,$0.42
2026-07-28T10:02:00,Included,composer,No,0,150,0,90,240,Included
```

If the export shape differs, pass `-F 'column_map={\\"date\\":\\"When\\",\\"model\\":\\"Which Model\\",\\"cost\\":\\"Charged\\",\\"total_tokens\\":\\"Tokens\\"}'`.

Then `GET /api/v1/cost/summary` shows the spend under `imported_usage` (event count, tokens, cost, per-model breakdown) with gateway `estimated_cost` untouched. If no agent is onboarded yet, run `preloop agents onboard cursor` first or pass `agent_id` explicitly.

## Test plan

- [x] Unit: CSV parser (header variants, BOM, reordering, column_map, cost/token cell normalization, per-row skip reasons), dedupe fingerprint, event schema validation — 26 tests
- [x] Real-DB ledger: labeled writes, fingerprint dedupe (account-scoped), windowed/principal/source-filtered aggregation, gateway aggregations blind to imported rows
- [x] Endpoints: JSON + CSV import success/idempotency, default-agent resolution (missing/ambiguous/explicit/foreign-account), validation failures, cost-summary integration — 16 tests
- [x] Neighboring suites (cost endpoints, gateway usage summary, api_usage, system roles, cost schemas): 106 passed total
- [x] `ruff check` / `ruff format` clean; `mypy` introduces no new errors on changed files
- [x] `alembic upgrade head` applied cleanly (single head)

Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-designed feature that ingests external usage data with proper isolation from gateway-metered spend. All 7 review issues have been addressed — TOCTOU race closed with DB-level unique partial index.
>
> **Overview**
> Adds `POST /api/v1/usage/import` and `POST /api/v1/usage/import/csv` endpoints to ingest Cursor bundled-model usage into cost analytics. Uses `action_type='imported_usage'` for structural isolation from gateway aggregations, SHA-256 fingerprints with DB-level unique index for idempotent deduplication, and surfaces imported spend as a separate `imported_usage` block in `GET /api/v1/cost/summary`.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit baf41637. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->