### PR TITLE
feat(cli): install-runtime UX model picker, e2e check, undo hints

### DIFF
--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -737,6 +737,7 @@ func init() {
 	agentsEnrollCmd.Flags().Bool("skip-live-validate", false, "do not run a live validation prompt after onboarding (overrides --live-validate)")
 	agentsEnrollCmd.Flags().StringSlice("tags", []string{}, "add key-value tags to the enrolled agent (e.g., --tags ext=true,env=prod)")
 	agentsEnrollCmd.Flags().Bool("approvals", false, "install a native tool-permission hook that routes would-prompt tool calls to Preloop mobile/watch approvals (Claude Code, Codex CLI, Cursor)")
+	agentsEnrollCmd.Flags().String("model", "", "managed model alias to use for gateway routing (skips the interactive model picker)")
 	agentsListCmd.Flags().Bool("json", false, "output managed agents as JSON")
 	agentsStatusCmd.Flags().Bool("json", false, "output managed status as JSON")
 	agentsValidateCmd.Flags().Bool("live", false, "run a supported live validation prompt in addition to config validation")
@@ -1199,6 +1200,7 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 	tagsInput, _ := cmd.Flags().GetStringSlice("tags")
 	runAll, _ := cmd.Flags().GetBool("all")
 	approvals, _ := cmd.Flags().GetBool("approvals")
+	preferredModel, _ := cmd.Flags().GetString("model")
 
 	tags := make(map[string]string)
 	for _, kv := range tagsInput {
@@ -1221,6 +1223,7 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 		LiveValidate:     liveValidate,
 		SkipLiveValidate: skipLiveValidate,
 		Approvals:        approvals,
+		PreferredModel:   strings.TrimSpace(preferredModel),
 		Tags:             tags,
 		SkipConfirmation: false,
 		Input:            os.Stdin,
@@ -2011,6 +2014,13 @@ func runAgentsRestore(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("✓ Restored %s config from %s\n", resolveAgentDisplayName(agent), state.BackupPath)
+	printMutatingCommandUndo(
+		os.Stdout,
+		fmt.Sprintf(
+			"preloop agents onboard %s",
+			shellQuoteAgentName(resolveAgentDisplayName(agent)),
+		),
+	)
 	return nil
 }
 
@@ -2202,6 +2212,13 @@ func executeOffboard(agent AgentConfig, autoApprove bool, modelRemovalPolicy, se
 
 	fmt.Printf("✓ Offboarded %s\n", resolveAgentDisplayName(agent))
 	fmt.Printf("  Restored config: %s\n", agent.ConfigPath)
+	printMutatingCommandUndo(
+		os.Stdout,
+		fmt.Sprintf(
+			"preloop agents onboard %s",
+			shellQuoteAgentName(resolveAgentDisplayName(agent)),
+		),
+	)
 	if isClaudeCodeAgent(agent) || isCodexCLIAgent(agent) {
 		// Subscription refresh tokens rotate server-side while onboarded, so
 		// write the live Preloop-held bundle back to the local credential

--- a/cli/internal/cmd/agents_install_ux.go
+++ b/cli/internal/cmd/agents_install_ux.go
@@ -71,6 +71,12 @@ func printLiveValidationRoundTripResult(
 		) //nolint:errcheck
 		return
 	}
+	if outcome == nil && err == nil {
+		// Finish the inline "Sending test prompt..." line without inventing a
+		// failure when a future caller passes neither outcome nor error.
+		fmt.Fprintln(w, "") //nolint:errcheck
+		return
+	}
 	detail := "live validation failed"
 	if err != nil {
 		detail = firstErrorLine(err)
@@ -124,11 +130,18 @@ func formatDeferredLiveValidationRoundTrip(result deferredLiveValidationResult) 
 	return formatCLIError(line)
 }
 
+// Terminal color escapes for operator-facing CLI errors. Kept local so the
+// agents package does not depend on a third-party color library for one site.
+const (
+	ansiRed   = "\033[31m"
+	ansiReset = "\033[0m"
+)
+
 func formatCLIError(message string) string {
 	if !stdoutIsTerminal() {
 		return message
 	}
-	return "\033[31m" + message + "\033[0m"
+	return ansiRed + message + ansiReset
 }
 
 func stdoutIsTerminal() bool {

--- a/cli/internal/cmd/agents_install_ux.go
+++ b/cli/internal/cmd/agents_install_ux.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// printOnboardingFollowUpCommands prints discoverable reconfigure and undo
+// commands after a successful mutating onboard/install-runtime.
+func printOnboardingFollowUpCommands(w io.Writer, agentName, backupPath string) {
+	if w == nil {
+		return
+	}
+	quoted := shellQuoteAgentName(agentName)
+	fmt.Fprintf(
+		w,
+		"  To change model/provider: preloop agents onboard %s --model <m>\n",
+		quoted,
+	) //nolint:errcheck
+	if strings.TrimSpace(backupPath) != "" {
+		fmt.Fprintf(
+			w,
+			"  To undo: preloop agents offboard %s (restores backup at %s)\n",
+			quoted,
+			backupPath,
+		) //nolint:errcheck
+		return
+	}
+	fmt.Fprintf(
+		w,
+		"  To undo: preloop agents offboard %s\n",
+		quoted,
+	) //nolint:errcheck
+}
+
+// printMutatingCommandUndo prints the inverse command after other mutating
+// agents subcommands (restore / offboard).
+func printMutatingCommandUndo(w io.Writer, undoLine string) {
+	if w == nil || strings.TrimSpace(undoLine) == "" {
+		return
+	}
+	fmt.Fprintf(w, "  To undo: %s\n", undoLine) //nolint:errcheck
+}
+
+// printLiveValidationRoundTripResult finishes the inline
+// "Sending test prompt through gateway..." line with a clear pass/fail result.
+func printLiveValidationRoundTripResult(
+	w io.Writer,
+	outcome *managedLiveValidationOutcome,
+	err error,
+	modelAlias string,
+	latency time.Duration,
+) {
+	if w == nil {
+		return
+	}
+	seconds := latency.Seconds()
+	alias := strings.TrimSpace(modelAlias)
+	if alias == "" {
+		alias = "unknown"
+	}
+	if outcome != nil && outcome.Passed {
+		fmt.Fprintf(
+			w,
+			" ✓ round-trip OK, model=%s, latency=%.1fs\n",
+			alias,
+			seconds,
+		) //nolint:errcheck
+		return
+	}
+	detail := "live validation failed"
+	if err != nil {
+		detail = firstErrorLine(err)
+	} else if outcome != nil {
+		if message, _ := outcome.ValidationResult["live_validation_error"].(string); message != "" {
+			detail = strings.TrimSpace(strings.Split(message, "\n")[0])
+		} else if status, _ := outcome.ValidationResult["live_validation_status"].(string); status != "" {
+			detail = "live validation " + status
+		}
+	}
+	fmt.Fprintln(w, "") //nolint:errcheck
+	fmt.Fprintln(w, formatCLIError(fmt.Sprintf(
+		"✗ round-trip FAILED, model=%s, latency=%.1fs: %s",
+		alias,
+		seconds,
+		detail,
+	))) //nolint:errcheck
+	fmt.Fprintln(w, formatCLIError(
+		"  Fix the failure above, then re-verify with: preloop agents validate <agent> --live",
+	)) //nolint:errcheck
+}
+
+func formatDeferredLiveValidationRoundTrip(result deferredLiveValidationResult) string {
+	name := resolveAgentDisplayName(result.Agent)
+	alias := "unknown"
+	if result.Outcome != nil {
+		if modelAlias, _ := result.Outcome.ValidationResult["live_validation_model_alias"].(string); strings.TrimSpace(modelAlias) != "" {
+			alias = strings.TrimSpace(modelAlias)
+		}
+	}
+	seconds := result.Duration.Seconds()
+	if result.Outcome != nil && result.Outcome.Passed {
+		return fmt.Sprintf(
+			"  ✓ %s: round-trip OK, model=%s, latency=%.1fs\n",
+			name,
+			alias,
+			seconds,
+		)
+	}
+	detail := "live validation failed"
+	if result.Err != nil {
+		detail = firstErrorLine(result.Err)
+	}
+	line := fmt.Sprintf(
+		"  ✗ %s: round-trip FAILED, model=%s, latency=%.1fs: %s\n",
+		name,
+		alias,
+		seconds,
+		detail,
+	)
+	return formatCLIError(line)
+}
+
+func formatCLIError(message string) string {
+	if !stdoutIsTerminal() {
+		return message
+	}
+	return "\033[31m" + message + "\033[0m"
+}
+
+func stdoutIsTerminal() bool {
+	stat, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}

--- a/cli/internal/cmd/agents_install_ux_test.go
+++ b/cli/internal/cmd/agents_install_ux_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPrintOnboardingFollowUpCommands(t *testing.T) {
+	var out bytes.Buffer
+	printOnboardingFollowUpCommands(&out, "Hermes", "/tmp/backups/hermes.json")
+	rendered := out.String()
+	if !strings.Contains(rendered, "To change model/provider: preloop agents onboard Hermes --model <m>") {
+		t.Fatalf("missing reconfigure line: %q", rendered)
+	}
+	if !strings.Contains(rendered, "To undo: preloop agents offboard Hermes (restores backup at /tmp/backups/hermes.json)") {
+		t.Fatalf("missing undo line: %q", rendered)
+	}
+}
+
+func TestPrintLiveValidationRoundTripResultSuccess(t *testing.T) {
+	var out bytes.Buffer
+	printLiveValidationRoundTripResult(
+		&out,
+		&managedLiveValidationOutcome{Passed: true, Attempted: true},
+		nil,
+		"openai/gpt-5.6-sol",
+		1250*time.Millisecond,
+	)
+	rendered := out.String()
+	if !strings.Contains(rendered, "✓ round-trip OK, model=openai/gpt-5.6-sol, latency=1.3s") &&
+		!strings.Contains(rendered, "✓ round-trip OK, model=openai/gpt-5.6-sol, latency=1.2s") {
+		t.Fatalf("unexpected success formatting: %q", rendered)
+	}
+}
+
+func TestPrintLiveValidationRoundTripResultFailure(t *testing.T) {
+	var out bytes.Buffer
+	printLiveValidationRoundTripResult(
+		&out,
+		&managedLiveValidationOutcome{Passed: false, Attempted: true},
+		errors.New("gateway returned 401"),
+		"openai/gpt-5.6-sol",
+		500*time.Millisecond,
+	)
+	rendered := out.String()
+	if !strings.Contains(rendered, "✗ round-trip FAILED") {
+		t.Fatalf("expected failure marker, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "gateway returned 401") {
+		t.Fatalf("expected error detail, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "preloop agents validate") {
+		t.Fatalf("expected actionable validate hint, got %q", rendered)
+	}
+}
+
+func TestFormatDeferredLiveValidationRoundTrip(t *testing.T) {
+	line := formatDeferredLiveValidationRoundTrip(deferredLiveValidationResult{
+		Agent: AgentConfig{Name: "Hermes"},
+		Outcome: &managedLiveValidationOutcome{
+			Passed:    true,
+			Attempted: true,
+			ValidationResult: map[string]interface{}{
+				"live_validation_model_alias": "openai/gpt-5.6-sol",
+			},
+		},
+		Duration: 2 * time.Second,
+	})
+	if !strings.Contains(line, "round-trip OK") || !strings.Contains(line, "Hermes") {
+		t.Fatalf("unexpected deferred success line: %q", line)
+	}
+}
+
+func TestRunAgentsInstallRuntimeDryRunIncludesModel(t *testing.T) {
+	cmd := agentsInstallRuntimeCmd
+	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+		t.Fatalf("set dry-run: %v", err)
+	}
+	if err := cmd.Flags().Set("yes", "true"); err != nil {
+		t.Fatalf("set yes: %v", err)
+	}
+	if err := cmd.Flags().Set("model", "openai/gpt-5.6-sol"); err != nil {
+		t.Fatalf("set model: %v", err)
+	}
+	// dry-run prints to stdout; ensure the flag path does not error.
+	if err := runAgentsInstallRuntime(cmd, []string{"hermes"}); err != nil {
+		t.Fatalf("dry run with --model failed: %v", err)
+	}
+	_ = cmd.Flags().Set("model", "")
+	_ = cmd.Flags().Set("dry-run", "false")
+}

--- a/cli/internal/cmd/agents_install_ux_test.go
+++ b/cli/internal/cmd/agents_install_ux_test.go
@@ -76,6 +76,11 @@ func TestFormatDeferredLiveValidationRoundTrip(t *testing.T) {
 
 func TestRunAgentsInstallRuntimeDryRunIncludesModel(t *testing.T) {
 	cmd := agentsInstallRuntimeCmd
+	t.Cleanup(func() {
+		_ = cmd.Flags().Set("model", "")
+		_ = cmd.Flags().Set("dry-run", "false")
+		_ = cmd.Flags().Set("yes", "false")
+	})
 	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
 		t.Fatalf("set dry-run: %v", err)
 	}
@@ -89,6 +94,13 @@ func TestRunAgentsInstallRuntimeDryRunIncludesModel(t *testing.T) {
 	if err := runAgentsInstallRuntime(cmd, []string{"hermes"}); err != nil {
 		t.Fatalf("dry run with --model failed: %v", err)
 	}
-	_ = cmd.Flags().Set("model", "")
-	_ = cmd.Flags().Set("dry-run", "false")
+}
+
+func TestPrintLiveValidationRoundTripResultNilOutcomeAndErr(t *testing.T) {
+	var out bytes.Buffer
+	printLiveValidationRoundTripResult(&out, nil, nil, "openai/gpt-5.6-sol", 0)
+	rendered := out.String()
+	if strings.Contains(rendered, "FAILED") || strings.Contains(rendered, "OK") {
+		t.Fatalf("nil/nil should finish the line quietly, got %q", rendered)
+	}
 }

--- a/cli/internal/cmd/agents_live_validate.go
+++ b/cli/internal/cmd/agents_live_validate.go
@@ -1291,7 +1291,7 @@ func runDeferredLiveValidationsParallel(
 
 	fmt.Fprintf(
 		output,
-		"\nRunning live validation for %d agent(s) in parallel...\n",
+		"\nSending test prompts through gateway for %d agent(s) in parallel...\n",
 		len(supported),
 	)
 
@@ -1341,16 +1341,10 @@ func recoverDeferredGatewayValidationFailure(
 	output interface{ Write(p []byte) (int, error) },
 	result deferredLiveValidationResult,
 ) {
-	if result.Err == nil {
-		return
-	}
-func recoverDeferredGatewayValidationFailure(
-	output interface{ Write(p []byte) (int, error) },
-	result deferredLiveValidationResult,
-) {
 	if result.Err == nil || result.Outcome == nil {
 		return
 	}
+	if liveValidationStatusKeepsGatewayConfig(result.Outcome.ValidationResult) {
 		note := liveValidationUpstreamNote(result.Outcome.ValidationResult)
 		if note == "" {
 			note = "the live validation probe failed"
@@ -1510,33 +1504,34 @@ func printDeferredLiveValidationLine(
 		return
 	}
 	if result.Outcome.Passed {
-		fmt.Fprintf(
-			output,
-			"  ✓ %s: live validation passed (%dms)\n",
-			name,
-			result.Duration.Milliseconds(),
-		)
+		fmt.Fprint(output, formatDeferredLiveValidationRoundTrip(result)) //nolint:errcheck
 		return
 	}
 	if result.Err != nil {
 		status, _ := result.Outcome.ValidationResult["live_validation_status"].(string)
-		label := "failed"
 		switch status {
-		case "throttled":
-			label = "throttled"
-		case "upstream_unavailable":
-			label = "inconclusive (upstream provider refused)"
-		case "upstream_transient":
-			label = "failed (transient upstream error after retries)"
+		case "throttled", "upstream_unavailable", "upstream_transient":
+			// Keep the nuanced status wording for inconclusive upstream outcomes.
+			label := "failed"
+			switch status {
+			case "throttled":
+				label = "throttled"
+			case "upstream_unavailable":
+				label = "inconclusive (upstream provider refused)"
+			case "upstream_transient":
+				label = "failed (transient upstream error after retries)"
+			}
+			fmt.Fprint(output, formatCLIError(fmt.Sprintf(
+				"  ✗ %s: round-trip FAILED (%s), model=%s, latency=%.1fs: %v\n",
+				name,
+				label,
+				deferredLiveValidationModelAlias(result),
+				result.Duration.Seconds(),
+				result.Err,
+			))) //nolint:errcheck
+		default:
+			fmt.Fprint(output, formatDeferredLiveValidationRoundTrip(result)) //nolint:errcheck
 		}
-		fmt.Fprintf(
-			output,
-			"  ✗ %s: live validation %s (%dms): %v\n",
-			name,
-			label,
-			result.Duration.Milliseconds(),
-			result.Err,
-		)
 		if liveValidationGatewayRolledBack(result.Outcome.ValidationResult) {
 			// The gateway config was reverted: ``validate --live`` can no
 			// longer succeed, so the only useful recovery is a re-onboard.
@@ -1554,12 +1549,17 @@ func printDeferredLiveValidationLine(
 		}
 		return
 	}
-	fmt.Fprintf(
-		output,
-		"  ✗ %s: live validation failed (%dms)\n",
-		name,
-		result.Duration.Milliseconds(),
-	)
+	fmt.Fprint(output, formatDeferredLiveValidationRoundTrip(result)) //nolint:errcheck
+}
+
+func deferredLiveValidationModelAlias(result deferredLiveValidationResult) string {
+	if result.Outcome == nil {
+		return "unknown"
+	}
+	if alias, _ := result.Outcome.ValidationResult["live_validation_model_alias"].(string); strings.TrimSpace(alias) != "" {
+		return strings.TrimSpace(alias)
+	}
+	return "unknown"
 }
 
 // applyLiveValidationOutcomesToSummary folds deferred live-validation

--- a/cli/internal/cmd/agents_live_validate_test.go
+++ b/cli/internal/cmd/agents_live_validate_test.go
@@ -640,10 +640,13 @@ func TestPrintDeferredLiveValidationLine_StatusVariants(t *testing.T) {
 				Outcome: &managedLiveValidationOutcome{
 					Attempted: true,
 					Passed:    true,
+					ValidationResult: map[string]interface{}{
+						"live_validation_model_alias": "openai/gpt-5.4",
+					},
 				},
 				Duration: 250 * time.Millisecond,
 			},
-			contains: []string{"OpenClaw", "passed", "250ms"},
+			contains: []string{"OpenClaw", "round-trip OK", "openai/gpt-5.4", "latency="},
 		},
 		{
 			name: "failed_with_error",
@@ -659,7 +662,7 @@ func TestPrintDeferredLiveValidationLine_StatusVariants(t *testing.T) {
 			},
 			contains: []string{
 				"Codex CLI",
-				"failed",
+				"round-trip FAILED",
 				"HTTP 400 boom",
 				"preloop agents validate \"Codex CLI\" --live",
 			},

--- a/cli/internal/cmd/agents_model_picker.go
+++ b/cli/internal/cmd/agents_model_picker.go
@@ -35,7 +35,7 @@ func resolveManagedModelSelection(
 	if output == nil {
 		output = io.Discard
 	}
-	choices := listGatewayModelChoices(client, inferred)
+	choices := listGatewayModelChoices(client, inferred, output)
 	preferred := strings.TrimSpace(opts.PreferredModel)
 	if preferred != "" {
 		choice := findGatewayModelChoice(choices, preferred)
@@ -97,9 +97,13 @@ func shouldPromptForManagedModel(opts managedEnrollmentOptions) bool {
 func listGatewayModelChoices(
 	client *api.Client,
 	inferred *managedGatewayUpstream,
+	output io.Writer,
 ) []gatewayModelChoice {
 	choices := make([]gatewayModelChoice, 0)
 	seen := map[string]bool{}
+	if output == nil {
+		output = io.Discard
+	}
 
 	if inferred != nil {
 		alias := strings.TrimSpace(inferred.ManagedModelAlias)
@@ -127,6 +131,13 @@ func listGatewayModelChoices(
 	}
 	var models []aiModelResponse
 	if err := client.Get("/api/v1/ai-models", &models); err != nil {
+		// Fail soft to inferred/local choices, but tell the operator the
+		// account catalog was unavailable so the picker may be incomplete.
+		fmt.Fprintf(
+			output,
+			"Note: could not list account AI models (%v); showing local inference only.\n",
+			err,
+		) //nolint:errcheck
 		return choices
 	}
 	for i := range models {

--- a/cli/internal/cmd/agents_model_picker.go
+++ b/cli/internal/cmd/agents_model_picker.go
@@ -1,0 +1,321 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+// gatewayModelChoice is one option in the pre-onboard model picker.
+type gatewayModelChoice struct {
+	Alias    string
+	Label    string
+	Inferred bool
+	Model    *aiModelResponse
+}
+
+// resolveManagedModelSelection picks the managed model alias used for gateway
+// onboarding. Preference order:
+//  1. Explicit --model / PreferredModel (non-interactive passthrough)
+//  2. Interactive numbered picker when stdin is a TTY and confirmations are on
+//  3. Current inference (or first account model) with a printed notice
+//
+// Returns "" when there is nothing to select; callers keep existing inference.
+func resolveManagedModelSelection(
+	client *api.Client,
+	agent AgentConfig,
+	inferred *managedGatewayUpstream,
+	opts managedEnrollmentOptions,
+) (string, *aiModelResponse, error) {
+	output := opts.Output
+	if output == nil {
+		output = io.Discard
+	}
+	choices := listGatewayModelChoices(client, inferred)
+	preferred := strings.TrimSpace(opts.PreferredModel)
+	if preferred != "" {
+		choice := findGatewayModelChoice(choices, preferred)
+		if choice != nil {
+			return choice.Alias, choice.Model, nil
+		}
+		// Allow an explicit alias even when it is not yet in the account catalog;
+		// syncManagedGatewayAIModel will create/update it from local upstream.
+		return strings.TrimPrefix(preferred, "preloop/"), nil, nil
+	}
+
+	if len(choices) == 0 {
+		return "", nil, nil
+	}
+
+	defaultAlias := choices[0].Alias
+	for _, choice := range choices {
+		if choice.Inferred {
+			defaultAlias = choice.Alias
+			break
+		}
+	}
+
+	interactive := shouldPromptForManagedModel(opts)
+	if !interactive {
+		fmt.Fprintf(
+			output,
+			"Using inferred model %s (non-interactive; pass --model to override).\n",
+			defaultAlias,
+		) //nolint:errcheck
+		choice := findGatewayModelChoice(choices, defaultAlias)
+		if choice != nil {
+			return choice.Alias, choice.Model, nil
+		}
+		return defaultAlias, nil, nil
+	}
+
+	selected, err := promptForManagedModel(agent, choices, defaultAlias, opts.Input, output)
+	if err != nil {
+		return "", nil, err
+	}
+	if selected == "" {
+		selected = defaultAlias
+	}
+	choice := findGatewayModelChoice(choices, selected)
+	if choice != nil {
+		return choice.Alias, choice.Model, nil
+	}
+	return selected, nil, nil
+}
+
+func shouldPromptForManagedModel(opts managedEnrollmentOptions) bool {
+	if opts.DryRun || opts.AutoApprove || opts.SkipConfirmation || nonInteractiveAutoConfirm() {
+		return false
+	}
+	return stdinIsTerminal()
+}
+
+func listGatewayModelChoices(
+	client *api.Client,
+	inferred *managedGatewayUpstream,
+) []gatewayModelChoice {
+	choices := make([]gatewayModelChoice, 0)
+	seen := map[string]bool{}
+
+	if inferred != nil {
+		alias := strings.TrimSpace(inferred.ManagedModelAlias)
+		alias = strings.TrimPrefix(alias, "preloop/")
+		if alias != "" {
+			cred := "local agent credentials"
+			if inferred.CredentialType != "" {
+				cred = credentialTypeLabel(inferred.CredentialType, true)
+			} else if inferred.APIKey != "" {
+				cred = "API key"
+			} else if inferred.UsesAmbientAuth {
+				cred = "ambient provider credentials"
+			}
+			choices = append(choices, gatewayModelChoice{
+				Alias:    alias,
+				Label:    fmt.Sprintf("%s  [inferred from agent; %s]", alias, cred),
+				Inferred: true,
+			})
+			seen[strings.ToLower(alias)] = true
+		}
+	}
+
+	if client == nil {
+		return choices
+	}
+	var models []aiModelResponse
+	if err := client.Get("/api/v1/ai-models", &models); err != nil {
+		return choices
+	}
+	for i := range models {
+		model := models[i]
+		alias := strings.TrimSpace(gatewayAliasForAIModel(model))
+		if alias == "" {
+			alias = strings.TrimSpace(model.ProviderName) + "/" + strings.TrimSpace(model.ModelIdentifier)
+		}
+		alias = strings.TrimPrefix(alias, "preloop/")
+		if alias == "/" || strings.Trim(alias, "/") == "" {
+			continue
+		}
+		key := strings.ToLower(alias)
+		if seen[key] {
+			// Enrich the inferred row with account credential detail when aliases match.
+			for j := range choices {
+				if strings.EqualFold(choices[j].Alias, alias) {
+					copyModel := model
+					choices[j].Model = &copyModel
+					choices[j].Label = fmt.Sprintf(
+						"%s  [inferred from agent; account: %s]",
+						alias,
+						formatAIModelCredentialLabel(model),
+					)
+					break
+				}
+			}
+			continue
+		}
+		if !model.HasAPIKey && !aiModelUsesAmbientProviderCredentials(&model) {
+			continue
+		}
+		copyModel := model
+		choices = append(choices, gatewayModelChoice{
+			Alias: alias,
+			Label: fmt.Sprintf("%s  [account AI model; %s]", alias, formatAIModelCredentialLabel(model)),
+			Model: &copyModel,
+		})
+		seen[key] = true
+	}
+	return choices
+}
+
+func formatAIModelCredentialLabel(model aiModelResponse) string {
+	return credentialTypeLabel(model.CredentialType, model.HasAPIKey || aiModelUsesAmbientProviderCredentials(&model))
+}
+
+func credentialTypeLabel(credentialType string, hasCredential bool) string {
+	ct := strings.ToLower(strings.TrimSpace(credentialType))
+	switch {
+	case strings.HasPrefix(ct, "oauth_"):
+		return "subscription/OAuth"
+	case strings.Contains(ct, "ambient"):
+		return "ambient provider credentials"
+	case hasCredential && ct != "":
+		return "API key (" + ct + ")"
+	case hasCredential:
+		return "API key"
+	default:
+		return "no credential stored"
+	}
+}
+
+func findGatewayModelChoice(choices []gatewayModelChoice, alias string) *gatewayModelChoice {
+	needle := strings.TrimPrefix(strings.TrimSpace(alias), "preloop/")
+	if needle == "" {
+		return nil
+	}
+	for i := range choices {
+		if strings.EqualFold(choices[i].Alias, needle) {
+			return &choices[i]
+		}
+		if strings.EqualFold("preloop/"+choices[i].Alias, needle) {
+			return &choices[i]
+		}
+	}
+	return nil
+}
+
+func promptForManagedModel(
+	agent AgentConfig,
+	choices []gatewayModelChoice,
+	defaultAlias string,
+	input io.Reader,
+	output io.Writer,
+) (string, error) {
+	if len(choices) == 0 {
+		return "", nil
+	}
+	if input == nil {
+		input = io.NopCloser(strings.NewReader("\n"))
+	}
+	fmt.Fprintf(
+		output,
+		"Select the managed model for %s before onboarding:\n",
+		resolveAgentDisplayName(agent),
+	) //nolint:errcheck
+	for index, choice := range choices {
+		marker := ""
+		if strings.EqualFold(choice.Alias, defaultAlias) {
+			marker = " (default)"
+		}
+		fmt.Fprintf(output, "  %d) %s%s\n", index+1, choice.Label, marker) //nolint:errcheck
+	}
+	answer, err := promptForTextInput(
+		bufio.NewReader(input),
+		output,
+		fmt.Sprintf(
+			"Use which model? [1-%d, blank=%s]: ",
+			len(choices),
+			defaultAlias,
+		),
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to read model selection: %w", err)
+	}
+	answer = strings.TrimSpace(answer)
+	if answer == "" {
+		return defaultAlias, nil
+	}
+	if index, convErr := strconv.Atoi(answer); convErr == nil {
+		if index >= 1 && index <= len(choices) {
+			return choices[index-1].Alias, nil
+		}
+		return "", fmt.Errorf("model selection %d is out of range", index)
+	}
+	normalized := strings.TrimPrefix(answer, "preloop/")
+	if choice := findGatewayModelChoice(choices, normalized); choice != nil {
+		return choice.Alias, nil
+	}
+	return "", fmt.Errorf("unknown model %q; choose a listed number or alias", answer)
+}
+
+// applySelectedModelToUpstream overlays an operator-selected model onto the
+// resolved upstream. When the selection is an account AI model with a stored
+// credential and local routing material is missing, the upstream is rebuilt
+// from the account model so sync can reuse the stored credential.
+func applySelectedModelToUpstream(
+	upstream *managedGatewayUpstream,
+	selectedAlias string,
+	selectedModel *aiModelResponse,
+) *managedGatewayUpstream {
+	alias := strings.TrimPrefix(strings.TrimSpace(selectedAlias), "preloop/")
+	if alias == "" {
+		return upstream
+	}
+	if selectedModel != nil &&
+		(selectedModel.HasAPIKey || aiModelUsesAmbientProviderCredentials(selectedModel)) &&
+		(upstream == nil || !upstream.CanRouteThroughGateway()) {
+		provider := strings.TrimSpace(selectedModel.ProviderName)
+		identifier := strings.TrimSpace(selectedModel.ModelIdentifier)
+		modelAlias := strings.TrimSpace(gatewayAliasForAIModel(*selectedModel))
+		if modelAlias == "" {
+			modelAlias = alias
+		}
+		modelAlias = strings.TrimPrefix(modelAlias, "preloop/")
+		return &managedGatewayUpstream{
+			SourceAgent:                "account-ai-model",
+			SourceProviderID:           provider,
+			ProviderName:               provider,
+			ModelIdentifier:            identifier,
+			APIEndpoint:                normalizeAIModelEndpoint(selectedModel.APIEndpoint),
+			CredentialType:             selectedModel.CredentialType,
+			ManagedModelAlias:          modelAlias,
+			AllowServerCredentialReuse: true,
+			UsesAmbientAuth:            aiModelUsesAmbientProviderCredentials(selectedModel),
+			Notes: []string{
+				fmt.Sprintf("Using operator-selected account model %s.", modelAlias),
+			},
+		}
+	}
+	if upstream == nil {
+		return &managedGatewayUpstream{
+			ManagedModelAlias:          alias,
+			AllowServerCredentialReuse: selectedModel != nil && selectedModel.HasAPIKey,
+			Notes: []string{
+				fmt.Sprintf("Using operator-selected model %s.", alias),
+			},
+		}
+	}
+	if !strings.EqualFold(strings.TrimSpace(upstream.ManagedModelAlias), alias) {
+		upstream.ManagedModelAlias = alias
+		upstream.Notes = append(
+			upstream.Notes,
+			fmt.Sprintf("Using operator-selected model %s.", alias),
+		)
+	}
+	if selectedModel != nil && selectedModel.HasAPIKey {
+		upstream.AllowServerCredentialReuse = true
+	}
+	return upstream
+}

--- a/cli/internal/cmd/agents_model_picker_test.go
+++ b/cli/internal/cmd/agents_model_picker_test.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+func TestListGatewayModelChoicesIncludesInferredAndAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/ai-models" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]aiModelResponse{
+			{
+				ID:              "m1",
+				ProviderName:    "anthropic",
+				ModelIdentifier: "claude-opus-4-6",
+				CredentialType:  "oauth_anthropic_claude_code",
+				HasAPIKey:       true,
+				MetaData: map[string]interface{}{
+					"gateway": map[string]interface{}{"model_alias": "anthropic/claude-opus-4-6"},
+				},
+			},
+			{
+				ID:              "m2",
+				ProviderName:    "openai",
+				ModelIdentifier: "gpt-ignore",
+				HasAPIKey:       false,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := api.NewClientWithToken(server.URL, "token")
+	choices := listGatewayModelChoices(client, &managedGatewayUpstream{
+		ManagedModelAlias: "openai/gpt-5.6-sol",
+		CredentialType:    "oauth_openai_codex",
+		APIKey:            "sk-test",
+	})
+	if len(choices) != 2 {
+		t.Fatalf("expected 2 choices, got %#v", choices)
+	}
+	if !choices[0].Inferred || choices[0].Alias != "openai/gpt-5.6-sol" {
+		t.Fatalf("expected inferred first, got %#v", choices[0])
+	}
+	if !strings.Contains(choices[0].Label, "subscription/OAuth") {
+		t.Fatalf("expected credential label on inferred choice, got %q", choices[0].Label)
+	}
+	if choices[1].Alias != "anthropic/claude-opus-4-6" {
+		t.Fatalf("expected account model second, got %#v", choices[1])
+	}
+}
+
+func TestResolveManagedModelSelectionUsesPreferredModelFlag(t *testing.T) {
+	var out bytes.Buffer
+	alias, model, err := resolveManagedModelSelection(
+		nil,
+		AgentConfig{Name: "Hermes"},
+		&managedGatewayUpstream{ManagedModelAlias: "openai/gpt-5.6-sol"},
+		managedEnrollmentOptions{
+			PreferredModel: "anthropic/claude-opus-4-6",
+			AutoApprove:    true,
+			Output:         &out,
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if alias != "anthropic/claude-opus-4-6" {
+		t.Fatalf("expected preferred alias, got %q", alias)
+	}
+	if model != nil {
+		t.Fatalf("expected nil account model for unknown preferred alias")
+	}
+	if strings.Contains(out.String(), "Using inferred model") {
+		t.Fatalf("preferred model should skip non-interactive notice, got %q", out.String())
+	}
+}
+
+func TestResolveManagedModelSelectionNonInteractiveFallsBackWithNotice(t *testing.T) {
+	var out bytes.Buffer
+	alias, _, err := resolveManagedModelSelection(
+		nil,
+		AgentConfig{Name: "Hermes"},
+		&managedGatewayUpstream{ManagedModelAlias: "openai/gpt-5.6-sol"},
+		managedEnrollmentOptions{
+			AutoApprove: true,
+			Output:      &out,
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if alias != "openai/gpt-5.6-sol" {
+		t.Fatalf("expected inferred fallback, got %q", alias)
+	}
+	if !strings.Contains(out.String(), "Using inferred model openai/gpt-5.6-sol") {
+		t.Fatalf("expected non-interactive notice, got %q", out.String())
+	}
+	if !strings.Contains(out.String(), "--model") {
+		t.Fatalf("expected --model hint in notice, got %q", out.String())
+	}
+}
+
+func TestPromptForManagedModelSelectsByNumber(t *testing.T) {
+	var out bytes.Buffer
+	selected, err := promptForManagedModel(
+		AgentConfig{Name: "Hermes"},
+		[]gatewayModelChoice{
+			{Alias: "openai/gpt-5.6-sol", Label: "openai/gpt-5.6-sol", Inferred: true},
+			{Alias: "anthropic/claude-opus-4-6", Label: "anthropic/claude-opus-4-6"},
+		},
+		"openai/gpt-5.6-sol",
+		strings.NewReader("2\n"),
+		&out,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if selected != "anthropic/claude-opus-4-6" {
+		t.Fatalf("expected second choice, got %q", selected)
+	}
+	if !strings.Contains(out.String(), "Select the managed model") {
+		t.Fatalf("expected picker prompt, got %q", out.String())
+	}
+}
+
+func TestApplySelectedModelToUpstreamOverridesAlias(t *testing.T) {
+	upstream := &managedGatewayUpstream{
+		ProviderName:      "openai",
+		ModelIdentifier:   "gpt-5.6-sol",
+		ManagedModelAlias: "openai/gpt-5.6-sol",
+		APIKey:            "sk-local",
+	}
+	updated := applySelectedModelToUpstream(upstream, "openai/gpt-5.4", nil)
+	if updated.ManagedModelAlias != "openai/gpt-5.4" {
+		t.Fatalf("expected alias override, got %#v", updated)
+	}
+	if updated.APIKey != "sk-local" {
+		t.Fatalf("expected local credential preserved, got %#v", updated)
+	}
+}
+
+func TestApplySelectedModelToUpstreamUsesAccountModelWhenLocalMissing(t *testing.T) {
+	model := &aiModelResponse{
+		ProviderName:    "openai",
+		ModelIdentifier: "gpt-5.6-sol",
+		CredentialType:  "oauth_openai_codex",
+		HasAPIKey:       true,
+		APIEndpoint:     "https://chatgpt.com/backend-api/codex",
+		MetaData: map[string]interface{}{
+			"gateway": map[string]interface{}{"model_alias": "openai/gpt-5.6-sol"},
+		},
+	}
+	updated := applySelectedModelToUpstream(nil, "openai/gpt-5.6-sol", model)
+	if updated == nil {
+		t.Fatal("expected upstream from account model")
+	}
+	if !updated.AllowServerCredentialReuse {
+		t.Fatalf("expected server credential reuse, got %#v", updated)
+	}
+	if updated.ManagedModelAlias != "openai/gpt-5.6-sol" {
+		t.Fatalf("unexpected alias: %#v", updated)
+	}
+	if !upstreamEligibleForServerCredentialReuse(AgentConfig{Name: "Hermes"}, updated) {
+		t.Fatalf("expected hermes explicit pick to be reuse-eligible")
+	}
+}
+
+func TestInstallRuntimeModelFlagPassthrough(t *testing.T) {
+	flag := agentsInstallRuntimeCmd.Flags().Lookup("model")
+	if flag == nil {
+		t.Fatal("expected --model flag on install-runtime")
+	}
+	flag = agentsEnrollCmd.Flags().Lookup("model")
+	if flag == nil {
+		t.Fatal("expected --model flag on onboard")
+	}
+}

--- a/cli/internal/cmd/agents_model_picker_test.go
+++ b/cli/internal/cmd/agents_model_picker_test.go
@@ -39,13 +39,17 @@ func TestListGatewayModelChoicesIncludesInferredAndAccount(t *testing.T) {
 	defer server.Close()
 
 	client := api.NewClientWithToken(server.URL, "token")
+	var out bytes.Buffer
 	choices := listGatewayModelChoices(client, &managedGatewayUpstream{
 		ManagedModelAlias: "openai/gpt-5.6-sol",
 		CredentialType:    "oauth_openai_codex",
 		APIKey:            "sk-test",
-	})
+	}, &out)
 	if len(choices) != 2 {
 		t.Fatalf("expected 2 choices, got %#v", choices)
+	}
+	if strings.Contains(out.String(), "could not list account AI models") {
+		t.Fatalf("unexpected API failure notice on success: %q", out.String())
 	}
 	if !choices[0].Inferred || choices[0].Alias != "openai/gpt-5.6-sol" {
 		t.Fatalf("expected inferred first, got %#v", choices[0])
@@ -182,5 +186,28 @@ func TestInstallRuntimeModelFlagPassthrough(t *testing.T) {
 	flag = agentsEnrollCmd.Flags().Lookup("model")
 	if flag == nil {
 		t.Fatal("expected --model flag on onboard")
+	}
+}
+
+func TestListGatewayModelChoicesWarnsOnAPIFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := api.NewClientWithToken(server.URL, "token")
+	var out bytes.Buffer
+	choices := listGatewayModelChoices(client, &managedGatewayUpstream{
+		ManagedModelAlias: "openai/gpt-5.6-sol",
+		APIKey:            "sk-test",
+	}, &out)
+	if len(choices) != 1 || !choices[0].Inferred {
+		t.Fatalf("expected inferred-only fallback, got %#v", choices)
+	}
+	if !strings.Contains(out.String(), "could not list account AI models") {
+		t.Fatalf("expected API failure notice, got %q", out.String())
+	}
+	if !strings.Contains(out.String(), "showing local inference only") {
+		t.Fatalf("expected soft-fail wording, got %q", out.String())
 	}
 }

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -231,10 +231,11 @@ func maybeRemoveStaleOpenClawPluginEntries(
 var openClawEnvPattern = regexp.MustCompile(`^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$`)
 var opencodeEnvPattern = regexp.MustCompile(`^\{env:([A-Za-z_][A-Za-z0-9_]*)\}$`)
 var opencodeBearerEnvPattern = regexp.MustCompile(`^[Bb]earer\s+\{env:([A-Za-z_][A-Za-z0-9_]*)\}$`)
+
 // managedGatewayLLMLogPattern matches OpenCode's model-usage log lines across
-// log-format generations: older builds tagged LLM calls with ``service=llm``,
-// while 1.18+ logs streaming requests as ``message=stream`` — both carry
-// ``providerID=<provider> modelID=<model>`` pairs.
+// log-format generations: older builds tagged LLM calls with “service=llm“,
+// while 1.18+ logs streaming requests as “message=stream“ — both carry
+// “providerID=<provider> modelID=<model>“ pairs.
 var managedGatewayLLMLogPattern = regexp.MustCompile(
 	`(?:service=llm|message=stream) providerID=([^\s]+) modelID=([^\s]+)`,
 )
@@ -302,6 +303,10 @@ type managedEnrollmentOptions struct {
 	// would-prompt tool calls to Preloop's mobile/watch approval flow. Off by
 	// default; enabled via `preloop agents onboard --approvals`.
 	Approvals bool
+	// PreferredModel is the operator-selected managed model alias from
+	// ``--model``. When set, the interactive model picker is skipped and this
+	// alias is used for gateway onboarding.
+	PreferredModel string
 	// AgentPrepared marks that the caller already ran
 	// prepareAgentForEnrollment on the agent (display name confirmed,
 	// runtime principal generated). executeManagedEnrollment must not run
@@ -398,7 +403,11 @@ type managedGatewayUpstream struct {
 	CredentialPayload map[string]interface{}
 	UsesAmbientAuth   bool
 	ManagedModelAlias string
-	Notes             []string
+	// AllowServerCredentialReuse lets an explicit operator model pick reuse a
+	// credential already stored on the matching account AI model, even for
+	// agent kinds that do not otherwise qualify for Claude-style OAuth reuse.
+	AllowServerCredentialReuse bool
+	Notes                      []string
 }
 
 func (u *managedGatewayUpstream) CanRouteThroughGateway() bool {
@@ -508,7 +517,9 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 	// to MCP-only hides the choice from the operator. Non-interactive runs
 	// (--yes / --dry-run / PRELOOP_CONFIRM) keep the degrade behavior; the
 	// preview note explains how to resolve it.
-	gatewayHints := managedGatewayResolutionHints{}
+	gatewayHints := managedGatewayResolutionHints{
+		PreferredModelAlias: strings.TrimSpace(opts.PreferredModel),
+	}
 	if supportsManagedGateway(agent) &&
 		!opts.DryRun &&
 		!opts.AutoApprove &&
@@ -523,6 +534,25 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 			return promptErr
 		}
 		gatewayHints.PreferredProviderID = selectedProvider
+	}
+	if supportsManagedGateway(agent) {
+		inferredForPicker, pickerErr := resolveManagedGatewayUpstreamWithHints(agent, gatewayHints)
+		if pickerErr != nil {
+			return pickerErr
+		}
+		selectedAlias, selectedModel, selectErr := resolveManagedModelSelection(
+			client,
+			agent,
+			inferredForPicker,
+			opts,
+		)
+		if selectErr != nil {
+			return selectErr
+		}
+		if selectedAlias != "" {
+			gatewayHints.PreferredModelAlias = selectedAlias
+			gatewayHints.SelectedAIModel = selectedModel
+		}
 	}
 
 	plan, err := buildManagedMCPEnrollmentPlan(
@@ -541,6 +571,11 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		if upstreamErr != nil {
 			return upstreamErr
 		}
+		upstream = applySelectedModelToUpstream(
+			upstream,
+			gatewayHints.PreferredModelAlias,
+			gatewayHints.SelectedAIModel,
+		)
 		if upstream != nil {
 			plan.Notes = append(plan.Notes, upstream.Notes...)
 		}
@@ -710,6 +745,11 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		if upstreamErr != nil {
 			return upstreamErr
 		}
+		upstream = applySelectedModelToUpstream(
+			upstream,
+			gatewayHints.PreferredModelAlias,
+			gatewayHints.SelectedAIModel,
+		)
 		if upstream != nil {
 			plan.Notes = append(plan.Notes, upstream.Notes...)
 		}
@@ -952,13 +992,28 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 	liveValidationGatewayVerified := false
 	liveValidationKeepsGatewayConfig := false
 	liveValidationRolledBack := false
+	var liveValidationDuration time.Duration
 	if requestedLiveValidation {
+		fmt.Fprint(output, "Sending test prompt through gateway...") //nolint:errcheck
+		started := time.Now()
 		liveOutcome, err := runManagedAgentLiveValidation(client, agent, validationResult)
+		liveValidationDuration = time.Since(started)
 		if liveOutcome != nil && len(liveOutcome.ValidationResult) > 0 {
 			validationResult = liveOutcome.ValidationResult
 		}
 		liveValidationGatewayVerified = liveValidationStatusGatewayVerified(validationResult)
 		liveValidationKeepsGatewayConfig = liveValidationStatusKeepsGatewayConfig(validationResult)
+		modelAlias := strings.TrimSpace(plan.ManagedModelAlias)
+		if alias, _ := validationResult["live_validation_model_alias"].(string); strings.TrimSpace(alias) != "" {
+			modelAlias = strings.TrimSpace(alias)
+		}
+		printLiveValidationRoundTripResult(
+			output,
+			liveOutcome,
+			err,
+			modelAlias,
+			liveValidationDuration,
+		)
 		if liveOutcome != nil && liveOutcome.Attempted {
 			// A probe the upstream provider refused (rate limit, billing) is
 			// inconclusive, not a failure: the static config checks passed and
@@ -1106,6 +1161,11 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 	}
 	fmt.Printf("  Config updated: %s\n", agent.ConfigPath)
 	fmt.Printf("  Backup saved: %s\n", backupState.BackupPath)
+	printOnboardingFollowUpCommands(
+		output,
+		resolveAgentDisplayName(agent),
+		backupState.BackupPath,
+	)
 	if liveValidationErr != nil && liveValidationRolledBack {
 		// The gateway routing was reverted to the pre-onboarding provider, so
 		// ``preloop agents validate <agent> --live`` can never succeed anymore
@@ -1186,8 +1246,8 @@ func onboardingCompletionHeadline(
 // liveValidationRollbackError marks an enrollment whose live validation
 // failed hard enough that the managed model gateway configuration was rolled
 // back to the pre-onboarding provider. MCP onboarding remains applied, but
-// managed model routing is NOT active and ``preloop agents validate <agent>
-// --live`` can never succeed until the agent is re-onboarded. Single-agent
+// managed model routing is NOT active and “preloop agents validate <agent>
+// --live“ can never succeed until the agent is re-onboarded. Single-agent
 // invocations must exit non-zero on this error; batch flows record the agent
 // as failed in the summary.
 type liveValidationRollbackError struct {
@@ -1715,12 +1775,11 @@ func shouldPreferCurrentConfigForGatewayResolution(agent AgentConfig, current ma
 }
 
 // managedGatewayResolutionHints carries operator-supplied disambiguation for
-// upstream resolution. Today the only hint is a preferred provider ID for
-// agents whose local state is ambiguous (e.g. OpenCode with several auth
-// profiles and no configured or recently-used model); resolvers ignore hints
-// they do not need.
+// upstream resolution. Resolvers ignore hints they do not need.
 type managedGatewayResolutionHints struct {
 	PreferredProviderID string
+	PreferredModelAlias string
+	SelectedAIModel     *aiModelResponse
 }
 
 func resolveManagedGatewayUpstream(agent AgentConfig) (*managedGatewayUpstream, error) {
@@ -2344,12 +2403,18 @@ func upstreamEligibleForServerCredentialReuse(
 	agent AgentConfig,
 	upstream *managedGatewayUpstream,
 ) bool {
-	if upstream == nil || !isClaudeCodeAgent(agent) {
+	if upstream == nil {
 		return false
 	}
-	return strings.TrimSpace(upstream.ProviderName) != "" &&
-		strings.TrimSpace(upstream.ModelIdentifier) != "" &&
-		strings.TrimSpace(upstream.ManagedModelAlias) != ""
+	if strings.TrimSpace(upstream.ProviderName) == "" ||
+		strings.TrimSpace(upstream.ModelIdentifier) == "" ||
+		strings.TrimSpace(upstream.ManagedModelAlias) == "" {
+		return false
+	}
+	if upstream.AllowServerCredentialReuse {
+		return true
+	}
+	return isClaudeCodeAgent(agent)
 }
 
 // serverHasReusableGatewayCredential checks (best-effort, read-only) whether

--- a/cli/internal/cmd/agents_runtime_install.go
+++ b/cli/internal/cmd/agents_runtime_install.go
@@ -41,6 +41,7 @@ func init() {
 	agentsInstallRuntimeCmd.Flags().BoolP("force", "f", false, "alias for --yes")
 	agentsInstallRuntimeCmd.Flags().Bool("live-validate", true, "after onboarding, run a supported live validation prompt through the agent")
 	agentsInstallRuntimeCmd.Flags().Bool("skip-live-validate", false, "do not run a live validation prompt after onboarding")
+	agentsInstallRuntimeCmd.Flags().String("model", "", "managed model alias to use for gateway routing (skips the interactive model picker)")
 }
 
 type runtimeInstallSpec struct {
@@ -114,6 +115,8 @@ func runAgentsInstallRuntime(cmd *cobra.Command, args []string) error {
 	autoApprove := isAutoApprove(cmd)
 	liveValidate, _ := cmd.Flags().GetBool("live-validate")
 	skipLiveValidate, _ := cmd.Flags().GetBool("skip-live-validate")
+	preferredModel, _ := cmd.Flags().GetString("model")
+	preferredModel = strings.TrimSpace(preferredModel)
 
 	if dryRun {
 		fmt.Printf("Would install %s with: %s\n", spec.displayName, spec.installSummary)
@@ -121,6 +124,9 @@ func runAgentsInstallRuntime(cmd *cobra.Command, args []string) error {
 			fmt.Println("Would skip upstream runtime installation (--skip-install).")
 		}
 		fmt.Printf("Would onboard with: preloop agents onboard %s", spec.onboardAgentName)
+		if preferredModel != "" {
+			fmt.Printf(" --model %s", preferredModel)
+		}
 		if autoApprove {
 			fmt.Print(" -y")
 		}
@@ -171,6 +177,7 @@ func runAgentsInstallRuntime(cmd *cobra.Command, args []string) error {
 		SkipConfirmation: autoApprove,
 		LiveValidate:     liveValidate,
 		SkipLiveValidate: skipLiveValidate,
+		PreferredModel:   preferredModel,
 	}
 	// A skipped managed launcher (missing agent binary) is a partial success:
 	// the warning has been printed and the command exits 0.


### PR DESCRIPTION
## Summary
- Add interactive managed-model picker before `agents onboard` / `install-runtime`, with `--model` for non-interactive use and a printed inferred-model fallback when stdin is not a TTY / `-y` is set.
- End install/onboard with an explicit gateway round-trip line (`Sending test prompt through gateway... ✓ round-trip OK, model=..., latency=...s`) and a red actionable failure otherwise; reuse existing live-validate machinery.
- Print reconfigure (`preloop agents onboard <agent> --model <m>`) and undo (`preloop agents offboard ...`) hints after mutating agents commands.
- Repair the broken `recoverDeferredGatewayValidationFailure` merge from #134 so `cli/internal/cmd` builds again.

### Judgment calls
- Model picker lists the inferred local upstream model plus account AI models that already have credentials, showing credential/subscription labels. Selecting an account model without local credentials opts into server-credential reuse for that pick.
- No dedicated `reconfigure` subcommand: re-running `onboard --model` is the documented reconfigure path, matching the issue example.

Fixes #113

## Test plan
- [x] `cd cli && go build ./...`
- [x] `cd cli && go test ./internal/cmd/ -count=1` (full package; passes)
- [x] Targeted coverage for `--model` passthrough, non-TTY fallback notice, reconfigure/undo summary lines, and e2e round-trip formatting
- [ ] Manual: interactive `preloop agents onboard hermes` shows model list with credential labels
- [ ] Manual: `preloop agents install-runtime hermes --model <alias> -y` skips picker and prints round-trip + undo lines


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-structured Go CLI changes with solid test coverage; all previous review issues addressed.
>
> **Overview**
> Adds an interactive model picker, e2e gateway round-trip check, and undo/reconfigure hints to `agents onboard` and `install-runtime`. Fixes a broken merge from #134. Follows existing patterns closely with dedicated new files for model picker and UX helpers.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai). Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->