### PR TITLE
feat(tools): per-tool schema token cost and context tax (#128 items 1-2)

### DIFF
--- a/backend/preloop/api/endpoints/tools.py
+++ b/backend/preloop/api/endpoints/tools.py
@@ -42,6 +42,7 @@ from preloop.schemas.tool_approval_condition import (
     ConditionTestResponse,
 )
 from preloop.services.policy_evaluator import evaluate_cel_expression
+from preloop.services.tool_schema_tokens import estimate_tool_schema_tokens
 from preloop.services.tool_usage_stats import ToolUsageStatsService
 from preloop.schemas.gateway_usage import GatewayUsageByTool
 from preloop.utils.audit import log_config_change
@@ -576,6 +577,9 @@ def list_all_tools(
             required_str = ", ".join(required_tracker_types)
             unsupported_reason = f"Add a {required_str} tracker to enable this tool"
 
+        justification_mode = config.justification_mode if config else None
+        if justification_mode is not None and not isinstance(justification_mode, str):
+            justification_mode = None
         tools.append(
             {
                 "name": builtin_tool["name"],
@@ -599,7 +603,13 @@ def list_all_tools(
                 if config_id
                 else False,
                 "access_rules": rules_by_config.get(config_id, []) if config_id else [],
-                "justification_mode": config.justification_mode if config else None,
+                "justification_mode": justification_mode,
+                "schema_tokens_estimate": estimate_tool_schema_tokens(
+                    name=builtin_tool["name"],
+                    description=builtin_tool["description"],
+                    schema=builtin_tool["schema"],
+                    justification_mode=justification_mode,
+                ),
             }
         )
 
@@ -612,10 +622,16 @@ def list_all_tools(
         for mcp_tool in mcp_tools:
             config = config_map.get((mcp_tool.name, "mcp", str(server.id)))
             config_id = str(config.id) if config else None
+            justification_mode = config.justification_mode if config else None
+            if justification_mode is not None and not isinstance(
+                justification_mode, str
+            ):
+                justification_mode = None
+            description = mcp_tool.description or ""
             tools.append(
                 {
                     "name": mcp_tool.name,
-                    "description": mcp_tool.description or "",
+                    "description": description,
                     "source": "mcp",
                     "source_id": str(server.id),
                     "source_name": server.name,
@@ -635,7 +651,13 @@ def list_all_tools(
                     "access_rules": rules_by_config.get(config_id, [])
                     if config_id
                     else [],
-                    "justification_mode": config.justification_mode if config else None,
+                    "justification_mode": justification_mode,
+                    "schema_tokens_estimate": estimate_tool_schema_tokens(
+                        name=mcp_tool.name,
+                        description=description,
+                        schema=mcp_tool.input_schema,
+                        justification_mode=justification_mode,
+                    ),
                 }
             )
 

--- a/backend/preloop/services/tool_schema_tokens.py
+++ b/backend/preloop/services/tool_schema_tokens.py
@@ -1,0 +1,98 @@
+"""Estimate per-tool schema token cost as served to agents.
+
+Mirrors the justification-parameter injection in
+``dynamic_fastmcp.list_tools`` and uses the same ``estimate_tokens``
+heuristic as gateway ``tools_meta`` attribution.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any, Mapping, Optional
+
+from preloop.services.context_optimization import estimate_tokens
+
+# Keep in sync with dynamic_fastmcp.list_tools justification injection.
+_JUSTIFICATION_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "description": (
+        "Provide your reasoning and context for why "
+        "this tool is being called. This will be "
+        "reviewed by approvers and logged for audit "
+        "purposes."
+    ),
+}
+
+
+def apply_justification_to_schema(
+    schema: Optional[Mapping[str, Any]],
+    justification_mode: Optional[str],
+) -> dict[str, Any]:
+    """Return a schema copy with justification injected when configured.
+
+    Args:
+        schema: Tool input JSON schema (may be None).
+        justification_mode: ``optional``, ``required``, or other/None.
+
+    Returns:
+        Schema dict reflecting what ``list_tools`` would advertise.
+    """
+    base: dict[str, Any]
+    if isinstance(schema, Mapping):
+        base = copy.deepcopy(dict(schema))
+    else:
+        base = {"type": "object", "properties": {}}
+
+    if justification_mode not in ("optional", "required"):
+        return base
+
+    properties = base.setdefault("properties", {})
+    if not isinstance(properties, dict):
+        properties = {}
+        base["properties"] = properties
+    properties["justification"] = copy.deepcopy(_JUSTIFICATION_PROPERTY)
+
+    if justification_mode == "required":
+        required = list(base.get("required") or [])
+        if "justification" not in required:
+            required.append("justification")
+        base["required"] = required
+
+    return base
+
+
+def estimate_tool_schema_tokens(
+    *,
+    name: str,
+    description: str,
+    schema: Optional[Mapping[str, Any]],
+    justification_mode: Optional[str] = None,
+) -> int:
+    """Estimate tokens for a tool definition as served to agents.
+
+    Serializes name, description, and parameters (with justification
+    injection when configured) the same way gateway ``tools_meta``
+    estimates schema cost: ``json.dumps(..., sort_keys=True)`` plus
+    ``estimate_tokens``.
+
+    Args:
+        name: Tool name.
+        description: Tool description.
+        schema: Input JSON schema before injection.
+        justification_mode: Optional/required justification setting.
+
+    Returns:
+        Estimated token count for one request that advertises this tool.
+    """
+    served_schema = apply_justification_to_schema(schema, justification_mode)
+    definition = {
+        "name": name,
+        "description": description or "",
+        "parameters": served_schema,
+    }
+    try:
+        schema_json = json.dumps(definition, default=str, sort_keys=True)
+    except (TypeError, ValueError):
+        schema_json = ""
+    return int(estimate_tokens(schema_json))

--- a/backend/tests/endpoints/test_tools.py
+++ b/backend/tests/endpoints/test_tools.py
@@ -86,6 +86,8 @@ class TestListAllTools:
         for tool in result:
             expected = tool["name"] not in default_disabled
             assert tool["is_enabled"] is expected
+            assert isinstance(tool["schema_tokens_estimate"], int)
+            assert tool["schema_tokens_estimate"] > 0
 
     async def test_default_disabled_tool_enabled_by_config(
         self, mock_db, mock_user, mock_account, mocker
@@ -131,6 +133,7 @@ class TestListAllTools:
         config.mcp_server_id = None
         config.is_enabled = False
         config.approval_workflow_id = workflow_id
+        config.justification_mode = None
 
         # Mock CRUD operations
         mocker.patch(
@@ -150,6 +153,50 @@ class TestListAllTools:
         get_issue_tool = next(t for t in result if t["name"] == "get_issue")
         assert get_issue_tool["is_enabled"] is False
         assert get_issue_tool["approval_workflow_id"] == str(workflow_id)
+
+    async def test_list_tools_schema_tokens_include_justification(
+        self, mock_db, mock_user, mock_account, mocker
+    ):
+        """Required justification increases the served schema token estimate."""
+        config = MagicMock(spec=ToolConfiguration)
+        config.id = uuid.uuid4()
+        config.tool_name = "get_issue"
+        config.tool_source = "builtin"
+        config.mcp_server_id = None
+        config.is_enabled = True
+        config.approval_workflow_id = None
+        config.justification_mode = "required"
+
+        mocker.patch(
+            "preloop.api.endpoints.tools.crud_tool_configuration.get_multi_by_account",
+            return_value=[config],
+        )
+        mocker.patch(
+            "preloop.api.endpoints.tools.crud_mcp_server.get_active_by_account",
+            return_value=[],
+        )
+        mocker.patch(
+            "preloop.api.endpoints.tools.crud_tool_access_rule.get_multi_by_account",
+            return_value=[],
+        )
+        mocker.patch(
+            "preloop.api.endpoints.tools.crud_tracker.get_for_account",
+            return_value=[],
+        )
+
+        with_justification = tools.list_all_tools(
+            account=mock_account, current_user=mock_user, db=mock_db
+        )
+        justified = next(t for t in with_justification if t["name"] == "get_issue")
+
+        config.justification_mode = None
+        without = tools.list_all_tools(
+            account=mock_account, current_user=mock_user, db=mock_db
+        )
+        plain = next(t for t in without if t["name"] == "get_issue")
+
+        assert justified["schema_tokens_estimate"] > plain["schema_tokens_estimate"]
+        assert justified["justification_mode"] == "required"
 
     async def test_list_tools_with_mcp_servers(
         self, mock_db, mock_user, mock_account, mocker

--- a/backend/tests/services/test_tool_schema_tokens.py
+++ b/backend/tests/services/test_tool_schema_tokens.py
@@ -1,0 +1,87 @@
+"""Unit tests for served-schema token estimates."""
+
+from __future__ import annotations
+
+import json
+
+from preloop.services.context_optimization import estimate_tokens
+from preloop.services.tool_schema_tokens import (
+    apply_justification_to_schema,
+    estimate_tool_schema_tokens,
+)
+
+
+def test_apply_justification_optional_adds_property_not_required() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+        "required": ["query"],
+    }
+    served = apply_justification_to_schema(schema, "optional")
+    assert "justification" in served["properties"]
+    assert "justification" not in served["required"]
+    # Original schema must not be mutated.
+    assert "justification" not in schema["properties"]
+
+
+def test_apply_justification_required_adds_to_required() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+        "required": ["query"],
+    }
+    served = apply_justification_to_schema(schema, "required")
+    assert "justification" in served["properties"]
+    assert served["required"] == ["query", "justification"]
+
+
+def test_apply_justification_ignored_for_other_modes() -> None:
+    schema = {"type": "object", "properties": {}}
+    assert apply_justification_to_schema(schema, None) == schema
+    assert apply_justification_to_schema(schema, "disabled") == schema
+
+
+def test_estimate_includes_justification_tokens() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+        "required": ["query"],
+    }
+    base = estimate_tool_schema_tokens(
+        name="search",
+        description="Search issues",
+        schema=schema,
+        justification_mode=None,
+    )
+    with_required = estimate_tool_schema_tokens(
+        name="search",
+        description="Search issues",
+        schema=schema,
+        justification_mode="required",
+    )
+    assert base > 0
+    assert with_required > base
+
+
+def test_estimate_matches_gateway_serialization() -> None:
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    expected = estimate_tokens(
+        json.dumps(
+            {
+                "description": "desc",
+                "name": "tool",
+                "parameters": schema,
+            },
+            default=str,
+            sort_keys=True,
+        )
+    )
+    assert (
+        estimate_tool_schema_tokens(
+            name="tool",
+            description="desc",
+            schema=schema,
+            justification_mode=None,
+        )
+        == expected
+    )

--- a/frontend/src/components/tool-card.ts
+++ b/frontend/src/components/tool-card.ts
@@ -49,6 +49,8 @@ export interface Tool {
   has_approval_condition: boolean;
   config_id: string | null;
   justification_mode?: string | null;
+  /** Estimated tokens for this tool's schema as served (incl. justification). */
+  schema_tokens_estimate?: number;
 }
 
 export interface ApprovalWorkflow {

--- a/frontend/src/components/tool-list-item.test.ts
+++ b/frontend/src/components/tool-list-item.test.ts
@@ -214,4 +214,16 @@ describe('ToolListItem – justification settings', () => {
 
     expect((el as any)._showJustificationDialog).to.be.false;
   });
+
+  it('shows per-tool schema token estimate', async () => {
+    stubApi();
+    const el = await createItem({ schema_tokens_estimate: 245 } as any);
+    await el.updateComplete;
+
+    const badge = el.shadowRoot?.querySelector('.schema-tokens');
+    expect(badge).to.exist;
+    expect(badge!.textContent?.replace(/\s+/g, ' ').trim()).to.equal(
+      '~245 tokens/request'
+    );
+  });
 });

--- a/frontend/src/components/tool-list-item.ts
+++ b/frontend/src/components/tool-list-item.ts
@@ -110,6 +110,14 @@ export class ToolListItem extends LitElement {
       flex-shrink: 0;
     }
 
+    .schema-tokens {
+      color: var(--sl-color-neutral-500);
+      font-size: var(--sl-font-size-x-small);
+      white-space: nowrap;
+      flex-shrink: 0;
+      font-variant-numeric: tabular-nums;
+    }
+
     .rule-summary {
       display: flex;
       align-items: center;
@@ -423,6 +431,19 @@ export class ToolListItem extends LitElement {
           <span class="tool-name">${this.tool.name}</span>
 
           <div class="tool-badges">
+            ${
+              typeof this.tool.schema_tokens_estimate === 'number' &&
+              this.tool.schema_tokens_estimate > 0
+                ? html`<sl-tooltip
+                    content="Estimated schema tokens added to every agent request that advertises this tool (includes justification parameters when configured)"
+                  >
+                    <span class="schema-tokens"
+                      >~${this.tool.schema_tokens_estimate.toLocaleString()}
+                      tokens/request</span
+                    >
+                  </sl-tooltip>`
+                : ''
+            }
             ${
               this.usageStat &&
               (this.usageStat.invocation_count > 0 ||

--- a/frontend/src/views/authed/tools-view.test.ts
+++ b/frontend/src/views/authed/tools-view.test.ts
@@ -182,6 +182,7 @@ describe('ToolsView (approvals + conditions)', () => {
       approval_workflow_id: null,
       has_approval_condition: false,
       config_id: null,
+      schema_tokens_estimate: 1200,
     };
     const unavailableTool = {
       ...availableTool,
@@ -189,6 +190,7 @@ describe('ToolsView (approvals + conditions)', () => {
       description: 'Needs a tracker',
       is_supported: false,
       unsupported_reason: 'Requires a connected tracker',
+      schema_tokens_estimate: 800,
     };
 
     fetchStub.callsFake(async (input: RequestInfo | URL) => {
@@ -224,6 +226,14 @@ describe('ToolsView (approvals + conditions)', () => {
     const note = el.shadowRoot?.querySelector('.unavailable-note');
     expect(note).to.exist;
     expect(note?.textContent).to.contain('Requires a connected tracker');
+
+    const contextTax = el.shadowRoot?.querySelector('.context-tax');
+    expect(contextTax).to.exist;
+    // Only enabled+supported tools contribute (1200), not unavailable (800).
+    expect(contextTax?.textContent?.replace(/\s+/g, ' ')).to.contain(
+      '~1,200 tokens'
+    );
+    expect(contextTax?.textContent).to.contain('to every agent request');
   });
 
   it('renders the native tool approvals account-default card with override links', async () => {

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -246,6 +246,19 @@ export class ToolsView extends LitElement {
         font-size: var(--sl-font-size-small);
       }
 
+      .context-tax {
+        margin-top: var(--sl-spacing-small);
+        color: var(--sl-color-neutral-700);
+        font-size: var(--sl-font-size-small);
+        line-height: 1.4;
+        max-width: 28rem;
+      }
+
+      .context-tax strong {
+        font-variant-numeric: tabular-nums;
+        color: var(--sl-color-neutral-900);
+      }
+
       .summary-table td {
         padding: 0;
         vertical-align: middle;
@@ -883,6 +896,11 @@ export class ToolsView extends LitElement {
         ) || t.approval_workflow_id
     );
     const noApproval = all.length - requireApproval.length;
+    // Sum schemas that are actually advertised (enabled + supported).
+    const contextTaxTokens = enabled.reduce((sum, tool) => {
+      const tokens = tool.schema_tokens_estimate;
+      return sum + (typeof tokens === 'number' && tokens > 0 ? tokens : 0);
+    }, 0);
 
     return {
       total: all.length,
@@ -896,6 +914,7 @@ export class ToolsView extends LitElement {
       withoutRules,
       requireApproval: requireApproval.length,
       noApproval,
+      contextTaxTokens,
       unavailableReasons: [
         ...new Set(
           unavailable
@@ -1862,6 +1881,17 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
               ${statCell('No approval', stats.noApproval, 'no_approval')}
             </tr>
           </table>
+          ${
+            stats.contextTaxTokens > 0
+              ? html`<div class="context-tax">
+                  Enabled tools add
+                  <strong
+                    >~${stats.contextTaxTokens.toLocaleString()} tokens</strong
+                  >
+                  to every agent request
+                </div>`
+              : ''
+          }
           ${
             stats.unavailable > 0
               ? html`<div class="unavailable-note">


### PR DESCRIPTION
## Summary
- Part of #128 (items 1-2): each tool on the Tools page now shows `~N tokens/request`, computed from the schema as served (including injected justification parameters when configured).
- Adds a summary line: "Enabled tools add ~N tokens to every agent request" summing enabled+supported tools.
- Items 3 (post-tracker review prompt) and 4 (session-optimizer for builtins) are deferred; this PR does not close #128.

## Implementation notes
- New helper `estimate_tool_schema_tokens` reuses `estimate_tokens` and mirrors `dynamic_fastmcp` justification injection.
- Additive `schema_tokens_estimate` field on `GET /tools` only (minimal overlap with in-flight #132 agent-scoped tool config work).

## Test plan
- [x] `pytest backend/tests/services/test_tool_schema_tokens.py backend/tests/endpoints/test_tools.py backend/tests/services/test_tool_usage_stats_unit.py`
- [x] `ruff check` / `ruff format` on touched backend files
- [x] Frontend: `tool-list-item` + `tools-view` tests for token badge and context-tax header
- [ ] Manual: open Tools page, confirm per-tool `~N tokens/request` and header total; toggle justification required and confirm estimate increases after reload


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **🟢 Low Risk**
> Additive change: new field on `GET /tools` response and a read-only frontend display. No mutable operations, no schema changes, no breaking API contracts.
>
> **Overview**
> Adds per-tool `schema_tokens_estimate` (computed from served schema including justification injection) and a "context tax" summary line on the Tools page. Implementation mirrors existing `dynamic_fastmcp` and `_capture_tools_meta` patterns. Well-tested across backend and frontend. Minor docs recommendation: document the new field in API docs.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/tools-context-tax-128. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->