### PR TITLE
hotfix: repair cli/internal/cmd compile break from #134 merge

### DIFF
--- a/cli/internal/cmd/agents_live_validate.go
+++ b/cli/internal/cmd/agents_live_validate.go
@@ -1341,16 +1341,10 @@ func recoverDeferredGatewayValidationFailure(
 	output interface{ Write(p []byte) (int, error) },
 	result deferredLiveValidationResult,
 ) {
-	if result.Err == nil {
-		return
-	}
-func recoverDeferredGatewayValidationFailure(
-	output interface{ Write(p []byte) (int, error) },
-	result deferredLiveValidationResult,
-) {
 	if result.Err == nil || result.Outcome == nil {
 		return
 	}
+	if liveValidationStatusKeepsGatewayConfig(result.Outcome.ValidationResult) {
 		note := liveValidationUpstreamNote(result.Outcome.ValidationResult)
 		if note == "" {
 			note = "the live validation probe failed"


### PR DESCRIPTION
## Summary
- The merge of #134 corrupted `recoverDeferredGatewayValidationFailure` in `cli/internal/cmd/agents_live_validate.go`: a duplicated function header and a missing `liveValidationStatusKeepsGatewayConfig` guard left `cli/internal/cmd` unable to compile.
- That breaks the **CLI Tests (Windows)** job on every open PR that builds against current main.
- This PR is the minimal repair only (restore the single correct function body, keep the nil-Outcome guard).

Also contained in PR #139 (install-runtime UX). After this hotfix merges, #139 should be rebased onto main (or merged second); the identical hunks will dedupe cleanly if unchanged.

## Test plan
- [x] `cd cli && go build ./...`
- [x] `cd cli && go test ./internal/cmd/ -count=1` (pass; clear Cursor host env when running locally under Cursor Agent)


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Minimal compile fix (1 file, +1/-7) restoring a corrupted function after merge conflict. Build compiles, all tests pass.
>
> **Overview**
> Hotfix repairing the `recoverDeferredGatewayValidationFailure` function in `cli/internal/cmd/agents_live_validate.go` after merge #134 corrupted it with a duplicated function header and a missing guard clause. This is a known-good fix also present in PR #139.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit `fix/cli-compile-main`. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
