### PR TITLE
feat(optimizer): recommend account-wide disable for unused builtins (#146)

### DIFF
--- a/backend/preloop/services/builtin_tool_optimizer.py
+++ b/backend/preloop/services/builtin_tool_optimizer.py
@@ -1,0 +1,209 @@
+"""Helpers for account-wide unused-builtin recommendations (#146).
+
+Maps session ``unused_tool_names`` onto Preloop builtins (handling
+``mcp__preloop__*`` prefixes without misclassifying external MCP tools),
+tiers them against account-wide invocation stats, and expands bare/prefixed
+name aliases for replay matching.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Optional, Sequence
+
+# Clients advertise Preloop gateway tools as ``mcp__<server>__<tool>``. Accept
+# both the product name and the FastMCP server name used in dynamic_fastmcp.
+PRELOOP_MCP_SERVERS = frozenset({"preloop", "preloop-mcp"})
+
+# Account-wide corroboration window for tier-1 disable recommendations.
+BUILTIN_USAGE_WINDOW_DAYS = 30
+
+
+def parse_mcp_tool_name(name: str) -> tuple[Optional[str], str]:
+    """Split an ``mcp__server__tool`` name into (server, bare_tool).
+
+    Bare names and non-``mcp__`` names return ``(None, name)``. Unlike a naive
+    first-``__`` split, this keeps the server segment intact so
+    ``mcp__preloop__get_issue`` yields ``("preloop", "get_issue")``.
+
+    Args:
+        name: Advertised or invoked tool name.
+
+    Returns:
+        Tuple of optional server segment and bare tool name.
+    """
+    if not name.startswith("mcp__"):
+        return (None, name)
+    parts = name.split("__", 2)
+    if len(parts) == 3 and parts[1] and parts[2]:
+        return (parts[1], parts[2])
+    return (None, name)
+
+
+def expand_tool_name_match_keys(name: str) -> set[str]:
+    """Return bare + Preloop-prefixed aliases that should match ``name``.
+
+    External MCP prefixes (e.g. ``mcp__github__search``) are not expanded to
+    bare names, so they never collide with Preloop builtins of the same bare
+    name.
+
+    Args:
+        name: A tool name in bare or ``mcp__…`` form.
+
+    Returns:
+        Set of equivalent names for matching.
+    """
+    keys = {name}
+    server, bare = parse_mcp_tool_name(name)
+    if server is None:
+        for alias in PRELOOP_MCP_SERVERS:
+            keys.add(f"mcp__{alias}__{name}")
+        return keys
+    if server in PRELOOP_MCP_SERVERS:
+        keys.add(bare)
+        for alias in PRELOOP_MCP_SERVERS:
+            keys.add(f"mcp__{alias}__{bare}")
+    return keys
+
+
+def tool_name_in_removed(definition_name: str, removed: set[str]) -> bool:
+    """Return whether a tool definition name matches a removed-name set.
+
+    Accepts builtin names in both bare and Preloop-prefixed forms.
+
+    Args:
+        definition_name: Name from a request tool definition.
+        removed: Candidate ``removed_tool_names``.
+
+    Returns:
+        True when the definition should be stripped.
+    """
+    if not definition_name or not removed:
+        return False
+    def_keys = expand_tool_name_match_keys(definition_name)
+    for candidate in removed:
+        if def_keys & expand_tool_name_match_keys(candidate):
+            return True
+    return False
+
+
+def resolve_builtin_tool_name(
+    unused_name: str, *, builtin_names: set[str]
+) -> Optional[str]:
+    """Map an unused advertised name onto a Preloop builtin bare name.
+
+    Prefixed names only resolve when the server segment is a Preloop gateway
+    alias. Bare names resolve when they appear in ``builtin_names``.
+
+    Args:
+        unused_name: Entry from ``unused_tool_names``.
+        builtin_names: Catalog of builtin bare names.
+
+    Returns:
+        Bare builtin name, or ``None`` when the name is not a Preloop builtin.
+    """
+    server, bare = parse_mcp_tool_name(unused_name)
+    if server is not None and server not in PRELOOP_MCP_SERVERS:
+        return None
+    if bare in builtin_names:
+        return bare
+    return None
+
+
+@dataclass(frozen=True)
+class UnusedBuiltinPartition:
+    """Tiered split of unused tools for optimizer suggestions.
+
+    Attributes:
+        tier1_raw_names: Unused advertised names with zero account-wide
+            invocations (eligible for account-wide disable).
+        tier1_builtin_names: Deduped bare builtin names for tier 1.
+        scope_raw_names: Remaining unused names (non-builtins, or builtins
+            still invoked elsewhere) for agent-scoped ``scope_tools``.
+        tier1_session_tokens: Resend-inclusive session tokens for tier-1 names.
+        scope_session_tokens: Resend-inclusive session tokens for scope names.
+    """
+
+    tier1_raw_names: list[str]
+    tier1_builtin_names: list[str]
+    scope_raw_names: list[str]
+    tier1_session_tokens: int
+    scope_session_tokens: int
+
+
+def partition_unused_tools(
+    unused_tool_names: Sequence[str],
+    *,
+    builtin_names: set[str],
+    unused_tool_tokens: Mapping[str, int],
+    invocation_counts: Mapping[str, int],
+) -> UnusedBuiltinPartition:
+    """Split unused tools into account-wide disable vs agent-scoped scope.
+
+    Tier 1 requires zero account-wide invocations for the bare builtin name
+    over the stats window. Tier 2 (invoked elsewhere) and non-builtins stay on
+    the agent-scoped path.
+
+    Args:
+        unused_tool_names: Advertised-but-unused names from the session.
+        builtin_names: Catalog of builtin bare names.
+        unused_tool_tokens: Per-advertised-name resend-inclusive token totals.
+        invocation_counts: Account-wide invocation counts keyed by bare name.
+
+    Returns:
+        Partition with carved token totals that sum to the unused total.
+    """
+    tier1_raw: list[str] = []
+    tier1_builtins: list[str] = []
+    seen_builtins: set[str] = set()
+    scope_raw: list[str] = []
+    tier1_tokens = 0
+    scope_tokens = 0
+
+    for raw_name in unused_tool_names:
+        tokens = int(unused_tool_tokens.get(raw_name, 0))
+        builtin = resolve_builtin_tool_name(raw_name, builtin_names=builtin_names)
+        if builtin is None:
+            scope_raw.append(raw_name)
+            scope_tokens += tokens
+            continue
+        if int(invocation_counts.get(builtin, 0)) > 0:
+            scope_raw.append(raw_name)
+            scope_tokens += tokens
+            continue
+        tier1_raw.append(raw_name)
+        tier1_tokens += tokens
+        if builtin not in seen_builtins:
+            seen_builtins.add(builtin)
+            tier1_builtins.append(builtin)
+
+    return UnusedBuiltinPartition(
+        tier1_raw_names=tier1_raw,
+        tier1_builtin_names=tier1_builtins,
+        scope_raw_names=scope_raw,
+        tier1_session_tokens=tier1_tokens,
+        scope_session_tokens=scope_tokens,
+    )
+
+
+def invocation_counts_by_tool(
+    usage_rows: Iterable[object],
+) -> dict[str, int]:
+    """Build bare-name → invocation_count from GatewayUsageByTool-like rows.
+
+    Args:
+        usage_rows: Rows with ``tool_name`` and ``invocation_count``.
+
+    Returns:
+        Mapping of bare tool name to account-wide invocation count.
+    """
+    counts: dict[str, int] = {}
+    for row in usage_rows:
+        tool_name = getattr(row, "tool_name", None)
+        if not tool_name:
+            continue
+        _server, bare = parse_mcp_tool_name(str(tool_name))
+        counts[bare] = counts.get(bare, 0) + int(
+            getattr(row, "invocation_count", 0) or 0
+        )
+    return counts

--- a/backend/preloop/services/context_analysis.py
+++ b/backend/preloop/services/context_analysis.py
@@ -131,6 +131,10 @@ class ToolSchemaOverheadProfile(BaseModel):
     advertised_tools: int = 0
     invoked_tools: int = 0
     unused_tool_names: list[str] = Field(default_factory=list)
+    # Per-advertised-name resend-inclusive token totals for unused tools.
+    # Used to carve disable-builtin-tools savings out of scope-tools without
+    # double-counting (#146).
+    unused_tool_tokens: dict[str, int] = Field(default_factory=dict)
     schema_tokens_estimate: int = 0
     unused_schema_tokens_estimate: int = 0
     resend_count: int = 0
@@ -177,9 +181,13 @@ def compute_profile_savings(
 
     Dedupe rules, in order:
 
-    * Unused tool-schema tokens are taken verbatim. ``analyze_tool_schema_overhead``
-      already accumulates each advertised schema once per resend, so multiplying
-      by ``resend_count`` again would be quadratic in the number of requests.
+    * Unused tool-schema tokens are taken verbatim from the profile. Suggestion
+      tiering (#146) may split those tokens across ``disable-builtin-tools`` and
+      ``scope-tools`` for display, but this roll-up still uses the single
+      profile figure so the headline total is unchanged by the split.
+      ``analyze_tool_schema_overhead`` already accumulates each advertised
+      schema once per resend, so multiplying by ``resend_count`` again would be
+      quadratic in the number of requests.
     * Tool-output waste takes ``max(compressible, largest oversized field)``:
       both measure the same tool-result bytes.
     * Cache-prefix waste overlaps the two above (the repeated prefix contains
@@ -989,11 +997,13 @@ def analyze_tool_schema_overhead(
         if isinstance(tool_name, str) and tool_name:
             invoked.add(tool_name)
     unused = sorted(set(advertised) - invoked)
-    unused_tokens = sum(advertised[name] for name in unused)
+    unused_tool_tokens = {name: advertised[name] for name in unused}
+    unused_tokens = sum(unused_tool_tokens.values())
     return ToolSchemaOverheadProfile(
         advertised_tools=len(advertised),
         invoked_tools=len(set(advertised) & invoked),
         unused_tool_names=unused,
+        unused_tool_tokens=unused_tool_tokens,
         schema_tokens_estimate=schema_tokens_total,
         unused_schema_tokens_estimate=unused_tokens,
         resend_count=resend_count,

--- a/backend/preloop/services/replay_savings_service.py
+++ b/backend/preloop/services/replay_savings_service.py
@@ -35,6 +35,7 @@ from preloop.services.replay_harness import (
     ReplayRunTokens,
     measure_replay_savings,
 )
+from preloop.services.builtin_tool_optimizer import tool_name_in_removed
 from preloop.services.savings_measurement import (
     InputTokenSavings,
     compute_input_token_savings,
@@ -533,7 +534,12 @@ def select_target_request(
             continue
         tools = request.get("tools") or request.get("functions") or []
         names = {_tool_name(t) for t in tools if isinstance(t, dict)}
-        has_removed = 1 if (names & removed_tool_names) else 0
+        # Accept bare/prefixed Preloop builtin aliases (#146).
+        has_removed = (
+            1
+            if any(tool_name_in_removed(name, removed_tool_names) for name in names)
+            else 0
+        )
         try:
             size = len(json.dumps(request, default=str))
         except (TypeError, ValueError):

--- a/backend/preloop/services/savings_measurement.py
+++ b/backend/preloop/services/savings_measurement.py
@@ -29,6 +29,7 @@ from typing import Any
 # this measurement matches the gateway's attribution byte-for-byte. Both symbols
 # are also re-exported from ``context_analysis`` for the billing plugin, but the
 # core module is their canonical home.
+from preloop.services.builtin_tool_optimizer import tool_name_in_removed
 from preloop.services.context_optimization import (
     estimate_tokens,
     tool_definition_name,
@@ -323,10 +324,14 @@ def _apply_tool_removal(
     tools = payload.get("tools")
     if not isinstance(tools, list):
         return
+    # Match bare builtin names against Preloop-prefixed advertisements and
+    # vice versa so replay candidates from disable-builtin-tools verify (#146).
     payload["tools"] = [
         definition
         for definition in tools
-        if tool_definition_name(definition) not in removed_tool_names
+        if not tool_name_in_removed(
+            tool_definition_name(definition), removed_tool_names
+        )
     ]
 
 

--- a/backend/preloop/services/session_optimization.py
+++ b/backend/preloop/services/session_optimization.py
@@ -31,6 +31,11 @@ from preloop.models.crud import (
     crud_runtime_session,
     crud_runtime_session_optimization_action,
     crud_runtime_session_optimization_result,
+    crud_tool_configuration,
+)
+from preloop.models.schemas.tool_configuration import (
+    ToolConfigurationCreate,
+    ToolConfigurationUpdate,
 )
 from preloop.models.models.account import Account
 from preloop.models.models.ai_model import AIModel
@@ -49,6 +54,12 @@ from preloop.schemas.gateway_usage import (
 )
 from preloop.services.account_governance_cache import (
     invalidate_account_governance_cache,
+)
+from preloop.services.builtin_tool_optimizer import (
+    BUILTIN_USAGE_WINDOW_DAYS,
+    UnusedBuiltinPartition,
+    invocation_counts_by_tool,
+    partition_unused_tools,
 )
 from preloop.services.context_analysis import (
     GatewayCallEvent,
@@ -76,6 +87,8 @@ from preloop.services.model_pricing import estimate_ai_model_usage_cost
 from preloop.services.model_runtime_resolver import resolve_ai_model_runtime
 from preloop.services.openai_gateway import OpenAIGatewayService
 from preloop.services.runtime_session_explorer import RuntimeSessionExplorerService
+from preloop.services.tool_schema_tokens import estimate_tool_schema_tokens
+from preloop.services.tool_usage_stats import ToolUsageStatsService
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +114,7 @@ LLM_SKIPPED_MODEL_EMPTY = "model_empty_response"
 
 # Server-applicable action types; open_events is resolved client-side.
 ACTION_SCOPE_TOOLS = "scope_tools"
+ACTION_DISABLE_BUILTIN_TOOLS = "disable_builtin_tools"
 ACTION_SET_BUDGET = "set_budget"
 ACTION_OPEN_EVENTS = "open_events"
 ACTION_ENABLE_COMPRESSION = "enable_compression"
@@ -108,6 +122,7 @@ ACTION_CAP_TOOL_RESULTS = "cap_tool_results"
 ACTION_MANAGE_OUTPUT_FILTER = "manage_output_filter"
 APPLYABLE_ACTION_TYPES = (
     ACTION_SCOPE_TOOLS,
+    ACTION_DISABLE_BUILTIN_TOOLS,
     ACTION_SET_BUDGET,
     ACTION_ENABLE_COMPRESSION,
     ACTION_CAP_TOOL_RESULTS,
@@ -197,7 +212,9 @@ class SessionOptimizationService:
             limit=GATEWAY_EVENT_LOAD_LIMIT,
         )
         profile = build_profile_from_events(runtime_session_id, gateway_events)
-        suggestions = self._local_optimization_suggestions(summary, profile)
+        suggestions = self._local_optimization_suggestions(
+            summary, profile, account=account
+        )
         llm_skipped_reason: Optional[str] = None
         if fast_model is not None and self._daily_optimization_cap_reached(account):
             logger.info(
@@ -459,6 +476,11 @@ class SessionOptimizationService:
             if profile and profile.tool_schema_overhead
             else []
         )
+        partition = self._partition_unused_for_account(account, profile)
+        tier1_builtins = list(partition.tier1_builtin_names) if partition else []
+        scope_tools = (
+            list(partition.scope_raw_names) if partition is not None else unused_tools
+        )
         suggested_budget = max(
             round(summary.estimated_cost * BUDGET_SUGGESTION_MULTIPLIER, 2), 1.0
         )
@@ -522,7 +544,13 @@ class SessionOptimizationService:
                     },
                 )
                 continue
-            if suggestion.id == "scope-tools" and agent_id and unused_tools:
+            if suggestion.id == "disable-builtin-tools" and tier1_builtins:
+                suggestion.action = RuntimeSessionOptimizationActionSpec(
+                    type=ACTION_DISABLE_BUILTIN_TOOLS,
+                    params={"tool_names": tier1_builtins},
+                )
+                continue
+            if suggestion.id == "scope-tools" and agent_id and scope_tools:
                 suggestion.action = RuntimeSessionOptimizationActionSpec(
                     type=ACTION_SCOPE_TOOLS,
                     params={
@@ -530,7 +558,7 @@ class SessionOptimizationService:
                         "subject_id": agent_id,
                         "subject_name": summary.runtime_principal_name
                         or summary.session_source_type,
-                        "tool_names": unused_tools,
+                        "tool_names": scope_tools,
                     },
                 )
             elif suggestion.id == "budget-guardrail" and agent_id:
@@ -554,7 +582,8 @@ class SessionOptimizationService:
                 inferred = self._infer_model_suggestion_action(
                     suggestion,
                     agent_id=agent_id,
-                    unused_tools=unused_tools,
+                    unused_tools=scope_tools,
+                    tier1_builtins=tier1_builtins,
                     top_oversized_field=top_oversized_field,
                     summary=summary,
                     suggested_budget=suggested_budget,
@@ -573,6 +602,7 @@ class SessionOptimizationService:
         *,
         agent_id: Optional[str],
         unused_tools: list[str],
+        tier1_builtins: list[str],
         top_oversized_field: Optional[Any],
         summary: RuntimeSessionSummary,
         suggested_budget: float,
@@ -587,7 +617,10 @@ class SessionOptimizationService:
         Args:
             suggestion: The model-authored suggestion.
             agent_id: Resolved managed-agent id, if any.
-            unused_tools: Advertised-but-unused tool names from the profile.
+            unused_tools: Advertised-but-unused tool names left for scope_tools
+                after carving out tier-1 builtins.
+            tier1_builtins: Bare builtin names with zero account-wide
+                invocations (account-wide disable candidates).
             top_oversized_field: Bulkiest droppable tool-output field, if any.
             summary: Session summary (for subject naming).
             suggested_budget: Suggested daily hard budget in USD.
@@ -615,6 +648,23 @@ class SessionOptimizationService:
                     "suggested_fields": list(top_oversized_field.field_names),
                     "managed_agent_id": agent_id,
                 },
+            )
+        # Account-wide disable of unused Preloop builtins when tier-1 evidence
+        # exists and the suggestion text targets builtins / Preloop tools.
+        targets_builtins = any(kw in text for kw in ("builtin", "built-in", "preloop"))
+        if (
+            not is_caching
+            and tier1_builtins
+            and targets_builtins
+            and "tool" in text
+            and any(
+                kw in text
+                for kw in ("unused", "advertised", "disable", "remove", "never")
+            )
+        ):
+            return RuntimeSessionOptimizationActionSpec(
+                type=ACTION_DISABLE_BUILTIN_TOOLS,
+                params={"tool_names": tier1_builtins},
             )
         # Disable advertised-but-unused tools (never for caching suggestions).
         if (
@@ -787,10 +837,124 @@ class SessionOptimizationService:
                 "Failed to cache session optimization response", exc_info=True
             )
 
+    def _builtin_catalog_names(self) -> set[str]:
+        """Return bare names from the BUILTIN_TOOLS catalog."""
+        from preloop.api.endpoints.tools import BUILTIN_TOOLS
+
+        return {
+            str(tool["name"])
+            for tool in BUILTIN_TOOLS
+            if isinstance(tool, dict) and tool.get("name")
+        }
+
+    def _builtin_catalog_by_name(self) -> dict[str, dict[str, Any]]:
+        """Return BUILTIN_TOOLS keyed by bare name."""
+        from preloop.api.endpoints.tools import BUILTIN_TOOLS
+
+        return {
+            str(tool["name"]): tool
+            for tool in BUILTIN_TOOLS
+            if isinstance(tool, dict) and tool.get("name")
+        }
+
+    def _partition_unused_for_account(
+        self,
+        account: Optional[Account],
+        profile: Optional[SessionContextProfile],
+    ) -> Optional[UnusedBuiltinPartition]:
+        """Tier unused tools using account-wide invocation stats.
+
+        Args:
+            account: Owning account; when missing, no partition is produced.
+            profile: Session context profile with unused tool names.
+
+        Returns:
+            Partition, or ``None`` when there is nothing to split.
+        """
+        if account is None or profile is None or profile.tool_schema_overhead is None:
+            return None
+        unused = list(profile.tool_schema_overhead.unused_tool_names)
+        if not unused:
+            return None
+        unused_tokens = dict(profile.tool_schema_overhead.unused_tool_tokens or {})
+        # Backfill tokens when older cached profiles omit the per-tool map.
+        unused_total = profile.tool_schema_overhead.unused_schema_tokens_estimate
+        if not unused_tokens and unused_total:
+            # Fall back to equal split only for action attachment; suggestion
+            # builders always see fresh profiles with unused_tool_tokens.
+            per = unused_total // max(len(unused), 1)
+            unused_tokens = {name: per for name in unused}
+        try:
+            end = datetime.now(timezone.utc)
+            start = end - timedelta(days=BUILTIN_USAGE_WINDOW_DAYS)
+            usage_rows = ToolUsageStatsService(self.db).get_account_usage_by_tool(
+                account_id=str(account.id),
+                start_date=start,
+                end_date=end,
+            )
+            counts = invocation_counts_by_tool(usage_rows)
+        except Exception:
+            logger.warning(
+                "Failed to load account tool usage for builtin disable tiering; "
+                "skipping account-wide disable recommendation",
+                exc_info=True,
+            )
+            # Without corroboration, keep everything on the agent-scoped path.
+            return UnusedBuiltinPartition(
+                tier1_raw_names=[],
+                tier1_builtin_names=[],
+                scope_raw_names=unused,
+                tier1_session_tokens=0,
+                scope_session_tokens=int(
+                    profile.tool_schema_overhead.unused_schema_tokens_estimate or 0
+                ),
+            )
+        return partition_unused_tools(
+            unused,
+            builtin_names=self._builtin_catalog_names(),
+            unused_tool_tokens=unused_tokens,
+            invocation_counts=counts,
+        )
+
+    def _catalog_schema_tokens_estimate(
+        self, tool_name: str, *, account: Optional[Account]
+    ) -> int:
+        """Estimate one-request schema tokens for a builtin via PR #140 helper.
+
+        Args:
+            tool_name: Bare builtin name.
+            account: Optional account for justification_mode lookup.
+
+        Returns:
+            Estimated schema tokens including justification injection when set.
+        """
+        catalog = self._builtin_catalog_by_name()
+        meta = catalog.get(tool_name)
+        if meta is None:
+            return 0
+        justification_mode: Optional[str] = None
+        if account is not None:
+            existing = crud_tool_configuration.get_by_tool_name_and_source(
+                self.db,
+                account_id=str(account.id),
+                tool_name=tool_name,
+                tool_source="builtin",
+            )
+            if existing is not None:
+                justification_mode = existing.justification_mode
+        return estimate_tool_schema_tokens(
+            name=tool_name,
+            description=str(meta.get("description") or ""),
+            schema=meta.get("schema") if isinstance(meta.get("schema"), dict) else None,
+            justification_mode=justification_mode,
+        )
+
     def _local_optimization_suggestions(
         self,
         summary: RuntimeSessionSummary,
         profile: Optional[SessionContextProfile] = None,
+        *,
+        account: Optional[Account] = None,
     ) -> list[RuntimeSessionOptimizationSuggestion]:
         """Build deterministic suggestions grounded in measured context waste.
 
@@ -798,6 +962,8 @@ class SessionOptimizationService:
             summary: Stored usage totals for the session.
             profile: Evidence-grounded context profile; savings estimates come
                 from its measured token counts instead of fixed multipliers.
+            account: Owning account; used to corroborate account-wide builtin
+                disable recommendations against 30-day tool usage stats.
 
         Returns:
             Suggestions ordered by expected token savings.
@@ -810,6 +976,7 @@ class SessionOptimizationService:
         cache_profile = profile.cache_profile if profile else None
         retry_profile = profile.retry_profile if profile else None
         schema_overhead = profile.tool_schema_overhead if profile else None
+        partition = self._partition_unused_for_account(account, profile)
 
         duplicate_tokens = tool_bloat.duplicate_output_tokens if tool_bloat else 0
         compressible_tokens = (
@@ -920,50 +1087,100 @@ class SessionOptimizationService:
                 )
             )
         if schema_overhead and schema_overhead.unused_schema_tokens_estimate > 0:
-            suggestions.append(
-                RuntimeSessionOptimizationSuggestion(
-                    id="scope-tools",
-                    title="Scope down advertised tools",
-                    description=(
-                        f"{len(schema_overhead.unused_tool_names)} of "
-                        f"{schema_overhead.advertised_tools} advertised tools "
-                        "were never called this session yet their schemas are "
-                        "re-sent on every request, costing ~"
-                        f"{schema_overhead.unused_schema_tokens_estimate:,} tokens "
-                        f"across {max(schema_overhead.resend_count, 1)} request(s)"
-                        + (
-                            " ("
-                            + ", ".join(schema_overhead.unused_tool_names[:4])
-                            + ")"
-                            if schema_overhead.unused_tool_names
-                            else ""
-                        )
-                        + ". Restrict tool visibility for this agent."
-                    ),
-                    # NOT multiplied by resend_count: analyze_tool_schema_overhead
-                    # already accumulates each advertised schema once per request
-                    # that carried it, so this estimate is resend-inclusive.
-                    # Multiplying again made the figure quadratic in request count
-                    # and pushed reported savings above 100% of analyzed tokens.
-                    expected_savings_tokens=(
-                        schema_overhead.unused_schema_tokens_estimate
-                    ),
-                    expected_savings_usd=round(
-                        schema_overhead.unused_schema_tokens_estimate * cost_per_token,
-                        6,
-                    ),
-                    confidence="high",
-                    action_label="Scope tool access",
-                    evidence=[
-                        (
-                            f"{len(schema_overhead.unused_tool_names)} of "
-                            f"{schema_overhead.advertised_tools} advertised "
-                            "tools never invoked"
-                        ),
-                        "Unused: " + ", ".join(schema_overhead.unused_tool_names[:5]),
-                    ],
-                )
+            # Carve unused Preloop builtins with zero account-wide invocations
+            # into a separate account-wide disable suggestion so the same
+            # schema tokens are never counted twice (#146).
+            tier1_names = partition.tier1_builtin_names if partition else []
+            tier1_tokens = partition.tier1_session_tokens if partition else 0
+            scope_names = (
+                partition.scope_raw_names
+                if partition is not None
+                else list(schema_overhead.unused_tool_names)
             )
+            scope_tokens = (
+                partition.scope_session_tokens
+                if partition is not None
+                else schema_overhead.unused_schema_tokens_estimate
+            )
+            if tier1_names and tier1_tokens > 0:
+                evidence = [
+                    (
+                        f"Account-wide window: last {BUILTIN_USAGE_WINDOW_DAYS} "
+                        "days; invocation_count = 0 for each listed builtin"
+                    ),
+                ]
+                for bare_name in tier1_names[:8]:
+                    catalog_tokens = self._catalog_schema_tokens_estimate(
+                        bare_name, account=account
+                    )
+                    evidence.append(
+                        (
+                            f"{bare_name}: invocation_count = 0; "
+                            f"schema_tokens_estimate = {catalog_tokens}"
+                        )
+                    )
+                suggestions.append(
+                    RuntimeSessionOptimizationSuggestion(
+                        id="disable-builtin-tools",
+                        title="Disable unused Preloop builtin tools",
+                        description=(
+                            f"{len(tier1_names)} Preloop builtin tool(s) were "
+                            "advertised this session but have zero invocations "
+                            f"account-wide over the last "
+                            f"{BUILTIN_USAGE_WINDOW_DAYS} days, yet their "
+                            "schemas are re-sent on every request, costing ~"
+                            f"{tier1_tokens:,} tokens across "
+                            f"{max(schema_overhead.resend_count, 1)} request(s) "
+                            f"({', '.join(tier1_names[:4])}). Disable them "
+                            "account-wide so every agent stops paying the "
+                            "schema tax; re-enable anytime on the Tools page."
+                        ),
+                        # NOT multiplied by resend_count: already resend-inclusive.
+                        expected_savings_tokens=tier1_tokens,
+                        expected_savings_usd=round(tier1_tokens * cost_per_token, 6),
+                        confidence="high",
+                        action_label="Disable builtins account-wide",
+                        evidence=evidence,
+                    )
+                )
+            if scope_names and scope_tokens > 0:
+                suggestions.append(
+                    RuntimeSessionOptimizationSuggestion(
+                        id="scope-tools",
+                        title="Scope down advertised tools",
+                        description=(
+                            f"{len(scope_names)} of "
+                            f"{schema_overhead.advertised_tools} advertised tools "
+                            "were never called this session yet their schemas are "
+                            "re-sent on every request, costing ~"
+                            f"{scope_tokens:,} tokens "
+                            f"across {max(schema_overhead.resend_count, 1)} request(s)"
+                            + (
+                                " (" + ", ".join(scope_names[:4]) + ")"
+                                if scope_names
+                                else ""
+                            )
+                            + ". Restrict tool visibility for this agent."
+                        ),
+                        # NOT multiplied by resend_count: analyze_tool_schema_overhead
+                        # already accumulates each advertised schema once per request
+                        # that carried it, so this estimate is resend-inclusive.
+                        # Multiplying again made the figure quadratic in request count
+                        # and pushed reported savings above 100% of analyzed tokens.
+                        expected_savings_tokens=scope_tokens,
+                        expected_savings_usd=round(scope_tokens * cost_per_token, 6),
+                        confidence="high",
+                        action_label="Scope tool access",
+                        evidence=[
+                            (
+                                f"{len(scope_names)} of "
+                                f"{schema_overhead.advertised_tools} advertised "
+                                "tools never invoked"
+                            ),
+                            "Unused: " + ", ".join(scope_names[:5]),
+                        ],
+                    )
+                )
         if cache_profile and cache_profile.cache_breaking_events:
             breaking = cache_profile.cache_breaking_events
             wasted_prefix_tokens = cache_profile.avg_repeated_prefix_tokens * len(
@@ -1488,6 +1705,10 @@ class SessionOptimizationService:
             )
         if action.type == ACTION_SCOPE_TOOLS:
             result = self._apply_scope_tools(account=account, params=action.params)
+        elif action.type == ACTION_DISABLE_BUILTIN_TOOLS:
+            result = self._apply_disable_builtin_tools(
+                account=account, params=action.params
+            )
         elif action.type in (ACTION_ENABLE_COMPRESSION, ACTION_CAP_TOOL_RESULTS):
             result = self._apply_context_optimization_settings(
                 account=account, params=action.params
@@ -1593,6 +1814,92 @@ class SessionOptimizationService:
             "subject_type": subject_type,
             "subject_id": subject_id,
             "disabled_tools": tool_names,
+        }
+
+    def _apply_disable_builtin_tools(
+        self, *, account: Account, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Disable Preloop builtins account-wide via ToolConfiguration rows.
+
+        Upserts ``tool_source="builtin"`` rows with ``is_enabled=False``. Never
+        touches rows with any other ``tool_source`` (including ``agent`` from
+        PR #132). Idempotent for already-disabled rows.
+
+        Args:
+            account: Account whose tool configurations are updated.
+            params: ``tool_names`` list of bare builtin names.
+
+        Returns:
+            Result payload listing the disabled tool names (revert via Tools
+            page re-enable).
+
+        Raises:
+            HTTPException: On empty list or unknown (non-builtin) tool names.
+        """
+        tool_names = [
+            str(name).strip()
+            for name in (params.get("tool_names") or [])
+            if str(name).strip()
+        ]
+        if not tool_names:
+            raise HTTPException(
+                status_code=400,
+                detail="disable_builtin_tools requires tool_names",
+            )
+        builtin_names = self._builtin_catalog_names()
+        unknown = sorted({name for name in tool_names if name not in builtin_names})
+        if unknown:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "disable_builtin_tools only accepts Preloop builtin names; "
+                    f"unknown: {', '.join(unknown)}"
+                ),
+            )
+        # Deduplicate while preserving order.
+        ordered_unique: list[str] = []
+        seen: set[str] = set()
+        for name in tool_names:
+            if name in seen:
+                continue
+            seen.add(name)
+            ordered_unique.append(name)
+
+        disabled: list[str] = []
+        for tool_name in ordered_unique:
+            existing = crud_tool_configuration.get_by_tool_name_and_source(
+                self.db,
+                account_id=str(account.id),
+                tool_name=tool_name,
+                tool_source="builtin",
+            )
+            if existing is not None:
+                # Strict keying on tool_source="builtin" already; never flip
+                # agent-approval or MCP rows.
+                if existing.is_enabled:
+                    update_in = ToolConfigurationUpdate(is_enabled=False)  # type: ignore[call-arg]
+                    crud_tool_configuration.update(
+                        self.db,
+                        db_obj=existing,
+                        config_in=update_in,
+                    )
+                disabled.append(tool_name)
+                continue
+            create_in = ToolConfigurationCreate(
+                tool_name=tool_name,
+                tool_source="builtin",
+                account_id=str(account.id),
+                mcp_server_id=None,
+                is_enabled=False,
+            )  # type: ignore[call-arg]
+            crud_tool_configuration.create(self.db, config_in=create_in)
+            disabled.append(tool_name)
+        return {
+            "disabled_tools": disabled,
+            "tool_source": "builtin",
+            "revert_hint": (
+                "Re-enable these tools from the Tools page (toggle is_enabled back on)."
+            ),
         }
 
     def _apply_context_optimization_settings(

--- a/backend/tests/services/test_builtin_tool_optimizer.py
+++ b/backend/tests/services/test_builtin_tool_optimizer.py
@@ -1,0 +1,582 @@
+"""Tests for unused-builtin detection and account-wide disable (#146)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from preloop.models.crud import (
+    crud_account,
+    crud_runtime_session,
+    crud_tool_configuration,
+)
+from preloop.models.schemas.tool_configuration import ToolConfigurationCreate
+from preloop.schemas.gateway_usage import (
+    RuntimeSessionOptimizationActionSpec,
+    RuntimeSessionOptimizationApplyRequest,
+    RuntimeSessionOptimizationSuggestion,
+)
+from preloop.services.builtin_tool_optimizer import (
+    expand_tool_name_match_keys,
+    partition_unused_tools,
+    resolve_builtin_tool_name,
+    tool_name_in_removed,
+)
+from preloop.services.context_analysis import (
+    SessionContextProfile,
+    ToolSchemaOverheadProfile,
+    compute_profile_savings,
+)
+from preloop.services.dynamic_mcp_server import UserContext
+from preloop.services.savings_measurement import compute_input_token_savings
+from preloop.services.session_optimization import (
+    ACTION_DISABLE_BUILTIN_TOOLS,
+    SessionOptimizationService,
+)
+
+
+BUILTIN_NAMES = {
+    "get_issue",
+    "create_issue",
+    "search",
+    "request_approval",
+    "permission_prompt",
+}
+
+
+def test_resolve_builtin_maps_preloop_prefix() -> None:
+    """mcp__preloop__get_issue maps to builtin get_issue."""
+    assert (
+        resolve_builtin_tool_name(
+            "mcp__preloop__get_issue", builtin_names=BUILTIN_NAMES
+        )
+        == "get_issue"
+    )
+    assert (
+        resolve_builtin_tool_name(
+            "mcp__preloop-mcp__get_issue", builtin_names=BUILTIN_NAMES
+        )
+        == "get_issue"
+    )
+
+
+def test_resolve_builtin_rejects_external_mcp_prefix() -> None:
+    """mcp__github__search must not map to builtin search."""
+    assert (
+        resolve_builtin_tool_name("mcp__github__search", builtin_names=BUILTIN_NAMES)
+        is None
+    )
+
+
+def test_resolve_builtin_accepts_bare_name() -> None:
+    """Bare get_issue maps when present in the catalog."""
+    assert (
+        resolve_builtin_tool_name("get_issue", builtin_names=BUILTIN_NAMES)
+        == "get_issue"
+    )
+
+
+def test_expand_keys_do_not_alias_external_mcp_to_bare() -> None:
+    """External MCP prefixes stay namespaced for matching."""
+    keys = expand_tool_name_match_keys("mcp__github__search")
+    assert "search" not in keys
+    assert "mcp__github__search" in keys
+
+
+def test_tool_name_in_removed_accepts_bare_and_preloop_prefix() -> None:
+    """Replay matching accepts bare builtin against Preloop-prefixed defs."""
+    assert tool_name_in_removed("mcp__preloop__get_issue", {"get_issue"})
+    assert tool_name_in_removed("get_issue", {"mcp__preloop__get_issue"})
+    assert not tool_name_in_removed("mcp__github__search", {"search"})
+
+
+def test_partition_tier1_zero_invocations() -> None:
+    """Zero account-wide invocations place builtins on the disable path."""
+    part = partition_unused_tools(
+        ["mcp__preloop__get_issue", "never_used_ext"],
+        builtin_names=BUILTIN_NAMES,
+        unused_tool_tokens={
+            "mcp__preloop__get_issue": 1200,
+            "never_used_ext": 800,
+        },
+        invocation_counts={},
+    )
+    assert part.tier1_builtin_names == ["get_issue"]
+    assert part.tier1_session_tokens == 1200
+    assert part.scope_raw_names == ["never_used_ext"]
+    assert part.scope_session_tokens == 800
+
+
+def test_partition_tier2_invoked_elsewhere_stays_on_scope() -> None:
+    """Builtins invoked by another agent stay on agent-scoped scope_tools."""
+    part = partition_unused_tools(
+        ["mcp__preloop__get_issue", "search"],
+        builtin_names=BUILTIN_NAMES,
+        unused_tool_tokens={
+            "mcp__preloop__get_issue": 1200,
+            "search": 500,
+        },
+        invocation_counts={"get_issue": 3},
+    )
+    assert part.tier1_builtin_names == ["search"]
+    assert "mcp__preloop__get_issue" in part.scope_raw_names
+    assert part.tier1_session_tokens == 500
+    assert part.scope_session_tokens == 1200
+
+
+def test_partition_dedupe_savings_sum_unchanged() -> None:
+    """Carved suggestion tokens sum to the original unused total."""
+    unused_tokens = {
+        "mcp__preloop__get_issue": 1200,
+        "mcp__github__search": 900,
+        "local_helper": 100,
+    }
+    total = sum(unused_tokens.values())
+    part = partition_unused_tools(
+        list(unused_tokens),
+        builtin_names=BUILTIN_NAMES,
+        unused_tool_tokens=unused_tokens,
+        invocation_counts={},
+    )
+    assert part.tier1_session_tokens + part.scope_session_tokens == total
+    # External search stays on scope; get_issue is tier 1.
+    assert "get_issue" in part.tier1_builtin_names
+    assert "mcp__github__search" in part.scope_raw_names
+
+
+def test_compute_profile_savings_unchanged_by_suggestion_split() -> None:
+    """Headline profile savings still use the single unused-schema figure."""
+    profile = SessionContextProfile(
+        session_id="s1",
+        analyzed_event_count=2,
+        total_prompt_tokens=10_000,
+        total_completion_tokens=500,
+        tool_schema_overhead=ToolSchemaOverheadProfile(
+            unused_tool_names=["mcp__preloop__get_issue", "ext"],
+            unused_tool_tokens={
+                "mcp__preloop__get_issue": 1200,
+                "ext": 800,
+            },
+            unused_schema_tokens_estimate=2000,
+            resend_count=2,
+        ),
+    )
+    before = compute_profile_savings(profile).total_tokens
+    # Suggestion-level split does not mutate the profile.
+    part = partition_unused_tools(
+        profile.tool_schema_overhead.unused_tool_names,
+        builtin_names=BUILTIN_NAMES,
+        unused_tool_tokens=profile.tool_schema_overhead.unused_tool_tokens,
+        invocation_counts={},
+    )
+    after = compute_profile_savings(profile).total_tokens
+    assert before == after == 2000
+    assert part.tier1_session_tokens + part.scope_session_tokens == 2000
+
+
+def _summary(*, total_tokens: int = 10_000, cost: float = 1.0) -> MagicMock:
+    summary = MagicMock()
+    summary.token_usage.total_tokens = total_tokens
+    summary.token_usage.prompt_tokens = total_tokens
+    summary.estimated_cost = cost
+    summary.failed_requests = 0
+    return summary
+
+
+def test_tier1_suggestion_emits_disable_builtin_tools() -> None:
+    """Unused builtins with zero account usage produce disable-builtin-tools."""
+    profile = SessionContextProfile(
+        session_id="s1",
+        analyzed_event_count=2,
+        total_prompt_tokens=8_000,
+        total_completion_tokens=500,
+        tool_schema_overhead=ToolSchemaOverheadProfile(
+            advertised_tools=3,
+            invoked_tools=1,
+            unused_tool_names=["mcp__preloop__get_issue", "ext_tool"],
+            unused_tool_tokens={
+                "mcp__preloop__get_issue": 1500,
+                "ext_tool": 500,
+            },
+            unused_schema_tokens_estimate=2000,
+            resend_count=2,
+        ),
+    )
+    account = MagicMock()
+    account.id = uuid4()
+    service = SessionOptimizationService(MagicMock())
+    with patch.object(
+        service,
+        "_partition_unused_for_account",
+        return_value=partition_unused_tools(
+            profile.tool_schema_overhead.unused_tool_names,
+            builtin_names={"get_issue"},
+            unused_tool_tokens=profile.tool_schema_overhead.unused_tool_tokens,
+            invocation_counts={},
+        ),
+    ):
+        suggestions = service._local_optimization_suggestions(
+            _summary(), profile, account=account
+        )
+    by_id = {s.id: s for s in suggestions}
+    assert "disable-builtin-tools" in by_id
+    assert by_id["disable-builtin-tools"].expected_savings_tokens == 1500
+    assert any(
+        "invocation_count = 0" in line
+        for line in by_id["disable-builtin-tools"].evidence
+    )
+    assert "scope-tools" in by_id
+    assert by_id["scope-tools"].expected_savings_tokens == 500
+    assert "ext_tool" in by_id["scope-tools"].evidence[1]
+    assert "get_issue" not in by_id["scope-tools"].evidence[1]
+
+
+def test_tier2_only_scope_tools_for_invoked_elsewhere() -> None:
+    """Builtins used elsewhere only get agent-scoped scope_tools."""
+    profile = SessionContextProfile(
+        session_id="s1",
+        analyzed_event_count=1,
+        total_prompt_tokens=4_000,
+        total_completion_tokens=100,
+        tool_schema_overhead=ToolSchemaOverheadProfile(
+            advertised_tools=2,
+            invoked_tools=0,
+            unused_tool_names=["get_issue"],
+            unused_tool_tokens={"get_issue": 900},
+            unused_schema_tokens_estimate=900,
+            resend_count=1,
+        ),
+    )
+    account = MagicMock()
+    account.id = uuid4()
+    service = SessionOptimizationService(MagicMock())
+    with patch.object(
+        service,
+        "_partition_unused_for_account",
+        return_value=partition_unused_tools(
+            ["get_issue"],
+            builtin_names={"get_issue"},
+            unused_tool_tokens={"get_issue": 900},
+            invocation_counts={"get_issue": 2},
+        ),
+    ):
+        suggestions = service._local_optimization_suggestions(
+            _summary(), profile, account=account
+        )
+    by_id = {s.id: s for s in suggestions}
+    assert "disable-builtin-tools" not in by_id
+    assert "scope-tools" in by_id
+    assert by_id["scope-tools"].expected_savings_tokens == 900
+
+
+def test_infer_model_suggestion_attaches_disable_builtin_action() -> None:
+    """Model text about unused Preloop builtins gets the disable action."""
+    service = SessionOptimizationService(MagicMock())
+    suggestion = RuntimeSessionOptimizationSuggestion(
+        id="model-1",
+        title="Disable the unused Preloop builtins",
+        description="These builtin tools were never called; disable them.",
+        expected_savings_tokens=100,
+        expected_savings_usd=0.0,
+        confidence="high",
+        action_label="Apply",
+    )
+    summary = MagicMock()
+    summary.runtime_principal_name = "agent"
+    summary.session_source_type = "claude_code"
+    action = service._infer_model_suggestion_action(
+        suggestion,
+        agent_id=str(uuid4()),
+        unused_tools=["ext"],
+        tier1_builtins=["get_issue", "permission_prompt"],
+        top_oversized_field=None,
+        summary=summary,
+        suggested_budget=3.0,
+    )
+    assert action is not None
+    assert action.type == ACTION_DISABLE_BUILTIN_TOOLS
+    assert action.params["tool_names"] == ["get_issue", "permission_prompt"]
+
+
+def test_replay_accepts_prefixed_builtin_removed_names() -> None:
+    """Removing bare get_issue strips mcp__preloop__get_issue from tools."""
+    payload = {
+        "tools": [
+            {"name": "mcp__preloop__get_issue", "description": "x" * 40},
+            {"name": "keep_me"},
+        ]
+    }
+    result = compute_input_token_savings(payload, removed_tool_names={"get_issue"})
+    assert result.delta_tokens > 0
+    # Inverse: prefixed candidate removes bare definition.
+    payload_bare = {
+        "tools": [
+            {"name": "get_issue", "description": "x" * 40},
+            {"name": "keep_me"},
+        ]
+    }
+    result2 = compute_input_token_savings(
+        payload_bare, removed_tool_names={"mcp__preloop__get_issue"}
+    )
+    assert result2.delta_tokens > 0
+
+
+def test_replay_does_not_strip_external_mcp_search_for_bare_search() -> None:
+    """Bare search must not remove mcp__github__search."""
+    payload = {
+        "tools": [
+            {"name": "mcp__github__search", "description": "x" * 40},
+            {"name": "keep_me"},
+        ]
+    }
+    result = compute_input_token_savings(payload, removed_tool_names={"search"})
+    assert result.delta_tokens == 0
+
+
+def _create_runtime_session(db_session, test_user, *, source_id: str) -> object:
+    now = datetime.now(UTC)
+    return crud_runtime_session.upsert_by_source(
+        db_session,
+        account_id=test_user.account_id,
+        session_source_type="claude_code",
+        session_source_id=source_id,
+        session_reference=f"claude-session-{source_id}",
+        runtime_principal_type="claude_code",
+        runtime_principal_id=source_id,
+        runtime_principal_name="Claude Workspace",
+        started_at=now,
+        last_activity_at=now,
+    )
+
+
+def test_apply_disable_builtin_tools_upserts_and_is_idempotent(
+    db_session, test_user
+) -> None:
+    """Apply creates disabled builtin configs and is idempotent per tool."""
+    runtime_session = _create_runtime_session(
+        db_session, test_user, source_id="workspace-disable-builtins"
+    )
+    db_session.commit()
+    account = crud_account.get(db_session, id=test_user.account_id)
+    assert account is not None
+    # Pre-create an agent-source row that must never be touched (#132).
+    agent_row = crud_tool_configuration.create(
+        db_session,
+        config_in=ToolConfigurationCreate(
+            tool_name="get_issue",
+            tool_source="agent",
+            account_id=str(account.id),
+            is_enabled=True,
+        ),
+    )
+    service = SessionOptimizationService(db_session)
+    request = RuntimeSessionOptimizationApplyRequest(
+        suggestion_id="disable-builtin-tools",
+        suggestion_title="Disable unused builtins",
+        action=RuntimeSessionOptimizationActionSpec(
+            type=ACTION_DISABLE_BUILTIN_TOOLS,
+            params={"tool_names": ["get_issue", "search"]},
+        ),
+    )
+    applied = service.apply_account_session_optimization_action(
+        account=account,
+        runtime_session_id=str(runtime_session.id),
+        request=request,
+        current_user=test_user,
+    )
+    assert applied.action_type == ACTION_DISABLE_BUILTIN_TOOLS
+    assert isinstance(applied.baseline, dict)
+    assert set(applied.result["disabled_tools"]) == {"get_issue", "search"}
+    assert applied.result["tool_source"] == "builtin"
+
+    get_issue_cfg = crud_tool_configuration.get_by_tool_name_and_source(
+        db_session,
+        account_id=str(account.id),
+        tool_name="get_issue",
+        tool_source="builtin",
+    )
+    assert get_issue_cfg is not None
+    assert get_issue_cfg.is_enabled is False
+    db_session.refresh(agent_row)
+    assert agent_row.is_enabled is True
+    assert agent_row.tool_source == "agent"
+
+    # Handler-level idempotency: already-disabled row is a no-op.
+    result = service._apply_disable_builtin_tools(
+        account=account, params={"tool_names": ["get_issue"]}
+    )
+    assert result["disabled_tools"] == ["get_issue"]
+    cfg_again = crud_tool_configuration.get_by_tool_name_and_source(
+        db_session,
+        account_id=str(account.id),
+        tool_name="get_issue",
+        tool_source="builtin",
+    )
+    assert cfg_again is not None
+    assert cfg_again.is_enabled is False
+
+
+def test_apply_disable_builtin_tools_rejects_unknown_names(
+    db_session, test_user
+) -> None:
+    """Unknown tool names return 400."""
+    runtime_session = _create_runtime_session(
+        db_session, test_user, source_id="workspace-disable-unknown"
+    )
+    db_session.commit()
+    account = crud_account.get(db_session, id=test_user.account_id)
+    assert account is not None
+    service = SessionOptimizationService(db_session)
+    with pytest.raises(HTTPException) as exc_info:
+        service.apply_account_session_optimization_action(
+            account=account,
+            runtime_session_id=str(runtime_session.id),
+            request=RuntimeSessionOptimizationApplyRequest(
+                suggestion_id="disable-builtin-tools",
+                suggestion_title="Disable",
+                action=RuntimeSessionOptimizationActionSpec(
+                    type=ACTION_DISABLE_BUILTIN_TOOLS,
+                    params={"tool_names": ["not_a_real_builtin"]},
+                ),
+            ),
+            current_user=test_user,
+        )
+    assert exc_info.value.status_code == 400
+
+
+def test_apply_disable_builtin_tools_duplicate_suggestion_409(
+    db_session, test_user
+) -> None:
+    """Duplicate apply for the same suggestion returns 409."""
+    runtime_session = _create_runtime_session(
+        db_session, test_user, source_id="workspace-disable-dupe"
+    )
+    db_session.commit()
+    account = crud_account.get(db_session, id=test_user.account_id)
+    assert account is not None
+    service = SessionOptimizationService(db_session)
+    request = RuntimeSessionOptimizationApplyRequest(
+        suggestion_id="disable-builtin-tools",
+        suggestion_title="Disable",
+        action=RuntimeSessionOptimizationActionSpec(
+            type=ACTION_DISABLE_BUILTIN_TOOLS,
+            params={"tool_names": ["get_issue"]},
+        ),
+    )
+    service.apply_account_session_optimization_action(
+        account=account,
+        runtime_session_id=str(runtime_session.id),
+        request=request,
+        current_user=test_user,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        service.apply_account_session_optimization_action(
+            account=account,
+            runtime_session_id=str(runtime_session.id),
+            request=request,
+            current_user=test_user,
+        )
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_gateway_hides_disabled_builtin_after_apply(
+    db_session, test_user
+) -> None:
+    """After apply, list_tools hides the builtin and call_tool denies it."""
+    from unittest.mock import AsyncMock
+
+    from fastmcp import FastMCP
+    from fastmcp.tools.tool import Tool, ToolResult
+
+    from preloop.services.dynamic_fastmcp import DynamicFastMCP
+
+    account = crud_account.get(db_session, id=test_user.account_id)
+    assert account is not None
+    service = SessionOptimizationService(db_session)
+    runtime_session = _create_runtime_session(
+        db_session, test_user, source_id="workspace-disable-gateway"
+    )
+    db_session.commit()
+    service.apply_account_session_optimization_action(
+        account=account,
+        runtime_session_id=str(runtime_session.id),
+        request=RuntimeSessionOptimizationApplyRequest(
+            suggestion_id="disable-builtin-tools-gw",
+            suggestion_title="Disable",
+            action=RuntimeSessionOptimizationActionSpec(
+                type=ACTION_DISABLE_BUILTIN_TOOLS,
+                params={"tool_names": ["get_issue"]},
+            ),
+        ),
+        current_user=test_user,
+    )
+    disabled_config = crud_tool_configuration.get_by_tool_name_and_source(
+        db_session,
+        account_id=str(account.id),
+        tool_name="get_issue",
+        tool_source="builtin",
+    )
+    assert disabled_config is not None
+    assert disabled_config.is_enabled is False
+
+    # Reuse PR #127 dynamic_fastmcp patterns with the row apply just wrote.
+    mcp = DynamicFastMCP("preloop-mcp")
+    user_context = UserContext(
+        user_id=str(test_user.id),
+        account_id=str(account.id),
+        username=test_user.username,
+        has_tracker=True,
+        enabled_default_tools=[],
+        enabled_proxied_tools=[],
+        tracker_types=["github"],
+    )
+    mcp._user_context_provider = lambda: user_context
+    default_tools = [
+        Tool(name="get_issue", description="Get issue", parameters={}),
+        Tool(name="create_issue", description="Create issue", parameters={}),
+    ]
+    with (
+        patch("preloop.services.dynamic_fastmcp.get_db") as mock_get_db,
+        patch(
+            "preloop.services.mcp_tool_discovery._get_proxied_tools_sync",
+            return_value=[],
+        ),
+        patch(
+            "preloop.services.dynamic_fastmcp.crud_tool_configuration.get_multi_by_account",
+            return_value=[disabled_config],
+        ),
+        patch(
+            "preloop.models.crud.crud_account.get",
+            return_value=MagicMock(meta_data={}),
+        ),
+        patch.object(FastMCP, "list_tools", new=AsyncMock(return_value=default_tools)),
+    ):
+        mock_get_db.side_effect = lambda: iter([MagicMock()])
+        listed = await mcp.list_tools()
+    names = {t.name for t in listed}
+    assert "get_issue" not in names
+    assert "create_issue" in names
+
+    with (
+        patch("preloop.services.dynamic_fastmcp.get_db") as mock_get_db,
+        patch(
+            "preloop.services.dynamic_fastmcp.crud_tool_configuration.get_multi_by_account",
+            return_value=[disabled_config],
+        ),
+        patch.object(
+            mcp.__class__.__bases__[0],
+            "call_tool",
+            new=AsyncMock(),
+            create=True,
+        ) as mock_super,
+    ):
+        mock_get_db.side_effect = lambda: iter([MagicMock()])
+        result = await mcp.call_tool("get_issue", {"issue": "ABC-1"})
+    mock_super.assert_not_called()
+    assert isinstance(result, ToolResult)
+    assert "disabled" in result.content[0].text.lower()


### PR DESCRIPTION
## Summary
- Depends on #140, merge after it. This branch includes `fix/tools-context-tax-128` so savings figures can use `estimate_tool_schema_tokens`.
- Adds a deterministic `disable-builtin-tools` Optimize suggestion for Preloop builtins that are unused in the session and have zero account-wide invocations over 30 days, with an apply action that upserts `ToolConfiguration(tool_source="builtin", is_enabled=false)`.
- Carves those builtins out of `scope-tools` so schema savings are not double-counted; builtins still invoked elsewhere stay on agent-scoped `scope_tools`. Never touches `tool_source="agent"` rows.

## Test plan
- [x] Name mapping: `mcp__preloop__get_issue` -> builtin; `mcp__github__search` does not
- [x] Tier 1 zero-invocation gate emits `disable_builtin_tools` with resend-inclusive savings
- [x] Tier 2 invoked-elsewhere keeps agent-scoped `scope_tools` only
- [x] Dedupe: suggestion split sums to unused total; `compute_profile_savings` unchanged
- [x] Apply upserts disabled builtin configs, idempotent, 400 unknown, ignores agent rows, records baseline
- [x] Duplicate apply returns 409
- [x] Gateway list_tools/call_tool deny after apply (PR #127 patterns)
- [x] Model inference attaches disable action under tier-1 + builtin/Preloop wording
- [x] Replay accepts bare and Preloop-prefixed builtin names in `removed_tool_names`

Fixes #146


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Clean, well-tested addition of an optimizer action for disabling unused builtins. No security concerns; comprehensive test coverage including gateway integration.

> **Overview**
> Adds a deterministic `disable-builtin-tools` optimization suggestion that identifies Preloop builtins unused in-session with zero account-wide invocations over 30 days, with a one-click apply action that upserts disabled `ToolConfiguration` rows. Carves builtins out of `scope-tools` to avoid double-counting savings.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai). Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->