### PR TITLE
fix: read runtime from raw YAML block in Hermes plugin verify

### DIFF
--- a/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/plugin.py
+++ b/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/plugin.py
@@ -442,8 +442,10 @@ class HermesPreloopPlugin:
     def verify(self) -> None:
         """Validate local plugin load and config shape."""
         config = self.load_config()
-        if config.runtime != self.runtime_name:
-            raise ValueError(f"Expected Hermes runtime config, got {config.runtime!r}")
+        block = self._read_control_block()
+        runtime = block.get("runtime")
+        if runtime != self.runtime_name:
+            raise ValueError(f"Expected Hermes runtime config, got {runtime!r}")
         if not config.control_ws_url:
             raise ValueError("preloop.control.control_ws_url is required")
         if not config.bearer_token:

--- a/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/plugin.py
+++ b/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/plugin.py
@@ -446,6 +446,12 @@ class HermesPreloopPlugin:
         runtime = block.get("runtime")
         if runtime != self.runtime_name:
             raise ValueError(f"Expected Hermes runtime config, got {runtime!r}")
+        """Validate local plugin load and config shape."""
+        config = self.load_config()
+        block = self._read_control_block()
+        runtime = block.get("runtime")
+        if runtime != self.runtime_name:
+            raise ValueError(f"Expected Hermes runtime config, got {runtime!r}")
         if not config.control_ws_url:
             raise ValueError("preloop.control.control_ws_url is required")
         if not config.bearer_token:


### PR DESCRIPTION
# Fix: Hermes plugin verify crashes on missing `runtime` field

## Problem
`preloop-hermes-plugin 0.2.0` fails during `verify()` with:

```
AttributeError: 'AgentControlConfig' object has no attribute 'runtime'
```

This blocks plugin verification and full Preloop control-plane integration for Hermes.

## Root Cause
`AgentControlConfig` in `preloop 0.13.x` does not expose a `runtime` attribute. The Hermes plugin reads `config.runtime`, but that field is only present in the raw YAML config block, not the parsed dataclass.

## Fix
Read `runtime` from the raw control block in `verify()` instead of the parsed `AgentControlConfig` object. This matches the on-disk config shape that `preloop agents onboard` writes.

## Changes
- `runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/plugin.py`: 
  - In `verify()`, read `runtime` from `self._read_control_block()` instead of `config.runtime`

## Verification
- `preloop-hermes-plugin verify` now exits cleanly with "preloop-hermes-plugin verified"
- No existing test behavior changed; `_load_control_settings()` still returns `(AgentControlConfig, dict[str, Any])`

## Reproducer
1. Install `preloop==0.13.0` and `preloop-hermes-plugin==0.2.0`
2. Run: `preloop-hermes-plugin verify --config <path-to-hermes-config>`
3. Observe `AttributeError` on `config.runtime`

## Related
- Fixes version-mismatch crash between `preloop` core and Hermes plugin
- Unblocks full Preloop enrollment for Hermes users

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Duplicate code block introduced in `verify()` — the fix is applied twice, causing redundant YAML reads. Functional but needs cleanup.
>
> **Overview**
> Fixes `AttributeError` crash in Hermes plugin `verify()` by reading the `runtime` field from the raw YAML control block instead of the parsed `AgentControlConfig` dataclass (which doesn't expose it). 1 file, +10/-2 lines.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/hermes-plugin-runtime-field. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->