### PR TITLE
feat(cli): add `preloop usage import` for externally observed spend (#123)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -119,6 +119,17 @@ preloop tools exec <tool-name> --args-file ./input.json
 
 `preloop tools` talks directly to the MCP endpoint, so the visible and executable tools are automatically filtered by the current token's policy. Agent tokens only see the tools they are allowed to use.
 
+### Usage Import
+
+```bash
+preloop usage import cursor-usage.csv                # Cursor dashboard Usage export
+preloop usage import events.json                     # Normalized usage events
+preloop usage import cursor-usage.csv --agent-id <id>
+preloop usage import export.csv --column-map '{"cost":"Cost to You"}'
+```
+
+Imports spend the model gateway never saw, such as Cursor's bundled models. Records are labeled as imported, so they are reported separately from gateway-metered spend and never count against gateway budgets. Re-importing the same file is safe: duplicates are detected and reported as skipped. Without `--agent-id`, the account's onboarded Cursor agent is used, so run `preloop agents onboard cursor` first or pass the id explicitly.
+
 ### Approvals
 
 ```bash

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -110,5 +110,6 @@ func init() {
 	rootCmd.AddCommand(toolsCmd)
 	rootCmd.AddCommand(approvalsCmd)
 	rootCmd.AddCommand(agentsCmd)
+	rootCmd.AddCommand(usageCmd)
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cli/internal/cmd/usage.go
+++ b/cli/internal/cmd/usage.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -23,6 +24,23 @@ const (
 	// idempotent, so a partially applied split can simply be re-run.
 	usageImportMaxEventsPerRequest = 5000
 )
+
+// usageImportColumnMapFields mirrors _CURSOR_LOGICAL_FIELDS in
+// backend/preloop/services/usage_import.py. The server rejects an unknown
+// field outright rather than ignoring it, so a typo is worth catching here
+// where the message can list the alternatives.
+var usageImportColumnMapFields = []string{
+	"date",
+	"kind",
+	"model",
+	"max_mode",
+	"input_with_cache_write",
+	"input_without_cache_write",
+	"cache_read",
+	"output_tokens",
+	"total_tokens",
+	"cost",
+}
 
 // usageImportResult is the response shape shared by both import endpoints.
 // The CSV endpoint adds the parsed/skipped row counters; they stay zero for
@@ -159,8 +177,26 @@ func validateUsageImportOptions(opts usageImportOptions) (bool, error) {
 			filepath.Base(opts.filePath),
 		)
 	}
-	if !json.Valid([]byte(opts.columnMap)) {
-		return false, fmt.Errorf("--column-map is not valid JSON")
+	// Checking the shape, not just the syntax: `null`, `42` and `[1,2,3]`
+	// are all valid JSON but not valid column maps, and the point of
+	// validating here is to catch exactly that before a round trip.
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(opts.columnMap), &parsed); err != nil {
+		return false, fmt.Errorf(
+			"--column-map must be a JSON object mapping field names to CSV "+
+				"headers, for example '{\"cost\":\"Cost to You\"}': %w", err,
+		)
+	}
+	if len(parsed) == 0 {
+		return false, fmt.Errorf("--column-map is empty; omit the flag instead")
+	}
+	for field := range parsed {
+		if !slices.Contains(usageImportColumnMapFields, field) {
+			return false, fmt.Errorf(
+				"--column-map has unknown field %q; valid fields are: %s",
+				field, strings.Join(usageImportColumnMapFields, ", "),
+			)
+		}
 	}
 	return true, nil
 }
@@ -284,6 +320,10 @@ func parseUsageEventsFile(content []byte) ([]json.RawMessage, error) {
 }
 
 func writeUsageImportSummary(writer io.Writer, filePath string, result *usageImportResult) error {
+	if result == nil {
+		return fmt.Errorf("no import result to report")
+	}
+
 	agent := result.AgentDisplayName
 	if agent == "" {
 		agent = "unknown agent"

--- a/cli/internal/cmd/usage.go
+++ b/cli/internal/cmd/usage.go
@@ -1,0 +1,334 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+const (
+	usageImportPath    = "/api/v1/usage/import"
+	usageImportCsvPath = "/api/v1/usage/import/csv"
+
+	// usageImportMaxEventsPerRequest mirrors MAX_EVENTS_PER_REQUEST in
+	// backend/preloop/schemas/usage_import.py. Larger JSON files are split
+	// into several requests instead of failing with a 422; the import is
+	// idempotent, so a partially applied split can simply be re-run.
+	usageImportMaxEventsPerRequest = 5000
+)
+
+// usageImportResult is the response shape shared by both import endpoints.
+// The CSV endpoint adds the parsed/skipped row counters; they stay zero for
+// JSON imports.
+type usageImportResult struct {
+	Imported          int      `json:"imported"`
+	SkippedDuplicates int      `json:"skipped_duplicates"`
+	AgentID           string   `json:"agent_id"`
+	AgentDisplayName  string   `json:"agent_display_name"`
+	Source            string   `json:"source"`
+	ParsedRows        int      `json:"parsed_rows"`
+	SkippedRows       int      `json:"skipped_rows"`
+	SkippedRowReasons []string `json:"skipped_row_reasons"`
+}
+
+// usageCmd represents the usage command group.
+var usageCmd = &cobra.Command{
+	Use:   "usage",
+	Short: "Work with usage and spend records",
+	Long: `Work with usage records Preloop did not meter itself.
+
+Spend from agents whose model traffic never reaches the Preloop gateway
+(for example Cursor's bundled models) can be imported so it shows up in
+Cost analytics alongside gateway-metered spend.`,
+}
+
+// usageImportCmd represents the usage import command.
+var usageImportCmd = &cobra.Command{
+	Use:   "import <file>",
+	Short: "Import externally observed usage into Cost analytics",
+	Long: `Import usage that the Preloop model gateway never saw.
+
+The file may be either:
+
+  .csv   a Cursor dashboard Usage export (Dashboard > Usage > Export CSV)
+  .json  normalized usage events, as an array or as {"events": [...]}
+
+Imported records are labeled as imported, so they are reported separately
+from gateway-metered spend and never count against gateway budgets.
+Re-importing the same file is safe: duplicate records are detected and
+reported as skipped instead of being counted twice.
+
+Events are attributed to a managed agent. Without --agent-id, the account's
+single onboarded Cursor agent is used, so run 'preloop agents onboard cursor'
+first or pass --agent-id explicitly.
+
+Examples:
+  preloop usage import cursor-usage.csv
+  preloop usage import cursor-usage.csv --agent-id 7f1c...c3
+  preloop usage import events.json --source cursor
+  preloop usage import odd-export.csv --column-map '{"cost":"Cost to You"}'`,
+	Args: cobra.ExactArgs(1),
+	RunE: runUsageImport,
+}
+
+func init() {
+	usageCmd.AddCommand(usageImportCmd)
+
+	usageImportCmd.Flags().String("agent-id", "", "managed agent to attribute the usage to (default: the onboarded Cursor agent)")
+	usageImportCmd.Flags().String("source", "cursor", "origin label stored on each record")
+	usageImportCmd.Flags().String("column-map", "", "JSON object mapping logical fields to CSV headers (CSV files only)")
+}
+
+// usageImportOptions carries the resolved flags for one import run.
+type usageImportOptions struct {
+	filePath  string
+	agentID   string
+	source    string
+	columnMap string
+}
+
+func runUsageImport(cmd *cobra.Command, args []string) error {
+	agentID, _ := cmd.Flags().GetString("agent-id")
+	source, _ := cmd.Flags().GetString("source")
+	columnMap, _ := cmd.Flags().GetString("column-map")
+
+	opts := usageImportOptions{
+		filePath:  args[0],
+		agentID:   agentID,
+		source:    source,
+		columnMap: columnMap,
+	}
+
+	isCSV, err := validateUsageImportOptions(opts)
+	if err != nil {
+		return err
+	}
+
+	content, err := os.ReadFile(opts.filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	client, err := api.NewClient(FlagToken, FlagURL)
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	var result *usageImportResult
+	if isCSV {
+		result, err = importUsageCSV(
+			client,
+			filepath.Base(opts.filePath),
+			content,
+			opts.agentID,
+			opts.source,
+			opts.columnMap,
+		)
+	} else {
+		result, err = importUsageJSON(client, content, opts.agentID, opts.source)
+	}
+	if err != nil {
+		return err
+	}
+
+	return writeUsageImportSummary(os.Stdout, opts.filePath, result)
+}
+
+// validateUsageImportOptions checks the flag combination before anything is
+// read or sent, and reports whether the file takes the CSV endpoint. Catching
+// this locally keeps an obvious mistake (a column map on a JSON file, or a
+// malformed map) from turning into a server-side 422.
+func validateUsageImportOptions(opts usageImportOptions) (bool, error) {
+	isCSV, err := usageImportIsCSV(opts.filePath)
+	if err != nil {
+		return false, err
+	}
+	if opts.columnMap == "" {
+		return isCSV, nil
+	}
+	if !isCSV {
+		return false, fmt.Errorf(
+			"--column-map applies to CSV files only; %s is a JSON file",
+			filepath.Base(opts.filePath),
+		)
+	}
+	if !json.Valid([]byte(opts.columnMap)) {
+		return false, fmt.Errorf("--column-map is not valid JSON")
+	}
+	return true, nil
+}
+
+// usageImportIsCSV decides which endpoint a file belongs to from its
+// extension. Guessing from the contents would silently send a mislabeled
+// file to the wrong parser, so an unknown extension is an error the operator
+// can fix by renaming.
+func usageImportIsCSV(filePath string) (bool, error) {
+	switch strings.ToLower(filepath.Ext(filePath)) {
+	case ".csv":
+		return true, nil
+	case ".json":
+		return false, nil
+	default:
+		return false, fmt.Errorf(
+			"unsupported file type %q: expected a .csv (Cursor Usage export) or .json (normalized events) file",
+			filepath.Ext(filePath),
+		)
+	}
+}
+
+func importUsageCSV(
+	client *api.Client,
+	fileName string,
+	content []byte,
+	agentID, source, columnMap string,
+) (*usageImportResult, error) {
+	fields := map[string]string{}
+	if source != "" {
+		fields["source"] = source
+	}
+	if agentID != "" {
+		fields["agent_id"] = agentID
+	}
+	if columnMap != "" {
+		fields["column_map"] = columnMap
+	}
+
+	var result usageImportResult
+	if err := client.PostMultipart(
+		usageImportCsvPath, fields, "file", fileName, content, &result,
+	); err != nil {
+		return nil, fmt.Errorf("usage import failed: %w", err)
+	}
+	return &result, nil
+}
+
+func importUsageJSON(
+	client *api.Client,
+	content []byte,
+	agentID, source string,
+) (*usageImportResult, error) {
+	events, err := parseUsageEventsFile(content)
+	if err != nil {
+		return nil, err
+	}
+	if len(events) == 0 {
+		return nil, fmt.Errorf("no usage events found in file")
+	}
+
+	// The API caps events per request, so long exports go up in batches and
+	// the per-batch counters are summed for the operator.
+	total := &usageImportResult{}
+	for start := 0; start < len(events); start += usageImportMaxEventsPerRequest {
+		end := start + usageImportMaxEventsPerRequest
+		if end > len(events) {
+			end = len(events)
+		}
+
+		request := map[string]interface{}{"events": events[start:end]}
+		if source != "" {
+			request["source"] = source
+		}
+		if agentID != "" {
+			request["agent_id"] = agentID
+		}
+
+		var batch usageImportResult
+		if err := client.Post(usageImportPath, request, &batch); err != nil {
+			return nil, fmt.Errorf("usage import failed: %w", err)
+		}
+		total.Imported += batch.Imported
+		total.SkippedDuplicates += batch.SkippedDuplicates
+		total.AgentID = batch.AgentID
+		total.AgentDisplayName = batch.AgentDisplayName
+		total.Source = batch.Source
+	}
+	return total, nil
+}
+
+// parseUsageEventsFile accepts both shapes people actually have on disk: a
+// bare JSON array of events, or the request envelope {"events": [...]} that
+// the API itself takes.
+func parseUsageEventsFile(content []byte) ([]json.RawMessage, error) {
+	trimmed := strings.TrimSpace(string(content))
+	if trimmed == "" {
+		return nil, fmt.Errorf("file is empty")
+	}
+
+	if strings.HasPrefix(trimmed, "[") {
+		var events []json.RawMessage
+		if err := json.Unmarshal([]byte(trimmed), &events); err != nil {
+			return nil, fmt.Errorf("failed to parse JSON events: %w", err)
+		}
+		return events, nil
+	}
+
+	var envelope struct {
+		Events []json.RawMessage `json:"events"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &envelope); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON events: %w", err)
+	}
+	if envelope.Events == nil {
+		return nil, fmt.Errorf(
+			`JSON file must be an array of events or an object with an "events" array`,
+		)
+	}
+	return envelope.Events, nil
+}
+
+func writeUsageImportSummary(writer io.Writer, filePath string, result *usageImportResult) error {
+	agent := result.AgentDisplayName
+	if agent == "" {
+		agent = "unknown agent"
+	}
+	if result.AgentID != "" {
+		agent = fmt.Sprintf("%s (%s)", agent, result.AgentID)
+	}
+
+	if _, err := fmt.Fprintf(
+		writer,
+		"✓ Imported %s from %s\n",
+		pluralizeUsageRecords(result.Imported),
+		filepath.Base(filePath),
+	); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(writer, "  Agent:      %s\n", agent); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(writer, "  Source:     %s\n", result.Source); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(
+		writer, "  Duplicates: %d skipped\n", result.SkippedDuplicates,
+	); err != nil {
+		return err
+	}
+	if result.SkippedRows > 0 {
+		if _, err := fmt.Fprintf(
+			writer, "  Rows the parser could not use: %d\n", result.SkippedRows,
+		); err != nil {
+			return err
+		}
+		for _, reason := range result.SkippedRowReasons {
+			if _, err := fmt.Fprintf(writer, "    - %s\n", reason); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func pluralizeUsageRecords(count int) string {
+	if count == 1 {
+		return "1 usage record"
+	}
+	return fmt.Sprintf("%d usage records", count)
+}

--- a/cli/internal/cmd/usage_test.go
+++ b/cli/internal/cmd/usage_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -430,7 +431,39 @@ func TestValidateUsageImportOptions(t *testing.T) {
 		{
 			name:      "malformed column map is rejected",
 			opts:      usageImportOptions{filePath: "cursor-usage.csv", columnMap: "{not json"},
-			errSubstr: "not valid JSON",
+			errSubstr: "must be a JSON object",
+		},
+		// json.Valid accepts all three of these, so syntax-only validation
+		// would have let them through to a server-side 422.
+		{
+			name:      "null column map is rejected",
+			opts:      usageImportOptions{filePath: "cursor-usage.csv", columnMap: "null"},
+			errSubstr: "empty",
+		},
+		{
+			name:      "scalar column map is rejected",
+			opts:      usageImportOptions{filePath: "cursor-usage.csv", columnMap: "42"},
+			errSubstr: "must be a JSON object",
+		},
+		{
+			name:      "array column map is rejected",
+			opts:      usageImportOptions{filePath: "cursor-usage.csv", columnMap: "[1,2,3]"},
+			errSubstr: "must be a JSON object",
+		},
+		{
+			name:      "non-string values are rejected",
+			opts:      usageImportOptions{filePath: "cursor-usage.csv", columnMap: `{"cost":7}`},
+			errSubstr: "must be a JSON object",
+		},
+		{
+			name:      "empty object column map is rejected",
+			opts:      usageImportOptions{filePath: "cursor-usage.csv", columnMap: "{}"},
+			errSubstr: "empty",
+		},
+		{
+			name:      "unknown field is rejected with the valid list",
+			opts:      usageImportOptions{filePath: "cursor-usage.csv", columnMap: `{"price":"Cost"}`},
+			errSubstr: `unknown field "price"`,
 		},
 		{
 			name:      "unsupported extension is rejected",
@@ -455,6 +488,29 @@ func TestValidateUsageImportOptions(t *testing.T) {
 				t.Fatalf("expected isCSV=%t, got %t", tc.expectCSV, isCSV)
 			}
 		})
+	}
+}
+
+// Every field the CLI accepts must be one the server also accepts;
+// otherwise the local check would reject a legitimate map, or wave through
+// one the server then rejects.
+func TestValidateUsageImportOptionsAcceptsEveryDocumentedField(t *testing.T) {
+	for _, field := range usageImportColumnMapFields {
+		t.Run(field, func(t *testing.T) {
+			columnMap := fmt.Sprintf(`{%q:"Some Header"}`, field)
+			if _, err := validateUsageImportOptions(usageImportOptions{
+				filePath: "cursor-usage.csv", columnMap: columnMap,
+			}); err != nil {
+				t.Fatalf("field %q should be accepted: %v", field, err)
+			}
+		})
+	}
+}
+
+func TestWriteUsageImportSummaryHandlesNilResult(t *testing.T) {
+	var output bytes.Buffer
+	if err := writeUsageImportSummary(&output, "events.json", nil); err == nil {
+		t.Fatal("expected an error rather than a panic")
 	}
 }
 

--- a/cli/internal/cmd/usage_test.go
+++ b/cli/internal/cmd/usage_test.go
@@ -1,0 +1,501 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+func TestUsageImportIsCSV(t *testing.T) {
+	testCases := []struct {
+		name      string
+		path      string
+		expectCSV bool
+		expectErr bool
+	}{
+		{name: "csv", path: "cursor-usage.csv", expectCSV: true},
+		{name: "csv uppercase", path: "CURSOR-USAGE.CSV", expectCSV: true},
+		{name: "json", path: "events.json", expectCSV: false},
+		{name: "json in nested path", path: "/tmp/exports/events.JSON", expectCSV: false},
+		{name: "unsupported", path: "usage.xlsx", expectErr: true},
+		{name: "no extension", path: "usage", expectErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			isCSV, err := usageImportIsCSV(tc.path)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error for %q", tc.path)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if isCSV != tc.expectCSV {
+				t.Fatalf("expected isCSV=%t for %q, got %t", tc.expectCSV, tc.path, isCSV)
+			}
+		})
+	}
+}
+
+func TestParseUsageEventsFileAcceptsArrayAndEnvelope(t *testing.T) {
+	array := `[{"timestamp":"2026-07-31T10:00:00Z","model":"composer","total_tokens":10}]`
+	envelope := `{"source":"cursor","events":[{"timestamp":"2026-07-31T10:00:00Z","model":"composer","total_tokens":10}]}`
+
+	for name, content := range map[string]string{"array": array, "envelope": envelope} {
+		t.Run(name, func(t *testing.T) {
+			events, err := parseUsageEventsFile([]byte(content))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(events) != 1 {
+				t.Fatalf("expected 1 event, got %d", len(events))
+			}
+			if !strings.Contains(string(events[0]), "composer") {
+				t.Fatalf("event not preserved verbatim: %s", events[0])
+			}
+		})
+	}
+}
+
+func TestParseUsageEventsFileRejectsBadInput(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content string
+	}{
+		{name: "empty", content: "   "},
+		{name: "not json", content: "Date,Kind,Model"},
+		{name: "object without events", content: `{"source":"cursor"}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseUsageEventsFile([]byte(tc.content)); err == nil {
+				t.Fatalf("expected an error for %q", tc.content)
+			}
+		})
+	}
+}
+
+func TestImportUsageJSONPostsEventsAndAgent(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(usageImportResult{
+			Imported:         2,
+			AgentID:          "ea7d00c9",
+			AgentDisplayName: "Cursor",
+			Source:           "cursor",
+		})
+	}))
+	defer server.Close()
+
+	content := []byte(`[
+	  {"timestamp":"2026-07-31T10:00:00Z","model":"composer","total_tokens":10},
+	  {"timestamp":"2026-07-31T10:05:00Z","model":"composer","total_tokens":20}
+	]`)
+
+	client := api.NewClientWithToken(server.URL, "tok")
+	result, err := importUsageJSON(client, content, "agent-1", "cursor")
+	if err != nil {
+		t.Fatalf("importUsageJSON: %v", err)
+	}
+
+	if gotPath != usageImportPath {
+		t.Fatalf("unexpected path %q", gotPath)
+	}
+	if gotBody["agent_id"] != "agent-1" {
+		t.Fatalf("unexpected agent_id: %#v", gotBody["agent_id"])
+	}
+	if gotBody["source"] != "cursor" {
+		t.Fatalf("unexpected source: %#v", gotBody["source"])
+	}
+	events, ok := gotBody["events"].([]interface{})
+	if !ok || len(events) != 2 {
+		t.Fatalf("unexpected events payload: %#v", gotBody["events"])
+	}
+	if result.Imported != 2 || result.AgentDisplayName != "Cursor" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestImportUsageJSONOmitsAgentIDWhenNotSet(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(usageImportResult{Imported: 1})
+	}))
+	defer server.Close()
+
+	client := api.NewClientWithToken(server.URL, "tok")
+	content := []byte(`[{"timestamp":"2026-07-31T10:00:00Z","model":"composer","total_tokens":10}]`)
+	if _, err := importUsageJSON(client, content, "", "cursor"); err != nil {
+		t.Fatalf("importUsageJSON: %v", err)
+	}
+
+	if _, present := gotBody["agent_id"]; present {
+		t.Fatalf("agent_id must be omitted so the server resolves the default agent: %#v", gotBody)
+	}
+}
+
+// The API caps events per request, so a longer file has to be split and the
+// per-batch counters summed; otherwise a big export fails with a 422.
+func TestImportUsageJSONBatchesLargeFiles(t *testing.T) {
+	var batchSizes []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Events []json.RawMessage `json:"events"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		batchSizes = append(batchSizes, len(body.Events))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(usageImportResult{
+			Imported:          len(body.Events),
+			SkippedDuplicates: 1,
+			AgentDisplayName:  "Cursor",
+			Source:            "cursor",
+		})
+	}))
+	defer server.Close()
+
+	total := usageImportMaxEventsPerRequest + 3
+	events := make([]string, 0, total)
+	for i := 0; i < total; i++ {
+		events = append(events, `{"timestamp":"2026-07-31T10:00:00Z","model":"composer","total_tokens":10}`)
+	}
+	content := []byte("[" + strings.Join(events, ",") + "]")
+
+	client := api.NewClientWithToken(server.URL, "tok")
+	result, err := importUsageJSON(client, content, "", "cursor")
+	if err != nil {
+		t.Fatalf("importUsageJSON: %v", err)
+	}
+
+	if len(batchSizes) != 2 ||
+		batchSizes[0] != usageImportMaxEventsPerRequest ||
+		batchSizes[1] != 3 {
+		t.Fatalf("unexpected batching: %v", batchSizes)
+	}
+	if result.Imported != total {
+		t.Fatalf("expected %d imported, got %d", total, result.Imported)
+	}
+	if result.SkippedDuplicates != 2 {
+		t.Fatalf("expected duplicate counts to be summed, got %d", result.SkippedDuplicates)
+	}
+}
+
+func TestImportUsageCSVSendsFileAndFormFields(t *testing.T) {
+	var gotPath, gotFileName string
+	gotFields := map[string]string{}
+	var gotFileContent []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			t.Fatalf("parse content type: %v", err)
+		}
+		reader := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("next part: %v", err)
+			}
+			value, err := io.ReadAll(part)
+			if err != nil {
+				t.Fatalf("read part: %v", err)
+			}
+			if part.FormName() == "file" {
+				gotFileName = part.FileName()
+				gotFileContent = value
+				continue
+			}
+			gotFields[part.FormName()] = string(value)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(usageImportResult{
+			Imported:          2,
+			SkippedDuplicates: 1,
+			AgentID:           "ea7d00c9",
+			AgentDisplayName:  "Cursor",
+			Source:            "cursor",
+			ParsedRows:        3,
+			SkippedRows:       1,
+			SkippedRowReasons: []string{"row 4: unparsable date"},
+		})
+	}))
+	defer server.Close()
+
+	csv := []byte("Date,Kind,Model,Total Tokens,Cost\n2026-07-28T09:15:00,Included,composer,240,Included\n")
+	client := api.NewClientWithToken(server.URL, "tok")
+	result, err := importUsageCSV(
+		client, "cursor-usage.csv", csv, "agent-1", "cursor", `{"cost":"Cost to You"}`,
+	)
+	if err != nil {
+		t.Fatalf("importUsageCSV: %v", err)
+	}
+
+	if gotPath != usageImportCsvPath {
+		t.Fatalf("unexpected path %q", gotPath)
+	}
+	if gotFileName != "cursor-usage.csv" {
+		t.Fatalf("unexpected file name %q", gotFileName)
+	}
+	if !bytes.Equal(gotFileContent, csv) {
+		t.Fatalf("file content not sent verbatim: %q", gotFileContent)
+	}
+	if gotFields["agent_id"] != "agent-1" {
+		t.Fatalf("unexpected agent_id field: %q", gotFields["agent_id"])
+	}
+	if gotFields["source"] != "cursor" {
+		t.Fatalf("unexpected source field: %q", gotFields["source"])
+	}
+	if gotFields["column_map"] != `{"cost":"Cost to You"}` {
+		t.Fatalf("unexpected column_map field: %q", gotFields["column_map"])
+	}
+	if result.ParsedRows != 3 || result.SkippedRows != 1 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestImportUsageCSVOmitsUnsetOptionalFields(t *testing.T) {
+	gotFields := map[string]string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			t.Fatalf("parse content type: %v", err)
+		}
+		reader := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("next part: %v", err)
+			}
+			value, err := io.ReadAll(part)
+			if err != nil {
+				t.Fatalf("read part: %v", err)
+			}
+			if part.FormName() != "file" {
+				gotFields[part.FormName()] = string(value)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(usageImportResult{Imported: 1})
+	}))
+	defer server.Close()
+
+	client := api.NewClientWithToken(server.URL, "tok")
+	if _, err := importUsageCSV(
+		client, "cursor-usage.csv", []byte("Date\n2026-07-28\n"), "", "cursor", "",
+	); err != nil {
+		t.Fatalf("importUsageCSV: %v", err)
+	}
+
+	if _, present := gotFields["agent_id"]; present {
+		t.Fatalf("agent_id must be omitted when unset: %#v", gotFields)
+	}
+	if _, present := gotFields["column_map"]; present {
+		t.Fatalf("column_map must be omitted when unset: %#v", gotFields)
+	}
+}
+
+func TestImportUsageSurfacesAPIErrorBody(t *testing.T) {
+	// The 422 an operator hits most often says which command to run first;
+	// swallowing the body would hide the fix.
+	detail := "No managed 'cursor' agent found. Onboard one with " +
+		"`preloop agents onboard cursor` or pass agent_id explicitly."
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": detail})
+	}))
+	defer server.Close()
+
+	client := api.NewClientWithToken(server.URL, "tok")
+	content := []byte(`[{"timestamp":"2026-07-31T10:00:00Z","model":"composer","total_tokens":10}]`)
+	_, err := importUsageJSON(client, content, "", "cursor")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "preloop agents onboard cursor") {
+		t.Fatalf("error must relay the server's guidance, got: %v", err)
+	}
+}
+
+func TestWriteUsageImportSummary(t *testing.T) {
+	var output bytes.Buffer
+	err := writeUsageImportSummary(&output, "/tmp/cursor-usage.csv", &usageImportResult{
+		Imported:          2,
+		SkippedDuplicates: 3,
+		AgentID:           "ea7d00c9",
+		AgentDisplayName:  "Cursor",
+		Source:            "cursor",
+		ParsedRows:        6,
+		SkippedRows:       1,
+		SkippedRowReasons: []string{"row 4: unparsable date"},
+	})
+	if err != nil {
+		t.Fatalf("writeUsageImportSummary: %v", err)
+	}
+
+	rendered := output.String()
+	for _, expected := range []string{
+		"Imported 2 usage records from cursor-usage.csv",
+		"Cursor (ea7d00c9)",
+		"cursor",
+		"3 skipped",
+		"row 4: unparsable date",
+	} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("expected output to contain %q, got:\n%s", expected, rendered)
+		}
+	}
+}
+
+func TestWriteUsageImportSummaryOmitsSkippedRowsWhenNone(t *testing.T) {
+	var output bytes.Buffer
+	if err := writeUsageImportSummary(&output, "events.json", &usageImportResult{
+		Imported:         1,
+		AgentDisplayName: "Cursor",
+		Source:           "cursor",
+	}); err != nil {
+		t.Fatalf("writeUsageImportSummary: %v", err)
+	}
+
+	rendered := output.String()
+	if !strings.Contains(rendered, "Imported 1 usage record from events.json") {
+		t.Fatalf("expected singular record wording, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "could not use") {
+		t.Fatalf("expected no skipped-row section, got:\n%s", rendered)
+	}
+}
+
+func TestValidateUsageImportOptions(t *testing.T) {
+	testCases := []struct {
+		name      string
+		opts      usageImportOptions
+		expectCSV bool
+		errSubstr string
+	}{
+		{
+			name:      "csv without column map",
+			opts:      usageImportOptions{filePath: "cursor-usage.csv"},
+			expectCSV: true,
+		},
+		{
+			name:      "csv with valid column map",
+			opts:      usageImportOptions{filePath: "cursor-usage.csv", columnMap: `{"cost":"Cost to You"}`},
+			expectCSV: true,
+		},
+		{
+			name:      "json without column map",
+			opts:      usageImportOptions{filePath: "events.json"},
+			expectCSV: false,
+		},
+		{
+			name:      "column map on json is rejected",
+			opts:      usageImportOptions{filePath: "events.json", columnMap: `{"cost":"Cost"}`},
+			errSubstr: "CSV files only",
+		},
+		{
+			name:      "malformed column map is rejected",
+			opts:      usageImportOptions{filePath: "cursor-usage.csv", columnMap: "{not json"},
+			errSubstr: "not valid JSON",
+		},
+		{
+			name:      "unsupported extension is rejected",
+			opts:      usageImportOptions{filePath: "usage.xlsx"},
+			errSubstr: "unsupported file type",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			isCSV, err := validateUsageImportOptions(tc.opts)
+			if tc.errSubstr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Fatalf("expected an error containing %q, got: %v", tc.errSubstr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if isCSV != tc.expectCSV {
+				t.Fatalf("expected isCSV=%t, got %t", tc.expectCSV, isCSV)
+			}
+		})
+	}
+}
+
+func TestRunUsageImportReportsMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.csv")
+
+	err := runUsageImport(usageImportCmd, []string{path})
+	if err == nil || !strings.Contains(err.Error(), "failed to read file") {
+		t.Fatalf("expected a read error, got: %v", err)
+	}
+}
+
+func TestUsageImportCommandIsRegistered(t *testing.T) {
+	var usage *cobra.Command
+	for _, command := range rootCmd.Commands() {
+		if command.Name() == "usage" {
+			usage = command
+			break
+		}
+	}
+	if usage == nil {
+		t.Fatal("expected `preloop usage` to be registered on the root command")
+	}
+
+	var importCmd *cobra.Command
+	for _, sub := range usage.Commands() {
+		if sub.Name() == "import" {
+			importCmd = sub
+			break
+		}
+	}
+	if importCmd == nil {
+		t.Fatal("expected `preloop usage import` to be registered")
+	}
+
+	for _, flag := range []string{"agent-id", "source", "column-map"} {
+		if importCmd.Flags().Lookup(flag) == nil {
+			t.Fatalf("expected --%s flag on `preloop usage import`", flag)
+		}
+	}
+	if got := importCmd.Flags().Lookup("source").DefValue; got != "cursor" {
+		t.Fatalf("expected --source to default to cursor, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

Adds `preloop usage import <file>`, the CLI path to the usage ingest
endpoints that landed in #137. Refs #123.

```
preloop usage import cursor-usage.csv
preloop usage import events.json --agent-id 7f1c...c3
preloop usage import export.csv --column-map '{"cost":"Cost to You"}'
```

## Why

#137 shipped `POST /api/v1/usage/import` (normalized JSON events) and
`POST /api/v1/usage/import/csv` (Cursor dashboard Usage export) so that
Cursor's bundled Composer/Auto spend, which never traverses the model
gateway, can appear in Cost analytics. Until now the only way to reach
either endpoint was hand-rolled curl, which does not match the real
workflow: export a CSV from the Cursor dashboard, then import it.

## How

The file extension picks the endpoint. `.csv` is posted as multipart to
the CSV endpoint; `.json` is parsed locally and posted as normalized
events. An unknown extension is an error rather than a content sniff,
because sending a mislabeled file to the wrong parser fails in a much
more confusing way than a rename does.

Flags mirror the API surface: `--agent-id`, `--source` (default
`cursor`), and `--column-map` for CSV shapes the built-in header matcher
does not recognize. `--column-map` is validated locally (JSON syntax, and
rejected outright for JSON input) so an obvious mistake does not turn
into a server-side 422.

Two behaviors worth review attention:

- JSON files are split into batches of 5000 events, matching
  `MAX_EVENTS_PER_REQUEST` in `backend/preloop/schemas/usage_import.py`,
  and the per-batch counters are summed. Without this a large export just
  fails validation. The import is idempotent, so a partially applied
  split can be re-run safely.
- Both the bare array and the `{"events": [...]}` envelope are accepted,
  since both are shapes people plausibly have on disk.

The summary prints imported and duplicate counts plus the attributed
agent, and surfaces the CSV endpoint's `skipped_row_reasons`. API errors
are wrapped rather than replaced: the 422 an operator hits most often
names the `preloop agents onboard cursor` prerequisite, and swallowing
that body would hide the fix.

## Testing

`cli/internal/cmd/usage_test.go` covers extension routing, both JSON
input shapes and their rejections, request shape for JSON and multipart
(including that unset optional fields are omitted so the server resolves
the default agent), batching of oversized JSON files with summed
counters, error-body pass-through of the onboard-prerequisite 422,
summary rendering with and without skipped rows, flag validation, and
command registration.

Full CLI suite green locally (`go test ./...` in `cli/`).

## Not in this PR

- CHANGELOG: the current `[Unreleased]` section is the 0.14.0 content
  owned by #164, which renames that heading. Adding a second heading here
  would conflict during the cut. This entry should go under a fresh
  `[Unreleased]` after 0.14.0 is tagged.
- Docs coverage lives in the separate `preloop-docs` repo and is tracked
  in a companion MR there.

## Note on merge

Do not merge before the 0.14.0 cut. This is post-0.14.0 work.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-tested CLI addition with no security concerns, proper input validation (including column-map shape and field-name validation), and comprehensive error handling.
>
> **Overview**
> Adds `preloop usage import <file>` for CSV and JSON usage ingest. File extension routing, local flag validation with field-name checking, JSON batching for large files, and full API error passthrough. 557 lines of tests covering all paths.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit c8d377b5. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->