### PR TITLE
feat(console): surface imported usage on cost analytics

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -916,7 +916,29 @@ export type ModelPriceOverrideCreate = Omit<
 
 export type ModelPriceOverrideUpdate = Partial<ModelPriceOverrideCreate>;
 
-export interface CostAnalyticsSummaryResponse extends AccountGatewayUsageSummaryResponse {}
+// Usage ingested from outside the gateway (e.g. a Cursor CSV/JSON export).
+// Reported as its own block so imported spend is never mixed into
+// `estimated_cost` or any budget figure (issue #123).
+export interface ImportedUsageByModel {
+  model_alias: string | null;
+  source: string | null;
+  request_count: number;
+  total_tokens: number;
+  imported_cost: number;
+  last_event_at: string | null;
+}
+
+export interface ImportedUsageSummary {
+  event_count: number;
+  total_tokens: number;
+  imported_cost: number;
+  usage_by_model: ImportedUsageByModel[];
+}
+
+export interface CostAnalyticsSummaryResponse extends AccountGatewayUsageSummaryResponse {
+  // Absent (null) when the window contains no imported usage.
+  imported_usage?: ImportedUsageSummary | null;
+}
 
 export interface ProviderBillingConnection {
   id: string;

--- a/frontend/src/views/authed/cost-view.test.ts
+++ b/frontend/src/views/authed/cost-view.test.ts
@@ -8,6 +8,9 @@ import { invalidateApiCaches } from '../../api';
 
 describe('CostView', () => {
   let fetchStub: sinon.SinonStub;
+  // Per-test copy of the payload so a test can add fields (e.g. the imported
+  // usage block) without leaking into the others.
+  let summaryPayload: Record<string, unknown>;
 
   const summary = {
     period_start: '2026-03-01T00:00:00Z',
@@ -73,12 +76,13 @@ describe('CostView', () => {
   beforeEach(() => {
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
+    summaryPayload = { ...summary };
     fetchStub = sinon.stub(window, 'fetch');
     fetchStub.callsFake(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
 
       if (url.includes('/api/v1/cost/summary')) {
-        return new Response(JSON.stringify(summary), {
+        return new Response(JSON.stringify(summaryPayload), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
@@ -140,6 +144,117 @@ describe('CostView', () => {
       '[role="status"][aria-busy="true"]'
     );
     expect(loading).to.exist;
+  });
+
+  describe('imported usage section', () => {
+    const importedUsage = {
+      event_count: 4,
+      total_tokens: 9680,
+      imported_cost: 2.09,
+      usage_by_model: [
+        {
+          model_alias: 'claude-4.5-sonnet',
+          source: 'cursor',
+          request_count: 2,
+          total_tokens: 7090,
+          imported_cost: 1.67,
+          last_event_at: '2026-07-31T10:05:00Z',
+        },
+        {
+          model_alias: 'composer',
+          source: 'cursor',
+          request_count: 2,
+          total_tokens: 2590,
+          imported_cost: 0.42,
+          last_event_at: '2026-07-31T10:00:00Z',
+        },
+      ],
+    };
+
+    async function loadView(imported?: unknown): Promise<CostView> {
+      if (imported !== undefined) {
+        summaryPayload = { ...summary, imported_usage: imported };
+      }
+      const element = (await fixture(
+        html`<cost-view></cost-view>`
+      )) as CostView;
+      await waitUntil(
+        () => (element as unknown as { loading: boolean }).loading === false
+      );
+      await element.updateComplete;
+      return element;
+    }
+
+    it('renders totals and a per-model table when imported usage exists', async () => {
+      const element = await loadView(importedUsage);
+
+      const totals = element.shadowRoot?.querySelector(
+        '[aria-label="Imported usage totals"]'
+      );
+      expect(totals).to.exist;
+      expect(totals?.textContent).to.contain('4');
+      expect(totals?.textContent).to.contain('9,680');
+      expect(totals?.textContent).to.contain('$2.09');
+
+      const table = element.shadowRoot?.querySelector(
+        'table[aria-label="Imported usage by model"]'
+      );
+      expect(table).to.exist;
+      expect(table?.querySelector('th[scope="col"]')).to.exist;
+      expect(table?.querySelectorAll('tbody tr').length).to.equal(2);
+
+      const body = table?.querySelector('tbody')?.textContent ?? '';
+      expect(body).to.contain('claude-4.5-sonnet');
+      expect(body).to.contain('cursor');
+      expect(body).to.contain('$1.67');
+    });
+
+    it('labels the section so imported spend reads as separate from gateway spend', async () => {
+      const element = await loadView(importedUsage);
+
+      const text = element.shadowRoot?.textContent ?? '';
+      expect(text).to.contain('Imported usage');
+      expect(text).to.contain('Not gateway metered');
+    });
+
+    it('keeps imported cost out of the gateway spend metric', async () => {
+      const element = await loadView(importedUsage);
+
+      const metrics = element.shadowRoot?.querySelector(
+        '[aria-label="Cost summary metrics"]'
+      );
+      // Gateway spend stays at the summary's estimated_cost (8.50); the
+      // imported 2.09 must not be added to it.
+      expect(metrics?.textContent).to.contain('$8.50');
+      expect(metrics?.textContent).to.not.contain('$10.59');
+    });
+
+    it('hides the section when there is no imported usage', async () => {
+      const element = await loadView({
+        event_count: 0,
+        total_tokens: 0,
+        imported_cost: 0,
+        usage_by_model: [],
+      });
+
+      expect(
+        element.shadowRoot?.querySelector(
+          '[aria-label="Imported usage totals"]'
+        )
+      ).to.not.exist;
+      expect(element.shadowRoot?.textContent).to.not.contain('Imported usage');
+    });
+
+    it('hides the section when the response omits the imported block', async () => {
+      const element = await loadView();
+
+      expect(
+        element.shadowRoot?.querySelector(
+          '[aria-label="Imported usage totals"]'
+        )
+      ).to.not.exist;
+      expect(element.shadowRoot?.textContent).to.not.contain('Imported usage');
+    });
   });
 
   it('renders the page title and description in the view header', async () => {

--- a/frontend/src/views/authed/cost-view.ts
+++ b/frontend/src/views/authed/cost-view.ts
@@ -25,6 +25,7 @@ import type {
   CostReconciliationRow,
   GatewayUsageBySession,
   GatewayUsageByTool,
+  ImportedUsageByModel,
   ModelPriceOverride,
   ModelPriceOverrideCreate,
   ProviderBillingConnection,
@@ -179,6 +180,7 @@ export class CostView extends AuthedElement {
   };
   @state() private sessionSort: SortState = { key: 'cost', dir: 'desc' };
   @state() private userSort: SortState = { key: 'cost', dir: 'desc' };
+  @state() private importedSort: SortState = { key: 'cost', dir: 'desc' };
 
   private get modelPriceOverridesEnabled(): boolean {
     return this.featureFlags.model_price_overrides === true;
@@ -374,6 +376,32 @@ export class CostView extends AuthedElement {
 
       .analytics-card::part(body) {
         padding: var(--sl-spacing-large);
+      }
+
+      .imported-usage-note {
+        margin-bottom: var(--sl-spacing-medium);
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        line-height: 1.5;
+      }
+
+      .imported-usage-totals {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sl-spacing-large);
+        margin-bottom: var(--sl-spacing-medium);
+      }
+
+      .imported-usage-total-label {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+      }
+
+      .imported-usage-total-value {
+        margin-top: var(--sl-spacing-2x-small);
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: var(--sl-color-neutral-950);
       }
 
       .analytics-table-wrap {
@@ -1238,6 +1266,144 @@ export class CostView extends AuthedElement {
       groups.set(owner, existing);
     }
     return [...groups.values()];
+  }
+
+  // Imported usage (issue #123): spend ingested from a provider's own export
+  // (e.g. Cursor) rather than metered by the gateway. It is rendered as its
+  // own section and never folded into the spend metrics, budgets, or the
+  // per-agent/session/tool tabs above, which all describe gateway traffic.
+  // Hidden entirely when the window holds no imported events.
+  private renderImportedUsage() {
+    const imported = this.summary?.imported_usage;
+    if (!imported || !imported.event_count) return nothing;
+    const columns: SortColumn<ImportedUsageByModel>[] = [
+      {
+        key: 'model',
+        label: 'Model',
+        numeric: false,
+        value: (r) => r.model_alias || 'Unknown',
+      },
+      {
+        key: 'source',
+        label: 'Source',
+        numeric: false,
+        value: (r) => r.source || 'Unknown',
+      },
+      {
+        key: 'requests',
+        label: 'Events',
+        numeric: true,
+        value: (r) => r.request_count,
+      },
+      {
+        key: 'tokens',
+        label: 'Tokens',
+        numeric: true,
+        value: (r) => r.total_tokens,
+      },
+      {
+        key: 'cost',
+        label: 'Imported cost',
+        numeric: true,
+        value: (r) => r.imported_cost,
+      },
+      {
+        key: 'last_event',
+        label: 'Last event',
+        numeric: true,
+        value: (r) =>
+          r.last_event_at ? new Date(r.last_event_at).getTime() : 0,
+      },
+    ];
+    const rows = this.sortRows(
+      imported.usage_by_model || [],
+      columns,
+      this.importedSort
+    );
+    return html`
+      <sl-card class="analytics-card">
+        ${this.renderSectionHeader(
+          'box-arrow-in-down',
+          'Imported usage',
+          html`<sl-badge variant="neutral" pill>Not gateway metered</sl-badge>`
+        )}
+        <div class="imported-usage-note">
+          Usage imported from a provider's own export. It is reported separately
+          and is not counted in the spend metrics, budgets, or breakdowns above,
+          which cover gateway-metered traffic only.
+        </div>
+        <div
+          class="imported-usage-totals"
+          role="region"
+          aria-label="Imported usage totals"
+        >
+          <div>
+            <div class="imported-usage-total-label">Imported events</div>
+            <div class="imported-usage-total-value">
+              ${this.formatNumber(imported.event_count)}
+            </div>
+          </div>
+          <div>
+            <div class="imported-usage-total-label">Imported tokens</div>
+            <div class="imported-usage-total-value">
+              ${this.formatNumber(imported.total_tokens)}
+            </div>
+          </div>
+          <div>
+            <div class="imported-usage-total-label">Imported cost</div>
+            <div class="imported-usage-total-value">
+              ${this.formatCurrency(imported.imported_cost)}
+            </div>
+          </div>
+        </div>
+        ${
+          rows.length
+            ? html`<div class="analytics-table-wrap">
+                <table
+                  class="styled-table"
+                  aria-label="Imported usage by model"
+                >
+                  <thead>
+                    <tr>
+                      ${columns.map((column) =>
+                        this.renderSortableHeader(
+                          column,
+                          this.importedSort,
+                          (key) =>
+                            (this.importedSort = this.toggleSort(
+                              this.importedSort,
+                              key
+                            ))
+                        )
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${rows.map(
+                      (row) => html`
+                        <tr>
+                          <td>${row.model_alias || 'Unknown'}</td>
+                          <td>${row.source || 'Unknown'}</td>
+                          <td>${this.formatNumber(row.request_count)}</td>
+                          <td>${this.formatNumber(row.total_tokens)}</td>
+                          <td>${this.formatCurrency(row.imported_cost)}</td>
+                          <td>
+                            ${
+                              row.last_event_at
+                                ? new Date(row.last_event_at).toLocaleString()
+                                : '-'
+                            }
+                          </td>
+                        </tr>
+                      `
+                    )}
+                  </tbody>
+                </table>
+              </div>`
+            : html`<div class="empty">No per-model imported usage yet.</div>`
+        }
+      </sl-card>
+    `;
   }
 
   private renderBreakdown() {
@@ -2221,7 +2387,9 @@ export class CostView extends AuthedElement {
                 ${this.renderMetrics()} ${this.renderCatalogInfo()}
                 ${this.renderUnpricedNotice()}
                 <div class="column-layout dashboard extra-wide">
-                  <div class="main-column">${this.renderBreakdown()}</div>
+                  <div class="main-column">
+                    ${this.renderBreakdown()} ${this.renderImportedUsage()}
+                  </div>
                   <div class="side-column">${this.renderControls()}</div>
                 </div>
               `


### PR DESCRIPTION
Followup to #123. Builds on #137, which added `POST /api/v1/usage/import` and `/usage/import/csv`.

## Problem

Imported spend already comes back from `GET /api/v1/cost/summary` in a separate `imported_usage` block, but `grep -r imported_usage frontend/src` returned zero hits. Anyone importing a Cursor export saw it land in the database and then vanish: the console rendered nothing for it.

## Change

Adds an "Imported usage" card to the cost analytics page:

- Header badge reading "Not gateway metered", plus a note stating the numbers are excluded from the metrics and budgets above.
- Totals for imported events, tokens, and cost.
- Sortable per-model table: model, source, events, tokens, imported cost, last event.
- Reuses the page's existing sort, format, and table helpers rather than introducing new patterns.
- Updates `types.ts` with `ImportedUsageByModel`, `ImportedUsageSummary`, and `CostAnalyticsSummaryResponse`.

## Keeping imported spend separate

Imported cost is never folded into gateway spend, budget figures, or the agent/tool/session/user breakdowns, all of which describe gateway-metered traffic. The new card is a sibling that reads only from `imported_usage`; no existing metric or budget code was touched. A regression test asserts the gateway spend metric stays at `estimated_cost` ($8.50) and never renders the combined total ($10.59).

## API shape note

`cost.py` sets `imported_usage = None` unless `imported_totals["event_count"]` is truthy, so the key is absent rather than zero-valued when there is no imported usage. The guard handles both the absent and the zero-count cases, and both are covered by tests.

## Verification

- 8/8 tests pass in `cost-view.test.ts` (5 new, covering render, labeling, the no-double-count rule, and both hide cases).
- `vite build` succeeds; prettier clean; no new tsc errors.
- Rendered against fixtures matching the verified live response from the 0.14.0 release check (4 events, 9,680 tokens, $2.09).

## Note for the release

Do not merge yet: v0.14.0 is being cut from current main today. This is open and ready to go in after that.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Clean, well-tested UI addition that reuses existing patterns. No security concerns, no architecture changes.
>
> **Overview**
> Adds an "Imported usage" card to the cost analytics page to surface spend ingested from provider exports (e.g. Cursor CSV). The section is fully isolated from gateway metrics, budgets, and breakdowns. 5 new tests cover rendering, labeling, gateway spend isolation, and both hide cases.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit feat/imported-usage-ui-123. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
