### PR TITLE
docs(changelog): note imported usage console section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,12 @@ across renames and re-onboarding.
   so re-importing the same CSV reports `skipped_duplicates` instead of
   double-counting. Imported spend surfaces as a separate `imported_usage`
   block in `GET /api/v1/cost/summary` and never mixes into gateway
-  `estimated_cost`, budgets, or spend caps.
+  `estimated_cost`, budgets, or spend caps. Cost analytics renders this as an
+  "Imported usage" section showing imported events, tokens, and cost, plus a
+  per-model table with the source and the last event time. The section carries a
+  "Not gateway metered" badge and stays out of the spend metrics, budgets, and
+  breakdowns, which continue to describe gateway-metered traffic only. It is
+  hidden when the selected window holds no imported usage.
 - **Rate-limit intelligence and subscription headroom** (#136): the gateway now
   captures upstream 429s and provider rate-limit headers (`Retry-After`,
   `anthropic-ratelimit-*`, `x-ratelimit-*`) as real observations, normalizes


### PR DESCRIPTION
Small docs-only followup to #168.

The Preloop review on #168 flagged that a CHANGELOG entry was recommended before merge. I pushed that commit, but it landed about 45 seconds after #168 was merged, so it never reached main. This carries it over.

The existing #123 entry described the API side only (the `imported_usage` block on `GET /api/v1/cost/summary`). It now also covers the Cost analytics section that #168 shipped, since that is the part a user actually sees.

Folded into the existing #123 bullet rather than added as a separate entry, because it is the same user-facing feature.

No code changes.

## Heads up on the branch

Pushing that commit recreated `feat/imported-usage-ui-123`, which had been deleted right after the merge. Safe to delete again: everything in it is either already on main or in this PR.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only CHANGELOG update with no code changes. Trivially safe to merge.
>
> **Overview**
> Expands the existing #123 "Cursor bundled-model usage import" CHANGELOG entry to also describe the Cost analytics UI section shipped in #168, keeping the same bullet rather than creating a duplicate entry.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 3f408c6. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->