### PR TITLE
fix(agents): decouple agent_kind from session_source_type (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,20 @@ across renames and re-onboarding.
 
 ### Fixed
 
+- **Managed agents report their real product kind** (#123): Cursor, Windsurf,
+  VS Code, Antigravity, and Devin agents all recorded `agent_kind` as
+  `desktop_agent` (or `custom` when created via `POST /api/v1/agents`), because
+  the kind was derived from the connection's `session_source_type`. As a
+  result they showed as generic agents in the console, and the default
+  attribution target for `POST /api/v1/usage/import` could never be resolved
+  (a bare import returned HTTP 422 for every account). `agent_kind` is now
+  decoupled from `session_source_type`: `POST /api/v1/agents` accepts an
+  optional `agent_kind`, and the CLI reports the product it is onboarding when
+  minting a runtime-session token. `session_source_type` is deliberately
+  unchanged, since it is part of the durable v2 principal-id fingerprint:
+  existing enrollments keep their identity, spend history, and credentials,
+  and are refined in place rather than re-keyed. An older CLI that does not
+  send `agent_kind` can no longer reset a known kind back to the generic one.
 - **Gateway upstream provider errors are classified** (#116, #117, #118): a
   shared `classify_upstream_error` taxonomy (`network`,
   `upstream_overloaded`, `upstream_rate_limited`, `upstream_quota_exhausted`,

--- a/backend/preloop/api/auth/router.py
+++ b/backend/preloop/api/auth/router.py
@@ -1,7 +1,6 @@
 """Authentication router for the API."""
 
 import logging
-import re
 import secrets
 import string
 from datetime import datetime, timedelta, UTC
@@ -56,6 +55,11 @@ from preloop.schemas.subject_governance import (
     SubjectGovernanceResponse,
 )
 from preloop.utils import get_client_ip
+from preloop.utils.agent_kind import (
+    AGENT_KIND_SHAPE_ERROR,
+    is_valid_agent_kind,
+    normalize_agent_kind,
+)
 from preloop.utils.email import send_password_reset_email
 from preloop.utils.tokens import (
     TokenError,
@@ -112,8 +116,6 @@ RUNTIME_SESSION_SOURCE_TYPES = {
     "custom",
 }
 RUNTIME_SESSION_ALLOWED_SCOPES = ("mcp:read", "mcp:write")
-#: Durable agent kinds are echoed into comma-separated filter query strings.
-_AGENT_KIND_PATTERN = re.compile(r"[a-z0-9_]+")
 API_KEY_ACTIVE_WINDOW = timedelta(minutes=10)
 API_KEY_RECENT_WINDOW = timedelta(hours=24)
 
@@ -138,13 +140,13 @@ def _normalize_runtime_session_agent_kind(agent_kind: Optional[str]) -> Optional
     """
     if agent_kind is None:
         return None
-    normalized = agent_kind.strip().lower().replace(" ", "_").replace("-", "_")
+    normalized = normalize_agent_kind(agent_kind)
     if not normalized:
         return None
-    if not _AGENT_KIND_PATTERN.fullmatch(normalized):
+    if not is_valid_agent_kind(normalized):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=("agent_kind must contain only letters, digits, and underscores"),
+            detail=AGENT_KIND_SHAPE_ERROR,
         )
     return normalized
 

--- a/backend/preloop/api/auth/router.py
+++ b/backend/preloop/api/auth/router.py
@@ -1,6 +1,7 @@
 """Authentication router for the API."""
 
 import logging
+import re
 import secrets
 import string
 from datetime import datetime, timedelta, UTC
@@ -111,8 +112,41 @@ RUNTIME_SESSION_SOURCE_TYPES = {
     "custom",
 }
 RUNTIME_SESSION_ALLOWED_SCOPES = ("mcp:read", "mcp:write")
+#: Durable agent kinds are echoed into comma-separated filter query strings.
+_AGENT_KIND_PATTERN = re.compile(r"[a-z0-9_]+")
 API_KEY_ACTIVE_WINDOW = timedelta(minutes=10)
 API_KEY_RECENT_WINDOW = timedelta(hours=24)
+
+
+def _normalize_runtime_session_agent_kind(agent_kind: Optional[str]) -> Optional[str]:
+    """Normalize a client-supplied durable agent kind.
+
+    Unlike ``session_source_type`` this is descriptive metadata rather than
+    part of the principal fingerprint, so it is not restricted to a fixed
+    allowlist: a newer CLI may know product kinds this server does not. It is
+    still shape-checked, because kinds are echoed into comma-separated filter
+    query strings.
+
+    Args:
+        agent_kind: Raw kind supplied by the client, if any.
+
+    Returns:
+        The normalized kind, or None when the client did not supply one.
+
+    Raises:
+        HTTPException: When the supplied kind is not a bare identifier.
+    """
+    if agent_kind is None:
+        return None
+    normalized = agent_kind.strip().lower().replace(" ", "_").replace("-", "_")
+    if not normalized:
+        return None
+    if not _AGENT_KIND_PATTERN.fullmatch(normalized):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=("agent_kind must contain only letters, digits, and underscores"),
+        )
+    return normalized
 
 
 def _normalize_runtime_session_scopes(requested_scopes: List[str]) -> List[str]:
@@ -1053,6 +1087,9 @@ async def create_runtime_session_token(
             ),
         )
 
+    normalized_agent_kind = _normalize_runtime_session_agent_kind(
+        session_data.agent_kind
+    )
     scopes = _normalize_runtime_session_scopes(session_data.scopes)
     allowed_mcp_servers, allowed_mcp_tools = _resolve_runtime_session_tool_restrictions(
         db,
@@ -1123,6 +1160,7 @@ async def create_runtime_session_token(
         owner_user_id=current_user.id,
         enrollment_hostname=identity.hostname if identity else None,
         identity_derivation=identity.derivation if identity else None,
+        agent_kind=normalized_agent_kind,
     )
     db.commit()
     db.refresh(runtime_session)

--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -1561,6 +1561,11 @@ async def create_account_managed_agent(
     ``active`` so the operator can immediately mint a gateway credential for it
     via ``POST /agents/{agent_id}/credentials``.
 
+    Pass ``agent_kind`` (for example ``cursor``) to record which product the
+    agent is; it defaults to ``custom``. The kind is what usage import resolves
+    a default attribution target by, so an API-created Cursor agent can now be
+    the implicit target of ``POST /usage/import``.
+
     Duplicate ``display_name`` values are allowed within an account: each custom
     agent is keyed by a unique generated ``session_source_id``, so two agents
     sharing a display name remain distinct registry entries. Operators may
@@ -1581,6 +1586,7 @@ async def create_account_managed_agent(
         display_name=payload.display_name,
         description=payload.description,
         owner_user_id=current_user.id,
+        agent_kind=payload.agent_kind,
         commit=True,
     )
     summary = crud_managed_agent.get_summary_for_account(
@@ -1604,6 +1610,7 @@ async def create_account_managed_agent(
                 "agent_id": str(agent.id),
                 "display_name": agent.display_name,
                 "session_source_type": agent.session_source_type,
+                "agent_kind": agent.agent_kind,
                 "registered_by_user_id": str(current_user.id),
             },
         )

--- a/backend/preloop/models/crud/managed_agent.py
+++ b/backend/preloop/models/crud/managed_agent.py
@@ -9,6 +9,8 @@ from typing import Any, Optional
 from sqlalchemy import and_, case, func, or_, tuple_
 from sqlalchemy.orm import Session
 
+from preloop.utils.agent_kind import normalize_agent_kind
+
 from ..models.api_usage import ApiUsage
 from ..models.managed_agent import ManagedAgent
 from ..models.runtime_session import RuntimeSession
@@ -41,11 +43,39 @@ def normalize_managed_agent_kind(
     Returns:
         The normalized durable agent kind.
     """
-    explicit = str(agent_kind or "").strip().lower().replace(" ", "_")
+    explicit = normalize_agent_kind(agent_kind)
     if explicit:
         return explicit
-    normalized = str(session_source_type or "").strip().lower().replace(" ", "_")
-    return normalized or "external_agent"
+    return normalize_agent_kind(session_source_type) or "external_agent"
+
+
+def should_refine_agent_kind(
+    stored_kind: Optional[str],
+    *,
+    session_source_type: Optional[str],
+    agent_kind: Optional[str],
+) -> bool:
+    """Decide whether a re-enrollment may overwrite the stored agent kind.
+
+    Refine the kind, never regress it. A client that supplies an explicit
+    kind always wins: it knows which product it is. A client that supplies
+    none (an older CLI, or one that cannot tell Cursor from Windsurf) may
+    only fill in a kind that is still empty or still the generic transport
+    value, because otherwise every re-enrollment from that client would
+    reset a known ``cursor`` back to ``desktop_agent``.
+
+    Args:
+        stored_kind: Kind currently recorded on the agent row.
+        session_source_type: Transport-level source type for this enrollment.
+        agent_kind: Explicit product kind supplied by the client, if any.
+
+    Returns:
+        True when the caller should write the refined kind.
+    """
+    if agent_kind:
+        return True
+    transport_kind = normalize_managed_agent_kind(session_source_type)
+    return (stored_kind or "") in ("", transport_kind)
 
 
 def _utc_now() -> datetime:
@@ -534,16 +564,14 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
             return db_obj
 
         db_obj.runtime_session_id = runtime_session_id
-        # Refine the kind, never regress it. An older CLI (or a client that
-        # cannot tell Cursor from Windsurf) sends no agent_kind, which would
-        # otherwise reset a known product kind back to "desktop_agent" every
-        # time that agent re-enrolled.
-        refined_kind = normalize_managed_agent_kind(
-            session_source_type, agent_kind=agent_kind
-        )
-        transport_kind = normalize_managed_agent_kind(session_source_type)
-        if agent_kind or (db_obj.agent_kind or "") in ("", transport_kind):
-            db_obj.agent_kind = refined_kind
+        if should_refine_agent_kind(
+            db_obj.agent_kind,
+            session_source_type=session_source_type,
+            agent_kind=agent_kind,
+        ):
+            db_obj.agent_kind = normalize_managed_agent_kind(
+                session_source_type, agent_kind=agent_kind
+            )
         # Preserve operator renames on reuse; only fill an empty display name.
         if not (db_obj.display_name or "").strip():
             db_obj.display_name = display_name

--- a/backend/preloop/models/crud/managed_agent.py
+++ b/backend/preloop/models/crud/managed_agent.py
@@ -19,8 +19,31 @@ MANAGED_AGENT_ACTIVE_WINDOW = timedelta(minutes=10)
 MANAGED_AGENT_RECENT_WINDOW = timedelta(hours=24)
 
 
-def normalize_managed_agent_kind(session_source_type: Optional[str]) -> str:
-    """Normalize one durable agent kind from a runtime source type."""
+def normalize_managed_agent_kind(
+    session_source_type: Optional[str], *, agent_kind: Optional[str] = None
+) -> str:
+    """Normalize one durable agent kind for a managed agent.
+
+    ``agent_kind`` records *which product* the agent is (``cursor``), while
+    ``session_source_type`` records *how it connects* (``desktop_agent``). For
+    most agents the two coincide, but several products (Cursor, Windsurf, VS
+    Code, Antigravity, Devin) share the generic ``desktop_agent`` transport, so
+    an explicit kind wins when supplied.
+
+    The two are deliberately decoupled: the source type is part of the v2
+    principal-id fingerprint, so changing it for existing agents would
+    invalidate their identity. See ``#123``.
+
+    Args:
+        session_source_type: Transport-level source type for the agent.
+        agent_kind: Optional explicit product kind supplied by the caller.
+
+    Returns:
+        The normalized durable agent kind.
+    """
+    explicit = str(agent_kind or "").strip().lower().replace(" ", "_")
+    if explicit:
+        return explicit
     normalized = str(session_source_type or "").strip().lower().replace(" ", "_")
     return normalized or "external_agent"
 
@@ -460,6 +483,7 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         owner_user_id: Any = None,
         enrollment_hostname: Optional[str] = None,
         identity_derivation: Optional[str] = None,
+        agent_kind: Optional[str] = None,
     ) -> ManagedAgent:
         """Create or update one registry entry from a runtime-session token flow.
 
@@ -467,6 +491,13 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         update only when the agent has no owner yet, so a manually assigned owner
         is never overwritten. This owner drives per-user cost attribution and
         per-user budgets.
+
+        ``agent_kind`` lets a newer CLI declare the product it is enrolling
+        (``cursor``) while keeping the transport ``session_source_type``
+        (``desktop_agent``) that the v2 principal id is derived from, so the
+        agent's identity is preserved. On update the stored kind is only
+        refined, never reset to the generic transport value, so an older CLI
+        re-enrolling an agent cannot regress a known product kind.
         """
         db_obj = self.get_by_source(
             db,
@@ -481,7 +512,9 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
             db_obj = ManagedAgent(
                 account_id=account_id,
                 runtime_session_id=runtime_session_id,
-                agent_kind=normalize_managed_agent_kind(session_source_type),
+                agent_kind=normalize_managed_agent_kind(
+                    session_source_type, agent_kind=agent_kind
+                ),
                 session_source_type=session_source_type,
                 session_source_id=session_source_id,
                 session_reference=session_reference,
@@ -501,7 +534,16 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
             return db_obj
 
         db_obj.runtime_session_id = runtime_session_id
-        db_obj.agent_kind = normalize_managed_agent_kind(session_source_type)
+        # Refine the kind, never regress it. An older CLI (or a client that
+        # cannot tell Cursor from Windsurf) sends no agent_kind, which would
+        # otherwise reset a known product kind back to "desktop_agent" every
+        # time that agent re-enrolled.
+        refined_kind = normalize_managed_agent_kind(
+            session_source_type, agent_kind=agent_kind
+        )
+        transport_kind = normalize_managed_agent_kind(session_source_type)
+        if agent_kind or (db_obj.agent_kind or "") in ("", transport_kind):
+            db_obj.agent_kind = refined_kind
         # Preserve operator renames on reuse; only fill an empty display name.
         if not (db_obj.display_name or "").strip():
             db_obj.display_name = display_name
@@ -528,6 +570,7 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         display_name: str,
         description: Optional[str] = None,
         owner_user_id: Any = None,
+        agent_kind: Optional[str] = None,
         commit: bool = True,
     ) -> ManagedAgent:
         """Register a custom managed agent the discovery CLI cannot find.
@@ -539,11 +582,19 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         discover`` keys off, so a later discovery run will not be deduped
         against this row.
 
+        ``agent_kind`` records which product the agent is (``cursor``) so
+        API-created agents are no longer indistinguishable from genuinely
+        bespoke ones. The ``custom`` ``session_source_type`` is kept regardless:
+        it drives the generated-id/dedupe contract above and is part of the v2
+        principal-id fingerprint, so it must not vary with the declared kind.
+
         Args:
             db: Active database session.
             account_id: Owning account identifier.
             display_name: Operator-facing name for the agent.
             description: Optional free-form description; stored under ``tags``.
+            owner_user_id: User credited as the agent owner.
+            agent_kind: Optional product kind; defaults to ``custom``.
             commit: Whether to commit the transaction.
 
         Returns:
@@ -558,7 +609,7 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         db_obj = ManagedAgent(
             account_id=account_id,
             runtime_session_id=None,
-            agent_kind=normalize_managed_agent_kind("custom"),
+            agent_kind=normalize_managed_agent_kind("custom", agent_kind=agent_kind),
             session_source_type="custom",
             session_source_id=session_source_id,
             session_reference=None,

--- a/backend/preloop/schemas/auth.py
+++ b/backend/preloop/schemas/auth.py
@@ -186,6 +186,10 @@ class RuntimeSessionTokenCreate(BaseModel):
     session_reference: Optional[str] = Field(None, max_length=255)
     runtime_principal_id: Optional[str] = Field(None, max_length=255)
     runtime_principal_name: Optional[str] = Field(None, max_length=255)
+    #: Durable product kind (``cursor``). Distinct from ``session_source_type``,
+    #: which is the transport and is part of the v2 principal fingerprint.
+    #: Older CLIs omit this; the server then keeps the stored kind. See #123.
+    agent_kind: Optional[str] = Field(None, max_length=64)
     expires_in_minutes: int = Field(default=120, ge=1, le=1440)
     scopes: List[str] = Field(default_factory=lambda: ["mcp:read", "mcp:write"])
     allowed_mcp_tools: List[Any] = Field(default_factory=list)

--- a/backend/preloop/schemas/gateway_usage.py
+++ b/backend/preloop/schemas/gateway_usage.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+#: Agent kinds are used verbatim in filter query strings (which are
+#: comma-separated), so keep them to a conservative identifier shape.
+_AGENT_KIND_PATTERN = re.compile(r"[a-z0-9_]+")
 
 
 class GatewayTokenUsage(BaseModel):
@@ -371,6 +376,31 @@ class ManagedAgentRegisterRequest(BaseModel):
 
     display_name: str = Field(..., min_length=1, max_length=255)
     description: Optional[str] = None
+    agent_kind: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=64,
+        description=(
+            "Product kind for the agent, for example 'cursor' or 'windsurf'. "
+            "Defaults to 'custom' when omitted. This records what the agent "
+            "is; it does not change how it connects."
+        ),
+    )
+
+    @field_validator("agent_kind")
+    @classmethod
+    def _normalize_agent_kind(cls, value: Optional[str]) -> Optional[str]:
+        """Lowercase and underscore the kind so lookups stay case-insensitive."""
+        if value is None:
+            return None
+        normalized = value.strip().lower().replace(" ", "_").replace("-", "_")
+        if not normalized:
+            raise ValueError("agent_kind must not be blank")
+        if not _AGENT_KIND_PATTERN.fullmatch(normalized):
+            raise ValueError(
+                "agent_kind must contain only letters, digits, and underscores"
+            )
+        return normalized
 
 
 class ManagedAgentCredentialCreateRequest(BaseModel):

--- a/backend/preloop/schemas/gateway_usage.py
+++ b/backend/preloop/schemas/gateway_usage.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-#: Agent kinds are used verbatim in filter query strings (which are
-#: comma-separated), so keep them to a conservative identifier shape.
-_AGENT_KIND_PATTERN = re.compile(r"[a-z0-9_]+")
+from preloop.utils.agent_kind import (
+    AGENT_KIND_SHAPE_ERROR,
+    is_valid_agent_kind,
+    normalize_agent_kind,
+)
 
 
 class GatewayTokenUsage(BaseModel):
@@ -393,13 +394,11 @@ class ManagedAgentRegisterRequest(BaseModel):
         """Lowercase and underscore the kind so lookups stay case-insensitive."""
         if value is None:
             return None
-        normalized = value.strip().lower().replace(" ", "_").replace("-", "_")
+        normalized = normalize_agent_kind(value)
         if not normalized:
             raise ValueError("agent_kind must not be blank")
-        if not _AGENT_KIND_PATTERN.fullmatch(normalized):
-            raise ValueError(
-                "agent_kind must contain only letters, digits, and underscores"
-            )
+        if not is_valid_agent_kind(normalized):
+            raise ValueError(AGENT_KIND_SHAPE_ERROR)
         return normalized
 
 

--- a/backend/preloop/services/usage_import.py
+++ b/backend/preloop/services/usage_import.py
@@ -96,8 +96,10 @@ def resolve_target_agent(
     if not candidates:
         raise UsageImportError(
             f"No managed '{default_agent_kind}' agent found. Onboard one with "
-            f"`preloop agents onboard {default_agent_kind}` or pass agent_id "
-            "explicitly."
+            f"`preloop agents onboard {default_agent_kind.title()}`, register "
+            f"one with `POST /api/v1/agents` "
+            f'(`{{"display_name": "...", "agent_kind": "{default_agent_kind}"}}`), '
+            "or pass agent_id explicitly."
         )
     if len(candidates) > 1:
         ids = ", ".join(str(agent.id) for agent in candidates[:5])

--- a/backend/preloop/utils/agent_kind.py
+++ b/backend/preloop/utils/agent_kind.py
@@ -1,0 +1,49 @@
+"""Shared normalization for durable managed-agent kinds (issue #123).
+
+An agent kind records *which product* an agent is (``cursor``), as opposed
+to ``session_source_type``, which records *how it connects*
+(``desktop_agent``). Kinds arrive from three places -- the runtime-session
+token endpoint, the ``POST /api/v1/agents`` request schema, and the managed
+agent CRUD layer -- and every one of them must agree on the accepted shape,
+because kinds are compared for equality during default-agent resolution and
+echoed verbatim into comma-separated filter query strings.
+
+Keeping one definition here means a kind normalized on the way in always
+matches the same kind normalized on the way out.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+#: Kinds are echoed into comma-separated filter query strings, so keep them
+#: to a conservative bare-identifier shape.
+AGENT_KIND_PATTERN = re.compile(r"[a-z0-9_]+")
+
+#: Human-readable constraint, reused verbatim in API error messages.
+AGENT_KIND_SHAPE_ERROR = "agent_kind must contain only letters, digits, and underscores"
+
+
+def normalize_agent_kind(value: Optional[str]) -> str:
+    """Fold one raw agent-kind token into its canonical form.
+
+    Case, surrounding whitespace, and the space/hyphen/underscore split are
+    all treated as insignificant, so ``"Gemini CLI"``, ``"gemini-cli"``, and
+    ``"gemini_cli"`` resolve to the same kind.
+
+    Args:
+        value: Raw kind as supplied by a client, or None.
+
+    Returns:
+        The normalized kind, or an empty string when nothing was supplied.
+        The result is not guaranteed to match ``AGENT_KIND_PATTERN``;
+        callers that accept untrusted input must check it with
+        ``is_valid_agent_kind``.
+    """
+    return str(value or "").strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def is_valid_agent_kind(value: str) -> bool:
+    """Report whether a normalized kind is a bare identifier."""
+    return bool(AGENT_KIND_PATTERN.fullmatch(value))

--- a/backend/tests/endpoints/test_agent_kind_123.py
+++ b/backend/tests/endpoints/test_agent_kind_123.py
@@ -1,0 +1,257 @@
+"""Agent-kind decoupling tests (#123 followup).
+
+``agent_kind`` records *which product* an agent is (``cursor``); the
+``session_source_type`` records *how it connects* (``desktop_agent``) and is
+part of the durable v2 principal-id fingerprint. These tests pin that split,
+because collapsing the two is what made every Cursor agent look ``custom``
+and what would silently re-key existing enrollments if "fixed" naively.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from preloop.models.crud import crud_managed_agent
+from preloop.models.crud.managed_agent import normalize_managed_agent_kind
+from preloop.services.usage_import import resolve_target_agent
+
+AGENTS_URL = "/api/v1/agents"
+TOKEN_URL = "/api/v1/auth/runtime-sessions/token"
+IMPORT_URL = "/api/v1/usage/import"
+
+
+def _events_payload():
+    timestamp = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    return {
+        "events": [
+            {
+                "timestamp": timestamp,
+                "model": "composer",
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "cost_usd": 0.25,
+            }
+        ]
+    }
+
+
+class TestApiCreatedAgentKind:
+    """POST /api/v1/agents must be able to declare a real product kind."""
+
+    def test_defaults_to_custom_when_kind_omitted(self, client):
+        """Omitting agent_kind keeps the historical 'custom' behaviour."""
+        response = client.post(AGENTS_URL, json={"display_name": "Bespoke bot"})
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["agent_kind"] == "custom"
+        assert body["session_source_type"] == "custom"
+
+    def test_accepts_declared_kind(self, client):
+        """A declared kind is stored without changing the source type."""
+        response = client.post(
+            AGENTS_URL,
+            json={"display_name": "My Cursor", "agent_kind": "cursor"},
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["agent_kind"] == "cursor"
+        # The transport must stay 'custom': it drives the generated-id dedupe
+        # contract and the v2 fingerprint.
+        assert body["session_source_type"] == "custom"
+
+    def test_kind_is_normalized(self, client):
+        """Kinds are case/separator normalized so filters stay predictable."""
+        response = client.post(
+            AGENTS_URL,
+            json={"display_name": "Gem", "agent_kind": " Gemini-CLI "},
+        )
+
+        assert response.status_code == 201
+        assert response.json()["agent_kind"] == "gemini_cli"
+
+    def test_rejects_malformed_kind(self, client):
+        """Kinds are echoed into comma-separated filters, so shape is checked."""
+        response = client.post(
+            AGENTS_URL,
+            json={"display_name": "Bad", "agent_kind": "cursor,windsurf"},
+        )
+
+        assert response.status_code == 422
+
+    def test_api_created_cursor_agent_is_listable_by_kind(self, client):
+        """The console filters by kind, so it must find API-created agents."""
+        client.post(
+            AGENTS_URL,
+            json={"display_name": "My Cursor", "agent_kind": "cursor"},
+        )
+
+        response = client.get(f"{AGENTS_URL}?agent_kind=cursor")
+
+        assert response.status_code == 200
+        assert [i["display_name"] for i in response.json()["items"]] == ["My Cursor"]
+
+
+class TestUsageImportDefaultResolution:
+    """The #123 symptom: /usage/import 422s for API-created Cursor agents."""
+
+    def test_import_resolves_api_created_cursor_agent(self, client, db_session):
+        """An API-created cursor agent is now a valid default target."""
+        created = client.post(
+            AGENTS_URL,
+            json={"display_name": "My Cursor", "agent_kind": "cursor"},
+        )
+        assert created.status_code == 201
+        agent_id = created.json()["id"]
+
+        response = client.post(IMPORT_URL, json=_events_payload())
+
+        assert response.status_code == 200, response.text
+        assert response.json()["agent_id"] == agent_id
+
+    def test_import_without_any_cursor_agent_still_errors(self, client):
+        """A custom-only account keeps the explicit, actionable error."""
+        client.post(AGENTS_URL, json={"display_name": "Bespoke bot"})
+
+        response = client.post(IMPORT_URL, json=_events_payload())
+
+        assert response.status_code == 422
+        assert "No managed 'cursor' agent found" in response.text
+
+
+class TestExistingAgentSurvivesUpgrade:
+    """The TRAP: pre-fix agents must keep working after the upgrade."""
+
+    def test_existing_desktop_agent_keeps_identity_and_authenticates(
+        self, client, db_session, test_user
+    ):
+        """A pre-fix Cursor enrollment must not be re-keyed by the upgrade.
+
+        Before this change the CLI enrolled Cursor as ``desktop_agent`` with a
+        principal id derived from that source type. After the upgrade the CLI
+        sends ``agent_kind='cursor'`` but the *same* source type and id, so the
+        existing row must be refined in place, not duplicated.
+        """
+        # Pre-fix enrollment: transport-derived id, no product kind.
+        legacy = crud_managed_agent.upsert_from_runtime_session(
+            db_session,
+            account_id=test_user.account_id,
+            runtime_session_id=None,
+            session_source_type="desktop_agent",
+            session_source_id="desktop-agent-aef692c7e4cb",
+            display_name="Cursor",
+        )
+        db_session.commit()
+        assert legacy.agent_kind == "desktop_agent"
+        legacy_id = str(legacy.id)
+
+        # Upgraded CLI re-enrolls: same identity, now declaring the product.
+        response = client.post(
+            TOKEN_URL,
+            json={
+                "session_source_type": "desktop_agent",
+                "session_source_id": "desktop-agent-aef692c7e4cb",
+                "runtime_principal_id": "desktop-agent-aef692c7e4cb",
+                "runtime_principal_name": "Cursor",
+                "agent_kind": "cursor",
+            },
+        )
+
+        assert response.status_code == 201, response.text
+
+        agents = client.get(AGENTS_URL).json()["items"]
+        # Refined in place: no duplicate row, identity preserved.
+        assert len(agents) == 1
+        assert agents[0]["id"] == legacy_id
+        assert agents[0]["session_source_id"] == "desktop-agent-aef692c7e4cb"
+        assert agents[0]["session_source_type"] == "desktop_agent"
+        assert agents[0]["agent_kind"] == "cursor"
+
+    def test_older_cli_does_not_regress_a_known_kind(
+        self, client, db_session, test_user
+    ):
+        """An older CLI omits agent_kind; that must not reset a known kind."""
+        crud_managed_agent.upsert_from_runtime_session(
+            db_session,
+            account_id=test_user.account_id,
+            runtime_session_id=None,
+            session_source_type="desktop_agent",
+            session_source_id="desktop-agent-aef692c7e4cb",
+            display_name="Cursor",
+            agent_kind="cursor",
+        )
+        db_session.commit()
+
+        # Older CLI: same enrollment, no agent_kind field at all.
+        response = client.post(
+            TOKEN_URL,
+            json={
+                "session_source_type": "desktop_agent",
+                "session_source_id": "desktop-agent-aef692c7e4cb",
+                "runtime_principal_id": "desktop-agent-aef692c7e4cb",
+                "runtime_principal_name": "Cursor",
+            },
+        )
+
+        assert response.status_code == 201, response.text
+        agents = client.get(AGENTS_URL).json()["items"]
+        assert len(agents) == 1
+        assert agents[0]["agent_kind"] == "cursor"
+
+    def test_source_type_allowlist_is_unchanged(self, client):
+        """Product kinds must not leak into the source-type allowlist.
+
+        If 'cursor' were accepted as a source type, a new CLI would enroll
+        under an id the old server cannot mint and existing rows would fork.
+        """
+        response = client.post(
+            TOKEN_URL,
+            json={
+                "session_source_type": "cursor",
+                "session_source_id": "cursor-ws-1",
+            },
+        )
+
+        assert response.status_code == 400
+        assert "Unsupported session_source_type" in response.text
+
+
+class TestNormalizeManagedAgentKind:
+    """Unit-level contract for the kind/source-type split."""
+
+    def test_explicit_kind_wins_over_source_type(self):
+        assert (
+            normalize_managed_agent_kind("desktop_agent", agent_kind="cursor")
+            == "cursor"
+        )
+
+    def test_falls_back_to_source_type(self):
+        assert normalize_managed_agent_kind("claude_code") == "claude_code"
+
+    def test_blank_kind_falls_back(self):
+        assert (
+            normalize_managed_agent_kind("claude_code", agent_kind="  ")
+            == "claude_code"
+        )
+
+    def test_empty_source_type_defaults_to_external_agent(self):
+        assert normalize_managed_agent_kind(None) == "external_agent"
+
+
+class TestResolveTargetAgentPrefersKind:
+    """resolve_target_agent keys off agent_kind, not session_source_type."""
+
+    def test_resolves_custom_transport_cursor_agent(self, db_session, test_user):
+        agent = crud_managed_agent.create_custom_agent(
+            db_session,
+            account_id=test_user.account_id,
+            display_name="My Cursor",
+            agent_kind="cursor",
+        )
+        db_session.commit()
+
+        resolved = resolve_target_agent(
+            db_session, account_id=str(test_user.account_id)
+        )
+
+        assert str(resolved.id) == str(agent.id)
+        assert resolved.session_source_type == "custom"

--- a/backend/tests/endpoints/test_agent_kind_123.py
+++ b/backend/tests/endpoints/test_agent_kind_123.py
@@ -10,8 +10,12 @@ and what would silently re-key existing enrollments if "fixed" naively.
 from datetime import UTC, datetime, timedelta
 
 from preloop.models.crud import crud_managed_agent
-from preloop.models.crud.managed_agent import normalize_managed_agent_kind
+from preloop.models.crud.managed_agent import (
+    normalize_managed_agent_kind,
+    should_refine_agent_kind,
+)
 from preloop.services.usage_import import resolve_target_agent
+from preloop.utils.agent_kind import is_valid_agent_kind, normalize_agent_kind
 
 AGENTS_URL = "/api/v1/agents"
 TOKEN_URL = "/api/v1/auth/runtime-sessions/token"
@@ -235,6 +239,56 @@ class TestNormalizeManagedAgentKind:
 
     def test_empty_source_type_defaults_to_external_agent(self):
         assert normalize_managed_agent_kind(None) == "external_agent"
+
+    def test_separators_and_case_are_insignificant(self):
+        """A kind must normalize the same wherever it enters the system.
+
+        Default-agent resolution compares kinds for equality, so if the
+        token endpoint folded "Gemini-CLI" differently from the CRUD layer
+        the agent would be stored under a kind no lookup could find.
+        """
+        for raw in ("Gemini CLI", "gemini-cli", "  GEMINI_CLI  "):
+            assert normalize_agent_kind(raw) == "gemini_cli"
+            assert normalize_managed_agent_kind("custom", agent_kind=raw) == (
+                "gemini_cli"
+            )
+
+    def test_rejects_shapes_that_would_break_filter_query_strings(self):
+        """Kinds are echoed into comma-separated filters, so stay identifiers."""
+        assert is_valid_agent_kind("cursor")
+        # Spaces and hyphens are folded into underscores, not rejected.
+        assert is_valid_agent_kind(normalize_agent_kind("vs code"))
+        for bad in ("a,b", "a/b", "a.b", "a:b", ""):
+            assert not is_valid_agent_kind(normalize_agent_kind(bad))
+
+
+class TestShouldRefineAgentKind:
+    """Refine the kind, never regress it."""
+
+    def test_explicit_kind_always_wins(self):
+        assert should_refine_agent_kind(
+            "cursor", session_source_type="desktop_agent", agent_kind="windsurf"
+        )
+
+    def test_older_client_cannot_regress_a_known_kind(self):
+        """The core guard: a CLI that predates #123 sends no kind.
+
+        Without this, every re-enrollment from an old CLI would reset a
+        known "cursor" back to the generic transport value.
+        """
+        assert not should_refine_agent_kind(
+            "cursor", session_source_type="desktop_agent", agent_kind=None
+        )
+
+    def test_generic_stored_kind_may_be_filled_in(self):
+        assert should_refine_agent_kind(
+            "desktop_agent", session_source_type="desktop_agent", agent_kind=None
+        )
+
+    def test_empty_stored_kind_may_be_filled_in(self):
+        assert should_refine_agent_kind(
+            None, session_source_type="desktop_agent", agent_kind=None
+        )
 
 
 class TestResolveTargetAgentPrefersKind:

--- a/backend/tests/endpoints/test_usage_import.py
+++ b/backend/tests/endpoints/test_usage_import.py
@@ -24,14 +24,22 @@ SAMPLE_CSV = (
 
 
 def _make_cursor_agent(db, account_id, *, source_id="cursor-ws-1", name="Cursor"):
-    """Register a managed Cursor agent like `preloop agents onboard cursor`."""
+    """Register a managed Cursor agent like `preloop agents onboard Cursor`.
+
+    Cursor connects over the generic MCP-config transport, so its
+    ``session_source_type`` is ``desktop_agent``; ``agent_kind`` is what marks
+    it as Cursor. Keeping those distinct here matters: the fixture previously
+    used a ``cursor`` source type that no code path can actually produce, which
+    is why these tests passed while real imports returned 422 (#123).
+    """
     return crud_managed_agent.upsert_from_runtime_session(
         db,
         account_id=account_id,
         runtime_session_id=None,
-        session_source_type="cursor",
+        session_source_type="desktop_agent",
         session_source_id=source_id,
         display_name=name,
+        agent_kind="cursor",
     )
 
 

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -409,6 +409,7 @@ type runtimeSessionTokenRequest struct {
 	SessionReference     string                    `json:"session_reference,omitempty"`
 	RuntimePrincipalID   string                    `json:"runtime_principal_id,omitempty"`
 	RuntimePrincipalName string                    `json:"runtime_principal_name,omitempty"`
+	AgentKind            string                    `json:"agent_kind,omitempty"`
 	ExpiresInMinutes     int                       `json:"expires_in_minutes,omitempty"`
 	Scopes               []string                  `json:"scopes,omitempty"`
 	AllowedMCPServers    []string                  `json:"allowed_mcp_servers,omitempty"`
@@ -2764,6 +2765,7 @@ func issueRuntimeSessionToken(client *api.Client, agent AgentConfig, allowedServ
 		SessionReference:     filepath.Clean(agent.ConfigPath),
 		RuntimePrincipalID:   runtimePrincipalIDForAgent(agent),
 		RuntimePrincipalName: runtimePrincipalNameForAgent(agent),
+		AgentKind:            managedAgentKindForAgent(agent.Name),
 		ExpiresInMinutes:     120,
 		Scopes:               []string{"mcp:read", "mcp:write"},
 		AllowedMCPServers:    serverNames,
@@ -2922,6 +2924,14 @@ func normalizeDiscoveredAgent(agent AgentConfig) AgentConfig {
 	return agent
 }
 
+// runtimeSessionSourceTypeForAgent maps an agent to the *transport* it
+// connects over. This value is part of the durable v2 principal-id
+// fingerprint (see stableRuntimePrincipalIDForAgent) and is validated
+// server-side against a fixed allowlist, so it must stay stable for a given
+// agent forever: changing it would re-key every existing enrollment and 400
+// against older servers. Products that share the generic MCP-config transport
+// (Cursor, Windsurf, VS Code, ...) are told apart by
+// managedAgentKindForAgent instead. See #123.
 func runtimeSessionSourceTypeForAgent(agentName string) string {
 	switch strings.ToLower(strings.TrimSpace(agentName)) {
 	case "claude code":
@@ -2940,6 +2950,29 @@ func runtimeSessionSourceTypeForAgent(agentName string) string {
 		return hermesSourceType
 	default:
 		return "desktop_agent"
+	}
+}
+
+// managedAgentKindForAgent maps an agent to the durable *product* kind stored
+// as ManagedAgent.agent_kind server-side. Unlike the source type above, this
+// is descriptive only: it is not part of any fingerprint, so it is safe to
+// refine for agents that already exist. Agents whose product is identical to
+// their transport reuse the source type; the ones that previously collapsed
+// into the generic "desktop_agent" bucket get their real kind here.
+func managedAgentKindForAgent(agentName string) string {
+	switch strings.ToLower(strings.TrimSpace(agentName)) {
+	case "cursor":
+		return "cursor"
+	case "windsurf":
+		return "windsurf"
+	case "vscode / copilot":
+		return "vscode"
+	case strings.ToLower(antigravityAgentName):
+		return "antigravity"
+	case strings.ToLower(devinAgentName):
+		return "devin"
+	default:
+		return runtimeSessionSourceTypeForAgent(agentName)
 	}
 }
 

--- a/cli/internal/cmd/agents_kind_123_test.go
+++ b/cli/internal/cmd/agents_kind_123_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"path/filepath"
 	"testing"
 )
 
@@ -48,14 +49,17 @@ func TestSourceTypeUnchangedForRekeyedProducts(t *testing.T) {
 // TestPrincipalIDStableAcrossKindChange proves the v2 identity of an existing
 // Cursor install is byte-identical before and after this change.
 func TestPrincipalIDStableAcrossKindChange(t *testing.T) {
-	agent := AgentConfig{Name: "Cursor", ConfigPath: "/home/u/.cursor/mcp.json"}
+	const configPath = "/home/u/.cursor/mcp.json"
+	agent := AgentConfig{Name: "Cursor", ConfigPath: configPath}
 
 	// Recompute the pre-fix derivation independently rather than hardcoding a
 	// digest: the id embeds the local hostname, so a literal golden value
-	// would only hold on the machine that captured it.
+	// would only hold on the machine that captured it. The path must go
+	// through filepath.Clean for the same reason the production derivation
+	// does, since it rewrites separators on Windows.
 	host, _ := enrollmentHostnameLabel()
 	nul := string([]byte{0})
-	sum := sha256.Sum256([]byte("v2" + nul + host + nul + "desktop_agent" + nul + "/home/u/.cursor/mcp.json"))
+	sum := sha256.Sum256([]byte("v2" + nul + host + nul + "desktop_agent" + nul + filepath.Clean(configPath)))
 	want := "desktop-agent-" + hex.EncodeToString(sum[:6])
 
 	if got := stableRuntimePrincipalIDForAgent(agent, ""); got != want {

--- a/cli/internal/cmd/agents_kind_123_test.go
+++ b/cli/internal/cmd/agents_kind_123_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+// TestManagedAgentKindForAgent pins the product kinds that previously all
+// collapsed into the generic "desktop_agent" bucket (#123).
+func TestManagedAgentKindForAgent(t *testing.T) {
+	cases := map[string]string{
+		"Cursor":           "cursor",
+		"Windsurf":         "windsurf",
+		"VSCode / Copilot": "vscode",
+		"Antigravity":      "antigravity",
+		"Devin":            "devin",
+		// Agents whose product and transport already agree.
+		"Claude Code":    "claude_code",
+		"Claude Desktop": "claude_desktop",
+		"Codex CLI":      "codex",
+		"Gemini CLI":     "gemini_cli",
+		"OpenCode":       "opencode",
+		"OpenClaw":       "openclaw",
+		// Unknown agents keep the generic transport kind.
+		"Totally Unknown Agent": "desktop_agent",
+	}
+	for name, want := range cases {
+		if got := managedAgentKindForAgent(name); got != want {
+			t.Errorf("managedAgentKindForAgent(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestSourceTypeUnchangedForRekeyedProducts is the regression guard for the
+// identity trap: the durable v2 principal id is derived from the *source
+// type*, so these agents must keep reporting "desktop_agent" forever. If this
+// test fails, every existing Cursor/Windsurf/VS Code enrollment in the field
+// has just been silently re-keyed.
+func TestSourceTypeUnchangedForRekeyedProducts(t *testing.T) {
+	for _, name := range []string{"Cursor", "Windsurf", "VSCode / Copilot", "Antigravity", "Devin"} {
+		if got := runtimeSessionSourceTypeForAgent(name); got != "desktop_agent" {
+			t.Errorf("runtimeSessionSourceTypeForAgent(%q) = %q, want desktop_agent", name, got)
+		}
+	}
+}
+
+// TestPrincipalIDStableAcrossKindChange proves the v2 identity of an existing
+// Cursor install is byte-identical before and after this change.
+func TestPrincipalIDStableAcrossKindChange(t *testing.T) {
+	agent := AgentConfig{Name: "Cursor", ConfigPath: "/home/u/.cursor/mcp.json"}
+
+	// Recompute the pre-fix derivation independently rather than hardcoding a
+	// digest: the id embeds the local hostname, so a literal golden value
+	// would only hold on the machine that captured it.
+	host, _ := enrollmentHostnameLabel()
+	nul := string([]byte{0})
+	sum := sha256.Sum256([]byte("v2" + nul + host + nul + "desktop_agent" + nul + "/home/u/.cursor/mcp.json"))
+	want := "desktop-agent-" + hex.EncodeToString(sum[:6])
+
+	if got := stableRuntimePrincipalIDForAgent(agent, ""); got != want {
+		t.Fatalf("v2 principal id changed: got %q want %q (existing enrollments would fork)", got, want)
+	}
+	if got := principalIdentityForAgent(agent).SourceType; got != "desktop_agent" {
+		t.Fatalf("principal identity source type = %q, want desktop_agent", got)
+	}
+	// Lookup must still search the transport bucket the agent is stored under.
+	if got := managedAgentLookupSourceTypes(agent); len(got) != 1 || got[0] != "desktop_agent" {
+		t.Fatalf("lookup source types = %v, want [desktop_agent]", got)
+	}
+}

--- a/frontend/src/utils/agent-display.ts
+++ b/frontend/src/utils/agent-display.ts
@@ -19,6 +19,16 @@ export function getAgentSourceLabel(
       return 'OpenCode';
     case 'hermes':
       return 'Hermes';
+    case 'cursor':
+      return 'Cursor';
+    case 'windsurf':
+      return 'Windsurf';
+    case 'vscode':
+      return 'VS Code';
+    case 'antigravity':
+      return 'Antigravity';
+    case 'devin':
+      return 'Devin';
     case 'desktop_agent':
       return 'Desktop Agent';
     case 'custom':

--- a/frontend/src/utils/agent-display.ts
+++ b/frontend/src/utils/agent-display.ts
@@ -1,41 +1,11 @@
 import { html, type TemplateResult } from 'lit';
 import type { ManagedAgentSummary } from '../types';
+import { getAgentKindPresentation } from './agent-kinds';
 
 export function getAgentSourceLabel(
   sourceType: string | null | undefined
 ): string {
-  switch (sourceType) {
-    case 'claude_code':
-      return 'Claude Code';
-    case 'claude_desktop':
-      return 'Claude Desktop';
-    case 'codex':
-      return 'Codex';
-    case 'openclaw':
-      return 'OpenClaw';
-    case 'gemini_cli':
-      return 'Gemini CLI';
-    case 'opencode':
-      return 'OpenCode';
-    case 'hermes':
-      return 'Hermes';
-    case 'cursor':
-      return 'Cursor';
-    case 'windsurf':
-      return 'Windsurf';
-    case 'vscode':
-      return 'VS Code';
-    case 'antigravity':
-      return 'Antigravity';
-    case 'devin':
-      return 'Devin';
-    case 'desktop_agent':
-      return 'Desktop Agent';
-    case 'custom':
-      return 'Custom Agent';
-    default:
-      return sourceType || 'Unknown';
-  }
+  return getAgentKindPresentation(sourceType)?.label || sourceType || 'Unknown';
 }
 
 export function getAgentLifecycleVariant(agent: ManagedAgentSummary): string {

--- a/frontend/src/utils/agent-icons.ts
+++ b/frontend/src/utils/agent-icons.ts
@@ -27,6 +27,16 @@ export function renderAgentIcon(
       return renderIcon('', '/images/logos/opencode.svg');
     case 'hermes':
       return renderIcon('', '/images/logos/hermes.svg');
+    case 'cursor':
+      return renderIcon('', '/images/logos/cursor.svg');
+    case 'windsurf':
+      return renderIcon('', '/images/logos/Windsurf-black-symbol.svg');
+    case 'vscode':
+      return renderIcon('', '/images/logos/vscode.svg');
+    case 'antigravity':
+      return renderIcon('rocket');
+    case 'devin':
+      return renderIcon('robot');
     case 'desktop_agent':
       return renderIcon('pc-display');
     case 'custom':

--- a/frontend/src/utils/agent-icons.ts
+++ b/frontend/src/utils/agent-icons.ts
@@ -1,47 +1,17 @@
 import { html, type TemplateResult } from 'lit';
+import { getAgentKindPresentation } from './agent-kinds';
 
 export function renderAgentIcon(
   sourceType: string | null | undefined,
   style: string = ''
 ): TemplateResult {
-  const renderIcon = (name: string, src?: string) => {
-    return src
-      ? html`<sl-icon src="${src}" style="${style}"></sl-icon>`
-      : html`<sl-icon name="${name}" style="${style}"></sl-icon>`;
-  };
-
-  switch (sourceType?.toLowerCase()) {
-    case 'claude_code':
-      return renderIcon('', '/images/logos/claude.svg');
-    case 'claude_desktop':
-      return renderIcon('display');
-    case 'openclaw':
-      return renderIcon('', '/images/logos/openclaw.svg');
-    case 'codex':
-      return renderIcon('', '/images/logos/codex.svg?v=2');
-    case 'gemini_cli':
-    case 'gemini-cli':
-    case 'geminicli':
-      return renderIcon('', '/images/logos/gemini-cli.svg');
-    case 'opencode':
-      return renderIcon('', '/images/logos/opencode.svg');
-    case 'hermes':
-      return renderIcon('', '/images/logos/hermes.svg');
-    case 'cursor':
-      return renderIcon('', '/images/logos/cursor.svg');
-    case 'windsurf':
-      return renderIcon('', '/images/logos/Windsurf-black-symbol.svg');
-    case 'vscode':
-      return renderIcon('', '/images/logos/vscode.svg');
-    case 'antigravity':
-      return renderIcon('rocket');
-    case 'devin':
-      return renderIcon('robot');
-    case 'desktop_agent':
-      return renderIcon('pc-display');
-    case 'custom':
-      return renderIcon('robot');
-    default:
-      return renderIcon('robot');
+  const presentation = getAgentKindPresentation(sourceType);
+  const logo = presentation?.logo;
+  if (logo) {
+    return html`<sl-icon src="${logo}" style="${style}"></sl-icon>`;
   }
+  return html`<sl-icon
+    name="${presentation?.icon || 'robot'}"
+    style="${style}"
+  ></sl-icon>`;
 }

--- a/frontend/src/utils/agent-kinds.ts
+++ b/frontend/src/utils/agent-kinds.ts
@@ -1,0 +1,72 @@
+/**
+ * Presentation metadata for durable agent kinds (issue #123).
+ *
+ * An agent's kind records which product it is (`cursor`), as opposed to its
+ * session source type, which records how it connects (`desktop_agent`).
+ * Several products share the generic desktop transport, so the console keys
+ * its label and icon off the kind.
+ *
+ * Label and icon live in one table so a newly supported product cannot end up
+ * named in one view and unnamed in another.
+ */
+
+export interface AgentKindPresentation {
+  /** Human-readable product name. */
+  label: string;
+  /** Shoelace icon name, used when no logo asset exists. */
+  icon: string;
+  /** Path to a logo asset, preferred over the icon when present. */
+  logo?: string;
+}
+
+export const AGENT_KIND_PRESENTATION: Record<string, AgentKindPresentation> = {
+  claude_code: {
+    label: 'Claude Code',
+    icon: '',
+    logo: '/images/logos/claude.svg',
+  },
+  claude_desktop: { label: 'Claude Desktop', icon: 'display' },
+  codex: { label: 'Codex', icon: '', logo: '/images/logos/codex.svg?v=2' },
+  openclaw: { label: 'OpenClaw', icon: '', logo: '/images/logos/openclaw.svg' },
+  gemini_cli: {
+    label: 'Gemini CLI',
+    icon: '',
+    logo: '/images/logos/gemini-cli.svg',
+  },
+  // Older rows recorded the kind without a separator.
+  geminicli: {
+    label: 'Gemini CLI',
+    icon: '',
+    logo: '/images/logos/gemini-cli.svg',
+  },
+  opencode: { label: 'OpenCode', icon: '', logo: '/images/logos/opencode.svg' },
+  hermes: { label: 'Hermes', icon: '', logo: '/images/logos/hermes.svg' },
+  cursor: { label: 'Cursor', icon: '', logo: '/images/logos/cursor.svg' },
+  windsurf: {
+    label: 'Windsurf',
+    icon: '',
+    logo: '/images/logos/Windsurf-black-symbol.svg',
+  },
+  vscode: { label: 'VS Code', icon: '', logo: '/images/logos/vscode.svg' },
+  antigravity: { label: 'Antigravity', icon: 'rocket' },
+  devin: { label: 'Devin', icon: 'robot' },
+  desktop_agent: { label: 'Desktop Agent', icon: 'pc-display' },
+  custom: { label: 'Custom Agent', icon: 'robot' },
+};
+
+/**
+ * Fold a raw kind into the canonical form used as a table key.
+ *
+ * Mirrors the server-side normalization so `Gemini CLI`, `gemini-cli`, and
+ * `gemini_cli` all resolve to the same entry.
+ */
+export function normalizeAgentKind(kind: string | null | undefined): string {
+  return (kind || '').trim().toLowerCase().replace(/[\s-]/g, '_');
+}
+
+/** Look up presentation metadata for a kind, or undefined if unknown. */
+export function getAgentKindPresentation(
+  kind: string | null | undefined
+): AgentKindPresentation | undefined {
+  return AGENT_KIND_PRESENTATION[normalizeAgentKind(kind)];
+}

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -61,6 +61,7 @@ import {
 } from '../../utils/scoped-governance';
 import { getAgentControlState } from '../../utils/agent-control';
 import { renderAgentIcon } from '../../utils/agent-icons';
+import { getAgentSourceLabel } from '../../utils/agent-display';
 
 interface GovernanceToolDefinition {
   name: string;
@@ -699,38 +700,7 @@ export class AgentDetailView extends LitElement {
   }
 
   private getSourceLabel(sourceType: string | null | undefined): string {
-    switch (sourceType) {
-      case 'claude_code':
-        return 'Claude Code';
-      case 'claude_desktop':
-        return 'Claude Desktop';
-      case 'codex':
-        return 'Codex';
-      case 'openclaw':
-        return 'OpenClaw';
-      case 'gemini_cli':
-        return 'Gemini CLI';
-      case 'opencode':
-        return 'OpenCode';
-      case 'hermes':
-        return 'Hermes';
-      case 'cursor':
-        return 'Cursor';
-      case 'windsurf':
-        return 'Windsurf';
-      case 'vscode':
-        return 'VS Code';
-      case 'antigravity':
-        return 'Antigravity';
-      case 'devin':
-        return 'Devin';
-      case 'desktop_agent':
-        return 'Desktop Agent';
-      case 'custom':
-        return 'Custom Agent';
-      default:
-        return sourceType || 'Unknown';
-    }
+    return getAgentSourceLabel(sourceType);
   }
 
   private formatMoney(amount: number | null | undefined): string {

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -714,6 +714,16 @@ export class AgentDetailView extends LitElement {
         return 'OpenCode';
       case 'hermes':
         return 'Hermes';
+      case 'cursor':
+        return 'Cursor';
+      case 'windsurf':
+        return 'Windsurf';
+      case 'vscode':
+        return 'VS Code';
+      case 'antigravity':
+        return 'Antigravity';
+      case 'devin':
+        return 'Devin';
       case 'desktop_agent':
         return 'Desktop Agent';
       case 'custom':

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -48,6 +48,7 @@ import { reducedMotionStyles } from '../../styles/reduced-motion';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import { getAgentControlState } from '../../utils/agent-control';
 import { renderAgentIcon } from '../../utils/agent-icons';
+import { getAgentSourceLabel } from '../../utils/agent-display';
 
 const AVAILABLE_AGENT_KINDS = [
   { value: 'openclaw', label: 'OpenClaw' },
@@ -1723,38 +1724,7 @@ export class AgentsView extends LitElement {
   }
 
   private getSourceLabel(sourceType: string | null | undefined): string {
-    switch (sourceType) {
-      case 'claude_code':
-        return 'Claude Code';
-      case 'claude_desktop':
-        return 'Claude Desktop';
-      case 'codex':
-        return 'Codex';
-      case 'openclaw':
-        return 'OpenClaw';
-      case 'gemini_cli':
-        return 'Gemini CLI';
-      case 'opencode':
-        return 'OpenCode';
-      case 'hermes':
-        return 'Hermes';
-      case 'cursor':
-        return 'Cursor';
-      case 'windsurf':
-        return 'Windsurf';
-      case 'vscode':
-        return 'VS Code';
-      case 'antigravity':
-        return 'Antigravity';
-      case 'devin':
-        return 'Devin';
-      case 'desktop_agent':
-        return 'Desktop Agent';
-      case 'custom':
-        return 'Custom Agent';
-      default:
-        return sourceType || 'Unknown';
-    }
+    return getAgentSourceLabel(sourceType);
   }
 
   private formatMoney(amount: number | null | undefined): string {

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -1738,6 +1738,16 @@ export class AgentsView extends LitElement {
         return 'OpenCode';
       case 'hermes':
         return 'Hermes';
+      case 'cursor':
+        return 'Cursor';
+      case 'windsurf':
+        return 'Windsurf';
+      case 'vscode':
+        return 'VS Code';
+      case 'antigravity':
+        return 'Antigravity';
+      case 'devin':
+        return 'Devin';
       case 'desktop_agent':
         return 'Desktop Agent';
       case 'custom':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1168,15 +1168,19 @@ paths:
         \nCreates a durable ManagedAgent row under the reserved ``custom`` source\n\
         type with a generated ``session_source_id`` and ``lifecycle_state`` of\n``active``\
         \ so the operator can immediately mint a gateway credential for it\nvia ``POST\
-        \ /agents/{agent_id}/credentials``.\n\nDuplicate ``display_name`` values are\
-        \ allowed within an account: each custom\nagent is keyed by a unique generated\
-        \ ``session_source_id``, so two agents\nsharing a display name remain distinct\
-        \ registry entries. Operators may\nlegitimately run several copies of the\
-        \ same agent, so we do not reject this.\n\nArgs:\n    payload: Display name\
-        \ and optional description for the new agent.\n    account: Resolved account\
-        \ for the authenticated user.\n    current_user: Authenticated active user\
-        \ performing the registration.\n    db: Database session.\n\nReturns:\n  \
-        \  The managed-agent summary for the newly registered agent."
+        \ /agents/{agent_id}/credentials``.\n\nPass ``agent_kind`` (for example ``cursor``)\
+        \ to record which product the\nagent is; it defaults to ``custom``. The kind\
+        \ is what usage import resolves\na default attribution target by, so an API-created\
+        \ Cursor agent can now be\nthe implicit target of ``POST /usage/import``.\n\
+        \nDuplicate ``display_name`` values are allowed within an account: each custom\n\
+        agent is keyed by a unique generated ``session_source_id``, so two agents\n\
+        sharing a display name remain distinct registry entries. Operators may\nlegitimately\
+        \ run several copies of the same agent, so we do not reject this.\n\nArgs:\n\
+        \    payload: Display name and optional description for the new agent.\n \
+        \   account: Resolved account for the authenticated user.\n    current_user:\
+        \ Authenticated active user performing the registration.\n    db: Database\
+        \ session.\n\nReturns:\n    The managed-agent summary for the newly registered\
+        \ agent."
       operationId: create_account_managed_agent_api_v1_agents_post
       security:
       - bearerAuth: []
@@ -13628,6 +13632,16 @@ components:
           - type: string
           - type: 'null'
           title: Description
+        agent_kind:
+          anyOf:
+          - type: string
+            maxLength: 64
+            minLength: 1
+          - type: 'null'
+          title: Agent Kind
+          description: Product kind for the agent, for example 'cursor' or 'windsurf'.
+            Defaults to 'custom' when omitted. This records what the agent is; it
+            does not change how it connects.
       type: object
       required:
       - display_name
@@ -16148,6 +16162,12 @@ components:
             maxLength: 255
           - type: 'null'
           title: Runtime Principal Name
+        agent_kind:
+          anyOf:
+          - type: string
+            maxLength: 64
+          - type: 'null'
+          title: Agent Kind
         expires_in_minutes:
           type: integer
           maximum: 1440.0


### PR DESCRIPTION
Fixes the `agent_kind` half of #123.

## Problem

Agents created via `POST /api/v1/agents` were always kind `custom`, and
Cursor / Windsurf / VS Code / Antigravity / Devin agents onboarded by the CLI
were always kind `desktop_agent`. Both fall out of the same root cause:
`agent_kind` was derived from the connection's `session_source_type`.

Two consequences:

1. **`POST /api/v1/usage/import` 422s.** Default attribution resolves agents
   with `agent_kind='cursor'`, which **no code path could produce**. This is
   broader than the original report: the documented workaround
   (`preloop agents onboard cursor`) did not help either, because
   `runtimeSessionSourceTypeForAgent(\"Cursor\")` returns `desktop_agent`. A bare
   import was unusable for every account, not just API-created agents.
2. Those agents render as generic \"Desktop Agent\" / \"Custom Agent\" in the console.

Existing tests missed this because the fixture hand-built an agent with
`session_source_type=\"cursor\"`, a value nothing in production emits. That
fixture is corrected here.

## The fix

Split the two concepts that were conflated:

| Field | Means | Changeable? |
|---|---|---|
| `session_source_type` | **how** it connects (`desktop_agent`) | No: identity input |
| `agent_kind` | **what** it is (`cursor`) | Yes: descriptive only |

- `POST /api/v1/agents` accepts an optional, validated `agent_kind`.
- The CLI sends `agent_kind` (new `managedAgentKindForAgent`) when minting a
  runtime-session token.
- Console labels/icons for the newly distinguishable kinds.

## Migration story: no migration needed, by design

`session_source_type` is **intentionally left unchanged**, which is what makes
this safe. The brief's literal ask (add `cursor` to
`runtimeSessionSourceTypeForAgent`) would have been a silent data-fragmentation
bug:

- The v2 principal id is `slug(sourceType) + sha256(\"v2\0host\0sourceType\0path\")`.
  Changing the source type changes **both halves**: `desktop-agent-aef692c7e4cb`
  becomes `cursor-7a237ce429b3`.
- `managedAgentLookupSourceTypes` would then search only the `cursor` bucket and
  never match the stored `desktop_agent` row, so onboarding an **existing** agent
  would create a **duplicate**, fragmenting its spend history, budgets, and
  credentials.
- `RUNTIME_SESSION_SOURCE_TYPES` is a server-side allowlist that does not contain
  `cursor`, so a new CLI would also get **HTTP 400 from any older server**.

So rather than re-keying and backfilling, existing agents keep their identity
untouched and have their kind **refined in place** on next enrollment. No rekey
call, no backfill, no downtime. Rekey/backfill from #152 remains reserved for
genuine identity changes.

Also guarded: an **older CLI** omits `agent_kind`, which must not reset a known
kind back to `desktop_agent` on every re-enrollment. `upsert_from_runtime_session`
only refines, never regresses.

## Tests

- API-created `cursor` agent now resolves as the `/usage/import` default (the #123 symptom).
- **Upgrade safety:** a pre-fix `desktop_agent` enrollment re-enrolls to the same
  row, same id, same source type, with no duplicate.
- Old CLI cannot regress a known kind.
- `cursor` is still rejected as a `session_source_type` (version-skew guard).
- Go golden test fails if Cursor's v2 principal id ever changes. Verified it
  **does** fail against the naive fix.
- Full backend suite: 4462 passed. The 7 failures in `test_openai_gateway`,
  `test_session_optimization`, `test_auth_integration`, and
  `test_bootstrap_registration` are **pre-existing on `main`** (confirmed by
  stashing this branch's changes). Go `./internal/cmd` suite green.

Note for the demo: this removes the GOTCHA-1 caveat in
`factory/briefs/2026-08-03-release-0.14.0-report.md`, but only for agents
enrolled/created **after** this ships. Pre-existing agents adopt their real kind
on next enrollment, or can be registered fresh with `agent_kind`.

**Do not merge yet:** v0.14.0 is being cut from current `main`.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> No security or data integrity issues. The migration is zero-downtime by design — existing agent identities are preserved untouched. All previous review feedback addressed.
>
> **Overview**
> Decouples `agent_kind` (what product an agent is) from `session_source_type` (how it connects) so Cursor/Windsurf/VS Code/Antigravity/Devin agents show their real product kind instead of generic \"Desktop Agent\", and `POST /api/v1/usage/import` can resolve Cursor agents as a default attribution target.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 19edbb1. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->