### PR TITLE
fix(models): route OpenRouter by stored provider, list its models, stop logging provider keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,36 @@ across renames and re-onboarding.
   does not expose a runtime attribute. The Hermes plugin reads config.runtime,
   but that field is only present in the raw YAML config block, not the parsed
   dataclass.
+- **OpenRouter models routed to the wrong vendor** (#172): a model id
+  containing a slash was treated as `provider/model` before the stored
+  provider and endpoint were consulted, so an "OpenAI-compatible" model on
+  `https://openrouter.ai/api/v1` with the id
+  `deepseek/deepseek-v4-flash-0731` was sent to api.deepseek.com with the
+  vendor prefix stripped, producing upstream `502 Invalid URL` errors. The
+  Auto Router (`openrouter/auto-beta`) failed for the same reason. The stored
+  `provider_name` and `api_endpoint` now take precedence over the prefix
+  heuristic: concrete OpenRouter ids, the `openrouter/`-prefixed workaround
+  form, and the Auto Router all route to OpenRouter with the model id intact.
+  Users who added the `openrouter/` prefix by hand are not broken by the fix.
+- **Model picker was empty for OpenRouter** (#171):
+  `available-models` returned `[]` for every openai-compatible provider,
+  because only the built-in providers had a discovery path. The configured
+  endpoint's OpenAI-compatible `GET /models` is now queried, so OpenRouter,
+  vLLM, LM Studio, and similar endpoints populate the picker. The request
+  takes an `api_endpoint`, which the picker sends from the form.
+
+### Security
+
+- **Provider API keys no longer travel in the URL**: the
+  `/api/v1/ai-models/providers/{provider}/available-models` endpoint accepted
+  `api_key` as a query parameter, so live provider keys were written to
+  server access logs in plaintext. The key now travels in the POST body (or
+  the `X-Provider-Api-Key` header on the deprecated GET form) and the query
+  parameter has been removed rather than deprecated. These endpoints also now
+  require authentication, and the endpoint they fetch is validated so it
+  cannot be aimed at loopback or link-local addresses. **Operators should
+  rotate any provider key entered through the model picker before this
+  release**, and check access logs for `api_key=`.
 
 ## [0.13.1] - 2026-07-28
 

--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -986,13 +986,6 @@ def create_app() -> FastAPI:
             tags=["Session Optimization"],
             dependencies=[Depends(get_current_active_user)],
         )
-        # Public AI models endpoints (no auth required)
-        app.include_router(
-            ai_models.public_router,
-            prefix="/api/v1",
-            tags=["AI Models"],
-        )
-
     # AI Model Gateway routers
     if is_gateway_role:
         app.include_router(

--- a/backend/preloop/api/endpoints/ai_models.py
+++ b/backend/preloop/api/endpoints/ai_models.py
@@ -3,7 +3,15 @@ import uuid
 from datetime import datetime
 from typing import List, Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status, Query, Response
+from fastapi import (
+    APIRouter,
+    Depends,
+    Header,
+    HTTPException,
+    status,
+    Query,
+    Response,
+)
 from sqlalchemy.orm import Session
 
 from preloop.api.auth.jwt import get_current_active_user
@@ -14,6 +22,7 @@ from preloop.schemas.ai_model import (
     AIModelGatewayUsageSummaryResponse,
     AIModelRead,
     AIModelUpdate,
+    AvailableModelsRequest,
 )
 from preloop.services.secret_service import (
     PRINCIPAL_BOUND_OAUTH_CREDENTIAL_TYPES,
@@ -36,7 +45,6 @@ from preloop.services.ai_model_provider import get_available_models_for_provider
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
-public_router = APIRouter()  # Router for endpoints that don't require authentication
 
 
 def _get_account_ai_model(
@@ -347,16 +355,55 @@ def export_ai_model_credentials(
     )
 
 
-@public_router.get(
+@router.post(
     "/ai-models/providers/{provider}/available-models",
     response_model=List[str],
     summary="Get Available Models for Provider",
     tags=["AI Models"],
 )
+async def list_provider_available_models(
+    provider: str,
+    request_in: Optional[AvailableModelsRequest] = None,
+) -> List[str]:
+    """
+    Fetch available models from the specified AI provider.
+
+    For OpenAI, this fetches the latest available models from their API. For
+    Anthropic and Google this returns a curated list of known models. For
+    openai-compatible / custom / openrouter providers, the configured
+    ``api_endpoint`` is queried for its OpenAI-compatible model list.
+
+    The provider API key travels in the request BODY, never the query string:
+    as a query parameter it was written to access logs in plaintext.
+    """
+    return await _fetch_provider_models(
+        provider=provider,
+        api_key=request_in.api_key if request_in else None,
+        model_kind=request_in.model_kind if request_in else "llm",
+        api_endpoint=request_in.api_endpoint if request_in else None,
+    )
+
+
+@router.get(
+    "/ai-models/providers/{provider}/available-models",
+    response_model=List[str],
+    summary="Get Available Models for Provider (deprecated)",
+    tags=["AI Models"],
+    deprecated=True,
+)
 async def get_provider_available_models(
     provider: str,
-    api_key: Optional[str] = Query(
-        None, description="Optional API key for fetching models"
+    x_provider_api_key: Optional[str] = Header(
+        None,
+        alias="X-Provider-Api-Key",
+        description="Provider API key. Headers are not written to access logs.",
+    ),
+    api_endpoint: Optional[str] = Query(
+        None,
+        description=(
+            "Base URL of an OpenAI-compatible endpoint, required for the "
+            "openai-compatible and custom providers."
+        ),
     ),
     model_kind: Literal["llm", "stt", "tts"] = Query(
         "llm",
@@ -365,27 +412,45 @@ async def get_provider_available_models(
     ),
 ) -> List[str]:
     """
-    Fetch available models from the specified AI provider.
+    Deprecated GET form, kept for clients that have not moved to POST yet.
 
-    For OpenAI, this will fetch the latest available models from their API.
-    For Anthropic and Google, this returns a curated list of known models.
-
-    Note: This endpoint does not require authentication as it's just fetching
-    publicly available model names. The api_key parameter is optional for
-    fetching live data from OpenAI.
+    The api_key query parameter this endpoint used to accept has been REMOVED,
+    not merely deprecated: it wrote live provider keys into access logs in
+    plaintext. Pass the key in the X-Provider-Api-Key header, or use the POST
+    form. A key sent as a query parameter is ignored.
     """
+    return await _fetch_provider_models(
+        provider=provider,
+        api_key=x_provider_api_key,
+        model_kind=model_kind,
+        api_endpoint=api_endpoint,
+    )
+
+
+async def _fetch_provider_models(
+    *,
+    provider: str,
+    api_key: Optional[str],
+    model_kind: Literal["llm", "stt", "tts"],
+    api_endpoint: Optional[str],
+) -> List[str]:
+    """Shared body of the GET and POST available-models endpoints."""
     try:
-        models = await get_available_models_for_provider(provider, api_key, model_kind)
-        return models
+        return await get_available_models_for_provider(
+            provider, api_key, model_kind, api_endpoint
+        )
     except ValueError as e:
-        # ValueError is raised for authentication errors
-        logger.warning(f"Authentication failed for provider {provider}: {e}")
+        # ValueError is raised for authentication and validation errors. The
+        # message is provider text, never the key.
+        logger.warning("Cannot list models for provider %s: %s", provider, e)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=str(e),
         )
     except Exception as e:
-        logger.error(f"Failed to fetch models for provider {provider}: {e}")
+        logger.error(
+            "Failed to fetch models for provider %s: %s", provider, type(e).__name__
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to fetch available models: {str(e)}",

--- a/backend/preloop/schemas/ai_model.py
+++ b/backend/preloop/schemas/ai_model.py
@@ -244,6 +244,40 @@ class AIModelCredentialExportResponse(BaseModel):
     account_id: Optional[str] = None
 
 
+class AvailableModelsRequest(BaseModel):
+    """Discovery request for a provider's model catalog.
+
+    The API key is carried in the body rather than the query string on
+    purpose: as a query parameter it was written to access logs in plaintext
+    and leaked live provider keys.
+    """
+
+    api_key: Optional[str] = Field(
+        None,
+        description=(
+            "Provider API key used to list models. Never logged and never "
+            "persisted by this endpoint."
+        ),
+    )
+    api_endpoint: Optional[str] = Field(
+        None,
+        description=(
+            "Base URL of an OpenAI-compatible endpoint, e.g. "
+            "https://openrouter.ai/api/v1. Required for the "
+            "'openai-compatible' and 'custom' providers, which have no fixed "
+            "model catalog."
+        ),
+    )
+    model_kind: Literal["llm", "stt", "tts"] = Field(
+        "llm", description="Model service kind to fetch"
+    )
+
+    @field_serializer("api_key")
+    def _hide_api_key(self, value: Optional[str]) -> Optional[str]:
+        """Keep the key out of any serialized copy of this model (logs, traces)."""
+        return "***" if value else value
+
+
 class AIModelGatewayUsageSummaryResponse(BaseModel):
     """Gateway usage summary for one durable AI model."""
 

--- a/backend/preloop/services/ai_model_provider.py
+++ b/backend/preloop/services/ai_model_provider.py
@@ -1,11 +1,29 @@
 """Service for fetching available models from AI providers."""
 
+import ipaddress
 import logging
 from typing import List, Literal, Optional
+from urllib.parse import urlsplit
 
 logger = logging.getLogger(__name__)
 
 ModelKind = Literal["llm", "stt", "tts"]
+
+# Provider names that mean "an OpenAI-compatible endpoint the user configured".
+# These have no fixed catalog: the model list has to come from the endpoint's
+# own GET /models (issue #171).
+OPENAI_COMPATIBLE_PROVIDERS = {"openai-compatible", "custom", "openrouter"}
+
+# Default endpoints for providers whose base URL we know, used when the caller
+# did not supply one.
+DEFAULT_PROVIDER_ENDPOINTS = {
+    "openrouter": "https://openrouter.ai/api/v1",
+}
+
+# Upper bound on models returned from an arbitrary endpoint. OpenRouter alone
+# lists 300+ and the picker is a dropdown, so an unbounded list is a UI and
+# payload hazard rather than a feature.
+MAX_DISCOVERED_MODELS = 1000
 
 OPENAI_STT_MODELS = [
     "gpt-4o-transcribe",
@@ -38,15 +56,22 @@ SUPPORTED_AUDIO_PROVIDER_KINDS: dict[str, set[ModelKind]] = {
 
 
 async def get_available_models_for_provider(
-    provider: str, api_key: Optional[str] = None, model_kind: ModelKind = "llm"
+    provider: str,
+    api_key: Optional[str] = None,
+    model_kind: ModelKind = "llm",
+    api_endpoint: Optional[str] = None,
 ) -> List[str]:
     """
     Fetch available models from the specified AI provider.
 
     Args:
-        provider: The provider name (openai, anthropic, google, qwen, deepseek)
+        provider: The provider name (openai, anthropic, google, qwen, deepseek,
+            openai-compatible, custom, openrouter)
         api_key: Optional API key for authentication
         model_kind: Service kind to fetch (llm, stt, or tts)
+        api_endpoint: Base URL of an OpenAI-compatible endpoint. Required for
+            the openai-compatible/custom providers, which have no fixed
+            catalog; defaulted for providers in DEFAULT_PROVIDER_ENDPOINTS.
 
     Returns:
         List of model identifiers/names
@@ -75,9 +100,123 @@ async def get_available_models_for_provider(
         return await _get_qwen_models(api_key)
     elif provider == "deepseek":
         return await _get_deepseek_models(api_key)
+    elif provider in OPENAI_COMPATIBLE_PROVIDERS:
+        endpoint = (api_endpoint or "").strip() or DEFAULT_PROVIDER_ENDPOINTS.get(
+            provider
+        )
+        if not endpoint:
+            # Nothing to query. Previously every openai-compatible provider
+            # landed here and silently returned [] (issue #171).
+            logger.info(
+                "No api_endpoint supplied for provider %s; cannot list models",
+                provider,
+            )
+            return []
+        return await _get_openai_compatible_models(endpoint, api_key)
     else:
-        # For custom providers, return empty list
+        # Unknown provider with no endpoint convention to follow.
         return []
+
+
+def validate_discovery_endpoint(api_endpoint: str) -> str:
+    """Validate a user-supplied model-discovery endpoint, or raise ValueError.
+
+    This endpoint makes the server fetch a URL chosen by the caller, so it is
+    an SSRF sink. Restrict it to http(s) on a non-literal-private host. DNS
+    names that resolve to private space are not caught here (that needs a
+    resolving/pinning transport); this blocks the trivial direct attempts at
+    link-local metadata and loopback services.
+    """
+    raw = (api_endpoint or "").strip()
+    if not raw:
+        raise ValueError("api_endpoint is required for this provider")
+
+    parts = urlsplit(raw)
+    if parts.scheme not in {"http", "https"}:
+        raise ValueError("api_endpoint must be an http(s) URL")
+    host = (parts.hostname or "").strip()
+    if not host:
+        raise ValueError("api_endpoint must include a host")
+
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        # A DNS name. Block the obvious loopback aliases; anything else is
+        # allowed, matching how api_endpoint is treated elsewhere.
+        if host.lower() in {"localhost", "localhost.localdomain"}:
+            raise ValueError("api_endpoint must not point at a private address")
+        return raw
+
+    if (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    ):
+        raise ValueError("api_endpoint must not point at a private address")
+    return raw
+
+
+async def _get_openai_compatible_models(
+    api_endpoint: str, api_key: Optional[str] = None
+) -> List[str]:
+    """List models from an OpenAI-compatible endpoint's ``GET /models``.
+
+    Works for OpenRouter, vLLM, LM Studio, Together, Groq and anything else
+    that implements the OpenAI list-models shape ``{"data": [{"id": ...}]}``.
+    Some servers (OpenRouter included) return a bare list, which is accepted
+    too.
+    """
+    from openai import AsyncOpenAI, AuthenticationError
+
+    base_url = validate_discovery_endpoint(api_endpoint).rstrip("/")
+    try:
+        client = AsyncOpenAI(
+            api_key=api_key or "placeholder",
+            base_url=base_url,
+            max_retries=1,
+            timeout=15.0,
+        )
+        response = await client.models.list()
+    except AuthenticationError as e:
+        # Do not log the key or the full request URL: a key passed as a query
+        # param would otherwise land in logs (see the api_key handling in the
+        # endpoint layer).
+        logger.warning("Authentication failed listing models from %s", base_url)
+        raise ValueError(
+            "Invalid API key for this endpoint. Please check your API key and "
+            "try again."
+        ) from e
+    except Exception as e:
+        logger.warning("Failed to list models from %s: %s", base_url, type(e).__name__)
+        return []
+
+    return _extract_model_ids(response)
+
+
+def _extract_model_ids(response: object) -> List[str]:
+    """Pull model ids out of an OpenAI-compatible list-models response."""
+    entries = getattr(response, "data", None)
+    if entries is None and isinstance(response, dict):
+        entries = response.get("data")
+    if entries is None and isinstance(response, list):
+        entries = response
+    if not entries:
+        return []
+
+    model_ids: List[str] = []
+    for entry in entries:
+        model_id = getattr(entry, "id", None)
+        if model_id is None and isinstance(entry, dict):
+            model_id = entry.get("id")
+        if isinstance(model_id, str) and model_id.strip():
+            model_ids.append(model_id.strip())
+
+    # Stable, de-duplicated, alphabetical: the picker is a flat dropdown and
+    # upstream ordering is neither stable nor meaningful.
+    return sorted(set(model_ids))[:MAX_DISCOVERED_MODELS]
 
 
 def _get_stt_models(provider: str) -> List[str]:

--- a/backend/preloop/services/litellm_routing.py
+++ b/backend/preloop/services/litellm_routing.py
@@ -7,25 +7,40 @@ session-explorer analysis previously carried divergent copies).
 
 Resolution order:
 
-1. An identifier that already carries a routable prefix (``azure/gpt-5.4``)
+1. An OpenRouter ``api_endpoint`` (or the ``openrouter`` provider) routes via
+   litellm's OpenRouter adapter, keeping the vendor-prefixed upstream id
+   intact (``openrouter/deepseek/deepseek-v4-flash-0731`` is sent upstream as
+   ``deepseek/deepseek-v4-flash-0731``).
+2. An explicit OpenAI-compatible provider with its own ``api_endpoint``
+   dispatches via litellm's generic OpenAI-compatible adapter, with the
+   stored identifier forwarded verbatim.
+3. An identifier that already carries a routable prefix (``azure/gpt-5.4``)
    passes through untouched.
-2. The local prefix map translates Preloop provider names to litellm ones
+4. The local prefix map translates Preloop provider names to litellm ones
    (``google`` -> ``gemini``, ``qwen`` -> ``openai``).
-3. Providers litellm routes natively (``mistral``, ``groq``, ...) pass
+5. Providers litellm routes natively (``mistral``, ``groq``, ...) pass
    through by name.
-4. Unknown provider names with their own endpoint — arbitrary
+6. Unknown provider names with their own endpoint — arbitrary
    OpenAI-compatible providers imported from agent configs, e.g. Hermes
    ``model.provider: custom`` entries like ``kimi-for-coding`` — dispatch via
    litellm's generic OpenAI-compatible adapter (``openai/<model>``); callers
    pass the model's ``api_endpoint`` as ``api_base``. litellm rejects unknown
    prefixes outright ("LLM Provider NOT provided") even when ``api_base`` is
    set, so the name must not be forwarded verbatim.
-5. Unknown provider names without an endpoint keep the name so the litellm
+7. Unknown provider names without an endpoint keep the name so the litellm
    error stays attributable instead of silently hitting api.openai.com.
+
+Rules 1 and 2 exist because the vendor prefix inside a model id is not a
+routing instruction: ``deepseek/deepseek-v4-flash-0731`` on
+``https://openrouter.ai/api/v1`` is an OpenRouter model id, not a request to
+call api.deepseek.com. Inferring the provider from that prefix (rule 3) ahead
+of the stored provider/endpoint sent live traffic to the wrong vendor with a
+truncated model id (issue #172).
 """
 
 from functools import lru_cache
-from typing import Dict
+from typing import Dict, Optional
+from urllib.parse import urlsplit
 
 import litellm
 
@@ -50,6 +65,19 @@ PROVIDER_PREFIX: Dict[str, str] = {
 }
 
 
+# Provider names that mean "an OpenAI-compatible endpoint I configured myself".
+# For these the stored ``api_endpoint`` is the routing authority, never the
+# vendor prefix inside the model id.
+OPENAI_COMPATIBLE_PROVIDERS = frozenset({"openai-compatible", "custom"})
+
+# Hosts served by OpenRouter. Matched on the endpoint host, not a substring of
+# the whole URL, so "https://evil.test/?x=openrouter.ai" is not treated as
+# OpenRouter.
+OPENROUTER_HOSTS = frozenset({"openrouter.ai"})
+
+OPENROUTER_PREFIX = "openrouter/"
+
+
 @lru_cache(maxsize=1)
 def known_litellm_providers() -> frozenset:
     """Provider names litellm can route natively (mistral, groq, ...)."""
@@ -61,10 +89,67 @@ def known_litellm_providers() -> frozenset:
         return frozenset()
 
 
+def _endpoint_host(endpoint: Optional[str]) -> str:
+    """Return the lowercase hostname of an endpoint URL, or "" if unparseable."""
+    if not isinstance(endpoint, str):
+        return ""
+    raw = endpoint.strip()
+    if not raw:
+        return ""
+    if "//" not in raw:
+        # Tolerate host-only endpoints such as "openrouter.ai/api/v1".
+        raw = f"//{raw}"
+    try:
+        return (urlsplit(raw).hostname or "").lower()
+    except ValueError:  # pragma: no cover - malformed URLs (bad IPv6 literal)
+        return ""
+
+
+def is_openrouter_endpoint(endpoint: Optional[str]) -> bool:
+    """Whether an api_endpoint points at OpenRouter."""
+    host = _endpoint_host(endpoint)
+    if not host:
+        return False
+    return any(
+        host == known or host.endswith(f".{known}") for known in OPENROUTER_HOSTS
+    )
+
+
+def _openrouter_model(identifier: str) -> str:
+    """Build the litellm string for an identifier that is an OpenRouter model id.
+
+    litellm strips the ``openrouter/`` prefix before calling upstream, so the
+    prefix has to be added on top of the id OpenRouter itself expects:
+
+    * ``deepseek/deepseek-v4-flash-0731`` -> ``openrouter/deepseek/...``
+    * ``openrouter/auto-beta`` (the Auto Router lives in OpenRouter's own
+      first-party namespace) -> ``openrouter/openrouter/auto-beta``
+
+    An identifier of the form ``openrouter/<vendor>/<model>`` is the manual
+    workaround people applied before this fix, where the prefix is a routing
+    hint rather than part of the upstream id. It is already the correct
+    litellm string, so it passes through unchanged.
+    """
+    if identifier.startswith(OPENROUTER_PREFIX):
+        remainder = identifier[len(OPENROUTER_PREFIX) :]
+        if "/" in remainder:
+            return identifier
+    return f"{OPENROUTER_PREFIX}{identifier}"
+
+
 def to_litellm_model(ai_model: AIModel) -> str:
     """Build the litellm model string for an AI model row."""
     provider = (ai_model.provider_name or "openai").strip().lower()
     identifier = (ai_model.model_identifier or "").strip()
+    endpoint = getattr(ai_model, "api_endpoint", None)
+
+    # The user's explicit provider/endpoint choice outranks any vendor prefix
+    # inside the model id (issue #172).
+    if provider == "openrouter" or is_openrouter_endpoint(endpoint):
+        return _openrouter_model(identifier)
+
+    if provider in OPENAI_COMPATIBLE_PROVIDERS and endpoint:
+        return f"openai/{identifier}"
 
     if "/" in identifier:
         head = identifier.split("/", 1)[0].strip().lower()

--- a/backend/tests/endpoints/test_available_models_key_handling.py
+++ b/backend/tests/endpoints/test_available_models_key_handling.py
@@ -1,0 +1,147 @@
+"""Available-models endpoints must never take the provider key in the URL.
+
+Incident (2026-08-04): these endpoints accepted ``api_key`` as a QUERY
+PARAMETER, so uvicorn access-logged live provider keys in plaintext:
+
+    "GET /api/v1/ai-models/providers/openrouter/available-models?...&api_key=sk-or-v1-..." 200
+
+Two live OpenRouter keys leaked this way during one onboarding session. The
+key now travels in the POST body or the X-Provider-Api-Key header, and the
+query parameter is gone rather than merely deprecated.
+"""
+
+import pytest
+import yaml
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from preloop.api.endpoints import ai_models
+from preloop.schemas.ai_model import AvailableModelsRequest
+
+ENDPOINT_PATH = "/ai-models/providers/{provider}/available-models"
+SPEC_PATH = "/api/v1" + ENDPOINT_PATH
+
+
+def _routes_for_path():
+    return [r for r in ai_models.router.routes if r.path == ENDPOINT_PATH]
+
+
+def test_endpoint_is_registered_for_get_and_post():
+    methods = set()
+    for route in _routes_for_path():
+        methods |= route.methods
+    assert {"GET", "POST"} <= methods
+
+
+def test_no_route_accepts_api_key_as_query_parameter():
+    """The regression that leaked the keys, pinned at the route level."""
+    for route in _routes_for_path():
+        for param in route.dependant.query_params:
+            assert param.name != "api_key", (
+                f"{route.methods} {route.path} still accepts api_key as a "
+                "query parameter; it would be written to access logs"
+            )
+
+
+def test_api_key_is_a_body_field_on_the_post_route():
+    assert "api_key" in AvailableModelsRequest.model_fields
+
+
+def test_serialized_request_never_carries_the_key():
+    """Anything that dumps this model (a log, a trace, an error report) is safe."""
+    payload = AvailableModelsRequest(api_key="sk-or-v1-secret-value")
+    dumped = payload.model_dump()
+    assert dumped["api_key"] == "***"
+    assert "sk-or-v1-secret-value" not in str(dumped)
+    assert "sk-or-v1-secret-value" not in payload.model_dump_json()
+
+
+def test_published_openapi_spec_has_no_api_key_query_parameter():
+    """Guards the contract clients generate from, not just the running app."""
+    spec_file = Path(__file__).resolve().parents[3] / "openapi.yaml"
+    spec = yaml.safe_load(spec_file.read_text(encoding="utf-8"))
+    operations = spec["paths"][SPEC_PATH]
+
+    for method, operation in operations.items():
+        for param in operation.get("parameters", []) or []:
+            assert not (param["in"] == "query" and param["name"] == "api_key"), (
+                f"openapi.yaml still documents api_key as a query parameter "
+                f"on {method.upper()} {SPEC_PATH}"
+            )
+
+
+def test_both_routes_require_authentication():
+    """The endpoint fetches a caller-supplied URL, so it cannot stay public."""
+    spec_file = Path(__file__).resolve().parents[3] / "openapi.yaml"
+    spec = yaml.safe_load(spec_file.read_text(encoding="utf-8"))
+    operations = spec["paths"][SPEC_PATH]
+
+    for method, operation in operations.items():
+        assert operation.get("security"), (
+            f"{method.upper()} {SPEC_PATH} is unauthenticated"
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_route_reads_the_key_from_the_header(mocker):
+    fetch = mocker.patch.object(
+        ai_models,
+        "get_available_models_for_provider",
+        new=AsyncMock(return_value=["a-model"]),
+    )
+
+    result = await ai_models.get_provider_available_models(
+        provider="openai-compatible",
+        x_provider_api_key="sk-or-v1-secret-value",
+        api_endpoint="https://openrouter.ai/api/v1",
+        model_kind="llm",
+    )
+
+    assert result == ["a-model"]
+    fetch.assert_awaited_once_with(
+        "openai-compatible",
+        "sk-or-v1-secret-value",
+        "llm",
+        "https://openrouter.ai/api/v1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_route_reads_the_key_from_the_body(mocker):
+    fetch = mocker.patch.object(
+        ai_models,
+        "get_available_models_for_provider",
+        new=AsyncMock(return_value=["openrouter/auto-beta"]),
+    )
+
+    result = await ai_models.list_provider_available_models(
+        provider="openai-compatible",
+        request_in=AvailableModelsRequest(
+            api_key="sk-or-v1-secret-value",
+            api_endpoint="https://openrouter.ai/api/v1",
+        ),
+    )
+
+    assert result == ["openrouter/auto-beta"]
+    fetch.assert_awaited_once_with(
+        "openai-compatible",
+        "sk-or-v1-secret-value",
+        "llm",
+        "https://openrouter.ai/api/v1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_route_works_without_a_body(mocker):
+    fetch = mocker.patch.object(
+        ai_models,
+        "get_available_models_for_provider",
+        new=AsyncMock(return_value=["gpt-5.4"]),
+    )
+
+    result = await ai_models.list_provider_available_models(
+        provider="openai", request_in=None
+    )
+
+    assert result == ["gpt-5.4"]
+    fetch.assert_awaited_once_with("openai", None, "llm", None)

--- a/backend/tests/services/test_ai_model_provider.py
+++ b/backend/tests/services/test_ai_model_provider.py
@@ -500,3 +500,191 @@ class TestGetDeepSeekModels:
             result = await _get_deepseek_models("test_key")
             # Should return known models even on network error
             assert "deepseek-chat" in result
+
+
+class TestOpenAICompatibleModels:
+    """Listing models from a user-configured OpenAI-compatible endpoint.
+
+    Issue #171: provider "openai-compatible" pointed at OpenRouter returned []
+    from the model picker, even though the same key against OpenRouter's own
+    GET /models returns hundreds of models. The generic adapter had no
+    discovery path at all and fell through to "return []".
+    """
+
+    @staticmethod
+    def _models_response(*model_ids):
+        response = MagicMock()
+        response.data = []
+        for model_id in model_ids:
+            entry = MagicMock()
+            entry.id = model_id
+            response.data.append(entry)
+        return response
+
+    @pytest.mark.asyncio
+    async def test_openai_compatible_lists_models_from_endpoint(self):
+        response = self._models_response(
+            "deepseek/deepseek-v4-flash-0731", "openrouter/auto-beta"
+        )
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=response)
+            mock_client.return_value = mock_instance
+
+            result = await get_available_models_for_provider(
+                "openai-compatible",
+                "test_key",
+                api_endpoint="https://openrouter.ai/api/v1",
+            )
+
+        assert result == ["deepseek/deepseek-v4-flash-0731", "openrouter/auto-beta"]
+        # The endpoint the user configured is the one queried.
+        assert (
+            mock_client.call_args.kwargs["base_url"] == "https://openrouter.ai/api/v1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_openrouter_provider_defaults_its_endpoint(self):
+        response = self._models_response("openrouter/auto-beta")
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=response)
+            mock_client.return_value = mock_instance
+
+            result = await get_available_models_for_provider("openrouter", "test_key")
+
+        assert result == ["openrouter/auto-beta"]
+        assert (
+            mock_client.call_args.kwargs["base_url"] == "https://openrouter.ai/api/v1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_provider_lists_models_from_endpoint(self):
+        response = self._models_response("k3", "k3-turbo")
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=response)
+            mock_client.return_value = mock_instance
+
+            result = await get_available_models_for_provider(
+                "custom", "test_key", api_endpoint="https://api.kimi.example/v1"
+            )
+
+        assert result == ["k3", "k3-turbo"]
+
+    @pytest.mark.asyncio
+    async def test_results_are_deduplicated_and_sorted(self):
+        response = self._models_response("b-model", "a-model", "b-model", "  ", None)
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=response)
+            mock_client.return_value = mock_instance
+
+            result = await get_available_models_for_provider(
+                "openai-compatible",
+                "test_key",
+                api_endpoint="https://gateway.example.com/v1",
+            )
+
+        assert result == ["a-model", "b-model"]
+
+    @pytest.mark.asyncio
+    async def test_openai_compatible_without_endpoint_returns_empty(self):
+        # Nothing to query, but this must not raise: the picker just shows no
+        # suggestions until an endpoint is entered.
+        result = await get_available_models_for_provider("openai-compatible", "key")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_auth_error_surfaces_as_value_error(self):
+        from openai import AuthenticationError
+
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(
+                side_effect=AuthenticationError(
+                    message="Invalid API key", response=MagicMock(), body=None
+                )
+            )
+            mock_client.return_value = mock_instance
+
+            with pytest.raises(ValueError, match="Invalid API key for this endpoint"):
+                await get_available_models_for_provider(
+                    "openai-compatible",
+                    "bad_key",
+                    api_endpoint="https://openrouter.ai/api/v1",
+                )
+
+    @pytest.mark.asyncio
+    async def test_network_error_returns_empty_rather_than_500(self):
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(side_effect=Exception("boom"))
+            mock_client.return_value = mock_instance
+
+            result = await get_available_models_for_provider(
+                "openai-compatible",
+                "test_key",
+                api_endpoint="https://gateway.example.com/v1",
+            )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_bare_list_response_shape_is_accepted(self):
+        # Some OpenAI-compatible servers return a bare list, not {"data": [...]}.
+        entry = MagicMock()
+        entry.id = "some-model"
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=[entry])
+            mock_client.return_value = mock_instance
+
+            result = await get_available_models_for_provider(
+                "openai-compatible",
+                "test_key",
+                api_endpoint="https://gateway.example.com/v1",
+            )
+
+        assert result == ["some-model"]
+
+
+class TestDiscoveryEndpointValidation:
+    """SSRF guard on the user-supplied discovery endpoint.
+
+    This endpoint makes the server fetch a URL the caller chose, so the
+    obvious internal targets have to be refused.
+    """
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "http://127.0.0.1:8000/v1",
+            "http://localhost/v1",
+            "http://169.254.169.254/latest/meta-data",
+            "http://10.0.0.5/v1",
+            "http://192.168.1.10/v1",
+            "http://[::1]/v1",
+            "file:///etc/passwd",
+            "gopher://example.com/v1",
+            "",
+        ],
+    )
+    def test_rejected_endpoints(self, endpoint):
+        from preloop.services.ai_model_provider import validate_discovery_endpoint
+
+        with pytest.raises(ValueError):
+            validate_discovery_endpoint(endpoint)
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://openrouter.ai/api/v1",
+            "https://gateway.example.com/v1",
+            "http://api.example.com:8080/v1",
+        ],
+    )
+    def test_allowed_endpoints(self, endpoint):
+        from preloop.services.ai_model_provider import validate_discovery_endpoint
+
+        assert validate_discovery_endpoint(endpoint) == endpoint

--- a/backend/tests/services/test_gateway_custom_provider_routing.py
+++ b/backend/tests/services/test_gateway_custom_provider_routing.py
@@ -86,6 +86,155 @@ def test_unknown_headed_identifier_still_gets_prefixed():
     )
 
 
+# --- issue #172: OpenRouter behind provider "openai-compatible" -------------
+#
+# Alex Lennon configured provider "openai-compatible" + endpoint
+# https://openrouter.ai/api/v1 and got 93 upstream 502s: the vendor prefix in
+# the model id ("deepseek/...") was read as a routing instruction, so litellm
+# loaded its native DeepSeek adapter, stripped the prefix, and rewrote the
+# api_base to api.deepseek.com. The stored provider/endpoint must win.
+
+OPENROUTER = "https://openrouter.ai/api/v1"
+
+
+def test_openrouter_endpoint_beats_vendor_prefix_in_model_id():
+    # The exact configuration from issue #172. Must NOT resolve to deepseek.
+    routed = OpenAIGatewayService._to_litellm_model(
+        _model("openai-compatible", "deepseek/deepseek-v4-flash-0731", OPENROUTER)
+    )
+    assert routed == "openrouter/deepseek/deepseek-v4-flash-0731"
+    assert not routed.startswith("deepseek/")
+
+
+def test_openrouter_auto_router_keeps_its_first_party_namespace():
+    # "openrouter/auto-beta" is an upstream model id in OpenRouter's own
+    # namespace, not a prefixed model. litellm strips one "openrouter/" before
+    # calling upstream, so the routed string needs both.
+    assert (
+        OpenAIGatewayService._to_litellm_model(
+            _model("openai-compatible", "openrouter/auto-beta", OPENROUTER)
+        )
+        == "openrouter/openrouter/auto-beta"
+    )
+
+
+def test_openrouter_prefixed_identifier_is_not_double_prefixed():
+    # The manual workaround (prefixing the id with "openrouter/") stays valid,
+    # so users who applied it are not broken by this fix.
+    assert (
+        OpenAIGatewayService._to_litellm_model(
+            _model(
+                "openai-compatible",
+                "openrouter/deepseek/deepseek-v4-flash-0731",
+                OPENROUTER,
+            )
+        )
+        == "openrouter/deepseek/deepseek-v4-flash-0731"
+    )
+
+
+def test_openrouter_provider_name_routes_without_endpoint():
+    assert (
+        OpenAIGatewayService._to_litellm_model(
+            _model("openrouter", "deepseek/deepseek-v4-flash-0731")
+        )
+        == "openrouter/deepseek/deepseek-v4-flash-0731"
+    )
+
+
+def test_openrouter_matched_on_host_not_substring():
+    # A host that merely mentions openrouter.ai in its path or query must not
+    # be routed to OpenRouter.
+    assert (
+        OpenAIGatewayService._to_litellm_model(
+            _model(
+                "openai-compatible",
+                "deepseek/deepseek-v4-flash-0731",
+                "https://proxy.example.com/openrouter.ai/api/v1",
+            )
+        )
+        == "openai/deepseek/deepseek-v4-flash-0731"
+    )
+
+
+def test_openai_compatible_endpoint_beats_vendor_prefix():
+    # Same precedence rule for any other OpenAI-compatible gateway: the id is
+    # forwarded verbatim and api_base (passed by callers) is honored.
+    assert (
+        OpenAIGatewayService._to_litellm_model(
+            _model(
+                "openai-compatible",
+                "deepseek/deepseek-chat",
+                "https://gateway.example.com/v1",
+            )
+        )
+        == "openai/deepseek/deepseek-chat"
+    )
+
+
+def test_custom_provider_with_endpoint_forwards_identifier_verbatim():
+    assert (
+        OpenAIGatewayService._to_litellm_model(
+            _model("custom", "qwen/qwen3-coder", "https://gateway.example.com/v1")
+        )
+        == "openai/qwen/qwen3-coder"
+    )
+
+
+def test_openai_compatible_without_endpoint_keeps_prefix_inference():
+    # No endpoint means nothing to honor, so the old heuristic still applies.
+    assert (
+        OpenAIGatewayService._to_litellm_model(
+            _model("openai-compatible", "deepseek/deepseek-chat")
+        )
+        == "deepseek/deepseek-chat"
+    )
+
+
+def test_native_deepseek_provider_is_unaffected():
+    # Regression guard: a genuine DeepSeek model must still route to DeepSeek.
+    assert (
+        OpenAIGatewayService._to_litellm_model(
+            _model("deepseek", "deepseek-chat", "https://api.deepseek.com/v1")
+        )
+        == "deepseek/deepseek-chat"
+    )
+
+
+@pytest.mark.parametrize(
+    "identifier, expected_upstream_id",
+    [
+        # (a) concrete OpenRouter id, (b) the prefixed workaround form,
+        # (c) the Auto Router. All three must reach OpenRouter with the id
+        # OpenRouter itself expects.
+        ("deepseek/deepseek-v4-flash-0731", "deepseek/deepseek-v4-flash-0731"),
+        (
+            "openrouter/deepseek/deepseek-v4-flash-0731",
+            "deepseek/deepseek-v4-flash-0731",
+        ),
+        ("openrouter/auto-beta", "openrouter/auto-beta"),
+    ],
+)
+def test_litellm_resolves_openrouter_models_without_mangling(
+    identifier, expected_upstream_id
+):
+    """What litellm does with our string, not just what our string looks like.
+
+    The pre-fix bug was only visible one layer down: litellm resolved provider
+    "deepseek" and sent a truncated model id. Assert on litellm's own
+    resolution so a future prefix-map change cannot silently reintroduce it.
+    """
+    import litellm
+
+    routed = OpenAIGatewayService._to_litellm_model(
+        _model("openai-compatible", identifier, OPENROUTER)
+    )
+    model_sent, provider = litellm.get_llm_provider(routed)[:2]
+
+    assert provider == "openrouter"
+    assert model_sent == expected_upstream_id
+
+
 @pytest.mark.asyncio
 async def test_extract_agent_name_uses_shared_routing(mocker):
     # Regression: this endpoint lazily imported the removed _PROVIDER_PREFIX

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2283,18 +2283,32 @@ export async function deleteAIModel(modelId: string) {
   }
 }
 
+/**
+ * List the models a provider offers, for the model picker.
+ *
+ * The API key goes in the POST body, never the query string: as a query
+ * parameter it was written to server access logs in plaintext.
+ *
+ * `apiEndpoint` is required for the openai-compatible and custom providers,
+ * which have no fixed catalog and are listed from the endpoint's own
+ * OpenAI-compatible GET /models.
+ */
 export async function getAvailableModelsForProvider(
   provider: string,
   apiKey?: string,
-  modelKind: 'llm' | 'stt' | 'tts' = 'llm'
+  modelKind: 'llm' | 'stt' | 'tts' = 'llm',
+  apiEndpoint?: string
 ): Promise<string[]> {
-  const params = new URLSearchParams({ model_kind: modelKind });
-  if (apiKey) {
-    params.set('api_key', apiKey);
-  }
-  const url = `/api/v1/ai-models/providers/${provider}/available-models?${params.toString()}`;
-  // Use fetch instead of fetchWithAuth since this endpoint doesn't require authentication
-  const response = await fetch(url);
+  const url = `/api/v1/ai-models/providers/${provider}/available-models`;
+  const response = await fetchWithAuth(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model_kind: modelKind,
+      ...(apiKey ? { api_key: apiKey } : {}),
+      ...(apiEndpoint ? { api_endpoint: apiEndpoint } : {}),
+    }),
+  });
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));
     throw new Error(

--- a/frontend/src/components/add-ai-model-modal.test.ts
+++ b/frontend/src/components/add-ai-model-modal.test.ts
@@ -173,3 +173,92 @@ describe('AddAIModelModal multi-model per key', () => {
     expect((element as any)._formError).to.contain('claude-sonnet-4-5');
   });
 });
+
+/**
+ * Issue #171 (empty model list for OpenRouter) and the key-in-URL leak found
+ * alongside it. The picker sends the endpoint so openai-compatible providers
+ * can be listed at all, and the key must never reach the query string.
+ */
+describe('AddAIModelModal model discovery', () => {
+  let element: AddAIModelModal;
+  let sandbox: SinonSandbox;
+  let fetchStub: SinonStub;
+
+  const discoveryCalls = () =>
+    fetchStub
+      .getCalls()
+      .filter((call) => String(call.args[0]).includes('available-models'));
+
+  beforeEach(async () => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    sandbox = sinon.createSandbox();
+    fetchStub = sandbox.stub(window, 'fetch');
+    fetchStub.callsFake(async (url: any) => {
+      if (String(url).includes('available-models')) {
+        return new Response(
+          JSON.stringify([
+            'deepseek/deepseek-v4-flash-0731',
+            'openrouter/auto-beta',
+          ])
+        );
+      }
+      return new Response(JSON.stringify([]));
+    });
+    element = await fixture(html`<add-ai-model-modal></add-ai-model-modal>`);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    localStorage.clear();
+  });
+
+  it('lists OpenRouter models for an openai-compatible endpoint', async () => {
+    (element as any)._currentModel = {
+      provider_name: 'openai-compatible',
+      api_endpoint: 'https://openrouter.ai/api/v1',
+      api_key: 'sk-or-v1-secret-value',
+    };
+
+    await (element as any)._fetchModelsForCurrentProvider();
+
+    expect((element as any)._modelSuggestions).to.deep.equal([
+      'deepseek/deepseek-v4-flash-0731',
+      'openrouter/auto-beta',
+    ]);
+    expect((element as any)._modelsFetchError).to.equal(null);
+
+    const [url, init] = discoveryCalls()[0].args;
+    const body = JSON.parse(String(init.body));
+    expect(init.method).to.equal('POST');
+    expect(body.api_endpoint).to.equal('https://openrouter.ai/api/v1');
+    expect(body.api_key).to.equal('sk-or-v1-secret-value');
+    // The leak that put live keys in access logs.
+    expect(String(url)).to.not.contain('api_key');
+    expect(String(url)).to.not.contain('sk-or-v1-secret-value');
+  });
+
+  it('asks for an endpoint before fetching openai-compatible models', async () => {
+    (element as any)._currentModel = {
+      provider_name: 'openai-compatible',
+      api_key: 'sk-or-v1-secret-value',
+    };
+
+    await (element as any)._fetchModelsForCurrentProvider();
+
+    expect((element as any)._modelsFetchError).to.contain('API endpoint');
+    expect(discoveryCalls()).to.have.lengthOf(0);
+  });
+
+  it('still fetches catalog providers without an endpoint', async () => {
+    (element as any)._currentModel = {
+      provider_name: 'anthropic',
+      api_key: 'sk-ant-secret',
+    };
+
+    await (element as any)._fetchModelsForCurrentProvider();
+
+    expect(discoveryCalls()).to.have.lengthOf(1);
+    expect(String(discoveryCalls()[0].args[0])).to.not.contain('sk-ant-secret');
+  });
+});

--- a/frontend/src/components/add-ai-model-modal.ts
+++ b/frontend/src/components/add-ai-model-modal.ts
@@ -44,6 +44,13 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
 ];
 
 /**
+ * Providers with no fixed model catalog: their models are listed from the
+ * user-supplied endpoint's own OpenAI-compatible GET /models, so an endpoint
+ * has to be entered before fetching can work.
+ */
+const ENDPOINT_LISTED_PROVIDERS = ['openai-compatible', 'custom'];
+
+/**
  * Reusable AI model add/edit dialog.
  *
  * Usage:
@@ -316,12 +323,14 @@ export class AddAIModelModal extends LitElement {
 
   private async _fetchModelSuggestionsForProvider(
     provider: string,
-    apiKey?: string
+    apiKey?: string,
+    apiEndpoint?: string
   ): Promise<string[]> {
     return await getAvailableModelsForProvider(
       provider,
       apiKey,
-      this._selectedServiceKind
+      this._selectedServiceKind,
+      apiEndpoint
     );
   }
 
@@ -331,13 +340,24 @@ export class AddAIModelModal extends LitElement {
       return;
     }
 
+    const provider = this._currentModel.provider_name;
+    const apiEndpoint = this._currentModel.api_endpoint?.trim();
+    // These providers have no fixed catalog: the list comes from the
+    // endpoint's own /models, so without an endpoint there is nothing to ask.
+    if (ENDPOINT_LISTED_PROVIDERS.includes(provider) && !apiEndpoint) {
+      this._modelsFetchError =
+        'Enter the API endpoint first, then fetch models';
+      return;
+    }
+
     this._isFetchingModels = true;
     this._modelsFetchError = null;
 
     try {
       this._modelSuggestions = await this._fetchModelSuggestionsForProvider(
-        this._currentModel.provider_name,
-        this._currentModel.api_key
+        provider,
+        this._currentModel.api_key,
+        apiEndpoint
       );
       if (this._modelSuggestions.length === 0) {
         this._modelsFetchError = `No ${this._selectedServiceKind.toUpperCase()} models available for this provider`;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5987,6 +5987,141 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/ai-models/providers/{provider}/available-models:
+    post:
+      tags:
+      - AI Models
+      - AI Models
+      summary: Get Available Models for Provider
+      description: 'Fetch available models from the specified AI provider.
+
+
+        For OpenAI, this fetches the latest available models from their API. For
+
+        Anthropic and Google this returns a curated list of known models. For
+
+        openai-compatible / custom / openrouter providers, the configured
+
+        ``api_endpoint`` is queried for its OpenAI-compatible model list.
+
+
+        The provider API key travels in the request BODY, never the query string:
+
+        as a query parameter it was written to access logs in plaintext.'
+      operationId: list_provider_available_models_api_v1_ai_models_providers__provider__available_models_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: provider
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Provider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/AvailableModelsRequest'
+              - type: 'null'
+              title: Request In
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                title: Response List Provider Available Models Api V1 Ai Models Providers  Provider  Available
+                  Models Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - AI Models
+      - AI Models
+      summary: Get Available Models for Provider (deprecated)
+      description: 'Deprecated GET form, kept for clients that have not moved to POST
+        yet.
+
+
+        The api_key query parameter this endpoint used to accept has been REMOVED,
+
+        not merely deprecated: it wrote live provider keys into access logs in
+
+        plaintext. Pass the key in the X-Provider-Api-Key header, or use the POST
+
+        form. A key sent as a query parameter is ignored.'
+      operationId: get_provider_available_models_api_v1_ai_models_providers__provider__available_models_get
+      deprecated: true
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: provider
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Provider
+      - name: api_endpoint
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Base URL of an OpenAI-compatible endpoint, required for the
+            openai-compatible and custom providers.
+          title: Api Endpoint
+        description: Base URL of an OpenAI-compatible endpoint, required for the openai-compatible
+          and custom providers.
+      - name: model_kind
+        in: query
+        required: false
+        schema:
+          enum:
+          - llm
+          - stt
+          - tts
+          type: string
+          description: Model service kind to fetch
+          default: llm
+          title: Model Kind
+        description: Model service kind to fetch
+      - name: X-Provider-Api-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Provider API key. Headers are not written to access logs.
+          title: X-Provider-Api-Key
+        description: Provider API key. Headers are not written to access logs.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                title: Response Get Provider Available Models Api V1 Ai Models Providers  Provider  Available
+                  Models Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/audio/transcriptions:
     post:
       tags:
@@ -6501,75 +6636,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/v1/ai-models/providers/{provider}/available-models:
-    get:
-      tags:
-      - AI Models
-      - AI Models
-      summary: Get Available Models for Provider
-      description: 'Fetch available models from the specified AI provider.
-
-
-        For OpenAI, this will fetch the latest available models from their API.
-
-        For Anthropic and Google, this returns a curated list of known models.
-
-
-        Note: This endpoint does not require authentication as it''s just fetching
-
-        publicly available model names. The api_key parameter is optional for
-
-        fetching live data from OpenAI.'
-      operationId: get_provider_available_models_api_v1_ai_models_providers__provider__available_models_get
-      parameters:
-      - name: provider
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Provider
-      - name: api_key
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          description: Optional API key for fetching models
-          title: Api Key
-        description: Optional API key for fetching models
-      - name: model_kind
-        in: query
-        required: false
-        schema:
-          enum:
-          - llm
-          - stt
-          - tts
-          type: string
-          description: Model service kind to fetch
-          default: llm
-          title: Model Kind
-        description: Model service kind to fetch
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
-                title: Response Get Provider Available Models Api V1 Ai Models Providers  Provider  Available
-                  Models Get
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      security:
-      - bearerAuth: []
   /api/v1/private/webhooks/{tracker_type}/{organization_id}:
     post:
       tags:
@@ -10485,6 +10551,42 @@ components:
       - challenge_token
       title: AuthenticationVerifyRequest
       description: Authenticator response for the authentication ceremony.
+    AvailableModelsRequest:
+      properties:
+        api_key:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Api Key
+          description: Provider API key used to list models. Never logged and never
+            persisted by this endpoint.
+        api_endpoint:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Api Endpoint
+          description: Base URL of an OpenAI-compatible endpoint, e.g. https://openrouter.ai/api/v1.
+            Required for the 'openai-compatible' and 'custom' providers, which have
+            no fixed model catalog.
+        model_kind:
+          type: string
+          enum:
+          - llm
+          - stt
+          - tts
+          title: Model Kind
+          description: Model service kind to fetch
+          default: llm
+      type: object
+      title: AvailableModelsRequest
+      description: 'Discovery request for a provider''s model catalog.
+
+
+        The API key is carried in the body rather than the query string on
+
+        purpose: as a query parameter it was written to access logs in plaintext
+
+        and leaked live provider keys.'
     Body_diff_policy_api_v1_policies_diff_post:
       properties:
         file:


### PR DESCRIPTION
Fixes #172 and #171, plus a HIGH severity key-logging issue found on the same endpoints. Targets **v0.14.0**.

Root cause for #172 was proven in production before this branch existed: the routing code, the stored config, and litellm's own resolution were all checked inside the running gateway pod.

## #172: OpenRouter models routed to the wrong vendor

`litellm_routing.to_litellm_model` treated anything before a `/` in the model id as the provider, **before** looking at the model's stored `provider_name` and `api_endpoint`.

So a model configured exactly as intended:

```
provider_name  openai-compatible
api_endpoint   https://openrouter.ai/api/v1
model_id       deepseek/deepseek-v4-flash-0731
```

was handed to litellm's native DeepSeek adapter, because `deepseek` is a real litellm provider. That adapter strips the vendor prefix (sending `deepseek-v4-flash-0731`) and rewrites `api_base` to `api.deepseek.com`. The user's explicit endpoint was discarded. OpenRouter answered `502 Invalid URL:` with an empty URL, 93 times in a single onboarding session. `openrouter/auto-beta` failed the same way.

The fix inverts the precedence: the stored provider and endpoint win over the prefix heuristic. The vendor prefix inside a model id is not a routing instruction, it is part of the upstream id.

All three forms now route correctly:

| stored model id | litellm string | sent to OpenRouter |
|---|---|---|
| `deepseek/deepseek-v4-flash-0731` | `openrouter/deepseek/deepseek-v4-flash-0731` | `deepseek/deepseek-v4-flash-0731` |
| `openrouter/deepseek/deepseek-v4-flash-0731` (manual workaround) | unchanged | `deepseek/deepseek-v4-flash-0731` |
| `openrouter/auto-beta` (Auto Router) | `openrouter/openrouter/auto-beta` | `openrouter/auto-beta` |

Notes:
- The manual `openrouter/` prefix workaround people applied stays valid, so nobody is broken by the fix.
- OpenRouter is matched on the endpoint **host**, not a substring of the URL, so `https://proxy.example.com/openrouter.ai/api/v1` is not misrouted.
- A genuine `deepseek` provider model still routes to DeepSeek (regression guard).

The tests assert on **litellm's own resolution** (`get_llm_provider`), not just the string we build, because the original bug was only visible one layer down. Verified red before green: 8 of the new tests fail on the pre-fix code.

## #171: model picker empty for OpenRouter

`available-models` returned `[]` for every openai-compatible provider: only the built-in providers had a discovery path, and everything else fell through to `return []`.

It now queries the configured endpoint's OpenAI-compatible `GET /models`, which covers OpenRouter, vLLM, LM Studio, Together and similar. Results are de-duplicated and sorted, and both the `{"data": [...]}` and bare-list response shapes are accepted. The picker sends the endpoint from the form, and asks for one before fetching instead of silently returning nothing.

## Security: provider API keys were written to access logs

These endpoints accepted `api_key` as a **query parameter**, so uvicorn access-logged live provider keys in plaintext:

```
"GET /api/v1/ai-models/providers/openrouter/available-models?...&api_key=sk-or-v1-..." 200
```

Changes:
- The key travels in the **POST body**, or the `X-Provider-Api-Key` header on the deprecated GET form.
- The query parameter is **removed, not deprecated**: a key sent that way is ignored, so the leak cannot be re-triggered by an old client.
- Both routes now **require authentication**. They make the server fetch a caller-supplied URL, so they cannot stay public.
- That URL is **validated** against loopback, private, link-local and non-http(s) targets, since this is an SSRF sink.
- Error logging no longer interpolates exception text that can carry a request URL.
- `AvailableModelsRequest.api_key` serializes as `***`, so any log, trace, or error report that dumps the model is safe.

**Operators should rotate any provider key entered through the model picker** and grep access logs for `api_key=`. Called out in the CHANGELOG under Security.

## Testing

- New and updated: 19 routing tests, 12 discovery/SSRF tests, 9 endpoint key-handling tests, 3 frontend picker tests.
- One key-handling test asserts against the **published openapi.yaml** itself, so the contract clients generate from cannot regress.
- Touched-area backend suites: 175 passed.
- Frontend: 589 passed, all 85 files.
- Full `backend/tests/endpoints` + `backend/tests/services`: **180 pre-existing failures, byte-identical before and after this branch** (verified by diffing the failure sets against a stashed tree). They are environment issues, mostly a missing `api_usage.rate_limit_retry_after_ms` column in the test database.
- mypy and ruff: no new findings versus baseline. The one `tsc` line that changed is a pre-existing error whose line number shifted.

`openapi.yaml` is regenerated.

## Not in this PR

The incident report also found that auxiliary paths (`approval_summary.py`, session titles) read the raw `model.api_key` column instead of resolving through the secret service, which causes 401s for any account whose credentials live in a secret. That is a separate bug with a different blast radius and is left for its own change.

**DO NOT MERGE** yet, per the brief.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-scoped fixes for two routing/discovery bugs and a security leak, with comprehensive test coverage (43 new/updated tests including OpenAPI contract pinning). No regressions in pre-existing test suites.
>
> **Overview**
> Fixes #172 (OpenRouter routed to wrong vendor), #171 (empty model picker for openai-compatible providers), and a HIGH-severity key-in-query-parameter leak. Routes are now determined by stored provider/endpoint before vendor-prefix heuristics, model discovery queries the endpoint's own GET /models, and provider keys travel in POST body or header only. An SSRF guard validates caller-supplied discovery URLs.
>
> <sup>Written by Preloop PR Reviewer for commit on `fix/openrouter-routing-171-172`. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->