### PR TITLE
fix: post commit statuses to the triggering repo, keep dashboard dismiss reachable (#174, #175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,24 @@ across renames and re-onboarding.
 
 ### Fixed
 
+- **Commit statuses post to the repository that triggered the flow** (#175): a
+  flow watching several projects always posted its GitHub check to
+  `trigger_project_ids[0]`, so a push or pull request in any other watched
+  repository targeted the wrong repository and the provider rejected the call
+  with `422 No commit found for SHA`. The failure was swallowed, so the run
+  still looked healthy while no check ever appeared. The project is now
+  resolved from the repository that actually triggered the execution. When the
+  triggering repository cannot be matched to a Preloop project, Preloop refuses
+  to guess and skips the status instead of posting to an unrelated repository,
+  and every skip or provider failure is surfaced as a warning on the execution
+  timeline rather than only in the server log.
+- **Dashboard Recent Flow Executions dismiss control stays reachable** (#174):
+  a long error message, typically a git clone failure containing an unbreakable
+  repository URL, widened the text column past the card and pushed the dismiss
+  button outside it, so a failed run could not be cleared from the dashboard.
+  The text column can now shrink, long URLs and paths wrap, the message is
+  capped at three lines with the full text available on hover, and the status
+  tag, links, and dismiss button keep their size at every viewport width.
 - **Managed agents report their real product kind** (#123): Cursor, Windsurf,
   VS Code, Antigravity, and Devin agents all recorded `agent_kind` as
   `desktop_agent` (or `custom` when created via `POST /api/v1/agents`), because

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -124,6 +124,10 @@ class FlowExecutionOrchestrator:
         self._commit_sha: Optional[str] = None
         self._status_context: str = "preloop"
         self._is_recovered: bool = False  # Set to True during execution recovery
+        # Warning messages already surfaced on the execution timeline, so a
+        # repeated condition (e.g. status posted at pending and again at
+        # success) does not spam the same line.
+        self._emitted_warnings: set[str] = set()
         # Set when a sync worker owns this orchestrator (claim lease heartbeat).
         self._orchestrator_worker_id: Optional[str] = None
 
@@ -200,6 +204,119 @@ class FlowExecutionOrchestrator:
         logger.debug(f"No commit SHA found in payload. Keys: {list(payload.keys())}")
         return None
 
+    def _extract_trigger_repository_identifier(self) -> Optional[str]:
+        """Return the repository identifier carried by the trigger payload.
+
+        GitHub sends ``repository.full_name`` and GitLab sends
+        ``project.path_with_namespace``. Used to tell "the webhook named a repo
+        we could not map to a project" (a real misconfiguration) apart from
+        "this execution has no repository context at all" (manual runs).
+        """
+        payload = self.trigger_event_data.get("payload", {})
+        if not isinstance(payload, dict):
+            return None
+
+        repo = payload.get("repository")
+        if isinstance(repo, dict):
+            identifier = repo.get("full_name") or repo.get("name")
+            if identifier:
+                return str(identifier)
+
+        project = payload.get("project")
+        if isinstance(project, dict):
+            identifier = project.get("path_with_namespace") or project.get("name")
+            if identifier:
+                return str(identifier)
+
+        return None
+
+    async def _resolve_commit_status_project_id(self) -> Optional[str]:
+        """Resolve the project the commit status must be posted to.
+
+        The status has to land on the repository that actually triggered this
+        execution. Posting to ``flow.trigger_project_ids[0]`` means every repo
+        other than the first one a multi-repo flow watches gets a
+        ``422 No commit found for SHA`` instead of a check (issue #175).
+        """
+        resolved = self._resolve_trigger_project_id(
+            allow_first_project_fallback=False,
+        )
+        if resolved:
+            return resolved
+
+        repo_identifier = self._extract_trigger_repository_identifier()
+        if repo_identifier:
+            # The webhook told us which repo it came from and we could not map
+            # it to a project. Falling back to the first trigger project would
+            # post the status to the wrong repository, so refuse and say so.
+            await self._emit_execution_warning(
+                "Commit status skipped: could not match the triggering repository "
+                f"'{repo_identifier}' to a Preloop project. Add it as a project on "
+                "the tracker so checks can be posted to the right repository.",
+                details={
+                    "repository": repo_identifier,
+                    "flow_trigger_project_ids": [
+                        str(pid) for pid in (self.flow.trigger_project_ids or [])
+                    ]
+                    if self.flow
+                    else [],
+                },
+            )
+            return None
+
+        trigger_project_ids = (
+            [str(pid) for pid in self.flow.trigger_project_ids]
+            if self.flow and self.flow.trigger_project_ids
+            else []
+        )
+        if not trigger_project_ids:
+            return None
+
+        if len(trigger_project_ids) > 1:
+            # No repository context and several candidates: any choice is a
+            # guess, so make the guess visible instead of silently picking one.
+            await self._emit_execution_warning(
+                "Commit status target is ambiguous: the trigger event carries no "
+                f"repository, and this flow watches {len(trigger_project_ids)} "
+                "projects. Using the first one, which may be the wrong repository.",
+                details={"flow_trigger_project_ids": trigger_project_ids},
+            )
+
+        return trigger_project_ids[0]
+
+    async def _emit_execution_warning(
+        self,
+        message: str,
+        *,
+        details: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Surface a non-fatal problem on the execution timeline, not just in logs.
+
+        Server-side ``logger.warning`` calls are invisible to the user whose
+        flow silently did half its job. This publishes an ``execution_warning``
+        entry, which is persisted with the execution logs and rendered in the
+        console.
+
+        Identical messages are emitted once per execution: commit status runs
+        two or three times per execution (pending, then success or failure),
+        and a misconfiguration would otherwise repeat verbatim each time.
+        """
+        if message in self._emitted_warnings:
+            logger.debug(f"Suppressing repeated execution warning: {message}")
+            return
+        self._emitted_warnings.add(message)
+
+        logger.warning(message)
+        payload: Dict[str, Any] = {"message": message, "level": "warning"}
+        if details:
+            payload["details"] = _make_json_serializable(details)
+        try:
+            await self._publish_update("execution_warning", payload)
+        except Exception as publish_error:
+            logger.warning(
+                f"Failed to publish execution warning: {publish_error}",
+            )
+
     async def _get_tracker_client_for_status(self):
         """Get a tracker client for updating commit status.
 
@@ -210,20 +327,19 @@ class FlowExecutionOrchestrator:
             return self._tracker_client
 
         try:
-            # Get project from trigger_project_ids on the flow
             if not self.flow:
                 logger.warning("[CommitStatus] No flow object available")
                 return None
 
-            # Get the first project ID from the array (if any)
-            trigger_project_id = None
-            if self.flow.trigger_project_ids and len(self.flow.trigger_project_ids) > 0:
-                trigger_project_id = self.flow.trigger_project_ids[0]
+            # Resolve the project from the repository that ACTUALLY triggered
+            # this execution, not from flow.trigger_project_ids[0].
+            trigger_project_id = await self._resolve_commit_status_project_id()
 
             if not trigger_project_id:
-                # This is expected for flows not tied to a specific project
+                # Expected for flows not tied to a specific project; the
+                # misconfigured cases already emitted a warning above.
                 logger.debug(
-                    "[CommitStatus] Flow has no trigger_project_ids - skipping status update"
+                    "[CommitStatus] No trigger project resolved - skipping status update"
                 )
                 return None
 
@@ -232,15 +348,16 @@ class FlowExecutionOrchestrator:
 
             project = crud_project.get(self.db, id=trigger_project_id)
             if not project:
-                logger.warning(
-                    f"[CommitStatus] Project not found for trigger_project_id: "
-                    f"{trigger_project_id}"
+                await self._emit_execution_warning(
+                    "Commit status skipped: the triggering project "
+                    f"{trigger_project_id} no longer exists.",
                 )
                 return None
 
             if not project.organization_id:
-                logger.warning(
-                    f"[CommitStatus] Project {project.id} has no organization_id"
+                await self._emit_execution_warning(
+                    f"Commit status skipped: project {project.name} is not linked "
+                    "to an organization, so the target repository is unknown.",
                 )
                 return None
 
@@ -279,6 +396,24 @@ class FlowExecutionOrchestrator:
                 exc_info=True,
             )
             return None
+
+    @staticmethod
+    def _describe_status_target(tracker_client: Any) -> str:
+        """Human-readable description of where a commit status is being posted."""
+        details = getattr(tracker_client, "connection_details", None)
+        if not isinstance(details, dict):
+            return "the triggering repository"
+
+        owner = details.get("owner")
+        repo = details.get("repo")
+        if owner and repo:
+            return f"{owner}/{repo}"
+
+        project_path = details.get("project_path") or details.get("project_id")
+        if project_path:
+            return str(project_path)
+
+        return "the triggering repository"
 
     async def _update_commit_status(
         self,
@@ -325,6 +460,7 @@ class FlowExecutionOrchestrator:
             )
             return
 
+        status_target = "the triggering repository"
         try:
             logger.info(
                 f"[CommitStatus] Getting tracker client. "
@@ -340,6 +476,8 @@ class FlowExecutionOrchestrator:
                     f"account_id: {self.flow.account_id if self.flow else None}"
                 )
                 return
+
+            status_target = self._describe_status_target(tracker_client)
 
             logger.info(
                 f"[CommitStatus] Got tracker client: {type(tracker_client).__name__}, "
@@ -396,10 +534,22 @@ class FlowExecutionOrchestrator:
             )
 
         except Exception as e:
-            # Don't fail the execution if status update fails
+            # Don't fail the execution if status update fails, but do not hide
+            # it either: a swallowed 422 used to leave the flow looking green
+            # while GitHub showed no check at all (issue #175).
             logger.error(
                 f"[CommitStatus] FAILED to update: {e}",
                 exc_info=True,
+            )
+            sha_label = self._commit_sha[:8] if self._commit_sha else "unknown"
+            await self._emit_execution_warning(
+                f"Commit status '{state}' could not be posted to {status_target} "
+                f"for commit {sha_label}: {_exception_message(e)}",
+                details={
+                    "state": state,
+                    "commit_sha": self._commit_sha,
+                    "target": status_target,
+                },
             )
 
     @staticmethod
@@ -1152,12 +1302,20 @@ class FlowExecutionOrchestrator:
             logger.debug(f"Error extracting PR branch: {e}")
             return None
 
-    def _resolve_trigger_project_id(self) -> Optional[str]:
+    def _resolve_trigger_project_id(
+        self, *, allow_first_project_fallback: bool = True
+    ) -> Optional[str]:
         """Resolve the project that triggered this execution.
 
         Prefer the repository from the webhook payload (e.g. the MR's project)
         over the first entry in flow.trigger_project_ids, which may be a
         different repo when the flow watches multiple projects.
+
+        Args:
+            allow_first_project_fallback: When False, return None instead of
+                falling back to ``flow.trigger_project_ids[0]``. Callers that
+                address a specific repository (commit statuses) need this,
+                because a wrong repo is worse than no repo.
         """
         project_id = self.trigger_event_data.get("project_id")
         if project_id:
@@ -1171,6 +1329,9 @@ class FlowExecutionOrchestrator:
         if resolved:
             logger.info(f"Resolved trigger project from event payload: {resolved}")
             return resolved
+
+        if not allow_first_project_fallback:
+            return None
 
         if self.flow.trigger_project_ids:
             fallback = str(self.flow.trigger_project_ids[0])

--- a/backend/tests/test_flow_commit_status.py
+++ b/backend/tests/test_flow_commit_status.py
@@ -1,0 +1,502 @@
+"""Commit status targeting for flow executions (issue #175).
+
+A flow can watch several repositories. The commit status must land on the
+repository that actually triggered the execution, not on
+``flow.trigger_project_ids[0]``, and a failure to post it must be visible on
+the execution rather than swallowed into a server log line.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from preloop.models.crud import (
+    crud_account,
+    crud_flow,
+    crud_organization,
+    crud_project,
+    crud_tracker,
+    crud_user,
+)
+from preloop.models.models import Account, Flow
+from preloop.models.models.user import User
+from preloop.models.schemas.flow import FlowCreate
+from preloop.services.flow_orchestrator import FlowExecutionOrchestrator
+
+
+@pytest.fixture
+def account(db_session: Session) -> Account:
+    return crud_account.create(
+        db_session,
+        obj_in={
+            "organization_name": f"Commit Status Org {uuid4().hex[:8]}",
+            "is_active": True,
+        },
+    )
+
+
+@pytest.fixture
+def account_user(db_session: Session, account: Account) -> User:
+    user = crud_user.create(
+        db_session,
+        obj_in={
+            "account_id": account.id,
+            "email": f"status_{uuid4().hex[:8]}@example.com",
+            "username": f"status_user_{uuid4().hex[:8]}",
+            "full_name": "Commit Status User",
+            "is_active": True,
+            "email_verified": True,
+            "hashed_password": "test_password",
+            "user_source": "local",
+        },
+    )
+    db_session.flush()
+    return user
+
+
+@pytest.fixture
+def github_projects(db_session: Session, account: Account, account_user: User):
+    """A GitHub tracker with one org and two repos, like Alex's setup."""
+    tracker = crud_tracker.create(
+        db_session,
+        obj_in={
+            "name": "GitHub",
+            "tracker_type": "github",
+            "url": "https://github.com",
+            "api_key": "test_key",
+            "account_id": str(account.id),
+            "is_active": True,
+        },
+    )
+    db_session.flush()
+
+    organization = crud_organization.create(
+        db_session,
+        obj_in={
+            "name": "acme",
+            "identifier": "acme",
+            "tracker_id": str(tracker.id),
+            "is_active": True,
+        },
+    )
+    db_session.flush()
+
+    projects = {}
+    for repo_name in ("cursor-config", "mender-mcu"):
+        project = crud_project.create(
+            db_session,
+            obj_in={
+                "name": repo_name,
+                "identifier": f"id-{repo_name}",
+                "slug": f"acme/{repo_name}",
+                "organization_id": str(organization.id),
+                "is_active": True,
+            },
+        )
+        db_session.flush()
+        projects[repo_name] = project
+
+    return {"tracker": tracker, "organization": organization, "projects": projects}
+
+
+@pytest.fixture
+def multi_repo_flow(db_session: Session, account: Account, github_projects) -> Flow:
+    """A PR-reviewer style flow watching two repositories."""
+    flow = crud_flow.create(
+        db=db_session,
+        flow_in=FlowCreate(
+            name="Pull Request Reviewer",
+            description="Reviews PRs across several repos",
+            trigger_event_source=str(github_projects["tracker"].id),
+            trigger_event_types=["pull_request_opened"],
+            prompt_template="Review {{payload.pull_request.title}}",
+            agent_type="claude",
+            agent_config={},
+            account_id=account.id,
+        ),
+        account_id=account.id,
+    )
+    flow.trigger_project_ids = [
+        str(github_projects["projects"]["cursor-config"].id),
+        str(github_projects["projects"]["mender-mcu"].id),
+    ]
+    db_session.add(flow)
+    db_session.commit()
+    db_session.refresh(flow)
+    return flow
+
+
+@pytest.fixture
+def mock_nats_client():
+    client = AsyncMock()
+    client.is_connected = True
+    client.publish = AsyncMock()
+    return client
+
+
+def _pull_request_event(account: Account, tracker_id: str, repo_full_name: str):
+    """Webhook payload for a PR opened in ``repo_full_name``."""
+    return {
+        "source": "github",
+        "type": "pull_request_opened",
+        "account_id": str(account.id),
+        "tracker_id": str(tracker_id),
+        "payload": {
+            "repository": {
+                "full_name": repo_full_name,
+                "name": repo_full_name.split("/")[-1],
+            },
+            "pull_request": {
+                "number": 7,
+                "title": "Bump toolchain",
+                "head": {"sha": "a" * 40},
+            },
+        },
+    }
+
+
+def _make_orchestrator(db_session, flow, event_data, nats_client):
+    orchestrator = FlowExecutionOrchestrator(
+        db=db_session,
+        flow_id=flow.id,
+        trigger_event_data=event_data,
+        nats_client=nats_client,
+    )
+    orchestrator._get_flow_details()
+    orchestrator.execution_log = MagicMock(id=uuid4())
+    return orchestrator
+
+
+class TestCommitStatusProjectResolution:
+    """The status must target the repo that triggered the run."""
+
+    @pytest.mark.asyncio
+    async def test_uses_second_watched_repo_when_it_triggered_the_flow(
+        self, db_session, account, github_projects, multi_repo_flow, mock_nats_client
+    ):
+        """A PR in the SECOND trigger project resolves to that project.
+
+        This is the exact reproduction from #175: before the fix the status
+        went to cursor-config (index 0) and GitHub answered 422.
+        """
+        mender = github_projects["projects"]["mender-mcu"]
+        orchestrator = _make_orchestrator(
+            db_session,
+            multi_repo_flow,
+            _pull_request_event(
+                account, github_projects["tracker"].id, "acme/mender-mcu"
+            ),
+            mock_nats_client,
+        )
+
+        resolved = await orchestrator._resolve_commit_status_project_id()
+
+        assert resolved == str(mender.id)
+        assert resolved != str(github_projects["projects"]["cursor-config"].id)
+
+    @pytest.mark.asyncio
+    async def test_uses_first_watched_repo_when_it_triggered_the_flow(
+        self, db_session, account, github_projects, multi_repo_flow, mock_nats_client
+    ):
+        """The previously-working case must keep working."""
+        cursor_config = github_projects["projects"]["cursor-config"]
+        orchestrator = _make_orchestrator(
+            db_session,
+            multi_repo_flow,
+            _pull_request_event(
+                account, github_projects["tracker"].id, "acme/cursor-config"
+            ),
+            mock_nats_client,
+        )
+
+        resolved = await orchestrator._resolve_commit_status_project_id()
+
+        assert resolved == str(cursor_config.id)
+
+    @pytest.mark.asyncio
+    async def test_explicit_project_id_on_the_event_wins(
+        self, db_session, account, github_projects, multi_repo_flow, mock_nats_client
+    ):
+        """A project_id already resolved upstream is used as-is."""
+        mender = github_projects["projects"]["mender-mcu"]
+        event = _pull_request_event(
+            account, github_projects["tracker"].id, "acme/mender-mcu"
+        )
+        event["project_id"] = str(mender.id)
+
+        orchestrator = _make_orchestrator(
+            db_session, multi_repo_flow, event, mock_nats_client
+        )
+
+        assert await orchestrator._resolve_commit_status_project_id() == str(mender.id)
+
+    @pytest.mark.asyncio
+    async def test_unmappable_repository_warns_instead_of_guessing(
+        self, db_session, account, github_projects, multi_repo_flow, mock_nats_client
+    ):
+        """A repo we cannot map must NOT fall back to trigger_project_ids[0].
+
+        Falling back would post the check to a repo the SHA does not exist in.
+        """
+        orchestrator = _make_orchestrator(
+            db_session,
+            multi_repo_flow,
+            _pull_request_event(
+                account, github_projects["tracker"].id, "acme/not-a-known-repo"
+            ),
+            mock_nats_client,
+        )
+
+        resolved = await orchestrator._resolve_commit_status_project_id()
+
+        assert resolved is None
+        warning = _published_warning(mock_nats_client)
+        assert warning is not None
+        assert "acme/not-a-known-repo" in warning["payload"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_single_project_flow_without_repo_context_still_posts(
+        self, db_session, account, github_projects, mock_nats_client
+    ):
+        """A one-repo flow triggered manually keeps its unambiguous target."""
+        cursor_config = github_projects["projects"]["cursor-config"]
+        flow = crud_flow.create(
+            db=db_session,
+            flow_in=FlowCreate(
+                name="Single Repo Flow",
+                description="Watches one repo",
+                trigger_event_source=str(github_projects["tracker"].id),
+                trigger_event_types=["pull_request_opened"],
+                prompt_template="Review",
+                agent_type="claude",
+                agent_config={},
+                account_id=account.id,
+            ),
+            account_id=account.id,
+        )
+        flow.trigger_project_ids = [str(cursor_config.id)]
+        db_session.add(flow)
+        db_session.commit()
+
+        orchestrator = _make_orchestrator(
+            db_session,
+            flow,
+            {"source": "github", "type": "manual", "payload": {}},
+            mock_nats_client,
+        )
+
+        resolved = await orchestrator._resolve_commit_status_project_id()
+
+        assert resolved == str(cursor_config.id)
+        assert _published_warning(mock_nats_client) is None
+
+    @pytest.mark.asyncio
+    async def test_multi_repo_flow_without_repo_context_warns_about_the_guess(
+        self, db_session, multi_repo_flow, mock_nats_client
+    ):
+        """With no repo context and several candidates, say the target is a guess."""
+        orchestrator = _make_orchestrator(
+            db_session,
+            multi_repo_flow,
+            {"source": "github", "type": "manual", "payload": {}},
+            mock_nats_client,
+        )
+
+        resolved = await orchestrator._resolve_commit_status_project_id()
+
+        assert resolved == str(multi_repo_flow.trigger_project_ids[0])
+        warning = _published_warning(mock_nats_client)
+        assert warning is not None
+        assert "ambiguous" in warning["payload"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_flow_with_no_trigger_projects_is_silent(
+        self, db_session, account, github_projects, mock_nats_client
+    ):
+        """Flows not tied to a repo are a normal case, not a warning."""
+        flow = crud_flow.create(
+            db=db_session,
+            flow_in=FlowCreate(
+                name="Repo-less Flow",
+                description="No trigger projects",
+                trigger_event_source=str(github_projects["tracker"].id),
+                trigger_event_types=["pull_request_opened"],
+                prompt_template="Review",
+                agent_type="claude",
+                agent_config={},
+                account_id=account.id,
+            ),
+            account_id=account.id,
+        )
+
+        orchestrator = _make_orchestrator(
+            db_session,
+            flow,
+            {"source": "github", "type": "manual", "payload": {}},
+            mock_nats_client,
+        )
+
+        assert await orchestrator._resolve_commit_status_project_id() is None
+        assert _published_warning(mock_nats_client) is None
+
+
+class TestCommitStatusClient:
+    """The tracker client must be built from the resolved project."""
+
+    @pytest.mark.asyncio
+    async def test_tracker_client_is_built_for_the_triggering_project(
+        self,
+        db_session,
+        account,
+        account_user,
+        github_projects,
+        multi_repo_flow,
+        mock_nats_client,
+    ):
+        mender = github_projects["projects"]["mender-mcu"]
+        orchestrator = _make_orchestrator(
+            db_session,
+            multi_repo_flow,
+            _pull_request_event(
+                account, github_projects["tracker"].id, "acme/mender-mcu"
+            ),
+            mock_nats_client,
+        )
+
+        fake_client = MagicMock()
+        with patch(
+            "preloop.api.common.get_tracker_client",
+            new=AsyncMock(return_value=fake_client),
+        ) as mock_get_client:
+            client = await orchestrator._get_tracker_client_for_status()
+
+        assert client is fake_client
+        assert mock_get_client.await_args.kwargs["project_id"] == mender.id
+
+    @pytest.mark.asyncio
+    async def test_no_client_when_the_repository_cannot_be_mapped(
+        self,
+        db_session,
+        account,
+        account_user,
+        github_projects,
+        multi_repo_flow,
+        mock_nats_client,
+    ):
+        orchestrator = _make_orchestrator(
+            db_session,
+            multi_repo_flow,
+            _pull_request_event(
+                account, github_projects["tracker"].id, "acme/somebody-elses-repo"
+            ),
+            mock_nats_client,
+        )
+
+        with patch(
+            "preloop.api.common.get_tracker_client",
+            new=AsyncMock(side_effect=AssertionError("must not be called")),
+        ):
+            assert await orchestrator._get_tracker_client_for_status() is None
+
+
+class TestCommitStatusFailureVisibility:
+    """A failed status POST must reach the execution timeline."""
+
+    @pytest.mark.asyncio
+    async def test_failed_post_emits_an_execution_warning(
+        self, db_session, account, github_projects, multi_repo_flow, mock_nats_client
+    ):
+        """The 422 from #175 used to be invisible while the flow showed green."""
+        orchestrator = _make_orchestrator(
+            db_session,
+            multi_repo_flow,
+            _pull_request_event(
+                account, github_projects["tracker"].id, "acme/mender-mcu"
+            ),
+            mock_nats_client,
+        )
+
+        failing_client = MagicMock()
+        failing_client.connection_details = {"owner": "acme", "repo": "mender-mcu"}
+        failing_client.create_commit_status = AsyncMock(
+            side_effect=RuntimeError("422 - No commit found for SHA")
+        )
+        orchestrator._tracker_client = failing_client
+
+        # Must not raise: a status failure never fails the execution.
+        await orchestrator._update_commit_status("success", "All good")
+
+        warning = _published_warning(mock_nats_client)
+        assert warning is not None
+        message = warning["payload"]["message"]
+        assert "acme/mender-mcu" in message
+        assert "No commit found for SHA" in message
+        assert warning["payload"]["details"]["state"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_successful_post_emits_no_warning(
+        self, db_session, account, github_projects, multi_repo_flow, mock_nats_client
+    ):
+        orchestrator = _make_orchestrator(
+            db_session,
+            multi_repo_flow,
+            _pull_request_event(
+                account, github_projects["tracker"].id, "acme/mender-mcu"
+            ),
+            mock_nats_client,
+        )
+
+        client = MagicMock()
+        client.connection_details = {"owner": "acme", "repo": "mender-mcu"}
+        client.create_commit_status = AsyncMock(return_value={"state": "success"})
+        orchestrator._tracker_client = client
+
+        await orchestrator._update_commit_status("success", "All good")
+
+        client.create_commit_status.assert_awaited_once()
+        assert _published_warning(mock_nats_client) is None
+
+    @pytest.mark.asyncio
+    async def test_repeated_failures_warn_once_per_execution(
+        self, db_session, account, github_projects, multi_repo_flow, mock_nats_client
+    ):
+        """pending + success would otherwise duplicate the same line."""
+        orchestrator = _make_orchestrator(
+            db_session,
+            multi_repo_flow,
+            _pull_request_event(
+                account, github_projects["tracker"].id, "acme/mender-mcu"
+            ),
+            mock_nats_client,
+        )
+
+        failing_client = MagicMock()
+        failing_client.connection_details = {"owner": "acme", "repo": "mender-mcu"}
+        failing_client.create_commit_status = AsyncMock(
+            side_effect=RuntimeError("422 - No commit found for SHA")
+        )
+        orchestrator._tracker_client = failing_client
+
+        await orchestrator._update_commit_status("success", "All good")
+        await orchestrator._update_commit_status("success", "All good")
+
+        assert len(_published_warnings(mock_nats_client)) == 1
+
+
+def _published_warnings(nats_client):
+    """All execution_warning messages published to NATS."""
+    import json
+
+    warnings = []
+    for call in nats_client.publish.await_args_list:
+        payload = json.loads(call.args[1].decode())
+        if payload.get("type") == "execution_warning":
+            warnings.append(payload)
+    return warnings
+
+
+def _published_warning(nats_client):
+    warnings = _published_warnings(nats_client)
+    return warnings[0] if warnings else None

--- a/frontend/src/styles/console-styles.css
+++ b/frontend/src/styles/console-styles.css
@@ -203,10 +203,22 @@ sl-dialog.large::part(panel) {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: var(--sl-spacing-small);
     padding: var(--sl-spacing-small);
     background: var(--sl-color-neutral-50);
     border-radius: var(--sl-border-radius-medium);
     border-left: 3px solid var(--sl-color-neutral-300);
+}
+
+/* Action group (status tag, links, dismiss). Must never be compressed or
+   pushed out of the card by long text in .item-info, otherwise controls such
+   as the dismiss button become unreachable. */
+.item-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--sl-spacing-small);
+    flex: 0 0 auto;
+    margin-left: auto;
 }
 
 .item-card.warning {
@@ -224,10 +236,16 @@ sl-dialog.large::part(panel) {
     flex-direction: column;
     gap: var(--sl-spacing-2x-small);
     flex: 1;
+    /* A flex item's automatic minimum size is its min-content width. Without
+       this, an unbreakable string (e.g. a repo URL in a clone error) makes
+       this column wider than the card and shoves the action group out of
+       view. */
+    min-width: 0;
 }
 
 .item-name {
     font-weight: 600;
+    overflow-wrap: anywhere;
 }
 
 .item-secondary {
@@ -239,6 +257,13 @@ sl-dialog.large::part(panel) {
     font-size: var(--sl-font-size-small);
     color: var(--sl-color-danger-700);
     font-style: italic;
+    /* Break inside long URLs and paths rather than overflowing the row, and
+       cap the message at three lines so one error cannot dominate the card. */
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 /* Empty state */

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -2702,7 +2702,9 @@ export class DashboardView extends AuthedElement {
                             >
                             ${
                               exec.error_message
-                                ? html`<span class="item-error"
+                                ? html`<span
+                                    class="item-error"
+                                    title=${exec.error_message}
                                     >${exec.error_message}</span
                                   >`
                                 : ''
@@ -2711,9 +2713,7 @@ export class DashboardView extends AuthedElement {
                               >${this.formatDate(exec.start_time)}</span
                             >
                           </div>
-                          <div
-                            style="display: flex; align-items: center; gap: var(--sl-spacing-small);"
-                          >
+                          <div class="item-actions">
                             <sl-tag
                               size="small"
                               variant="${this.getStatusColor(exec.status)}"
@@ -2727,8 +2727,11 @@ export class DashboardView extends AuthedElement {
                               View
                             </sl-button>
                             <sl-icon-button
+                              class="item-dismiss"
                               name="x-lg"
-                              label="Dismiss"
+                              label="Dismiss execution ${
+                                exec.flow_name || 'Unnamed Flow'
+                              }"
                               @click=${(e: Event) => {
                                 e.preventDefault();
                                 this.dismissExecution(exec.id);

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -548,6 +548,125 @@ describe('DashboardView', () => {
     expect(element.shadowRoot?.querySelector('.item-card.danger')).to.not.exist;
   });
 
+  describe('Recent Flow Executions dismiss control (#174)', () => {
+    // Alex's failing run: a git clone error long enough to overflow the row.
+    // The URL has no break opportunity, which is what actually broke the
+    // layout: it set the min-content width of the flex column.
+    const LONG_ERROR =
+      'Git clone failed! Could not clone repository ' +
+      'https://github.com/example_org/mender_mcu_firmware_integration_service_repository_mirror.git ' +
+      'into /workspace/src: authentication failed';
+
+    async function mountWithFailedExecution(width: string) {
+      flowExecutionsResponse = [
+        {
+          id: 'execution-failed',
+          flow_id: 'flow-1',
+          flow_name: 'Security Vulnerability Scanner',
+          status: 'FAILED',
+          start_time: '2026-08-04T14:37:00Z',
+          end_time: '2026-08-04T14:38:00Z',
+          error_message: LONG_ERROR,
+        },
+      ];
+
+      const element = await mountDashboard();
+      // Constrain to the main column width the card gets beside the sidebar.
+      element.style.display = 'block';
+      element.style.width = width;
+      await waitUntil(
+        () => !element['loading'],
+        'dashboard did not finish loading'
+      );
+      await element.updateComplete;
+      return element;
+    }
+
+    function dismissButtonOf(element: DashboardView) {
+      const row = element.shadowRoot?.querySelector(
+        '.item-card.failed-execution'
+      ) as HTMLElement | null;
+      const button = row?.querySelector(
+        'sl-icon-button.item-dismiss'
+      ) as HTMLElement | null;
+      return { row, button };
+    }
+
+    // The bug: a long error message pushed the action group past the row's
+    // right edge, so the dismiss control could not be clicked.
+    ['520px', '640px', '900px'].forEach((width) => {
+      it(`keeps the dismiss control inside the row at ${width}`, async () => {
+        const element = await mountWithFailedExecution(width);
+        const { row, button } = dismissButtonOf(element);
+
+        expect(row, 'failed execution row').to.exist;
+        expect(button, 'dismiss button').to.exist;
+
+        const rowBox = row!.getBoundingClientRect();
+        const buttonBox = button!.getBoundingClientRect();
+
+        expect(buttonBox.width, 'dismiss button has width').to.be.greaterThan(
+          0
+        );
+        expect(buttonBox.height, 'dismiss button has height').to.be.greaterThan(
+          0
+        );
+        // Allow a 1px rounding tolerance on the border-box edge.
+        expect(
+          buttonBox.right,
+          'dismiss button overflows the row on the right'
+        ).to.be.at.most(rowBox.right + 1);
+        expect(
+          buttonBox.left,
+          'dismiss button starts beyond the row'
+        ).to.be.at.least(rowBox.left - 1);
+      });
+    });
+
+    it('does not let the error text overflow the row horizontally', async () => {
+      const element = await mountWithFailedExecution('520px');
+      const row = element.shadowRoot?.querySelector(
+        '.item-card.failed-execution'
+      ) as HTMLElement;
+      const error = row.querySelector('.item-error') as HTMLElement;
+
+      expect(error).to.exist;
+      // scrollWidth exceeding clientWidth means content spills out of the box.
+      expect(
+        error.scrollWidth,
+        'error text is wider than its container'
+      ).to.be.at.most(error.clientWidth + 1);
+    });
+
+    it('dismisses the failed execution when the control is clicked', async () => {
+      const element = await mountWithFailedExecution('520px');
+      const { button } = dismissButtonOf(element);
+
+      (button as HTMLElement).click();
+      await element.updateComplete;
+
+      expect(
+        element.shadowRoot?.querySelector('.item-card.failed-execution'),
+        'row remains after dismiss'
+      ).to.not.exist;
+      expect(
+        JSON.parse(
+          localStorage.getItem('dashboard_dismissed_executions') || '[]'
+        )
+      ).to.include('execution-failed');
+    });
+
+    it('exposes an accessible name on the dismiss control', async () => {
+      const element = await mountWithFailedExecution('520px');
+      const { button } = dismissButtonOf(element);
+
+      expect(button?.getAttribute('label')).to.contain('Dismiss');
+      expect(button?.getAttribute('label')).to.contain(
+        'Security Vulnerability Scanner'
+      );
+    });
+  });
+
   it('hides exception cards when there is nothing actionable to show', async () => {
     gatewaySearchResponse = {
       ...gatewaySearchResponse,


### PR DESCRIPTION
Fixes #175 and #174. Target release: v0.14.0.

**Please do not merge yet.** Opened for review.

## #175: commit statuses posted to the wrong repository

`FlowOrchestrator._get_tracker_client_for_status` resolved the project as
`self.flow.trigger_project_ids[0]`, ignoring which repository actually fired the
webhook. For a flow watching more than one project, a push or pull request in
any repository other than the first one produced a status POST against the first
repository, which does not contain that commit. GitHub answered
`422 No commit found for SHA`, `_update_commit_status` caught the exception and
logged it at debug level, and the execution finished green. From the user side
the check simply never appeared, with nothing in the UI explaining why.

Changes:

- `_resolve_commit_status_project_id` resolves the project from the repository
  named in the trigger payload (`repository.full_name` for GitHub,
  `project.path_with_namespace` for GitLab) instead of taking the first
  configured project.
- When the payload names a repository we cannot map to a Preloop project, the
  status is skipped rather than posted to an unrelated repository. Posting a
  check to the wrong repository is worse than posting none.
- `_resolve_trigger_project_id` gained
  `allow_first_project_fallback: bool = True`. Commit status resolution passes
  `False`; every other caller keeps the previous behaviour, so this is not a
  behaviour change for workspace or clone resolution.
- Manual and scheduled runs carry no repository context. With a single
  configured project we use it silently, since there is no ambiguity. With
  several, we warn that the target is ambiguous and keep the historical
  first-project behaviour, so no existing single-repo flow changes.
- Every skip and every provider failure is now surfaced through
  `_emit_execution_warning`, which logs at warning level and publishes an
  `execution_warning` update. Those updates are already persisted by the NATS
  log-persister and already rendered as warnings by the execution view, so the
  reason appears on the execution timeline with no frontend change. Warnings are
  deduped per execution, so a condition hit at both pending and success reports
  once.

## #174: dashboard dismiss control unreachable

The Recent Flow Executions card clipped the dismiss button, so a failed run
could not be cleared from the dashboard.

Root cause is the automatic minimum size of a flex item. `.item-info` was
`flex: 1` with the default `min-width: auto`, which resolves to the min-content
width. A failed execution shows its error message, and a git clone failure
contains a repository URL with no break opportunity, so min-content became as
wide as that URL. The text column then grew past the card and pushed the action
group outside it. Measured at 1512px viewport: row scroll width 809 against
client width 740, with the dismiss button's right edge 68.5px beyond the card.

Changes in `console-styles.css`, plus small markup changes in the card:

- `.item-info` gets `min-width: 0` so the column can shrink. This is the fix.
- `.item-error` and `.item-name` get `overflow-wrap: anywhere`, so long URLs and
  paths wrap instead of forcing width.
- `.item-error` is clamped to three lines, with the full message on the element
  `title` for hover, so one long error cannot dominate the card.
- The action group moved from inline styles to a shared `.item-actions` class
  with `flex: 0 0 auto`, so the tag, links, and dismiss button are never
  compressed.
- The dismiss button has an explicit accessible label naming the flow.

After the fix, 1512px, 1280px, 1100px, and 1024px all report zero horizontal
overflow and the row's scroll width equal to its client width.

Note on overlap: the Mohammed PR #97 evaluation observed that this same card can
render half width beside an empty pair slot. That is a separate grid pairing
concern in `dashboard-control-plane-view.ts`. This PR does not touch the pair
grid, `view-header.ts`, or any hunk that PR #97 modifies, and it does not absorb
that PR. The clipping fixed here reproduces at full width as well, so the two are
independent.

## Tests

- `backend/tests/test_flow_commit_status.py`, 12 new tests. Includes the exact
  #175 repro: a flow with `trigger_project_ids = [cursor-config, mender-mcu]`
  triggered by a `mender-mcu` webhook now resolves to the `mender-mcu` project
  id. Also covers an unmappable repository skipping the status with a warning, a
  provider failure surfacing a warning, a successful post emitting none, and
  warning dedupe.
- `frontend/src/views/authed/dashboard-view.test.ts`, 6 new tests asserting the
  dismiss button stays inside the row at 520px, 640px, and 900px, that the error
  text does not overflow horizontally, that dismissing persists, and that the
  button has an accessible name. The fixture error string uses an unbreakable
  URL, which is what actually triggers the bug.

Both fixes were red/green verified: with the fix reverted the new backend tests
fail on the wrong project id, and the frontend geometry tests fail with the
button overflowing the row by roughly 166px.

Full frontend suite passes at 592 tests, `vite build` succeeds, and
`ruff check` is clean. The 6 failures and 12 errors in the broader
`pytest -k flow` selection reproduce identically on unmodified `main` and come
from a local test database missing the `api_usage.rate_limit_retry_after_ms`
column, so they are unrelated to this change.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Two well-tested bug fixes with no security implications. The commit status fix correctly resolves target repositories from webhook payloads rather than hardcoding the first trigger project. The CSS fix uses the standard `min-width: 0` pattern to prevent flex overflow from long error messages. Both fixes have thorough regression tests with red/green verification.
>
> **Overview**
> Fixes commit statuses posting to the wrong repository in multi-repo flows (#175) and the dashboard dismiss button being pushed out of view by long error messages (#174). The backend fix resolves the target project from the triggering repository payload and surfaces failures as visible execution warnings. The frontend fix prevents flex item overflow by constraining the info column width and clamping error messages.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/flow-status-and-dashboard-174-175. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->