### PR TITLE
fix: stop embedding tracker PATs in git remote URLs (#173)

### DIFF
--- a/backend/preloop/agents/aider.py
+++ b/backend/preloop/agents/aider.py
@@ -300,7 +300,12 @@ exit $AIDER_EXIT_CODE
         # Container configuration
         container_config = {
             "Image": self.image,
-            "Env": [f"{k}={v}" for k, v in env.items()],
+            "Env": [
+                f"{k}={v}"
+                for k, v in self._apply_git_credential_env(
+                    env, execution_context
+                ).items()
+            ],
             "Entrypoint": ["bash", "-c"],  # Override image entrypoint
             "Cmd": [aider_cmd],  # Pass the script as single argument to bash -c
             "WorkingDir": "/workspace",

--- a/backend/preloop/agents/codex.py
+++ b/backend/preloop/agents/codex.py
@@ -224,7 +224,12 @@ class CodexAgent(ContainerAgentExecutor):
         # Container configuration
         container_config = {
             "Image": self.image,
-            "Env": [f"{k}={v}" for k, v in env.items()],
+            "Env": [
+                f"{k}={v}"
+                for k, v in self._apply_git_credential_env(
+                    env, execution_context
+                ).items()
+            ],
             # Don't override entrypoint - let codex-universal image configure environment
             # The entrypoint drops into bash, so pass -c and script as arguments to bash
             "Cmd": ["-c", script],

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -11,7 +11,17 @@ from aiodocker.exceptions import DockerError
 
 from .base import AgentExecutionResult, AgentExecutor, AgentStatus
 from preloop.services.mcp_config_service import MCPConfigService
-from preloop.utils.repo_urls import inject_oauth_token, tracker_host_kind
+from preloop.utils.git_credentials import (
+    GitCredential,
+    build_credential_env,
+    build_credential_setup_shell,
+    credential_username,
+    git_token_env_var,
+    needs_http_path_scoping,
+    strip_url_credentials,
+)
+from preloop.utils.repo_urls import repo_url_log_location, tracker_host_kind
+from preloop.utils.secret_scrubbing import scrub_secret_lines, scrub_secrets
 
 logger = logging.getLogger(__name__)
 
@@ -221,7 +231,12 @@ class ContainerAgentExecutor(AgentExecutor):
         # Container configuration
         container_config = {
             "Image": self.image,
-            "Env": [f"{k}={v}" for k, v in env.items()],
+            "Env": [
+                f"{k}={v}"
+                for k, v in self._apply_git_credential_env(
+                    env, execution_context
+                ).items()
+            ],
             "User": "10000:10000",  # Explicitly set user and group
             "WorkingDir": working_dir,  # Set working directory to git repo if configured
             "Labels": {
@@ -339,8 +354,13 @@ class ContainerAgentExecutor(AgentExecutor):
             )
             env["MCP_CONFIG_JSON"] = json.dumps(mcp_config)
 
-        # Convert env dict to list of V1EnvVar
-        env_vars = [client.V1EnvVar(name=k, value=v) for k, v in env.items()]
+        # Convert env dict to list of V1EnvVar. Git credentials are merged in
+        # here rather than baked into the agent script, so the token stays out
+        # of the pod's command line (issue #173).
+        env_vars = [
+            client.V1EnvVar(name=k, value=v)
+            for k, v in self._apply_git_credential_env(env, execution_context).items()
+        ]
 
         # Get resource limits from config or use defaults
         memory_limit = os.getenv("AGENT_MEMORY_LIMIT", "2Gi")
@@ -1029,15 +1049,21 @@ class ContainerAgentExecutor(AgentExecutor):
         """
         Get logs from a container (batch mode).
 
+        Output is scrubbed of known credential formats before it is returned,
+        because every consumer of this method either persists the lines or
+        shows them to a user (issue #173).
+
         Args:
             session_reference: Container ID or Job name
             tail: Number of recent log lines, or None for all logs
 
         Returns:
-            List of log lines
+            List of log lines, with secrets redacted
         """
         if self.use_kubernetes:
-            return await self._get_kubernetes_logs(session_reference, tail)
+            return scrub_secret_lines(
+                await self._get_kubernetes_logs(session_reference, tail)
+            )
 
         try:
             docker = await self._get_docker_client()
@@ -1054,7 +1080,7 @@ class ContainerAgentExecutor(AgentExecutor):
                     decoded_logs.append(line.decode("utf-8", errors="replace"))
                 else:
                     decoded_logs.append(line)
-            return decoded_logs
+            return scrub_secret_lines(decoded_logs)
 
         except DockerError as e:
             self.logger.error(
@@ -1066,18 +1092,22 @@ class ContainerAgentExecutor(AgentExecutor):
         """
         Stream logs from a container in real-time.
 
+        Lines are scrubbed of known credential formats before they are yielded,
+        so neither the persisted execution log nor the live console feed can
+        carry a token (issue #173).
+
         Args:
             session_reference: Container ID or Job name
 
         Yields:
-            Log lines as they are produced
+            Log lines as they are produced, with secrets redacted
         """
         if self.use_kubernetes:
             async for line in self._stream_kubernetes_logs(session_reference):
-                yield line
+                yield scrub_secrets(line)
         else:
             async for line in self._stream_docker_logs(session_reference):
-                yield line
+                yield scrub_secrets(line)
 
     async def _stream_docker_logs(self, container_id: str):
         """
@@ -1294,6 +1324,67 @@ class ContainerAgentExecutor(AgentExecutor):
             )
             yield f"[ERROR] Unexpected error: {error_message}"
 
+    # Keys under which resolved git secrets are stashed on the execution
+    # context, to be turned into container environment variables. Private to
+    # this class; nothing outside the agent layer should read them.
+    GIT_CREDENTIALS_CONTEXT_KEY = "_git_credentials"
+    GIT_API_TOKENS_CONTEXT_KEY = "_git_api_tokens"
+
+    def _register_git_credentials(
+        self,
+        execution_context: Dict[str, Any],
+        credentials: Dict[int, GitCredential],
+    ) -> None:
+        """Stash resolved git-transport credentials for conversion to env vars."""
+
+        if credentials:
+            execution_context[self.GIT_CREDENTIALS_CONTEXT_KEY] = credentials
+
+    def _register_git_api_token(
+        self, execution_context: Dict[str, Any], repo_index: int, token: str
+    ) -> str:
+        """Stash a REST API token for one repository and return its env var name.
+
+        The post-execution PR/MR calls talk to the GitHub/GitLab REST API, not
+        to git, so they cannot use the credential helper. They read the token
+        from this variable instead of having it baked into the shell script.
+        """
+
+        tokens = execution_context.setdefault(self.GIT_API_TOKENS_CONTEXT_KEY, {})
+        tokens[repo_index] = token
+        return git_token_env_var(repo_index)
+
+    def _git_credential_env(self, execution_context: Dict[str, Any]) -> Dict[str, str]:
+        """Return env vars carrying git secrets for this execution.
+
+        Called by every container start path after the init and post-execution
+        commands have been built, since that is when secrets are resolved.
+        Returns an empty dict when the flow clones nothing or has no token.
+        """
+
+        credentials: Dict[int, GitCredential] = (
+            execution_context.get(self.GIT_CREDENTIALS_CONTEXT_KEY) or {}
+        )
+        env = dict(
+            build_credential_env(credentials[index] for index in sorted(credentials))
+        )
+
+        api_tokens: Dict[int, str] = (
+            execution_context.get(self.GIT_API_TOKENS_CONTEXT_KEY) or {}
+        )
+        for repo_index, token in api_tokens.items():
+            env[git_token_env_var(repo_index)] = token
+
+        return env
+
+    def _apply_git_credential_env(
+        self, env: Dict[str, str], execution_context: Dict[str, Any]
+    ) -> Dict[str, str]:
+        """Merge git credential env vars into an agent's environment."""
+
+        env.update(self._git_credential_env(execution_context))
+        return env
+
     def _prepare_init_commands(self, execution_context: Dict[str, Any]) -> str:
         """
         Prepare initialization commands (git clone, custom commands).
@@ -1467,53 +1558,73 @@ class ContainerAgentExecutor(AgentExecutor):
 
         return repo_url
 
-    def _inject_git_credentials_into_url(
+    def _resolve_repository_token(
         self,
-        repo_url: str,
         repo_config: Dict[str, Any],
         execution_context: Dict[str, Any],
-    ) -> str:
-        """Inject tracker credentials into HTTPS clone URLs when needed."""
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Return ``(token, tracker_type)`` for one repository entry."""
 
-        if "@" in repo_url:
-            return repo_url
-
-        token: Optional[str] = None
-        tracker_type: Optional[str] = None
         tracker_id = repo_config.get("tracker_id")
         git_credentials_map = execution_context.get("git_credentials_map", {})
 
         if tracker_id and tracker_id in git_credentials_map:
             tracker_creds = git_credentials_map.get(tracker_id, {})
-            token = tracker_creds.get("token")
-            tracker_type = tracker_creds.get("tracker_type")
-        else:
-            trigger_project_id = execution_context.get("trigger_project_id")
-            if trigger_project_id:
-                token, tracker_type = self._get_token_from_project(
-                    trigger_project_id, execution_context.get("account_id")
-                )
+            return tracker_creds.get("token"), tracker_creds.get("tracker_type")
 
+        trigger_project_id = execution_context.get("trigger_project_id")
+        if trigger_project_id:
+            return self._get_token_from_project(
+                trigger_project_id, execution_context.get("account_id")
+            )
+
+        return None, None
+
+    def _build_git_credential(
+        self,
+        repo_url: str,
+        repo_config: Dict[str, Any],
+        execution_context: Dict[str, Any],
+    ) -> Optional[GitCredential]:
+        """Resolve the credential for a repository without touching its URL.
+
+        The returned credential is written to a git credential store inside the
+        container. The clone URL itself stays credential-free, so ``git remote
+        -v`` in the workspace cannot leak the token (issue #173).
+        """
+
+        safe_url = strip_url_credentials(repo_url)
+
+        token, tracker_type = self._resolve_repository_token(
+            repo_config, execution_context
+        )
         if not token:
             self.logger.warning(
-                "No token available to inject into repository URL. "
-                "Clone may fail if the repository is private."
+                "No token available for %s. "
+                "Clone may fail if the repository is private.",
+                repo_url_log_location(safe_url),
             )
-            return repo_url
+            return None
 
-        host_kind = tracker_host_kind(repo_url)
-        if host_kind == "github" or tracker_type == "github":
-            self.logger.info("Injected GitHub token into URL")
-            return inject_oauth_token(repo_url, token, token_as_username=True)
-        if host_kind == "gitlab" or tracker_type == "gitlab":
-            self.logger.info("Injected GitLab token into URL")
-            return inject_oauth_token(repo_url, token, user="gitlab-ci-token")
+        host_kind = tracker_host_kind(safe_url)
+        if host_kind is None and tracker_type not in {"github", "gitlab"}:
+            # Still authenticate: an unrecognized host is usually a self-hosted
+            # instance, and refusing here would break clones that work today.
+            # Only the username convention is uncertain, not the token itself.
+            self.logger.warning(
+                "Could not determine tracker type for %s (tracker_type=%s); "
+                "using the generic credential username",
+                repo_url_log_location(safe_url),
+                tracker_type,
+            )
 
-        self.logger.warning(
-            "Could not determine tracker type for token injection (tracker_type=%s)",
-            tracker_type,
+        username = credential_username(host_kind, tracker_type)
+        self.logger.info(
+            "Prepared git credential for %s (user=%s, token not in URL)",
+            repo_url_log_location(safe_url),
+            username,
         )
-        return repo_url
+        return GitCredential(repo_url=safe_url, username=username, token=token)
 
     def _resolve_repository_clone_path(
         self, repo_config: Dict[str, Any], repo_index: int
@@ -1710,8 +1821,14 @@ echo "========================================="
         target_branch: str,
         commit_sha: Optional[str],
         trigger_data: Dict[str, Any],
+        credentials: Optional[Dict[int, GitCredential]] = None,
     ) -> Optional[list[str]]:
-        """Build shell command blocks for one repository."""
+        """Build shell command blocks for one repository.
+
+        Any resolved credential is recorded in ``credentials`` rather than
+        written into the clone URL, so the remote stored in ``.git/config``
+        never contains a secret (issue #173).
+        """
 
         repo_url = self._resolve_repository_clone_url(
             repo_config, repo_index, execution_context, trigger_data
@@ -1726,9 +1843,14 @@ echo "========================================="
             )
             return None
 
-        repo_url = self._inject_git_credentials_into_url(
+        credential = self._build_git_credential(
             repo_url, repo_config, execution_context
         )
+        if credential is not None and credentials is not None:
+            credentials[repo_index] = credential
+
+        # The URL that reaches `git clone` is always credential-free.
+        repo_url = strip_url_credentials(repo_url)
         full_path = self._resolve_repository_clone_path(repo_config, repo_index)
         clone_branch = self._resolve_repository_clone_branch(
             repo_config,
@@ -1786,6 +1908,7 @@ echo "========================================="
             )
 
             clone_commands: list[str] = []
+            credentials: Dict[int, GitCredential] = {}
             configured_repos_count = 0
             for idx, repo_config in enumerate(repositories):
                 command_block = self._build_repository_clone_command_block(
@@ -1796,6 +1919,7 @@ echo "========================================="
                     target_branch=target_branch,
                     commit_sha=commit_sha,
                     trigger_data=trigger_data,
+                    credentials=credentials,
                 )
                 if command_block is None:
                     continue
@@ -1818,9 +1942,19 @@ echo "========================================="
                 self.logger.error(error_msg)
                 return f'echo "{error_msg}" && exit 1'
 
+            # Stash the credentials on the context so the agent can pass them
+            # to the container as environment variables. They must never be
+            # rendered into the script itself, which is echoed by some images
+            # and can end up in `kubectl describe`.
+            self._register_git_credentials(execution_context, credentials)
+
+            credential_setup = build_credential_setup_shell(
+                use_http_path=needs_http_path_scoping(credentials.values())
+            )
+
             execution_context["_git_target_branch"] = target_branch
             execution_context["_git_source_branch"] = source_branch
-            return " && ".join(git_setup_commands + clone_commands)
+            return " && ".join(git_setup_commands + [credential_setup] + clone_commands)
 
         except Exception as e:
             self.logger.error(f"Error preparing git clone command: {e}", exc_info=True)
@@ -1887,6 +2021,16 @@ echo "========================================="
                 tracker_type = tracker_creds.get("tracker_type")
                 token = tracker_creds.get("token")
 
+                # The REST API token is passed through the environment rather
+                # than interpolated into the script, so it cannot leak via the
+                # container command line, `kubectl describe`, or a shell trace
+                # (issue #173). `token_ref` is the shell expansion to use.
+                token_ref = ""
+                if token:
+                    token_ref = "${%s}" % self._register_git_api_token(
+                        execution_context, idx, token
+                    )
+
                 # Commands to check for commits and push
                 # Note: Directory is guaranteed to exist because git clone validation would have failed earlier
                 repo_post_commands = [
@@ -1946,7 +2090,7 @@ echo "========================================="
                                     # Use custom title and description
                                     pr_create_cmd = f"""
     curl -X POST \\
-      -H "Authorization: token {token}" \\
+      -H "Authorization: token {token_ref}" \\
       -H "Accept: application/vnd.github.v3+json" \\
       https://api.github.com/repos/{owner}/{repo}/pulls \\
       -d "$(cat <<'PREOF'
@@ -1979,7 +2123,7 @@ PREOF
 
     # Create PR with dynamic title/body
     curl -X POST \\
-      -H "Authorization: token {token}" \\
+      -H "Authorization: token {token_ref}" \\
       -H "Accept: application/vnd.github.v3+json" \\
       https://api.github.com/repos/{owner}/{repo}/pulls \\
       -d "$(cat <<PREOF
@@ -2048,7 +2192,7 @@ PREOF
                                 mr_create_cmd = f"""
     echo "Creating Merge Request on {gitlab_host}..."
     curl -X POST \\
-      -H "PRIVATE-TOKEN: {token}" \\
+      -H "PRIVATE-TOKEN: {token_ref}" \\
       -H "Content-Type: application/json" \\
       https://{gitlab_host}/api/v4/projects/{encoded_path}/merge_requests \\
       -d "$(cat <<'MREOF'
@@ -2081,7 +2225,7 @@ MREOF
 
     echo "Creating Merge Request on {gitlab_host}..."
     curl -X POST \\
-      -H "PRIVATE-TOKEN: {token}" \\
+      -H "PRIVATE-TOKEN: {token_ref}" \\
       -H "Content-Type: application/json" \\
       https://{gitlab_host}/api/v4/projects/{encoded_path}/merge_requests \\
       -d "$(cat <<MREOF
@@ -2125,17 +2269,22 @@ MREOF
     ) -> Optional[str]:
         """Construct repository URL from project and tracker information.
 
-        Uses the tracker URL, project slug, and authentication token to construct
-        a complete clone URL in the format:
-        - GitLab: https://gitlab-ci-token:{token}@{host}/{slug}.git
-        - GitHub: https://{token}@github.com/{slug}.git
+        Uses the tracker URL and project slug to construct a clone URL in the
+        format:
+        - GitLab: https://{host}/{slug}.git
+        - GitHub: https://github.com/{slug}.git
+
+        The URL is deliberately credential-free (issue #173). The tracker token
+        is still required for the lookup to succeed, because a project whose
+        tracker has no key configured cannot be cloned at all, but the token is
+        delivered separately through the git credential helper.
 
         Args:
             project_id: Project ID
             account_id: Account ID
 
         Returns:
-            Repository clone URL with token injected, or None if not found
+            Credential-free repository clone URL, or None if not found
         """
         self.logger.info(
             f"Looking up repo URL for project_id={project_id}, account_id={account_id}"
@@ -2207,7 +2356,7 @@ MREOF
                 slug = project.slug
 
                 if tracker_type == "gitlab":
-                    # GitLab format: https://gitlab-ci-token:{token}@{host}/{slug}.git
+                    # GitLab format: https://{host}/{slug}.git (no credentials)
                     if not tracker.url:
                         self.logger.warning(
                             f"GitLab tracker {tracker.id} has no URL configured"
@@ -2225,19 +2374,19 @@ MREOF
                     if not slug.endswith(".git"):
                         slug = f"{slug}.git"
 
-                    clone_url = f"https://gitlab-ci-token:{token}@{host}/{slug}"
+                    clone_url = f"https://{host}/{slug}"
                     self.logger.info(
                         f"Constructed GitLab clone URL for {slug} on {host}"
                     )
                     return clone_url
 
                 elif tracker_type == "github":
-                    # GitHub format: https://{token}@github.com/{slug}.git
+                    # GitHub format: https://github.com/{slug}.git (no credentials)
                     # Ensure slug ends with .git
                     if not slug.endswith(".git"):
                         slug = f"{slug}.git"
 
-                    clone_url = f"https://{token}@github.com/{slug}"
+                    clone_url = f"https://github.com/{slug}"
                     self.logger.info(f"Constructed GitHub clone URL for {slug}")
                     return clone_url
 

--- a/backend/preloop/agents/gemini.py
+++ b/backend/preloop/agents/gemini.py
@@ -228,7 +228,12 @@ class GeminiAgent(ContainerAgentExecutor):
         # Container configuration
         container_config = {
             "Image": self.image,
-            "Env": [f"{k}={v}" for k, v in env.items()],
+            "Env": [
+                f"{k}={v}"
+                for k, v in self._apply_git_credential_env(
+                    env, execution_context
+                ).items()
+            ],
             "Cmd": ["/bin/bash", "-c", script],
             "WorkingDir": working_dir,
             "Labels": {

--- a/backend/preloop/agents/opencode.py
+++ b/backend/preloop/agents/opencode.py
@@ -244,7 +244,12 @@ class OpenCodeAgent(ContainerAgentExecutor):
         # Container configuration
         container_config = {
             "Image": self.image,
-            "Env": [f"{k}={v}" for k, v in env.items()],
+            "Env": [
+                f"{k}={v}"
+                for k, v in self._apply_git_credential_env(
+                    env, execution_context
+                ).items()
+            ],
             "Cmd": ["/bin/bash", "-c", script],
             "WorkingDir": working_dir,
             "Labels": {

--- a/backend/preloop/agents/openhands.py
+++ b/backend/preloop/agents/openhands.py
@@ -3,16 +3,18 @@
 import json
 import logging
 import os
+import shlex
 from typing import Any, Dict
 
 from aiodocker.exceptions import DockerError
 
 from preloop.services.mcp_config_service import MCPConfigService
 from preloop.services.model_runtime_resolver import gateway_url_for_api
-from preloop.utils.repo_urls import (
-    inject_oauth_token,
-    repo_url_log_location,
-    tracker_host_kind,
+from preloop.utils.git_credentials import (
+    GitCredential,
+    build_credential_setup_shell,
+    needs_http_path_scoping,
+    strip_url_credentials,
 )
 
 from .container import ContainerAgentExecutor
@@ -150,7 +152,12 @@ class OpenHandsAgent(ContainerAgentExecutor):
         # Container configuration
         container_config = {
             "Image": self.image,
-            "Env": [f"{k}={v}" for k, v in env.items()],
+            "Env": [
+                f"{k}={v}"
+                for k, v in self._apply_git_credential_env(
+                    env, execution_context
+                ).items()
+            ],
             # Override entrypoint completely - set to empty list to disable entrypoint.sh
             "Entrypoint": [],
             # Run OpenHands in headless mode
@@ -361,6 +368,7 @@ class OpenHandsAgent(ContainerAgentExecutor):
                     return ""
 
             clone_commands = []
+            credentials: Dict[int, GitCredential] = {}
             trigger_data = execution_context.get("trigger_event_data", {})
             trigger_project_id = execution_context.get("trigger_project_id")
 
@@ -385,51 +393,16 @@ class OpenHandsAgent(ContainerAgentExecutor):
                     )
                     continue
 
-                # Inject token if URL doesn't have credentials
-                if repo_url and "@" not in repo_url:
-                    token = None
-                    tracker_type = None
+                # Resolve the tracker credential without touching the URL, so
+                # the remote written into .git/config stays secret-free and
+                # `git remote -v` cannot leak it (issue #173).
+                credential = self._build_git_credential(
+                    repo_url, repo_config, execution_context
+                )
+                if credential is not None:
+                    credentials[idx] = credential
 
-                    # Try to get credentials from repo config's tracker_id
-                    tracker_id = repo_config.get("tracker_id")
-                    git_credentials_map = execution_context.get(
-                        "git_credentials_map", {}
-                    )
-
-                    if tracker_id and tracker_id in git_credentials_map:
-                        tracker_creds = git_credentials_map.get(tracker_id)
-                        token = tracker_creds.get("token")
-                        tracker_type = tracker_creds.get("tracker_type")
-                    elif trigger_project_id:
-                        # Fallback: try to get token from trigger project's tracker
-                        token, tracker_type = self._get_token_from_project(
-                            trigger_project_id, execution_context.get("account_id")
-                        )
-
-                    if token:
-                        host_kind = tracker_host_kind(repo_url)
-                        if host_kind == "github" or tracker_type == "github":
-                            repo_url = inject_oauth_token(
-                                repo_url, token, token_as_username=True
-                            )
-                            self.logger.info("Injected GitHub token into URL")
-                        elif host_kind == "gitlab" or tracker_type == "gitlab":
-                            repo_url = inject_oauth_token(
-                                repo_url, token, user="gitlab-ci-token"
-                            )
-                            self.logger.info("Injected GitLab token into URL")
-                        else:
-                            self.logger.warning(
-                                "Could not determine tracker type for token injection. "
-                                "URL: %s, tracker_type: %s",
-                                repo_url_log_location(repo_url),
-                                tracker_type,
-                            )
-                    else:
-                        self.logger.warning(
-                            "No token available for repository URL. "
-                            "Clone may fail if the repository is private."
-                        )
+                repo_url = strip_url_credentials(repo_url)
 
                 # Get clone path - if it starts with /, use as-is (absolute), otherwise make it relative to /workspace
                 clone_path = repo_config.get("clone_path", f"workspace-{idx + 1}")
@@ -442,10 +415,13 @@ class OpenHandsAgent(ContainerAgentExecutor):
 
                 # Get branch if specified
                 branch = repo_config.get("branch")
-                branch_arg = f" -b {branch}" if branch else ""
+                branch_arg = f" -b {shlex.quote(branch)}" if branch else ""
 
                 # Build git clone command
-                git_cmd = f"git clone{branch_arg} {repo_url} {full_path}"
+                git_cmd = (
+                    f"git clone{branch_arg} "
+                    f"{shlex.quote(repo_url)} {shlex.quote(full_path)}"
+                )
                 clone_commands.append(git_cmd)
 
                 self.logger.info(f"Prepared git clone command for {full_path}")
@@ -453,8 +429,16 @@ class OpenHandsAgent(ContainerAgentExecutor):
             if not clone_commands:
                 return ""
 
-            # Create workspace directory first, then clone all repos
-            all_commands = ["mkdir -p /workspace"] + clone_commands
+            self._register_git_credentials(execution_context, credentials)
+
+            # Create workspace directory, install the credential helper, then
+            # clone all repos.
+            all_commands = [
+                "mkdir -p /workspace",
+                build_credential_setup_shell(
+                    use_http_path=needs_http_path_scoping(credentials.values())
+                ),
+            ] + clone_commands
             return " && ".join(all_commands)
 
         except Exception as e:

--- a/backend/preloop/models/crud/flow_execution.py
+++ b/backend/preloop/models/crud/flow_execution.py
@@ -376,6 +376,7 @@ class CRUDFlowExecution(CRUDBase[FlowExecution]):
                 after the loop.
         """
         from preloop.models.models.flow_execution_log import FlowExecutionLog
+        from preloop.utils.secret_scrubbing import scrub_secrets, scrub_structure
 
         # NATS messages nest actual content under "payload" (e.g. payload.line
         # for agent_log_line).  Derive message from the best available field
@@ -386,11 +387,14 @@ class CRUDFlowExecution(CRUDBase[FlowExecution]):
         )
         metadata = payload or log_data.get("metadata") or log_data.get("data")
 
+        # Last gate before persistence: redact known credential formats so a
+        # secret cannot be stored even if its producer skipped scrubbing
+        # (issue #173).
         log_entry = FlowExecutionLog(
             execution_id=execution_id,
             log_type=log_data.get("type", "log"),
-            message=message,
-            metadata_=metadata if metadata else None,
+            message=scrub_secrets(message),
+            metadata_=scrub_structure(metadata) if metadata else None,
         )
         db.add(log_entry)
         if commit:

--- a/backend/preloop/models/crud/flow_execution_log.py
+++ b/backend/preloop/models/crud/flow_execution_log.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from preloop.models.models.flow_execution_log import FlowExecutionLog
+from preloop.utils.secret_scrubbing import scrub_secrets, scrub_structure
 from .base import CRUDBase
 
 
@@ -64,6 +65,10 @@ class CRUDFlowExecutionLog(CRUDBase[FlowExecutionLog]):
         """Append a log entry.
 
         Moved from crud_flow_execution.append_log for better grouping.
+
+        Both the message and the metadata payload are scrubbed of known
+        credential formats here. This is the last gate before persistence, so
+        it also covers producers that did not scrub at the source (issue #173).
         """
         payload = log_data.get("payload") or {}
         message = (
@@ -74,8 +79,8 @@ class CRUDFlowExecutionLog(CRUDBase[FlowExecutionLog]):
         log_entry = FlowExecutionLog(
             execution_id=execution_id,
             log_type=log_data.get("type", "log"),
-            message=message,
-            metadata_=metadata if metadata else None,
+            message=scrub_secrets(message),
+            metadata_=scrub_structure(metadata) if metadata else None,
         )
         db.add(log_entry)
         if commit:

--- a/backend/preloop/services/flow_execution_logger.py
+++ b/backend/preloop/services/flow_execution_logger.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from preloop.utils.redaction import redact_dict
+from preloop.utils.secret_scrubbing import scrub_secrets
 
 logger = logging.getLogger(__name__)
 
@@ -147,10 +148,14 @@ class FlowExecutionLogger:
         """
         Log a line of agent output.
 
+        The line is scrubbed of known credential formats before it is stored,
+        because these lines become ``model_output_summary``, which is served
+        over the API and rendered in the console (issue #173).
+
         Args:
             line: A single line of agent stdout/stderr
         """
-        self.agent_output_lines.append(line)
+        self.agent_output_lines.append(scrub_secrets(line) or "")
 
     def get_agent_output_lines(self) -> List[str]:
         """

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 import json
 import asyncio
+import shlex
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 import re
@@ -33,7 +34,14 @@ from preloop.services.prompt_resolvers import (
 from preloop.services.flow_execution_logger import FlowExecutionLogger
 from preloop.sync.event_normalizer import attach_trigger_subject
 from preloop.services.model_runtime_resolver import resolve_ai_model_runtime
-from preloop.utils.repo_urls import inject_oauth_token, tracker_host_kind
+from preloop.utils.git_credentials import (
+    GitCredential,
+    credential_username,
+    strip_url_credentials,
+    temporary_credential_file,
+)
+from preloop.utils.repo_urls import repo_url_log_location, tracker_host_kind
+from preloop.utils.secret_scrubbing import scrub_secrets
 from preloop.services.account_realtime import (
     ACCOUNT_TOPIC_AUDIT,
     ACCOUNT_TOPIC_RUNTIME_SESSIONS,
@@ -964,40 +972,47 @@ class FlowExecutionOrchestrator:
                 else:
                     branch = self._extract_pr_branch_from_trigger()
 
-            branch_arg = f" -b {branch}" if branch else ""
+            branch_arg = f" -b {shlex.quote(branch)}" if branch else ""
 
-            # Prepare git clone command
+            # Resolve tracker credentials. The token is written to a
+            # short-lived credential file rather than into the clone URL, so
+            # the resulting remote carries no secret (issue #173).
+            credential: Optional[GitCredential] = None
             use_tracker_creds = git_config.get("use_tracker_credentials", True)
             if use_tracker_creds:
-                # Get tracker credentials from trigger event
                 credentials = await self._get_tracker_credentials()
                 if credentials:
-                    # Inject credentials into URL
-                    repo_url = self._inject_credentials_into_url(repo_url, credentials)
+                    credential = self._build_clone_credential(repo_url, credentials)
 
+            repo_url = strip_url_credentials(repo_url)
             clone_cmd = (
-                f"git clone --recursive{branch_arg} {repo_url} {full_clone_path}"
+                f"git clone --recursive{branch_arg} "
+                f"{shlex.quote(repo_url)} {shlex.quote(full_clone_path)}"
             )
 
             logger.info(f"Executing git clone to {full_clone_path}")
 
-            # Execute git clone
-            process = await asyncio.create_subprocess_shell(
-                clone_cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=work_dir,
-            )
+            with temporary_credential_file(credential) as clone_env:
+                # Execute git clone
+                process = await asyncio.create_subprocess_shell(
+                    clone_cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=work_dir,
+                    env=clone_env,
+                )
 
-            stdout, stderr = await process.communicate()
+                stdout, stderr = await process.communicate()
 
             if process.returncode != 0:
                 logger.error(
-                    f"Git clone failed with code {process.returncode}: {stderr.decode()}"
+                    "Git clone failed with code %s: %s",
+                    process.returncode,
+                    scrub_secrets(stderr.decode()),
                 )
                 return None
 
-            logger.info(f"Git clone successful: {stdout.decode()}")
+            logger.info(f"Git clone successful: {scrub_secrets(stdout.decode())}")
 
             # Checkout the specific commit SHA from trigger event if available
             # This ensures we're reviewing the exact code from the PR/push event
@@ -1243,35 +1258,45 @@ class FlowExecutionOrchestrator:
             )
             return None
 
-    def _inject_credentials_into_url(
+    def _build_clone_credential(
         self, repo_url: str, credentials: Dict[str, str]
-    ) -> str:
-        """Inject credentials into repository URL for authentication."""
+    ) -> Optional[GitCredential]:
+        """Build a credential for a repository without altering its URL.
+
+        Replaces the previous ``_inject_credentials_into_url``. Embedding the
+        token in the URL made it the repository's ``origin`` remote, so any
+        later ``git remote -v`` leaked it into flow execution logs (issue
+        #173). The token is now supplied through a short-lived credential file
+        instead, leaving the remote clean.
+        """
         try:
             token = credentials.get("token")
             tracker_type = credentials.get("tracker_type")
 
             if not token:
-                return repo_url
+                return None
 
             host_kind = tracker_host_kind(repo_url)
-            if host_kind in {"github", "gitlab"} or tracker_type in {
-                "github",
-                "gitlab",
-            }:
-                return inject_oauth_token(repo_url, token)
+            if host_kind is None and tracker_type not in {"github", "gitlab"}:
+                logger.warning(
+                    "Could not determine tracker type for %s; "
+                    "using the generic credential username",
+                    repo_url_log_location(repo_url),
+                )
 
-            # If we can't inject, return original URL
-            logger.warning("Could not inject credentials into repository URL")
-            return repo_url
+            return GitCredential(
+                repo_url=strip_url_credentials(repo_url),
+                username=credential_username(host_kind, tracker_type),
+                token=token,
+            )
 
         except Exception as e:
             logger.error(
-                "Error injecting credentials: %s",
+                "Error building git credential: %s",
                 type(e).__name__,
                 exc_info=True,
             )
-            return repo_url
+            return None
 
     async def _execute_custom_commands(self, work_dir: str) -> bool:
         """

--- a/backend/preloop/utils/git_credentials.py
+++ b/backend/preloop/utils/git_credentials.py
@@ -246,5 +246,5 @@ def temporary_credential_file(
     finally:
         try:
             os.unlink(path)
-        except OSError:
+        except FileNotFoundError:
             logger.warning("Could not remove temporary git credential file")

--- a/backend/preloop/utils/git_credentials.py
+++ b/backend/preloop/utils/git_credentials.py
@@ -1,0 +1,250 @@
+"""Credential-free git authentication for agent containers.
+
+Historically Preloop authenticated git operations by embedding the tracker
+token directly in the clone URL (``https://<token>@github.com/org/repo.git``).
+That makes the secret part of the repository's ``origin`` remote, so anything
+that prints remotes (``git remote -v``, ``git config --list``, most clone error
+messages) leaks the token into flow execution logs, which are readable through
+the console and the API.
+
+This module builds the pieces needed to authenticate without ever putting the
+secret in the remote URL:
+
+- the repository is cloned from a credential-free URL,
+- the token is delivered to the container in an environment variable,
+- an init snippet writes a mode-0600 ``git credential store`` file from that
+  variable and unsets it.
+
+``git remote -v`` inside the workspace then prints a clean URL.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Dict, Iterable, Iterator, List, Optional
+from urllib.parse import quote, urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
+
+# Environment variable carrying the credential store file contents. Kept in the
+# environment (not the shell script) so the secret is not part of the container
+# command line, and so it can later be sourced from a Kubernetes Secret without
+# touching the script.
+GIT_CREDENTIALS_ENV_VAR = "PRELOOP_GIT_CREDENTIALS"
+
+# Environment variable prefix for per-repository API tokens used by the
+# post-execution PR/MR creation calls.
+GIT_TOKEN_ENV_PREFIX = "PRELOOP_GIT_TOKEN_"
+
+# Location of the generated credential store file inside the container.
+GIT_CREDENTIALS_FILE = "/tmp/.preloop-git-credentials"
+
+# GitHub accepts any username when the fine-grained PAT is sent as the
+# password; ``x-access-token`` is the convention GitHub itself uses.
+GITHUB_CREDENTIAL_USER = "x-access-token"
+GITLAB_CREDENTIAL_USER = "gitlab-ci-token"
+DEFAULT_CREDENTIAL_USER = "oauth2"
+
+
+def credential_username(host_kind: Optional[str], tracker_type: Optional[str]) -> str:
+    """Return the username to pair with a tracker token."""
+
+    kind = (host_kind or tracker_type or "").lower()
+    if kind == "github":
+        return GITHUB_CREDENTIAL_USER
+    if kind == "gitlab":
+        return GITLAB_CREDENTIAL_USER
+    return DEFAULT_CREDENTIAL_USER
+
+
+def strip_url_credentials(repo_url: str) -> str:
+    """Return ``repo_url`` with any embedded userinfo removed.
+
+    Used both to sanitize URLs that arrive with credentials already attached
+    and to guarantee the URL handed to ``git clone`` is safe to print.
+    """
+
+    try:
+        parsed = urlparse(repo_url)
+    except ValueError:
+        return repo_url
+
+    if parsed.scheme not in {"http", "https"}:
+        return repo_url
+    if not parsed.username and not parsed.password:
+        return repo_url
+
+    hostport = parsed.hostname or ""
+    if parsed.port is not None:
+        hostport = f"{hostport}:{parsed.port}"
+
+    return urlunparse(
+        (
+            parsed.scheme,
+            hostport,
+            parsed.path,
+            parsed.params,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+@dataclass(frozen=True)
+class GitCredential:
+    """A token scoped to one repository URL."""
+
+    repo_url: str
+    username: str
+    token: str
+
+    def store_line(self) -> Optional[str]:
+        """Render one line of a ``git credential store`` file.
+
+        Returns None when the URL is not an HTTP(S) URL, since the store helper
+        only applies to HTTP(S) transports (SSH remotes carry no secret here).
+        """
+
+        parsed = urlparse(strip_url_credentials(self.repo_url))
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            return None
+
+        hostport = parsed.hostname
+        if parsed.port is not None:
+            hostport = f"{hostport}:{parsed.port}"
+
+        # Percent-encode userinfo: tokens and usernames may contain characters
+        # that would otherwise break the URL parse git performs on this file.
+        user = quote(self.username, safe="")
+        secret = quote(self.token, safe="")
+        return f"{parsed.scheme}://{user}:{secret}@{hostport}{parsed.path}"
+
+
+def build_credentials_file_content(credentials: Iterable[GitCredential]) -> str:
+    """Render the credential store file for the given credentials.
+
+    Entries are path-scoped so that, when ``credential.useHttpPath`` is on, a
+    flow cloning two repositories from the same host with two different tracker
+    tokens authenticates each one with its own token. Duplicate lines are
+    collapsed while preserving order.
+    """
+
+    lines: List[str] = []
+    seen = set()
+    for credential in credentials:
+        line = credential.store_line()
+        if line and line not in seen:
+            seen.add(line)
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def build_credential_env(credentials: Iterable[GitCredential]) -> Dict[str, str]:
+    """Return the environment variables carrying git credentials, if any."""
+
+    content = build_credentials_file_content(credentials)
+    if not content:
+        return {}
+    return {GIT_CREDENTIALS_ENV_VAR: content}
+
+
+def needs_http_path_scoping(credentials: Iterable[GitCredential]) -> bool:
+    """Return True when a host is served by more than one distinct credential.
+
+    ``credential.useHttpPath=true`` makes git match the stored entry against
+    the full repository path. That is required to keep two tokens for the same
+    host apart, but it also makes lookups brittle: any URL whose path differs
+    from the one we stored (a submodule, a redirect, a ``.git`` suffix
+    mismatch) finds no credential and, with ``GIT_TERMINAL_PROMPT=0``, fails.
+
+    So it is enabled only for the ambiguous case it exists to solve, and left
+    off (host-level matching, which still works against path-scoped entries)
+    for the overwhelmingly common single-token flow.
+    """
+
+    per_host: Dict[str, set] = {}
+    for credential in credentials:
+        if credential.store_line() is None:
+            continue
+        parsed = urlparse(strip_url_credentials(credential.repo_url))
+        host = (parsed.hostname or "").lower()
+        per_host.setdefault(host, set()).add((credential.username, credential.token))
+    return any(len(secrets) > 1 for secrets in per_host.values())
+
+
+def build_credential_setup_shell(*, use_http_path: bool = False) -> str:
+    """Return shell that installs the credential helper from the environment.
+
+    The snippet is a no-op when no credentials were provided, so it is safe to
+    emit unconditionally. ``GIT_TERMINAL_PROMPT=0`` is exported so that a
+    credential miss fails immediately with a readable error instead of blocking
+    the container on an interactive password prompt.
+    """
+
+    http_path_line = (
+        "    git config --global credential.useHttpPath true\n" if use_http_path else ""
+    )
+    return f"""
+export GIT_TERMINAL_PROMPT=0
+if [ -n "${{{GIT_CREDENTIALS_ENV_VAR}:-}}" ]; then
+    (umask 077 && printf '%s\\n' "${GIT_CREDENTIALS_ENV_VAR}" > {GIT_CREDENTIALS_FILE})
+    chmod 600 {GIT_CREDENTIALS_FILE}
+    git config --global credential.helper 'store --file={GIT_CREDENTIALS_FILE}'
+{http_path_line}    unset {GIT_CREDENTIALS_ENV_VAR}
+    echo "Configured git credential helper (credentials are not stored in remotes)"
+fi
+""".strip()
+
+
+def git_token_env_var(repo_index: int) -> str:
+    """Return the env var name holding the API token for one repository."""
+
+    return f"{GIT_TOKEN_ENV_PREFIX}{repo_index + 1}"
+
+
+@contextmanager
+def temporary_credential_file(
+    credential: Optional[GitCredential],
+) -> Iterator[Optional[Dict[str, str]]]:
+    """Yield an environment that authenticates git via a temporary file.
+
+    For git operations Preloop runs directly on the host (rather than inside an
+    agent container). The credential file is created with mode 0600, exists
+    only for the duration of the block, and is removed in a ``finally`` so a
+    failed clone does not leave a token on disk.
+
+    Yields ``None`` when there is no credential, which callers pass straight to
+    ``subprocess`` as ``env`` to mean "inherit the current environment".
+    """
+
+    if credential is None:
+        yield None
+        return
+
+    content = build_credentials_file_content([credential])
+    if not content:
+        yield None
+        return
+
+    handle, path = tempfile.mkstemp(prefix="preloop-git-cred-")
+    try:
+        with os.fdopen(handle, "w") as fh:
+            fh.write(content + "\n")
+        os.chmod(path, 0o600)
+
+        env = os.environ.copy()
+        # -c flags apply to the git invocation without mutating any config file.
+        env["GIT_CONFIG_COUNT"] = "1"
+        env["GIT_CONFIG_KEY_0"] = "credential.helper"
+        env["GIT_CONFIG_VALUE_0"] = f"store --file={path}"
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        yield env
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            logger.warning("Could not remove temporary git credential file")

--- a/backend/preloop/utils/repo_urls.py
+++ b/backend/preloop/utils/repo_urls.py
@@ -1,9 +1,13 @@
-"""Helpers for safe repository URL handling and credential injection."""
+"""Helpers for safe repository URL handling.
+
+Credential handling deliberately lives in ``preloop.utils.git_credentials``:
+URLs here are only ever parsed or sanitized, never given a secret.
+"""
 
 from __future__ import annotations
 
 from typing import Optional
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse
 
 
 def tracker_host_kind(url: str) -> Optional[str]:
@@ -30,42 +34,13 @@ def tracker_host_kind(url: str) -> Optional[str]:
     return None
 
 
-def inject_oauth_token(
-    repo_url: str,
-    token: str,
-    *,
-    user: str = "oauth2",
-    token_as_username: bool = False,
-) -> str:
-    """Insert credentials into an HTTPS repo URL using urlparse/urlunparse."""
-
-    parsed = urlparse(repo_url)
-    if parsed.scheme not in {"http", "https"}:
-        return repo_url
-
-    if parsed.username or parsed.password:
-        return repo_url
-
-    hostname = parsed.hostname or ""
-    hostport = hostname
-    if parsed.port is not None:
-        hostport = f"{hostname}:{parsed.port}"
-
-    if token_as_username:
-        netloc = f"{token}@{hostport}"
-    else:
-        netloc = f"{user}:{token}@{hostport}"
-
-    return urlunparse(
-        (
-            parsed.scheme,
-            netloc,
-            parsed.path,
-            parsed.params,
-            parsed.query,
-            parsed.fragment,
-        )
-    )
+# NOTE: ``inject_oauth_token`` used to live here. It embedded a tracker token
+# in the clone URL, which made the secret part of the repository's ``origin``
+# remote and leaked it into flow execution logs via ``git remote -v``
+# (issue #173). It has been removed rather than deprecated so it cannot be
+# reintroduced by autocomplete. Use ``preloop.utils.git_credentials`` instead,
+# which supplies the token through a git credential helper and leaves the
+# remote URL clean.
 
 
 def repo_url_log_location(repo_url: str) -> str:

--- a/backend/preloop/utils/secret_scrubbing.py
+++ b/backend/preloop/utils/secret_scrubbing.py
@@ -126,7 +126,11 @@ def scrub_secrets(text: Optional[str]) -> Optional[str]:
 
 
 def scrub_secret_lines(lines: List[str]) -> List[str]:
-    """Scrub a batch of log lines."""
+    """Scrub a batch of log lines.
+
+    None-safe by design: entries that are ``None`` become ``""`` so callers
+    always get back a list of strings.
+    """
 
     return [scrub_secrets(line) or "" for line in lines]
 

--- a/backend/preloop/utils/secret_scrubbing.py
+++ b/backend/preloop/utils/secret_scrubbing.py
@@ -1,0 +1,150 @@
+"""Redaction of secrets from agent output before it is persisted or displayed.
+
+This is the defense-in-depth half of the fix for the credential leak in issue
+#173. The primary fix stops Preloop from putting tokens in git remote URLs at
+all, but agent output is arbitrary: an agent can echo an environment variable,
+paste a curl command, or print a URL it constructed itself. Anything that
+reaches flow execution logs is visible in the console and over the API, so it
+is scrubbed on the way in.
+
+Applied to every agent log line, so patterns must be anchored and cheap.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, List, Match, Optional, Pattern, Tuple
+
+REDACTED = "[REDACTED]"
+
+# Known token formats, most specific first. Each pattern keeps its
+# human-recognizable prefix so a redacted log still says which kind of
+# credential leaked, which is what an operator needs in order to rotate it.
+_TOKEN_PATTERNS: List[Tuple[Pattern[str], str]] = [
+    # GitHub fine-grained PAT, and the classic ghp_/gho_/ghu_/ghs_/ghr_ family.
+    (re.compile(r"github_pat_[A-Za-z0-9_]{20,}"), f"github_pat_{REDACTED}"),
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}"), f"ghp_{REDACTED}"),
+    # GitLab personal/project/deploy tokens and CI job tokens.
+    (re.compile(r"\bglpat-[A-Za-z0-9_\-]{16,}"), f"glpat-{REDACTED}"),
+    (
+        re.compile(r"\bgl(?:ptt|rt|soat|ft|imt|agent)-[A-Za-z0-9_\-]{16,}"),
+        f"gl-token-{REDACTED}",
+    ),
+    # OpenAI and Anthropic keys, which flow through the same containers.
+    (re.compile(r"\bsk-ant-[A-Za-z0-9_\-]{16,}"), f"sk-ant-{REDACTED}"),
+    (re.compile(r"\bsk-[A-Za-z0-9_\-]{20,}"), f"sk-{REDACTED}"),
+    # Preloop's own API tokens.
+    (re.compile(r"\bpreloop_[A-Za-z0-9_\-]{16,}"), f"preloop_{REDACTED}"),
+]
+
+# Credentials embedded in a URL's userinfo section:
+#   https://user:token@host/path   ->  https://user:[REDACTED]@host/path
+#   https://github_pat_xxx@host/p  ->  https://[REDACTED]@host/path
+# The userinfo grammar excludes "/" so this cannot run past the authority into
+# the path, and it requires a scheme so it does not fire on email addresses.
+_URL_USERINFO_WITH_PASSWORD = re.compile(
+    r"(?P<scheme>[A-Za-z][A-Za-z0-9+.\-]*://)"
+    r"(?P<user>[^\s:/@]{1,256}):"
+    r"(?P<password>[^\s/@]{1,4096})"
+    r"(?=@[^\s/@]+)"
+)
+_URL_USERINFO_TOKEN_ONLY = re.compile(
+    r"(?P<scheme>[A-Za-z][A-Za-z0-9+.\-]*://)"
+    r"(?P<user>[^\s:/@]{1,4096})"
+    r"(?=@[^\s/@]+)"
+)
+
+# Bearer/PRIVATE-TOKEN style headers, as produced by the PR/MR creation curls.
+_AUTH_HEADER_PATTERNS: List[Pattern[str]] = [
+    re.compile(
+        r"(?P<prefix>[Aa]uthorization:\s*(?:[Bb]earer|[Tt]oken|[Bb]asic)\s+)"
+        r"(?P<secret>[^\s\"']+)"
+    ),
+    re.compile(r"(?P<prefix>PRIVATE-TOKEN:\s*)(?P<secret>[^\s\"']+)"),
+    re.compile(r"(?P<prefix>[Xx]-[Gg]itlab-[Tt]oken:\s*)(?P<secret>[^\s\"']+)"),
+]
+
+# Usernames that carry no secret on their own; when the userinfo is only one of
+# these there is nothing to redact and blanking it would make the log
+# needlessly unreadable.
+_NON_SECRET_USERINFO = {
+    "git",
+    "oauth2",
+    "gitlab-ci-token",
+    "x-access-token",
+    "x-oauth-basic",
+    "token",
+    "user",
+    "username",
+}
+
+
+def _redact_url_credentials(text: str) -> str:
+    """Blank the userinfo portion of any URL that carries a credential."""
+
+    def _password_sub(match: Match[str]) -> str:
+        return f"{match.group('scheme')}{match.group('user')}:{REDACTED}"
+
+    text = _URL_USERINFO_WITH_PASSWORD.sub(_password_sub, text)
+
+    def _token_only_sub(match: Match[str]) -> str:
+        user = match.group("user")
+        # Already handled above, or a bare username with no secret in it.
+        if user == REDACTED or user.lower() in _NON_SECRET_USERINFO:
+            return match.group(0)
+        return f"{match.group('scheme')}{REDACTED}"
+
+    return _URL_USERINFO_TOKEN_ONLY.sub(_token_only_sub, text)
+
+
+def scrub_secrets(text: Optional[str]) -> Optional[str]:
+    """Return ``text`` with known credential formats replaced by placeholders.
+
+    Order matters: URL userinfo is blanked first so that a token inside a URL
+    becomes ``https://[REDACTED]@host/...`` (hiding the fact that a credential
+    was present at all in that position), and remaining bare tokens elsewhere
+    in the line are then replaced by their prefix-preserving placeholder.
+
+    ``None`` and empty input are passed through so callers can apply this
+    without branching.
+    """
+
+    if not text:
+        return text
+
+    scrubbed = _redact_url_credentials(text)
+
+    for header_pattern in _AUTH_HEADER_PATTERNS:
+        scrubbed = header_pattern.sub(
+            lambda m: f"{m.group('prefix')}{REDACTED}", scrubbed
+        )
+
+    for pattern, replacement in _TOKEN_PATTERNS:
+        scrubbed = pattern.sub(replacement, scrubbed)
+
+    return scrubbed
+
+
+def scrub_secret_lines(lines: List[str]) -> List[str]:
+    """Scrub a batch of log lines."""
+
+    return [scrub_secrets(line) or "" for line in lines]
+
+
+def scrub_structure(data: Any) -> Any:
+    """Recursively scrub every string inside a dict/list structure.
+
+    Used as the last gate before log rows are written to the database, so that
+    a secret cannot be persisted by a producer that skipped scrubbing at the
+    source. Non-string scalars are returned unchanged.
+    """
+
+    if isinstance(data, str):
+        return scrub_secrets(data)
+    if isinstance(data, dict):
+        return {key: scrub_structure(value) for key, value in data.items()}
+    if isinstance(data, list):
+        return [scrub_structure(item) for item in data]
+    if isinstance(data, tuple):
+        return tuple(scrub_structure(item) for item in data)
+    return data

--- a/backend/tests/agents/test_agent_openhands.py
+++ b/backend/tests/agents/test_agent_openhands.py
@@ -303,3 +303,69 @@ class TestOpenHandsAgent:
         # Should not fail, just skip the parameters
         assert "LLM_TEMPERATURE" not in env
         assert "LLM_MAX_TOKENS" not in env
+
+
+class TestOpenHandsGitCloneCredentials:
+    """OpenHands overrides _prepare_git_clone_command, so it needs its own
+    coverage for the credential leak in issue #173.
+    """
+
+    PAT = "github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+
+    def _context(self, repo_url="https://github.com/acme/private.git"):
+        return {
+            "flow_id": "flow-1",
+            "execution_id": "exec-1",
+            "git_clone_config": {
+                "enabled": True,
+                "repositories": [
+                    {
+                        "repository_url": repo_url,
+                        "clone_path": "/workspace",
+                        "tracker_id": "tracker-1",
+                    }
+                ],
+            },
+            "git_credentials_map": {
+                "tracker-1": {"token": self.PAT, "tracker_type": "github"}
+            },
+        }
+
+    def test_clone_command_contains_no_token(self, openhands_config):
+        agent = OpenHandsAgent(openhands_config)
+        command = agent._prepare_git_clone_command(self._context())
+        assert self.PAT not in command
+        assert "@github.com" not in command
+
+    def test_clone_url_is_credential_free(self, openhands_config):
+        agent = OpenHandsAgent(openhands_config)
+        command = agent._prepare_git_clone_command(self._context())
+        assert "git clone https://github.com/acme/private.git /workspace" in command
+
+    def test_credential_helper_is_installed_before_cloning(self, openhands_config):
+        agent = OpenHandsAgent(openhands_config)
+        command = agent._prepare_git_clone_command(self._context())
+        assert command.index("credential.helper") < command.index("git clone")
+
+    def test_token_travels_in_the_environment(self, openhands_config):
+        agent = OpenHandsAgent(openhands_config)
+        context = self._context()
+        agent._prepare_git_clone_command(context)
+        env = agent._git_credential_env(context)
+        assert self.PAT in env["PRELOOP_GIT_CREDENTIALS"]
+
+    def test_url_token_is_stripped(self, openhands_config):
+        agent = OpenHandsAgent(openhands_config)
+        command = agent._prepare_git_clone_command(
+            self._context(f"https://{self.PAT}@github.com/acme/private.git")
+        )
+        assert self.PAT not in command
+
+    def test_repo_url_and_branch_are_shell_quoted(self, openhands_config):
+        """Both are attacker-influenced through webhook payloads."""
+        agent = OpenHandsAgent(openhands_config)
+        context = self._context("https://github.com/acme/repo.git; echo pwned")
+        context["git_clone_config"]["repositories"][0]["branch"] = "main; echo pwned"
+        command = agent._prepare_git_clone_command(context)
+        assert "-b 'main; echo pwned'" in command
+        assert "'https://github.com/acme/repo.git; echo pwned'" in command

--- a/backend/tests/agents/test_container.py
+++ b/backend/tests/agents/test_container.py
@@ -1077,3 +1077,221 @@ class TestKubernetesPodWaitMessage:
 
         assert "ImagePullBackOff" in message
         assert "Back-off pulling image" in message
+
+
+class TestGitCloneCredentialsNotInUrl:
+    """Regression tests for issue #173: the tracker PAT leaked into flow logs
+    because it was embedded in the clone URL, which made it part of the cloned
+    repository's ``origin`` remote and therefore visible in ``git remote -v``.
+    """
+
+    PAT = "github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+
+    def _context(self, repo_url="https://github.com/acme/private.git", **overrides):
+        context = {
+            "flow_id": "flow-1",
+            "execution_id": "exec-1",
+            "git_clone_config": {
+                "enabled": True,
+                "repositories": [
+                    {
+                        "repository_url": repo_url,
+                        "clone_path": "/workspace",
+                        "tracker_id": "tracker-1",
+                    }
+                ],
+            },
+            "git_credentials_map": {
+                "tracker-1": {"token": self.PAT, "tracker_type": "github"}
+            },
+        }
+        context.update(overrides)
+        return context
+
+    def test_clone_command_contains_no_token(self, container_executor):
+        command = container_executor._prepare_git_clone_command(self._context())
+        assert self.PAT not in command
+
+    def test_clone_url_is_credential_free(self, container_executor):
+        """The URL handed to ``git clone`` becomes the origin remote verbatim."""
+        command = container_executor._prepare_git_clone_command(self._context())
+        assert "https://github.com/acme/private.git" in command
+        assert "@github.com" not in command
+
+    def test_clone_url_is_stripped_when_config_already_has_a_token(
+        self, container_executor
+    ):
+        """A token pasted into the configured URL must not survive either."""
+        context = self._context(
+            repo_url=f"https://{self.PAT}@github.com/acme/private.git"
+        )
+        command = container_executor._prepare_git_clone_command(context)
+        assert self.PAT not in command
+        assert "@github.com" not in command
+
+    def test_credential_helper_is_configured(self, container_executor):
+        command = container_executor._prepare_git_clone_command(self._context())
+        assert "credential.helper" in command
+        assert "PRELOOP_GIT_CREDENTIALS" in command
+
+    def test_token_is_passed_through_the_environment(self, container_executor):
+        """The secret travels as an env var, never inside the shell script."""
+        context = self._context()
+        container_executor._prepare_git_clone_command(context)
+
+        env = container_executor._git_credential_env(context)
+        assert self.PAT in env["PRELOOP_GIT_CREDENTIALS"]
+        assert "x-access-token" in env["PRELOOP_GIT_CREDENTIALS"]
+
+    def test_gitlab_uses_its_credential_username(self, container_executor):
+        context = self._context(repo_url="https://gitlab.com/acme/repo.git")
+        context["git_credentials_map"]["tracker-1"]["tracker_type"] = "gitlab"
+        container_executor._prepare_git_clone_command(context)
+
+        env = container_executor._git_credential_env(context)
+        assert "gitlab-ci-token" in env["PRELOOP_GIT_CREDENTIALS"]
+
+    def test_no_credential_env_without_a_token(self, container_executor):
+        context = self._context()
+        context["git_credentials_map"] = {}
+        with patch.object(
+            container_executor, "_get_token_from_project", return_value=(None, None)
+        ):
+            command = container_executor._prepare_git_clone_command(context)
+
+        assert "git clone" in command
+        assert container_executor._git_credential_env(context) == {}
+
+    def test_multiple_repos_each_get_a_credential(self, container_executor):
+        context = self._context()
+        context["git_clone_config"]["repositories"].append(
+            {
+                "repository_url": "https://gitlab.com/acme/other.git",
+                "clone_path": "/workspace-2",
+                "tracker_id": "tracker-2",
+            }
+        )
+        context["git_credentials_map"]["tracker-2"] = {
+            "token": "glpat-aBcDeFgHiJkLmNoPqRs",
+            "tracker_type": "gitlab",
+        }
+
+        command = container_executor._prepare_git_clone_command(context)
+        assert self.PAT not in command
+        assert "glpat-aBcDeFgHiJkLmNoPqRs" not in command
+
+        credentials = context[container_executor.GIT_CREDENTIALS_CONTEXT_KEY]
+        assert len(credentials) == 2
+
+    def test_credentials_are_keyed_by_repository_index(self, container_executor):
+        """A skipped repository must not shift the remaining tokens' indices,
+        which would give repo #2 the API token belonging to repo #1.
+        """
+        context = self._context()
+        context["git_clone_config"]["repositories"].insert(
+            0, {"clone_path": "/workspace-0"}
+        )  # no repository_url: this one is skipped
+
+        container_executor._prepare_git_clone_command(context)
+
+        credentials = context[container_executor.GIT_CREDENTIALS_CONTEXT_KEY]
+        assert list(credentials) == [1]
+
+    def test_setup_runs_before_any_clone(self, container_executor):
+        """Otherwise the first clone would prompt for credentials and hang."""
+        command = container_executor._prepare_git_clone_command(self._context())
+        assert command.index("credential.helper") < command.index("git clone")
+
+
+class TestGitApiTokensNotInScript:
+    """The PR/MR creation curls used to interpolate the raw token into the
+    generated shell script (issue #173).
+    """
+
+    PAT = "github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+
+    def _context(self):
+        return {
+            "flow_id": "flow-1",
+            "execution_id": "exec-1",
+            "flow_name": "PR Reviewer",
+            "_git_target_branch": "preloop/fix",
+            "_git_source_branch": "main",
+            "git_clone_config": {
+                "enabled": True,
+                "create_pull_request": True,
+                "repositories": [
+                    {
+                        "repository_url": "https://github.com/acme/private.git",
+                        "clone_path": "/workspace",
+                        "tracker_id": "tracker-1",
+                    }
+                ],
+            },
+            "git_credentials_map": {
+                "tracker-1": {"token": self.PAT, "tracker_type": "github"}
+            },
+            "trigger_event_data": {
+                "repository": {"clone_url": "https://github.com/acme/private.git"},
+            },
+        }
+
+    def test_post_execution_commands_contain_no_token(self, container_executor):
+        context = self._context()
+        commands = container_executor._prepare_git_post_execution_commands(context)
+        assert self.PAT not in commands
+
+    def test_post_execution_uses_an_env_var_reference(self, container_executor):
+        context = self._context()
+        commands = container_executor._prepare_git_post_execution_commands(context)
+        assert "${PRELOOP_GIT_TOKEN_1}" in commands
+
+    def test_token_reaches_the_container_environment(self, container_executor):
+        context = self._context()
+        container_executor._prepare_git_post_execution_commands(context)
+        env = container_executor._apply_git_credential_env({}, context)
+        assert env["PRELOOP_GIT_TOKEN_1"] == self.PAT
+
+
+class TestLogScrubbing:
+    """Logs are scrubbed on read as well, so a token already present in a
+    running container's output never reaches the API or the console (#173).
+    """
+
+    PAT = "github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+
+    @patch.object(ContainerAgentExecutor, "_get_docker_client")
+    async def test_get_logs_scrubs_leaked_remote(
+        self, mock_get_client, container_executor
+    ):
+        leak = f"origin\thttps://{self.PAT}@github.com/acme/private.git (fetch)"
+        mock_docker = AsyncMock()
+        mock_container = AsyncMock()
+        mock_container.log.return_value = ["Cloning...", leak]
+        mock_docker.containers.get.return_value = mock_container
+        mock_get_client.return_value = mock_docker
+
+        logs = await container_executor.get_logs("container-123")
+
+        assert not any(self.PAT in line for line in logs)
+        assert any("[REDACTED]" in line for line in logs)
+        assert logs[0] == "Cloning...", "clean lines pass through unchanged"
+
+    @patch.object(ContainerAgentExecutor, "_stream_docker_logs")
+    async def test_stream_logs_scrubs_leaked_remote(
+        self, mock_stream, container_executor
+    ):
+        leak = f"origin\thttps://{self.PAT}@github.com/acme/private.git (push)"
+
+        async def _lines(_session_reference):
+            yield leak
+
+        mock_stream.side_effect = _lines
+
+        streamed = [
+            line async for line in container_executor.stream_logs("container-123")
+        ]
+
+        assert streamed == [
+            "origin\thttps://[REDACTED]@github.com/acme/private.git (push)"
+        ]

--- a/backend/tests/models/crud/test_flow_execution_log_scrubbing.py
+++ b/backend/tests/models/crud/test_flow_execution_log_scrubbing.py
@@ -1,0 +1,72 @@
+"""Persistence-layer scrubbing tests for issue #173.
+
+``append_log`` is the last gate before a log row is written, so it scrubs even
+when the producer did not. Both implementations are covered because both are
+still called: ``CRUDFlowExecution.append_log`` and the newer
+``CRUDFlowExecutionLog.append_log``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from preloop.models.crud.flow_execution import CRUDFlowExecution
+from preloop.models.crud.flow_execution_log import CRUDFlowExecutionLog
+
+PAT = "github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+LEAK = f"origin\thttps://{PAT}@github.com/acme/private.git (fetch)"
+
+
+@pytest.fixture(params=[CRUDFlowExecution, CRUDFlowExecutionLog])
+def crud(request):
+    return request.param()
+
+
+@pytest.fixture
+def db():
+    session = MagicMock()
+    session.added = []
+    session.add.side_effect = session.added.append
+    return session
+
+
+def _append(crud, db, log_data):
+    crud.append_log(db, "execution-1", log_data)
+    assert len(db.added) == 1
+    return db.added[0]
+
+
+class TestAppendLogScrubbing:
+    def test_message_is_scrubbed(self, crud, db):
+        row = _append(crud, db, {"message": LEAK})
+        assert PAT not in row.message
+        assert "[REDACTED]" in row.message
+
+    def test_nats_payload_line_is_scrubbed(self, crud, db):
+        row = _append(crud, db, {"type": "agent_log_line", "payload": {"line": LEAK}})
+        assert PAT not in row.message
+
+    def test_metadata_is_scrubbed(self, crud, db):
+        row = _append(crud, db, {"message": "ok", "payload": {"line": LEAK}})
+        assert PAT not in str(row.metadata_)
+
+    def test_nested_metadata_is_scrubbed(self, crud, db):
+        row = _append(
+            crud,
+            db,
+            {"message": "ok", "metadata": {"remotes": [LEAK], "count": 1}},
+        )
+        assert PAT not in str(row.metadata_)
+        assert row.metadata_["count"] == 1
+
+    def test_clean_message_is_unchanged(self, crud, db):
+        row = _append(crud, db, {"message": "Cloning into 'repo'..."})
+        assert row.message == "Cloning into 'repo'..."
+
+    def test_log_type_is_preserved(self, crud, db):
+        row = _append(crud, db, {"type": "stderr", "message": LEAK})
+        assert row.log_type == "stderr"
+
+    def test_missing_message_stays_none(self, crud, db):
+        row = _append(crud, db, {"type": "heartbeat"})
+        assert row.message is None

--- a/backend/tests/services/test_flow_execution_logger.py
+++ b/backend/tests/services/test_flow_execution_logger.py
@@ -442,3 +442,42 @@ class TestPrivateParsers:
         logger._try_extract_command_execution("")
 
         # May or may not extract depending on implementation
+
+
+class TestLogAgentOutputScrubbing:
+    """Agent output becomes ``model_output_summary``, which the issue #173
+    report names as one of the places the PAT was visible.
+    """
+
+    PAT = "github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+
+    def test_leaked_remote_line_is_scrubbed(self):
+        logger = FlowExecutionLogger()
+        logger.log_agent_output(
+            f"origin\thttps://{self.PAT}@github.com/acme/private.git (fetch)"
+        )
+
+        assert self.PAT not in logger.get_agent_output_lines()[0]
+        assert "[REDACTED]" in logger.get_agent_output_lines()[0]
+
+    def test_summary_carries_no_token(self):
+        logger = FlowExecutionLogger()
+        logger.log_agent_output("$ git remote -v")
+        logger.log_agent_output(
+            f"origin\thttps://{self.PAT}@github.com/acme/private.git (push)"
+        )
+
+        assert self.PAT not in logger.get_agent_output_summary()
+
+    def test_clean_output_is_unchanged(self):
+        logger = FlowExecutionLogger()
+        logger.log_agent_output("Running tests...")
+
+        assert logger.get_agent_output_lines() == ["Running tests..."]
+
+    def test_empty_line_is_preserved(self):
+        """The summary is joined by newline, so blank lines must survive."""
+        logger = FlowExecutionLogger()
+        logger.log_agent_output("")
+
+        assert logger.get_agent_output_lines() == [""]

--- a/backend/tests/services/test_flow_execution_logger.py
+++ b/backend/tests/services/test_flow_execution_logger.py
@@ -481,3 +481,15 @@ class TestLogAgentOutputScrubbing:
         logger.log_agent_output("")
 
         assert logger.get_agent_output_lines() == [""]
+
+    def test_token_only_line_keeps_redaction_marker(self):
+        """A line that is nothing but a token must scrub to the prefixed
+        ``github_pat_[REDACTED]`` form, not collapse to the empty string.
+
+        This locks in that the ``or ""`` fallback in ``log_agent_output`` only
+        guards against ``None``; it must never swallow the redaction marker.
+        """
+        logger = FlowExecutionLogger()
+        logger.log_agent_output(self.PAT)
+
+        assert logger.get_agent_output_lines() == ["github_pat_[REDACTED]"]

--- a/backend/tests/services/test_flow_orchestrator_git_credentials.py
+++ b/backend/tests/services/test_flow_orchestrator_git_credentials.py
@@ -1,0 +1,146 @@
+"""Tests for credential-free cloning in the flow orchestrator (issue #173).
+
+The orchestrator has its own clone path, separate from the container agents.
+It used to embed the tracker token in the clone URL, so the cloned workspace's
+``origin`` remote carried the secret and any ``git remote -v`` run by the agent
+leaked it into the execution logs.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from preloop.services.flow_orchestrator import FlowExecutionOrchestrator
+
+pytestmark = pytest.mark.asyncio
+
+PAT = "github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+REPO_URL = "https://github.com/acme/private.git"
+
+
+@pytest.fixture
+def orchestrator():
+    orch = FlowExecutionOrchestrator(
+        db=MagicMock(),
+        flow_id="test-flow-id",
+        trigger_event_data={},
+        nats_client=AsyncMock(),
+    )
+    orch.flow = MagicMock()
+    orch.flow.git_clone_config = {
+        "enabled": True,
+        "repository_url": REPO_URL,
+        "clone_path": "repo",
+        "branch": "main",
+        "use_tracker_credentials": True,
+    }
+    orch.execution_log = MagicMock()
+    orch.execution_log.id = "test-execution-id"
+    return orch
+
+
+class TestBuildCloneCredential:
+    def test_returns_credential_without_touching_url(self, orchestrator):
+        credential = orchestrator._build_clone_credential(
+            REPO_URL, {"token": PAT, "tracker_type": "github"}
+        )
+        assert credential.repo_url == REPO_URL
+        assert credential.token == PAT
+        assert credential.username == "x-access-token"
+
+    def test_strips_a_token_already_in_the_url(self, orchestrator):
+        credential = orchestrator._build_clone_credential(
+            f"https://{PAT}@github.com/acme/private.git",
+            {"token": PAT, "tracker_type": "github"},
+        )
+        assert credential.repo_url == REPO_URL
+
+    def test_gitlab_username(self, orchestrator):
+        credential = orchestrator._build_clone_credential(
+            "https://gitlab.com/acme/repo.git",
+            {"token": "glpat-aBcDeFgHiJkLmNoPqRs", "tracker_type": "gitlab"},
+        )
+        assert credential.username == "gitlab-ci-token"
+
+    def test_no_token_yields_no_credential(self, orchestrator):
+        assert orchestrator._build_clone_credential(REPO_URL, {}) is None
+
+
+class TestPerformGitCloneCommand:
+    """Assert on the command and environment handed to the subprocess."""
+
+    async def _run_clone(self, orchestrator, tracker_credentials):
+        captured = {}
+
+        async def fake_subprocess_shell(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env")
+            if captured["env"] and "GIT_CONFIG_VALUE_0" in captured["env"]:
+                path = captured["env"]["GIT_CONFIG_VALUE_0"].split("=", 1)[1]
+                captured["credential_file"] = path
+                captured["credential_file_content"] = open(path).read()
+            process = AsyncMock()
+            process.returncode = 0
+            process.communicate.return_value = (b"done", b"")
+            return process
+
+        with (
+            patch.object(
+                orchestrator,
+                "_get_tracker_credentials",
+                AsyncMock(return_value=tracker_credentials),
+            ),
+            patch(
+                "asyncio.create_subprocess_shell",
+                side_effect=fake_subprocess_shell,
+            ),
+        ):
+            await orchestrator._perform_git_clone("/tmp/work")
+
+        return captured
+
+    async def test_clone_command_has_no_credentials(self, orchestrator):
+        captured = await self._run_clone(
+            orchestrator, {"token": PAT, "tracker_type": "github"}
+        )
+        assert PAT not in captured["cmd"]
+        assert "@github.com" not in captured["cmd"]
+        assert REPO_URL in captured["cmd"]
+
+    async def test_token_is_delivered_through_a_credential_file(self, orchestrator):
+        captured = await self._run_clone(
+            orchestrator, {"token": PAT, "tracker_type": "github"}
+        )
+        assert PAT in captured["credential_file_content"]
+        assert captured["env"]["GIT_CONFIG_KEY_0"] == "credential.helper"
+
+    async def test_credential_file_is_removed_after_the_clone(self, orchestrator):
+        captured = await self._run_clone(
+            orchestrator, {"token": PAT, "tracker_type": "github"}
+        )
+        assert not os.path.exists(captured["credential_file"])
+
+    async def test_url_token_is_stripped_before_cloning(self, orchestrator):
+        orchestrator.flow.git_clone_config["repository_url"] = (
+            f"https://{PAT}@github.com/acme/private.git"
+        )
+        captured = await self._run_clone(
+            orchestrator, {"token": PAT, "tracker_type": "github"}
+        )
+        assert PAT not in captured["cmd"]
+
+    async def test_clone_without_credentials_passes_no_env(self, orchestrator):
+        captured = await self._run_clone(orchestrator, None)
+        assert PAT not in captured["cmd"]
+        assert captured["env"] is None, "inherit the parent environment as before"
+
+    async def test_repo_url_is_shell_quoted(self, orchestrator):
+        """The URL can come from a webhook payload, so it is untrusted."""
+        orchestrator.flow.git_clone_config["repository_url"] = (
+            "https://github.com/acme/repo.git; echo pwned"
+        )
+        captured = await self._run_clone(orchestrator, None)
+        assert "; echo pwned" not in captured["cmd"].replace(
+            "'https://github.com/acme/repo.git; echo pwned'", ""
+        )

--- a/backend/tests/services/test_flow_orchestrator_git_credentials.py
+++ b/backend/tests/services/test_flow_orchestrator_git_credentials.py
@@ -79,7 +79,8 @@ class TestPerformGitCloneCommand:
             if captured["env"] and "GIT_CONFIG_VALUE_0" in captured["env"]:
                 path = captured["env"]["GIT_CONFIG_VALUE_0"].split("=", 1)[1]
                 captured["credential_file"] = path
-                captured["credential_file_content"] = open(path).read()
+                with open(path) as cred_file:
+                    captured["credential_file_content"] = cred_file.read()
             process = AsyncMock()
             process.returncode = 0
             process.communicate.return_value = (b"done", b"")

--- a/backend/tests/utils/test_git_credentials.py
+++ b/backend/tests/utils/test_git_credentials.py
@@ -1,0 +1,389 @@
+"""Tests for preloop.utils.git_credentials.
+
+These cover the primary half of the fix for issue #173: tracker tokens are
+delivered through a git credential helper, so the clone URL (and therefore the
+repository's ``origin`` remote) never contains a secret.
+"""
+
+import os
+import re
+import stat
+import subprocess
+
+import pytest
+
+from preloop.utils.git_credentials import (
+    GIT_CREDENTIALS_ENV_VAR,
+    GitCredential,
+    build_credential_env,
+    build_credential_setup_shell,
+    build_credentials_file_content,
+    credential_username,
+    git_token_env_var,
+    needs_http_path_scoping,
+    strip_url_credentials,
+    temporary_credential_file,
+)
+
+# The exact leak shape reported in issue #173.
+LEAKED_PAT = "github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+
+
+class TestStripUrlCredentials:
+    def test_removes_token_as_username(self) -> None:
+        url = f"https://{LEAKED_PAT}@github.com/acme/private.git"
+        assert strip_url_credentials(url) == "https://github.com/acme/private.git"
+
+    def test_removes_user_and_password(self) -> None:
+        url = "https://gitlab-ci-token:glpat-secret@gitlab.com/acme/repo.git"
+        assert strip_url_credentials(url) == "https://gitlab.com/acme/repo.git"
+
+    def test_preserves_port_and_path(self) -> None:
+        url = "https://token@gitlab.example.com:8443/group/sub/repo.git"
+        assert (
+            strip_url_credentials(url)
+            == "https://gitlab.example.com:8443/group/sub/repo.git"
+        )
+
+    def test_leaves_clean_url_untouched(self) -> None:
+        url = "https://github.com/acme/private.git"
+        assert strip_url_credentials(url) == url
+
+    def test_leaves_ssh_url_untouched(self) -> None:
+        """SSH remotes carry no secret in the URL and must not be rewritten."""
+        url = "git@github.com:acme/private.git"
+        assert strip_url_credentials(url) == url
+
+
+class TestCredentialUsername:
+    def test_github_uses_x_access_token(self) -> None:
+        assert credential_username("github", None) == "x-access-token"
+
+    def test_gitlab_uses_ci_token_user(self) -> None:
+        assert credential_username("gitlab", None) == "gitlab-ci-token"
+
+    def test_falls_back_to_tracker_type(self) -> None:
+        """Self-hosted hosts are unrecognized by hostname but known by type."""
+        assert credential_username(None, "gitlab") == "gitlab-ci-token"
+
+    def test_unknown_uses_generic_user(self) -> None:
+        assert credential_username(None, None) == "oauth2"
+
+
+class TestCredentialStoreFile:
+    def test_store_line_carries_token(self) -> None:
+        credential = GitCredential(
+            "https://github.com/acme/private.git", "x-access-token", LEAKED_PAT
+        )
+        assert (
+            credential.store_line()
+            == f"https://x-access-token:{LEAKED_PAT}@github.com/acme/private.git"
+        )
+
+    def test_store_line_percent_encodes_secret(self) -> None:
+        """A token containing URL metacharacters must not corrupt the file."""
+        credential = GitCredential(
+            "https://github.com/acme/private.git", "x-access-token", "a/b:c@d"
+        )
+        line = credential.store_line()
+        assert "a%2Fb%3Ac%40d" in line
+        # Exactly one '@' separator, so git still parses host correctly.
+        assert line.count("@") == 1
+
+    def test_store_line_ignores_ssh_urls(self) -> None:
+        credential = GitCredential("git@github.com:acme/x.git", "u", "t")
+        assert credential.store_line() is None
+
+    def test_existing_url_credentials_are_not_duplicated(self) -> None:
+        """A URL that already carries a token is sanitized before storing."""
+        credential = GitCredential(
+            f"https://{LEAKED_PAT}@github.com/acme/private.git",
+            "x-access-token",
+            LEAKED_PAT,
+        )
+        line = credential.store_line()
+        assert line == (
+            f"https://x-access-token:{LEAKED_PAT}@github.com/acme/private.git"
+        )
+        assert line.count("@") == 1
+
+    def test_duplicate_credentials_collapse(self) -> None:
+        credential = GitCredential(
+            "https://github.com/acme/private.git", "x-access-token", LEAKED_PAT
+        )
+        content = build_credentials_file_content([credential, credential])
+        assert len(content.splitlines()) == 1
+
+    def test_multiple_repos_each_get_a_line(self) -> None:
+        content = build_credentials_file_content(
+            [
+                GitCredential("https://github.com/acme/a.git", "x-access-token", "t1"),
+                GitCredential("https://gitlab.com/acme/b.git", "gitlab-ci-token", "t2"),
+            ]
+        )
+        assert len(content.splitlines()) == 2
+
+    def test_empty_credentials_produce_no_env(self) -> None:
+        assert build_credential_env([]) == {}
+
+    def test_env_carries_the_file_content(self) -> None:
+        env = build_credential_env(
+            [
+                GitCredential(
+                    "https://github.com/acme/private.git", "x-access-token", LEAKED_PAT
+                )
+            ]
+        )
+        assert LEAKED_PAT in env[GIT_CREDENTIALS_ENV_VAR]
+
+
+class TestHttpPathScoping:
+    def test_single_token_does_not_need_scoping(self) -> None:
+        """The common case stays on host matching, which is more forgiving."""
+        credentials = [
+            GitCredential("https://github.com/acme/a.git", "x-access-token", "t1"),
+            GitCredential("https://github.com/acme/b.git", "x-access-token", "t1"),
+        ]
+        assert needs_http_path_scoping(credentials) is False
+
+    def test_two_tokens_on_one_host_need_scoping(self) -> None:
+        """Without path scoping, one token would shadow the other."""
+        credentials = [
+            GitCredential("https://github.com/acme/a.git", "x-access-token", "t1"),
+            GitCredential("https://github.com/other/b.git", "x-access-token", "t2"),
+        ]
+        assert needs_http_path_scoping(credentials) is True
+
+    def test_two_tokens_on_different_hosts_do_not(self) -> None:
+        credentials = [
+            GitCredential("https://github.com/acme/a.git", "x-access-token", "t1"),
+            GitCredential("https://gitlab.com/acme/b.git", "gitlab-ci-token", "t2"),
+        ]
+        assert needs_http_path_scoping(credentials) is False
+
+
+class TestCredentialSetupShell:
+    def test_shell_never_contains_a_secret(self) -> None:
+        """The token reaches the container by env var, never via the script."""
+        shell = build_credential_setup_shell()
+        assert LEAKED_PAT not in shell
+        assert GIT_CREDENTIALS_ENV_VAR in shell
+
+    def test_shell_is_a_noop_without_credentials(self) -> None:
+        """Guarded by -n so it is safe to emit for flows with no token."""
+        shell = build_credential_setup_shell()
+        assert f'[ -n "${{{GIT_CREDENTIALS_ENV_VAR}:-}}" ]' in shell
+
+    def test_shell_unsets_the_variable(self) -> None:
+        """So the agent process cannot read the token out of its environment."""
+        assert f"unset {GIT_CREDENTIALS_ENV_VAR}" in build_credential_setup_shell()
+
+    def test_shell_restricts_file_permissions(self) -> None:
+        shell = build_credential_setup_shell()
+        assert "umask 077" in shell
+        assert "chmod 600" in shell
+
+    def test_shell_disables_interactive_prompt(self) -> None:
+        """Otherwise a credential miss hangs the container until it times out."""
+        assert "GIT_TERMINAL_PROMPT=0" in build_credential_setup_shell()
+
+    def test_http_path_flag_is_opt_in(self) -> None:
+        assert "credential.useHttpPath" not in build_credential_setup_shell()
+        assert "credential.useHttpPath true" in build_credential_setup_shell(
+            use_http_path=True
+        )
+
+
+class TestGitTokenEnvVar:
+    def test_names_are_one_based_and_distinct(self) -> None:
+        assert git_token_env_var(0) == "PRELOOP_GIT_TOKEN_1"
+        assert git_token_env_var(1) == "PRELOOP_GIT_TOKEN_2"
+
+
+class TestTemporaryCredentialFile:
+    def test_yields_none_without_credential(self) -> None:
+        with temporary_credential_file(None) as env:
+            assert env is None
+
+    def test_creates_private_file_and_removes_it(self) -> None:
+        credential = GitCredential(
+            "https://github.com/acme/private.git", "x-access-token", LEAKED_PAT
+        )
+        with temporary_credential_file(credential) as env:
+            assert env is not None
+            match = re.search(r"store --file=(\S+)", env["GIT_CONFIG_VALUE_0"])
+            assert match
+            path = match.group(1)
+
+            assert LEAKED_PAT in open(path).read()
+            mode = stat.S_IMODE(os.stat(path).st_mode)
+            assert mode == 0o600, (
+                f"credential file is world/group readable: {oct(mode)}"
+            )
+
+        assert not os.path.exists(path), "credential file outlived the context"
+
+    def test_file_is_removed_even_when_the_block_raises(self) -> None:
+        """A failed clone must not leave a token on disk."""
+        credential = GitCredential(
+            "https://github.com/acme/private.git", "x-access-token", LEAKED_PAT
+        )
+        path = None
+        try:
+            with temporary_credential_file(credential) as env:
+                match = re.search(r"store --file=(\S+)", env["GIT_CONFIG_VALUE_0"])
+                path = match.group(1)
+                raise RuntimeError("clone failed")
+        except RuntimeError:
+            pass
+
+        assert path is not None
+        assert not os.path.exists(path)
+
+    def test_env_disables_interactive_prompt(self) -> None:
+        credential = GitCredential(
+            "https://github.com/acme/private.git", "x-access-token", LEAKED_PAT
+        )
+        with temporary_credential_file(credential) as env:
+            assert env["GIT_TERMINAL_PROMPT"] == "0"
+
+
+class TestRealGitClone:
+    """End-to-end check with a real git binary.
+
+    The unit tests above assert on strings; this one asserts on what git
+    actually writes into ``.git/config``, which is what issue #173 was about.
+    """
+
+    def _git(self, *args, cwd, env):
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @pytest.fixture
+    def sandbox(self, tmp_path):
+        """An isolated HOME so the real user's gitconfig is never touched."""
+        home = tmp_path / "home"
+        home.mkdir()
+        env = {
+            "HOME": str(home),
+            "PATH": os.environ.get("PATH", ""),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+        return env
+
+    @pytest.fixture
+    def origin_repo(self, tmp_path, sandbox):
+        """A local repository to clone from."""
+        repo = tmp_path / "origin"
+        repo.mkdir()
+        self._git("init", "-q", "-b", "main", cwd=repo, env=sandbox)
+        self._git("config", "user.email", "t@example.com", cwd=repo, env=sandbox)
+        self._git("config", "user.name", "Test", cwd=repo, env=sandbox)
+        (repo / "README.md").write_text("hello\n")
+        self._git("add", "README.md", cwd=repo, env=sandbox)
+        self._git("commit", "-qm", "init", cwd=repo, env=sandbox)
+        return repo
+
+    def test_setup_shell_configures_git_and_leaves_no_secret_in_config(
+        self, tmp_path, sandbox
+    ):
+        """Run the generated setup script through a real shell, then ask git."""
+        credential = GitCredential(
+            "https://github.com/acme/private.git", "x-access-token", LEAKED_PAT
+        )
+        env = dict(sandbox)
+        env[GIT_CREDENTIALS_ENV_VAR] = build_credentials_file_content([credential])
+
+        credentials_file = tmp_path / "creds"
+        script = build_credential_setup_shell().replace(
+            "/tmp/.preloop-git-credentials", str(credentials_file)
+        )
+        subprocess.run(
+            ["sh", "-c", script], cwd=tmp_path, env=env, check=True, capture_output=True
+        )
+
+        helper = self._git(
+            "config", "--global", "credential.helper", cwd=tmp_path, env=sandbox
+        ).stdout
+        assert "store --file=" in helper
+
+        gitconfig = (tmp_path / "home" / ".gitconfig").read_text()
+        assert LEAKED_PAT not in gitconfig, "token must live in the store, not config"
+
+        assert LEAKED_PAT in credentials_file.read_text()
+        assert stat.S_IMODE(os.stat(credentials_file).st_mode) == 0o600
+
+    def test_cloned_repo_has_a_credential_free_remote(
+        self, tmp_path, sandbox, origin_repo
+    ):
+        """The regression test for the report: ``git remote -v`` is safe."""
+        clone_path = tmp_path / "clone"
+        env = dict(sandbox)
+        env[GIT_CREDENTIALS_ENV_VAR] = build_credentials_file_content(
+            [
+                GitCredential(
+                    "https://github.com/acme/private.git", "x-access-token", LEAKED_PAT
+                )
+            ]
+        )
+
+        script = build_credential_setup_shell().replace(
+            "/tmp/.preloop-git-credentials", str(tmp_path / "creds")
+        )
+        script += f" && git clone -q {origin_repo} {clone_path}"
+        subprocess.run(
+            ["sh", "-c", script], cwd=tmp_path, env=env, check=True, capture_output=True
+        )
+
+        remotes = self._git("remote", "-v", cwd=clone_path, env=sandbox).stdout
+        assert LEAKED_PAT not in remotes
+        assert "@" not in remotes.replace(str(origin_repo), "")
+
+        config = (clone_path / ".git" / "config").read_text()
+        assert LEAKED_PAT not in config
+
+    def test_env_var_is_not_visible_to_the_agent_process(self, tmp_path, sandbox):
+        """The setup script unsets it, so a later `env` dump cannot leak it."""
+        env = dict(sandbox)
+        env[GIT_CREDENTIALS_ENV_VAR] = build_credentials_file_content(
+            [
+                GitCredential(
+                    "https://github.com/acme/private.git", "x-access-token", LEAKED_PAT
+                )
+            ]
+        )
+        script = build_credential_setup_shell().replace(
+            "/tmp/.preloop-git-credentials", str(tmp_path / "creds")
+        )
+        script += " && env"
+
+        result = subprocess.run(
+            ["sh", "-c", script],
+            cwd=tmp_path,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert LEAKED_PAT not in result.stdout
+
+    def test_setup_shell_is_a_noop_without_the_env_var(self, tmp_path, sandbox):
+        """Flows that clone nothing must not fail or write a global config."""
+        script = build_credential_setup_shell().replace(
+            "/tmp/.preloop-git-credentials", str(tmp_path / "creds")
+        )
+        subprocess.run(
+            ["sh", "-c", script],
+            cwd=tmp_path,
+            env=sandbox,
+            check=True,
+            capture_output=True,
+        )
+        assert not (tmp_path / "creds").exists()

--- a/backend/tests/utils/test_git_credentials.py
+++ b/backend/tests/utils/test_git_credentials.py
@@ -215,7 +215,9 @@ class TestTemporaryCredentialFile:
             assert match
             path = match.group(1)
 
-            assert LEAKED_PAT in open(path).read()
+            with open(path) as cred_file:
+                content = cred_file.read()
+            assert LEAKED_PAT in content
             mode = stat.S_IMODE(os.stat(path).st_mode)
             assert mode == 0o600, (
                 f"credential file is world/group readable: {oct(mode)}"

--- a/backend/tests/utils/test_repo_urls.py
+++ b/backend/tests/utils/test_repo_urls.py
@@ -1,7 +1,8 @@
 """Tests for preloop.utils.repo_urls module."""
 
+import pytest
+
 from preloop.utils.repo_urls import (
-    inject_oauth_token,
     repo_url_log_location,
     tracker_host_kind,
 )
@@ -21,31 +22,24 @@ class TestTrackerHostKind:
         assert tracker_host_kind("https://mygitlab.com/repo") is None
 
 
-class TestInjectOauthToken:
-    def test_default_oauth2_user(self) -> None:
-        url = "https://github.com/org/repo.git"
-        assert (
-            inject_oauth_token(url, "secret-token")
-            == "https://oauth2:secret-token@github.com/org/repo.git"
-        )
+class TestInjectOauthTokenRemoved:
+    """``inject_oauth_token`` was removed as part of the fix for issue #173.
 
-    def test_gitlab_ci_token_user(self) -> None:
-        url = "https://gitlab.com/org/repo.git"
-        assert (
-            inject_oauth_token(url, "secret-token", user="gitlab-ci-token")
-            == "https://gitlab-ci-token:secret-token@gitlab.com/org/repo.git"
-        )
+    It embedded the tracker token in the clone URL, which made the secret part
+    of the repository's ``origin`` remote and leaked it through ``git remote
+    -v`` into flow execution logs. Credentials are now delivered by
+    ``preloop.utils.git_credentials`` via a git credential helper.
 
-    def test_token_as_username(self) -> None:
-        url = "https://github.com/org/repo.git"
-        assert (
-            inject_oauth_token(url, "secret-token", token_as_username=True)
-            == "https://secret-token@github.com/org/repo.git"
-        )
+    This test pins the removal so the helper cannot quietly come back.
+    """
 
-    def test_skips_existing_credentials(self) -> None:
-        url = "https://oauth2:existing@github.com/org/repo.git"
-        assert inject_oauth_token(url, "secret-token") == url
+    def test_helper_is_gone(self) -> None:
+        import preloop.utils.repo_urls as repo_urls
+
+        assert not hasattr(repo_urls, "inject_oauth_token")
+
+        with pytest.raises(ImportError):
+            from preloop.utils.repo_urls import inject_oauth_token  # noqa: F401
 
 
 class TestRepoUrlLogLocation:

--- a/backend/tests/utils/test_repo_urls.py
+++ b/backend/tests/utils/test_repo_urls.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from preloop.utils import repo_urls
 from preloop.utils.repo_urls import (
     repo_url_log_location,
     tracker_host_kind,
@@ -34,8 +35,6 @@ class TestInjectOauthTokenRemoved:
     """
 
     def test_helper_is_gone(self) -> None:
-        import preloop.utils.repo_urls as repo_urls
-
         assert not hasattr(repo_urls, "inject_oauth_token")
 
         with pytest.raises(ImportError):

--- a/backend/tests/utils/test_secret_scrubbing.py
+++ b/backend/tests/utils/test_secret_scrubbing.py
@@ -1,0 +1,218 @@
+"""Tests for preloop.utils.secret_scrubbing.
+
+The samples below are the shapes Alex Lennon reported in issue #173: a tracker
+PAT embedded in a git remote URL, surfacing through ``git remote -v`` output
+captured into flow execution logs.
+"""
+
+from preloop.utils.secret_scrubbing import (
+    REDACTED,
+    scrub_secret_lines,
+    scrub_secrets,
+    scrub_structure,
+)
+
+# Realistically shaped but fake credentials.
+GITHUB_PAT = "github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+GITHUB_CLASSIC = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+GITLAB_PAT = "glpat-aBcDeFgHiJkLmNoPqRs"
+
+
+class TestIssue173Samples:
+    """The exact leak reported in the issue."""
+
+    def test_git_remote_v_fetch_line(self) -> None:
+        line = f"origin\thttps://{GITHUB_PAT}@github.com/acme/private.git (fetch)"
+        scrubbed = scrub_secrets(line)
+        assert GITHUB_PAT not in scrubbed
+        assert scrubbed == (
+            f"origin\thttps://{REDACTED}@github.com/acme/private.git (fetch)"
+        )
+
+    def test_git_remote_v_push_line(self) -> None:
+        line = f"origin\thttps://{GITHUB_PAT}@github.com/acme/private.git (push)"
+        scrubbed = scrub_secrets(line)
+        assert GITHUB_PAT not in scrubbed
+        assert scrubbed.endswith("(push)")
+
+    def test_both_remote_lines_at_once(self) -> None:
+        lines = [
+            f"origin\thttps://{GITHUB_PAT}@github.com/acme/private.git (fetch)",
+            f"origin\thttps://{GITHUB_PAT}@github.com/acme/private.git (push)",
+        ]
+        scrubbed = scrub_secret_lines(lines)
+        assert not any(GITHUB_PAT in line for line in scrubbed)
+        assert len(scrubbed) == 2
+
+    def test_clone_progress_line(self) -> None:
+        line = f"Cloning into 'https://{GITHUB_PAT}@github.com/acme/private.git'..."
+        assert GITHUB_PAT not in scrub_secrets(line)
+
+    def test_git_error_line_echoes_the_url(self) -> None:
+        """The failure mode behind the errored PR-reviewer pods."""
+        line = (
+            f"fatal: could not read Username for "
+            f"'https://{GITHUB_PAT}@github.com': terminal prompts disabled"
+        )
+        assert GITHUB_PAT not in scrub_secrets(line)
+
+    def test_config_dump_line(self) -> None:
+        line = f"remote.origin.url=https://{GITHUB_PAT}@github.com/acme/private.git"
+        assert GITHUB_PAT not in scrub_secrets(line)
+
+    def test_gitlab_variant(self) -> None:
+        line = f"origin\thttps://oauth2:{GITLAB_PAT}@gitlab.com/acme/repo.git (fetch)"
+        scrubbed = scrub_secrets(line)
+        assert GITLAB_PAT not in scrubbed
+        assert "oauth2" in scrubbed, "username is not a secret and aids debugging"
+
+    def test_credential_helper_user_is_kept(self) -> None:
+        line = f"https://x-access-token:{GITHUB_PAT}@github.com/acme/private.git"
+        scrubbed = scrub_secrets(line)
+        assert GITHUB_PAT not in scrubbed
+        assert (
+            scrubbed == f"https://x-access-token:{REDACTED}@github.com/acme/private.git"
+        )
+
+
+class TestBareTokens:
+    """Tokens printed outside any URL, e.g. an agent echoing an env var."""
+
+    def test_github_fine_grained_pat(self) -> None:
+        scrubbed = scrub_secrets(f"the token is {GITHUB_PAT} ok")
+        assert GITHUB_PAT not in scrubbed
+        assert "github_pat_" in scrubbed, (
+            "prefix is kept so operators know what to rotate"
+        )
+
+    def test_github_classic_token(self) -> None:
+        assert GITHUB_CLASSIC not in scrub_secrets(f"GITHUB_TOKEN={GITHUB_CLASSIC}")
+
+    def test_gitlab_pat(self) -> None:
+        scrubbed = scrub_secrets(f"GITLAB_TOKEN={GITLAB_PAT}")
+        assert GITLAB_PAT not in scrubbed
+        assert "glpat-" in scrubbed
+
+    def test_anthropic_key(self) -> None:
+        key = "sk-ant-api03-aBcDeFgHiJkLmNoPqRsTuVwXyZ"
+        scrubbed = scrub_secrets(f"ANTHROPIC_API_KEY={key}")
+        assert key not in scrubbed
+        assert "sk-ant-" in scrubbed
+
+    def test_openai_key(self) -> None:
+        key = "sk-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+        assert key not in scrub_secrets(f"OPENAI_API_KEY={key}")
+
+    def test_preloop_token(self) -> None:
+        token = "preloop_aBcDeFgHiJkLmNoPqRsTuVwXyZ"
+        assert token not in scrub_secrets(f"PRELOOP_API_KEY={token}")
+
+    def test_multiple_tokens_in_one_line(self) -> None:
+        scrubbed = scrub_secrets(f"{GITHUB_PAT} and also {GITLAB_PAT}")
+        assert GITHUB_PAT not in scrubbed
+        assert GITLAB_PAT not in scrubbed
+
+
+class TestAuthHeaders:
+    """The PR/MR creation curls are echoed by some agents."""
+
+    def test_authorization_token_header(self) -> None:
+        line = f'curl -H "Authorization: token {GITHUB_PAT}" https://api.github.com/x'
+        scrubbed = scrub_secrets(line)
+        assert GITHUB_PAT not in scrubbed
+        assert "Authorization: token [REDACTED]" in scrubbed
+
+    def test_authorization_bearer_header(self) -> None:
+        assert GITHUB_PAT not in scrub_secrets(f"Authorization: Bearer {GITHUB_PAT}")
+
+    def test_authorization_basic_header(self) -> None:
+        secret = "eC1hY2Nlc3MtdG9rZW46Z2hwX3NlY3JldA=="
+        assert secret not in scrub_secrets(f"Authorization: Basic {secret}")
+
+    def test_private_token_header(self) -> None:
+        line = f'curl -H "PRIVATE-TOKEN: {GITLAB_PAT}" https://gitlab.com/api/v4/x'
+        scrubbed = scrub_secrets(line)
+        assert GITLAB_PAT not in scrubbed
+        assert "PRIVATE-TOKEN: [REDACTED]" in scrubbed
+
+    def test_gitlab_webhook_token_header(self) -> None:
+        assert "s3cr3tvalue" not in scrub_secrets("X-Gitlab-Token: s3cr3tvalue")
+
+    def test_lowercase_header_name(self) -> None:
+        assert GITHUB_PAT not in scrub_secrets(f"authorization: bearer {GITHUB_PAT}")
+
+
+class TestFalsePositives:
+    """Scrubbing must not make ordinary logs unreadable."""
+
+    def test_clean_clone_url_is_untouched(self) -> None:
+        line = "Cloning into https://github.com/acme/private.git"
+        assert scrub_secrets(line) == line
+
+    def test_email_address_is_untouched(self) -> None:
+        line = "contact us at support@preloop.ai"
+        assert scrub_secrets(line) == line
+
+    def test_git_author_line_is_untouched(self) -> None:
+        line = "Author: Alex Lennon <alex@example.com>"
+        assert scrub_secrets(line) == line
+
+    def test_ssh_remote_is_untouched(self) -> None:
+        line = "origin\tgit@github.com:acme/private.git (fetch)"
+        assert scrub_secrets(line) == line
+
+    def test_commit_sha_is_untouched(self) -> None:
+        line = "26ca5628f4a1b2c3d4e5f60718293a4b5c6d7e8f HEAD"
+        assert scrub_secrets(line) == line
+
+    def test_url_with_path_is_untouched(self) -> None:
+        line = "GET https://api.github.com/repos/acme/private/pulls 200"
+        assert scrub_secrets(line) == line
+
+    def test_short_sk_word_is_untouched(self) -> None:
+        """Guard against the sk- pattern eating ordinary hyphenated words."""
+        line = "running sk-lint on the tree"
+        assert scrub_secrets(line) == line
+
+
+class TestPassthrough:
+    def test_none_passes_through(self) -> None:
+        assert scrub_secrets(None) is None
+
+    def test_empty_string_passes_through(self) -> None:
+        assert scrub_secrets("") == ""
+
+    def test_scrub_lines_replaces_none_with_empty(self) -> None:
+        assert scrub_secret_lines(["", "ok"]) == ["", "ok"]
+
+
+class TestScrubStructure:
+    """Log metadata is JSON, so scrubbing has to reach nested values."""
+
+    def test_nested_dict_values(self) -> None:
+        data = {
+            "payload": {
+                "line": f"origin https://{GITHUB_PAT}@github.com/acme/x.git (fetch)"
+            }
+        }
+        assert GITHUB_PAT not in str(scrub_structure(data))
+
+    def test_list_of_lines(self) -> None:
+        data = {"lines": [f"remote: {GITHUB_PAT}", "clean line"]}
+        scrubbed = scrub_structure(data)
+        assert GITHUB_PAT not in str(scrubbed)
+        assert scrubbed["lines"][1] == "clean line"
+
+    def test_keys_are_preserved(self) -> None:
+        assert set(scrub_structure({"a": "x", "b": "y"})) == {"a", "b"}
+
+    def test_non_string_scalars_survive(self) -> None:
+        data = {"count": 3, "ok": True, "ratio": 1.5, "nothing": None}
+        assert scrub_structure(data) == data
+
+    def test_tuples_stay_tuples(self) -> None:
+        assert scrub_structure(("a", "b")) == ("a", "b")
+
+    def test_deeply_nested(self) -> None:
+        data = {"a": [{"b": {"c": [f"token {GITHUB_PAT}"]}}]}
+        assert GITHUB_PAT not in str(scrub_structure(data))


### PR DESCRIPTION
Target release: **v0.14.0**. Fixes #173.

## The leak

Flows with `git_clone_config` had the tracker PAT spliced into the clone URL:

```
https://github_pat_xxxx@github.com/org/repo.git
```

That URL becomes the cloned repository's `origin` remote, so any `git remote -v`
the agent ran printed the token straight into the flow execution log, which is
served over the API and rendered in the console. The reporter had rotated PATs
twice before the underlying cause was identified.

## Primary fix: tokens never touch URLs

New `preloop.utils.git_credentials` hands the token to git through a credential
store helper instead:

1. The token travels to the container as `PRELOOP_GIT_CREDENTIALS`.
2. The init script writes it to a `0600` file under `umask 077`, points
   `credential.helper` at that file, then **unsets the variable**, so the agent
   process cannot read it back out of its own environment.
3. The URL handed to `git clone` is always credential-free, so the remote it
   writes into `.git/config` is safe to print.

The secret is deliberately never rendered into the shell script itself, since
some images echo their init commands and the script is visible in
`kubectl describe`.

`GIT_TERMINAL_PROMPT=0` is set so a credential miss fails fast instead of
hanging the container until timeout.

## Five sites embedded credentials, not one

The issue pointed at the clone path. Auditing turned up five:

| Site | Fix |
| --- | --- |
| `container.py::_inject_git_credentials_into_url` | removed |
| `container.py::_get_repo_url_from_project` | returns a credential-free URL |
| `container.py` post-exec PR/MR curls | raw token was interpolated into the generated script; now reads `${PRELOOP_GIT_TOKEN_N}` |
| `openhands.py::_prepare_git_clone_command` | has its own clone path, same fix |
| `flow_orchestrator.py::_inject_credentials_into_url` | removed; clone now runs with an ephemeral credential file unlinked in a `finally` |

`repo_urls.inject_oauth_token` is **deleted** rather than deprecated, so it
cannot be reintroduced by autocomplete. A comment in its place explains why.

## Defense in depth: log scrubbing

New `preloop.utils.secret_scrubbing` redacts:

- URL userinfo (`https://user:token@host` and `https://token@host`), with an
  allowlist so harmless usernames like `git` and `x-access-token` survive and
  logs stay readable
- `Authorization: Bearer/Token/Basic`, `PRIVATE-TOKEN:`, `X-Gitlab-Token:`
- Known token formats: `github_pat_`, `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`,
  `glpat-`, GitLab project/deploy tokens, `sk-ant-`, `sk-`, `preloop_`

Each replacement keeps its prefix, so a redacted log still tells an operator
which kind of credential leaked and therefore what to rotate.

Applied at four layers:

1. `container.get_logs` (read)
2. `container.stream_logs` (live console feed)
3. `FlowExecutionLogger.log_agent_output`, which feeds `model_output_summary`,
   named explicitly in the issue
4. **both** `append_log` implementations, as the last gate before persistence,
   covering producers that skip scrubbing at the source

## Incidental fixes

`repo_url` and `branch` were interpolated unquoted into the openhands and
orchestrator clone commands. Both are webhook-derived. Now `shlex.quote`d, with
tests.

## Testing

100 new tests. Highlights:

- A real-git integration test that runs the generated setup script through a
  shell, clones, and asserts `git remote -v` and `.git/config` contain no token,
  that the credential file is `0600`, and that a later `env` dump cannot see the
  secret.
- Redaction tests built from the leak samples in the issue, plus false-positive
  tests so email addresses, SSH remotes, commit SHAs and clean URLs pass through
  untouched.
- `append_log` tests parameterized over both CRUD implementations.

Verified by mutation: making `strip_url_credentials` a no-op fails 7 tests
across all four affected layers, and disabling `scrub_secrets` fails 36.

Full backend suite: **229 pre-existing failures before and after, identical
sets** (they stem from a local `.env` whose `SECRET_KEY` cannot decrypt test
fixtures, and reproduce on a clean worktree at the base commit). No new mypy
errors; both new modules are mypy-clean.

## Not included

This stops new leaks. Logs already retained from before the fix may still
contain tokens; no backfill is performed here. Worth a follow-up issue, since
the whole point of the report is that a rotated token still sits in history.

Related but untouched, per the brief: the 7 errored agent pods in
preloop-prod are on this same code path. **Prod was not touched.**

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Defense-in-depth security fix: tokens leave URLs and get 4-layer log scrubbing. Well-tested with real-git integration tests and mutation verification. No new mypy errors.
>
> **Overview**
> Fixes credential leak (#173) by moving PATs from git clone URLs into a credential helper, scrubbing agent logs at every persistence layer, and hardening shell commands. 100+ tests cover the fix, edge cases, and false-positive guardrails.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 38434c5. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->