### PR TITLE
feat: OpenRouter provider in add-model dialog, live DeepSeek/Qwen model lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,15 @@ across renames and re-onboarding.
   use), an explicit gateway round-trip check at the end of install
   (`round-trip OK, model=..., latency=...s`) with an actionable failure
   message, and printed reconfigure/undo hints after mutating agents commands.
+- **OpenRouter as a first-class provider in the add-model dialog**: the backend
+  has routed OpenRouter since the gateway fix, but the console never listed it,
+  so adding an OpenRouter model meant choosing "OpenAI-compatible" and knowing
+  the base URL by heart. OpenRouter is now its own entry in the provider list
+  with `https://openrouter.ai/api/v1` prefilled, so "Fetch Available Models"
+  works without typing an endpoint. The model list comes from OpenRouter's own
+  `GET /models` (300+ entries render in full), and the "Other..." escape hatch
+  still accepts custom identifiers such as the Auto Router
+  (`openrouter/auto-beta`).
 
 ### Changed
 
@@ -125,6 +134,17 @@ across renames and re-onboarding.
   archived match; use `preloop agents remove` for permanent deletion.
 
 ### Fixed
+
+- **DeepSeek and Qwen model pickers show the models the provider actually
+  serves**: both providers were queried with a valid API key and the response
+  was thrown away, the key being validated and nothing more, so the picker only
+  ever offered a catalog hardcoded in early 2025. Newer models such as
+  `deepseek-v4-flash` and `deepseek-v4-pro` were invisible in the console even
+  though the bundled price table already prices them. The live list is now
+  returned (sorted and de-duplicated) whenever a key is supplied. An invalid
+  key still surfaces as an authentication error; a network or listing failure
+  falls back to the bundled catalog instead of emptying the picker. The
+  keyless fallback catalog now includes the DeepSeek v4 models.
 
 - **Commit statuses post to the repository that triggered the flow** (#175): a
   flow watching several projects always posted its GitHub check to

--- a/backend/preloop/services/ai_model_provider.py
+++ b/backend/preloop/services/ai_model_provider.py
@@ -436,70 +436,97 @@ async def _get_google_models(api_key: Optional[str] = None) -> List[str]:
     return known_models
 
 
+async def _get_catalog_provider_models(
+    *,
+    provider_label: str,
+    base_url: str,
+    known_models: List[str],
+    api_key: Optional[str] = None,
+) -> List[str]:
+    """List models for a provider that ships an OpenAI-compatible ``/models``.
+
+    Without a key there is nothing to query, so the bundled catalog is
+    returned. With a key we return what the provider actually serves: these
+    catalogs go stale the moment the vendor ships a model (DeepSeek v4 was
+    hidden from the picker for exactly this reason) while litellm already
+    prices the new ids.
+
+    An authentication failure still raises, since the user needs to know the
+    key is bad. Any other failure (network, SDK, unexpected payload) falls
+    back to the bundled catalog rather than showing an empty picker.
+    """
+    if not api_key:
+        return known_models
+
+    from openai import AsyncOpenAI, AuthenticationError
+
+    try:
+        client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            max_retries=1,
+            timeout=15.0,
+        )
+        response = await client.models.list()
+    except AuthenticationError as e:
+        logger.warning("%s authentication failed: %s", provider_label, type(e).__name__)
+        raise ValueError(
+            f"Invalid {provider_label} API key. Please check your API key and "
+            "try again."
+        ) from e
+    except Exception as e:
+        logger.warning(
+            "Failed to list %s models, using bundled catalog: %s",
+            provider_label,
+            type(e).__name__,
+        )
+        return known_models
+
+    live_models = _extract_model_ids(response)
+    if not live_models:
+        # A valid key that lists nothing is more likely a proxy quirk than an
+        # empty account; an empty picker is the worse outcome either way.
+        logger.info("%s returned no models, using bundled catalog", provider_label)
+        return known_models
+
+    logger.info("Listed %d %s models", len(live_models), provider_label)
+    return live_models
+
+
+# Fallback catalog used when no Qwen key is available to list the live set.
+QWEN_KNOWN_MODELS = [
+    "qwen-plus",
+    "qwen-turbo",
+    "qwen-max",
+    "qwq-32b-preview",
+]
+
+# Fallback catalog used when no DeepSeek key is available to list the live set.
+# Keep in step with the deepseek entries in services/data/model_prices.json:
+# a model missing here is invisible in the picker even though it can be priced.
+DEEPSEEK_KNOWN_MODELS = [
+    "deepseek-chat",
+    "deepseek-reasoner",
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
+]
+
+
 async def _get_qwen_models(api_key: Optional[str] = None) -> List[str]:
-    """Return list of known Qwen models and validate API key if provided."""
-
-    # List of known Qwen models (as of January 2025)
-    known_models = [
-        "qwen-plus",
-        "qwen-turbo",
-        "qwen-max",
-        "qwq-32b-preview",
-    ]
-
-    # Qwen uses OpenAI-compatible API
-    if api_key:
-        try:
-            from openai import AsyncOpenAI, AuthenticationError
-
-            client = AsyncOpenAI(
-                api_key=api_key,
-                base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
-            )
-
-            # Try to list models to validate the key
-            await client.models.list()
-
-            logger.info("Qwen API key validated successfully")
-        except AuthenticationError as e:
-            logger.warning(f"Qwen authentication failed: {e}")
-            raise ValueError(
-                "Invalid Qwen API key. Please check your API key and try again."
-            )
-        except Exception as e:
-            logger.error(f"Unexpected error validating Qwen key: {e}")
-
-    return known_models
+    """Return Qwen models, live from the API when a key is supplied."""
+    return await _get_catalog_provider_models(
+        provider_label="Qwen",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        known_models=QWEN_KNOWN_MODELS,
+        api_key=api_key,
+    )
 
 
 async def _get_deepseek_models(api_key: Optional[str] = None) -> List[str]:
-    """Return list of known DeepSeek models and validate API key if provided."""
-
-    # List of known DeepSeek models (as of January 2025)
-    known_models = [
-        "deepseek-chat",
-        "deepseek-reasoner",
-    ]
-
-    # DeepSeek uses OpenAI-compatible API
-    if api_key:
-        try:
-            from openai import AsyncOpenAI, AuthenticationError
-
-            client = AsyncOpenAI(
-                api_key=api_key, base_url="https://api.deepseek.com/v1"
-            )
-
-            # Try to list models to validate the key
-            await client.models.list()
-
-            logger.info("DeepSeek API key validated successfully")
-        except AuthenticationError as e:
-            logger.warning(f"DeepSeek authentication failed: {e}")
-            raise ValueError(
-                "Invalid DeepSeek API key. Please check your API key and try again."
-            )
-        except Exception as e:
-            logger.error(f"Unexpected error validating DeepSeek key: {e}")
-
-    return known_models
+    """Return DeepSeek models, live from the API when a key is supplied."""
+    return await _get_catalog_provider_models(
+        provider_label="DeepSeek",
+        base_url="https://api.deepseek.com/v1",
+        known_models=DEEPSEEK_KNOWN_MODELS,
+        api_key=api_key,
+    )

--- a/backend/tests/services/test_ai_model_provider.py
+++ b/backend/tests/services/test_ai_model_provider.py
@@ -6,12 +6,24 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from preloop.services.ai_model_provider import (
     get_available_models_for_provider,
+    DEEPSEEK_KNOWN_MODELS,
     _get_openai_models,
     _get_anthropic_models,
     _get_google_models,
     _get_qwen_models,
     _get_deepseek_models,
 )
+
+
+def _models_response(*model_ids):
+    """Build an OpenAI-shaped ``models.list()`` response."""
+    response = MagicMock()
+    response.data = []
+    for model_id in model_ids:
+        entry = MagicMock()
+        entry.id = model_id
+        response.data.append(entry)
+    return response
 
 
 class TestGetAvailableModelsForProvider:
@@ -390,16 +402,20 @@ class TestGetQwenModels:
         assert "qwen-max" in result
 
     @pytest.mark.asyncio
-    async def test_get_qwen_models_with_valid_key(self):
-        """Test validation with valid API key."""
+    async def test_get_qwen_models_with_valid_key_returns_live_list(self):
+        """A valid key returns what Qwen actually serves, not the fallback."""
         with patch("openai.AsyncOpenAI") as mock_client:
             mock_instance = MagicMock()
-            mock_instance.models.list = AsyncMock(return_value=MagicMock())
+            mock_instance.models.list = AsyncMock(
+                return_value=_models_response("qwen3-max", "qwen3.5-plus")
+            )
             mock_client.return_value = mock_instance
 
             result = await _get_qwen_models("valid_key")
 
-            assert "qwen-plus" in result
+            assert result == ["qwen3-max", "qwen3.5-plus"]
+            # The stale bundled catalog must not leak into a live answer.
+            assert "qwq-32b-preview" not in result
             mock_client.assert_called_once()
             # Verify it's using Qwen's base URL
             call_kwargs = mock_client.call_args[1]
@@ -407,6 +423,18 @@ class TestGetQwenModels:
                 call_kwargs["base_url"]
                 == "https://dashscope.aliyuncs.com/compatible-mode/v1"
             )
+
+    @pytest.mark.asyncio
+    async def test_get_qwen_models_empty_live_list_falls_back(self):
+        """An empty listing is a proxy quirk, not a reason for an empty picker."""
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=_models_response())
+            mock_client.return_value = mock_instance
+
+            result = await _get_qwen_models("valid_key")
+
+            assert "qwen-plus" in result
 
     @pytest.mark.asyncio
     async def test_get_qwen_models_authentication_error(self):
@@ -453,20 +481,62 @@ class TestGetDeepSeekModels:
         assert "deepseek-reasoner" in result
 
     @pytest.mark.asyncio
-    async def test_get_deepseek_models_with_valid_key(self):
-        """Test validation with valid API key."""
+    async def test_keyless_catalog_includes_v4_models(self):
+        """The bundled catalog must not hide models litellm already prices."""
+        result = await _get_deepseek_models(None)
+        assert "deepseek-v4-flash" in result
+        assert "deepseek-v4-pro" in result
+
+    @pytest.mark.asyncio
+    async def test_keyless_catalog_entries_are_priced(self):
+        """Every fallback id should resolve in the bundled price table.
+
+        This is what keeps the hardcoded list honest as DeepSeek ships models.
+        """
+        import json
+
+        from preloop.services.model_price_catalog import CATALOG_PATH
+
+        prices = json.loads(CATALOG_PATH.read_text())
+        for model_id in DEEPSEEK_KNOWN_MODELS:
+            assert model_id in prices, f"{model_id} missing from model_prices.json"
+
+    @pytest.mark.asyncio
+    async def test_get_deepseek_models_with_valid_key_returns_live_list(self):
+        """A valid key returns the live catalog, which is the point of #171.
+
+        The old code called models.list() purely to validate the key and threw
+        the response away, so deepseek-v4-* stayed invisible in the console.
+        """
         with patch("openai.AsyncOpenAI") as mock_client:
             mock_instance = MagicMock()
-            mock_instance.models.list = AsyncMock(return_value=MagicMock())
+            mock_instance.models.list = AsyncMock(
+                return_value=_models_response(
+                    "deepseek-v4-flash", "deepseek-chat", "deepseek-v4-flash"
+                )
+            )
+            mock_client.return_value = mock_instance
+
+            result = await _get_deepseek_models("valid_key")
+
+            # Sorted and de-duplicated.
+            assert result == ["deepseek-chat", "deepseek-v4-flash"]
+            mock_client.assert_called_once()
+            # Verify it's using DeepSeek's base URL
+            call_kwargs = mock_client.call_args[1]
+            assert call_kwargs["base_url"] == "https://api.deepseek.com/v1"
+
+    @pytest.mark.asyncio
+    async def test_get_deepseek_models_empty_live_list_falls_back(self):
+        """An empty listing falls back rather than emptying the picker."""
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=_models_response())
             mock_client.return_value = mock_instance
 
             result = await _get_deepseek_models("valid_key")
 
             assert "deepseek-chat" in result
-            mock_client.assert_called_once()
-            # Verify it's using DeepSeek's base URL
-            call_kwargs = mock_client.call_args[1]
-            assert call_kwargs["base_url"] == "https://api.deepseek.com/v1"
 
     @pytest.mark.asyncio
     async def test_get_deepseek_models_authentication_error(self):

--- a/frontend/src/components/add-ai-model-modal.test.ts
+++ b/frontend/src/components/add-ai-model-modal.test.ts
@@ -262,3 +262,178 @@ describe('AddAIModelModal model discovery', () => {
     expect(String(discoveryCalls()[0].args[0])).to.not.contain('sk-ant-secret');
   });
 });
+
+/**
+ * OpenRouter as a first-class provider. The backend has supported it since
+ * #176; the picker just never offered it, so users had to know to pick
+ * "OpenAI-compatible" and type the base URL by hand.
+ */
+describe('AddAIModelModal OpenRouter provider', () => {
+  let element: AddAIModelModal;
+  let sandbox: SinonSandbox;
+  let fetchStub: SinonStub;
+
+  const discoveryCalls = () =>
+    fetchStub
+      .getCalls()
+      .filter((call) => String(call.args[0]).includes('available-models'));
+
+  beforeEach(async () => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    sandbox = sinon.createSandbox();
+    fetchStub = sandbox.stub(window, 'fetch');
+    fetchStub.callsFake(async (url: any) => {
+      if (String(url).includes('available-models')) {
+        return new Response(
+          JSON.stringify(['openrouter/auto-beta', 'z-ai/glm-4.6'])
+        );
+      }
+      return new Response(JSON.stringify([]));
+    });
+    element = await fixture(html`<add-ai-model-modal></add-ai-model-modal>`);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    localStorage.clear();
+  });
+
+  it('offers OpenRouter as an LLM provider', () => {
+    const values = (element as any)._availableProviders.map(
+      (p: { value: string }) => p.value
+    );
+    expect(values).to.contain('openrouter');
+  });
+
+  it('does not offer OpenRouter for stt or tts', async () => {
+    (element as any)._currentModel = { model_kind: 'stt' };
+    const values = (element as any)._availableProviders.map(
+      (p: { value: string }) => p.value
+    );
+    expect(values).to.not.contain('openrouter');
+  });
+
+  it('prefills the OpenRouter base URL when the provider is chosen', async () => {
+    await (element as any)._handleProviderChange({
+      target: { value: 'openrouter' },
+    } as unknown as Event);
+
+    expect((element as any)._currentModel.api_endpoint).to.equal(
+      'https://openrouter.ai/api/v1'
+    );
+  });
+
+  it('fetches models without the user typing an endpoint', async () => {
+    await (element as any)._handleProviderChange({
+      target: { value: 'openrouter' },
+    } as unknown as Event);
+    (element as any)._currentModel.api_key = 'sk-or-v1-secret-value';
+
+    await (element as any)._fetchModelsForCurrentProvider();
+
+    expect((element as any)._modelsFetchError).to.equal(null);
+    expect((element as any)._modelSuggestions).to.deep.equal([
+      'openrouter/auto-beta',
+      'z-ai/glm-4.6',
+    ]);
+    // The provider travels in the URL, the endpoint in the body.
+    expect(String(discoveryCalls()[0].args[0])).to.contain(
+      '/providers/openrouter/available-models'
+    );
+    const body = JSON.parse(String(discoveryCalls()[0].args[1].body));
+    expect(body.api_endpoint).to.equal('https://openrouter.ai/api/v1');
+  });
+
+  it('falls back to the default endpoint if the field was cleared', async () => {
+    (element as any)._currentModel = {
+      provider_name: 'openrouter',
+      api_endpoint: '   ',
+      api_key: 'sk-or-v1-secret-value',
+    };
+
+    await (element as any)._fetchModelsForCurrentProvider();
+
+    expect((element as any)._modelsFetchError).to.equal(null);
+    const body = JSON.parse(String(discoveryCalls()[0].args[1].body));
+    expect(body.api_endpoint).to.equal('https://openrouter.ai/api/v1');
+  });
+
+  it('keeps the Other... escape hatch for Auto Router ids', async () => {
+    (element as any)._modelSuggestions = ['z-ai/glm-4.6'];
+    (element as any)._handleModelNameChange({
+      target: { value: 'other' },
+    } as unknown as Event);
+    expect((element as any)._isOtherModel).to.be.true;
+
+    (element as any)._handleCustomModelInput({
+      target: { value: 'openrouter/auto-beta' },
+    } as unknown as Event);
+
+    expect((element as any)._currentModel.model_identifier).to.equal(
+      'openrouter/auto-beta'
+    );
+  });
+
+  it('renders an existing openrouter model in edit mode', async () => {
+    const model = {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      name: 'OpenRouter Auto',
+      provider_name: 'openrouter',
+      model_identifier: 'openrouter/auto-beta',
+      api_endpoint: 'https://openrouter.ai/api/v1',
+      model_kind: 'llm',
+      has_api_key: true,
+    };
+    const el: AddAIModelModal = await fixture(
+      html`<add-ai-model-modal
+        .model=${model as any}
+        ?open=${true}
+      ></add-ai-model-modal>`
+    );
+    await el.updateComplete;
+
+    const providerSelect = el.shadowRoot?.querySelector(
+      'sl-select[label="Provider"]'
+    ) as any;
+    expect(providerSelect?.value).to.equal('openrouter');
+    const urlInput = Array.from(
+      el.shadowRoot?.querySelectorAll('sl-input') ?? []
+    ).find((i) => i.getAttribute('label') === 'API URL') as any;
+    expect(urlInput?.value).to.equal('https://openrouter.ai/api/v1');
+    // Editing must not wipe the stored id just because it is not in the
+    // (unfetched) suggestion list.
+    expect((el as any)._currentModel.model_identifier).to.equal(
+      'openrouter/auto-beta'
+    );
+  });
+
+  it('renders a full OpenRouter-sized catalog without dropping entries', async () => {
+    const many = Array.from({ length: 338 }, (_, i) => `vendor/model-${i}`);
+    fetchStub.callsFake(async (url: any) => {
+      if (String(url).includes('available-models')) {
+        return new Response(JSON.stringify(many));
+      }
+      return new Response(JSON.stringify([]));
+    });
+    // Open first: opening repopulates the form and would clear these fields.
+    element.open = true;
+    await element.updateComplete;
+    (element as any)._currentModel = {
+      provider_name: 'openrouter',
+      api_endpoint: 'https://openrouter.ai/api/v1',
+      api_key: 'sk-or-v1-secret-value',
+    };
+
+    await (element as any)._fetchModelsForCurrentProvider();
+    await element.updateComplete;
+
+    expect((element as any)._modelSuggestions).to.have.lengthOf(338);
+    const modelSelect = element.shadowRoot?.querySelector(
+      'sl-select[label="Model Name / ID"]'
+    );
+    const options = modelSelect?.querySelectorAll('sl-option') ?? [];
+    // Every model plus the "Other..." entry.
+    expect(options.length).to.equal(339);
+  });
+});

--- a/frontend/src/components/add-ai-model-modal.ts
+++ b/frontend/src/components/add-ai-model-modal.ts
@@ -35,6 +35,7 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
   { value: 'google', label: 'Google', serviceKinds: ['llm', 'stt'] },
   { value: 'qwen', label: 'Qwen', serviceKinds: ['llm'] },
   { value: 'deepseek', label: 'DeepSeek', serviceKinds: ['llm'] },
+  { value: 'openrouter', label: 'OpenRouter', serviceKinds: ['llm'] },
   {
     value: 'openai-compatible',
     label: 'OpenAI-compatible',
@@ -44,11 +45,30 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
 ];
 
 /**
- * Providers with no fixed model catalog: their models are listed from the
- * user-supplied endpoint's own OpenAI-compatible GET /models, so an endpoint
- * has to be entered before fetching can work.
+ * Base URLs we already know, prefilled when the provider is chosen. Empty
+ * string means "the user has to supply it". OpenRouter has a fixed base URL,
+ * so it is prefilled here and also defaulted server-side
+ * (ai_model_provider.DEFAULT_PROVIDER_ENDPOINTS); the form still needs a value
+ * because api_endpoint is a required field on submit.
  */
-const ENDPOINT_LISTED_PROVIDERS = ['openai-compatible', 'custom'];
+const PROVIDER_DEFAULT_ENDPOINTS: Record<string, string> = {
+  openai: 'https://api.openai.com/v1',
+  anthropic: 'https://api.anthropic.com/v1',
+  google: 'https://generativelanguage.googleapis.com/v1beta',
+  qwen: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+  deepseek: 'https://api.deepseek.com/v1',
+  openrouter: 'https://openrouter.ai/api/v1',
+  'openai-compatible': '',
+  custom: '',
+};
+
+/**
+ * Providers with no fixed model catalog: their models are listed from the
+ * endpoint's own OpenAI-compatible GET /models. Fetching needs an endpoint, so
+ * one must be present before we can ask; for providers with a known default
+ * (OpenRouter) that is already satisfied without the user typing anything.
+ */
+const ENDPOINT_LISTED_PROVIDERS = ['openai-compatible', 'custom', 'openrouter'];
 
 /**
  * Reusable AI model add/edit dialog.
@@ -247,20 +267,10 @@ export class AddAIModelModal extends LitElement {
   private async _handleProviderChange(e: Event) {
     const provider = (e.target as SlSelect).value as string;
 
-    const defaultUrls: Record<string, string> = {
-      openai: 'https://api.openai.com/v1',
-      anthropic: 'https://api.anthropic.com/v1',
-      google: 'https://generativelanguage.googleapis.com/v1beta',
-      qwen: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
-      deepseek: 'https://api.deepseek.com/v1',
-      'openai-compatible': '',
-      custom: '',
-    };
-
     this._currentModel = {
       ...this._currentModel,
       provider_name: provider,
-      api_endpoint: defaultUrls[provider] || '',
+      api_endpoint: PROVIDER_DEFAULT_ENDPOINTS[provider] || '',
       model_identifier: '',
     };
 
@@ -286,6 +296,8 @@ export class AddAIModelModal extends LitElement {
         return 'https://dashscope.console.aliyun.com/apiKey';
       case 'deepseek':
         return 'https://platform.deepseek.com/api_keys';
+      case 'openrouter':
+        return 'https://openrouter.ai/keys';
       case 'openai-compatible':
       case 'custom':
         return 'https://platform.openai.com/api-keys';
@@ -341,7 +353,12 @@ export class AddAIModelModal extends LitElement {
     }
 
     const provider = this._currentModel.provider_name;
-    const apiEndpoint = this._currentModel.api_endpoint?.trim();
+    // A provider with a known base URL can be listed even if the field was
+    // cleared: the default stands in, matching the server-side default.
+    const apiEndpoint =
+      this._currentModel.api_endpoint?.trim() ||
+      PROVIDER_DEFAULT_ENDPOINTS[provider] ||
+      '';
     // These providers have no fixed catalog: the list comes from the
     // endpoint's own /models, so without an endpoint there is nothing to ask.
     if (ENDPOINT_LISTED_PROVIDERS.includes(provider) && !apiEndpoint) {


### PR DESCRIPTION
Two related gaps in the add-model dialog, both reachable from the same screen.

## OpenRouter as a first-class provider

The backend has handled `openrouter` as an OpenAI-compatible provider with a
known default endpoint since #176, but `PROVIDER_OPTIONS` never listed it. To
add an OpenRouter model you had to pick "OpenAI-compatible" and know the base
URL by heart.

OpenRouter is now its own entry (LLM only), with
`https://openrouter.ai/api/v1` prefilled on selection. Model fetching works
without the user typing an endpoint.

Two details worth noting for review:

- The per-provider endpoint map was a local inside `_handleProviderChange`, so
  the fetch guard could not see it. It is now a module constant
  (`PROVIDER_DEFAULT_ENDPOINTS`) used by both, and `_fetchModelsForCurrentProvider`
  falls back to it when the field has been cleared. This mirrors the server
  default in `ai_model_provider.DEFAULT_PROVIDER_ENDPOINTS` rather than
  assuming one side supplies it. The field stays editable (proxy and gateway
  users need that) and `api_endpoint` is still required on submit, which is why
  it is prefilled rather than hidden.
- The list size needed no special handling. A 338-model response renders 339
  options (every model plus "Other..."), asserted in a test, so no filterable
  select or cap was introduced. The "Other..." path still accepts custom ids,
  including the Auto Router `openrouter/auto-beta`.

## Live model lists for DeepSeek and Qwen

`_get_deepseek_models` returned a list hardcoded "as of January 2025" and, when
given a key, called `client.models.list()` purely to validate it and then threw
the response away. DeepSeek has since shipped `deepseek-v4-flash` and
`deepseek-v4-pro`, so the console hid models the bundled price table already
prices. `_get_qwen_models` had the identical pattern.

Both now go through one helper `_get_catalog_provider_models`:

- with a key: return the live `models.list()` ids, sorted and de-duplicated
- `AuthenticationError`: still raises the invalid-key error
- any other failure (network, SDK, unexpected payload): falls back to the
  bundled catalog rather than showing an empty picker
- an empty live listing also falls back, since a valid key that lists nothing
  is more likely a proxy quirk than an empty account
- without a key: the bundled catalog, which now includes the DeepSeek v4 models

### Sibling provider audit

As requested, the rest of the file:

- `_get_openai_models` and `_get_google_models`: already return live lists, no
  change needed.
- `_get_anthropic_models`: still hardcoded, and validates with a
  `messages.create()` ping rather than a listing. The SDK does expose
  `models.list()`, so this is fixable the same way, but it is a behavior change
  outside this brief's scope and the current catalog is not stale in the way
  DeepSeek's was. Left as a follow-up rather than folded in silently.

## Tests

- Frontend: 7 new cases covering the provider entry, LLM-only service kinds,
  endpoint prefill, fetching with no typed endpoint, cleared-field fallback,
  the Auto Router "Other..." path, edit mode for an existing openrouter model,
  and the 338-model render.
- Backend: live-list happy path (including de-duplication), auth failure
  raises, network failure falls back, empty listing falls back, the keyless
  catalog contains the v4 models, and every fallback id resolves in
  `model_prices.json` so the hardcoded list cannot drift from pricing again.

## Verification

- Red/green proven both sides: reverting the frontend source fails 5 of the new
  tests; restoring the old DeepSeek logic fails the live-list and v4 tests.
- Frontend full suite: 603 passed, 0 failed (85 files).
- Backend: `test_ai_model_provider.py` 56 passed, plus `test_ai_models.py` and
  `test_model_pricing.py` 22 passed.
- `tsc --noEmit`: 81 errors before and after, all pre-existing and unrelated
  (the one in this file is a pre-existing checkbox cast).
- mypy clean on the changed backend file; ruff, ruff-format and prettier clean.

Targets the v0.14.x line. Not merging this myself.


<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Clean refactoring with no security issues, comprehensive test coverage, and no breaking changes.
>
> **Overview**
> Adds OpenRouter as a first-class provider in the add-model dialog with endpoint prefill, and replaces hardcoded DeepSeek/Qwen model catalogs with live `models.list()` responses via a shared `_get_catalog_provider_models` helper.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit feat/model-picker-openrouter-deepseek. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->