### PR TITLE
fix: sanitize, cap and isolate gateway activity metadata (502 on binary content)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,23 @@ across renames and re-onboarding.
 
 ### Fixed
 
+- **Gateway no longer returns 502 when activity metadata contains binary
+  content**: an agent that fetched a gzip or otherwise binary URL through the
+  gateway could take down its own request. The response body was embedded into
+  `runtime_session_activity.metadata` (JSONB), Postgres rejected the NUL byte
+  it contained (`UntranslatableCharacter`), and because that insert shares the
+  request's database session, the failed flush left the session in a
+  pending-rollback state. A model call that had already succeeded upstream came
+  back to the customer as a 502, and later operations on the same session
+  failed too. Three changes: all activity and usage metadata is now sanitized
+  of NUL, control characters and lone surrogates (tab, newline and carriage
+  return are preserved) before any JSONB write; request and response bodies
+  stored in activity metadata are capped (default 8192 characters per string,
+  `MODEL_GATEWAY_ACTIVITY_MAX_BODY_CHARS`) with an explicit truncation marker,
+  since one incident row reached 533,682 characters; and usage recording is now
+  non-fatal, rolling the session back and logging the failure type so that
+  bookkeeping can never fail a request whose model call succeeded.
+
 - **Auxiliary model calls resolve credentials from the secret service**: nine
   internal sites (approval summaries, session/interaction titles, policy
   generation, agent name extraction, issue compliance/duplicates/dependencies)

--- a/backend/preloop/config.py
+++ b/backend/preloop/config.py
@@ -322,6 +322,21 @@ class Settings(BaseSettings):
             "and untruncated; a cleaner follow-up is to read those directly.)"
         ),
     )
+    model_gateway_activity_max_body_chars: int = Field(
+        8192,
+        description=(
+            "Maximum characters retained per string inside the request and "
+            "response bodies embedded in runtime_session_activity metadata "
+            "(JSONB). This is deliberately tighter than "
+            "MODEL_GATEWAY_MAX_PREVIEW_CHARS because the UI never renders "
+            "these bodies in full: the transcript reads conversation_preview, "
+            "and the only direct consumers take a 300-character substring for "
+            "the activity preview or read request.tools. A gateway request "
+            "that returned a binary body once produced a 533KB activity row, "
+            "which is a database bloat and query-latency problem independent "
+            "of encoding. Tune via MODEL_GATEWAY_ACTIVITY_MAX_BODY_CHARS."
+        ),
+    )
     flow_execution_max_wait_seconds: int = Field(
         3600,
         description="Maximum wall-clock time to wait for one flow execution before failing it",
@@ -600,6 +615,9 @@ class Settings(BaseSettings):
             in ("true", "1", "t", "yes"),
             model_gateway_max_preview_chars=int(
                 os.getenv("MODEL_GATEWAY_MAX_PREVIEW_CHARS", "32768")
+            ),
+            model_gateway_activity_max_body_chars=int(
+                os.getenv("MODEL_GATEWAY_ACTIVITY_MAX_BODY_CHARS", "8192")
             ),
             flow_execution_max_wait_seconds=int(
                 os.getenv("FLOW_EXECUTION_MAX_WAIT_SECONDS", "3600")

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -13,6 +13,7 @@ from ..models.flow_execution import FlowExecution
 from ..models.managed_agent import ManagedAgent
 from ..models.runtime_session import RuntimeSession
 from ..models.user import User
+from ...utils.jsonb_sanitize import sanitize_for_jsonb
 from .base import CRUDBase
 
 # Known ``meta_data.purpose`` tags for internal model-gateway usage rows.
@@ -229,7 +230,9 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             runtime_principal_id=runtime_principal_id,
             runtime_principal_name=runtime_principal_name,
             rate_limit_retry_after_ms=rate_limit_retry_after_ms,
-            meta_data=meta_data,
+            # error_detail here can carry raw upstream body text, which for a
+            # binary response contains NUL and would be rejected by JSONB.
+            meta_data=sanitize_for_jsonb(meta_data),
             timestamp=datetime.now(timezone.utc),
         )
 

--- a/backend/preloop/models/crud/runtime_session_activity.py
+++ b/backend/preloop/models/crud/runtime_session_activity.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from ..models.managed_agent import ManagedAgent
 from ..models.runtime_session import RuntimeSession
 from ..models.runtime_session_activity import RuntimeSessionActivity
+from ...utils.jsonb_sanitize import sanitize_for_jsonb
 from .base import CRUDBase
 
 MAX_AGENT_CONTROL_MESSAGE_SUMMARY_LEN = 2000
@@ -86,7 +87,7 @@ class CRUDRuntimeSessionActivity(CRUDBase[RuntimeSessionActivity]):
             tool_name=tool_name,
             status=status,
             summary=summary,
-            metadata_=metadata,
+            metadata_=sanitize_for_jsonb(metadata),
             timestamp=activity_timestamp,
         )
         db.add(db_obj)
@@ -126,7 +127,7 @@ class CRUDRuntimeSessionActivity(CRUDBase[RuntimeSessionActivity]):
             activity_type="model_gateway_call",
             status=status,
             summary=summary,
-            metadata_=metadata,
+            metadata_=sanitize_for_jsonb(metadata),
             timestamp=activity_timestamp,
         )
         db.add(db_obj)
@@ -163,7 +164,7 @@ class CRUDRuntimeSessionActivity(CRUDBase[RuntimeSessionActivity]):
             activity_type="agent_control_message",
             status=status,
             summary=summary,
-            metadata_=metadata,
+            metadata_=sanitize_for_jsonb(metadata),
             timestamp=activity_timestamp,
         )
         db.add(db_obj)

--- a/backend/preloop/services/model_gateway_events.py
+++ b/backend/preloop/services/model_gateway_events.py
@@ -24,6 +24,7 @@ from preloop.services.account_realtime import (
     emit_account_event,
 )
 from preloop.sync.services.event_bus import get_nats_client
+from preloop.utils.jsonb_sanitize import sanitize_for_jsonb
 from preloop.utils.request_fingerprint import public_request_fingerprint
 
 logger = logging.getLogger(__name__)
@@ -292,8 +293,16 @@ class ModelGatewayEventEmitter:
                 "error_detail": error_detail,
                 "capture_policy": self._build_capture_policy(conversation_preview),
                 "conversation_preview": conversation_preview,
-                "request": self._sanitize_payload(request_payload),
-                "response": self._sanitize_payload(response_payload),
+                # These two bodies are the ones that carried 533KB of binary
+                # content in the 2026-08-05 incident. Cap them here, at the
+                # point they enter the activity payload, so the JSONB row stays
+                # a bounded size regardless of what the upstream returned.
+                "request": self._cap_activity_body(
+                    self._sanitize_payload(request_payload)
+                ),
+                "response": self._cap_activity_body(
+                    self._sanitize_payload(response_payload)
+                ),
             },
         }
 
@@ -333,6 +342,19 @@ class ModelGatewayEventEmitter:
         if status_code >= 400:
             return "error"
         return "success"
+
+    @staticmethod
+    def _cap_activity_body(value: Any) -> Any:
+        """Bound one request/response body before it is stored as JSONB.
+
+        Separate from the preview cap on purpose. Previews feed the transcript
+        UI and are tuned for readability; these bodies are archival and are
+        never rendered in full, so they get the tighter activity cap.
+        """
+        return sanitize_for_jsonb(
+            value,
+            max_string_chars=settings.model_gateway_activity_max_body_chars,
+        )
 
     def _sanitize_payload(self, value: Any) -> Any:
         if value is None:

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -5189,13 +5189,89 @@ class OpenAIGatewayService:
                 usage_source="partial" if has_partial_usage else None,
                 accumulated_output_text=accumulated_output_text,
             )
-        except Exception:  # pragma: no cover - defensive; never break teardown
-            logger.warning(
-                "Failed to record gateway usage after client disconnect",
-                exc_info=True,
+        except Exception as exc:  # pragma: no cover - defensive; never break teardown
+            # Catching alone is not enough: a failed flush poisons the session
+            # for anything that runs after this teardown. Roll back too.
+            self._rollback_activity_recording(
+                exc, context="gateway usage recording after client disconnect"
             )
 
+    def _rollback_activity_recording(self, exc: Exception, *, context: str) -> None:
+        """Restore the request's db session after a failed telemetry write.
+
+        The gateway shares one SQLAlchemy session between the response path and
+        the usage/activity bookkeeping. When a bookkeeping flush fails (for
+        example Postgres rejecting a JSONB value), the session enters a
+        pending-rollback state where every subsequent statement raises. Rolling
+        back here returns the session to a usable state so the caller can still
+        return the upstream response and any later query still works.
+
+        A separate session was considered and rejected: bookkeeping reads
+        objects (usage_row) that are live in this session, so a second session
+        would need them re-fetched or merged, which adds a query per request
+        and a new class of stale-read bug. Rollback is cheap, local, and keeps
+        the existing object graph valid.
+        """
+        try:
+            self.db.rollback()
+        except Exception:  # pragma: no cover - rollback of a dead connection
+            logger.warning("Failed to roll back the session after %s failed", context)
+        logger.warning(
+            "Skipped %s after %s; returning the upstream response unchanged",
+            context,
+            type(exc).__name__,
+        )
+
     def _record_gateway_request(
+        self,
+        *,
+        endpoint: str,
+        method: str,
+        status_code: int,
+        duration: float,
+        ai_model: AIModel,
+        requested_model: Optional[str],
+        response_payload: Optional[Dict[str, Any]],
+        upstream_response: Optional[Dict[str, Any]],
+        endpoint_kind: str,
+        budget_result: Optional[BudgetCheckResult] = None,
+        error_detail: Optional[str] = None,
+        error_class: Optional[str] = None,
+        request_payload: Optional[Dict[str, Any]] = None,
+        usage_source: Optional[str] = None,
+        accumulated_output_text: Optional[str] = None,
+    ) -> None:
+        """Persist one usage fact for a gateway request, never fatally.
+
+        Recording usage is bookkeeping. It runs on the request path and shares
+        the request's db session, so a failure here (a rejected JSONB value, a
+        constraint violation) would otherwise poison that session and turn an
+        upstream success into a customer-visible 502. Every caller, streaming
+        and non-streaming alike, gets that protection by going through this
+        wrapper rather than each site wrapping itself and one being forgotten.
+        """
+        try:
+            self._record_gateway_request_inner(
+                endpoint=endpoint,
+                method=method,
+                status_code=status_code,
+                duration=duration,
+                ai_model=ai_model,
+                requested_model=requested_model,
+                response_payload=response_payload,
+                upstream_response=upstream_response,
+                endpoint_kind=endpoint_kind,
+                budget_result=budget_result,
+                error_detail=error_detail,
+                error_class=error_class,
+                request_payload=request_payload,
+                usage_source=usage_source,
+                accumulated_output_text=accumulated_output_text,
+            )
+        except Exception as exc:
+            self._rollback_activity_recording(exc, context="gateway usage recording")
+
+    def _record_gateway_request_inner(
         self,
         *,
         endpoint: str,
@@ -5475,11 +5551,20 @@ class OpenAIGatewayService:
             total_tokens=total_tokens,
             estimated_cost=float(usage_row.estimated_cost or 0.0),
         )
-        ModelGatewayEventEmitter(self.db).emit_for_usage(
-            usage=usage_row,
-            request_payload=request_payload,
-            response_payload=response_payload,
-        )
+        try:
+            ModelGatewayEventEmitter(self.db).emit_for_usage(
+                usage=usage_row,
+                request_payload=request_payload,
+                response_payload=response_payload,
+            )
+        except Exception as exc:
+            # Bookkeeping must never turn a successful model call into a 502.
+            # A failed flush leaves the shared session in a pending-rollback
+            # state, so roll it back explicitly: catching the exception alone
+            # would let the poisoned session break every later query on this
+            # request. Log the exception TYPE only; the payload that triggered
+            # this can contain customer content.
+            self._rollback_activity_recording(exc, context="gateway activity event")
         try:
             GatewayUsageSearchService(self.db).auto_index_interaction(
                 usage=usage_row,

--- a/backend/preloop/utils/jsonb_sanitize.py
+++ b/backend/preloop/utils/jsonb_sanitize.py
@@ -1,0 +1,152 @@
+"""Make arbitrary payloads safe to store in Postgres JSONB columns.
+
+Gateway telemetry embeds request and response bodies into JSONB metadata.
+Those bodies are attacker-shaped in practice: an agent that fetches a gzip or
+otherwise binary URL hands us a body full of NUL and control bytes. Postgres
+rejects U+0000 in JSONB outright (psycopg2 raises UntranslatableCharacter),
+and because the telemetry insert shares the request's SQLAlchemy session, a
+rejected insert used to poison that session and turn a successful model call
+into a 502 for the customer.
+
+This module is the single place that decides what is storable. It is
+deliberately conservative: telemetry is lossy by nature, so we would rather
+drop odd bytes than fail a customer request.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Control characters are stripped except the three that carry real meaning in
+# captured text. Tab, newline and carriage return survive so that transcripts
+# and code blocks keep their shape in the UI.
+_ALLOWED_CONTROL_CHARS = {"\t", "\n", "\r"}
+
+# Guards against pathological or self-referential payloads. Real gateway
+# bodies nest a handful of levels; anything past this is a bug or an attack,
+# and either way it must not be able to hang the request path.
+DEFAULT_MAX_DEPTH = 24
+
+_TRUNCATION_MARKER = "... [truncated {dropped} bytes]"
+
+
+def _is_disallowed_char(char: str) -> bool:
+    code_point = ord(char)
+    if char in _ALLOWED_CONTROL_CHARS:
+        return False
+    # C0 controls (includes U+0000, the one Postgres refuses) and DEL.
+    if code_point < 0x20 or code_point == 0x7F:
+        return True
+    # C1 controls. These are invisible and routinely appear in binary bodies.
+    if 0x80 <= code_point <= 0x9F:
+        return True
+    # Lone surrogates. Valid text never contains them and they break the
+    # psycopg2 encode path with a UnicodeEncodeError before Postgres sees them.
+    if 0xD800 <= code_point <= 0xDFFF:
+        return True
+    return False
+
+
+def sanitize_string(value: str, *, max_chars: int | None = None) -> str:
+    """Strip JSONB-hostile characters from one string, optionally capping it.
+
+    The cap is applied after stripping so the limit describes what we actually
+    store, and it reports the number of characters dropped so an operator
+    reading the row knows the value is partial rather than genuinely short.
+    """
+    if any(_is_disallowed_char(char) for char in value):
+        value = "".join(char for char in value if not _is_disallowed_char(char))
+    if max_chars is not None and len(value) > max_chars:
+        dropped = len(value) - max_chars
+        return value[:max_chars] + _TRUNCATION_MARKER.format(dropped=dropped)
+    return value
+
+
+def sanitize_for_jsonb(
+    value: Any,
+    *,
+    max_string_chars: int | None = None,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+) -> Any:
+    """Return a copy of ``value`` that Postgres will accept in a JSONB column.
+
+    Walks dicts (keys and values), lists, tuples and sets recursively. Scalars
+    that are not strings pass through untouched. Structures deeper than
+    ``max_depth``, and cycles, collapse to a marker string rather than
+    recursing forever.
+    """
+    return _sanitize(
+        value,
+        max_string_chars=max_string_chars,
+        max_depth=max_depth,
+        depth=0,
+        seen=frozenset(),
+    )
+
+
+def _sanitize(
+    value: Any,
+    *,
+    max_string_chars: int | None,
+    max_depth: int,
+    depth: int,
+    seen: frozenset[int],
+) -> Any:
+    if isinstance(value, str):
+        return sanitize_string(value, max_chars=max_string_chars)
+
+    # bool must be checked before int; it is a subclass of int in Python.
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    if isinstance(value, (bytes, bytearray)):
+        # Bytes are not JSON serializable at all. Decode leniently and let the
+        # string path strip whatever survives.
+        decoded = bytes(value).decode("utf-8", errors="replace")
+        return sanitize_string(decoded, max_chars=max_string_chars)
+
+    if isinstance(value, (dict, list, tuple, set, frozenset)):
+        if depth >= max_depth:
+            return "[truncated: max depth exceeded]"
+        identity = id(value)
+        if identity in seen:
+            return "[truncated: circular reference]"
+        next_seen = seen | {identity}
+
+        if isinstance(value, dict):
+            sanitized: dict[Any, Any] = {}
+            for key, item in value.items():
+                # Keys become JSON object names, so they need the same
+                # treatment as values. A NUL in a key is just as fatal.
+                safe_key = (
+                    sanitize_string(key, max_chars=max_string_chars)
+                    if isinstance(key, str)
+                    else key
+                )
+                sanitized[safe_key] = _sanitize(
+                    item,
+                    max_string_chars=max_string_chars,
+                    max_depth=max_depth,
+                    depth=depth + 1,
+                    seen=next_seen,
+                )
+            return sanitized
+
+        sanitized_items = [
+            _sanitize(
+                item,
+                max_string_chars=max_string_chars,
+                max_depth=max_depth,
+                depth=depth + 1,
+                seen=next_seen,
+            )
+            for item in value
+        ]
+        # Sets and tuples are not JSON types; JSONB stores them as arrays, so
+        # normalize here rather than leaving it to the driver.
+        return sanitized_items
+
+    # Anything else (datetime, UUID, model objects) is left for the existing
+    # serializer to handle. Stringifying here would silently change stored
+    # shapes that callers already depend on.
+    return value

--- a/backend/tests/services/test_model_gateway_activity_isolation.py
+++ b/backend/tests/services/test_model_gateway_activity_isolation.py
@@ -1,0 +1,165 @@
+"""Gateway bookkeeping must never be fatal to the customer's request.
+
+Incident 2026-08-05: a JSONB insert of activity metadata failed on a NUL byte.
+Because that insert shares the request's SQLAlchemy session, the failed flush
+left the session in a pending-rollback state and an upstream SUCCESS became a
+customer-visible 502.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from preloop.services.openai_gateway import OpenAIGatewayService
+
+
+class _Recorder(OpenAIGatewayService):
+    """Bare instance exposing only the recording helpers under test."""
+
+    def __init__(self, db):
+        self.db = db
+
+
+def _service_with_failing_recorder(exc):
+    db = MagicMock()
+    service = _Recorder(db)
+
+    def _boom(**_kwargs):
+        raise exc
+
+    service._record_gateway_request_inner = _boom
+    return service, db
+
+
+def test_recording_failure_does_not_propagate_to_the_request():
+    """A failed usage write must not raise into the response path."""
+    service, _db = _service_with_failing_recorder(
+        RuntimeError("(psycopg2.errors.UntranslatableCharacter)")
+    )
+
+    # Must not raise. Before the fix this exception reached the caller and
+    # became a 502.
+    service._record_gateway_request(
+        endpoint="/v1/chat/completions",
+        method="POST",
+        status_code=200,
+        duration=0.1,
+        ai_model=MagicMock(),
+        requested_model="openai/gpt-5",
+        response_payload={"usage": {}},
+        upstream_response=None,
+        endpoint_kind="chat_completions",
+    )
+
+
+def test_recording_failure_rolls_the_session_back():
+    """The shared session must be returned to a usable state."""
+    service, db = _service_with_failing_recorder(RuntimeError("flush failed"))
+
+    service._record_gateway_request(
+        endpoint="/v1/chat/completions",
+        method="POST",
+        status_code=200,
+        duration=0.1,
+        ai_model=MagicMock(),
+        requested_model="openai/gpt-5",
+        response_payload={"usage": {}},
+        upstream_response=None,
+        endpoint_kind="chat_completions",
+    )
+
+    # Catching alone leaves the session poisoned for every later query.
+    db.rollback.assert_called_once()
+
+
+def test_recording_failure_logs_the_exception_type_not_the_body(caplog):
+    """Log the failure class, never the payload that triggered it."""
+    secret_body = "customer-content-that-must-not-be-logged"
+    service, _db = _service_with_failing_recorder(RuntimeError(secret_body))
+
+    with caplog.at_level(logging.WARNING):
+        service._record_gateway_request(
+            endpoint="/v1/chat/completions",
+            method="POST",
+            status_code=200,
+            duration=0.1,
+            ai_model=MagicMock(),
+            requested_model="openai/gpt-5",
+            response_payload={"usage": {}},
+            upstream_response=None,
+            endpoint_kind="chat_completions",
+        )
+
+    combined = caplog.text
+    assert "RuntimeError" in combined
+    assert secret_body not in combined
+
+
+def test_rollback_helper_survives_a_dead_connection(caplog):
+    """A rollback that itself fails must still not raise."""
+    db = MagicMock()
+    db.rollback.side_effect = RuntimeError("connection already closed")
+    service = _Recorder(db)
+
+    with caplog.at_level(logging.WARNING):
+        service._rollback_activity_recording(
+            ValueError("original failure"), context="unit test"
+        )
+
+    assert "ValueError" in caplog.text
+
+
+@pytest.mark.parametrize("status_code", [200, 201])
+def test_successful_calls_are_unaffected_when_recording_works(status_code):
+    """The happy path must still record exactly once."""
+    db = MagicMock()
+    service = _Recorder(db)
+    calls = []
+
+    service._record_gateway_request_inner = lambda **kwargs: calls.append(kwargs)
+
+    service._record_gateway_request(
+        endpoint="/v1/chat/completions",
+        method="POST",
+        status_code=status_code,
+        duration=0.1,
+        ai_model=MagicMock(),
+        requested_model="openai/gpt-5",
+        response_payload={"usage": {}},
+        upstream_response=None,
+        endpoint_kind="chat_completions",
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["status_code"] == status_code
+    db.rollback.assert_not_called()
+
+
+def test_activity_crud_sanitizes_metadata_before_the_jsonb_write():
+    """The crud layer is the chokepoint: every caller gets sanitized."""
+    from unittest.mock import patch
+
+    from preloop.models.crud.runtime_session_activity import (
+        CRUDRuntimeSessionActivity,
+    )
+    from preloop.models.models.runtime_session_activity import RuntimeSessionActivity
+
+    crud = CRUDRuntimeSessionActivity(RuntimeSessionActivity)
+    db = MagicMock()
+    # The session lookup that _touch_runtime_session_and_agent performs.
+    db.get.return_value = None
+
+    with patch.object(crud, "_touch_runtime_session_and_agent"):
+        activity = crud.log_model_gateway_call(
+            db,
+            account_id="acct-1",
+            runtime_session_id="sess-1",
+            status="success",
+            metadata={"response": {"body": "gzip\x1f\x8b\x08\x00body"}},
+            commit=False,
+        )
+
+    stored = activity.metadata_["response"]["body"]
+    assert stored == "gzipbody"
+    assert "\x00" not in stored

--- a/backend/tests/services/test_model_gateway_events.py
+++ b/backend/tests/services/test_model_gateway_events.py
@@ -489,3 +489,79 @@ async def test_publish_to_nats_drops_event_when_truncated_payload_is_still_too_l
         await emitter._publish_to_nats(event)
 
     nats_client.publish.assert_not_called()
+
+
+def test_build_event_strips_nul_and_control_bytes_from_bodies():
+    """Regression: gzip/binary bodies must not reach a JSONB column.
+
+    Incident 2026-08-05: an agent fetched a URL that returned gzip, the body
+    landed in runtime_session_activity.metadata, and Postgres rejected the NUL
+    with UntranslatableCharacter, poisoning the request's session.
+    """
+    import json
+
+    emitter = ModelGatewayEventEmitter(MagicMock())
+    usage = _build_usage()
+    gzip_magic = "\x1f\x8b\x08\x00"
+
+    with (
+        patch.object(settings, "model_gateway_capture_content", True),
+        patch.object(settings, "model_gateway_max_preview_chars", 100000),
+        patch.object(settings, "model_gateway_activity_max_body_chars", 100000),
+    ):
+        event = emitter._build_event(
+            usage=usage,
+            request_payload={"messages": [{"role": "user", "content": "fetch it"}]},
+            response_payload={"body": gzip_magic + "binary\x00payload"},
+        )
+
+    payload = event["payload"]
+    assert payload["response"]["body"] == "binarypayload"
+    # The captured bodies must survive the same encode path psycopg2 uses.
+    # (api_key_name is a MagicMock attribute here, so encode only the bodies.)
+    encoded = json.dumps(
+        {"request": payload["request"], "response": payload["response"]}
+    )
+    assert "\x00" not in encoded
+    assert "\u0000" not in encoded
+
+
+def test_build_event_caps_activity_bodies_with_an_explicit_marker():
+    """533KB activity rows are a DB bloat problem independent of encoding."""
+    emitter = ModelGatewayEventEmitter(MagicMock())
+    usage = _build_usage()
+
+    with (
+        patch.object(settings, "model_gateway_capture_content", True),
+        patch.object(settings, "model_gateway_max_preview_chars", 100000),
+        patch.object(settings, "model_gateway_activity_max_body_chars", 50),
+    ):
+        event = emitter._build_event(
+            usage=usage,
+            request_payload={"messages": [{"role": "user", "content": "hi"}]},
+            response_payload={"body": "z" * 500},
+        )
+
+    body = event["payload"]["response"]["body"]
+    assert body.startswith("z" * 50)
+    assert body.endswith("... [truncated 450 bytes]")
+
+
+def test_build_event_preserves_newlines_and_tabs_in_bodies():
+    """Transcripts must keep their shape; only invisible controls are dropped."""
+    emitter = ModelGatewayEventEmitter(MagicMock())
+    usage = _build_usage()
+    text = "def f():\n\treturn 1\r\n"
+
+    with (
+        patch.object(settings, "model_gateway_capture_content", True),
+        patch.object(settings, "model_gateway_max_preview_chars", 100000),
+        patch.object(settings, "model_gateway_activity_max_body_chars", 100000),
+    ):
+        event = emitter._build_event(
+            usage=usage,
+            request_payload={"messages": [{"role": "user", "content": "hi"}]},
+            response_payload={"body": text},
+        )
+
+    assert event["payload"]["response"]["body"] == text

--- a/backend/tests/utils/test_jsonb_sanitize.py
+++ b/backend/tests/utils/test_jsonb_sanitize.py
@@ -1,0 +1,127 @@
+"""Tests for the JSONB sanitizer.
+
+Regression coverage for the 2026-08-05 incident: an agent fetched a URL that
+returned gzip binary, the body was embedded into runtime_session_activity
+metadata, and Postgres rejected the NUL byte with UntranslatableCharacter.
+"""
+
+import json
+
+import pytest
+
+from preloop.utils.jsonb_sanitize import sanitize_for_jsonb, sanitize_string
+
+# The exact leading bytes of the gzip response from the incident.
+GZIP_MAGIC = "\x1f\x8b\x08\x00"
+
+
+class TestSanitizeString:
+    def test_strips_nul(self):
+        assert sanitize_string("before\x00after") == "beforeafter"
+
+    def test_strips_gzip_magic_sequence(self):
+        result = sanitize_string(GZIP_MAGIC + "payload")
+        assert result == "payload"
+        assert "\x00" not in result
+
+    def test_preserves_newline_carriage_return_and_tab(self):
+        value = "line one\nline two\r\ncol\tcol"
+        assert sanitize_string(value) == value
+
+    def test_strips_c0_controls_but_not_the_allowed_three(self):
+        assert sanitize_string("a\x01b\x1fc") == "abc"
+
+    def test_strips_del_and_c1_controls(self):
+        assert sanitize_string("a\x7fb\x85c\x9fd") == "abcd"
+
+    def test_strips_lone_surrogates(self):
+        assert sanitize_string("a\ud800b\udfffc") == "abc"
+
+    def test_leaves_ordinary_unicode_alone(self):
+        value = "hello e世界 \U0001f600"
+        assert sanitize_string(value) == value
+
+    def test_truncates_with_marker_reporting_dropped_count(self):
+        result = sanitize_string("x" * 100, max_chars=10)
+        assert result == "x" * 10 + "... [truncated 90 bytes]"
+
+    def test_does_not_mark_a_string_at_the_limit(self):
+        assert sanitize_string("x" * 10, max_chars=10) == "x" * 10
+
+    def test_truncation_counts_after_stripping(self):
+        result = sanitize_string("\x00" * 10 + "y" * 20, max_chars=10)
+        assert result == "y" * 10 + "... [truncated 10 bytes]"
+
+
+class TestSanitizeForJsonb:
+    def test_sanitizes_nested_dicts_and_lists(self):
+        payload = {
+            "choices": [
+                {"message": {"content": "body" + GZIP_MAGIC + "end"}},
+                {"message": {"content": "clean"}},
+            ]
+        }
+        result = sanitize_for_jsonb(payload)
+        assert result["choices"][0]["message"]["content"] == "bodyend"
+        assert result["choices"][1]["message"]["content"] == "clean"
+
+    def test_sanitizes_dict_keys(self):
+        result = sanitize_for_jsonb({"bad\x00key": "value"})
+        assert result == {"badkey": "value"}
+
+    def test_preserves_non_string_scalars(self):
+        payload = {"count": 3, "cost": 1.5, "ok": True, "missing": None}
+        assert sanitize_for_jsonb(payload) == payload
+
+    def test_bool_is_not_coerced_to_int(self):
+        result = sanitize_for_jsonb({"flag": True})
+        assert result["flag"] is True
+
+    def test_decodes_bytes_leniently(self):
+        # Bytes are not a JSON type at all. Invalid UTF-8 (0x8b in the gzip
+        # header) becomes U+FFFD, which is printable and JSONB-safe; the
+        # control bytes around it are stripped.
+        result = sanitize_for_jsonb({"body": b"\x1f\x8b\x08\x00data"})
+        assert result["body"].endswith("data")
+        assert "\x00" not in result["body"]
+        assert "\x1f" not in result["body"]
+
+    def test_normalizes_tuples_and_sets_to_lists(self):
+        result = sanitize_for_jsonb({"t": ("a\x00", "b"), "s": {"c\x00"}})
+        assert result["t"] == ["a", "b"]
+        assert result["s"] == ["c"]
+
+    def test_applies_the_string_cap_recursively(self):
+        payload = {"outer": {"inner": "z" * 50}}
+        result = sanitize_for_jsonb(payload, max_string_chars=5)
+        assert result["outer"]["inner"] == "zzzzz... [truncated 45 bytes]"
+
+    def test_handles_a_circular_reference_without_hanging(self):
+        payload = {"name": "root"}
+        payload["self"] = payload
+        result = sanitize_for_jsonb(payload)
+        assert result["name"] == "root"
+        # The cycle is caught the first time the same object is re-entered.
+        assert result["self"] == "[truncated: circular reference]"
+
+    def test_bounds_deeply_nested_structures(self):
+        payload = {}
+        node = payload
+        for _ in range(100):
+            node["child"] = {}
+            node = node["child"]
+        result = sanitize_for_jsonb(payload, max_depth=3)
+        assert "[truncated: max depth exceeded]" in repr(result)
+
+    def test_result_is_json_serializable(self):
+        payload = {
+            "response": {"body": GZIP_MAGIC + "\x00binary"},
+            "tokens": 10,
+            "tags": ("a", "b"),
+        }
+        # json.dumps is the same encode path psycopg2 uses for JSONB.
+        assert "\x00" not in json.dumps(sanitize_for_jsonb(payload))
+
+    @pytest.mark.parametrize("value", ["", " ", "\n", "\t"])
+    def test_edge_case_strings_survive(self, value):
+        assert sanitize_for_jsonb(value) == value


### PR DESCRIPTION
Closes #182

## The bug

Observed live in production on 2026-08-05 (approximately 16:37 to 16:45 UTC).
An agent fetched a URL that returned gzip binary. The body landed in
`runtime_session_activity.metadata` (JSONB) and took down the request.

**Trigger:** Postgres JSONB cannot store U+0000. The gzip magic sequence
(`0x1f 0x8b 0x08 0x00`) contains it, so the insert raised
`psycopg2.errors.UntranslatableCharacter`.

**Amplifier:** that insert runs on the request path and shares the response
path's SQLAlchemy session. The failed flush left the session in a
pending-rollback state, so an upstream **success** returned **502** to the
customer and later operations on the session failed too.

## The fix

**1. Sanitize.** New `backend/preloop/utils/jsonb_sanitize.py` recursively
strips NUL, C0/C1 controls, DEL and lone surrogates, preserving tab, newline
and carriage return so transcripts keep their shape. It is depth-bounded and
cycle-safe so a pathological payload cannot hang the request path.

Placed at the **crud chokepoints** (`log_model_gateway_call` and friends, plus
`ApiUsage.meta_data`) rather than only in the gateway, so every caller is
covered and no future call site can bypass it. `ApiUsage.meta_data` was audited
and sanitized too: it carries `error_detail`, which can hold raw upstream body
text.

**2. Cap.** Bodies inside activity metadata are capped at
`MODEL_GATEWAY_ACTIVITY_MAX_BODY_CHARS` (default **8192**) with an explicit
`... [truncated N bytes]` marker.

The number was chosen after checking what the UI actually renders, not guessed.
The transcript reads `conversation_preview`, not these bodies. The only direct
consumers are `agents-view.ts` (which takes a 300-character substring for the
activity preview) and `session-replay-panel.ts` (which reads `request.tools`).
So a tighter cap than the 32768-character preview cap loses nothing visible,
and the separate setting means tuning one does not disturb the other. One
incident row reached 533,682 characters, which is a bloat and query-latency
problem independent of the encoding bug.

**3. Isolate.** `_record_gateway_request` is now a thin non-fatal wrapper
around the original body (`_record_gateway_request_inner`). This protects all
~25 call sites, streaming and non-streaming, instead of wrapping each one and
risking a missed site later. On failure it rolls the shared session back and
logs the exception **type** only, never the payload, consistent with the
logging rule applied in #181. The client-disconnect handler previously caught
the exception but never rolled back, leaving the session poisoned; it now uses
the same helper.

**Session strategy justification:** rollback on the shared session, not a
separate session. Bookkeeping reads objects (`usage_row`) that are live in the
request's session; a second session would require re-fetching or merging them,
adding a query per request and a new class of stale-read bug. Rollback is
cheap, local, and keeps the existing object graph valid.

## Tests

24 sanitizer unit tests (NUL, the incident's exact gzip magic bytes, nested
structures, dict keys, surrogates, cycles, depth bounds, JSON-serializability),
3 event-level tests (stripping, capping with marker, newline/tab preservation),
and 7 isolation tests (failure does not propagate, session is rolled back,
exception type is logged but customer content is not, rollback survives a dead
connection, happy path unaffected). **44 passing.**

**Mutation-checked, all three parts independently:** neutering the sanitizer
turns 12 tests red, removing the cap turns 2 red, and making recording fatal
again turns 3 red. Every mutation was reverted afterward.

**Stashed vs applied on `tests/services tests/utils tests/models`:** 146
failures on both sides, byte-identical sets (`diff` clean), so all are
pre-existing and none are introduced here. They are the known shared-Postgres
stale-schema issue (`column \"rate_limit_retry_after_ms\" of relation
\"api_usage\" does not exist`, a migration not applied to the shared test
database), unrelated to this change.

Ruff and ruff-format clean; all pre-commit hooks passed.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-structured bug fix with three independent layers (sanitize, cap, isolate), 44 passing tests with mutation verification. No security concerns, no schema changes, no API surface changes.
>
> **Overview**
> Fixes a production 502 caused by binary content in gateway activity metadata. Adds a JSONB sanitizer that strips NUL/control bytes, caps stored bodies at 8192 chars, and isolates bookkeeping failures so they never poison the request session. All three parts independently mutation-verified.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/gateway-activity-jsonb. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->