### PR TITLE
fix: split runtime sessions by Claude Code native session id

### DIFF
--- a/backend/preloop/api/endpoints/anthropic_gateway.py
+++ b/backend/preloop/api/endpoints/anthropic_gateway.py
@@ -61,6 +61,9 @@ def create_message(
     auth_context: ModelGatewayAuthContext = Depends(get_anthropic_gateway_auth_context),
     budget_enforcer: Any = Depends(get_budget_enforcer),
     x_preloop_session_id: Optional[str] = Header(None, alias="X-Preloop-Session-Id"),
+    x_claude_code_session_id: Optional[str] = Header(
+        None, alias="X-Claude-Code-Session-Id"
+    ),
     anthropic_version: Optional[str] = Header(None, alias="anthropic-version"),
     anthropic_beta: Optional[str] = Header(None, alias="anthropic-beta"),
 ) -> Any:
@@ -69,12 +72,19 @@ def create_message(
     The ``anthropic-version`` and ``anthropic-beta`` headers are forwarded to
     the service so the subscription-OAuth passthrough can preserve the
     client's requested API surface (e.g. prompt-caching betas) upstream.
+
+    Claude Code does not send ``X-Preloop-Session-Id``; it stamps its own
+    conversation id on ``X-Claude-Code-Session-Id`` (and, redundantly, inside
+    ``metadata.user_id``). Accepting it here means each real Claude Code session
+    gets its own runtime session instead of every run on a machine collapsing
+    onto one eternal session row. Preloop's own header still wins when both are
+    present, so an explicit per-run id is never overridden.
     """
     service = OpenAIGatewayService(
         db,
         auth_context,
         budget_enforcer=budget_enforcer,
-        client_session_id=x_preloop_session_id,
+        client_session_id=x_preloop_session_id or x_claude_code_session_id,
     )
     if payload.get("stream"):
         return StreamingResponse(

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -241,6 +241,55 @@ def _normalize_client_session_id(raw: Optional[str]) -> Optional[str]:
     return candidate
 
 
+# Claude Code stamps its OWN session id on every Anthropic request in two
+# places: the ``X-Claude-Code-Session-Id`` header and the Anthropic-native
+# ``metadata.user_id`` field, which carries a JSON *string* shaped like
+# ``{"device_id": ..., "account_uuid": ..., "session_id": "<uuid>"}``. That
+# ``session_id`` is Claude Code's real conversation id — it is the filename of
+# the transcript at ``~/.claude/projects/<slug>/<session-uuid>.jsonl``.
+#
+# Without reading it, every Claude Code run on one machine keys to the same
+# durable-credential principal and collapses into a single eternal runtime
+# session, so a brand-new conversation appends onto an old session row. Reading
+# it lets the existing per-run session keying (see ``_resolve_runtime_session``)
+# give each real Claude Code session its own runtime session.
+#
+# The metadata blob is bounded before parsing so a hostile client cannot make us
+# parse an unbounded string, and every failure mode degrades to ``None`` (the
+# pre-existing source-keyed behavior) rather than raising.
+_NATIVE_SESSION_METADATA_MAX_LEN = 4096
+
+
+def _session_id_from_anthropic_metadata(
+    payload: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """Extract the agent's own session id from an Anthropic ``metadata`` block.
+
+    Args:
+        payload: The Anthropic Messages request payload (may be ``None``).
+
+    Returns:
+        The client's native session id when the payload carries a parseable
+        ``metadata.user_id`` JSON object containing a ``session_id`` that
+        passes :func:`_normalize_client_session_id`; otherwise ``None``.
+    """
+    if not isinstance(payload, dict):
+        return None
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    user_id = metadata.get("user_id")
+    if not isinstance(user_id, str) or len(user_id) > _NATIVE_SESSION_METADATA_MAX_LEN:
+        return None
+    try:
+        decoded = json.loads(user_id)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    return _normalize_client_session_id(decoded.get("session_id"))
+
+
 class OpenAIGatewayService:
     """Service for Preloop's OpenAI-compatible gateway."""
 
@@ -257,7 +306,8 @@ class OpenAIGatewayService:
         self.auth_context = auth_context
         self.upstream_backend = upstream_backend or get_model_gateway_backend()
         self.budget_enforcer = budget_enforcer
-        # Per-run session id supplied by the client (X-Preloop-Session-Id).
+        # Per-run session id supplied by the client (X-Preloop-Session-Id, or
+        # an agent-native equivalent such as X-Claude-Code-Session-Id).
         # Validated/normalized once; invalid values fall back to source keying.
         self._client_session_id = _normalize_client_session_id(client_session_id)
         self._resolved_runtime_session_id: Optional[str] = None
@@ -282,6 +332,28 @@ class OpenAIGatewayService:
         # Computed once from the account inventory on first use so listing,
         # alias resolution, and default selection all consume the same set.
         self._authorized_model_ids_cache: Optional[frozenset[str]] = None
+
+    def _adopt_native_session_id(self, payload: Optional[Dict[str, Any]]) -> None:
+        """Adopt the agent's own session id from an Anthropic request payload.
+
+        Claude Code never sends ``X-Preloop-Session-Id``; it identifies its
+        conversation in ``metadata.user_id`` instead. Without this, every run on
+        one machine shares the durable credential's single principal id and all
+        traffic collapses onto one eternal runtime session, so a new Claude Code
+        conversation appends onto a previous session's logs.
+
+        An explicit ``X-Preloop-Session-Id`` always wins, and this is a no-op
+        once the runtime session has been resolved for the request, so the
+        session identity of an in-flight request can never change mid-call.
+
+        Args:
+            payload: The Anthropic Messages request payload.
+        """
+        if self._client_session_id or self._resolved_runtime_session_attempted:
+            return
+        native_session_id = _session_id_from_anthropic_metadata(payload)
+        if native_session_id:
+            self._client_session_id = native_session_id
 
     def _resolve_runtime_session(self) -> Optional[str]:
         if self._resolved_runtime_session_attempted:
@@ -683,6 +755,7 @@ class OpenAIGatewayService:
         anthropic_beta: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Handle Anthropic Messages API-compatible requests."""
+        self._adopt_native_session_id(payload)
         if payload.get("stream"):
             raise ModelGatewayAPIError(
                 provider="anthropic",
@@ -819,6 +892,7 @@ class OpenAIGatewayService:
         anthropic_beta: Optional[str] = None,
     ) -> Iterator[str]:
         """Handle streaming Anthropic Messages API-compatible requests."""
+        self._adopt_native_session_id(payload)
         model = self._resolve_requested_model(
             payload.get("model"), provider="anthropic"
         )

--- a/backend/tests/endpoints/test_anthropic_gateway.py
+++ b/backend/tests/endpoints/test_anthropic_gateway.py
@@ -368,3 +368,50 @@ def test_messages_stream_midstream_failure_emits_sse_error_event(
     assert "event: error" in response.text
     assert "upstream connection reset" in response.text
     assert "event: message_stop" not in response.text
+
+
+def test_claude_code_session_header_reaches_gateway_service(
+    app, client, db_session, test_user
+):
+    """``X-Claude-Code-Session-Id`` must become the gateway's per-run session id.
+
+    Claude Code never sends ``X-Preloop-Session-Id``; dropping its native header
+    is what let a brand-new Claude Code conversation append onto the previous
+    session's logs. Preloop's own header still wins when both are present.
+    """
+    app.dependency_overrides[get_anthropic_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token="runtime-token", user=test_user)
+    )
+    session_uuid = "26d2f152-2d10-49e5-a68c-e471d55aadad"
+
+    for headers, expected in (
+        ({"X-Claude-Code-Session-Id": session_uuid}, session_uuid),
+        (
+            {
+                "X-Claude-Code-Session-Id": session_uuid,
+                "X-Preloop-Session-Id": "explicit-run",
+            },
+            "explicit-run",
+        ),
+        ({}, None),
+    ):
+        with patch(
+            "preloop.api.endpoints.anthropic_gateway.OpenAIGatewayService"
+        ) as service_cls:
+            service_cls.return_value.create_message.return_value = {"type": "message"}
+            response = client.post(
+                "/anthropic/v1/messages",
+                headers={
+                    "x-api-key": "ignored",
+                    "anthropic-version": "2023-06-01",
+                    **headers,
+                },
+                json={
+                    "model": "anthropic/claude-sonnet-4-5",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "max_tokens": 256,
+                },
+            )
+
+        assert response.status_code == 200
+        assert service_cls.call_args.kwargs["client_session_id"] == expected

--- a/backend/tests/services/test_openai_gateway_attribution_sessions.py
+++ b/backend/tests/services/test_openai_gateway_attribution_sessions.py
@@ -8,6 +8,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
@@ -555,3 +556,215 @@ def test_optimize_request_context_skips_repeated_account_fetch(
         service._optimize_request_context(messages=messages, payload=payload)
         service._optimize_request_context(messages=messages, payload=payload)
         assert get_mock.call_count == 1
+
+
+# --------------------------------------------------------------------------
+# Claude Code session identity -- a NEW Claude Code conversation must get its
+# own runtime session instead of appending onto the previous one.
+#
+# Claude Code never sends X-Preloop-Session-Id. It stamps its real conversation
+# id (the ~/.claude/projects/<slug>/<uuid>.jsonl transcript name) on the
+# X-Claude-Code-Session-Id header and inside metadata.user_id, which is a JSON
+# *string*. Before the fix, both were ignored, so every run on a machine keyed
+# to the durable credential's single principal id and collapsed into one
+# eternal session row.
+# --------------------------------------------------------------------------
+
+
+_ANTHROPIC_LITELLM_RESPONSE = {
+    "id": "msg_session_identity",
+    "created": 1710000000,
+    "choices": [
+        {
+            "message": {"role": "assistant", "content": "ok"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+}
+
+
+def _create_anthropic_gateway_model(db_session, account_id) -> Any:
+    return crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Gateway Model",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "anthropic/claude-sonnet-4-5",
+                    "provider_adapter": "preloop",
+                },
+                "pricing": {
+                    "input_price_per_1k": 0.01,
+                    "output_price_per_1k": 0.02,
+                },
+            },
+            "is_default": True,
+        },
+        account_id=account_id,
+    )
+
+
+def _claude_code_key(db_session, test_user) -> Any:
+    """A durable Claude Code credential: one principal id reused for every run."""
+    runtime_api_key, _ = crud_api_key.create_runtime_key(
+        db_session,
+        name="Claude Code Durable Credential",
+        account_id=test_user.account_id,
+        user_id=test_user.id,
+        context_data={
+            "credential_kind": "managed_agent_durable",
+            "runtime_principal": {
+                "type": "claude_code",
+                "id": "claude-code-64fd76044120",
+                "name": "Claude Code",
+            },
+        },
+    )
+    return runtime_api_key
+
+
+def _claude_code_payload(session_id: Optional[str]) -> Dict[str, Any]:
+    """Build the Anthropic payload Claude Code actually sends."""
+    payload: Dict[str, Any] = {
+        "model": "anthropic/claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 256,
+    }
+    if session_id is not None:
+        payload["metadata"] = {
+            "user_id": json.dumps(
+                {
+                    "device_id": "87f960fb6adfa93494bd7141bcbf3a9489c897fa7c0a9d0ac60f07b6078503db",
+                    "account_uuid": "",
+                    "session_id": session_id,
+                }
+            )
+        }
+    return payload
+
+
+def _run_message(service: OpenAIGatewayService, payload: Dict[str, Any]) -> Any:
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_ANTHROPIC_LITELLM_RESPONSE,
+    ):
+        return service.create_message(payload)
+
+
+def _anthropic_usage_rows(db_session) -> List[ApiUsage]:
+    return (
+        db_session.query(ApiUsage)
+        .filter(ApiUsage.endpoint == "/anthropic/v1/messages")
+        .order_by(ApiUsage.timestamp.asc())
+        .all()
+    )
+
+
+def test_claude_code_native_metadata_splits_sessions(db_session, test_user):
+    """Two Claude Code conversations must not merge into one runtime session."""
+    _create_anthropic_gateway_model(db_session, test_user.account_id)
+
+    api_key = _claude_code_key(db_session, test_user)
+    _run_message(
+        _service(db_session, test_user, api_key),
+        _claude_code_payload("26d2f152-2d10-49e5-a68c-e471d55aadad"),
+    )
+    _run_message(
+        _service(db_session, test_user, api_key),
+        _claude_code_payload("5436a7b6-8e38-493b-a172-304a1a000000"),
+    )
+
+    rows = _anthropic_usage_rows(db_session)
+    session_ids = {r.runtime_session_id for r in rows}
+    assert None not in session_ids
+    assert len(session_ids) == 2
+
+
+def test_claude_code_same_conversation_reuses_session(db_session, test_user):
+    """Turns of ONE Claude Code conversation stay in one runtime session."""
+    _create_anthropic_gateway_model(db_session, test_user.account_id)
+
+    api_key = _claude_code_key(db_session, test_user)
+    payload = _claude_code_payload("26d2f152-2d10-49e5-a68c-e471d55aadad")
+    _run_message(_service(db_session, test_user, api_key), payload)
+    _run_message(_service(db_session, test_user, api_key), payload)
+
+    rows = _anthropic_usage_rows(db_session)
+    session_ids = {r.runtime_session_id for r in rows}
+    assert None not in session_ids
+    assert len(session_ids) == 1
+
+
+def test_claude_code_session_id_lands_on_runtime_session_row(db_session, test_user):
+    """The runtime session is keyed by Claude Code's own conversation id."""
+    _create_anthropic_gateway_model(db_session, test_user.account_id)
+
+    session_uuid = "26d2f152-2d10-49e5-a68c-e471d55aadad"
+    api_key = _claude_code_key(db_session, test_user)
+    _run_message(
+        _service(db_session, test_user, api_key), _claude_code_payload(session_uuid)
+    )
+
+    row = _anthropic_usage_rows(db_session)[0]
+    runtime_session = crud_runtime_session.get_account_session(
+        db_session,
+        account_id=str(test_user.account_id),
+        runtime_session_id=str(row.runtime_session_id),
+    )
+    assert runtime_session is not None
+    # `<principal id>:<claude code session id>` -- the transcript uuid is what
+    # makes this row traceable back to a real Claude Code conversation.
+    assert runtime_session.session_source_id.endswith(f":{session_uuid}")
+
+
+def test_preloop_session_header_wins_over_claude_metadata(db_session, test_user):
+    """An explicit X-Preloop-Session-Id is never overridden by the payload."""
+    _create_anthropic_gateway_model(db_session, test_user.account_id)
+
+    api_key = _claude_code_key(db_session, test_user)
+    _run_message(
+        _service(db_session, test_user, api_key, client_session_id="explicit-run"),
+        _claude_code_payload("26d2f152-2d10-49e5-a68c-e471d55aadad"),
+    )
+
+    row = _anthropic_usage_rows(db_session)[0]
+    runtime_session = crud_runtime_session.get_account_session(
+        db_session,
+        account_id=str(test_user.account_id),
+        runtime_session_id=str(row.runtime_session_id),
+    )
+    assert runtime_session is not None
+    assert runtime_session.session_source_id.endswith(":explicit-run")
+
+
+def test_claude_code_malformed_metadata_falls_back_without_error(db_session, test_user):
+    """Unparseable/oversized/hostile metadata degrades to source keying."""
+    _create_anthropic_gateway_model(db_session, test_user.account_id)
+    api_key = _claude_code_key(db_session, test_user)
+
+    base = _claude_code_payload(None)
+    for metadata in (
+        {"user_id": "not-json"},
+        {"user_id": json.dumps({"session_id": "bad value!"})},
+        {"user_id": json.dumps({"device_id": "d"})},  # no session_id
+        {"user_id": json.dumps(["not", "an", "object"])},
+        {"user_id": "x" * 5000},  # over the parse cap
+        {"user_id": 12345},  # wrong type
+        {"user_id": json.dumps({"session_id": "x" * 400})},  # over the id cap
+    ):
+        _run_message(
+            _service(db_session, test_user, api_key), {**base, "metadata": metadata}
+        )
+
+    rows = _anthropic_usage_rows(db_session)
+    assert len(rows) == 7
+    session_ids = {r.runtime_session_id for r in rows}
+    assert None not in session_ids
+    # No usable session id anywhere -> all collapse to one source-keyed row,
+    # exactly the pre-fix behavior. Nothing raised.
+    assert len(session_ids) == 1


### PR DESCRIPTION
## Symptom

Every Claude Code run on a machine collapses onto **one** runtime session row
that never ends, so a brand-new conversation appends onto logs from days
earlier. On the dogfood account, one row absorbed **10,209 `api_usage` rows
over 12 days**, and forensics on the search corpus prove those rows belong to
**at least 129 distinct real conversations**. Every per-session metric on that
row — session replay, cost-per-session, waste analysis, the presence KPI — is
meaningless.

```
id                 cd08add2-7100-4010-9584-554eaedb771d
session_source_id  claude-code-64fd76044120-1785060768292917000
started_at         2026-07-26 10:12:48
last_activity_at   2026-08-06 12:23:27   <- still growing, never ended
```

## Mechanism

- **The credential is durable and carries one static principal id.** Onboarding
  mints a long-lived credential whose `context_data.runtime_principal.id` is
  fixed for the machine. Nothing in it changes when a new conversation starts.
- **The per-run split depends entirely on `X-Preloop-Session-Id`.**
  `openai_gateway.py` only appends the `` `<principal>:<run>` `` suffix when
  `self._client_session_id` is set.
- **Claude Code never sends `X-Preloop-Session-Id`.** So `_client_session_id`
  is always `None`, the suffix is never applied, and `get_by_source(...)`
  returns the same never-`ended_at` row forever.

Not an inactivity-window heuristic — there is no time bound at all, which is
worse in one sense and, being deterministic, makes the fix exact.

## The signal was there all along

Running the real Claude Code binary against a local capture server (isolated
`HOME`, throwaway key, no Preloop involved) shows every request carries its own
session id **twice**:

```json
{
  \"metadata\": { \"user_id\": \"{\\"device_id\\":\\"87f960…\\",\\"account_uuid\\":\\"\\",\\"session_id\\":\\"26d2f152-2d10-49e5-a68c-e471d55aadad\\"}\" },
  \"headers\":  { \"X-Claude-Code-Session-Id\": \"26d2f152-2d10-49e5-a68c-e471d55aadad\" }
}
```

That uuid **is** the conversation identity: the transcript written was
`~/.claude/projects/<slug>/26d2f152-2d10-49e5-a68c-e471d55aadad.jsonl`.
Confirmed in shipped `@anthropic-ai/claude-code` 0.94.0. Preloop was receiving
the correct session id on every single request and discarding it.

## The fix

Two independent readers, so it survives either signal being dropped:

1. **Header (primary)** — the Anthropic endpoint accepts
   `X-Claude-Code-Session-Id` and passes
   `x_preloop_session_id or x_claude_code_session_id`.
2. **Payload (fallback)** — `_session_id_from_anthropic_metadata()` parses
   `metadata.user_id`; `_adopt_native_session_id()` applies it at the top of
   `create_message` / `stream_message`, before any session resolution.

Deliberate safety properties:

- **`X-Preloop-Session-Id` always wins** — no regression for custom
  agents/wizard.
- **Fail-soft everywhere** — non-dict payload, non-JSON string, non-object
  JSON, missing/oversized/bad-charset/wrong-type `session_id` all return `None`
  and fall back to today's behavior. Nothing new can raise on the request path.
- **Bounded parse** (4096 chars) before `json.loads`, then reuses the existing
  `_normalize_client_session_id` charset/length validation. No new attack
  surface.
- **Never mutates an in-flight request's identity** — no-op once the runtime
  session is resolved.
- Reuses the existing per-run keying, so sessions/agent views and the
  `:`-suffix matching in `crud/runtime_session.py` work unchanged.

## Tests

6 new tests, **each verified to actually catch the bug** — reverting the source
change turns them red:

```
FAILED test_claude_code_native_metadata_splits_sessions
FAILED test_claude_code_session_id_lands_on_runtime_session_row
FAILED test_claude_code_session_header_reaches_gateway_service
# restored: 27 passed
```

`test_claude_code_native_metadata_splits_sessions` is the bug in miniature: two
conversations on one durable credential must not share a session. Others cover
same-conversation reuse, the runtime-session row's `session_source_id` suffix,
`X-Preloop-Session-Id` precedence, and 7 malformed-metadata shapes degrading
without error.

Full backend suite on a clean DB: **4840 passed, 10 skipped**. The 6 remaining
failures are pre-existing `caplog` assertions that fail identically on stock
`main` in this local environment (verified by re-running with the patch
stashed); CI is green on the base commit.

## Targeting 0.14.0

Small, isolated to the Anthropic gateway path, strictly additive (every new
code path degrades to current behavior), and it fixes a founder-visible day-one
dogfood bug.

## Deliberately not in this PR

- **No backfill.** Session boundaries were never stored; only 7.6% of the glued
  rows have a recoverable `session_id`, skewed to recent days and to request
  shapes that survived truncation. A backfill would invent *biased* partial
  sessions — worse than an honest gap. Fix forward; treat pre-fix `claude_code`
  sessions as a known-bad range.
- **Other agents likely have the same hole.** The `:`-suffix mechanism is
  generic but only Claude Code's native id is read today; Codex/OpenCode/Gemini
  on durable credentials plausibly collapse the same way. Same bug class, worth
  one probe each.
- **Sessions never end.** Nothing sets `ended_at` for plugin agents, so rows
  grow forever; an idle-timeout closer would bound damage from any future
  identity gap.
- **`metadata.user_id` reaches the search corpus** (device id + session id land
  in `searchable_text`). It made this diagnosis possible, but it is unintended
  retention of client identifiers — worth a privacy look.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Strictly additive bug fix isolated to the Anthropic gateway path. Every new code path degrades to current behavior on malformed input. Six regression tests verify the fix catches the actual bug.

> **Overview**
> Claude Code sends per-conversation session identifiers via header and metadata that Preloop was discarding, causing all runs on a machine to collapse into one eternal session row. This fix reads both signals, falling back gracefully, and gives each real Claude Code conversation its own runtime session for accurate per-session metrics.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit on branch fix/claude-code-session-identity. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->