### PR TITLE
Show which rule required the approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Matched-rule context on approval requests**: the approval the human
+  reviews now records which access rule gated the call (id, name, expression,
+  priority, and any lower-priority rules that also matched), snapshotted at
+  create time so later rule edits cannot rewrite history. The console shows a
+  "Why this needs approval" block with the expression verbatim; list rows and
+  push payloads show the rule name only. Rule-less gates (tool default,
+  evaluation error, agent permission hook) say so plainly instead of
+  inventing an expression. New nullable JSONB `rule_context` column; the
+  API field is optional so historical rows stay blank.
 - **Native scheduled (cron) flow triggers**: flows can now run on a schedule
   without an external cron caller hitting the webhook endpoint. Create or
   update a flow with `trigger_event_source: "schedule"` and

--- a/backend/preloop/models/alembic/versions/20260806_approval_rule_context.py
+++ b/backend/preloop/models/alembic/versions/20260806_approval_rule_context.py
@@ -1,0 +1,41 @@
+"""add rule_context to approval_request
+
+Carries the matched ToolAccessRule (id, name, condition expression, priority)
+onto the approval request so an approver can see WHY the call was gated, not
+just which tool was called with which arguments. Nullable: approvals raised
+without rule evaluation (the request_approval builtin) and every pre-existing
+row legitimately have no rule context, and surfaces omit the block rather than
+fabricate one.
+
+Revision ID: 20260806_approval_rule_ctx
+Revises: 20260806_ai_model_updated_at
+Create Date: 2026-08-06
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "20260806_approval_rule_ctx"
+down_revision: Union[str, None] = "20260806_ai_model_updated_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+# Alembic reads these module globals by name; keep a local reference so static
+# analysis treats them as used.
+_ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)
+assert _ALEMBIC_IDENTIFIERS, "Alembic revision metadata must be defined"
+
+
+def upgrade() -> None:
+    """Add the nullable rule_context JSONB column."""
+    op.add_column(
+        "approval_request",
+        sa.Column("rule_context", JSONB, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the rule_context column."""
+    op.drop_column("approval_request", "rule_context")

--- a/backend/preloop/models/alembic/versions/20260806_approval_rule_context.py
+++ b/backend/preloop/models/alembic/versions/20260806_approval_rule_context.py
@@ -8,7 +8,7 @@ row legitimately have no rule context, and surfaces omit the block rather than
 fabricate one.
 
 Revision ID: 20260806_approval_rule_ctx
-Revises: 20260806_ai_model_updated_at
+Revises: 20260815_flow_schedule_config
 Create Date: 2026-08-06
 """
 
@@ -19,7 +19,7 @@ from alembic import op
 from sqlalchemy.dialects.postgresql import JSONB
 
 revision: str = "20260806_approval_rule_ctx"
-down_revision: Union[str, None] = "20260806_ai_model_updated_at"
+down_revision: Union[str, None] = "20260815_flow_schedule_config"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 # Alembic reads these module globals by name; keep a local reference so static

--- a/backend/preloop/models/models/approval_request.py
+++ b/backend/preloop/models/models/approval_request.py
@@ -142,6 +142,21 @@ class ApprovalRequest(Base):
         comment="Agent's reasoning for the tool call",
     )
 
+    # Why this request exists: the matched ToolAccessRule (id, name, condition
+    # expression, priority) or, when no rule fired, a plain statement of the
+    # gating that did. Snapshotted at creation time rather than recomputed at
+    # read time, so editing or deleting a rule later cannot rewrite the reason
+    # a past approval was asked for. NULL for approvals raised without rule
+    # evaluation (the request_approval builtin) and for rows created before
+    # this column existed; surfaces omit the block rather than guess.
+    # Shape is built by services/approval_rule_context.py.
+    rule_context: Mapped[Optional[dict]] = mapped_column(
+        JSONB,
+        nullable=True,
+        default=None,
+        comment="Snapshot of the policy rule that required this approval",
+    )
+
     summary: Mapped[Optional[str]] = mapped_column(
         Text,
         nullable=True,

--- a/backend/preloop/models/schemas/approval_request.py
+++ b/backend/preloop/models/schemas/approval_request.py
@@ -85,6 +85,13 @@ class ApprovalRequestResponse(ApprovalRequestBase):
     # MUST NOT count them as human approvals in approval-rate stats.
     auto_approved_reason: Optional[str] = None
     auto_approval_bypass_id: Optional[UUID] = None
+    # Why this request exists: the rule that gated the call, snapshotted at
+    # creation time. Optional for backward compatibility: rows created before
+    # this field existed, and approvals raised without rule evaluation (the
+    # request_approval builtin), carry None and surfaces must omit the block
+    # rather than fabricate a reason. Shape is documented in
+    # services/approval_rule_context.py.
+    rule_context: Optional[Dict[str, Any]] = None
 
     @computed_field
     def was_bypassed(self) -> bool:

--- a/backend/preloop/services/agent_permission_service.py
+++ b/backend/preloop/services/agent_permission_service.py
@@ -374,6 +374,10 @@ async def request_agent_permission(
     if decision == "deny":
         return ("deny", "Denied by client policy", None, False)
 
+    from preloop.services.approval_rule_context import (
+        SOURCE_AGENT_PERMISSION_HOOK,
+        build_rule_context,
+    )
     from preloop.services.approval_service import ApprovalService
     from preloop.models.crud.approval_request import get_approval_request_async
 
@@ -414,6 +418,15 @@ async def request_agent_permission(
                     models.AutoApprovedReason.NATIVE_TOOL_APPROVALS_OFF
                     if approvals_off
                     else None
+                ),
+                # This path does not consult Preloop access rules at all: the
+                # agent's own hook already decided to escalate. Say that
+                # instead of leaving the approver hunting for a rule that
+                # never existed.
+                rule_context=build_rule_context(
+                    source=SOURCE_AGENT_PERMISSION_HOOK,
+                    decision="require_approval",
+                    rule_name="Agent permission hook",
                 ),
             )
         except Exception:

--- a/backend/preloop/services/approval_helper.py
+++ b/backend/preloop/services/approval_helper.py
@@ -105,6 +105,7 @@ async def require_approval(
     correlation_id: Optional[str] = None,
     justification: Optional[str] = None,
     return_comment_on_approve: bool = False,
+    rule_context: Optional[dict] = None,
 ) -> Tuple[bool, str]:
     """Check if tool requires approval and wait for decision with streaming.
 
@@ -125,6 +126,14 @@ async def require_approval(
         justification: Optional justification text provided by the agent explaining
                       why this tool is being called. Injected by DynamicFastMCP when
                       justification_mode is configured on the tool.
+        rule_context: Snapshot of the policy rule that demanded this approval
+                      (see services/approval_rule_context.py). When omitted,
+                      falls back to whatever DynamicFastMCP's central policy
+                      evaluation stored in ``_rule_context_var``, and finally to
+                      the rule this function matches itself in the legacy
+                      inline path below. None means no rule was evaluated (e.g.
+                      the request_approval builtin) and surfaces omit the
+                      explanation rather than invent one.
 
     Returns:
         Tuple of (approved: bool, error_message: str)
@@ -154,6 +163,23 @@ async def require_approval(
             get_tool_config_by_name_and_source_async,
         )
         from preloop.models.crud.approval_workflow import get_approval_workflow_async
+        from preloop.services.approval_rule_context import (
+            SOURCE_TOOL_ACCESS_RULE,
+            SOURCE_TOOL_DEFAULT_WORKFLOW,
+            build_rule_context,
+        )
+
+        # DynamicFastMCP's central policy evaluation runs before the tool
+        # wrapper and already knows which rule fired; prefer that over
+        # anything we rediscover here, and never overwrite an explicit
+        # argument.
+        if rule_context is None:
+            try:
+                from preloop.services.dynamic_fastmcp import _rule_context_var
+
+                rule_context = _rule_context_var.get(None)
+            except Exception:  # pragma: no cover - contextvar lookup is optional
+                rule_context = None
 
         logger.info(
             f"Checking approval requirement for {tool_source} tool '{tool_name}' "
@@ -302,6 +328,21 @@ async def require_approval(
                         return (False, f"Tool '{tool_name}' is denied by access rule")
                     elif rule.action == "require_approval":
                         matched_require_approval = True
+                        # Record WHICH rule gated the call. Only when the
+                        # central evaluator did not already hand us one: it
+                        # sees the same rules with more context (subject
+                        # scoping, also-matched rules) and is authoritative.
+                        if rule_context is None:
+                            rule_context = build_rule_context(
+                                source=SOURCE_TOOL_ACCESS_RULE,
+                                decision="require_approval",
+                                rule_id=rule.id,
+                                rule_name=rule.description,
+                                expression=rule.condition_expression,
+                                expression_type=rule.condition_type,
+                                priority=rule.priority,
+                                tool_configuration_id=config.id,
+                            )
                         break  # Proceed to approval flow below
 
                 # If access rules exist but none matched, default to allow.
@@ -312,6 +353,18 @@ async def require_approval(
                         f"access rules exist but none matched — default allow"
                     )
                     return (True, "")
+
+                if not access_rules and rule_context is None:
+                    # No rules exist at all: the tool config itself pins an
+                    # approval workflow, so every call is gated whatever the
+                    # arguments are. Say that plainly rather than leaving the
+                    # approver to guess which rule they cannot find.
+                    rule_context = build_rule_context(
+                        source=SOURCE_TOOL_DEFAULT_WORKFLOW,
+                        decision="require_approval",
+                        rule_name="Tool default policy",
+                        tool_configuration_id=config.id,
+                    )
 
                 # Get approval workflow from tool configuration
                 workflow = await get_approval_workflow_async(
@@ -349,6 +402,7 @@ async def require_approval(
                     tool_args=arguments,
                     agent_reasoning=justification,
                     execution_id=None,
+                    rule_context=rule_context,
                 )
 
                 # Derive notification channel from approval_type

--- a/backend/preloop/services/approval_rule_context.py
+++ b/backend/preloop/services/approval_rule_context.py
@@ -87,8 +87,11 @@ _GENERIC_LABELS = {
 _ARGS_REFERENCE = re.compile(r"\bargs\.([A-Za-z_][A-Za-z0-9_]*)")
 
 #: Bare leading identifier for the shorthand form users may write in rules
-#: ("amount > 300" instead of "args.amount > 300").
+#: ("amount > 300" instead of "args.amount > 300"). Boolean literals are
+#: catch-alls (``_evaluate_simple_condition`` accepts bare ``true``/``false``)
+#: and are not argument names.
 _BARE_REFERENCE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\b")
+_BOOLEAN_LITERALS = frozenset({"true", "false"})
 
 
 def referenced_args(expression: Optional[str]) -> List[str]:
@@ -106,7 +109,7 @@ def referenced_args(expression: Optional[str]) -> List[str]:
             names.append(name)
     if not names:
         bare = _BARE_REFERENCE.match(expression)
-        if bare:
+        if bare and bare.group(1).lower() not in _BOOLEAN_LITERALS:
             names.append(bare.group(1))
     return names
 

--- a/backend/preloop/services/approval_rule_context.py
+++ b/backend/preloop/services/approval_rule_context.py
@@ -1,0 +1,187 @@
+"""Matched-rule context carried onto approval requests.
+
+Why this exists: when a human reviews an approval request they see the tool
+name and the argument values, but not WHICH rule demanded the approval. That
+makes a boundary case (``args.amount == threshold``) indistinguishable from a
+mid-band one, and it hides a mis-scoped rule at exactly the moment someone is
+in a position to notice it.
+
+This module builds a small, durable, JSON-serialisable record of the winning
+rule so it can be persisted on ``ApprovalRequest.rule_context`` and rendered
+on every approval surface. It is deliberately a *description of what matched*,
+never a risk score or a recommendation: we know which expression evaluated
+true, and nothing more.
+
+Absence is meaningful. Approvals raised without any rule evaluation (the
+``request_approval`` builtin, historical rows created before this field
+existed) carry ``None`` and surfaces must simply omit the block rather than
+invent an explanation.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List, Optional
+
+#: A rule row in ``tool_access_rules`` matched the call.
+SOURCE_TOOL_ACCESS_RULE = "tool_access_rule"
+
+#: A subject-scoped governance rule (stored on the account's meta_data and
+#: scoped to an agent or API key) matched the call.
+SOURCE_SUBJECT_SCOPED_RULE = "subject_scoped_rule"
+
+#: No rule matched: the tool configuration itself pins an approval workflow,
+#: so every call to the tool is gated regardless of arguments.
+SOURCE_TOOL_DEFAULT_WORKFLOW = "tool_default_workflow"
+
+#: A rule could not be evaluated (malformed expression, bad argument types).
+#: Policy evaluation fails closed, so the approval exists because of the
+#: failure, not because a condition was met.
+SOURCE_RULE_EVALUATION_ERROR = "rule_evaluation_error"
+
+#: The approval came from an agent's own permission hook (e.g. Claude Code
+#: PreToolUse escalating an "ask" verdict). Preloop's tool access rules are
+#: not consulted on that path.
+SOURCE_AGENT_PERMISSION_HOOK = "agent_permission_hook"
+
+#: Every ``source`` value a caller may persist.
+KNOWN_SOURCES = frozenset(
+    {
+        SOURCE_TOOL_ACCESS_RULE,
+        SOURCE_SUBJECT_SCOPED_RULE,
+        SOURCE_TOOL_DEFAULT_WORKFLOW,
+        SOURCE_RULE_EVALUATION_ERROR,
+        SOURCE_AGENT_PERMISSION_HOOK,
+    }
+)
+
+#: Plain statements for the cases where no named rule fired. These say what
+#: actually happened; they do not imply anyone assessed the call.
+_DEFAULT_EXPLANATIONS = {
+    SOURCE_TOOL_DEFAULT_WORKFLOW: (
+        "No access rule matched. This tool is configured to require approval "
+        "for every call, whatever the arguments are."
+    ),
+    SOURCE_RULE_EVALUATION_ERROR: (
+        "An access rule could not be evaluated, so Preloop failed closed and "
+        "asked for approval instead of deciding on its own."
+    ),
+    SOURCE_AGENT_PERMISSION_HOOK: (
+        "The agent's own permission hook escalated this call for human "
+        "approval. No Preloop access rule was evaluated for it."
+    ),
+}
+
+#: Label of last resort when a rule has neither description nor expression.
+_GENERIC_LABELS = {
+    SOURCE_TOOL_ACCESS_RULE: "Access rule",
+    SOURCE_SUBJECT_SCOPED_RULE: "Scoped governance rule",
+    SOURCE_TOOL_DEFAULT_WORKFLOW: "Tool default policy",
+    SOURCE_RULE_EVALUATION_ERROR: "Rule evaluation error",
+    SOURCE_AGENT_PERMISSION_HOOK: "Agent permission hook",
+}
+
+#: Identifiers referenced through ``args.`` in an expression, e.g. the
+#: ``amount`` in ``args.amount > 1000``. Used to point the reviewer at the
+#: argument the rule actually looked at.
+_ARGS_REFERENCE = re.compile(r"\bargs\.([A-Za-z_][A-Za-z0-9_]*)")
+
+#: Bare leading identifier for the shorthand form users may write in rules
+#: ("amount > 300" instead of "args.amount > 300").
+_BARE_REFERENCE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\b")
+
+
+def referenced_args(expression: Optional[str]) -> List[str]:
+    """Return argument names the expression mentions, in first-seen order.
+
+    Best effort and purely presentational: a name here means the expression
+    text mentions it, not that it decided the outcome.
+    """
+    if not expression:
+        return []
+    names: List[str] = []
+    for match in _ARGS_REFERENCE.finditer(expression):
+        name = match.group(1)
+        if name not in names:
+            names.append(name)
+    if not names:
+        bare = _BARE_REFERENCE.match(expression)
+        if bare:
+            names.append(bare.group(1))
+    return names
+
+
+def build_rule_context(
+    *,
+    source: str,
+    decision: str,
+    rule_id: Optional[Any] = None,
+    rule_name: Optional[str] = None,
+    expression: Optional[str] = None,
+    expression_type: Optional[str] = None,
+    priority: Optional[int] = None,
+    explanation: Optional[str] = None,
+    also_matched_rule_ids: Optional[Iterable[Any]] = None,
+    tool_configuration_id: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Build the JSON payload persisted on ``ApprovalRequest.rule_context``.
+
+    Args:
+        source: One of the ``SOURCE_*`` constants above.
+        decision: The policy action that produced the approval. In practice
+            always ``"require_approval"``; recorded so a future action does
+            not silently reuse this field with a different meaning.
+        rule_id: Identifier of the winning rule, when it has one. Subject
+            scoped rules live in JSON config and have none.
+        rule_name: Human label for the rule. Falls back to the expression,
+            then to a generic label for the source.
+        expression: The condition expression as written by the operator.
+        expression_type: ``"cel"`` or ``"simple"``.
+        priority: The rule's evaluation priority (lower runs first).
+        explanation: Overrides the default plain statement for the source.
+        also_matched_rule_ids: Lower-priority rules that would also have
+            matched. Informational only: the winning rule is the one that
+            decided.
+        tool_configuration_id: Tool config the rule belongs to, so surfaces
+            can link to where the rule is edited.
+
+    Returns:
+        A dict with no ``None`` values, safe to store as JSONB.
+
+    Raises:
+        ValueError: If ``source`` is not a known source constant.
+    """
+    if source not in KNOWN_SOURCES:
+        raise ValueError(f"Unknown approval rule context source: {source!r}")
+
+    label = (rule_name or "").strip() or (expression or "").strip()
+    if not label:
+        label = _GENERIC_LABELS.get(source, "Approval rule")
+
+    context: Dict[str, Any] = {
+        "source": source,
+        "decision": decision,
+        "rule_name": label,
+    }
+
+    explanation_text = explanation or _DEFAULT_EXPLANATIONS.get(source)
+    if explanation_text:
+        context["explanation"] = explanation_text
+    if rule_id is not None:
+        context["rule_id"] = str(rule_id)
+    if expression:
+        context["expression"] = expression
+        references = referenced_args(expression)
+        if references:
+            context["referenced_args"] = references
+    if expression_type:
+        context["expression_type"] = expression_type
+    if priority is not None:
+        context["priority"] = int(priority)
+    if tool_configuration_id is not None:
+        context["tool_configuration_id"] = str(tool_configuration_id)
+    also = [str(rule) for rule in (also_matched_rule_ids or [])]
+    if also:
+        context["also_matched_rule_ids"] = also
+
+    return context

--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -496,6 +496,10 @@ class ApprovalService:
                 "tool_args": redact_dict(approval_request.tool_args or {}),
                 "agent_reasoning": approval_request.agent_reasoning,
                 "managed_agent_name": approval_request.managed_agent_name,
+                # Why the call was gated. Rule names and expressions are
+                # operator-authored policy text, not call arguments, so they
+                # are not redacted; tool_args above still are.
+                "rule_context": approval_request.rule_context,
                 "status": approval_request.status,
                 "requested_at": approval_request.requested_at.isoformat(),
                 "resolved_at": (
@@ -541,6 +545,7 @@ class ApprovalService:
         managed_agent_id: Optional[uuid.UUID] = None,
         runtime_session_id: Optional[uuid.UUID] = None,
         managed_agent_name: Optional[str] = None,
+        rule_context: Optional[Dict[str, Any]] = None,
     ) -> ApprovalRequest:
         """Create a new approval request.
 
@@ -553,6 +558,12 @@ class ApprovalService:
             agent_reasoning: Agent's reasoning for the tool call
             execution_id: Flow execution ID (if applicable)
             timeout_seconds: How long to wait for approval (default: 5 minutes)
+            rule_context: Snapshot of the policy rule that required this
+                approval (see services/approval_rule_context.py). Stored as
+                given so a later edit to the rule cannot rewrite the reason a
+                past approval was asked for. None when no rule was evaluated
+                (e.g. the request_approval builtin), in which case surfaces
+                omit the explanation rather than invent one.
 
         Returns:
             Created approval request
@@ -574,6 +585,7 @@ class ApprovalService:
             managed_agent_id=managed_agent_id,
             runtime_session_id=runtime_session_id,
             managed_agent_name=managed_agent_name,
+            rule_context=rule_context,
             status="pending",
             requested_at=datetime.utcnow(),
             expires_at=expires_at,
@@ -609,6 +621,7 @@ class ApprovalService:
                 "approval_workflow_id": str(approval_workflow_id),
                 "tool_args": redact_dict(tool_args),
                 "timeout_seconds": timeout,
+                **({"rule_context": rule_context} if rule_context else {}),
             },
         )
 
@@ -1656,6 +1669,7 @@ class ApprovalService:
         runtime_session_id: Optional[uuid.UUID] = None,
         managed_agent_name: Optional[str] = None,
         standing_bypass_reason: Optional[str] = None,
+        rule_context: Optional[Dict[str, Any]] = None,
     ) -> ApprovalRequest:
         """Create approval request and send notifications through configured channels.
 
@@ -1677,6 +1691,9 @@ class ApprovalService:
                 request is still created and recorded, then immediately
                 auto-approved without notifying anyone. Must be an
                 :class:`AutoApprovedReason` value.
+            rule_context: Snapshot of the policy rule that required this
+                approval, built by services/approval_rule_context.py. Passed
+                straight through to the row; None when no rule was evaluated.
 
         Returns:
             Created approval request (may be already resolved if AI-driven)
@@ -1696,6 +1713,7 @@ class ApprovalService:
             managed_agent_id=managed_agent_id,
             runtime_session_id=runtime_session_id,
             managed_agent_name=managed_agent_name,
+            rule_context=rule_context,
         )
 
         # Generate user-facing summary before any notifications fire.
@@ -2527,6 +2545,7 @@ class ApprovalService:
             agent_reasoning=approval_request.agent_reasoning,
             tool_args=redact_dict(approval_request.tool_args or {}),
             summary=approval_request.summary,
+            rule_context=approval_request.rule_context,
         )
 
         apns_priority = 10 if priority_str in ["urgent", "high"] else 5
@@ -3145,6 +3164,7 @@ class ApprovalService:
             agent_reasoning=f"ESCALATED: {approval_request.agent_reasoning or 'Original approvers did not respond'}",
             tool_args=redact_dict(approval_request.tool_args or {}),
             summary=approval_request.summary,
+            rule_context=approval_request.rule_context,
         )
 
         sent_count = 0

--- a/backend/preloop/services/approval_wrapper.py
+++ b/backend/preloop/services/approval_wrapper.py
@@ -78,11 +78,7 @@ def with_approval(tool_func: Callable) -> Callable:
                 # Evaluate workflow rules (ToolAccessRule) to determine action
                 # This checks allow/deny/require_approval rules with conditions
 
-                (
-                    action,
-                    approval_workflow_id,
-                    rule_description,
-                ) = await evaluate_policy_async(
+                policy_decision = await evaluate_policy_async(
                     db=db,
                     tool_name=tool_name,
                     tool_args=kwargs,
@@ -91,6 +87,7 @@ def with_approval(tool_func: Callable) -> Callable:
                     user_id=getattr(user_context, "user_id", None),
                     execution_id=getattr(user_context, "execution_id", None),
                 )
+                action, approval_workflow_id, rule_description = policy_decision
 
                 logger.info(
                     f"Policy evaluation for tool '{tool_name}': "
@@ -161,6 +158,10 @@ def with_approval(tool_func: Callable) -> Callable:
                         tool_args=kwargs,  # Use kwargs as tool arguments
                         agent_reasoning=None,
                         execution_id=None,
+                        # getattr: a patched evaluator may return a plain
+                        # tuple, and a missing snapshot must read as
+                        # "not recorded" rather than raise here.
+                        rule_context=getattr(policy_decision, "rule_context", None),
                     )
 
                     notification_channel = (

--- a/backend/preloop/services/dynamic_fastmcp.py
+++ b/backend/preloop/services/dynamic_fastmcp.py
@@ -71,6 +71,17 @@ _rule_workflow_id_var: ContextVar[Optional[str]] = ContextVar(
     "_rule_workflow_id_var", default=None
 )
 
+# Context variable carrying the matched-rule snapshot from _call_tool()'s
+# policy evaluation through to require_approval(), which persists it on the
+# approval request. Without this the approver sees the tool and the arguments
+# but not WHICH rule demanded approval, so a boundary case is indistinguishable
+# from a mid-band one. Set in the same places as _rule_workflow_id_var and
+# cleared on every non-approval path so a stale rule can never be attributed
+# to a later call.
+_rule_context_var: ContextVar[Optional[dict]] = ContextVar(
+    "_rule_context_var", default=None
+)
+
 # Context variable to pass a unique correlation_id from _call_tool() through
 # to all audit-logging helpers (policy_evaluator, approval_helper, tool execution).
 # Every audit log entry from the same tool invocation shares this ID so the
@@ -1117,7 +1128,7 @@ async def {internal_name}({params_str}) -> str:
             from preloop.services.policy_evaluator import evaluate_policy_async
 
             async with get_async_db_session() as db:
-                action, approval_workflow_id, reason = await evaluate_policy_async(
+                _policy_decision = await evaluate_policy_async(
                     db=db,
                     tool_name=name,
                     tool_args=arguments,
@@ -1144,6 +1155,8 @@ async def {internal_name}({params_str}) -> str:
                     },
                 )
 
+            action, approval_workflow_id, reason = _policy_decision
+
             logger.info(
                 f"Policy evaluation for '{name}': action={action}, "
                 f"workflow_id={approval_workflow_id}, reason={reason}"
@@ -1158,6 +1171,12 @@ async def {internal_name}({params_str}) -> str:
                 )
 
             if action == "require_approval":
+                # Carry the matched rule through to require_approval() so it
+                # lands on the approval row. getattr because tests (and any
+                # future caller) may patch the evaluator with a plain tuple;
+                # a missing snapshot must read as "not recorded", never raise
+                # on the enforcement path.
+                _rule_context_var.set(getattr(_policy_decision, "rule_context", None))
                 if approval_workflow_id:
                     # Store the workflow_id so require_approval() in the tool
                     # wrapper picks it up instead of relying on the legacy
@@ -1170,6 +1189,7 @@ async def {internal_name}({params_str}) -> str:
                     # tool through, otherwise an explicit ``require_approval``
                     # rule would behave like ``allow``.
                     _rule_workflow_id_var.set(None)
+                    _rule_context_var.set(None)
                     logger.error(
                         f"Tool '{name}' matched require_approval rule but no "
                         "approval workflow is configured (rule, tool config, "
@@ -1190,6 +1210,7 @@ async def {internal_name}({params_str}) -> str:
                     )
             else:
                 _rule_workflow_id_var.set(None)
+                _rule_context_var.set(None)
 
         except Exception as e:
             logger.error(
@@ -1203,6 +1224,7 @@ async def {internal_name}({params_str}) -> str:
             # infrastructure error. Block the call and surface a ret600able
             # error to the agent.
             _rule_workflow_id_var.set(None)
+            _rule_context_var.set(None)
             return ToolResult(
                 content=[
                     TextContent(
@@ -1257,6 +1279,7 @@ async def {internal_name}({params_str}) -> str:
 
             # Clean up context vars after execution
             _rule_workflow_id_var.set(None)
+            _rule_context_var.set(None)
             _correlation_id_var.set(None)
 
             # ── Audit: log tool execution ───────────────────────────────
@@ -1606,6 +1629,7 @@ def create_user_context_from_scope(scope: dict) -> Optional[UserContext]:
 # out of ``__all__`` so ``import *`` stays a public-API surface only.
 _CONTEXT_VAR_EXPORTS = (
     _rule_workflow_id_var,
+    _rule_context_var,
     _correlation_id_var,
     _justification_var,
     _bypass_approval_var,

--- a/backend/preloop/services/dynamic_mcp_server.py
+++ b/backend/preloop/services/dynamic_mcp_server.py
@@ -278,11 +278,14 @@ class DynamicMCPServer:
                     ]
 
                 # Evaluate policy rules to determine action (allow/deny/require_approval)
+                policy_decision = await self._evaluate_policy(
+                    user_context, name, arguments or {}
+                )
                 (
                     action,
                     approval_workflow_id,
                     rule_description,
-                ) = await self._evaluate_policy(user_context, name, arguments or {})
+                ) = policy_decision
 
                 logger.info(
                     f"Policy evaluation for tool '{name}': "
@@ -309,7 +312,14 @@ class DynamicMCPServer:
                     try:
                         # Wait for approval
                         await self._request_and_wait_for_approval(
-                            user_context, name, arguments or {}, approval_workflow_id
+                            user_context,
+                            name,
+                            arguments or {},
+                            approval_workflow_id,
+                            # getattr, not attribute access: tests patch
+                            # _evaluate_policy with a plain tuple and a missing
+                            # snapshot must read as "not recorded".
+                            rule_context=getattr(policy_decision, "rule_context", None),
                         )
                         logger.info(f"Tool {name} approved - proceeding with execution")
                     except TimeoutError as e:
@@ -488,17 +498,29 @@ class DynamicMCPServer:
             tool_args: Tool arguments for condition evaluation
 
         Returns:
-            Tuple of (action, approval_workflow_id, rule_description)
+            A ``PolicyDecision``, which unpacks as the 3-tuple
+            (action, approval_workflow_id, rule_description) and carries
+            ``.rule_context`` describing the rule that gated the call.
             - action: 'allow', 'deny', or 'require_approval'
             - approval_workflow_id: UUID of approval workflow (if require_approval)
             - rule_description: Description of the matched rule
         """
+        # Imported outside the try: the fail-closed branch below builds a
+        # PolicyDecision, and it must not itself blow up with a NameError.
+        from preloop.services.approval_rule_context import (
+            SOURCE_RULE_EVALUATION_ERROR,
+            build_rule_context,
+        )
+        from preloop.services.policy_evaluator import (
+            PolicyDecision,
+            evaluate_policy_async,
+        )
+
         try:
             from preloop.models.db.session import get_async_db_session
             from preloop.models.crud.tool_configuration import (
                 get_tool_config_by_name_and_source_async,
             )
-            from preloop.services.policy_evaluator import evaluate_policy_async
 
             logger.info(
                 f"Evaluating policy for tool '{tool_name}' "
@@ -526,11 +548,7 @@ class DynamicMCPServer:
                     )
 
                 # Evaluate policy rules
-                (
-                    action,
-                    approval_workflow_id,
-                    rule_description,
-                ) = await evaluate_policy_async(
+                decision = await evaluate_policy_async(
                     db=db,
                     tool_name=tool_name,
                     tool_args=tool_args,
@@ -574,18 +592,33 @@ class DynamicMCPServer:
                     },
                 )
 
+                action, approval_workflow_id, rule_description = decision
+
                 logger.info(
                     f"Policy evaluation result for '{tool_name}': "
                     f"action={action}, approval_workflow_id={approval_workflow_id}, "
                     f"rule='{rule_description}'"
                 )
 
-                return action, approval_workflow_id, rule_description
+                return decision
 
         except Exception as e:
             # SECURITY: Fail closed on errors
             logger.error(f"Error evaluating policy for {tool_name}: {e}", exc_info=True)
-            return "require_approval", None, f"Policy evaluation error: {e}"
+            return PolicyDecision(
+                "require_approval",
+                None,
+                f"Policy evaluation error: {e}",
+                build_rule_context(
+                    source=SOURCE_RULE_EVALUATION_ERROR,
+                    decision="require_approval",
+                    explanation=(
+                        "Preloop could not evaluate this tool call's access "
+                        "rules, so it failed closed and asked for approval "
+                        "instead of deciding on its own."
+                    ),
+                ),
+            )
 
     async def _request_and_wait_for_approval(
         self,
@@ -593,6 +626,7 @@ class DynamicMCPServer:
         tool_name: str,
         tool_args: dict,
         approval_workflow_id: Optional[str] = None,
+        rule_context: Optional[dict] = None,
     ):
         """Request approval and wait for user response.
 
@@ -600,6 +634,9 @@ class DynamicMCPServer:
             user_context: User context
             tool_name: Name of the tool
             tool_args: Tool arguments
+            approval_workflow_id: Workflow to raise the approval against
+            rule_context: Snapshot of the rule that gated the call, persisted
+                on the request so the approver can see why it was raised
 
         Raises:
             TimeoutError: If approval request times out
@@ -672,6 +709,7 @@ class DynamicMCPServer:
                     tool_args=tool_args,
                     agent_reasoning=None,  # Could be extracted from context if available
                     execution_id=None,  # Could be extracted from context if available
+                    rule_context=rule_context,
                 )
 
                 logger.info(

--- a/backend/preloop/services/permission_prompt.py
+++ b/backend/preloop/services/permission_prompt.py
@@ -297,6 +297,10 @@ async def evaluate_permission_prompt(
 
     # 2) No reusable request — raise a fresh approval through the shared
     #    agent-permission machinery.
+    from preloop.services.approval_rule_context import (
+        SOURCE_AGENT_PERMISSION_HOOK,
+        build_rule_context,
+    )
     from preloop.services.approval_service import ApprovalService
 
     async with get_async_db_session() as db:
@@ -332,6 +336,13 @@ async def evaluate_permission_prompt(
                 models.AutoApprovedReason.NATIVE_TOOL_APPROVALS_OFF
                 if approvals_off
                 else None
+            ),
+            # The agent's own permission prompt escalated this; no Preloop
+            # access rule was evaluated. State that plainly.
+            rule_context=build_rule_context(
+                source=SOURCE_AGENT_PERMISSION_HOOK,
+                decision="require_approval",
+                rule_name="Agent permission prompt",
             ),
         )
         request_id = str(approval.id)

--- a/backend/preloop/services/policy_evaluator.py
+++ b/backend/preloop/services/policy_evaluator.py
@@ -375,6 +375,183 @@ def _evaluate_rule_candidates(
     return None
 
 
+def _evaluate_loaded_access_rules(
+    *,
+    rules: list[Any],
+    tool_config: Any,
+    tool_name: str,
+    tool_args: Dict[str, Any],
+    context: Dict[str, Any],
+    account_id: uuid.UUID,
+    user_id: Optional[uuid.UUID],
+    execution_id: Optional[uuid.UUID],
+    default_workflow_id_for_account: Optional[Any] = None,
+    correlation_id: Optional[str] = None,
+    extra_details: Optional[Dict[str, Any]] = None,
+) -> PolicyDecision:
+    """Evaluate already-loaded ToolAccessRule rows.
+
+    Shared by the sync and async evaluators so match order, fail-closed,
+    and the legacy no-rules path cannot drift. Callers keep their own I/O.
+    """
+    logger.info(
+        f"Policy evaluation for '{tool_name}': found {len(rules)} access rules, "
+        f"tool_config.approval_workflow_id={tool_config.approval_workflow_id}"
+    )
+
+    if not rules:
+        if tool_config.approval_workflow_id:
+            logger.warning(
+                f"LEGACY PATH: tool '{tool_name}' has approval_workflow_id="
+                f"{tool_config.approval_workflow_id} but no access rules. "
+                f"ALL calls will require approval regardless of arguments. "
+                f"Add access rules with conditions to enable conditional approval."
+            )
+            _log_policy_decision_async(
+                account_id=account_id,
+                tool_name=tool_name,
+                action="require_approval",
+                rule_description="Tool has approval workflow configured (legacy mode)",
+                tool_args=tool_args,
+                user_id=user_id,
+                execution_id=execution_id,
+                correlation_id=correlation_id,
+                extra_details=extra_details,
+            )
+            return PolicyDecision(
+                "require_approval",
+                tool_config.approval_workflow_id,
+                "Tool has approval workflow configured (legacy mode)",
+                build_rule_context(
+                    source=SOURCE_TOOL_DEFAULT_WORKFLOW,
+                    decision="require_approval",
+                    rule_name="Tool default policy",
+                    tool_configuration_id=tool_config.id,
+                ),
+            )
+        _log_policy_decision_async(
+            account_id=account_id,
+            tool_name=tool_name,
+            action="allow",
+            rule_description="No access rules defined",
+            tool_args=tool_args,
+            user_id=user_id,
+            execution_id=execution_id,
+            correlation_id=correlation_id,
+            extra_details=extra_details,
+        )
+        return PolicyDecision("allow", None, "No access rules defined")
+
+    for index, rule in enumerate(rules):
+        try:
+            logger.info(
+                f"Evaluating rule {rule.id} (priority={rule.priority}, "
+                f"action={rule.action}): condition_type={rule.condition_type}, "
+                f"expression={rule.condition_expression!r}, args={tool_args}"
+            )
+            matches = _evaluate_rule_condition(
+                expression=rule.condition_expression,
+                condition_type=rule.condition_type,
+                tool_args=tool_args,
+                context=context,
+            )
+            logger.info(f"Rule {rule.id} evaluated: matches={matches}")
+
+            if matches:
+                logger.info(
+                    f"Rule matched: {rule.description or rule.condition_expression} "
+                    f"-> action={rule.action}"
+                )
+
+                approval_workflow_id = None
+                if rule.action == "require_approval":
+                    approval_workflow_id = (
+                        rule.approval_workflow_id
+                        or tool_config.approval_workflow_id
+                        or default_workflow_id_for_account
+                    )
+
+                rule_desc = (
+                    rule.description or f"Rule matched: {rule.condition_expression}"
+                )
+
+                _log_policy_decision_async(
+                    account_id=account_id,
+                    tool_name=tool_name,
+                    action=rule.action,
+                    rule_description=rule_desc,
+                    condition_matched=rule.condition_expression,
+                    tool_args=tool_args,
+                    user_id=user_id,
+                    execution_id=execution_id,
+                    correlation_id=correlation_id,
+                    extra_details=extra_details,
+                )
+
+                rule_context = _matched_rule_context(
+                    rule,
+                    rules=rules,
+                    index=index,
+                    tool_config=tool_config,
+                    tool_args=tool_args,
+                    context=context,
+                )
+
+                return PolicyDecision(
+                    rule.action,
+                    approval_workflow_id,
+                    rule_desc,
+                    rule_context,
+                )
+
+        except Exception as e:
+            logger.error(
+                f"Error evaluating rule {rule.id}: {e}. "
+                f"Failing closed with require_approval for security."
+            )
+            error_desc = f"Rule evaluation error: {e} (failing closed)"
+            _log_policy_decision_async(
+                account_id=account_id,
+                tool_name=tool_name,
+                action="require_approval",
+                rule_description=error_desc,
+                condition_matched=rule.condition_expression,
+                tool_args=tool_args,
+                user_id=user_id,
+                execution_id=execution_id,
+                correlation_id=correlation_id,
+                extra_details=extra_details,
+            )
+            return PolicyDecision(
+                "require_approval",
+                tool_config.approval_workflow_id or default_workflow_id_for_account,
+                error_desc,
+                build_rule_context(
+                    source=SOURCE_RULE_EVALUATION_ERROR,
+                    decision="require_approval",
+                    rule_id=rule.id,
+                    rule_name=rule.description,
+                    expression=rule.condition_expression,
+                    expression_type=rule.condition_type,
+                    priority=rule.priority,
+                    tool_configuration_id=tool_config.id,
+                ),
+            )
+
+    _log_policy_decision_async(
+        account_id=account_id,
+        tool_name=tool_name,
+        action="allow",
+        rule_description="No rules matched (default allow)",
+        tool_args=tool_args,
+        user_id=user_id,
+        execution_id=execution_id,
+        correlation_id=correlation_id,
+        extra_details=extra_details,
+    )
+    return PolicyDecision("allow", None, "No rules matched (default allow)")
+
+
 def evaluate_policy(
     db: Session,
     tool_name: str,
@@ -514,167 +691,17 @@ def evaluate_policy(
         enabled_only=True,
     )
 
-    logger.info(
-        f"Policy evaluation for '{tool_name}': found {len(rules)} access rules, "
-        f"tool_config.approval_workflow_id={tool_config.approval_workflow_id}"
-    )
-
-    if not rules:
-        # No rules defined, check for legacy approval_workflow_id on tool config
-        if tool_config.approval_workflow_id:
-            # Legacy behavior: tool has approval workflow but no rules
-            logger.warning(
-                f"LEGACY PATH: tool '{tool_name}' has approval_workflow_id="
-                f"{tool_config.approval_workflow_id} but no access rules. "
-                f"ALL calls will require approval regardless of arguments. "
-                f"Add access rules with conditions to enable conditional approval."
-            )
-            _log_policy_decision_async(
-                account_id=account_id,
-                tool_name=tool_name,
-                action="require_approval",
-                rule_description="Tool has approval workflow configured (legacy mode)",
-                tool_args=tool_args,
-                user_id=user_id,
-                execution_id=execution_id,
-            )
-            return PolicyDecision(
-                "require_approval",
-                tool_config.approval_workflow_id,
-                "Tool has approval workflow configured (legacy mode)",
-                build_rule_context(
-                    source=SOURCE_TOOL_DEFAULT_WORKFLOW,
-                    decision="require_approval",
-                    rule_name="Tool default policy",
-                    tool_configuration_id=tool_config.id,
-                ),
-            )
-        _log_policy_decision_async(
-            account_id=account_id,
-            tool_name=tool_name,
-            action="allow",
-            rule_description="No access rules defined",
-            tool_args=tool_args,
-            user_id=user_id,
-            execution_id=execution_id,
-        )
-        return PolicyDecision("allow", None, "No access rules defined")
-
-    # Evaluate rules in priority order
-    for index, rule in enumerate(rules):
-        try:
-            logger.info(
-                f"Evaluating rule {rule.id} (priority={rule.priority}, "
-                f"action={rule.action}): condition_type={rule.condition_type}, "
-                f"expression={rule.condition_expression!r}, args={tool_args}"
-            )
-            matches = _evaluate_rule_condition(
-                expression=rule.condition_expression,
-                condition_type=rule.condition_type,
-                tool_args=tool_args,
-                context=context,
-            )
-            logger.info(f"Rule {rule.id} evaluated: matches={matches}")
-
-            if matches:
-                logger.info(
-                    f"Rule matched: {rule.description or rule.condition_expression} "
-                    f"-> action={rule.action}"
-                )
-
-                # Determine approval workflow ID for require_approval action
-                approval_workflow_id = None
-                if rule.action == "require_approval":
-                    # Prefer the rule-level policy; fall back to tool config
-                    # default; finally fall back to the account default so a
-                    # ``require_approval`` rule never silently auto-approves.
-                    approval_workflow_id = (
-                        rule.approval_workflow_id
-                        or tool_config.approval_workflow_id
-                        or default_workflow_id_for_account
-                    )
-
-                rule_desc = (
-                    rule.description or f"Rule matched: {rule.condition_expression}"
-                )
-
-                # Log the policy decision (fire-and-forget)
-                _log_policy_decision_async(
-                    account_id=account_id,
-                    tool_name=tool_name,
-                    action=rule.action,
-                    rule_description=rule_desc,
-                    condition_matched=rule.condition_expression,
-                    tool_args=tool_args,
-                    user_id=user_id,
-                    execution_id=execution_id,
-                )
-
-                rule_context = _matched_rule_context(
-                    rule,
-                    rules=rules,
-                    index=index,
-                    tool_config=tool_config,
-                    tool_args=tool_args,
-                    context=context,
-                )
-
-                return PolicyDecision(
-                    rule.action,
-                    approval_workflow_id,
-                    rule_desc,
-                    rule_context,
-                )
-
-        except Exception as e:
-            # SECURITY: Fail closed on evaluation errors
-            # Rather than skipping to the next rule (which could lead to default-allow),
-            # we require approval when rule evaluation fails. This ensures that:
-            # 1. Malformed rules don't silently get bypassed
-            # 2. Unexpected errors don't result in unauthorized access
-            # 3. The action is conservative (require human review) rather than permissive
-            logger.error(
-                f"Error evaluating rule {rule.id}: {e}. "
-                f"Failing closed with require_approval for security."
-            )
-            error_desc = f"Rule evaluation error: {e} (failing closed)"
-            _log_policy_decision_async(
-                account_id=account_id,
-                tool_name=tool_name,
-                action="require_approval",
-                rule_description=error_desc,
-                condition_matched=rule.condition_expression,
-                tool_args=tool_args,
-                user_id=user_id,
-                execution_id=execution_id,
-            )
-            return PolicyDecision(
-                "require_approval",
-                tool_config.approval_workflow_id or default_workflow_id_for_account,
-                error_desc,
-                build_rule_context(
-                    source=SOURCE_RULE_EVALUATION_ERROR,
-                    decision="require_approval",
-                    rule_id=rule.id,
-                    rule_name=rule.description,
-                    expression=rule.condition_expression,
-                    expression_type=rule.condition_type,
-                    priority=rule.priority,
-                    tool_configuration_id=tool_config.id,
-                ),
-            )
-
-    # No rules matched, default allow
-    _log_policy_decision_async(
-        account_id=account_id,
+    return _evaluate_loaded_access_rules(
+        rules=rules,
+        tool_config=tool_config,
         tool_name=tool_name,
-        action="allow",
-        rule_description="No rules matched (default allow)",
         tool_args=tool_args,
+        context=context,
+        account_id=account_id,
         user_id=user_id,
         execution_id=execution_id,
+        default_workflow_id_for_account=default_workflow_id_for_account,
     )
-    return PolicyDecision("allow", None, "No rules matched (default allow)")
 
 
 def _evaluate_rule_condition(
@@ -1112,151 +1139,16 @@ async def evaluate_policy_async(
         enabled_only=True,
     )
 
-    if not rules:
-        # No rules defined, check for legacy approval_workflow_id on tool config
-        if tool_config.approval_workflow_id:
-            _log_policy_decision_async(
-                account_id=account_id,
-                tool_name=tool_name,
-                action="require_approval",
-                rule_description="Tool has approval workflow configured (legacy mode)",
-                tool_args=tool_args,
-                user_id=user_id,
-                execution_id=execution_id,
-                correlation_id=correlation_id,
-                extra_details=extra_details,
-            )
-            return PolicyDecision(
-                "require_approval",
-                tool_config.approval_workflow_id,
-                "Tool has approval workflow configured (legacy mode)",
-                build_rule_context(
-                    source=SOURCE_TOOL_DEFAULT_WORKFLOW,
-                    decision="require_approval",
-                    rule_name="Tool default policy",
-                    tool_configuration_id=tool_config.id,
-                ),
-            )
-        _log_policy_decision_async(
-            account_id=account_id,
-            tool_name=tool_name,
-            action="allow",
-            rule_description="No access rules defined",
-            tool_args=tool_args,
-            user_id=user_id,
-            execution_id=execution_id,
-            correlation_id=correlation_id,
-            extra_details=extra_details,
-        )
-        return PolicyDecision("allow", None, "No access rules defined")
-
-    # Evaluate rules in priority order
-    for index, rule in enumerate(rules):
-        try:
-            matches = _evaluate_rule_condition(
-                expression=rule.condition_expression,
-                condition_type=rule.condition_type,
-                tool_args=tool_args,
-                context=context,
-            )
-
-            if matches:
-                logger.info(
-                    f"Rule matched: {rule.description or rule.condition_expression} "
-                    f"-> action={rule.action}"
-                )
-
-                approval_workflow_id = None
-                if rule.action == "require_approval":
-                    # Prefer the rule's own approval_workflow_id; fall back to
-                    # the tool config's legacy approval_workflow_id; finally fall
-                    # back to the account's default workflow so a bare
-                    # ``require_approval`` rule never silently auto-approves.
-                    approval_workflow_id = (
-                        rule.approval_workflow_id
-                        or tool_config.approval_workflow_id
-                        or default_workflow_id_for_account
-                    )
-
-                rule_desc = (
-                    rule.description or f"Rule matched: {rule.condition_expression}"
-                )
-
-                # Log the policy decision (fire-and-forget)
-                _log_policy_decision_async(
-                    account_id=account_id,
-                    tool_name=tool_name,
-                    action=rule.action,
-                    rule_description=rule_desc,
-                    condition_matched=rule.condition_expression,
-                    tool_args=tool_args,
-                    user_id=user_id,
-                    execution_id=execution_id,
-                    correlation_id=correlation_id,
-                    extra_details=extra_details,
-                )
-
-                rule_context = _matched_rule_context(
-                    rule,
-                    rules=rules,
-                    index=index,
-                    tool_config=tool_config,
-                    tool_args=tool_args,
-                    context=context,
-                )
-
-                return PolicyDecision(
-                    rule.action,
-                    approval_workflow_id,
-                    rule_desc,
-                    rule_context,
-                )
-
-        except Exception as e:
-            # SECURITY: Fail closed on evaluation errors
-            logger.error(
-                f"Error evaluating rule {rule.id}: {e}. "
-                f"Failing closed with require_approval for security."
-            )
-            error_desc = f"Rule evaluation error: {e} (failing closed)"
-            _log_policy_decision_async(
-                account_id=account_id,
-                tool_name=tool_name,
-                action="require_approval",
-                rule_description=error_desc,
-                condition_matched=rule.condition_expression,
-                tool_args=tool_args,
-                user_id=user_id,
-                execution_id=execution_id,
-                correlation_id=correlation_id,
-                extra_details=extra_details,
-            )
-            return PolicyDecision(
-                "require_approval",
-                tool_config.approval_workflow_id or default_workflow_id_for_account,
-                error_desc,
-                build_rule_context(
-                    source=SOURCE_RULE_EVALUATION_ERROR,
-                    decision="require_approval",
-                    rule_id=rule.id,
-                    rule_name=rule.description,
-                    expression=rule.condition_expression,
-                    expression_type=rule.condition_type,
-                    priority=rule.priority,
-                    tool_configuration_id=tool_config.id,
-                ),
-            )
-
-    # No rules matched, default allow
-    _log_policy_decision_async(
-        account_id=account_id,
+    return _evaluate_loaded_access_rules(
+        rules=rules,
+        tool_config=tool_config,
         tool_name=tool_name,
-        action="allow",
-        rule_description="No rules matched (default allow)",
         tool_args=tool_args,
+        context=context,
+        account_id=account_id,
         user_id=user_id,
         execution_id=execution_id,
+        default_workflow_id_for_account=default_workflow_id_for_account,
         correlation_id=correlation_id,
         extra_details=extra_details,
     )
-    return PolicyDecision("allow", None, "No rules matched (default allow)")

--- a/backend/preloop/services/policy_evaluator.py
+++ b/backend/preloop/services/policy_evaluator.py
@@ -133,6 +133,52 @@ def _also_matched_rule_ids(
     return also
 
 
+def _matched_rule_context(
+    rule: Any,
+    *,
+    rules: list[Any],
+    index: int,
+    tool_config: Any,
+    tool_args: Dict[str, Any],
+    context: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Snapshot of the rule that gated a call, or None when it did not gate.
+
+    Shared by the sync and async evaluators so the two cannot drift into
+    recording different things about the same rule. Only ``require_approval``
+    produces a snapshot: allow and deny create no approval to attach one to.
+
+    Args:
+        rule: The winning rule.
+        rules: The full priority-ordered rule list.
+        index: Index of the winning rule within ``rules``.
+        tool_config: The tool configuration the rules belong to.
+        tool_args: Arguments the call was made with.
+        context: Evaluation context.
+
+    Returns:
+        The snapshot dict, or None when the action is not require_approval.
+    """
+    if rule.action != "require_approval":
+        return None
+    return build_rule_context(
+        source=SOURCE_TOOL_ACCESS_RULE,
+        decision=rule.action,
+        rule_id=rule.id,
+        rule_name=rule.description,
+        expression=rule.condition_expression,
+        expression_type=rule.condition_type,
+        priority=rule.priority,
+        tool_configuration_id=tool_config.id,
+        also_matched_rule_ids=_also_matched_rule_ids(
+            rules,
+            start_index=index + 1,
+            tool_args=tool_args,
+            context=context,
+        ),
+    )
+
+
 def _get_audit_service():
     """Get the audit service instance (lazy import to avoid circular deps)."""
     try:
@@ -564,24 +610,14 @@ def evaluate_policy(
                     execution_id=execution_id,
                 )
 
-                rule_context = None
-                if rule.action == "require_approval":
-                    rule_context = build_rule_context(
-                        source=SOURCE_TOOL_ACCESS_RULE,
-                        decision=rule.action,
-                        rule_id=rule.id,
-                        rule_name=rule.description,
-                        expression=rule.condition_expression,
-                        expression_type=rule.condition_type,
-                        priority=rule.priority,
-                        tool_configuration_id=tool_config.id,
-                        also_matched_rule_ids=_also_matched_rule_ids(
-                            rules,
-                            start_index=index + 1,
-                            tool_args=tool_args,
-                            context=context,
-                        ),
-                    )
+                rule_context = _matched_rule_context(
+                    rule,
+                    rules=rules,
+                    index=index,
+                    tool_config=tool_config,
+                    tool_args=tool_args,
+                    context=context,
+                )
 
                 return PolicyDecision(
                     rule.action,
@@ -1160,24 +1196,14 @@ async def evaluate_policy_async(
                     extra_details=extra_details,
                 )
 
-                rule_context = None
-                if rule.action == "require_approval":
-                    rule_context = build_rule_context(
-                        source=SOURCE_TOOL_ACCESS_RULE,
-                        decision=rule.action,
-                        rule_id=rule.id,
-                        rule_name=rule.description,
-                        expression=rule.condition_expression,
-                        expression_type=rule.condition_type,
-                        priority=rule.priority,
-                        tool_configuration_id=tool_config.id,
-                        also_matched_rule_ids=_also_matched_rule_ids(
-                            rules,
-                            start_index=index + 1,
-                            tool_args=tool_args,
-                            context=context,
-                        ),
-                    )
+                rule_context = _matched_rule_context(
+                    rule,
+                    rules=rules,
+                    index=index,
+                    tool_config=tool_config,
+                    tool_args=tool_args,
+                    context=context,
+                )
 
                 return PolicyDecision(
                     rule.action,

--- a/backend/preloop/services/policy_evaluator.py
+++ b/backend/preloop/services/policy_evaluator.py
@@ -8,7 +8,7 @@ actions with priority-based rule evaluation.
 import logging
 import re
 import uuid
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 from sqlalchemy.orm import Session
 
@@ -27,12 +27,110 @@ from preloop.models.crud.tool_configuration import (
     get_tool_config_by_tool_name_async,
 )
 from preloop.models.crud.tool_access_rule import get_multi_by_config_async
+from preloop.services.approval_rule_context import (
+    SOURCE_RULE_EVALUATION_ERROR,
+    SOURCE_SUBJECT_SCOPED_RULE,
+    SOURCE_TOOL_ACCESS_RULE,
+    SOURCE_TOOL_DEFAULT_WORKFLOW,
+    build_rule_context,
+)
 from preloop.services.subject_governance import (
     get_scoped_tool_rules,
     is_tool_enabled_for_subject,
 )
 
 logger = logging.getLogger(__name__)
+
+
+class PolicyDecision(tuple):
+    """A policy outcome that is still the historical 3-tuple.
+
+    Every caller unpacks ``action, approval_workflow_id, rule_description``,
+    and several tests patch the evaluator with a plain tuple, so widening the
+    return type would break them silently. This subclasses ``tuple`` with
+    exactly those three items and hangs the new ``rule_context`` off the side:
+    old unpacking keeps working unchanged, new callers read the attribute.
+
+    Read ``rule_context`` with ``getattr(decision, "rule_context", None)``:
+    a mocked evaluator returns a bare tuple, and a missing attribute must
+    degrade to "no rule context recorded" rather than raise on the approval
+    path.
+
+    Attributes:
+        rule_context: JSON-serialisable snapshot of the rule that produced a
+            ``require_approval`` decision, or None when nothing gated the call
+            (allow/deny) or no rule identity exists.
+    """
+
+    # No __slots__: CPython rejects a nonempty __slots__ on a tuple subclass,
+    # so rule_context lives in the instance dict.
+
+    def __new__(
+        cls,
+        action: str,
+        approval_workflow_id: Optional[Any],
+        rule_description: Optional[str],
+        rule_context: Optional[Dict[str, Any]] = None,
+    ) -> "PolicyDecision":
+        """Build the 3-tuple and attach the rule context."""
+        decision = super().__new__(
+            cls, (action, approval_workflow_id, rule_description)
+        )
+        decision.rule_context = rule_context
+        return decision
+
+    @property
+    def action(self) -> str:
+        """'allow', 'deny', or 'require_approval'."""
+        return self[0]
+
+    @property
+    def approval_workflow_id(self) -> Optional[Any]:
+        """Workflow to raise the approval against, when gating."""
+        return self[1]
+
+    @property
+    def rule_description(self) -> Optional[str]:
+        """Human-readable description of what decided this."""
+        return self[2]
+
+
+def _also_matched_rule_ids(
+    rules: list[Any],
+    *,
+    start_index: int,
+    tool_args: Dict[str, Any],
+    context: Dict[str, Any],
+) -> list[str]:
+    """Ids of lower-priority rules that would also have matched.
+
+    Informational only: the winning rule already decided. Reviewers use this
+    to spot overlapping rules they did not intend. Errors are swallowed
+    because a broken lower-priority rule must not affect a decision that has
+    already been made by a higher-priority one.
+
+    Args:
+        rules: The full priority-ordered rule list.
+        start_index: Index just past the winning rule.
+        tool_args: Arguments the call was made with.
+        context: Evaluation context.
+
+    Returns:
+        Rule ids as strings, in priority order. Empty when none also matched.
+    """
+    also: list[str] = []
+    for rule in rules[start_index:]:
+        try:
+            if _evaluate_rule_condition(
+                expression=rule.condition_expression,
+                condition_type=rule.condition_type,
+                tool_args=tool_args,
+                context=context,
+            ):
+                also.append(str(rule.id))
+        except Exception:  # pragma: no cover - best effort annotation only
+            continue
+    return also
 
 
 def _get_audit_service():
@@ -127,7 +225,7 @@ def _evaluate_rule_candidates(
     correlation_id: Optional[str] = None,
     extra_details: Optional[Dict[str, Any]] = None,
     default_approval_workflow_id: Optional[Any] = None,
-) -> Optional[Tuple[str, Optional[Any], Optional[str]]]:
+) -> Optional[PolicyDecision]:
     for index, rule in enumerate(rules):
         is_enabled = (
             rule.get("is_enabled", True) if isinstance(rule, dict) else rule.is_enabled
@@ -177,7 +275,26 @@ def _evaluate_rule_candidates(
                 correlation_id=correlation_id,
                 extra_details=extra_details,
             )
-            return action, approval_workflow_id, rule_desc
+            rule_context = None
+            if action == "require_approval":
+                rule_context = build_rule_context(
+                    source=SOURCE_SUBJECT_SCOPED_RULE,
+                    decision=action,
+                    rule_id=(
+                        rule.get("id")
+                        if isinstance(rule, dict)
+                        else getattr(rule, "id", None)
+                    ),
+                    rule_name=description,
+                    expression=condition_expression,
+                    expression_type=str(condition_type or "simple"),
+                    priority=(
+                        rule.get("priority")
+                        if isinstance(rule, dict)
+                        else getattr(rule, "priority", None)
+                    ),
+                )
+            return PolicyDecision(action, approval_workflow_id, rule_desc, rule_context)
         except Exception as e:
             error_desc = f"Rule evaluation error: {e} (failing closed)"
             _log_policy_decision_async(
@@ -192,7 +309,23 @@ def _evaluate_rule_candidates(
                 correlation_id=correlation_id,
                 extra_details=extra_details,
             )
-            return "require_approval", approval_workflow_id, error_desc
+            return PolicyDecision(
+                "require_approval",
+                approval_workflow_id,
+                error_desc,
+                build_rule_context(
+                    source=SOURCE_RULE_EVALUATION_ERROR,
+                    decision="require_approval",
+                    rule_name=description or None,
+                    expression=condition_expression,
+                    expression_type=str(condition_type or "simple"),
+                    explanation=(
+                        "A scoped governance rule could not be evaluated, so "
+                        "Preloop failed closed and asked for approval instead "
+                        "of deciding on its own."
+                    ),
+                ),
+            )
     return None
 
 
@@ -206,7 +339,7 @@ def evaluate_policy(
     execution_id: Optional[uuid.UUID] = None,
     trigger_event: Optional[Dict[str, Any]] = None,
     subject_context: Optional[Dict[str, Any]] = None,
-) -> Tuple[str, Optional[uuid.UUID], Optional[str]]:
+) -> PolicyDecision:
     """Evaluate tool access policy and determine the action to take.
 
     This function implements the policy evaluation logic:
@@ -227,10 +360,15 @@ def evaluate_policy(
         trigger_event: Optional trigger event data (for condition evaluation context).
 
     Returns:
-        Tuple of (action, approval_workflow_id, matched_rule_description).
+        A :class:`PolicyDecision`, which unpacks as the historical 3-tuple
+        (action, approval_workflow_id, matched_rule_description) and also
+        carries ``.rule_context`` describing the rule that gated the call.
         - action: 'allow', 'deny', or 'require_approval'
         - approval_workflow_id: Policy ID to use if action is 'require_approval'
         - matched_rule_description: Description of the matched rule (or reason for default)
+        - rule_context: Snapshot of the winning rule for 'require_approval'
+          decisions, else None. Persisted on the approval request so the
+          approver can see WHICH rule fired and what its expression was.
     """
     account = crud_account.get(db, id=account_id)
     account_meta = (account.meta_data or {}) if account else {}
@@ -238,7 +376,9 @@ def evaluate_policy(
     if not is_tool_enabled_for_subject(
         account_meta, tool_name=tool_name, subject_context=subject_context or {}
     ):
-        return "deny", None, "Tool disabled by agent or API key configuration"
+        return PolicyDecision(
+            "deny", None, "Tool disabled by agent or API key configuration"
+        )
 
     scoped_rules = get_scoped_tool_rules(
         account_meta,
@@ -302,7 +442,9 @@ def evaluate_policy(
             user_id=user_id,
             execution_id=execution_id,
         )
-        return "allow", None, "No scoped rules matched (default allow for subject)"
+        return PolicyDecision(
+            "allow", None, "No scoped rules matched (default allow for subject)"
+        )
 
     if not tool_config:
         # No configuration found, default allow
@@ -316,7 +458,7 @@ def evaluate_policy(
             user_id=user_id,
             execution_id=execution_id,
         )
-        return "allow", None, "No tool configuration found"
+        return PolicyDecision("allow", None, "No tool configuration found")
 
     # Load all access rules for this tool, ordered by priority (lower first)
     rules = crud_tool_access_rule.get_multi_by_config(
@@ -350,10 +492,16 @@ def evaluate_policy(
                 user_id=user_id,
                 execution_id=execution_id,
             )
-            return (
+            return PolicyDecision(
                 "require_approval",
                 tool_config.approval_workflow_id,
                 "Tool has approval workflow configured (legacy mode)",
+                build_rule_context(
+                    source=SOURCE_TOOL_DEFAULT_WORKFLOW,
+                    decision="require_approval",
+                    rule_name="Tool default policy",
+                    tool_configuration_id=tool_config.id,
+                ),
             )
         _log_policy_decision_async(
             account_id=account_id,
@@ -364,10 +512,10 @@ def evaluate_policy(
             user_id=user_id,
             execution_id=execution_id,
         )
-        return "allow", None, "No access rules defined"
+        return PolicyDecision("allow", None, "No access rules defined")
 
     # Evaluate rules in priority order
-    for rule in rules:
+    for index, rule in enumerate(rules):
         try:
             logger.info(
                 f"Evaluating rule {rule.id} (priority={rule.priority}, "
@@ -416,10 +564,30 @@ def evaluate_policy(
                     execution_id=execution_id,
                 )
 
-                return (
+                rule_context = None
+                if rule.action == "require_approval":
+                    rule_context = build_rule_context(
+                        source=SOURCE_TOOL_ACCESS_RULE,
+                        decision=rule.action,
+                        rule_id=rule.id,
+                        rule_name=rule.description,
+                        expression=rule.condition_expression,
+                        expression_type=rule.condition_type,
+                        priority=rule.priority,
+                        tool_configuration_id=tool_config.id,
+                        also_matched_rule_ids=_also_matched_rule_ids(
+                            rules,
+                            start_index=index + 1,
+                            tool_args=tool_args,
+                            context=context,
+                        ),
+                    )
+
+                return PolicyDecision(
                     rule.action,
                     approval_workflow_id,
                     rule_desc,
+                    rule_context,
                 )
 
         except Exception as e:
@@ -444,10 +612,20 @@ def evaluate_policy(
                 user_id=user_id,
                 execution_id=execution_id,
             )
-            return (
+            return PolicyDecision(
                 "require_approval",
                 tool_config.approval_workflow_id or default_workflow_id_for_account,
                 error_desc,
+                build_rule_context(
+                    source=SOURCE_RULE_EVALUATION_ERROR,
+                    decision="require_approval",
+                    rule_id=rule.id,
+                    rule_name=rule.description,
+                    expression=rule.condition_expression,
+                    expression_type=rule.condition_type,
+                    priority=rule.priority,
+                    tool_configuration_id=tool_config.id,
+                ),
             )
 
     # No rules matched, default allow
@@ -460,7 +638,7 @@ def evaluate_policy(
         user_id=user_id,
         execution_id=execution_id,
     )
-    return "allow", None, "No rules matched (default allow)"
+    return PolicyDecision("allow", None, "No rules matched (default allow)")
 
 
 def _evaluate_rule_condition(
@@ -788,7 +966,7 @@ async def evaluate_policy_async(
     correlation_id: Optional[str] = None,
     extra_details: Optional[Dict[str, Any]] = None,
     subject_context: Optional[Dict[str, Any]] = None,
-) -> Tuple[str, Optional[uuid.UUID], Optional[str]]:
+) -> PolicyDecision:
     """Async version of evaluate_policy.
 
     See evaluate_policy for full documentation.
@@ -798,7 +976,9 @@ async def evaluate_policy_async(
     if not is_tool_enabled_for_subject(
         account_meta_data, tool_name=tool_name, subject_context=subject_context or {}
     ):
-        return "deny", None, "Tool disabled by agent or API key configuration"
+        return PolicyDecision(
+            "deny", None, "Tool disabled by agent or API key configuration"
+        )
 
     scoped_rules = get_scoped_tool_rules(
         account_meta_data,
@@ -869,7 +1049,9 @@ async def evaluate_policy_async(
             correlation_id=correlation_id,
             extra_details=extra_details,
         )
-        return "allow", None, "No scoped rules matched (default allow for subject)"
+        return PolicyDecision(
+            "allow", None, "No scoped rules matched (default allow for subject)"
+        )
 
     if not tool_config:
         # Log the policy decision (fire-and-forget)
@@ -884,7 +1066,7 @@ async def evaluate_policy_async(
             correlation_id=correlation_id,
             extra_details=extra_details,
         )
-        return "allow", None, "No tool configuration found"
+        return PolicyDecision("allow", None, "No tool configuration found")
 
     # Load all access rules for this tool, ordered by priority (lower first)
     rules = await get_multi_by_config_async(
@@ -908,10 +1090,16 @@ async def evaluate_policy_async(
                 correlation_id=correlation_id,
                 extra_details=extra_details,
             )
-            return (
+            return PolicyDecision(
                 "require_approval",
                 tool_config.approval_workflow_id,
                 "Tool has approval workflow configured (legacy mode)",
+                build_rule_context(
+                    source=SOURCE_TOOL_DEFAULT_WORKFLOW,
+                    decision="require_approval",
+                    rule_name="Tool default policy",
+                    tool_configuration_id=tool_config.id,
+                ),
             )
         _log_policy_decision_async(
             account_id=account_id,
@@ -924,10 +1112,10 @@ async def evaluate_policy_async(
             correlation_id=correlation_id,
             extra_details=extra_details,
         )
-        return "allow", None, "No access rules defined"
+        return PolicyDecision("allow", None, "No access rules defined")
 
     # Evaluate rules in priority order
-    for rule in rules:
+    for index, rule in enumerate(rules):
         try:
             matches = _evaluate_rule_condition(
                 expression=rule.condition_expression,
@@ -972,10 +1160,30 @@ async def evaluate_policy_async(
                     extra_details=extra_details,
                 )
 
-                return (
+                rule_context = None
+                if rule.action == "require_approval":
+                    rule_context = build_rule_context(
+                        source=SOURCE_TOOL_ACCESS_RULE,
+                        decision=rule.action,
+                        rule_id=rule.id,
+                        rule_name=rule.description,
+                        expression=rule.condition_expression,
+                        expression_type=rule.condition_type,
+                        priority=rule.priority,
+                        tool_configuration_id=tool_config.id,
+                        also_matched_rule_ids=_also_matched_rule_ids(
+                            rules,
+                            start_index=index + 1,
+                            tool_args=tool_args,
+                            context=context,
+                        ),
+                    )
+
+                return PolicyDecision(
                     rule.action,
                     approval_workflow_id,
                     rule_desc,
+                    rule_context,
                 )
 
         except Exception as e:
@@ -997,10 +1205,20 @@ async def evaluate_policy_async(
                 correlation_id=correlation_id,
                 extra_details=extra_details,
             )
-            return (
+            return PolicyDecision(
                 "require_approval",
                 tool_config.approval_workflow_id or default_workflow_id_for_account,
                 error_desc,
+                build_rule_context(
+                    source=SOURCE_RULE_EVALUATION_ERROR,
+                    decision="require_approval",
+                    rule_id=rule.id,
+                    rule_name=rule.description,
+                    expression=rule.condition_expression,
+                    expression_type=rule.condition_type,
+                    priority=rule.priority,
+                    tool_configuration_id=tool_config.id,
+                ),
             )
 
     # No rules matched, default allow
@@ -1015,4 +1233,4 @@ async def evaluate_policy_async(
         correlation_id=correlation_id,
         extra_details=extra_details,
     )
-    return "allow", None, "No rules matched (default allow)"
+    return PolicyDecision("allow", None, "No rules matched (default allow)")

--- a/backend/preloop/services/push_notifications/notification_payloads.py
+++ b/backend/preloop/services/push_notifications/notification_payloads.py
@@ -57,6 +57,7 @@ class NotificationPayloadBuilder:
         agent_reasoning: Optional[str] = None,
         tool_args: Optional[Dict[str, Any]] = None,
         summary: Optional[str] = None,
+        rule_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Build payload for new approval request.
 
@@ -70,6 +71,10 @@ class NotificationPayloadBuilder:
             agent_reasoning: Agent's explanation (truncated to 100 chars).
             tool_args: Tool arguments to show in notification body.
             summary: Plain-language ask shown as the notification body when set.
+            rule_context: Snapshot of the rule that gated the call. Only the
+                rule NAME travels in a push: an expression does not fit and
+                truncating one would misrepresent it. Clients fetch the full
+                context from the API when the request is opened.
 
         Returns:
             APNs payload dictionary.
@@ -184,6 +189,11 @@ class NotificationPayloadBuilder:
         }
         if ask_text:
             custom_data["summary"] = ask_text
+        rule_name = (rule_context or {}).get("rule_name")
+        if rule_name:
+            # Name only. The expression belongs on a surface that can show it
+            # in full; a clipped CEL expression reads as a different rule.
+            custom_data["rule_name"] = str(rule_name)
         if expires_at:
             custom_data["expires_at"] = expires_at.isoformat()
         if is_question:

--- a/backend/tests/models/test_approval_rule_context_persistence.py
+++ b/backend/tests/models/test_approval_rule_context_persistence.py
@@ -1,0 +1,132 @@
+"""The matched-rule snapshot must survive a real round trip through Postgres.
+
+Mock-based tests never exercise the JSONB column. This seeds approval rows on
+a live database and reads them back, so a missing migration or a type mismatch
+fails here rather than in production, where the approver would silently lose
+the only explanation of why they are being asked.
+"""
+
+import uuid
+
+from preloop.models import models
+from preloop.models.schemas.approval_request import ApprovalRequestResponse
+from preloop.services.approval_rule_context import (
+    SOURCE_TOOL_ACCESS_RULE,
+    build_rule_context,
+)
+
+
+def _workflow_and_config(db_session, test_user):
+    """Minimal workflow + tool config an approval row can point at."""
+    workflow = models.ApprovalWorkflow(
+        account_id=test_user.account_id,
+        name=f"rule-context-test-{uuid.uuid4().hex[:8]}",
+        approval_type="manual",
+        channel="email",
+    )
+    db_session.add(workflow)
+    db_session.flush()
+
+    config = models.ToolConfiguration(
+        account_id=test_user.account_id,
+        tool_name="send_payment",
+        tool_source="mcp",
+        approval_workflow_id=workflow.id,
+        is_enabled=True,
+        custom_config={},
+    )
+    db_session.add(config)
+    db_session.flush()
+    return workflow, config
+
+
+def test_rule_context_round_trips_through_postgres(db_session, test_user):
+    """Every field an approver reads survives the write and the read."""
+    workflow, config = _workflow_and_config(db_session, test_user)
+    rule_id = uuid.uuid4()
+    context = build_rule_context(
+        source=SOURCE_TOOL_ACCESS_RULE,
+        decision="require_approval",
+        rule_id=rule_id,
+        rule_name="High-value payments",
+        expression="args.amount >= 1000",
+        expression_type="cel",
+        priority=10,
+        tool_configuration_id=config.id,
+    )
+
+    request = models.ApprovalRequest(
+        account_id=test_user.account_id,
+        tool_configuration_id=config.id,
+        approval_workflow_id=workflow.id,
+        tool_name="send_payment",
+        tool_args={"amount": 1000},
+        rule_context=context,
+        status="pending",
+    )
+    db_session.add(request)
+    db_session.flush()
+    db_session.expire(request)
+
+    stored = db_session.get(models.ApprovalRequest, request.id)
+    assert stored.rule_context["rule_id"] == str(rule_id)
+    assert stored.rule_context["expression"] == "args.amount >= 1000"
+    assert stored.rule_context["priority"] == 10
+    assert stored.rule_context["referenced_args"] == ["amount"]
+
+
+def test_rule_context_is_nullable_for_approvals_with_no_rule(db_session, test_user):
+    """request_approval and pre-existing rows legitimately have no context.
+
+    If the column were NOT NULL, those paths would start failing to create
+    approvals at all, which is a far worse outcome than a missing explanation.
+    """
+    workflow, config = _workflow_and_config(db_session, test_user)
+
+    request = models.ApprovalRequest(
+        account_id=test_user.account_id,
+        tool_configuration_id=config.id,
+        approval_workflow_id=workflow.id,
+        tool_name="request_approval",
+        tool_args={"operation": "deploy"},
+        status="pending",
+    )
+    db_session.add(request)
+    db_session.flush()
+    db_session.expire(request)
+
+    stored = db_session.get(models.ApprovalRequest, request.id)
+    assert stored.rule_context is None
+
+    # And the read schema serialises the absence rather than choking on it.
+    payload = ApprovalRequestResponse.model_validate(stored)
+    assert payload.rule_context is None
+
+
+def test_read_schema_exposes_the_context_for_the_api(db_session, test_user):
+    """The console reads this off the API, so it has to leave the schema."""
+    workflow, config = _workflow_and_config(db_session, test_user)
+    context = build_rule_context(
+        source=SOURCE_TOOL_ACCESS_RULE,
+        decision="require_approval",
+        rule_name="Production deploys",
+        expression="args.environment == 'production'",
+        expression_type="cel",
+        priority=0,
+    )
+    request = models.ApprovalRequest(
+        account_id=test_user.account_id,
+        tool_configuration_id=config.id,
+        approval_workflow_id=workflow.id,
+        tool_name="deploy",
+        tool_args={"environment": "production"},
+        rule_context=context,
+        status="pending",
+    )
+    db_session.add(request)
+    db_session.flush()
+
+    payload = ApprovalRequestResponse.model_validate(request)
+    assert payload.rule_context["rule_name"] == "Production deploys"
+    assert payload.rule_context["expression"] == "args.environment == 'production'"
+    assert payload.rule_context["referenced_args"] == ["environment"]

--- a/backend/tests/services/test_approval_rule_context.py
+++ b/backend/tests/services/test_approval_rule_context.py
@@ -1,0 +1,569 @@
+"""Tests for the matched-rule context carried onto approval requests.
+
+The product claim under test: an approver can see WHICH rule demanded the
+approval and read its expression, so a boundary case is distinguishable from
+a mid-band one. The absence cases matter as much as the presence ones:
+approvals raised without rule evaluation must carry nothing rather than a
+fabricated explanation.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from preloop.services.approval_rule_context import (
+    KNOWN_SOURCES,
+    SOURCE_AGENT_PERMISSION_HOOK,
+    SOURCE_RULE_EVALUATION_ERROR,
+    SOURCE_TOOL_ACCESS_RULE,
+    SOURCE_TOOL_DEFAULT_WORKFLOW,
+    build_rule_context,
+    referenced_args,
+)
+from preloop.services.policy_evaluator import PolicyDecision, evaluate_policy
+
+
+# --------------------------------------------------------------------------
+# build_rule_context
+# --------------------------------------------------------------------------
+
+
+def test_build_carries_rule_identity_and_expression():
+    """The four facts an approver needs: which rule, what it says, how it ranks."""
+    rule_id = uuid.uuid4()
+    context = build_rule_context(
+        source=SOURCE_TOOL_ACCESS_RULE,
+        decision="require_approval",
+        rule_id=rule_id,
+        rule_name="High-value payments",
+        expression="args.amount >= 1000",
+        expression_type="cel",
+        priority=10,
+    )
+
+    assert context["source"] == SOURCE_TOOL_ACCESS_RULE
+    assert context["decision"] == "require_approval"
+    assert context["rule_id"] == str(rule_id)
+    assert context["rule_name"] == "High-value payments"
+    assert context["expression"] == "args.amount >= 1000"
+    assert context["expression_type"] == "cel"
+    assert context["priority"] == 10
+
+
+def test_build_falls_back_to_expression_then_generic_label():
+    """An unnamed rule still gets a label; a bare one gets a generic label."""
+    from_expression = build_rule_context(
+        source=SOURCE_TOOL_ACCESS_RULE,
+        decision="require_approval",
+        expression="args.env == 'production'",
+    )
+    assert from_expression["rule_name"] == "args.env == 'production'"
+
+    bare = build_rule_context(
+        source=SOURCE_TOOL_ACCESS_RULE,
+        decision="require_approval",
+    )
+    assert bare["rule_name"] == "Access rule"
+
+
+def test_build_omits_absent_fields_entirely():
+    """No None values reach JSONB; absence is expressed by a missing key."""
+    context = build_rule_context(
+        source=SOURCE_TOOL_DEFAULT_WORKFLOW,
+        decision="require_approval",
+        rule_name="Tool default policy",
+    )
+    assert "rule_id" not in context
+    assert "expression" not in context
+    assert "priority" not in context
+    assert None not in context.values()
+
+
+def test_build_states_default_gating_plainly_without_a_rule():
+    """No rule fired: say what actually gated the call, do not invent a rule."""
+    context = build_rule_context(
+        source=SOURCE_TOOL_DEFAULT_WORKFLOW,
+        decision="require_approval",
+    )
+    assert "expression" not in context
+    explanation = context["explanation"]
+    assert "No access rule matched" in explanation
+    assert "every call" in explanation
+    # Honesty guard: the block explains WHY, it never claims an assessment.
+    assert "risk" not in explanation.lower()
+
+
+def test_agent_hook_explanation_does_not_claim_a_preloop_rule():
+    """The agent's own hook escalated; no Preloop rule was consulted."""
+    context = build_rule_context(
+        source=SOURCE_AGENT_PERMISSION_HOOK,
+        decision="require_approval",
+    )
+    assert "No Preloop access rule was evaluated" in context["explanation"]
+
+
+def test_build_rejects_an_unknown_source():
+    """A typo in a source must fail loudly, not persist a meaningless label."""
+    with pytest.raises(ValueError, match="Unknown approval rule context source"):
+        build_rule_context(source="made_up", decision="require_approval")
+
+
+def test_all_known_sources_build():
+    """Every declared source is constructible; no half-registered constant."""
+    for source in KNOWN_SOURCES:
+        context = build_rule_context(source=source, decision="require_approval")
+        assert context["source"] == source
+        assert context["rule_name"]
+
+
+def test_also_matched_rule_ids_recorded_when_present():
+    """Overlapping rules are surfaced so a mis-scoped one can be spotted."""
+    other = uuid.uuid4()
+    context = build_rule_context(
+        source=SOURCE_TOOL_ACCESS_RULE,
+        decision="require_approval",
+        expression="args.amount > 0",
+        also_matched_rule_ids=[other],
+    )
+    assert context["also_matched_rule_ids"] == [str(other)]
+
+
+def test_no_also_matched_key_when_nothing_else_matched():
+    """The common case stays clean: no empty list in the payload."""
+    context = build_rule_context(
+        source=SOURCE_TOOL_ACCESS_RULE,
+        decision="require_approval",
+        expression="args.amount > 0",
+        also_matched_rule_ids=[],
+    )
+    assert "also_matched_rule_ids" not in context
+
+
+# --------------------------------------------------------------------------
+# referenced_args
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "expression,expected",
+    [
+        ("args.amount >= 1000", ["amount"]),
+        ("args.amount == 1000 && args.currency == 'EUR'", ["amount", "currency"]),
+        ("args.amount > 1 || args.amount < 5", ["amount"]),  # deduped, ordered
+        ("amount > 300", ["amount"]),  # bare shorthand form users write
+        ("", []),
+        (None, []),
+    ],
+)
+def test_referenced_args_extracts_the_arguments_the_rule_looks_at(expression, expected):
+    """Highlighting hint: which arguments the expression text mentions."""
+    assert referenced_args(expression) == expected
+
+
+# --------------------------------------------------------------------------
+# PolicyDecision back-compatibility
+# --------------------------------------------------------------------------
+
+
+def test_policy_decision_still_unpacks_as_the_historical_three_tuple():
+    """Every existing caller unpacks 3 values; widening would break them."""
+    decision = PolicyDecision("require_approval", "wf-1", "why", {"source": "x"})
+    action, workflow_id, description = decision
+    assert (action, workflow_id, description) == ("require_approval", "wf-1", "why")
+    assert len(decision) == 3
+    assert decision == ("require_approval", "wf-1", "why")
+
+
+def test_policy_decision_exposes_rule_context_off_to_the_side():
+    """New callers read the snapshot without disturbing the tuple shape."""
+    decision = PolicyDecision("require_approval", None, "why", {"rule_name": "R"})
+    assert decision.rule_context == {"rule_name": "R"}
+    assert decision.action == "require_approval"
+    assert decision.rule_description == "why"
+
+
+def test_policy_decision_rule_context_defaults_to_none():
+    """allow/deny decisions gate nothing, so they carry no rule context."""
+    assert PolicyDecision("allow", None, "nothing matched").rule_context is None
+
+
+# --------------------------------------------------------------------------
+# evaluate_policy end to end (sync path, mocked CRUD)
+# --------------------------------------------------------------------------
+
+
+def _rule(*, action, expression, priority, description=None, condition_type="cel"):
+    rule = MagicMock()
+    rule.id = uuid.uuid4()
+    rule.action = action
+    rule.condition_expression = expression
+    rule.condition_type = condition_type
+    rule.priority = priority
+    rule.description = description
+    rule.is_enabled = True
+    rule.approval_workflow_id = None
+    return rule
+
+
+@pytest.fixture
+def policy_env(monkeypatch):
+    """Patch the CRUD surface evaluate_policy() reads, returning a setter."""
+    account = MagicMock()
+    account.meta_data = {}
+    monkeypatch.setattr(
+        "preloop.services.policy_evaluator.crud_account.get",
+        lambda db, id: account,
+    )
+    tool_config = MagicMock()
+    tool_config.id = uuid.uuid4()
+    tool_config.approval_workflow_id = None
+    monkeypatch.setattr(
+        "preloop.services.policy_evaluator.crud_tool_configuration.get_by_tool_name",
+        lambda db, account_id, tool_name: tool_config,
+    )
+    monkeypatch.setattr(
+        "preloop.services.policy_evaluator.crud_approval_workflow.get_default",
+        lambda db, account_id: None,
+    )
+    monkeypatch.setattr(
+        "preloop.services.policy_evaluator._log_policy_decision_async",
+        lambda **kwargs: None,
+    )
+
+    def set_rules(rules):
+        monkeypatch.setattr(
+            "preloop.services.policy_evaluator.crud_tool_access_rule.get_multi_by_config",
+            lambda db, config_id, account_id, enabled_only: rules,
+        )
+
+    set_rules([])
+    return set_rules, tool_config
+
+
+def test_matched_rule_is_persisted_verbatim_on_a_boundary_amount(policy_env):
+    """The Dylan case: amount exactly on the threshold names the >= rule."""
+    set_rules, tool_config = policy_env
+    rule = _rule(
+        action="require_approval",
+        expression="args.amount >= 1000",
+        priority=10,
+        description="High-value payments",
+    )
+    set_rules([rule])
+
+    decision = evaluate_policy(
+        db=MagicMock(),
+        tool_name="send_payment",
+        tool_args={"amount": 1000},
+        account_id=uuid.uuid4(),
+    )
+
+    assert decision.action == "require_approval"
+    context = decision.rule_context
+    assert context["source"] == SOURCE_TOOL_ACCESS_RULE
+    assert context["rule_id"] == str(rule.id)
+    assert context["rule_name"] == "High-value payments"
+    assert context["expression"] == "args.amount >= 1000"
+    assert context["priority"] == 10
+    assert context["referenced_args"] == ["amount"]
+    assert context["tool_configuration_id"] == str(tool_config.id)
+
+
+def test_winning_rule_is_the_highest_priority_one_not_merely_the_last(policy_env):
+    """Two rules match; the row must name the one that actually decided."""
+    set_rules, _ = policy_env
+    winner = _rule(
+        action="require_approval",
+        expression="args.amount >= 1000",
+        priority=1,
+        description="Winner",
+    )
+    loser = _rule(
+        action="require_approval",
+        expression="args.amount >= 100",
+        priority=2,
+        description="Loser",
+    )
+    set_rules([winner, loser])
+
+    decision = evaluate_policy(
+        db=MagicMock(),
+        tool_name="send_payment",
+        tool_args={"amount": 5000},
+        account_id=uuid.uuid4(),
+    )
+
+    assert decision.rule_context["rule_id"] == str(winner.id)
+    assert decision.rule_context["rule_name"] == "Winner"
+    # The overlap is reported, so a mis-scoped rule is visible at review time.
+    assert decision.rule_context["also_matched_rule_ids"] == [str(loser.id)]
+
+
+def test_non_matching_lower_priority_rule_is_not_listed_as_also_matched(policy_env):
+    """also_matched must mean 'would also have matched', not 'exists'."""
+    set_rules, _ = policy_env
+    winner = _rule(
+        action="require_approval", expression="args.amount >= 1000", priority=1
+    )
+    unrelated = _rule(
+        action="require_approval", expression="args.amount >= 90000", priority=2
+    )
+    set_rules([winner, unrelated])
+
+    decision = evaluate_policy(
+        db=MagicMock(),
+        tool_name="send_payment",
+        tool_args={"amount": 5000},
+        account_id=uuid.uuid4(),
+    )
+    assert "also_matched_rule_ids" not in decision.rule_context
+
+
+def test_allow_decision_carries_no_rule_context(policy_env):
+    """Nothing was gated, so there is nothing to explain."""
+    set_rules, _ = policy_env
+    set_rules([_rule(action="allow", expression="args.amount < 10", priority=1)])
+
+    decision = evaluate_policy(
+        db=MagicMock(),
+        tool_name="send_payment",
+        tool_args={"amount": 5},
+        account_id=uuid.uuid4(),
+    )
+    assert decision.action == "allow"
+    assert decision.rule_context is None
+
+
+def test_deny_decision_carries_no_rule_context(policy_env):
+    """A denial never becomes an approval row, so it needs no snapshot."""
+    set_rules, _ = policy_env
+    set_rules([_rule(action="deny", expression="args.amount > 10", priority=1)])
+
+    decision = evaluate_policy(
+        db=MagicMock(),
+        tool_name="send_payment",
+        tool_args={"amount": 5000},
+        account_id=uuid.uuid4(),
+    )
+    assert decision.action == "deny"
+    assert decision.rule_context is None
+
+
+def test_legacy_tool_workflow_with_no_rules_states_the_default_plainly(policy_env):
+    """No rule exists; the approver is told that, not shown a phantom rule."""
+    set_rules, tool_config = policy_env
+    tool_config.approval_workflow_id = uuid.uuid4()
+    set_rules([])
+
+    decision = evaluate_policy(
+        db=MagicMock(),
+        tool_name="send_payment",
+        tool_args={"amount": 5},
+        account_id=uuid.uuid4(),
+    )
+
+    assert decision.action == "require_approval"
+    context = decision.rule_context
+    assert context["source"] == SOURCE_TOOL_DEFAULT_WORKFLOW
+    assert "rule_id" not in context
+    assert "expression" not in context
+    assert "No access rule matched" in context["explanation"]
+
+
+def test_fail_closed_on_a_broken_rule_says_so_rather_than_claiming_a_match(
+    policy_env,
+):
+    """A malformed rule gates the call; the row must not imply it matched."""
+    set_rules, _ = policy_env
+    broken = _rule(
+        action="require_approval",
+        expression="args.amount >>> nonsense(",
+        priority=1,
+        description="Broken rule",
+    )
+    set_rules([broken])
+
+    decision = evaluate_policy(
+        db=MagicMock(),
+        tool_name="send_payment",
+        tool_args={"amount": 5},
+        account_id=uuid.uuid4(),
+    )
+
+    assert decision.action == "require_approval"
+    context = decision.rule_context
+    assert context["source"] == SOURCE_RULE_EVALUATION_ERROR
+    assert context["rule_id"] == str(broken.id)
+    assert "failed closed" in context["explanation"]
+
+
+@pytest.mark.asyncio
+async def test_agent_permission_hook_records_that_no_rule_was_evaluated(
+    monkeypatch,
+):
+    """Claude Code style escalation: state the hook, do not name a rule."""
+    from preloop.services import agent_permission_service
+
+    captured = {}
+
+    class _FakeService:
+        def __init__(self, db, base_url):
+            pass
+
+        async def create_and_notify(self, **kwargs):
+            captured.update(kwargs)
+            approval = MagicMock()
+            approval.id = uuid.uuid4()
+            approval.status = "approved"
+            approval.approver_comment = None
+            return approval
+
+    monkeypatch.setattr(
+        "preloop.services.approval_service.ApprovalService", _FakeService
+    )
+    monkeypatch.setattr(
+        agent_permission_service,
+        "native_tool_approvals_disabled",
+        AsyncMock(return_value=False),
+    )
+    workflow = MagicMock()
+    workflow.timeout_seconds = 60
+    workflow.id = uuid.uuid4()
+    monkeypatch.setattr(
+        agent_permission_service, "resolve_workflow", AsyncMock(return_value=workflow)
+    )
+    config = MagicMock()
+    config.id = uuid.uuid4()
+    monkeypatch.setattr(
+        agent_permission_service, "resolve_tool_config", AsyncMock(return_value=config)
+    )
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return MagicMock()
+
+        async def __aexit__(self, *args):
+            return None
+
+    monkeypatch.setattr(
+        agent_permission_service, "get_async_db_session", lambda: _FakeSession()
+    )
+
+    await agent_permission_service.request_agent_permission(
+        base_url="http://localhost:8000",
+        account_id=str(uuid.uuid4()),
+        user_id=None,
+        managed_agent_id=None,
+        runtime_session_id=None,
+        managed_agent_name="claude",
+        source="claude_code",
+        tool_name="Bash",
+        tool_input={"command": "rm -rf /"},
+        agent_reasoning=None,
+        client_decision="ask",
+    )
+
+    context = captured["rule_context"]
+    assert context["source"] == SOURCE_AGENT_PERMISSION_HOOK
+    assert "expression" not in context
+    assert "No Preloop access rule was evaluated" in context["explanation"]
+
+
+# --------------------------------------------------------------------------
+# Persistence through ApprovalService
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_approval_request_stores_the_snapshot_on_the_row():
+    """The context must reach the ORM object, not just travel as a kwarg."""
+    from preloop.services.approval_service import ApprovalService
+
+    db = MagicMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    service = ApprovalService(db, "http://localhost:8000")
+    service._broadcast_approval_update = AsyncMock()
+
+    context = build_rule_context(
+        source=SOURCE_TOOL_ACCESS_RULE,
+        decision="require_approval",
+        rule_name="High-value payments",
+        expression="args.amount >= 1000",
+    )
+
+    request = await service.create_approval_request(
+        account_id=str(uuid.uuid4()),
+        tool_configuration_id=uuid.uuid4(),
+        approval_workflow_id=uuid.uuid4(),
+        tool_name="send_payment",
+        tool_args={"amount": 1000},
+        rule_context=context,
+    )
+
+    assert request.rule_context == context
+    db.add.assert_called_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_create_approval_request_defaults_to_no_snapshot():
+    """Callers that evaluated no rule leave the column NULL, not empty-ish."""
+    from preloop.services.approval_service import ApprovalService
+
+    db = MagicMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    service = ApprovalService(db, "http://localhost:8000")
+    service._broadcast_approval_update = AsyncMock()
+
+    request = await service.create_approval_request(
+        account_id=str(uuid.uuid4()),
+        tool_configuration_id=uuid.uuid4(),
+        approval_workflow_id=uuid.uuid4(),
+        tool_name="request_approval",
+        tool_args={"operation": "deploy"},
+    )
+
+    assert request.rule_context is None
+
+
+# --------------------------------------------------------------------------
+# Compact surface: push payload
+# --------------------------------------------------------------------------
+
+
+def test_push_payload_carries_the_rule_name_only():
+    """A push has no room for an expression, and a clipped one would mislead."""
+    from preloop.services.push_notifications.notification_payloads import (
+        NotificationPayloadBuilder,
+    )
+
+    payload = NotificationPayloadBuilder.new_approval_request(
+        request_id=str(uuid.uuid4()),
+        tool_name="send_payment",
+        rule_context=build_rule_context(
+            source=SOURCE_TOOL_ACCESS_RULE,
+            decision="require_approval",
+            rule_name="High-value payments",
+            expression="args.amount >= 1000",
+        ),
+    )
+
+    assert payload["data"]["rule_name"] == "High-value payments"
+    assert "expression" not in payload["data"]
+
+
+def test_push_payload_omits_the_rule_name_when_there_is_none():
+    """No snapshot, no key: clients branch on presence, not on empty strings."""
+    from preloop.services.push_notifications.notification_payloads import (
+        NotificationPayloadBuilder,
+    )
+
+    payload = NotificationPayloadBuilder.new_approval_request(
+        request_id=str(uuid.uuid4()),
+        tool_name="request_approval",
+    )
+    assert "rule_name" not in payload["data"]

--- a/backend/tests/services/test_approval_rule_context.py
+++ b/backend/tests/services/test_approval_rule_context.py
@@ -80,6 +80,19 @@ def test_build_omits_absent_fields_entirely():
     assert None not in context.values()
 
 
+def test_build_omits_referenced_args_for_catchall_boolean_literals():
+    """A catch-all ``true`` inspects no argument; do not render \"Checks true\"."""
+    context = build_rule_context(
+        source=SOURCE_TOOL_ACCESS_RULE,
+        decision="require_approval",
+        rule_name="Always ask",
+        expression="true",
+        expression_type="simple",
+    )
+    assert context["expression"] == "true"
+    assert "referenced_args" not in context
+
+
 def test_build_states_default_gating_plainly_without_a_rule():
     """No rule fired: say what actually gated the call, do not invent a rule."""
     context = build_rule_context(
@@ -152,6 +165,10 @@ def test_no_also_matched_key_when_nothing_else_matched():
         ("args.amount == 1000 && args.currency == 'EUR'", ["amount", "currency"]),
         ("args.amount > 1 || args.amount < 5", ["amount"]),  # deduped, ordered
         ("amount > 300", ["amount"]),  # bare shorthand form users write
+        ("true", []),  # catch-all literal, not an argument named "true"
+        ("false", []),
+        ("TRUE", []),
+        ("  False", []),
         ("", []),
         (None, []),
     ],

--- a/frontend/src/components/approval-rule-context-block.test.ts
+++ b/frontend/src/components/approval-rule-context-block.test.ts
@@ -1,0 +1,148 @@
+import { html, fixture, expect } from '@open-wc/testing';
+import './approval-rule-context-block.ts';
+import type { ApprovalRuleContextBlock } from './approval-rule-context-block';
+import type { ApprovalRuleContext } from '../types';
+
+/**
+ * The point of this block is that an approver can tell a boundary case from a
+ * mid-band one. So the tests care about exactly two things: the rule text is
+ * shown verbatim when we have it, and nothing at all is shown when we do not.
+ */
+describe('ApprovalRuleContextBlock', () => {
+  const boundaryRule: ApprovalRuleContext = {
+    source: 'tool_access_rule',
+    decision: 'require_approval',
+    rule_id: '3f1d9b4e-0000-4000-8000-000000000001',
+    rule_name: 'Large refunds need a human',
+    expression: 'args.amount >= 5000',
+    expression_type: 'cel',
+    priority: 10,
+    referenced_args: ['amount'],
+    tool_configuration_id: '3f1d9b4e-0000-4000-8000-000000000002',
+  };
+
+  async function mount(
+    context: ApprovalRuleContext | null,
+    compact = false
+  ): Promise<ApprovalRuleContextBlock> {
+    const element = (await fixture(html`
+      <approval-rule-context-block
+        .ruleContext=${context}
+        ?compact=${compact}
+      ></approval-rule-context-block>
+    `)) as ApprovalRuleContextBlock;
+    await element.updateComplete;
+    return element;
+  }
+
+  /**
+   * Presence as a boolean. The test runner cannot serialize a DOM node into a
+   * failure report and hangs instead, so assertions never hold one.
+   */
+  function has(element: ApprovalRuleContextBlock, selector: string): boolean {
+    return (
+      element.shadowRoot?.querySelector(selector) !== null &&
+      element.shadowRoot?.querySelector(selector) !== undefined
+    );
+  }
+
+  it('shows the rule name and the expression that fired', async () => {
+    const element = await mount(boundaryRule);
+
+    const text = element.shadowRoot?.textContent || '';
+    expect(text).to.contain('Why this needs approval');
+    expect(text).to.contain('Large refunds need a human');
+
+    expect(has(element, '.rule-expression'), 'expression is rendered').to.be
+      .true;
+    const expression = element.shadowRoot?.querySelector('.rule-expression');
+    // Verbatim: a reworded threshold is a different rule.
+    expect(expression?.textContent?.trim()).to.equal('args.amount >= 5000');
+  });
+
+  it('names the arguments the rule inspects and its priority', async () => {
+    const element = await mount(boundaryRule);
+
+    const tags = [
+      ...(element.shadowRoot?.querySelectorAll('sl-tag') || []),
+    ].map((tag) => tag.textContent?.replace(/\s+/g, ' ').trim());
+    expect(tags).to.contain('Priority 10');
+    expect(tags).to.contain('Checks amount');
+  });
+
+  it('flags when lower-priority rules also matched', async () => {
+    const element = await mount({
+      ...boundaryRule,
+      also_matched_rule_ids: [
+        '3f1d9b4e-0000-4000-8000-000000000003',
+        '3f1d9b4e-0000-4000-8000-000000000004',
+      ],
+    });
+
+    const text = (element.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
+    expect(text).to.contain('2 lower-priority rules also matched');
+  });
+
+  it('says "rule" not "rules" when exactly one also matched', async () => {
+    const element = await mount({
+      ...boundaryRule,
+      also_matched_rule_ids: ['3f1d9b4e-0000-4000-8000-000000000003'],
+    });
+
+    const text = (element.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
+    expect(text).to.contain('1 lower-priority rule also matched');
+    expect(text).to.not.contain('rules also matched');
+  });
+
+  it('renders nothing at all when there is no rule context', async () => {
+    const element = await mount(null);
+
+    expect(has(element, '.rule-block'), 'no block is rendered').to.be.false;
+    expect((element.shadowRoot?.textContent || '').trim()).to.equal('');
+  });
+
+  it('renders nothing when the context carries no rule name', async () => {
+    // Defensive: a malformed payload must not produce an empty accusing box.
+    const element = await mount({
+      source: 'tool_access_rule',
+      decision: 'require_approval',
+      rule_name: '',
+    } as ApprovalRuleContext);
+
+    expect(has(element, '.rule-block'), 'no block is rendered').to.be.false;
+  });
+
+  it('explains default gating without inventing a rule expression', async () => {
+    const element = await mount({
+      source: 'tool_default_workflow',
+      decision: 'require_approval',
+      rule_name: 'Default policy',
+      explanation:
+        'No access rule matched. This tool is configured to require approval for every call, whatever the arguments are.',
+    });
+
+    const text = (element.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
+    expect(text).to.contain('require approval for every call');
+    expect(has(element, '.rule-expression'), 'no expression invented').to.be
+      .false;
+  });
+
+  it('shows the rule name only in compact mode', async () => {
+    const element = await mount(boundaryRule, true);
+
+    const text = element.shadowRoot?.textContent || '';
+    expect(text).to.contain('Large refunds need a human');
+    // A clipped expression reads as a different rule, so list rows omit it.
+    expect(has(element, '.rule-expression'), 'compact hides the expression').to
+      .be.false;
+    expect(text).to.not.contain('Why this needs approval');
+    const compact = element.shadowRoot?.querySelector('.compact');
+    expect(compact?.getAttribute('title')).to.equal('args.amount >= 5000');
+  });
+
+  it('renders nothing in compact mode without a context', async () => {
+    const element = await mount(null, true);
+
+    expect(has(element, '.compact'), 'nothing rendered').to.be.false;
+  });
+});

--- a/frontend/src/components/approval-rule-context-block.test.ts
+++ b/frontend/src/components/approval-rule-context-block.test.ts
@@ -140,6 +140,28 @@ describe('ApprovalRuleContextBlock', () => {
     expect(compact?.getAttribute('title')).to.equal('args.amount >= 5000');
   });
 
+  it('links to the tool the rule gates, not the whole catalogue', async () => {
+    const element = (await fixture(html`
+      <approval-rule-context-block
+        .ruleContext=${boundaryRule}
+        .toolName=${'issue_refund'}
+      ></approval-rule-context-block>
+    `)) as ApprovalRuleContextBlock;
+    await element.updateComplete;
+
+    const link = element.shadowRoot?.querySelector('.rule-link');
+    expect(link?.getAttribute('href')).to.equal(
+      '/console/tools#tool=issue_refund'
+    );
+  });
+
+  it('falls back to the Tools page when the tool is unknown', async () => {
+    const element = await mount(boundaryRule);
+
+    const link = element.shadowRoot?.querySelector('.rule-link');
+    expect(link?.getAttribute('href')).to.equal('/console/tools');
+  });
+
   it('renders nothing in compact mode without a context', async () => {
     const element = await mount(null, true);
 

--- a/frontend/src/components/approval-rule-context-block.ts
+++ b/frontend/src/components/approval-rule-context-block.ts
@@ -1,0 +1,207 @@
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { ApprovalRuleContext } from '../types';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/tag/tag.js';
+
+/**
+ * "Why this needs approval": the policy rule that gated a tool call.
+ *
+ * The problem it solves: an approver used to see the tool name and the
+ * argument values but not which rule fired, so a call sitting exactly on a
+ * threshold looked identical to one in the middle of a band, and a
+ * mis-scoped rule was invisible at the one moment someone could catch it.
+ *
+ * It reports what matched and nothing more. There is no risk score here and
+ * no recommendation: an expression evaluated true, that is the whole claim.
+ *
+ * Renders nothing when there is no rule context. Approvals raised without
+ * rule evaluation (the `request_approval` builtin) and rows created before
+ * the field existed legitimately have none, and inventing an explanation for
+ * them would be worse than showing none.
+ */
+@customElement('approval-rule-context-block')
+export class ApprovalRuleContextBlock extends LitElement {
+  /** The snapshot taken when the approval was created. */
+  @property({ type: Object })
+  ruleContext: ApprovalRuleContext | null = null;
+
+  /**
+   * Compact mode for list rows and other tight surfaces: rule name only, no
+   * expression. A clipped expression reads as a different rule, so it is
+   * omitted rather than truncated.
+   */
+  @property({ type: Boolean })
+  compact = false;
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .rule-block {
+      background: var(--sl-color-neutral-50);
+      border: 1px solid var(--sl-color-neutral-200);
+      border-left: 3px solid var(--sl-color-primary-500);
+      border-radius: var(--sl-border-radius-medium);
+      padding: 0.875rem 1rem;
+    }
+
+    .rule-heading {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      font-size: 0.9rem;
+      color: var(--sl-color-neutral-900);
+      margin-bottom: 0.5rem;
+    }
+
+    .rule-name {
+      font-weight: 600;
+      color: var(--sl-color-neutral-900);
+    }
+
+    .rule-expression {
+      font-family: var(--sl-font-mono);
+      font-size: 0.8125rem;
+      background: var(--sl-color-neutral-0);
+      border: 1px solid var(--sl-color-neutral-200);
+      border-radius: var(--sl-border-radius-small);
+      padding: 0.5rem 0.625rem;
+      margin-top: 0.5rem;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
+      color: var(--sl-color-neutral-900);
+    }
+
+    .rule-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.375rem;
+      margin-top: 0.5rem;
+    }
+
+    .rule-explanation {
+      font-size: 0.85rem;
+      color: var(--sl-color-neutral-700);
+      line-height: 1.5;
+    }
+
+    .rule-link {
+      display: inline-block;
+      margin-top: 0.625rem;
+      font-size: 0.8125rem;
+      color: var(--sl-color-primary-700);
+    }
+
+    .compact {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.8125rem;
+      color: var(--sl-color-neutral-700);
+    }
+
+    .compact sl-icon {
+      color: var(--sl-color-primary-600);
+    }
+  `;
+
+  /** True when this context names a real rule with an expression. */
+  private get hasExpression(): boolean {
+    return Boolean(this.ruleContext?.expression);
+  }
+
+  private renderCompact(context: ApprovalRuleContext) {
+    return html`
+      <span class="compact" title=${context.expression ?? ''}>
+        <sl-icon name="funnel"></sl-icon>
+        <span>${context.rule_name}</span>
+      </span>
+    `;
+  }
+
+  render() {
+    const context = this.ruleContext;
+    if (!context || !context.rule_name) {
+      // No recorded reason. Say nothing rather than guess.
+      return nothing;
+    }
+
+    if (this.compact) {
+      return this.renderCompact(context);
+    }
+
+    const referenced = context.referenced_args ?? [];
+    const alsoMatched = context.also_matched_rule_ids ?? [];
+
+    return html`
+      <div class="rule-block" part="block">
+        <div class="rule-heading">
+          <sl-icon name="funnel"></sl-icon>
+          <span>Why this needs approval</span>
+        </div>
+
+        <div class="rule-name">${context.rule_name}</div>
+
+        ${
+          context.explanation
+            ? html`<div class="rule-explanation">${context.explanation}</div>`
+            : nothing
+        }
+        ${
+          this.hasExpression
+            ? html`<div class="rule-expression">${context.expression}</div>`
+            : nothing
+        }
+        ${
+          referenced.length > 0 ||
+          alsoMatched.length > 0 ||
+          context.priority !== undefined
+            ? html`
+                <div class="rule-meta">
+                  ${
+                    context.priority !== undefined
+                      ? html`<sl-tag size="small" variant="neutral"
+                          >Priority ${context.priority}</sl-tag
+                        >`
+                      : nothing
+                  }
+                  ${referenced.map(
+                    (name) =>
+                      html`<sl-tag size="small" variant="primary"
+                        >Checks ${name}</sl-tag
+                      >`
+                  )}
+                  ${
+                    alsoMatched.length > 0
+                      ? html`<sl-tag size="small" variant="warning"
+                          >${alsoMatched.length} lower-priority
+                          ${alsoMatched.length === 1 ? 'rule' : 'rules'} also
+                          matched</sl-tag
+                        >`
+                      : nothing
+                  }
+                </div>
+              `
+            : nothing
+        }
+        ${
+          context.tool_configuration_id
+            ? html`<a class="rule-link" href="/console/tools"
+                >Review this rule in Tools</a
+              >`
+            : nothing
+        }
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'approval-rule-context-block': ApprovalRuleContextBlock;
+  }
+}

--- a/frontend/src/components/approval-rule-context-block.ts
+++ b/frontend/src/components/approval-rule-context-block.ts
@@ -34,6 +34,14 @@ export class ApprovalRuleContextBlock extends LitElement {
   @property({ type: Boolean })
   compact = false;
 
+  /**
+   * The tool this approval is for, used to narrow the Tools page when the
+   * reviewer follows the link. There is no per-tool route to deep-link to
+   * yet, so the next best thing is to not make them scroll a catalogue.
+   */
+  @property({ type: String })
+  toolName: string | null = null;
+
   static styles = css`
     :host {
       display: block;
@@ -114,6 +122,13 @@ export class ApprovalRuleContextBlock extends LitElement {
     return Boolean(this.ruleContext?.expression);
   }
 
+  /** Tools page, narrowed to this tool when we know which one it is. */
+  private get toolsHref(): string {
+    return this.toolName
+      ? `/console/tools#tool=${encodeURIComponent(this.toolName)}`
+      : '/console/tools';
+  }
+
   private renderCompact(context: ApprovalRuleContext) {
     return html`
       <span class="compact" title=${context.expression ?? ''}>
@@ -190,7 +205,7 @@ export class ApprovalRuleContextBlock extends LitElement {
         }
         ${
           context.tool_configuration_id
-            ? html`<a class="rule-link" href="/console/tools"
+            ? html`<a class="rule-link" href=${this.toolsHref}
                 >Review this rule in Tools</a
               >`
             : nothing

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1351,6 +1351,58 @@ export interface ApprovalRequest {
    * would overstate how much human oversight actually happened.
    */
   decided_by_human?: boolean;
+  /**
+   * Why this request exists: the policy rule that gated the call, captured
+   * when the request was created. Absent on rows created before this field
+   * existed and on approvals raised without rule evaluation (the
+   * `request_approval` builtin). Surfaces must omit the explanation rather
+   * than guess at one.
+   */
+  rule_context?: ApprovalRuleContext | null;
+}
+
+/**
+ * Where an approval's gating came from.
+ *
+ * `tool_access_rule` and `subject_scoped_rule` name an actual rule with an
+ * expression. The rest describe gating that no rule produced, and carry an
+ * `explanation` instead.
+ */
+export type ApprovalRuleContextSource =
+  | 'tool_access_rule'
+  | 'subject_scoped_rule'
+  | 'tool_default_workflow'
+  | 'rule_evaluation_error'
+  | 'agent_permission_hook';
+
+/**
+ * Snapshot of the policy rule that required an approval.
+ *
+ * Recorded at request creation, not recomputed at read time, so editing or
+ * deleting a rule later cannot rewrite the reason a past approval was asked
+ * for. It states WHAT matched. It is not a risk assessment: nobody scored
+ * this call, an expression simply evaluated true.
+ */
+export interface ApprovalRuleContext {
+  source: ApprovalRuleContextSource;
+  /** The policy action taken. In practice always `'require_approval'`. */
+  decision: string;
+  /** Rule description, falling back to its expression, then a generic label. */
+  rule_name: string;
+  /** Plain statement used when no named rule fired. */
+  explanation?: string;
+  rule_id?: string;
+  /** The condition as the operator wrote it, e.g. `args.amount > 1000`. */
+  expression?: string;
+  expression_type?: string;
+  /** Evaluation order; lower runs first. */
+  priority?: number;
+  /** Argument names the expression mentions. Presentational hint only. */
+  referenced_args?: string[];
+  /** Tool config the rule belongs to, for linking to where it is edited. */
+  tool_configuration_id?: string;
+  /** Lower-priority rules that would also have matched. Informational. */
+  also_matched_rule_ids?: string[];
 }
 
 /** Mode of a time-boxed approval bypass. */

--- a/frontend/src/views/authed/approval-view.ts
+++ b/frontend/src/views/authed/approval-view.ts
@@ -603,6 +603,7 @@ export class ApprovalView extends AuthedElement {
                 <div class="content-section">
                   <approval-rule-context-block
                     .ruleContext=${this.approvalRequest.rule_context}
+                    .toolName=${this.approvalRequest.tool_name}
                   ></approval-rule-context-block>
                 </div>
               `

--- a/frontend/src/views/authed/approval-view.ts
+++ b/frontend/src/views/authed/approval-view.ts
@@ -10,6 +10,7 @@ import {
   withoutApprovalMetadata,
 } from '../../utils/approval-identity';
 import '../../components/question-answer-panel';
+import '../../components/approval-rule-context-block';
 import type { QuestionAnswerDetail } from '../../components/question-answer-panel';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
@@ -596,6 +597,17 @@ export class ApprovalView extends AuthedElement {
           </div>
         </div>
 
+        ${
+          this.approvalRequest.rule_context
+            ? html`
+                <div class="content-section">
+                  <approval-rule-context-block
+                    .ruleContext=${this.approvalRequest.rule_context}
+                  ></approval-rule-context-block>
+                </div>
+              `
+            : ''
+        }
         ${
           this.approvalRequest.agent_reasoning
             ? html`

--- a/frontend/src/views/authed/approvals-view.ts
+++ b/frontend/src/views/authed/approvals-view.ts
@@ -11,6 +11,7 @@ import {
 } from '../../utils/date';
 import { formatApprovalRequester } from '../../utils/approval-identity';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
+import '../../components/approval-rule-context-block';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
@@ -300,6 +301,10 @@ export class ApprovalsView extends AuthedElement {
         tool_args: message.tool_args || {},
         agent_reasoning: message.agent_reasoning || null,
         managed_agent_name: message.managed_agent_name || null,
+        // The broadcast carries the matched-rule snapshot so a live-arriving
+        // row explains itself the same way a fetched one does. Null when the
+        // approval was raised without rule evaluation.
+        rule_context: message.rule_context || null,
         status: 'pending',
         requested_at: message.requested_at || new Date().toISOString(),
         resolved_at: null,
@@ -917,6 +922,21 @@ export class ApprovalsView extends AuthedElement {
                                             >${request.tool_name}</code
                                           >
                                         </span>
+                                      </div>
+                                    `
+                                  : ''
+                              }
+                              ${
+                                request.rule_context
+                                  ? html`
+                                      <div
+                                        class="approval-meta"
+                                        style="margin-top: 2px;"
+                                      >
+                                        <approval-rule-context-block
+                                          compact
+                                          .ruleContext=${request.rule_context}
+                                        ></approval-rule-context-block>
                                       </div>
                                     `
                                   : ''

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -765,6 +765,14 @@ export class ToolsView extends LitElement {
       } else if (setupMcp === 'error') {
         this.oauthAlert = 'error';
       }
+      // Arriving from an approval's "Review this rule" link. There is no
+      // per-tool route yet, so narrow the list to that tool instead of
+      // dropping the reviewer into the full catalogue.
+      const tool = hashParams.get('tool');
+      if (tool) {
+        this.filterText = tool;
+        this.activeFilter = 'all';
+      }
       // Clean up the hash
       window.history.replaceState({}, '', window.location.pathname);
     }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9979,6 +9979,12 @@ components:
             format: uuid
           - type: 'null'
           title: Auto Approval Bypass Id
+        rule_context:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Rule Context
         was_bypassed:
           type: boolean
           title: Was Bypassed


### PR DESCRIPTION
## The gap

Reviewing a **policy**, you can read its CEL expression. Reviewing an actual
**approval request**, you saw the tool name and the argument values and nothing
else.

So a call sitting exactly on a threshold looked identical to one in the middle
of a band, and a mis-scoped rule was invisible at the one moment someone could
still catch it. The approver had the numbers but not the line they were being
measured against.

Origin: a LinkedIn thread with Dylan Merigaud, who shipped PO approval routing
at Pivot. His "amount exactly on the threshold" story is this exact blindness,
on our surface.

## What changed

The matched rule is snapshotted onto the approval request when it is created:
rule id, name, expression, expression type, priority, the decision, and the ids
of any lower-priority rules that also matched (the mis-scoping signal).

Snapshotted, not recomputed at read time. Editing or deleting a rule tomorrow
must not rewrite the record of why a call was gated last week.

The console approval view gets a "Why this needs approval" block with the
expression verbatim in monospace, tags for its priority and the arguments it
inspects, and a link to review the rule. List rows and push payloads show the
rule name only: a clipped expression reads as a different rule.

## Where there is no rule

Five things can gate a call and only one is a `ToolAccessRule`. The rule-less
cases say so plainly instead of inventing an expression:

- default tool gating: "No access rule matched. This tool is configured to
  require approval for every call, whatever the arguments are."
- a rule that could not be evaluated: says Preloop failed closed
- the agent's own permission hook: says no Preloop rule was evaluated
- the `request_approval` builtin: records nothing at all

No context means the block is not rendered. Historical rows stay blank rather
than get a fabricated reason.

The block reports what matched and nothing more. There is no risk score here
and no recommendation; a test asserts the copy does not claim one.

## Compatibility

`evaluate_policy()` returns `PolicyDecision`, a `tuple` subclass that IS the
same 3-tuple and carries `.rule_context` on the side. Existing callers unpack
it unchanged; tests that patch the evaluator with a plain tuple still work,
because every consumer reads the snapshot with `getattr(..., None)` and a
missing one reads as "not recorded" rather than raising on the enforcement
path.

New column is nullable JSONB; the read-schema field is optional.

## Tests

36 backend tests (including the boundary-amount case, winning-rule-by-priority,
also-matched rules, and all three rule-less paths) and 9 frontend tests.
Nine mutations were run against the implementation and each killed the intended
test; one initially survived, so a test was added for it. Details in
`factory/briefs/2026-08-06-approval-rule-context-report.md`.

## Note

Migration is parented on `20260806_ai_model_updated_at` (from #190), not on
`20260801_stagger_email`, to keep a single alembic head.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-tested snapshot of rule context onto approval requests with a backward-compatible tuple-subclass design and no security concerns. The previously noted duplicate sync/async eval loops have been deduplicated into shared helpers.
>
> **Overview**
> Adds a `rule_context` JSONB column to `ApprovalRequest` capturing the policy rule that gated a call. The `PolicyDecision` tuple subclass preserves backward compatibility while carrying rule identity, expression, priority, and also-matched rules through the approval pipeline. A new frontend block renders "Why this needs approval" with the expression verbatim.
>
> <sup>Written by Preloop PR Reviewer for commit 1abcc3bc. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->