### PR TITLE
feat: session transcript chat view, cache accounting, nginx route parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -382,8 +382,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Highlights: **Cursor usage import** brings bundled-model spend into Cost
 analytics, **rate-limit intelligence** turns upstream 429s into a headroom
-report, and **agent identity v2** gives managed agents a stable durable id
-across renames and re-onboarding.
+report, **agent identity v2** gives managed agents a stable durable id across
+renames and re-onboarding, and **live model discovery** lists what each
+provider actually serves instead of a catalog frozen in early 2025.
+
+This release also fixes two credential leaks. Tracker tokens were being
+written into flow execution logs through git remote URLs, and provider API
+keys entered in the model picker were being written to server access logs.
+Both are fixed, and both call for rotating the affected credentials: see the
+Security section below.
 
 ### Added
 
@@ -526,6 +533,14 @@ across renames and re-onboarding.
   the notice invites you to add one and fetch again instead of blaming the
   provider. The reason vocabulary is fixed and carries no provider text, so a
   failing provider cannot echo a URL or key material into the console.
+- **Verifiable trust signals on the README** (#108): CI status, latest GitHub
+  release, and PyPI version badges sit alongside the existing Python and
+  license badges, and every badge points at a signal you can check yourself.
+  An OpenSSF Scorecard workflow runs weekly and on every push to main,
+  publishing its results and uploading SARIF to code scanning, and
+  `docs/OPENSSF_BEST_PRACTICES.md` maps the bestpractices.dev criteria to
+  current repository evidence with the open gaps listed honestly. No badge is
+  claimed before the corresponding result is published.
 
 ### Changed
 
@@ -533,6 +548,17 @@ across renames and re-onboarding.
   decommissions the managed-agent row (PATCH `lifecycle_action=decommission`)
   so usage history and audit trail remain. Re-onboarding reactivates an
   archived match; use `preloop agents remove` for permanent deletion.
+- **Compliance estimation tools no longer ship to every session**:
+  `estimate_compliance` and `improve_compliance` are now default-disabled, so
+  accounts that never use them stop paying their schema cost on every agent
+  request. Enable them on the Tools page to get them back. The `test_progress`
+  debug tool is removed entirely; it was pure schema noise in user sessions.
+- **Cursor onboarding notes describe BYOK accurately**: the CLI's Cursor
+  support note said the base-URL override applied to chat only. It routes the
+  AI panel's third-party model calls in Ask, Plan, and Agent modes through the
+  Preloop gateway, while Tab, inline edit, and Cursor-billed bundled models
+  stay on Cursor's own backend. Those bundled models are exactly what
+  `preloop usage import` exists to account for.
 
 ### Fixed
 
@@ -692,6 +718,33 @@ across renames and re-onboarding.
   existing enrollments keep their identity, spend history, and credentials,
   and are refined in place rather than re-keyed. An older CLI that does not
   send `agent_kind` can no longer reset a known kind back to the generic one.
+- **Gateway streams no longer die as a silent empty HTTP 200** (#109): a
+  streaming completion could return 200 with a zero-byte body, no events and
+  no `finish_reason`, and with a `tools` array present it failed every time.
+  Errors were being raised inside the SSE generator after the 200 status line
+  had already gone out, so nothing could replace it and the client saw an
+  empty success. Upstream calls on the Codex paths now happen before the
+  generator is handed to the server, and the litellm streaming paths pull the
+  first upstream chunk eagerly, so a failure that early surfaces as a real
+  error response with a real status code. A failure that happens mid-stream
+  now emits a provider-native SSE error event (OpenAI, Responses-API,
+  Anthropic, and Gemini shapes) and deliberately omits the terminating
+  `[DONE]` / `message_stop`, so a client can always tell a finished stream
+  from a broken one. The invariant is that a stream either completes, emits an
+  error event, or never returns 200 in the first place.
+- **Claude and ChatGPT subscription traffic no longer 400s on ordinary
+  parameters**: requests routed over the Codex subscription-OAuth branch
+  failed with `Unsupported parameter: max_completion_tokens`, which some
+  runtimes send on every single request. The Codex upstream accepts a fixed
+  parameter set and has no token-limit parameter at all, so unsupported keys
+  are now dropped at the single point where the upstream body is built rather
+  than being passed through to be rejected. The Anthropic Claude Code
+  passthrough got the same treatment from the other direction: it drops only
+  the keys known to break it, so genuinely new Anthropic features keep working
+  without waiting for a gateway release, and `max_completion_tokens` /
+  `max_output_tokens` translate to Anthropic's `max_tokens` when the client
+  did not send one. Messages, system prompts, tools, and `cache_control`
+  blocks pass through byte-identical, so prompt caching is unaffected.
 - **Gateway upstream provider errors are classified** (#116, #117, #118): a
   shared `classify_upstream_error` taxonomy (`network`,
   `upstream_overloaded`, `upstream_rate_limited`, `upstream_quota_exhausted`,
@@ -713,9 +766,64 @@ across renames and re-onboarding.
   transient errors (5xx, network) no longer clear tokens and force re-login;
   only definitive 401/403 does. OAuth logins now store refresh tokens.
   Active sessions slide up to a 30-day cap.
+- **Onboarding tells the truth when live validation fails** (#110): a
+  transient upstream 5xx during `preloop agents onboard` quietly reverted
+  model routing to the previous provider, then printed a green
+  `✓ Onboarded` and pointed you at `preloop agents validate --live`, which
+  could never succeed afterwards. Transient upstream failures are now retried
+  with a short backoff and, if they persist, the gateway configuration is
+  kept in place so `validate --live` really is re-runnable. A rollback that
+  does happen is loud: the headline says the onboarding is incomplete and that
+  routing was reverted, the remediation says to re-run `onboard` rather than
+  `validate`, and the command exits non-zero so scripts and batch runs see the
+  failure. Onboarding that genuinely succeeded still reports `✓ Onboarded`,
+  and a kept-config failure reports degraded validation rather than success.
+- **Hermes plugin installs on a stock Linux box** (#111): every install path
+  failed. Hermes' own plugin installer rejects the package name, and the pip
+  fallback used the system interpreter, which modern distributions refuse to
+  let you write to. The CLI now locates Hermes' own virtualenv from
+  `hermes --version` and installs there; the system interpreter is never used.
+  When the virtualenv cannot be found, the error prints the exact
+  copy-pasteable pip command instead of a bare `pip install`, and `--dry-run`
+  prints the command that actually works. Validation also stopped reporting
+  `control_plugin_installed: no` after a manual install: it now checks the
+  virtualenv and asks Hermes for its plugin list, and a plugin that is
+  installed but disabled is reported as installed with an enable step rather
+  than as missing.
 - **CLI build repair** (#144): restore `recoverDeferredGatewayValidationFailure`
   in `cli/internal/cmd`, which a bad merge left uncompilable and which broke
   the Windows CLI test job on every open PR.
+- **Disabling a built-in tool actually disables it**: the account-level tool
+  toggle on the Tools page was never enforced on the live gateway, so turning
+  a built-in tool off changed nothing for connected agents and its schema kept
+  shipping in every request. Disabled tools are now hidden from the tool list
+  and rejected at call time, and the Tools page reflects what an agent will
+  really see. Flow executions that carry their own explicit tool allow-list,
+  such as the Pull Request Reviewer preset, are unaffected: an account-level
+  disable cannot silently break a preset flow.
+- **MCP scan failures say what actually went wrong** (#124): a failing server
+  scan produced the admin alert `unhandled errors in a TaskGroup
+  (1 sub-exception)`, which named neither the server nor the cause. The real
+  underlying error is now surfaced. Repeated rescans of a server that is
+  already known to be unhealthy no longer re-notify admins on every cycle;
+  the alert fires on the transition into failure.
+- **Deploys no longer drop gateway requests** (#124): the Helm chart shipped
+  the Kubernetes default rollout strategy, which allows healthy pods to be
+  killed before replacements are ready, so upgrades produced brief 502s on
+  small replica counts. API, gateway, and console deployments now roll with
+  `maxUnavailable: 0` and a pre-stop delay so the pod leaves the load
+  balancer's rotation before it starts shutting down. The console deployment
+  gained readiness and liveness probes; it previously had none and was
+  considered ready the instant its container started.
+- **Production error triage from launch week** (#115): GitLab merge-request
+  reviews no longer fail outright when GitLab has no approval to revoke or
+  rejects an inline diff comment, both of which are ordinary GitLab
+  limitations rather than errors; the review completes and the comment falls
+  back to a general discussion referencing the file and line. Duplicate
+  webhook deliveries for the same comment no longer roll back the whole
+  webhook transaction on an embedding insert race. A client that disconnects
+  during the websocket handshake is now treated as an early disconnect with
+  normal cleanup rather than logged as a server error.
 - **Code Quality / Scorecard hygiene**: clear GitHub Code Quality
   maintainability warnings (implicit string concat in gateway tests;
   unused-export false positives), pin GitHub Actions and Docker base images by
@@ -724,6 +832,23 @@ across renames and re-onboarding.
   override frontend `basic-ftp`/`yaml` advisories, harden refresh-token error
   responses, and document/wire `REFRESH_TOKEN_EXPIRE_DAYS` / `MAX_SESSION_DAYS`
   in Helm.
+- **Build reproducibility and supply-chain pinning**: every pip install in CI,
+  the publish and release workflows, and both Dockerfiles now installs from a
+  hash-pinned lockfile, so a compromised or re-uploaded package version cannot
+  silently enter a build. Each lockfile records the command that regenerates
+  it. The one global npm install is pinned to an exact version, npm having no
+  hash mode for global installs. Application dependencies installed with
+  `pip install -e .` are not yet hash-pinned.
+- **Summary and title generation on reasoning models**: approval summaries,
+  session and interaction titles, policy generation, agent name extraction and
+  the issue compliance, duplicate and dependency endpoints now pass the
+  model's own configured parameters through to the provider, and explicitly
+  ask reasoning models not to spend a thinking budget on these short internal
+  calls. The instruction is capability-checked per provider rather than sent
+  blindly, since sending it to a model that does not accept it produced a
+  hard 400 on the request. A reasoning model that returns nothing but a
+  thinking block is now treated as a failure that can fall back to the
+  system-wide default model, instead of quietly producing a blank summary.
 - **Single Alembic head restored** (#162, #163): parallel feature merges left
   the migration graph with multiple heads, breaking `alembic upgrade head` on
   self-hosted upgrades. The heads are collapsed into one mergepoint
@@ -752,6 +877,36 @@ across renames and re-onboarding.
 
 ### Security
 
+- **Tracker access tokens are no longer embedded in git remote URLs** (#173):
+  flows that cloned a repository had the tracker token spliced into the clone
+  URL, which git then wrote into the cloned repository's `origin` remote. Any
+  `git remote -v` the agent ran printed the token straight into the flow
+  execution log, which is served over the API and rendered in the console.
+  Tokens are now handed to git through a short-lived credential file created
+  with restrictive permissions and removed afterwards, and the environment
+  variable that carried it is unset before the agent runs, so the agent cannot
+  read it back out of its own environment. The URL given to `git clone` is
+  always credential-free, and the secret is never written into the container's
+  init script, which is visible to anyone who can describe the pod. Five
+  separate sites were embedding credentials this way, not just the clone path,
+  and the helper that did it has been deleted rather than deprecated so it
+  cannot be reintroduced. As defense in depth, flow logs are now scrubbed at
+  four layers (log read, live stream, agent output capture, and persistence)
+  for URL credentials, authorization and tracker headers, and known token
+  formats including GitHub, GitLab, Anthropic, OpenAI and Preloop keys. Each
+  redaction keeps its prefix, so an operator can still tell which kind of
+  credential leaked and therefore what to rotate. **Operators should rotate
+  any tracker token used by a flow with a git clone step, and treat existing
+  flow execution logs as potentially containing it.**
+- **Service logs no longer echo agent output or email bodies**: debug logging
+  in the flow execution logger wrote agent-derived content into service logs
+  that are not scrubbed; it now records only metadata such as action type,
+  status, and line length. Separately, when SMTP is unconfigured the mailer
+  logged the entire email body, and password reset, verification, and
+  invitation emails all carry a single-use authentication token in that body.
+  The body is no longer logged. Log scrubbing was also made resistant to a
+  crafted long input that could make its URL matching quadratic, which
+  mattered because the input is agent-controlled log lines.
 - **Provider API keys no longer travel in the URL**: the
   `/api/v1/ai-models/providers/{provider}/available-models` endpoint accepted
   `api_key` as a query parameter, so live provider keys were written to
@@ -762,6 +917,14 @@ across renames and re-onboarding.
   cannot be aimed at loopback or link-local addresses. **Operators should
   rotate any provider key entered through the model picker before this
   release**, and check access logs for `api_key=`.
+- **Google model discovery keys are scoped per request**: fetching the Google
+  model list configured the provider SDK through process-global state, so two
+  accounts refreshing their model list at the same time could race and list
+  one account's models using the other account's key. Each discovery call now
+  builds its own client bound to its own key. Model-picker errors also stopped
+  reporting every validation failure as an authentication failure: a blocked
+  endpoint or an invalid model kind used to tell you your API key was wrong.
+  Validation problems now return a distinct status from authentication ones.
 
 ## [0.13.1] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Unpriced-model admin alert on accounted $0 and empty completions**:
+  when OpenRouter usage accounting was requested, an explicit `usage.cost`
+  of `0` is now recorded as provider $0 (`cost_source=provider`) instead of
+  treated as "not accounted". A response with `completion_tokens == 0` and
+  no `cost` / `cost_details` fields may still land unpriced, but it no
+  longer pages admins to add catalog pricing. `cost: -1` stays the catalog
+  sentinel (not accounted). Prompt plus completion with no cost and no
+  catalog price still alerts.
+
 - **Per-execution cost rollup understated real gateway spend (#209)**:
   `flow_execution.estimated_cost` is written once when the run finishes, but
   most gateway usage rows are priced *later* — the live price lookup and the
@@ -408,15 +417,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Highlights: **Cursor usage import** brings bundled-model spend into Cost
 analytics, **rate-limit intelligence** turns upstream 429s into a headroom
-report, **agent identity v2** gives managed agents a stable durable id across
-renames and re-onboarding, and **live model discovery** lists what each
-provider actually serves instead of a catalog frozen in early 2025.
-
-This release also fixes two credential leaks. Tracker tokens were being
-written into flow execution logs through git remote URLs, and provider API
-keys entered in the model picker were being written to server access logs.
-Both are fixed, and both call for rotating the affected credentials: see the
-Security section below.
+report, and **agent identity v2** gives managed agents a stable durable id
+across renames and re-onboarding.
 
 ### Added
 
@@ -559,14 +561,6 @@ Security section below.
   the notice invites you to add one and fetch again instead of blaming the
   provider. The reason vocabulary is fixed and carries no provider text, so a
   failing provider cannot echo a URL or key material into the console.
-- **Verifiable trust signals on the README** (#108): CI status, latest GitHub
-  release, and PyPI version badges sit alongside the existing Python and
-  license badges, and every badge points at a signal you can check yourself.
-  An OpenSSF Scorecard workflow runs weekly and on every push to main,
-  publishing its results and uploading SARIF to code scanning, and
-  `docs/OPENSSF_BEST_PRACTICES.md` maps the bestpractices.dev criteria to
-  current repository evidence with the open gaps listed honestly. No badge is
-  claimed before the corresponding result is published.
 
 ### Changed
 
@@ -574,17 +568,6 @@ Security section below.
   decommissions the managed-agent row (PATCH `lifecycle_action=decommission`)
   so usage history and audit trail remain. Re-onboarding reactivates an
   archived match; use `preloop agents remove` for permanent deletion.
-- **Compliance estimation tools no longer ship to every session**:
-  `estimate_compliance` and `improve_compliance` are now default-disabled, so
-  accounts that never use them stop paying their schema cost on every agent
-  request. Enable them on the Tools page to get them back. The `test_progress`
-  debug tool is removed entirely; it was pure schema noise in user sessions.
-- **Cursor onboarding notes describe BYOK accurately**: the CLI's Cursor
-  support note said the base-URL override applied to chat only. It routes the
-  AI panel's third-party model calls in Ask, Plan, and Agent modes through the
-  Preloop gateway, while Tab, inline edit, and Cursor-billed bundled models
-  stay on Cursor's own backend. Those bundled models are exactly what
-  `preloop usage import` exists to account for.
 
 ### Fixed
 
@@ -744,33 +727,6 @@ Security section below.
   existing enrollments keep their identity, spend history, and credentials,
   and are refined in place rather than re-keyed. An older CLI that does not
   send `agent_kind` can no longer reset a known kind back to the generic one.
-- **Gateway streams no longer die as a silent empty HTTP 200** (#109): a
-  streaming completion could return 200 with a zero-byte body, no events and
-  no `finish_reason`, and with a `tools` array present it failed every time.
-  Errors were being raised inside the SSE generator after the 200 status line
-  had already gone out, so nothing could replace it and the client saw an
-  empty success. Upstream calls on the Codex paths now happen before the
-  generator is handed to the server, and the litellm streaming paths pull the
-  first upstream chunk eagerly, so a failure that early surfaces as a real
-  error response with a real status code. A failure that happens mid-stream
-  now emits a provider-native SSE error event (OpenAI, Responses-API,
-  Anthropic, and Gemini shapes) and deliberately omits the terminating
-  `[DONE]` / `message_stop`, so a client can always tell a finished stream
-  from a broken one. The invariant is that a stream either completes, emits an
-  error event, or never returns 200 in the first place.
-- **Claude and ChatGPT subscription traffic no longer 400s on ordinary
-  parameters**: requests routed over the Codex subscription-OAuth branch
-  failed with `Unsupported parameter: max_completion_tokens`, which some
-  runtimes send on every single request. The Codex upstream accepts a fixed
-  parameter set and has no token-limit parameter at all, so unsupported keys
-  are now dropped at the single point where the upstream body is built rather
-  than being passed through to be rejected. The Anthropic Claude Code
-  passthrough got the same treatment from the other direction: it drops only
-  the keys known to break it, so genuinely new Anthropic features keep working
-  without waiting for a gateway release, and `max_completion_tokens` /
-  `max_output_tokens` translate to Anthropic's `max_tokens` when the client
-  did not send one. Messages, system prompts, tools, and `cache_control`
-  blocks pass through byte-identical, so prompt caching is unaffected.
 - **Gateway upstream provider errors are classified** (#116, #117, #118): a
   shared `classify_upstream_error` taxonomy (`network`,
   `upstream_overloaded`, `upstream_rate_limited`, `upstream_quota_exhausted`,
@@ -792,64 +748,9 @@ Security section below.
   transient errors (5xx, network) no longer clear tokens and force re-login;
   only definitive 401/403 does. OAuth logins now store refresh tokens.
   Active sessions slide up to a 30-day cap.
-- **Onboarding tells the truth when live validation fails** (#110): a
-  transient upstream 5xx during `preloop agents onboard` quietly reverted
-  model routing to the previous provider, then printed a green
-  `✓ Onboarded` and pointed you at `preloop agents validate --live`, which
-  could never succeed afterwards. Transient upstream failures are now retried
-  with a short backoff and, if they persist, the gateway configuration is
-  kept in place so `validate --live` really is re-runnable. A rollback that
-  does happen is loud: the headline says the onboarding is incomplete and that
-  routing was reverted, the remediation says to re-run `onboard` rather than
-  `validate`, and the command exits non-zero so scripts and batch runs see the
-  failure. Onboarding that genuinely succeeded still reports `✓ Onboarded`,
-  and a kept-config failure reports degraded validation rather than success.
-- **Hermes plugin installs on a stock Linux box** (#111): every install path
-  failed. Hermes' own plugin installer rejects the package name, and the pip
-  fallback used the system interpreter, which modern distributions refuse to
-  let you write to. The CLI now locates Hermes' own virtualenv from
-  `hermes --version` and installs there; the system interpreter is never used.
-  When the virtualenv cannot be found, the error prints the exact
-  copy-pasteable pip command instead of a bare `pip install`, and `--dry-run`
-  prints the command that actually works. Validation also stopped reporting
-  `control_plugin_installed: no` after a manual install: it now checks the
-  virtualenv and asks Hermes for its plugin list, and a plugin that is
-  installed but disabled is reported as installed with an enable step rather
-  than as missing.
 - **CLI build repair** (#144): restore `recoverDeferredGatewayValidationFailure`
   in `cli/internal/cmd`, which a bad merge left uncompilable and which broke
   the Windows CLI test job on every open PR.
-- **Disabling a built-in tool actually disables it**: the account-level tool
-  toggle on the Tools page was never enforced on the live gateway, so turning
-  a built-in tool off changed nothing for connected agents and its schema kept
-  shipping in every request. Disabled tools are now hidden from the tool list
-  and rejected at call time, and the Tools page reflects what an agent will
-  really see. Flow executions that carry their own explicit tool allow-list,
-  such as the Pull Request Reviewer preset, are unaffected: an account-level
-  disable cannot silently break a preset flow.
-- **MCP scan failures say what actually went wrong** (#124): a failing server
-  scan produced the admin alert `unhandled errors in a TaskGroup
-  (1 sub-exception)`, which named neither the server nor the cause. The real
-  underlying error is now surfaced. Repeated rescans of a server that is
-  already known to be unhealthy no longer re-notify admins on every cycle;
-  the alert fires on the transition into failure.
-- **Deploys no longer drop gateway requests** (#124): the Helm chart shipped
-  the Kubernetes default rollout strategy, which allows healthy pods to be
-  killed before replacements are ready, so upgrades produced brief 502s on
-  small replica counts. API, gateway, and console deployments now roll with
-  `maxUnavailable: 0` and a pre-stop delay so the pod leaves the load
-  balancer's rotation before it starts shutting down. The console deployment
-  gained readiness and liveness probes; it previously had none and was
-  considered ready the instant its container started.
-- **Production error triage from launch week** (#115): GitLab merge-request
-  reviews no longer fail outright when GitLab has no approval to revoke or
-  rejects an inline diff comment, both of which are ordinary GitLab
-  limitations rather than errors; the review completes and the comment falls
-  back to a general discussion referencing the file and line. Duplicate
-  webhook deliveries for the same comment no longer roll back the whole
-  webhook transaction on an embedding insert race. A client that disconnects
-  during the websocket handshake is now treated as an early disconnect with
-  normal cleanup rather than logged as a server error.
 - **Code Quality / Scorecard hygiene**: clear GitHub Code Quality
   maintainability warnings (implicit string concat in gateway tests;
   unused-export false positives), pin GitHub Actions and Docker base images by
@@ -858,23 +759,6 @@ Security section below.
   override frontend `basic-ftp`/`yaml` advisories, harden refresh-token error
   responses, and document/wire `REFRESH_TOKEN_EXPIRE_DAYS` / `MAX_SESSION_DAYS`
   in Helm.
-- **Build reproducibility and supply-chain pinning**: every pip install in CI,
-  the publish and release workflows, and both Dockerfiles now installs from a
-  hash-pinned lockfile, so a compromised or re-uploaded package version cannot
-  silently enter a build. Each lockfile records the command that regenerates
-  it. The one global npm install is pinned to an exact version, npm having no
-  hash mode for global installs. Application dependencies installed with
-  `pip install -e .` are not yet hash-pinned.
-- **Summary and title generation on reasoning models**: approval summaries,
-  session and interaction titles, policy generation, agent name extraction and
-  the issue compliance, duplicate and dependency endpoints now pass the
-  model's own configured parameters through to the provider, and explicitly
-  ask reasoning models not to spend a thinking budget on these short internal
-  calls. The instruction is capability-checked per provider rather than sent
-  blindly, since sending it to a model that does not accept it produced a
-  hard 400 on the request. A reasoning model that returns nothing but a
-  thinking block is now treated as a failure that can fall back to the
-  system-wide default model, instead of quietly producing a blank summary.
 - **Single Alembic head restored** (#162, #163): parallel feature merges left
   the migration graph with multiple heads, breaking `alembic upgrade head` on
   self-hosted upgrades. The heads are collapsed into one mergepoint
@@ -903,36 +787,6 @@ Security section below.
 
 ### Security
 
-- **Tracker access tokens are no longer embedded in git remote URLs** (#173):
-  flows that cloned a repository had the tracker token spliced into the clone
-  URL, which git then wrote into the cloned repository's `origin` remote. Any
-  `git remote -v` the agent ran printed the token straight into the flow
-  execution log, which is served over the API and rendered in the console.
-  Tokens are now handed to git through a short-lived credential file created
-  with restrictive permissions and removed afterwards, and the environment
-  variable that carried it is unset before the agent runs, so the agent cannot
-  read it back out of its own environment. The URL given to `git clone` is
-  always credential-free, and the secret is never written into the container's
-  init script, which is visible to anyone who can describe the pod. Five
-  separate sites were embedding credentials this way, not just the clone path,
-  and the helper that did it has been deleted rather than deprecated so it
-  cannot be reintroduced. As defense in depth, flow logs are now scrubbed at
-  four layers (log read, live stream, agent output capture, and persistence)
-  for URL credentials, authorization and tracker headers, and known token
-  formats including GitHub, GitLab, Anthropic, OpenAI and Preloop keys. Each
-  redaction keeps its prefix, so an operator can still tell which kind of
-  credential leaked and therefore what to rotate. **Operators should rotate
-  any tracker token used by a flow with a git clone step, and treat existing
-  flow execution logs as potentially containing it.**
-- **Service logs no longer echo agent output or email bodies**: debug logging
-  in the flow execution logger wrote agent-derived content into service logs
-  that are not scrubbed; it now records only metadata such as action type,
-  status, and line length. Separately, when SMTP is unconfigured the mailer
-  logged the entire email body, and password reset, verification, and
-  invitation emails all carry a single-use authentication token in that body.
-  The body is no longer logged. Log scrubbing was also made resistant to a
-  crafted long input that could make its URL matching quadratic, which
-  mattered because the input is agent-controlled log lines.
 - **Provider API keys no longer travel in the URL**: the
   `/api/v1/ai-models/providers/{provider}/available-models` endpoint accepted
   `api_key` as a query parameter, so live provider keys were written to
@@ -943,14 +797,6 @@ Security section below.
   cannot be aimed at loopback or link-local addresses. **Operators should
   rotate any provider key entered through the model picker before this
   release**, and check access logs for `api_key=`.
-- **Google model discovery keys are scoped per request**: fetching the Google
-  model list configured the provider SDK through process-global state, so two
-  accounts refreshing their model list at the same time could race and list
-  one account's models using the other account's key. Each discovery call now
-  builds its own client bound to its own key. Model-picker errors also stopped
-  reporting every validation failure as an authentication failure: a blocked
-  endpoint or an invalid model kind used to tell you your API key was wrong.
-  Validation problems now return a distinct status from authentication ones.
 
 ## [0.13.1] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   claiming to still be running. Both timestamps were already returned by the
   API, so this is a console-only change.
 
+- **Chat-style session transcript ("Conversation" view)**: the session observer
+  now reconstructs a chat-shaped transcript from the captured gateway events
+  and activity rows. Only top-level user prompts and final agent responses are
+  expanded; tool calls, tool results, system prompts, injected harness segments
+  (system reminders, compaction summaries, Preloop question notices) and
+  intermediate agent output are collapsed into expandable step groups.
+  Tool results are detected exactly from the raw request body structure when it
+  was captured; otherwise the view discloses how many requests lacked structure
+  instead of guessing.
+
+- **Per-request and per-session prompt-cache accounting**: the session request
+  timeline now reports each request's cache read/write/miss tokens (`null`
+  means "not reported by the provider", never zero; misses are labelled
+  `reported` or `derived`) and a whole-session rollup with hit ratio over
+  covered requests, coverage disclosure, a per-model breakdown, and estimated
+  cache savings computed only from exact catalog prices (`catalog_exact`, or
+  `catalog_exact_partial` as a lower bound in mixed-model sessions; omitted
+  with a stated reason otherwise). Replay-validation traffic is excluded.
+
+- **Nginx route parity test**: `backend/tests/test_nginx_route_parity.py`
+  asserts that every prerendered marketing route resolves to prerendered HTML
+  in BOTH the docker nginx template and the production Helm ConfigMap by
+  implementing nginx location-matching precedence, preventing the recurring
+  "works locally, serves the SPA homepage in production" drift. Also adds the
+  missing `/ai-act-readiness` route to the docker template.
+
 - **Admin alert for unpriceable models**: the gateway now notifies admins the
   first time a `(model_alias, provider)` pair proves unpriceable, including the
   account and token volume, so missing pricing is noticed instead of silently

--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -60,6 +60,8 @@ from preloop.schemas.gateway_usage import (
     ManagedAgentUsageAggregate,
     RuntimeSessionActivityListResponse,
     RuntimeSessionInteractionSummary,
+    RuntimeSessionCacheSummary,
+    RuntimeSessionRequestCache,
     RuntimeSessionRequestItem,
     RuntimeSessionRequestListResponse,
     RuntimeSessionRequestTool,
@@ -83,6 +85,10 @@ from preloop.services.account_realtime import (
 )
 from preloop.services.account_governance_cache import (
     invalidate_account_governance_cache,
+)
+from preloop.services.cache_accounting import (
+    build_request_cache_accounting,
+    summarize_session_cache,
 )
 from preloop.services.managed_agent_identity import (
     ManagedAgentIdentityError,
@@ -2449,6 +2455,9 @@ async def get_account_session_activity_timeline(
 def _request_row_to_item(row: Any) -> RuntimeSessionRequestItem:
     """Convert an ApiUsage row into a unified-timeline request item.
 
+    Also carries the per-call prompt-cache split (read / write / miss) built by
+    :func:`preloop.services.cache_accounting.build_request_cache_accounting`.
+
     Args:
         row: One ``ApiUsage`` ORM row for a gateway request.
 
@@ -2475,6 +2484,7 @@ def _request_row_to_item(row: Any) -> RuntimeSessionRequestItem:
                 )
             )
     status_code = int(row.status_code or 0)
+    cache = build_request_cache_accounting(row)
     return RuntimeSessionRequestItem(
         id=str(row.id),
         timestamp=row.timestamp,
@@ -2492,6 +2502,9 @@ def _request_row_to_item(row: Any) -> RuntimeSessionRequestItem:
         endpoint=row.endpoint,
         tools=tools,
         tools_total_schema_tokens=tools_total,
+        # NULL cache columns stay NULL through the wire: the UI must say
+        # "not reported by provider", never zero.
+        cache=RuntimeSessionRequestCache(**cache.as_dict()),
     )
 
 
@@ -2550,6 +2563,15 @@ async def list_account_runtime_session_requests(
         failed_only=True,
     )
     items = [_request_row_to_item(row) for row in rows]
+    # The cache rollup spans the whole session, not the current page, so the
+    # summary block is stable while the user pages or filters the list.
+    cache_summary = summarize_session_cache(
+        crud_api_usage.list_session_cache_rows(
+            db,
+            account_id=account.id,
+            runtime_session_id=runtime_session_id,
+        )
+    )
     next_offset = offset + len(items)
     return RuntimeSessionRequestListResponse(
         items=items,
@@ -2559,6 +2581,7 @@ async def list_account_runtime_session_requests(
         offset=offset,
         next_offset=next_offset if next_offset < total else None,
         has_more=next_offset < total,
+        cache_summary=RuntimeSessionCacheSummary(**cache_summary.as_dict()),
     )
 
 

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -1,6 +1,7 @@
 """CRUD operations for ApiUsage model."""
 
 from datetime import datetime, timedelta, timezone
+import logging
 from types import SimpleNamespace
 import uuid
 from typing import Any, Dict, List, Optional, Sequence, Union
@@ -16,6 +17,8 @@ from ..models.runtime_session import RuntimeSession
 from ..models.user import User
 from ...utils.jsonb_sanitize import sanitize_for_jsonb
 from .base import CRUDBase
+
+logger = logging.getLogger(__name__)
 
 # Known ``meta_data.purpose`` tags for internal model-gateway usage rows.
 GATEWAY_USAGE_PURPOSES = frozenset(
@@ -1863,6 +1866,12 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             .all()
         )
 
+    # Hard cap on cache-rollup rows per session. Even a very long-lived agent
+    # session stays well under this; the cap only guards against a pathological
+    # session flooding the API pod's memory. Hitting it is logged because the
+    # resulting summary silently under-counts the session.
+    SESSION_CACHE_ROWS_LIMIT = 50_000
+
     def list_session_cache_rows(
         self,
         db: Session,
@@ -1877,6 +1886,9 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         and full rows carry ``meta_data`` with capped-but-still-large request
         and response bodies. Only ``meta_data['usage_details']`` is pulled from
         the JSONB, which is the sole part cache accounting reads.
+
+        Rows are capped at :attr:`SESSION_CACHE_ROWS_LIMIT` as a memory guard;
+        exceeding it logs a warning because the rollup then under-counts.
 
         Args:
             db: Database session.
@@ -1898,12 +1910,23 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
                 self.model.meta_data["usage_details"].label("usage_details"),
             )
             .filter(
+                exclude_replay_usage_condition(),
                 self.model.action_type == "model_gateway",
                 self.model.account_id == account_id,
                 self.model.runtime_session_id == runtime_session_id,
             )
+            .limit(self.SESSION_CACHE_ROWS_LIMIT + 1)
             .all()
         )
+        if len(rows) > self.SESSION_CACHE_ROWS_LIMIT:
+            rows = rows[: self.SESSION_CACHE_ROWS_LIMIT]
+            logger.warning(
+                "Session cache rollup truncated at %d rows for runtime session "
+                "%s (account %s); the cache summary under-counts this session.",
+                self.SESSION_CACHE_ROWS_LIMIT,
+                runtime_session_id,
+                account_id,
+            )
         return [
             SimpleNamespace(
                 prompt_tokens=row.prompt_tokens,

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -1,6 +1,7 @@
 """CRUD operations for ApiUsage model."""
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 import uuid
 from typing import Any, Dict, List, Optional, Sequence, Union
 from sqlalchemy import Float, String, and_, case, cast, func, or_
@@ -1861,6 +1862,62 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             .offset(offset)
             .all()
         )
+
+    def list_session_cache_rows(
+        self,
+        db: Session,
+        *,
+        account_id: Union[uuid.UUID, str],
+        runtime_session_id: Union[uuid.UUID, str],
+    ) -> List[SimpleNamespace]:
+        """List the cache-accounting columns for every request in a session.
+
+        Deliberately column-projected rather than a full ORM load: the session
+        cache rollup covers ALL requests (it must not change as the UI pages),
+        and full rows carry ``meta_data`` with capped-but-still-large request
+        and response bodies. Only ``meta_data['usage_details']`` is pulled from
+        the JSONB, which is the sole part cache accounting reads.
+
+        Args:
+            db: Database session.
+            account_id: Owning account id.
+            runtime_session_id: Runtime session to summarize.
+
+        Returns:
+            Lightweight namespaces shaped like ``ApiUsage`` rows for the fields
+            :mod:`preloop.services.cache_accounting` consumes.
+        """
+        rows = (
+            db.query(
+                self.model.prompt_tokens,
+                self.model.cache_read_tokens,
+                self.model.cache_creation_tokens,
+                self.model.model_alias,
+                self.model.provider_name,
+                self.model.usage_source,
+                self.model.meta_data["usage_details"].label("usage_details"),
+            )
+            .filter(
+                self.model.action_type == "model_gateway",
+                self.model.account_id == account_id,
+                self.model.runtime_session_id == runtime_session_id,
+            )
+            .all()
+        )
+        return [
+            SimpleNamespace(
+                prompt_tokens=row.prompt_tokens,
+                cache_read_tokens=row.cache_read_tokens,
+                cache_creation_tokens=row.cache_creation_tokens,
+                model_alias=row.model_alias,
+                provider_name=row.provider_name,
+                usage_source=row.usage_source,
+                meta_data={"usage_details": row.usage_details}
+                if row.usage_details is not None
+                else None,
+            )
+            for row in rows
+        ]
 
     def count_session_request_rows(
         self,

--- a/backend/preloop/schemas/gateway_usage.py
+++ b/backend/preloop/schemas/gateway_usage.py
@@ -662,7 +662,12 @@ class RuntimeSessionRequestItem(BaseModel):
 
 
 class RuntimeSessionCacheModelGroup(BaseModel):
-    """Per-(model, provider) breakdown inside the session cache rollup."""
+    """Per-(model, provider) breakdown inside the session cache rollup.
+
+    ``requests_with_unknown_prompt_tokens`` counts this group's rows whose
+    provider reported no prompt total; their tokens are excluded from
+    ``prompt_tokens`` rather than counted as zero.
+    """
 
     model_alias: Optional[str] = None
     provider_name: Optional[str] = None
@@ -670,6 +675,7 @@ class RuntimeSessionCacheModelGroup(BaseModel):
     cache_read_tokens: int = 0
     cache_creation_tokens: int = 0
     prompt_tokens: int = 0
+    requests_with_unknown_prompt_tokens: int = 0
     write_reported: bool = False
 
 

--- a/backend/preloop/schemas/gateway_usage.py
+++ b/backend/preloop/schemas/gateway_usage.py
@@ -612,6 +612,26 @@ class RuntimeSessionRequestTool(BaseModel):
     stripped: bool = False
 
 
+class RuntimeSessionRequestCache(BaseModel):
+    """Prompt-cache accounting for one gateway request.
+
+    Every token field is ``Optional`` on purpose: ``None`` means *the provider
+    did not report this*, and clients MUST render it as "not reported" rather
+    than as zero. A ``0`` here is a real, provider-reported zero.
+
+    ``cache_miss_source`` distinguishes a miss count the provider sent us
+    (``reported`` — today only DeepSeek's ``prompt_cache_miss_tokens``) from one
+    we derived arithmetically as ``prompt - read - write`` (``derived``).
+    """
+
+    cache_read_tokens: Optional[int] = None
+    cache_creation_tokens: Optional[int] = None
+    cache_miss_tokens: Optional[int] = None
+    cache_miss_source: Optional[str] = None
+    has_cache_data: bool = False
+    usage_source: Optional[str] = None
+
+
 class RuntimeSessionRequestItem(BaseModel):
     """One per-request gateway usage row for the unified session timeline."""
 
@@ -636,6 +656,42 @@ class RuntimeSessionRequestItem(BaseModel):
     endpoint: Optional[str] = None
     tools: List[RuntimeSessionRequestTool] = Field(default_factory=list)
     tools_total_schema_tokens: int = 0
+    cache: RuntimeSessionRequestCache = Field(
+        default_factory=RuntimeSessionRequestCache
+    )
+
+
+class RuntimeSessionCacheSummary(BaseModel):
+    """Whole-session prompt-cache rollup.
+
+    The ratio's denominator is the *covered* traffic only: requests whose
+    provider actually reported a cache split. ``uncovered_prompt_tokens`` is
+    surfaced next to it so the UI can state coverage instead of folding blind
+    rows in as misses.
+
+    ``cache_write_tokens`` is ``None`` when no provider in this session has a
+    billable cache-write concept at all (OpenAI, Gemini, DeepSeek), which is
+    not the same statement as zero rewritten tokens.
+
+    ``estimated_cache_savings_usd`` is populated only when the vendored price
+    catalog carries explicit input AND cache-read prices for every model that
+    contributed cache reads; otherwise it is ``None`` and
+    ``savings_omitted_reason`` says why. No multiplier-based approximation is
+    ever returned here.
+    """
+
+    requests_total: int = 0
+    requests_with_cache_data: int = 0
+    requests_without_cache_data: int = 0
+    covered_prompt_tokens: int = 0
+    uncovered_prompt_tokens: int = 0
+    cached_prompt_tokens: int = 0
+    uncached_prompt_tokens: int = 0
+    cache_write_tokens: Optional[int] = None
+    cache_hit_ratio: Optional[float] = None
+    estimated_cache_savings_usd: Optional[float] = None
+    savings_basis: Optional[str] = None
+    savings_omitted_reason: Optional[str] = None
 
 
 class RuntimeSessionRequestListResponse(BaseModel):
@@ -648,6 +704,11 @@ class RuntimeSessionRequestListResponse(BaseModel):
     offset: int = 0
     next_offset: Optional[int] = None
     has_more: bool = False
+    # Rollup over the whole session, not just the returned page, so the summary
+    # does not change as the user pages through requests.
+    cache_summary: RuntimeSessionCacheSummary = Field(
+        default_factory=RuntimeSessionCacheSummary
+    )
 
 
 class RuntimeSessionSummaryInsight(BaseModel):

--- a/backend/preloop/schemas/gateway_usage.py
+++ b/backend/preloop/schemas/gateway_usage.py
@@ -661,23 +661,38 @@ class RuntimeSessionRequestItem(BaseModel):
     )
 
 
+class RuntimeSessionCacheModelGroup(BaseModel):
+    """Per-(model, provider) breakdown inside the session cache rollup."""
+
+    model_alias: Optional[str] = None
+    provider_name: Optional[str] = None
+    requests: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    prompt_tokens: int = 0
+    write_reported: bool = False
+
+
 class RuntimeSessionCacheSummary(BaseModel):
     """Whole-session prompt-cache rollup.
 
     The ratio's denominator is the *covered* traffic only: requests whose
     provider actually reported a cache split. ``uncovered_prompt_tokens`` is
     surfaced next to it so the UI can state coverage instead of folding blind
-    rows in as misses.
+    rows in as misses. ``requests_with_unknown_prompt_tokens`` counts rows
+    whose provider reported no prompt total at all; their tokens are excluded
+    from both sums rather than counted as zero.
 
     ``cache_write_tokens`` is ``None`` when no provider in this session has a
     billable cache-write concept at all (OpenAI, Gemini, DeepSeek), which is
     not the same statement as zero rewritten tokens.
 
-    ``estimated_cache_savings_usd`` is populated only when the vendored price
-    catalog carries explicit input AND cache-read prices for every model that
-    contributed cache reads; otherwise it is ``None`` and
-    ``savings_omitted_reason`` says why. No multiplier-based approximation is
-    ever returned here.
+    ``estimated_cache_savings_usd`` is computed only from explicit catalog
+    input AND cache-read prices — never a multiplier-based approximation.
+    ``savings_basis`` is ``catalog_exact`` when every model that contributed
+    cache reads was priced, ``catalog_exact_partial`` when the figure is a
+    lower bound covering only the priced models. When no contributing model is
+    priced the figure is ``None`` and ``savings_omitted_reason`` says why.
     """
 
     requests_total: int = 0
@@ -692,6 +707,8 @@ class RuntimeSessionCacheSummary(BaseModel):
     estimated_cache_savings_usd: Optional[float] = None
     savings_basis: Optional[str] = None
     savings_omitted_reason: Optional[str] = None
+    requests_with_unknown_prompt_tokens: int = 0
+    models: List[RuntimeSessionCacheModelGroup] = Field(default_factory=list)
 
 
 class RuntimeSessionRequestListResponse(BaseModel):
@@ -705,10 +722,10 @@ class RuntimeSessionRequestListResponse(BaseModel):
     next_offset: Optional[int] = None
     has_more: bool = False
     # Rollup over the whole session, not just the returned page, so the summary
-    # does not change as the user pages through requests.
-    cache_summary: RuntimeSessionCacheSummary = Field(
-        default_factory=RuntimeSessionCacheSummary
-    )
+    # does not change as the user pages through requests. Required on purpose:
+    # a defaulted zeroed-out summary would silently mask an endpoint that
+    # forgot to compute it.
+    cache_summary: RuntimeSessionCacheSummary
 
 
 class RuntimeSessionSummaryInsight(BaseModel):

--- a/backend/preloop/services/cache_accounting.py
+++ b/backend/preloop/services/cache_accounting.py
@@ -213,7 +213,7 @@ def build_request_cache_accounting(row: Any) -> RequestCacheAccounting:
         cache_creation_tokens=creation,
         cache_miss_tokens=miss,
         cache_miss_source=miss_source,
-        has_cache_data=read is not None or creation is not None,
+        has_cache_data=read is not None or creation is not None or miss is not None,
         usage_source=getattr(row, "usage_source", None),
     )
 

--- a/backend/preloop/services/cache_accounting.py
+++ b/backend/preloop/services/cache_accounting.py
@@ -276,6 +276,10 @@ class SessionCacheModelGroup:
     cache_read_tokens: int = 0
     cache_creation_tokens: int = 0
     prompt_tokens: int = 0
+    # Rows in this group whose provider reported NO prompt total. Their tokens
+    # are excluded from ``prompt_tokens`` rather than folded in as 0, matching
+    # the session-level ``requests_with_unknown_prompt_tokens`` semantics.
+    requests_with_unknown_prompt_tokens: int = 0
     write_reported: bool = False
 
     def as_dict(self) -> dict[str, Any]:
@@ -286,6 +290,9 @@ class SessionCacheModelGroup:
             "cache_read_tokens": self.cache_read_tokens,
             "cache_creation_tokens": self.cache_creation_tokens,
             "prompt_tokens": self.prompt_tokens,
+            "requests_with_unknown_prompt_tokens": (
+                self.requests_with_unknown_prompt_tokens
+            ),
             "write_reported": self.write_reported,
         }
 
@@ -398,7 +405,13 @@ def summarize_session_cache(rows: Iterable[Any]) -> SessionCacheSummary:
             group = SessionCacheModelGroup(model_alias=key[0], provider_name=key[1])
             groups[key] = group
         group.requests += 1
-        group.prompt_tokens += prompt_tokens or 0
+        # None is "not reported", never zero — same contract as the
+        # session-level sums above. Unknown rows are disclosed per group
+        # instead of silently contributing a misleading 0-token share.
+        if prompt_tokens is None:
+            group.requests_with_unknown_prompt_tokens += 1
+        else:
+            group.prompt_tokens += prompt_tokens
         group.cache_read_tokens += read
         if creation is not None:
             group.write_reported = True

--- a/backend/preloop/services/cache_accounting.py
+++ b/backend/preloop/services/cache_accounting.py
@@ -1,0 +1,390 @@
+"""Per-request and per-session prompt-cache accounting for the session view.
+
+The gateway already persists an exact, provider-sourced cache split on every
+``ApiUsage`` row (``cache_read_tokens`` / ``cache_creation_tokens``, written by
+``OpenAIGatewayService._extract_token_details``). The local estimation fallback
+never fabricates that split, so a cache column is either a provider's number or
+NULL. This module turns those columns into something a UI can render **without
+lying**:
+
+* a NULL cache column is reported as ``None`` ("not reported by provider"),
+  never as ``0``;
+* a cache miss is ``reported`` when the provider actually sent a miss count
+  (DeepSeek's ``prompt_cache_miss_tokens``, which otherwise sits unused in
+  ``meta_data["usage_details"]``), ``derived`` when we subtract a reported read
+  from the reported prompt total, and ``None`` when neither is possible;
+* estimated cache savings are computed only from explicit catalog cache prices.
+  When the catalog lacks an exact price for any model that contributed cache
+  reads, savings are omitted with a reason rather than approximated.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional
+
+# Provenance of a per-request cache-miss number.
+CACHE_MISS_SOURCE_REPORTED = "reported"
+CACHE_MISS_SOURCE_DERIVED = "derived"
+
+# Why a session-level savings figure was withheld.
+SAVINGS_OMITTED_NO_CACHE_READS = "no_cache_reads"
+SAVINGS_OMITTED_NO_CATALOG_PRICE = "no_catalog_cache_price"
+
+# Basis label for a savings number we are willing to show.
+SAVINGS_BASIS_CATALOG_EXACT = "catalog_exact"
+
+_PRICE_CATALOG_PATH = Path(__file__).resolve().parent / "data" / "model_prices.json"
+
+
+@lru_cache(maxsize=1)
+def _price_catalog() -> dict[str, Any]:
+    try:
+        loaded: Any = json.loads(_PRICE_CATALOG_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _as_int(value: Any) -> Optional[int]:
+    """Coerce a provider-reported token count to int, or None."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _usage_details(meta_data: Any) -> Mapping[str, Any]:
+    if not isinstance(meta_data, Mapping):
+        return {}
+    details = meta_data.get("usage_details")
+    return details if isinstance(details, Mapping) else {}
+
+
+def _prompt_tokens_details(usage_details: Mapping[str, Any]) -> Mapping[str, Any]:
+    nested = usage_details.get("prompt_tokens_details")
+    return nested if isinstance(nested, Mapping) else {}
+
+
+def reported_cache_miss_tokens(meta_data: Any) -> Optional[int]:
+    """Return a provider-reported cache MISS token count, if one exists.
+
+    Today only DeepSeek reports misses directly (``prompt_cache_miss_tokens``).
+    litellm maps its hit count onto ``cached_tokens`` but drops the miss count,
+    which survives verbatim in ``meta_data["usage_details"]``. This promotes it.
+
+    Args:
+        meta_data: The ``ApiUsage.meta_data`` JSONB value.
+
+    Returns:
+        The reported miss token count, or ``None`` when the provider sent none.
+    """
+    details = _usage_details(meta_data)
+    if not details:
+        return None
+    nested = _prompt_tokens_details(details)
+    for candidate in (
+        details.get("prompt_cache_miss_tokens"),
+        nested.get("prompt_cache_miss_tokens"),
+        details.get("cache_miss_input_tokens"),
+    ):
+        parsed = _as_int(candidate)
+        if parsed is not None:
+            return max(parsed, 0)
+    return None
+
+
+def _fallback_cache_read(details: Mapping[str, Any]) -> Optional[int]:
+    nested = _prompt_tokens_details(details)
+    for candidate in (
+        nested.get("cached_tokens"),
+        details.get("cache_read_input_tokens"),
+    ):
+        parsed = _as_int(candidate)
+        if parsed is not None:
+            return max(parsed, 0)
+    return None
+
+
+def _fallback_cache_creation(details: Mapping[str, Any]) -> Optional[int]:
+    nested = _prompt_tokens_details(details)
+    for candidate in (
+        nested.get("cache_creation_tokens"),
+        details.get("cache_creation_input_tokens"),
+    ):
+        parsed = _as_int(candidate)
+        if parsed is not None:
+            return max(parsed, 0)
+    return None
+
+
+@dataclass
+class RequestCacheAccounting:
+    """Cache accounting for one gateway request, with honest absences."""
+
+    cache_read_tokens: Optional[int] = None
+    cache_creation_tokens: Optional[int] = None
+    cache_miss_tokens: Optional[int] = None
+    cache_miss_source: Optional[str] = None
+    # True when the provider reported anything at all about this call's cache.
+    has_cache_data: bool = False
+    # provider | estimated | partial | imported | None (legacy rows).
+    usage_source: Optional[str] = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "cache_miss_tokens": self.cache_miss_tokens,
+            "cache_miss_source": self.cache_miss_source,
+            "has_cache_data": self.has_cache_data,
+            "usage_source": self.usage_source,
+        }
+
+
+def build_request_cache_accounting(row: Any) -> RequestCacheAccounting:
+    """Build the per-call cache view for one ``ApiUsage`` row.
+
+    Reads the authoritative first-class columns and falls back to the verbatim
+    provider payload in ``meta_data["usage_details"]`` only for rows written
+    before those columns existed. Nothing is inferred beyond the arithmetic
+    identity ``miss = prompt - read - write``, and that only when the read side
+    was actually reported.
+
+    Args:
+        row: An ``ApiUsage`` ORM row (or any object with the same attributes).
+
+    Returns:
+        A :class:`RequestCacheAccounting` where ``None`` means "not reported".
+    """
+    meta_data = getattr(row, "meta_data", None)
+    details = _usage_details(meta_data)
+
+    read = _as_int(getattr(row, "cache_read_tokens", None))
+    if read is None:
+        read = _fallback_cache_read(details)
+    creation = _as_int(getattr(row, "cache_creation_tokens", None))
+    if creation is None:
+        creation = _fallback_cache_creation(details)
+
+    reported_miss = reported_cache_miss_tokens(meta_data)
+    miss: Optional[int] = None
+    miss_source: Optional[str] = None
+    if reported_miss is not None:
+        miss = reported_miss
+        miss_source = CACHE_MISS_SOURCE_REPORTED
+    elif read is not None:
+        prompt_tokens = _as_int(getattr(row, "prompt_tokens", None))
+        if prompt_tokens is not None:
+            miss = max(prompt_tokens - read - (creation or 0), 0)
+            miss_source = CACHE_MISS_SOURCE_DERIVED
+
+    return RequestCacheAccounting(
+        cache_read_tokens=read,
+        cache_creation_tokens=creation,
+        cache_miss_tokens=miss,
+        cache_miss_source=miss_source,
+        has_cache_data=read is not None or creation is not None,
+        usage_source=getattr(row, "usage_source", None),
+    )
+
+
+def _catalog_cache_read_prices_per_1k(
+    *, model_alias: Optional[str], provider_name: Optional[str]
+) -> tuple[Optional[float], Optional[float]]:
+    """Look up EXACT catalog input and cache-read prices, per 1k tokens.
+
+    Deliberately narrower than
+    ``preloop.services.context_analysis.resolve_cache_prices_per_1k``: that
+    helper synthesizes a cache price from an input price times a per-provider
+    multiplier when the catalog is silent. A synthesized price is fine for a
+    relative "this rewrite cost extra" signal but not for a dollar figure shown
+    as cache savings, so this resolver returns ``(None, None)`` instead of
+    guessing.
+
+    Returns:
+        ``(input_price_per_1k, cache_read_price_per_1k)``; both ``None`` when
+        the catalog carries no explicit pair for the model.
+    """
+    catalog = _price_catalog()
+    if not catalog:
+        return None, None
+    candidates: list[str] = []
+    alias = (model_alias or "").strip()
+    if alias:
+        candidates.append(alias)
+        if "/" in alias:
+            bare = alias.split("/", 1)[1]
+            candidates.append(bare)
+            candidates.append(alias.replace("/", "."))
+        provider = (provider_name or "").strip().lower()
+        if provider and alias:
+            bare = alias.split("/", 1)[1] if "/" in alias else alias
+            candidates.append(f"{provider}/{bare}")
+            candidates.append(f"{provider}.{bare}")
+    for candidate in candidates:
+        entry = catalog.get(candidate)
+        if not isinstance(entry, dict):
+            continue
+        input_cost = entry.get("input_cost_per_token")
+        read_cost = entry.get("cache_read_input_token_cost")
+        if input_cost is None or read_cost is None:
+            continue
+        try:
+            return float(input_cost) * 1000.0, float(read_cost) * 1000.0
+        except (TypeError, ValueError):
+            continue
+    return None, None
+
+
+@dataclass
+class SessionCacheModelGroup:
+    """One (model, provider) group inside a session cache rollup."""
+
+    model_alias: Optional[str] = None
+    provider_name: Optional[str] = None
+    requests: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    prompt_tokens: int = 0
+    write_reported: bool = False
+
+
+@dataclass
+class SessionCacheSummary:
+    """Whole-session prompt-cache rollup with explicit coverage and honesty."""
+
+    requests_total: int = 0
+    # Requests where the provider reported at least one cache number.
+    requests_with_cache_data: int = 0
+    requests_without_cache_data: int = 0
+    # Prompt tokens of the covered requests only; the ratio's denominator.
+    covered_prompt_tokens: int = 0
+    uncovered_prompt_tokens: int = 0
+    cached_prompt_tokens: int = 0
+    uncached_prompt_tokens: int = 0
+    # None when NO provider in this session reports cache writes at all
+    # (OpenAI/Gemini/DeepSeek have no billable write concept) — not zero.
+    cache_write_tokens: Optional[int] = None
+    cache_hit_ratio: Optional[float] = None
+    estimated_cache_savings_usd: Optional[float] = None
+    savings_basis: Optional[str] = None
+    savings_omitted_reason: Optional[str] = None
+    models: list[SessionCacheModelGroup] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "requests_total": self.requests_total,
+            "requests_with_cache_data": self.requests_with_cache_data,
+            "requests_without_cache_data": self.requests_without_cache_data,
+            "covered_prompt_tokens": self.covered_prompt_tokens,
+            "uncovered_prompt_tokens": self.uncovered_prompt_tokens,
+            "cached_prompt_tokens": self.cached_prompt_tokens,
+            "uncached_prompt_tokens": self.uncached_prompt_tokens,
+            "cache_write_tokens": self.cache_write_tokens,
+            "cache_hit_ratio": self.cache_hit_ratio,
+            "estimated_cache_savings_usd": self.estimated_cache_savings_usd,
+            "savings_basis": self.savings_basis,
+            "savings_omitted_reason": self.savings_omitted_reason,
+        }
+
+
+def summarize_session_cache(rows: Iterable[Any]) -> SessionCacheSummary:
+    """Roll per-request cache accounting up to one session-level summary.
+
+    The hit ratio is computed **only over requests whose provider reported a
+    cache split**, and the uncovered prompt tokens are reported alongside it so
+    a caller can state the coverage rather than silently averaging blind rows
+    in as misses.
+
+    Savings are the difference between paying the full input price and the
+    cache-read price for the tokens actually served from cache, and are emitted
+    only when every contributing model has explicit catalog prices for both.
+
+    Args:
+        rows: ``ApiUsage`` rows for one runtime session.
+
+    Returns:
+        A :class:`SessionCacheSummary`.
+    """
+    summary = SessionCacheSummary()
+    groups: dict[tuple[Optional[str], Optional[str]], SessionCacheModelGroup] = {}
+    any_write_reported = False
+    write_total = 0
+
+    for row in rows:
+        summary.requests_total += 1
+        accounting = build_request_cache_accounting(row)
+        prompt_tokens = _as_int(getattr(row, "prompt_tokens", None)) or 0
+        if not accounting.has_cache_data:
+            summary.requests_without_cache_data += 1
+            summary.uncovered_prompt_tokens += prompt_tokens
+            continue
+
+        summary.requests_with_cache_data += 1
+        summary.covered_prompt_tokens += prompt_tokens
+        read = accounting.cache_read_tokens or 0
+        creation = accounting.cache_creation_tokens
+        summary.cached_prompt_tokens += read
+        if accounting.cache_miss_tokens is not None:
+            summary.uncached_prompt_tokens += accounting.cache_miss_tokens
+        if creation is not None:
+            any_write_reported = True
+            write_total += creation
+
+        key = (
+            getattr(row, "model_alias", None),
+            getattr(row, "provider_name", None),
+        )
+        group = groups.get(key)
+        if group is None:
+            group = SessionCacheModelGroup(model_alias=key[0], provider_name=key[1])
+            groups[key] = group
+        group.requests += 1
+        group.prompt_tokens += prompt_tokens
+        group.cache_read_tokens += read
+        if creation is not None:
+            group.write_reported = True
+            group.cache_creation_tokens += creation
+
+    summary.cache_write_tokens = write_total if any_write_reported else None
+    summary.models = list(groups.values())
+
+    denominator = summary.cached_prompt_tokens + summary.uncached_prompt_tokens
+    if denominator > 0:
+        summary.cache_hit_ratio = round(summary.cached_prompt_tokens / denominator, 4)
+
+    savings, basis, omitted = _session_cache_savings(summary.models)
+    summary.estimated_cache_savings_usd = savings
+    summary.savings_basis = basis
+    summary.savings_omitted_reason = omitted
+    return summary
+
+
+def _session_cache_savings(
+    models: Iterable[SessionCacheModelGroup],
+) -> tuple[Optional[float], Optional[str], Optional[str]]:
+    """Compute exact-only cache savings across the session's models."""
+    total = 0.0
+    contributing = 0
+    for group in models:
+        if group.cache_read_tokens <= 0:
+            continue
+        contributing += 1
+        input_per_1k, read_per_1k = _catalog_cache_read_prices_per_1k(
+            model_alias=group.model_alias, provider_name=group.provider_name
+        )
+        if input_per_1k is None or read_per_1k is None:
+            return None, None, SAVINGS_OMITTED_NO_CATALOG_PRICE
+        differential = input_per_1k - read_per_1k
+        if differential <= 0:
+            continue
+        total += (group.cache_read_tokens / 1000.0) * differential
+    if contributing == 0:
+        return None, None, SAVINGS_OMITTED_NO_CACHE_READS
+    return round(total, 6), SAVINGS_BASIS_CATALOG_EXACT, None

--- a/backend/preloop/services/cache_accounting.py
+++ b/backend/preloop/services/cache_accounting.py
@@ -14,17 +14,22 @@ lying**:
   ``meta_data["usage_details"]``), ``derived`` when we subtract a reported read
   from the reported prompt total, and ``None`` when neither is possible;
 * estimated cache savings are computed only from explicit catalog cache prices.
-  When the catalog lacks an exact price for any model that contributed cache
-  reads, savings are omitted with a reason rather than approximated.
+  Models without an exact catalog price never contribute an approximation: the
+  savings figure is either exact for every contributing model
+  (``catalog_exact``), an exact-but-partial lower bound when some models are
+  unpriced (``catalog_exact_partial``), or omitted with a reason.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional
+
+logger = logging.getLogger(__name__)
 
 # Provenance of a per-request cache-miss number.
 CACHE_MISS_SOURCE_REPORTED = "reported"
@@ -34,8 +39,12 @@ CACHE_MISS_SOURCE_DERIVED = "derived"
 SAVINGS_OMITTED_NO_CACHE_READS = "no_cache_reads"
 SAVINGS_OMITTED_NO_CATALOG_PRICE = "no_catalog_cache_price"
 
-# Basis label for a savings number we are willing to show.
+# Basis labels for a savings number we are willing to show. ``catalog_exact``
+# means every model that contributed cache reads had explicit catalog prices;
+# ``catalog_exact_partial`` means the figure covers only the priced models and
+# at least one contributing model was skipped for lack of a catalog price.
 SAVINGS_BASIS_CATALOG_EXACT = "catalog_exact"
+SAVINGS_BASIS_CATALOG_EXACT_PARTIAL = "catalog_exact_partial"
 
 _PRICE_CATALOG_PATH = Path(__file__).resolve().parent / "data" / "model_prices.json"
 
@@ -45,8 +54,23 @@ def _price_catalog() -> dict[str, Any]:
     try:
         loaded: Any = json.loads(_PRICE_CATALOG_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
+        # A missing or corrupted catalog silently disables the savings figure
+        # for every model, so make the degradation visible to operators.
+        logger.warning(
+            "Failed to load model price catalog from %s; cache savings will "
+            "be omitted for all models.",
+            _PRICE_CATALOG_PATH,
+            exc_info=True,
+        )
         return {}
-    return loaded if isinstance(loaded, dict) else {}
+    if not isinstance(loaded, dict):
+        logger.warning(
+            "Model price catalog at %s is not a JSON object; cache savings "
+            "will be omitted for all models.",
+            _PRICE_CATALOG_PATH,
+        )
+        return {}
+    return loaded
 
 
 def _as_int(value: Any) -> Optional[int]:
@@ -254,6 +278,17 @@ class SessionCacheModelGroup:
     prompt_tokens: int = 0
     write_reported: bool = False
 
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "model_alias": self.model_alias,
+            "provider_name": self.provider_name,
+            "requests": self.requests,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "prompt_tokens": self.prompt_tokens,
+            "write_reported": self.write_reported,
+        }
+
 
 @dataclass
 class SessionCacheSummary:
@@ -275,6 +310,10 @@ class SessionCacheSummary:
     estimated_cache_savings_usd: Optional[float] = None
     savings_basis: Optional[str] = None
     savings_omitted_reason: Optional[str] = None
+    # Covered requests whose provider reported no prompt total at all: their
+    # prompt tokens are UNKNOWN, not zero, so they are counted here instead of
+    # being folded into ``covered_prompt_tokens`` as 0.
+    requests_with_unknown_prompt_tokens: int = 0
     models: list[SessionCacheModelGroup] = field(default_factory=list)
 
     def as_dict(self) -> dict[str, Any]:
@@ -291,6 +330,10 @@ class SessionCacheSummary:
             "estimated_cache_savings_usd": self.estimated_cache_savings_usd,
             "savings_basis": self.savings_basis,
             "savings_omitted_reason": self.savings_omitted_reason,
+            "requests_with_unknown_prompt_tokens": (
+                self.requests_with_unknown_prompt_tokens
+            ),
+            "models": [group.as_dict() for group in self.models],
         }
 
 
@@ -320,14 +363,23 @@ def summarize_session_cache(rows: Iterable[Any]) -> SessionCacheSummary:
     for row in rows:
         summary.requests_total += 1
         accounting = build_request_cache_accounting(row)
-        prompt_tokens = _as_int(getattr(row, "prompt_tokens", None)) or 0
+        # None means the provider reported NO prompt total, which is not the
+        # same claim as zero prompt tokens; such rows are counted separately
+        # instead of contributing 0 to the prompt-token sums.
+        prompt_tokens = _as_int(getattr(row, "prompt_tokens", None))
         if not accounting.has_cache_data:
             summary.requests_without_cache_data += 1
-            summary.uncovered_prompt_tokens += prompt_tokens
+            if prompt_tokens is None:
+                summary.requests_with_unknown_prompt_tokens += 1
+            else:
+                summary.uncovered_prompt_tokens += prompt_tokens
             continue
 
         summary.requests_with_cache_data += 1
-        summary.covered_prompt_tokens += prompt_tokens
+        if prompt_tokens is None:
+            summary.requests_with_unknown_prompt_tokens += 1
+        else:
+            summary.covered_prompt_tokens += prompt_tokens
         read = accounting.cache_read_tokens or 0
         creation = accounting.cache_creation_tokens
         summary.cached_prompt_tokens += read
@@ -346,7 +398,7 @@ def summarize_session_cache(rows: Iterable[Any]) -> SessionCacheSummary:
             group = SessionCacheModelGroup(model_alias=key[0], provider_name=key[1])
             groups[key] = group
         group.requests += 1
-        group.prompt_tokens += prompt_tokens
+        group.prompt_tokens += prompt_tokens or 0
         group.cache_read_tokens += read
         if creation is not None:
             group.write_reported = True
@@ -369,9 +421,16 @@ def summarize_session_cache(rows: Iterable[Any]) -> SessionCacheSummary:
 def _session_cache_savings(
     models: Iterable[SessionCacheModelGroup],
 ) -> tuple[Optional[float], Optional[str], Optional[str]]:
-    """Compute exact-only cache savings across the session's models."""
+    """Compute exact-only cache savings across the session's models.
+
+    Models without an exact catalog price never contribute an approximated
+    figure. When SOME models are priced and some are not, the priced subtotal
+    is still returned, labelled ``catalog_exact_partial`` so the UI can state
+    that the figure is a lower bound rather than dropping it entirely.
+    """
     total = 0.0
     contributing = 0
+    unpriced = 0
     for group in models:
         if group.cache_read_tokens <= 0:
             continue
@@ -380,11 +439,17 @@ def _session_cache_savings(
             model_alias=group.model_alias, provider_name=group.provider_name
         )
         if input_per_1k is None or read_per_1k is None:
-            return None, None, SAVINGS_OMITTED_NO_CATALOG_PRICE
+            unpriced += 1
+            continue
         differential = input_per_1k - read_per_1k
         if differential <= 0:
             continue
         total += (group.cache_read_tokens / 1000.0) * differential
     if contributing == 0:
         return None, None, SAVINGS_OMITTED_NO_CACHE_READS
-    return round(total, 6), SAVINGS_BASIS_CATALOG_EXACT, None
+    if unpriced == contributing:
+        return None, None, SAVINGS_OMITTED_NO_CATALOG_PRICE
+    basis = (
+        SAVINGS_BASIS_CATALOG_EXACT_PARTIAL if unpriced else SAVINGS_BASIS_CATALOG_EXACT
+    )
+    return round(total, 6), basis, None

--- a/backend/preloop/services/model_gateway_events.py
+++ b/backend/preloop/services/model_gateway_events.py
@@ -23,6 +23,7 @@ from preloop.services.account_realtime import (
     encode_realtime_event_for_nats,
     emit_account_event,
 )
+from preloop.services.cache_accounting import reported_cache_miss_tokens
 from preloop.sync.services.event_bus import get_nats_client
 from preloop.utils.jsonb_sanitize import sanitize_for_jsonb
 from preloop.utils.request_fingerprint import public_request_fingerprint
@@ -276,6 +277,13 @@ class ModelGatewayEventEmitter:
                     else (meta_data.get("usage_details") or {}).get(
                         "cache_creation_input_tokens"
                     )
+                ),
+                # A cache-MISS count the provider reported outright (today only
+                # DeepSeek's prompt_cache_miss_tokens, which litellm drops on the
+                # floor). None means "no provider miss count" — consumers must
+                # not read that as zero misses.
+                "cache_miss_input_tokens_reported": reported_cache_miss_tokens(
+                    meta_data
                 ),
                 "runtime_session_id": str(usage.runtime_session_id)
                 if usage.runtime_session_id

--- a/backend/tests/endpoints/test_runtime_session_requests.py
+++ b/backend/tests/endpoints/test_runtime_session_requests.py
@@ -231,3 +231,182 @@ def test_runtime_session_requests_expose_error_class(client, db_session, test_us
     assert items[0]["status_code"] == 499
     assert items[0]["is_error"] is True
     assert items[0]["error_class"] == "stream_abandoned"
+
+
+def _log_cache_request(
+    db_session,
+    *,
+    account_id,
+    runtime_session_id,
+    prompt_tokens,
+    cache_read_tokens=None,
+    cache_creation_tokens=None,
+    model_alias="anthropic/claude-sonnet-4",
+    provider_name="anthropic",
+    meta_data=None,
+):
+    """Insert a gateway row carrying an explicit prompt-cache split."""
+    return crud_api_usage.log_gateway_request(
+        db_session,
+        endpoint="/v1/messages",
+        method="POST",
+        status_code=200,
+        duration=0.5,
+        account_id=str(account_id),
+        runtime_session_id=str(runtime_session_id),
+        model_alias=model_alias,
+        provider_name=provider_name,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=100,
+        total_tokens=prompt_tokens + 100,
+        cache_read_tokens=cache_read_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        estimated_cost=0.01,
+        usage_source="provider",
+        meta_data=meta_data,
+    )
+
+
+def test_runtime_session_requests_expose_per_call_cache_split(
+    client, db_session, test_user
+):
+    """Each request item should carry read/write/derived-miss cache tokens."""
+    session = _make_session(db_session, test_user.account_id)
+    _log_cache_request(
+        db_session,
+        account_id=test_user.account_id,
+        runtime_session_id=session.id,
+        prompt_tokens=10_000,
+        cache_read_tokens=7_000,
+        cache_creation_tokens=2_000,
+    )
+    db_session.commit()
+
+    response = client.get(f"/api/v1/runtime-sessions/{session.id}/requests")
+    assert response.status_code == 200
+    cache = response.json()["items"][0]["cache"]
+    assert cache["cache_read_tokens"] == 7_000
+    assert cache["cache_creation_tokens"] == 2_000
+    assert cache["cache_miss_tokens"] == 1_000
+    assert cache["cache_miss_source"] == "derived"
+    assert cache["has_cache_data"] is True
+    assert cache["usage_source"] == "provider"
+
+
+def test_runtime_session_requests_absent_cache_is_null_not_zero(
+    client, db_session, test_user
+):
+    """A provider that reports no cache split must serialize to null, not 0."""
+    session = _make_session(db_session, test_user.account_id)
+    _log_request(
+        db_session,
+        account_id=test_user.account_id,
+        runtime_session_id=session.id,
+        status_code=200,
+        total_tokens=1000,
+        estimated_cost=0.02,
+        when=datetime.now(UTC),
+    )
+    db_session.commit()
+
+    response = client.get(f"/api/v1/runtime-sessions/{session.id}/requests")
+    assert response.status_code == 200
+    cache = response.json()["items"][0]["cache"]
+    assert cache["cache_read_tokens"] is None
+    assert cache["cache_creation_tokens"] is None
+    assert cache["cache_miss_tokens"] is None
+    assert cache["has_cache_data"] is False
+
+
+def test_runtime_session_requests_promote_deepseek_reported_miss(
+    client, db_session, test_user
+):
+    """DeepSeek's prompt_cache_miss_tokens should surface as a reported miss."""
+    session = _make_session(db_session, test_user.account_id)
+    _log_cache_request(
+        db_session,
+        account_id=test_user.account_id,
+        runtime_session_id=session.id,
+        prompt_tokens=1_500,
+        cache_read_tokens=1_280,
+        model_alias="deepseek/deepseek-chat",
+        provider_name="deepseek",
+        meta_data={
+            "usage_details": {
+                "prompt_cache_hit_tokens": 1_280,
+                "prompt_cache_miss_tokens": 220,
+            }
+        },
+    )
+    db_session.commit()
+
+    response = client.get(f"/api/v1/runtime-sessions/{session.id}/requests")
+    assert response.status_code == 200
+    cache = response.json()["items"][0]["cache"]
+    assert cache["cache_miss_tokens"] == 220
+    assert cache["cache_miss_source"] == "reported"
+
+
+def test_runtime_session_requests_cache_summary_spans_whole_session(
+    client, db_session, test_user
+):
+    """The rollup must cover all requests, not just the returned page."""
+    session = _make_session(db_session, test_user.account_id)
+    for _ in range(3):
+        _log_cache_request(
+            db_session,
+            account_id=test_user.account_id,
+            runtime_session_id=session.id,
+            prompt_tokens=1_000,
+            cache_read_tokens=800,
+            cache_creation_tokens=100,
+        )
+    # One blind row: no provider cache split at all.
+    _log_request(
+        db_session,
+        account_id=test_user.account_id,
+        runtime_session_id=session.id,
+        status_code=200,
+        total_tokens=4_000,
+        estimated_cost=0.02,
+        when=datetime.now(UTC),
+    )
+    db_session.commit()
+
+    response = client.get(f"/api/v1/runtime-sessions/{session.id}/requests?limit=1")
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 1
+
+    summary = body["cache_summary"]
+    assert summary["requests_total"] == 4
+    assert summary["requests_with_cache_data"] == 3
+    assert summary["requests_without_cache_data"] == 1
+    assert summary["cached_prompt_tokens"] == 2_400
+    assert summary["uncached_prompt_tokens"] == 300
+    assert summary["cache_write_tokens"] == 300
+    assert summary["cache_hit_ratio"] == 0.8889
+    assert summary["uncovered_prompt_tokens"] == 2_000
+
+
+def test_runtime_session_cache_summary_omits_savings_without_exact_prices(
+    client, db_session, test_user
+):
+    """No catalog cache price means no dollar figure, with a stated reason."""
+    session = _make_session(db_session, test_user.account_id)
+    _log_cache_request(
+        db_session,
+        account_id=test_user.account_id,
+        runtime_session_id=session.id,
+        prompt_tokens=1_000,
+        cache_read_tokens=900,
+        model_alias="totally-unknown-model-xyz",
+        provider_name="custom",
+    )
+    db_session.commit()
+
+    response = client.get(f"/api/v1/runtime-sessions/{session.id}/requests")
+    assert response.status_code == 200
+    summary = response.json()["cache_summary"]
+    assert summary["estimated_cache_savings_usd"] is None
+    assert summary["savings_omitted_reason"] == "no_catalog_cache_price"

--- a/backend/tests/endpoints/test_runtime_session_requests.py
+++ b/backend/tests/endpoints/test_runtime_session_requests.py
@@ -410,3 +410,68 @@ def test_runtime_session_cache_summary_omits_savings_without_exact_prices(
     summary = response.json()["cache_summary"]
     assert summary["estimated_cache_savings_usd"] is None
     assert summary["savings_omitted_reason"] == "no_catalog_cache_price"
+
+
+def test_runtime_session_cache_summary_excludes_replay_validation_rows(
+    client, db_session, test_user
+):
+    """Replay-validation traffic must not inflate the cache rollup."""
+    session = _make_session(db_session, test_user.account_id)
+    _log_cache_request(
+        db_session,
+        account_id=test_user.account_id,
+        runtime_session_id=session.id,
+        prompt_tokens=1_000,
+        cache_read_tokens=800,
+    )
+    # A Preloop-driven replay-validation re-execution of the same call.
+    _log_cache_request(
+        db_session,
+        account_id=test_user.account_id,
+        runtime_session_id=session.id,
+        prompt_tokens=1_000,
+        cache_read_tokens=800,
+        meta_data={"purpose": "replay_validation"},
+    )
+    db_session.commit()
+
+    response = client.get(f"/api/v1/runtime-sessions/{session.id}/requests")
+    assert response.status_code == 200
+    summary = response.json()["cache_summary"]
+    assert summary["requests_total"] == 1
+    assert summary["cached_prompt_tokens"] == 800
+
+
+def test_runtime_session_cache_summary_exposes_per_model_groups(
+    client, db_session, test_user
+):
+    """The per-model breakdown must reach the API response."""
+    session = _make_session(db_session, test_user.account_id)
+    _log_cache_request(
+        db_session,
+        account_id=test_user.account_id,
+        runtime_session_id=session.id,
+        prompt_tokens=1_000,
+        cache_read_tokens=800,
+        cache_creation_tokens=100,
+    )
+    _log_cache_request(
+        db_session,
+        account_id=test_user.account_id,
+        runtime_session_id=session.id,
+        prompt_tokens=2_000,
+        cache_read_tokens=1_500,
+        model_alias="gpt-4o",
+        provider_name="openai",
+    )
+    db_session.commit()
+
+    response = client.get(f"/api/v1/runtime-sessions/{session.id}/requests")
+    assert response.status_code == 200
+    summary = response.json()["cache_summary"]
+    models = {entry["model_alias"]: entry for entry in summary["models"]}
+    assert set(models) == {"anthropic/claude-sonnet-4", "gpt-4o"}
+    assert models["anthropic/claude-sonnet-4"]["cache_read_tokens"] == 800
+    assert models["anthropic/claude-sonnet-4"]["write_reported"] is True
+    assert models["gpt-4o"]["cache_read_tokens"] == 1_500
+    assert models["gpt-4o"]["write_reported"] is False

--- a/backend/tests/services/test_cache_accounting.py
+++ b/backend/tests/services/test_cache_accounting.py
@@ -89,6 +89,20 @@ class TestRequestAccounting:
         assert accounting.cache_miss_tokens == 220
         assert accounting.cache_miss_source == CACHE_MISS_SOURCE_REPORTED
 
+    def test_reported_miss_alone_is_cache_data(self):
+        """A miss-only report is cache data, even with no read or write."""
+        accounting = build_request_cache_accounting(
+            _row(
+                prompt_tokens=500,
+                meta_data={"usage_details": {"prompt_cache_miss_tokens": 500}},
+            )
+        )
+        assert accounting.cache_read_tokens is None
+        assert accounting.cache_creation_tokens is None
+        assert accounting.cache_miss_tokens == 500
+        assert accounting.cache_miss_source == CACHE_MISS_SOURCE_REPORTED
+        assert accounting.has_cache_data is True
+
     def test_legacy_row_falls_back_to_usage_details(self):
         """Rows written before the columns existed still read out correctly."""
         accounting = build_request_cache_accounting(
@@ -172,6 +186,23 @@ class TestSessionSummary:
         assert summary.cached_prompt_tokens == 800
         assert summary.uncached_prompt_tokens == 200
         assert summary.cache_hit_ratio == 0.8
+
+    def test_miss_only_report_is_not_without_cache_data(self):
+        """A reported miss with no read/write is covered, not a blind row."""
+        summary = summarize_session_cache(
+            [
+                _row(
+                    prompt_tokens=500,
+                    meta_data={"usage_details": {"prompt_cache_miss_tokens": 500}},
+                )
+            ]
+        )
+        assert summary.requests_total == 1
+        assert summary.requests_with_cache_data == 1
+        assert summary.requests_without_cache_data == 0
+        assert summary.covered_prompt_tokens == 500
+        assert summary.uncovered_prompt_tokens == 0
+        assert summary.uncached_prompt_tokens == 500
 
     def test_write_tokens_none_when_no_provider_reports_writes(self):
         """No write concept is not the same claim as zero rewritten tokens."""

--- a/backend/tests/services/test_cache_accounting.py
+++ b/backend/tests/services/test_cache_accounting.py
@@ -1,0 +1,221 @@
+"""Unit tests for per-request and per-session prompt-cache accounting."""
+
+from types import SimpleNamespace
+
+from preloop.services.cache_accounting import (
+    CACHE_MISS_SOURCE_DERIVED,
+    CACHE_MISS_SOURCE_REPORTED,
+    SAVINGS_BASIS_CATALOG_EXACT,
+    SAVINGS_OMITTED_NO_CACHE_READS,
+    SAVINGS_OMITTED_NO_CATALOG_PRICE,
+    build_request_cache_accounting,
+    reported_cache_miss_tokens,
+    summarize_session_cache,
+)
+
+
+def _row(**overrides):
+    """Build a minimal ApiUsage-shaped row for accounting."""
+    base = {
+        "prompt_tokens": 1000,
+        "cache_read_tokens": None,
+        "cache_creation_tokens": None,
+        "model_alias": "gpt-4o",
+        "provider_name": "openai",
+        "usage_source": "provider",
+        "meta_data": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestRequestAccounting:
+    def test_absent_cache_columns_stay_none_not_zero(self):
+        """A provider that reports nothing must not be shown as zero cache."""
+        accounting = build_request_cache_accounting(_row())
+        assert accounting.cache_read_tokens is None
+        assert accounting.cache_creation_tokens is None
+        assert accounting.cache_miss_tokens is None
+        assert accounting.cache_miss_source is None
+        assert accounting.has_cache_data is False
+
+    def test_reported_zero_read_is_kept_as_zero(self):
+        """A real provider-reported zero is data, and stays zero."""
+        accounting = build_request_cache_accounting(_row(cache_read_tokens=0))
+        assert accounting.cache_read_tokens == 0
+        assert accounting.has_cache_data is True
+        assert accounting.cache_miss_tokens == 1000
+        assert accounting.cache_miss_source == CACHE_MISS_SOURCE_DERIVED
+
+    def test_anthropic_exact_read_and_write_derives_miss(self):
+        accounting = build_request_cache_accounting(
+            _row(
+                prompt_tokens=10_000,
+                cache_read_tokens=7_000,
+                cache_creation_tokens=2_000,
+                model_alias="anthropic/claude-sonnet-4",
+                provider_name="anthropic",
+            )
+        )
+        assert accounting.cache_read_tokens == 7_000
+        assert accounting.cache_creation_tokens == 2_000
+        assert accounting.cache_miss_tokens == 1_000
+        assert accounting.cache_miss_source == CACHE_MISS_SOURCE_DERIVED
+
+    def test_derived_miss_never_goes_negative(self):
+        """Provider rounding must not produce a negative miss count."""
+        accounting = build_request_cache_accounting(
+            _row(prompt_tokens=100, cache_read_tokens=90, cache_creation_tokens=30)
+        )
+        assert accounting.cache_miss_tokens == 0
+
+    def test_deepseek_reported_miss_is_promoted_and_labelled(self):
+        """DeepSeek's explicit miss count wins over arithmetic derivation."""
+        accounting = build_request_cache_accounting(
+            _row(
+                prompt_tokens=1_500,
+                cache_read_tokens=1_280,
+                model_alias="deepseek/deepseek-chat",
+                provider_name="deepseek",
+                meta_data={
+                    "usage_details": {
+                        "prompt_cache_hit_tokens": 1_280,
+                        "prompt_cache_miss_tokens": 220,
+                    }
+                },
+            )
+        )
+        assert accounting.cache_miss_tokens == 220
+        assert accounting.cache_miss_source == CACHE_MISS_SOURCE_REPORTED
+
+    def test_legacy_row_falls_back_to_usage_details(self):
+        """Rows written before the columns existed still read out correctly."""
+        accounting = build_request_cache_accounting(
+            _row(
+                prompt_tokens=5_000,
+                meta_data={
+                    "usage_details": {
+                        "cache_read_input_tokens": 4_000,
+                        "cache_creation_input_tokens": 500,
+                    }
+                },
+            )
+        )
+        assert accounting.cache_read_tokens == 4_000
+        assert accounting.cache_creation_tokens == 500
+        assert accounting.cache_miss_tokens == 500
+
+    def test_openai_nested_cached_tokens_fallback(self):
+        accounting = build_request_cache_accounting(
+            _row(
+                prompt_tokens=2_000,
+                meta_data={
+                    "usage_details": {"prompt_tokens_details": {"cached_tokens": 1_024}}
+                },
+            )
+        )
+        assert accounting.cache_read_tokens == 1_024
+        assert accounting.cache_creation_tokens is None
+
+    def test_reported_cache_miss_tokens_absent_returns_none(self):
+        assert reported_cache_miss_tokens(None) is None
+        assert reported_cache_miss_tokens({"usage_details": {}}) is None
+        assert reported_cache_miss_tokens({"usage_details": "nope"}) is None
+
+
+class TestSessionSummary:
+    def test_ratio_denominator_excludes_uncovered_requests(self):
+        """Blind rows must not be averaged in as cache misses."""
+        summary = summarize_session_cache(
+            [
+                _row(
+                    prompt_tokens=1_000,
+                    cache_read_tokens=800,
+                    cache_creation_tokens=0,
+                    model_alias="anthropic/claude-sonnet-4",
+                    provider_name="anthropic",
+                ),
+                _row(prompt_tokens=4_000),  # provider reported no cache split
+            ]
+        )
+        assert summary.requests_total == 2
+        assert summary.requests_with_cache_data == 1
+        assert summary.requests_without_cache_data == 1
+        assert summary.covered_prompt_tokens == 1_000
+        assert summary.uncovered_prompt_tokens == 4_000
+        assert summary.cached_prompt_tokens == 800
+        assert summary.uncached_prompt_tokens == 200
+        assert summary.cache_hit_ratio == 0.8
+
+    def test_write_tokens_none_when_no_provider_reports_writes(self):
+        """No write concept is not the same claim as zero rewritten tokens."""
+        summary = summarize_session_cache(
+            [_row(prompt_tokens=1_000, cache_read_tokens=500)]
+        )
+        assert summary.cache_write_tokens is None
+
+    def test_write_tokens_summed_when_reported(self):
+        summary = summarize_session_cache(
+            [
+                _row(
+                    prompt_tokens=1_000,
+                    cache_read_tokens=500,
+                    cache_creation_tokens=200,
+                    model_alias="anthropic/claude-sonnet-4",
+                    provider_name="anthropic",
+                ),
+                _row(
+                    prompt_tokens=1_000,
+                    cache_read_tokens=900,
+                    cache_creation_tokens=0,
+                    model_alias="anthropic/claude-sonnet-4",
+                    provider_name="anthropic",
+                ),
+            ]
+        )
+        assert summary.cache_write_tokens == 200
+
+    def test_savings_from_exact_catalog_prices(self):
+        """gpt-4o carries explicit input and cache-read costs in the catalog."""
+        summary = summarize_session_cache(
+            [
+                _row(
+                    prompt_tokens=10_000,
+                    cache_read_tokens=10_000,
+                    model_alias="gpt-4o",
+                    provider_name="openai",
+                )
+            ]
+        )
+        # input 2.5e-06/token, cache read 1.25e-06/token -> 1.25e-06 saved each.
+        assert summary.savings_basis == SAVINGS_BASIS_CATALOG_EXACT
+        assert summary.savings_omitted_reason is None
+        assert summary.estimated_cache_savings_usd == 0.0125
+
+    def test_savings_omitted_when_catalog_lacks_cache_price(self):
+        """Honesty rail: no multiplier guesswork behind a dollar figure."""
+        summary = summarize_session_cache(
+            [
+                _row(
+                    prompt_tokens=1_000,
+                    cache_read_tokens=900,
+                    model_alias="totally-unknown-model-xyz",
+                    provider_name="custom",
+                )
+            ]
+        )
+        assert summary.estimated_cache_savings_usd is None
+        assert summary.savings_omitted_reason == SAVINGS_OMITTED_NO_CATALOG_PRICE
+
+    def test_savings_omitted_when_no_cache_reads(self):
+        summary = summarize_session_cache(
+            [_row(prompt_tokens=1_000, cache_read_tokens=0)]
+        )
+        assert summary.estimated_cache_savings_usd is None
+        assert summary.savings_omitted_reason == SAVINGS_OMITTED_NO_CACHE_READS
+
+    def test_empty_session_has_no_ratio(self):
+        summary = summarize_session_cache([])
+        assert summary.requests_total == 0
+        assert summary.cache_hit_ratio is None
+        assert summary.cache_write_tokens is None

--- a/backend/tests/services/test_cache_accounting.py
+++ b/backend/tests/services/test_cache_accounting.py
@@ -282,6 +282,23 @@ class TestSessionSummary:
         assert summary.covered_prompt_tokens == 1_000
         assert summary.uncovered_prompt_tokens == 0
 
+    def test_unknown_prompt_totals_not_zeroed_in_model_groups(self):
+        """A group must disclose unknown prompt totals, not absorb them as 0."""
+        summary = summarize_session_cache(
+            [
+                _row(prompt_tokens=None, cache_read_tokens=500),
+                _row(prompt_tokens=1_000, cache_read_tokens=800),
+            ]
+        )
+        assert len(summary.models) == 1
+        group = summary.models[0]
+        # The None row contributes to the unknown counter, never 0 tokens.
+        assert group.prompt_tokens == 1_000
+        assert group.requests_with_unknown_prompt_tokens == 1
+        assert group.requests == 2
+        payload = group.as_dict()
+        assert payload["requests_with_unknown_prompt_tokens"] == 1
+
     def test_summary_as_dict_exposes_models(self):
         """The per-model breakdown is part of the serialized summary."""
         summary = summarize_session_cache(

--- a/backend/tests/services/test_cache_accounting.py
+++ b/backend/tests/services/test_cache_accounting.py
@@ -6,6 +6,7 @@ from preloop.services.cache_accounting import (
     CACHE_MISS_SOURCE_DERIVED,
     CACHE_MISS_SOURCE_REPORTED,
     SAVINGS_BASIS_CATALOG_EXACT,
+    SAVINGS_BASIS_CATALOG_EXACT_PARTIAL,
     SAVINGS_OMITTED_NO_CACHE_READS,
     SAVINGS_OMITTED_NO_CATALOG_PRICE,
     build_request_cache_accounting,
@@ -122,6 +123,31 @@ class TestRequestAccounting:
         assert reported_cache_miss_tokens({"usage_details": {}}) is None
         assert reported_cache_miss_tokens({"usage_details": "nope"}) is None
 
+    def test_reported_miss_nested_prompt_tokens_details_path(self):
+        """The nested prompt_tokens_details.prompt_cache_miss_tokens is read."""
+        meta_data = {
+            "usage_details": {
+                "prompt_tokens_details": {"prompt_cache_miss_tokens": 640}
+            }
+        }
+        assert reported_cache_miss_tokens(meta_data) == 640
+
+    def test_reported_miss_cache_miss_input_tokens_fallback(self):
+        """The third fallback key, cache_miss_input_tokens, is honored."""
+        meta_data = {"usage_details": {"cache_miss_input_tokens": 77}}
+        assert reported_cache_miss_tokens(meta_data) == 77
+
+    def test_reported_miss_key_precedence(self):
+        """Top-level prompt_cache_miss_tokens wins over the fallbacks."""
+        meta_data = {
+            "usage_details": {
+                "prompt_cache_miss_tokens": 1,
+                "prompt_tokens_details": {"prompt_cache_miss_tokens": 2},
+                "cache_miss_input_tokens": 3,
+            }
+        }
+        assert reported_cache_miss_tokens(meta_data) == 1
+
 
 class TestSessionSummary:
     def test_ratio_denominator_excludes_uncovered_requests(self):
@@ -219,3 +245,69 @@ class TestSessionSummary:
         assert summary.requests_total == 0
         assert summary.cache_hit_ratio is None
         assert summary.cache_write_tokens is None
+
+    def test_mixed_models_savings_is_partial_lower_bound(self):
+        """A priced model's savings survive an unpriced model in the session."""
+        summary = summarize_session_cache(
+            [
+                _row(
+                    prompt_tokens=10_000,
+                    cache_read_tokens=10_000,
+                    model_alias="gpt-4o",
+                    provider_name="openai",
+                ),
+                _row(
+                    prompt_tokens=1_000,
+                    cache_read_tokens=900,
+                    model_alias="totally-unknown-model-xyz",
+                    provider_name="custom",
+                ),
+            ]
+        )
+        assert summary.estimated_cache_savings_usd == 0.0125
+        assert summary.savings_basis == SAVINGS_BASIS_CATALOG_EXACT_PARTIAL
+        assert summary.savings_omitted_reason is None
+
+    def test_unknown_prompt_totals_counted_not_zeroed(self):
+        """prompt_tokens=None is unknown, not zero, in the rollup."""
+        summary = summarize_session_cache(
+            [
+                _row(prompt_tokens=None, cache_read_tokens=500),
+                _row(prompt_tokens=None),
+                _row(prompt_tokens=1_000, cache_read_tokens=800),
+            ]
+        )
+        assert summary.requests_with_unknown_prompt_tokens == 2
+        # Only the row with a real prompt total contributes to the sums.
+        assert summary.covered_prompt_tokens == 1_000
+        assert summary.uncovered_prompt_tokens == 0
+
+    def test_summary_as_dict_exposes_models(self):
+        """The per-model breakdown is part of the serialized summary."""
+        summary = summarize_session_cache(
+            [
+                _row(
+                    prompt_tokens=1_000,
+                    cache_read_tokens=800,
+                    cache_creation_tokens=100,
+                    model_alias="anthropic/claude-sonnet-4",
+                    provider_name="anthropic",
+                ),
+                _row(
+                    prompt_tokens=2_000,
+                    cache_read_tokens=1_500,
+                    model_alias="gpt-4o",
+                    provider_name="openai",
+                ),
+            ]
+        )
+        payload = summary.as_dict()
+        models = {entry["model_alias"]: entry for entry in payload["models"]}
+        assert set(models) == {"anthropic/claude-sonnet-4", "gpt-4o"}
+        anthropic = models["anthropic/claude-sonnet-4"]
+        assert anthropic["cache_read_tokens"] == 800
+        assert anthropic["cache_creation_tokens"] == 100
+        assert anthropic["write_reported"] is True
+        openai = models["gpt-4o"]
+        assert openai["cache_read_tokens"] == 1_500
+        assert openai["write_reported"] is False

--- a/backend/tests/test_nginx_route_parity.py
+++ b/backend/tests/test_nginx_route_parity.py
@@ -1,0 +1,240 @@
+"""Route parity between the two nginx configs.
+
+This repo serves the marketing site from two independently maintained nginx
+configs:
+
+* ``frontend/docker/nginx.conf.template`` - docker-compose and the standalone
+  image.
+* ``helm/preloop/templates/configmap-nginx.yaml`` - **production preloop.ai**,
+  mounted into ``preloop-console`` at ``/etc/nginx/templates``.
+
+They have drifted twice, both times the same way: a prerendered route was added
+to the docker template only, so production quietly fell through to the SPA
+catch-all and returned homepage HTML with a 200 (not a 404, which is why it
+went unnoticed).
+
+1. ``/about|/pricing|/privacy|...`` - documented in a comment in the Helm file.
+2. ``/blog``, ``/blog/<slug>``, ``/blog/feed.xml`` - added in 4c17027e, missing
+   from Helm; preloop.ai served the homepage for every blog URL.
+
+A prose comment did not prevent the second recurrence, so this asserts it.
+
+The comparison is on **behaviour, not text**: the two configs legitimately
+spell the same routing differently (Helm folds the marketing pages into one
+alternation regex, docker lists them individually). So this implements nginx's
+location-matching precedence and compares which config block each URL lands in.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKER_TEMPLATE = REPO_ROOT / "frontend" / "docker" / "nginx.conf.template"
+HELM_CONFIGMAP = REPO_ROOT / "helm" / "preloop" / "templates" / "configmap-nginx.yaml"
+
+# Marketing URLs that must serve prerendered HTML rather than the SPA shell.
+# Extensionless on purpose: these are the ones the catch-all silently swallows.
+# Files with extensions (/robots.txt, /sitemap.xml, /llms.txt) are served by
+# `try_files $uri` in both configs and are not a drift risk.
+PRERENDERED_URLS = (
+    "/about",
+    "/pricing",
+    "/privacy",
+    "/terms",
+    "/whatis-mcp",
+    "/blog",
+    "/blog/govern-your-qm-fleet",
+    "/vs/litellm",
+    "/resources/ai-agent-control-plane-2026",
+)
+
+# URLs that must keep falling through to the SPA shell.
+SPA_URLS = ("/", "/console", "/blog/no-such-post-exists")
+
+_LOCATION = re.compile(r"^[ \t]*location\s+(?P<matcher>[^{]+?)\s*\{", re.MULTILINE)
+
+
+def _read_docker_template() -> str:
+    return DOCKER_TEMPLATE.read_text(encoding="utf-8")
+
+
+def _read_helm_server_block() -> str:
+    """Extract the nginx template string out of the Helm ConfigMap.
+
+    The file is a Go template and therefore not valid YAML as-is. Blanking the
+    ``{{ ... }}`` actions is enough to recover ``default.conf.template``, which
+    is all this test inspects.
+    """
+    raw = HELM_CONFIGMAP.read_text(encoding="utf-8")
+    without_actions = re.sub(r"\{\{-?.*?-?\}\}", "", raw, flags=re.DOTALL)
+    doc = yaml.safe_load(without_actions)
+    return doc["data"]["default.conf.template"]
+
+
+def _location_body(config: str, start: int) -> str:
+    """Return the text of one balanced ``{ ... }`` block, given the index after `{`."""
+    depth = 1
+    index = start
+    while index < len(config) and depth:
+        char = config[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        index += 1
+    return config[start : index - 1]
+
+
+def _parse_locations(config: str) -> list[tuple[str, str, str]]:
+    """Return ``(kind, pattern, body)`` for each location block, in file order.
+
+    ``kind`` is one of ``exact``, ``prefix_priority`` (``^~``), ``regex``
+    (``~`` / ``~*``) or ``prefix``.
+    """
+    parsed: list[tuple[str, str, str]] = []
+    for match in _LOCATION.finditer(config):
+        matcher = " ".join(match.group("matcher").split())
+        body = _location_body(config, match.end())
+        if matcher.startswith("= "):
+            parsed.append(("exact", matcher[2:].strip(), body))
+        elif matcher.startswith("^~ "):
+            parsed.append(("prefix_priority", matcher[3:].strip(), body))
+        elif matcher.startswith("~* "):
+            parsed.append(("regex", matcher[3:].strip(), body))
+        elif matcher.startswith("~ "):
+            parsed.append(("regex", matcher[2:].strip(), body))
+        else:
+            parsed.append(("prefix", matcher.strip(), body))
+    return parsed
+
+
+def _resolve(config: str, url: str) -> str | None:
+    """Return the body of the location block nginx would use for ``url``.
+
+    Implements nginx precedence: exact ``=`` wins; then the longest matching
+    prefix, and if that prefix is ``^~`` it wins outright; otherwise regexes are
+    tried in file order; otherwise the longest prefix match applies.
+    """
+    locations = _parse_locations(config)
+
+    for kind, pattern, body in locations:
+        if kind == "exact" and pattern == url:
+            return body
+
+    best_prefix: tuple[int, str, str] | None = None
+    for kind, pattern, body in locations:
+        if kind in ("prefix", "prefix_priority") and url.startswith(pattern):
+            if best_prefix is None or len(pattern) > best_prefix[0]:
+                best_prefix = (len(pattern), kind, body)
+
+    if best_prefix and best_prefix[1] == "prefix_priority":
+        return best_prefix[2]
+
+    for kind, pattern, body in locations:
+        if kind == "regex" and re.search(pattern, url):
+            return body
+
+    return best_prefix[2] if best_prefix else None
+
+
+def _serves_prerendered(body: str, url: str) -> bool:
+    """True when the block serves a static file for ``url`` before any SPA fallback.
+
+    Both configs express this as ``try_files /<something> ... /index.html``: the
+    distinguishing feature is a first argument that is a rooted static path
+    rather than ``$uri``.
+    """
+    match = re.search(r"try_files\s+(?P<args>[^;]+);", body)
+    if not match:
+        return False
+    first = match.group("args").split()[0]
+    return first.startswith("/") and first != "/index.html"
+
+
+@pytest.fixture(scope="module")
+def configs() -> dict[str, str]:
+    return {"docker": _read_docker_template(), "helm": _read_helm_server_block()}
+
+
+def test_both_nginx_configs_exist() -> None:
+    assert DOCKER_TEMPLATE.is_file(), f"missing {DOCKER_TEMPLATE}"
+    assert HELM_CONFIGMAP.is_file(), f"missing {HELM_CONFIGMAP}"
+
+
+def test_helm_configmap_parses(configs: dict[str, str]) -> None:
+    assert "server {" in configs["helm"]
+    assert _parse_locations(configs["helm"]), "no location blocks parsed from Helm"
+
+
+@pytest.mark.parametrize("url", PRERENDERED_URLS)
+def test_marketing_urls_serve_prerendered_html_in_both_configs(
+    configs: dict[str, str], url: str
+) -> None:
+    """A route prerendered in one config must be prerendered in the other.
+
+    Production mounts the Helm ConfigMap. A route wired up only in the docker
+    template works locally and silently serves the SPA homepage on preloop.ai
+    with a 200, which is exactly how the /blog outage stayed invisible.
+    """
+    for name, config in configs.items():
+        body = _resolve(config, url)
+        assert body is not None, f"{name}: no location block matches {url}"
+        assert _serves_prerendered(body, url), (
+            f"{name} nginx config does not serve prerendered HTML for {url}; "
+            "it falls through to the SPA catch-all, which returns the homepage "
+            "with a 200. Add the route to "
+            f"{'helm/preloop/templates/configmap-nginx.yaml' if name == 'helm' else 'frontend/docker/nginx.conf.template'}."
+        )
+
+
+@pytest.mark.parametrize("url", SPA_URLS)
+def test_spa_fallback_preserved_in_both_configs(
+    configs: dict[str, str], url: str
+) -> None:
+    """Unknown and app routes must still reach the SPA shell."""
+    for name, config in configs.items():
+        body = _resolve(config, url)
+        assert body is not None, f"{name}: no location block matches {url}"
+        assert "/index.html" in body, (
+            f"{name} nginx config no longer falls back to the SPA for {url}"
+        )
+
+
+def test_blog_index_uses_exact_match(configs: dict[str, str]) -> None:
+    """`/blog` needs `location = /blog`, not a prefix match.
+
+    With only a prefix match the catch-all's ``try_files $uri $uri/`` finds the
+    ``blog`` *directory* and issues ``301 -> /blog/``. The canonical URL, the
+    sitemap entry and every ``rel=alternate`` use the slash-less ``/blog``, so
+    the published URL would never serve the index.
+    """
+    for name, config in configs.items():
+        kinds = {(kind, pattern) for kind, pattern, _ in _parse_locations(config)}
+        assert ("exact", "/blog") in kinds, (
+            f"{name} nginx config lost `location = /blog` (exact match); "
+            "a prefix match 301s to /blog/ and breaks the canonical URL."
+        )
+
+
+def test_blog_feed_is_served_as_rss(configs: dict[str, str]) -> None:
+    """`default_type` alone is not enough for .xml; an empty `types` block is required.
+
+    nginx's mime.types already maps ``.xml`` -> ``text/xml``. ``default_type``
+    only applies when *nothing* matched, so without ``types { }`` the feed is
+    served as text/xml. Verified against nginx:alpine.
+    """
+    for name, config in configs.items():
+        body = _resolve(config, "/blog/feed.xml")
+        assert body is not None, f"{name}: no location block matches /blog/feed.xml"
+        assert "application/rss+xml" in body, (
+            f"{name} feed location does not set application/rss+xml"
+        )
+        assert re.search(r"types\s*\{\s*\}", body), (
+            f"{name} feed location sets default_type without an empty `types {{ }}` "
+            "block, so nginx's mime.types wins and the feed is served as text/xml."
+        )

--- a/backend/tests/test_nginx_route_parity.py
+++ b/backend/tests/test_nginx_route_parity.py
@@ -47,6 +47,7 @@ PRERENDERED_URLS = (
     "/privacy",
     "/terms",
     "/whatis-mcp",
+    "/ai-act-readiness",
     "/blog",
     "/blog/govern-your-qm-fleet",
     "/vs/litellm",

--- a/frontend/docker/nginx.conf.template
+++ b/frontend/docker/nginx.conf.template
@@ -229,6 +229,13 @@ server {
         try_files /whatis-mcp.html =404;
     }
 
+    # EU AI Act readiness page. Prerendered only for brands that ship the
+    # content, so fall back to the SPA (as the Helm config does) instead of
+    # 404ing self-hosted builds that do not emit the file.
+    location = /ai-act-readiness {
+        try_files /ai-act-readiness.html /index.html;
+    }
+
     location = /robots.txt {
         try_files /robots.txt =404;
     }
@@ -289,10 +296,11 @@ server {
         add_header Expires "0";
     }
 
-    # Health check endpoint
+    # Health check endpoint. `default_type` (not `add_header Content-Type`,
+    # which is dead code after `return`) sets the response MIME type.
     location /health {
         access_log off;
+        default_type text/plain;
         return 200 "healthy\n";
-        add_header Content-Type text/plain;
     }
 }

--- a/frontend/docker/nginx.conf.template
+++ b/frontend/docker/nginx.conf.template
@@ -264,6 +264,10 @@ server {
 
     # RSS feed. Exact-match so it wins over the /blog/<slug> regex below.
     location = /blog/feed.xml {
+        # `types { }` empties the MIME map for this location. Without it
+        # mime.types already maps .xml -> text/xml, that match wins, and
+        # default_type (which only applies when nothing matched) is dead code.
+        types { }
         default_type application/rss+xml;
         try_files /blog/feed.xml =404;
     }

--- a/frontend/src/components/app-header.ts
+++ b/frontend/src/components/app-header.ts
@@ -214,6 +214,7 @@ export class AppHeader extends LitElement {
               isSaaS()
                 ? html`
                     <sl-button href="/about" variant="text">About</sl-button>
+                    <sl-button href="/blog" variant="text">Blog</sl-button>
                     <sl-button href="/pricing" variant="text"
                       >Pricing</sl-button
                     >

--- a/frontend/src/components/preloop-session-observer.ts
+++ b/frontend/src/components/preloop-session-observer.ts
@@ -37,6 +37,7 @@ import type {
   RuntimeSessionOptimizationAppliedAction,
   RuntimeSessionOptimizationResponse,
   RuntimeSessionActivityItem,
+  RuntimeSessionCacheSummary,
   RuntimeSessionRequestItem,
   RuntimeSessionSummary,
 } from '../types';
@@ -53,6 +54,7 @@ import {
   normalizeObservedSessions,
 } from '../utils/session-observer';
 import { reducedMotionStyles } from '../styles/reduced-motion';
+import './session-chat-view';
 import './session-list-panel';
 import './session-replay-panel';
 import './session-request-timeline';
@@ -224,6 +226,11 @@ export class PreloopSessionObserver extends LitElement {
 
   @state()
   private requestFailedCount: Record<string, number> = {};
+
+  // Whole-session prompt-cache rollup per session id. Sent with every requests
+  // page (it covers the session, not the page), so the latest response wins.
+  @state()
+  private requestCacheSummary: Record<string, RuntimeSessionCacheSummary> = {};
 
   @state()
   private budgetDialogSession: ObservedSession | null = null;
@@ -686,7 +693,9 @@ export class PreloopSessionObserver extends LitElement {
           },
         };
       }
-      if (this.followLive) {
+      if (this.followLive && this.replayMode !== 'conversation') {
+        // Newest-first modes pin to the top. The conversation view is
+        // oldest-first and pins itself to the bottom via its followLive prop.
         this.updateComplete.then(() => {
           const content = this.renderRoot.querySelector('.content');
           content?.scrollTo({ top: 0, behavior: 'smooth' });
@@ -1015,6 +1024,12 @@ export class PreloopSessionObserver extends LitElement {
         ...this.requestFailedCount,
         [sessionId]: response.failed_count,
       };
+      if (response.cache_summary) {
+        this.requestCacheSummary = {
+          ...this.requestCacheSummary,
+          [sessionId]: response.cache_summary,
+        };
+      }
     } catch (error) {
       console.error('Failed to load session requests:', error);
       this.error =
@@ -1472,6 +1487,7 @@ export class PreloopSessionObserver extends LitElement {
       label: string;
       icon: string | null;
     }> = [
+      { mode: 'conversation', label: 'Chat', icon: 'chat-left-text' },
       { mode: 'timeline', label: 'Transcript', icon: 'list-ul' },
       { mode: 'replay', label: 'Replay', icon: 'play-circle' },
     ];
@@ -1487,7 +1503,9 @@ export class PreloopSessionObserver extends LitElement {
   private replayModeFromUrl(): SessionReplayMode | null {
     if (!this.syncModeToUrl) return null;
     const raw = new URLSearchParams(window.location.search).get('replay');
-    if (raw === 'timeline' || raw === 'replay') return raw;
+    if (raw === 'conversation' || raw === 'timeline' || raw === 'replay') {
+      return raw;
+    }
     if (raw === 'optimize' && this.enabledFeatures.optimization) return raw;
     return null;
   }
@@ -1595,6 +1613,38 @@ export class PreloopSessionObserver extends LitElement {
       return 'No sessions yet for this agent. Its first gateway call will appear here live.';
     }
     return 'Select a session to follow it live or replay it.';
+  }
+
+  /**
+   * Chat-style transcript (P1 of the transcript redesign): only top-level
+   * user prompts and final agent responses expanded; tool calls/results,
+   * system and injected segments collapsed. Rendered ALONGSIDE the replay
+   * panel (which is hidden, not unmounted, in this mode) so switching tabs
+   * never loses the panel's expand/replay/optimize state.
+   */
+  private renderConversationView() {
+    if (!this.activeSession) {
+      return html`<div class="empty">${this.replayEmptyText}</div>`;
+    }
+    return html`
+      <session-chat-view
+        .events=${this.activeEvents}
+        .activity=${this.activeActivity}
+        .loading=${
+          this.activeSessionId !== null &&
+          this.loadingSessionId === this.activeSessionId
+        }
+        .hasMoreEvents=${this.activeEventPage?.hasMore ?? false}
+        .loadingMoreEvents=${
+          this.loadingMoreEventsForSessionId === this.activeSessionId
+        }
+        .followLive=${this.followLive}
+        @session-events-page-requested=${() =>
+          this.activeSessionId
+            ? this.loadMoreEvents(this.activeSessionId)
+            : undefined}
+      ></session-chat-view>
+    `;
   }
 
   private renderToolbar() {
@@ -1747,6 +1797,11 @@ export class PreloopSessionObserver extends LitElement {
                       : 0
                   }
                   .failedOnly=${this.requestsFailedOnly}
+                  .cacheSummary=${
+                    this.activeSessionId
+                      ? this.requestCacheSummary[this.activeSessionId]
+                      : undefined
+                  }
                   .loading=${
                     this.loadingRequestsForSessionId === this.activeSessionId
                   }
@@ -1821,7 +1876,13 @@ export class PreloopSessionObserver extends LitElement {
               `
             : nothing
         }
+        ${
+          this.replayMode === 'conversation'
+            ? this.renderConversationView()
+            : nothing
+        }
         <session-replay-panel
+          style=${this.replayMode === 'conversation' ? 'display: none;' : ''}
           .session=${this.activeSession}
           .emptyText=${this.replayEmptyText}
           .events=${this.activeEvents}

--- a/frontend/src/components/session-chat-view.test.ts
+++ b/frontend/src/components/session-chat-view.test.ts
@@ -1,7 +1,26 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import './session-chat-view';
 import type { SessionChatView } from './session-chat-view';
-import type { FlowGatewayEvent } from '../types';
+import type { FlowGatewayEvent, RuntimeSessionActivityItem } from '../types';
+
+function activityItem(
+  overrides: Partial<RuntimeSessionActivityItem> &
+    Pick<RuntimeSessionActivityItem, 'activity_type' | 'timestamp' | 'title'>
+): RuntimeSessionActivityItem {
+  return {
+    summary: null,
+    status: null,
+    api_usage_id: null,
+    tool_name: null,
+    server_name: null,
+    auth_subject_type: null,
+    api_key_id: null,
+    api_key_name: null,
+    estimated_cost: null,
+    total_tokens: null,
+    ...overrides,
+  };
+}
 
 function previewEvent(
   id: string,
@@ -146,6 +165,106 @@ describe('session-chat-view', () => {
     expect(button).to.exist;
     button.click();
     expect(paged).to.equal(true);
+  });
+
+  it('shows the loading state before any data arrives', async () => {
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view .loading=${true}></session-chat-view>`
+    );
+    expect(el.shadowRoot!.querySelector('.loading')).to.exist;
+    expect(el.shadowRoot!.querySelector('.loading')!.textContent).to.contain(
+      'Loading conversation'
+    );
+  });
+
+  it('renders operator messages as operator bubbles', async () => {
+    const events = [
+      previewEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: 'run the tests' },
+        { role: 'assistant', text: 'done', source: 'response' },
+      ]),
+    ];
+    const activity = [
+      activityItem({
+        activity_type: 'agent_control_message',
+        timestamp: '2026-08-06T10:02:00Z',
+        title: 'Operator message',
+        summary: 'please also run lint',
+        status: 'delivered',
+      }),
+    ];
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view
+        .events=${events}
+        .activity=${activity}
+      ></session-chat-view>`
+    );
+    const operator = el.shadowRoot!.querySelector(
+      '.bubble[data-kind="operator"]'
+    );
+    expect(operator).to.exist;
+    expect(operator!.textContent).to.contain('please also run lint');
+  });
+
+  it('renders session lifecycle markers as dividers', async () => {
+    const events = [
+      previewEvent('e1', '2026-08-06T10:01:00Z', [
+        { role: 'user', text: 'hello' },
+        { role: 'assistant', text: 'hi', source: 'response' },
+      ]),
+    ];
+    const activity = [
+      activityItem({
+        activity_type: 'session_started',
+        timestamp: '2026-08-06T10:00:00Z',
+        title: 'Session started',
+      }),
+      activityItem({
+        activity_type: 'session_ended',
+        timestamp: '2026-08-06T10:05:00Z',
+        title: 'Session ended',
+      }),
+    ];
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view
+        .events=${events}
+        .activity=${activity}
+      ></session-chat-view>`
+    );
+    const dividers = el.shadowRoot!.querySelectorAll('.divider');
+    expect(dividers).to.have.length(2);
+    expect(dividers[0].textContent).to.contain('Session started');
+    expect(dividers[1].textContent).to.contain('Session ended');
+  });
+
+  it('rebuilds the transcript only when events or activity change', async () => {
+    const events = [
+      previewEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: 'hello' },
+        { role: 'assistant', text: 'hi', source: 'response' },
+      ]),
+    ];
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view .events=${events}></session-chat-view>`
+    );
+    const internals = el as unknown as {
+      conversation: { items: unknown[] };
+    };
+    const built = internals.conversation;
+    // A state-only re-render must reuse the cached transcript object.
+    el.requestUpdate();
+    await el.updateComplete;
+    expect(internals.conversation).to.equal(built);
+    // New events must trigger a rebuild.
+    el.events = [
+      ...events,
+      previewEvent('e2', '2026-08-06T10:01:00Z', [
+        { role: 'user', text: 'more' },
+        { role: 'assistant', text: 'ok', source: 'response' },
+      ]),
+    ];
+    await el.updateComplete;
+    expect(internals.conversation).to.not.equal(built);
   });
 
   it('clamps long messages with a manual reveal', async () => {

--- a/frontend/src/components/session-chat-view.test.ts
+++ b/frontend/src/components/session-chat-view.test.ts
@@ -1,0 +1,175 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import './session-chat-view';
+import type { SessionChatView } from './session-chat-view';
+import type { FlowGatewayEvent } from '../types';
+
+function previewEvent(
+  id: string,
+  timestamp: string,
+  messages: Array<{ role: string; text: string; source?: string }>,
+  overrides: Record<string, unknown> = {}
+): FlowGatewayEvent {
+  return {
+    id,
+    execution_id: 'exec-1',
+    timestamp,
+    type: 'model_gateway_call',
+    payload: {
+      outcome: 'success',
+      conversation_preview: {
+        messages: messages.map((message) => ({
+          source: message.source || 'request',
+          role: message.role,
+          text: message.text,
+        })),
+      },
+      ...overrides,
+    },
+  } as FlowGatewayEvent;
+}
+
+describe('session-chat-view', () => {
+  it('renders empty state without events', async () => {
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view></session-chat-view>`
+    );
+    expect(el.shadowRoot!.querySelector('.empty')).to.exist;
+  });
+
+  it('expands prompts and responses, collapses steps by default', async () => {
+    const events = [
+      previewEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: 'Fix the login bug' },
+        { role: 'assistant', text: 'Looking at auth.ts', source: 'response' },
+      ]),
+      previewEvent(
+        'e2',
+        '2026-08-06T10:01:00Z',
+        [
+          { role: 'user', text: 'Fix the login bug' },
+          { role: 'user', text: 'auth.ts contents: const x = 1' },
+          { role: 'assistant', text: 'Fixed', source: 'response' },
+        ],
+        {
+          request: {
+            messages: [
+              { role: 'user', content: 'Fix the login bug' },
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'tool_result',
+                    content: 'auth.ts contents: const x = 1',
+                  },
+                ],
+              },
+            ],
+          },
+        }
+      ),
+    ];
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view .events=${events}></session-chat-view>`
+    );
+    const bubbles = el.shadowRoot!.querySelectorAll('.bubble');
+    expect(bubbles).to.have.length(2);
+    expect(bubbles[0].getAttribute('data-kind')).to.equal('user_prompt');
+    expect(bubbles[1].getAttribute('data-kind')).to.equal('agent_response');
+    expect(bubbles[1].textContent).to.contain('Fixed');
+
+    // Tool result + intermediate response live in one collapsed group.
+    const details = el.shadowRoot!.querySelectorAll('sl-details.steps');
+    expect(details).to.have.length(1);
+    expect((details[0] as HTMLElement & { open: boolean }).open).to.equal(
+      false
+    );
+    expect(details[0].textContent).to.contain('tool result');
+  });
+
+  it('discloses partial structure coverage instead of guessing', async () => {
+    const events = [
+      previewEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: 'maybe a prompt, maybe a tool result' },
+        { role: 'assistant', text: 'ok', source: 'response' },
+      ]),
+    ];
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view .events=${events}></session-chat-view>`
+    );
+    const note = el.shadowRoot!.querySelector('.coverage-note');
+    expect(note).to.exist;
+    expect(note!.textContent).to.contain('structure was unavailable');
+  });
+
+  it('marks injected segments and keeps the real prompt expanded', async () => {
+    const events = [
+      previewEvent('e1', '2026-08-06T10:00:00Z', [
+        {
+          role: 'user',
+          text: '<system-reminder>plan mode is active</system-reminder>',
+        },
+        { role: 'user', text: 'Real user prompt' },
+        { role: 'assistant', text: 'ok', source: 'response' },
+      ]),
+    ];
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view .events=${events}></session-chat-view>`
+    );
+    const prompts = el.shadowRoot!.querySelectorAll(
+      '.bubble[data-kind="user_prompt"]'
+    );
+    expect(prompts).to.have.length(1);
+    expect(prompts[0].textContent).to.contain('Real user prompt');
+    const group = el.shadowRoot!.querySelector('sl-details.steps');
+    expect(group).to.exist;
+    expect(group!.textContent).to.contain('injected segment');
+  });
+
+  it('shows a load-earlier control when more events exist', async () => {
+    const events = [
+      previewEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: 'hello' },
+        { role: 'assistant', text: 'hi', source: 'response' },
+      ]),
+    ];
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view
+        .events=${events}
+        .hasMoreEvents=${true}
+      ></session-chat-view>`
+    );
+    let paged = false;
+    el.addEventListener('session-events-page-requested', () => {
+      paged = true;
+    });
+    const button = el.shadowRoot!.querySelector('.load-earlier') as HTMLElement;
+    expect(button).to.exist;
+    button.click();
+    expect(paged).to.equal(true);
+  });
+
+  it('clamps long messages with a manual reveal', async () => {
+    const longText = `start ${'x'.repeat(3000)} end`;
+    const events = [
+      previewEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: longText },
+        { role: 'assistant', text: 'ok', source: 'response' },
+      ]),
+    ];
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view .events=${events}></session-chat-view>`
+    );
+    const prompt = el.shadowRoot!.querySelector(
+      '.bubble[data-kind="user_prompt"]'
+    )!;
+    expect(prompt.textContent).to.not.contain(' end');
+    const toggle = prompt.querySelector('.inline-toggle') as HTMLElement;
+    expect(toggle).to.exist;
+    toggle.click();
+    await el.updateComplete;
+    const expanded = el.shadowRoot!.querySelector(
+      '.bubble[data-kind="user_prompt"]'
+    )!;
+    expect(expanded.textContent).to.contain(' end');
+  });
+});

--- a/frontend/src/components/session-chat-view.ts
+++ b/frontend/src/components/session-chat-view.ts
@@ -78,6 +78,7 @@ export class SessionChatView extends LitElement {
       injectedCount: 0,
       toolCallCount: 0,
       eventsWithoutRawBody: 0,
+      eventsWithPartialToolResults: 0,
       totalEvents: 0,
     },
   };
@@ -552,6 +553,17 @@ ${
                   ${stats.eventsWithoutRawBody} of ${stats.totalEvents}
                   requests, so some tool results may appear as user prompts
                   there.
+                </div>
+              `
+            : nothing
+        }
+        ${
+          stats.eventsWithPartialToolResults > 0
+            ? html`
+                <div class="coverage-note" role="note">
+                  ${stats.eventsWithPartialToolResults} of ${stats.totalEvents}
+                  requests carried tool results with no extractable text, so
+                  some of those may appear as user prompts.
                 </div>
               `
             : nothing

--- a/frontend/src/components/session-chat-view.ts
+++ b/frontend/src/components/session-chat-view.ts
@@ -11,6 +11,7 @@
  * observer's existing `session-events-page-requested` event.
  */
 import { LitElement, css, html, nothing } from 'lit';
+import type { PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
@@ -20,22 +21,26 @@ import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import type { FlowGatewayEvent, RuntimeSessionActivityItem } from '../types';
 import type {
+  TranscriptBuildResult,
   TranscriptItem,
   TranscriptMessageItem,
   TranscriptStep,
   TranscriptStepGroupItem,
 } from '../utils/transcript';
 import { buildConversation } from '../utils/transcript';
+import { SESSION_EVENTS_PAGE_REQUESTED_EVENT } from '../utils/session-observer';
 
 const MESSAGE_PREVIEW_CHARS = 2000;
 const STEP_PREVIEW_CHARS = 600;
 
 @customElement('session-chat-view')
 export class SessionChatView extends LitElement {
-  @property({ type: Array })
+  // `attribute: false`: these are data-only properties set via property
+  // bindings; an attribute path would (de)serialize large arrays as JSON.
+  @property({ attribute: false })
   events: FlowGatewayEvent[] = [];
 
-  @property({ type: Array })
+  @property({ attribute: false })
   activity: RuntimeSessionActivityItem[] = [];
 
   @property({ type: Boolean })
@@ -59,6 +64,27 @@ export class SessionChatView extends LitElement {
 
   @state()
   private expandedStepKeys = new Set<string>();
+
+  // Rebuilt in willUpdate() only when `events`/`activity` change, NOT on
+  // every render: expanding a message or toggling a step must not re-run the
+  // whole O(n log n) transcript reconstruction.
+  private conversation: TranscriptBuildResult = {
+    items: [],
+    stats: {
+      promptCount: 0,
+      responseCount: 0,
+      stepCount: 0,
+      toolResultCount: 0,
+      injectedCount: 0,
+      toolCallCount: 0,
+      eventsWithoutRawBody: 0,
+      totalEvents: 0,
+    },
+  };
+
+  // Events seen at the last follow-live scroll; scrolling happens only when
+  // new events actually arrive, never on state-only re-renders.
+  private lastScrolledEventCount = 0;
 
   static styles = css`
     :host {
@@ -241,8 +267,20 @@ export class SessionChatView extends LitElement {
     }
   `;
 
-  updated(): void {
+  willUpdate(changed: PropertyValues<this>): void {
+    if (changed.has('events') || changed.has('activity')) {
+      this.conversation = buildConversation(this.events, this.activity);
+    }
+  }
+
+  updated(changed: PropertyValues<this>): void {
     if (!this.followLive) return;
+    // Scroll only when new events arrived (or follow-live was just switched
+    // on); a scrollTop write on every update would force a reflow — and yank
+    // the view — each time the user expands a message they are reading.
+    const newEvents = this.events.length > this.lastScrolledEventCount;
+    this.lastScrolledEventCount = this.events.length;
+    if (!newEvents && !changed.has('followLive')) return;
     const thread = this.renderRoot.querySelector('.thread');
     if (thread) thread.scrollTop = thread.scrollHeight;
   }
@@ -270,7 +308,7 @@ export class SessionChatView extends LitElement {
 
   private requestEarlierEvents(): void {
     this.dispatchEvent(
-      new CustomEvent('session-events-page-requested', {
+      new CustomEvent(SESSION_EVENTS_PAGE_REQUESTED_EVENT, {
         bubbles: true,
         composed: true,
       })
@@ -485,7 +523,7 @@ ${
       `;
     }
 
-    const { items, stats } = buildConversation(this.events, this.activity);
+    const { items, stats } = this.conversation;
     if (!items.length) {
       return html`<div class="empty">${this.emptyText}</div>`;
     }

--- a/frontend/src/components/session-chat-view.ts
+++ b/frontend/src/components/session-chat-view.ts
@@ -1,0 +1,529 @@
+/**
+ * Chat-style session transcript: ONLY top-level user prompts and final agent
+ * responses are expanded; tool calls, tool results, system/injected segments
+ * and intermediate agent output are nested in collapsed, manually expandable
+ * step groups. Reference UX: Claude Code web chat. When in doubt, collapse —
+ * except for prompt classification, where doubt keeps the prompt visible
+ * (see utils/transcript.ts).
+ *
+ * Presentational only: events/activity arrive as props from
+ * <preloop-session-observer>; paging is requested by re-emitting the
+ * observer's existing `session-events-page-requested` event.
+ */
+import { LitElement, css, html, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import '@shoelace-style/shoelace/dist/components/badge/badge.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/details/details.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
+import type { FlowGatewayEvent, RuntimeSessionActivityItem } from '../types';
+import type {
+  TranscriptItem,
+  TranscriptMessageItem,
+  TranscriptStep,
+  TranscriptStepGroupItem,
+} from '../utils/transcript';
+import { buildConversation } from '../utils/transcript';
+
+const MESSAGE_PREVIEW_CHARS = 2000;
+const STEP_PREVIEW_CHARS = 600;
+
+@customElement('session-chat-view')
+export class SessionChatView extends LitElement {
+  @property({ type: Array })
+  events: FlowGatewayEvent[] = [];
+
+  @property({ type: Array })
+  activity: RuntimeSessionActivityItem[] = [];
+
+  @property({ type: Boolean })
+  loading = false;
+
+  @property({ type: Boolean })
+  hasMoreEvents = false;
+
+  @property({ type: Boolean })
+  loadingMoreEvents = false;
+
+  /** Pin the scroll position to the newest message as events stream in. */
+  @property({ type: Boolean })
+  followLive = false;
+
+  @property({ type: String })
+  emptyText = 'No conversation captured for this session yet.';
+
+  @state()
+  private expandedMessageKeys = new Set<string>();
+
+  @state()
+  private expandedStepKeys = new Set<string>();
+
+  static styles = css`
+    :host {
+      display: block;
+      min-height: 0;
+    }
+
+    .thread {
+      display: flex;
+      flex-direction: column;
+      gap: var(--sl-spacing-medium);
+      padding: var(--sl-spacing-small) 0;
+    }
+
+    .empty,
+    .loading {
+      color: var(--sl-color-neutral-600);
+      padding: var(--sl-spacing-x-large);
+      text-align: center;
+    }
+
+    .coverage-note {
+      background: var(--sl-color-neutral-50);
+      border: 1px solid var(--sl-color-neutral-200);
+      border-left: 3px solid var(--sl-color-amber-400, #f5c518);
+      border-radius: 4px;
+      color: var(--sl-color-neutral-700);
+      font-size: var(--sl-font-size-x-small);
+      line-height: 1.5;
+      padding: var(--sl-spacing-x-small) var(--sl-spacing-small);
+    }
+
+    .bubble {
+      border-radius: var(--sl-border-radius-large);
+      max-width: 88%;
+      padding: var(--sl-spacing-small) var(--sl-spacing-medium);
+    }
+
+    .bubble.user {
+      align-self: flex-end;
+      background: var(--sl-color-primary-100);
+      border: 1px solid var(--sl-color-primary-200);
+    }
+
+    .bubble.agent {
+      align-self: flex-start;
+      background: var(--sl-color-neutral-0);
+      border: 1px solid var(--sl-color-neutral-200);
+    }
+
+    .bubble.operator {
+      align-self: flex-end;
+      background: var(--sl-color-success-100, #e6f6ec);
+      border: 1px solid var(--sl-color-success-200, #bfe8cd);
+    }
+
+    .bubble.failed {
+      border-color: var(--sl-color-danger-300);
+    }
+
+    .bubble-meta {
+      align-items: center;
+      color: var(--sl-color-neutral-600);
+      display: flex;
+      flex-wrap: wrap;
+      font-size: var(--sl-font-size-x-small);
+      gap: var(--sl-spacing-x-small);
+      margin-bottom: var(--sl-spacing-2x-small);
+    }
+
+    .bubble-role {
+      font-weight: var(--sl-font-weight-semibold);
+      text-transform: capitalize;
+    }
+
+    .bubble-text {
+      color: var(--sl-color-neutral-900);
+      font-size: var(--sl-font-size-small);
+      line-height: 1.55;
+      margin: 0;
+      overflow-wrap: anywhere;
+      white-space: pre-wrap;
+    }
+
+    .steps {
+      align-self: stretch;
+      border: 1px dashed var(--sl-color-neutral-300);
+      border-radius: var(--sl-border-radius-medium);
+      background: var(--sl-color-neutral-50);
+      margin: 0 var(--sl-spacing-medium);
+    }
+
+    .steps::part(summary) {
+      color: var(--sl-color-neutral-600);
+      font-size: var(--sl-font-size-x-small);
+      padding: var(--sl-spacing-x-small) var(--sl-spacing-small);
+    }
+
+    .steps::part(content) {
+      padding: var(--sl-spacing-x-small) var(--sl-spacing-small)
+        var(--sl-spacing-small);
+    }
+
+    .steps-summary {
+      align-items: center;
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: var(--sl-spacing-x-small);
+    }
+
+    .step {
+      border-left: 2px solid var(--sl-color-neutral-300);
+      margin: var(--sl-spacing-x-small) 0;
+      padding: var(--sl-spacing-2x-small) var(--sl-spacing-small);
+    }
+
+    .step-header {
+      align-items: center;
+      color: var(--sl-color-neutral-700);
+      display: flex;
+      flex-wrap: wrap;
+      font-size: var(--sl-font-size-x-small);
+      gap: var(--sl-spacing-x-small);
+    }
+
+    .step-label {
+      font-weight: var(--sl-font-weight-semibold);
+    }
+
+    .step-kind-tool_call .step-label,
+    .step-kind-tool_result .step-label {
+      color: var(--sl-color-primary-700);
+    }
+
+    .step-kind-injected .step-label {
+      color: var(--sl-color-warning-700);
+    }
+
+    .step-text {
+      color: var(--sl-color-neutral-700);
+      font-family: var(--sl-font-mono);
+      font-size: var(--sl-font-size-x-small);
+      line-height: 1.5;
+      margin: var(--sl-spacing-2x-small) 0 0;
+      overflow-wrap: anywhere;
+      white-space: pre-wrap;
+    }
+
+    .divider {
+      align-items: center;
+      color: var(--sl-color-neutral-500);
+      display: flex;
+      font-size: var(--sl-font-size-x-small);
+      gap: var(--sl-spacing-small);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .divider::before,
+    .divider::after {
+      background: var(--sl-color-neutral-200);
+      content: '';
+      flex: 1;
+      height: 1px;
+    }
+
+    .load-earlier {
+      align-self: center;
+    }
+
+    .inline-toggle {
+      background: none;
+      border: none;
+      color: var(--sl-color-primary-600);
+      cursor: pointer;
+      font: inherit;
+      font-size: var(--sl-font-size-x-small);
+      padding: 0;
+      text-decoration: underline;
+    }
+  `;
+
+  updated(): void {
+    if (!this.followLive) return;
+    const thread = this.renderRoot.querySelector('.thread');
+    if (thread) thread.scrollTop = thread.scrollHeight;
+  }
+
+  private formatTime(value: string | null): string {
+    if (!value) return '';
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return value;
+    return parsed.toLocaleTimeString();
+  }
+
+  private toggleMessage(key: string): void {
+    const next = new Set(this.expandedMessageKeys);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    this.expandedMessageKeys = next;
+  }
+
+  private toggleStep(key: string): void {
+    const next = new Set(this.expandedStepKeys);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    this.expandedStepKeys = next;
+  }
+
+  private requestEarlierEvents(): void {
+    this.dispatchEvent(
+      new CustomEvent('session-events-page-requested', {
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private renderClampedText(
+    text: string,
+    key: string,
+    limit: number,
+    expanded: boolean,
+    className: string
+  ) {
+    const isLong = text.length > limit;
+    const shown = isLong && !expanded ? `${text.slice(0, limit)}…` : text;
+    return html`
+      <pre class=${className}>${shown}</pre>
+      ${
+        isLong
+          ? html`
+              <button
+                class="inline-toggle"
+                type="button"
+                @click=${() => this.toggleMessage(key)}
+              >
+                ${expanded ? 'Show less' : 'Show full message'}
+              </button>
+            `
+          : nothing
+      }
+    `;
+  }
+
+  private renderMessage(item: TranscriptMessageItem) {
+    const bubbleClass =
+      item.kind === 'user_prompt'
+        ? 'user'
+        : item.kind === 'operator'
+          ? 'operator'
+          : 'agent';
+    const displayText = item.text
+      ? item.text
+      : item.redacted
+        ? 'Content redacted by capture policy.'
+        : 'No text content captured.';
+    return html`
+      <div
+        class="bubble ${bubbleClass} ${item.failed ? 'failed' : ''}"
+        data-kind=${item.kind}
+      >
+        <div class="bubble-meta">
+          <span class="bubble-role">
+            ${
+              item.kind === 'user_prompt'
+                ? 'You'
+                : item.kind === 'operator'
+                  ? 'Operator'
+                  : 'Agent'
+            }
+          </span>
+          <span>${this.formatTime(item.timestamp)}</span>
+          ${
+            item.redacted
+              ? html`<sl-badge variant="warning" pill>Redacted</sl-badge>`
+              : nothing
+          }
+          ${
+            item.truncated
+              ? html`<sl-badge variant="warning" pill>Truncated</sl-badge>`
+              : nothing
+          }
+          ${
+            item.failed
+              ? html`<sl-badge variant="danger" pill>Failed</sl-badge>`
+              : nothing
+          }
+        </div>
+        ${this.renderClampedText(
+          displayText,
+          item.key,
+          MESSAGE_PREVIEW_CHARS,
+          this.expandedMessageKeys.has(item.key),
+          'bubble-text'
+        )}
+      </div>
+    `;
+  }
+
+  private describeSteps(steps: TranscriptStep[]): string {
+    const counts = new Map<string, number>();
+    for (const step of steps) {
+      const label =
+        step.kind === 'tool_call'
+          ? 'tool call'
+          : step.kind === 'tool_result'
+            ? 'tool result'
+            : step.kind === 'injected'
+              ? 'injected segment'
+              : step.kind === 'system'
+                ? 'system segment'
+                : 'agent step';
+      counts.set(label, (counts.get(label) || 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([label, count]) => `${count} ${label}${count === 1 ? '' : 's'}`)
+      .join(' · ');
+  }
+
+  private renderStep(step: TranscriptStep) {
+    const expanded = this.expandedStepKeys.has(step.key);
+    const displayText = step.text
+      ? step.text
+      : step.redacted
+        ? 'Content redacted by capture policy.'
+        : '';
+    return html`
+      <div class="step step-kind-${step.kind}">
+        <div class="step-header">
+          <span class="step-label">${step.label}</span>
+          ${step.serverName ? html`<span>${step.serverName}</span>` : nothing}
+          <span>${this.formatTime(step.timestamp)}</span>
+          ${
+            step.status
+              ? html`<sl-badge
+                  pill
+                  variant=${
+                    step.status.toLowerCase().includes('fail')
+                      ? 'danger'
+                      : 'neutral'
+                  }
+                  >${step.status}</sl-badge
+                >`
+              : nothing
+          }
+          ${
+            step.kind === 'injected'
+              ? html`<sl-badge variant="warning" pill>Injected</sl-badge>`
+              : nothing
+          }
+          ${
+            !step.detectionExact
+              ? html`<sl-badge
+                  variant="neutral"
+                  pill
+                  title="Classified by pattern, not by message structure"
+                >
+                  pattern match
+                </sl-badge>`
+              : nothing
+          }
+          ${
+            displayText.length > STEP_PREVIEW_CHARS
+              ? html`
+                  <button
+                    class="inline-toggle"
+                    type="button"
+                    @click=${() => this.toggleStep(step.key)}
+                  >
+                    ${expanded ? 'Show less' : 'Show all'}
+                  </button>
+                `
+              : nothing
+          }
+        </div>
+        ${
+          displayText
+            ? html`
+                <pre class="step-text">
+${
+  displayText.length > STEP_PREVIEW_CHARS && !expanded
+    ? `${displayText.slice(0, STEP_PREVIEW_CHARS)}…`
+    : displayText
+}</pre>
+              `
+            : nothing
+        }
+      </div>
+    `;
+  }
+
+  private renderStepGroup(item: TranscriptStepGroupItem) {
+    return html`
+      <sl-details class="steps">
+        <span slot="summary" class="steps-summary">
+          <sl-icon name="three-dots"></sl-icon>
+          ${item.steps.length} step${item.steps.length === 1 ? '' : 's'} —
+          ${this.describeSteps(item.steps)}
+        </span>
+        ${item.steps.map((step) => this.renderStep(step))}
+      </sl-details>
+    `;
+  }
+
+  private renderItem(item: TranscriptItem) {
+    if (item.type === 'message') return this.renderMessage(item);
+    if (item.type === 'steps') return this.renderStepGroup(item);
+    return html`
+      <div class="divider">
+        ${item.label}
+        ${item.timestamp ? html`· ${this.formatTime(item.timestamp)}` : nothing}
+      </div>
+    `;
+  }
+
+  render() {
+    if (this.loading && !this.events.length && !this.activity.length) {
+      return html`
+        <div class="loading">
+          <sl-spinner></sl-spinner>
+          <div>Loading conversation...</div>
+        </div>
+      `;
+    }
+
+    const { items, stats } = buildConversation(this.events, this.activity);
+    if (!items.length) {
+      return html`<div class="empty">${this.emptyText}</div>`;
+    }
+
+    return html`
+      <div class="thread">
+        ${
+          this.hasMoreEvents
+            ? html`
+                <sl-button
+                  class="load-earlier"
+                  size="small"
+                  ?loading=${this.loadingMoreEvents}
+                  @click=${() => this.requestEarlierEvents()}
+                >
+                  Load earlier conversation
+                </sl-button>
+              `
+            : nothing
+        }
+        ${
+          stats.eventsWithoutRawBody > 0
+            ? html`
+                <div class="coverage-note" role="note">
+                  Message structure was unavailable for
+                  ${stats.eventsWithoutRawBody} of ${stats.totalEvents}
+                  requests, so some tool results may appear as user prompts
+                  there.
+                </div>
+              `
+            : nothing
+        }
+        ${repeat(
+          items,
+          (item) => item.key,
+          (item) => this.renderItem(item)
+        )}
+      </div>
+    `;
+  }
+}

--- a/frontend/src/components/session-replay-panel.ts
+++ b/frontend/src/components/session-replay-panel.ts
@@ -28,6 +28,7 @@ import type {
   SessionReplayMode,
 } from '../utils/session-observer';
 import {
+  SESSION_EVENTS_PAGE_REQUESTED_EVENT,
   formatCost,
   formatNumber,
   getGatewayEventPreviewMessages,
@@ -1645,7 +1646,7 @@ export class SessionReplayPanel extends LitElement {
   private requestMoreEvents(): void {
     if (!this.hasMoreEvents || this.loadingMoreEvents) return;
     this.dispatchEvent(
-      new CustomEvent('session-events-page-requested', {
+      new CustomEvent(SESSION_EVENTS_PAGE_REQUESTED_EVENT, {
         bubbles: true,
         composed: true,
       })

--- a/frontend/src/components/session-request-timeline.test.ts
+++ b/frontend/src/components/session-request-timeline.test.ts
@@ -1,7 +1,10 @@
 import { fixture, html, expect, oneEvent } from '@open-wc/testing';
 import './session-request-timeline';
 import type { SessionRequestTimeline } from './session-request-timeline';
-import type { RuntimeSessionRequestItem } from '../types';
+import type {
+  RuntimeSessionCacheSummary,
+  RuntimeSessionRequestItem,
+} from '../types';
 
 function makeRequest(
   overrides: Partial<RuntimeSessionRequestItem>
@@ -122,5 +125,220 @@ describe('SessionRequestTimeline', () => {
     setTimeout(() => button!.click());
     const event = await oneEvent(el, 'request-timeline-failed-only');
     expect(event.detail.failedOnly).to.be.true;
+  });
+});
+
+function makeCacheSummary(
+  overrides: Partial<RuntimeSessionCacheSummary> = {}
+): RuntimeSessionCacheSummary {
+  return {
+    requests_total: 4,
+    requests_with_cache_data: 3,
+    requests_without_cache_data: 1,
+    covered_prompt_tokens: 3000,
+    uncovered_prompt_tokens: 2000,
+    cached_prompt_tokens: 2400,
+    uncached_prompt_tokens: 300,
+    cache_write_tokens: 300,
+    cache_hit_ratio: 0.8889,
+    estimated_cache_savings_usd: 0.0125,
+    savings_basis: 'catalog_exact',
+    savings_omitted_reason: null,
+    ...overrides,
+  };
+}
+
+describe('SessionRequestTimeline cache accounting', () => {
+  const plainRequests: RuntimeSessionRequestItem[] = [
+    makeRequest({ id: 'a' }),
+    makeRequest({ id: 'b' }),
+  ];
+
+  it('renders read/write/miss for a call the provider reported on', async () => {
+    const el = (await fixture(
+      html`<session-request-timeline
+        .requests=${[
+          makeRequest({
+            id: 'cached',
+            prompt_tokens: 10000,
+            cache: {
+              cache_read_tokens: 7000,
+              cache_creation_tokens: 2000,
+              cache_miss_tokens: 1000,
+              cache_miss_source: 'derived',
+              has_cache_data: true,
+              usage_source: 'provider',
+            },
+          }),
+        ]}
+      ></session-request-timeline>`
+    )) as SessionRequestTimeline;
+    await el.updateComplete;
+    const line = el.shadowRoot?.querySelector(
+      '[data-testid="request-cache-line"]'
+    );
+    expect(line).to.exist;
+    const text = (line?.textContent || '').replace(/\s+/g, ' ');
+    expect(text).to.include('read 7,000');
+    expect(text).to.include('write 2,000');
+    expect(text).to.include('miss 1,000');
+  });
+
+  it('says "not reported" instead of zero for an absent write count', async () => {
+    const el = (await fixture(
+      html`<session-request-timeline
+        .requests=${[
+          makeRequest({
+            id: 'openai',
+            cache: {
+              cache_read_tokens: 1024,
+              cache_creation_tokens: null,
+              cache_miss_tokens: 476,
+              cache_miss_source: 'derived',
+              has_cache_data: true,
+              usage_source: 'provider',
+            },
+          }),
+        ]}
+      ></session-request-timeline>`
+    )) as SessionRequestTimeline;
+    await el.updateComplete;
+    const text = (
+      el.shadowRoot?.querySelector('[data-testid="request-cache-line"]')
+        ?.textContent || ''
+    ).replace(/\s+/g, ' ');
+    expect(text).to.include('write not reported');
+    expect(text).to.not.include('write 0');
+  });
+
+  it('omits the cache line entirely when the provider reported nothing', async () => {
+    const el = (await fixture(
+      html`<session-request-timeline
+        .requests=${[
+          makeRequest({
+            id: 'blind',
+            cache: {
+              cache_read_tokens: null,
+              cache_creation_tokens: null,
+              cache_miss_tokens: null,
+              cache_miss_source: null,
+              has_cache_data: false,
+              usage_source: 'provider',
+            },
+          }),
+        ]}
+      ></session-request-timeline>`
+    )) as SessionRequestTimeline;
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector('[data-testid="request-cache-line"]'))
+      .to.not.exist;
+  });
+
+  it('renders the session rollup with ratio, writes and savings', async () => {
+    const el = (await fixture(
+      html`<session-request-timeline
+        .requests=${plainRequests}
+        .cacheSummary=${makeCacheSummary()}
+      ></session-request-timeline>`
+    )) as SessionRequestTimeline;
+    await el.updateComplete;
+    const block = el.shadowRoot?.querySelector(
+      '[data-testid="session-cache-summary"]'
+    );
+    expect(block).to.exist;
+    expect(
+      el.shadowRoot?.querySelector('[data-testid="cache-hit-ratio"]')
+        ?.textContent
+    ).to.include('88.9%');
+    expect(
+      el.shadowRoot?.querySelector('[data-testid="cache-write-tokens"]')
+        ?.textContent
+    ).to.include('300');
+    expect(
+      el.shadowRoot?.querySelector('[data-testid="cache-savings"]')?.textContent
+    ).to.include('$0.0125');
+  });
+
+  it('states coverage when some requests reported no cache data', async () => {
+    const el = (await fixture(
+      html`<session-request-timeline
+        .requests=${plainRequests}
+        .cacheSummary=${makeCacheSummary()}
+      ></session-request-timeline>`
+    )) as SessionRequestTimeline;
+    await el.updateComplete;
+    const text = (
+      el.shadowRoot?.querySelector('[data-testid="cache-coverage"]')
+        ?.textContent || ''
+    ).replace(/\s+/g, ' ');
+    expect(text).to.include('3 of 4 requests');
+    expect(text).to.include('not counted as misses');
+  });
+
+  it('shows the reason instead of a number when savings are unpriced', async () => {
+    const el = (await fixture(
+      html`<session-request-timeline
+        .requests=${plainRequests}
+        .cacheSummary=${makeCacheSummary({
+          estimated_cache_savings_usd: null,
+          savings_basis: null,
+          savings_omitted_reason: 'no_catalog_cache_price',
+        })}
+      ></session-request-timeline>`
+    )) as SessionRequestTimeline;
+    await el.updateComplete;
+    const text =
+      el.shadowRoot?.querySelector('[data-testid="cache-savings"]')
+        ?.textContent || '';
+    expect(text).to.include('no exact catalog price');
+    expect(text).to.not.include('$');
+  });
+
+  it('renders cache writes as "not reported" when no provider reports them', async () => {
+    const el = (await fixture(
+      html`<session-request-timeline
+        .requests=${plainRequests}
+        .cacheSummary=${makeCacheSummary({ cache_write_tokens: null })}
+      ></session-request-timeline>`
+    )) as SessionRequestTimeline;
+    await el.updateComplete;
+    expect(
+      el.shadowRoot?.querySelector('[data-testid="cache-write-tokens"]')
+        ?.textContent
+    ).to.include('not reported');
+  });
+
+  it('does not round a sub-cent savings figure down to $0.01', async () => {
+    const el = (await fixture(
+      html`<session-request-timeline
+        .requests=${plainRequests}
+        .cacheSummary=${makeCacheSummary({
+          estimated_cache_savings_usd: 0.0125,
+        })}
+      ></session-request-timeline>`
+    )) as SessionRequestTimeline;
+    await el.updateComplete;
+    const text =
+      el.shadowRoot?.querySelector('[data-testid="cache-savings"]')
+        ?.textContent || '';
+    expect(text).to.include('$0.0125');
+  });
+
+  it('renders no rollup when no request carried cache data', async () => {
+    const el = (await fixture(
+      html`<session-request-timeline
+        .requests=${plainRequests}
+        .cacheSummary=${makeCacheSummary({
+          requests_with_cache_data: 0,
+          cached_prompt_tokens: 0,
+          uncached_prompt_tokens: 0,
+          cache_hit_ratio: null,
+        })}
+      ></session-request-timeline>`
+    )) as SessionRequestTimeline;
+    await el.updateComplete;
+    expect(
+      el.shadowRoot?.querySelector('[data-testid="session-cache-summary"]')
+    ).to.not.exist;
   });
 });

--- a/frontend/src/components/session-request-timeline.ts
+++ b/frontend/src/components/session-request-timeline.ts
@@ -461,7 +461,9 @@ export class SessionRequestTimeline extends LitElement {
             title=${
               summary.estimated_cache_savings_usd === null
                 ? 'Omitted: a savings figure is only shown when the price catalog supports it exactly'
-                : 'Input price minus cache-read price over the tokens served from cache'
+                : summary.savings_basis === 'catalog_exact_partial'
+                  ? 'Lower bound: covers only the models with exact catalog prices'
+                  : 'Input price minus cache-read price over the tokens served from cache'
             }
           >
             ${
@@ -470,6 +472,11 @@ export class SessionRequestTimeline extends LitElement {
                 : SessionRequestTimeline.savings(
                     summary.estimated_cache_savings_usd
                   )
+            }${
+              summary.estimated_cache_savings_usd !== null &&
+              summary.savings_basis === 'catalog_exact_partial'
+                ? '+'
+                : ''
             }
           </span>
         </div>

--- a/frontend/src/components/session-request-timeline.ts
+++ b/frontend/src/components/session-request-timeline.ts
@@ -5,7 +5,10 @@ import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
-import type { RuntimeSessionRequestItem } from '../types';
+import type {
+  RuntimeSessionCacheSummary,
+  RuntimeSessionRequestItem,
+} from '../types';
 import { formatCost, formatNumber } from '../utils/session-observer';
 
 export type RequestTimelineSort =
@@ -41,6 +44,13 @@ export class SessionRequestTimeline extends LitElement {
 
   @property({ type: Boolean })
   failedOnly = false;
+
+  /**
+   * Whole-session prompt-cache rollup. Undefined when the backend did not
+   * send one (older API); the summary block is then simply not rendered.
+   */
+  @property({ type: Object })
+  cacheSummary?: RuntimeSessionCacheSummary;
 
   @state()
   private sort: RequestTimelineSort = 'recent';
@@ -156,7 +166,90 @@ export class SessionRequestTimeline extends LitElement {
       padding: var(--sl-spacing-large);
       text-align: center;
     }
+
+    /* Per-call cache line: quiet, one line, never competes with the title. */
+    .cache-line {
+      color: var(--sl-color-neutral-600);
+      font-size: var(--sl-font-size-x-small);
+    }
+
+    .cache-line .not-reported {
+      font-style: italic;
+      opacity: 0.75;
+    }
+
+    .cache-line .derived::after {
+      content: '~';
+      font-size: 0.85em;
+      vertical-align: super;
+    }
+
+    /* Session rollup: one compact block above the stream. */
+    .cache-summary {
+      background: var(--sl-color-neutral-50);
+      border: 1px solid var(--sl-color-neutral-200);
+      border-radius: var(--sl-border-radius-medium);
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--sl-spacing-medium);
+      margin-bottom: var(--sl-spacing-small);
+      padding: var(--sl-spacing-x-small) var(--sl-spacing-small);
+    }
+
+    .cache-stat {
+      display: grid;
+      gap: 1px;
+    }
+
+    .cache-stat-label {
+      color: var(--sl-color-neutral-600);
+      font-size: var(--sl-font-size-x-small);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .cache-stat-value {
+      font-size: var(--sl-font-size-small);
+      font-weight: 600;
+    }
+
+    .cache-stat-value.muted {
+      font-style: italic;
+      font-weight: 400;
+      opacity: 0.75;
+    }
+
+    .cache-coverage {
+      align-self: center;
+      color: var(--sl-color-neutral-600);
+      font-size: var(--sl-font-size-x-small);
+      margin-left: auto;
+      max-width: 22rem;
+      text-align: right;
+    }
   `;
+
+  /** Human label for a token count that may legitimately be absent. */
+  private static tokens(value: number | null | undefined) {
+    return value === null || value === undefined
+      ? html`<span class="not-reported">not reported</span>`
+      : html`${formatNumber(value)}`;
+  }
+
+  /**
+   * Format a cache-savings amount without rounding it away.
+   *
+   * The shared `formatCost` snaps anything >= $0.01 to two decimals, which
+   * turns $0.0125 of measured savings into "$0.01" — a 20% understatement of a
+   * figure whose whole point is precision. Sub-dollar savings therefore keep
+   * four decimals here, and a non-zero amount below the last displayed digit
+   * is shown as a "<" bound rather than as $0.00.
+   */
+  private static savings(value: number): string {
+    if (value >= 1) return `$${value.toFixed(2)}`;
+    if (value >= 0.0001) return `$${value.toFixed(4)}`;
+    return value > 0 ? '<$0.0001' : '$0.00';
+  }
 
   private get filteredSorted(): RuntimeSessionRequestItem[] {
     let rows = [...this.requests];
@@ -204,6 +297,43 @@ export class SessionRequestTimeline extends LitElement {
     );
   }
 
+  /**
+   * One quiet line of cache accounting under an existing request row.
+   *
+   * Suppressed entirely when the provider reported no cache data for the call:
+   * a row of three "not reported" values would be noise, and the session
+   * summary already states how many requests are uncovered. When cache data
+   * IS present, every field is shown with its honest status — an absent write
+   * count reads "not reported", never 0, and a miss carries a marker when it
+   * was derived rather than reported by the provider.
+   */
+  private renderCacheLine(row: RuntimeSessionRequestItem) {
+    const cache = row.cache;
+    if (!cache || !cache.has_cache_data) return nothing;
+    const derived = cache.cache_miss_source === 'derived';
+    const missTitle =
+      cache.cache_miss_source === 'reported'
+        ? 'Cache miss tokens reported directly by the provider'
+        : derived
+          ? 'Cache miss derived as prompt - cache read - cache write'
+          : 'Provider reported no cache miss count';
+    return html`
+      <div class="cache-line" data-testid="request-cache-line">
+        Cache: read ${SessionRequestTimeline.tokens(cache.cache_read_tokens)} ·
+        write ${SessionRequestTimeline.tokens(cache.cache_creation_tokens)} ·
+        <span class=${derived ? 'derived' : ''} title=${missTitle}
+          >miss ${SessionRequestTimeline.tokens(cache.cache_miss_tokens)}</span
+        >
+        ${
+          cache.usage_source && cache.usage_source !== 'provider'
+            ? html` ·
+                <span class="not-reported">tokens ${cache.usage_source}</span>`
+            : nothing
+        }
+      </div>
+    `;
+  }
+
   private renderRequest(row: RuntimeSessionRequestItem) {
     const model = row.model_alias || row.provider_name || 'request';
     const ts = row.timestamp ? new Date(row.timestamp) : null;
@@ -246,10 +376,114 @@ export class SessionRequestTimeline extends LitElement {
                 `
               : nothing
           }
+          ${this.renderCacheLine(row)}
         </div>
         <div class="request-cost">
           <div class="cost-value">${formatCost(row.estimated_cost)}</div>
         </div>
+      </div>
+    `;
+  }
+
+  /**
+   * Session-level cache rollup.
+   *
+   * Ratio and cached/uncached totals are over the covered requests only, and
+   * the coverage note says so whenever any request lacked a provider cache
+   * split. Savings are rendered only when the backend supplied an exact
+   * catalog-priced figure; otherwise the reason is shown instead of a number.
+   */
+  private renderCacheSummary() {
+    const summary = this.cacheSummary;
+    if (!summary || !summary.requests_with_cache_data) return nothing;
+    const ratio =
+      summary.cache_hit_ratio === null
+        ? null
+        : Math.round(summary.cache_hit_ratio * 1000) / 10;
+    const savingsOmittedText =
+      summary.savings_omitted_reason === 'no_catalog_cache_price'
+        ? 'no exact catalog price'
+        : summary.savings_omitted_reason === 'no_cache_reads'
+          ? 'no cache reads'
+          : 'unavailable';
+    return html`
+      <div
+        class="cache-summary"
+        data-testid="session-cache-summary"
+        role="group"
+        aria-label="Prompt cache summary"
+      >
+        <div class="cache-stat">
+          <span class="cache-stat-label">Cache hit ratio</span>
+          <span class="cache-stat-value" data-testid="cache-hit-ratio">
+            ${ratio === null ? 'not reported' : `${ratio}%`}
+          </span>
+        </div>
+        <div class="cache-stat">
+          <span class="cache-stat-label">Cached prompt</span>
+          <span class="cache-stat-value"
+            >${formatNumber(summary.cached_prompt_tokens)}</span
+          >
+        </div>
+        <div class="cache-stat">
+          <span class="cache-stat-label">Uncached prompt</span>
+          <span class="cache-stat-value"
+            >${formatNumber(summary.uncached_prompt_tokens)}</span
+          >
+        </div>
+        <div class="cache-stat">
+          <span class="cache-stat-label">Cache writes</span>
+          <span
+            class="cache-stat-value ${
+              summary.cache_write_tokens === null ? 'muted' : ''
+            }"
+            data-testid="cache-write-tokens"
+            title=${
+              summary.cache_write_tokens === null
+                ? 'No provider used in this session reports cache-write tokens'
+                : 'Prompt tokens (re)written into the provider cache'
+            }
+          >
+            ${
+              summary.cache_write_tokens === null
+                ? 'not reported'
+                : formatNumber(summary.cache_write_tokens)
+            }
+          </span>
+        </div>
+        <div class="cache-stat">
+          <span class="cache-stat-label">Est. cache savings</span>
+          <span
+            class="cache-stat-value ${
+              summary.estimated_cache_savings_usd === null ? 'muted' : ''
+            }"
+            data-testid="cache-savings"
+            title=${
+              summary.estimated_cache_savings_usd === null
+                ? 'Omitted: a savings figure is only shown when the price catalog supports it exactly'
+                : 'Input price minus cache-read price over the tokens served from cache'
+            }
+          >
+            ${
+              summary.estimated_cache_savings_usd === null
+                ? savingsOmittedText
+                : SessionRequestTimeline.savings(
+                    summary.estimated_cache_savings_usd
+                  )
+            }
+          </span>
+        </div>
+        ${
+          summary.requests_without_cache_data
+            ? html`<span class="cache-coverage" data-testid="cache-coverage">
+                Based on ${formatNumber(summary.requests_with_cache_data)} of
+                ${formatNumber(summary.requests_total)} requests;
+                ${formatNumber(summary.requests_without_cache_data)} reported no
+                cache data (${formatNumber(summary.uncovered_prompt_tokens)}
+                prompt tokens excluded, not counted as misses).
+              </span>`
+            : nothing
+        }
       </div>
     `;
   }
@@ -312,6 +546,7 @@ export class SessionRequestTimeline extends LitElement {
           requests
         </span>
       </div>
+      ${this.renderCacheSummary()}
       ${
         this.loading && !rows.length
           ? html`<div class="empty"><sl-spinner></sl-spinner></div>`

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -549,7 +549,13 @@ export interface RuntimeSessionUpdateRequest {
 }
 
 export interface RuntimeSessionActivityItem {
-  activity_type: 'model_interaction' | 'tool_call' | string;
+  activity_type:
+    | 'model_interaction'
+    | 'tool_call'
+    | 'session_started'
+    | 'session_ended'
+    | 'agent_control_message'
+    | string;
   timestamp: string;
   title: string;
   summary: string | null;
@@ -625,6 +631,16 @@ export interface RuntimeSessionRequestItem {
  * cache-write concept at all. `estimated_cache_savings_usd` is null unless the
  * price catalog supports an exact figure, with `savings_omitted_reason` set.
  */
+export interface RuntimeSessionCacheModelGroup {
+  model_alias: string | null;
+  provider_name: string | null;
+  requests: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  prompt_tokens: number;
+  write_reported: boolean;
+}
+
 export interface RuntimeSessionCacheSummary {
   requests_total: number;
   requests_with_cache_data: number;
@@ -636,8 +652,12 @@ export interface RuntimeSessionCacheSummary {
   cache_write_tokens: number | null;
   cache_hit_ratio: number | null;
   estimated_cache_savings_usd: number | null;
+  /** 'catalog_exact' | 'catalog_exact_partial' (lower bound) | null. */
   savings_basis: string | null;
   savings_omitted_reason: string | null;
+  /** Covered requests whose provider reported no prompt total at all. */
+  requests_with_unknown_prompt_tokens?: number;
+  models?: RuntimeSessionCacheModelGroup[];
 }
 
 export interface RuntimeSessionRequestListResponse {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -638,6 +638,9 @@ export interface RuntimeSessionCacheModelGroup {
   cache_read_tokens: number;
   cache_creation_tokens: number;
   prompt_tokens: number;
+  /** Rows whose provider reported no prompt total; excluded from
+   *  `prompt_tokens` rather than counted as zero. */
+  requests_with_unknown_prompt_tokens?: number;
   write_reported: boolean;
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -580,6 +580,23 @@ export interface RuntimeSessionRequestTool {
   stripped: boolean;
 }
 
+/**
+ * Prompt-cache accounting for one gateway request.
+ *
+ * `null` on any token field means the provider did NOT report that number.
+ * It must be rendered as "not reported", never as zero — a `0` here is a real
+ * provider-reported zero and carries the opposite meaning.
+ */
+export interface RuntimeSessionRequestCache {
+  cache_read_tokens: number | null;
+  cache_creation_tokens: number | null;
+  cache_miss_tokens: number | null;
+  /** 'reported' = provider sent a miss count; 'derived' = prompt - read - write. */
+  cache_miss_source: 'reported' | 'derived' | null;
+  has_cache_data: boolean;
+  usage_source: string | null;
+}
+
 export interface RuntimeSessionRequestItem {
   id: string;
   timestamp: string | null;
@@ -596,6 +613,31 @@ export interface RuntimeSessionRequestItem {
   endpoint: string | null;
   tools: RuntimeSessionRequestTool[];
   tools_total_schema_tokens: number;
+  cache?: RuntimeSessionRequestCache;
+}
+
+/**
+ * Whole-session prompt-cache rollup.
+ *
+ * The hit ratio covers only requests whose provider reported a cache split;
+ * `uncovered_prompt_tokens` is the traffic excluded from that denominator.
+ * `cache_write_tokens` is null when no provider in the session has a billable
+ * cache-write concept at all. `estimated_cache_savings_usd` is null unless the
+ * price catalog supports an exact figure, with `savings_omitted_reason` set.
+ */
+export interface RuntimeSessionCacheSummary {
+  requests_total: number;
+  requests_with_cache_data: number;
+  requests_without_cache_data: number;
+  covered_prompt_tokens: number;
+  uncovered_prompt_tokens: number;
+  cached_prompt_tokens: number;
+  uncached_prompt_tokens: number;
+  cache_write_tokens: number | null;
+  cache_hit_ratio: number | null;
+  estimated_cache_savings_usd: number | null;
+  savings_basis: string | null;
+  savings_omitted_reason: string | null;
 }
 
 export interface RuntimeSessionRequestListResponse {
@@ -606,6 +648,7 @@ export interface RuntimeSessionRequestListResponse {
   offset: number;
   next_offset: number | null;
   has_more: boolean;
+  cache_summary?: RuntimeSessionCacheSummary;
 }
 
 export interface RuntimeSessionSummaryInsight {

--- a/frontend/src/utils/session-observer.ts
+++ b/frontend/src/utils/session-observer.ts
@@ -15,7 +15,12 @@ export type SessionObserverScope =
   | 'ai_model'
   | 'audit';
 
-export type SessionReplayMode = 'timeline' | 'chat' | 'replay' | 'optimize';
+// 'conversation' is the chat-style transcript (<session-chat-view>): only
+// top-level prompts/responses expanded, everything else collapsed.
+// 'timeline' is the original turn/delta transcript, 'chat' its talk-dialog
+// variant; both keep rendering through <session-replay-panel>.
+export type SessionReplayMode =
+  'conversation' | 'timeline' | 'chat' | 'replay' | 'optimize';
 
 export interface ObservedSession {
   id: string;

--- a/frontend/src/utils/session-observer.ts
+++ b/frontend/src/utils/session-observer.ts
@@ -22,6 +22,15 @@ export type SessionObserverScope =
 export type SessionReplayMode =
   'conversation' | 'timeline' | 'chat' | 'replay' | 'optimize';
 
+/**
+ * Event dispatched by transcript views to ask <preloop-session-observer> for
+ * the next (earlier) page of gateway events. Dispatch sites use this constant;
+ * Lit template `@event=` listener bindings must stay literal, so the observer's
+ * templates repeat the string — keep them in sync with this.
+ */
+export const SESSION_EVENTS_PAGE_REQUESTED_EVENT =
+  'session-events-page-requested';
+
 export interface ObservedSession {
   id: string;
   sourceId: string | null;

--- a/frontend/src/utils/transcript.test.ts
+++ b/frontend/src/utils/transcript.test.ts
@@ -3,6 +3,7 @@ import type { FlowGatewayEvent, RuntimeSessionActivityItem } from '../types';
 import {
   buildConversation,
   collectRawToolResultPrefixes,
+  isModelGatewayEventType,
   matchInjectedSegment,
 } from './transcript';
 
@@ -116,6 +117,40 @@ describe('collectRawToolResultPrefixes', () => {
     const prefixes = collectRawToolResultPrefixes(event)!;
     expect(prefixes.has('exit code 0')).to.equal(true);
     expect(prefixes.has('ls output')).to.equal(true);
+  });
+
+  it('returns null when tool results exist but yield no matchable text', () => {
+    // Unrecognized structure: exact detection would silently misclassify
+    // every tool result as a prompt, so this must degrade to "no raw body".
+    const event = gatewayEvent('e1', '2026-08-06T10:00:00Z', [], {
+      request: {
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'tool_result', content: [{ weird: true }] }],
+          },
+        ],
+      },
+    });
+    expect(collectRawToolResultPrefixes(event)).to.equal(null);
+  });
+
+  it('returns an empty set when the raw body truly has no tool results', () => {
+    const event = gatewayEvent('e1', '2026-08-06T10:00:00Z', [], {
+      request: { messages: [{ role: 'user', content: 'plain prompt' }] },
+    });
+    const prefixes = collectRawToolResultPrefixes(event);
+    expect(prefixes).to.not.equal(null);
+    expect(prefixes!.size).to.equal(0);
+  });
+});
+
+describe('isModelGatewayEventType', () => {
+  it('prefix-matches gateway event types, not substrings', () => {
+    expect(isModelGatewayEventType('model_gateway_call')).to.equal(true);
+    expect(isModelGatewayEventType('model_gateway')).to.equal(true);
+    expect(isModelGatewayEventType('audit_model_gateway_call')).to.equal(false);
+    expect(isModelGatewayEventType('tool_call')).to.equal(false);
   });
 });
 
@@ -240,6 +275,51 @@ describe('buildConversation', () => {
     const { stats } = buildConversation(events);
     expect(stats.eventsWithoutRawBody).to.equal(1);
     expect(stats.totalEvents).to.equal(1);
+  });
+
+  it('counts raw bodies with unusable tool-result structure as unavailable', () => {
+    // Raw body present but its tool_result blocks yield no matchable text:
+    // exact detection is impossible, so the disclosure stat must include it.
+    const events = [
+      gatewayEvent(
+        'e1',
+        '2026-08-06T10:00:00Z',
+        [
+          { role: 'user', text: 'possibly a tool result' },
+          { role: 'assistant', text: 'ok', source: 'response' },
+        ],
+        {
+          request: {
+            messages: [
+              {
+                role: 'user',
+                content: [{ type: 'tool_result', content: [{ weird: 1 }] }],
+              },
+            ],
+          },
+        }
+      ),
+    ];
+    const { stats } = buildConversation(events);
+    expect(stats.eventsWithoutRawBody).to.equal(1);
+  });
+
+  it('keeps identical texts at different conversation positions distinct', () => {
+    const events = [
+      gatewayEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: 'continue' },
+        { role: 'assistant', text: 'step one done', source: 'response' },
+      ]),
+      gatewayEvent('e2', '2026-08-06T10:01:00Z', [
+        { role: 'user', text: 'continue' },
+        { role: 'assistant', text: 'step one done' },
+        { role: 'user', text: 'continue' },
+        { role: 'assistant', text: 'step two done', source: 'response' },
+      ]),
+    ];
+    const { stats } = buildConversation(events);
+    // The user saying "continue" twice is two prompts, not one.
+    expect(stats.promptCount).to.equal(2);
   });
 
   it('classifies system messages as collapsed steps', () => {

--- a/frontend/src/utils/transcript.test.ts
+++ b/frontend/src/utils/transcript.test.ts
@@ -77,7 +77,7 @@ describe('collectRawToolResultPrefixes', () => {
     const event = gatewayEvent('e1', '2026-08-06T10:00:00Z', [
       { role: 'user', text: 'hello' },
     ]);
-    expect(collectRawToolResultPrefixes(event)).to.equal(null);
+    expect(collectRawToolResultPrefixes(event).prefixes).to.equal(null);
   });
 
   it('detects Anthropic tool_result blocks inside user messages', () => {
@@ -102,7 +102,7 @@ describe('collectRawToolResultPrefixes', () => {
         },
       }
     );
-    const prefixes = collectRawToolResultPrefixes(event);
+    const { prefixes } = collectRawToolResultPrefixes(event);
     expect(prefixes).to.not.equal(null);
     expect(prefixes!.has('file contents here')).to.equal(true);
   });
@@ -114,7 +114,7 @@ describe('collectRawToolResultPrefixes', () => {
         input: [{ type: 'function_call_output', output: 'ls output' }],
       },
     });
-    const prefixes = collectRawToolResultPrefixes(event)!;
+    const prefixes = collectRawToolResultPrefixes(event).prefixes!;
     expect(prefixes.has('exit code 0')).to.equal(true);
     expect(prefixes.has('ls output')).to.equal(true);
   });
@@ -132,16 +132,44 @@ describe('collectRawToolResultPrefixes', () => {
         ],
       },
     });
-    expect(collectRawToolResultPrefixes(event)).to.equal(null);
+    const scan = collectRawToolResultPrefixes(event);
+    expect(scan.prefixes).to.equal(null);
+    expect(scan.unusableToolResults).to.equal(1);
   });
 
   it('returns an empty set when the raw body truly has no tool results', () => {
     const event = gatewayEvent('e1', '2026-08-06T10:00:00Z', [], {
       request: { messages: [{ role: 'user', content: 'plain prompt' }] },
     });
-    const prefixes = collectRawToolResultPrefixes(event);
-    expect(prefixes).to.not.equal(null);
-    expect(prefixes!.size).to.equal(0);
+    const scan = collectRawToolResultPrefixes(event);
+    expect(scan.prefixes).to.not.equal(null);
+    expect(scan.prefixes!.size).to.equal(0);
+    expect(scan.unusableToolResults).to.equal(0);
+  });
+
+  it('keeps usable prefixes and counts the unusable rest (partial)', () => {
+    // One tool result yields text, a sibling does not: exact matching must
+    // still work for the extractable one, while the other is disclosed.
+    const event = gatewayEvent('e1', '2026-08-06T10:00:00Z', [], {
+      request: {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                content: [{ type: 'text', text: 'good output' }],
+              },
+              { type: 'tool_result', content: [{ weird: true }] },
+            ],
+          },
+        ],
+      },
+    });
+    const scan = collectRawToolResultPrefixes(event);
+    expect(scan.prefixes).to.not.equal(null);
+    expect(scan.prefixes!.has('good output')).to.equal(true);
+    expect(scan.unusableToolResults).to.equal(1);
   });
 });
 
@@ -302,6 +330,44 @@ describe('buildConversation', () => {
     ];
     const { stats } = buildConversation(events);
     expect(stats.eventsWithoutRawBody).to.equal(1);
+  });
+
+  it('discloses partial tool-result extraction separately', () => {
+    // The raw body yields one usable prefix but a second tool result has no
+    // extractable text: the event still gets exact matching for the usable
+    // one, and the partial-coverage stat discloses the other.
+    const events = [
+      gatewayEvent(
+        'e1',
+        '2026-08-06T10:00:00Z',
+        [
+          { role: 'user', text: 'good output' },
+          { role: 'user', text: 'mystery text' },
+          { role: 'assistant', text: 'ok', source: 'response' },
+        ],
+        {
+          request: {
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'tool_result',
+                    content: [{ type: 'text', text: 'good output' }],
+                  },
+                  { type: 'tool_result', content: [{ weird: 1 }] },
+                ],
+              },
+            ],
+          },
+        }
+      ),
+    ];
+    const { stats } = buildConversation(events);
+    expect(stats.eventsWithoutRawBody).to.equal(0);
+    expect(stats.eventsWithPartialToolResults).to.equal(1);
+    // The extractable tool result was still exactly matched.
+    expect(stats.toolResultCount).to.equal(1);
   });
 
   it('keeps identical texts at different conversation positions distinct', () => {

--- a/frontend/src/utils/transcript.test.ts
+++ b/frontend/src/utils/transcript.test.ts
@@ -1,0 +1,363 @@
+import { expect } from '@open-wc/testing';
+import type { FlowGatewayEvent, RuntimeSessionActivityItem } from '../types';
+import {
+  buildConversation,
+  collectRawToolResultPrefixes,
+  matchInjectedSegment,
+} from './transcript';
+
+function gatewayEvent(
+  id: string,
+  timestamp: string,
+  messages: Array<{
+    role: string;
+    text: string;
+    source?: string;
+    redacted?: boolean;
+    truncated?: boolean;
+  }>,
+  overrides: Record<string, unknown> = {}
+): FlowGatewayEvent {
+  return {
+    id,
+    execution_id: 'exec-1',
+    timestamp,
+    type: 'model_gateway_call',
+    payload: {
+      outcome: 'success',
+      conversation_preview: {
+        messages: messages.map((message) => ({
+          source: message.source || 'request',
+          role: message.role,
+          text: message.text,
+          redacted: Boolean(message.redacted),
+          truncated: Boolean(message.truncated),
+        })),
+      },
+      ...overrides,
+    },
+  } as FlowGatewayEvent;
+}
+
+describe('matchInjectedSegment', () => {
+  it('matches known harness injection conventions', () => {
+    expect(
+      matchInjectedSegment('[Preloop] Question for the human operator:')?.id
+    ).to.equal('preloop_notice');
+    expect(
+      matchInjectedSegment('before <system-reminder>x</system-reminder>')?.id
+    ).to.equal('system_reminder');
+    expect(
+      matchInjectedSegment('Caveat: The messages below were generated')?.id
+    ).to.equal('caveat');
+    expect(
+      matchInjectedSegment('<command-name>/clear</command-name>')?.id
+    ).to.equal('local_command');
+    expect(
+      matchInjectedSegment(
+        'This session is being continued from a previous conversation.'
+      )?.id
+    ).to.equal('compaction');
+    expect(matchInjectedSegment('[Request interrupted by user]')?.id).to.equal(
+      'interrupted'
+    );
+  });
+
+  it('never matches ordinary prompts (when in doubt, keep the prompt)', () => {
+    expect(matchInjectedSegment('Fix the login bug please')).to.equal(null);
+    expect(matchInjectedSegment('The caveat here is we need tests')).to.equal(
+      null
+    );
+  });
+});
+
+describe('collectRawToolResultPrefixes', () => {
+  it('returns null without a captured raw body (honest degradation)', () => {
+    const event = gatewayEvent('e1', '2026-08-06T10:00:00Z', [
+      { role: 'user', text: 'hello' },
+    ]);
+    expect(collectRawToolResultPrefixes(event)).to.equal(null);
+  });
+
+  it('detects Anthropic tool_result blocks inside user messages', () => {
+    const event = gatewayEvent(
+      'e1',
+      '2026-08-06T10:00:00Z',
+      [{ role: 'user', text: 'file contents here' }],
+      {
+        request: {
+          messages: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'tool_result',
+                  tool_use_id: 't1',
+                  content: [{ type: 'text', text: 'file contents here' }],
+                },
+              ],
+            },
+          ],
+        },
+      }
+    );
+    const prefixes = collectRawToolResultPrefixes(event);
+    expect(prefixes).to.not.equal(null);
+    expect(prefixes!.has('file contents here')).to.equal(true);
+  });
+
+  it('detects OpenAI tool-role messages and Responses function_call_output', () => {
+    const event = gatewayEvent('e1', '2026-08-06T10:00:00Z', [], {
+      request: {
+        messages: [{ role: 'tool', content: 'exit code 0' }],
+        input: [{ type: 'function_call_output', output: 'ls output' }],
+      },
+    });
+    const prefixes = collectRawToolResultPrefixes(event)!;
+    expect(prefixes.has('exit code 0')).to.equal(true);
+    expect(prefixes.has('ls output')).to.equal(true);
+  });
+});
+
+describe('buildConversation', () => {
+  it('expands prompts and final responses; collapses tool results exactly', () => {
+    const events = [
+      gatewayEvent(
+        'e1',
+        '2026-08-06T10:00:00Z',
+        [
+          { role: 'user', text: 'Fix the login bug' },
+          { role: 'assistant', text: 'Reading auth.ts', source: 'response' },
+        ],
+        {}
+      ),
+      gatewayEvent(
+        'e2',
+        '2026-08-06T10:01:00Z',
+        [
+          { role: 'user', text: 'Fix the login bug' },
+          { role: 'user', text: 'contents of auth.ts: export const x = 1' },
+          {
+            role: 'assistant',
+            text: 'Fixed it in auth.ts',
+            source: 'response',
+          },
+        ],
+        {
+          request: {
+            messages: [
+              { role: 'user', content: 'Fix the login bug' },
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'tool_result',
+                    content: 'contents of auth.ts: export const x = 1',
+                  },
+                ],
+              },
+            ],
+          },
+        }
+      ),
+    ];
+
+    const { items, stats } = buildConversation(events);
+    const messages = items.filter((item) => item.type === 'message');
+    expect(messages).to.have.length(2);
+    expect(messages[0]).to.include({ kind: 'user_prompt' });
+    expect(messages[1]).to.include({
+      kind: 'agent_response',
+      text: 'Fixed it in auth.ts',
+    });
+
+    // The tool result (Anthropic user-role shape) and the intermediate
+    // response are collapsed steps between prompt and final response.
+    const stepGroups = items.filter((item) => item.type === 'steps');
+    expect(stepGroups).to.have.length(1);
+    const kinds = (
+      stepGroups[0] as { steps: Array<{ kind: string }> }
+    ).steps.map((step) => step.kind);
+    expect(kinds).to.include('tool_result');
+    expect(kinds).to.include('intermediate');
+    expect(stats.promptCount).to.equal(1);
+    expect(stats.responseCount).to.equal(1);
+    expect(stats.toolResultCount).to.equal(1);
+  });
+
+  it('deduplicates the growing prefix across requests', () => {
+    const events = [
+      gatewayEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: 'prompt one' },
+        { role: 'assistant', text: 'answer one', source: 'response' },
+      ]),
+      gatewayEvent('e2', '2026-08-06T10:02:00Z', [
+        { role: 'user', text: 'prompt one' },
+        { role: 'assistant', text: 'answer one' },
+        { role: 'user', text: 'prompt two' },
+        { role: 'assistant', text: 'answer two', source: 'response' },
+      ]),
+    ];
+    const { items, stats } = buildConversation(events);
+    const prompts = items.filter(
+      (item) => item.type === 'message' && item.kind === 'user_prompt'
+    );
+    expect(prompts).to.have.length(2);
+    expect(stats.promptCount).to.equal(2);
+    // "answer one" replayed as request history collapses to a step, and the
+    // final response of each exchange stays expanded.
+    const responses = items.filter(
+      (item) => item.type === 'message' && item.kind === 'agent_response'
+    );
+    expect(responses).to.have.length(2);
+  });
+
+  it('collapses injected segments and counts them', () => {
+    const events = [
+      gatewayEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: '<system-reminder>plan mode</system-reminder>' },
+        { role: 'user', text: 'Real prompt' },
+        { role: 'user', text: '[Preloop] Question for the human operator:' },
+        { role: 'assistant', text: 'ok', source: 'response' },
+      ]),
+    ];
+    const { items, stats } = buildConversation(events);
+    expect(stats.injectedCount).to.equal(2);
+    const prompts = items.filter(
+      (item) => item.type === 'message' && item.kind === 'user_prompt'
+    );
+    expect(prompts).to.have.length(1);
+    expect((prompts[0] as { text: string }).text).to.equal('Real prompt');
+  });
+
+  it('reports missing raw bodies instead of guessing', () => {
+    const events = [
+      gatewayEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: 'could be a prompt or a tool result' },
+        { role: 'assistant', text: 'ok', source: 'response' },
+      ]),
+    ];
+    const { stats } = buildConversation(events);
+    expect(stats.eventsWithoutRawBody).to.equal(1);
+    expect(stats.totalEvents).to.equal(1);
+  });
+
+  it('classifies system messages as collapsed steps', () => {
+    const events = [
+      gatewayEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'system', text: 'You are a helpful agent' },
+        { role: 'user', text: 'hi' },
+        { role: 'assistant', text: 'hello', source: 'response' },
+      ]),
+    ];
+    const { items } = buildConversation(events);
+    const stepGroups = items.filter((item) => item.type === 'steps');
+    expect(stepGroups).to.have.length(1);
+    expect(
+      (stepGroups[0] as { steps: Array<{ kind: string }> }).steps[0].kind
+    ).to.equal('system');
+  });
+
+  it('interleaves tool_call activity, operator messages and lifecycle dividers', () => {
+    const events = [
+      gatewayEvent('e1', '2026-08-06T10:01:00Z', [
+        { role: 'user', text: 'run the tests' },
+        { role: 'assistant', text: 'done', source: 'response' },
+      ]),
+    ];
+    const activity: RuntimeSessionActivityItem[] = [
+      {
+        activity_type: 'session_started',
+        timestamp: '2026-08-06T10:00:00Z',
+        title: 'Session started',
+        summary: null,
+        status: null,
+        api_usage_id: null,
+        tool_name: null,
+        server_name: null,
+        auth_subject_type: null,
+        api_key_id: null,
+        api_key_name: null,
+        estimated_cost: null,
+        total_tokens: null,
+      },
+      {
+        activity_type: 'tool_call',
+        timestamp: '2026-08-06T10:01:30Z',
+        title: 'Tool call',
+        summary: 'pytest -q',
+        status: 'completed',
+        api_usage_id: null,
+        tool_name: 'run_tests',
+        server_name: 'ci',
+        auth_subject_type: null,
+        api_key_id: null,
+        api_key_name: null,
+        estimated_cost: null,
+        total_tokens: null,
+      },
+      {
+        activity_type: 'agent_control_message',
+        timestamp: '2026-08-06T10:02:00Z',
+        title: 'Operator message',
+        summary: 'please also run lint',
+        status: 'delivered',
+        api_usage_id: null,
+        tool_name: null,
+        server_name: null,
+        auth_subject_type: null,
+        api_key_id: null,
+        api_key_name: null,
+        estimated_cost: null,
+        total_tokens: null,
+      },
+    ];
+    const { items, stats } = buildConversation(events, activity);
+    expect(items[0]).to.include({ type: 'divider', label: 'Session started' });
+    expect(stats.toolCallCount).to.equal(1);
+    const operator = items.find(
+      (item) => item.type === 'message' && item.kind === 'operator'
+    );
+    expect(operator).to.not.equal(undefined);
+    expect((operator as { text: string }).text).to.equal(
+      'please also run lint'
+    );
+  });
+
+  it('keeps redacted messages visible with their redaction flag', () => {
+    const events = [
+      gatewayEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: '', redacted: true },
+        { role: 'assistant', text: '', source: 'response', redacted: true },
+      ]),
+    ];
+    const { items } = buildConversation(events);
+    const messages = items.filter((item) => item.type === 'message');
+    expect(messages.length).to.be.greaterThan(0);
+    expect((messages[0] as { redacted?: boolean }).redacted).to.equal(true);
+  });
+
+  it('accepts events in newest-first order (observer storage order)', () => {
+    const events = [
+      gatewayEvent('e2', '2026-08-06T10:05:00Z', [
+        { role: 'user', text: 'first prompt' },
+        { role: 'user', text: 'second prompt' },
+        { role: 'assistant', text: 'second answer', source: 'response' },
+      ]),
+      gatewayEvent('e1', '2026-08-06T10:00:00Z', [
+        { role: 'user', text: 'first prompt' },
+        { role: 'assistant', text: 'first answer', source: 'response' },
+      ]),
+    ];
+    const { items } = buildConversation(events);
+    const messageTexts = items
+      .filter((item) => item.type === 'message')
+      .map((item) => (item as { text: string }).text);
+    expect(messageTexts).to.deep.equal([
+      'first prompt',
+      'first answer',
+      'second prompt',
+      'second answer',
+    ]);
+  });
+});

--- a/frontend/src/utils/transcript.ts
+++ b/frontend/src/utils/transcript.ts
@@ -89,6 +89,10 @@ export interface TranscriptStats {
    *  tool-result detection. When > 0 the UI must disclose that some
    *  user-role bubbles may actually be tool results. */
   eventsWithoutRawBody: number;
+  /** Gateway events whose raw body WAS captured but where one or more
+   *  tool-result items yielded no matchable text — exact detection is only
+   *  partial there, so those results may still render as user prompts. */
+  eventsWithPartialToolResults: number;
   totalEvents: number;
 }
 
@@ -201,31 +205,47 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+/** Result of scanning a raw request body for exact tool-result texts. */
+export interface RawToolResultScan {
+  /** Normalized match prefixes, or null when exact detection is IMPOSSIBLE
+   *  (no raw message array captured, or tool-result-shaped items present but
+   *  NONE yielded usable text). An EMPTY set is a positive claim: the raw
+   *  body was parsed and contains no tool results at all. */
+  prefixes: Set<string> | null;
+  /** Tool-result-shaped items that yielded no matchable text. When
+   *  `prefixes` is non-null and this is > 0, exact detection is PARTIAL for
+   *  the event: the unextractable results cannot be matched and may be
+   *  misclassified, so the UI must disclose the uncertainty. */
+  unusableToolResults: number;
+}
+
 /**
  * Exact tool-result texts from the raw request body, as normalized match
  * prefixes. Detects OpenAI `role: "tool"` messages, Anthropic user messages
  * whose content array carries `type: "tool_result"` blocks, and Responses
  * API `function_call_output` items.
  *
- * Returns null when exact detection is IMPOSSIBLE, so callers can degrade
- * honestly: either no raw message array was captured (capture off, older
- * rows), or tool-result-shaped items were present but none yielded usable
- * text (unrecognized structure). An EMPTY set is a positive claim: the raw
- * body was parsed and contains no tool results at all.
+ * `prefixes` is null when exact detection is IMPOSSIBLE, so callers can
+ * degrade honestly: either no raw message array was captured (capture off,
+ * older rows), or tool-result-shaped items were present but none yielded
+ * usable text (unrecognized structure). When only SOME items yielded text,
+ * the set is returned (exact matching still helps for those) and
+ * `unusableToolResults` counts the rest so callers can disclose the gap.
  */
 export function collectRawToolResultPrefixes(
   event: FlowGatewayEvent
-): Set<string> | null {
+): RawToolResultScan {
   const request = isRecord(event.payload?.request)
     ? (event.payload!.request as Record<string, unknown>)
     : null;
-  if (!request) return null;
+  if (!request) return { prefixes: null, unusableToolResults: 0 };
   const arrays: Array<readonly unknown[]> = [];
   if (Array.isArray(request.messages)) arrays.push(request.messages);
   if (Array.isArray(request.input)) arrays.push(request.input);
-  if (!arrays.length) return null;
+  if (!arrays.length) return { prefixes: null, unusableToolResults: 0 };
 
   const prefixes = new Set<string>();
+  let unusableToolResults = 0;
   let sawToolResultShape = false;
   for (const rawMessages of arrays) {
     for (const raw of rawMessages) {
@@ -236,6 +256,7 @@ export function collectRawToolResultPrefixes(
         sawToolResultShape = true;
         const text = contentToText(raw.content ?? raw.output ?? raw);
         if (text.trim()) prefixes.add(normalizeForMatch(text));
+        else unusableToolResults += 1;
         continue;
       }
       const content = raw.content;
@@ -246,6 +267,7 @@ export function collectRawToolResultPrefixes(
           sawToolResultShape = true;
           const text = contentToText(block.content ?? block);
           if (text.trim()) prefixes.add(normalizeForMatch(text));
+          else unusableToolResults += 1;
         }
       }
     }
@@ -254,8 +276,10 @@ export function collectRawToolResultPrefixes(
   // detection would silently misclassify every one of them as a prompt, so
   // report "no usable raw body" instead and let the heuristics (and the
   // stats disclosure) take over.
-  if (sawToolResultShape && !prefixes.size) return null;
-  return prefixes;
+  if (sawToolResultShape && !prefixes.size) {
+    return { prefixes: null, unusableToolResults };
+  }
+  return { prefixes, unusableToolResults };
 }
 
 function previewMessages(
@@ -306,6 +330,7 @@ export function buildConversation(
     injectedCount: 0,
     toolCallCount: 0,
     eventsWithoutRawBody: 0,
+    eventsWithPartialToolResults: 0,
     totalEvents: 0,
   };
 
@@ -326,8 +351,12 @@ export function buildConversation(
   const seenSignatures = new Set<string>();
 
   for (const event of gatewayEvents) {
-    const toolResultPrefixes = collectRawToolResultPrefixes(event);
+    const scan = collectRawToolResultPrefixes(event);
+    const toolResultPrefixes = scan.prefixes;
     if (toolResultPrefixes === null) stats.eventsWithoutRawBody += 1;
+    else if (scan.unusableToolResults > 0) {
+      stats.eventsWithPartialToolResults += 1;
+    }
     const failed = eventIsFailure(event);
 
     previewMessages(event).forEach((message, messageIndex) => {

--- a/frontend/src/utils/transcript.ts
+++ b/frontend/src/utils/transcript.ts
@@ -1,0 +1,572 @@
+/**
+ * Conversation reconstruction for the chat-style session transcript.
+ *
+ * Pure functions only: no Lit, no fetch. The builder turns stored gateway
+ * events (each carrying the full accumulated message history as a
+ * conversation preview, plus the capped raw request body) and activity rows
+ * into a chat-shaped item list where ONLY top-level user prompts and final
+ * agent responses are expanded; tool calls, tool results, system/injected
+ * segments and intermediate agent output are collapsed step groups.
+ *
+ * Classification honesty rules (binding, see
+ * factory/briefs/2026-08-06-transcript-redesign-spec.md section 2):
+ * - Anthropic-style tool results arrive as role "user". They are detected
+ *   EXACTLY from the raw request body's content-block structure
+ *   (`type: "tool_result"` / role "tool" / Responses `function_call_output`)
+ *   when that body was captured, and only heuristically (role substring)
+ *   otherwise. Events without a usable raw body are counted in
+ *   `stats.eventsWithoutRawBody` so the UI can say so instead of guessing.
+ * - Injected pseudo-user segments (system reminders, [Preloop] question
+ *   notices, local-command wrappers, compaction summaries) are matched by a
+ *   deliberately conservative pattern list. When in doubt a user-role
+ *   message STAYS a visible prompt: hiding a real prompt is worse than
+ *   showing a misclassified reminder.
+ */
+
+import type {
+  FlowGatewayConversationPreviewMessage,
+  FlowGatewayEvent,
+  RuntimeSessionActivityItem,
+} from '../types';
+
+export type TranscriptStepKind =
+  'tool_call' | 'tool_result' | 'system' | 'injected' | 'intermediate';
+
+export interface TranscriptStep {
+  key: string;
+  kind: TranscriptStepKind;
+  label: string;
+  text: string;
+  timestamp: string | null;
+  /** Which injection pattern matched (kind === 'injected' only). */
+  injectedPatternId?: string;
+  redacted?: boolean;
+  truncated?: boolean;
+  toolName?: string | null;
+  serverName?: string | null;
+  status?: string | null;
+  /** True when the classification came from exact structure, not a heuristic. */
+  detectionExact: boolean;
+}
+
+export interface TranscriptMessageItem {
+  type: 'message';
+  key: string;
+  kind: 'user_prompt' | 'agent_response' | 'operator';
+  role: string;
+  text: string;
+  timestamp: string | null;
+  event: FlowGatewayEvent | null;
+  redacted?: boolean;
+  truncated?: boolean;
+  failed?: boolean;
+}
+
+export interface TranscriptStepGroupItem {
+  type: 'steps';
+  key: string;
+  steps: TranscriptStep[];
+}
+
+export interface TranscriptDividerItem {
+  type: 'divider';
+  key: string;
+  label: string;
+  timestamp: string | null;
+}
+
+export type TranscriptItem =
+  TranscriptMessageItem | TranscriptStepGroupItem | TranscriptDividerItem;
+
+export interface TranscriptStats {
+  promptCount: number;
+  responseCount: number;
+  stepCount: number;
+  toolResultCount: number;
+  injectedCount: number;
+  toolCallCount: number;
+  /** Gateway events whose raw request body was unavailable for exact
+   *  tool-result detection. When > 0 the UI must disclose that some
+   *  user-role bubbles may actually be tool results. */
+  eventsWithoutRawBody: number;
+  totalEvents: number;
+}
+
+export interface TranscriptBuildResult {
+  items: TranscriptItem[];
+  stats: TranscriptStats;
+}
+
+/**
+ * Conservative harness-injection pattern list. Every entry is a known,
+ * verifiable convention; anything not matched stays a visible prompt.
+ */
+export const INJECTED_SEGMENT_PATTERNS: Array<{
+  id: string;
+  label: string;
+  test: (text: string) => boolean;
+}> = [
+  {
+    // Preloop's own in-session question/approval notice
+    // (backend services/ask_user_inband.py format_question_notice).
+    id: 'preloop_notice',
+    label: 'Preloop question notice',
+    test: (text) => text.startsWith('[Preloop]'),
+  },
+  {
+    id: 'system_reminder',
+    label: 'System reminder',
+    test: (text) => text.includes('<system-reminder>'),
+  },
+  {
+    id: 'caveat',
+    label: 'Harness caveat',
+    test: (text) => text.startsWith('Caveat: The messages below'),
+  },
+  {
+    id: 'local_command',
+    label: 'Local command',
+    test: (text) =>
+      text.includes('<command-name>') ||
+      text.includes('<local-command-stdout>'),
+  },
+  {
+    id: 'compaction',
+    label: 'Compaction summary',
+    test: (text) =>
+      text.startsWith(
+        'This session is being continued from a previous conversation'
+      ),
+  },
+  {
+    id: 'interrupted',
+    label: 'Interrupt marker',
+    test: (text) => text.startsWith('[Request interrupted'),
+  },
+];
+
+/** First-match injected pattern for a user-role text, or null. */
+export function matchInjectedSegment(
+  text: string
+): { id: string; label: string } | null {
+  const trimmed = text.trimStart();
+  for (const pattern of INJECTED_SEGMENT_PATTERNS) {
+    if (pattern.test(trimmed)) return { id: pattern.id, label: pattern.label };
+  }
+  return null;
+}
+
+// Prefix length used to match preview text against raw-body tool-result
+// text. The two are capped at different lengths server-side (preview
+// 32768/message, activity body strings 8192), so equality can only be
+// asserted on a common prefix.
+const TOOL_RESULT_MATCH_PREFIX = 400;
+
+function normalizeForMatch(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().slice(0, TOOL_RESULT_MATCH_PREFIX);
+}
+
+/** Mirror of the backend's _content_to_preview_text flattening. */
+function contentToText(content: unknown): string {
+  if (content === null || content === undefined) return '';
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((item) => contentToText(item))
+      .filter(Boolean)
+      .join('\n');
+  }
+  if (typeof content === 'object') {
+    const record = content as Record<string, unknown>;
+    if (typeof record.text === 'string') return record.text;
+    if (record.content !== undefined) return contentToText(record.content);
+    if (typeof record.output === 'string') return record.output;
+    return '';
+  }
+  return String(content);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Exact tool-result texts from the raw request body, as normalized match
+ * prefixes. Detects OpenAI `role: "tool"` messages, Anthropic user messages
+ * whose content array carries `type: "tool_result"` blocks, and Responses
+ * API `function_call_output` items. Returns null when no raw message array
+ * was captured (capture off, older rows) so callers can degrade honestly.
+ */
+export function collectRawToolResultPrefixes(
+  event: FlowGatewayEvent
+): Set<string> | null {
+  const request = isRecord(event.payload?.request)
+    ? (event.payload!.request as Record<string, unknown>)
+    : null;
+  if (!request) return null;
+  const arrays: Array<readonly unknown[]> = [];
+  if (Array.isArray(request.messages)) arrays.push(request.messages);
+  if (Array.isArray(request.input)) arrays.push(request.input);
+  if (!arrays.length) return null;
+
+  const prefixes = new Set<string>();
+  for (const rawMessages of arrays) {
+    for (const raw of rawMessages) {
+      if (!isRecord(raw)) continue;
+      const role = String(raw.role || '').toLowerCase();
+      const itemType = String(raw.type || '').toLowerCase();
+      if (role === 'tool' || itemType === 'function_call_output') {
+        const text = contentToText(raw.content ?? raw.output ?? raw);
+        if (text.trim()) prefixes.add(normalizeForMatch(text));
+        continue;
+      }
+      const content = raw.content;
+      if (!Array.isArray(content)) continue;
+      for (const block of content) {
+        if (!isRecord(block)) continue;
+        if (String(block.type || '').toLowerCase() === 'tool_result') {
+          const text = contentToText(block.content ?? block);
+          if (text.trim()) prefixes.add(normalizeForMatch(text));
+        }
+      }
+    }
+  }
+  return prefixes;
+}
+
+function previewMessages(
+  event: FlowGatewayEvent
+): FlowGatewayConversationPreviewMessage[] {
+  const messages = event.payload?.conversation_preview?.messages;
+  return Array.isArray(messages) ? messages : [];
+}
+
+function eventIsFailure(event: FlowGatewayEvent): boolean {
+  const outcome = String(event.payload?.outcome || '').toLowerCase();
+  if (outcome === 'error' || outcome === 'budget_denied') return true;
+  const statusCode = Number(event.payload?.status_code || 0);
+  return statusCode >= 400;
+}
+
+// Internal chronological atom before grouping.
+type Atom =
+  | { type: 'message'; item: TranscriptMessageItem; order: number }
+  | { type: 'step'; step: TranscriptStep; order: number }
+  | { type: 'divider'; item: TranscriptDividerItem; order: number };
+
+function atomTime(atom: Atom): number {
+  const timestamp =
+    atom.type === 'message'
+      ? atom.item.timestamp
+      : atom.type === 'step'
+        ? atom.step.timestamp
+        : atom.item.timestamp;
+  const parsed = new Date(timestamp || 0).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+/**
+ * Build the chat-shaped transcript. `events` may arrive in any order (the
+ * observer stores them newest-first); `activity` rows supply tool calls,
+ * operator messages and lifecycle markers.
+ */
+export function buildConversation(
+  events: FlowGatewayEvent[],
+  activity: RuntimeSessionActivityItem[] = []
+): TranscriptBuildResult {
+  const stats: TranscriptStats = {
+    promptCount: 0,
+    responseCount: 0,
+    stepCount: 0,
+    toolResultCount: 0,
+    injectedCount: 0,
+    toolCallCount: 0,
+    eventsWithoutRawBody: 0,
+    totalEvents: 0,
+  };
+
+  const gatewayEvents = events
+    .filter(
+      (event) =>
+        event.type.includes('model_gateway') || previewMessages(event).length
+    )
+    .sort(
+      (left, right) =>
+        new Date(left.timestamp || 0).getTime() -
+        new Date(right.timestamp || 0).getTime()
+    );
+  stats.totalEvents = gatewayEvents.length;
+
+  const atoms: Atom[] = [];
+  let order = 0;
+  const seenSignatures = new Set<string>();
+
+  for (const event of gatewayEvents) {
+    const toolResultPrefixes = collectRawToolResultPrefixes(event);
+    if (toolResultPrefixes === null) stats.eventsWithoutRawBody += 1;
+    const failed = eventIsFailure(event);
+
+    previewMessages(event).forEach((message, messageIndex) => {
+      const text = (message.text || '').trim();
+      if (!text && !message.redacted) return;
+      const role = (message.role || 'message').toLowerCase();
+      const source = (message.source || 'request').toLowerCase();
+      const signature = `${role}::${text}`;
+      // Growing-prefix delta: render a message only the first time it
+      // appears across the session's accumulated request histories.
+      if (text && seenSignatures.has(signature)) return;
+      if (text) seenSignatures.add(signature);
+
+      const key = `${event.id}:m:${messageIndex}`;
+      const base = {
+        key,
+        text,
+        timestamp: event.timestamp || null,
+        redacted: Boolean(message.redacted),
+        truncated: Boolean(message.truncated),
+      };
+
+      if (source === 'response') {
+        // Provisional agent response; the grouping pass demotes all but the
+        // final response of each exchange to an 'intermediate' step.
+        atoms.push({
+          type: 'message',
+          order: order++,
+          item: {
+            type: 'message',
+            kind: 'agent_response',
+            role: message.role || 'assistant',
+            event,
+            failed,
+            ...base,
+          },
+        });
+        return;
+      }
+
+      if (role === 'system') {
+        atoms.push({
+          type: 'step',
+          order: order++,
+          step: {
+            kind: 'system',
+            label: 'System prompt',
+            detectionExact: true,
+            ...base,
+          },
+        });
+        return;
+      }
+
+      if (role.includes('tool') || role.includes('function')) {
+        stats.toolResultCount += 1;
+        atoms.push({
+          type: 'step',
+          order: order++,
+          step: {
+            kind: 'tool_result',
+            label: 'Tool result',
+            detectionExact: true,
+            ...base,
+          },
+        });
+        return;
+      }
+
+      if (role === 'assistant' || role.includes('agent')) {
+        // Assistant text replayed inside a request body is conversation
+        // history, not a new response: collapse it.
+        atoms.push({
+          type: 'step',
+          order: order++,
+          step: {
+            kind: 'intermediate',
+            label: 'Assistant (history)',
+            detectionExact: true,
+            ...base,
+          },
+        });
+        return;
+      }
+
+      // User-role request message: exact tool-result check first.
+      if (
+        text &&
+        toolResultPrefixes !== null &&
+        toolResultPrefixes.has(normalizeForMatch(text))
+      ) {
+        stats.toolResultCount += 1;
+        atoms.push({
+          type: 'step',
+          order: order++,
+          step: {
+            kind: 'tool_result',
+            label: 'Tool result',
+            detectionExact: true,
+            ...base,
+          },
+        });
+        return;
+      }
+
+      const injected = text ? matchInjectedSegment(text) : null;
+      if (injected) {
+        stats.injectedCount += 1;
+        atoms.push({
+          type: 'step',
+          order: order++,
+          step: {
+            kind: 'injected',
+            label: injected.label,
+            injectedPatternId: injected.id,
+            detectionExact: false,
+            ...base,
+          },
+        });
+        return;
+      }
+
+      atoms.push({
+        type: 'message',
+        order: order++,
+        item: {
+          type: 'message',
+          kind: 'user_prompt',
+          role: message.role || 'user',
+          event,
+          ...base,
+        },
+      });
+    });
+  }
+
+  for (const [index, item] of activity.entries()) {
+    const activityType = (item.activity_type || '').toLowerCase();
+    const key = `activity:${index}:${item.timestamp || ''}`;
+    if (activityType === 'tool_call') {
+      stats.toolCallCount += 1;
+      atoms.push({
+        type: 'step',
+        order: order++,
+        step: {
+          key,
+          kind: 'tool_call',
+          label: item.tool_name || item.title || 'Tool call',
+          text: item.summary || '',
+          timestamp: item.timestamp || null,
+          toolName: item.tool_name,
+          serverName: item.server_name,
+          status: item.status,
+          detectionExact: true,
+        },
+      });
+      continue;
+    }
+    if (activityType === 'agent_control_message') {
+      const metadata = (item.metadata || {}) as Record<string, unknown>;
+      const role =
+        typeof metadata.role === 'string' && metadata.role.trim()
+          ? metadata.role
+          : 'operator';
+      atoms.push({
+        type: 'message',
+        order: order++,
+        item: {
+          type: 'message',
+          key,
+          kind: 'operator',
+          role,
+          text: item.summary || item.title || '',
+          timestamp: item.timestamp || null,
+          event: null,
+        },
+      });
+      continue;
+    }
+    if (
+      activityType === 'session_started' ||
+      activityType === 'session_ended'
+    ) {
+      atoms.push({
+        type: 'divider',
+        order: order++,
+        item: {
+          type: 'divider',
+          key,
+          label:
+            activityType === 'session_started'
+              ? 'Session started'
+              : 'Session ended',
+          timestamp: item.timestamp || null,
+        },
+      });
+    }
+  }
+
+  atoms.sort((left, right) => {
+    const delta = atomTime(left) - atomTime(right);
+    return delta !== 0 ? delta : left.order - right.order;
+  });
+
+  // Demote every agent response except the LAST one of each exchange (the
+  // stretch between consecutive user prompts) to a collapsed step.
+  const responseIndexes: number[] = [];
+  const finalResponses = new Set<number>();
+  const flush = () => {
+    const last = responseIndexes[responseIndexes.length - 1];
+    if (last !== undefined) finalResponses.add(last);
+    responseIndexes.length = 0;
+  };
+  atoms.forEach((atom, index) => {
+    if (atom.type === 'message' && atom.item.kind === 'user_prompt') flush();
+    if (atom.type === 'message' && atom.item.kind === 'agent_response') {
+      responseIndexes.push(index);
+    }
+  });
+  flush();
+
+  const items: TranscriptItem[] = [];
+  let currentSteps: TranscriptStep[] = [];
+  const closeSteps = () => {
+    if (!currentSteps.length) return;
+    items.push({
+      type: 'steps',
+      key: `steps:${currentSteps[0].key}`,
+      steps: currentSteps,
+    });
+    stats.stepCount += currentSteps.length;
+    currentSteps = [];
+  };
+
+  atoms.forEach((atom, index) => {
+    if (atom.type === 'step') {
+      currentSteps.push(atom.step);
+      return;
+    }
+    if (atom.type === 'divider') {
+      closeSteps();
+      items.push(atom.item);
+      return;
+    }
+    if (atom.item.kind === 'agent_response' && !finalResponses.has(index)) {
+      currentSteps.push({
+        key: atom.item.key,
+        kind: 'intermediate',
+        label: 'Agent (working)',
+        text: atom.item.text,
+        timestamp: atom.item.timestamp,
+        redacted: atom.item.redacted,
+        truncated: atom.item.truncated,
+        detectionExact: true,
+      });
+      return;
+    }
+    closeSteps();
+    if (atom.item.kind === 'user_prompt') stats.promptCount += 1;
+    if (atom.item.kind === 'agent_response') stats.responseCount += 1;
+    items.push(atom.item);
+  });
+  closeSteps();
+
+  return { items, stats };
+}

--- a/frontend/src/utils/transcript.ts
+++ b/frontend/src/utils/transcript.ts
@@ -145,6 +145,17 @@ export const INJECTED_SEGMENT_PATTERNS: Array<{
   },
 ];
 
+/**
+ * Exact-prefix gateway event-type check. The backend emits
+ * `model_gateway_call` (services/model_gateway_events.py); prefix (not
+ * substring) matching keeps hypothetical namespaced variants like
+ * `model_gateway_call_v2` while excluding unrelated types that merely
+ * contain the words somewhere inside.
+ */
+export function isModelGatewayEventType(type: string): boolean {
+  return type.startsWith('model_gateway');
+}
+
 /** First-match injected pattern for a user-role text, or null. */
 export function matchInjectedSegment(
   text: string
@@ -194,8 +205,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * Exact tool-result texts from the raw request body, as normalized match
  * prefixes. Detects OpenAI `role: "tool"` messages, Anthropic user messages
  * whose content array carries `type: "tool_result"` blocks, and Responses
- * API `function_call_output` items. Returns null when no raw message array
- * was captured (capture off, older rows) so callers can degrade honestly.
+ * API `function_call_output` items.
+ *
+ * Returns null when exact detection is IMPOSSIBLE, so callers can degrade
+ * honestly: either no raw message array was captured (capture off, older
+ * rows), or tool-result-shaped items were present but none yielded usable
+ * text (unrecognized structure). An EMPTY set is a positive claim: the raw
+ * body was parsed and contains no tool results at all.
  */
 export function collectRawToolResultPrefixes(
   event: FlowGatewayEvent
@@ -210,12 +226,14 @@ export function collectRawToolResultPrefixes(
   if (!arrays.length) return null;
 
   const prefixes = new Set<string>();
+  let sawToolResultShape = false;
   for (const rawMessages of arrays) {
     for (const raw of rawMessages) {
       if (!isRecord(raw)) continue;
       const role = String(raw.role || '').toLowerCase();
       const itemType = String(raw.type || '').toLowerCase();
       if (role === 'tool' || itemType === 'function_call_output') {
+        sawToolResultShape = true;
         const text = contentToText(raw.content ?? raw.output ?? raw);
         if (text.trim()) prefixes.add(normalizeForMatch(text));
         continue;
@@ -225,12 +243,18 @@ export function collectRawToolResultPrefixes(
       for (const block of content) {
         if (!isRecord(block)) continue;
         if (String(block.type || '').toLowerCase() === 'tool_result') {
+          sawToolResultShape = true;
           const text = contentToText(block.content ?? block);
           if (text.trim()) prefixes.add(normalizeForMatch(text));
         }
       }
     }
   }
+  // Tool-result items existed but none produced matchable text: exact
+  // detection would silently misclassify every one of them as a prompt, so
+  // report "no usable raw body" instead and let the heuristics (and the
+  // stats disclosure) take over.
+  if (sawToolResultShape && !prefixes.size) return null;
   return prefixes;
 }
 
@@ -288,7 +312,7 @@ export function buildConversation(
   const gatewayEvents = events
     .filter(
       (event) =>
-        event.type.includes('model_gateway') || previewMessages(event).length
+        isModelGatewayEventType(event.type) || previewMessages(event).length
     )
     .sort(
       (left, right) =>
@@ -311,9 +335,17 @@ export function buildConversation(
       if (!text && !message.redacted) return;
       const role = (message.role || 'message').toLowerCase();
       const source = (message.source || 'request').toLowerCase();
-      const signature = `${role}::${text}`;
       // Growing-prefix delta: render a message only the first time it
-      // appears across the session's accumulated request histories.
+      // appears across the session's accumulated request histories. The
+      // position index is part of the signature so a genuinely repeated
+      // identical text at a DIFFERENT conversation point (e.g. the user
+      // sending "continue" twice) is not collapsed into one bubble, while
+      // the same message replayed at the same position in later requests
+      // still deduplicates — including an event's response, which the next
+      // request replays as history at that same position. (An event-id
+      // component would defeat the dedup outright: every request replays
+      // the whole history.)
+      const signature = `${messageIndex}::${role}::${text}`;
       if (text && seenSignatures.has(signature)) return;
       if (text) seenSignatures.add(signature);
 

--- a/frontend/src/views/authed/runtime-sessions-view.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.ts
@@ -1995,7 +1995,7 @@ export class RuntimeSessionsView extends LitElement {
                         .selectedSessionId=${this.selectedSessionId}
                         .syncModeToUrl=${true}
                         layout="full"
-                        defaultReplayMode="timeline"
+                        defaultReplayMode="conversation"
                         .features=${{
                           summaries: true,
                           optimization:

--- a/helm/preloop/templates/configmap-nginx.yaml
+++ b/helm/preloop/templates/configmap-nginx.yaml
@@ -244,6 +244,35 @@ data:
             try_files /resources/$1.html /index.html;
         }
 
+        # Blog index (/blog): prerender-first, same as /vs and /resources.
+        # Exact match, because the generic catch-all below would otherwise
+        # `try_files $uri $uri/` -> see the /blog DIRECTORY -> emit a 301 to
+        # /blog/ instead of serving blog/index.html. Only SaaS builds emit
+        # blog/index.html; self-hosted builds fall through to the SPA, whose
+        # /blog route redirects home.
+        location = /blog {
+            try_files /blog/index.html /index.html;
+        }
+
+        # RSS feed. Exact match so it wins over the /blog/<slug> regex below,
+        # which would otherwise not match "feed.xml" anyway (the dot) but would
+        # leave the feed to the catch-all with the wrong content type.
+        location = /blog/feed.xml {
+            # `types { }` empties the MIME map for this location. Without it
+            # mime.types already maps .xml -> text/xml, that match wins, and
+            # default_type (which only applies when nothing matched) is dead
+            # code. Verified in nginx:alpine: without the empty types block
+            # the feed is served as text/xml.
+            types { }
+            default_type application/rss+xml;
+            try_files /blog/feed.xml =404;
+        }
+
+        # Blog posts (/blog/<slug>): prerender-first, SPA fallback.
+        location ~ ^/blog/([a-z0-9][a-z0-9-]*)/?$ {
+            try_files /blog/$1.html /index.html;
+        }
+
         # Top-level marketing pages: same prerender-first serving as /vs and
         # /resources above. Without these they fell through to the SPA
         # catch-all, so every one of them returned byte-identical home

--- a/helm/preloop/templates/configmap-nginx.yaml
+++ b/helm/preloop/templates/configmap-nginx.yaml
@@ -303,10 +303,11 @@ data:
             add_header Expires "0";
         }
 
-        # Health check endpoint
+        # Health check endpoint. `default_type` (not `add_header Content-Type`,
+        # which is dead code after `return`) sets the response MIME type.
         location /health {
             access_log off;
+            default_type text/plain;
             return 200 "healthy\n";
-            add_header Content-Type text/plain;
         }
     }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15939,6 +15939,91 @@ components:
       type: object
       title: RuntimeSessionActivityListResponse
       description: List of activity items for a runtime session.
+    RuntimeSessionCacheSummary:
+      properties:
+        requests_total:
+          type: integer
+          title: Requests Total
+          default: 0
+        requests_with_cache_data:
+          type: integer
+          title: Requests With Cache Data
+          default: 0
+        requests_without_cache_data:
+          type: integer
+          title: Requests Without Cache Data
+          default: 0
+        covered_prompt_tokens:
+          type: integer
+          title: Covered Prompt Tokens
+          default: 0
+        uncovered_prompt_tokens:
+          type: integer
+          title: Uncovered Prompt Tokens
+          default: 0
+        cached_prompt_tokens:
+          type: integer
+          title: Cached Prompt Tokens
+          default: 0
+        uncached_prompt_tokens:
+          type: integer
+          title: Uncached Prompt Tokens
+          default: 0
+        cache_write_tokens:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cache Write Tokens
+        cache_hit_ratio:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Cache Hit Ratio
+        estimated_cache_savings_usd:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Estimated Cache Savings Usd
+        savings_basis:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Savings Basis
+        savings_omitted_reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Savings Omitted Reason
+      type: object
+      title: RuntimeSessionCacheSummary
+      description: 'Whole-session prompt-cache rollup.
+
+
+        The ratio''s denominator is the *covered* traffic only: requests whose
+
+        provider actually reported a cache split. ``uncovered_prompt_tokens`` is
+
+        surfaced next to it so the UI can state coverage instead of folding blind
+
+        rows in as misses.
+
+
+        ``cache_write_tokens`` is ``None`` when no provider in this session has a
+
+        billable cache-write concept at all (OpenAI, Gemini, DeepSeek), which is
+
+        not the same statement as zero rewritten tokens.
+
+
+        ``estimated_cache_savings_usd`` is populated only when the vendored price
+
+        catalog carries explicit input AND cache-read prices for every model that
+
+        contributed cache reads; otherwise it is ``None`` and
+
+        ``savings_omitted_reason`` says why. No multiplier-based approximation is
+
+        ever returned here.'
     RuntimeSessionInteractionSummary:
       properties:
         event_id:
@@ -16423,6 +16508,55 @@ components:
       - n_runs
       title: RuntimeSessionReplayResponse
       description: 'Outcome of a replay: the exact input delta plus the banded end-to-end.'
+    RuntimeSessionRequestCache:
+      properties:
+        cache_read_tokens:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cache Read Tokens
+        cache_creation_tokens:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cache Creation Tokens
+        cache_miss_tokens:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cache Miss Tokens
+        cache_miss_source:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cache Miss Source
+        has_cache_data:
+          type: boolean
+          title: Has Cache Data
+          default: false
+        usage_source:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Usage Source
+      type: object
+      title: RuntimeSessionRequestCache
+      description: 'Prompt-cache accounting for one gateway request.
+
+
+        Every token field is ``Optional`` on purpose: ``None`` means *the provider
+
+        did not report this*, and clients MUST render it as "not reported" rather
+
+        than as zero. A ``0`` here is a real, provider-reported zero.
+
+
+        ``cache_miss_source`` distinguishes a miss count the provider sent us
+
+        (``reported`` — today only DeepSeek''s ``prompt_cache_miss_tokens``) from
+        one
+
+        we derived arithmetically as ``prompt - read - write`` (``derived``).'
     RuntimeSessionRequestItem:
       properties:
         id:
@@ -16496,6 +16630,8 @@ components:
           type: integer
           title: Tools Total Schema Tokens
           default: 0
+        cache:
+          $ref: '#/components/schemas/RuntimeSessionRequestCache'
       type: object
       required:
       - id
@@ -16533,6 +16669,8 @@ components:
           type: boolean
           title: Has More
           default: false
+        cache_summary:
+          $ref: '#/components/schemas/RuntimeSessionCacheSummary'
       type: object
       title: RuntimeSessionRequestListResponse
       description: Paginated per-request rows for one runtime session.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15967,13 +15967,24 @@ components:
           type: integer
           title: Prompt Tokens
           default: 0
+        requests_with_unknown_prompt_tokens:
+          type: integer
+          title: Requests With Unknown Prompt Tokens
+          default: 0
         write_reported:
           type: boolean
           title: Write Reported
           default: false
       type: object
       title: RuntimeSessionCacheModelGroup
-      description: Per-(model, provider) breakdown inside the session cache rollup.
+      description: 'Per-(model, provider) breakdown inside the session cache rollup.
+
+
+        ``requests_with_unknown_prompt_tokens`` counts this group''s rows whose
+
+        provider reported no prompt total; their tokens are excluded from
+
+        ``prompt_tokens`` rather than counted as zero.'
     RuntimeSessionCacheSummary:
       properties:
         requests_total:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15939,6 +15939,41 @@ components:
       type: object
       title: RuntimeSessionActivityListResponse
       description: List of activity items for a runtime session.
+    RuntimeSessionCacheModelGroup:
+      properties:
+        model_alias:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Model Alias
+        provider_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Provider Name
+        requests:
+          type: integer
+          title: Requests
+          default: 0
+        cache_read_tokens:
+          type: integer
+          title: Cache Read Tokens
+          default: 0
+        cache_creation_tokens:
+          type: integer
+          title: Cache Creation Tokens
+          default: 0
+        prompt_tokens:
+          type: integer
+          title: Prompt Tokens
+          default: 0
+        write_reported:
+          type: boolean
+          title: Write Reported
+          default: false
+      type: object
+      title: RuntimeSessionCacheModelGroup
+      description: Per-(model, provider) breakdown inside the session cache rollup.
     RuntimeSessionCacheSummary:
       properties:
         requests_total:
@@ -15994,6 +16029,15 @@ components:
           - type: string
           - type: 'null'
           title: Savings Omitted Reason
+        requests_with_unknown_prompt_tokens:
+          type: integer
+          title: Requests With Unknown Prompt Tokens
+          default: 0
+        models:
+          items:
+            $ref: '#/components/schemas/RuntimeSessionCacheModelGroup'
+          type: array
+          title: Models
       type: object
       title: RuntimeSessionCacheSummary
       description: 'Whole-session prompt-cache rollup.
@@ -16005,7 +16049,11 @@ components:
 
         surfaced next to it so the UI can state coverage instead of folding blind
 
-        rows in as misses.
+        rows in as misses. ``requests_with_unknown_prompt_tokens`` counts rows
+
+        whose provider reported no prompt total at all; their tokens are excluded
+
+        from both sums rather than counted as zero.
 
 
         ``cache_write_tokens`` is ``None`` when no provider in this session has a
@@ -16015,15 +16063,17 @@ components:
         not the same statement as zero rewritten tokens.
 
 
-        ``estimated_cache_savings_usd`` is populated only when the vendored price
+        ``estimated_cache_savings_usd`` is computed only from explicit catalog
 
-        catalog carries explicit input AND cache-read prices for every model that
+        input AND cache-read prices — never a multiplier-based approximation.
 
-        contributed cache reads; otherwise it is ``None`` and
+        ``savings_basis`` is ``catalog_exact`` when every model that contributed
 
-        ``savings_omitted_reason`` says why. No multiplier-based approximation is
+        cache reads was priced, ``catalog_exact_partial`` when the figure is a
 
-        ever returned here.'
+        lower bound covering only the priced models. When no contributing model is
+
+        priced the figure is ``None`` and ``savings_omitted_reason`` says why.'
     RuntimeSessionInteractionSummary:
       properties:
         event_id:
@@ -16672,6 +16722,8 @@ components:
         cache_summary:
           $ref: '#/components/schemas/RuntimeSessionCacheSummary'
       type: object
+      required:
+      - cache_summary
       title: RuntimeSessionRequestListResponse
       description: Paginated per-request rows for one runtime session.
     RuntimeSessionRequestTool:


### PR DESCRIPTION
Ships three feature areas that were reviewed together (snapshot of staged work, commit e7218e36):

## 1. Session transcript chat view (frontend)
- New `<session-chat-view>` chat-style transcript: only top-level user prompts and final agent responses are expanded; tool calls/results, system prompts, injected harness segments (system reminders, `[Preloop]` notices, local-command wrappers, compaction summaries), and intermediate agent output collapse into step groups.
- Pure reconstruction logic in `frontend/src/utils/transcript.ts` with explicit honesty rules: tool results detected exactly from captured raw request bodies where available; events without raw bodies are counted (`stats.eventsWithoutRawBody`) so the UI can disclose uncertainty instead of guessing. Ambiguous user-role messages stay visible prompts.
- New `conversation` replay mode wired into `<preloop-session-observer>` and made the default in the runtime sessions view; replay panel is hidden (not unmounted) so tab switches keep state.

## 2. Cache accounting (backend + API)
- New `preloop/services/cache_accounting.py`: per-request cache read/write/miss accounting and whole-session rollup with strict semantics — `None` means "not reported by provider", never zero; miss counts are `reported` (DeepSeek's `prompt_cache_miss_tokens`) or `derived` (`prompt - read - write`), never fabricated; dollar savings are emitted only from exact catalog prices, otherwise omitted with a reason.
- `GET /runtime-sessions/{id}/requests` now returns per-request `cache` blocks and a page-stable session-wide `cache_summary` (new `RuntimeSessionRequestCache` / `RuntimeSessionCacheSummary` schemas, openapi.yaml updated).
- DB access goes through a new column-projected `crud_api_usage.list_session_cache_rows` (only `meta_data['usage_details']` pulled from JSONB, avoiding large body payloads).
- Gateway realtime events gain `cache_miss_input_tokens_reported`.

## 3. nginx route parity (infra + test)
- Adds `/blog`, `/blog/<slug>`, `/blog/feed.xml` prerender routes to the Helm ConfigMap (production preloop.ai), which had drifted from the docker template — blog URLs were silently serving homepage HTML with a 200.
- New `tests/test_nginx_route_parity.py` implements nginx location-matching precedence and asserts both configs route the same URLs to equivalent behaviour, so the drift cannot recur.
- `types { }` fix so the RSS feed is actually served as `application/rss+xml`.

Also: `js-yaml` bumped to ^4.3.1; Blog link added to the SaaS header.

## Test evidence
- `backend/tests/services/test_cache_accounting.py` + `backend/tests/test_nginx_route_parity.py`: **31 passed**
- `backend/tests/endpoints/test_runtime_session_requests.py`: **9 passed**
- Frontend `web-test-runner` on `transcript.test.ts`, `session-chat-view.test.ts`, `session-request-timeline.test.ts`: **32 passed, 0 failed**
- `ruff check` on all changed backend files: clean
- `mypy` on new/changed backend files: no new errors introduced (pre-existing repo-wide errors unchanged)
- Secrets scan of the full diff: nothing found

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> All 21 previously raised issues are now resolved — the final CHANGELOG rebase artifact (unrelated release-note entries) was trimmed in `ff0da491`, leaving only this PR's three feature entries. Code is well-structured with honest transcript reconstruction and strict cache semantics, and comprehensive test coverage.
>
> **Overview**
> Adds session transcript chat view, prompt-cache accounting (OpenAI/Anthropic), and nginx route parity for marketing/blog pages. Well-architected with careful honesty rules in transcript reconstruction and explicit cache semantics.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit ff0da491. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->