### PR TITLE
fix: remove duplicate verify block and add regression tests

### DIFF
--- a/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/plugin.py
+++ b/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/plugin.py
@@ -446,12 +446,6 @@ class HermesPreloopPlugin:
         runtime = block.get("runtime")
         if runtime != self.runtime_name:
             raise ValueError(f"Expected Hermes runtime config, got {runtime!r}")
-        """Validate local plugin load and config shape."""
-        config = self.load_config()
-        block = self._read_control_block()
-        runtime = block.get("runtime")
-        if runtime != self.runtime_name:
-            raise ValueError(f"Expected Hermes runtime config, got {runtime!r}")
         if not config.control_ws_url:
             raise ValueError("preloop.control.control_ws_url is required")
         if not config.bearer_token:

--- a/runtime-plugins/hermes-preloop/tests/test_verify.py
+++ b/runtime-plugins/hermes-preloop/tests/test_verify.py
@@ -1,0 +1,82 @@
+"""Tests for HermesPreloopPlugin.verify() runtime validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# Make the standalone plugin package importable without installation.
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in __import__("sys").path:
+    __import__("sys").path.insert(0, str(SRC))
+
+from preloop_hermes_plugin.plugin import HermesPreloopPlugin  # noqa: E402
+from preloop.integrations.agent_control import AgentControlConfig  # noqa: E402
+
+
+def _config() -> AgentControlConfig:
+    return AgentControlConfig(
+        control_ws_url="wss://staging.preloop.ai/api/v1/agents/control/ws",
+        bearer_token="agt_test",
+        runtime_principal_id="hermes-1",
+    )
+
+
+def test_verify_passes_when_runtime_matches() -> None:
+    plugin = HermesPreloopPlugin()
+    config = _config()
+    block = {"runtime": "hermes"}
+    with patch.object(plugin, "load_config", return_value=config):
+        with patch.object(plugin, "_read_control_block", return_value=block):
+            plugin.verify()
+
+
+def test_verify_raises_on_runtime_mismatch() -> None:
+    plugin = HermesPreloopPlugin()
+    config = _config()
+    block = {"runtime": "other"}
+    with patch.object(plugin, "load_config", return_value=config):
+        with patch.object(plugin, "_read_control_block", return_value=block):
+            with pytest.raises(ValueError, match="Expected Hermes runtime config, got 'other'"):
+                plugin.verify()
+
+
+def test_verify_raises_on_missing_runtime() -> None:
+    plugin = HermesPreloopPlugin()
+    config = _config()
+    block = {}
+    with patch.object(plugin, "load_config", return_value=config):
+        with patch.object(plugin, "_read_control_block", return_value=block):
+            with pytest.raises(ValueError, match="Expected Hermes runtime config, got None"):
+                plugin.verify()
+
+
+def test_verify_raises_on_missing_control_ws_url() -> None:
+    plugin = HermesPreloopPlugin()
+    config = AgentControlConfig(
+        control_ws_url="",
+        bearer_token="agt_test",
+        runtime_principal_id="hermes-1",
+    )
+    block = {"runtime": "hermes"}
+    with patch.object(plugin, "load_config", return_value=config):
+        with patch.object(plugin, "_read_control_block", return_value=block):
+            with pytest.raises(ValueError, match="preloop.control.control_ws_url is required"):
+                plugin.verify()
+
+
+def test_verify_raises_on_missing_bearer_token() -> None:
+    plugin = HermesPreloopPlugin()
+    config = AgentControlConfig(
+        control_ws_url="wss://staging.preloop.ai/api/v1/agents/control/ws",
+        bearer_token="",
+        runtime_principal_id="hermes-1",
+    )
+    block = {"runtime": "hermes"}
+    with patch.object(plugin, "load_config", return_value=config):
+        with patch.object(plugin, "_read_control_block", return_value=block):
+            with pytest.raises(ValueError, match="preloop.control.bearer_token is required"):
+                plugin.verify()

--- a/runtime-plugins/hermes-preloop/tests/test_verify.py
+++ b/runtime-plugins/hermes-preloop/tests/test_verify.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -40,7 +39,9 @@ def test_verify_raises_on_runtime_mismatch() -> None:
     block = {"runtime": "other"}
     with patch.object(plugin, "load_config", return_value=config):
         with patch.object(plugin, "_read_control_block", return_value=block):
-            with pytest.raises(ValueError, match="Expected Hermes runtime config, got 'other'"):
+            with pytest.raises(
+                ValueError, match="Expected Hermes runtime config, got 'other'"
+            ):
                 plugin.verify()
 
 
@@ -50,7 +51,9 @@ def test_verify_raises_on_missing_runtime() -> None:
     block = {}
     with patch.object(plugin, "load_config", return_value=config):
         with patch.object(plugin, "_read_control_block", return_value=block):
-            with pytest.raises(ValueError, match="Expected Hermes runtime config, got None"):
+            with pytest.raises(
+                ValueError, match="Expected Hermes runtime config, got None"
+            ):
                 plugin.verify()
 
 
@@ -64,7 +67,9 @@ def test_verify_raises_on_missing_control_ws_url() -> None:
     block = {"runtime": "hermes"}
     with patch.object(plugin, "load_config", return_value=config):
         with patch.object(plugin, "_read_control_block", return_value=block):
-            with pytest.raises(ValueError, match="preloop.control.control_ws_url is required"):
+            with pytest.raises(
+                ValueError, match="preloop.control.control_ws_url is required"
+            ):
                 plugin.verify()
 
 
@@ -78,5 +83,7 @@ def test_verify_raises_on_missing_bearer_token() -> None:
     block = {"runtime": "hermes"}
     with patch.object(plugin, "load_config", return_value=config):
         with patch.object(plugin, "_read_control_block", return_value=block):
-            with pytest.raises(ValueError, match="preloop.control.bearer_token is required"):
+            with pytest.raises(
+                ValueError, match="preloop.control.bearer_token is required"
+            ):
                 plugin.verify()


### PR DESCRIPTION
Follow-up to #165: remove duplicate block in HermesPreloopPlugin.verify() and add tests for runtime validation.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Simple deduplication of a copy-pasted code block in `verify()` with comprehensive regression tests. No logic changes.
>
> **Overview**
> Removes a duplicate `load_config()` / `_read_control_block()` block from `HermesPreloopPlugin.verify()` that was accidentally left in. Adds 5 regression tests covering all validation paths: runtime match, runtime mismatch, missing runtime, missing control_ws_url, and missing bearer_token.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/remove-duplicate-verify-block. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->