### PR TITLE
fix: prevent DB pool exhaustion and log-batch data loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Database connection pool exhaustion and execution-log data loss**: a
+  production gateway pod exhausted its SQLAlchemy pool
+  (`QueuePool limit of size 3 overflow 7 reached`) under PR-reviewer load,
+  which dropped a batch of NATS execution logs, failed the readiness probe,
+  broke token validation, and ended in a pod restart. Four changes:
+  - `_sync_batch_insert_logs` now retries transient failures
+    (`TimeoutError`/`OperationalError`) up to 3 times with exponential backoff
+    (0.5s, 1.0s) before dropping a batch, rolls back on failure so no dirty
+    transaction is returned to the pool, and returns a success boolean.
+    Background log persistence is additionally bounded by a semaphore so it
+    cannot starve request-serving connections. Batches are still only dropped
+    as a last resort, and admins are still notified when that happens.
+  - Health checks use a dedicated single-connection engine with fast timeouts
+    instead of a pooled request session, so readiness reports "can I reach
+    Postgres" rather than "is the request pool momentarily full".
+  - `/api/v1/ping` (the liveness probe) is now `async`, keeping it on the event
+    loop. As a sync endpoint it ran in Starlette's bounded anyio threadpool and
+    could queue behind blocked database calls, causing Kubernetes to SIGKILL a
+    pod that was merely busy.
+  - Gateway connection pool sizing raised from 3+7 to 6+14 per pod, api tuned
+    to 8+12 and workers to 2+4. Chart comments now document that each pod
+    creates two pools (sync + async engine) and reflect real production replica
+    counts (api=2, gateway=5, workers=8).
+
+- **Gateway log noise**: WebSocket broadcasts with no matching listeners logged
+  at INFO on every event, accounting for ~69% of gateway log lines (8170 of
+  11810 in a two-hour sample). These now log at DEBUG; broadcasts with actual
+  listeners still log at INFO.
+
 ## [0.14.0] - 2026-08-07
 
 Highlights: **Cursor usage import** brings bundled-model spend into Cost

--- a/backend/preloop/api/endpoints/health.py
+++ b/backend/preloop/api/endpoints/health.py
@@ -4,22 +4,25 @@ import logging
 from datetime import UTC, datetime
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter
 from sqlalchemy import text
-from sqlalchemy.orm import Session
 
-from preloop.models.db.session import get_db_session as get_db
+from preloop.models.db.session import get_health_engine
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
 @router.get("/ping")
-def ping() -> Dict[str, str]:
+async def ping() -> Dict[str, str]:
     """Simple liveness check - no database, no external dependencies.
 
-    Use this for Kubernetes liveness probes to avoid killing pods
-    due to temporary database issues.
+    Declared ``async`` on purpose: a plain ``def`` endpoint is executed in
+    Starlette's bounded anyio worker threadpool (40 threads by default). During
+    a database stall, sync endpoints block those threads waiting on pool
+    checkout, so even this DB-free probe would queue behind them and the
+    liveness probe would time out and get the pod SIGKILLed. Running on the
+    event loop keeps liveness answerable no matter how saturated the DB is.
 
     Returns:
         Simple pong response
@@ -28,8 +31,13 @@ def ping() -> Dict[str, str]:
 
 
 @router.get("/health")
-def health_check(db: Session = Depends(get_db)) -> Dict[str, Any]:
+def health_check() -> Dict[str, Any]:
     """Health check endpoint with database and MCP server status.
+
+    Uses a dedicated single-connection engine rather than the shared request
+    pool: readiness should reflect "can I reach Postgres", not "is the request
+    pool momentarily full". Consuming a pooled connection here made the probe
+    fail during saturation, which amplified load spikes into pod restarts.
 
     Returns:
         Dictionary with health status including:
@@ -47,9 +55,10 @@ def health_check(db: Session = Depends(get_db)) -> Dict[str, Any]:
         "upstream_connections": 0,
     }
 
-    # Verify database connection
+    # Verify database connection via the dedicated health engine
     try:
-        db.execute(text("SELECT 1"))
+        with get_health_engine().connect() as conn:
+            conn.execute(text("SELECT 1"))
         health_status["database"] = "connected"
     except Exception as e:
         logger.error("Database health check failed", exc_info=True)

--- a/backend/preloop/models/db/session.py
+++ b/backend/preloop/models/db/session.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 
 from loguru import logger
 from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -22,6 +23,7 @@ _engine = None
 _session_factory = None
 _async_engine = None
 _async_session_factory = None
+_health_engine = None
 
 
 def _env_int(name: str, default: int) -> int:
@@ -148,6 +150,43 @@ def get_db_session() -> Generator[Session, None, None]:
         yield db
     finally:
         _safe_close_db_session(db)
+
+
+def get_health_engine(database_url: Optional[str] = None) -> Engine:
+    """Return a tiny dedicated engine used only by health checks.
+
+    Health probes must report whether Postgres is reachable, not whether the
+    request pool happens to be saturated. Sharing the main pool made the
+    readiness probe fail exactly when the app was busiest, marking every pod
+    NotReady at once and turning a load spike into an outage.
+
+    This engine keeps a single connection, never overflows, and fails fast so
+    a probe can never sit for the full 30s request-pool timeout.
+    """
+    global _health_engine
+
+    if _health_engine is not None:
+        return _health_engine
+
+    url = database_url or os.getenv("DATABASE_URL")
+    if not url:
+        raise Exception("DATABASE_URL not in env")
+
+    _health_engine = create_engine(
+        url,
+        pool_size=1,
+        max_overflow=0,
+        pool_pre_ping=True,
+        pool_recycle=_env_int("DATABASE_POOL_RECYCLE", 1800),
+        # Fail fast: a probe should time out well inside its own deadline.
+        pool_timeout=_env_int("DATABASE_HEALTH_POOL_TIMEOUT", 3),
+        connect_args={
+            "connect_timeout": 3,
+            "options": "-c statement_timeout=3000",
+        },
+        echo=False,
+    )
+    return _health_engine
 
 
 def get_async_engine(database_url: Optional[str] = None) -> AsyncEngine:

--- a/backend/preloop/models/db/session.py
+++ b/backend/preloop/models/db/session.py
@@ -1,6 +1,7 @@
 """Database session management."""
 
 import os
+import threading
 from typing import AsyncGenerator, Generator, Optional
 from contextlib import asynccontextmanager
 
@@ -24,6 +25,10 @@ _session_factory = None
 _async_engine = None
 _async_session_factory = None
 _health_engine = None
+# Health probes can arrive concurrently on different threads (Starlette's
+# threadpool), and a plain check-then-create global would let two of them each
+# build an engine, leaking a connection pool the code then forgets about.
+_health_engine_lock = threading.Lock()
 
 
 def _env_int(name: str, default: int) -> int:
@@ -165,28 +170,34 @@ def get_health_engine(database_url: Optional[str] = None) -> Engine:
     """
     global _health_engine
 
+    # Double-checked locking: the fast path stays lock-free once the engine
+    # exists, while concurrent first probes create exactly one engine.
     if _health_engine is not None:
         return _health_engine
 
-    url = database_url or os.getenv("DATABASE_URL")
-    if not url:
-        raise Exception("DATABASE_URL not in env")
+    with _health_engine_lock:
+        if _health_engine is not None:
+            return _health_engine
 
-    _health_engine = create_engine(
-        url,
-        pool_size=1,
-        max_overflow=0,
-        pool_pre_ping=True,
-        pool_recycle=_env_int("DATABASE_POOL_RECYCLE", 1800),
-        # Fail fast: a probe should time out well inside its own deadline.
-        pool_timeout=_env_int("DATABASE_HEALTH_POOL_TIMEOUT", 3),
-        connect_args={
-            "connect_timeout": 3,
-            "options": "-c statement_timeout=3000",
-        },
-        echo=False,
-    )
-    return _health_engine
+        url = database_url or os.getenv("DATABASE_URL")
+        if not url:
+            raise Exception("DATABASE_URL not in env")
+
+        _health_engine = create_engine(
+            url,
+            pool_size=1,
+            max_overflow=0,
+            pool_pre_ping=True,
+            pool_recycle=_env_int("DATABASE_POOL_RECYCLE", 1800),
+            # Fail fast: a probe should time out well inside its own deadline.
+            pool_timeout=_env_int("DATABASE_HEALTH_POOL_TIMEOUT", 3),
+            connect_args={
+                "connect_timeout": 3,
+                "options": "-c statement_timeout=3000",
+            },
+            echo=False,
+        )
+        return _health_engine
 
 
 def get_async_engine(database_url: Optional[str] = None) -> AsyncEngine:

--- a/backend/preloop/services/websocket_manager.py
+++ b/backend/preloop/services/websocket_manager.py
@@ -365,6 +365,17 @@ class WebSocketManager:
                 f"Broadcast complete: sent to {sent_count} connection(s) for account {account_id}"
             )
 
+    def _count_account_connections(self, account_id: str) -> int:
+        """Count connections currently bound to one account.
+
+        Args:
+            account_id: Account whose listeners should be counted.
+
+        Returns:
+            Number of active connections registered to ``account_id``.
+        """
+        return sum(1 for acc in self.connection_accounts.values() if acc == account_id)
+
     async def broadcast_json(self, data: dict, account_id: str = None):
         """
         Broadcasts a JSON message to connected clients, optionally filtered by account_id.
@@ -379,32 +390,35 @@ class WebSocketManager:
         high_freq_types = {"agent_log_line", "token_usage_update", "tool_calls_update"}
 
         if account_id:
-            matching_count = sum(
-                1 for acc in self.connection_accounts.values() if acc == account_id
-            )
-            # Only log high-frequency messages at debug level, or when someone is listening
+            # The matching count only ever feeds a log line, so it is computed
+            # lazily. Counting every connection on each broadcast was pure
+            # overhead on the hottest path (agent_log_line), where the result is
+            # discarded whenever DEBUG is off.
             if msg_type in high_freq_types:
-                if matching_count > 0:
-                    logger.debug(
-                        f"Broadcasting {msg_type} to {matching_count} connection(s) "
-                        f"for account {account_id}"
-                    )
-                # Skip logging entirely when no one is listening for high-freq messages
-            elif matching_count > 0:
-                # Non-high-frequency messages (status updates, etc.) log at INFO
-                # only when someone is actually listening.
-                logger.info(
-                    f"Broadcasting {msg_type} to account_id={account_id}, "
-                    f"matching_connections={matching_count}"
-                )
+                # High-frequency messages only ever log at DEBUG, so skip the
+                # scan entirely when that line would be discarded anyway.
+                if logger.isEnabledFor(logging.DEBUG):
+                    matching_count = self._count_account_connections(account_id)
+                    if matching_count > 0:
+                        logger.debug(
+                            f"Broadcasting {msg_type} to {matching_count} "
+                            f"connection(s) for account {account_id}"
+                        )
             else:
-                # No listeners: still useful when debugging missing updates,
-                # but not worth an INFO line per event (this was ~69% of all
-                # gateway log volume in production).
-                logger.debug(
-                    f"Broadcasting {msg_type} to account_id={account_id}, "
-                    f"matching_connections=0"
-                )
+                # Low-volume messages: one scan feeds either the INFO line (when
+                # someone is listening) or the DEBUG "no listeners" line, which
+                # was ~69% of all gateway log volume in production.
+                matching_count = self._count_account_connections(account_id)
+                if matching_count > 0:
+                    logger.info(
+                        f"Broadcasting {msg_type} to account_id={account_id}, "
+                        f"matching_connections={matching_count}"
+                    )
+                else:
+                    logger.debug(
+                        f"Broadcasting {msg_type} to account_id={account_id}, "
+                        f"matching_connections=0"
+                    )
         else:
             logger.info(
                 f"Broadcasting {msg_type} to all {len(self.active_connections)} connections"

--- a/backend/preloop/services/websocket_manager.py
+++ b/backend/preloop/services/websocket_manager.py
@@ -1,12 +1,15 @@
 import asyncio
 import json
 import logging
+import threading
+import time
 import uuid
-from typing import Dict, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 from fastapi import WebSocket
 from nats.aio.client import Client
 from nats.aio.msg import Msg
+from sqlalchemy.exc import OperationalError, TimeoutError as SQLAlchemyTimeoutError
 
 from preloop.sync.services.event_bus import get_task_publisher
 from preloop.models.db.session import get_db_session as get_db
@@ -19,6 +22,21 @@ logger = logging.getLogger(__name__)
 # Dictionary to hold loop-specific queues to prevent test runner cross-loop panics
 _log_queues: dict[asyncio.AbstractEventLoop, asyncio.Queue] = {}
 
+# Background log persistence must never starve request-serving connections.
+# Only this many threads may hold a pooled DB connection for log writes at a
+# time, so a burst of NATS logs cannot consume the whole QueuePool.
+LOG_PERSIST_MAX_CONCURRENCY = 1
+_log_persist_semaphore = threading.BoundedSemaphore(LOG_PERSIST_MAX_CONCURRENCY)
+
+# Bounded retry for transient pool/connection failures before dropping data.
+LOG_PERSIST_MAX_ATTEMPTS = 3
+LOG_PERSIST_BASE_BACKOFF_SECONDS = 0.5
+
+# Transient errors worth retrying: pool checkout timeouts (QueuePool limit
+# reached) and dropped/failed connections. Anything else is a real bug and is
+# not retried.
+_RETRYABLE_DB_ERRORS = (SQLAlchemyTimeoutError, OperationalError)
+
 
 def get_log_queue() -> asyncio.Queue:
     """Returns the logging queue associated with the current running event loop."""
@@ -28,35 +46,112 @@ def get_log_queue() -> asyncio.Queue:
     return _log_queues[loop]
 
 
-def _sync_batch_insert_logs(batch: list):
-    """
-    Synchronously insert a batch of log records into the database.
-    """
-    try:
-        from preloop.models.crud import crud_flow_execution
+def _write_log_batch(batch: List[Tuple[str, dict]]) -> None:
+    """Write one batch of log records in a single transaction.
 
-        db = next(get_db())
+    Raises whatever the database layer raises; retry policy lives in the
+    caller. DB access stays behind ``preloop.models.crud``.
+    """
+    from preloop.models.crud import crud_flow_execution
+
+    db = next(get_db())
+    try:
+        for execution_id, log_data in batch:
+            crud_flow_execution.append_log(
+                db, execution_id=execution_id, log_data=log_data, commit=False
+            )
+        db.commit()
+    except Exception:
+        # Never leave a half-applied transaction on a pooled connection.
         try:
-            for execution_id, log_data in batch:
-                crud_flow_execution.append_log(
-                    db, execution_id=execution_id, log_data=log_data, commit=False
+            db.rollback()
+        except Exception:  # pragma: no cover - rollback failure is best-effort
+            logger.warning("Rollback failed while aborting log batch", exc_info=True)
+        raise
+    finally:
+        db.close()
+
+
+def _sync_batch_insert_logs(batch: list) -> bool:
+    """Insert a batch of log records, retrying transient database failures.
+
+    Pool exhaustion (``QueuePool limit ... reached``) and dropped connections
+    are transient: the previous implementation dropped the whole batch on the
+    first error, silently losing execution logs during load spikes. We now
+    retry with exponential backoff and only drop as a last resort.
+
+    A semaphore bounds how many threads may hold a pooled connection for log
+    persistence, so background writes cannot exhaust the pool that serves user
+    requests and health checks.
+
+    Args:
+        batch: Sequence of ``(execution_id, log_data)`` pairs.
+
+    Returns:
+        True if the batch was persisted, False if it was dropped.
+    """
+    if not batch:
+        return True
+
+    last_error: Optional[BaseException] = None
+
+    with _log_persist_semaphore:
+        for attempt in range(1, LOG_PERSIST_MAX_ATTEMPTS + 1):
+            try:
+                _write_log_batch(batch)
+                if attempt > 1:
+                    logger.info(
+                        "Persisted batch of %d logs on attempt %d/%d",
+                        len(batch),
+                        attempt,
+                        LOG_PERSIST_MAX_ATTEMPTS,
+                    )
+                return True
+            except _RETRYABLE_DB_ERRORS as exc:
+                last_error = exc
+                if attempt == LOG_PERSIST_MAX_ATTEMPTS:
+                    break
+                backoff = LOG_PERSIST_BASE_BACKOFF_SECONDS * (2 ** (attempt - 1))
+                logger.warning(
+                    "Transient DB error persisting %d logs "
+                    "(attempt %d/%d), retrying in %.1fs: %s",
+                    len(batch),
+                    attempt,
+                    LOG_PERSIST_MAX_ATTEMPTS,
+                    backoff,
+                    exc,
                 )
-            db.commit()
-        finally:
-            db.close()
-    except Exception as e:
-        logger.error(
-            f"Failed to persist batch of {len(batch)} logs: {e}", exc_info=True
+                time.sleep(backoff)
+            except Exception as exc:  # non-retryable: fail fast
+                last_error = exc
+                logger.error(
+                    "Non-retryable error persisting batch of %d logs: %s",
+                    len(batch),
+                    exc,
+                    exc_info=True,
+                )
+                break
+
+    # Exhausted retries (or hit a non-retryable error): drop, but loudly.
+    logger.error(
+        "Dropping batch of %d logs after %d attempt(s): %s",
+        len(batch),
+        LOG_PERSIST_MAX_ATTEMPTS,
+        last_error,
+        exc_info=True,
+    )
+    try:
+        notify_admins(
+            subject="[Preloop Alert] NATS Log Persistence Failed",
+            message=(
+                f"A batch of {len(batch)} logs failed to persist to the database "
+                f"after {LOG_PERSIST_MAX_ATTEMPTS} attempts and were dropped. "
+                f"Error: {last_error}"
+            ),
         )
-        try:
-            notify_admins(
-                subject="[Preloop Alert] NATS Log Persistence Failed",
-                message=f"A batch of {len(batch)} logs failed to persist to the database and were dropped. Error: {str(e)}",
-            )
-        except Exception as alert_err:
-            logger.error(
-                f"Failed to send admin notification for dropped logs: {alert_err}"
-            )
+    except Exception as alert_err:
+        logger.error(f"Failed to send admin notification for dropped logs: {alert_err}")
+    return False
 
 
 async def _log_writer_worker():
@@ -295,11 +390,20 @@ class WebSocketManager:
                         f"for account {account_id}"
                     )
                 # Skip logging entirely when no one is listening for high-freq messages
-            else:
-                # Non-high-frequency messages (status updates, etc.) always log at INFO
+            elif matching_count > 0:
+                # Non-high-frequency messages (status updates, etc.) log at INFO
+                # only when someone is actually listening.
                 logger.info(
                     f"Broadcasting {msg_type} to account_id={account_id}, "
                     f"matching_connections={matching_count}"
+                )
+            else:
+                # No listeners: still useful when debugging missing updates,
+                # but not worth an INFO line per event (this was ~69% of all
+                # gateway log volume in production).
+                logger.debug(
+                    f"Broadcasting {msg_type} to account_id={account_id}, "
+                    f"matching_connections=0"
                 )
         else:
             logger.info(

--- a/backend/tests/endpoints/test_health.py
+++ b/backend/tests/endpoints/test_health.py
@@ -28,7 +28,7 @@ class TestHealthCheck:
         mock_pool.get_active_servers.return_value = ["server1", "server2"]
         mock_get_client_pool.return_value = mock_pool
 
-        result = health_check(db=mock_db_session)
+        result = health_check()
 
         assert result["status"] == "healthy"
         assert result["database"] == "connected"
@@ -55,7 +55,7 @@ class TestHealthCheck:
         mock_pool.get_active_servers.return_value = []
         mock_get_client_pool.return_value = mock_pool
 
-        result = health_check(db=mock_db_session)
+        result = health_check()
 
         assert result["status"] == "unhealthy"
         # Health responses expose exception type only (no detail / stack).
@@ -82,7 +82,7 @@ class TestHealthCheck:
         mock_pool.get_active_servers.return_value = []
         mock_get_client_pool.return_value = mock_pool
 
-        result = health_check(db=mock_db_session)
+        result = health_check()
 
         assert result["status"] == "healthy"
         assert result["database"] == "connected"
@@ -108,7 +108,7 @@ class TestHealthCheck:
         mock_pool.get_active_servers.return_value = []
         mock_get_client_pool.return_value = mock_pool
 
-        result = health_check(db=mock_db_session)
+        result = health_check()
 
         assert result["status"] == "healthy"
         assert result["database"] == "connected"
@@ -133,7 +133,7 @@ class TestHealthCheck:
         # Mock MCP client pool error
         mock_get_client_pool.side_effect = Exception("Client pool unavailable")
 
-        result = health_check(db=mock_db_session)
+        result = health_check()
 
         assert result["status"] == "healthy"
         assert result["database"] == "connected"
@@ -160,7 +160,7 @@ class TestHealthCheck:
         mock_pool.get_active_servers.return_value = []
         mock_get_client_pool.return_value = mock_pool
 
-        result = health_check(db=mock_db_session)
+        result = health_check()
 
         assert result["status"] == "healthy"
         assert result["database"] == "connected"
@@ -171,5 +171,45 @@ class TestHealthCheck:
 
 @pytest.fixture
 def mock_db_session():
-    """Create a mock database session."""
-    return MagicMock()
+    """Patch the dedicated health engine and expose its connection mock.
+
+    The health endpoint no longer takes a pooled request session; it uses a
+    small dedicated engine so probes stay answerable while the request pool is
+    saturated. Tests configure ``.execute`` exactly as before.
+    """
+    conn = MagicMock()
+    engine = MagicMock()
+    engine.connect.return_value.__enter__.return_value = conn
+    with patch("preloop.api.endpoints.health.get_health_engine", return_value=engine):
+        yield conn
+
+
+class TestPingLiveness:
+    """The liveness probe must survive database saturation."""
+
+    def test_ping_is_async(self):
+        """Regression guard for the 2026-08-08 gateway SIGKILL.
+
+        A sync ``def`` endpoint runs in Starlette's bounded anyio threadpool.
+        When sync DB endpoints block that pool waiting on connection checkout,
+        a sync /ping queues behind them, the liveness probe times out and
+        Kubernetes kills the pod. Staying async keeps liveness on the event
+        loop and independent of the DB.
+        """
+        import inspect
+
+        from preloop.api.endpoints.health import ping
+
+        assert inspect.iscoroutinefunction(ping)
+
+    def test_ping_does_not_touch_database(self):
+        """/ping must never acquire a database connection."""
+        import asyncio
+
+        from preloop.api.endpoints.health import ping
+
+        with patch("preloop.api.endpoints.health.get_health_engine") as engine:
+            result = asyncio.run(ping())
+
+        assert not engine.called
+        assert result["status"] == "pong"

--- a/backend/tests/models/test_db_session.py
+++ b/backend/tests/models/test_db_session.py
@@ -1,6 +1,7 @@
 """Tests for the database session module."""
 
 import os
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -262,3 +263,42 @@ def test_get_db_session_invalidates_when_rollback_fails():
 
         mock_session.rollback.assert_called_once()
         mock_session.invalidate.assert_called_once()
+
+
+def test_get_health_engine_is_created_once_under_concurrency(mock_engine_dependencies):
+    """Concurrent first calls must not build more than one health engine.
+
+    The health engine used a plain check-then-create global, so two threads
+    racing on the first probe could each build an engine (and each open its own
+    connection), leaking a pool the code would then forget about.
+    """
+    import threading
+
+    session_module._health_engine = None
+    started = threading.Barrier(8)
+    engines: list = []
+
+    def slow_create_engine(*args, **kwargs):
+        # Widen the race window between the check and the assignment.
+        time.sleep(0.05)
+        return MagicMock(name="health_engine")
+
+    mock_engine_dependencies["create_engine"].side_effect = slow_create_engine
+
+    def call_it() -> None:
+        started.wait()
+        engines.append(
+            session_module.get_health_engine("postgresql://user:pass@host/db")
+        )
+
+    threads = [threading.Thread(target=call_it) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    try:
+        assert mock_engine_dependencies["create_engine"].call_count == 1
+        assert len({id(engine) for engine in engines}) == 1
+    finally:
+        session_module._health_engine = None

--- a/backend/tests/services/test_websocket_manager.py
+++ b/backend/tests/services/test_websocket_manager.py
@@ -83,13 +83,19 @@ class TestPersistExecutionLog:
         assert mock_db.commit.called
         assert mock_db.close.called
 
+    @patch("preloop.services.websocket_manager.notify_admins")
     @patch("preloop.services.websocket_manager.get_db")
     @patch("preloop.services.websocket_manager.logger")
     @patch("preloop.models.crud.crud_flow_execution.append_log")
     def test_sync_batch_insert_logs_database_error(
-        self, mock_append, mock_logger, mock_get_db
+        self, mock_append, mock_logger, mock_get_db, mock_notify
     ):
-        """Test handling database error when persisting log batch."""
+        """Test handling database error when persisting log batch.
+
+        ``notify_admins`` is patched because the drop path really sends admin
+        email/Slack/Mattermost alerts; tests must not depend on TESTING=true
+        being exported to stay quiet.
+        """
         execution_id = "exec_789"
         log_data = {"message": "Test"}
         batch = [(execution_id, log_data)]
@@ -105,6 +111,9 @@ class TestPersistExecutionLog:
         assert mock_logger.error.called
         # Database should still close, but commit shouldn't happen after error
         assert mock_db.close.called
+        # Operators are alerted about the dropped batch (and no live alert
+        # escaped the test suite).
+        assert mock_notify.called
 
     @patch("preloop.services.websocket_manager.get_db")
     def test_sync_batch_insert_logs_closes_db_on_success(self, mock_get_db):
@@ -263,6 +272,57 @@ class TestBroadcastLoggingVolume:
 
         assert mock_logger.info.called
         assert "matching_connections=1" in mock_logger.info.call_args.args[0]
+
+    async def test_high_frequency_broadcast_skips_scan_when_debug_disabled(
+        self, manager
+    ):
+        """The hot path must not scan every connection just to pick a log level.
+
+        ``agent_log_line`` is the highest-volume message type. When DEBUG is
+        off (production), the count is never rendered, so paying an
+        O(connections) scan per message is pure waste.
+        """
+
+        class CountingAccounts(dict):
+            """Dict that records how often the full set of values is scanned."""
+
+            scans = 0
+
+            def values(self):  # type: ignore[override]
+                type(self).scans += 1
+                return super().values()
+
+        manager.connection_accounts = CountingAccounts({"conn-1": "acct-1"})
+
+        with patch("preloop.services.websocket_manager.logger") as mock_logger:
+            mock_logger.isEnabledFor.return_value = False
+            await manager.broadcast_json(
+                {"type": "agent_log_line"}, account_id="acct-1"
+            )
+
+        assert CountingAccounts.scans == 0
+        assert not mock_logger.debug.called
+        assert not mock_logger.info.called
+
+    async def test_high_frequency_broadcast_still_logs_count_when_debug_on(
+        self, manager
+    ):
+        """With DEBUG enabled the count is still reported accurately."""
+        ws = AsyncMock()
+        manager.active_connections["conn-1"] = ws
+        manager.connection_accounts["conn-1"] = "acct-1"
+
+        with patch("preloop.services.websocket_manager.logger") as mock_logger:
+            mock_logger.isEnabledFor.return_value = True
+            await manager.broadcast_json(
+                {"type": "agent_log_line"}, account_id="acct-1"
+            )
+
+        assert mock_logger.debug.called
+        assert any(
+            "1 connection(s)" in call.args[0]
+            for call in mock_logger.debug.call_args_list
+        )
 
 
 class TestWebSocketManager:
@@ -531,9 +591,17 @@ class TestNatsConsumer:
         # Verify error was logged
         assert mock_logger.error.called
 
+    @patch("preloop.services.websocket_manager.notify_admins")
     @patch("preloop.services.websocket_manager.get_task_publisher")
-    async def test_nats_consumer_handles_invalid_json(self, mock_get_publisher):
-        """Test NATS consumer handles invalid JSON messages."""
+    async def test_nats_consumer_handles_invalid_json(
+        self, mock_get_publisher, mock_notify
+    ):
+        """Test NATS consumer handles invalid JSON messages.
+
+        The malformed-message path also alerts admins (on a worker thread), so
+        ``notify_admins`` is patched here for the same reason as the log-drop
+        path: tests must never emit real notifications.
+        """
         manager = WebSocketManager()
 
         # Mock NATS client
@@ -566,6 +634,10 @@ class TestNatsConsumer:
         with patch("preloop.services.websocket_manager.logger") as mock_logger:
             await captured_handler(mock_msg)
             assert mock_logger.warning.called
+
+        # The alert is dispatched to a worker thread; give it a moment to land.
+        await asyncio.sleep(0.1)
+        assert mock_notify.called
 
         # Clean up
         consumer_task.cancel()

--- a/backend/tests/services/test_websocket_manager.py
+++ b/backend/tests/services/test_websocket_manager.py
@@ -6,9 +6,13 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy.exc import OperationalError, TimeoutError as SQLAlchemyTimeoutError
 
 from preloop.services.websocket_manager import (
+    LOG_PERSIST_MAX_ATTEMPTS,
+    LOG_PERSIST_MAX_CONCURRENCY,
     WebSocketManager,
+    _log_persist_semaphore,
     nats_consumer,
     persist_execution_log,
     _sync_batch_insert_logs,
@@ -113,6 +117,152 @@ class TestPersistExecutionLog:
             _sync_batch_insert_logs(batch)
 
         assert mock_db.close.called
+
+
+class TestSyncBatchInsertLogsRetry:
+    """Retry/backoff behaviour for transient DB failures (2026-08-08 incident).
+
+    A pool checkout timeout used to drop the whole batch on the first error,
+    silently losing execution logs. These tests pin the retry contract.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self):
+        """Keep tests fast while still asserting the backoff schedule."""
+        with patch("preloop.services.websocket_manager.time.sleep") as sleep:
+            yield sleep
+
+    @patch("preloop.services.websocket_manager.get_db")
+    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    def test_retries_pool_timeout_then_succeeds(self, mock_append, mock_get_db):
+        """A transient QueuePool timeout is retried and the batch is saved."""
+        mock_db = MagicMock()
+        mock_get_db.side_effect = lambda: iter([mock_db])
+        # Fail once with the exact error seen in production, then succeed.
+        mock_append.side_effect = [
+            SQLAlchemyTimeoutError("QueuePool limit of size 3 overflow 7 reached"),
+            None,
+        ]
+
+        assert _sync_batch_insert_logs([("exec_1", {"message": "hi"})]) is True
+        assert mock_append.call_count == 2
+        assert mock_db.commit.called
+
+    @patch("preloop.services.websocket_manager.notify_admins")
+    @patch("preloop.services.websocket_manager.get_db")
+    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    def test_drops_only_after_max_attempts(
+        self, mock_append, mock_get_db, mock_notify, _no_sleep
+    ):
+        """Persistent failure drops the batch, but only after all attempts."""
+        mock_db = MagicMock()
+        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_append.side_effect = SQLAlchemyTimeoutError("QueuePool limit reached")
+
+        assert _sync_batch_insert_logs([("exec_1", {"message": "hi"})]) is False
+        assert mock_append.call_count == LOG_PERSIST_MAX_ATTEMPTS
+        # Operator is still told about real data loss.
+        assert mock_notify.called
+        # Exponential backoff between attempts: 0.5s then 1.0s.
+        assert [c.args[0] for c in _no_sleep.call_args_list] == [0.5, 1.0]
+
+    @patch("preloop.services.websocket_manager.get_db")
+    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    def test_retries_operational_error(self, mock_append, mock_get_db):
+        """Dropped connections (OperationalError) are also transient."""
+        mock_db = MagicMock()
+        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_append.side_effect = [
+            OperationalError("SELECT 1", {}, Exception("server closed connection")),
+            None,
+        ]
+
+        assert _sync_batch_insert_logs([("exec_1", {"message": "hi"})]) is True
+        assert mock_append.call_count == 2
+
+    @patch("preloop.services.websocket_manager.notify_admins")
+    @patch("preloop.services.websocket_manager.get_db")
+    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    def test_non_retryable_error_fails_fast(
+        self, mock_append, mock_get_db, mock_notify, _no_sleep
+    ):
+        """Programming errors are not retried - no point hammering the DB."""
+        mock_db = MagicMock()
+        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_append.side_effect = ValueError("bad log payload")
+
+        assert _sync_batch_insert_logs([("exec_1", {"message": "hi"})]) is False
+        assert mock_append.call_count == 1
+        assert not _no_sleep.called
+        assert mock_notify.called
+
+    @patch("preloop.services.websocket_manager.get_db")
+    @patch("preloop.models.crud.crud_flow_execution.append_log")
+    def test_failed_attempt_rolls_back(self, mock_append, mock_get_db):
+        """A failed batch must not leave a dirty transaction on the pool."""
+        mock_db = MagicMock()
+        mock_get_db.side_effect = lambda: iter([mock_db])
+        mock_append.side_effect = [SQLAlchemyTimeoutError("pool"), None]
+
+        _sync_batch_insert_logs([("exec_1", {"message": "hi"})])
+
+        assert mock_db.rollback.called
+        assert mock_db.close.call_count == 2
+
+    @patch("preloop.services.websocket_manager.get_db")
+    def test_empty_batch_touches_no_connection(self, mock_get_db):
+        """An empty batch must not check out a connection at all."""
+        assert _sync_batch_insert_logs([]) is True
+        assert not mock_get_db.called
+
+    def test_semaphore_bounds_log_persistence_concurrency(self):
+        """Background log writes are capped so they cannot drain the pool."""
+        assert LOG_PERSIST_MAX_CONCURRENCY >= 1
+        # Acquire every permit; the next attempt must not succeed immediately.
+        acquired = [
+            _log_persist_semaphore.acquire(blocking=False)
+            for _ in range(LOG_PERSIST_MAX_CONCURRENCY)
+        ]
+        try:
+            assert all(acquired)
+            assert _log_persist_semaphore.acquire(blocking=False) is False
+        finally:
+            for ok in acquired:
+                if ok:
+                    _log_persist_semaphore.release()
+
+
+class TestBroadcastLoggingVolume:
+    """Zero-listener broadcasts were ~69% of production gateway log lines."""
+
+    @pytest.fixture
+    def manager(self):
+        return WebSocketManager()
+
+    async def test_no_info_log_when_no_listeners(self, manager):
+        """Status broadcasts with zero matching connections log at DEBUG."""
+        with patch("preloop.services.websocket_manager.logger") as mock_logger:
+            await manager.broadcast_json(
+                {"type": "flow_status_update"}, account_id="acct-1"
+            )
+
+        assert not mock_logger.info.called
+        assert mock_logger.debug.called
+
+    async def test_info_log_retained_when_listeners_present(self, manager):
+        """Real listeners still produce the operator-visible INFO line."""
+        ws = AsyncMock()
+        conn_id = "conn-1"
+        manager.active_connections[conn_id] = ws
+        manager.connection_accounts[conn_id] = "acct-1"
+
+        with patch("preloop.services.websocket_manager.logger") as mock_logger:
+            await manager.broadcast_json(
+                {"type": "flow_status_update"}, account_id="acct-1"
+            )
+
+        assert mock_logger.info.called
+        assert "matching_connections=1" in mock_logger.info.call_args.args[0]
 
 
 class TestWebSocketManager:

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -268,25 +268,44 @@ config:
 # Database configuration
 database:
   # SQLAlchemy connection pool sizing per component, injected as
-  # DATABASE_POOL_SIZE / DATABASE_MAX_OVERFLOW. Peak connections per pod =
-  # size + maxOverflow. The application defaults (20 + 40 per pod) are NOT
-  # safe once the gateway autoscales: 11 pods x 60 = 660 potential
-  # connections against max_connections=200. Budget with these values:
-  #   api        (1 pod):   10 + 20 = 30
-  #   gateway (<=5 pods):    3 +  7 = 10 each -> 50
-  #   sync workers/monitor/scheduler (5 pods): 2 + 3 = 5 each -> 25
-  # Peak ~105 against max_connections=200 (see cnpg.parameters below),
-  # leaving headroom for jobs, replication, and superuser connections.
+  # DATABASE_POOL_SIZE / DATABASE_MAX_OVERFLOW.
+  #
+  # IMPORTANT: each pod builds TWO pools (the sync engine and the async
+  # engine in models/db/session.py share these settings), plus one connection
+  # for the dedicated health-check engine. So:
+  #   steady per pod  = size * 2 + 1
+  #   ceiling per pod = (size + maxOverflow) * 2 + 1
+  #
+  # The previous comment assumed 1 api pod and 5 worker pods; production
+  # actually runs api=2, gateway=5 (HPA max), workers/monitor/scheduler=8.
+  #
+  # Budget with the values below (api=2, gateway=5, worker=8 pods):
+  #   api     2 x (8+12):  steady  34, ceiling  82
+  #   gateway 5 x (6+14):  steady  65, ceiling 205
+  #   worker  8 x (2+4):   steady  40, ceiling 104
+  #   TOTAL:               steady 139, ceiling 391
+  #
+  # Steady state (139) fits inside max_connections=200 minus the 3 superuser
+  # reserved slots, with ~58 spare for jobs and psql. The absolute ceiling is
+  # deliberately oversubscribed: overflow connections are short-lived and
+  # never all claimed at once (measured production peak is ~65 total). The
+  # 2026-08-08 incident was per-pod starvation, not a global shortage -- one
+  # gateway pod exhausted its 10-connection ceiling while the server as a
+  # whole was 65/200. Raising the gateway ceiling from 10 to 20 per pod is
+  # what fixes it.
+  #
+  # If you increase gateway maxReplicas or add components, re-check the
+  # steady total against max_connections (see cnpg.parameters below).
   pool:
     api:
-      size: 10
-      maxOverflow: 20
+      size: 8
+      maxOverflow: 12
     gateway:
-      size: 3
-      maxOverflow: 7
+      size: 6
+      maxOverflow: 14
     worker:
       size: 2
-      maxOverflow: 3
+      maxOverflow: 4
   # If true, deploys a PostgreSQL instance using CloudNativePG
   enabled: true
   # If external is true, uses an external PostgreSQL instance


### PR DESCRIPTION
## Problem

Under a burst of concurrent flow work, a gateway pod exhausted its SQLAlchemy connection pool:

```
TimeoutError: QueuePool limit of size N overflow M reached, connection timed out, timeout 30.00
```

The cascade, in order:

1. `websocket_manager._sync_batch_insert_logs` failed and **dropped a batch of NATS logs** (data loss)
2. `Database health check failed` (`health.py:52`)
3. `preloop.api.auth.jwt.get_user_from_token_if_valid` failed
4. Pod restart (`exitCode: 137, reason: Error`, not OOMKilled)

The database itself was nearly idle throughout. This was per-pod pool starvation, not a global connection shortage.

## Root cause

Two distinct problems, both fixed here.

**1. Per-pod pool sizing did not account for two engines per pod.**
`models/db/session.py` passes the same `_database_pool_kwargs()` to both the sync and the async engine, so each pod's real connection use is roughly twice what a single `pool_size` reading suggests:

```
per pod:  steady  = size * 2 + 1     (+1 for the new health engine)
          ceiling = (size + maxOverflow) * 2 + 1
```

The chart comments did not reflect this. They are corrected here, and the gateway defaults are raised so a single pod is not capped at a handful of connections while the database sits idle.

**2. The pod died even though liveness is already DB-free.**
Liveness is `/api/v1/ping`, which touches no database, so the SIGKILL was surprising. Cause: `ping()` was declared `def`, not `async def`. FastAPI runs sync endpoints in Starlette's bounded anyio threadpool. Sync DB endpoints blocked those threads for up to the 30s pool-checkout timeout, so the DB-free liveness probe queued behind them, exceeded its timeout, and Kubernetes killed a pod that was merely busy. This is the actual restart mechanism, and it is a one-word fix.

## Changes

- **`websocket_manager._sync_batch_insert_logs`**: bounded retry (3 attempts, 0.5s/1.0s backoff) on `TimeoutError`/`OperationalError` before dropping; rolls back on failure so no dirty transaction returns to the pool; returns a success bool; non-retryable errors fail fast. Still notifies admins on real loss. A semaphore bounds background log persistence so it cannot starve request-serving connections. DB access stays behind `preloop.models.crud`.
- **`health.py`**: `/health` uses a dedicated 1-connection engine (`get_health_engine`) with 3s timeouts, so readiness reflects DB reachability rather than pool saturation. Previously a saturated pool marked every pod NotReady at once.
- **`health.py`**: `/ping` is now `async` (see root cause 2).
- **`values.yaml`**: chart-default pool sizing plus corrected documentation of the two-engines-per-pod arithmetic.
- **Broadcast log noise**: zero-listener broadcasts accounted for roughly 69% of gateway log lines in a sample. Downgraded to DEBUG; broadcasts with real listeners still log at INFO. This is log/CPU waste only, it performs no DB work and did not contribute to the incident.

## Deployment note

Chart defaults alone do not govern every deployment. Any environment that sets `DATABASE_POOL_SIZE` / `DATABASE_MAX_OVERFLOW` explicitly (via its own values file, deployment env, or `--set` at deploy time) must be updated separately, or this chart change has no effect there. Operators should size with the `steady`/`ceiling` formula above against their own `max_connections`, keeping steady-state totals comfortably below the usable limit.

## Tests

11 new tests: retry-then-succeed, drop-only-after-max-attempts (asserting the exact 0.5s/1.0s backoff schedule), `OperationalError` retry, non-retryable fail-fast, rollback-on-failure, empty batch opens no connection, semaphore bound, both broadcast logging levels, and two liveness regression guards.

```
backend/tests/services/test_websocket_manager.py  29 passed
backend/tests/endpoints/test_health.py             8 passed
```

Wider suite `backend/tests/{services,endpoints,api}`: **3061 passed** vs **3050 passed** on clean `main`, with the same **20 pre-existing failures** before and after (`test_openai_gateway_attribution_sessions.py` and others, unrelated). ruff + ruff-format clean; mypy shows no new errors on touched files (24 before, 24 after; the new `get_health_engine` is fully typed).

## What I did NOT change

- No cluster-side changes of any kind. No `kubectl apply/edit/scale/delete/restart`, no DB writes.
- No PostgreSQL/CNPG change. `max_connections` was not the binding constraint.
- Did not touch HPA settings, resource limits, probe timings, or the 30s `pool_timeout`.
- Did not change the app-level defaults in `config.py` (20/40), which suit single-pod and dev use; the chart governs deployed environments.
- Did not restructure the sync+async dual-engine design, which is the deeper reason per-pod connection use is 2x what it appears. Worth a follow-up.
- Author: d-mo

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Surgical incident response with comprehensive test coverage. No security-sensitive changes.
>
> **Overview**
> Fixes per-pod SQLAlchemy pool exhaustion through retry logic, dedicated health-check engine, async liveness probe, and corrected Helm pool sizing. Addresses two distinct root causes with 14 tests covering retry schedules, concurrency, and regression guards.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 0f8f27dc. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->