### PR TITLE
fix: tracker sync backoff and upstream disconnect handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tracker sync loop on out-of-scope repositories**: a webhook naming a
+  project we never imported triggered a full forced tracker re-sync on *every*
+  event, and logged a "Project ... not found. Triggering a sync" warning plus
+  an admin notification each time. When the repository is outside the
+  integration's scope (a GitHub App installed on *selected repositories*, or an
+  `EXCLUDE` scope rule) the sync can never resolve it, so every subsequent
+  webhook repeated the whole cycle — burning GitHub API calls and admin noise
+  indefinitely. Unknown projects are now tracked per (tracker, project) with
+  exponential backoff (5m doubling to a 1h cap) and are marked **degraded**
+  after 5 failed attempts, at which point syncs stop entirely and the project
+  is surfaced to the user via the new `degraded_projects` field on the tracker
+  API response. The log line is now actionable (account, tracker, project,
+  attempt count and the likely cause) and the per-event admin notification is
+  gone. State clears automatically when the project later syncs successfully.
+
 ## [0.14.0] - 2026-08-07
 
 Highlights: **Cursor usage import** brings bundled-model spend into Cost

--- a/backend/preloop/api/endpoints/webhooks.py
+++ b/backend/preloop/api/endpoints/webhooks.py
@@ -13,6 +13,7 @@ from preloop.models.crud import (
     crud_issue_embedding,
     crud_organization,
     crud_project,
+    crud_tracker,
 )
 from preloop.models.db.session import get_db_session
 from preloop.models.models.tracker import Tracker
@@ -485,19 +486,51 @@ async def receive_webhook(
 
             project = crud_project.get_by_identifier(db, identifier=project_identifier)
             if not project:
+                # The webhook names a project we never imported. Usually the
+                # repo is outside the integration's scope (GitHub App installed
+                # on selected repositories only, or a TrackerScopeRule excludes
+                # it), in which case a sync can never resolve it -- so retry
+                # with backoff and eventually mark it degraded rather than
+                # re-scanning on every event (#tracker-sync-loop).
+                state = crud_tracker.record_unknown_project(
+                    db,
+                    id=str(resolved_tracker.id),
+                    project_identifier=project_identifier,
+                )
+                context = (
+                    f"project={project_identifier} tracker={resolved_tracker.id} "
+                    f"tracker_type={tracker_type} account={resolved_tracker.account_id} "
+                    f"attempts={state.attempts}"
+                )
+                if state.degraded:
+                    logger.warning(
+                        f"Unknown project on webhook; tracker marked degraded, not syncing. {context}. "
+                        "Reason: the project is not visible to this integration after repeated syncs "
+                        "(check that the repository is in the integration's selected repositories and "
+                        "not excluded by a scope rule)."
+                    )
+                    return {
+                        "status": "accepted",
+                        "message": "Project not found; tracker needs attention.",
+                        "degraded": True,
+                    }
+                if not state.should_sync:
+                    logger.info(
+                        f"Unknown project on webhook; sync suppressed by backoff "
+                        f"(retry_after={state.retry_after_seconds}s). {context}."
+                    )
+                    return {
+                        "status": "accepted",
+                        "message": "Project not found; sync backoff in effect.",
+                    }
                 logger.warning(
-                    f"Project with identifier {project_identifier} not found. Triggering a sync for tracker {resolved_tracker.id}."
+                    f"Unknown project on webhook; triggering sync. {context}. "
+                    "Reason: no project row matches the webhook's project identifier."
                 )
                 await task_publisher.publish_task(
                     "poll_tracker",
                     tracker_id=resolved_tracker.id,
                     force_update=True,
-                )
-                # Notify admins
-                await task_publisher.publish_task(
-                    "notify_admins",
-                    subject="Project not found",
-                    message=f"Project with identifier {project_identifier} not found. Triggering a sync for tracker {resolved_tracker.id}.",
                 )
                 return {
                     "status": "accepted",

--- a/backend/preloop/models/crud/tracker.py
+++ b/backend/preloop/models/crud/tracker.py
@@ -1,15 +1,62 @@
 """CRUD operations for Tracker model."""
 
-from datetime import datetime, timezone
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
 
 from ..models.tracker import Tracker, TrackerType
 from .base import CRUDBase
 
 TRACKER_API_KEY_SECRET_KIND = "tracker_api_key"
 TRACKER_WEBHOOK_SECRET_KIND = "tracker_webhook_secret"
+
+# Key under Tracker.meta_data holding per-project unknown-project failure
+# state: {"<project_identifier>": {"attempts": int, "last_attempt_at": iso,
+# "first_seen_at": iso, "last_seen_at": iso, "degraded": bool}}.
+UNKNOWN_PROJECTS_META_KEY = "unknown_projects"
+
+# Backoff schedule for re-syncing a tracker after a webhook named a project we
+# do not know about. Doubles per attempt: 5m, 10m, 20m, 40m, capped at 1h.
+UNKNOWN_PROJECT_BASE_BACKOFF = timedelta(minutes=5)
+UNKNOWN_PROJECT_MAX_BACKOFF = timedelta(hours=1)
+
+# After this many failed sync attempts the project is considered degraded and
+# we stop triggering syncs, surfacing it to the user instead.
+UNKNOWN_PROJECT_ATTEMPTS_BEFORE_DEGRADED = 5
+
+
+@dataclass(frozen=True)
+class UnknownProjectState:
+    """Outcome of recording a webhook for a project we cannot resolve.
+
+    Attributes:
+        should_sync: True when the caller should trigger a tracker sync now.
+        attempts: Number of sync attempts made for this project so far.
+        degraded: True once retries are exhausted and the project needs user
+            attention (repo outside the integration's scope).
+        retry_after_seconds: Backoff before the next attempt is due.
+    """
+
+    should_sync: bool
+    attempts: int
+    degraded: bool
+    retry_after_seconds: int
+
+
+def _parse_timestamp(raw: Any) -> Optional[datetime]:
+    """Parse an ISO timestamp from meta_data, tolerating junk/naive values."""
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(raw))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def store_tracker_secret(
@@ -244,6 +291,112 @@ class CRUDTracker(CRUDBase[Tracker]):
             db.commit()
             db.refresh(tracker)
         return tracker
+
+    def record_unknown_project(
+        self,
+        db: Session,
+        *,
+        id: str,
+        project_identifier: str,
+        now: Optional[datetime] = None,
+    ) -> UnknownProjectState:
+        """Record a webhook referencing a project we do not have, with backoff.
+
+        A webhook can name a project the sync has never imported (repo outside
+        the GitHub App's selected-repositories scope, or excluded by a
+        ``TrackerScopeRule``). Re-syncing on every such event is useless work:
+        the scan cannot return a repo the installation cannot see, so the next
+        webhook fails the same lookup and triggers another scan.
+
+        This tracks one failure counter per (tracker, project) in
+        ``Tracker.meta_data`` and returns whether the caller should trigger a
+        sync now. Retries use exponential backoff
+        (:data:`UNKNOWN_PROJECT_BASE_BACKOFF` doubling up to
+        :data:`UNKNOWN_PROJECT_MAX_BACKOFF`); after
+        :data:`UNKNOWN_PROJECT_ATTEMPTS_BEFORE_DEGRADED` failed attempts the
+        project is marked degraded so it is surfaced to the user instead of
+        being retried forever.
+
+        Args:
+            db: Database session.
+            id: Tracker id.
+            project_identifier: Provider-side project/repo id from the webhook.
+            now: Injectable clock for tests.
+
+        Returns:
+            An :class:`UnknownProjectState` describing whether to sync, the
+            attempt count, and whether the project is degraded.
+        """
+        current_time = now or datetime.now(timezone.utc)
+        tracker = self.get(db, id=id)
+        if tracker is None:
+            return UnknownProjectState(
+                should_sync=False, attempts=0, degraded=False, retry_after_seconds=0
+            )
+
+        meta_data = dict(tracker.meta_data or {})
+        unknown_projects = dict(meta_data.get(UNKNOWN_PROJECTS_META_KEY) or {})
+        entry = dict(unknown_projects.get(project_identifier) or {})
+
+        attempts = int(entry.get("attempts") or 0)
+        last_attempt = _parse_timestamp(entry.get("last_attempt_at"))
+
+        backoff = min(
+            UNKNOWN_PROJECT_BASE_BACKOFF * (2 ** max(attempts - 1, 0)),
+            UNKNOWN_PROJECT_MAX_BACKOFF,
+        )
+        due = last_attempt is None or (current_time - last_attempt) >= backoff
+        degraded = attempts >= UNKNOWN_PROJECT_ATTEMPTS_BEFORE_DEGRADED
+        should_sync = due and not degraded
+
+        if should_sync:
+            attempts += 1
+            entry["attempts"] = attempts
+            entry["last_attempt_at"] = current_time.isoformat()
+            entry.setdefault("first_seen_at", current_time.isoformat())
+            degraded = attempts >= UNKNOWN_PROJECT_ATTEMPTS_BEFORE_DEGRADED
+
+        entry["degraded"] = degraded
+        entry["last_seen_at"] = current_time.isoformat()
+        unknown_projects[project_identifier] = entry
+        meta_data[UNKNOWN_PROJECTS_META_KEY] = unknown_projects
+        tracker.meta_data = meta_data
+        flag_modified(tracker, "meta_data")
+        tracker.last_updated = current_time
+        db.add(tracker)
+        db.commit()
+
+        next_backoff = min(
+            UNKNOWN_PROJECT_BASE_BACKOFF * (2 ** max(attempts - 1, 0)),
+            UNKNOWN_PROJECT_MAX_BACKOFF,
+        )
+        return UnknownProjectState(
+            should_sync=should_sync,
+            attempts=attempts,
+            degraded=degraded,
+            retry_after_seconds=int(next_backoff.total_seconds()),
+        )
+
+    def clear_unknown_project(
+        self, db: Session, *, id: str, project_identifier: str
+    ) -> None:
+        """Drop the unknown-project failure state once the project resolves."""
+        tracker = self.get(db, id=id)
+        if tracker is None:
+            return
+        meta_data = dict(tracker.meta_data or {})
+        unknown_projects = dict(meta_data.get(UNKNOWN_PROJECTS_META_KEY) or {})
+        if project_identifier not in unknown_projects:
+            return
+        unknown_projects.pop(project_identifier)
+        if unknown_projects:
+            meta_data[UNKNOWN_PROJECTS_META_KEY] = unknown_projects
+        else:
+            meta_data.pop(UNKNOWN_PROJECTS_META_KEY, None)
+        tracker.meta_data = meta_data
+        flag_modified(tracker, "meta_data")
+        db.add(tracker)
+        db.commit()
 
     def deactivate(self, db: Session, *, id: str) -> Optional[Tracker]:
         """Deactivate a tracker."""

--- a/backend/preloop/schemas/tracker.py
+++ b/backend/preloop/schemas/tracker.py
@@ -4,8 +4,9 @@ from typing import Any, Dict, List, Optional
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field, HttpUrl, ConfigDict
+from pydantic import BaseModel, Field, HttpUrl, ConfigDict, computed_field
 
+from preloop.models.crud.tracker import UNKNOWN_PROJECTS_META_KEY
 from preloop.models.models.tracker import TrackerType
 from .tracker_scope_rule import TrackerScopeRuleCreate, TrackerScopeRuleResponse
 
@@ -136,6 +137,26 @@ class TrackerResponse(TrackerBase):
     )
 
     model_config = {"from_attributes": True}
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def degraded_projects(self) -> List[str]:
+        """Project identifiers seen on webhooks that never resolved.
+
+        These are repositories/projects the tracker receives webhooks for but
+        which repeated syncs could not import -- almost always because the
+        integration's scope excludes them (GitHub App installed on selected
+        repositories only, or an EXCLUDE scope rule). Surfaced so the user can
+        fix the scope instead of the sync retrying forever.
+        """
+        unknown = (self.meta_data or {}).get(UNKNOWN_PROJECTS_META_KEY) or {}
+        if not isinstance(unknown, dict):
+            return []
+        return sorted(
+            identifier
+            for identifier, entry in unknown.items()
+            if isinstance(entry, dict) and entry.get("degraded")
+        )
 
 
 class TrackerTestRequest(BaseModel):

--- a/backend/preloop/sync/scanner/core.py
+++ b/backend/preloop/sync/scanner/core.py
@@ -19,6 +19,7 @@ from preloop.models.crud import (
     crud_organization,
     crud_project,
     crud_comment,
+    crud_tracker,
 )
 from preloop.models.models import (
     Issue,
@@ -257,6 +258,13 @@ class TrackerClient:
                 else:
                     project = crud_project.create(db, obj_in=proj_create_data)
                 processed_projects.append(project)
+                # The project resolved, so any unknown-project backoff/degraded
+                # state recorded from webhooks is stale -- drop it.
+                crud_tracker.clear_unknown_project(
+                    db,
+                    id=str(self.tracker.id),
+                    project_identifier=str(project_identifier),
+                )
             except Exception as e:
                 logger.error(
                     f"Error processing project data for {proj_data.get('name', 'N/A')}: {e}",

--- a/backend/tests/endpoints/test_webhooks.py
+++ b/backend/tests/endpoints/test_webhooks.py
@@ -8,6 +8,7 @@ import pytest
 
 from fastapi import HTTPException
 from preloop.api.endpoints import webhooks
+from preloop.models.crud.tracker import UnknownProjectState
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -583,6 +584,103 @@ class TestWebhooksEndpoint:
 
         assert response.status_code == 200
         assert response.json()["status"] == "accepted"
+
+    def _post_unknown_project_webhook(self, org_mock, secret):
+        """POST an issues webhook whose repository id is unknown to us."""
+        payload_dict = {
+            "action": "opened",
+            "issue": {"id": 789, "number": 2, "title": "T", "body": "B"},
+            "repository": {"id": 1327729611, "full_name": "acme/unknown"},
+            "organization": {"id": "test-org-fixture"},
+        }
+        body = json.dumps(payload_dict, separators=(",", ":")).encode("utf-8")
+        signature = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        return self.test_client.post(
+            f"/api/v1/private/webhooks/github/{org_mock.id}",
+            json=payload_dict,
+            headers={
+                "X-Hub-Signature-256": f"sha256={signature}",
+                "X-GitHub-Event": "issues",
+            },
+        )
+
+    def _unknown_project_org(self, configured_mock_org_fixture, secret):
+        """Wire up an org whose tracker will see an unresolvable project."""
+        org = configured_mock_org_fixture
+        setup_mock_webhook_secret(org, secret)
+        org.tracker = MagicMock(name="MockTrackerUnknownProject")
+        org.tracker.id = "tracker-gh-unknown-project"
+        org.tracker.account_id = "account-1"
+        org.tracker.is_active = True
+        org.tracker.tracker_type = "github"
+        org.tracker.subscribed_events = ["issues"]
+        self.mock_session.query.return_value.options.return_value.filter.return_value.first.return_value = org
+        return org
+
+    @patch("preloop.api.endpoints.webhooks.crud_tracker")
+    @patch("preloop.api.endpoints.webhooks.crud_project")
+    def test_unknown_project_backoff_suppresses_sync(
+        self, mock_crud_project, mock_crud_tracker, configured_mock_org_fixture
+    ):
+        """While backoff is active no sync task is published (the loop fix)."""
+        secret = "unknown-project-secret"
+        org = self._unknown_project_org(configured_mock_org_fixture, secret)
+        mock_crud_project.get_by_identifier.return_value = None
+        mock_crud_tracker.record_unknown_project.return_value = UnknownProjectState(
+            should_sync=False, attempts=2, degraded=False, retry_after_seconds=600
+        )
+
+        response = self._post_unknown_project_webhook(org, secret)
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "accepted"
+        published = [
+            c.args[0] for c in self.mock_task_publisher.publish_task.call_args_list
+        ]
+        assert "poll_tracker" not in published
+
+    @patch("preloop.api.endpoints.webhooks.crud_tracker")
+    @patch("preloop.api.endpoints.webhooks.crud_project")
+    def test_unknown_project_degraded_reports_needs_attention(
+        self, mock_crud_project, mock_crud_tracker, configured_mock_org_fixture
+    ):
+        """Once degraded we stop syncing and say the tracker needs attention."""
+        secret = "unknown-project-degraded-secret"
+        org = self._unknown_project_org(configured_mock_org_fixture, secret)
+        mock_crud_project.get_by_identifier.return_value = None
+        mock_crud_tracker.record_unknown_project.return_value = UnknownProjectState(
+            should_sync=False, attempts=5, degraded=True, retry_after_seconds=3600
+        )
+
+        response = self._post_unknown_project_webhook(org, secret)
+
+        assert response.status_code == 200
+        assert response.json()["degraded"] is True
+        published = [
+            c.args[0] for c in self.mock_task_publisher.publish_task.call_args_list
+        ]
+        assert "poll_tracker" not in published
+
+    @patch("preloop.api.endpoints.webhooks.crud_tracker")
+    @patch("preloop.api.endpoints.webhooks.crud_project")
+    def test_unknown_project_first_sighting_still_syncs(
+        self, mock_crud_project, mock_crud_tracker, configured_mock_org_fixture
+    ):
+        """The first sighting must still trigger exactly one sync."""
+        secret = "unknown-project-first-secret"
+        org = self._unknown_project_org(configured_mock_org_fixture, secret)
+        mock_crud_project.get_by_identifier.return_value = None
+        mock_crud_tracker.record_unknown_project.return_value = UnknownProjectState(
+            should_sync=True, attempts=1, degraded=False, retry_after_seconds=300
+        )
+
+        response = self._post_unknown_project_webhook(org, secret)
+
+        assert response.status_code == 200
+        published = [
+            c.args[0] for c in self.mock_task_publisher.publish_task.call_args_list
+        ]
+        assert published.count("poll_tracker") == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/models/crud/test_tracker_unknown_project.py
+++ b/backend/tests/models/crud/test_tracker_unknown_project.py
@@ -1,0 +1,187 @@
+"""Tests for unknown-project backoff/degraded state on trackers.
+
+Covers the webhook sync loop fix: a webhook naming a project we never
+imported must retry with exponential backoff and eventually mark the project
+degraded instead of triggering a tracker sync on every single event.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from preloop.models.crud import crud_tracker
+from preloop.models.crud.tracker import (
+    UNKNOWN_PROJECT_ATTEMPTS_BEFORE_DEGRADED,
+    UNKNOWN_PROJECT_BASE_BACKOFF,
+    UNKNOWN_PROJECT_MAX_BACKOFF,
+    UNKNOWN_PROJECTS_META_KEY,
+)
+
+PROJECT = "1327729611"
+
+
+def test_first_unknown_project_event_triggers_sync(db_session: Session, test_tracker):
+    """The first sighting of an unknown project should trigger one sync."""
+    state = crud_tracker.record_unknown_project(
+        db_session, id=str(test_tracker.id), project_identifier=PROJECT
+    )
+
+    assert state.should_sync is True
+    assert state.attempts == 1
+    assert state.degraded is False
+
+
+def test_immediate_repeat_is_suppressed_by_backoff(db_session: Session, test_tracker):
+    """A second webhook right away must not trigger another sync."""
+    now = datetime.now(timezone.utc)
+    first = crud_tracker.record_unknown_project(
+        db_session, id=str(test_tracker.id), project_identifier=PROJECT, now=now
+    )
+    second = crud_tracker.record_unknown_project(
+        db_session,
+        id=str(test_tracker.id),
+        project_identifier=PROJECT,
+        now=now + timedelta(seconds=30),
+    )
+
+    assert first.should_sync is True
+    assert second.should_sync is False
+    # Suppressed attempts must not inflate the counter.
+    assert second.attempts == 1
+
+
+def test_sync_retried_once_backoff_elapsed(db_session: Session, test_tracker):
+    """Once the backoff window passes, one more sync is allowed."""
+    now = datetime.now(timezone.utc)
+    crud_tracker.record_unknown_project(
+        db_session, id=str(test_tracker.id), project_identifier=PROJECT, now=now
+    )
+    later = crud_tracker.record_unknown_project(
+        db_session,
+        id=str(test_tracker.id),
+        project_identifier=PROJECT,
+        now=now + UNKNOWN_PROJECT_BASE_BACKOFF + timedelta(seconds=1),
+    )
+
+    assert later.should_sync is True
+    assert later.attempts == 2
+
+
+def test_backoff_grows_exponentially_and_is_capped(db_session: Session, test_tracker):
+    """Retry interval doubles per attempt and never exceeds the cap."""
+    now = datetime.now(timezone.utc)
+    seen = []
+    for _ in range(UNKNOWN_PROJECT_ATTEMPTS_BEFORE_DEGRADED):
+        state = crud_tracker.record_unknown_project(
+            db_session,
+            id=str(test_tracker.id),
+            project_identifier=PROJECT,
+            now=now,
+        )
+        seen.append(state.retry_after_seconds)
+        # Jump past whatever backoff was just set.
+        now += timedelta(seconds=state.retry_after_seconds + 1)
+
+    assert seen[0] == int(UNKNOWN_PROJECT_BASE_BACKOFF.total_seconds())
+    assert seen[1] == 2 * seen[0]
+    assert all(s <= UNKNOWN_PROJECT_MAX_BACKOFF.total_seconds() for s in seen)
+
+
+def test_becomes_degraded_and_stops_syncing(db_session: Session, test_tracker):
+    """After the attempt budget is spent the project stops triggering syncs."""
+    now = datetime.now(timezone.utc)
+    for _ in range(UNKNOWN_PROJECT_ATTEMPTS_BEFORE_DEGRADED):
+        state = crud_tracker.record_unknown_project(
+            db_session,
+            id=str(test_tracker.id),
+            project_identifier=PROJECT,
+            now=now,
+        )
+        now += timedelta(seconds=state.retry_after_seconds + 1)
+
+    assert state.degraded is True
+
+    # Far in the future the backoff has long elapsed, but degraded wins.
+    after = crud_tracker.record_unknown_project(
+        db_session,
+        id=str(test_tracker.id),
+        project_identifier=PROJECT,
+        now=now + timedelta(days=7),
+    )
+    assert after.should_sync is False
+    assert after.degraded is True
+    assert after.attempts == UNKNOWN_PROJECT_ATTEMPTS_BEFORE_DEGRADED
+
+
+def test_degraded_state_is_persisted_on_tracker(db_session: Session, test_tracker):
+    """Degraded projects are recorded in meta_data so the API can show them."""
+    now = datetime.now(timezone.utc)
+    for _ in range(UNKNOWN_PROJECT_ATTEMPTS_BEFORE_DEGRADED):
+        state = crud_tracker.record_unknown_project(
+            db_session,
+            id=str(test_tracker.id),
+            project_identifier=PROJECT,
+            now=now,
+        )
+        now += timedelta(seconds=state.retry_after_seconds + 1)
+
+    db_session.refresh(test_tracker)
+    entry = (test_tracker.meta_data or {})[UNKNOWN_PROJECTS_META_KEY][PROJECT]
+    assert entry["degraded"] is True
+    assert entry["attempts"] == UNKNOWN_PROJECT_ATTEMPTS_BEFORE_DEGRADED
+    assert entry["first_seen_at"]
+
+
+def test_separate_projects_have_independent_counters(db_session: Session, test_tracker):
+    """Backoff for one project must not suppress a different project."""
+    now = datetime.now(timezone.utc)
+    crud_tracker.record_unknown_project(
+        db_session, id=str(test_tracker.id), project_identifier=PROJECT, now=now
+    )
+    other = crud_tracker.record_unknown_project(
+        db_session,
+        id=str(test_tracker.id),
+        project_identifier="1227805380",
+        now=now,
+    )
+
+    assert other.should_sync is True
+    assert other.attempts == 1
+
+
+def test_clear_unknown_project_resets_state(db_session: Session, test_tracker):
+    """A project that later syncs successfully clears its failure state."""
+    now = datetime.now(timezone.utc)
+    for _ in range(UNKNOWN_PROJECT_ATTEMPTS_BEFORE_DEGRADED):
+        state = crud_tracker.record_unknown_project(
+            db_session,
+            id=str(test_tracker.id),
+            project_identifier=PROJECT,
+            now=now,
+        )
+        now += timedelta(seconds=state.retry_after_seconds + 1)
+
+    crud_tracker.clear_unknown_project(
+        db_session, id=str(test_tracker.id), project_identifier=PROJECT
+    )
+
+    db_session.refresh(test_tracker)
+    assert UNKNOWN_PROJECTS_META_KEY not in (test_tracker.meta_data or {})
+
+    # And syncing is allowed again from scratch.
+    fresh = crud_tracker.record_unknown_project(
+        db_session, id=str(test_tracker.id), project_identifier=PROJECT, now=now
+    )
+    assert fresh.should_sync is True
+    assert fresh.attempts == 1
+
+
+def test_missing_tracker_is_a_no_op(db_session: Session):
+    """An unknown tracker id must not raise or trigger a sync."""
+    state = crud_tracker.record_unknown_project(
+        db_session,
+        id="00000000-0000-0000-0000-000000000000",
+        project_identifier=PROJECT,
+    )
+    assert state.should_sync is False
+    assert state.degraded is False

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17299,6 +17299,24 @@ components:
           type: array
           title: Scope Rules
           description: List of scope rules for the tracker
+        degraded_projects:
+          items:
+            type: string
+          type: array
+          title: Degraded Projects
+          description: 'Project identifiers seen on webhooks that never resolved.
+
+
+            These are repositories/projects the tracker receives webhooks for but
+
+            which repeated syncs could not import -- almost always because the
+
+            integration''s scope excludes them (GitHub App installed on selected
+
+            repositories only, or an EXCLUDE scope rule). Surfaced so the user can
+
+            fix the scope instead of the sync retrying forever.'
+          readOnly: true
       type: object
       required:
       - name
@@ -17307,6 +17325,7 @@ components:
       - account_id
       - created
       - last_updated
+      - degraded_projects
       title: TrackerResponse
       description: Response model for tracker data (excluding sensitive info like
         api_key).


### PR DESCRIPTION
## Summary

Two lower-severity production issues investigated. **One was ours and is fixed here; the other is an upstream flake that we already handle correctly and is left unchanged.**

### Issue A — repeating tracker sync loop (fixed)

`webhooks.py` logged `Project with identifier <id> not found. Triggering a sync for tracker <id>.` and, for **every** such webhook, published a forced `poll_tracker` re-scan **and** an admin notification.

Root cause: the project genuinely cannot be resolved. The tracker authenticates as a **GitHub App with `resource_selection = "selected"`**, and the repo sending webhooks is not in the selected set — `get_projects()` reads `/installation/repositories`, so the scan can never return it. Webhooks arrive org-wide, so each event failed the lookup and triggered another full re-scan that was guaranteed not to help. A self-sustaining loop with no exit condition.

Fix: track unknown projects per `(tracker, project)` in `Tracker.meta_data` with exponential backoff (5m doubling → 1h cap), and mark them **degraded** after 5 attempts, at which point syncs stop entirely and the project is surfaced to the user via a new read-only `degraded_projects` field on the tracker response. The log line is now actionable (tracker, project, attempt count, likely cause) and the per-event admin notification is gone. State clears automatically if the project later syncs.

### Issue B — upstream mid-stream disconnects (no code change)

Investigated and concluded **upstream flake, already handled correctly**:

- **2 occurrences in 24h out of 39,210 gateway calls (0.005%)**, both on the same OpenRouter-routed model. First ever occurrences of this `error_class`.
- `MidStreamFallbackError` does **not** mean our fallback failed — we never configure litellm `fallbacks` and never use `litellm.Router`. It is litellm's generic wrapper for a mid-stream transport failure raised from `streaming_handler.py`.
- The client gets a **clean terminal error**, not a silent truncation: `_stream_error` remaps to `upstream_disconnect` / HTTP 502 and emits an SSE `error` event followed by `[DONE]` (#109/#117).
- Billing is **correct**: both rows recorded `prompt_tokens=0`, `completion_tokens=0`, `cost_source='unpriced'`, no cost. The local usage estimator only runs for `status_code in (200, 499)`, so a dead stream is never billed.

Existing coverage in `test_upstream_errors.py`, `test_openai_gateway_upstream_errors.py` and `test_openai_gateway.py` already asserts this behaviour, so no change was made.

## Testing

- New `backend/tests/models/crud/test_tracker_unknown_project.py` (9 tests): first sighting syncs, immediate repeat suppressed, retry after backoff elapses, exponential growth + cap, becomes degraded and stops, degraded state persisted, per-project independent counters, clear-on-success, missing tracker no-op.
- New webhook-level tests asserting `poll_tracker` is **not** published under backoff or when degraded, and published exactly once on first sighting.
- `531 passed, 1 skipped` across the webhook / tracker / CRUD / gateway suites.
- `ruff check` + `ruff format` clean; `mypy` introduces no new errors (verified by diffing the pre-existing baseline).

`openapi.yaml` is regenerated by the pre-commit hook and contains only the new `degraded_projects` field.

## Note

This PR stops the pointless retry loop and makes the condition visible to the affected user, but a repo that sends webhooks while sitting outside the GitHub App's selected repositories still needs the installation scope corrected (or its webhooks removed) by the account owner. No production state was modified during this investigation (read-only).