### PR TITLE
fix: PR reviewer flow reliability (checkout, loop guard, error surfacing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR reviewer flows killed by a false "repeated MCP tool loop"**: removing a
+  reaction that was already gone (the `eyes` "I'm looking at this" marker that
+  PR-review presets clear when finishing) was reported by
+  `update_pull_request` as `FAILED: remove reaction (eyes)`. Agents believed
+  the call had failed and retried it verbatim; after four identical retries the
+  orchestrator's loop guard stopped the run and marked the whole execution
+  FAILED — even though the review had already been posted to the PR. Reaction
+  removal is now idempotent: "already absent" is reported as success. This was
+  the single largest source of PR-reviewer failures for daily users.
+
+- **User-requested stops reported as "Execution timed out after 3600 seconds"**:
+  the stop branch of the agent monitoring loop used `break`, falling through to
+  the timeout handler at the end of the loop. Executions cancelled after a few
+  seconds were persisted as FAILED with a bogus 3600-second timeout message.
+  Stops now return status `STOPPED` with an accurate elapsed time.
+
+- **Opaque git checkout failures**: every step of the checkout fallback chain
+  discards stderr, so an unrecoverable failure produced only
+  `FATAL ERROR: Could not checkout commit <sha>` with no cause. The failure
+  path now re-runs the fetch/checkout with stderr attached and prints the
+  remote plus available refs, so the log shows whether the commit was
+  force-pushed away, the ref is missing, or credentials failed.
+
 ## [0.14.0] - 2026-08-07
 
 Highlights: **Cursor usage import** brings bundled-model spend into Cost

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -1747,6 +1747,20 @@ if ! git checkout {q_commit} 2>/dev/null; then
         echo "========================================="
         echo "FATAL ERROR: Could not checkout commit {q_commit_short}"
         echo "Tried direct checkout, commit fetch, source branch, and MR ref."
+        echo "--- diagnostics ---"
+        # Every attempt above hides stderr so the fallback chain stays quiet on
+        # the happy path. Once we have actually failed, re-run the fetch and
+        # checkout WITH stderr so the real cause (auth failure, unknown ref,
+        # commit force-pushed away) reaches the execution log instead of a
+        # generic "could not checkout".
+        echo "$ git fetch origin {q_commit}"
+        git fetch origin {q_commit} 2>&1 | tail -n 5 || true
+        echo "$ git checkout {q_commit}"
+        git checkout {q_commit} 2>&1 | tail -n 5 || true
+        echo "$ git remote -v"
+        git remote -v 2>&1 | sed -n '1,2p' || true
+        echo "available refs:"
+        git for-each-ref --format='%(refname)' --count=20 2>&1 || true
         echo "========================================="
         exit 1
     fi

--- a/backend/preloop/api/endpoints/mcp.py
+++ b/backend/preloop/api/endpoints/mcp.py
@@ -2100,6 +2100,10 @@ async def update_pull_request(
         # Handle reactions
         reaction_added = False
         reaction_removed = False
+        # True when the reaction we were asked to remove was already absent.
+        # Removal is idempotent: "not there" is the desired end state, so we
+        # must NOT report it as a failure or the agent will retry forever.
+        reaction_already_absent = False
         reaction_errors = []
 
         if add_reaction or remove_reaction:
@@ -2139,7 +2143,9 @@ async def update_pull_request(
                             )
                             reaction_removed = True
                         else:
-                            # Reaction not found - not an error, but note it
+                            # Reaction not found - not an error. Removal is
+                            # idempotent, so treat "already absent" as success.
+                            reaction_already_absent = True
                             logger.info(
                                 f"Reaction '{remove_reaction}' not found on PR {pr_number} "
                                 "(may have been already removed or never added)"
@@ -2202,6 +2208,11 @@ async def update_pull_request(
         if remove_reaction:
             if reaction_removed:
                 actions_taken.append(f"removed reaction ({remove_reaction})")
+            elif reaction_already_absent:
+                # Idempotent no-op: the end state the caller asked for already
+                # holds. Reporting this as a failure made agents retry the
+                # same call until the loop guard killed the execution.
+                actions_taken.append(f"reaction already absent ({remove_reaction})")
             else:
                 actions_failed.append(f"remove reaction ({remove_reaction})")
 

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -2114,7 +2114,22 @@ class FlowExecutionOrchestrator:
                     )
                     await agent_executor.stop(session_reference)
                     await self._publish_update("user_stopped", {"elapsed": elapsed})
-                    break
+                    self.execution_logger.log_milestone(
+                        "user_requested_stop", {"elapsed": elapsed}
+                    )
+                    # Return explicitly: falling through to the end of the
+                    # while loop would report this as "Execution timed out
+                    # after {max_wait_time} seconds", which is wrong and very
+                    # confusing (executions stopped after 45s were reported as
+                    # 3600s timeouts).
+                    return {
+                        "status": "STOPPED",
+                        "error_message": (
+                            f"Execution stopped by user request after {elapsed} seconds."
+                        ),
+                        "actions_taken": self.execution_logger.get_actions_taken(),
+                        "mcp_usage_logs": self.execution_logger.get_mcp_usage_logs(),
+                    }
 
                 # Get status with error handling
                 try:

--- a/backend/tests/agents/test_container.py
+++ b/backend/tests/agents/test_container.py
@@ -870,6 +870,10 @@ class TestExtractBranchFromTrigger:
 
         assert "refs/merge-requests/2/head:preloop-mr-head" in command
         assert "FATAL ERROR: Could not checkout commit" in command
+        # On failure we must re-run git WITH stderr so the log shows why.
+        assert "--- diagnostics ---" in command
+        assert "git fetch origin" in command
+        assert "git for-each-ref" in command
 
 
 class TestGitShellQuoting:

--- a/backend/tests/endpoints/test_mcp.py
+++ b/backend/tests/endpoints/test_mcp.py
@@ -2981,3 +2981,73 @@ def test_detect_platform_from_url_unknown():
     with pytest.raises(ValueError) as exc_info:
         mcp._detect_platform_from_url("https://example.com/unknown/path")
     assert "Cannot determine platform" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_update_pull_request_remove_absent_reaction_is_success(
+    db_session: Session, test_user: User
+):
+    """Removing a reaction that is already gone must report success.
+
+    Regression: the tool reported "FAILED: remove reaction (eyes)" when the
+    reaction was not present. Agents then retried the identical call until the
+    orchestrator's repeated-MCP-tool-loop guard killed the whole execution,
+    after the review had already been posted.
+    """
+    tracker = Tracker(
+        name="test-tracker-absent-reaction",
+        account_id=test_user.account_id,
+        tracker_type="github",
+        api_key="test_key",
+        url="https://github.com",
+    )
+    db_session.add(tracker)
+    db_session.commit()
+
+    organization = Organization(
+        name="test-org-absent-reaction",
+        identifier="test-org-absent-reaction",
+        tracker_id=tracker.id,
+    )
+    db_session.add(organization)
+    db_session.commit()
+
+    project = Project(
+        name="owner/repo",
+        identifier="owner/repo",
+        slug="owner/repo",
+        organization_id=organization.id,
+    )
+    db_session.add(project)
+    db_session.commit()
+
+    with (
+        patch("preloop.api.endpoints.mcp.get_http_request") as mock_get_request,
+        patch("preloop.api.endpoints.mcp.get_db") as mock_get_db,
+        patch(
+            "preloop.api.endpoints.mcp._get_authenticated_user",
+            new_callable=AsyncMock,
+        ) as mock_auth,
+        patch(
+            "preloop.api.endpoints.mcp.get_tracker_client",
+            new_callable=AsyncMock,
+        ) as mock_get_tracker,
+    ):
+        mock_get_request.return_value.headers = {"authorization": "Bearer testtoken"}
+        mock_get_db.return_value = iter([db_session])
+        mock_auth.return_value = (db_session, test_user)
+
+        mock_tracker = MagicMock()
+        mock_tracker.tracker_type = "github"
+        # False == "no such reaction found to remove"
+        mock_tracker.remove_issue_reaction = AsyncMock(return_value=False)
+        mock_get_tracker.return_value = mock_tracker
+
+        response = await mcp.update_pull_request(
+            pull_request="owner/repo#123",
+            remove_reaction="eyes",
+        )
+
+    assert response.status == "updated"
+    assert "FAILED" not in response.message
+    assert "already absent" in response.message

--- a/backend/tests/services/test_flow_orchestrator_streaming.py
+++ b/backend/tests/services/test_flow_orchestrator_streaming.py
@@ -737,3 +737,44 @@ class TestMonitoringIntegration:
             except asyncio.CancelledError:
                 # Expected when cancelling the orchestrator run task in the test.
                 pass
+
+
+class TestUserStopResult:
+    """A user-requested stop must not be reported as a timeout."""
+
+    @pytest.mark.asyncio
+    async def test_stop_returns_stopped_status_not_timeout(self, orchestrator):
+        """Regression: stop used to fall through to the timeout branch.
+
+        Executions cancelled after a few seconds were persisted with
+        "Execution timed out after 3600 seconds", which was both a wrong
+        status (FAILED instead of STOPPED) and a nonsensical message.
+        """
+        from preloop.agents.base import AgentStatus
+
+        mock_agent_executor = AsyncMock()
+        mock_agent_executor.get_status = AsyncMock(return_value=AgentStatus.RUNNING)
+        mock_agent_executor.stop = AsyncMock()
+
+        async def mock_stream(session_reference):
+            yield "Test log"
+
+        mock_agent_executor.stream_logs = mock_stream
+
+        orchestrator.flow = MagicMock()
+        orchestrator.flow.agent_type = "test"
+        orchestrator.flow.agent_config = {}
+        orchestrator.execution_logger.get_actions_taken = MagicMock(return_value=[])
+        orchestrator.execution_logger.get_mcp_usage_logs = MagicMock(return_value=[])
+        orchestrator.execution_logger.log_milestone = MagicMock()
+
+        orchestrator._stop_requested.set()
+
+        result = await orchestrator._monitor_agent_execution(
+            "session-123", mock_agent_executor
+        )
+
+        assert result["status"] == "STOPPED"
+        assert "timed out" not in (result["error_message"] or "")
+        assert "stopped by user request" in result["error_message"]
+        mock_agent_executor.stop.assert_any_call("session-123")


### PR DESCRIPTION
## Context

The PR-reviewer flow presets were failing ~44% of the time for a daily external
user (49 SUCCEEDED / 38 FAILED lifetime across two preset-derived flows). Full
investigation, per-mode frequencies and prod execution IDs are in the
investigation report; this PR implements only the fixes that are clearly correct
and low-risk. Speculative items were deliberately left out (see "Not fixed here").

## 1. False "repeated MCP tool loop" — the top active failure mode

PR-review presets add an 👀 reaction when they start and remove it when done.
`remove_issue_reaction` returns `False` when the reaction is already gone
(`sync/trackers/github.py:3327`), and `update_pull_request` classified that as
`FAILED: remove reaction (eyes)`.

A successful idempotent no-op was reported to the agent as a failure. The agent
retried the identical call; after 4 identical retries the orchestrator loop guard
(`flow_orchestrator.py:2173`) stopped the run and marked the execution FAILED.

Confirmed in prod (`runtime_session_activity` for execution
`03c1a9d6-d347-4b15-a73d-b0be6304c2d6`): the final 10 tool calls are
byte-identical `{remove_reaction: "eyes"}` calls **after** the review comment and
verdict were already posted. In `443c7fd5-…` the agent even alternated between
`"👀"` and `"eyes"`, i.e. guessing at the spelling because the tool claimed failure.

**The user sees a red FAILED execution on a PR that has a complete, correct
Preloop review on it.**

The loop guard itself is correct and its threshold is fine — these really are
identical no-progress calls. The tool was lying to the agent. Reaction removal is
now idempotent: "already absent" is success.

## 2. User stops reported as "Execution timed out after 3600 seconds"

The stop branch used `break`, falling through to the timeout handler at the end
of the `while elapsed < max_wait_time` loop. Real prod rows: executions that ran
**21s**, **45s** and **888s** were all persisted as FAILED with
"Execution timed out after 3600 seconds".

Stops now return `STOPPED` (already a valid status in prod) with the true elapsed
time. This also un-poisons our diagnostics: this bucket looked like "big PRs need
a higher limit" when it was mostly cancellations. The 3600s limit is unchanged —
there is no evidence any affected run approached it.

The pre-existing stop test never asserted the return value, which is why this
survived; the new test does.

## 3. Unactionable checkout failures (diagnostics only)

Every step of the checkout fallback chain is `2>/dev/null`, so failures surfaced
only as `FATAL ERROR: Could not checkout commit <sha>` with no cause. The failure
path now re-runs fetch/checkout with stderr attached and prints the remote and
available refs.

No behaviour change — this runs only on the path that was already about to
`exit 1`. (The 8 real occurrences were all on 2026-08-04, non-fork repo, correct
`pull/N/head` refspec, and have not recurred; most likely commits force-pushed
away before clone. I found no reproducible defect and deliberately did not change
refspec handling.)

## Not fixed here (recommendations in the report)

- **`504 / [object Object]`** — not our string; it is Gemini CLI stringifying a JS
  error object inside the agent container. The three occurrences correlate exactly
  with the 2026-08-08 17:14 DB pool-exhaustion incident (gateway pod terminated
  17:15:06 with `QueuePool limit of size 3 overflow 7 reached`), owned by another
  agent. Sanitizing degenerate error strings needs a product decision to avoid
  masking genuine agent errors.
- **Missing success sentinel** — the override is deliberate and correct (Gemini/
  OpenCode exit 0 even on error). Recommend attaching the last log lines to the
  message rather than changing the guard.

## Testing

- 3 regression tests, each verified to **fail without** its corresponding fix:
  - `test_update_pull_request_remove_absent_reaction_is_success` (asserts `'failed' != 'updated'` before fix)
  - `test_stop_returns_stopped_status_not_timeout`
  - checkout diagnostics assertions in `test_container.py`
- Targeted suites: 190 passed, 5 skipped.
- Broad run (`services` + `endpoints` + `agents`): 3257 passed / 20 failed, vs a
  **baseline of 3254 passed / 23 failed** on the same tree with the source changes
  reverted. The 20 failures are pre-existing and unrelated (openai gateway
  attribution sessions); this PR fixes exactly its 3 and regresses nothing.
- `ruff check` + `ruff format` clean; `mypy` error count unchanged at 1045
  (pre-existing baseline, no new errors).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Three targeted reliability fixes — reaction idempotency, stop status correction, and checkout diagnostics — each with a regression test. No architecture changes, no API contract changes, no behavior change on happy paths.

> **Overview**
> Fixes the top three failure modes observed in PR-reviewer flow execution: false loop-guard kills from non-idempotent reaction removal, user stops misreported as 3600-second timeouts, and opaque git checkout errors. All fixes are scoped to the failure paths only and backed by tests that fail without their corresponding fixes.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/pr-reviewer-flow-reliability. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->