### PR TITLE
fix: price OpenRouter-routed models and stop reporting unpriced usage as $0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remote plus available refs, so the log shows whether the commit was
   force-pushed away, the ref is missing, or credentials failed.
 
+- **Unpriced usage no longer reports as $0.00**: gateway traffic routed through
+  OpenRouter/`openai-compatible` endpoints was metered correctly (tokens
+  captured) but could never be priced, so flows that cost real money displayed
+  a confident `$0.00`. Three defects combined: the synthetic
+  `openai-compatible/` prefix was carried into price-catalog lookups where it
+  can never match; OpenRouter-routed models were not tried under litellm's
+  `openrouter/vendor/model` keys; and a `sum()` over NULL costs was coalesced
+  to `0.0` in `get_gateway_usage_for_execution`, with `FlowOrchestrator`
+  defaulting `estimated_cost` to `0.0`. Cost now stays NULL when nothing could
+  be priced, and the token volume is surfaced instead of a fake zero. Aggregates
+  that mix priced and unpriced rows expose `cost_is_partial` plus the unpriced
+  request/token counts so a subtotal is never presented as a complete bill.
+  Subscription-covered traffic (`cost_source='subscription'`) is unchanged and
+  still reports a legitimate `$0.00`.
+
+- **OpenRouter model pricing**: models served from `openrouter.ai` are now
+  priced from OpenRouter's own `/api/v1/models` endpoint when litellm's map
+  does not carry them, cached and backed off like the existing price-map fetch.
+  Date-stamped marketplace ids (e.g. `deepseek-v4-flash-0731`) are deliberately
+  NOT aliased to their undated entry: they are separately priced SKUs, and the
+  fallback would have overstated cost by ~55% for that model. Models that still
+  cannot be priced stay explicitly unpriced rather than being given a guess.
+
+### Added
+
+- **Admin alert for unpriceable models**: the gateway now notifies admins the
+  first time a `(model_alias, provider)` pair proves unpriceable, including the
+  account and token volume, so missing pricing is noticed instead of silently
+  surfacing as no spend. Deduplicated via a persisted `audit_log` marker with a
+  24h cooldown (`UNPRICED_MODEL_ALERT_COOLDOWN_HOURS`), so it holds across
+  replicas rather than firing once per process, and every failure path is
+  swallowed so alerting can never break a user request.
+
+- **`scripts/reprice_unpriced_usage.py`**: operator script to backfill costs for
+  historical rows recorded while a model was unpriced. Dry run by default;
+  requires `--apply` to persist.
+
 ## [0.14.0] - 2026-08-07
 
 Highlights: **Cursor usage import** brings bundled-model spend into Cost

--- a/backend/preloop/api/endpoints/flows.py
+++ b/backend/preloop/api/endpoints/flows.py
@@ -579,8 +579,13 @@ def get_flow_execution_metrics(
         - tool_calls: Number of MCP tool calls made
         - api_requests: Number of API requests made during execution
         - token_usage: Token usage statistics
-        - estimated_cost: Estimated cost based on token usage (0.0 if no pricing)
-        - has_pricing: Whether pricing is configured in AI model metadata
+        - estimated_cost: Estimated cost in USD, or null when no usage could
+          be priced (never a placeholder 0.0, which would misreport real
+          spend as free)
+        - has_pricing: Whether any request could be priced
+        - cost_is_partial: Whether estimated_cost excludes unpriced requests
+        - unpriced_requests: Requests that could not be priced
+        - unpriced_tokens: Token volume behind the unpriced requests
     """
     from preloop.services.execution_metrics import ExecutionMetricsService
 
@@ -606,8 +611,13 @@ def get_flow_execution_metrics(
             "tool_calls": 0,
             "api_requests": 0,
             "token_usage": {"total_tokens": 0, "input_tokens": 0, "output_tokens": 0},
-            "estimated_cost": 0.0,
+            # Metrics could not be computed, so the cost is unknown rather
+            # than zero; the UI renders this as unavailable, not as free.
+            "estimated_cost": None,
             "has_pricing": False,
+            "cost_is_partial": False,
+            "unpriced_requests": 0,
+            "unpriced_tokens": 0,
         }
 
 

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -1498,7 +1498,26 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         db: Session,
         execution_id: str,
     ) -> Dict[str, Any]:
-        """Return explicit gateway usage totals for an execution when available."""
+        """Return explicit gateway usage totals for an execution when available.
+
+        ``estimated_cost`` is deliberately NOT coalesced to ``0.0``: a NULL
+        cost means "we could not price this", which is different from "this
+        was free". When no request could be priced the cost stays ``None`` and
+        callers render the token volume instead (see ``unpriced_tokens``).
+
+        Args:
+            db: Database session.
+            execution_id: Owning flow execution id.
+
+        Returns:
+            Usage totals including ``estimated_cost`` (``None`` when nothing
+            was priceable), ``cost_is_partial`` when priced and unpriced rows
+            are mixed, and the unpriced request/token volume.
+        """
+        unpriced_condition = and_(
+            ApiUsage.estimated_cost.is_(None),
+            func.coalesce(ApiUsage.cost_source, "") != "subscription",
+        )
         row = (
             db.query(
                 func.count(ApiUsage.id).label("api_requests"),
@@ -1509,10 +1528,21 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
                     "completion_tokens"
                 ),
                 func.coalesce(func.sum(ApiUsage.total_tokens), 0).label("total_tokens"),
-                func.coalesce(func.sum(ApiUsage.estimated_cost), 0.0).label(
-                    "estimated_cost"
-                ),
+                # Left un-coalesced on purpose: NULL means "unknown", not zero.
+                func.sum(ApiUsage.estimated_cost).label("estimated_cost"),
                 func.count(ApiUsage.estimated_cost).label("priced_requests"),
+                func.count(ApiUsage.id)
+                .filter(unpriced_condition)
+                .label("unpriced_requests"),
+                func.coalesce(
+                    func.sum(ApiUsage.total_tokens).filter(unpriced_condition), 0
+                ).label("unpriced_tokens"),
+                func.coalesce(
+                    func.sum(ApiUsage.prompt_tokens).filter(unpriced_condition), 0
+                ).label("unpriced_prompt_tokens"),
+                func.coalesce(
+                    func.sum(ApiUsage.completion_tokens).filter(unpriced_condition), 0
+                ).label("unpriced_completion_tokens"),
             )
             .filter(
                 ApiUsage.action_type == "model_gateway",
@@ -1531,8 +1561,16 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
                 },
                 "estimated_cost": 0.0,
                 "has_pricing": False,
+                "cost_is_partial": False,
+                "unpriced_requests": 0,
+                "unpriced_tokens": 0,
+                "unpriced_prompt_tokens": 0,
+                "unpriced_completion_tokens": 0,
             }
 
+        priced_requests = int(row.priced_requests or 0)
+        unpriced_requests = int(row.unpriced_requests or 0)
+        raw_cost = row.estimated_cost
         return {
             "api_requests": int(row.api_requests or 0),
             "token_usage": {
@@ -1540,8 +1578,17 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
                 "input_tokens": int(row.prompt_tokens or 0),
                 "output_tokens": int(row.completion_tokens or 0),
             },
-            "estimated_cost": round(float(row.estimated_cost or 0.0), 6),
-            "has_pricing": int(row.priced_requests or 0) > 0,
+            "estimated_cost": (
+                round(float(raw_cost), 6) if raw_cost is not None else None
+            ),
+            "has_pricing": priced_requests > 0,
+            # True when a real cost exists but excludes unpriced traffic, so
+            # callers can label the number as incomplete rather than final.
+            "cost_is_partial": priced_requests > 0 and unpriced_requests > 0,
+            "unpriced_requests": unpriced_requests,
+            "unpriced_tokens": int(row.unpriced_tokens or 0),
+            "unpriced_prompt_tokens": int(row.unpriced_prompt_tokens or 0),
+            "unpriced_completion_tokens": int(row.unpriced_completion_tokens or 0),
         }
 
     def count_by_execution_timeframe(

--- a/backend/preloop/services/execution_metrics.py
+++ b/backend/preloop/services/execution_metrics.py
@@ -29,8 +29,12 @@ class ExecutionMetricsService:
             - tool_calls: Number of MCP tool calls
             - api_requests: Number of API requests made
             - token_usage: Token usage from codex logs
-            - estimated_cost: Estimated cost based on token usage (0.0 if no pricing)
-            - has_pricing: Whether pricing is configured in AI model metadata
+            - estimated_cost: Estimated cost in USD, or None when no usage
+              could be priced (never a placeholder 0.0)
+            - has_pricing: Whether any request could be priced
+            - cost_is_partial: Whether the cost excludes unpriced requests
+            - unpriced_requests: Number of requests that could not be priced
+            - unpriced_tokens: Token volume behind the unpriced requests
         """
         from preloop.models.crud import crud_flow_execution
 
@@ -46,15 +50,27 @@ class ExecutionMetricsService:
         gateway_usage = self._get_gateway_usage(execution)
         api_requests = gateway_usage["api_requests"]
 
+        cost_is_partial = False
+        unpriced_requests = 0
+        unpriced_tokens = 0
         if api_requests > 0:
             token_usage = gateway_usage["token_usage"]
             estimated_cost = gateway_usage["estimated_cost"]
             has_pricing = gateway_usage["has_pricing"]
+            cost_is_partial = bool(gateway_usage.get("cost_is_partial"))
+            unpriced_requests = int(gateway_usage.get("unpriced_requests") or 0)
+            unpriced_tokens = int(gateway_usage.get("unpriced_tokens") or 0)
         else:
             # Fall back to legacy log parsing when the execution did not use
             # explicit gateway attribution.
             token_usage = self._parse_token_usage(execution)
             estimated_cost, has_pricing = self._calculate_cost(execution, token_usage)
+            if not has_pricing and token_usage.get("total_tokens"):
+                # Tokens were spent but no price resolved: report the volume
+                # rather than a $0.00 that the user would read as "free".
+                estimated_cost = None
+                unpriced_tokens = int(token_usage.get("total_tokens") or 0)
+                unpriced_requests = 1
 
         return {
             "tool_calls": tool_calls,
@@ -62,6 +78,9 @@ class ExecutionMetricsService:
             "token_usage": token_usage,
             "estimated_cost": estimated_cost,
             "has_pricing": has_pricing,
+            "cost_is_partial": cost_is_partial,
+            "unpriced_requests": unpriced_requests,
+            "unpriced_tokens": unpriced_tokens,
         }
 
     def _get_gateway_usage(self, execution: models.FlowExecution) -> Dict:

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -125,7 +125,9 @@ class FlowExecutionOrchestrator:
         # Execution metrics tracked during execution
         self.total_tokens: int = 0
         self.tool_calls_count: int = 0
-        self.estimated_cost: float = 0.0
+        # None means "not priced yet / could not be priced". Defaulting this to
+        # 0.0 made unpriced executions display a confident $0.00 in the UI.
+        self.estimated_cost: Optional[float] = None
 
         # Commit status tracking
         self._tracker_client = None

--- a/backend/preloop/services/model_price_catalog.py
+++ b/backend/preloop/services/model_price_catalog.py
@@ -54,6 +54,19 @@ _NEGATIVE_TTL_SECONDS = int(
 )
 _REMOTE_FETCH_RETRIES = int(os.getenv("MODEL_PRICE_MAP_FETCH_RETRIES", "2"))
 
+# OpenRouter publishes authoritative per-token prices for every model it
+# routes, including marketplace snapshots (e.g. dated DeepSeek builds) that
+# litellm's map does not carry. Used as a secondary source when the primary
+# map misses an ``openrouter/``-prefixed candidate.
+OPENROUTER_MODELS_URL = os.getenv(
+    "OPENROUTER_MODELS_URL", "https://openrouter.ai/api/v1/models"
+)
+_OPENROUTER_PREFIX = "openrouter/"
+
+_openrouter_map: Optional[Dict[str, Any]] = None
+_openrouter_fetched_at: float = 0.0
+_openrouter_failed_at: float = 0.0
+
 _lock = threading.Lock()
 _loaded = False
 _metadata: Optional[Dict[str, Any]] = None
@@ -230,6 +243,126 @@ def _fetch_remote_price_map() -> Optional[Dict[str, Any]]:
     return fetched
 
 
+def _positive_price(value: Any) -> Optional[float]:
+    """Parse a vendor price string into a positive float.
+
+    Args:
+        value: Raw price value from the vendor payload.
+
+    Returns:
+        The parsed price, or None when absent, unparseable or not positive.
+        Zero is rejected so a missing price is never asserted as free.
+    """
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _openrouter_entries_from_payload(payload: Any) -> Dict[str, Any]:
+    """Convert an OpenRouter ``/models`` payload into litellm price entries.
+
+    OpenRouter reports prices in USD per token as decimal strings, which is
+    already litellm's unit, so values are carried across without rescaling.
+    Models without a usable positive prompt/completion price are skipped so
+    they stay honestly unpriced instead of being recorded as free.
+
+    Args:
+        payload: Decoded JSON body from the OpenRouter models endpoint.
+
+    Returns:
+        Mapping of ``openrouter/<model id>`` to litellm-shaped price entries.
+    """
+    if isinstance(payload, dict):
+        models = payload.get("data")
+    else:
+        models = payload
+    if not isinstance(models, list):
+        return {}
+
+    entries: Dict[str, Any] = {}
+    for model in models:
+        if not isinstance(model, dict):
+            continue
+        model_id = model.get("id")
+        pricing = model.get("pricing")
+        if not isinstance(model_id, str) or not isinstance(pricing, dict):
+            continue
+        prompt_cost = _positive_price(pricing.get("prompt"))
+        completion_cost = _positive_price(pricing.get("completion"))
+        if prompt_cost is None and completion_cost is None:
+            continue
+
+        entry: Dict[str, Any] = {
+            "litellm_provider": "openrouter",
+            "mode": "chat",
+            "input_cost_per_token": prompt_cost or 0.0,
+            "output_cost_per_token": completion_cost or 0.0,
+        }
+        cache_read = _positive_price(pricing.get("input_cache_read"))
+        if cache_read is not None:
+            entry["cache_read_input_token_cost"] = cache_read
+        cache_write = _positive_price(pricing.get("input_cache_write"))
+        if cache_write is not None:
+            entry["cache_creation_input_token_cost"] = cache_write
+        entries[f"{_OPENROUTER_PREFIX}{model_id.strip()}"] = entry
+
+    return entries
+
+
+def _fetch_openrouter_price_map() -> Optional[Dict[str, Any]]:
+    """Download OpenRouter's model price list, with cache and failure backoff.
+
+    Returns:
+        Mapping of ``openrouter/<model id>`` to price entries, or None when a
+        backoff is in effect or the download fails.
+    """
+    global _openrouter_map, _openrouter_fetched_at, _openrouter_failed_at
+    now = time.monotonic()
+    with _lookup_lock:
+        if (
+            _openrouter_map is not None
+            and now - _openrouter_fetched_at < _REMOTE_TTL_SECONDS
+        ):
+            return _openrouter_map
+        if _openrouter_failed_at and now - _openrouter_failed_at < (
+            _REMOTE_FAILURE_BACKOFF_SECONDS
+        ):
+            return None
+
+    try:
+        import httpx
+    except ImportError:
+        logger.warning("httpx is unavailable; skipping OpenRouter price lookup")
+        with _lookup_lock:
+            _openrouter_failed_at = time.monotonic()
+        return None
+
+    try:
+        response = httpx.get(OPENROUTER_MODELS_URL, timeout=30.0)
+        response.raise_for_status()
+        entries = _openrouter_entries_from_payload(response.json())
+    except Exception:  # noqa: BLE001 - network is best-effort here
+        logger.warning("OpenRouter price list download failed", exc_info=True)
+        with _lookup_lock:
+            _openrouter_failed_at = time.monotonic()
+        return None
+
+    if not entries:
+        with _lookup_lock:
+            _openrouter_failed_at = time.monotonic()
+        return None
+
+    with _lookup_lock:
+        _openrouter_map = entries
+        _openrouter_fetched_at = time.monotonic()
+        _openrouter_failed_at = 0.0
+    return entries
+
+
 def lookup_model_price_now(candidates: List[str]) -> Optional[str]:
     """Try to price the given model candidates from the live upstream map.
 
@@ -254,9 +387,17 @@ def lookup_model_price_now(candidates: List[str]) -> Optional[str]:
     if not fresh:
         return None
 
-    remote = _fetch_remote_price_map()
-    if remote is None:
+    primary = _fetch_remote_price_map()
+    # Marketplace-routed models (openrouter/vendor/model) are frequently
+    # absent from litellm's map; OpenRouter itself is authoritative for them.
+    marketplace: Optional[Dict[str, Any]] = None
+    if any(candidate.startswith(_OPENROUTER_PREFIX) for candidate in fresh):
+        marketplace = _fetch_openrouter_price_map()
+    if primary is None and marketplace is None:
+        # Every source is unavailable: retry later rather than negative-cache
+        # a model that may well be priceable.
         return None
+    remote: Dict[str, Any] = {**(marketplace or {}), **(primary or {})}
 
     matched_key: Optional[str] = None
     for candidate in fresh:
@@ -365,10 +506,14 @@ def _reprice_usage_row(api_usage_id: str) -> None:
 def reset_lookup_state_for_tests() -> None:
     """Clear all live-lookup caches (test isolation only)."""
     global _remote_map, _remote_fetched_at, _remote_failed_at
+    global _openrouter_map, _openrouter_fetched_at, _openrouter_failed_at
     with _lookup_lock:
         _remote_map = None
         _remote_fetched_at = 0.0
         _remote_failed_at = 0.0
+        _openrouter_map = None
+        _openrouter_fetched_at = 0.0
+        _openrouter_failed_at = 0.0
         _negative_cache.clear()
         _pending_lookups.clear()
 

--- a/backend/preloop/services/model_price_catalog.py
+++ b/backend/preloop/services/model_price_catalog.py
@@ -28,8 +28,9 @@ import os
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -63,19 +64,98 @@ OPENROUTER_MODELS_URL = os.getenv(
 )
 _OPENROUTER_PREFIX = "openrouter/"
 
-_openrouter_map: Optional[Dict[str, Any]] = None
-_openrouter_fetched_at: float = 0.0
-_openrouter_failed_at: float = 0.0
-
 _lock = threading.Lock()
 _loaded = False
 _metadata: Optional[Dict[str, Any]] = None
 
 # Live-lookup state (per process). All guarded by _lookup_lock.
 _lookup_lock = threading.Lock()
-_remote_map: Optional[Dict[str, Any]] = None
-_remote_fetched_at: float = 0.0
-_remote_failed_at: float = 0.0
+
+
+@dataclass
+class _PriceMapCache:
+    """In-process cache for one remote price map, with failure backoff.
+
+    Both price sources (litellm's published map and OpenRouter's model list)
+    follow the same rules: serve the cached map for ``_REMOTE_TTL_SECONDS``,
+    and after a failed download refuse to retry for
+    ``_REMOTE_FAILURE_BACKOFF_SECONDS`` so an unreachable source cannot be
+    hammered once per unpriced request. All state is guarded by the module's
+    ``_lookup_lock``.
+
+    Attributes:
+        label: Human-readable source name, used in log messages.
+    """
+
+    label: str
+    _map: Optional[Dict[str, Any]] = field(default=None, repr=False)
+    _fetched_at: float = field(default=0.0, repr=False)
+    _failed_at: float = field(default=0.0, repr=False)
+
+    def get(
+        self, fetch: Callable[[], Optional[Dict[str, Any]]]
+    ) -> Optional[Dict[str, Any]]:
+        """Return the cached map, downloading it via ``fetch`` when stale.
+
+        Args:
+            fetch: Callable performing the actual download. It must return
+                None for any failure (network, validation, empty payload);
+                that outcome starts the failure backoff window.
+
+        Returns:
+            The cached or freshly downloaded map, or None when a backoff is in
+            effect or the download failed.
+        """
+        now = time.monotonic()
+        with _lookup_lock:
+            if self._map is not None and now - self._fetched_at < _REMOTE_TTL_SECONDS:
+                return self._map
+            if self._failed_at and now - self._failed_at < (
+                _REMOTE_FAILURE_BACKOFF_SECONDS
+            ):
+                return None
+
+        fetched = fetch()
+        if fetched is None:
+            self.mark_failed()
+            return None
+        self.set(fetched)
+        return fetched
+
+    def set(self, price_map: Dict[str, Any]) -> None:
+        """Store a freshly downloaded map and clear any failure backoff."""
+        with _lookup_lock:
+            self._map = price_map
+            self._fetched_at = time.monotonic()
+            self._failed_at = 0.0
+
+    def mark_failed(self) -> None:
+        """Start the failure backoff window after a failed download."""
+        with _lookup_lock:
+            self._failed_at = time.monotonic()
+
+    def reset(self) -> None:
+        """Drop the cached map and any backoff state (test isolation only)."""
+        with _lookup_lock:
+            self._map = None
+            self._fetched_at = 0.0
+            self._failed_at = 0.0
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return the cache's current state for tests and diagnostics."""
+        with _lookup_lock:
+            return {
+                "map": self._map,
+                "fetched_at": self._fetched_at,
+                "failed_at": self._failed_at,
+            }
+
+
+# litellm's published map; the primary source for every model.
+_remote_cache = _PriceMapCache("litellm")
+# OpenRouter's own model list; secondary source for marketplace-routed models.
+_openrouter_cache = _PriceMapCache("openrouter")
+
 # candidate name -> monotonic time of the failed lookup (negative cache).
 _negative_cache: Dict[str, float] = {}
 # candidate names with a lookup currently in flight.
@@ -176,34 +256,26 @@ def catalog_metadata() -> Optional[Dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def _fetch_remote_price_map() -> Optional[Dict[str, Any]]:
-    """Download the upstream price map, honoring cache and failure backoff.
+def _download_remote_price_map() -> Optional[Dict[str, Any]]:
+    """Download litellm's published price map.
 
-    Returns the cached/downloaded map, or None while a failure backoff is in
-    effect or the download fails. When ``MODEL_PRICE_MAP_SHA256`` is set, the
-    response body must match that digest or the fetch is rejected.
+    When ``MODEL_PRICE_MAP_SHA256`` is set the response body must match that
+    digest or the fetch is rejected, so a compromised upstream revision cannot
+    silently change pricing.
+
+    Returns:
+        The decoded map, or None on any failure (the caller starts the
+        failure backoff).
     """
-    global _remote_map, _remote_fetched_at, _remote_failed_at
-    now = time.monotonic()
-    with _lookup_lock:
-        if _remote_map is not None and now - _remote_fetched_at < _REMOTE_TTL_SECONDS:
-            return _remote_map
-        if _remote_failed_at and now - _remote_failed_at < (
-            _REMOTE_FAILURE_BACKOFF_SECONDS
-        ):
-            return None
-
     try:
         import httpx
     except ImportError:
         # Optional dependency for live lookups; do not retry a missing module.
         logger.warning("httpx is unavailable; skipping live model price lookup")
-        with _lookup_lock:
-            _remote_failed_at = time.monotonic()
         return None
 
-    last_error: Optional[BaseException] = None
-    for attempt in range(max(1, _REMOTE_FETCH_RETRIES + 1)):
+    attempts = max(1, _REMOTE_FETCH_RETRIES + 1)
+    for attempt in range(attempts):
         try:
             response = httpx.get(REMOTE_PRICE_MAP_URL, timeout=30.0)
             response.raise_for_status()
@@ -216,31 +288,25 @@ def _fetch_remote_price_map() -> Optional[Dict[str, Any]]:
                         f"(expected {REMOTE_PRICE_MAP_SHA256}, got {digest})"
                     )
             fetched = response.json()
-            last_error = None
-            break
-        except Exception as exc:  # noqa: BLE001 - network is best-effort here
-            last_error = exc
+            return fetched if isinstance(fetched, dict) else None
+        except Exception:  # noqa: BLE001 - network is best-effort here
             logger.warning(
                 "Live model price map download failed (attempt %s/%s)",
                 attempt + 1,
-                max(1, _REMOTE_FETCH_RETRIES + 1),
+                attempts,
                 exc_info=True,
             )
-            fetched = None
-    if last_error is not None or fetched is None:
-        with _lookup_lock:
-            _remote_failed_at = time.monotonic()
-        return None
+    return None
 
-    if not isinstance(fetched, dict):
-        with _lookup_lock:
-            _remote_failed_at = time.monotonic()
-        return None
-    with _lookup_lock:
-        _remote_map = fetched
-        _remote_fetched_at = time.monotonic()
-        _remote_failed_at = 0.0
-    return fetched
+
+def _fetch_remote_price_map() -> Optional[Dict[str, Any]]:
+    """Return litellm's price map, honoring cache and failure backoff.
+
+    Returns:
+        The cached/downloaded map, or None while a failure backoff is in
+        effect or the download fails.
+    """
+    return _remote_cache.get(_download_remote_price_map)
 
 
 def _positive_price(value: Any) -> Optional[float]:
@@ -313,32 +379,18 @@ def _openrouter_entries_from_payload(payload: Any) -> Dict[str, Any]:
     return entries
 
 
-def _fetch_openrouter_price_map() -> Optional[Dict[str, Any]]:
-    """Download OpenRouter's model price list, with cache and failure backoff.
+def _download_openrouter_price_map() -> Optional[Dict[str, Any]]:
+    """Download OpenRouter's model list and convert it to price entries.
 
     Returns:
-        Mapping of ``openrouter/<model id>`` to price entries, or None when a
-        backoff is in effect or the download fails.
+        Mapping of ``openrouter/<model id>`` to price entries, or None on any
+        failure or when the payload yields no usable prices (the caller starts
+        the failure backoff).
     """
-    global _openrouter_map, _openrouter_fetched_at, _openrouter_failed_at
-    now = time.monotonic()
-    with _lookup_lock:
-        if (
-            _openrouter_map is not None
-            and now - _openrouter_fetched_at < _REMOTE_TTL_SECONDS
-        ):
-            return _openrouter_map
-        if _openrouter_failed_at and now - _openrouter_failed_at < (
-            _REMOTE_FAILURE_BACKOFF_SECONDS
-        ):
-            return None
-
     try:
         import httpx
     except ImportError:
         logger.warning("httpx is unavailable; skipping OpenRouter price lookup")
-        with _lookup_lock:
-            _openrouter_failed_at = time.monotonic()
         return None
 
     try:
@@ -347,20 +399,19 @@ def _fetch_openrouter_price_map() -> Optional[Dict[str, Any]]:
         entries = _openrouter_entries_from_payload(response.json())
     except Exception:  # noqa: BLE001 - network is best-effort here
         logger.warning("OpenRouter price list download failed", exc_info=True)
-        with _lookup_lock:
-            _openrouter_failed_at = time.monotonic()
         return None
 
-    if not entries:
-        with _lookup_lock:
-            _openrouter_failed_at = time.monotonic()
-        return None
+    return entries or None
 
-    with _lookup_lock:
-        _openrouter_map = entries
-        _openrouter_fetched_at = time.monotonic()
-        _openrouter_failed_at = 0.0
-    return entries
+
+def _fetch_openrouter_price_map() -> Optional[Dict[str, Any]]:
+    """Return OpenRouter's price map, with cache and failure backoff.
+
+    Returns:
+        Mapping of ``openrouter/<model id>`` to price entries, or None when a
+        backoff is in effect or the download fails.
+    """
+    return _openrouter_cache.get(_download_openrouter_price_map)
 
 
 def lookup_model_price_now(candidates: List[str]) -> Optional[str]:
@@ -505,24 +556,17 @@ def _reprice_usage_row(api_usage_id: str) -> None:
 
 def reset_lookup_state_for_tests() -> None:
     """Clear all live-lookup caches (test isolation only)."""
-    global _remote_map, _remote_fetched_at, _remote_failed_at
-    global _openrouter_map, _openrouter_fetched_at, _openrouter_failed_at
+    _remote_cache.reset()
+    _openrouter_cache.reset()
     with _lookup_lock:
-        _remote_map = None
-        _remote_fetched_at = 0.0
-        _remote_failed_at = 0.0
-        _openrouter_map = None
-        _openrouter_fetched_at = 0.0
-        _openrouter_failed_at = 0.0
         _negative_cache.clear()
         _pending_lookups.clear()
 
 
 def _module_state_for_tests() -> dict[str, Any]:
-    """Expose module cache globals for tests and static analysis."""
+    """Expose module cache state for tests and diagnostics."""
     return {
         "loaded": _loaded,
-        "remote_map": _remote_map,
-        "remote_fetched_at": _remote_fetched_at,
-        "remote_failed_at": _remote_failed_at,
+        "remote": _remote_cache.snapshot(),
+        "openrouter": _openrouter_cache.snapshot(),
     }

--- a/backend/preloop/services/model_pricing.py
+++ b/backend/preloop/services/model_pricing.py
@@ -30,6 +30,52 @@ _DATE_SUFFIX_PATTERNS = (
     re.compile(r"@\d+$"),
 )
 
+# Provider labels that describe HOW Preloop reaches an endpoint rather than a
+# namespace in any price map. Left on a candidate they guarantee a miss, so
+# they are stripped before catalog lookup (issue: OpenRouter usage priced $0).
+_SYNTHETIC_PROVIDER_PREFIXES = ("openai-compatible/", "custom/", "preloop/")
+
+# Hosts that front a model marketplace whose catalog keys litellm namespaces
+# under a provider prefix (e.g. ``openrouter/deepseek/deepseek-chat``).
+_ENDPOINT_HOST_PREFIXES = (("openrouter.ai", "openrouter"),)
+
+
+def _strip_synthetic_prefix(candidate: str) -> str:
+    """Remove Preloop's routing-only provider prefixes from a model name.
+
+    ``openai-compatible``/``custom`` are transport labels, not price-map
+    namespaces, so they must not participate in catalog matching.
+
+    Args:
+        candidate: A raw model alias or identifier.
+
+    Returns:
+        The candidate without a leading synthetic provider prefix.
+    """
+    lowered = candidate.lower()
+    for prefix in _SYNTHETIC_PROVIDER_PREFIXES:
+        if lowered.startswith(prefix):
+            return candidate[len(prefix) :].strip()
+    return candidate
+
+
+def _endpoint_prefix(api_endpoint: Optional[str]) -> Optional[str]:
+    """Return the price-map provider prefix implied by a model's endpoint.
+
+    Args:
+        api_endpoint: The configured base URL for the model, if any.
+
+    Returns:
+        The provider prefix (e.g. ``openrouter``) or None when unknown.
+    """
+    if not isinstance(api_endpoint, str) or not api_endpoint.strip():
+        return None
+    lowered = api_endpoint.lower()
+    for host, prefix in _ENDPOINT_HOST_PREFIXES:
+        if host in lowered:
+            return prefix
+    return None
+
 
 def normalize_gateway_model_alias(alias: Optional[str]) -> Optional[str]:
     """Normalize a gateway/client model alias for pricing and matching.
@@ -47,14 +93,36 @@ def normalize_gateway_model_alias(alias: Optional[str]) -> Optional[str]:
     return trimmed or None
 
 
-def _expand_candidate(candidate: str, provider: str) -> Iterable[str]:
+def _expand_candidate(
+    candidate: str, provider: str, endpoint_prefix: Optional[str] = None
+) -> Iterable[str]:
     """Yield normalized fallback forms of one candidate model name.
 
-    Ordered from most to least specific: the raw name first, then with the
-    Bedrock region prefix stripped, then with trailing date/version stamps
-    removed (litellm aliases the undated name for most models).
+    Ordered from most to least specific. Preloop's routing-only provider
+    prefixes are stripped first, then the marketplace form implied by the
+    model's endpoint is offered (``openrouter/vendor/model``, which is how
+    litellm prices marketplace-routed traffic), then the bare name, then the
+    Bedrock region-stripped form, then the undated form.
+
+    Date suffixes are deliberately NOT stripped from ``vendor/model`` names:
+    on model marketplaces a dated snapshot is a separately priced product
+    (``deepseek-v4-flash-0731`` is $0.09/$0.18 per Mtok while the undated
+    ``deepseek-v4-flash`` is $0.14/$0.28), so aliasing them would invent a
+    price that is wrong by ~55%.
+
+    Args:
+        candidate: Raw model alias or identifier.
+        provider: Configured provider name for the model.
+        endpoint_prefix: Price-map prefix implied by the model's endpoint.
+
+    Yields:
+        Candidate keys to try against the price catalog, most specific first.
     """
     normalized = normalize_gateway_model_alias(candidate) or candidate
+    normalized = _strip_synthetic_prefix(normalized) or normalized
+
+    if endpoint_prefix and not normalized.lower().startswith(f"{endpoint_prefix}/"):
+        yield f"{endpoint_prefix}/{normalized}"
     yield normalized
 
     stripped = normalized
@@ -65,6 +133,13 @@ def _expand_candidate(candidate: str, provider: str) -> Iterable[str]:
             if "/" not in stripped:
                 yield f"bedrock/{stripped}"
             break
+
+    # Marketplace ids carry the vendor in the name (``deepseek/...``). For
+    # those, a date stamp identifies a distinct SKU with its own price, so
+    # falling back to the undated entry would report a confidently wrong
+    # number. Only undate flat, single-segment vendor model names.
+    if "/" in stripped:
+        return
 
     for pattern in _DATE_SUFFIX_PATTERNS:
         undated = pattern.sub("", stripped)
@@ -319,6 +394,7 @@ def _iter_litellm_model_candidates(ai_model: AIModel) -> Iterable[str]:
     gateway_config = (
         meta_data.get("gateway") if isinstance(meta_data.get("gateway"), dict) else {}
     )
+    endpoint_prefix = _endpoint_prefix(getattr(ai_model, "api_endpoint", None))
 
     candidates = []
     gateway_alias = gateway_config.get("model_alias")
@@ -328,14 +404,13 @@ def _iter_litellm_model_candidates(ai_model: AIModel) -> Iterable[str]:
     if model_identifier:
         candidates.append(model_identifier)
         prefix = _PROVIDER_PREFIX.get(provider, provider)
-        if "/" not in model_identifier and not model_identifier.lower().startswith(
-            "preloop/"
-        ):
-            candidates.append(f"{prefix}/{model_identifier}")
+        bare_identifier = _strip_synthetic_prefix(model_identifier)
+        if "/" not in bare_identifier and prefix not in _SYNTHETIC_PROVIDER_PREFIXES:
+            candidates.append(f"{prefix}/{bare_identifier}")
 
     seen = set()
     for candidate in candidates:
-        for expanded in _expand_candidate(candidate.strip(), provider):
+        for expanded in _expand_candidate(candidate.strip(), provider, endpoint_prefix):
             normalized = normalize_gateway_model_alias(expanded) or expanded.strip()
             if not normalized or normalized in seen:
                 continue

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -84,6 +84,7 @@ from preloop.services.upstream_errors import (
     classify_upstream_error,
 )
 from preloop.services.model_price_catalog import schedule_price_lookup
+from preloop.services.unpriced_model_alert import notify_unpriced_model
 from preloop.services.rate_limit_telemetry import (
     RateLimitSnapshot,
     classify_rate_limit_subtype,
@@ -5867,6 +5868,19 @@ class OpenAIGatewayService:
                 schedule_price_lookup(ai_model=ai_model, api_usage_id=str(usage_row.id))
             except Exception:  # noqa: BLE001 - never break recording
                 logger.debug("Scheduling live price lookup failed", exc_info=True)
+            # Tell an admin the catalog is missing this model. Deduplicated
+            # per (model_alias, provider) via a persisted marker, so hot-path
+            # traffic yields one actionable alert, not one per request.
+            try:
+                notify_unpriced_model(
+                    self.db,
+                    account_id=str(self.auth_context.user.account_id),
+                    model_alias=model_alias,
+                    provider_name=ai_model.provider_name,
+                    total_tokens=int(total_tokens or 0),
+                )
+            except Exception:  # noqa: BLE001 - never break recording
+                logger.debug("Unpriced-model admin alert failed", exc_info=True)
 
         log_model_gateway_request(
             self.db,

--- a/backend/preloop/services/unpriced_model_alert.py
+++ b/backend/preloop/services/unpriced_model_alert.py
@@ -1,0 +1,192 @@
+"""Admin alerting for gateway traffic the price catalog cannot price.
+
+When the gateway records usage with ``cost_source='unpriced'`` the tokens are
+metered but no cost can be attributed, so the user sees no spend for real
+spend. That is a silent failure of Preloop's core promise, and in production
+1667 such calls accumulated before anyone noticed.
+
+This module notifies admins the first time a given ``(model_alias, provider)``
+pair proves unpriceable, then stays quiet for :data:`ALERT_COOLDOWN_HOURS`.
+
+Two properties matter because this runs on the hot gateway path:
+
+- **Cross-replica dedup.** The cooldown marker is an ``audit_log`` row, not
+  process memory. Production runs several API and gateway replicas, and a
+  previous incident was caused by an in-memory-only throttle firing once per
+  replica. The in-process cache here is only a fast path in front of the
+  persisted marker.
+- **Never fails the request.** Every database and notification error is caught
+  and logged. A pricing-visibility alert must never turn into a user-facing
+  gateway error.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from preloop.models.crud import crud_audit_log
+from preloop.sync.tasks import notify_admins
+
+logger = logging.getLogger(__name__)
+
+#: Audit action used as the persisted, cross-replica dedup marker.
+UNPRICED_ALERT_ACTION = "unpriced_model_alert"
+
+#: Quiet period per (model_alias, provider) after an alert is sent.
+ALERT_COOLDOWN_HOURS = int(os.getenv("UNPRICED_MODEL_ALERT_COOLDOWN_HOURS", "24"))
+
+# Fast path only; the audit-log marker remains authoritative across replicas.
+_local_lock = threading.Lock()
+_local_recent: dict[str, float] = {}
+
+
+def _dedupe_key(model_alias: str, provider_name: Optional[str]) -> str:
+    """Build the per-model dedup key.
+
+    Args:
+        model_alias: Recorded model alias that could not be priced.
+        provider_name: Provider that served the request.
+
+    Returns:
+        A stable key identifying the model/provider pair.
+    """
+    return f"{(provider_name or 'unknown').strip().lower()}|{model_alias.strip()}"
+
+
+def reset_alert_state_for_tests() -> None:
+    """Clear the in-process fast-path cache (test isolation only)."""
+    with _local_lock:
+        _local_recent.clear()
+
+
+def _recently_alerted_locally(key: str, cooldown_seconds: float) -> bool:
+    """Return True when this process alerted for ``key`` inside the cooldown."""
+    now = time.monotonic()
+    with _local_lock:
+        last = _local_recent.get(key)
+        return last is not None and now - last < cooldown_seconds
+
+
+def _mark_locally(key: str) -> None:
+    """Record a local alert timestamp for the fast path."""
+    with _local_lock:
+        _local_recent[key] = time.monotonic()
+
+
+def _recently_alerted_in_db(
+    db: Session, *, account_id: str, key: str, cooldown_hours: int
+) -> bool:
+    """Return True when any replica already alerted for ``key`` recently.
+
+    Args:
+        db: Database session.
+        account_id: Account whose traffic was unpriced.
+        key: Dedup key for the model/provider pair.
+        cooldown_hours: Quiet period length.
+
+    Returns:
+        True when a marker newer than the cooldown exists.
+    """
+    since = datetime.now(timezone.utc) - timedelta(hours=cooldown_hours)
+    existing = crud_audit_log.get_by_account(
+        db,
+        account_id=account_id,
+        action=UNPRICED_ALERT_ACTION,
+        resource_type="model_pricing",
+        start_date=since,
+        limit=200,
+    )
+    return any(entry.resource_id == key for entry in existing)
+
+
+def notify_unpriced_model(
+    db: Session,
+    *,
+    account_id: str,
+    model_alias: str,
+    provider_name: Optional[str],
+    total_tokens: int,
+    cooldown_hours: Optional[int] = None,
+) -> bool:
+    """Alert admins that a model could not be priced, at most once per cooldown.
+
+    Safe to call on every unpriced gateway request: repeats inside the cooldown
+    are dropped, and all failures are swallowed so the caller's request is
+    never affected.
+
+    Args:
+        db: Database session.
+        account_id: Account whose usage could not be priced.
+        model_alias: Model alias recorded on the usage row.
+        provider_name: Provider that served the request.
+        total_tokens: Tokens on the triggering request, for context.
+        cooldown_hours: Override for the quiet period.
+
+    Returns:
+        True when a notification was actually sent.
+    """
+    if not model_alias or not account_id:
+        return False
+
+    window = ALERT_COOLDOWN_HOURS if cooldown_hours is None else cooldown_hours
+    key = _dedupe_key(model_alias, provider_name)
+
+    try:
+        if _recently_alerted_locally(key, window * 3600):
+            return False
+        if _recently_alerted_in_db(
+            db, account_id=account_id, key=key, cooldown_hours=window
+        ):
+            _mark_locally(key)
+            return False
+
+        # Claim the cooldown BEFORE notifying so a notification failure cannot
+        # turn into a retry storm on the next request.
+        crud_audit_log.log_action(
+            db,
+            account_id=account_id,
+            action=UNPRICED_ALERT_ACTION,
+            resource_type="model_pricing",
+            resource_id=key,
+            status="success",
+            details={
+                "model_alias": model_alias,
+                "provider_name": provider_name,
+                "total_tokens": total_tokens,
+            },
+        )
+        _mark_locally(key)
+    except Exception:  # noqa: BLE001 - alerting must never break the gateway
+        logger.exception(
+            "Unpriced-model alert bookkeeping failed for provider %s",
+            provider_name,
+        )
+        return False
+
+    subject = f"Preloop: no pricing for model {model_alias}"
+    message = (
+        "Preloop metered gateway usage it could not price, so this traffic "
+        "shows no cost for the customer.\n\n"
+        f"Model alias: {model_alias}\n"
+        f"Provider: {provider_name or 'unknown'}\n"
+        f"Account: {account_id}\n"
+        f"Tokens on triggering request: {total_tokens:,}\n\n"
+        "Add pricing for this model (or a per-account price override), then "
+        "reprice historical rows with the usage repricing task so the "
+        "customer's dashboard becomes accurate retroactively.\n"
+        f"Further alerts for this model are suppressed for {window}h."
+    )
+
+    try:
+        notify_admins(subject, message)
+    except Exception:  # noqa: BLE001 - never raise into the request path
+        logger.exception("Failed to send unpriced-model notification")
+        return False
+    return True

--- a/backend/tests/models/crud/test_unpriced_usage_reporting.py
+++ b/backend/tests/models/crud/test_unpriced_usage_reporting.py
@@ -1,0 +1,173 @@
+"""Unpriced gateway usage must never be reported as a confident $0.00.
+
+User-reported (2026-08-08): PR review flows costing real
+money displayed as costing nothing. The gateway metered tokens correctly but
+the model was missing from the price catalog, so every row landed with
+``cost_source='unpriced'`` and ``estimated_cost=NULL`` — which a ``sum()``
+then coalesced into a confident ``0.0``.
+
+These tests pin the reporting contract:
+
+  1. Unpriced rows expose their token volume, not a zero cost.
+  2. An aggregate mixing priced and unpriced rows reports the priced subtotal
+     plus an explicit unpriced qualifier, never one misleadingly-low number.
+  3. ``cost_source='subscription'`` remains a legitimate, complete $0.00.
+"""
+
+import uuid
+
+from preloop.models.crud import crud_ai_model, crud_flow, crud_flow_execution
+from preloop.models.crud.api_usage import crud_api_usage
+from preloop.models.schemas.flow import FlowCreate
+from preloop.models.schemas.flow_execution import FlowExecutionCreate
+
+
+def _setup_execution(db_session, account, model_identifier="deepseek/deepseek-v4"):
+    """Create an account-scoped model, flow and execution for usage rows."""
+    ai_model = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": f"Unpriced Model {uuid.uuid4()}",
+            "provider_name": "openai-compatible",
+            "model_identifier": model_identifier,
+            "api_key": "provider-secret",
+        },
+        account_id=account.id,
+    )
+    flow = crud_flow.create(
+        db=db_session,
+        flow_in=FlowCreate(
+            name=f"Unpriced Flow {uuid.uuid4()}",
+            prompt_template="Test",
+            trigger_event_source="manual",
+            trigger_event_types=["test"],
+            ai_model_id=ai_model.id,
+            agent_type="gemini",
+            agent_config={},
+            allowed_mcp_servers=[],
+            allowed_mcp_tools=[],
+            account_id=account.id,
+        ),
+        account_id=account.id,
+    )
+    execution = crud_flow_execution.create(
+        db_session,
+        FlowExecutionCreate(flow_id=flow.id, status="RUNNING"),
+    )
+    return ai_model, flow, execution
+
+
+def _log(db_session, *, account, user, flow, execution, **overrides):
+    """Log one gateway usage row against the execution."""
+    params = dict(
+        endpoint="/openai/v1/chat/completions",
+        method="POST",
+        status_code=200,
+        duration=0.1,
+        user_id=str(user.id),
+        account_id=str(account.id),
+        flow_id=str(flow.id),
+        flow_execution_id=str(execution.id),
+        model_alias="openai-compatible/deepseek/deepseek-v4-flash-0731",
+        provider_name="openai-compatible",
+        prompt_tokens=1000,
+        completion_tokens=200,
+        total_tokens=1200,
+    )
+    params.update(overrides)
+    return crud_api_usage.log_gateway_request(db_session, **params)
+
+
+def test_unpriced_execution_reports_tokens_instead_of_zero_cost(
+    db_session, create_account, create_user
+):
+    """An all-unpriced execution reports None cost and its unpriced tokens."""
+    account = create_account()
+    user = create_user(account=account)
+    _, flow, execution = _setup_execution(db_session, account)
+
+    _log(
+        db_session,
+        account=account,
+        user=user,
+        flow=flow,
+        execution=execution,
+        estimated_cost=None,
+        cost_source="unpriced",
+    )
+
+    usage = crud_api_usage.get_gateway_usage_for_execution(
+        db_session, str(execution.id)
+    )
+
+    # The core complaint: this must not read as "this cost you $0.00".
+    assert usage["estimated_cost"] is None
+    assert usage["has_pricing"] is False
+    assert usage["unpriced_requests"] == 1
+    assert usage["unpriced_tokens"] == 1200
+
+
+def test_mixed_execution_keeps_priced_subtotal_and_flags_unpriced(
+    db_session, create_account, create_user
+):
+    """A mixed aggregate exposes the unpriced remainder, not just a subtotal."""
+    account = create_account()
+    user = create_user(account=account)
+    _, flow, execution = _setup_execution(db_session, account)
+
+    _log(
+        db_session,
+        account=account,
+        user=user,
+        flow=flow,
+        execution=execution,
+        estimated_cost=0.25,
+        cost_source="catalog",
+    )
+    _log(
+        db_session,
+        account=account,
+        user=user,
+        flow=flow,
+        execution=execution,
+        estimated_cost=None,
+        cost_source="unpriced",
+        total_tokens=5000,
+    )
+
+    usage = crud_api_usage.get_gateway_usage_for_execution(
+        db_session, str(execution.id)
+    )
+
+    # The priced part is still a real number, but the total is incomplete.
+    assert usage["estimated_cost"] == 0.25
+    assert usage["has_pricing"] is True
+    assert usage["cost_is_partial"] is True
+    assert usage["unpriced_requests"] == 1
+    assert usage["unpriced_tokens"] == 5000
+
+
+def test_subscription_zero_is_a_complete_zero(db_session, create_account, create_user):
+    """Subscription-covered traffic is genuinely $0.00 and not flagged."""
+    account = create_account()
+    user = create_user(account=account)
+    _, flow, execution = _setup_execution(db_session, account)
+
+    _log(
+        db_session,
+        account=account,
+        user=user,
+        flow=flow,
+        execution=execution,
+        estimated_cost=0.0,
+        cost_source="subscription",
+    )
+
+    usage = crud_api_usage.get_gateway_usage_for_execution(
+        db_session, str(execution.id)
+    )
+
+    assert usage["estimated_cost"] == 0.0
+    assert usage["cost_is_partial"] is False
+    assert usage["unpriced_requests"] == 0
+    assert usage["unpriced_tokens"] == 0

--- a/backend/tests/services/test_execution_metrics.py
+++ b/backend/tests/services/test_execution_metrics.py
@@ -489,5 +489,8 @@ def test_get_execution_metrics_falls_back_to_log_parsing_without_gateway_usage(
     assert metrics["tool_calls"] == 2
     assert metrics["api_requests"] == 0
     assert metrics["token_usage"]["total_tokens"] == 1234
-    assert metrics["estimated_cost"] == 0.0
+    # 1234 tokens were spent with no resolvable price. Reporting 0.0 here is
+    # what made real spend look free; the volume is surfaced instead.
+    assert metrics["estimated_cost"] is None
     assert metrics["has_pricing"] is False
+    assert metrics["unpriced_tokens"] == 1234

--- a/backend/tests/services/test_model_price_catalog.py
+++ b/backend/tests/services/test_model_price_catalog.py
@@ -192,3 +192,90 @@ def test_schedule_price_lookup_uses_bounded_executor(monkeypatch) -> None:
     assert model_price_catalog.schedule_price_lookup(ai_model=ai_model) is True
     assert len(submitted) == 1
     assert "executor-test-model" in model_price_catalog._pending_lookups
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter marketplace pricing (models absent from litellm's map)
+# ---------------------------------------------------------------------------
+
+
+def test_openrouter_map_converts_per_token_pricing() -> None:
+    """OpenRouter's per-token strings become litellm-shaped price entries.
+
+    OpenRouter publishes authoritative per-token prices as decimal strings.
+    They are converted verbatim (no unit rescaling) so a dashboard number can
+    always be traced back to the vendor's published price.
+    """
+    payload = {
+        "data": [
+            {
+                "id": "deepseek/deepseek-v4-flash-0731",
+                "pricing": {
+                    "prompt": "0.00000009",
+                    "completion": "0.00000018",
+                    "input_cache_read": "0.000000018",
+                },
+            }
+        ]
+    }
+
+    entries = model_price_catalog._openrouter_entries_from_payload(payload)
+
+    entry = entries["openrouter/deepseek/deepseek-v4-flash-0731"]
+    assert entry["input_cost_per_token"] == 9e-08
+    assert entry["output_cost_per_token"] == 1.8e-07
+    assert entry["cache_read_input_token_cost"] == 1.8e-08
+    assert entry["litellm_provider"] == "openrouter"
+
+
+def test_openrouter_map_skips_models_without_usable_prices() -> None:
+    """Zero/missing prices are not registered as a real $0 price.
+
+    A free-tier or price-less listing must stay unpriced rather than assert
+    that the model costs nothing.
+    """
+    payload = {
+        "data": [
+            {"id": "vendor/no-pricing"},
+            {"id": "vendor/zero", "pricing": {"prompt": "0", "completion": "0"}},
+            {"id": "vendor/bad", "pricing": {"prompt": "abc", "completion": "x"}},
+        ]
+    }
+
+    entries = model_price_catalog._openrouter_entries_from_payload(payload)
+
+    assert entries == {}
+
+
+def test_live_lookup_falls_back_to_openrouter_for_marketplace_models(
+    monkeypatch,
+) -> None:
+    """A model missing from litellm's map is priced from OpenRouter.
+
+    This is the exact customer-reported case: OpenRouter-routed DeepSeek usage
+    that litellm does not carry, which previously surfaced as $0.00.
+    """
+    model_price_catalog.reset_lookup_state_for_tests()
+    monkeypatch.setattr(model_price_catalog, "_fetch_remote_price_map", lambda: {})
+    monkeypatch.setattr(
+        model_price_catalog,
+        "_fetch_openrouter_price_map",
+        lambda: {
+            "openrouter/deepseek/deepseek-v4-flash-0731": {
+                "litellm_provider": "openrouter",
+                "mode": "chat",
+                "input_cost_per_token": 9e-08,
+                "output_cost_per_token": 1.8e-07,
+            }
+        },
+    )
+
+    matched = model_price_catalog.lookup_model_price_now(
+        [
+            "openrouter/deepseek/deepseek-v4-flash-0731",
+            "deepseek/deepseek-v4-flash-0731",
+        ]
+    )
+
+    assert matched == "openrouter/deepseek/deepseek-v4-flash-0731"
+    assert "openrouter/deepseek/deepseek-v4-flash-0731" in litellm.model_cost

--- a/backend/tests/services/test_model_price_catalog.py
+++ b/backend/tests/services/test_model_price_catalog.py
@@ -279,3 +279,74 @@ def test_live_lookup_falls_back_to_openrouter_for_marketplace_models(
 
     assert matched == "openrouter/deepseek/deepseek-v4-flash-0731"
     assert "openrouter/deepseek/deepseek-v4-flash-0731" in litellm.model_cost
+
+
+def test_price_map_cache_serves_within_ttl_and_refetches_after_expiry() -> None:
+    """The shared cache hits once within the TTL and refetches once stale."""
+    cache = model_price_catalog._PriceMapCache("test")
+    calls = {"count": 0}
+
+    def _fetch():
+        calls["count"] += 1
+        return {"model": {"input_cost_per_token": 1e-06}}
+
+    assert cache.get(_fetch) is not None
+    assert cache.get(_fetch) is not None
+    assert calls["count"] == 1  # second call served from cache
+
+    # Age the cache past its TTL and confirm exactly one more download.
+    cache._fetched_at -= model_price_catalog._REMOTE_TTL_SECONDS + 1
+    assert cache.get(_fetch) is not None
+    assert calls["count"] == 2
+
+
+def test_price_map_cache_backs_off_after_failure() -> None:
+    """A failed fetch suppresses the next attempt until the backoff expires."""
+    cache = model_price_catalog._PriceMapCache("test")
+    calls = {"count": 0}
+
+    def _failing_fetch():
+        calls["count"] += 1
+        return None
+
+    assert cache.get(_failing_fetch) is None
+    assert cache.get(_failing_fetch) is None
+    assert calls["count"] == 1  # second call sits out the backoff
+
+    cache._failed_at -= model_price_catalog._REMOTE_FAILURE_BACKOFF_SECONDS + 1
+    assert cache.get(_failing_fetch) is None
+    assert calls["count"] == 2
+
+
+def test_openrouter_fetch_failure_backs_off(monkeypatch) -> None:
+    """OpenRouter downloads honor the same backoff as litellm's map."""
+    model_price_catalog.reset_lookup_state_for_tests()
+    calls = {"count": 0}
+
+    class _FakeHttpx:
+        @staticmethod
+        def get(*args, **kwargs):
+            calls["count"] += 1
+            raise RuntimeError("network down")
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+
+    assert model_price_catalog._fetch_openrouter_price_map() is None
+    assert model_price_catalog._fetch_openrouter_price_map() is None
+    assert calls["count"] == 1  # second call sits out backoff
+
+
+def test_reset_lookup_state_clears_both_caches() -> None:
+    """Test reset clears the litellm and OpenRouter caches together."""
+    model_price_catalog._remote_cache.set({"a": {}})
+    model_price_catalog._openrouter_cache.set({"openrouter/b": {}})
+
+    model_price_catalog.reset_lookup_state_for_tests()
+
+    state = model_price_catalog._module_state_for_tests()
+    assert state["remote"]["map"] is None
+    assert state["remote"]["failed_at"] == 0.0
+    assert state["openrouter"]["map"] is None
+    assert state["openrouter"]["failed_at"] == 0.0

--- a/backend/tests/services/test_model_pricing.py
+++ b/backend/tests/services/test_model_pricing.py
@@ -345,3 +345,64 @@ def test_model_price_override_serializes_adjustment_terms() -> None:
     assert pricing["discount_percent"] == 10.0
     assert pricing["prepaid_token_balance"] == 2000
     assert pricing["prepaid_credit_balance_usd"] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter / openai-compatible routed models (customer-reported $0.00 bug)
+# ---------------------------------------------------------------------------
+
+
+def test_candidates_strip_openai_compatible_provider_prefix() -> None:
+    """The synthetic ``openai-compatible/`` prefix is not a price-map namespace.
+
+    The affected models are recorded as
+    ``openai-compatible/deepseek/deepseek-v4-flash-0731``. ``openai-compatible``
+    is a Preloop routing label, not a litellm provider, so the prefixed form can
+    never match the catalog and must be reduced to the bare vendor/model id.
+    """
+    ai_model = AIModel(
+        provider_name="openai-compatible",
+        model_identifier="deepseek/deepseek-v4-flash-0731",
+        api_endpoint="https://openrouter.ai/api/v1",
+        meta_data={
+            "gateway": {
+                "model_alias": "openai-compatible/deepseek/deepseek-v4-flash-0731"
+            }
+        },
+    )
+    candidates = list(_iter_litellm_model_candidates(ai_model))
+    assert "deepseek/deepseek-v4-flash-0731" in candidates
+    assert "openai-compatible/deepseek/deepseek-v4-flash-0731" not in candidates
+
+
+def test_candidates_add_openrouter_prefix_for_openrouter_endpoint() -> None:
+    """A model served via openrouter.ai gains ``openrouter/`` catalog keys.
+
+    litellm prices OpenRouter-routed models under ``openrouter/vendor/model``,
+    so the endpoint must contribute that candidate form.
+    """
+    ai_model = AIModel(
+        provider_name="openai-compatible",
+        model_identifier="deepseek/deepseek-chat",
+        api_endpoint="https://openrouter.ai/api/v1",
+    )
+    candidates = list(_iter_litellm_model_candidates(ai_model))
+    assert "openrouter/deepseek/deepseek-chat" in candidates
+
+
+def test_dated_openrouter_variant_never_falls_back_to_undated_price() -> None:
+    """A dated OpenRouter snapshot must not inherit the undated model's price.
+
+    ``deepseek-v4-flash-0731`` really costs $0.09/$0.18 per million tokens while
+    the undated ``deepseek-v4-flash`` costs $0.14/$0.28. Silently stripping the
+    ``-0731`` suffix would overstate the bill by ~55%, which is a worse
+    failure than reporting the usage as unpriced.
+    """
+    ai_model = AIModel(
+        provider_name="openai-compatible",
+        model_identifier="deepseek/deepseek-v4-flash-0731",
+        api_endpoint="https://openrouter.ai/api/v1",
+    )
+    candidates = list(_iter_litellm_model_candidates(ai_model))
+    assert "deepseek/deepseek-v4-flash" not in candidates
+    assert "openrouter/deepseek/deepseek-v4-flash" not in candidates

--- a/backend/tests/services/test_unpriced_model_alert.py
+++ b/backend/tests/services/test_unpriced_model_alert.py
@@ -1,0 +1,161 @@
+"""Admin alerting for models the price catalog cannot price.
+
+1667 unpriced gateway calls accumulated in production without anyone being
+told. These tests pin the alerting contract:
+
+  1. An unpriceable model notifies admins with the model, account and token
+     volume needed to act.
+  2. Repeat traffic for the same (model_alias, provider) inside the cooldown
+     notifies once, not once per request. The dedup marker is persisted in the
+     database so it holds across the multiple API/gateway replicas that run in
+     production (a past incident was caused by per-process state).
+  3. A notification failure never propagates into the request path.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from preloop.services import unpriced_model_alert
+from preloop.services.unpriced_model_alert import notify_unpriced_model
+
+
+@pytest.fixture(autouse=True)
+def _clear_alert_cache():
+    """Isolate the process-local fast-path cache between tests."""
+    unpriced_model_alert.reset_alert_state_for_tests()
+    yield
+    unpriced_model_alert.reset_alert_state_for_tests()
+
+
+def test_first_unpriced_model_notifies_admins(db_session, test_user):
+    """The first sighting alerts with model, provider, account and volume."""
+    account_id = str(test_user.account_id)
+
+    with patch.object(unpriced_model_alert, "notify_admins") as mock_notify:
+        sent = notify_unpriced_model(
+            db_session,
+            account_id=account_id,
+            model_alias="openai-compatible/deepseek/deepseek-v4-flash-0731",
+            provider_name="openai-compatible",
+            total_tokens=62932308,
+        )
+
+    assert sent is True
+    mock_notify.assert_called_once()
+    body = mock_notify.call_args.args[1]
+    assert "deepseek/deepseek-v4-flash-0731" in body
+    assert "openai-compatible" in body
+    assert account_id in body
+    assert "62,932,308" in body
+
+
+def test_repeat_unpriced_model_is_deduped_within_cooldown(db_session, test_user):
+    """Hot-path repeats collapse to a single notification per model/provider."""
+    account_id = str(test_user.account_id)
+
+    with patch.object(unpriced_model_alert, "notify_admins") as mock_notify:
+        results = [
+            notify_unpriced_model(
+                db_session,
+                account_id=account_id,
+                model_alias="openai-compatible/deepseek/deepseek-v4-flash-0731",
+                provider_name="openai-compatible",
+                total_tokens=1200,
+            )
+            for _ in range(25)
+        ]
+
+    assert results.count(True) == 1
+    assert mock_notify.call_count == 1
+
+
+def test_distinct_models_alert_independently(db_session, test_user):
+    """Dedup is per (model_alias, provider), not global."""
+    account_id = str(test_user.account_id)
+
+    with patch.object(unpriced_model_alert, "notify_admins") as mock_notify:
+        notify_unpriced_model(
+            db_session,
+            account_id=account_id,
+            model_alias="openai-compatible/deepseek/deepseek-v4-flash-0731",
+            provider_name="openai-compatible",
+            total_tokens=10,
+        )
+        notify_unpriced_model(
+            db_session,
+            account_id=account_id,
+            model_alias="openai/moonshotai/kimi-k3",
+            provider_name="openai",
+            total_tokens=20,
+        )
+
+    assert mock_notify.call_count == 2
+
+
+def test_dedup_marker_is_persisted_not_process_local(db_session, test_user):
+    """The cooldown survives a fresh process: the marker lives in the DB."""
+    account_id = str(test_user.account_id)
+
+    with patch.object(unpriced_model_alert, "notify_admins") as mock_notify:
+        notify_unpriced_model(
+            db_session,
+            account_id=account_id,
+            model_alias="openai-compatible/deepseek/deepseek-v4-flash-0731",
+            provider_name="openai-compatible",
+            total_tokens=10,
+        )
+    assert mock_notify.call_count == 1
+
+    # Simulate a different replica / restarted process: no in-memory state.
+    unpriced_model_alert.reset_alert_state_for_tests()
+
+    with patch.object(unpriced_model_alert, "notify_admins") as mock_notify:
+        sent = notify_unpriced_model(
+            db_session,
+            account_id=account_id,
+            model_alias="openai-compatible/deepseek/deepseek-v4-flash-0731",
+            provider_name="openai-compatible",
+            total_tokens=10,
+        )
+
+    assert sent is False
+    mock_notify.assert_not_called()
+
+
+def test_notification_failure_never_raises(db_session, test_user):
+    """A broken notification channel must not fail the user's request."""
+    account_id = str(test_user.account_id)
+
+    with patch.object(
+        unpriced_model_alert, "notify_admins", side_effect=RuntimeError("smtp down")
+    ):
+        sent = notify_unpriced_model(
+            db_session,
+            account_id=account_id,
+            model_alias="openai-compatible/deepseek/deepseek-v4-flash-0731",
+            provider_name="openai-compatible",
+            total_tokens=10,
+        )
+
+    assert sent is False
+
+
+def test_database_failure_never_raises(db_session, test_user):
+    """A dedup-store failure degrades quietly instead of breaking the gateway."""
+    account_id = str(test_user.account_id)
+
+    with patch.object(
+        unpriced_model_alert.crud_audit_log,
+        "log_action",
+        side_effect=RuntimeError("db down"),
+    ):
+        sent = notify_unpriced_model(
+            db_session,
+            account_id=account_id,
+            model_alias="openai-compatible/deepseek/deepseek-v4-flash-0731",
+            provider_name="openai-compatible",
+            total_tokens=10,
+        )
+
+    assert sent is False

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,10 +38,10 @@
         "deck.gl": "^9.1.12",
         "dompurify": "^3.4.12",
         "events": "^3.3.0",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.1",
         "lit": "^3.1.0",
         "marked": "^16.4.1",
-        "mermaid": "^10.9.5",
+        "mermaid": "^10.9.8",
         "tsne-js": "^1.0.3"
       },
       "devDependencies": {
@@ -7533,9 +7533,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -8510,9 +8510,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "10.9.6",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.6.tgz",
-      "integrity": "sha512-XRjjRaI4aPCAMpVaOhxIwLYdx3U4Cb6mN0M268ggFAfFRqsvyFW8zxWbEZazN/mPkqsVWThb0oa1UawWK+XMNg==",
+      "version": "10.9.8",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.8.tgz",
+      "integrity": "sha512-gmIhmkmD/3DL5lErDV71E/cFUkEbBW4VTFpsJH1HSYjeBICRKOoc4AZem+RNz/FhhCXKBMZiD75bIfBlb2A4yA==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.1",
@@ -9127,9 +9127,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,10 +71,10 @@
     "deck.gl": "^9.1.12",
     "dompurify": "^3.4.12",
     "events": "^3.3.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "lit": "^3.1.0",
     "marked": "^16.4.1",
-    "mermaid": "^10.9.5",
+    "mermaid": "^10.9.8",
     "tsne-js": "^1.0.3"
   },
   "devDependencies": {

--- a/frontend/src/views/authed/flow-execution-view.test.ts
+++ b/frontend/src/views/authed/flow-execution-view.test.ts
@@ -399,4 +399,69 @@ describe('FlowExecutionView', () => {
     expect(content).to.contain('search_issues');
     expect(content).to.contain('get_issue');
   });
+
+  it('does not claim pricing when a stored cost is a placeholder zero', async () => {
+    // Customer-reported: OpenRouter-routed flows metered 28M tokens but the
+    // model was unpriceable, so estimated_cost persisted as 0 and the UI
+    // announced "$0.00" for real spend. A zero cost with tokens spent must
+    // fall back to the token display instead.
+    const element = await fixture<FlowExecutionView>(
+      html`<flow-execution-view></flow-execution-view>`
+    );
+    (element as any).execution = {
+      id: 'exec-unpriced',
+      total_tokens: 28553143,
+      estimated_cost: 0,
+      tool_calls_count: 3,
+      mcp_usage_logs: [],
+    };
+    (element as any).gatewayEvents = [];
+
+    (element as any).hydrateMetricsFromExecution();
+
+    expect((element as any).hasPricing).to.equal(false);
+    expect((element as any).totalTokens).to.equal(28553143);
+  });
+
+  it('treats a null cost with tokens as unpriced, not free', async () => {
+    const element = await fixture<FlowExecutionView>(
+      html`<flow-execution-view></flow-execution-view>`
+    );
+    (element as any).execution = {
+      id: 'exec-null-cost',
+      total_tokens: 1000,
+      estimated_cost: null,
+      tool_calls_count: 0,
+      mcp_usage_logs: [],
+    };
+    (element as any).gatewayEvents = [];
+
+    (element as any).hydrateMetricsFromExecution();
+
+    expect((element as any).hasPricing).to.equal(false);
+  });
+
+  it('does not treat a zero-cost gateway event as priced', async () => {
+    const element = await fixture<FlowExecutionView>(
+      html`<flow-execution-view></flow-execution-view>`
+    );
+    (element as any).gatewayEvents = [
+      {
+        execution_id: 'exec-1',
+        timestamp: '2026-08-08T10:00:00Z',
+        type: 'model_gateway_call',
+        payload: {
+          api_usage_id: 'usage-unpriced',
+          total_tokens: 5000,
+          estimated_cost: 0,
+          outcome: 'success',
+        },
+      },
+    ];
+
+    (element as any).applyGatewayMetricsFromEvents();
+
+    expect((element as any).totalTokens).to.equal(5000);
+    expect((element as any).hasPricing).to.equal(false);
+  });
 });

--- a/frontend/src/views/authed/flow-execution-view.ts
+++ b/frontend/src/views/authed/flow-execution-view.ts
@@ -1213,8 +1213,12 @@ export class FlowExecutionView extends LitElement {
         totals.estimatedCost += this.getGatewayMetricNumber(
           event.payload.estimated_cost
         );
+        // A zero cost on a token-bearing call is an unpriced model, not a
+        // free call, so it must not mark the execution as priced.
         if (
-          typeof event.payload.estimated_cost === 'number' ||
+          (typeof event.payload.estimated_cost === 'number' &&
+            (event.payload.estimated_cost > 0 ||
+              !this.getGatewayMetricNumber(event.payload.total_tokens))) ||
           (event.payload.budget as { pricing_available?: unknown } | null)
             ?.pricing_available === true
         ) {
@@ -1259,6 +1263,9 @@ export class FlowExecutionView extends LitElement {
       }
       if (typeof this.execution.estimated_cost === 'number') {
         this.budgetUsed = this.execution.estimated_cost;
+        // Only a non-zero stored cost proves the execution was priced. A 0
+        // alongside spent tokens means "we could not price this", not "this
+        // was free", and must fall through to the token display.
         if (this.execution.estimated_cost > 0) {
           this.hasPricing = true;
         }
@@ -1996,7 +2003,9 @@ export class FlowExecutionView extends LitElement {
                 ${
                   this.hasPricing
                     ? `${this.totalTokens.toLocaleString()} tokens`
-                    : `${this.getTotalToolCallCount().toLocaleString()} tool calls recorded`
+                    : this.totalTokens > 0
+                      ? 'cost unavailable: model not priced'
+                      : `${this.getTotalToolCallCount().toLocaleString()} tool calls recorded`
                 }
               </div>
             </sl-card>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7060,8 +7060,11 @@ paths:
         \nReturns:\n    Dictionary with:\n    - tool_calls: Number of MCP tool calls\
         \ made\n    - api_requests: Number of API requests made during execution\n\
         \    - token_usage: Token usage statistics\n    - estimated_cost: Estimated\
-        \ cost based on token usage (0.0 if no pricing)\n    - has_pricing: Whether\
-        \ pricing is configured in AI model metadata"
+        \ cost in USD, or null when no usage could\n      be priced (never a placeholder\
+        \ 0.0, which would misreport real\n      spend as free)\n    - has_pricing:\
+        \ Whether any request could be priced\n    - cost_is_partial: Whether estimated_cost\
+        \ excludes unpriced requests\n    - unpriced_requests: Requests that could\
+        \ not be priced\n    - unpriced_tokens: Token volume behind the unpriced requests"
       operationId: get_flow_execution_metrics_api_v1_flows_executions__execution_id__metrics_get
       security:
       - bearerAuth: []

--- a/scripts/reprice_unpriced_usage.py
+++ b/scripts/reprice_unpriced_usage.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+"""Backfill costs for gateway usage rows recorded as unpriced.
+
+Historical rows recorded while a model was missing from the price catalog
+carry ``estimated_cost = NULL`` and ``cost_source = 'unpriced'``. Once pricing
+resolves for that model, this script recomputes their cost from the tokens
+already stored on each row, so past dashboards become accurate retroactively.
+
+Defaults to a DRY RUN: it reports what would change and writes nothing until
+``--apply`` is passed. Subscription-covered rows are skipped (their $0 is
+correct by construction) and budget spend is never rewritten, because spend
+was charged at request time and repricing is analytics-only.
+
+Examples:
+    # See what would change for one account, writing nothing.
+    python scripts/reprice_unpriced_usage.py \\
+        --account-id 5796260a-ff3d-4362-a656-c78df2d439b4 --days 30
+
+    # Apply it.
+    python scripts/reprice_unpriced_usage.py \\
+        --account-id 5796260a-ff3d-4362-a656-c78df2d439b4 --days 30 --apply
+
+    # Every account with unpriced rows.
+    python scripts/reprice_unpriced_usage.py --all-accounts --days 30 --apply
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+import click
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from preloop.models.db.session import get_db_session
+from preloop.services.model_price_catalog import load_catalog
+from preloop.services.usage_repricing import reprice_gateway_usage
+
+
+def _accounts_with_unpriced_rows(db: Session, start: datetime) -> List[str]:
+    """Return account ids holding unpriced gateway rows in the window.
+
+    Args:
+        db: Database session.
+        start: Inclusive lower bound on the usage timestamp.
+
+    Returns:
+        Account ids as strings, most affected first.
+    """
+    rows = db.execute(
+        text(
+            """
+            SELECT account_id, count(*) AS n
+            FROM api_usage
+            WHERE action_type = 'model_gateway'
+              AND cost_source = 'unpriced'
+              AND estimated_cost IS NULL
+              AND total_tokens > 0
+              AND timestamp >= :start
+            GROUP BY account_id
+            ORDER BY n DESC
+            """
+        ),
+        {"start": start},
+    ).fetchall()
+    return [str(row[0]) for row in rows if row[0]]
+
+
+@click.command()
+@click.option("--account-id", default=None, help="Account to reprice.")
+@click.option(
+    "--all-accounts",
+    is_flag=True,
+    default=False,
+    help="Reprice every account that has unpriced rows in the window.",
+)
+@click.option("--days", default=30, show_default=True, help="Lookback in days.")
+@click.option(
+    "--apply",
+    "apply_changes",
+    is_flag=True,
+    default=False,
+    help="Persist changes. Without this the run is a dry run.",
+)
+def main(
+    account_id: str | None, all_accounts: bool, days: int, apply_changes: bool
+) -> None:
+    """Reprice unpriced gateway usage rows for one or all accounts."""
+    if not account_id and not all_accounts:
+        raise click.UsageError("Pass --account-id <uuid> or --all-accounts.")
+
+    # Ensure the price catalog (and its live-lookup fallbacks) are loaded, or
+    # every row would simply be found unpriced again.
+    load_catalog()
+
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=days)
+    db = next(get_db_session())
+    try:
+        targets = (
+            _accounts_with_unpriced_rows(db, start) if all_accounts else [account_id]
+        )
+        if not targets:
+            click.echo("No accounts with unpriced usage in the window.")
+            return
+
+        mode = "APPLY" if apply_changes else "DRY RUN"
+        click.echo(f"[{mode}] {len(targets)} account(s), window {start} .. {end}")
+
+        total_updated = 0
+        total_delta = 0.0
+        for target in targets:
+            result = reprice_gateway_usage(
+                db,
+                account_id=target,
+                start=start,
+                end=end,
+                only_unpriced=True,
+                dry_run=not apply_changes,
+            )
+            delta = result.cost_after - result.cost_before
+            total_updated += result.rows_updated
+            total_delta += delta
+            click.echo(
+                f"  {target}: examined={result.rows_examined} "
+                f"updated={result.rows_updated} skipped={result.rows_skipped} "
+                f"cost {result.cost_before:.4f} -> {result.cost_after:.4f} "
+                f"(+{delta:.4f})"
+            )
+
+        click.echo(
+            f"[{mode}] total rows updated={total_updated}, "
+            f"total cost recovered=${total_delta:.4f}"
+        )
+        if not apply_changes:
+            click.echo("Dry run only. Re-run with --apply to persist.")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001 - operator-facing script
+        click.echo(f"Repricing failed: {exc}", err=True)
+        sys.exit(1)


### PR DESCRIPTION
## The bug

Flow executions were displaying `estimated_cost = 0.0000` even though the gateway had correctly metered **62.9M tokens** across 1,667 calls on the affected models. At the provider's published prices that traffic has a real, non-zero cost. We were reporting a confident $0.00 for traffic we simply could not price.

Reporting a confident zero is worse than reporting nothing: cost credibility is the core value proposition.

## Root cause

Three defects compounded. Token metering was never broken; pricing and presentation were.

1. **Alias never matched the catalog.** Usage on a user-configured OpenAI-compatible provider is recorded as `openai-compatible/<vendor>/<model>`. `openai-compatible` is a Preloop *routing* label, not a price-map namespace, and it was carried straight into catalog lookup, guaranteeing a miss. OpenRouter-routed models were also never tried under litellm's `openrouter/vendor/model` key form.
2. **No price source for the model.** litellm's map does not carry dated OpenRouter SKUs at all, so even a correctly-formed key missed. `cost_source` was set to `unpriced` and `estimated_cost` left NULL, which is correct behavior.
3. **The NULL was then rendered as a confident zero.** `get_gateway_usage_for_execution` wrapped `sum(estimated_cost)` in `coalesce(..., 0.0)`, and `FlowOrchestrator.estimated_cost` defaulted to `0.0`. "We could not price this" was persisted and displayed as "this was free". The frontend compounded it by treating a numeric `0` cost as proof of pricing.

## A trap worth calling out

The obvious fix, stripping the `-0731` date suffix to reach the undated entry, would have been **wrong**. Verified against OpenRouter's API:

| model | prompt /Mtok | completion /Mtok |
|---|---|---|
| `deepseek-v4-flash-0731` (dated, in use) | **$0.09** | **$0.18** |
| `deepseek-v4-flash` (undated) | $0.14 | $0.28 |

Dated marketplace ids are separately priced SKUs. That fallback would have overstated the bill by ~55%. Date-suffix stripping is now explicitly disabled for `vendor/model` names. A wrong number in a cost dashboard is worse than an honest "unknown".

## Platform-wide unpriced volume

`api_usage` grouped by `cost_source`:

| cost_source | calls | tokens |
|---|---|---|
| **unpriced** | **1,727** | **63,005,680** |
| subscription (legitimate $0) | 13,173 | 13,995,362 |
| catalog (priced) | 53 | 339,846 |
| null (mostly non-token rows) | 490,122 | 2,165,591 |

**Essentially all metered token volume on the platform, ~63M tokens, was unpriced**, concentrated in OpenRouter-routed models. Other affected models: `moonshotai/kimi-k3`, `openrouter/auto-beta`, `kimi-for-coding/*`, several `gpt-5-codex` variants.

## What is fixed

- **Alias normalization**: synthetic `openai-compatible/`, `custom/`, `preloop/` prefixes stripped before lookup; models served from `openrouter.ai` also tried under `openrouter/vendor/model`.
- **Real price source**: OpenRouter's own `/api/v1/models` is used when litellm's map misses, cached and backed off like the existing price-map fetch. Zero/missing vendor prices are skipped rather than registered as "free". Verified end to end: an affected dated SKU now resolves to its exact per-Mtok input/output price from `catalog`.
- **Never a fake zero** (founder directive A): cost stays `NULL` when nothing could be priced and the **token count is surfaced in its place**. Aggregates mixing priced and unpriced rows now expose `cost_is_partial` plus unpriced request/token counts, so a subtotal is never presented as a complete bill. Frontend shows `cost unavailable: model not priced` instead of `$0.00`.
- **Subscription zero preserved**: `cost_source='subscription'` is a legitimate, complete $0.00 and is explicitly excluded from unpriced counting.
- **Admin alert** (founder directive B): first time a `(model_alias, provider)` proves unpriceable, `notify_admins` fires with the model, account id and token volume. Deduped via a **persisted `audit_log` marker** with a 24h cooldown, so it holds across the multiple prod replicas rather than firing once per process (the failure mode of a past incident). The cooldown is claimed *before* notifying, and every DB/notification error is swallowed: alerting can never break a user request. 1,667 unpriced calls produce ~1 alert.

## Why our own alarm never fired (systemic)

The `costs_priced` check in `gateway_accounting_check.py` works correctly and would have failed on this traffic. It is simply **never invoked**: it is exposed only as `GET /api/v1/cost/health`, is per-account, requires auth, and has no scheduler, cron or k8s job polling it. Nobody was ever going to be told. The new push-based alert on the recording path closes that gap; wiring the health check into a scheduled sweep is a sensible follow-up.

## Zero-token executions (investigated, not ours)

28 of 91 executions recorded zero tokens. All 28 are `status = FAILED` **with zero `api_usage` rows**, failing at `Fetching merge request ref pull/N/head... FATAL` before any model call. This is lost git/checkout work, not lost accounting, and is unrelated to the DB pool incident. No fix here; it belongs with the PR-reviewer reliability work.

## Founder actions required

**1. Backfill (prepared, NOT executed).** Nothing was run against prod. Dry run first:

```bash
python scripts/reprice_unpriced_usage.py --all-accounts --days 30
python scripts/reprice_unpriced_usage.py --all-accounts --days 30 --apply
```

Scope: **1,684 rows** across **2 accounts**, 2026-07-26 to 2026-08-08. Repricing is analytics-only: budget spend is never rewritten and subscription rows are skipped.

**2. Prod egress.** The gateway pods must be able to reach `https://openrouter.ai/api/v1/models` for live pricing. If egress is restricted, allowlist it or set `OPENROUTER_MODELS_URL` to a mirror. Without it, affected models stay honestly unpriced (tokens shown) rather than falsely $0.00.

**3. Optional.** `UNPRICED_MODEL_ALERT_COOLDOWN_HOURS` (default 24) tunes alert frequency.

## Tests

Red-first throughout. Added coverage for alias normalization on openai-compatible/OpenRouter forms, the dated-SKU guard, OpenRouter price conversion (including refusing zero prices), unpriced never rendering as 0 and rendering tokens instead, mixed aggregates flagging the unpriced remainder, subscription-zero staying a legitimate 0, and `notify_admins` firing exactly once per (model, provider) per cooldown, surviving a simulated replica restart, and never raising into the request path.

`test_model_pricing.py`, `test_model_price_catalog.py`, `test_usage_repricing.py`, `test_cost_health.py`, `test_execution_metrics.py`, `test_unpriced_model_alert.py`, `test_unpriced_usage_reporting.py`, `test_replay_usage_exclusion.py`: **90 passed**. Full `tests/endpoints`: **865 passed**. Frontend `flow-execution-view`: **6 passed**. Pre-existing unrelated failures (`test_openai_gateway_attribution_sessions.py`, `test_ai_model_updated_at_trigger.py`, gateway e2e) were confirmed identical on clean `main` before and after. ruff format + check clean; mypy on the new module clean.

- Author: d-mo

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk** — ✅ Approved
> Thorough bug fix with defensive patterns, comprehensive tests, and no security concerns. The change to cost display semantics (NULL vs 0.0) is the most impactful user-facing shift and is well-tested.
>
> **Overview**
> Fixes three compounding defects that caused OpenRouter-routed and other unpriceable gateway traffic to display a confident $0.00 cost. Strips synthetic routing prefixes before pricing lookup, adds OpenRouter's own `/api/v1/models` as a secondary price source, and ensures NULL costs are never coalesced to zero. Adds cross-replica admin alerting for unpriceable models via persisted audit_log markers.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 757d708. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->