### PR TITLE
fix: seamless re-onboarding, suspended-agent recovery, login skip, onboarding CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -433,6 +433,28 @@ test:unit:cli:
   variables:
     CGO_ENABLED: "1"
 
+# Install script + e2e-rig pure-python logic. The installer's shell helpers
+# (architecture detection, the already-signed-in check) and the rig helpers
+# shared with the CI onboarding job are the pieces most likely to break
+# silently, since neither the Go nor the backend suites cover them.
+test:unit:scripts:
+  stage: test
+  needs: []
+  image: python:3.12-alpine
+  before_script:
+    - apk add --no-cache bash
+    - pip install -U pip pytest
+  script:
+    - sh scripts/test_install_cli_detect_arch.sh
+    - sh scripts/test_install_cli_login_skip.sh
+    - pytest -v scripts/e2e-rig/tests
+  rules:
+    - changes:
+        - scripts/install-cli.sh
+        - scripts/test_install_cli_*.sh
+        - scripts/e2e-rig/**/*
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
 # Standalone runtime plugins (Hermes Python + OpenClaw npm). Lightweight —
 # no postgres / backend image required.
 test:unit:runtime-plugins:
@@ -802,6 +824,52 @@ test:integration:api:hermes:
     - cd backend
   script:
     - pytest --confcutdir=tests/integration tests/integration/test_hermes_onboarding.py -v -s
+
+# Manual end-to-end CLI onboarding check against the deployed test environment.
+# Builds the CLI from this ref, logs in, onboards a planted Claude Code install
+# in API-key mode, and asserts that the enrollment routes through the gateway
+# and that a request made with the minted credential is metered.
+#
+# The assertions live in scripts/e2e-rig/ci_cli_onboard.py, which shares its
+# onboarding semantics with the recorded rig module
+# scripts/e2e-rig/modules/08-cli-onboard.py through
+# scripts/e2e-rig/lib/cli_onboard.py. Module 08 itself cannot run here: it
+# needs a VM, an ssh transport and the pexpect+agg recording toolchain. Only
+# the transport differs; what "onboarded" means is defined in one place.
+#
+# Manual, not automatic, for the same reason deploy:test is manual — it needs a
+# live review deployment and drives real gateway traffic.
+#
+# CI variables (both already defined in the global `variables:` block above):
+#   PRELOOP_TEST_API_KEY  - API key for an account in the deployed test env,
+#                           seeded by deploy:test with SEED_ENABLED=true.
+#   PRELOOP_TEST_URL      - set per-job below, as in .test:integration:template.
+# No new secret variables are required. If this job ever needs its own key,
+# name it PRELOOP_TEST_CLI_ONBOARD_API_KEY and define it in the GitLab CI/CD
+# settings — never hardcode a value here.
+test:integration:cli-onboard:
+  stage: integration
+  when: manual
+  needs:
+    - deploy:test
+  image: golang:1.26-alpine
+  variables:
+    # Telemetry opt-out is mandatory for every test run.
+    PRELOOP_DISABLE_TELEMETRY: "true"
+    PRELOOP_TEST_URL: "https://oss-$CI_COMMIT_REF_SLUG.test.preloop.ai"
+    # Pure-Go build: no cgo toolchain needed for the CLI in this image.
+    CGO_ENABLED: "0"
+    CLI_ONBOARD_ARTIFACTS: "$CI_PROJECT_DIR/cli-onboard-artifacts"
+  before_script:
+    - apk add --no-cache python3 ca-certificates
+    - cd cli && go build -o /usr/local/bin/preloop ./cmd/preloop && cd ..
+  script:
+    - python3 scripts/e2e-rig/ci_cli_onboard.py
+  artifacts:
+    when: always
+    paths:
+      - cli-onboard-artifacts/
+    expire_in: 7 days
 
 # =============================================================================
 # CLEANUP STAGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   NOT aliased to their undated entry: they are separately priced SKUs, and the
   fallback would have overstated cost by ~55% for that model. Models that still
   cannot be priced stay explicitly unpriced rather than being given a guess.
+- **Re-onboarding could reactivate an enrollment server-side and then refuse
+  it locally**: when `preloop agents onboard` matched an existing enrollment by
+  a v1 or legacy runtime-principal id, it PATCHed `lifecycle_action=reenroll`
+  and printed "Reactivated ..." *before* deciding whether to re-attach — and
+  the re-attach confirmation only ever ran for fuzzy ("fallback") matches. An
+  interactive run without `-y` therefore failed with "declined re-attaching
+  enrollment ..." without ever asking, leaving the account with a reactivated
+  agent and the machine with no config written. The confirmation now runs for
+  every non-v2 match (default yes) and happens before any server-side change;
+  if the subsequent re-key fails, the enrollment is restored to its previous
+  lifecycle state instead of being left reactivated.
+- **Paused (suspended) enrollments are now resumed automatically on
+  re-onboarding**: only decommissioned agents were revived, so re-onboarding a
+  suspended agent left it suspended and every token issuance for it kept
+  failing with 403. Onboarding now maps the lifecycle state to the correct
+  revival action — `decommissioned` → `reenroll`, `suspended` → `resume`, per
+  the backend's lifecycle map — and prints "Resuming paused enrollment ..."
+  before doing it.
+- **`preloop login` no longer re-authenticates when you are already signed
+  in**: it prints the current identity and exits; pass `--force` to switch
+  accounts. `--token` and non-interactive logins are unchanged. The install
+  script does the same check before prompting, so re-running the installer on
+  a machine that already has a valid session goes straight to onboarding
+  instead of asking you to log in again.
+- **Keychain service names in onboarding output are now quoted**, so the
+  hyphenated macOS service `"Claude Code-credentials"` can no longer be
+  misread as running into the surrounding prose.
 
 ### Added
 
@@ -110,6 +137,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`scripts/reprice_unpriced_usage.py`**: operator script to backfill costs for
   historical rows recorded while a model was unpriced. Dry run by default;
   requires `--apply` to persist.
+
+- **`test:integration:cli-onboard` CI job** (manual): builds the CLI from the
+  branch, onboards a planted Claude Code install in API-key mode against the
+  deployed test environment, and asserts that the enrollment routes through the
+  gateway and that a request made with the minted credential is metered. Shares
+  its onboarding semantics with the recorded e2e rig module 08 via
+  `scripts/e2e-rig/lib/cli_onboard.py`. Uses the existing `PRELOOP_TEST_API_KEY`
+  variable; no new secrets.
+- **`test:unit:scripts` CI job**: runs the install script's shell-helper tests
+  and the e2e rig's pure-python unit tests, neither of which any existing job
+  executed.
 
 ## [0.14.0] - 2026-08-07
 

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -4958,21 +4958,20 @@ func ensureManagedAgentIdentityReady(
 		return agent, nil, nil
 	}
 
-	if strings.EqualFold(strings.TrimSpace(matched.LifecycleState), "decommissioned") {
-		reenrolled, err := reenrollArchivedManagedAgent(
-			client,
-			matched,
-			autoApprove,
-			input,
-			output,
-		)
-		if err != nil {
-			return agent, nil, err
-		}
-		matched = reenrolled
-	}
-
 	if matchKind == "v2" {
+		if managedAgentLifecycleRevivalAction(matched.LifecycleState) != "" {
+			revived, err := reenrollArchivedManagedAgent(
+				client,
+				matched,
+				autoApprove,
+				input,
+				output,
+			)
+			if err != nil {
+				return agent, nil, err
+			}
+			matched = revived
+		}
 		agent.RuntimePrincipalID = matched.SessionSourceID
 		_ = pinLocalRuntimePrincipalID(agent, matched.SessionSourceID)
 		if strings.TrimSpace(agent.DisplayName) == "" {
@@ -4981,9 +4980,13 @@ func ensureManagedAgentIdentityReady(
 		return agent, matched, nil
 	}
 
-	// v1/legacy/fallback: re-key to v2 before continuing.
-	reuse := autoApprove || nonInteractiveAutoConfirm() || matchKind == "fallback"
-	if matchKind == "fallback" && !autoApprove && !nonInteractiveAutoConfirm() {
+	// v1/legacy/fallback: confirm re-attaching BEFORE any server mutation so
+	// declining leaves the server record exactly as it was (previously the
+	// reenroll PATCH ran first and v1/legacy interactive runs errored with
+	// "declined re-attaching enrollment" without ever prompting, leaving a
+	// reactivated server enrollment with no local config — split-brain).
+	reuse := autoApprove || nonInteractiveAutoConfirm()
+	if !reuse {
 		confirmed, err := confirmActionDefaultYes(
 			bufio.NewReader(input),
 			output,
@@ -5006,7 +5009,23 @@ func ensureManagedAgentIdentityReady(
 			matched.ID,
 		)
 	}
+	priorLifecycleState := matched.LifecycleState
+	revivedBeforeRekey := false
+	if managedAgentLifecycleRevivalAction(matched.LifecycleState) != "" {
+		revived, err := reviveManagedAgentLifecycle(client, matched, output)
+		if err != nil {
+			return agent, nil, err
+		}
+		matched = revived
+		revivedBeforeRekey = true
+	}
 	if err := rekeyManagedAgentRecord(client, matched.ID, v2ID, principalIdentityForAgent(agent)); err != nil {
+		if revivedBeforeRekey {
+			// Best effort: put the enrollment back the way we found it so a
+			// failed re-key does not leave a reactivated server record with
+			// no local config.
+			restoreManagedAgentLifecycle(client, matched, priorLifecycleState, output)
+		}
 		return agent, nil, err
 	}
 	agent.RuntimePrincipalID = v2ID
@@ -5119,10 +5138,138 @@ func ensureArchivedManagedAgentReenrolled(
 	if matched == nil {
 		return nil, nil
 	}
-	if !strings.EqualFold(strings.TrimSpace(matched.LifecycleState), "decommissioned") {
+	if managedAgentLifecycleRevivalAction(matched.LifecycleState) == "" {
 		return matched, nil
 	}
 	return reenrollArchivedManagedAgent(client, matched, autoApprove, input, output)
+}
+
+// managedAgentLifecycleRevivalAction maps a non-active lifecycle state to the
+// PATCH lifecycle_action that revives it (see the lifecycle map in
+// backend/preloop/api/endpoints/account.py): a decommissioned (archived)
+// agent is revived with "reenroll", a suspended (paused) agent with "resume".
+// Returns "" when the agent needs no revival.
+func managedAgentLifecycleRevivalAction(lifecycleState string) string {
+	switch strings.ToLower(strings.TrimSpace(lifecycleState)) {
+	case "decommissioned":
+		return "reenroll"
+	case "suspended":
+		return "resume"
+	default:
+		return ""
+	}
+}
+
+// reviveManagedAgentLifecycle PATCHes the revival lifecycle_action for a
+// suspended or decommissioned managed agent without prompting (callers are
+// expected to have confirmed with the user already).
+func reviveManagedAgentLifecycle(
+	client *api.Client,
+	matched *managedAgentSummary,
+	output io.Writer,
+) (*managedAgentSummary, error) {
+	if matched == nil {
+		return nil, nil
+	}
+	if output == nil {
+		output = os.Stdout
+	}
+	action := managedAgentLifecycleRevivalAction(matched.LifecycleState)
+	if action == "" {
+		return matched, nil
+	}
+	if action == "resume" {
+		fmt.Fprintf( //nolint:errcheck
+			output,
+			"Resuming paused enrollment %s (%s)...\n",
+			matched.DisplayName,
+			matched.ID,
+		)
+	}
+	request := map[string]interface{}{
+		"lifecycle_action": action,
+	}
+	var updated managedAgentSummary
+	if err := client.Patch("/api/v1/agents/"+matched.ID, request, &updated); err != nil {
+		return nil, fmt.Errorf(
+			"failed to %s managed agent %q: %w", action, matched.ID, err,
+		)
+	}
+	fmt.Fprintf( //nolint:errcheck
+		output,
+		"Reactivated enrollment %s (%s).\n",
+		matched.DisplayName,
+		matched.ID,
+	)
+	mergeRevivedManagedAgentSummary(&updated, matched)
+	return &updated, nil
+}
+
+// restoreManagedAgentLifecycle best-effort re-applies the prior lifecycle
+// state after a failed follow-up step, so a decline/failure does not leave the
+// server record reactivated while the local install has no config.
+func restoreManagedAgentLifecycle(
+	client *api.Client,
+	matched *managedAgentSummary,
+	priorLifecycleState string,
+	output io.Writer,
+) {
+	if matched == nil || client == nil {
+		return
+	}
+	if output == nil {
+		output = os.Stdout
+	}
+	var action string
+	switch strings.ToLower(strings.TrimSpace(priorLifecycleState)) {
+	case "decommissioned":
+		action = "decommission"
+	case "suspended":
+		action = "suspend"
+	default:
+		return
+	}
+	request := map[string]interface{}{
+		"lifecycle_action": action,
+		"reason":           "rolled back: re-onboarding did not complete",
+	}
+	var updated managedAgentSummary
+	if err := client.Patch("/api/v1/agents/"+matched.ID, request, &updated); err != nil {
+		fmt.Fprintf( //nolint:errcheck
+			output,
+			"Warning: could not restore enrollment %s to %s after failure: %v\n",
+			matched.ID,
+			priorLifecycleState,
+			err,
+		)
+		return
+	}
+	fmt.Fprintf( //nolint:errcheck
+		output,
+		"Restored enrollment %s to %s after failure.\n",
+		matched.ID,
+		priorLifecycleState,
+	)
+}
+
+// mergeRevivedManagedAgentSummary fills fields the PATCH response may omit
+// from the previously fetched summary.
+func mergeRevivedManagedAgentSummary(updated, previous *managedAgentSummary) {
+	if strings.TrimSpace(updated.ID) == "" {
+		updated.ID = previous.ID
+	}
+	if strings.TrimSpace(updated.DisplayName) == "" {
+		updated.DisplayName = previous.DisplayName
+	}
+	if strings.TrimSpace(updated.SessionSourceID) == "" {
+		updated.SessionSourceID = previous.SessionSourceID
+	}
+	if strings.TrimSpace(updated.SessionSourceType) == "" {
+		updated.SessionSourceType = previous.SessionSourceType
+	}
+	if strings.TrimSpace(updated.LifecycleState) == "" {
+		updated.LifecycleState = "active"
+	}
 }
 
 func reenrollArchivedManagedAgent(
@@ -5142,58 +5289,64 @@ func reenrollArchivedManagedAgent(
 		output = os.Stdout
 	}
 
+	action := managedAgentLifecycleRevivalAction(matched.LifecycleState)
+	if action == "" {
+		return matched, nil
+	}
+	stateLabel := "archived"
+	if action == "resume" {
+		stateLabel = "paused"
+	}
+
 	reuse := autoApprove || nonInteractiveAutoConfirm()
 	if !reuse {
 		confirmed, err := confirmActionDefaultYes(
 			bufio.NewReader(input),
 			output,
 			fmt.Sprintf(
-				"An archived enrollment for this install already exists as '%s'. Reuse it? [Y/n]: ",
+				"An %s enrollment for this install already exists as '%s'. Reuse it? [Y/n]: ",
+				stateLabel,
 				matched.DisplayName,
 			),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read reenroll confirmation: %w", err)
+			return nil, fmt.Errorf("failed to read %s confirmation: %w", action, err)
 		}
 		reuse = confirmed
 	}
 	if !reuse {
 		return nil, fmt.Errorf(
-			"declined reusing archived enrollment %s (%s). Run 'preloop agents remove %s' first if you want a fresh identity",
+			"declined reusing %s enrollment %s (%s). Run 'preloop agents remove %s' first if you want a fresh identity",
+			stateLabel,
 			matched.DisplayName,
 			matched.ID,
 			matched.ID,
 		)
 	}
 
+	if action == "resume" {
+		fmt.Fprintf( //nolint:errcheck
+			output,
+			"Resuming paused enrollment %s (%s)...\n",
+			matched.DisplayName,
+			matched.ID,
+		)
+	}
 	request := map[string]interface{}{
-		"lifecycle_action": "reenroll",
+		"lifecycle_action": action,
 	}
 	var updated managedAgentSummary
 	if err := client.Patch("/api/v1/agents/"+matched.ID, request, &updated); err != nil {
-		return nil, fmt.Errorf("failed to reenroll archived managed agent %q: %w", matched.ID, err)
+		return nil, fmt.Errorf("failed to %s %s managed agent %q: %w", action, stateLabel, matched.ID, err)
 	}
 	fmt.Fprintf( //nolint:errcheck
 		output,
-		"Reactivated archived enrollment %s (%s).\n",
+		"Reactivated %s enrollment %s (%s).\n",
+		stateLabel,
 		matched.DisplayName,
 		matched.ID,
 	)
-	if strings.TrimSpace(updated.ID) == "" {
-		updated.ID = matched.ID
-	}
-	if strings.TrimSpace(updated.DisplayName) == "" {
-		updated.DisplayName = matched.DisplayName
-	}
-	if strings.TrimSpace(updated.SessionSourceID) == "" {
-		updated.SessionSourceID = matched.SessionSourceID
-	}
-	if strings.TrimSpace(updated.SessionSourceType) == "" {
-		updated.SessionSourceType = matched.SessionSourceType
-	}
-	if strings.TrimSpace(updated.LifecycleState) == "" {
-		updated.LifecycleState = "active"
-	}
+	mergeRevivedManagedAgentSummary(&updated, matched)
 	return &updated, nil
 }
 

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -5178,14 +5178,6 @@ func reviveManagedAgentLifecycle(
 	if action == "" {
 		return matched, nil
 	}
-	if action == "resume" {
-		fmt.Fprintf( //nolint:errcheck
-			output,
-			"Resuming paused enrollment %s (%s)...\n",
-			matched.DisplayName,
-			matched.ID,
-		)
-	}
 	request := map[string]interface{}{
 		"lifecycle_action": action,
 	}
@@ -5195,9 +5187,16 @@ func reviveManagedAgentLifecycle(
 			"failed to %s managed agent %q: %w", action, matched.ID, err,
 		)
 	}
+	// One line per revival, naming what actually happened: a paused agent was
+	// resumed, a decommissioned one re-enrolled.
+	outcome := "Reactivated enrollment"
+	if action == "resume" {
+		outcome = "Resumed paused enrollment"
+	}
 	fmt.Fprintf( //nolint:errcheck
 		output,
-		"Reactivated enrollment %s (%s).\n",
+		"%s %s (%s).\n",
+		outcome,
 		matched.DisplayName,
 		matched.ID,
 	)
@@ -5324,14 +5323,6 @@ func reenrollArchivedManagedAgent(
 		)
 	}
 
-	if action == "resume" {
-		fmt.Fprintf( //nolint:errcheck
-			output,
-			"Resuming paused enrollment %s (%s)...\n",
-			matched.DisplayName,
-			matched.ID,
-		)
-	}
 	request := map[string]interface{}{
 		"lifecycle_action": action,
 	}
@@ -5339,13 +5330,23 @@ func reenrollArchivedManagedAgent(
 	if err := client.Patch("/api/v1/agents/"+matched.ID, request, &updated); err != nil {
 		return nil, fmt.Errorf("failed to %s %s managed agent %q: %w", action, stateLabel, matched.ID, err)
 	}
-	fmt.Fprintf( //nolint:errcheck
-		output,
-		"Reactivated %s enrollment %s (%s).\n",
-		stateLabel,
-		matched.DisplayName,
-		matched.ID,
-	)
+	// One line per revival, naming what actually happened.
+	if action == "resume" {
+		fmt.Fprintf( //nolint:errcheck
+			output,
+			"Resumed paused enrollment %s (%s).\n",
+			matched.DisplayName,
+			matched.ID,
+		)
+	} else {
+		fmt.Fprintf( //nolint:errcheck
+			output,
+			"Reactivated %s enrollment %s (%s).\n",
+			stateLabel,
+			matched.DisplayName,
+			matched.ID,
+		)
+	}
 	mergeRevivedManagedAgentSummary(&updated, matched)
 	return &updated, nil
 }

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -2738,7 +2738,7 @@ func resolveGeminiKeyringAPIKey() (string, string) {
 	}
 	if apiKey := extractGeminiAPIKeyFromCredentialBlob(raw); apiKey != "" {
 		return apiKey, fmt.Sprintf(
-			"Resolved Gemini CLI API key from OS secure storage (service: %s, account: %s).",
+			"Resolved Gemini CLI API key from OS secure storage (service: %q, account: %q).",
 			geminiAPIKeyServiceName,
 			geminiAPIKeyAccountName,
 		)
@@ -2961,7 +2961,7 @@ func resolveClaudeManagedAPIKey() (string, string) {
 	if runtime.GOOS == "darwin" {
 		if user := strings.TrimSpace(os.Getenv("USER")); user != "" {
 			if token, err := keyring.Get("Claude Code", user); err == nil && strings.TrimSpace(token) != "" {
-				return strings.TrimSpace(token), "Resolved Claude Code managed API key from OS Keychain (service: Claude Code)."
+				return strings.TrimSpace(token), "Resolved Claude Code managed API key from OS Keychain (service: \"Claude Code\")."
 			}
 		}
 	}
@@ -3010,7 +3010,7 @@ func resolveClaudeKeychainToken() (string, string) {
 	}
 	if raw := readClaudeKeychainCredentialBlob(); raw != "" {
 		if token := extractClaudeTokenFromCredentialBlob(raw); token != "" {
-			return token, "Resolved Claude Code auth token from OS Keychain (service: Claude Code-credentials)."
+			return token, "Resolved Claude Code auth token from OS Keychain (service: \"Claude Code-credentials\")."
 		}
 	}
 	candidates := []string{}
@@ -3037,7 +3037,7 @@ func resolveClaudeKeychainToken() (string, string) {
 		}
 		if token := extractClaudeTokenFromCredentialBlob(secret); token != "" {
 			return token, fmt.Sprintf(
-				"Resolved Claude Code auth token from OS Keychain (service: Claude Code-credentials, account: %s).",
+				"Resolved Claude Code auth token from OS Keychain (service: \"Claude Code-credentials\", account: %s).",
 				account,
 			)
 		}
@@ -3128,7 +3128,7 @@ func resolveClaudeKeychainOAuthCredential() (*claudeOAuthCredential, string) {
 			raw,
 			time.Now().UTC().Add(time.Hour).UnixMilli(),
 		); credential != nil {
-			return credential, "Resolved Claude Code OAuth credentials from OS Keychain (service: Claude Code-credentials)."
+			return credential, "Resolved Claude Code OAuth credentials from OS Keychain (service: \"Claude Code-credentials\")."
 		}
 	}
 	return nil, ""
@@ -3720,7 +3720,7 @@ func readCodexKeychainOAuthCredential() (*codexOAuthCredential, string) {
 		return nil, ""
 	}
 	return credential, fmt.Sprintf(
-		"Resolved Codex ChatGPT OAuth credentials from OS Keychain (service: Codex Auth, account: %s).",
+		"Resolved Codex ChatGPT OAuth credentials from OS Keychain (service: \"Codex Auth\", account: %s).",
 		account,
 	)
 }
@@ -7428,22 +7428,22 @@ func resolveOpenClawProviderAPIKey(
 
 		for _, account := range accountsToCheck {
 			if secret, err := keyring.Get("openclaw", account); err == nil && secret != "" {
-				return secret, fmt.Sprintf("Resolved OpenClaw provider API key from OS Keychain (service: openclaw, account: %s).", account)
+				return secret, fmt.Sprintf("Resolved OpenClaw provider API key from OS Keychain (service: \"openclaw\", account: %s).", account)
 			}
 
 			// Fallback check for "OpenClaw" capitalized service name
 			if secret, err := keyring.Get("OpenClaw", account); err == nil && secret != "" {
-				return secret, fmt.Sprintf("Resolved OpenClaw provider API key from OS Keychain (service: OpenClaw, account: %s).", account)
+				return secret, fmt.Sprintf("Resolved OpenClaw provider API key from OS Keychain (service: \"OpenClaw\", account: %s).", account)
 			}
 
 			// Fallback check for "openclaw-ai" NPM package service name
 			if secret, err := keyring.Get("openclaw-ai", account); err == nil && secret != "" {
-				return secret, fmt.Sprintf("Resolved OpenClaw provider API key from OS Keychain (service: openclaw-ai, account: %s).", account)
+				return secret, fmt.Sprintf("Resolved OpenClaw provider API key from OS Keychain (service: \"openclaw-ai\", account: %s).", account)
 			}
 
 			// Fallback check for "OpenClaw-AI" package service name
 			if secret, err := keyring.Get("OpenClaw-AI", account); err == nil && secret != "" {
-				return secret, fmt.Sprintf("Resolved OpenClaw provider API key from OS Keychain (service: OpenClaw-AI, account: %s).", account)
+				return secret, fmt.Sprintf("Resolved OpenClaw provider API key from OS Keychain (service: \"OpenClaw-AI\", account: %s).", account)
 			}
 		}
 

--- a/cli/internal/cmd/agents_preflight.go
+++ b/cli/internal/cmd/agents_preflight.go
@@ -176,7 +176,7 @@ func detectClaudeCodeAuthState() (agentAuthState, string) {
 		return agentAuthStateReady, "API key configured in ~/.claude.json"
 	}
 	if claudeKeychainPresenceProbe() {
-		return agentAuthStateReady, "OS keychain entry present (service: Claude Code-credentials)"
+		return agentAuthStateReady, "OS keychain entry present (service: \"Claude Code-credentials\")"
 	}
 	return agentAuthStateNotLoggedIn, "no credential file, keychain entry, or API key found"
 }
@@ -187,7 +187,7 @@ func detectCodexAuthState() (agentAuthState, string) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			if codexKeychainPresenceProbe() {
-				return agentAuthStateReady, "OS keychain entry present (service: Codex Auth)"
+				return agentAuthStateReady, "OS keychain entry present (service: \"Codex Auth\")"
 			}
 			return agentAuthStateNotLoggedIn, "no auth.json found"
 		}

--- a/cli/internal/cmd/agents_reonboard_ux_test.go
+++ b/cli/internal/cmd/agents_reonboard_ux_test.go
@@ -1,0 +1,382 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/api"
+	"github.com/preloop/preloop/cli/internal/testenv"
+)
+
+// The re-onboarding flow must (a) always ask before re-attaching an existing
+// enrollment when running interactively, (b) never mutate the server before
+// that confirmation, and (c) auto-revive suspended agents with the "resume"
+// lifecycle action (not just decommissioned ones with "reenroll").
+// Regression tests for the 2026-08-07 "phantom decline" split-brain bug.
+
+func TestManagedAgentLifecycleRevivalAction(t *testing.T) {
+	cases := map[string]string{
+		"decommissioned":  "reenroll",
+		"Decommissioned":  "reenroll",
+		" suspended ":     "resume",
+		"suspended":       "resume",
+		"active":          "",
+		"":                "",
+		"something-weird": "",
+	}
+	for state, want := range cases {
+		if got := managedAgentLifecycleRevivalAction(state); got != want {
+			t.Errorf("managedAgentLifecycleRevivalAction(%q) = %q, want %q", state, got, want)
+		}
+	}
+}
+
+// identityTestServer wires a minimal agents API. It records every request in
+// order and captures PATCH bodies so tests can assert both what was sent and
+// when (relative to the confirmation prompt).
+func identityTestServer(
+	t *testing.T,
+	item managedAgentSummary,
+	rekeyStatus int,
+) (*httptest.Server, *[]string, *[]map[string]interface{}) {
+	t.Helper()
+	requests := &[]string{}
+	patches := &[]map[string]interface{}{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*requests = append(*requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/agents":
+			_ = json.NewEncoder(w).Encode(managedAgentListResponse{
+				Items: []managedAgentSummary{item},
+			})
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/v1/agents/"+item.ID:
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			*patches = append(*patches, body)
+			state := "active"
+			if action, _ := body["lifecycle_action"].(string); action == "suspend" {
+				state = "suspended"
+			} else if action, _ := body["lifecycle_action"].(string); action == "decommission" {
+				state = "decommissioned"
+			}
+			_ = json.NewEncoder(w).Encode(managedAgentSummary{
+				ID:             item.ID,
+				LifecycleState: state,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/"+item.ID+"/rekey":
+			if rekeyStatus >= 400 {
+				w.WriteHeader(rekeyStatus)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"detail": "boom"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, requests, patches
+}
+
+func newIdentityTestAgent(t *testing.T) AgentConfig {
+	t.Helper()
+	testenv.SetTempHome(t)
+	t.Setenv("PRELOOP_CONFIRM", "")
+	agent := AgentConfig{
+		Name:        "Codex CLI",
+		DisplayName: "Codex",
+		ConfigPath:  "/tmp/codex/config.toml",
+	}
+	return normalizeDiscoveredAgent(agent)
+}
+
+func TestIdentityReadyV1MatchPromptsBeforeAnyServerMutation(t *testing.T) {
+	agent := newIdentityTestAgent(t)
+	v1 := generatedRuntimePrincipalID(resolveAgentDisplayName(agent), agent.ConfigPath)
+
+	item := managedAgentSummary{
+		ID:                "v1-agent",
+		DisplayName:       "Codex",
+		SessionSourceType: "codex",
+		SessionSourceID:   v1,
+		LifecycleState:    "decommissioned",
+	}
+
+	t.Run("decline leaves the server untouched", func(t *testing.T) {
+		server, requests, patches := identityTestServer(t, item, 200)
+		client := api.NewClientWithToken(server.URL, "tok")
+		var out bytes.Buffer
+		_, _, err := ensureManagedAgentIdentityReady(
+			client,
+			agent,
+			false, // interactive, no -y
+			false,
+			strings.NewReader("n\n"),
+			&out,
+		)
+		if err == nil || !strings.Contains(err.Error(), "declined re-attaching enrollment") {
+			t.Fatalf("expected decline error, got %v", err)
+		}
+		if len(*patches) != 0 {
+			t.Fatalf("decline must not PATCH the server, got %v", *patches)
+		}
+		for _, request := range *requests {
+			if strings.HasPrefix(request, "PATCH") || strings.HasPrefix(request, "POST") {
+				t.Fatalf("decline must not mutate the server, got %v", *requests)
+			}
+		}
+		if !strings.Contains(out.String(), "Reuse it?") {
+			t.Fatalf("expected an interactive prompt before declining, got %q", out.String())
+		}
+		if strings.Contains(out.String(), "Reactivated") {
+			t.Fatalf("nothing may be reactivated before confirmation, got %q", out.String())
+		}
+	})
+
+	t.Run("accept revives then rekeys, in that order", func(t *testing.T) {
+		server, requests, patches := identityTestServer(t, item, 200)
+		client := api.NewClientWithToken(server.URL, "tok")
+		var out bytes.Buffer
+		updated, matched, err := ensureManagedAgentIdentityReady(
+			client,
+			agent,
+			false,
+			false,
+			strings.NewReader("y\n"),
+			&out,
+		)
+		if err != nil {
+			t.Fatalf("ensureManagedAgentIdentityReady: %v", err)
+		}
+		if matched == nil || matched.ID != "v1-agent" {
+			t.Fatalf("expected matched v1-agent, got %#v", matched)
+		}
+		v2 := stableRuntimePrincipalIDForAgent(agent, identitySaltForAgent(agent))
+		if updated.RuntimePrincipalID != v2 {
+			t.Fatalf("expected rekey to v2 id %q, got %q", v2, updated.RuntimePrincipalID)
+		}
+		if len(*patches) != 1 || (*patches)[0]["lifecycle_action"] != "reenroll" {
+			t.Fatalf("expected one reenroll PATCH, got %v", *patches)
+		}
+		patchIdx, rekeyIdx := -1, -1
+		for i, request := range *requests {
+			if strings.HasPrefix(request, "PATCH") {
+				patchIdx = i
+			}
+			if strings.Contains(request, "/rekey") {
+				rekeyIdx = i
+			}
+		}
+		if patchIdx == -1 || rekeyIdx == -1 || patchIdx > rekeyIdx {
+			t.Fatalf("expected revive PATCH before rekey, got %v", *requests)
+		}
+	})
+
+	t.Run("failed rekey rolls the revival back", func(t *testing.T) {
+		server, _, patches := identityTestServer(t, item, 500)
+		client := api.NewClientWithToken(server.URL, "tok")
+		var out bytes.Buffer
+		_, _, err := ensureManagedAgentIdentityReady(
+			client,
+			agent,
+			true, // -y
+			false,
+			strings.NewReader(""),
+			&out,
+		)
+		if err == nil {
+			t.Fatal("expected rekey failure to propagate")
+		}
+		if len(*patches) != 2 {
+			t.Fatalf("expected revive + rollback PATCHes, got %v", *patches)
+		}
+		if (*patches)[0]["lifecycle_action"] != "reenroll" {
+			t.Fatalf("expected reenroll first, got %v", *patches)
+		}
+		if (*patches)[1]["lifecycle_action"] != "decommission" {
+			t.Fatalf("expected rollback to decommission, got %v", *patches)
+		}
+	})
+}
+
+func TestIdentityReadySuspendedMatchIsResumed(t *testing.T) {
+	agent := newIdentityTestAgent(t)
+	v2 := stableRuntimePrincipalIDForAgent(agent, identitySaltForAgent(agent))
+
+	item := managedAgentSummary{
+		ID:                "paused-1",
+		DisplayName:       "Codex",
+		SessionSourceType: "codex",
+		SessionSourceID:   v2,
+		SessionReference:  "/tmp/codex/config.toml",
+		LifecycleState:    "suspended",
+	}
+	// Pin local state so the v2 match does not take the cross-host
+	// "reuse?" branch and goes straight to lifecycle revival.
+	if err := saveLocalEnrollmentState(&localEnrollmentState{
+		AgentName:          agent.Name,
+		DisplayName:        resolveAgentDisplayName(agent),
+		ConfigPath:         agent.ConfigPath,
+		RuntimePrincipalID: v2,
+	}); err != nil {
+		t.Fatalf("saveLocalEnrollmentState: %v", err)
+	}
+
+	server, _, patches := identityTestServer(t, item, 200)
+	client := api.NewClientWithToken(server.URL, "tok")
+	var out bytes.Buffer
+	_, matched, err := ensureManagedAgentIdentityReady(
+		client,
+		agent,
+		true,
+		false,
+		strings.NewReader(""),
+		&out,
+	)
+	if err != nil {
+		t.Fatalf("ensureManagedAgentIdentityReady: %v", err)
+	}
+	if matched == nil || matched.ID != "paused-1" {
+		t.Fatalf("expected matched paused-1, got %#v", matched)
+	}
+	if strings.EqualFold(matched.LifecycleState, "suspended") {
+		t.Fatalf("expected revived lifecycle state, got %q", matched.LifecycleState)
+	}
+	if len(*patches) != 1 || (*patches)[0]["lifecycle_action"] != "resume" {
+		t.Fatalf("expected one resume PATCH for a suspended agent, got %v", *patches)
+	}
+	if !strings.Contains(out.String(), "Resuming paused enrollment") {
+		t.Fatalf("expected resume note, got %q", out.String())
+	}
+}
+
+func TestReenrollArchivedManagedAgentResumesSuspended(t *testing.T) {
+	_ = newIdentityTestAgent(t)
+	item := managedAgentSummary{
+		ID:                "paused-2",
+		DisplayName:       "Codex",
+		SessionSourceType: "codex",
+		SessionSourceID:   "codex-abc",
+		LifecycleState:    "suspended",
+	}
+	server, _, patches := identityTestServer(t, item, 200)
+	client := api.NewClientWithToken(server.URL, "tok")
+	var out bytes.Buffer
+	revived, err := reenrollArchivedManagedAgent(
+		client,
+		&item,
+		false,
+		strings.NewReader("y\n"),
+		&out,
+	)
+	if err != nil {
+		t.Fatalf("reenrollArchivedManagedAgent: %v", err)
+	}
+	if revived == nil || revived.ID != "paused-2" {
+		t.Fatalf("expected revived paused-2, got %#v", revived)
+	}
+	if len(*patches) != 1 || (*patches)[0]["lifecycle_action"] != "resume" {
+		t.Fatalf("expected resume PATCH, got %v", *patches)
+	}
+	if !strings.Contains(out.String(), "paused enrollment") {
+		t.Fatalf("expected paused wording in prompt/output, got %q", out.String())
+	}
+}
+
+// Declining a paused enrollment must leave it paused: the old code path
+// PATCHed first and asked afterwards, so a decline still resumed the agent.
+func TestReenrollArchivedManagedAgentDeclineLeavesSuspended(t *testing.T) {
+	_ = newIdentityTestAgent(t)
+	item := managedAgentSummary{
+		ID:                "paused-3",
+		DisplayName:       "Codex",
+		SessionSourceType: "codex",
+		SessionSourceID:   "codex-abc",
+		LifecycleState:    "suspended",
+	}
+	server, requests, patches := identityTestServer(t, item, 200)
+	client := api.NewClientWithToken(server.URL, "tok")
+	var out bytes.Buffer
+	revived, err := reenrollArchivedManagedAgent(
+		client,
+		&item,
+		false,
+		strings.NewReader("n\n"),
+		&out,
+	)
+	if err == nil || !strings.Contains(err.Error(), "declined reusing paused enrollment") {
+		t.Fatalf("expected a paused-specific decline error, got %v (%#v)", err, revived)
+	}
+	if len(*patches) != 0 {
+		t.Fatalf("a decline must not change the lifecycle state, got %v", *patches)
+	}
+	for _, request := range *requests {
+		if strings.HasPrefix(request, "PATCH") {
+			t.Fatalf("a decline must not PATCH, got %v", *requests)
+		}
+	}
+}
+
+// Keychain service names are hyphenated multi-word strings ("Claude
+// Code-credentials", "Codex Auth"). Printed bare they run into the surrounding
+// prose and get misread as a garbled word — the "Claude Coderedentials" report.
+// Quoting makes the boundary unambiguous.
+func TestKeychainServiceLabelsAreQuoted(t *testing.T) {
+	setPreflightTestEnv(t)
+	claudeKeychainPresenceProbe = func() bool { return true }
+	state, detail := detectClaudeCodeAuthState()
+	if state != agentAuthStateReady {
+		t.Fatalf("expected ready with keychain probe, got %v (%s)", state, detail)
+	}
+	if !strings.Contains(detail, `"Claude Code-credentials"`) {
+		t.Fatalf("keychain service name must be quoted, got %q", detail)
+	}
+
+	codexKeychainPresenceProbe = func() bool { return true }
+	state, detail = detectCodexAuthState()
+	if state != agentAuthStateReady {
+		t.Fatalf("expected ready with codex keychain probe, got %v (%s)", state, detail)
+	}
+	if !strings.Contains(detail, `"Codex Auth"`) {
+		t.Fatalf("keychain service name must be quoted, got %q", detail)
+	}
+}
+
+// Guard the whole package rather than the two strings above: any new
+// "(service: X" message must quote X, or this fails.
+func TestNoUnquotedKeychainServiceLabelsRemain(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	// Matches `service: ` followed by anything but an escaped quote or a %q
+	// verb (both of which render the name quoted).
+	unquoted := regexp.MustCompile(`service: (?:[^\\%]|%[^q])`)
+	checked := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		source, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		checked++
+		for i, line := range strings.Split(string(source), "\n") {
+			if unquoted.MatchString(line) {
+				t.Errorf("%s:%d: keychain service name must be quoted: %s", name, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("scanned no source files; the guard would silently pass")
+	}
+}

--- a/cli/internal/cmd/agents_reonboard_ux_test.go
+++ b/cli/internal/cmd/agents_reonboard_ux_test.go
@@ -252,8 +252,11 @@ func TestIdentityReadySuspendedMatchIsResumed(t *testing.T) {
 	if len(*patches) != 1 || (*patches)[0]["lifecycle_action"] != "resume" {
 		t.Fatalf("expected one resume PATCH for a suspended agent, got %v", *patches)
 	}
-	if !strings.Contains(out.String(), "Resuming paused enrollment") {
+	if !strings.Contains(out.String(), "Resumed paused enrollment") {
 		t.Fatalf("expected resume note, got %q", out.String())
+	}
+	if strings.Contains(out.String(), "Reactivated enrollment") {
+		t.Fatalf("resume must not also print the reenroll wording, got %q", out.String())
 	}
 }
 

--- a/cli/internal/cmd/auth.go
+++ b/cli/internal/cmd/auth.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -157,6 +158,7 @@ var (
 	loginHeadless bool
 	loginLoopback bool
 	loginCode     string
+	loginForce    bool
 	// signupRequested tracks whether the current OAuth login flow was
 	// initiated via 'preloop signup'. When true, the browser is sent to the
 	// sign-up page first instead of the sign-in page.
@@ -198,6 +200,16 @@ func runAuthLogin(cmd *cobra.Command, args []string) error {
 
 	if token != "" {
 		return runTokenLogin(token)
+	}
+
+	// Skip the interactive OAuth flow when a valid login already exists.
+	// --force re-authenticates anyway; token login above is always explicit
+	// and proceeds regardless (unattended flows keep working).
+	if !loginForce {
+		if identity := currentVerifiedLoginIdentity(); identity != nil {
+			printAlreadyLoggedIn(os.Stdout, cmd, identity)
+			return nil
+		}
 	}
 
 	if loginLoopback && loginHeadless {
@@ -273,11 +285,67 @@ func runTokenLogin(token string) error {
 	return nil
 }
 
+// printAlreadyLoggedIn reports the identity behind an existing session and how
+// to override it. The hint names the command the user actually typed
+// ('preloop login', 'preloop signup', 'preloop auth login', ...) so it stays
+// correct for every alias configureLoginFlags is applied to.
+func printAlreadyLoggedIn(output io.Writer, cmd *cobra.Command, identity *UserInfo) {
+	invocation := "preloop login"
+	if cmd != nil {
+		if path := strings.TrimSpace(cmd.CommandPath()); path != "" {
+			invocation = path
+		}
+	}
+	name := strings.TrimSpace(identity.Name)
+	if name == "" {
+		// The server omits a display name for accounts that never set one;
+		// the email alone is still an unambiguous identity.
+		fmt.Fprintf(output, "Already logged in\n  User:    %s\n", identity.Email) //nolint:errcheck
+	} else {
+		fmt.Fprintf(output, "Already logged in\n  User:    %s (%s)\n", name, identity.Email) //nolint:errcheck
+	}
+	if identity.Organization != "" {
+		fmt.Fprintf(output, "  Org:     %s\n", identity.Organization) //nolint:errcheck
+	}
+	fmt.Fprintf( //nolint:errcheck
+		output,
+		"Run '%s --force' to re-authenticate as a different user.\n",
+		invocation,
+	)
+}
+
+// currentVerifiedLoginIdentity returns the identity behind the stored login
+// when it is still usable (refreshing the access token if needed and
+// verifying it against the server). Returns nil when there is no stored
+// login or it can no longer be verified — callers should proceed with a
+// fresh login in that case.
+func currentVerifiedLoginIdentity() *UserInfo {
+	cfg, err := config.Resolve(FlagToken, FlagURL)
+	if err != nil || cfg.AccessToken == "" {
+		return nil
+	}
+	client, err := api.NewClient(FlagToken, FlagURL)
+	if err != nil {
+		return nil
+	}
+	if FlagToken == "" && cfg.RefreshToken != "" {
+		if err := client.RefreshAccessToken(); err != nil {
+			return nil
+		}
+	}
+	var userInfo UserInfo
+	if err := client.Get(userInfoPath, &userInfo); err != nil {
+		return nil
+	}
+	return &userInfo
+}
+
 func configureLoginFlags(command *cobra.Command) {
 	command.Flags().StringVar(&loginToken, "token", "", "API access token (skip OAuth and save directly)")
 	command.Flags().BoolVar(&loginHeadless, "headless", false, "use copy/paste OAuth for SSH or no-GUI environments")
 	command.Flags().BoolVar(&loginLoopback, "loopback", false, "force the local loopback callback OAuth flow")
 	command.Flags().StringVar(&loginCode, "code", "", "authorization code from a previous headless OAuth login")
+	command.Flags().BoolVar(&loginForce, "force", false, "re-authenticate even when a valid login already exists")
 }
 
 func shouldUseHeadlessOAuth() bool {

--- a/cli/internal/cmd/auth_test.go
+++ b/cli/internal/cmd/auth_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/preloop/preloop/cli/internal/config"
 
 	"github.com/preloop/preloop/cli/internal/testenv"
@@ -239,12 +241,14 @@ func snapshotLoginFlags() func() {
 	originalLoginHeadless := loginHeadless
 	originalLoginLoopback := loginLoopback
 	originalLoginCode := loginCode
+	originalLoginForce := loginForce
 
 	return func() {
 		loginToken = originalLoginToken
 		loginHeadless = originalLoginHeadless
 		loginLoopback = originalLoginLoopback
 		loginCode = originalLoginCode
+		loginForce = originalLoginForce
 	}
 }
 
@@ -324,4 +328,221 @@ func TestMain(m *testing.M) {
 	restoreHome()
 	_ = os.RemoveAll(tempHome)
 	os.Exit(code)
+}
+
+// A valid existing login must short-circuit `preloop login` (the install
+// script re-runs it on every install); --force must re-authenticate.
+func TestRunAuthLoginSkipsWhenAlreadyAuthenticated(t *testing.T) {
+	tempHome := t.TempDir()
+	testenv.SetHome(t, tempHome)
+
+	restore := snapshotLoginFlags()
+	defer restore()
+	loginToken = ""
+	loginForce = false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != userInfoPath {
+			t.Fatalf("unexpected path %q (login should not start OAuth)", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"u1","email":"user@example.com","name":"Test User","organization":"Acme"}`))
+	}))
+	defer server.Close()
+
+	if err := config.Save(&config.Config{
+		AccessToken: "valid-token",
+		APIURL:      server.URL,
+	}); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	output := captureStdout(t, func() error {
+		return runAuthLogin(authLoginCmd, nil)
+	})
+	if !strings.Contains(output, "Already logged in") {
+		t.Fatalf("expected already-logged-in short circuit, got %q", output)
+	}
+	if !strings.Contains(output, "Test User") || !strings.Contains(output, "user@example.com") {
+		t.Fatalf("expected identity in output, got %q", output)
+	}
+	if !strings.Contains(output, "--force") {
+		t.Fatalf("expected --force hint, got %q", output)
+	}
+}
+
+// An invalid/unverifiable stored login must NOT short-circuit: the login flow
+// should proceed (here: headless OAuth against an unreachable server errors,
+// proving we got past the pre-check).
+func TestRunAuthLoginProceedsWhenStoredLoginInvalid(t *testing.T) {
+	tempHome := t.TempDir()
+	testenv.SetHome(t, tempHome)
+
+	restore := snapshotLoginFlags()
+	defer restore()
+	loginToken = ""
+	loginForce = false
+	loginHeadless = true
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"invalid token"}`))
+	}))
+	server.Close() // immediately unreachable
+
+	if err := config.Save(&config.Config{
+		AccessToken: "stale-token",
+		APIURL:      server.URL,
+	}); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	var loginErr error
+	output := captureStdout(t, func() error {
+		loginErr = runAuthLogin(authLoginCmd, nil)
+		return nil
+	})
+	if strings.Contains(output, "Already logged in") {
+		t.Fatalf("stale login must not short-circuit, got %q", output)
+	}
+	if loginErr == nil {
+		t.Fatal("expected headless OAuth against a dead server to fail (proves pre-check passed through)")
+	}
+}
+
+// --token login must ignore the pre-check entirely (unattended/CI flows).
+func TestRunAuthLoginTokenBypassesPreCheck(t *testing.T) {
+	tempHome := t.TempDir()
+	testenv.SetHome(t, tempHome)
+
+	restore := snapshotLoginFlags()
+	defer restore()
+	loginForce = false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != userInfoPath {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"u2","email":"new@example.com","name":"New User"}`))
+	}))
+	defer server.Close()
+
+	if err := config.Save(&config.Config{
+		AccessToken: "old-token",
+		APIURL:      server.URL,
+	}); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+	loginToken = "new-token"
+
+	output := captureStdout(t, func() error {
+		return runAuthLogin(authLoginCmd, nil)
+	})
+	if strings.Contains(output, "Already logged in") {
+		t.Fatalf("--token must bypass the pre-check, got %q", output)
+	}
+	if !strings.Contains(output, "Authenticated successfully") {
+		t.Fatalf("expected token login to complete, got %q", output)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config load: %v", err)
+	}
+	if cfg.AccessToken != "new-token" {
+		t.Fatalf("expected new token saved, got %q", cfg.AccessToken)
+	}
+}
+
+// --force must skip the pre-check and start a real login even when the stored
+// session is perfectly valid (switching accounts).
+func TestRunAuthLoginForceIgnoresExistingSession(t *testing.T) {
+	tempHome := t.TempDir()
+	testenv.SetHome(t, tempHome)
+
+	restore := snapshotLoginFlags()
+	defer restore()
+	loginToken = ""
+	loginForce = true
+	loginHeadless = true
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"u1","email":"user@example.com","name":"Test User"}`))
+	}))
+	server.Close() // OAuth must fail; we only care that it was attempted
+
+	if err := config.Save(&config.Config{
+		AccessToken: "valid-token",
+		APIURL:      server.URL,
+	}); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	var loginErr error
+	output := captureStdout(t, func() error {
+		loginErr = runAuthLogin(authLoginCmd, nil)
+		return nil
+	})
+	if strings.Contains(output, "Already logged in") {
+		t.Fatalf("--force must not short-circuit, got %q", output)
+	}
+	if loginErr == nil {
+		t.Fatal("expected --force to attempt OAuth against the dead server")
+	}
+}
+
+// The re-auth hint must name the command the user actually ran, so that
+// `preloop auth login` does not tell them to run `preloop login --force`.
+func TestPrintAlreadyLoggedInNamesTheInvokedCommand(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		cmd      *cobra.Command
+		identity UserInfo
+		wants    []string
+		notWant  string
+	}{
+		{
+			name:     "login",
+			cmd:      loginCmd,
+			identity: UserInfo{Name: "Test User", Email: "user@example.com", Organization: "Acme"},
+			wants:    []string{"Test User (user@example.com)", "Org:     Acme", "'preloop login --force'"},
+		},
+		{
+			name:     "auth login alias",
+			cmd:      authLoginCmd,
+			identity: UserInfo{Name: "Test User", Email: "user@example.com"},
+			wants:    []string{"'preloop auth login --force'"},
+			notWant:  "Org:",
+		},
+		{
+			name:     "signup alias",
+			cmd:      signupCmd,
+			identity: UserInfo{Name: "Test User", Email: "user@example.com"},
+			wants:    []string{"'preloop signup --force'"},
+		},
+		{
+			// Accounts without a display name still get an unambiguous line.
+			name:     "email only",
+			cmd:      loginCmd,
+			identity: UserInfo{Email: "user@example.com"},
+			wants:    []string{"User:    user@example.com"},
+			notWant:  "()",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			identity := tt.identity
+			printAlreadyLoggedIn(&buf, tt.cmd, &identity)
+			for _, want := range tt.wants {
+				if !strings.Contains(buf.String(), want) {
+					t.Fatalf("expected %q in %q", want, buf.String())
+				}
+			}
+			if tt.notWant != "" && strings.Contains(buf.String(), tt.notWant) {
+				t.Fatalf("did not expect %q in %q", tt.notWant, buf.String())
+			}
+		})
+	}
 }

--- a/scripts/e2e-rig/README.md
+++ b/scripts/e2e-rig/README.md
@@ -54,7 +54,24 @@ Module exit codes: `0` pass, `3` skip (recorded with a note), anything else
 fails the run.
 
 Unit tests for the pure-python pieces (snapshot diff semantics, output
-redaction) live in `tests/` — run them with `pytest scripts/e2e-rig/tests`.
+redaction, the shared onboarding semantics in `lib/cli_onboard.py`) live in
+`tests/` — run them with `pytest scripts/e2e-rig/tests`.
+
+### Headless CI twin
+
+`ci_cli_onboard.py` runs module 08's assertions inside a GitLab job
+(`test:integration:cli-onboard`, manual) against a deployed test environment:
+it onboards a planted Claude Code install in API-key mode and checks that the
+enrollment routes through the gateway and that a request made with the minted
+credential is metered. It cannot be module 08 itself — no VM, no ssh, no
+pexpect/agg in the job container — so the parts that define what "onboarded"
+means (login persistence, `agents list --json` parsing, gateway env
+extraction) live in `lib/cli_onboard.py` and are shared by both.
+
+```bash
+PRELOOP_TEST_URL=https://<env> PRELOOP_TEST_API_KEY=<key> \
+  python3 scripts/e2e-rig/ci_cli_onboard.py
+```
 
 ## Requirements
 

--- a/scripts/e2e-rig/ci_cli_onboard.py
+++ b/scripts/e2e-rig/ci_cli_onboard.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Headless CLI-onboarding e2e check for GitLab CI (test:integration:cli-onboard).
+
+The CI twin of `modules/08-cli-onboard.py`. Module 08 needs a VM, an ssh
+transport and the pexpect+agg recording toolchain — none of which exist in a
+CI job container — so this entrypoint reuses module 08's *logic* through
+`lib/cli_onboard.py` (login persistence, agents-list parsing, gateway env
+extraction) and swaps only the transport: subprocess instead of a recorded pty,
+localhost instead of ssh. `lib/riglib.py` supplies the HTTP/redaction helpers
+so failure output here is redacted exactly like the rig's.
+
+What it asserts, in order:
+  1. a token login persisted by the CLI's own config path verifies server-side
+     (`preloop auth status`);
+  2. `preloop agents onboard --yes` enrolls a planted Claude Code install in
+     API-key mode, non-interactively, with no prompt left unanswered;
+  3. the enrollment reports gateway routing and wrote a durable credential
+     into the agent's settings;
+  4. a request made with that credential is accepted by the Preloop gateway
+     (not 401/403) and lands as a usage row on the account.
+
+Environment:
+  PRELOOP_TEST_URL      base URL of the deployed test environment
+  PRELOOP_TEST_API_KEY  API key for an account in that environment
+Exit codes: 0 pass, non-zero fail (no skip path — CI runs this deliberately).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+
+import cli_onboard  # noqa: E402
+import riglib  # noqa: E402
+
+URL = os.environ.get("PRELOOP_TEST_URL", "").rstrip("/")
+TOKEN = os.environ.get("PRELOOP_TEST_API_KEY", "")
+PRELOOP_BIN = os.environ.get("PRELOOP_BIN", "preloop")
+HOME = Path(os.environ["HOME"])
+ARTIFACT_DIR = Path(os.environ.get("CLI_ONBOARD_ARTIFACTS", "cli-onboard-artifacts"))
+
+# Upstream Anthropic never sees this: onboarding replaces it with the durable
+# Preloop credential. Its only job is to put the install in API-key mode so
+# no OAuth/subscription lineage is exercised (module 08 covers that path on a
+# real machine).
+PLACEHOLDER_UPSTREAM_KEY = "sk-ant-ci-placeholder-not-a-real-key"
+
+ANTHROPIC_VERSION = "2023-06-01"
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}", flush=True)
+    sys.exit(1)
+
+
+def save_artifact(name: str, content: str) -> None:
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    (ARTIFACT_DIR / name).write_text(riglib.redact(content, limit=20000))
+
+
+def cli(*args: str, check: bool = True, timeout: int = 900) -> str:
+    """Run the CLI non-interactively with telemetry off.
+
+    stdin is closed: any prompt that --yes fails to cover must surface as a
+    failure here rather than hanging the job until its timeout.
+    """
+    env = dict(os.environ)
+    env["PRELOOP_DISABLE_TELEMETRY"] = "true"
+    printable = " ".join([PRELOOP_BIN, *args])
+    print(f"$ {printable}", flush=True)
+    proc = subprocess.run(
+        [PRELOOP_BIN, *args],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+    output = proc.stdout + proc.stderr
+    print(riglib.redact(output, limit=20000), flush=True)
+    if check and proc.returncode != 0:
+        fail(f"`{printable}` exited {proc.returncode}")
+    return proc.stdout
+
+
+def stage_login() -> None:
+    """Persist the CLI login without the token entering argv or the log.
+
+    Same reasoning as module 08's stage_cli_login: `preloop login --token <t>`
+    would expose the key in this job's process listing and in any `set -x`
+    trace. The CLI reads exactly this file, so writing it is equivalent.
+    """
+    config_path = HOME / cli_onboard.CLI_CONFIG_RELPATH
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(cli_onboard.login_config_yaml(TOKEN, URL))
+    config_path.chmod(0o600)
+
+
+def plant_claude_code_install() -> None:
+    """Minimal Claude Code install that discovery recognises, in API-key mode.
+
+    `~/.claude.json` is what the discoverer keys on; ANTHROPIC_API_KEY makes
+    the auth state 'ready' via an API key rather than a subscription token.
+    """
+    (HOME / ".claude").mkdir(parents=True, exist_ok=True)
+    (HOME / ".claude.json").write_text("{}\n")
+    os.environ["ANTHROPIC_API_KEY"] = PLACEHOLDER_UPSTREAM_KEY
+
+
+def gateway_request(base_url: str, api_key: str, model: str) -> tuple[int, str]:
+    """One Anthropic-shaped request through the Preloop gateway."""
+    body = json.dumps(
+        {
+            "model": model,
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "ping"}],
+        }
+    ).encode()
+    req = urllib.request.Request(
+        f"{base_url}/v1/messages",
+        data=body,
+        method="POST",
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode()
+
+
+def account_gateway_requests() -> int:
+    """Total metered gateway requests on the account.
+
+    Deliberately the *summary* endpoint, not gateway-usage/search: the search
+    corpus skips interactions with status >= 400 unless
+    model_gateway_auto_index_failed_interactions is on (default off), so a
+    request that the gateway accepted but upstream rejected is metered in
+    ApiUsage yet absent from search. total_requests counts the ApiUsage rows,
+    which is exactly the fact under test. include_breakdown=false keeps the
+    response small.
+    """
+    status, body = riglib.api_request(
+        f"{URL}/api/v1/account/gateway-usage/summary?include_breakdown=false",
+        token=TOKEN,
+    )
+    if status != 200:
+        fail(f"gateway-usage/summary failed ({status}): {riglib.redact(body)}")
+    return int((body or {}).get("total_requests") or 0)
+
+
+def main() -> None:
+    if not URL or not TOKEN:
+        fail("PRELOOP_TEST_URL and PRELOOP_TEST_API_KEY are required")
+
+    print("== login (staged via the CLI's own config file) ==", flush=True)
+    stage_login()
+    status_output = cli("auth", "status")
+    # The degraded variants ("Authenticated (stored login could not be
+    # refreshed)", "Authenticated (token may be invalid ...)") must not pass:
+    # they mean the CLI never reached the server.
+    if not any(line.strip() == "Authenticated" for line in status_output.splitlines()):
+        fail("auth status did not report a verified login")
+
+    print("== plant a Claude Code install (API-key mode) ==", flush=True)
+    plant_claude_code_install()
+
+    print("== onboard ==", flush=True)
+    # --skip-live-validate: the placeholder upstream key cannot answer a real
+    # model prompt. Gateway wiring and metering are what this job proves;
+    # module 08 exercises live validation against real agent credentials.
+    cli("agents", "onboard", "Claude Code", "--yes", "--skip-live-validate")
+
+    print("== assert the enrollment ==", flush=True)
+    listing = cli("agents", "list", "--json")
+    save_artifact("agents.json", listing)
+    agents = cli_onboard.agents_from_list_json(listing)
+    claude = cli_onboard.find_agents_by_source_type(agents, "claude_code")
+    if not claude:
+        fail(
+            "no claude_code managed agent after onboarding; "
+            f"saw: {cli_onboard.onboarded_agent_names(agents)}"
+        )
+    if not any(cli_onboard.is_gateway_routed(a) for a in claude):
+        fail("claude_code agent enrolled but reports no model-gateway routing")
+
+    print("== drive one request through the minted credential ==", flush=True)
+    settings_path = HOME / ".claude" / "settings.json"
+    if not settings_path.exists():
+        fail(f"onboarding wrote no {settings_path}")
+    settings = json.loads(settings_path.read_text())
+    base_url, api_key = cli_onboard.gateway_env_from_settings(settings)
+    if not base_url or not api_key:
+        fail("onboarding wrote no ANTHROPIC_BASE_URL/ANTHROPIC_API_KEY")
+    if api_key == PLACEHOLDER_UPSTREAM_KEY:
+        fail("onboarding left the upstream key in place; no credential was minted")
+    model = str(settings.get("model") or "claude-sonnet-4-5")
+
+    before = account_gateway_requests()
+    print(f"gateway requests before: {before}", flush=True)
+
+    code, body = gateway_request(base_url, api_key, model)
+    save_artifact("gateway-response.json", body)
+    print(f"gateway responded {code}: {riglib.redact(body)}", flush=True)
+    if code in (401, 403):
+        # Preloop itself refused the credential it just minted — precisely the
+        # halt/re-onboard class of bug this job exists to catch.
+        fail("the Preloop gateway rejected the credential onboarding minted")
+
+    print("== assert the request was metered ==", flush=True)
+    # Usage is written on the request path, but the response can return before
+    # the commit is visible to a follow-up read; poll briefly.
+    total = before
+    for attempt in range(1, 7):
+        total = account_gateway_requests()
+        print(f"gateway requests now: {total} (attempt {attempt})", flush=True)
+        if total > before:
+            break
+        time.sleep(5)
+    if total <= before:
+        fail(f"no usage row recorded (before={before}, after={total})")
+
+    print("CLI onboarding e2e passed", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/e2e-rig/ci_cli_onboard.py
+++ b/scripts/e2e-rig/ci_cli_onboard.py
@@ -47,6 +47,12 @@ PRELOOP_BIN = os.environ.get("PRELOOP_BIN", "preloop")
 HOME = Path(os.environ["HOME"])
 ARTIFACT_DIR = Path(os.environ.get("CLI_ONBOARD_ARTIFACTS", "cli-onboard-artifacts"))
 
+# Usage is committed on the request path, but a follow-up read can race the
+# commit. Poll rather than sleep once. Slower deployments can widen the window
+# without touching the job definition.
+USAGE_POLL_ATTEMPTS = int(os.environ.get("CLI_ONBOARD_USAGE_POLL_ATTEMPTS", "6"))
+USAGE_POLL_INTERVAL = float(os.environ.get("CLI_ONBOARD_USAGE_POLL_INTERVAL", "5"))
+
 # Upstream Anthropic never sees this: onboarding replaces it with the durable
 # Preloop credential. Its only job is to put the install in API-key mode so
 # no OAuth/subscription lineage is exercised (module 08 covers that path on a
@@ -220,17 +226,24 @@ def main() -> None:
         fail("the Preloop gateway rejected the credential onboarding minted")
 
     print("== assert the request was metered ==", flush=True)
-    # Usage is written on the request path, but the response can return before
-    # the commit is visible to a follow-up read; poll briefly.
     total = before
-    for attempt in range(1, 7):
+    for attempt in range(1, USAGE_POLL_ATTEMPTS + 1):
         total = account_gateway_requests()
-        print(f"gateway requests now: {total} (attempt {attempt})", flush=True)
+        print(
+            f"gateway requests now: {total} (attempt {attempt}/{USAGE_POLL_ATTEMPTS})",
+            flush=True,
+        )
         if total > before:
             break
-        time.sleep(5)
+        if attempt < USAGE_POLL_ATTEMPTS:
+            time.sleep(USAGE_POLL_INTERVAL)
     if total <= before:
-        fail(f"no usage row recorded (before={before}, after={total})")
+        waited = USAGE_POLL_ATTEMPTS * USAGE_POLL_INTERVAL
+        fail(
+            f"no usage row recorded after {waited:.0f}s "
+            f"(before={before}, after={total}); raise "
+            f"CLI_ONBOARD_USAGE_POLL_ATTEMPTS if this deployment is slower"
+        )
 
     print("CLI onboarding e2e passed", flush=True)
 

--- a/scripts/e2e-rig/lib/cli_onboard.py
+++ b/scripts/e2e-rig/lib/cli_onboard.py
@@ -1,0 +1,116 @@
+"""Shared CLI-onboarding logic for the e2e rig and its CI twin.
+
+Module 08 (`modules/08-cli-onboard.py`) drives the CLI through a real pty on a
+VM and records the session; `ci_cli_onboard.py` drives the same CLI headlessly
+inside a GitLab job. The transports differ, but the *semantics* must not: how a
+login is persisted, how `agents list --json` is parsed, and what counts as a
+successfully onboarded agent all live here so the recorded rig and CI can never
+drift apart in what they assert.
+
+Stdlib only (the rig's modules run under a bare `python3`).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# The CLI's login persistence target and key names; see
+# cli/internal/config/config.go (Config struct mapstructure tags).
+CLI_CONFIG_RELPATH = ".preloop/config.yaml"
+
+
+def login_config_yaml(token: str, api_url: str) -> str:
+    """Render the CLI's config file for a token login.
+
+    Used instead of `preloop login --token <t>` so the token never lands in
+    any argv (visible in `ps`), environment, or asciicast. `preloop login
+    --token` writes exactly these three keys via config.SetTokens, so writing
+    the file is behaviourally identical and strictly safer.
+
+    json.dumps supplies YAML-compatible double-quoted scalars, which keeps
+    tokens containing `:`/`#` from corrupting the document.
+    """
+    return (
+        f"access_token: {json.dumps(token)}\n"
+        f'refresh_token: ""\n'
+        f"api_url: {json.dumps(api_url.rstrip('/'))}\n"
+    )
+
+
+def agents_from_list_json(stdout: str) -> list[dict[str, Any]]:
+    """Parse `preloop agents list --json`.
+
+    The command emits a bare JSON array, but older builds (and the paged
+    /api/v1/agents response some tooling forwards) wrap it in an object. Accept
+    both rather than making the caller guess which CLI version it is talking
+    to. Anything unparseable is an empty list — callers assert on emptiness and
+    report the raw text themselves.
+    """
+    try:
+        parsed = json.loads(stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    if isinstance(parsed, list):
+        return [a for a in parsed if isinstance(a, dict)]
+    if isinstance(parsed, dict):
+        items = parsed.get("items") or parsed.get("agents") or []
+        return [a for a in items if isinstance(a, dict)]
+    return []
+
+
+def onboarded_agent_names(agents: list[dict[str, Any]]) -> list[str]:
+    """Display names of agents that actually carry an enrollment."""
+    return [
+        str(a.get("display_name"))
+        for a in agents
+        if isinstance(a, dict) and a.get("display_name")
+    ]
+
+
+def find_agents_by_source_type(
+    agents: list[dict[str, Any]], source_type: str
+) -> list[dict[str, Any]]:
+    """Every managed agent enrolled from a given runtime (e.g. claude_code)."""
+    wanted = source_type.strip().lower()
+    return [
+        a
+        for a in agents
+        if str(a.get("session_source_type", "")).strip().lower() == wanted
+    ]
+
+
+# Onboarding states the backend reports for an agent whose model traffic is
+# actually routed through Preloop (see backend account.py enrollment summary).
+ROUTED_ONBOARDING_STATES = {"fully_onboarded"}
+
+
+def is_gateway_routed(agent: dict[str, Any]) -> bool:
+    """True when the enrollment claims working model-gateway routing.
+
+    `model_gateway_configured` is the direct signal; `onboarding_state` is
+    checked too because a build that has not yet populated the boolean still
+    reports the state string.
+    """
+    if agent.get("model_gateway_configured"):
+        return True
+    state = str(agent.get("onboarding_state", "")).strip().lower()
+    return state in ROUTED_ONBOARDING_STATES
+
+
+def gateway_env_from_settings(settings: Any) -> tuple[str, str]:
+    """Extract (base_url, api_key) that onboarding wrote into an agent config.
+
+    Mirrors applyClaudeManagedGateway in cli/internal/cmd/agents.go, which sets
+    env.ANTHROPIC_BASE_URL to "<preloop>/anthropic" and env.ANTHROPIC_API_KEY
+    to the minted durable credential. Returns ("", "") when either is absent so
+    the caller can fail with its own message.
+    """
+    if not isinstance(settings, dict):
+        return "", ""
+    env = settings.get("env")
+    if not isinstance(env, dict):
+        return "", ""
+    base_url = str(env.get("ANTHROPIC_BASE_URL") or "").rstrip("/")
+    api_key = str(env.get("ANTHROPIC_API_KEY") or "")
+    return base_url, api_key

--- a/scripts/e2e-rig/modules/08-cli-onboard.py
+++ b/scripts/e2e-rig/modules/08-cli-onboard.py
@@ -5,7 +5,6 @@ over ssh and is recorded to an asciicast (pexpect+agg pipeline, never vhs).
 
 from __future__ import annotations
 
-import json
 import subprocess
 import sys
 import time
@@ -14,6 +13,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 
 import capture  # noqa: E402
+import cli_onboard  # noqa: E402
 import riglib  # noqa: E402
 
 HOST = riglib.env("RIG_HOST")
@@ -23,7 +23,8 @@ CLI_VERSION = riglib.env("RIG_CLI_VERSION")
 CAST = riglib.run_dir() / "casts" / "08-cli-onboard.cast"
 MP4 = riglib.run_dir() / "casts" / "08-cli-onboard.mp4"
 # The CLI's own login persistence target (see cli/internal/config/config.go).
-CLI_CONFIG_FILE = "$HOME/.preloop/config.yaml"
+# Shared with the CI twin (scripts/e2e-rig/ci_cli_onboard.py) via lib/cli_onboard.py.
+CLI_CONFIG_FILE = f"$HOME/{cli_onboard.CLI_CONFIG_RELPATH}"
 
 
 def ssh(cmd: str, check: bool = True) -> subprocess.CompletedProcess:
@@ -56,11 +57,7 @@ def stage_cli_login(token: str) -> None:
     secret. The recorded scene then runs `preloop auth status`, which
     verifies the stored login against the server on camera.
     """
-    config_yaml = (
-        f"access_token: {json.dumps(token)}\n"
-        f'refresh_token: ""\n'
-        f"api_url: {json.dumps(URL)}\n"
-    )
+    config_yaml = cli_onboard.login_config_yaml(token, URL)
     subprocess.run(
         [
             "ssh",
@@ -151,19 +148,16 @@ def main() -> None:
 
     # Structured post-check (not recorded): what actually got onboarded.
     result = ssh("preloop agents list --json 2>/dev/null || true", check=False)
-    agents = []
-    try:
-        parsed = json.loads(result.stdout or "[]")
-        agents = parsed if isinstance(parsed, list) else parsed.get("agents", [])
-    except json.JSONDecodeError:
+    agents = cli_onboard.agents_from_list_json(result.stdout)
+    if not agents:
         riglib.note("agents list --json unavailable/unparseable; saving raw text")
         (riglib.run_dir() / "state" / "onboarded-agents.txt").write_text(result.stdout)
     riglib.save_state("onboarded-agents.json", agents)
 
-    names = [a.get("display_name") for a in agents if isinstance(a, dict)]
+    names = cli_onboard.onboarded_agent_names(agents)
     if not names:
         raise SystemExit("no agents onboarded — check the cast/log")
-    riglib.note(f"onboarded agents: {', '.join(str(n) for n in names)}")
+    riglib.note(f"onboarded agents: {', '.join(names)}")
 
 
 if __name__ == "__main__":

--- a/scripts/e2e-rig/tests/test_rig_units.py
+++ b/scripts/e2e-rig/tests/test_rig_units.py
@@ -1,7 +1,8 @@
 """Unit tests for the e2e rig's pure-python logic.
 
-Covers snapshot_diff (the offboarding-assertion semantics) and the output
-redaction shared by lib/riglib.py and research_agent.py. Stdlib + pytest
+Covers snapshot_diff (the offboarding-assertion semantics), the output
+redaction shared by lib/riglib.py and research_agent.py, and cli_onboard (the
+onboarding semantics shared by module 08 and its CI twin). Stdlib + pytest
 only; no VM, network, or recording toolchain involved.
 
 Run: pytest scripts/e2e-rig/tests
@@ -19,6 +20,7 @@ RIG_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(RIG_DIR))
 sys.path.insert(0, str(RIG_DIR / "lib"))
 
+import cli_onboard  # noqa: E402
 import research_agent  # noqa: E402
 import riglib  # noqa: E402
 import snapshot_diff  # noqa: E402
@@ -179,3 +181,82 @@ class TestCompareSnapshots:
         write(final, ".config/opencode/config.json", "{}")
         report = snapshot_diff.compare_snapshots(baseline, final, tmp_path / "diffs")
         assert report["verdict"] == "PASS"
+
+
+# --- cli_onboard (shared by module 08 and ci_cli_onboard.py) ----------------
+
+
+class TestLoginConfigYaml:
+    def test_matches_the_cli_config_schema(self):
+        out = cli_onboard.login_config_yaml("tok", "https://preloop.example/")
+        assert 'access_token: "tok"' in out
+        assert 'refresh_token: ""' in out
+        # Trailing slash stripped: the CLI joins paths onto api_url directly.
+        assert 'api_url: "https://preloop.example"' in out
+
+    def test_quotes_tokens_that_would_break_yaml(self):
+        # A raw `a: b` scalar containing ": " parses as a nested mapping.
+        out = cli_onboard.login_config_yaml("ab: cd#ef", "https://x")
+        assert 'access_token: "ab: cd#ef"' in out
+
+
+class TestAgentsFromListJson:
+    def test_bare_array(self):
+        agents = cli_onboard.agents_from_list_json('[{"display_name": "Claude Code"}]')
+        assert cli_onboard.onboarded_agent_names(agents) == ["Claude Code"]
+
+    def test_paged_object_shape(self):
+        agents = cli_onboard.agents_from_list_json('{"items": [{"display_name": "x"}]}')
+        assert cli_onboard.onboarded_agent_names(agents) == ["x"]
+
+    def test_unparseable_is_empty_not_fatal(self):
+        assert cli_onboard.agents_from_list_json("not json at all") == []
+
+    def test_entries_without_a_name_are_not_counted_as_onboarded(self):
+        agents = cli_onboard.agents_from_list_json('[{"id": "a"}]')
+        assert cli_onboard.onboarded_agent_names(agents) == []
+
+
+class TestFindAgentsBySourceType:
+    def test_case_insensitive_match(self):
+        agents = [
+            {"session_source_type": "Claude_Code"},
+            {"session_source_type": "codex"},
+        ]
+        assert cli_onboard.find_agents_by_source_type(agents, "claude_code") == [
+            agents[0]
+        ]
+
+    def test_no_match(self):
+        assert cli_onboard.find_agents_by_source_type([{"a": 1}], "claude_code") == []
+
+
+class TestIsGatewayRouted:
+    def test_boolean_signal(self):
+        assert cli_onboard.is_gateway_routed({"model_gateway_configured": True})
+
+    def test_state_string_fallback(self):
+        assert cli_onboard.is_gateway_routed({"onboarding_state": "fully_onboarded"})
+
+    def test_mcp_only_enrollment_is_not_routed(self):
+        assert not cli_onboard.is_gateway_routed({"onboarding_state": "mcp_proxy_only"})
+
+
+class TestGatewayEnvFromSettings:
+    def test_reads_what_onboarding_writes(self):
+        settings = {
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://preloop.example/anthropic/",
+                "ANTHROPIC_API_KEY": "pl-durable",
+            }
+        }
+        assert cli_onboard.gateway_env_from_settings(settings) == (
+            "https://preloop.example/anthropic",
+            "pl-durable",
+        )
+
+    def test_missing_env_block(self):
+        assert cli_onboard.gateway_env_from_settings({"model": "x"}) == ("", "")
+
+    def test_non_dict_input(self):
+        assert cli_onboard.gateway_env_from_settings(None) == ("", "")

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -269,9 +269,42 @@ fi
 PRELOOP_URL="$target_url"
 export PRELOOP_URL
 
-# Step 3: offer to authenticate. If we found local agents we tell the user
-# explicitly that logging in lets us onboard them.
+# existing_login_identity echoes the identity lines of an already-verified
+# login and returns 0; it returns 1 when there is no usable session.
+#
+# `preloop auth status` exits 0 in every case, including its degraded verdicts
+# ("Authenticated (stored login could not be refreshed)", "Authenticated
+# (token may be invalid or server unreachable)") which mean the CLI never
+# confirmed the session with the server. Only the exact "Authenticated" line
+# counts as signed in; everything else must fall through to a real login.
+existing_login_identity() {
+  status_output="$("$1" auth status 2>/dev/null || true)"
+  printf '%s\n' "$status_output" | grep -q '^Authenticated$' || return 1
+  printf '%s\n' "$status_output" | grep -E '^  (User|Email|Org):' || true
+  return 0
+}
+
+# Step 3: offer to authenticate — unless this machine already has a verified
+# session, in which case say who it belongs to and go straight to onboarding.
+# If we found local agents we tell the user explicitly that logging in lets us
+# onboard them.
 echo ""
+if identity_lines="$(existing_login_identity "$PRELOOP_BIN")"; then
+  echo "Already signed in to ${target_url}:"
+  [ -n "$identity_lines" ] && printf '%s\n' "$identity_lines"
+  echo "Run 'preloop login --force' to switch accounts."
+  if [ "$discovered_agents" = "1" ]; then
+    echo ""
+    onboard_ans="$(prompt_default_yes "Onboard discovered agents now? [Y/n]")"
+    case "$onboard_ans" in
+      y|yes)
+        "$PRELOOP_BIN" agents discover < /dev/tty || true
+        ;;
+    esac
+  fi
+  exit 0
+fi
+
 if [ "$discovered_agents" = "1" ]; then
   prompt="Sign in (or sign up) to ${target_url} now to onboard the agents above? [Y/s/n]"
 else

--- a/scripts/test_install_cli_login_skip.sh
+++ b/scripts/test_install_cli_login_skip.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env sh
+# Unit tests for existing_login_identity in install-cli.sh — the check that
+# lets a re-run of the installer skip the login prompt when the machine
+# already has a verified session.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+INSTALLER="${SCRIPT_DIR}/install-cli.sh"
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT INT TERM
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "ok - $*"
+}
+
+HELPER="${TMP_DIR}/existing_login_identity.sh"
+awk '
+  /^existing_login_identity\(\)/ { printing=1 }
+  printing { print }
+  printing && /^}/ { exit }
+' "$INSTALLER" > "$HELPER"
+[ -s "$HELPER" ] || fail "could not extract existing_login_identity from $INSTALLER"
+
+# Fake `preloop` whose `auth status` prints whatever FAKE_STATUS holds.
+FAKE_CLI="${TMP_DIR}/preloop"
+cat > "$FAKE_CLI" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' "${FAKE_STATUS:-}"
+exit 0
+EOF
+chmod +x "$FAKE_CLI"
+
+cat > "${TMP_DIR}/run.sh" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+# shellcheck disable=SC1090
+. "$1"
+existing_login_identity "$2"
+EOF
+chmod +x "${TMP_DIR}/run.sh"
+
+run_case() {
+  name="$1"
+  expect_status="$2"
+  expect_substr="$3"
+  status=0
+  got="$(FAKE_STATUS="$FAKE_STATUS" sh "${TMP_DIR}/run.sh" "$HELPER" "$FAKE_CLI")" || status=$?
+
+  if [ "$status" != "$expect_status" ]; then
+    fail "$name: expected exit $expect_status, got $status (output: '$got')"
+  fi
+  if [ -n "$expect_substr" ]; then
+    case "$got" in
+      *"$expect_substr"*) ;;
+      *) fail "$name: expected output to contain '$expect_substr', got '$got'" ;;
+    esac
+  fi
+  pass "$name"
+}
+
+FAKE_STATUS='Authenticated
+  User:    Ada Lovelace
+  Email:   ada@example.com
+  Org:     Analytical
+  API URL: https://preloop.ai' \
+  run_case "verified login is detected and identity echoed" 0 "ada@example.com"
+
+FAKE_STATUS='Not authenticated
+Run '\''preloop login --token <your-token>'\'' to authenticate' \
+  run_case "no session falls through to login" 1 ""
+
+# The degraded verdicts still start with "Authenticated": they mean the CLI
+# could not confirm the session with the server, so the installer must NOT
+# skip the login prompt.
+FAKE_STATUS='Authenticated (stored login could not be refreshed)
+  API URL: https://preloop.ai' \
+  run_case "unrefreshable login falls through to login" 1 ""
+
+FAKE_STATUS='Authenticated (token may be invalid or server unreachable)
+  API URL: https://preloop.ai' \
+  run_case "unverifiable token falls through to login" 1 ""
+
+FAKE_STATUS='' \
+  run_case "empty status output falls through to login" 1 ""
+
+echo "All existing_login_identity tests passed."


### PR DESCRIPTION
Re-onboarding an agent that already had an enrollment could leave the account and the machine disagreeing about it, and re-running the installer always asked for a login it did not need.

## 1. Re-onboarding reactivated the enrollment, then refused it (P1, reproduced live)

`ensureManagedAgentIdentityReady` PATCHed `lifecycle_action=reenroll` and printed "Reactivated ..." *before* deciding whether to re-attach — but the re-attach confirmation only ever ran for fuzzy ("fallback") matches. A v1/legacy match in an interactive run without `-y` therefore ended at:

```
declined re-attaching enrollment <name> (<id>)
```

...without ever having asked. The account was left with a reactivated agent and the machine with no config written: split-brain.

Now the confirmation runs for **every** non-v2 match (default yes) and happens **before** any server-side change. If the subsequent re-key fails, the enrollment is restored to its previous lifecycle state rather than left reactivated.

## 2. Suspended enrollments were never recovered

Only `decommissioned` was revived, so re-onboarding a suspended agent left it suspended — and token issuance for a suspended agent 403s, so nothing worked afterwards. Lifecycle state now maps to the action the backend actually defines (`account.py`): `decommissioned` → `reenroll`, `suspended` → `resume`, with a "Resuming paused enrollment ..." note.

This reads the lifecycle contract as it exists on `main` and only asks for `resume`; it stays correct if `resume` is later extended to reactivate keys too.

## 3. Login is skipped when you are already signed in

`preloop login` prints the current identity and exits; `--force` re-authenticates. `--token` and non-interactive flows are untouched. The installer does the same check before prompting, so re-running it on a machine with a valid session goes straight to onboarding.

Only the exact `Authenticated` verdict counts as signed in — `auth status` also prints "Authenticated (stored login could not be refreshed)" and "Authenticated (token may be invalid or server unreachable)", which mean the CLI never confirmed the session with the server and must still trigger a real login.

## 4. "Claude Coderedentials"

There is no truncating format string in the CLI — the reported text does not exist as a literal anywhere in the tree, and the shipped binary prints `service: Claude Code-credentials)`. The garbling comes from printing the hyphenated keychain service name bare, where it runs into the surrounding prose. Every keychain service name is now quoted, and a package-wide test fails on any new unquoted `(service: X` message. That guard immediately caught one more instance (`%s` → `%q` for the Gemini CLI service).

## 5. Manual CI onboarding e2e

`test:integration:cli-onboard` builds the CLI from the branch, onboards a planted Claude Code install in API-key mode against the deployed test environment, and asserts the enrollment routes through the gateway and that a request made with the minted credential is metered.

The shared logic extracts login persistence, `agents list --json` parsing, and gateway env extraction into `scripts/e2e-rig/lib/cli_onboard.py`, and both module 08 and `ci_cli_onboard.py` use it. Only the transport differs.

**No new CI variables are required.** It uses `PRELOOP_TEST_API_KEY`, already defined globally.

Also adds `test:unit:scripts`, which runs the installer's shell-helper tests and the rig's python unit tests — neither ran in CI before.

## Tests

- New Go regression tests for the re-onboarding flow: prompt-before-mutation, decline leaves the server untouched, revive-then-rekey ordering, rollback on re-key failure, suspended → `resume`, decline leaves a paused agent paused. **All of them fail against the pre-fix code** (verified by reverting `agents.go` and re-running).
- New `auth` tests: already-logged-in short-circuit, stale login falls through, `--token` bypasses the pre-check, `--force` ignores a valid session, and the re-auth hint names the command actually invoked (`preloop auth login --force`, not `preloop login --force`).
- New shell tests for the installer's `existing_login_identity`, including all three degraded `auth status` verdicts.
- New python tests for the shared rig helpers.

`go build`, `go vet`, `go test -race -count=1 ./...` all green under `cli/`; `golangci-lint` findings are byte-identical to the pre-existing baseline. `PRELOOP_DISABLE_TELEMETRY=true` on every test run.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Five targeted CLI fixes with comprehensive regression coverage. No security issues, no breaking changes. Reviewed and approved by two independent passes.
>
> **Overview**
> Fixes split-brain re-onboarding (confirm-before-mutate with rollback), adds suspended-agent revival, skips redundant login prompts, quotes keychain service names, and adds a manual CI e2e onboarding job sharing logic with the recorded rig.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/cli-onboarding-ux. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->