### PR TITLE
fix: make agent pause/resume fully reversible; rename Halt to Pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Keychain service names in onboarding output are now quoted**, so the
   hyphenated macOS service `"Claude Code-credentials"` can no longer be
   misread as running into the surrounding prose.
+- **Agent pause is now fully reversible** (#193): pausing an agent
+  (`lifecycle_action=suspend`) deactivated *every* runtime API key the agent
+  owned and closed its runtime session, but resume only flipped the lifecycle
+  flag back to `active` — nothing reactivated the keys or reopened the session.
+  A resumed agent therefore looked healthy in the console while every gateway
+  request 401'd before a usage row could be written, so the agent silently
+  logged nothing. Pause is now enforced purely as a lifecycle check on the
+  read-through auth path (`authenticate_bearer_token`, API-key auth, and
+  runtime token issuance already re-read `lifecycle_state` from the database on
+  every request), so credentials are left untouched and resume is an exact
+  inverse. Hard credential revocation is now reserved for the terminal states:
+  decommission and delete. Resume and `reenroll` additionally heal agents
+  bricked by the previous behavior — reactivating that agent's own unexpired
+  keys and clearing `ended_at` — without ever reviving a credential an operator
+  revoked on purpose.
+
+- **Deterministic agent lookup by source**: `managed_agent.get_by_source()`
+  returned an arbitrary row when several agents shared a session source, so a
+  stale suspended or decommissioned sibling could shadow the live agent during
+  token issuance. It now orders by lifecycle state (active, then suspended,
+  then decommissioned) and falls back to most-recent-first.
 
 ### Added
 
@@ -148,6 +169,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`test:unit:scripts` CI job**: runs the install script's shell-helper tests
   and the e2e rig's pure-python unit tests, neither of which any existing job
   executed.
+
+### Changed
+
+- **"Halt" is now "Pause" throughout the console**, rendered as a play/pause
+  toggle in amber/warning tones. Red/danger styling stays reserved for the
+  genuinely destructive offboard and remove actions, matching the fact that
+  pausing is now reversible.
+
+- **`identity.*` tags are hidden from the default agent tag chips** and shown
+  instead under a collapsed "Identity history" disclosure on the agent detail
+  view. These tags are server-written bookkeeping from agent re-keying, not
+  operator labels; they are preserved unchanged when an operator edits tags.
 
 ## [0.14.0] - 2026-08-07
 

--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -2031,8 +2031,23 @@ async def update_account_managed_agent(
     bound_runtime_session_id = (
         str(agent.runtime_session_id) if agent.runtime_session_id is not None else None
     )
-    should_revoke_runtime_access = lifecycle_state in {"suspended", "decommissioned"}
+    # Pause (``suspended``) is a REVERSIBLE lifecycle flag: every auth path
+    # re-reads ``lifecycle_state`` from the database on every request
+    # (model_gateway_auth.authenticate_bearer_token, jwt._authenticate_with_api_key,
+    # runtime token issuance), so a paused agent is rejected without touching
+    # its credentials. Deactivating keys made pause irreversible, because
+    # resume had no inverse and every later gateway call 401'd before any
+    # usage row was written. Hard credential revocation now belongs to the
+    # terminal states only: decommission (offboard) and delete.
+    should_revoke_runtime_access = lifecycle_state == "decommissioned"
     revoke_timestamp = datetime.now(UTC) if should_revoke_runtime_access else None
+    # Resume/reenroll heal agents whose keys a previous release revoked on
+    # suspend, and un-archive decommissioned agents. Restoration is narrow
+    # (see crud_api_key.reactivate_runtime_keys_for_managed_agent): only this
+    # agent's own unexpired, non-operator-revoked keys.
+    should_restore_runtime_access = (
+        lifecycle_state == "active" and agent.lifecycle_state != "active"
+    )
     updated = crud_managed_agent.update_operator_state(
         db,
         account_id=str(account.id),
@@ -2077,6 +2092,24 @@ async def update_account_managed_agent(
                 ended_at=revoke_timestamp,
                 commit=False,
             )
+    if should_restore_runtime_access:
+        crud_api_key.reactivate_runtime_keys_for_managed_agent(
+            db,
+            account_id=account.id,
+            managed_agent_id=str(agent.id),
+            commit=False,
+        )
+        # A previous release ended the bound session on suspend and nothing
+        # ever reopened it, which kept session-bound runtime keys rejected
+        # after resume. Reopen the agent's own session so the inverse of a
+        # pause is a genuine round trip.
+        crud_runtime_session.reopen_for_managed_agent(
+            db,
+            account_id=str(account.id),
+            session_source_type=agent.session_source_type,
+            session_source_id=agent.session_source_id,
+            commit=False,
+        )
     db.commit()
     db.refresh(updated)
 

--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -1989,13 +1989,18 @@ async def update_account_managed_agent(
     db: Session = Depends(get_db_session),
 ):
     """Update managed-agent ownership or lifecycle controls."""
+    # Locked for the whole handler: ``lifecycle_state`` is read here and the
+    # credential restore/revoke decision below is made from that read, so a
+    # concurrent operator action (a resume racing a decommission) must not
+    # land in between and leave keys reactivated on a decommissioned agent.
     agent = crud_managed_agent.get_for_account(
-        db, account_id=str(account.id), agent_id=agent_id
+        db, account_id=str(account.id), agent_id=agent_id, for_update=True
     )
     if agent is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Managed agent not found"
         )
+    prior_lifecycle_state = agent.lifecycle_state
 
     set_owner = "owner_user_id" in update.model_fields_set
     set_display_name = "display_name" in update.model_fields_set
@@ -2040,13 +2045,12 @@ async def update_account_managed_agent(
     # usage row was written. Hard credential revocation now belongs to the
     # terminal states only: decommission (offboard) and delete.
     should_revoke_runtime_access = lifecycle_state == "decommissioned"
-    revoke_timestamp = datetime.now(UTC) if should_revoke_runtime_access else None
     # Resume/reenroll heal agents whose keys a previous release revoked on
     # suspend, and un-archive decommissioned agents. Restoration is narrow
     # (see crud_api_key.reactivate_runtime_keys_for_managed_agent): only this
     # agent's own unexpired, non-operator-revoked keys.
     should_restore_runtime_access = (
-        lifecycle_state == "active" and agent.lifecycle_state != "active"
+        lifecycle_state == "active" and prior_lifecycle_state != "active"
     )
     updated = crud_managed_agent.update_operator_state(
         db,
@@ -2066,7 +2070,8 @@ async def update_account_managed_agent(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Managed agent not found"
         )
-    if should_revoke_runtime_access and revoke_timestamp is not None:
+    if should_revoke_runtime_access:
+        revoke_timestamp = datetime.now(UTC)
         # Revoke only this agent's keys (plus legacy keys with no agent
         # binding). Several registry entries can share one runtime principal,
         # and a principal-wide sweep would also kill sibling agents' durable

--- a/backend/preloop/models/crud/api_key.py
+++ b/backend/preloop/models/crud/api_key.py
@@ -5,9 +5,11 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from ..models.api_key import ApiKey
+from ..models.managed_agent_credential import ManagedAgentCredential
 from ..models.user import User
 from .base import CRUDBase
 
@@ -354,6 +356,78 @@ class CRUDApiKey(CRUDBase[ApiKey]):
         else:
             db.flush()
         return deactivated
+
+    def reactivate_runtime_keys_for_managed_agent(
+        self,
+        db: Session,
+        *,
+        account_id: Any,
+        managed_agent_id: str,
+        commit: bool = True,
+    ) -> List[ApiKey]:
+        """Reactivate runtime keys a past suspension deactivated.
+
+        Pausing an agent is a lifecycle flag today (every auth path rejects
+        non-active agents on every request), so nothing needs restoring for
+        agents paused by current code. This heals agents that were suspended
+        by the older revoke-on-suspend behavior, whose durable gateway
+        credential stayed ``is_active = False`` forever because resume had no
+        inverse.
+
+        Deliberately narrow so it can never resurrect a credential an
+        operator killed on purpose:
+
+        - only keys bound to this managed agent (never principal-wide sweeps,
+          which would touch sibling agents' credentials),
+        - never a key whose ``ManagedAgentCredential`` row is ``revoked``,
+        - never an expired key.
+
+        Args:
+            db: Database session.
+            account_id: Account that owns the keys.
+            managed_agent_id: Managed agent whose keys are being restored.
+            commit: Commit the transaction when True.
+
+        Returns:
+            The API keys that were reactivated.
+        """
+        key_objs = (
+            db.query(ApiKey)
+            .outerjoin(
+                ManagedAgentCredential,
+                ManagedAgentCredential.api_key_id == ApiKey.id,
+            )
+            .filter(
+                ApiKey.account_id == account_id,
+                ApiKey.is_active.is_(False),
+                ApiKey.context_data.op("->>")("managed_agent_id")
+                == str(managed_agent_id),
+                or_(
+                    ManagedAgentCredential.id.is_(None),
+                    ManagedAgentCredential.status != "revoked",
+                ),
+            )
+            .all()
+        )
+
+        reactivated: List[ApiKey] = []
+        for key_obj in key_objs:
+            if key_obj.is_expired:
+                continue
+            key_obj.is_active = True
+            db.add(key_obj)
+            reactivated.append(key_obj)
+
+        if not reactivated:
+            return reactivated
+
+        if commit:
+            db.commit()
+            for key_obj in reactivated:
+                db.refresh(key_obj)
+        else:
+            db.flush()
+        return reactivated
 
     def validate_key(
         self, db: Session, *, key: str, required_scopes: Optional[List[str]] = None

--- a/backend/preloop/models/crud/api_key.py
+++ b/backend/preloop/models/crud/api_key.py
@@ -1,6 +1,7 @@
 """CRUD operations for ApiKey model."""
 
 import hashlib
+import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
@@ -12,6 +13,8 @@ from ..models.api_key import ApiKey
 from ..models.managed_agent_credential import ManagedAgentCredential
 from ..models.user import User
 from .base import CRUDBase
+
+logger = logging.getLogger(__name__)
 
 
 class CRUDApiKey(CRUDBase[ApiKey]):
@@ -391,6 +394,10 @@ class CRUDApiKey(CRUDBase[ApiKey]):
         Returns:
             The API keys that were reactivated.
         """
+        # ``expires_at`` is a naive column holding UTC (see ApiKey.is_expired),
+        # so the cutoff is computed here rather than with func.now(), which
+        # would compare a timestamptz against a naive column.
+        now_naive = datetime.now(timezone.utc).replace(tzinfo=None)
         key_objs = (
             db.query(ApiKey)
             .outerjoin(
@@ -406,19 +413,34 @@ class CRUDApiKey(CRUDBase[ApiKey]):
                     ManagedAgentCredential.id.is_(None),
                     ManagedAgentCredential.status != "revoked",
                 ),
+                or_(
+                    ApiKey.expires_at.is_(None),
+                    ApiKey.expires_at > now_naive,
+                ),
             )
             .all()
         )
 
         reactivated: List[ApiKey] = []
+        skipped_expired = 0
         for key_obj in key_objs:
+            # Belt and braces: the SQL filter above does the real work, this
+            # catches a row that expired between the query and this loop.
             if key_obj.is_expired:
+                skipped_expired += 1
                 continue
             key_obj.is_active = True
             db.add(key_obj)
             reactivated.append(key_obj)
 
         if not reactivated:
+            logger.info(
+                "No runtime keys reactivated for managed agent %s "
+                "(candidates=%d, skipped_expired=%d)",
+                managed_agent_id,
+                len(key_objs),
+                skipped_expired,
+            )
             return reactivated
 
         if commit:

--- a/backend/preloop/models/crud/managed_agent.py
+++ b/backend/preloop/models/crud/managed_agent.py
@@ -20,6 +20,11 @@ from .base import CRUDBase
 MANAGED_AGENT_ACTIVE_WINDOW = timedelta(minutes=10)
 MANAGED_AGENT_RECENT_WINDOW = timedelta(hours=24)
 
+# The only lifecycle states the system understands. ``get_by_source`` ranks
+# these explicitly and the auth paths branch on them, so writing anything else
+# would silently change how an agent resolves and authenticates.
+MANAGED_AGENT_LIFECYCLE_STATES = frozenset({"active", "suspended", "decommissioned"})
+
 
 def normalize_managed_agent_kind(
     session_source_type: Optional[str], *, agent_kind: Optional[str] = None
@@ -346,7 +351,8 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         agent, which nondeterministically blocked runtime token issuance and
         broke key-to-agent resolution on the gateway auth path. Resolution is
         therefore explicit: most usable lifecycle first (active, then the
-        resumable suspended, then decommissioned), then most recent.
+        resumable suspended, then decommissioned, then anything unrecognised),
+        then most recent.
 
         Args:
             db: Database session.
@@ -357,11 +363,14 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         Returns:
             The best-matching managed agent, or None when there is no match.
         """
+        # Unknown states sort last, not between suspended and decommissioned:
+        # an unrecognised value is the one case where we know least, so it must
+        # never win over a state we do understand.
         lifecycle_rank = case(
             (self.model.lifecycle_state == "active", 0),
             (self.model.lifecycle_state == "suspended", 1),
-            (self.model.lifecycle_state == "decommissioned", 3),
-            else_=2,
+            (self.model.lifecycle_state == "decommissioned", 2),
+            else_=99,
         )
         return (
             db.query(self.model)
@@ -412,14 +421,33 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         return query.order_by(self.model.created_at.desc()).all()
 
     def get_for_account(
-        self, db: Session, *, account_id: str, agent_id: str
+        self,
+        db: Session,
+        *,
+        account_id: str,
+        agent_id: str,
+        for_update: bool = False,
     ) -> Optional[ManagedAgent]:
-        """Return one managed agent scoped to the given account."""
-        return (
-            db.query(self.model)
-            .filter(self.model.account_id == account_id, self.model.id == agent_id)
-            .first()
+        """Return one managed agent scoped to the given account.
+
+        Args:
+            db: Database session.
+            account_id: Account the agent must belong to.
+            agent_id: Identifier of the agent to load.
+            for_update: Take a row lock (``SELECT ... FOR UPDATE``) so the
+                caller can read ``lifecycle_state``, decide on it, and write
+                without a concurrent operator action landing in between. Only
+                meaningful inside a transaction that commits afterwards.
+
+        Returns:
+            The managed agent, or ``None`` when no such agent exists.
+        """
+        query = db.query(self.model).filter(
+            self.model.account_id == account_id, self.model.id == agent_id
         )
+        if for_update:
+            query = query.with_for_update()
+        return query.first()
 
     def touch_last_seen_for_principal(
         self,
@@ -470,7 +498,19 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         set_tags: bool = False,
         commit: bool = True,
     ) -> Optional[ManagedAgent]:
-        """Update ownership and lifecycle controls for one managed agent."""
+        """Update ownership and lifecycle controls for one managed agent.
+
+        Raises:
+            ValueError: If ``lifecycle_state`` is not a recognised state.
+        """
+        if (
+            lifecycle_state is not None
+            and lifecycle_state not in MANAGED_AGENT_LIFECYCLE_STATES
+        ):
+            raise ValueError(
+                f"Invalid managed agent lifecycle_state {lifecycle_state!r}; "
+                f"expected one of {sorted(MANAGED_AGENT_LIFECYCLE_STATES)}"
+            )
         db_obj = self.get_for_account(db, account_id=account_id, agent_id=agent_id)
         if db_obj is None:
             return None
@@ -483,6 +523,10 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
             db_obj.tags = tags
         if lifecycle_state is not None:
             db_obj.lifecycle_state = lifecycle_state
+            # Reset deliberately, including to None. lifecycle_reason explains
+            # the CURRENT state, alongside lifecycle_updated_at; carrying a
+            # previous transition's reason forward would label a resumed agent
+            # with the reason it was paused.
             db_obj.lifecycle_reason = lifecycle_reason
             db_obj.lifecycle_updated_at = now
             # Only the terminal state unbinds the runtime session. Pausing is

--- a/backend/preloop/models/crud/managed_agent.py
+++ b/backend/preloop/models/crud/managed_agent.py
@@ -337,13 +337,43 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         session_source_type: str,
         session_source_id: str,
     ) -> Optional[ManagedAgent]:
-        """Look up one agent by its durable source identity."""
+        """Look up one agent by its durable source identity, deterministically.
+
+        A unique constraint normally keeps one row per
+        ``(account, source_type, source_id)``, but sibling rows do exist in
+        the field (rekey/merge races, databases restored from older dumps).
+        An unordered ``.first()`` let a stale archived sibling shadow the live
+        agent, which nondeterministically blocked runtime token issuance and
+        broke key-to-agent resolution on the gateway auth path. Resolution is
+        therefore explicit: most usable lifecycle first (active, then the
+        resumable suspended, then decommissioned), then most recent.
+
+        Args:
+            db: Database session.
+            account_id: Account that owns the agent.
+            session_source_type: Durable principal type.
+            session_source_id: Durable principal id.
+
+        Returns:
+            The best-matching managed agent, or None when there is no match.
+        """
+        lifecycle_rank = case(
+            (self.model.lifecycle_state == "active", 0),
+            (self.model.lifecycle_state == "suspended", 1),
+            (self.model.lifecycle_state == "decommissioned", 3),
+            else_=2,
+        )
         return (
             db.query(self.model)
             .filter(
                 self.model.account_id == account_id,
                 self.model.session_source_type == session_source_type,
                 self.model.session_source_id == session_source_id,
+            )
+            .order_by(
+                lifecycle_rank.asc(),
+                self.model.created_at.desc(),
+                self.model.id.desc(),
             )
             .first()
         )
@@ -455,7 +485,11 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
             db_obj.lifecycle_state = lifecycle_state
             db_obj.lifecycle_reason = lifecycle_reason
             db_obj.lifecycle_updated_at = now
-            if lifecycle_state in {"suspended", "decommissioned"}:
+            # Only the terminal state unbinds the runtime session. Pausing is
+            # reversible and every auth path rejects non-active agents on each
+            # request, so dropping the binding here would just make resume
+            # unable to restore the agent to its previous state.
+            if lifecycle_state == "decommissioned":
                 db_obj.runtime_session_id = None
         db.add(db_obj)
         if commit:

--- a/backend/preloop/models/crud/runtime_session.py
+++ b/backend/preloop/models/crud/runtime_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional
 
@@ -22,6 +23,8 @@ from ..models.api_usage import ApiUsage
 from ..models.flow import Flow
 from ..models.runtime_session import RuntimeSession
 from .base import CRUDBase
+
+logger = logging.getLogger(__name__)
 
 _summary_columns_cache: dict[int, bool] = {}
 
@@ -339,11 +342,21 @@ class CRUDRuntimeSession(CRUDBase[RuntimeSession]):
             session_source_type=session_source_type,
             session_source_id=session_source_id,
         )
-        if db_obj is None or db_obj.ended_at is None:
+        if db_obj is None:
+            logger.info(
+                "No runtime session to reopen for %s/%s (account %s)",
+                session_source_type,
+                session_source_id,
+                account_id,
+            )
+            return None
+        if db_obj.ended_at is None:
+            # Already open: resuming an agent that was never session-ended.
             return db_obj
         now = datetime.now(UTC)
         db_obj.ended_at = None
-        db_obj.started_at = db_obj.started_at or now
+        # started_at is NOT NULL, so it is left alone: reopening continues the
+        # original session rather than pretending it began now.
         db_obj.last_activity_at = now
         db.add(db_obj)
         if commit:

--- a/backend/preloop/models/crud/runtime_session.py
+++ b/backend/preloop/models/crud/runtime_session.py
@@ -307,6 +307,52 @@ class CRUDRuntimeSession(CRUDBase[RuntimeSession]):
             db.flush()
         return db_obj
 
+    def reopen_for_managed_agent(
+        self,
+        db: Session,
+        *,
+        account_id: str,
+        session_source_type: str,
+        session_source_id: str,
+        commit: bool = True,
+    ) -> Optional[RuntimeSession]:
+        """Reopen the identity session of a resumed managed agent.
+
+        A previous release stamped ``ended_at`` when an agent was suspended
+        and never cleared it, so session-bound runtime keys kept failing after
+        resume. Reopening is a no-op when no session exists or the session is
+        already open.
+
+        Args:
+            db: Database session.
+            account_id: Account that owns the session.
+            session_source_type: Durable principal type of the agent.
+            session_source_id: Durable principal id of the agent.
+            commit: Commit the transaction when True.
+
+        Returns:
+            The reopened session, or None when there is nothing to reopen.
+        """
+        db_obj = self.get_by_source(
+            db,
+            account_id=account_id,
+            session_source_type=session_source_type,
+            session_source_id=session_source_id,
+        )
+        if db_obj is None or db_obj.ended_at is None:
+            return db_obj
+        now = datetime.now(UTC)
+        db_obj.ended_at = None
+        db_obj.started_at = db_obj.started_at or now
+        db_obj.last_activity_at = now
+        db.add(db_obj)
+        if commit:
+            db.commit()
+            db.refresh(db_obj)
+        else:
+            db.flush()
+        return db_obj
+
     def upsert_by_source(
         self,
         db: Session,

--- a/backend/tests/endpoints/test_account_agents.py
+++ b/backend/tests/endpoints/test_account_agents.py
@@ -1458,6 +1458,72 @@ def test_account_agent_resume_does_not_revive_operator_revoked_credentials(
     assert durable_key.is_active is False
 
 
+def test_account_agent_resume_does_not_revive_expired_credentials(
+    client, db_session, test_user
+):
+    """Healing on resume must never reactivate a key that has expired.
+
+    The expiry filter runs in SQL, so this also guards against the filter
+    silently not matching the column's naive-UTC storage.
+    """
+    from datetime import timedelta
+
+    from preloop.models.crud import crud_api_key
+
+    agent_id, durable_token = _seed_pauseable_agent(
+        client, db_session, test_user, source_id="expired-credential-host"
+    )
+    agent = crud_managed_agent.get_for_account(
+        db_session, account_id=str(test_user.account_id), agent_id=agent_id
+    )
+    assert agent is not None
+
+    # Recreate a legacy-bricked agent (the only state that has keys to heal)
+    # whose durable key has since expired.
+    agent.lifecycle_state = "suspended"
+    db_session.add(agent)
+    crud_api_key.deactivate_runtime_keys_for_managed_agent(
+        db_session,
+        account_id=test_user.account_id,
+        managed_agent_id=agent_id,
+        commit=False,
+    )
+    durable_key = crud_api_key.get_by_key(db_session, key=durable_token)
+    assert durable_key is not None
+    durable_key.expires_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
+    db_session.add(durable_key)
+    db_session.flush()
+    assert durable_key.is_active is False
+
+    resume_response = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"lifecycle_action": "resume"},
+    )
+    assert resume_response.status_code == 200
+
+    db_session.refresh(durable_key)
+    assert durable_key.is_expired is True
+    assert durable_key.is_active is False
+
+
+def test_managed_agent_update_operator_state_rejects_unknown_lifecycle_state(
+    db_session, test_user
+):
+    """The CRUD layer refuses a lifecycle state the rest of the system cannot read."""
+    import pytest as _pytest
+
+    from preloop.models.crud import crud_managed_agent
+
+    with _pytest.raises(ValueError, match="Invalid managed agent lifecycle_state"):
+        crud_managed_agent.update_operator_state(
+            db_session,
+            account_id=str(test_user.account_id),
+            agent_id=str(uuid4()),
+            lifecycle_state="bypass",
+            commit=False,
+        )
+
+
 def test_account_agent_decommission_still_revokes_credentials(
     client, db_session, test_user
 ):

--- a/backend/tests/endpoints/test_account_agents.py
+++ b/backend/tests/endpoints/test_account_agents.py
@@ -1,6 +1,7 @@
 """Endpoint tests for managed-agent registry surfaces."""
 
 from datetime import UTC, datetime
+from unittest.mock import patch
 from uuid import uuid4
 
 from preloop.api.endpoints.account import (
@@ -16,6 +17,7 @@ from preloop.models.crud import (
     crud_runtime_session,
     crud_runtime_session_activity,
 )
+from preloop.models.models.api_usage import ApiUsage
 from preloop.models.models.mcp_server import MCPServer
 from preloop.models.models.mcp_tool import MCPTool
 
@@ -1176,6 +1178,313 @@ def test_account_agent_update_endpoint_controls_lifecycle_and_owner(
     )
     assert reenroll_response.status_code == 200
     assert reenroll_response.json()["lifecycle_state"] == "active"
+
+
+def _seed_pauseable_agent(client, db_session, test_user, *, source_id: str):
+    """Onboard one managed agent and return ``(agent_id, durable_token)``.
+
+    Mirrors the CLI onboarding shape: a runtime-session token mints the
+    registry entry, then a durable credential is created and written into the
+    local agent config as ``ANTHROPIC_API_KEY``.
+
+    Args:
+        client: FastAPI test client.
+        db_session: Active database session.
+        test_user: Authenticated account owner.
+        source_id: Durable principal id for the simulated local agent.
+
+    Returns:
+        Tuple of the managed-agent id and its durable credential token.
+    """
+    token_response = client.post(
+        "/api/v1/auth/runtime-sessions/token",
+        json={
+            "session_source_type": "claude_code",
+            "session_source_id": source_id,
+            "runtime_principal_name": "Claude Code",
+        },
+    )
+    assert token_response.status_code == 201
+
+    agent = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id=source_id,
+    )
+    assert agent is not None
+    agent_id = str(agent.id)
+
+    credential_response = client.post(
+        f"/api/v1/agents/{agent_id}/credentials",
+        json={
+            "name": "durable-gateway-credential",
+            "expires_in_days": 365,
+            "scopes": ["mcp:read", "mcp:write"],
+        },
+    )
+    assert credential_response.status_code == 201
+    return agent_id, credential_response.json()["token"]
+
+
+def _post_anthropic_message(client, token: str):
+    """Drive one gateway request with a durable agent credential."""
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value={
+            "id": "msg_pause_resume",
+            "created": 1710000000,
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "pong"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+        },
+    ):
+        return client.post(
+            "/anthropic/v1/messages",
+            headers={"x-api-key": token, "anthropic-version": "2023-06-01"},
+            json={
+                "model": "anthropic/claude-pause-resume",
+                "messages": [{"role": "user", "content": "ping"}],
+                "max_tokens": 64,
+            },
+        )
+
+
+def _seed_anthropic_gateway_model(db_session, account_id) -> None:
+    """Create the gateway-enabled model the pause/resume tests dispatch to."""
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Pause Resume Model",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "anthropic/claude-pause-resume",
+                    "provider_adapter": "preloop",
+                }
+            },
+        },
+        account_id=account_id,
+    )
+
+
+def _usage_count(db_session, account_id) -> int:
+    """Count persisted Anthropic-gateway usage rows for one account."""
+    return (
+        db_session.query(ApiUsage)
+        .filter(
+            ApiUsage.account_id == account_id,
+            ApiUsage.endpoint == "/anthropic/v1/messages",
+        )
+        .count()
+    )
+
+
+def test_account_agent_pause_then_resume_restores_gateway_traffic(
+    client, db_session, test_user
+):
+    """Pause must block gateway traffic and resume must restore it.
+
+    Regression for the halt/resume asymmetry: suspend deactivated every
+    runtime API key while resume only flipped the lifecycle flag back, so a
+    resumed agent 401'd forever with no usage row ever written.
+    """
+    _seed_anthropic_gateway_model(db_session, test_user.account_id)
+    agent_id, durable_token = _seed_pauseable_agent(
+        client, db_session, test_user, source_id="pause-resume-host"
+    )
+
+    before = _post_anthropic_message(client, durable_token)
+    assert before.status_code == 200, before.text
+    assert _usage_count(db_session, test_user.account_id) == 1
+
+    pause_response = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"lifecycle_action": "suspend", "reason": "paused by admin"},
+    )
+    assert pause_response.status_code == 200
+    assert pause_response.json()["lifecycle_state"] == "suspended"
+
+    paused = _post_anthropic_message(client, durable_token)
+    assert paused.status_code == 401
+    assert _usage_count(db_session, test_user.account_id) == 1
+
+    resume_response = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"lifecycle_action": "resume", "reason": "resumed by admin"},
+    )
+    assert resume_response.status_code == 200
+    assert resume_response.json()["lifecycle_state"] == "active"
+
+    after = _post_anthropic_message(client, durable_token)
+    assert after.status_code == 200, after.text
+    assert _usage_count(db_session, test_user.account_id) == 2
+
+
+def test_account_agent_pause_then_reenroll_restores_gateway_traffic(
+    client, db_session, test_user
+):
+    """The CLI's reenroll action must also restore gateway function."""
+    _seed_anthropic_gateway_model(db_session, test_user.account_id)
+    agent_id, durable_token = _seed_pauseable_agent(
+        client, db_session, test_user, source_id="pause-reenroll-host"
+    )
+
+    pause_response = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"lifecycle_action": "suspend", "reason": "paused by admin"},
+    )
+    assert pause_response.status_code == 200
+    assert _post_anthropic_message(client, durable_token).status_code == 401
+
+    reenroll_response = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"lifecycle_action": "reenroll"},
+    )
+    assert reenroll_response.status_code == 200
+    assert reenroll_response.json()["lifecycle_state"] == "active"
+
+    after = _post_anthropic_message(client, durable_token)
+    assert after.status_code == 200, after.text
+    assert _usage_count(db_session, test_user.account_id) == 1
+
+
+def test_account_agent_resume_heals_legacy_revoked_credentials(
+    client, db_session, test_user
+):
+    """Resume must revive agents left dead by the old revoke-on-suspend release.
+
+    Reproduces the state a shipped release leaves behind: lifecycle
+    ``suspended``, durable key ``is_active = False`` and the bound session
+    stamped ``ended_at``. Resume has to undo all three or the agent stays
+    silently dead in production.
+    """
+    from preloop.models.crud import crud_api_key
+
+    _seed_anthropic_gateway_model(db_session, test_user.account_id)
+    agent_id, durable_token = _seed_pauseable_agent(
+        client, db_session, test_user, source_id="legacy-halted-host"
+    )
+    agent = crud_managed_agent.get_for_account(
+        db_session, account_id=str(test_user.account_id), agent_id=agent_id
+    )
+    assert agent is not None
+    runtime_session_id = str(agent.runtime_session_id)
+
+    # Recreate the pre-fix suspension exactly.
+    agent.lifecycle_state = "suspended"
+    agent.lifecycle_reason = "halted by the previous release"
+    agent.runtime_session_id = None
+    db_session.add(agent)
+    crud_api_key.deactivate_runtime_keys_for_managed_agent(
+        db_session,
+        account_id=test_user.account_id,
+        managed_agent_id=agent_id,
+        commit=False,
+    )
+    crud_runtime_session.update_operator_state(
+        db_session,
+        account_id=str(test_user.account_id),
+        runtime_session_id=runtime_session_id,
+        ended_at=datetime.now(UTC),
+        commit=False,
+    )
+    db_session.flush()
+    assert _post_anthropic_message(client, durable_token).status_code == 401
+
+    resume_response = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"lifecycle_action": "resume"},
+    )
+    assert resume_response.status_code == 200
+
+    durable_key = crud_api_key.get_by_key(db_session, key=durable_token)
+    assert durable_key is not None
+    db_session.refresh(durable_key)
+    assert durable_key.is_active is True
+
+    runtime_session = crud_runtime_session.get_account_session(
+        db_session,
+        account_id=str(test_user.account_id),
+        runtime_session_id=runtime_session_id,
+    )
+    assert runtime_session is not None
+    assert runtime_session.ended_at is None
+
+    after = _post_anthropic_message(client, durable_token)
+    assert after.status_code == 200, after.text
+    assert _usage_count(db_session, test_user.account_id) == 1
+
+
+def test_account_agent_resume_does_not_revive_operator_revoked_credentials(
+    client, db_session, test_user
+):
+    """Healing on resume must never resurrect a deliberately revoked credential."""
+    from preloop.models.crud import crud_api_key
+
+    agent_id, durable_token = _seed_pauseable_agent(
+        client, db_session, test_user, source_id="revoked-credential-host"
+    )
+    detail_response = client.get(f"/api/v1/agents/{agent_id}")
+    assert detail_response.status_code == 200
+    credential_id = detail_response.json()["credentials"][0]["id"]
+
+    revoke_response = client.delete(
+        f"/api/v1/agents/{agent_id}/credentials/{credential_id}"
+    )
+    assert revoke_response.status_code == 200
+
+    pause_response = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"lifecycle_action": "suspend", "reason": "paused by admin"},
+    )
+    assert pause_response.status_code == 200
+    resume_response = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"lifecycle_action": "resume"},
+    )
+    assert resume_response.status_code == 200
+
+    durable_key = crud_api_key.get_by_key(db_session, key=durable_token)
+    assert durable_key is not None
+    db_session.refresh(durable_key)
+    assert durable_key.is_active is False
+
+
+def test_account_agent_decommission_still_revokes_credentials(
+    client, db_session, test_user
+):
+    """Decommission keeps hard credential revocation (offboard semantics)."""
+    from preloop.models.crud import crud_api_key
+
+    _agent_id, durable_token = _seed_pauseable_agent(
+        client, db_session, test_user, source_id="decommission-revokes-host"
+    )
+    agent = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="decommission-revokes-host",
+    )
+    assert agent is not None
+
+    decommission_response = client.patch(
+        f"/api/v1/agents/{agent.id}",
+        json={"lifecycle_action": "decommission", "reason": "offboarded"},
+    )
+    assert decommission_response.status_code == 200
+
+    durable_key = crud_api_key.get_by_key(db_session, key=durable_token)
+    assert durable_key is not None
+    db_session.refresh(durable_key)
+    assert durable_key.is_active is False
 
 
 def test_account_agent_detail_includes_credentials_and_enrollments(

--- a/backend/tests/endpoints/test_runtime_session_tokens.py
+++ b/backend/tests/endpoints/test_runtime_session_tokens.py
@@ -515,11 +515,10 @@ def test_runtime_session_token_issuance_succeeds_after_reenroll(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("lifecycle_action", ["suspend", "decommission"])
-async def test_existing_runtime_session_token_is_revoked_for_non_active_agents(
-    client, db_session, test_user, lifecycle_action
+async def test_existing_runtime_session_token_is_revoked_on_decommission(
+    client, db_session, test_user
 ):
-    """Suspending or decommissioning an agent should revoke its existing runtime token."""
+    """Decommissioning an agent should hard-revoke its existing runtime token."""
     initial_response = client.post(
         "/api/v1/auth/runtime-sessions/token",
         json={
@@ -551,8 +550,8 @@ async def test_existing_runtime_session_token_is_revoked_for_non_active_agents(
     update_response = client.patch(
         f"/api/v1/agents/{managed_agent_id}",
         json={
-            "lifecycle_action": lifecycle_action,
-            "reason": f"{lifecycle_action} for operator control",
+            "lifecycle_action": "decommission",
+            "reason": "decommission for operator control",
         },
     )
     assert update_response.status_code == 200
@@ -572,9 +571,7 @@ async def test_existing_runtime_session_token_is_revoked_for_non_active_agents(
     )
     assert managed_agent is not None
     assert managed_agent.runtime_session_id is None
-    assert managed_agent.lifecycle_state == (
-        "suspended" if lifecycle_action == "suspend" else "decommissioned"
-    )
+    assert managed_agent.lifecycle_state == "decommissioned"
 
     api_key = crud_api_key.get_by_key(db_session, key=token)
     assert api_key is not None
@@ -586,6 +583,79 @@ async def test_existing_runtime_session_token_is_revoked_for_non_active_agents(
     ):
         assert await get_user_from_token_if_valid(token, db_session) is None
         assert await authenticate_bearer_token(token, db_session) is None
+
+
+@pytest.mark.asyncio
+async def test_pause_blocks_runtime_token_without_revoking_credentials(
+    client, db_session, test_user
+):
+    """Pause must block auth by lifecycle alone, leaving credentials intact.
+
+    Pausing used to deactivate the agent's API keys, which made it
+    irreversible: resume only flipped the lifecycle flag back, so the durable
+    credential stayed dead. Auth must reject the paused agent while the key
+    row itself survives for resume.
+    """
+    initial_response = client.post(
+        "/api/v1/auth/runtime-sessions/token",
+        json={
+            "session_source_type": "claude_code",
+            "session_source_id": "workspace-lifecycle-pause",
+            "runtime_principal_name": "Lifecycle Pause Workspace",
+        },
+    )
+    assert initial_response.status_code == 201
+    token = initial_response.json()["token"]
+    runtime_session_id = initial_response.json()["runtime_session_id"]
+
+    managed_agent = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="workspace-lifecycle-pause",
+    )
+    assert managed_agent is not None
+    managed_agent_id = str(managed_agent.id)
+
+    update_response = client.patch(
+        f"/api/v1/agents/{managed_agent_id}",
+        json={"lifecycle_action": "suspend", "reason": "paused for operator control"},
+    )
+    assert update_response.status_code == 200
+
+    # Auth is rejected purely on lifecycle state, re-read per request.
+    with patch(
+        "preloop.api.auth.jwt.get_db_session",
+        side_effect=lambda: iter([db_session]),
+    ):
+        assert await get_user_from_token_if_valid(token, db_session) is None
+        assert await authenticate_bearer_token(token, db_session) is None
+
+    api_key = crud_api_key.get_by_key(db_session, key=token)
+    assert api_key is not None
+    db_session.refresh(api_key)
+    assert api_key.is_active is True
+
+    runtime_session = crud_runtime_session.get_account_session(
+        db_session,
+        account_id=str(test_user.account_id),
+        runtime_session_id=str(runtime_session_id),
+    )
+    assert runtime_session is not None
+    assert runtime_session.ended_at is None
+
+    resume_response = client.patch(
+        f"/api/v1/agents/{managed_agent_id}",
+        json={"lifecycle_action": "resume"},
+    )
+    assert resume_response.status_code == 200
+
+    with patch(
+        "preloop.api.auth.jwt.get_db_session",
+        side_effect=lambda: iter([db_session]),
+    ):
+        assert await get_user_from_token_if_valid(token, db_session) is not None
+        assert await authenticate_bearer_token(token, db_session) is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/models/crud/test_managed_agent_get_by_source.py
+++ b/backend/tests/models/crud/test_managed_agent_get_by_source.py
@@ -1,0 +1,167 @@
+"""Determinism tests for managed-agent source lookups."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from sqlalchemy import text
+
+from preloop.models import models
+from preloop.models.crud import crud_managed_agent
+
+
+def _make_agent(
+    db_session,
+    test_user,
+    *,
+    source_id: str,
+    source_type: str = "claude_code",
+    lifecycle_state: str = "active",
+    created_at: datetime | None = None,
+) -> models.ManagedAgent:
+    """Insert one managed-agent row for source-lookup tests.
+
+    Args:
+        db_session: Active database session.
+        test_user: Account owner fixture.
+        source_id: Durable principal id.
+        source_type: Durable principal type.
+        lifecycle_state: Lifecycle marker for the row.
+        created_at: Explicit creation timestamp for ordering assertions.
+
+    Returns:
+        The persisted managed agent.
+    """
+    now = datetime.now(UTC).replace(tzinfo=None)
+    agent = models.ManagedAgent(
+        id=uuid4(),
+        account_id=test_user.account_id,
+        runtime_session_id=None,
+        agent_kind=source_type,
+        session_source_type=source_type,
+        session_source_id=source_id,
+        display_name=f"{source_type} {source_id} {lifecycle_state}",
+        enrolled_via="runtime_session_token",
+        lifecycle_state=lifecycle_state,
+        lifecycle_updated_at=now,
+        last_seen_at=now,
+        created_at=created_at or now,
+    )
+    db_session.add(agent)
+    db_session.flush()
+    return agent
+
+
+def _drop_source_unique_constraint(db_session) -> None:
+    """Allow sibling rows sharing one source identity inside this test.
+
+    Production guards duplicates with ``uq_managed_agent_account_source``, but
+    databases restored from older dumps (and merge/rekey races) can still hold
+    siblings, which is exactly the state ``get_by_source`` must resolve
+    deterministically. The DDL is rolled back with the test transaction.
+    """
+    db_session.execute(
+        text(
+            "ALTER TABLE managed_agent "
+            "DROP CONSTRAINT IF EXISTS uq_managed_agent_account_source"
+        )
+    )
+
+
+def test_get_by_source_prefers_active_over_archived_siblings(db_session, test_user):
+    """A stale decommissioned sibling must never shadow the active row."""
+    _drop_source_unique_constraint(db_session)
+    base = datetime.now(UTC).replace(tzinfo=None)
+    archived = _make_agent(
+        db_session,
+        test_user,
+        source_id="shadowed-host",
+        lifecycle_state="decommissioned",
+        created_at=base,
+    )
+    suspended = _make_agent(
+        db_session,
+        test_user,
+        source_id="shadowed-host",
+        lifecycle_state="suspended",
+        created_at=base + timedelta(minutes=1),
+    )
+    active = _make_agent(
+        db_session,
+        test_user,
+        source_id="shadowed-host",
+        lifecycle_state="active",
+        created_at=base - timedelta(days=1),
+    )
+
+    resolved = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="shadowed-host",
+    )
+
+    assert resolved is not None
+    assert str(resolved.id) == str(active.id)
+    assert str(resolved.id) not in {str(archived.id), str(suspended.id)}
+
+
+def test_get_by_source_prefers_suspended_over_decommissioned(db_session, test_user):
+    """With no active row, a resumable suspended row wins over an archived one."""
+    _drop_source_unique_constraint(db_session)
+    base = datetime.now(UTC).replace(tzinfo=None)
+    _make_agent(
+        db_session,
+        test_user,
+        source_id="archived-only-host",
+        lifecycle_state="decommissioned",
+        created_at=base,
+    )
+    suspended = _make_agent(
+        db_session,
+        test_user,
+        source_id="archived-only-host",
+        lifecycle_state="suspended",
+        created_at=base - timedelta(days=2),
+    )
+
+    resolved = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="archived-only-host",
+    )
+
+    assert resolved is not None
+    assert str(resolved.id) == str(suspended.id)
+
+
+def test_get_by_source_breaks_ties_by_recency(db_session, test_user):
+    """Same-lifecycle siblings resolve to the most recently created row."""
+    _drop_source_unique_constraint(db_session)
+    base = datetime.now(UTC).replace(tzinfo=None)
+    _make_agent(
+        db_session,
+        test_user,
+        source_id="tied-host",
+        lifecycle_state="active",
+        created_at=base - timedelta(days=3),
+    )
+    newest = _make_agent(
+        db_session,
+        test_user,
+        source_id="tied-host",
+        lifecycle_state="active",
+        created_at=base,
+    )
+
+    resolved = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="tied-host",
+    )
+
+    assert resolved is not None
+    assert str(resolved.id) == str(newest.id)

--- a/backend/tests/models/crud/test_managed_agent_get_by_source.py
+++ b/backend/tests/models/crud/test_managed_agent_get_by_source.py
@@ -165,3 +165,39 @@ def test_get_by_source_breaks_ties_by_recency(db_session, test_user):
 
     assert resolved is not None
     assert str(resolved.id) == str(newest.id)
+
+
+def test_get_by_source_ranks_unknown_lifecycle_last(db_session, test_user):
+    """An unrecognised lifecycle state never outranks a state we understand.
+
+    A row written outside the API (a direct DB mutation, or a state added by a
+    future release and read by an older one) must not shadow a decommissioned
+    sibling, because ranking it higher would resolve token issuance to a row
+    whose semantics this code does not know.
+    """
+    _drop_source_unique_constraint(db_session)
+    base = datetime.now(UTC).replace(tzinfo=None)
+    decommissioned = _make_agent(
+        db_session,
+        test_user,
+        source_id="unknown-state-host",
+        lifecycle_state="decommissioned",
+        created_at=base - timedelta(days=1),
+    )
+    _make_agent(
+        db_session,
+        test_user,
+        source_id="unknown-state-host",
+        lifecycle_state="bypass",
+        created_at=base,
+    )
+
+    resolved = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="unknown-state-host",
+    )
+
+    assert resolved is not None
+    assert str(resolved.id) == str(decommissioned.id)

--- a/frontend/src/utils/agent-display.test.ts
+++ b/frontend/src/utils/agent-display.test.ts
@@ -1,0 +1,93 @@
+import { expect } from '@open-wc/testing';
+
+import type { ManagedAgentSummary } from '../types';
+import {
+  getAgentLifecycleLabel,
+  getAgentLifecycleVariant,
+  getSystemAgentTags,
+  getVisibleAgentTags,
+  isSystemAgentTag,
+} from './agent-display';
+
+const baseAgent = {
+  id: 'agent-1',
+  runtime_session_id: null,
+  owner_user_id: null,
+  owner_username: null,
+  owner_email: null,
+  display_name: 'OpenClaw',
+  session_source_type: 'openclaw',
+  session_source_id: 'openclaw-1',
+  session_reference: null,
+  enrolled_via: 'cli',
+  managed_mcp_servers: [],
+  lifecycle_state: 'active',
+  lifecycle_reason: null,
+  lifecycle_updated_at: null,
+  is_active_now: false,
+  activity_status: 'idle',
+  last_seen_at: new Date().toISOString(),
+  started_at: null,
+  last_activity_at: null,
+  ended_at: null,
+  total_requests: 0,
+  estimated_cost: 0,
+  configured_model_alias: null,
+  latest_model_alias: null,
+  latest_provider_name: null,
+  last_request_at: null,
+  mcp_proxy_configured: false,
+  model_gateway_configured: false,
+  onboarding_state: 'incomplete',
+  live_validation_supported: false,
+  live_validation_passed: null,
+  live_validation_status: 'unsupported',
+  last_validated_at: null,
+} satisfies ManagedAgentSummary;
+
+describe('agent lifecycle presentation', () => {
+  it('labels a suspended agent as Paused, not Halted', () => {
+    const agent = { ...baseAgent, lifecycle_state: 'suspended' };
+
+    expect(getAgentLifecycleLabel(agent)).to.equal('Paused');
+  });
+
+  it('renders pause in warning tones so danger stays for offboarding', () => {
+    expect(
+      getAgentLifecycleVariant({ ...baseAgent, lifecycle_state: 'suspended' })
+    ).to.equal('warning');
+    expect(
+      getAgentLifecycleVariant({
+        ...baseAgent,
+        lifecycle_state: 'decommissioned',
+      })
+    ).to.equal('danger');
+  });
+});
+
+describe('agent tag visibility', () => {
+  const tags = {
+    team: 'platform',
+    'identity.previous_ids': 'openclaw-0,openclaw-00',
+  };
+
+  it('treats the identity namespace as server bookkeeping', () => {
+    expect(isSystemAgentTag('identity.previous_ids')).to.equal(true);
+    expect(isSystemAgentTag('team')).to.equal(false);
+  });
+
+  it('hides identity tags from the default chip row', () => {
+    expect(getVisibleAgentTags(tags)).to.deep.equal([['team', 'platform']]);
+  });
+
+  it('keeps identity tags so a tag edit cannot drop them', () => {
+    expect(getSystemAgentTags(tags)).to.deep.equal({
+      'identity.previous_ids': 'openclaw-0,openclaw-00',
+    });
+  });
+
+  it('tolerates agents without tags', () => {
+    expect(getVisibleAgentTags(null)).to.deep.equal([]);
+    expect(getSystemAgentTags(undefined)).to.deep.equal({});
+  });
+});

--- a/frontend/src/utils/agent-display.ts
+++ b/frontend/src/utils/agent-display.ts
@@ -19,17 +19,43 @@ export function getAgentLifecycleVariant(agent: ManagedAgentSummary): string {
 
 export function getAgentLifecycleLabel(agent: ManagedAgentSummary): string {
   if (agent.lifecycle_state === 'decommissioned') return 'Decommissioned';
-  if (agent.lifecycle_state === 'suspended') return 'Suspended';
+  if (agent.lifecycle_state === 'suspended') return 'Paused';
   if (agent.activity_status === 'active_now') return 'Active now';
   if (agent.activity_status === 'recently_active') return 'Recently active';
   if (agent.ended_at) return 'Ended';
   return 'Idle';
 }
 
+/**
+ * Tags in the reserved `identity.*` namespace are written by the server
+ * (re-keying records `identity.previous_ids=...`). They are bookkeeping, not
+ * operator labels, so they stay out of the default chip rows and out of the
+ * tag editor — while still being preserved on save.
+ */
+export function isSystemAgentTag(key: string): boolean {
+  return key.startsWith('identity.');
+}
+
+/** Operator-authored tags, i.e. everything outside the system namespaces. */
+export function getVisibleAgentTags(
+  tags: Record<string, string> | null | undefined
+): [string, string][] {
+  return Object.entries(tags || {}).filter(([key]) => !isSystemAgentTag(key));
+}
+
+/** Server-owned tags that must survive an operator tag edit. */
+export function getSystemAgentTags(
+  tags: Record<string, string> | null | undefined
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(tags || {}).filter(([key]) => isSystemAgentTag(key))
+  );
+}
+
 export function renderAgentIdentityBadges(
   agent: ManagedAgentSummary
 ): TemplateResult {
-  const tags = Object.entries(agent.tags || {});
+  const tags = getVisibleAgentTags(agent.tags);
   return html`
     <div class="agent-identity-badges">
       <sl-badge variant="${getAgentLifecycleVariant(agent)}" pill>

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -61,7 +61,11 @@ import {
 } from '../../utils/scoped-governance';
 import { getAgentControlState } from '../../utils/agent-control';
 import { renderAgentIcon } from '../../utils/agent-icons';
-import { getAgentSourceLabel } from '../../utils/agent-display';
+import {
+  getAgentSourceLabel,
+  getSystemAgentTags,
+  getVisibleAgentTags,
+} from '../../utils/agent-display';
 
 interface GovernanceToolDefinition {
   name: string;
@@ -721,7 +725,7 @@ export class AgentDetailView extends LitElement {
     if (!this.agent) return 'Unknown';
     if (this.agent.lifecycle_state === 'decommissioned')
       return 'Decommissioned';
-    if (this.agent.lifecycle_state === 'suspended') return 'Suspended';
+    if (this.agent.lifecycle_state === 'suspended') return 'Paused';
     if (this.agent.activity_status === 'active_now') return 'Active now';
     if (this.agent.activity_status === 'recently_active')
       return 'Recently active';
@@ -1049,7 +1053,7 @@ export class AgentDetailView extends LitElement {
 
   private promptEditTags(): void {
     if (!this.agent) return;
-    const currentTags = Object.entries(this.agent.tags || {})
+    const currentTags = getVisibleAgentTags(this.agent.tags)
       .map(([k, v]) => (v && v !== 'true' ? `${k}=${v}` : k))
       .join(' ');
 
@@ -1059,7 +1063,9 @@ export class AgentDetailView extends LitElement {
 
   private submitTagsDialog(): void {
     if (this.tagsDialogInput !== null) {
-      const tags: Record<string, string> = {};
+      // Server-owned identity.* tags are hidden from the editor, so carry
+      // them over explicitly; the PATCH replaces the whole tag map.
+      const tags: Record<string, string> = getSystemAgentTags(this.agent?.tags);
       this.tagsDialogInput.split(/\s+/).forEach((t: string) => {
         if (!t) return;
         const [k, ...vParts] = t.split('=');
@@ -1068,6 +1074,40 @@ export class AgentDetailView extends LitElement {
       void this.saveTags(tags);
     }
     this.showTagsDialog = false;
+  }
+
+  /**
+   * Render re-keying history behind a collapsed disclosure.
+   *
+   * Re-keying records the agent's superseded principal ids as an
+   * `identity.previous_ids` tag. It is useful for support, but rendering it
+   * as a normal tag chip put a long comma-separated id string in the header.
+   */
+  private renderIdentityHistory() {
+    const previousIds = (this.agent?.tags || {})['identity.previous_ids'];
+    if (!previousIds) return nothing;
+    const ids = previousIds
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean);
+    if (ids.length === 0) return nothing;
+    return html`
+      <details
+        style="margin-top: var(--sl-spacing-x-small); font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-600);"
+      >
+        <summary style="cursor: pointer;">
+          Identity history (${ids.length})
+        </summary>
+        <div style="display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px;">
+          ${ids.map(
+            (id) =>
+              html`<code style="font-size: var(--sl-font-size-x-small);"
+                >${id}</code
+              >`
+          )}
+        </div>
+      </details>
+    `;
   }
 
   private async saveTags(tags: Record<string, string>): Promise<void> {
@@ -1332,7 +1372,7 @@ export class AgentDetailView extends LitElement {
     if (!this.agentId || !this.agent) {
       return;
     }
-    const actionLabel = lifecycleAction === 'suspend' ? 'halt' : 'resume';
+    const actionLabel = lifecycleAction === 'suspend' ? 'pause' : 'resume';
     if (
       !window.confirm(
         `Are you sure you want to ${actionLabel} ${this.agent.display_name}?`
@@ -1346,7 +1386,7 @@ export class AgentDetailView extends LitElement {
         lifecycle_action: lifecycleAction,
         reason:
           lifecycleAction === 'suspend'
-            ? 'Manually halted by admin'
+            ? 'Manually paused by admin'
             : 'Manually resumed by admin',
       });
       await this.loadData();
@@ -1427,26 +1467,29 @@ export class AgentDetailView extends LitElement {
       this.agent.lifecycle_state === 'suspended' ||
       this.agent.lifecycle_state === 'decommissioned';
 
+    // Play/pause toggle in warning (amber) tones: pausing is reversible, so
+    // danger red stays reserved for offboard/remove.
     if (isSuspendedOrDecommissioned) {
       actions.push({
         id: 'resume',
         label: 'Resume',
         variant: 'success',
-        icon: 'plug',
+        icon: 'play-fill',
         loading: this.actionLoading,
         onClick: () => this.updateAgentLifecycle('resume'),
-        tooltip: "This action re-enables the agent's API keys.",
+        tooltip:
+          'Resume this agent. Its existing credentials start working again immediately.',
       });
     } else {
       actions.push({
-        id: 'halt',
-        label: 'Halt',
-        variant: 'danger',
-        icon: 'power',
+        id: 'pause',
+        label: 'Pause',
+        variant: 'warning',
+        icon: 'pause-fill',
         loading: this.actionLoading,
         onClick: () => this.updateAgentLifecycle('suspend'),
         tooltip:
-          "This action immediately disables the agent's API keys and is fully reversible.",
+          'Pause this agent. Requests are blocked while paused; Resume restores it without re-onboarding.',
       });
     }
 
@@ -2424,7 +2467,7 @@ export class AgentDetailView extends LitElement {
               </div>
 
               ${
-                this.agent.tags && Object.keys(this.agent.tags).length > 0
+                getVisibleAgentTags(this.agent.tags).length > 0
                   ? html`
                       <div
                         style="display: flex; gap: var(--sl-spacing-small); align-items: center; margin-top: var(--sl-spacing-x-small);"
@@ -2435,7 +2478,7 @@ export class AgentDetailView extends LitElement {
                           Tags:
                         </div>
                         <div style="display: flex; flex-wrap: wrap; gap: 4px;">
-                          ${Object.entries(this.agent.tags).map(
+                          ${getVisibleAgentTags(this.agent.tags).map(
                             ([k, v]) => html`
                               <sl-badge
                                 variant="neutral"
@@ -2457,6 +2500,7 @@ export class AgentDetailView extends LitElement {
                     `
                   : nothing
               }
+              ${this.renderIdentityHistory()}
             </div>
           </div>
 

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -48,7 +48,11 @@ import { reducedMotionStyles } from '../../styles/reduced-motion';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import { getAgentControlState } from '../../utils/agent-control';
 import { renderAgentIcon } from '../../utils/agent-icons';
-import { getAgentSourceLabel } from '../../utils/agent-display';
+import {
+  getAgentSourceLabel,
+  getSystemAgentTags,
+  getVisibleAgentTags,
+} from '../../utils/agent-display';
 
 const AVAILABLE_AGENT_KINDS = [
   { value: 'openclaw', label: 'OpenClaw' },
@@ -1749,7 +1753,7 @@ export class AgentsView extends LitElement {
 
   private getLifecycleLabel(agent: ManagedAgentSummary): string {
     if (agent.lifecycle_state === 'decommissioned') return 'Decommissioned';
-    if (agent.lifecycle_state === 'suspended') return 'Suspended';
+    if (agent.lifecycle_state === 'suspended') return 'Paused';
     if (agent.activity_status === 'active_now') return 'Active now';
     if (agent.activity_status === 'recently_active') return 'Recently active';
     if (agent.ended_at) return 'Ended';
@@ -2191,7 +2195,7 @@ export class AgentsView extends LitElement {
   }
 
   private promptEditAgentTags(agent: ManagedAgentSummary): void {
-    const currentTags = Object.entries(agent.tags || {})
+    const currentTags = getVisibleAgentTags(agent.tags)
       .map(([key, value]) =>
         value && value !== 'true' ? `${key}=${value}` : key
       )
@@ -2202,7 +2206,8 @@ export class AgentsView extends LitElement {
     );
     if (input === null) return;
 
-    const tags: Record<string, string> = {};
+    // Hidden server-owned identity.* tags must survive the replace.
+    const tags: Record<string, string> = getSystemAgentTags(agent.tags);
     input.split(/\s+/).forEach((tag) => {
       if (!tag) return;
       const [key, ...valueParts] = tag.split('=');
@@ -2240,7 +2245,7 @@ export class AgentsView extends LitElement {
     agent: ManagedAgentSummary,
     lifecycleAction: 'suspend' | 'resume'
   ): Promise<void> {
-    const label = lifecycleAction === 'suspend' ? 'halt' : 'resume';
+    const label = lifecycleAction === 'suspend' ? 'pause' : 'resume';
     if (
       !window.confirm(
         `Are you sure you want to ${label} ${agent.display_name}?`
@@ -2252,7 +2257,7 @@ export class AgentsView extends LitElement {
       lifecycle_action: lifecycleAction,
       reason:
         lifecycleAction === 'suspend'
-          ? 'Manually halted from managed agents view'
+          ? 'Manually paused from managed agents view'
           : 'Manually resumed from managed agents view',
     });
   }
@@ -2516,12 +2521,14 @@ export class AgentsView extends LitElement {
     const isSuspendedOrDecommissioned =
       agent.lifecycle_state === 'suspended' ||
       agent.lifecycle_state === 'decommissioned';
+    // Play/pause toggle in warning (amber) tones; danger red is reserved for
+    // the destructive Remove action below.
     actions.push(
       isSuspendedOrDecommissioned
         ? {
             id: 'resume',
             label: 'Resume',
-            icon: 'plug',
+            icon: 'play-fill',
             variant: 'success',
             loading: this.actionAgentId === agent.id,
             onClick: () => {
@@ -2529,10 +2536,10 @@ export class AgentsView extends LitElement {
             },
           }
         : {
-            id: 'halt',
-            label: 'Halt',
-            icon: 'power',
-            variant: 'danger',
+            id: 'pause',
+            label: 'Pause',
+            icon: 'pause-fill',
+            variant: 'warning',
             loading: this.actionAgentId === agent.id,
             onClick: () => {
               void this.updateAgentLifecycle(agent, 'suspend');
@@ -2578,7 +2585,7 @@ export class AgentsView extends LitElement {
   }
 
   private renderAgentIdentityBadges(agent: ManagedAgentSummary) {
-    const tags = Object.entries(agent.tags || {});
+    const tags = getVisibleAgentTags(agent.tags);
     return html`
       <div class="identity-badges">
         <sl-badge variant="${this.getLifecycleVariant(agent)}" pill>
@@ -3331,13 +3338,11 @@ export class AgentsView extends LitElement {
                               : ''
                           }
                           ${
-                            !isFlow &&
-                            agent?.tags &&
-                            Object.keys(agent.tags).length > 0
+                            !isFlow && getVisibleAgentTags(agent?.tags).length
                               ? html` <div
                                   style="display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 8px;"
                                 >
-                                  ${Object.entries(agent.tags)
+                                  ${getVisibleAgentTags(agent?.tags)
                                     .slice(0, 3)
                                     .map(
                                       ([k, v]) => html`
@@ -3357,11 +3362,14 @@ export class AgentsView extends LitElement {
                                       `
                                     )}
                                   ${
-                                    Object.keys(agent.tags).length > 3
+                                    getVisibleAgentTags(agent?.tags).length > 3
                                       ? html`<div
                                           style="font-size: 0.65rem; padding: 2px;"
                                         >
-                                          +${Object.keys(agent.tags).length - 3}
+                                          +${
+                                            getVisibleAgentTags(agent?.tags)
+                                              .length - 3
+                                          }
                                         </div>`
                                       : ''
                                   }


### PR DESCRIPTION
## The failure chain

A live demo agent was paused, resumed, and then silently logged nothing. It looked healthy in the console the whole time.

1. `PATCH /agents/{id}` with `lifecycle_action=suspend` set `lifecycle_state='suspended'` **and** deactivated every runtime API key the agent owned (`is_active=False`) **and** set `ended_at` on its runtime session.
2. `lifecycle_action=resume` only flipped `lifecycle_state` back to `'active'`. Nothing reactivated the keys. Nothing cleared `ended_at`. There was no inverse.
3. Every subsequent gateway request 401'd in `authenticate_bearer_token` — **before** any `ApiUsage` row could be written.
4. So the console showed an active agent with zero traffic, and the operator had no signal that the agent was bricked. The only recovery was full re-onboarding.

Pause was implemented as *irreversible credential revocation* plus a *reversible* lifecycle flag.

## Chosen design: A (lifecycle check only)

I verified that the managed agent is already resolved and its `lifecycle_state` re-read **from the database on every request** on all three auth paths:

- `services/model_gateway_auth.py` — `authenticate_bearer_token`
- `api/auth/jwt.py` — `_authenticate_with_api_key`
- runtime session token issuance

There is no TTL cache, no `lru_cache`, and no per-replica in-memory auth state anywhere on those paths. So suspension can be enforced purely as a lifecycle check, and credentials never need to be touched:

- **Pause leaves credentials alone.** A paused agent is rejected because it is paused, not because its keys are dead. Resume is then an exact inverse — no restoration logic required for anything paused by this code.
- **Hard credential revocation is now reserved for the terminal states**: `decommission` (offboard) and `DELETE /agents/{id}`. Those still revoke exactly as before.
- **No new in-memory state**, so this is safe across multiple replicas. (Explicitly avoided given the past incident caused by per-replica state.)
- **Auth and audit are not weakened.** The check that rejects a paused agent moves from "its keys are dead" to "its lifecycle says paused", evaluated per request from the DB. Audit events are unchanged.

### Why Design B elements still appear

Production already has rows bricked by the shipped behavior: keys with `is_active=False` and sessions with `ended_at` set. Design A alone fixes the future but leaves those agents dead forever. So resume/reenroll also **heal** them — and only them:

- Scoped to **this agent's own keys** (`context_data->>'managed_agent_id'`), never a principal-wide sweep that would touch sibling agents' credentials.
- **Never** revives a key whose `ManagedAgentCredential.status == 'revoked'` — an operator's deliberate revocation stays revoked. Covered by a dedicated test.
- **Never** revives an expired key.
- Reopens only the agent's own bound session.

This runs solely on the `suspended|decommissioned → active` transition, so it is a no-op for agents paused by current code.

### Other backend fix

`managed_agent.get_by_source()` did `.first()` with **no `order_by`** — when several agents shared a session source, a stale suspended or decommissioned sibling could shadow the live agent during token issuance and key→agent resolution. It now ranks active < suspended < other < decommissioned, then most-recent-first, then by id.

`update_operator_state` no longer unbinds `runtime_session_id` on suspend (only on decommission), since dropping the binding made resume unable to restore the previous state.

## Frontend

- **"Halt" → "Pause"** everywhere user-facing, rendered as a **play/pause toggle** using the existing `warning` (amber) design token. Danger red stays reserved for offboard/remove, which is now honest: pause is reversible, those are not. `grep -i halt` over `frontend/src`, `backend/preloop`, and `cli` returns nothing but a test name asserting the rename.
- No global pause-all button — deliberately deferred per the ticket.
- **`identity.*` tags hidden** from the default chip rows (they are server-written re-keying bookkeeping, not operator labels) and surfaced under a collapsed `Identity history (N)` disclosure on the detail view. They are seeded back into the tag editor payload so an operator tag edit — which is a replace — cannot silently drop them.

## Test evidence

All new backend tests were confirmed **red before the fix**. The headline red failure reproduced the exact reported bug: `assert after.status_code == 200` → `401 authentication_error`.

New tests in `tests/endpoints/test_account_agents.py` drive real gateway traffic through `/anthropic/v1/messages` and assert `ApiUsage` rows are actually written:

- `test_account_agent_pause_then_resume_restores_gateway_traffic` — 200 → pause → 401 → resume → 200, usage rows 1 → 1 → 2
- `test_account_agent_pause_then_reenroll_restores_gateway_traffic`
- `test_account_agent_resume_heals_legacy_revoked_credentials` — recreates the pre-fix bricked state, asserts the key is reactivated, `ended_at` cleared, traffic flows
- `test_account_agent_resume_does_not_revive_operator_revoked_credentials`
- `test_account_agent_decommission_still_revokes_credentials`

Plus `tests/models/crud/test_managed_agent_get_by_source.py` (3 tests, all red pre-fix) and a rewrite of the runtime-token test that asserted the old behavior: decommission still revokes; a new `test_pause_blocks_runtime_token_without_revoking_credentials` asserts pause blocks by lifecycle only, leaves `is_active=True` and `ended_at=None`, and that both auth paths succeed again after resume.

```
tests/endpoints/test_account_agents.py .................. 37 passed  (was 32)
tests/models/crud/test_managed_agent_get_by_source.py .... 3 passed
tests/endpoints/test_runtime_session_tokens.py .......... 17 passed
full non-integration suite ......................... 4867 passed, 3 failed
frontend (agent-detail, agents-view, agent-display) ..... 20 passed
```

The 3 backend failures are **pre-existing** — verified by `git stash -u`, re-running on the clean tree (same 3 fail), then `git stash pop`: two in `tests/test_auth_integration.py`, one in `tests/test_bootstrap_registration.py`.

`ruff format` + `ruff check` clean on all changed files. `mypy` diffed against a clean-tree baseline on the four changed modules: **no new errors** (62 before, 62 after, identical set).

`openapi.yaml` unchanged — the API surface is identical (same `lifecycle_action` values, same request/response schemas). Only the *semantics* of `suspend` changed.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> All previously raised MEDIUM issues have been addressed (row lock, SQL expiry filter, lifecycle ranking, input validation). Remaining items are low-priority style suggestions only.
>
> **Overview**
> Makes agent pause truly reversible by enforcing suspension via lifecycle check only (no credential mutation), with targeted healing for agents bricked by the previous revoke-on-pause behavior. Renames "Halt" → "Pause" in the frontend and hides `identity.*` server bookkeeping tags from default chip rows.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fix/halt-resume-reversible. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->