### PR TITLE
chore: use neutral placeholders in test fixtures and comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,24 @@ Use the Lit.dev framework for frontend code. If you create new web components en
 - After making changes, present them to the user for review before any git operations beyond committing locally
 - After making significant changes, consider their impact on README.md and ARCHITECTURE.md and update these files accordingly.
 
+## Keep sample data generic
+This repository is public, so anything written here is written for a general
+audience. In commit messages, PR and issue text, comments, docstrings,
+fixtures and changelog entries, prefer generic examples over data copied from
+a real deployment:
+
+- use `example.com` addresses and placeholder names such as `Jane Doe`
+- describe a configuration by its shape ("a user configured an
+  OpenAI-compatible provider"), not by whose it is
+- use synthetic ids in fixtures rather than real account, tracker or project
+  identifiers
+- keep infrastructure sizing (replica counts, resource limits, database
+  tuning) in deployment config and internal runbooks, not in prose
+
+Generic examples read better anyway: they describe the case under test
+instead of an anecdote the reader has no context for. Citing a public issue
+number is fine and usually more useful than restating its background.
+
 ## Code Style
 - **Formatting**: Ruff format with 88 character line length
 - **Imports**: Use isort with black profile, group stdlib/third-party/local

--- a/backend/tests/services/test_aux_openrouter_reasoning.py
+++ b/backend/tests/services/test_aux_openrouter_reasoning.py
@@ -51,7 +51,7 @@ class TestOpenRouterReasoningDisable:
     """OpenRouter-routed models must get OpenRouter's knob, not the vendor's."""
 
     def test_openrouter_endpoint_beats_deepseek_prefix(self):
-        """Alex's exact prod config: openai-compatible + openrouter.ai + deepseek/ id.
+        """A real-world prod config: openai-compatible + openrouter.ai + deepseek/ id.
 
         Must produce the OpenRouter reasoning-disable form. The DeepSeek
         ``thinking`` knob is ignored by OpenRouter and lets reasoning eat the

--- a/backend/tests/services/test_gateway_custom_provider_routing.py
+++ b/backend/tests/services/test_gateway_custom_provider_routing.py
@@ -88,7 +88,7 @@ def test_unknown_headed_identifier_still_gets_prefixed():
 
 # --- issue #172: OpenRouter behind provider "openai-compatible" -------------
 #
-# Alex Lennon configured provider "openai-compatible" + endpoint
+# A user configured provider "openai-compatible" with endpoint
 # https://openrouter.ai/api/v1 and got 93 upstream 502s: the vendor prefix in
 # the model id ("deepseek/...") was read as a routing instruction, so litellm
 # loaded its native DeepSeek adapter, stripped the prefix, and rewrote the

--- a/backend/tests/services/test_usage_import.py
+++ b/backend/tests/services/test_usage_import.py
@@ -88,7 +88,7 @@ class TestParseCursorUsageCsv:
         """Team exports carry extra columns (e.g. User) that are ignored."""
         content = (
             "Date,User,Kind,Model,Total Tokens,Cost\n"
-            "2026-07-28,alex@example.com,Usage-based,composer,500,$0.10\n"
+            "2026-07-28,user@example.com,Usage-based,composer,500,$0.10\n"
         ).encode("utf-8")
 
         result = parse_cursor_usage_csv(content)

--- a/backend/tests/test_flow_commit_status.py
+++ b/backend/tests/test_flow_commit_status.py
@@ -58,7 +58,7 @@ def account_user(db_session: Session, account: Account) -> User:
 
 @pytest.fixture
 def github_projects(db_session: Session, account: Account, account_user: User):
-    """A GitHub tracker with one org and two repos, like Alex's setup."""
+    """A GitHub tracker with one org and two repos, mirroring a real setup."""
     tracker = crud_tracker.create(
         db_session,
         obj_in={

--- a/backend/tests/utils/test_secret_scrubbing.py
+++ b/backend/tests/utils/test_secret_scrubbing.py
@@ -1,6 +1,6 @@
 """Tests for preloop.utils.secret_scrubbing.
 
-The samples below are the shapes Alex Lennon reported in issue #173: a tracker
+The samples below are the shapes reported in issue #173: a tracker
 PAT embedded in a git remote URL, surfacing through ``git remote -v`` output
 captured into flow execution logs.
 """
@@ -154,7 +154,7 @@ class TestFalsePositives:
         assert scrub_secrets(line) == line
 
     def test_git_author_line_is_untouched(self) -> None:
-        line = "Author: Alex Lennon <alex@example.com>"
+        line = "Author: Jane Doe <jane@example.com>"
         assert scrub_secrets(line) == line
 
     def test_ssh_remote_is_untouched(self) -> None:

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -549,7 +549,7 @@ describe('DashboardView', () => {
   });
 
   describe('Recent Flow Executions dismiss control (#174)', () => {
-    // Alex's failing run: a git clone error long enough to overflow the row.
+    // A real failing run: a git clone error long enough to overflow the row.
     // The URL has no break opportunity, which is what actually broke the
     // layout: it set the min-content width of the flex column.
     const LONG_ERROR =


### PR DESCRIPTION
Test docstrings, comments read better as generic scenarios,
so they now use neutral descriptions and `example.com` placeholders.

| file | change |
|---|---|
| `tests/utils/test_secret_scrubbing.py` | module docstring cites issue #173 rather than restating its background |
| `tests/utils/test_secret_scrubbing.py` | git author sample line uses `Jane Doe <jane@example.com>` |
| `tests/services/test_gateway_custom_provider_routing.py` | "A user configured provider ..." |
| `tests/services/test_aux_openrouter_reasoning.py` | "A real-world prod config" |
| `tests/test_flow_commit_status.py` | "mirroring a real setup" |
| `tests/services/test_usage_import.py` | CSV fixture uses `user@example.com` |
| `frontend/.../dashboard-view.test.ts` | "A real failing run" |

No behavioural change. Every assertion and the scenario it encodes is
unchanged; the edited strings are comments, or fixture values the parser
ignores by design (that test asserts unknown CSV columns are skipped).

Also adds a short contributor guideline to `AGENTS.md` (symlinked as
`CLAUDE.md`) on preferring generic sample data.

Tests: `pytest tests/utils/test_secret_scrubbing.py tests/services/test_usage_import.py` -> 61 passed. Pre-commit clean.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment/docstring-only changes with a docs guideline addition — no functional code, zero behavioural impact.
>
> **Overview**
> Replaces 7 occurrences of real names and email addresses across 6 files with neutral `example.com` placeholders and generic descriptions. Adds a "Keep sample data generic" standing rule to `AGENTS.md`. All test assertions unchanged; tests pass clean.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit chore/scrub-identifying-info. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->