### PR TITLE
fix: consult the live price lookup when repricing unpriced usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Backfilled costs stayed $0 for models missing from the price snapshot**:
+  `reprice_unpriced_usage.py` recomputed every row against the locally bundled
+  price catalog only. A row is recorded `unpriced` precisely when the model was
+  absent from that snapshot, so the backfill re-derived the same "unpriced"
+  result and reported `updated=0` — those rows could never become priceable by
+  repricing, and the account's dashboard kept showing ~$0 for real usage. The
+  gateway already resolves this at record time via the live upstream price
+  lookup; repricing now performs the same lookup (once per model, not per row,
+  and never fatal when the upstream source is unavailable).
+
 - **Tracker sync loop on out-of-scope repositories**: a webhook naming a
   project we never imported triggered a full forced tracker re-sync on *every*
   event, and logged a "Project ... not found. Triggering a sync" warning plus

--- a/backend/preloop/services/usage_repricing.py
+++ b/backend/preloop/services/usage_repricing.py
@@ -25,7 +25,11 @@ from sqlalchemy.orm import Session
 
 from preloop.models.crud import crud_ai_model, crud_api_usage
 from preloop.models.models.ai_model import AIModel
-from preloop.services.model_pricing import estimate_ai_model_usage_cost_detailed
+from preloop.services.model_price_catalog import lookup_model_price_now
+from preloop.services.model_pricing import (
+    _iter_litellm_model_candidates,
+    estimate_ai_model_usage_cost_detailed,
+)
 from preloop.services.pricing_overrides import resolve_pricing_override
 
 logger = logging.getLogger(__name__)
@@ -131,6 +135,9 @@ def reprice_gateway_usage(
     result = RepriceResult(dry_run=dry_run)
     model_cache: Dict[str, Optional[AIModel]] = {}
     override_cache: Dict[str, Optional[dict]] = {}
+    # Models already offered to the live upstream lookup, so a backfill over
+    # thousands of rows performs at most one lookup per model, not per row.
+    lookup_attempted: set[str] = set()
     repriced_at = datetime.now(timezone.utc).isoformat()
     pending_updates = 0
 
@@ -178,14 +185,38 @@ def reprice_gateway_usage(
         usage_details = meta.get("usage_details")
         usage_details = usage_details if isinstance(usage_details, dict) else None
 
-        estimate = estimate_ai_model_usage_cost_detailed(
-            ai_model,
-            prompt_tokens=int(row.prompt_tokens or 0),
-            completion_tokens=int(row.completion_tokens or 0),
-            total_tokens=int(row.total_tokens or 0),
-            usage_details=usage_details,
-            pricing_override=pricing_override,
-        )
+        estimate_kwargs = {
+            "prompt_tokens": int(row.prompt_tokens or 0),
+            "completion_tokens": int(row.completion_tokens or 0),
+            "total_tokens": int(row.total_tokens or 0),
+            "usage_details": usage_details,
+            "pricing_override": pricing_override,
+        }
+        estimate = estimate_ai_model_usage_cost_detailed(ai_model, **estimate_kwargs)
+
+        # A row is recorded ``unpriced`` precisely when the model was missing
+        # from the local price snapshot, and the snapshot ships frozen at
+        # build time. Without consulting the live upstream map here, a
+        # backfill re-derives the same "unpriced" for every such row and
+        # reports updated=0 — the model can never become priceable by
+        # repricing alone. The gateway already resolves this at record time
+        # via schedule_price_lookup; this is the same lookup, run
+        # synchronously because the operator is waiting on the result.
+        # Registration is process-wide, so retrying the estimate afterwards
+        # prices this row and every later row on the same model.
+        if estimate.cost is None and model_id not in lookup_attempted:
+            lookup_attempted.add(model_id)
+            try:
+                if lookup_model_price_now(
+                    list(_iter_litellm_model_candidates(ai_model))
+                ):
+                    estimate = estimate_ai_model_usage_cost_detailed(
+                        ai_model, **estimate_kwargs
+                    )
+            except Exception:  # noqa: BLE001 - pricing must never break a backfill
+                logger.exception(
+                    "Live price lookup failed while repricing model %s", model_id
+                )
 
         unchanged = (
             estimate.cost == row.estimated_cost and estimate.source == row.cost_source

--- a/backend/tests/services/test_usage_repricing.py
+++ b/backend/tests/services/test_usage_repricing.py
@@ -4,6 +4,8 @@ from datetime import datetime, timedelta, timezone
 
 from preloop.models.crud import crud_ai_model, crud_api_usage
 from preloop.models.models.budget import BudgetSpendActivity
+from preloop.services import usage_repricing
+from preloop.services.model_pricing import CostEstimate
 from preloop.services.usage_repricing import reprice_gateway_usage
 
 
@@ -228,3 +230,89 @@ def test_reprice_single_row_after_live_lookup(db_session, test_user):
         assert (row.meta_data or {}).get("repriced_by") == "live_price_lookup"
     finally:
         litellm.model_cost.pop("live-lookup-model-x", None)
+
+
+def test_reprice_consults_live_lookup_for_models_missing_from_the_catalog(
+    db_session, test_user, monkeypatch
+):
+    """A model absent from the local snapshot is priced via the live lookup.
+
+    Without this, a backfill re-derives "unpriced" for every such row and
+    reports updated=0, so the rows can never become priceable by repricing.
+    """
+    ai_model = _create_model(db_session, test_user)
+    _log_unpriced_row(db_session, test_user, ai_model)
+
+    calls = []
+
+    def _fake_lookup(candidates):
+        calls.append(list(candidates))
+        # Simulate upstream registration making the model priceable.
+        monkeypatch.setattr(
+            usage_repricing,
+            "estimate_ai_model_usage_cost_detailed",
+            lambda *a, **k: CostEstimate(cost=0.25, source="catalog"),
+        )
+        return candidates[0]
+
+    monkeypatch.setattr(
+        usage_repricing,
+        "estimate_ai_model_usage_cost_detailed",
+        lambda *a, **k: CostEstimate(cost=None, source="unpriced"),
+    )
+    monkeypatch.setattr(usage_repricing, "lookup_model_price_now", _fake_lookup)
+
+    start, end = _window()
+    result = reprice_gateway_usage(
+        db_session, account_id=str(test_user.account_id), start=start, end=end
+    )
+
+    assert calls, "an unpriced row must trigger the live price lookup"
+    assert result.rows_updated == 1
+    assert result.cost_after == 0.25
+
+
+def test_reprice_looks_up_each_model_once_not_once_per_row(
+    db_session, test_user, monkeypatch
+):
+    """The lookup is cached per model so a large backfill stays cheap."""
+    ai_model = _create_model(db_session, test_user)
+    for _ in range(5):
+        _log_unpriced_row(db_session, test_user, ai_model)
+
+    calls = []
+    monkeypatch.setattr(
+        usage_repricing,
+        "estimate_ai_model_usage_cost_detailed",
+        lambda *a, **k: CostEstimate(cost=None, source="unpriced"),
+    )
+    monkeypatch.setattr(
+        usage_repricing,
+        "lookup_model_price_now",
+        lambda candidates: calls.append(1) or None,
+    )
+
+    start, end = _window()
+    reprice_gateway_usage(
+        db_session, account_id=str(test_user.account_id), start=start, end=end
+    )
+
+    assert len(calls) == 1, f"expected one lookup for one model, got {len(calls)}"
+
+
+def test_reprice_survives_a_failing_live_lookup(db_session, test_user, monkeypatch):
+    """A lookup error must not abort the backfill."""
+    ai_model = _create_model(db_session, test_user)
+    _log_unpriced_row(db_session, test_user, ai_model)
+
+    def _boom(candidates):
+        raise RuntimeError("upstream down")
+
+    monkeypatch.setattr(usage_repricing, "lookup_model_price_now", _boom)
+
+    start, end = _window()
+    result = reprice_gateway_usage(
+        db_session, account_id=str(test_user.account_id), start=start, end=end
+    )
+
+    assert result.rows_examined == 1


### PR DESCRIPTION
## Problem

`scripts/reprice_unpriced_usage.py` reports `updated=0` for rows it should be
able to price, leaving affected dashboards showing ~$0 for real metered usage.

A row is recorded `cost_source='unpriced'` *precisely when* the model was
missing from the bundled price snapshot, and that snapshot is frozen at build
time. Repricing recomputed against the same snapshot, so it re-derived
"unpriced" for every one of those rows. The rows could never become priceable
by repricing, by construction.

A representative run before the fix — 1,698 rows examined, only 2 skipped, so
1,696 rows went through the full pricing path and came back unchanged:

```
examined=1698 updated=0 skipped=2 cost 0.0000 -> 0.0000 (+0.0000)
```

The `Provider List: ...` banner litellm prints on every failed lookup was
repeated once per row, which is the visible symptom.

## Fix

The gateway already solves this at record time: an unpriced row schedules a
live lookup against the upstream price maps and re-prices itself when it
resolves. Repricing was the only path that never did.

Reprice now performs the same lookup:

- **synchronously**, because an operator is waiting on the result
- **memoized per model**, so a backfill over thousands of rows costs one
  lookup per model rather than one per row
- **never fatal** — a raising or unavailable upstream is logged and skipped,
  so a backfill is not aborted by a network failure

Registration with litellm is process-wide, so retrying the estimate after a
successful lookup also prices every later row on that model.

## Verification

Dry run against real data (writes nothing), same window, before and after:

```
before: examined=1698 updated=0    skipped=2 cost 0.0000 -> 0.0000
after:  examined=1698 updated=1679 skipped=2 cost 0.0000 -> 1.7829
```

The 19 rows that remain unpriced have no stored token counts, so there is
nothing to price them from. The recovered figure correctly applies the
cache-read rate via `usage_details` rather than charging all input at the full
rate.

## Tests

Three new tests, each confirmed to fail without the fix:

- the live lookup is consulted for a model missing from the catalog
- the lookup runs once per model, not once per row
- a raising lookup does not abort the backfill

`52 passed` across the repricing, price-catalog and model-pricing suites.

## Note for a follow-up (not in this PR)

The unpriced-model admin alert is emitted at record time, before the live
lookup completes. In practice the lookup succeeds milliseconds later and
re-prices the row in place, so the alert describes a condition that has
already resolved itself and nothing retracts it. The alert would be more
useful fired only when the lookup *fails*.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-contained fix that mirrors an existing async code path into the synchronous repricing flow. No schema changes, no new dependencies.
>
> **Overview**
> Fixes `reprice_unpriced_usage.py` reporting `updated=0` for models missing from the bundled price snapshot by consulting the live upstream price lookup — the same mechanism the gateway already uses at record time. The lookup is memoized per model and never fatal, so backfills over thousands of rows cost O(models) lookups and survive network failures.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit `fix/reprice-live-lookup`. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->