### PR TITLE
feat: show flow execution duration beside the start time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Flow execution duration in the console**: the executions table now shows a
+  **Duration** column in place of the raw "End Time" (the start time already
+  said when the run happened; the end time alone never said how long it took),
+  and the same value is appended to the "Started …" line on the Flows and
+  dashboard execution lists. Running executions display `Running · <elapsed>`,
+  ticking every second on the execution detail page and recomputed on each
+  render elsewhere; runs that ended without an `end_time` show `—` instead of
+  claiming to still be running. Both timestamps were already returned by the
+  API, so this is a console-only change.
+
 - **Admin alert for unpriceable models**: the gateway now notifies admins the
   first time a `(model_alias, provider)` pair proves unpriceable, including the
   account and token volume, so missing pricing is noticed instead of silently

--- a/frontend/src/utils/date.test.ts
+++ b/frontend/src/utils/date.test.ts
@@ -1,5 +1,7 @@
 import { expect } from '@open-wc/testing';
 import {
+  calculateDuration,
+  formatDurationBetween,
   formatFutureRelativeTime,
   formatRelativeTime,
   parseUTCDate,
@@ -32,5 +34,94 @@ describe('date utilities', () => {
     expect(formatFutureRelativeTime('2026-07-12T19:59:00', now)).to.equal(
       'expired'
     );
+  });
+});
+
+describe('formatDurationBetween', () => {
+  it('formats sub-minute spans in seconds', () => {
+    expect(
+      formatDurationBetween('2026-08-09T10:00:00Z', '2026-08-09T10:00:25Z')
+    ).to.equal('25s');
+  });
+
+  it('formats zero-length spans as 0s', () => {
+    expect(
+      formatDurationBetween('2026-08-09T10:00:00Z', '2026-08-09T10:00:00Z')
+    ).to.equal('0s');
+  });
+
+  it('formats sub-hour spans in minutes and seconds', () => {
+    expect(
+      formatDurationBetween('2026-08-09T10:00:00Z', '2026-08-09T10:04:32Z')
+    ).to.equal('4m 32s');
+  });
+
+  it('formats spans over an hour in hours and minutes', () => {
+    expect(
+      formatDurationBetween('2026-08-09T10:00:00Z', '2026-08-09T11:05:00Z')
+    ).to.equal('1h 5m');
+  });
+
+  it('keeps multi-day spans in hours rather than rolling into days', () => {
+    expect(
+      formatDurationBetween('2026-08-09T10:00:00Z', '2026-08-10T12:00:00Z')
+    ).to.equal('26h 0m');
+  });
+
+  it('treats naive backend strings as UTC on both ends', () => {
+    expect(
+      formatDurationBetween('2026-08-09 10:00:00', '2026-08-09 10:04:32')
+    ).to.equal('4m 32s');
+  });
+
+  it('returns an empty string when the start time is missing', () => {
+    expect(formatDurationBetween(null, '2026-08-09T10:04:32Z')).to.equal('');
+    expect(formatDurationBetween(undefined, '2026-08-09T10:04:32Z')).to.equal(
+      ''
+    );
+    expect(formatDurationBetween('', '2026-08-09T10:04:32Z')).to.equal('');
+  });
+
+  it('returns an empty string when the end precedes the start', () => {
+    expect(
+      formatDurationBetween('2026-08-09T10:05:00Z', '2026-08-09T10:00:00Z')
+    ).to.equal('');
+  });
+
+  it('returns an empty string for unparseable timestamps', () => {
+    expect(
+      formatDurationBetween('not-a-date', '2026-08-09T10:04:32Z')
+    ).to.equal('');
+  });
+
+  it('never emits NaN when the end timestamp is garbage', () => {
+    const now = new Date('2026-08-09T10:00:30Z');
+
+    expect(
+      formatDurationBetween('2026-08-09T10:00:00Z', 'garbage', now)
+    ).to.equal('30s');
+  });
+
+  it('measures elapsed time against now when there is no end time', () => {
+    const now = new Date('2026-08-09T10:07:05Z');
+
+    expect(formatDurationBetween('2026-08-09T10:00:00Z', null, now)).to.equal(
+      '7m 5s'
+    );
+    expect(
+      formatDurationBetween('2026-08-09T10:00:00Z', undefined, now)
+    ).to.equal('7m 5s');
+  });
+
+  it('keeps calculateDuration output identical', () => {
+    expect(
+      calculateDuration('2026-08-09T10:00:00Z', '2026-08-09T10:04:32Z')
+    ).to.equal('4m 32s');
+    expect(
+      calculateDuration('2026-08-09T10:00:00Z', '2026-08-09T11:05:00Z')
+    ).to.equal('1h 5m');
+    expect(
+      calculateDuration('2026-08-09T10:00:00Z', '2026-08-09T10:00:25Z')
+    ).to.equal('25s');
   });
 });

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -120,6 +120,51 @@ export function formatFutureRelativeTime(
 }
 
 /**
+ * Formats the elapsed time between two instants, tolerating missing or
+ * unusable data.
+ *
+ * Used for flow execution durations, where the end timestamp is absent while
+ * the run is still going (in which case elapsed time is measured against
+ * `now`) and can be inconsistent on legacy or clock-skewed rows. Callers get
+ * an empty string rather than "NaN" or a negative duration so they can decide
+ * on their own placeholder.
+ *
+ * @param startTimeString - Start datetime string from backend
+ * @param endTimeString - End datetime string from backend; falls back to `now`
+ * @param now - Instant to measure against when there is no end time
+ * @returns Duration string (e.g., "2h 15m", "45m 30s", "25s") or '' if unknown
+ */
+export function formatDurationBetween(
+  startTimeString: string | null | undefined,
+  endTimeString?: string | null,
+  now: Date = new Date()
+): string {
+  if (!startTimeString) return '';
+
+  const start = parseUTCDate(startTimeString);
+  if (isNaN(start.getTime())) return '';
+
+  let endMs = now.getTime();
+  if (endTimeString) {
+    const end = parseUTCDate(endTimeString);
+    if (!isNaN(end.getTime())) {
+      endMs = end.getTime();
+    }
+  }
+
+  const durationMs = endMs - start.getTime();
+  if (isNaN(durationMs) || durationMs < 0) return '';
+
+  const seconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+
+  if (hours > 0) return `${hours}h ${minutes % 60}m`;
+  if (minutes > 0) return `${minutes}m ${seconds % 60}s`;
+  return `${seconds}s`;
+}
+
+/**
  * Calculates duration between two datetime strings.
  *
  * @param startTimeString - Start datetime string from backend
@@ -130,14 +175,5 @@ export function calculateDuration(
   startTimeString: string,
   endTimeString: string
 ): string {
-  const start = parseUTCDate(startTimeString);
-  const end = parseUTCDate(endTimeString);
-  const durationMs = end.getTime() - start.getTime();
-  const seconds = Math.floor(durationMs / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-
-  if (hours > 0) return `${hours}h ${minutes % 60}m`;
-  if (minutes > 0) return `${minutes}m ${seconds % 60}s`;
-  return `${seconds}s`;
+  return formatDurationBetween(startTimeString, endTimeString);
 }

--- a/frontend/src/utils/execution.test.ts
+++ b/frontend/src/utils/execution.test.ts
@@ -1,0 +1,76 @@
+import { expect } from '@open-wc/testing';
+
+import { RUNNING_STATUSES, executionDurationText } from './execution';
+
+describe('RUNNING_STATUSES', () => {
+  it('contains exactly the non-terminal statuses', () => {
+    expect([...RUNNING_STATUSES].sort()).to.deep.equal([
+      'INITIALIZING',
+      'PENDING',
+      'RUNNING',
+      'STARTING',
+    ]);
+  });
+});
+
+describe('executionDurationText', () => {
+  it('shows the finished span when end_time is present, regardless of status', () => {
+    expect(
+      executionDurationText({
+        status: 'SUCCEEDED',
+        start_time: '2026-08-09 12:00:00',
+        end_time: '2026-08-09 12:04:32',
+      })
+    ).to.equal('4m 32s');
+  });
+
+  it('shows a live Running prefix for a running execution without end_time', () => {
+    expect(
+      executionDurationText(
+        {
+          status: 'RUNNING',
+          start_time: '2026-08-09 12:00:00',
+          end_time: null,
+        },
+        new Date('2026-08-09T12:00:25Z')
+      )
+    ).to.equal('Running · 25s');
+  });
+
+  it('measures against the provided now for all running-like statuses', () => {
+    const now = new Date('2026-08-09T12:01:05Z');
+    for (const status of ['PENDING', 'STARTING', 'INITIALIZING', 'RUNNING']) {
+      expect(
+        executionDurationText(
+          { status, start_time: '2026-08-09 12:00:00' },
+          now
+        )
+      ).to.equal('Running · 1m 5s');
+    }
+  });
+
+  it('returns an empty string for a legacy terminal row without end_time', () => {
+    expect(
+      executionDurationText({
+        status: 'FAILED',
+        start_time: '2026-08-09 12:00:00',
+      })
+    ).to.equal('');
+  });
+
+  it('returns an empty string when the timestamps are unusable', () => {
+    expect(
+      executionDurationText({
+        status: 'SUCCEEDED',
+        start_time: 'not-a-date',
+        end_time: '2026-08-09 12:04:32',
+      })
+    ).to.equal('');
+    expect(
+      executionDurationText(
+        { status: 'RUNNING', start_time: '2026-08-09 12:00:10' },
+        new Date('2026-08-09T12:00:00Z')
+      )
+    ).to.equal('');
+  });
+});

--- a/frontend/src/utils/execution.ts
+++ b/frontend/src/utils/execution.ts
@@ -1,0 +1,42 @@
+import { formatDurationBetween } from './date';
+
+/**
+ * Statuses that mean a flow execution has not reached a terminal state yet.
+ *
+ * Matches the running-like set used by the execution detail view; everything
+ * else (SUCCEEDED, FAILED, STOPPED, TIMEOUT, CANCELLED, …) is terminal.
+ */
+export const RUNNING_STATUSES: ReadonlySet<string> = new Set([
+  'PENDING',
+  'STARTING',
+  'INITIALIZING',
+  'RUNNING',
+]);
+
+/**
+ * Duration text for an execution row shared by the list views.
+ *
+ * Finished runs show their span, live runs show `Running · <elapsed>`
+ * measured against `now` (recomputed on each render — list views add no
+ * per-row timers and refresh via their existing polling/WebSocket updates),
+ * and anything unusable — a legacy terminal row without an `end_time`, or
+ * unparseable/skewed timestamps — yields an empty string so the caller can
+ * render a placeholder (or nothing, in inline contexts).
+ */
+export function executionDurationText(
+  exec: {
+    status: string;
+    start_time: string;
+    end_time?: string | null;
+  },
+  now: Date = new Date()
+): string {
+  if (exec.end_time) {
+    return formatDurationBetween(exec.start_time, exec.end_time);
+  }
+  if (RUNNING_STATUSES.has(exec.status)) {
+    const elapsed = formatDurationBetween(exec.start_time, null, now);
+    return elapsed ? `Running · ${elapsed}` : '';
+  }
+  return '';
+}

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -54,7 +54,7 @@ import type {
   RuntimeSessionSummary,
   AIModel,
 } from '../../types';
-import { parseUTCDate } from '../../utils/date';
+import { parseUTCDate, formatDurationBetween } from '../../utils/date';
 import { getAgentControlState } from '../../utils/agent-control';
 import {
   pickDefaultModel,
@@ -96,6 +96,14 @@ interface MCPServer {
   url: string;
   status: string;
 }
+
+/** Statuses that mean the run has not reached a terminal state yet. */
+const RUNNING_STATUSES = new Set([
+  'PENDING',
+  'STARTING',
+  'INITIALIZING',
+  'RUNNING',
+]);
 
 interface FlowExecution {
   id: string;
@@ -228,6 +236,30 @@ export class DashboardView extends AuthedElement {
         JSON.stringify(this.dismissedExecutions)
       );
     }
+  }
+
+  /**
+   * Duration suffix for an execution row. Finished runs show their span,
+   * live runs count up on each render (rows refresh with the dashboard's
+   * existing polling, no per-row timers), and anything unusable yields an
+   * empty string so the caller appends nothing.
+   */
+  private executionDuration(exec: FlowExecution): string {
+    if (exec.end_time) {
+      return formatDurationBetween(exec.start_time, exec.end_time);
+    }
+    if (RUNNING_STATUSES.has(exec.status)) {
+      const elapsed = formatDurationBetween(exec.start_time, null);
+      return elapsed ? `Running · ${elapsed}` : '';
+    }
+    return '';
+  }
+
+  /** Start time plus, when known, how long the run took or has been going. */
+  private executionSecondaryText(exec: FlowExecution): string {
+    const started = this.formatDate(exec.start_time);
+    const duration = this.executionDuration(exec);
+    return duration ? `${started} · ${duration}` : started;
   }
 
   private formatDate(dateStr: string | null | undefined): string {
@@ -2710,7 +2742,7 @@ export class DashboardView extends AuthedElement {
                                 : ''
                             }
                             <span class="item-secondary"
-                              >${this.formatDate(exec.start_time)}</span
+                              >${this.executionSecondaryText(exec)}</span
                             >
                           </div>
                           <div class="item-actions">

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -54,7 +54,8 @@ import type {
   RuntimeSessionSummary,
   AIModel,
 } from '../../types';
-import { parseUTCDate, formatDurationBetween } from '../../utils/date';
+import { parseUTCDate } from '../../utils/date';
+import { executionDurationText } from '../../utils/execution';
 import { getAgentControlState } from '../../utils/agent-control';
 import {
   pickDefaultModel,
@@ -96,14 +97,6 @@ interface MCPServer {
   url: string;
   status: string;
 }
-
-/** Statuses that mean the run has not reached a terminal state yet. */
-const RUNNING_STATUSES = new Set([
-  'PENDING',
-  'STARTING',
-  'INITIALIZING',
-  'RUNNING',
-]);
 
 interface FlowExecution {
   id: string;
@@ -238,27 +231,10 @@ export class DashboardView extends AuthedElement {
     }
   }
 
-  /**
-   * Duration suffix for an execution row. Finished runs show their span,
-   * live runs count up on each render (rows refresh with the dashboard's
-   * existing polling, no per-row timers), and anything unusable yields an
-   * empty string so the caller appends nothing.
-   */
-  private executionDuration(exec: FlowExecution): string {
-    if (exec.end_time) {
-      return formatDurationBetween(exec.start_time, exec.end_time);
-    }
-    if (RUNNING_STATUSES.has(exec.status)) {
-      const elapsed = formatDurationBetween(exec.start_time, null);
-      return elapsed ? `Running · ${elapsed}` : '';
-    }
-    return '';
-  }
-
   /** Start time plus, when known, how long the run took or has been going. */
   private executionSecondaryText(exec: FlowExecution): string {
     const started = this.formatDate(exec.start_time);
-    const duration = this.executionDuration(exec);
+    const duration = executionDurationText(exec);
     return duration ? `${started} · ${duration}` : started;
   }
 

--- a/frontend/src/views/authed/flow-execution-view.test.ts
+++ b/frontend/src/views/authed/flow-execution-view.test.ts
@@ -441,6 +441,84 @@ describe('FlowExecutionView', () => {
     expect((element as any).hasPricing).to.equal(false);
   });
 
+  describe('timing card duration', () => {
+    const timingSubtext = (element: FlowExecutionView) => {
+      const cards = Array.from(
+        element.shadowRoot?.querySelectorAll('sl-card') || []
+      );
+      const timing = cards.find((card) =>
+        (card.textContent || '').includes('Timing')
+      );
+      return (timing?.querySelector('.summary-subtext')?.textContent || '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    };
+
+    async function load(executionId: string) {
+      const element = (await fixture(
+        html`<flow-execution-view></flow-execution-view>`
+      )) as FlowExecutionView;
+      element.executionId = executionId;
+      await element.updateComplete;
+      await waitUntil(
+        () =>
+          (element as any).execution?.id === executionId &&
+          !(element as any).isLoading,
+        `Execution view did not finish loading ${executionId}`
+      );
+      await element.updateComplete;
+      return element;
+    }
+
+    it('shows the finished duration for a completed execution', async () => {
+      const element = await load('exec-1');
+
+      expect(timingSubtext(element)).to.equal('2m 0s');
+    });
+
+    it('shows a live elapsed duration for a running execution', async () => {
+      const element = await load('exec-running');
+
+      expect(timingSubtext(element)).to.match(/^Running · /);
+    });
+
+    it('ticks the elapsed duration while the execution runs', async () => {
+      const clock = sinon.useFakeTimers({
+        now: new Date('2026-03-09T10:00:10Z'),
+        toFake: ['setInterval', 'clearInterval', 'Date'],
+      });
+
+      try {
+        const element = await load('exec-running');
+        expect(timingSubtext(element)).to.equal('Running · 10s');
+
+        clock.tick(2000);
+        await element.updateComplete;
+
+        expect(timingSubtext(element)).to.equal('Running · 12s');
+      } finally {
+        clock.restore();
+      }
+    });
+
+    it('clears the tick interval when disconnected', async () => {
+      const element = await load('exec-running');
+      const intervalId = (element as any).durationTickIntervalId;
+      expect(intervalId).to.be.a('number');
+
+      const clearSpy = sinon.spy(window, 'clearInterval');
+      try {
+        element.remove();
+        await element.updateComplete;
+
+        expect(clearSpy.calledWith(intervalId)).to.equal(true);
+        expect((element as any).durationTickIntervalId).to.equal(undefined);
+      } finally {
+        clearSpy.restore();
+      }
+    });
+  });
+
   it('does not treat a zero-cost gateway event as priced', async () => {
     const element = await fixture<FlowExecutionView>(
       html`<flow-execution-view></flow-execution-view>`

--- a/frontend/src/views/authed/flow-execution-view.ts
+++ b/frontend/src/views/authed/flow-execution-view.ts
@@ -27,8 +27,8 @@ import {
   parseUTCDate,
   formatLocalTime,
   formatUTCDateTime,
-  formatDurationBetween,
 } from '../../utils/date';
+import { RUNNING_STATUSES, executionDurationText } from '../../utils/execution';
 import '../../components/preloop-gateway-event.ts';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
@@ -612,12 +612,7 @@ export class FlowExecutionView extends LitElement {
   /** Whether the loaded execution has not reached a terminal state yet. */
   private isExecutionRunning(): boolean {
     const status = this.execution?.status;
-    return (
-      status === 'RUNNING' ||
-      status === 'STARTING' ||
-      status === 'INITIALIZING' ||
-      status === 'PENDING'
-    );
+    return status !== undefined && RUNNING_STATUSES.has(status);
   }
 
   private startDurationTicker() {
@@ -650,29 +645,15 @@ export class FlowExecutionView extends LitElement {
 
   /**
    * Duration text for the Timing card: the final span once the run ended,
-   * a live-ticking elapsed value while it runs, and an em dash when the
+   * a live-ticking elapsed value while it runs (measured against
+   * `durationNow`, which the ticker refreshes), and an em dash when the
    * timestamps cannot produce anything meaningful.
    */
   private renderTimingDuration(): string {
     const execution = this.execution;
     if (!execution) return '—';
 
-    if (execution.end_time) {
-      return (
-        formatDurationBetween(execution.start_time, execution.end_time) || '—'
-      );
-    }
-
-    if (this.isExecutionRunning()) {
-      const elapsed = formatDurationBetween(
-        execution.start_time,
-        null,
-        this.durationNow
-      );
-      return elapsed ? `Running · ${elapsed}` : '—';
-    }
-
-    return '—';
+    return executionDurationText(execution, this.durationNow) || '—';
   }
 
   async updated(changedProperties: Map<string, any>) {

--- a/frontend/src/views/authed/flow-execution-view.ts
+++ b/frontend/src/views/authed/flow-execution-view.ts
@@ -27,7 +27,7 @@ import {
   parseUTCDate,
   formatLocalTime,
   formatUTCDateTime,
-  calculateDuration,
+  formatDurationBetween,
 } from '../../utils/date';
 import '../../components/preloop-gateway-event.ts';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
@@ -570,6 +570,16 @@ export class FlowExecutionView extends LitElement {
   @state()
   private isRetrying = false;
 
+  /**
+   * Clock used to render the elapsed time of a still-running execution.
+   * Advanced once a second by `durationTickIntervalId` so the Timing card
+   * counts up without waiting for a log message or a page reload.
+   */
+  @state()
+  private durationNow: Date = new Date();
+
+  private durationTickIntervalId?: number;
+
   private logContainerRef?: HTMLElement;
   private wsConnected = false;
   private autoScrollInterval?: number;
@@ -593,12 +603,85 @@ export class FlowExecutionView extends LitElement {
       clearInterval(this.bufferFlushInterval);
       this.bufferFlushInterval = undefined;
     }
+    // Stop the elapsed-duration ticker
+    this.stopDurationTicker();
     // Unsubscribe from WebSocket
     this.unsubscribe?.();
   }
 
+  /** Whether the loaded execution has not reached a terminal state yet. */
+  private isExecutionRunning(): boolean {
+    const status = this.execution?.status;
+    return (
+      status === 'RUNNING' ||
+      status === 'STARTING' ||
+      status === 'INITIALIZING' ||
+      status === 'PENDING'
+    );
+  }
+
+  private startDurationTicker() {
+    // Started from updated(); do not touch reactive state here, or every
+    // render of a running execution would schedule another one.
+    if (this.durationTickIntervalId !== undefined) return;
+    this.durationTickIntervalId = window.setInterval(() => {
+      this.durationNow = new Date();
+    }, 1000);
+  }
+
+  private stopDurationTicker() {
+    if (this.durationTickIntervalId !== undefined) {
+      clearInterval(this.durationTickIntervalId);
+      this.durationTickIntervalId = undefined;
+    }
+  }
+
+  /**
+   * Runs the elapsed-time ticker only while the execution is live, so a
+   * finished run does not leave a timer behind re-rendering forever.
+   */
+  private syncDurationTicker() {
+    if (this.isExecutionRunning()) {
+      this.startDurationTicker();
+    } else {
+      this.stopDurationTicker();
+    }
+  }
+
+  /**
+   * Duration text for the Timing card: the final span once the run ended,
+   * a live-ticking elapsed value while it runs, and an em dash when the
+   * timestamps cannot produce anything meaningful.
+   */
+  private renderTimingDuration(): string {
+    const execution = this.execution;
+    if (!execution) return '—';
+
+    if (execution.end_time) {
+      return (
+        formatDurationBetween(execution.start_time, execution.end_time) || '—'
+      );
+    }
+
+    if (this.isExecutionRunning()) {
+      const elapsed = formatDurationBetween(
+        execution.start_time,
+        null,
+        this.durationNow
+      );
+      return elapsed ? `Running · ${elapsed}` : '—';
+    }
+
+    return '—';
+  }
+
   async updated(changedProperties: Map<string, any>) {
     super.updated(changedProperties);
+
+    // Keep the elapsed-duration ticker aligned with the execution's state:
+    // start it once a running execution is loaded, stop it as soon as the
+    // status turns terminal.
+    this.syncDurationTicker();
 
     // When executionId property changes, fetch execution data
     if (
@@ -1957,16 +2040,7 @@ export class FlowExecutionView extends LitElement {
                   ></sl-relative-time>
                 </div>
               </sl-tooltip>
-              <div class="summary-subtext">
-                ${
-                  this.execution.end_time
-                    ? calculateDuration(
-                        this.execution.start_time,
-                        this.execution.end_time
-                      )
-                    : 'Running'
-                }
-              </div>
+              <div class="summary-subtext">${this.renderTimingDuration()}</div>
             </sl-card>
             <sl-card>
               <div slot="header">

--- a/frontend/src/views/authed/flow-executions-view.test.ts
+++ b/frontend/src/views/authed/flow-executions-view.test.ts
@@ -103,4 +103,94 @@ describe('FlowExecutionsView', () => {
         .some((c) => String(c.args[0]).includes('/api/v1/flows/executions'))
     ).to.be.true;
   });
+
+  describe('duration column', () => {
+    async function renderRows(rows: unknown[]) {
+      fetchStub = stub(rows);
+      const el = (await fixture(
+        html`<flow-executions-view></flow-executions-view>`
+      )) as FlowExecutionsView;
+      await tick();
+      await el.updateComplete;
+      return el;
+    }
+
+    const cellText = (el: FlowExecutionsView, rowIndex: number) => {
+      const cells = el.shadowRoot
+        ?.querySelectorAll('tbody tr')
+        [rowIndex]?.querySelectorAll('td');
+      // Flow Name, Subject, Status, Start Time, Duration, Tool Calls, Details
+      return (cells?.[4]?.textContent || '').replace(/\s+/g, ' ').trim();
+    };
+
+    it('replaces the End Time header with Duration', async () => {
+      const el = await renderRows(EXECUTIONS);
+      const headers = Array.from(
+        el.shadowRoot?.querySelectorAll('thead th') || []
+      ).map((th) => (th.textContent || '').trim());
+
+      expect(headers).to.contain('Duration');
+      expect(headers).to.contain('Start Time');
+      expect(headers).to.not.contain('End Time');
+    });
+
+    it('shows the completed duration for a finished execution', async () => {
+      const el = await renderRows([
+        {
+          id: 'exec-done',
+          flow_id: 'flow-1',
+          flow_name: 'Nightly Sync',
+          status: 'SUCCEEDED',
+          start_time: '2026-03-09T10:00:00Z',
+          end_time: '2026-03-09T10:04:32Z',
+        },
+      ]);
+
+      expect(cellText(el, 0)).to.equal('4m 32s');
+    });
+
+    it('shows live elapsed time for a running execution', async () => {
+      const el = await renderRows([
+        {
+          id: 'exec-running',
+          flow_id: 'flow-2',
+          flow_name: 'Triage',
+          status: 'RUNNING',
+          start_time: new Date(Date.now() - 65_000).toISOString(),
+        },
+      ]);
+
+      const text = cellText(el, 0);
+      expect(text).to.match(/^Running · \d+m \d+s$/);
+    });
+
+    it('shows an em dash for a terminal execution with no end time', async () => {
+      const el = await renderRows([
+        {
+          id: 'exec-legacy',
+          flow_id: 'flow-3',
+          flow_name: 'Legacy',
+          status: 'FAILED',
+          start_time: '2026-03-09T10:00:00Z',
+        },
+      ]);
+
+      expect(cellText(el, 0)).to.equal('—');
+    });
+
+    it('shows an em dash when the timestamps are unusable', async () => {
+      const el = await renderRows([
+        {
+          id: 'exec-skew',
+          flow_id: 'flow-4',
+          flow_name: 'Skewed',
+          status: 'SUCCEEDED',
+          start_time: '2026-03-09T10:05:00Z',
+          end_time: '2026-03-09T10:00:00Z',
+        },
+      ]);
+
+      expect(cellText(el, 0)).to.equal('—');
+    });
+  });
 });

--- a/frontend/src/views/authed/flow-executions-view.ts
+++ b/frontend/src/views/authed/flow-executions-view.ts
@@ -9,22 +9,11 @@ import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
-import {
-  parseUTCDate,
-  formatLocalDateTime,
-  formatDurationBetween,
-} from '../../utils/date';
+import { parseUTCDate, formatLocalDateTime } from '../../utils/date';
+import { executionDurationText } from '../../utils/execution';
 import consoleStyles from '../../styles/console-styles.css?inline';
 import { reducedMotionStyles } from '../../styles/reduced-motion';
 import '../../components/view-header.ts';
-
-/** Statuses that mean the run has not reached a terminal state yet. */
-const RUNNING_STATUSES = new Set([
-  'PENDING',
-  'STARTING',
-  'INITIALIZING',
-  'RUNNING',
-]);
 
 interface FlowExecution {
   id: string;
@@ -362,7 +351,7 @@ export class FlowExecutionsView extends AuthedElement {
                                 </div>
                               </td>
                               <td>${formatLocalDateTime(exec.start_time)}</td>
-                              <td>${this.executionDuration(exec) || '—'}</td>
+                              <td>${executionDurationText(exec) || '—'}</td>
                               <td>${exec.tool_calls_count || 0}</td>
                               <td>
                                 <sl-button
@@ -458,25 +447,5 @@ export class FlowExecutionsView extends AuthedElement {
       default:
         return 'neutral';
     }
-  }
-
-  /**
-   * Duration text for an execution row.
-   *
-   * Finished runs show the elapsed span; still-running ones show live elapsed
-   * time (recomputed on each render, refreshed by the existing polling, no
-   * per-row timers). Legacy rows that ended without an `end_time`, and rows
-   * whose timestamps are unusable, get an empty string so the caller can show
-   * a placeholder.
-   */
-  private executionDuration(exec: FlowExecution): string {
-    if (exec.end_time) {
-      return formatDurationBetween(exec.start_time, exec.end_time);
-    }
-    if (RUNNING_STATUSES.has(exec.status)) {
-      const elapsed = formatDurationBetween(exec.start_time, null);
-      return elapsed ? `Running · ${elapsed}` : '';
-    }
-    return '';
   }
 }

--- a/frontend/src/views/authed/flow-executions-view.ts
+++ b/frontend/src/views/authed/flow-executions-view.ts
@@ -9,10 +9,22 @@ import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
-import { parseUTCDate, formatLocalDateTime } from '../../utils/date';
+import {
+  parseUTCDate,
+  formatLocalDateTime,
+  formatDurationBetween,
+} from '../../utils/date';
 import consoleStyles from '../../styles/console-styles.css?inline';
 import { reducedMotionStyles } from '../../styles/reduced-motion';
 import '../../components/view-header.ts';
+
+/** Statuses that mean the run has not reached a terminal state yet. */
+const RUNNING_STATUSES = new Set([
+  'PENDING',
+  'STARTING',
+  'INITIALIZING',
+  'RUNNING',
+]);
 
 interface FlowExecution {
   id: string;
@@ -318,7 +330,7 @@ export class FlowExecutionsView extends AuthedElement {
                           <th>Subject</th>
                           <th>Status</th>
                           <th>Start Time</th>
-                          <th>End Time</th>
+                          <th>Duration</th>
                           <th>Tool Calls</th>
                           <th>Details</th>
                         </tr>
@@ -350,13 +362,7 @@ export class FlowExecutionsView extends AuthedElement {
                                 </div>
                               </td>
                               <td>${formatLocalDateTime(exec.start_time)}</td>
-                              <td>
-                                ${
-                                  exec.end_time
-                                    ? formatLocalDateTime(exec.end_time)
-                                    : '-'
-                                }
-                              </td>
+                              <td>${this.executionDuration(exec) || '—'}</td>
                               <td>${exec.tool_calls_count || 0}</td>
                               <td>
                                 <sl-button
@@ -452,5 +458,25 @@ export class FlowExecutionsView extends AuthedElement {
       default:
         return 'neutral';
     }
+  }
+
+  /**
+   * Duration text for an execution row.
+   *
+   * Finished runs show the elapsed span; still-running ones show live elapsed
+   * time (recomputed on each render, refreshed by the existing polling, no
+   * per-row timers). Legacy rows that ended without an `end_time`, and rows
+   * whose timestamps are unusable, get an empty string so the caller can show
+   * a placeholder.
+   */
+  private executionDuration(exec: FlowExecution): string {
+    if (exec.end_time) {
+      return formatDurationBetween(exec.start_time, exec.end_time);
+    }
+    if (RUNNING_STATUSES.has(exec.status)) {
+      const elapsed = formatDurationBetween(exec.start_time, null);
+      return elapsed ? `Running · ${elapsed}` : '';
+    }
+    return '';
   }
 }

--- a/frontend/src/views/authed/flow-view.ts
+++ b/frontend/src/views/authed/flow-view.ts
@@ -15,11 +15,8 @@ import {
   getAccountAgents,
 } from '../../api';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
-import {
-  parseUTCDate,
-  formatLocalDateTime,
-  formatDurationBetween,
-} from '../../utils/date';
+import { parseUTCDate, formatLocalDateTime } from '../../utils/date';
+import { executionDurationText } from '../../utils/execution';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
@@ -68,14 +65,6 @@ interface CustomCommands {
 interface WebhookConfig {
   webhook_secret: string;
 }
-
-/** Statuses that mean the run has not reached a terminal state yet. */
-const RUNNING_STATUSES = new Set([
-  'PENDING',
-  'STARTING',
-  'INITIALIZING',
-  'RUNNING',
-]);
 
 interface Flow {
   id?: string;
@@ -904,7 +893,7 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre>
                                 ${formatLocalDateTime(exec.start_time)}
                               </td>
                               <td style="padding: 8px;">
-                                ${this.executionDuration(exec) || '—'}
+                                ${executionDurationText(exec) || '—'}
                               </td>
                               <td style="padding: 8px;">
                                 <sl-button
@@ -939,24 +928,6 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre>
       default:
         return 'neutral';
     }
-  }
-
-  /**
-   * Duration cell for the recent-executions table. Finished runs show their
-   * span, live runs count up on each render (list refreshes come from the
-   * existing WebSocket updates, no per-row timers), and rows that ended
-   * without an `end_time` fall back to an em dash instead of claiming the run
-   * is still going.
-   */
-  private executionDuration(exec: any): string {
-    if (exec.end_time) {
-      return formatDurationBetween(exec.start_time, exec.end_time);
-    }
-    if (RUNNING_STATUSES.has(exec.status)) {
-      const elapsed = formatDurationBetween(exec.start_time, null);
-      return elapsed ? `Running · ${elapsed}` : '';
-    }
-    return '';
   }
 
   private extractTriggerEventPlaceholders(): string[] {

--- a/frontend/src/views/authed/flow-view.ts
+++ b/frontend/src/views/authed/flow-view.ts
@@ -18,7 +18,7 @@ import { unifiedWebSocketManager } from '../../services/unified-websocket-manage
 import {
   parseUTCDate,
   formatLocalDateTime,
-  calculateDuration,
+  formatDurationBetween,
 } from '../../utils/date';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
@@ -68,6 +68,14 @@ interface CustomCommands {
 interface WebhookConfig {
   webhook_secret: string;
 }
+
+/** Statuses that mean the run has not reached a terminal state yet. */
+const RUNNING_STATUSES = new Set([
+  'PENDING',
+  'STARTING',
+  'INITIALIZING',
+  'RUNNING',
+]);
 
 interface Flow {
   id?: string;
@@ -896,14 +904,7 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre>
                                 ${formatLocalDateTime(exec.start_time)}
                               </td>
                               <td style="padding: 8px;">
-                                ${
-                                  exec.end_time
-                                    ? calculateDuration(
-                                        exec.start_time,
-                                        exec.end_time
-                                      )
-                                    : 'Running...'
-                                }
+                                ${this.executionDuration(exec) || '—'}
                               </td>
                               <td style="padding: 8px;">
                                 <sl-button
@@ -938,6 +939,24 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre>
       default:
         return 'neutral';
     }
+  }
+
+  /**
+   * Duration cell for the recent-executions table. Finished runs show their
+   * span, live runs count up on each render (list refreshes come from the
+   * existing WebSocket updates, no per-row timers), and rows that ended
+   * without an `end_time` fall back to an em dash instead of claiming the run
+   * is still going.
+   */
+  private executionDuration(exec: any): string {
+    if (exec.end_time) {
+      return formatDurationBetween(exec.start_time, exec.end_time);
+    }
+    if (RUNNING_STATUSES.has(exec.status)) {
+      const elapsed = formatDurationBetween(exec.start_time, null);
+      return elapsed ? `Running · ${elapsed}` : '';
+    }
+    return '';
   }
 
   private extractTriggerEventPlaceholders(): string[] {

--- a/frontend/src/views/authed/flows-view.test.ts
+++ b/frontend/src/views/authed/flows-view.test.ts
@@ -150,4 +150,58 @@ describe('FlowsView', () => {
     const urls = fetchStub.getCalls().map((c) => String(c.args[0]));
     expect(urls.some((u) => u.includes('/api/v1/flows'))).to.be.true;
   });
+
+  describe('recent execution duration', () => {
+    async function renderItem(exec: Record<string, unknown>) {
+      fetchStub = createFetchStub([], []);
+      const element = (await fixture(
+        html`<flows-view></flows-view>`
+      )) as FlowsView;
+      await waitUntil(
+        () => !(element as any).isLoading,
+        'Flows view did not finish loading'
+      );
+
+      const item = await fixture(
+        (element as any).renderExecutionItem(exec) as any
+      );
+      return (item.textContent || '').replace(/\s+/g, ' ').trim();
+    }
+
+    it('appends the duration to the started timestamp when the run finished', async () => {
+      const text = await renderItem({
+        id: 'exec-done',
+        flow_id: 'flow-1',
+        status: 'SUCCEEDED',
+        start_time: '2026-03-09T10:00:00Z',
+        end_time: '2026-03-09T10:04:32Z',
+      });
+
+      expect(text).to.contain('Started');
+      expect(text).to.contain('· 4m 32s');
+    });
+
+    it('shows the live elapsed time for a running execution', async () => {
+      const text = await renderItem({
+        id: 'exec-running',
+        flow_id: 'flow-1',
+        status: 'RUNNING',
+        start_time: new Date(Date.now() - 65_000).toISOString(),
+      });
+
+      expect(text).to.match(/Started .*· Running · \d+m \d+s/);
+    });
+
+    it('appends nothing for a legacy terminal execution without an end time', async () => {
+      const text = await renderItem({
+        id: 'exec-legacy',
+        flow_id: 'flow-1',
+        status: 'FAILED',
+        start_time: '2026-03-09T10:00:00Z',
+      });
+
+      expect(text).to.contain('Started');
+      expect(text).to.not.contain('·');
+    });
+  });
 });

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -15,7 +15,8 @@ import {
   getFlowExecutions,
   triggerFlowExecution,
 } from '../../api';
-import { formatLocalDateTime, formatDurationBetween } from '../../utils/date';
+import { formatLocalDateTime } from '../../utils/date';
+import { executionDurationText } from '../../utils/execution';
 import consoleStyles from '../../styles/console-styles.css?inline';
 
 interface Flow {
@@ -31,14 +32,6 @@ interface Flow {
     estimated_cost?: number;
   };
 }
-
-/** Statuses that mean the run has not reached a terminal state yet. */
-const RUNNING_STATUSES = new Set([
-  'PENDING',
-  'STARTING',
-  'INITIALIZING',
-  'RUNNING',
-]);
 
 interface FlowExecution {
   id: string;
@@ -614,7 +607,7 @@ export class FlowsView extends LitElement {
 
   renderExecutionItem(exec: FlowExecution) {
     const flow = this.flows.find((f) => f.id === exec.flow_id);
-    const duration = this.executionDuration(exec);
+    const duration = executionDurationText(exec);
     return html`
       <div
         class="execution-item"
@@ -642,23 +635,6 @@ export class FlowsView extends LitElement {
         </sl-button>
       </div>
     `;
-  }
-
-  /**
-   * Duration suffix for the "Started …" line: the final span for finished
-   * runs, live elapsed time for running ones (recomputed on render; list
-   * items refresh via the existing WebSocket updates), and an empty string
-   * when there is nothing trustworthy to show.
-   */
-  private executionDuration(exec: FlowExecution): string {
-    if (exec.end_time) {
-      return formatDurationBetween(exec.start_time, exec.end_time);
-    }
-    if (RUNNING_STATUSES.has(exec.status)) {
-      const elapsed = formatDurationBetween(exec.start_time, null);
-      return elapsed ? `Running · ${elapsed}` : '';
-    }
-    return '';
   }
 
   getStatusVariant(status: string) {

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -15,7 +15,7 @@ import {
   getFlowExecutions,
   triggerFlowExecution,
 } from '../../api';
-import { formatLocalDateTime } from '../../utils/date';
+import { formatLocalDateTime, formatDurationBetween } from '../../utils/date';
 import consoleStyles from '../../styles/console-styles.css?inline';
 
 interface Flow {
@@ -31,6 +31,14 @@ interface Flow {
     estimated_cost?: number;
   };
 }
+
+/** Statuses that mean the run has not reached a terminal state yet. */
+const RUNNING_STATUSES = new Set([
+  'PENDING',
+  'STARTING',
+  'INITIALIZING',
+  'RUNNING',
+]);
 
 interface FlowExecution {
   id: string;
@@ -606,6 +614,7 @@ export class FlowsView extends LitElement {
 
   renderExecutionItem(exec: FlowExecution) {
     const flow = this.flows.find((f) => f.id === exec.flow_id);
+    const duration = this.executionDuration(exec);
     return html`
       <div
         class="execution-item"
@@ -621,7 +630,10 @@ export class FlowsView extends LitElement {
             <div
               style="font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-600);"
             >
-              Started ${formatLocalDateTime(exec.start_time)}
+              Started
+              ${formatLocalDateTime(exec.start_time)}${
+                duration ? ` · ${duration}` : ''
+              }
             </div>
           </div>
         </div>
@@ -630,6 +642,23 @@ export class FlowsView extends LitElement {
         </sl-button>
       </div>
     `;
+  }
+
+  /**
+   * Duration suffix for the "Started …" line: the final span for finished
+   * runs, live elapsed time for running ones (recomputed on render; list
+   * items refresh via the existing WebSocket updates), and an empty string
+   * when there is nothing trustworthy to show.
+   */
+  private executionDuration(exec: FlowExecution): string {
+    if (exec.end_time) {
+      return formatDurationBetween(exec.start_time, exec.end_time);
+    }
+    if (RUNNING_STATUSES.has(exec.status)) {
+      const elapsed = formatDurationBetween(exec.start_time, null);
+      return elapsed ? `Running · ${elapsed}` : '';
+    }
+    return '';
   }
 
   getStatusVariant(status: string) {


### PR DESCRIPTION
## Why

The flow executions table showed **Start Time** next to **End Time**. Between
them they say when a run happened and when it stopped, but neither answers the
question people actually scan that table for: *how long did it take?* Working
that out meant subtracting two wall-clock timestamps by eye, and for a run
still in flight there was nothing at all — the End Time cell was just `-`.

Both timestamps have always been on the API (`start_time` non-null,
`end_time` nullable), so this is a console-only change.

## What changed

**New formatter** — `formatDurationBetween(start, end?, now?)` in
`utils/date.ts`. It tolerates the messy cases the UI actually hits:

- no end time → measures elapsed against `now` (injectable, so tests are
  deterministic)
- missing/unparseable start, garbage end, or an end before the start
  (clock skew) → returns `''` rather than `NaN` or a negative span, letting
  each caller pick its own placeholder

`calculateDuration()` now delegates to it, so the existing output style
(`1h 5m` / `4m 32s` / `25s`) is shared and unchanged.

**Rendering rule**, applied consistently:

| State | Shown |
|---|---|
| `end_time` present | the finished span, e.g. `4m 32s` |
| No `end_time`, still running | `Running · 4m 32s` |
| No `end_time`, terminal status (legacy rows) | `—` in tables, nothing inline |
| Unusable timestamps | `—` in tables, nothing inline |

That last row matters: those legacy rows previously rendered `Running...` on
the flow detail page, claiming a long-dead execution was still going.

**Where:** executions table (End Time column → Duration), flow detail recent
executions table, Flows list and dashboard rows (appended to the
`Started …` line), and the execution detail Timing card.

**Live ticking** is limited to the detail view, where a single interval
advances a `durationNow` state once a second. It stops when the status turns
terminal and on `disconnectedCallback`, so nothing is left re-rendering a
finished run. List views compute elapsed time at render and add **no** timers
— rows already refresh via the existing polling/WebSocket updates.

## Testing

Written red-first, then implemented.

- `date.test.ts` — 12 cases on the formatter: each format bucket, ≥24h staying
  in hours, naive backend strings as UTC, missing/reversed/garbage inputs, an
  explicit `now`, plus a `calculateDuration` regression check.
- `flow-executions-view.test.ts` — header is `Duration` and no longer
  `End Time`; completed / running / legacy-terminal / clock-skewed rows.
- `flow-execution-view.test.ts` — completed and running Timing card, the value
  advancing under fake timers, and the interval cleared on disconnect.
- `flows-view.test.ts` — duration appended for finished and running runs,
  nothing appended for a legacy terminal row.

Full suite: **86 files, 648 passed, 0 failed**. `tsc --noEmit` reports the same
81 pre-existing errors as `main` — none new. No backend tests: no API change.

## Out of scope

Backend/OpenAPI (nothing to add), Duration sorting/filtering, per-row tickers
in lists, and runtime-session durations.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-tested frontend-only change with thorough edge-case handling and no API modifications.
>
> **Overview**
> Replaces raw end timestamps with computed durations across the console UI. Adds a `formatDurationBetween` utility that gracefully handles missing/garbage/clock-skewed timestamps. Live ticking is scoped to the execution detail view only. All previous review feedback has been addressed — duplicated constants and methods are now extracted to a shared `utils/execution.ts` module.
>
> <sup>Written by Preloop PR Reviewer for commit `54c2fa2`. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->