### PR TITLE
fix: streaming gateway requests cut at 60s by proxy layers, plus abort observability and transient-failure retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only retried when the agent process exited non-zero, which is the condition
   under which the container's post-execution git block does not run.
 
+- **Streaming gateway requests killed in front of the gateway left no trace**:
+  every streaming endpoint calls the upstream model provider *before* handing
+  its SSE generator to the web layer, so that upstream failures surface as real
+  HTTP errors instead of empty `200` streams. If the client was already gone
+  when the first chunk was due — which is exactly what a proxy read-timeout in
+  front of the gateway looks like — the generator body never ran, and neither
+  did the usage accounting inside it (a Python generator closed before its
+  first `next()` never executes, `finally` included). The provider had already
+  been asked to generate and was billing for it, but Preloop recorded no usage
+  row, no status code and no error class: the user's agent failed while the
+  console reported a clean bill of health. Such requests are now recorded as
+  status `499` with a new `stream_abandoned` error class, distinct from the
+  `client_cancelled` class used when a client drops a stream it was actively
+  reading. `ApiUsage.error_class` is also exposed on the per-request session
+  timeline API, so failures that share a status code (a proxy timeout versus a
+  user cancelling) can finally be told apart in the product. Spend semantics
+  are unchanged: an abandoned stream streamed nothing, so no provider tokens
+  are invented, and the already-working mid-stream disconnect path still
+  records exactly one row.
+
 - **Backfilled costs stayed $0 for models missing from the price snapshot**:
   `reprice_unpriced_usage.py` recomputed every row against the locally bundled
   price catalog only. A row is recorded `unpriced` precisely when the model was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   token issuance. It now orders by lifecycle state (active, then suspended,
   then decommissioned) and falls back to most-recent-first.
 
+- **Streaming model-gateway requests were cut off at 60s with a 504**: the
+  `/openai`, `/anthropic` and `/gemini` routes are the only ones that relay
+  streaming LLM responses, and they were the only proxied routes with no
+  `proxy_read_timeout` override — so they inherited nginx's 60s default at
+  *both* proxy layers (the console nginx and the ingress, which has its own
+  independent default). Time-to-first-byte on a streaming completion is the
+  model's thinking time, so this was deterministic on prompt size rather than
+  intermittent: short prompts answered in seconds, while one large enough to
+  make the model reason past a minute was killed by the proxy. The client saw
+  a 504 that the gateway never observed and could not report, since the
+  request was terminated in front of the application. All three routes now
+  carry an explicit timeout (configurable via `gateway.proxy.*`, default
+  900s), the ingress carries the matching annotations so a default install is
+  correct without extra flags, and `proxy_buffering` is off so tokens are
+  relayed as they arrive instead of being accumulated by nginx. A chart test
+  asserts all of this so the override cannot be silently dropped again.
+
 ### Added
 
 - **Admin alert for unpriceable models**: the gateway now notifies admins the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Unhelpful failure messages and no retry when an upstream model provider
+  failed**: when the model provider in front of an agent returned a gateway
+  timeout, the agent CLI exhausted its own internal retries hundreds of log
+  lines before exiting, and the extractor that builds
+  `FlowExecution.error_message` returned only the tail of the log. A user
+  reviewing a failed run saw exactly
+  `"  status: 504\n}\nAn unexpected critical error occurred:[object Object]"`
+  — 69 characters that name no cause and suggest no action. Agent-log failure
+  analysis now scans the whole log for the *meaningful* signal (an upstream
+  HTTP status plus the agent's exhausted retry loop) instead of the last
+  error-shaped line, and produces messages like `Upstream model provider timed
+  out (HTTP 504) after 3 attempts.` Lines that carry no information
+  (`[object Object]`, bare `status: NNN` fragments, proxy HTML error pages) are
+  never surfaced as the cause when a real signal exists. Classification reuses
+  the shared upstream-error taxonomy, so a hard quota exhaustion is still
+  distinguished from a transient throttle.
+
+  A transient upstream failure is also no longer terminal: a flow execution
+  whose attempt failed on a retryable upstream error (timeout, bad gateway,
+  overload, throttling, connection reset) is retried with exponential backoff
+  (`FLOW_EXECUTION_MAX_ATTEMPTS`, default 2;
+  `FLOW_EXECUTION_RETRY_BACKOFF_SECONDS`, default 15). Retries are never
+  silent — each one is recorded as an `execution_retry_scheduled` milestone and
+  surfaced on the execution timeline. Non-transient failures (bad credentials,
+  denied permissions, exhausted quota, unknown model) are never retried. To
+  rule out double-posting a review comment, push or pull request, an attempt is
+  only retried when the agent process exited non-zero, which is the condition
+  under which the container's post-execution git block does not run.
+
 - **Backfilled costs stayed $0 for models missing from the price snapshot**:
   `reprice_unpriced_usage.py` recomputed every row against the locally bundled
   price catalog only. A row is recorded `unpriced` precisely when the model was

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -10,6 +10,7 @@ import aiodocker
 from aiodocker.exceptions import DockerError
 
 from .base import AgentExecutionResult, AgentExecutor, AgentStatus
+from .failure_analysis import analyze_agent_failure
 from preloop.services.mcp_config_service import MCPConfigService
 from preloop.utils.git_credentials import (
     GitCredential,
@@ -923,10 +924,14 @@ class ContainerAgentExecutor(AgentExecutor):
 
     def _extract_error_from_logs(self, logs_text: str) -> str:
         """
-        Extract error message from logs.
+        Extract a human-actionable error message from logs.
 
-        Searches from the END of logs for the most relevant error, filtering
-        out status/metadata lines that don't contain useful error information.
+        Delegates to :func:`analyze_agent_failure`, which looks for the
+        *meaningful* failure signal (an upstream provider status and the
+        agent's own exhausted retry loop) anywhere in the log, rather than
+        returning whatever the last error-shaped line happened to be. The tail
+        of a failed run is usually a stack trace or a stringified error object
+        (``[object Object]``), which names no cause.
 
         Args:
             logs_text: Full log text
@@ -934,60 +939,7 @@ class ContainerAgentExecutor(AgentExecutor):
         Returns:
             Extracted error message or empty string
         """
-        lines = logs_text.split("\n")
-
-        # Filter out status/metadata lines that aren't useful for error display
-        status_prefixes = (
-            "[Agent Status]",
-            "[Status Update]",
-            "Status:",
-            '{"status":',
-        )
-
-        # Get content lines (non-empty, non-status lines)
-        content_lines = []
-        for line in lines:
-            stripped = line.strip()
-            if stripped and not stripped.startswith(status_prefixes):
-                content_lines.append(line)
-
-        if not content_lines:
-            return ""
-
-        # Priority 1: Look for explicit ERROR: lines from the end (most relevant)
-        # These are typically agent-generated errors like "ERROR: Quota exceeded"
-        for i in range(len(content_lines) - 1, -1, -1):
-            line = content_lines[i]
-            if line.strip().upper().startswith("ERROR:"):
-                # Found an explicit error line - return it with some context
-                start = max(0, i - 2)
-                end = min(len(content_lines), i + 3)
-                return "\n".join(content_lines[start:end])
-
-        # Priority 2: Look for Python exceptions/tracebacks from the end
-        for i in range(len(content_lines) - 1, -1, -1):
-            line_lower = content_lines[i].lower()
-            if any(
-                pattern in line_lower
-                for pattern in ["traceback", "exception:", "raise "]
-            ):
-                # Found exception - include context
-                start = max(0, i)
-                end = min(len(content_lines), i + 10)
-                return "\n".join(content_lines[start:end])
-
-        # Priority 3: Look for other error patterns from the end
-        for i in range(len(content_lines) - 1, -1, -1):
-            line_lower = content_lines[i].lower()
-            if any(pattern in line_lower for pattern in ["error", "failed", "fatal"]):
-                # Include some context around the error
-                start = max(0, i - 2)
-                end = min(len(content_lines), i + 3)
-                return "\n".join(content_lines[start:end])
-
-        # Priority 4: If no error patterns found, return last few content lines
-        # as they may contain relevant information about why the execution failed
-        return "\n".join(content_lines[-5:])
+        return analyze_agent_failure(logs_text).message
 
     async def stop(self, session_reference: str) -> None:
         """

--- a/backend/preloop/agents/failure_analysis.py
+++ b/backend/preloop/agents/failure_analysis.py
@@ -1,0 +1,422 @@
+"""Turn raw agent-container logs into an actionable failure summary.
+
+When an agent container fails, the only thing a user ever sees is
+``FlowExecution.error_message``. Historically that was "the last few lines of
+the log that happened to contain the word error", which for the common case of
+an upstream model-provider outage produced text like::
+
+    "  status: 504\\n}\\nAn unexpected critical error occurred:[object Object]"
+
+That names no cause and suggests no action. The real signal — an agent CLI
+retrying an upstream call and exhausting its attempts — sat hundreds of lines
+earlier and was discarded.
+
+This module scans the whole log for the *meaningful* failure signal instead of
+the last error-shaped line, and classifies it using the shared upstream-error
+taxonomy in :mod:`preloop.services.upstream_errors` so retry decisions and
+recorded error classes speak the same vocabulary as the model gateway.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from preloop.services.upstream_errors import (
+    ERROR_CLASS_UPSTREAM_QUOTA_EXHAUSTED,
+    classify_recorded_error,
+)
+from preloop.utils.secret_scrubbing import scrub_secrets
+
+# Same cap the gateway uses when surfacing upstream text to end users
+# (``model_gateway_errors._MAX_SURFACED_MESSAGE_CHARS``). Agent logs embed
+# whole HTML error pages and multi-KB JSON blobs; the user needs the sentence.
+MAX_SURFACED_MESSAGE_CHARS = 400
+
+# Status/metadata lines the agent wrapper emits; never a failure cause.
+_STATUS_PREFIXES = (
+    "[Agent Status]",
+    "[Status Update]",
+    "Status:",
+    '{"status":',
+)
+
+# A line that matches one of these carries no information on its own. They are
+# skipped when choosing *which* line to surface, but a status code embedded in
+# one is still harvested as a hint. ``[object Object]`` is the classic case: a
+# JS runtime stringifying an error object instead of serialising it.
+_LOW_VALUE_LINE_RES = (
+    # "[object Object]", with or without a leading "...error occurred:" preamble
+    re.compile(r"\[object \w+\]\s*$", re.IGNORECASE),
+    # Bare "status: 504" / "code: 502" fragments from a dumped object
+    re.compile(
+        r"^\W*(?:status|statuscode|status_code|code)\W*\d{3}\W*$", re.IGNORECASE
+    ),
+    # Structural punctuation left over from a pretty-printed object
+    re.compile(r"^[\s{}\[\](),;:'\"]*$"),
+    # Proxy/server HTML error pages
+    re.compile(r"^\s*<"),
+    re.compile(r"^\s*\w+/[\d.]+\s*$"),
+    # A "critical error" preamble with no payload after the colon
+    re.compile(r"error occurred[:\s]*$", re.IGNORECASE),
+)
+
+# Lines where an agent CLI reports one failed attempt of its internal retry
+# loop. Deliberately generic: any "attempt N ... fail" phrasing, so this is not
+# tied to one provider or one CLI's wording.
+_ATTEMPT_LINE_RE = re.compile(
+    r"\battempt\b[^\n]{0,40}?\bfail(?:ed|ure)?\b|\bfail(?:ed|ure)?\b[^\n]{0,40}?\battempt\b",
+    re.IGNORECASE,
+)
+_ATTEMPT_NUMBER_RE = re.compile(
+    r"\battempt\s*#?\s*(\d{1,3})(?:\s*(?:/|of)\s*(\d{1,3}))?", re.IGNORECASE
+)
+
+# "Max attempts reached", "max retries exceeded", "all attempts failed", …
+_EXHAUSTED_RE = re.compile(
+    r"\b(?:max(?:imum)?\s+(?:attempts?|retries|retry\s+attempts)\s+"
+    r"(?:reached|exceeded|exhausted)"
+    r"|all\s+(?:\d+\s+)?(?:attempts?|retries)\s+(?:failed|exhausted)"
+    r"|retr(?:y|ies)\s+(?:limit\s+)?exhausted"
+    r"|giving\s+up)\b",
+    re.IGNORECASE,
+)
+
+# An HTTP status attached to a status-ish keyword. Requires the keyword so
+# arbitrary three-digit numbers in agent prose are not mistaken for statuses.
+_STATUS_RE = re.compile(
+    r"\b(?:status(?:\s*_?\s*code)?|http(?:\s*status)?|response\s*code|returned)\b"
+    r"\W{0,4}(\d{3})\b",
+    re.IGNORECASE,
+)
+
+# Transport-level failures that never produced an HTTP status but are just as
+# retryable as a 504.
+_TRANSIENT_NETWORK_RE = re.compile(
+    r"\b(?:connection\s+(?:reset|refused|closed|aborted|error)"
+    r"|econnreset|econnrefused|epipe|etimedout"
+    r"|socket\s+hang\s+up"
+    r"|network\s+error"
+    r"|(?:request|read|socket)\s+timed?\s*out"
+    r"|timeout\s+(?:of\s+)?\d+\s*ms\s+exceeded)\b",
+    re.IGNORECASE,
+)
+
+# HTTP statuses worth another attempt. 5xx gateway/overload family plus the
+# throttling and request-timeout codes. 401/403/404/400/422 are deliberately
+# absent: retrying them burns money and time and can never succeed.
+_TRANSIENT_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504, 520, 522, 524, 529})
+
+# Opening of the sentence this module generates for an upstream failure.
+# The generated message is the only thing that survives into
+# ``FlowExecution.error_message``, so it is also the input the orchestrator
+# re-analyses when deciding whether to retry. Recognising our own phrasing
+# makes ``analyze_agent_failure`` idempotent: analysing its output reproduces
+# the same classification.
+_UPSTREAM_SENTENCE_PREFIX = "Upstream model provider"
+_GENERATED_ATTEMPTS_RE = re.compile(r"after\s+(\d{1,3})\s+attempts?\b", re.IGNORECASE)
+_GENERATED_EXHAUSTED_RE = re.compile(r"exhausted its retries", re.IGNORECASE)
+
+# Human phrasing per status family. Generic across providers on purpose.
+_STATUS_PHRASES = {
+    400: "rejected the request as invalid",
+    401: "rejected our credentials",
+    403: "denied access",
+    404: "could not find the requested model",
+    408: "timed out",
+    413: "rejected the request as too large",
+    422: "rejected the request as unprocessable",
+    429: "rate-limited the request",
+    500: "returned an internal error",
+    502: "returned a bad gateway error",
+    503: "was unavailable",
+    504: "timed out",
+    529: "was overloaded",
+}
+
+
+def _status_phrase(status: int) -> str:
+    if status in _STATUS_PHRASES:
+        return _STATUS_PHRASES[status]
+    if 500 <= status < 600:
+        return "returned a server error"
+    if 400 <= status < 500:
+        return "rejected the request"
+    return "failed the request"
+
+
+@dataclass(frozen=True)
+class AgentFailureAnalysis:
+    """What actually went wrong inside an agent container.
+
+    Attributes:
+        message: The user-facing sentence stored on the execution. Always
+            secret-scrubbed and length-capped; never empty unless the logs
+            were.
+        upstream_status: HTTP status reported by the upstream model provider,
+            when the logs named one.
+        attempts: How many attempts the agent's own retry loop made, when it
+            reported them.
+        retry_exhausted: True when the agent reported giving up after
+            exhausting its internal retries.
+        transient: True when another attempt could plausibly succeed. Drives
+            flow-level retry; never True for auth, quota or request errors.
+        error_class: Shared taxonomy value from
+            :mod:`preloop.services.upstream_errors`, or ``None`` when the
+            failure was not upstream-related.
+    """
+
+    message: str
+    upstream_status: Optional[int] = None
+    attempts: Optional[int] = None
+    retry_exhausted: bool = False
+    transient: bool = False
+    error_class: Optional[str] = None
+
+
+def _content_lines(logs_text: str) -> list[str]:
+    """Log lines with wrapper status/metadata noise removed."""
+    return [
+        line
+        for line in logs_text.split("\n")
+        if line.strip() and not line.strip().startswith(_STATUS_PREFIXES)
+    ]
+
+
+def _is_low_value(line: str) -> bool:
+    """True when a line cannot, on its own, tell a human what broke."""
+    stripped = line.strip()
+    if not stripped:
+        return True
+    return any(pattern.search(stripped) for pattern in _LOW_VALUE_LINE_RES)
+
+
+def _finalize(message: str) -> str:
+    """Scrub secrets and cap length on anything surfaced to a user."""
+    return (scrub_secrets(message.strip()) or "")[:MAX_SURFACED_MESSAGE_CHARS]
+
+
+@dataclass(frozen=True)
+class _RetrySignal:
+    """What the agent's own retry loop reported, lifted out of the logs."""
+
+    status: Optional[int] = None
+    attempts: Optional[int] = None
+    exhausted: bool = False
+    saw_network_failure: bool = False
+    # Raw text of the matching log lines. Classification runs against this,
+    # not against the sentence we generate, so provider wording like
+    # "you exceeded your current quota" still reaches the taxonomy.
+    evidence: str = ""
+
+    @property
+    def found(self) -> bool:
+        return self.status is not None or self.attempts is not None or self.exhausted
+
+
+def _scan_upstream_retry_signal(lines: list[str]) -> _RetrySignal:
+    """Find the agent's internal retry loop in the logs."""
+    statuses: list[int] = []
+    attempts: Optional[int] = None
+    exhausted = False
+    saw_network_failure = False
+    evidence: list[str] = []
+
+    for line in lines:
+        is_attempt_line = bool(_ATTEMPT_LINE_RE.search(line))
+        if _EXHAUSTED_RE.search(line):
+            exhausted = True
+            evidence.append(line)
+
+        if is_attempt_line:
+            evidence.append(line)
+            number_match = _ATTEMPT_NUMBER_RE.search(line)
+            if number_match:
+                seen = int(number_match.group(1))
+                total = number_match.group(2)
+                if total:
+                    seen = max(seen, int(total))
+                attempts = seen if attempts is None else max(attempts, seen)
+            status_match = _STATUS_RE.search(line)
+            if status_match:
+                statuses.append(int(status_match.group(1)))
+            if _TRANSIENT_NETWORK_RE.search(line):
+                saw_network_failure = True
+
+    return _RetrySignal(
+        # The last reported attempt is the one that ended the run.
+        status=statuses[-1] if statuses else None,
+        attempts=attempts,
+        exhausted=exhausted,
+        saw_network_failure=saw_network_failure,
+        evidence="\n".join(evidence),
+    )
+
+
+def _scan_any_upstream_status(lines: list[str]) -> Optional[int]:
+    """Last upstream HTTP status mentioned anywhere, including in dumps.
+
+    A bare ``status: 504`` fragment is useless *as a message*, but the number
+    in it is still the best clue about what happened, so it is harvested even
+    from lines that are otherwise discarded.
+    """
+    found: Optional[int] = None
+    for line in lines:
+        match = _STATUS_RE.search(line)
+        if match:
+            status = int(match.group(1))
+            if 400 <= status < 600:
+                found = status
+    return found
+
+
+def _build_upstream_message(
+    status: Optional[int], attempts: Optional[int], exhausted: bool
+) -> str:
+    """Compose the user-facing sentence for an upstream provider failure."""
+    if status is not None:
+        subject = f"Upstream model provider {_status_phrase(status)} (HTTP {status})"
+    else:
+        subject = "Upstream model provider was unreachable"
+
+    if attempts and attempts > 1:
+        return f"{subject} after {attempts} attempts."
+    if exhausted:
+        return f"{subject}; the agent exhausted its retries."
+    return f"{subject}."
+
+
+def _fallback_message(lines: list[str]) -> str:
+    """Legacy best-effort extraction, skipping information-free lines.
+
+    Priority: explicit ``ERROR:`` lines, then exceptions/tracebacks, then any
+    error-shaped line, then the log tail. Unlike the original implementation,
+    lines that carry no information (``[object Object]``, bare ``status: NNN``,
+    HTML error pages, stray braces) are never selected as the answer.
+    """
+
+    def window(index: int, before: int, after: int) -> str:
+        start = max(0, index - before)
+        end = min(len(lines), index + after)
+        return "\n".join(lines[start:end])
+
+    for index in range(len(lines) - 1, -1, -1):
+        if lines[index].strip().upper().startswith("ERROR:"):
+            return window(index, 2, 3)
+
+    for index in range(len(lines) - 1, -1, -1):
+        lowered = lines[index].lower()
+        if any(marker in lowered for marker in ("traceback", "exception:", "raise ")):
+            return window(index, 0, 10)
+
+    for index in range(len(lines) - 1, -1, -1):
+        if _is_low_value(lines[index]):
+            continue
+        lowered = lines[index].lower()
+        if any(marker in lowered for marker in ("error", "failed", "fatal")):
+            return window(index, 2, 3)
+
+    informative = [line for line in lines if not _is_low_value(line)]
+    return "\n".join((informative or lines)[-5:])
+
+
+def _reanalyze_generated_message(text: str) -> Optional[AgentFailureAnalysis]:
+    """Re-derive an analysis from a message this module previously generated.
+
+    The orchestrator stores only the generated sentence, then re-analyses it
+    to decide whether to retry. Parsing our own output keeps that decision
+    identical to the one made from the full logs, instead of silently
+    downgrading a known-transient failure to "not transient".
+    """
+    stripped = text.strip()
+    if not stripped.startswith(_UPSTREAM_SENTENCE_PREFIX):
+        return None
+
+    status_match = re.search(r"\bHTTP\s+(\d{3})\b", stripped)
+    status = int(status_match.group(1)) if status_match else None
+
+    attempts_match = _GENERATED_ATTEMPTS_RE.search(stripped)
+    attempts = int(attempts_match.group(1)) if attempts_match else None
+    exhausted = bool(_GENERATED_EXHAUSTED_RE.search(stripped)) or bool(attempts)
+
+    error_class = (
+        classify_recorded_error(status, stripped) if status is not None else None
+    )
+    if status is not None:
+        transient = (
+            status in _TRANSIENT_STATUSES
+            and error_class != ERROR_CLASS_UPSTREAM_QUOTA_EXHAUSTED
+        )
+    else:
+        # "Upstream model provider was unreachable" — a transport failure.
+        transient = True
+
+    return AgentFailureAnalysis(
+        message=_finalize(stripped),
+        upstream_status=status,
+        attempts=attempts,
+        retry_exhausted=exhausted,
+        transient=transient,
+        error_class=error_class,
+    )
+
+
+def analyze_agent_failure(logs_text: str) -> AgentFailureAnalysis:
+    """Explain why an agent container failed, from its logs.
+
+    Args:
+        logs_text: Full (or tailed) container log text.
+
+    Returns:
+        An :class:`AgentFailureAnalysis`. ``message`` is always safe to store
+        on ``FlowExecution.error_message`` and show to a user.
+    """
+    lines = _content_lines(logs_text)
+    if not lines:
+        return AgentFailureAnalysis(message="")
+
+    already_analyzed = _reanalyze_generated_message(logs_text)
+    if already_analyzed is not None:
+        return already_analyzed
+
+    signal = _scan_upstream_retry_signal(lines)
+    status = signal.status
+
+    # No retry loop reported: an upstream status may still be the only real
+    # clue, hiding inside an otherwise information-free object dump.
+    if not signal.found:
+        tail_is_noise = all(_is_low_value(line) for line in lines[-3:])
+        harvested = _scan_any_upstream_status(lines)
+        if harvested is not None and tail_is_noise:
+            status = harvested
+
+    if signal.found or status is not None:
+        message = _build_upstream_message(status, signal.attempts, signal.exhausted)
+        # Classify against the original log text, not the sentence we just
+        # generated: provider wording ("exceeded your current quota") is what
+        # separates a hard quota exhaustion from a transient 429.
+        error_class = (
+            classify_recorded_error(status, signal.evidence or logs_text)
+            if status is not None
+            else None
+        )
+        if status is not None:
+            transient = (
+                status in _TRANSIENT_STATUSES
+                and error_class != ERROR_CLASS_UPSTREAM_QUOTA_EXHAUSTED
+            )
+        else:
+            # Attempts were reported but no status: only treat as transient
+            # when the logs showed a transport-level failure.
+            transient = signal.saw_network_failure
+        return AgentFailureAnalysis(
+            message=_finalize(message),
+            upstream_status=status,
+            attempts=signal.attempts,
+            retry_exhausted=signal.exhausted,
+            transient=transient,
+            error_class=error_class,
+        )
+
+    return AgentFailureAnalysis(message=_finalize(_fallback_message(lines)))

--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -2482,6 +2482,7 @@ def _request_row_to_item(row: Any) -> RuntimeSessionRequestItem:
         provider_name=row.provider_name,
         status_code=status_code,
         is_error=status_code >= 400,
+        error_class=row.error_class,
         finish_reason=(meta.get("finish_reason") if isinstance(meta, dict) else None),
         is_retry=bool(meta.get("is_retry", False)) if isinstance(meta, dict) else False,
         prompt_tokens=int(row.prompt_tokens or 0),

--- a/backend/preloop/config.py
+++ b/backend/preloop/config.py
@@ -357,6 +357,23 @@ class Settings(BaseSettings):
         3600,
         description="Maximum wall-clock time to wait for one flow execution before failing it",
     )
+    flow_execution_max_attempts: int = Field(
+        2,
+        description=(
+            "Maximum agent attempts per flow execution. Attempts beyond the "
+            "first are only made when the failure was a transient upstream "
+            "model-provider error (timeout, overload, throttling) and the "
+            "failed attempt produced no external side effects. Set to 1 to "
+            "disable flow-level retries."
+        ),
+    )
+    flow_execution_retry_backoff_seconds: int = Field(
+        15,
+        description=(
+            "Base backoff before retrying a flow execution attempt. Doubles "
+            "per attempt, giving an overloaded provider time to recover."
+        ),
+    )
     flow_execution_worker_enabled: bool = Field(
         False,
         description=(
@@ -637,6 +654,12 @@ class Settings(BaseSettings):
             ),
             flow_execution_max_wait_seconds=int(
                 os.getenv("FLOW_EXECUTION_MAX_WAIT_SECONDS", "3600")
+            ),
+            flow_execution_max_attempts=int(
+                os.getenv("FLOW_EXECUTION_MAX_ATTEMPTS", "2")
+            ),
+            flow_execution_retry_backoff_seconds=int(
+                os.getenv("FLOW_EXECUTION_RETRY_BACKOFF_SECONDS", "15")
             ),
             flow_execution_worker_enabled=os.getenv(
                 "FLOW_EXECUTION_WORKER_ENABLED", "false"

--- a/backend/preloop/schemas/gateway_usage.py
+++ b/backend/preloop/schemas/gateway_usage.py
@@ -621,6 +621,12 @@ class RuntimeSessionRequestItem(BaseModel):
     provider_name: Optional[str] = None
     status_code: int = 0
     is_error: bool = False
+    #: Stable failure taxonomy (see ``preloop.services.upstream_errors``).
+    #: Distinguishes failures that share a status code — notably a stream the
+    #: client never consumed because something in front of the gateway timed
+    #: it out (``stream_abandoned``) from a client that cancelled a stream it
+    #: was reading (``client_cancelled``); both are recorded as 499.
+    error_class: Optional[str] = None
     finish_reason: Optional[str] = None
     is_retry: bool = False
     prompt_tokens: int = 0

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -25,6 +25,7 @@ from preloop.models.models.ai_model import AIModel
 from preloop.models.models.runtime_session import RuntimeSession
 from preloop.agents import create_agent_executor, AgentStatus
 from preloop.agents.failure_analysis import analyze_agent_failure
+from preloop.config import settings
 from preloop.services.prompt_resolvers import (
     resolver_registry,
     ResolverContext,
@@ -507,8 +508,6 @@ class FlowExecutionOrchestrator:
             if self.execution_log:
                 # Construct absolute URL to the execution details page
                 # GitHub/GitLab require absolute URLs for commit status links
-                from preloop.config import settings
-
                 base_url = getattr(settings, "preloop_url", None) or getattr(
                     settings, "PRELOOP_URL", None
                 )
@@ -2062,8 +2061,6 @@ class FlowExecutionOrchestrator:
         )
 
         try:
-            from preloop.config import settings
-
             # Start listening for user commands
             await self._listen_for_commands()
 
@@ -2495,8 +2492,6 @@ class FlowExecutionOrchestrator:
             Tuple of ``(agent_result, session_reference)`` for the final
             attempt made.
         """
-        from preloop.config import settings
-
         max_attempts = max(1, int(settings.flow_execution_max_attempts))
         backoff_seconds = max(0, int(settings.flow_execution_retry_backoff_seconds))
 
@@ -2524,6 +2519,20 @@ class FlowExecutionOrchestrator:
                         "Execution %s exhausted all %s attempts",
                         self.execution_log.id if self.execution_log else "unknown",
                         max_attempts,
+                    )
+                    # Mirror the per-retry milestone: without this, the final
+                    # failure of a retried run looks identical on the timeline
+                    # to a first-attempt failure.
+                    self.execution_logger.log_milestone(
+                        "execution_retries_exhausted",
+                        {
+                            "attempts": max_attempts,
+                            "session_reference": session_reference,
+                        },
+                    )
+                    await self._emit_execution_warning(
+                        f"All {max_attempts} attempts failed; giving up.",
+                        details={"attempts": max_attempts},
                     )
                 break
 

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -24,6 +24,7 @@ from preloop.models.models.flow import Flow
 from preloop.models.models.ai_model import AIModel
 from preloop.models.models.runtime_session import RuntimeSession
 from preloop.agents import create_agent_executor, AgentStatus
+from preloop.agents.failure_analysis import analyze_agent_failure
 from preloop.services.prompt_resolvers import (
     resolver_registry,
     ResolverContext,
@@ -2434,6 +2435,148 @@ class FlowExecutionOrchestrator:
 
         logger.debug(f"Execution log updated: status={status}")
 
+    def _retry_decision(self, agent_result: Dict[str, Any]) -> Optional[str]:
+        """Decide whether a failed attempt may be retried.
+
+        Returns ``None`` when the attempt is retryable, or a short reason
+        string explaining why it is not. The reason is logged so an operator
+        can see *why* a failure was treated as terminal.
+
+        The safety boundary is the container's post-execution block (git push,
+        pull-request/merge-request creation), which the agent entrypoints run
+        only when the agent process exited ``0``. A non-zero exit therefore
+        means no external side effect was produced by the container and the
+        attempt can be repeated safely. Anything else — an exit code of 0, an
+        unknown exit code, or side effects already recorded on the timeline —
+        is treated as unsafe, because re-running it risks a duplicate comment,
+        push or pull request. A wrong retry is worse than no retry.
+        """
+        status = agent_result.get("status")
+        if status != "FAILED":
+            # STOPPED (user requested) and SUCCEEDED are never retried.
+            return f"status is {status}, not FAILED"
+
+        exit_code = agent_result.get("exit_code")
+        if exit_code is None:
+            return "agent exit code is unknown, so external side effects cannot be ruled out"
+        if exit_code == 0:
+            return (
+                "agent exited 0, so the container ran its post-execution "
+                "push/pull-request block; retrying could double-post"
+            )
+
+        if self.execution_logger.get_actions_taken():
+            return "the agent already recorded actions; retrying could repeat them"
+
+        analysis = analyze_agent_failure(agent_result.get("error_message") or "")
+        if not analysis.transient:
+            return "the failure is not a transient upstream failure"
+
+        return None
+
+    async def _run_agent_with_retries(
+        self, execution_context: Dict[str, Any]
+    ) -> tuple[Dict[str, Any], Optional[str]]:
+        """Start and monitor the agent, retrying transient upstream failures.
+
+        One provider having a bad minute should not kill a whole review. Each
+        attempt gets a fresh agent session; between attempts we back off so a
+        briefly-overloaded provider has time to recover.
+
+        Retries are deliberately conservative — see :meth:`_retry_decision`
+        for the side-effect boundary that governs them — and always visible:
+        every retry is recorded as an ``execution_retry_scheduled`` milestone
+        and surfaced on the execution timeline, so flakiness is never hidden.
+
+        Args:
+            execution_context: Context prepared for the agent.
+
+        Returns:
+            Tuple of ``(agent_result, session_reference)`` for the final
+            attempt made.
+        """
+        from preloop.config import settings
+
+        max_attempts = max(1, int(settings.flow_execution_max_attempts))
+        backoff_seconds = max(0, int(settings.flow_execution_retry_backoff_seconds))
+
+        agent_result: Dict[str, Any] = {}
+        session_reference: Optional[str] = None
+
+        for attempt in range(1, max_attempts + 1):
+            session_reference, agent_executor = await self._start_agent_session(
+                execution_context
+            )
+
+            await self._update_execution_log(
+                status="RUNNING",
+                agent_session_reference=session_reference,
+            )
+            self._sync_runtime_session(session_reference=session_reference)
+
+            agent_result = await self._monitor_agent_execution(
+                session_reference, agent_executor
+            )
+
+            if attempt >= max_attempts:
+                if agent_result.get("status") == "FAILED" and max_attempts > 1:
+                    logger.info(
+                        "Execution %s exhausted all %s attempts",
+                        self.execution_log.id if self.execution_log else "unknown",
+                        max_attempts,
+                    )
+                break
+
+            reason = self._retry_decision(agent_result)
+            if reason is not None:
+                logger.info(
+                    "Not retrying execution %s: %s",
+                    self.execution_log.id if self.execution_log else "unknown",
+                    reason,
+                )
+                break
+
+            delay = backoff_seconds * (2 ** (attempt - 1))
+            failure_summary = (agent_result.get("error_message") or "").strip()
+            logger.warning(
+                "Attempt %s/%s of execution %s hit a transient upstream failure; "
+                "retrying in %ss",
+                attempt,
+                max_attempts,
+                self.execution_log.id if self.execution_log else "unknown",
+                delay,
+            )
+            self.execution_logger.log_milestone(
+                "execution_retry_scheduled",
+                {
+                    "attempt": attempt,
+                    "max_attempts": max_attempts,
+                    "delay_seconds": delay,
+                    "reason": failure_summary,
+                    "session_reference": session_reference,
+                },
+            )
+            # Surfaced on the timeline so a user can see the run was retried
+            # rather than silently taking twice as long.
+            await self._emit_execution_warning(
+                f"Attempt {attempt} of {max_attempts} failed with a transient "
+                f"upstream error; retrying. ({failure_summary})",
+                details={"attempt": attempt, "max_attempts": max_attempts},
+            )
+            await self._publish_update(
+                "execution_retry",
+                {
+                    "attempt": attempt,
+                    "max_attempts": max_attempts,
+                    "delay_seconds": delay,
+                },
+            )
+
+            if delay:
+                await asyncio.sleep(delay)
+
+        return agent_result, session_reference
+
     async def run(self):
         """
         Execute the flow through its full lifecycle.
@@ -2443,6 +2586,9 @@ class FlowExecutionOrchestrator:
         2. INITIALIZING: Flow and AI model details retrieved
         3. RUNNING: Agent session started
         4. SUCCEEDED/FAILED: Execution completed
+
+        A failed attempt whose cause was a transient upstream model-provider
+        failure is retried (see :meth:`_run_agent_with_retries`).
         """
         try:
             # Stage 1: Retrieve flow details first (needed for account_id in messages)
@@ -2485,22 +2631,11 @@ class FlowExecutionOrchestrator:
                 resolved_input_prompt=execution_context["prompt"],
             )
 
-            # Stage 4: Start agent session (returns both session reference and executor)
-            session_reference, agent_executor = await self._start_agent_session(
+            # Stages 4 and 5: start the agent and monitor it, retrying the
+            # whole attempt when the upstream model provider failed in a way
+            # that another attempt could plausibly survive.
+            agent_result, session_reference = await self._run_agent_with_retries(
                 execution_context
-            )
-
-            # Agent started successfully - now mark as RUNNING with session reference
-            await self._update_execution_log(
-                status="RUNNING",
-                agent_session_reference=session_reference,
-            )
-            self._sync_runtime_session(session_reference=session_reference)
-
-            # Stage 5: Monitor agent execution and collect results
-            # Pass the executor so we don't create a duplicate instance
-            agent_result = await self._monitor_agent_execution(
-                session_reference, agent_executor
             )
 
             # Update execution log with final results including detailed logs

--- a/backend/preloop/services/gemini_gateway.py
+++ b/backend/preloop/services/gemini_gateway.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from preloop.services.model_gateway_auth import ModelGatewayAuthContext
 from preloop.services.model_gateway_errors import ModelGatewayAPIError
+from preloop.services.model_gateway_stream_observer import ObservedGatewayStream
 from preloop.services.model_runtime_resolver import resolve_ai_model_runtime
 from preloop.services.openai_gateway import OpenAIGatewayService
 
@@ -164,7 +165,15 @@ class GeminiGatewayService(OpenAIGatewayService):
                 )
             yield self._sse_event(final_payload)
 
-        return event_stream()
+        # The Gemini stream is a translating generator wrapped around the
+        # shared responses stream, which owns the usage accounting. Closing
+        # this outer generator does not close the inner one (and if this outer
+        # generator was never started, closing it runs no code at all), so the
+        # inner stream would only be torn down whenever the garbage collector
+        # got around to it — by which point the request's database session can
+        # already be closed and the usage row is lost. Hand the inner stream to
+        # the observer so it is closed deterministically.
+        return ObservedGatewayStream(event_stream(), closes=(upstream_events,))
 
     def _translate_generate_content_request(
         self, model_name: str, payload: Dict[str, Any]

--- a/backend/preloop/services/model_gateway_stream_observer.py
+++ b/backend/preloop/services/model_gateway_stream_observer.py
@@ -1,0 +1,139 @@
+"""Notice streaming gateway responses that no client ever consumed.
+
+Every streaming gateway endpoint calls the upstream model provider *before*
+handing its SSE generator to the ASGI layer (see
+``OpenAIGatewayService._prefetch_upstream_stream``): the first upstream chunk
+is pulled eagerly so upstream failures become real HTTP errors instead of
+empty ``200`` streams. From that moment the provider is generating — and
+billing — regardless of what happens to the connection.
+
+The gateway's usage accounting, however, lives inside the generator body: the
+success record at the end of the happy path, and the ``finally`` that records
+a client disconnect. A Python generator that is closed *before its first
+``next()``* never enters its body, so **none** of those blocks run:
+
+    >>> def gen():
+    ...     try:
+    ...         yield 1
+    ...     finally:
+    ...         print("finally")
+    >>> g = gen(); g.close()      # prints nothing
+
+That is exactly the shape of a proxy read-timeout in front of the gateway:
+the upstream call happened, the proxy gave up waiting for the first byte and
+dropped the connection, the ASGI layer never pulled a chunk, and the request
+vanished without a usage row, a status code, or an error class. The product
+then reports a clean bill of health for a request the user saw fail.
+
+:class:`ObservedGatewayStream` closes that gap. It wraps the SSE iterator and
+tracks whether anything was ever consumed, so an unconsumed stream can be
+recorded on teardown. It deliberately does **not** replace the in-generator
+accounting: once iteration starts, the wrapper stays silent and the
+generator's own ``finally`` owns the outcome. That split is what keeps a
+disconnect from being counted twice.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Iterable, Iterator, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+class ObservedGatewayStream:
+    """SSE iterator wrapper that reports streams nobody ever consumed.
+
+    Exactly one of three things happens to a wrapped stream, and exactly one
+    accounting record results:
+
+    - **Consumed to completion** — the wrapped generator records its own
+      success row; the wrapper stays silent.
+    - **Consumed then dropped** — the wrapped generator's ``finally`` runs and
+      records the client disconnect; the wrapper stays silent.
+    - **Never consumed** — no generator code ran at all, so the wrapper calls
+      ``on_abandoned`` once.
+
+    This is an explicit iterator class rather than a wrapping generator
+    because a generator would inherit the very problem it is meant to solve:
+    closing a never-started generator does not run its ``finally``.
+
+    Args:
+        stream: The underlying SSE iterator (usually a generator).
+        on_abandoned: Called at most once when the stream is torn down
+            without a single item having been requested. Must not raise;
+            it runs during teardown, where an exception would replace a
+            silent-but-harmless disconnect with a hard failure.
+        closes: Extra resources to close **only when the stream was never
+            consumed**. Their cleanup normally lives in the wrapped
+            generator's ``finally``, which does run once iteration has
+            started; closing them here as well would double-close them.
+            They would otherwise leak when that body never runs at all.
+    """
+
+    __slots__ = ("_stream", "_on_abandoned", "_closes", "_consumed", "_closed")
+
+    def __init__(
+        self,
+        stream: Iterable[Any],
+        *,
+        on_abandoned: Optional[Callable[[], None]] = None,
+        closes: Sequence[Any] = (),
+    ) -> None:
+        self._stream: Iterator[Any] = iter(stream)
+        self._on_abandoned = on_abandoned
+        self._closes = tuple(closes)
+        self._consumed = False
+        self._closed = False
+
+    def __iter__(self) -> "ObservedGatewayStream":
+        return self
+
+    def __next__(self) -> Any:
+        # Mark before delegating: a stream that raised on its first chunk was
+        # still started, and its own error handling owns that outcome.
+        self._consumed = True
+        return next(self._stream)
+
+    def close(self) -> None:
+        """Tear the stream down, recording it when it was never consumed.
+
+        Safe to call repeatedly; only the first call has any effect.
+        """
+        if self._closed:
+            return
+        self._closed = True
+
+        abandoned = not self._consumed
+        if abandoned and self._on_abandoned is not None:
+            try:
+                self._on_abandoned()
+            except Exception:  # noqa: BLE001 - teardown must never raise
+                logger.warning(
+                    "Recording an abandoned gateway stream failed", exc_info=True
+                )
+
+        # ``_closes`` are owned by the wrapped generator's ``finally`` once it
+        # has started; closing them again here would double-close an upstream
+        # HTTP response. Only take ownership when that body never ran.
+        extra = self._closes if abandoned else ()
+        for resource in (self._stream, *extra):
+            closer = getattr(resource, "close", None)
+            if closer is None:
+                continue
+            try:
+                closer()
+            except Exception:  # noqa: BLE001 - teardown must never raise
+                logger.warning(
+                    "Closing a gateway stream resource failed", exc_info=True
+                )
+
+    def __del__(self) -> None:
+        # The ASGI server does not always close the iterator explicitly; it
+        # may simply drop its reference when the response task ends. Under
+        # CPython refcounting that lands here, which is the only remaining
+        # chance to account for an abandoned stream.
+        try:
+            self.close()
+        except Exception:  # noqa: BLE001 - never raise from __del__
+            pass

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -12,7 +12,7 @@ import time
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from itertools import chain
-from typing import Any, Dict, Iterator, List, Optional, Protocol, Set
+from typing import Any, Dict, Iterator, List, Optional, Protocol, Sequence, Set
 from urllib import error as urllib_error
 from urllib import request as urllib_request
 
@@ -74,9 +74,11 @@ from preloop.services.model_gateway_errors import (
     ModelGatewayAPIError,
     extract_upstream_error_detail,
 )
+from preloop.services.model_gateway_stream_observer import ObservedGatewayStream
 from preloop.services.upstream_errors import (
     ERROR_CLASS_CLIENT_CANCELLED,
     ERROR_CLASS_NETWORK,
+    ERROR_CLASS_STREAM_ABANDONED,
     ERROR_CLASS_UPSTREAM_DISCONNECT,
     ERROR_CLASS_UPSTREAM_OVERLOADED,
     ERROR_CLASS_UPSTREAM_QUOTA_EXHAUSTED,
@@ -1465,7 +1467,15 @@ class OpenAIGatewayService:
                         accumulated_output_text="".join(assistant_parts),
                     )
 
-        return event_stream()
+        return self._observe_stream(
+            event_stream(),
+            endpoint="/anthropic/v1/messages",
+            endpoint_kind="anthropic_messages_stream",
+            started_at=started_at,
+            ai_model=model,
+            payload=payload,
+            budget_result=budget_result,
+        )
 
     def stream_chat_completion(self, payload: Dict[str, Any]) -> Iterator[str]:
         """Handle streaming OpenAI-compatible chat completions."""
@@ -1726,7 +1736,15 @@ class OpenAIGatewayService:
                         accumulated_output_text="".join(assistant_parts),
                     )
 
-        return event_stream()
+        return self._observe_stream(
+            event_stream(),
+            endpoint="/openai/v1/chat/completions",
+            endpoint_kind="chat_completions_stream",
+            started_at=started_at,
+            ai_model=model,
+            payload=payload,
+            budget_result=budget_result,
+        )
 
     def stream_response(self, payload: Dict[str, Any]) -> Iterator[str]:
         """Handle streaming OpenAI Responses API-compatible requests."""
@@ -2124,7 +2142,15 @@ class OpenAIGatewayService:
                         accumulated_output_text="".join(assistant_parts),
                     )
 
-        return event_stream()
+        return self._observe_stream(
+            event_stream(),
+            endpoint="/openai/v1/responses",
+            endpoint_kind="responses_stream",
+            started_at=started_at,
+            ai_model=model,
+            payload=payload,
+            budget_result=budget_result,
+        )
 
     def _get_account_models(self) -> List[AIModel]:
         account_id = self.auth_context.user.account_id
@@ -3341,7 +3367,15 @@ class OpenAIGatewayService:
                 yield self._responses_stream_error_event(exc)
                 yield "data: [DONE]\n\n"
 
-        return event_stream()
+        return self._observe_stream(
+            event_stream(),
+            endpoint="/openai/v1/responses",
+            endpoint_kind="responses_stream",
+            started_at=started_at,
+            ai_model=ai_model,
+            payload=payload,
+            budget_result=budget_result,
+        )
 
     def _stream_openai_codex_chat_completion(
         self,
@@ -3553,7 +3587,15 @@ class OpenAIGatewayService:
                 yield self._openai_stream_error_event(exc)
                 yield self._sse_done()
 
-        return event_stream()
+        return self._observe_stream(
+            event_stream(),
+            endpoint="/openai/v1/chat/completions",
+            endpoint_kind="chat_completions_stream",
+            started_at=started_at,
+            ai_model=ai_model,
+            payload=payload,
+            budget_result=budget_result,
+        )
 
     def _build_responses_api_payload(
         self,
@@ -4190,7 +4232,19 @@ class OpenAIGatewayService:
                 upstream_response.close()
                 upstream_client.close()
 
-        return event_stream()
+        # The upstream HTTP response and client are closed in the generator's
+        # finally, which never runs for a stream nobody consumed — hand them to
+        # the observer so an abandoned passthrough does not leak a connection.
+        return self._observe_stream(
+            event_stream(),
+            endpoint="/anthropic/v1/messages",
+            endpoint_kind="anthropic_messages_stream",
+            started_at=started_at,
+            ai_model=ai_model,
+            payload=payload,
+            budget_result=budget_result,
+            closes=(upstream_response, upstream_client),
+        )
 
     def _build_completion_kwargs(
         self,
@@ -5567,6 +5621,108 @@ class OpenAIGatewayService:
             # for anything that runs after this teardown. Roll back too.
             self._rollback_activity_recording(
                 exc, context="gateway usage recording after client disconnect"
+            )
+
+    def _observe_stream(
+        self,
+        stream: Iterator[str],
+        *,
+        endpoint: str,
+        endpoint_kind: str,
+        started_at: float,
+        ai_model: AIModel,
+        payload: Dict[str, Any],
+        budget_result: Optional[BudgetCheckResult],
+        closes: Sequence[Any] = (),
+    ) -> Iterator[str]:
+        """Wrap an SSE stream so an unconsumed one still records usage.
+
+        The upstream provider is already generating by the time a streaming
+        response is handed to the ASGI layer, so a stream that is torn down
+        before its first chunk is a real, billable request that would
+        otherwise leave no trace (see
+        :mod:`preloop.services.model_gateway_stream_observer`). In production
+        this is what a proxy read-timeout in front of the gateway looks like.
+
+        Args:
+            stream: The SSE iterator to wrap.
+            endpoint: Client-facing endpoint path for the usage row.
+            endpoint_kind: Gateway endpoint kind for the usage row.
+            started_at: ``time.perf_counter()`` taken when the request began.
+            ai_model: Model the request resolved to.
+            payload: Client request payload, used for token estimation.
+            budget_result: Budget decision recorded alongside the row.
+            closes: Extra resources to close on teardown (an upstream HTTP
+                response, a nested gateway stream) whose cleanup normally
+                lives in the wrapped generator's ``finally``.
+
+        Returns:
+            An iterator yielding the same items as ``stream``.
+        """
+
+        def _on_abandoned() -> None:
+            self._record_stream_abandoned(
+                endpoint=endpoint,
+                endpoint_kind=endpoint_kind,
+                started_at=started_at,
+                ai_model=ai_model,
+                payload=payload,
+                budget_result=budget_result,
+            )
+
+        return ObservedGatewayStream(stream, on_abandoned=_on_abandoned, closes=closes)
+
+    def _record_stream_abandoned(
+        self,
+        *,
+        endpoint: str,
+        endpoint_kind: str,
+        started_at: float,
+        ai_model: AIModel,
+        payload: Dict[str, Any],
+        budget_result: Optional[BudgetCheckResult],
+    ) -> None:
+        """Record a streaming request whose response was never consumed.
+
+        Status 499 ("client closed request") matches the mid-stream disconnect
+        record; ``error_class`` is ``stream_abandoned`` so this is
+        distinguishable from a client that cancelled a stream it was actively
+        reading. Nothing was streamed, so there are no provider usage numbers:
+        the shared record path falls back to a local estimate over the request
+        payload, which keeps the request visible without inventing output
+        tokens.
+
+        Never raises — it runs during response teardown.
+        """
+        logger.warning(
+            "Gateway stream abandoned before first chunk: "
+            "endpoint=%s provider=%s model=%s",
+            endpoint,
+            getattr(ai_model, "provider_name", None),
+            payload.get("model"),
+        )
+        try:
+            self._record_gateway_request(
+                endpoint=endpoint,
+                method="POST",
+                status_code=499,
+                duration=time.perf_counter() - started_at,
+                ai_model=ai_model,
+                requested_model=payload.get("model"),
+                response_payload=None,
+                upstream_response=None,
+                endpoint_kind=endpoint_kind,
+                budget_result=budget_result,
+                error_detail=(
+                    "client was gone before the stream produced its first "
+                    "chunk (upstream request had already been sent)"
+                ),
+                error_class=ERROR_CLASS_STREAM_ABANDONED,
+                request_payload=payload,
+            )
+        except Exception as exc:  # pragma: no cover - defensive; never break teardown
+            self._rollback_activity_recording(
+                exc, context="gateway usage recording after stream abandonment"
             )
 
     def _rollback_activity_recording(self, exc: Exception, *, context: str) -> None:

--- a/backend/preloop/services/upstream_errors.py
+++ b/backend/preloop/services/upstream_errors.py
@@ -28,6 +28,13 @@ ERROR_CLASS_UPSTREAM_AUTH = "upstream_auth"
 ERROR_CLASS_UPSTREAM_ERROR = "upstream_error"
 ERROR_CLASS_UPSTREAM_DISCONNECT = "upstream_disconnect"
 ERROR_CLASS_CLIENT_CANCELLED = "client_cancelled"
+# The client was already gone when the gateway tried to write the FIRST byte
+# of a streaming response, so the response generator never ran. Distinct from
+# ``client_cancelled`` (client left part-way through a stream it was reading):
+# an abandoned stream usually means something in front of the gateway — a
+# proxy read timeout, an ingress hang-up — killed the request, whereas a
+# cancellation is normal client behaviour (user hit Ctrl-C, agent moved on).
+ERROR_CLASS_STREAM_ABANDONED = "stream_abandoned"
 
 
 @dataclass(frozen=True)

--- a/backend/tests/agents/test_failure_analysis.py
+++ b/backend/tests/agents/test_failure_analysis.py
@@ -1,0 +1,222 @@
+"""Tests for agent-log failure analysis.
+
+The log fixtures here reproduce the shape an agent CLI produces when the model
+gateway in front of it returns a proxy timeout: an internal retry loop, an HTML
+error page from the proxy, a long stack trace, and a final line where the JS
+runtime stringified an error object instead of serialising it.
+"""
+
+from preloop.agents.container import ContainerAgentExecutor
+from preloop.agents.failure_analysis import analyze_agent_failure
+from preloop.services.upstream_errors import (
+    ERROR_CLASS_UPSTREAM_AUTH,
+    ERROR_CLASS_UPSTREAM_QUOTA_EXHAUSTED,
+)
+
+
+def _gateway_timeout_logs(status: int = 504) -> str:
+    """Agent logs for an upstream proxy timeout, in the real observed shape."""
+    return "\n".join(
+        ["Starting agent run", "Reading changed files", "Building review prompt"]
+        + [f"processing hunk {index}" for index in range(300)]
+        + [
+            f"Attempt 1 failed with status {status}. Retrying with backoff... <html>",
+            f"<head><title>{status} Gateway Time-out</title></head>",
+            f"<body><center><h1>{status} Gateway Time-out</h1></center>",
+            "<hr><center>nginx</center>",
+            "</body></html>",
+            f"Attempt 2 failed with status {status}. Retrying with backoff...",
+            f"Attempt 3 failed with status {status}. Max attempts reached.",
+        ]
+        + [
+            f"    at frame{index} (/usr/lib/agent-cli/index.js:1:1)"
+            for index in range(200)
+        ]
+        + [
+            "  at makeRequest (/usr/lib/agent-cli/index.js:1:1)",
+            f"  status: {status}",
+            "}",
+            "An unexpected critical error occurred:[object Object]",
+        ]
+    )
+
+
+class TestUpstreamTimeoutExtraction:
+    """The incident case: a proxy timeout must be named, not swallowed."""
+
+    def test_names_status_and_retry_exhaustion(self):
+        analysis = analyze_agent_failure(_gateway_timeout_logs())
+
+        assert analysis.upstream_status == 504
+        assert analysis.attempts == 3
+        assert analysis.retry_exhausted is True
+        assert "504" in analysis.message
+        assert "3 attempts" in analysis.message
+        assert analysis.message.lower().startswith("upstream model provider")
+
+    def test_does_not_surface_the_useless_object_dump(self):
+        """The pre-fix output was exactly this 69-char string."""
+        analysis = analyze_agent_failure(_gateway_timeout_logs())
+
+        assert "[object Object]" not in analysis.message
+        assert analysis.message.strip() != (
+            "status: 504\n}\nAn unexpected critical error occurred:[object Object]"
+        )
+        # Nor may it be a bare stack-trace tail.
+        assert "at makeRequest" not in analysis.message
+
+    def test_executor_extraction_uses_the_analysis(self):
+        """The executor's extraction hook must produce the same answer."""
+        executor = ContainerAgentExecutor(
+            agent_type="codex", config={}, image="test:latest", use_kubernetes=True
+        )
+
+        message = executor._extract_error_from_logs(_gateway_timeout_logs())
+
+        assert "504" in message
+        assert "[object Object]" not in message
+        assert len(message) > 0
+
+
+class TestTransience:
+    """Transient vs terminal drives whether a retry is allowed at all."""
+
+    def test_gateway_timeout_is_transient(self):
+        assert analyze_agent_failure(_gateway_timeout_logs(504)).transient is True
+
+    def test_bad_gateway_is_transient(self):
+        assert analyze_agent_failure(_gateway_timeout_logs(502)).transient is True
+
+    def test_auth_failure_is_not_transient(self):
+        analysis = analyze_agent_failure(_gateway_timeout_logs(401))
+
+        assert analysis.transient is False
+        assert analysis.error_class == ERROR_CLASS_UPSTREAM_AUTH
+        assert "401" in analysis.message
+
+    def test_forbidden_is_not_transient(self):
+        assert analyze_agent_failure(_gateway_timeout_logs(403)).transient is False
+
+    def test_not_found_model_is_not_transient(self):
+        assert analyze_agent_failure(_gateway_timeout_logs(404)).transient is False
+
+    def test_rate_limit_is_transient(self):
+        assert analyze_agent_failure(_gateway_timeout_logs(429)).transient is True
+
+    def test_exhausted_quota_is_not_transient(self):
+        """A hard quota exhaustion is a 429 that retrying can never fix."""
+        logs = "\n".join(
+            [
+                "Attempt 1 failed with status 429: You exceeded your current quota.",
+                "Attempt 2 failed with status 429: You exceeded your current quota.",
+                "Max attempts reached.",
+            ]
+        )
+
+        analysis = analyze_agent_failure(logs)
+
+        assert analysis.error_class == ERROR_CLASS_UPSTREAM_QUOTA_EXHAUSTED
+        assert analysis.transient is False
+
+    def test_connection_reset_without_status_is_transient(self):
+        logs = "\n".join(
+            [
+                "Attempt 1 failed: connection reset by peer",
+                "Attempt 2 failed: connection reset by peer",
+                "Giving up.",
+            ]
+        )
+
+        analysis = analyze_agent_failure(logs)
+
+        assert analysis.transient is True
+        assert analysis.retry_exhausted is True
+
+    def test_plain_agent_error_is_not_transient(self):
+        """No upstream signal at all must never be treated as retryable."""
+        logs = "\n".join(
+            [
+                "Starting agent run",
+                "ERROR: The requested tool is not permitted by policy.",
+            ]
+        )
+
+        analysis = analyze_agent_failure(logs)
+
+        assert analysis.transient is False
+        assert analysis.upstream_status is None
+        assert "not permitted by policy" in analysis.message
+
+
+class TestLowValueLines:
+    """Information-free lines must never win over a real signal."""
+
+    def test_object_object_tail_does_not_mask_a_real_error(self):
+        logs = "\n".join(
+            [
+                "Starting agent run",
+                "ERROR: Repository checkout failed: reference not found.",
+                "  at run (/usr/lib/agent-cli/index.js:1:1)",
+                "}",
+                "An unexpected critical error occurred:[object Object]",
+            ]
+        )
+
+        message = analyze_agent_failure(logs).message
+
+        assert "Repository checkout failed" in message
+
+    def test_pure_noise_still_returns_something(self):
+        logs = "\n".join(["}", "An unexpected critical error occurred:[object Object]"])
+
+        message = analyze_agent_failure(logs).message
+
+        assert message  # never empty when there were logs at all
+
+    def test_empty_logs_return_empty_message(self):
+        assert analyze_agent_failure("").message == ""
+
+
+class TestMessageHygiene:
+    """Whatever is surfaced is capped and scrubbed."""
+
+    def test_message_is_length_capped(self):
+        logs = "ERROR: " + ("x" * 5000)
+
+        assert len(analyze_agent_failure(logs).message) <= 400
+
+    def test_secrets_are_scrubbed(self):
+        logs = "\n".join(
+            [
+                "ERROR: request rejected",
+                "Authorization: Bearer sk-abcdefghijklmnopqrstuvwxyz0123456789",
+            ]
+        )
+
+        message = analyze_agent_failure(logs).message
+
+        assert "sk-abcdefghijklmnopqrstuvwxyz0123456789" not in message
+
+
+class TestIdempotence:
+    """Re-analysing a generated message must reproduce the classification.
+
+    The orchestrator persists only the generated sentence and later re-reads
+    it to decide whether a retry is allowed. If analysing our own output lost
+    the transient/terminal verdict, retries would silently stop working.
+    """
+
+    def test_reanalysis_preserves_transient_verdict(self):
+        first = analyze_agent_failure(_gateway_timeout_logs(504))
+        second = analyze_agent_failure(first.message)
+
+        assert second.transient is True
+        assert second.upstream_status == 504
+        assert second.message == first.message
+
+    def test_reanalysis_preserves_terminal_verdict(self):
+        first = analyze_agent_failure(_gateway_timeout_logs(401))
+        second = analyze_agent_failure(first.message)
+
+        assert second.transient is False
+        assert second.upstream_status == 401

--- a/backend/tests/endpoints/test_runtime_session_requests.py
+++ b/backend/tests/endpoints/test_runtime_session_requests.py
@@ -206,7 +206,6 @@ def test_runtime_session_requests_expose_error_class(client, db_session, test_us
     simply cancelled a stream (``client_cancelled``) — both are status 499.
     """
     session = _make_session(db_session, test_user.account_id)
-    now = datetime.now(UTC)
 
     crud_api_usage.log_gateway_request(
         db_session,

--- a/backend/tests/endpoints/test_runtime_session_requests.py
+++ b/backend/tests/endpoints/test_runtime_session_requests.py
@@ -195,3 +195,40 @@ def test_runtime_session_requests_unknown_session_returns_404(client):
         "/api/v1/runtime-sessions/00000000-0000-0000-0000-000000000000/requests"
     )
     assert response.status_code == 404
+
+
+def test_runtime_session_requests_expose_error_class(client, db_session, test_user):
+    """Failed rows must carry ``error_class`` so the console can explain them.
+
+    ``ApiUsage.error_class`` is recorded for every gateway failure but was not
+    serialized anywhere, so a request killed by a proxy read-timeout
+    (``stream_abandoned``) was indistinguishable in the UI from a user who
+    simply cancelled a stream (``client_cancelled``) — both are status 499.
+    """
+    session = _make_session(db_session, test_user.account_id)
+    now = datetime.now(UTC)
+
+    crud_api_usage.log_gateway_request(
+        db_session,
+        endpoint="/gemini/v1beta/models/test:streamGenerateContent",
+        method="POST",
+        status_code=499,
+        duration=60.0,
+        account_id=str(test_user.account_id),
+        runtime_session_id=str(session.id),
+        model_alias="test-model",
+        provider_name="openai",
+        error_class="stream_abandoned",
+        meta_data={"error_detail": "client was gone before the first chunk"},
+    )
+
+    response = client.get(
+        f"/api/v1/runtime-sessions/{session.id}/requests?failed_only=true"
+    )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["status_code"] == 499
+    assert items[0]["is_error"] is True
+    assert items[0]["error_class"] == "stream_abandoned"

--- a/backend/tests/helm/test_gateway_proxy_timeouts.py
+++ b/backend/tests/helm/test_gateway_proxy_timeouts.py
@@ -1,0 +1,252 @@
+"""Guards on the console-nginx and ingress proxy settings for gateway routes.
+
+The model-gateway routes (``/openai``, ``/anthropic``, ``/gemini``) proxy
+streaming LLM responses. A large prompt can keep the upstream model thinking
+for well over a minute before the first token appears, and nginx's default
+``proxy_read_timeout`` is 60s — so a route without an explicit override kills
+the connection and hands the client a 504 that never reaches the application.
+
+Both proxy layers in front of the gateway (the console nginx and the ingress)
+default to 60s, so both need the override; fixing one still leaves the other
+at 60s. These tests exist so a future edit that drops either one fails CI
+instead of shipping.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Iterator, List
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHART_DIR = REPO_ROOT / "helm" / "preloop"
+NGINX_CONFIGMAP = CHART_DIR / "templates" / "configmap-nginx.yaml"
+CHART_VALUES = CHART_DIR / "values.yaml"
+DOCKER_NGINX_TEMPLATE = REPO_ROOT / "frontend" / "docker" / "nginx.conf.template"
+
+# The gateway route prefixes that carry streaming model traffic.
+GATEWAY_LOCATIONS = ("^~ /openai/", "^~ /anthropic/", "^~ /gemini/")
+
+# A streaming request must survive a slow first token. Anything at or below
+# nginx's 60s default reintroduces the bug this guard exists for.
+MIN_STREAMING_TIMEOUT_SECONDS = 300
+
+
+def _load_values() -> Dict:
+    """Return the chart's default values."""
+    return yaml.safe_load(CHART_VALUES.read_text())
+
+
+def _resolve_values_path(values: Dict, dotted: str):
+    """Look up a dotted ``.Values`` path, returning None when absent."""
+    node = values
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def _render_with_default_values(template_text: str) -> str:
+    """Substitute ``.Values`` references so the config can be parsed.
+
+    This is a deliberately tiny stand-in for Helm: it resolves
+    ``{{ .Values.a.b }}`` from values.yaml and drops every other action. It
+    lets the assertions run in a test environment that has no ``helm``
+    binary; when helm *is* available a separate test checks the real render.
+    """
+    values = _load_values()
+
+    def _replace(match: re.Match) -> str:
+        expression = match.group(1).strip()
+        values_ref = re.fullmatch(r"\.Values\.([\w.]+)", expression)
+        if values_ref:
+            resolved = _resolve_values_path(values, values_ref.group(1))
+            if resolved is not None:
+                return str(resolved)
+        return ""
+
+    return re.sub(r"{{-?\s*(.*?)\s*-?}}", _replace, template_text, flags=re.DOTALL)
+
+
+def _nginx_config_from_configmap(rendered_yaml: str) -> str:
+    """Pull the nginx server config out of the rendered ConfigMap."""
+    document = yaml.safe_load(rendered_yaml)
+    return document["data"]["default.conf.template"]
+
+
+def _location_body(config: str, location: str) -> str:
+    """Return the directives inside one ``location`` block.
+
+    Args:
+        config: The nginx configuration text.
+        location: The location matcher exactly as written in the config.
+
+    Returns:
+        Everything between the block's braces.
+    """
+    marker = f"location {location} {{"
+    start = config.find(marker)
+    assert start != -1, f"no `location {location}` block found in the nginx config"
+
+    depth = 0
+    cursor = start + len(marker) - 1
+    for index in range(cursor, len(config)):
+        if config[index] == "{":
+            depth += 1
+        elif config[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return config[cursor + 1 : index]
+    raise AssertionError(f"unterminated `location {location}` block")
+
+
+def _directive_seconds(body: str, directive: str) -> int:
+    """Return a timeout directive's value in seconds."""
+    match = re.search(rf"^\s*{directive}\s+(\d+)(m?s)\s*;", body, re.MULTILINE)
+    assert match, f"`{directive}` is not set on this location"
+    seconds = int(match.group(1))
+    return seconds // 1000 if match.group(2) == "ms" else seconds
+
+
+def _gateway_nginx_configs() -> List[pytest.param]:
+    """Every nginx config in the repo that fronts the model gateway."""
+    return [
+        pytest.param(NGINX_CONFIGMAP, True, id="helm-configmap"),
+        pytest.param(DOCKER_NGINX_TEMPLATE, False, id="docker-compose"),
+    ]
+
+
+def _read_nginx_config(path: Path, is_configmap: bool) -> str:
+    text = _render_with_default_values(path.read_text())
+    return _nginx_config_from_configmap(text) if is_configmap else text
+
+
+@pytest.mark.parametrize("config_path,is_configmap", _gateway_nginx_configs())
+@pytest.mark.parametrize("location", GATEWAY_LOCATIONS)
+def test_gateway_location_survives_a_slow_first_token(
+    config_path: Path, is_configmap: bool, location: str
+) -> None:
+    """Streaming gateway routes must not inherit nginx's 60s read timeout."""
+    body = _location_body(_read_nginx_config(config_path, is_configmap), location)
+
+    assert _directive_seconds(body, "proxy_read_timeout") >= (
+        MIN_STREAMING_TIMEOUT_SECONDS
+    ), f"`location {location}` would 504 a slow-to-start stream"
+    assert (
+        _directive_seconds(body, "proxy_send_timeout") >= MIN_STREAMING_TIMEOUT_SECONDS
+    )
+    assert _directive_seconds(body, "proxy_connect_timeout") > 0
+
+
+@pytest.mark.parametrize("config_path,is_configmap", _gateway_nginx_configs())
+@pytest.mark.parametrize("location", GATEWAY_LOCATIONS)
+def test_gateway_location_streams_tokens_through(
+    config_path: Path, is_configmap: bool, location: str
+) -> None:
+    """Buffering an SSE stream delays the first byte the client sees."""
+    body = _location_body(_read_nginx_config(config_path, is_configmap), location)
+
+    assert re.search(r"^\s*proxy_buffering\s+off\s*;", body, re.MULTILINE), (
+        f"`location {location}` buffers the SSE stream instead of relaying it"
+    )
+
+
+def test_ingress_annotations_match_the_console_timeout() -> None:
+    """The ingress is the second 60s proxy in front of the gateway."""
+    values = _load_values()
+    read_timeout = _resolve_values_path(values, "gateway.proxy.readTimeout")
+    send_timeout = _resolve_values_path(values, "gateway.proxy.sendTimeout")
+
+    assert read_timeout is not None and int(read_timeout) >= (
+        MIN_STREAMING_TIMEOUT_SECONDS
+    )
+    assert send_timeout is not None and int(send_timeout) >= (
+        MIN_STREAMING_TIMEOUT_SECONDS
+    )
+
+    rendered = _render_ingress()
+    annotations = rendered["metadata"]["annotations"]
+    assert annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] == str(
+        read_timeout
+    )
+    assert annotations["nginx.ingress.kubernetes.io/proxy-send-timeout"] == str(
+        send_timeout
+    )
+
+
+def test_ingress_annotations_stay_overridable() -> None:
+    """An operator's own annotation value must win over the chart default."""
+    rendered = _render_ingress(
+        overrides=[
+            "ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/proxy-read-timeout=1200"
+        ]
+    )
+    annotations = rendered["metadata"]["annotations"]
+    assert annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] == "1200"
+    # The cert-manager default is still there: overriding one key must not
+    # replace the whole annotation map.
+    assert "cert-manager.io/cluster-issuer" in annotations
+
+
+@contextmanager
+def _offline_chart() -> Iterator[Path]:
+    """Yield a copy of the chart that renders without fetching dependencies.
+
+    ``helm template`` refuses to run while a declared subchart is missing from
+    ``charts/``, which would make these tests require network access. The
+    subcharts are irrelevant to the templates under test, so the copy simply
+    declares none.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        chart_copy = Path(tmp) / CHART_DIR.name
+        shutil.copytree(CHART_DIR, chart_copy)
+        chart_yaml = chart_copy / "Chart.yaml"
+        metadata = yaml.safe_load(chart_yaml.read_text())
+        metadata.pop("dependencies", None)
+        chart_yaml.write_text(yaml.safe_dump(metadata))
+        yield chart_copy
+
+
+def _helm_template(template: str, overrides: List[str] | None = None) -> str:
+    """Render one chart template, skipping when helm is unavailable."""
+    helm = shutil.which("helm")
+    if helm is None:  # pragma: no cover - depends on the local toolchain
+        pytest.skip("helm binary not available")
+
+    with _offline_chart() as chart_dir:
+        command = [helm, "template", "preloop", str(chart_dir), "--show-only", template]
+        for override in overrides or []:
+            command += ["--set", override]
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def _render_ingress(overrides: List[str] | None = None) -> Dict:
+    """Render the ingress template with the chart's default values."""
+    rendered = _helm_template(
+        "templates/ingress.yaml",
+        ["ingress.enabled=true", *(overrides or [])],
+    )
+    return yaml.safe_load(rendered)
+
+
+@pytest.mark.parametrize("location", GATEWAY_LOCATIONS)
+def test_helm_render_keeps_the_gateway_timeouts(location: str) -> None:
+    """The same guard, against a real ``helm template`` render."""
+    rendered = _helm_template("templates/configmap-nginx.yaml")
+
+    body = _location_body(_nginx_config_from_configmap(rendered), location)
+    assert _directive_seconds(body, "proxy_read_timeout") >= (
+        MIN_STREAMING_TIMEOUT_SECONDS
+    )
+    assert re.search(r"^\s*proxy_buffering\s+off\s*;", body, re.MULTILINE)

--- a/backend/tests/services/test_flow_orchestrator_retry.py
+++ b/backend/tests/services/test_flow_orchestrator_retry.py
@@ -1,0 +1,454 @@
+"""Tests for flow-level retry of transient upstream failures.
+
+An upstream model provider having a bad minute used to kill an entire flow
+permanently: the agent CLI exhausted its own internal retries and the run was
+marked FAILED with no second chance. These tests pin the retry policy and,
+more importantly, the safety boundary that keeps a retry from double-posting
+external side effects (pull-request comments, commit statuses, pushes).
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from preloop.agents.base import AgentExecutionResult, AgentStatus
+from preloop.models.crud import crud_account, crud_flow, crud_user
+from preloop.models.models import Account, Flow
+from preloop.models.models.user import User
+from preloop.models.schemas.flow import FlowCreate
+from preloop.services.flow_orchestrator import FlowExecutionOrchestrator
+
+
+@pytest.fixture
+def test_account(db_session: Session) -> Account:
+    return crud_account.create(
+        db_session,
+        obj_in={"organization_name": f"Test Org {uuid4().hex[:8]}", "is_active": True},
+    )
+
+
+@pytest.fixture
+def test_user(db_session: Session, test_account: Account) -> User:
+    user = crud_user.create(
+        db_session,
+        obj_in={
+            "account_id": test_account.id,
+            "email": f"retry_test_{uuid4().hex[:8]}@example.com",
+            "username": f"retry_test_user_{uuid4().hex[:8]}",
+            "full_name": "Retry Test User",
+            "is_active": True,
+            "email_verified": True,
+            "hashed_password": "test_password",
+            "user_source": "local",
+        },
+    )
+    db_session.flush()
+    test_account.primary_user_id = user.id
+    db_session.add(test_account)
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
+def test_flow(db_session: Session, test_account: Account, test_user: User) -> Flow:
+    flow_in = FlowCreate(
+        name="Test Retry Flow",
+        description="A test flow for retry behaviour",
+        trigger_event_source="github",
+        trigger_event_types=["pull_request_updated"],
+        prompt_template="Review: {{payload.pull_request.title}}",
+        agent_type="codex",
+        agent_config={},
+        account_id=test_account.id,
+    )
+    return crud_flow.create(db=db_session, flow_in=flow_in, account_id=test_account.id)
+
+
+@pytest.fixture
+def mock_nats_client():
+    client = AsyncMock()
+    client.is_connected = True
+    client.publish = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def event_data():
+    return {
+        "source": "github",
+        "type": "pull_request_updated",
+        "event_id": "evt_retry_1",
+        "payload": {
+            "pull_request": {"title": "Add a feature", "number": 7},
+            "repository": "example-org/example-repo",
+        },
+        "account_id": str(uuid4()),
+    }
+
+
+UPSTREAM_TIMEOUT_LOGS = "\n".join(
+    [
+        "Attempt 1 failed with status 504. Retrying...",
+        "Attempt 2 failed with status 504. Retrying...",
+        "Attempt 3 failed with status 504. Max attempts reached.",
+        "An unexpected critical error occurred:[object Object]",
+    ]
+)
+
+
+def _failed_result(logs: str, exit_code: int = 1) -> AgentExecutionResult:
+    """An agent result carrying an upstream-failure log tail."""
+    from preloop.agents.failure_analysis import analyze_agent_failure
+
+    return AgentExecutionResult(
+        status=AgentStatus.FAILED,
+        session_reference="session-under-test",
+        output_summary=logs,
+        error_message=analyze_agent_failure(logs).message,
+        exit_code=exit_code,
+    )
+
+
+def _build_orchestrator(db_session, test_flow, event_data, mock_nats_client):
+    return FlowExecutionOrchestrator(
+        db=db_session,
+        flow_id=test_flow.id,
+        trigger_event_data=event_data,
+        nats_client=mock_nats_client,
+    )
+
+
+@pytest.mark.asyncio
+class TestTransientRetry:
+    """Transient upstream failures get another attempt; others do not."""
+
+    async def test_transient_upstream_failure_is_retried(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        attempts = []
+
+        async def monitor(session_reference, agent_executor):
+            attempts.append(session_reference)
+            if len(attempts) == 1:
+                return {
+                    "status": "FAILED",
+                    "error_message": "Upstream model provider timed out (HTTP 504) "
+                    "after 3 attempts.",
+                    "exit_code": 1,
+                    "actions_taken": [],
+                    "mcp_usage_logs": [],
+                }
+            return {
+                "status": "SUCCEEDED",
+                "output_summary": "review posted",
+                "error_message": None,
+                "exit_code": 0,
+                "actions_taken": [],
+                "mcp_usage_logs": [],
+            }
+
+        executor = AsyncMock()
+        executor.start = AsyncMock(return_value="session-under-test")
+        executor.cleanup = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.flow_orchestrator.create_agent_executor",
+                return_value=executor,
+            ),
+            patch.object(
+                FlowExecutionOrchestrator,
+                "_monitor_agent_execution",
+                side_effect=monitor,
+            ),
+            patch("preloop.services.flow_orchestrator.asyncio.sleep", AsyncMock()),
+        ):
+            orchestrator = _build_orchestrator(
+                db_session, test_flow, event_data, mock_nats_client
+            )
+            await orchestrator.run()
+
+        assert len(attempts) == 2, "transient upstream failure should be retried once"
+        assert orchestrator.execution_log.status == "SUCCEEDED"
+
+    async def test_retry_is_visible_in_the_execution_record(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        """Flakiness must never be hidden: the retry has to be recorded."""
+        calls = []
+
+        async def monitor(session_reference, agent_executor):
+            calls.append(session_reference)
+            if len(calls) == 1:
+                return {
+                    "status": "FAILED",
+                    "error_message": "Upstream model provider timed out (HTTP 504).",
+                    "exit_code": 1,
+                    "actions_taken": [],
+                    "mcp_usage_logs": [],
+                }
+            return {
+                "status": "SUCCEEDED",
+                "output_summary": "ok",
+                "error_message": None,
+                "exit_code": 0,
+                "actions_taken": [],
+                "mcp_usage_logs": [],
+            }
+
+        executor = AsyncMock()
+        executor.start = AsyncMock(return_value="session-under-test")
+        executor.cleanup = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.flow_orchestrator.create_agent_executor",
+                return_value=executor,
+            ),
+            patch.object(
+                FlowExecutionOrchestrator,
+                "_monitor_agent_execution",
+                side_effect=monitor,
+            ),
+            patch("preloop.services.flow_orchestrator.asyncio.sleep", AsyncMock()),
+        ):
+            orchestrator = _build_orchestrator(
+                db_session, test_flow, event_data, mock_nats_client
+            )
+            await orchestrator.run()
+
+        milestones = [
+            entry["milestone"]
+            for entry in orchestrator.execution_logger.get_milestones()
+        ]
+        assert "execution_retry_scheduled" in milestones
+
+    async def test_non_transient_failure_is_not_retried(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        """Auth failures can never succeed on retry: do not burn money."""
+        calls = []
+
+        async def monitor(session_reference, agent_executor):
+            calls.append(session_reference)
+            return {
+                "status": "FAILED",
+                "error_message": "Upstream model provider rejected our credentials "
+                "(HTTP 401).",
+                "exit_code": 1,
+                "actions_taken": [],
+                "mcp_usage_logs": [],
+            }
+
+        executor = AsyncMock()
+        executor.start = AsyncMock(return_value="session-under-test")
+        executor.cleanup = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.flow_orchestrator.create_agent_executor",
+                return_value=executor,
+            ),
+            patch.object(
+                FlowExecutionOrchestrator,
+                "_monitor_agent_execution",
+                side_effect=monitor,
+            ),
+            patch("preloop.services.flow_orchestrator.asyncio.sleep", AsyncMock()),
+        ):
+            orchestrator = _build_orchestrator(
+                db_session, test_flow, event_data, mock_nats_client
+            )
+            await orchestrator.run()
+
+        assert len(calls) == 1, "a 401 must never be retried"
+        assert orchestrator.execution_log.status == "FAILED"
+
+    async def test_user_stop_is_not_retried(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        calls = []
+
+        async def monitor(session_reference, agent_executor):
+            calls.append(session_reference)
+            return {
+                "status": "STOPPED",
+                "error_message": "Execution stopped by user request after 45 seconds.",
+                "actions_taken": [],
+                "mcp_usage_logs": [],
+            }
+
+        executor = AsyncMock()
+        executor.start = AsyncMock(return_value="session-under-test")
+        executor.cleanup = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.flow_orchestrator.create_agent_executor",
+                return_value=executor,
+            ),
+            patch.object(
+                FlowExecutionOrchestrator,
+                "_monitor_agent_execution",
+                side_effect=monitor,
+            ),
+            patch("preloop.services.flow_orchestrator.asyncio.sleep", AsyncMock()),
+        ):
+            orchestrator = _build_orchestrator(
+                db_session, test_flow, event_data, mock_nats_client
+            )
+            await orchestrator.run()
+
+        assert len(calls) == 1, "a user-requested stop must never be retried"
+
+    async def test_retries_are_bounded(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        """A permanently-down provider must not loop forever."""
+        calls = []
+
+        async def monitor(session_reference, agent_executor):
+            calls.append(session_reference)
+            return {
+                "status": "FAILED",
+                "error_message": "Upstream model provider timed out (HTTP 504).",
+                "exit_code": 1,
+                "actions_taken": [],
+                "mcp_usage_logs": [],
+            }
+
+        executor = AsyncMock()
+        executor.start = AsyncMock(return_value="session-under-test")
+        executor.cleanup = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.flow_orchestrator.create_agent_executor",
+                return_value=executor,
+            ),
+            patch.object(
+                FlowExecutionOrchestrator,
+                "_monitor_agent_execution",
+                side_effect=monitor,
+            ),
+            patch("preloop.services.flow_orchestrator.asyncio.sleep", AsyncMock()),
+        ):
+            orchestrator = _build_orchestrator(
+                db_session, test_flow, event_data, mock_nats_client
+            )
+            await orchestrator.run()
+
+        assert 1 < len(calls) <= 3, f"expected bounded retries, got {len(calls)}"
+        assert orchestrator.execution_log.status == "FAILED"
+
+
+@pytest.mark.asyncio
+class TestSideEffectSafety:
+    """A retry must never double-post external side effects."""
+
+    async def test_no_retry_once_the_agent_produced_external_effects(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        """If the agent already pushed or opened a PR, a retry would double-post.
+
+        Post-execution git operations (push, PR/MR creation) run inside the
+        container only when the agent exits 0. An agent that exits 0 but is
+        judged failed may therefore already have posted; that case must not be
+        retried even when the log mentions a transient upstream status.
+        """
+        calls = []
+
+        async def monitor(session_reference, agent_executor):
+            calls.append(session_reference)
+            return {
+                "status": "FAILED",
+                "error_message": "Upstream model provider timed out (HTTP 504).",
+                # Exit code 0 => the container ran its push / PR-creation block.
+                "exit_code": 0,
+                "actions_taken": [],
+                "mcp_usage_logs": [],
+            }
+
+        executor = AsyncMock()
+        executor.start = AsyncMock(return_value="session-under-test")
+        executor.cleanup = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.flow_orchestrator.create_agent_executor",
+                return_value=executor,
+            ),
+            patch.object(
+                FlowExecutionOrchestrator,
+                "_monitor_agent_execution",
+                side_effect=monitor,
+            ),
+            patch("preloop.services.flow_orchestrator.asyncio.sleep", AsyncMock()),
+        ):
+            orchestrator = _build_orchestrator(
+                db_session, test_flow, event_data, mock_nats_client
+            )
+            await orchestrator.run()
+
+        assert len(calls) == 1, (
+            "an agent that exited 0 may already have pushed or opened a PR; "
+            "retrying it risks double-posting"
+        )
+
+    async def test_commit_status_is_posted_once_per_outcome(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        """Retrying must not emit a failure status for the recovered attempt."""
+        calls = []
+
+        async def monitor(session_reference, agent_executor):
+            calls.append(session_reference)
+            if len(calls) == 1:
+                return {
+                    "status": "FAILED",
+                    "error_message": "Upstream model provider timed out (HTTP 504).",
+                    "exit_code": 1,
+                    "actions_taken": [],
+                    "mcp_usage_logs": [],
+                }
+            return {
+                "status": "SUCCEEDED",
+                "output_summary": "ok",
+                "error_message": None,
+                "exit_code": 0,
+                "actions_taken": [],
+                "mcp_usage_logs": [],
+            }
+
+        executor = AsyncMock()
+        executor.start = AsyncMock(return_value="session-under-test")
+        executor.cleanup = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.flow_orchestrator.create_agent_executor",
+                return_value=executor,
+            ),
+            patch.object(
+                FlowExecutionOrchestrator,
+                "_monitor_agent_execution",
+                side_effect=monitor,
+            ),
+            patch.object(
+                FlowExecutionOrchestrator, "_update_commit_status", AsyncMock()
+            ) as mock_status,
+            patch("preloop.services.flow_orchestrator.asyncio.sleep", AsyncMock()),
+        ):
+            orchestrator = _build_orchestrator(
+                db_session, test_flow, event_data, mock_nats_client
+            )
+            await orchestrator.run()
+
+        states = [call.kwargs.get("state") for call in mock_status.call_args_list]
+        assert "failure" not in states, (
+            "the intermediate transient failure must not be reported as a "
+            f"final failure status; got {states}"
+        )
+        assert states[-1] == "success"

--- a/backend/tests/services/test_flow_orchestrator_retry.py
+++ b/backend/tests/services/test_flow_orchestrator_retry.py
@@ -343,6 +343,15 @@ class TestTransientRetry:
         assert 1 < len(calls) <= 3, f"expected bounded retries, got {len(calls)}"
         assert orchestrator.execution_log.status == "FAILED"
 
+        # Exhaustion must be visible on the timeline: without a marker, the
+        # final failure of a retried run looks identical to a first-attempt
+        # failure.
+        milestones = [
+            entry["milestone"]
+            for entry in orchestrator.execution_logger.get_milestones()
+        ]
+        assert "execution_retries_exhausted" in milestones
+
 
 @pytest.mark.asyncio
 class TestSideEffectSafety:

--- a/backend/tests/services/test_gateway_stream_abandonment.py
+++ b/backend/tests/services/test_gateway_stream_abandonment.py
@@ -1,0 +1,298 @@
+"""Observability for gateway streams the client never consumed.
+
+A proxy in front of the gateway (ingress, sidecar) can time a streaming
+request out and drop the connection before the ASGI layer pulls a single
+chunk from the response generator. The upstream model call has already been
+made and billed by the provider at that point, but the generator body never
+runs, so its ``finally``-based abort accounting never fires and the request
+leaves no trace at all: no usage row, no status code, no error class.
+
+These tests pin the "never consumed" path down for every streaming gateway
+entrypoint, and pin the already-working paths (clean completion, mid-stream
+disconnect) so the new accounting cannot start double-counting spend.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any, Iterator
+from unittest.mock import patch
+
+from preloop.models.crud import crud_ai_model
+from preloop.models.models.api_usage import ApiUsage
+from preloop.services.gemini_gateway import GeminiGatewayService
+from preloop.services.model_gateway_auth import ModelGatewayAuthContext
+from preloop.services.openai_gateway import OpenAIGatewayService
+from preloop.services.upstream_errors import (
+    ERROR_CLASS_CLIENT_CANCELLED,
+    ERROR_CLASS_STREAM_ABANDONED,
+)
+
+
+def _create_gateway_model(db_session, account_id, alias: str) -> Any:
+    """Create a gateway-enabled, priced model so usage rows carry a cost."""
+    return crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": f"Gateway Model {alias}",
+            "provider_name": "openai",
+            "model_identifier": "test-model",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": alias,
+                    "provider_adapter": "preloop",
+                },
+                "pricing": {
+                    "input_price_per_1k": 0.01,
+                    "output_price_per_1k": 0.02,
+                },
+            },
+            "is_default": True,
+        },
+        account_id=account_id,
+    )
+
+
+def _upstream_chunks() -> Iterator[dict]:
+    """A well-formed upstream stream that ends with a usage chunk."""
+    yield {"choices": [{"delta": {"content": "Hel"}}]}
+    yield {"choices": [{"delta": {"content": "lo"}}]}
+    yield {
+        "choices": [{"delta": {}, "finish_reason": "stop"}],
+        "usage": {
+            "prompt_tokens": 11,
+            "completion_tokens": 5,
+            "total_tokens": 16,
+        },
+    }
+
+
+def _service(db_session, test_user) -> OpenAIGatewayService:
+    return OpenAIGatewayService(
+        db_session, ModelGatewayAuthContext(token="t", user=test_user)
+    )
+
+
+def _rows_for(db_session, ai_model) -> list[ApiUsage]:
+    """Gateway usage rows for exactly this test's model, oldest first."""
+    return (
+        db_session.query(ApiUsage)
+        .filter(
+            ApiUsage.action_type == "model_gateway",
+            ApiUsage.ai_model_id == ai_model.id,
+        )
+        .order_by(ApiUsage.timestamp.asc())
+        .all()
+    )
+
+
+def test_abandoned_responses_stream_is_recorded(db_session, test_user):
+    """A responses stream closed before its first chunk must leave a row.
+
+    This is the shape of a proxy read-timeout: the upstream call has already
+    happened (the gateway prefetches the first chunk to surface early
+    failures), then the client is gone before consuming anything.
+    """
+    ai_model = _create_gateway_model(db_session, test_user.account_id, "abandon-resp")
+    service = _service(db_session, test_user)
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_upstream_chunks(),
+    ) as mock_completion:
+        stream = service.stream_response({"model": "abandon-resp", "input": "Hello"})
+        # The upstream provider has already been called and is billing us.
+        assert mock_completion.called
+        stream.close()
+
+    rows = _rows_for(db_session, ai_model)
+    assert len(rows) == 1, f"expected exactly one usage row, got {len(rows)}"
+    assert rows[0].status_code == 499
+    assert rows[0].error_class == ERROR_CLASS_STREAM_ABANDONED
+    assert rows[0].endpoint == "/openai/v1/responses"
+
+
+def test_abandoned_chat_completions_stream_is_recorded(db_session, test_user):
+    """The chat-completions streaming entrypoint has the same blind spot."""
+    ai_model = _create_gateway_model(db_session, test_user.account_id, "abandon-chat")
+    service = _service(db_session, test_user)
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_upstream_chunks(),
+    ):
+        stream = service.stream_chat_completion(
+            {
+                "model": "abandon-chat",
+                "messages": [{"role": "user", "content": "Hello"}],
+            }
+        )
+        stream.close()
+
+    rows = _rows_for(db_session, ai_model)
+    assert len(rows) == 1
+    assert rows[0].status_code == 499
+    assert rows[0].error_class == ERROR_CLASS_STREAM_ABANDONED
+    assert rows[0].endpoint == "/openai/v1/chat/completions"
+
+
+def test_abandoned_anthropic_stream_is_recorded(db_session, test_user):
+    """The Anthropic messages streaming entrypoint has the same blind spot."""
+    ai_model = _create_gateway_model(db_session, test_user.account_id, "abandon-anth")
+    service = _service(db_session, test_user)
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_upstream_chunks(),
+    ):
+        stream = service.stream_message(
+            {
+                "model": "abandon-anth",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 64,
+            }
+        )
+        stream.close()
+
+    rows = _rows_for(db_session, ai_model)
+    assert len(rows) == 1
+    assert rows[0].status_code == 499
+    assert rows[0].error_class == ERROR_CLASS_STREAM_ABANDONED
+    assert rows[0].endpoint == "/anthropic/v1/messages"
+
+
+def test_abandoned_gemini_stream_is_recorded(db_session, test_user):
+    """Gemini streaming (the reported incident's surface) must record too.
+
+    Gemini wraps the shared responses stream in a translating generator, so
+    an abandoned Gemini request abandons a *nested* generator. Closing must
+    be deterministic: no ``gc.collect()`` here on purpose, because by the time
+    the collector runs the request's database session can already be closed
+    and the usage row would be lost for good.
+    """
+    ai_model = _create_gateway_model(db_session, test_user.account_id, "abandon-gem")
+    service = GeminiGatewayService(
+        db_session, ModelGatewayAuthContext(token="t", user=test_user)
+    )
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_upstream_chunks(),
+    ):
+        stream = service.stream_generate_content(
+            "abandon-gem",
+            {"contents": [{"role": "user", "parts": [{"text": "Hello"}]}]},
+        )
+        stream.close()
+
+    rows = _rows_for(db_session, ai_model)
+    assert len(rows) == 1
+    assert rows[0].status_code == 499
+    assert rows[0].error_class == ERROR_CLASS_STREAM_ABANDONED
+
+
+def test_fully_consumed_stream_records_one_success_row(db_session, test_user):
+    """The happy path must stay a single 200 row with provider tokens.
+
+    Guards against the abandonment accounting adding a second, phantom row
+    (which would double-count spend) once the stream completed normally.
+    """
+    ai_model = _create_gateway_model(db_session, test_user.account_id, "ok-resp")
+    service = _service(db_session, test_user)
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_upstream_chunks(),
+    ):
+        stream = service.stream_response({"model": "ok-resp", "input": "Hello"})
+        events = list(stream)
+        stream.close()
+        del stream
+        gc.collect()
+
+    assert events, "expected SSE events from a completed stream"
+    rows = _rows_for(db_session, ai_model)
+    assert len(rows) == 1, f"expected exactly one usage row, got {len(rows)}"
+    assert rows[0].status_code == 200
+    assert rows[0].error_class is None
+    assert rows[0].prompt_tokens == 11
+    assert rows[0].completion_tokens == 5
+
+
+def test_midstream_disconnect_still_records_client_cancelled_once(
+    db_session, test_user
+):
+    """A stream dropped after partial consumption keeps its existing shape.
+
+    This path already worked (the generator body ran, so its ``finally``
+    fired). It must keep recording exactly one ``client_cancelled`` row and
+    must not also gain an abandonment row.
+    """
+    ai_model = _create_gateway_model(db_session, test_user.account_id, "midstream")
+    service = _service(db_session, test_user)
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_upstream_chunks(),
+    ):
+        stream = service.stream_response({"model": "midstream", "input": "Hello"})
+        next(stream)
+        stream.close()
+        del stream
+        gc.collect()
+
+    rows = _rows_for(db_session, ai_model)
+    assert len(rows) == 1, f"expected exactly one usage row, got {len(rows)}"
+    assert rows[0].status_code == 499
+    assert rows[0].error_class == ERROR_CLASS_CLIENT_CANCELLED
+
+
+class _Closeable:
+    """Records how many times it was closed."""
+
+    def __init__(self) -> None:
+        self.close_count = 0
+
+    def close(self) -> None:
+        self.close_count += 1
+
+
+def test_observer_closes_owned_resources_only_when_abandoned():
+    """``closes`` resources are owned by the generator once it has started.
+
+    The wrapped generator's ``finally`` closes its own upstream response, so
+    the observer must not close it again — a double close on a real httpx
+    response is what broke the Anthropic passthrough when this was first
+    written.
+    """
+    from preloop.services.model_gateway_stream_observer import ObservedGatewayStream
+
+    resource = _Closeable()
+    consumed = ObservedGatewayStream(iter(["a", "b"]), closes=(resource,))
+    next(consumed)
+    consumed.close()
+    assert resource.close_count == 0
+
+    resource = _Closeable()
+    abandoned = ObservedGatewayStream(iter(["a", "b"]), closes=(resource,))
+    abandoned.close()
+    assert resource.close_count == 1
+
+
+def test_observer_reports_abandonment_once_and_never_raises():
+    """Teardown is idempotent, and a failing recorder must not propagate."""
+    from preloop.services.model_gateway_stream_observer import ObservedGatewayStream
+
+    calls: list[int] = []
+    stream = ObservedGatewayStream(iter(["a"]), on_abandoned=lambda: calls.append(1))
+    stream.close()
+    stream.close()
+    assert calls == [1]
+
+    def _boom() -> None:
+        raise RuntimeError("recording failed")
+
+    exploding = ObservedGatewayStream(iter(["a"]), on_abandoned=_boom)
+    exploding.close()  # must not raise

--- a/frontend/docker/nginx.conf.template
+++ b/frontend/docker/nginx.conf.template
@@ -73,7 +73,22 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # OpenAI-compatible model gateway endpoints
+    # Model gateway endpoints (OpenAI-, Anthropic- and Gemini-compatible).
+    #
+    # These three carry streaming LLM traffic and are the route class that most
+    # needs a long timeout, yet they were the only proxied routes without one —
+    # so they silently inherited nginx's 60s default. On a streaming completion
+    # the clock to the first byte is the model's thinking time: a short prompt
+    # answers in seconds, while a large one (a full diff, a repository's worth
+    # of context) can reason for minutes before emitting a single token. At 60s
+    # that connection is killed and the caller sees a 504 from the proxy — a
+    # failure the gateway never observes and cannot report, and one that looks
+    # intermittent because it depends entirely on prompt size.
+    #
+    # proxy_buffering must stay off: with buffering on nginx accumulates the
+    # token stream rather than relaying it, which both defeats the point of SSE
+    # for the client and pushes the observed first byte later, making any
+    # ceiling easier to hit.
     location ^~ /openai/ {
         set $gateway_backend "${GATEWAY_URL}";
 
@@ -83,9 +98,14 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 900s;
+        proxy_read_timeout 900s;
+        proxy_buffering off;
+        proxy_cache off;
+        client_max_body_size 32m;
     }
 
-    # Anthropic-compatible model gateway endpoints
     location ^~ /anthropic/ {
         set $gateway_backend "${GATEWAY_URL}";
 
@@ -95,9 +115,14 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 900s;
+        proxy_read_timeout 900s;
+        proxy_buffering off;
+        proxy_cache off;
+        client_max_body_size 32m;
     }
 
-    # Gemini-compatible model gateway endpoints
     location ^~ /gemini/ {
         set $gateway_backend "${GATEWAY_URL}";
 
@@ -107,6 +132,12 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 900s;
+        proxy_read_timeout 900s;
+        proxy_buffering off;
+        proxy_cache off;
+        client_max_body_size 32m;
     }
 
     # OAuth server endpoints (authorize, token, register, revoke)

--- a/helm/preloop/templates/configmap-nginx.yaml
+++ b/helm/preloop/templates/configmap-nginx.yaml
@@ -160,7 +160,23 @@ data:
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # OpenAI-compatible model gateway endpoints
+        # Model gateway endpoints (OpenAI-, Anthropic- and Gemini-compatible).
+        #
+        # These three carry streaming LLM traffic and are the route class that
+        # most needs a long timeout, yet they were the only proxied routes
+        # without one — so they silently inherited nginx's 60s default. On a
+        # streaming completion the clock to the first byte is the model's
+        # thinking time: a short prompt answers in seconds, while a large one
+        # (a full diff, a repository's worth of context) can reason for minutes
+        # before emitting a single token. At 60s that connection is killed and
+        # the caller sees a 504 from the proxy — a failure the gateway never
+        # observes and cannot report, and one that looks intermittent because
+        # it depends entirely on prompt size.
+        #
+        # proxy_buffering must stay off: with buffering on nginx accumulates
+        # the token stream rather than relaying it, which both defeats the
+        # point of SSE for the client and pushes the observed first byte later,
+        # making any ceiling easier to hit.
         location ^~ /openai/ {
             proxy_pass http://{{ include "preloop.fullname" . }}-gateway:80;
             proxy_http_version 1.1;
@@ -168,9 +184,14 @@ data:
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout {{ .Values.gateway.proxy.connectTimeout }}s;
+            proxy_send_timeout {{ .Values.gateway.proxy.sendTimeout }}s;
+            proxy_read_timeout {{ .Values.gateway.proxy.readTimeout }}s;
+            proxy_buffering off;
+            proxy_cache off;
+            client_max_body_size {{ .Values.gateway.proxy.bodySize }};
         }
 
-        # Anthropic-compatible model gateway endpoints
         location ^~ /anthropic/ {
             proxy_pass http://{{ include "preloop.fullname" . }}-gateway:80;
             proxy_http_version 1.1;
@@ -178,9 +199,14 @@ data:
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout {{ .Values.gateway.proxy.connectTimeout }}s;
+            proxy_send_timeout {{ .Values.gateway.proxy.sendTimeout }}s;
+            proxy_read_timeout {{ .Values.gateway.proxy.readTimeout }}s;
+            proxy_buffering off;
+            proxy_cache off;
+            client_max_body_size {{ .Values.gateway.proxy.bodySize }};
         }
 
-        # Gemini-compatible model gateway endpoints
         location ^~ /gemini/ {
             proxy_pass http://{{ include "preloop.fullname" . }}-gateway:80;
             proxy_http_version 1.1;
@@ -188,6 +214,12 @@ data:
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout {{ .Values.gateway.proxy.connectTimeout }}s;
+            proxy_send_timeout {{ .Values.gateway.proxy.sendTimeout }}s;
+            proxy_read_timeout {{ .Values.gateway.proxy.readTimeout }}s;
+            proxy_buffering off;
+            proxy_cache off;
+            client_max_body_size {{ .Values.gateway.proxy.bodySize }};
         }
 
         # Static files with caching

--- a/helm/preloop/templates/ingress.yaml
+++ b/helm/preloop/templates/ingress.yaml
@@ -18,7 +18,41 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "preloop.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- /*
+    The ingress is the outermost of the two proxies in front of the model
+    gateway, and it enforces its own timeouts independently of the console
+    nginx config. Its defaults are 60s, which is shorter than a streaming
+    model response can legitimately take to produce its first token, so a
+    long-running generation is terminated here with a 504 before the
+    application is ever aware of it. These annotations carry the same budget
+    the console nginx uses (see `gateway.proxy` in values.yaml) so that a
+    default install is correct without extra flags — a chart that fixed only
+    the inner proxy would still fail at 60s.
+
+    The controller runs with `allow-snippet-annotations: false` in many
+    deployments, so this must use the first-class annotations rather than a
+    configuration snippet. Operator-supplied `ingress.annotations` are merged
+    last and therefore win.
+  */}}
+  {{- $proxy := .Values.gateway.proxy | default dict }}
+  {{- $annotations := dict
+        "nginx.ingress.kubernetes.io/proxy-read-timeout" $proxy.readTimeout
+        "nginx.ingress.kubernetes.io/proxy-send-timeout" $proxy.sendTimeout
+        "nginx.ingress.kubernetes.io/proxy-connect-timeout" $proxy.connectTimeout
+        "nginx.ingress.kubernetes.io/proxy-body-size" $proxy.bodySize }}
+  {{- $annotations = merge (deepCopy (.Values.ingress.annotations | default dict)) $annotations }}
+  {{- $rendered := dict }}
+  {{- range $key, $value := $annotations }}
+  {{- /*
+    Annotation values must be strings. A numeric timeout supplied via `--set`
+    arrives as an int and would render unquoted, which the API server rejects
+    on apply — so coerce every value rather than trusting the input's type.
+  */}}
+  {{- if not (kindIs "invalid" $value) }}
+  {{- $_ := set $rendered $key (toString $value) }}
+  {{- end }}
+  {{- end }}
+  {{- with $rendered }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -185,6 +185,26 @@ healthMonitor:
 
 # Gateway resources
 gateway:
+  # Proxy settings applied to the model-gateway routes (/openai, /anthropic,
+  # /gemini) at BOTH proxy layers in front of the gateway: the console nginx
+  # and the ingress. These routes relay streaming LLM responses, where the
+  # upstream model can spend minutes reasoning over a large prompt before the
+  # first token exists — nginx's 60s default read timeout is a ceiling on how
+  # long a model is allowed to think, and hitting it returns a 504 the
+  # application never sees. Both layers default to 60s, so both are set here;
+  # raising only one leaves the other cutting the stream.
+  proxy:
+    # Seconds. Generous rather than exact: the cost of waiting is an idle
+    # connection, the cost of being short is a failed request plus whatever
+    # tokens the upstream already billed.
+    readTimeout: 900
+    sendTimeout: 900
+    # Connecting to an in-cluster service either works immediately or is a
+    # real fault; no reason to wait on it.
+    connectTimeout: 10
+    # Agent requests carry whole file trees and diffs as context, which
+    # comfortably exceeds the ingress default of 1m.
+    bodySize: "32m"
   resources:
     requests:
       cpu: "100m"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15999,6 +15999,11 @@ components:
           type: boolean
           title: Is Error
           default: false
+        error_class:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Class
         finish_reason:
           anyOf:
           - type: string


### PR DESCRIPTION
## Problem

An operator's flow executions failed with 504s on long streaming model calls. Three compounding defects:

1. **Proxy timeout (root cause).** The console nginx template gives `/api/` a 300s `proxy_read_timeout`, but the three model-gateway locations (`^~ /openai/`, `^~ /anthropic/`, `^~ /gemini/`) set no timeout at all and inherit nginx's 60s default. The ingress had no `proxy-read-timeout` annotation either, so both proxy layers killed any streaming request that took more than 60s to first byte. Deterministic on time-to-first-byte, which made it look intermittent: many small calls survive, one large call dies. The same bug existed in `frontend/docker/nginx.conf.template`, so docker-compose installs were equally exposed.

2. **Invisible failures.** When a stream was killed in front of the gateway app (or the client vanished before the first chunk), nothing was recorded: the upstream provider had already been called and billed, but no `ApiUsage` row, no status, no error class. The product showed a clean bill of health while the user's agent failed.

3. **Useless error surface + no retry.** The stored `error_message` for such a failure was the tail of a stack trace ("`status: 504 ... [object Object]`", 69 chars); the actual cause (upstream retries exhausted) was hundreds of log lines earlier and discarded. And one transient upstream failure permanently killed the whole flow execution.

## Fix (three commits, one per defect)

- `16c9d4a0` — new `gateway.proxy` values block (read/send 900s, connect 10s, body 32m) applied to the three gateway locations in the helm ConfigMap **and** as first-class ingress annotations (operator-supplied annotations win; values coerced to strings so `--set` ints don't break apply). Same fix in the docker nginx template. 17 chart tests.
- `4d01544b` — `ObservedGatewayStream` wraps every streaming return site: a stream that is never consumed fires exactly one `stream_abandoned` (499) usage record; consumed-then-dropped and completed paths are unchanged (no double-counting, pinned by tests). Gemini's inner stream is closed deterministically instead of at GC time. `error_class` is now serialized on the session-timeline API.
- `afb7eeca` — `failure_analysis` module extracts the real cause from agent logs (e.g. "Upstream model provider timed out (HTTP 504) after 3 attempts"), and the orchestrator retries transient upstream failures (504/502/429/connect-reset) with bounded backoff, only when the agent exited non-zero (verified: no external side effects have happened by then). Retries are recorded as `execution_retry_scheduled` milestones, never hidden. Non-transient failures (auth, config, policy, budget) never retry.

## Deploy note (operators)

The chart defaults now carry the timeouts, so a plain `helm upgrade` fixes the 60s cutoff. If you previously hand-patched a ConfigMap or ingress to work around this, those edits are superseded (and would be reverted by upgrade anyway — that is expected). nginx renders the template at container start, so the console pod must restart to pick up the ConfigMap change; the chart handles this via the usual rollout.

## Tests

56 tests across the three commits (chart rendering, stream abandonment incl. no-double-count guards, failure extraction red/green against the real log shape, retry gating and side-effect safety). Full backend suite verified against a pristine baseline: same pre-existing failures before and after, zero regressions.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-tested fix with conservative retry gating and backward-compatible proxy timeouts.
>
> **Overview**
> Fixes streaming gateway 504s (60s proxy timeout → 900s), adds stream-abandonment observability, and implements bounded, side-effect-aware retry for transient upstream failures. 56 tests, zero regressions against baseline. All previously raised issues addressed.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit afb7eeca. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
