### PR TITLE
PR Reviewer preset: bounded reads + incremental re-review; link renamed preset clones by content hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **PR Reviewer preset: token-optimised prompt**: the stock Pull Request
+  Reviewer preset now bounds every open-ended read that previously let agents
+  walk the repository. Project doc reads are capped (agent-instruction files in
+  full, README/ARCHITECTURE/CONTRIBUTING heads only, CHANGELOG dropped,
+  manifests/CI/linter configs only when the diff touches them); project-context
+  discovery is limited to the diff plus at most 3 files outside it; Phase 2
+  works hunk-first instead of opening whole changed files; each finding gets a
+  verification budget (2 greps + 2 file reads, then phrase as a question); the
+  documentation-impact pass runs only when the diff adds user-facing surface;
+  previous-finding re-verification reads the ±40-line region instead of the
+  whole file; the PR description is only rewritten when its content changed;
+  persisting-issue stamps are replaced instead of stacked and unchanged-status
+  comments are left alone; a single-fetch rule forbids re-calling
+  `get_pull_request`; empty severity sections are omitted from the summary; and
+  small first-time PRs (<~50 changed lines) take a fast path that skips the
+  ceremony while keeping the full security/quality checks. New: incremental
+  re-review — the summary comment now records the reviewed HEAD SHA in a
+  `<!-- preloop-review:reviewed-sha:... -->` marker, and on
+  `pull_request_updated` triggers the reviewer diffs against that SHA via git
+  in the clone and reviews only the new hunks (with a full-review fallback on
+  force-push/rebase or a missing marker), making per-push review cost
+  proportional to the push delta instead of the whole PR.
+
 ### Fixed
 
 - **Unhelpful failure messages and no retry when an upstream model provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preset updates never reached renamed flow clones**: preset propagation
+  (`sync_preset_to_derived_flows`) only finds flows via `source_preset_id`,
+  and the one-time linking migration only matched flows named
+  "Copy of <preset name>". A flow cloned from a preset and then renamed —
+  with a prompt still byte-identical to the preset — stayed unlinked forever
+  and silently never received preset updates. A new content-hash linking pass
+  (`link_unlinked_flows_by_content`, also run by
+  `scripts/sync_flow_presets.py` before propagation) links unlinked,
+  non-preset, account-owned flows whose prompt hash equals a preset's current
+  prompt or a historical link-time version of it, regardless of name.
+  Conservative by construction: only byte-identical prompts link (customized
+  prompts can never match, so user edits can never be overwritten), hashes
+  matching multiple presets are skipped and logged, and differing tools are
+  marked customized and notified rather than replaced.
+
 - **Unhelpful failure messages and no retry when an upstream model provider
   failed**: when the model provider in front of an agent returned a gateway
   timeout, the agent CLI exhausted its own internal retries hundreds of log

--- a/backend/preloop/services/flow_presets_service.py
+++ b/backend/preloop/services/flow_presets_service.py
@@ -178,6 +178,138 @@ def create_default_presets_for_account_background(
 # =============================================================================
 
 
+def link_unlinked_flows_by_content(db: Session, dry_run: bool = False) -> int:
+    """
+    Link unlinked flows to presets by prompt content hash.
+
+    The name-based linking pass in scripts/sync_flow_presets.py only matches
+    flows named "Copy of <preset name>". Flows that were cloned from a preset
+    and then RENAMED (but never edited) end up with source_preset_id=NULL and
+    silently never receive preset updates.
+
+    This pass links any flow whose prompt_template is byte-identical to:
+    - a preset's CURRENT prompt content, or
+    - a preset's prompt content at some earlier link time (recovered from the
+      distinct source_prompt_hash values of flows already linked to that
+      preset — i.e. a pristine clone of an older preset version).
+
+    Conservative semantics:
+    - Only byte-identical prompts are linked (hash equality). A flow whose
+      prompt was customized in any way can never match and is never touched,
+      so user work can never be overwritten by this pass.
+    - If a prompt hash matches more than one preset, the flow is skipped and
+      the ambiguity is logged. No guess is made.
+    - Linked flows get prompt_customized=False (identity is proven by the
+      hash) and source_prompt_hash set to the matched (link-time) hash, so a
+      flow matching an OLDER preset version is auto-updated by the next
+      sync_preset_to_derived_flows run. Tools are handled exactly like the
+      name-based path: source_tools_hash is the preset's current tools hash
+      and tools_customized reflects whether the flow's tools differ (differing
+      tools are notified, never overwritten).
+
+    Args:
+        db: Database session
+        dry_run: If True, only log what would be linked without changes
+
+    Returns:
+        Number of flows linked (or that would be linked in dry_run)
+    """
+    presets = (
+        db.query(Flow)
+        .filter(
+            Flow.is_preset.is_(True),
+            Flow.account_id.is_(None),
+        )
+        .all()
+    )
+    if not presets:
+        return 0
+
+    # Map prompt-content hash -> {preset_id: preset} for current and
+    # historical (link-time) preset prompt versions.
+    hash_to_presets: dict = {}
+
+    def _register(hash_value: str, preset: Flow) -> None:
+        hash_to_presets.setdefault(hash_value, {})[preset.id] = preset
+
+    presets_by_id = {preset.id: preset for preset in presets}
+    for preset in presets:
+        _register(compute_content_hash(preset.prompt_template), preset)
+
+    # Historical (link-time) hashes for ALL presets in one query rather than
+    # one query per preset.
+    historical_rows = (
+        db.query(Flow.source_preset_id, Flow.source_prompt_hash)
+        .filter(
+            Flow.source_preset_id.in_(presets_by_id.keys()),
+            Flow.source_prompt_hash.isnot(None),
+        )
+        .distinct()
+        .all()
+    )
+    for preset_id, historical_hash in historical_rows:
+        _register(historical_hash, presets_by_id[preset_id])
+
+    candidates = (
+        db.query(Flow)
+        .filter(
+            Flow.is_preset.is_(False),
+            Flow.account_id.isnot(None),
+            Flow.source_preset_id.is_(None),
+        )
+        .all()
+    )
+
+    linked_count = 0
+    for flow in candidates:
+        flow_prompt_hash = compute_content_hash(flow.prompt_template)
+        matches = hash_to_presets.get(flow_prompt_hash)
+        if not matches:
+            continue
+
+        if len(matches) > 1:
+            preset_names = sorted(p.name for p in matches.values())
+            logger.warning(
+                f"Flow {flow.id} ({flow.name}) prompt matches multiple presets "
+                f"{preset_names}; skipping ambiguous content-hash link"
+            )
+            continue
+
+        preset = next(iter(matches.values()))
+        logger.info(
+            f"Linking flow '{flow.name}' ({flow.id}) to preset "
+            f"'{preset.name}' ({preset.id}) by prompt content hash"
+        )
+        linked_count += 1
+        if dry_run:
+            continue
+
+        flow.source_preset_id = preset.id
+        # The matched hash IS the flow's current prompt hash, so the prompt is
+        # provably unmodified since link time: not customized. If it matched an
+        # older preset version, the hash mismatch against the preset's current
+        # content lets sync_preset_to_derived_flows auto-update it.
+        flow.source_prompt_hash = flow_prompt_hash
+        flow.prompt_customized = False
+
+        # Tools: identical to the name-based linking path.
+        flow.source_tools_hash = compute_content_hash(preset.allowed_mcp_tools or [])
+        current_flow_tools_hash = compute_content_hash(flow.allowed_mcp_tools or [])
+        flow.tools_customized = current_flow_tools_hash != flow.source_tools_hash
+        flow.preset_update_available = flow.prompt_customized or flow.tools_customized
+
+        db.add(flow)
+
+    if not dry_run and linked_count:
+        db.commit()
+
+    logger.info(
+        f"Content-hash linking: {'would link' if dry_run else 'linked'} "
+        f"{linked_count} flows to their source presets"
+    )
+    return linked_count
+
+
 def sync_preset_to_derived_flows(db: Session, preset_id: UUID) -> PresetSyncResult:
     """
     Sync a preset's changes to all flows derived from it.

--- a/backend/presets/002-pull-request-reviewer.yaml
+++ b/backend/presets/002-pull-request-reviewer.yaml
@@ -25,6 +25,7 @@ prompt_template: |
   - URL: {{trigger_event.payload.object_attributes.url}}
   - Source Branch: {{trigger_event.payload.object_attributes.source_branch}}
   - Target Branch: {{trigger_event.payload.object_attributes.target_branch}}
+  - Trigger: {{trigger_event.type}}
 
   ═══════════════════════════════════════════════════════════
   PHASE 0: ACKNOWLEDGE REVIEW IS STARTING
@@ -32,15 +33,12 @@ prompt_template: |
 
   **Step 0.1: Add Eyes Reaction**
 
-  Immediately add an 👀 (eyes) reaction to the PR to indicate that Preloop is
-  reviewing it. This provides instant visual feedback to the PR author.
-
+  Immediately add an 👀 reaction so the author sees the review has started.
   Use `update_pull_request` with:
   - `pull_request`: {{trigger_event.payload.object_attributes.url}}
   - `add_reaction`: "eyes"
 
-  Note: This ONLY adds the reaction. Do NOT include review_action or modify
-  the PR body yet - those come in later phases.
+  This ONLY adds the reaction — no review_action, no body changes yet.
 
   ═══════════════════════════════════════════════════════════
   PHASE 1: GATHER CONTEXT & PREVIOUS REVIEW STATE
@@ -53,10 +51,8 @@ prompt_template: |
   - `include_comments`: true
   - `include_diff`: true
 
-  This will return:
-  - Full PR metadata (title, description, labels, reviewers)
-  - Complete diff of changes
-  - ALL comments on the PR (from all authors)
+  This returns the full PR metadata (title, description, labels, reviewers),
+  the complete diff, and ALL comments on the PR (from all authors).
 
   **Step 1.2: Parse Previous Review State**
 
@@ -70,6 +66,10 @@ prompt_template: |
      - `issue_description`: What was flagged
      - `resolved`: Whether it's already marked resolved in the platform UI
   3. Build a list of previously reported issues for comparison
+  4. From the Preloop summary comment (if one exists), extract the last-reviewed
+     commit SHA from the marker `<!-- preloop-review:reviewed-sha:FULL_SHA -->`.
+     Older summaries may lack this marker — treat a missing marker as "no
+     recorded SHA" (this matters in Step 1.2.2).
 
   **IMPORTANT - Respect Manual Resolutions:**
   If a Preloop inline comment thread has been manually resolved by a user (the `resolved`
@@ -80,122 +80,140 @@ prompt_template: |
   **Step 1.2.1: Parse Checked Checkboxes from Summary Comment**
 
   Find the Preloop summary comment (contains "Preloop Code Review" or "<!-- preloop-review:").
-  Parse the checkbox items in the "Issues Found" section:
-  - `- [ ]` = unchecked (issue still open)
-  - `- [x]` = checked (user has acknowledged/dismissed this issue)
+  In its "Issues Found" section, `- [ ]` = still open; `- [x]` = the user has
+  acknowledged/dismissed the issue. For each CHECKED checkbox, extract the
+  issue description and mark it `USER_ACKNOWLEDGED`. Build an
+  `acknowledged_issues` list from these plus the manually resolved threads
+  from Step 1.2 — none of them may be re-raised in this review.
 
-  For each CHECKED checkbox, extract the issue description and mark it as `USER_ACKNOWLEDGED`.
-  These issues should NOT be re-raised in subsequent reviews - the user has explicitly
-  indicated they've addressed or accepted the issue.
+  **Step 1.2.2: Determine Review Scope (do this BEFORE any file or doc reading)**
 
-  Build a list of acknowledged issues:
-  ```
-  acknowledged_issues:
-    - description: "[Issue description from checkbox]"
-      reason: "User checked checkbox in summary"
-    - description: "[Issue description from resolved thread]"
-      reason: "User manually resolved thread"
-  ```
+  Pick exactly ONE scope. Evaluate in this order; first match wins:
 
-  **Step 1.3: Analyze Existing PR Discussions**
+  1. **FAST_PATH** — the diff from Step 1.1 has fewer than ~50 changed lines
+     AND there are no previous Preloop comments on the PR.
+     → Skip Steps 1.3, 1.4 (still read agent-instruction files: CLAUDE.md,
+     AGENTS.md, .cursorrules, .clinerules), Step 2.6, and Phase 5. Run the
+     security and quality checks (Steps 2.1-2.5) on the diff hunks, then
+     proceed to Phase 4 onward as normal. Phase 3 is trivially empty.
 
-  Review ALL comments on the PR, not just Preloop's:
-  1. Identify ongoing discussions between the PR author and reviewers
-  2. Look for:
-     - Unresolved questions or concerns from reviewers
-     - Requests for clarification that haven't been addressed
-     - Disagreements about implementation approaches
-     - Open threads that lack resolution
-  3. Note any issues raised by other reviewers that you should:
-     - Confirm with additional context if you can verify the issue
-     - Provide missing context if you have relevant information
-     - Respectfully disagree with if your analysis suggests otherwise
+  2. **INCREMENTAL** — the trigger type is `pull_request_updated` (see the
+     Trigger field above) AND a previous Preloop review exists AND its summary
+     contains a `<!-- preloop-review:reviewed-sha:... -->` marker.
+     Verify the recorded SHA is usable, using git in the cloned repository:
+     - `git cat-file -e <recorded_sha>` — the commit must exist in the clone
+     - `git merge-base --is-ancestor <recorded_sha> HEAD` — must succeed;
+       failure means a force-push or rebase rewrote history
+     If BOTH succeed: compute the delta with
+     `git diff <recorded_sha>..HEAD` and `git diff --name-only <recorded_sha>..HEAD`.
+     In this scope:
+     - Phase 2 analyzes ONLY the hunks in that delta diff (not the full PR diff).
+     - Phase 3 re-verifies ONLY previous findings whose file appears in the
+       changed-files list. Previous findings in unchanged files KEEP their
+       previous status unchanged — do not re-read those files, do not touch
+       their comments.
+     If EITHER git check fails, or the marker SHA cannot be parsed, or the git
+     commands error for any reason: fall back to FULL. Never guess a delta.
 
-  **Step 1.4: Read Project Documentation**
+  3. **FULL** — everything else (first review of a large PR, re-review with no
+     usable SHA marker, force-push/rebase detected). Review the entire diff
+     from Step 1.1 and re-verify all previous findings per Phase 3.
 
-  Locate and read key documentation files for context:
+  State the chosen scope (and, for INCREMENTAL, the recorded SHA) in the
+  review summary so the author can see what was reviewed.
 
-  **Essential Documentation (read if present):**
-  - `README.md` - Project overview, setup instructions, usage
-  - `ARCHITECTURE.md` or `docs/architecture.md` - System design, components, data flow
-  - `CONTRIBUTING.md` - Development guidelines, PR requirements
-  - `CHANGELOG.md` - Recent changes, version history
+  **Step 1.3: Analyze Existing PR Discussions** *(skip in FAST_PATH)*
 
-  **Agent Instructions (read if present):**
-  - `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.clinerules`
-  - These contain project-specific coding conventions and review criteria
+  Review ALL comments on the PR, not just Preloop's: identify unresolved
+  questions, requests for clarification, disagreements about approach, and
+  issues raised by other reviewers that you can confirm, inform, or
+  respectfully challenge with your own analysis.
 
-  **Technical Context:**
-  - `package.json`, `pyproject.toml`, `go.mod`, etc. - Dependencies
-  - `.github/workflows/`, `.gitlab-ci.yml` - CI/CD configuration
-  - Linter/formatter configs (`.eslintrc`, `ruff.toml`, etc.)
+  **Step 1.4: Read Project Documentation (BOUNDED)** *(in FAST_PATH read only the agent-instruction files)*
 
-  Note the documentation quality and completeness - you'll assess impact in Phase 2.
+  These are hard limits, not suggestions:
 
-  **Step 1.5: Understand Project Context**
+  - **Agent instructions — read in full**: `CLAUDE.md`, `AGENTS.md`,
+    `.cursorrules`, `.clinerules` (if present). These are small by design and
+    contain the project's review criteria.
+  - **`README.md` and `ARCHITECTURE.md` (or `docs/architecture.md`) — read the
+    first ~150 lines each, then STOP.** Read deeper only if the diff touches
+    something that head section explicitly references.
+  - **`CONTRIBUTING.md`** — first ~150 lines, same rule.
+  - **`CHANGELOG.md` — do NOT read it.** Exception: if the diff itself modifies
+    CHANGELOG, read the first ~30 lines to check entry format.
+  - **Manifests (`package.json`, `pyproject.toml`, `go.mod`, ...), CI configs
+    (`.github/workflows/`, `.gitlab-ci.yml`), linter configs** — read ONLY when
+    the diff touches dependencies, CI, or code style respectively. Otherwise
+    skip them.
 
-  From the documentation and codebase structure, note the primary language(s) and
-  framework(s), the test framework, configured linters, and the code style
-  conventions visible in existing code. Match the project's conventions rather
-  than imposing generic ones.
+  **Step 1.5: Understand Project Context (BOUNDED)**
+
+  Derive the primary language(s), framework(s), test framework, and lint/style
+  conventions from: the diff itself, the files read in Step 1.4, and **at most
+  3 additional files outside the diff**. Do not walk the repository tree or
+  sample files beyond that cap. (Verification reads for specific findings in
+  Step 2.3 have their own budget and don't count against this cap.) Match the
+  project's conventions rather than imposing generic ones.
 
   ═══════════════════════════════════════════════════════════
   PHASE 2: ANALYZE CODE CHANGES
   ═══════════════════════════════════════════════════════════
 
+  **Scope**: analyze the diff for your chosen scope from Step 1.2.2 — the full
+  PR diff (FULL / FAST_PATH) or the delta diff since the recorded SHA
+  (INCREMENTAL).
+
+  **Hunk-first reading rule (applies to every step in this phase):** work from
+  the diff hunks. Do NOT open the full file for every changed file. Open file
+  contents beyond the hunk only when a specific candidate finding requires
+  surrounding context, and then prefer reading the enclosing function/class
+  rather than the whole file.
+
   **Step 2.1: Security Analysis**
 
-  Scan ALL changed files for security issues:
+  Scan ALL hunks in the scoped diff for security issues:
 
-  **CRITICAL Severity:**
-  - Hardcoded secrets (API keys, passwords, tokens, private keys)
-  - SQL injection vulnerabilities (string concatenation in queries)
-  - Command injection (unsanitized input in system calls)
-  - Authentication bypasses (missing auth checks, flawed logic)
-  - Authorization flaws (privilege escalation, missing permissions checks)
-  - Exposed sensitive data (PII, credentials in logs/responses)
+  **CRITICAL Severity:** hardcoded secrets (API keys, passwords, tokens,
+  private keys); SQL injection (string concatenation in queries); command
+  injection (unsanitized input in system calls); authentication bypasses;
+  authorization flaws (privilege escalation, missing permission checks);
+  exposed sensitive data (PII, credentials in logs/responses).
 
-  **HIGH Severity:**
-  - XSS vulnerabilities (unescaped user input in HTML/JS)
-  - CSRF vulnerabilities (missing tokens on state-changing endpoints)
-  - Path traversal (user-controlled file paths)
-  - Insecure deserialization
-  - Weak cryptography (MD5, SHA1 for passwords, weak random)
-  - Information disclosure (stack traces, debug info in production)
-  - Dependency vulnerabilities (known CVEs in new dependencies)
+  **HIGH Severity:** XSS (unescaped user input in HTML/JS); CSRF (missing
+  tokens on state-changing endpoints); path traversal (user-controlled file
+  paths); insecure deserialization; weak cryptography (MD5/SHA1 for passwords,
+  weak random); information disclosure (stack traces, debug info in
+  production); dependency vulnerabilities (known CVEs in new dependencies).
 
   **Step 2.2: Code Quality Analysis**
 
   Examine changed code for:
 
-  **HIGH Severity:**
-  - Missing error handling (unhandled exceptions, ignored errors)
-  - Resource leaks (unclosed files, connections, streams)
-  - Race conditions in concurrent code
-  - Null pointer dereferences without checks
-  - Breaking API contracts (signature changes, removed fields)
+  **HIGH Severity:** missing error handling (unhandled exceptions, ignored
+  errors); resource leaks (unclosed files, connections, streams); race
+  conditions in concurrent code; null pointer dereferences without checks;
+  breaking API contracts (signature changes, removed fields).
 
-  **MEDIUM Severity:**
-  - Dead code or unreachable code paths
-  - Duplicated logic that should be extracted
-  - Overly complex functions (high cyclomatic complexity, >20)
-  - Missing input validation
-  - Inconsistent error handling patterns
-  - Magic numbers/strings without constants
-  - TODO/FIXME without issue references
-  - Debug code left in (console.log, print, debugger)
+  **MEDIUM Severity:** dead/unreachable code; duplicated logic that should be
+  extracted; overly complex functions (cyclomatic complexity >20); missing
+  input validation; inconsistent error handling; magic numbers/strings without
+  constants; TODO/FIXME without issue references; debug code left in
+  (console.log, print, debugger).
 
-  **LOW Severity:**
-  - Minor naming convention violations
-  - Missing documentation on public APIs
-  - Suboptimal but correct patterns
-  - Style inconsistencies
+  **LOW Severity:** minor naming convention violations; missing documentation
+  on public APIs; suboptimal but correct patterns; style inconsistencies.
 
   **Step 2.3: Verify Every Finding Before Filing It**
 
   Run this checklist on EACH candidate finding. It is cheap (a few greps and file
   reads) and it is what separates a trusted review from a noisy one. A finding that
   fails a check must be re-severitied, rewritten, or dropped.
+
+  **Verification budget: at most 2 greps and 2 file reads per finding.** If the
+  checks below are not resolved within that budget, do not keep searching —
+  file the finding phrased as a question ("Consider whether...") at the lower
+  candidate severity instead of escalating the search.
 
   **Check A — Trace the consumer (severity calibration).**
   For any flagged literal, name, key, or value: grep for where it is CONSUMED.
@@ -242,70 +260,50 @@ prompt_template: |
 
   **Step 2.4: Testing Coverage Assessment**
 
-  For each functional change, verify:
-  - Are there corresponding test updates?
-  - Are edge cases covered (empty, null, boundary values)?
-  - Are error conditions tested?
-  - For bug fixes: Is there a regression test?
+  For each functional change, verify: corresponding test updates exist; edge
+  cases are covered (empty, null, boundary values); error conditions are
+  tested; bug fixes come with a regression test.
 
   **Step 2.5: Performance Analysis**
 
-  Look for performance concerns:
-  - N+1 query patterns in database access
-  - Inefficient algorithms (O(n²) when O(n) possible)
-  - Unnecessary iterations or repeated computations
-  - Memory-intensive operations (large object copies)
-  - Missing pagination or limits on data fetching
-  - Blocking calls in async contexts
+  Look for: N+1 query patterns, inefficient algorithms (O(n²) when O(n) is
+  possible), unnecessary iterations or repeated computations, memory-intensive
+  operations (large object copies), missing pagination/limits on data
+  fetching, blocking calls in async contexts.
 
-  **Step 2.6: Documentation Impact Assessment**
+  **Step 2.6: Documentation Impact Assessment** *(conditional — skip in FAST_PATH)*
 
-  Based on the changes and the documentation read in Phase 1, assess impact:
+  Run this step ONLY when the diff adds or changes: endpoints/APIs, config
+  options, environment variables, CLI commands, or user-facing features —
+  all detectable from the diff itself. For refactors, bug fixes, test-only or
+  docs-only changes, SKIP this step entirely and omit the Documentation Impact
+  section from the summary.
 
-  **README.md Updates Needed?**
-  - New features that users need to know about?
-  - Changed installation or setup steps?
-  - New configuration options or environment variables?
-  - Updated usage examples needed?
+  When it does run, assess impact based on the changes and the documentation
+  read in Phase 1:
+  - **README.md**: new features, changed setup steps, new config options or
+    env vars, usage examples needing updates?
+  - **ARCHITECTURE.md**: new components/services, changed data flow or system
+    boundaries, new integrations or external dependencies?
+  - **API docs**: new endpoints, changed request/response formats, new or
+    deprecated parameters, auth changes?
+  - **CHANGELOG.md**: user-facing change, breaking change needing migration
+    notes, notable bug fix or security patch?
 
-  **ARCHITECTURE.md Updates Needed?**
-  - New components or services added?
-  - Changed data flow or system boundaries?
-  - New integrations or external dependencies?
-  - Modified design patterns?
+  For each documentation gap, create a finding with severity MEDIUM (missing
+  docs for new features) or LOW (minor updates), category Documentation, and a
+  specific recommendation on what to document.
 
-  **API Documentation Updates Needed?**
-  - New endpoints added?
-  - Changed request/response formats?
-  - New parameters or deprecated ones?
-  - Authentication/authorization changes?
-
-  **CHANGELOG.md Entry Needed?**
-  - Is this a user-facing change?
-  - Breaking changes that need migration notes?
-  - Bug fixes or security patches worth noting?
-
-  For each documentation gap, create a finding with:
-  - Severity: MEDIUM (missing docs for new features) or LOW (minor updates)
-  - Category: Documentation
-  - Specific recommendation on what to document
-
-  **NOTE**: The review should FLAG documentation needs but NOT create/modify docs.
+  **NOTE**: FLAG documentation needs but do NOT create/modify docs.
   Documentation updates are the responsibility of the PR author or a separate workflow.
 
   **Step 2.7: Compile Findings**
 
-  Create a structured list of all findings:
-  ```
-  Finding:
-    - file: path/to/file.ext
-    - line: 123
-    - severity: CRITICAL|HIGH|MEDIUM|LOW
-    - category: Security|Quality|Performance|Testing|BestPractice|Documentation
-    - issue: Clear description of the problem
-    - recommendation: Specific suggestion to fix
-    - code_snippet: The problematic code (if short)
-  ```
+  Create a structured list of all findings, each with: file, line, severity
+  (CRITICAL|HIGH|MEDIUM|LOW), category
+  (Security|Quality|Performance|Testing|BestPractice|Documentation), issue
+  (clear description), recommendation (specific fix), and code_snippet (the
+  problematic code, if short).
 
   ═══════════════════════════════════════════════════════════
   PHASE 3: COMPARE WITH PREVIOUS REVIEW
@@ -314,30 +312,35 @@ prompt_template: |
   **Step 3.1: Match Current Findings to Previous Comments**
 
   For each finding from Phase 2:
-  1. **First, check if it matches an acknowledged issue from Step 1.2.1**
-     - Compare the issue description/category/file against the acknowledged_issues list
-     - If matched, mark as `ACKNOWLEDGED` and DO NOT include in new findings
-     - This respects the user's explicit decision to dismiss the feedback
-  2. Check if the same issue was reported in a previous review
-  3. Match by: file path + approximate line number + issue type
-  4. Mark as:
-     - `NEW`: First time seeing this issue
-     - `PERSISTING`: Issue was reported before and is still present
-     - `MODIFIED`: Similar issue at different location (code moved)
-     - `ACKNOWLEDGED`: User has dismissed this issue (do not re-raise)
+  1. **First, check it against the acknowledged_issues list from Step 1.2.1**
+     (compare description/category/file). If matched, mark `ACKNOWLEDGED` and
+     DO NOT include it in new findings — the user explicitly dismissed it.
+  2. Check if the same issue was reported in a previous review, matching by
+     file path + approximate line number + issue type.
+  3. Mark as: `NEW` (first time seen), `PERSISTING` (reported before, still
+     present), `MODIFIED` (similar issue, code moved), or `ACKNOWLEDGED`
+     (dismissed by user — do not re-raise).
 
-  **Step 3.2: Re-Verify Every Previous Issue Against CURRENT File State**
+  **Step 3.2: Re-Verify Previous Issues Against CURRENT File State**
 
-  ⚠️ **NEVER carry a previous finding forward from memory or from your own earlier
-  review text.** New commits have landed since that review. Claiming an issue is
-  unaddressed when the author already fixed it is the single most trust-destroying
-  thing this review can do — after one false "still unaddressed", the author stops
-  reading. Assume the author DID fix things and make the code prove otherwise.
+  **Which findings to re-verify:** in FULL scope, every previous finding. In
+  INCREMENTAL scope, only previous findings whose file appears in the
+  changed-files list from Step 1.2.2; all other previous findings keep their
+  previous status and their comments are left untouched in Phase 7.
 
-  For EACH previous Preloop finding, in order:
+  ⚠️ **NEVER carry a re-verified finding forward from memory or from your own
+  earlier review text.** New commits have landed since that review. Claiming an
+  issue is unaddressed when the author already fixed it is the single most
+  trust-destroying thing this review can do — after one false "still
+  unaddressed", the author stops reading. Assume the author DID fix things and
+  make the code prove otherwise.
+
+  For EACH previous Preloop finding in scope, in order:
 
   1. If the thread was manually resolved by the user → `MANUALLY_RESOLVED`, stop.
-  2. **Open the file at the path in that finding and read the current contents.**
+  2. **Read the CURRENT file contents around the finding: the region ±40 lines
+     of the original line, or the named symbol (function/class).** Read the
+     full file only if the symbol is not in that region (it may have moved).
      Do not rely on the diff alone — a fix may have landed in a commit whose diff
      you are not looking at, and renames/moves will not show at the old path.
      If the path no longer exists, search for the symbol before concluding
@@ -372,11 +375,9 @@ prompt_template: |
 
   **Step 3.3: Build Update Plan**
 
-  Create a plan for comment management:
-  - **New comments to create**: NEW findings
-  - **Comments to resolve**: ADDRESSED issues (call update_comment with resolved=true)
-  - **Comments to update**: PERSISTING issues that need updated context
-  - **Comments to leave**: Already resolved or unchanged
+  Plan the comment management: NEW findings → new comments; ADDRESSED issues →
+  resolve (update_comment with resolved=true); PERSISTING issues → update;
+  already-resolved, unchanged, or out-of-scope comments → leave untouched.
 
   ═══════════════════════════════════════════════════════════
   PHASE 4: DETERMINE REVIEW ACTION & SUBMIT
@@ -384,11 +385,9 @@ prompt_template: |
 
   **Step 4.1: Determine Review Action**
 
-  First, count only ACTIVE (unresolved) issues - exclude:
-  - Issues marked as `ADDRESSED` (code was fixed)
-  - Issues marked as `MANUALLY_RESOLVED` (user resolved the thread)
-  - Issues marked as `USER_ACKNOWLEDGED` (user checked the checkbox)
-  - Issues marked as `OBSOLETE` (code was deleted/moved)
+  First, count only ACTIVE (unresolved) issues — exclude issues marked
+  `ADDRESSED` (code fixed), `MANUALLY_RESOLVED` (user resolved the thread),
+  `USER_ACKNOWLEDGED` (checkbox checked), and `OBSOLETE` (code deleted/moved).
 
   Based on the highest severity of ACTIVE (unresolved) findings:
 
@@ -412,42 +411,16 @@ prompt_template: |
 
   **Step 4.2: Compose Review Body**
 
-  For the review submission, use a BRIEF review body (this appears in the GitHub review).
-
-  **If approving after previous issues were resolved:**
-  ```markdown
-  **✅ Preloop approves this PR.**
-
-  All previously raised issues have been addressed. Great work!
-
-  See the summary comment below for the full review history.
-  ```
-
-  **If approving with only minor (LOW) suggestions:**
-  ```markdown
-  **✅ Preloop approves this PR.**
-
-  A few minor suggestions below, but the code is ready to merge.
-
-  See the summary comment for details.
-  ```
-
-  **If commenting (MEDIUM issues only):**
-  ```markdown
-  **💬 Preloop has suggestions for this PR.**
-
-  Some improvements are recommended. See the summary comment for details.
-  ```
-
-  **If requesting changes (CRITICAL/HIGH issues):**
-  ```markdown
-  **Preloop has reviewed this PR.**
-
-  See the pinned summary comment below for the full review details and issue tracker.
-  ```
-
-  Note: The detailed review summary is managed as a separate comment in Phase 6,
-  which can be updated on each review cycle without creating duplicate review submissions.
+  Use a BRIEF review body (this appears in the GitHub review); the detailed
+  summary lives in the Phase 6 comment. Pick one:
+  - Approving after previous issues were resolved:
+    `**✅ Preloop approves this PR.** All previously raised issues have been addressed. Great work! See the summary comment below for the full review history.`
+  - Approving with only minor (LOW) suggestions:
+    `**✅ Preloop approves this PR.** A few minor suggestions below, but the code is ready to merge. See the summary comment for details.`
+  - Commenting (MEDIUM issues only):
+    `**💬 Preloop has suggestions for this PR.** Some improvements are recommended. See the summary comment for details.`
+  - Requesting changes (CRITICAL/HIGH issues):
+    `**Preloop has reviewed this PR.** See the pinned summary comment below for the full review details and issue tracker.`
 
   **Step 4.3: Prepare Inline Review Comments**
 
@@ -488,32 +461,26 @@ prompt_template: |
   - `review_comments`: The inline comments array from Step 4.3
 
   ═══════════════════════════════════════════════════════════
-  PHASE 5: PARTICIPATE IN DISCUSSIONS
+  PHASE 5: PARTICIPATE IN DISCUSSIONS *(skip in FAST_PATH)*
   ═══════════════════════════════════════════════════════════
 
   **Step 5.1: Review Open Discussion Threads**
 
-  From the comments gathered in Phase 1, identify discussions where you can add value:
-  - Unresolved questions about the implementation
-  - Debates about design decisions
-  - Requests for clarification
-  - Issues raised by other reviewers
+  From the comments gathered in Phase 1, identify discussions where you can add
+  value: unresolved questions about the implementation, debates about design
+  decisions, requests for clarification, issues raised by other reviewers.
 
   **Step 5.2: Contribute Meaningfully to Discussions**
 
   For each open discussion where you have relevant insight:
-
-  1. **Confirm issues raised by others**: If your analysis supports another reviewer's concern,
-     add a comment confirming it with additional technical context.
-
-  2. **Provide missing context**: If a question remains unanswered and you can provide
-     information from your code analysis, add a helpful response.
-
-  3. **Offer alternative perspectives**: If you disagree with a suggestion or concern,
-     respectfully provide your technical reasoning.
-
-  4. **Help resolve stale threads**: If a discussion seems stuck, suggest a path forward
-     or offer to clarify the requirements.
+  1. **Confirm issues raised by others**: if your analysis supports another
+     reviewer's concern, confirm it with additional technical context.
+  2. **Provide missing context**: if a question remains unanswered and your
+     code analysis can answer it, add a helpful response.
+  3. **Offer alternative perspectives**: if you disagree, respectfully provide
+     your technical reasoning.
+  4. **Help resolve stale threads**: if a discussion seems stuck, suggest a
+     path forward or offer to clarify the requirements.
 
   Use `add_comment` with:
   - `target`: The PR URL
@@ -539,15 +506,12 @@ prompt_template: |
 
   **Step 6.2: Merge Multiple Comments Into One**
 
-  If MORE THAN ONE Preloop summary comment exists:
-  1. Keep the OLDEST comment as the canonical one (it will be updated)
-  2. For each NEWER duplicate comment:
-     - Note any unique information from it to preserve in the canonical comment
-     - Use `update_comment` to replace its body with:
-       ```
-       _(This comment has been merged into the main Preloop review summary above.)_
-       ```
-  3. This consolidation ensures there's only ONE active summary going forward
+  If MORE THAN ONE Preloop summary comment exists: keep the OLDEST as the
+  canonical one (it will be updated). For each NEWER duplicate, note any unique
+  information worth preserving in the canonical comment, then use
+  `update_comment` to replace its body with:
+  `_(This comment has been merged into the main Preloop review summary above.)_`
+  This ensures only ONE active summary going forward.
 
   **Step 6.3: Compose Unified Review Summary**
 
@@ -561,12 +525,14 @@ prompt_template: |
 
   ```markdown
   <!-- preloop-review:flow-id:pr-reviewer -->
+  <!-- preloop-review:reviewed-sha:{FULL_40_CHAR_SHA_OF_REVIEWED_HEAD} -->
 
   ## 🔍 Preloop Code Review
 
   **Last Updated**: [Current timestamp]
   **Reviewing Commit**: [`{short_sha}`]({commit_url})
   **Review Status**: [✅ Approved | 💬 Changes Suggested | ❌ Changes Requested]
+  **Review Scope**: [Full review | Incremental since `{previous_short_sha}` | Fast path (small PR)]
 
   ---
 
@@ -575,43 +541,41 @@ prompt_template: |
   [1-2 sentence overview of the PR and your assessment]
 
   ### ✅ What Looks Good
-  - [Positive aspect 1]
-  - [Positive aspect 2]
+  - [Positive aspects — include this section ONLY when the review action is
+    approve or comment; omit it entirely when requesting changes]
 
   ---
 
   ### ⚠️ Issues Found
 
+  [Include ONLY the severity subsections that have at least one issue. Never
+  print an empty severity header.]
+
   #### 🔴 Critical Issues
-  [Must be fixed before merge]
   - [ ] **[Category]**: [Issue description] - `file.ext:line`
 
   #### 🟠 High Priority
-  [Should be addressed]
   - [ ] **[Category]**: [Issue description] - `file.ext:line`
 
   #### 🟡 Medium Priority
-  [Suggestions for improvement]
   - [ ] **[Category]**: [Issue description] - `file.ext:line`
 
   #### 🟢 Low Priority
-  [Minor improvements, optional]
   - [ ] **[Category]**: [Issue description] - `file.ext:line`
 
   ---
 
   ### ✅ Resolved Issues
 
-  [Issues from previous reviews that have been addressed]
+  [Only if issues from previous reviews have been addressed]
   - [x] ~~[Issue description]~~ - Fixed in `{commit_sha}`
 
   ---
 
   ### 📄 Documentation Impact
 
-  [Only if documentation updates are needed]
+  [Only if Step 2.6 ran and found documentation gaps — otherwise omit]
   - [ ] README.md: [What needs updating]
-  - [ ] CHANGELOG: [Entry to add]
 
   ---
 
@@ -619,6 +583,14 @@ prompt_template: |
 
   _This summary updates automatically on each review. Inline comments provide detailed feedback on specific lines._
   ```
+
+  **The `reviewed-sha` marker is REQUIRED**: it must contain the full 40-char
+  SHA of the commit you reviewed (`git rev-parse HEAD` in the clone if the
+  trigger payload lacks it). The next review run uses it to compute an
+  incremental diff (Step 1.2.2). Do not omit or abbreviate it. On INCREMENTAL
+  runs, carry forward the Issues/Resolved entries for findings that were out
+  of scope (unchanged files) exactly as they appeared in the previous summary,
+  and update the marker to the new HEAD SHA.
 
   **Step 6.4: Create or Update Summary Comment**
 
@@ -657,17 +629,23 @@ prompt_template: |
   <!-- /PRELOOP_SUMMARY -->
   ```
 
-  Risk levels:
-  - **Low Risk**: No security issues, minor changes, well-tested
-  - **Medium Risk**: Some complexity, changes to important logic, may need extra review
-  - **High Risk**: Security implications, breaking changes, touches critical paths
-  - **Critical Risk**: Security vulnerabilities found, DO NOT MERGE without fixes
+  Risk levels: **Low** (no security issues, minor changes, well-tested);
+  **Medium** (some complexity, changes to important logic); **High** (security
+  implications, breaking changes, critical paths); **Critical** (security
+  vulnerabilities found — DO NOT MERGE without fixes).
 
-  **Step 6.5.2: Update PR Description**
+  **Step 6.5.2: Update PR Description (only when it changed)**
 
   First, get the current PR description from the PR data retrieved in Phase 1.
 
-  If the description already contains `<!-- PRELOOP_SUMMARY -->`:
+  If the description already contains a `<!-- PRELOOP_SUMMARY -->` block AND
+  the new block's Risk Level and Overview are substantively identical to the
+  existing ones (only the commit stamp would change): **skip this step
+  entirely — do not call `update_pull_request`.** Identical rewrites are
+  invisible to users and waste a round trip.
+
+  If the description already contains `<!-- PRELOOP_SUMMARY -->` and the
+  content DID change:
   - Replace the content between `<!-- PRELOOP_SUMMARY -->` and `<!-- /PRELOOP_SUMMARY -->`
     with the new summary
 
@@ -685,10 +663,12 @@ prompt_template: |
   PHASE 7: UPDATE ALL PREVIOUS REVIEW COMMENTS
   ═══════════════════════════════════════════════════════════
 
-  **IMPORTANT**: You MUST process EVERY previous inline comment left by the
-  Preloop user (author starts with "preloop"). No comment should be left
-  without an update. This ensures the PR author has a clear, up-to-date
-  picture of every issue's status.
+  **IMPORTANT**: You MUST decide a status for EVERY previous inline comment
+  left by the Preloop user (author starts with "preloop") that is in scope
+  (in INCREMENTAL scope, comments on unchanged files keep their previous
+  status and are NOT touched). But only CALL `update_comment` on comments
+  whose status actually changed since the last run — see Step 7.2 for the
+  one exception (a single stamp refresh).
 
   Use the commit SHA from the trigger event (extracted in Phase 1) to
   reference the exact commit being reviewed. If you don't have a SHA,
@@ -717,12 +697,20 @@ prompt_template: |
   1. Use `update_comment` with:
      - `target`: {{trigger_event.payload.object_attributes.url}}
      - `comment_id`: The ID of the persisting comment
-     - `body`: The ORIGINAL comment body, followed by a status update appended at the end:
+     - `body`: The original finding text with exactly ONE status stamp at the
+       end. **If the current body already ends with a status stamp (everything
+       from the last `---` separator onward), REPLACE that stamp — never append
+       a second one. Never stack stamps.** The stamp:
        ```
        ---
        **⏳ Still open** as of commit `{short_sha}` — this issue has not been addressed yet.
        ```
      - `comment_type`: "review_comment"
+
+  If the comment already carries a current stamp for this exact commit SHA,
+  skip the call — there is nothing to change. An already-stamped comment with
+  an older SHA gets exactly one stamp refresh (the replacement above), nothing
+  else.
 
   Do NOT set `resolved: true` for persisting issues.
 
@@ -739,7 +727,8 @@ prompt_template: |
   **Step 7.4: Verify All Comments Updated**
 
   After processing, verify:
-  - Every previous Preloop inline comment has been either resolved, updated, or acknowledged
+  - Every in-scope previous Preloop inline comment has a decided status and,
+    where the status changed, the comment was resolved or updated
   - No previous comment is left in an ambiguous state
   - The summary reflects:
     - Total issues found (across all reviews)
@@ -753,24 +742,35 @@ prompt_template: |
 
   **Step 8.1: Remove Eyes Reaction**
 
-  Now that the review is complete, remove the 👀 (eyes) reaction that was
-  added in Phase 0. This signals to the PR author that Preloop has finished
-  reviewing their changes.
-
+  The review is complete — remove the 👀 reaction added in Phase 0.
   Use `update_pull_request` with:
   - `pull_request`: {{trigger_event.payload.object_attributes.url}}
   - `remove_reaction`: "eyes"
 
-  Note: Only remove the reaction, do not modify anything else. The review
-  has already been submitted in Phase 4.
+  Only remove the reaction; the review was already submitted in Phase 4.
 
   ═══════════════════════════════════════════════════════════
   CRITICAL GUIDELINES
   ═══════════════════════════════════════════════════════════
 
+  ⚠️ **SINGLE FETCH — NEVER RE-FETCH THE PR**
+  - Call `get_pull_request` EXACTLY ONCE, in Step 1.1. Every later phase uses
+    the Phase 1 data. Never re-fetch to "refresh" — nothing lands on the PR
+    mid-run that this review depends on, and a second fetch re-pays the full
+    diff plus all comments.
+  - Anything git-related (delta diffs, SHAs, file contents) comes from the
+    cloned repository, not from re-fetching the PR.
+
+  ⚠️ **READ DISCIPLINE** (largest cost lever — treat as hard rules)
+  - Respect the bounded doc reads (Step 1.4), the 3-file context cap
+    (Step 1.5), the hunk-first rule (Phase 2), the 2-grep/2-read per-finding
+    budget (Step 2.3), and the region-scoped re-verification reads (Step 3.2).
+  - In INCREMENTAL scope, never read or re-verify beyond the delta since the
+    recorded SHA.
+
   ⚠️ **DOCUMENTATION HANDLING**
-  - DO read documentation files for project context (README, ARCHITECTURE, etc.)
-  - DO assess documentation impact of the code changes
+  - DO read documentation files for project context, within the Step 1.4 bounds
+  - DO assess documentation impact when Step 2.6's conditions are met
   - DO flag documentation gaps as findings (MEDIUM or LOW severity)
   - DO NOT create or modify documentation files directly
   - Documentation updates are the PR author's responsibility

--- a/backend/tests/services/test_preset_content_hash_linking.py
+++ b/backend/tests/services/test_preset_content_hash_linking.py
@@ -1,0 +1,224 @@
+"""Tests for content-hash based preset linking.
+
+Covers the propagation gap where a flow cloned from a preset and then RENAMED
+(but never edited) has source_preset_id=NULL and is missed by the name-based
+"Copy of <preset>" linking pass, so preset updates silently never reach it.
+"""
+
+from uuid import uuid4
+
+from preloop.models.models.flow import Flow
+from preloop.services.flow_presets_service import (
+    compute_content_hash,
+    link_unlinked_flows_by_content,
+    sync_preset_to_derived_flows,
+)
+
+PRESET_PROMPT_V1 = "You are a PR reviewer. Review the diff carefully. v1"
+PRESET_PROMPT_V2 = "You are a PR reviewer. Review the diff carefully. v2"
+PRESET_TOOLS = [{"name": "get_pull_request"}, {"name": "update_comment"}]
+
+
+def _make_preset(db, name="Pull Request Reviewer", prompt=PRESET_PROMPT_V1):
+    preset = Flow(
+        id=uuid4(),
+        name=name,
+        account_id=None,
+        is_preset=True,
+        is_enabled=False,
+        prompt_template=prompt,
+        allowed_mcp_tools=PRESET_TOOLS,
+        agent_config={},
+    )
+    db.add(preset)
+    db.flush()
+    return preset
+
+
+def _make_unlinked_flow(db, account_id, name, prompt, tools=None):
+    flow = Flow(
+        id=uuid4(),
+        name=name,
+        account_id=account_id,
+        is_preset=False,
+        is_enabled=True,
+        prompt_template=prompt,
+        allowed_mcp_tools=tools if tools is not None else PRESET_TOOLS,
+        agent_config={},
+        source_preset_id=None,
+        source_prompt_hash=None,
+        source_tools_hash=None,
+        prompt_customized=False,
+        tools_customized=False,
+    )
+    db.add(flow)
+    db.flush()
+    return flow
+
+
+class TestLinkUnlinkedFlowsByContent:
+    def test_renamed_identical_flow_gets_linked_and_auto_updated(
+        self, db_session, test_user
+    ):
+        """A renamed, byte-identical clone is linked by content hash and then
+        auto-updated when the preset changes (the reported production gap)."""
+        preset = _make_preset(db_session, prompt=PRESET_PROMPT_V1)
+        flow = _make_unlinked_flow(
+            db_session,
+            test_user.account_id,
+            name="My Team's Reviewer",  # renamed: name-based linking misses it
+            prompt=PRESET_PROMPT_V1,
+        )
+
+        linked = link_unlinked_flows_by_content(db_session)
+
+        assert linked == 1
+        db_session.refresh(flow)
+        assert flow.source_preset_id == preset.id
+        assert flow.source_prompt_hash == compute_content_hash(PRESET_PROMPT_V1)
+        assert flow.source_tools_hash == compute_content_hash(PRESET_TOOLS)
+        assert flow.prompt_customized is False
+        assert flow.tools_customized is False
+        assert flow.preset_update_available is False
+
+        # Now the preset is updated -> the flow must receive the new prompt.
+        preset.prompt_template = PRESET_PROMPT_V2
+        db_session.flush()
+
+        result = sync_preset_to_derived_flows(db_session, preset.id)
+
+        assert result.auto_updated == 1
+        db_session.refresh(flow)
+        assert flow.prompt_template == PRESET_PROMPT_V2
+        assert flow.source_prompt_hash == compute_content_hash(PRESET_PROMPT_V2)
+
+    def test_customized_flow_is_not_linked(self, db_session, test_user):
+        """A genuinely customized (non-identical) unlinked flow is never
+        force-linked, so its prompt can never be overwritten by preset sync."""
+        preset = _make_preset(db_session, prompt=PRESET_PROMPT_V1)
+        customized_prompt = PRESET_PROMPT_V1 + "\nAlways answer in French."
+        flow = _make_unlinked_flow(
+            db_session,
+            test_user.account_id,
+            name="My Team's Reviewer",
+            prompt=customized_prompt,
+        )
+
+        linked = link_unlinked_flows_by_content(db_session)
+
+        assert linked == 0
+        db_session.refresh(flow)
+        assert flow.source_preset_id is None
+        assert flow.source_prompt_hash is None
+        assert flow.prompt_customized is False  # untouched
+
+        # Preset update must not touch the unlinked flow either.
+        preset.prompt_template = PRESET_PROMPT_V2
+        db_session.flush()
+        sync_preset_to_derived_flows(db_session, preset.id)
+        db_session.refresh(flow)
+        assert flow.prompt_template == customized_prompt
+
+    def test_flow_matching_older_preset_version_is_linked_then_updated(
+        self, db_session, test_user
+    ):
+        """A pristine clone of an OLDER preset version (recovered via the
+        link-time hashes of already-linked flows) is linked at the old hash,
+        which makes the subsequent sync auto-update it."""
+        preset = _make_preset(db_session, prompt=PRESET_PROMPT_V2)
+        old_hash = compute_content_hash(PRESET_PROMPT_V1)
+
+        # An already-linked flow that recorded the old preset version's hash.
+        linked_old = _make_unlinked_flow(
+            db_session,
+            test_user.account_id,
+            name="Copy of Pull Request Reviewer",
+            prompt=PRESET_PROMPT_V1,
+        )
+        linked_old.source_preset_id = preset.id
+        linked_old.source_prompt_hash = old_hash
+        linked_old.source_tools_hash = compute_content_hash(PRESET_TOOLS)
+        db_session.flush()
+
+        # A renamed unlinked clone of the same OLD version.
+        stale_clone = _make_unlinked_flow(
+            db_session,
+            test_user.account_id,
+            name="Renamed Old Clone",
+            prompt=PRESET_PROMPT_V1,
+        )
+
+        linked = link_unlinked_flows_by_content(db_session)
+
+        assert linked == 1
+        db_session.refresh(stale_clone)
+        assert stale_clone.source_preset_id == preset.id
+        assert stale_clone.source_prompt_hash == old_hash
+        assert stale_clone.prompt_customized is False
+
+        result = sync_preset_to_derived_flows(db_session, preset.id)
+        assert result.auto_updated == 2  # both stale flows catch up
+        db_session.refresh(stale_clone)
+        assert stale_clone.prompt_template == PRESET_PROMPT_V2
+
+    def test_ambiguous_hash_across_presets_is_skipped(self, db_session, test_user):
+        """If two presets share the same prompt content, no link is made."""
+        _make_preset(db_session, name="Preset A", prompt=PRESET_PROMPT_V1)
+        _make_preset(db_session, name="Preset B", prompt=PRESET_PROMPT_V1)
+        flow = _make_unlinked_flow(
+            db_session,
+            test_user.account_id,
+            name="Which preset am I?",
+            prompt=PRESET_PROMPT_V1,
+        )
+
+        linked = link_unlinked_flows_by_content(db_session)
+
+        assert linked == 0
+        db_session.refresh(flow)
+        assert flow.source_preset_id is None
+
+    def test_customized_tools_are_notified_not_overwritten(self, db_session, test_user):
+        """Identical prompt but different tools: link, mark tools_customized,
+        set the update notification, and never overwrite the tools."""
+        preset = _make_preset(db_session, prompt=PRESET_PROMPT_V1)
+        custom_tools = [{"name": "get_pull_request"}]
+        flow = _make_unlinked_flow(
+            db_session,
+            test_user.account_id,
+            name="Reviewer With Fewer Tools",
+            prompt=PRESET_PROMPT_V1,
+            tools=custom_tools,
+        )
+
+        linked = link_unlinked_flows_by_content(db_session)
+
+        assert linked == 1
+        db_session.refresh(flow)
+        assert flow.source_preset_id == preset.id
+        assert flow.tools_customized is True
+        assert flow.preset_update_available is True
+        assert flow.allowed_mcp_tools == custom_tools
+
+        preset.prompt_template = PRESET_PROMPT_V2
+        db_session.flush()
+        sync_preset_to_derived_flows(db_session, preset.id)
+        db_session.refresh(flow)
+        # Prompt (not customized) auto-updates; tools (customized) survive.
+        assert flow.prompt_template == PRESET_PROMPT_V2
+        assert flow.allowed_mcp_tools == custom_tools
+
+    def test_dry_run_makes_no_changes(self, db_session, test_user):
+        _make_preset(db_session, prompt=PRESET_PROMPT_V1)
+        flow = _make_unlinked_flow(
+            db_session,
+            test_user.account_id,
+            name="Renamed",
+            prompt=PRESET_PROMPT_V1,
+        )
+
+        linked = link_unlinked_flows_by_content(db_session, dry_run=True)
+
+        assert linked == 1
+        db_session.refresh(flow)
+        assert flow.source_preset_id is None

--- a/scripts/sync_flow_presets.py
+++ b/scripts/sync_flow_presets.py
@@ -40,6 +40,7 @@ from preloop.models import schemas
 from preloop.flow_presets import FLOW_PRESETS, PRESETS_DIR
 from preloop.services.flow_presets_service import (
     compute_content_hash,
+    link_unlinked_flows_by_content,
     sync_preset_to_derived_flows,
     PresetSyncResult,
 )
@@ -344,6 +345,13 @@ def link_existing_flows_to_presets(db: Session, dry_run: bool = False) -> int:
     if not dry_run:
         db.commit()
 
+    logger.info(f"Linked {linked_count} existing flows by name pattern")
+
+    # Second pass: link renamed-but-unmodified clones by prompt content hash.
+    # The name pattern above misses flows that were renamed after cloning;
+    # a byte-identical prompt is proof of origin regardless of the name.
+    linked_count += link_unlinked_flows_by_content(db, dry_run=dry_run)
+
     logger.info(f"Linked {linked_count} existing flows to their source presets")
     return linked_count
 
@@ -363,6 +371,11 @@ def sync_derived_flows(db: Session, dry_run: bool = False) -> List[PresetSyncRes
         List of sync results per preset
     """
     results = []
+
+    # Before propagating, link any unlinked flows whose prompt is
+    # byte-identical to a preset (renamed clones that the name-based
+    # one-time migration missed). Safe: only exact-content matches.
+    link_unlinked_flows_by_content(db, dry_run=dry_run)
 
     # Get all global presets
     presets = (


### PR DESCRIPTION
## Summary

Two independent commits, one theme: preset flows should be cheap to run and easy to keep up to date.

### 1. Token-optimised PR Reviewer preset

The stock Pull Request Reviewer prompt let agents read without bounds: full CHANGELOG (~40k tokens on a mature repo), open-ended "understand the codebase" repo walks, whole-file opens for two-line hunks, and unbounded verification searches. Fresh reads during the run are exactly the part of a review that prompt caching does not cover, so this is where the bill is.

Changes (all hard rules — agent CLIs follow hard bounds well):

- **Bounded doc reads**: agent-instruction files in full; README/ARCHITECTURE/CONTRIBUTING capped at the first ~150 lines; CHANGELOG dropped entirely (head −30 only when the diff touches it); manifests/CI/linter configs read only when the diff touches deps/CI/style.
- **Bounded context discovery**: language/framework/conventions derived from the diff + at most 3 files outside it. No repo walking.
- **Hunk-first reading**: work from diff hunks; open surrounding context (enclosing function/class, not whole files) only when a finding needs it.
- **Per-finding verification budget**: the five verification checks stay intact, but capped at 2 greps + 2 file reads per finding; unresolved findings get filed as questions instead of triggering search spirals.
- **Conditional documentation-impact pass**: runs only when the diff adds user-facing surface (endpoints, config, env vars, CLI, features).
- **Region-scoped re-verification**: previous findings are re-checked against the ±40-line region or named symbol, not the whole file. Quote-it-or-drop-it unchanged.
- **Skip identical PR-description rewrites**; **replace status stamps instead of stacking them**, and only touch comments whose status changed.
- **Single-fetch rule**: `get_pull_request` exactly once; everything git-related comes from the clone.
- **Small-PR fast path**: <~50 changed lines and no previous Preloop comments → skip discussion scan, doc reads, and doc-impact; the security/quality checks still run on the same hunks.
- **Leaner output**: empty severity sections omitted; "What Looks Good" dropped when requesting changes. The Affected-files block is kept (load-bearing for cross-flow use).

**New: incremental re-review.** The summary comment now records the reviewed HEAD SHA in a `<!-- preloop-review:reviewed-sha:... -->` marker. When the trigger is `pull_request_updated` and a marker exists, the reviewer validates it in the clone (`git cat-file -e` + `git merge-base --is-ancestor` to detect force-push/rebase), reviews only `git diff <sha>..HEAD` hunks, and re-verifies only previous findings whose files changed — with an explicit full-review fallback whenever the delta cannot be derived safely. **Expected effect: per-push review cost becomes proportional to the push delta instead of the whole PR.**

Not included: a cap on discussion replies (audit finding A7) — pending a product decision.

Prompt length: 799 lines (was 834).

### 2. Fix: preset updates never reached renamed flow clones

`sync_preset_to_derived_flows` finds derived flows via `source_preset_id`, but the one-time linking migration only matched flows named `Copy of <preset name>`. Operators who cloned a preset and renamed the flow — prompt still byte-identical to the preset — ended up with `source_preset_id=NULL`, and preset updates silently never reached a customer's flows.

New `link_unlinked_flows_by_content` pass (service + wired into `scripts/sync_flow_presets.py`, both in `--link-existing` and before propagation in the default run) links unlinked, non-preset, account-owned flows whose prompt hash equals a preset's current prompt **or** a historical link-time version of it (recovered from the distinct `source_prompt_hash` values of already-linked flows), regardless of name.

Conservative by construction:
- Only byte-identical prompts link — a customized prompt can never match, so user edits can never be overwritten by this pass.
- A hash matching multiple presets is skipped and logged; no guessing.
- Flags are set exactly like the name-based path; differing tools are marked `tools_customized` + `preset_update_available` (notified, never replaced).

## Test plan

- [x] `tests/test_flow_presets.py` (14 passed) — preset schema/loading, revised YAML parses
- [x] `tests/services/test_preset_content_hash_linking.py` (6 passed, new) — renamed identical clone linked then auto-updated; customized flow never linked/touched; older-preset-version clone linked at old hash and updated on next sync; ambiguous hash skipped; customized tools notified not overwritten; dry-run mutates nothing
- [x] `tests/services/test_flow_presets_service.py` (55 passed) — existing sync semantics unchanged
- [x] pre-commit (ruff, ruff-format, yaml check) clean

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> No security concerns. The content-hash linking is conservative (byte-identical only) and the preset prompt changes are instruction-only with no code execution changes.

> **Overview**
> Two independent improvements: a token-optimised PR Reviewer preset prompt with incremental re-review (bounds reads, adds verification budgets, and supports per-push delta reviews), and a content-hash based linking pass that fixes preset updates silently failing to reach renamed-but-unmodified cloned flows. Well-tested with 6 new test cases and 75 existing tests unchanged. Previously noted N+1 query resolved in this revision.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai). Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->