### PR TITLE
fix: policy 'true' literal evaluation and create_project 500

### DIFF
--- a/backend/preloop/models/crud/project.py
+++ b/backend/preloop/models/crud/project.py
@@ -109,10 +109,15 @@ class CRUDProject(CRUDBase[Project]):
         return query.order_by(Project.updated_at.desc()).first()
 
     def get_by_identifier(
-        self, db: Session, *, identifier: str, account_id: Optional[str] = None
+        self,
+        db: Session,
+        *,
+        identifier: str,
+        organization_id: Optional[str] = None,
+        account_id: Optional[str] = None,
     ) -> Optional[Project]:
         """
-        Get a project by identifier or slug.
+        Get a project by identifier or slug, optionally scoped to an organization.
 
         For trackers like Jira that use both numeric IDs and human-readable keys,
         this method checks both the identifier field and the slug field.
@@ -120,6 +125,8 @@ class CRUDProject(CRUDBase[Project]):
         query = db.query(Project).filter(
             (Project.identifier == identifier) | (Project.slug == identifier)
         )
+        if organization_id:
+            query = query.filter(Project.organization_id == organization_id)
         if account_id:
             query = (
                 query.join(Project.organization)

--- a/backend/preloop/services/policy_evaluator.py
+++ b/backend/preloop/services/policy_evaluator.py
@@ -516,6 +516,15 @@ def _evaluate_simple_condition(expression: str, tool_args: Dict[str, Any]) -> bo
     """
     expression = expression.strip()
 
+    # Handle boolean literals before any normalisation. Users configure
+    # catch-all rules with a bare 'true' (or 'false'); prepending 'args.'
+    # would turn these into unparsable field references.
+    lowered = expression.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+
     # Normalise: if the expression doesn't start with 'args.', prepend it.
     # Users often configure rules via the UI with just the field name, e.g.
     # "amount > 300" instead of "args.amount > 300".

--- a/backend/tests/endpoints/test_projects.py
+++ b/backend/tests/endpoints/test_projects.py
@@ -138,6 +138,46 @@ class TestCreateProject:
                     assert result["name"] == "Test Project"
                     assert result["identifier"] == "test-project"
 
+    def test_create_project_duplicate_check_matches_crud_signature(
+        self, mock_user, mock_organization, mock_project, mock_db_session
+    ):
+        """The duplicate-check call must match CRUDProject.get_by_identifier's signature.
+
+        Regression: create_project passed organization_id= to
+        get_by_identifier, which did not accept it, so every create_project
+        request 500ed with a TypeError before reaching the duplicate check.
+        autospec=True makes the mock enforce the real method signature.
+        """
+        project_create = ProjectCreate(
+            name="Test Project",
+            identifier="test-project",
+            description="A test project",
+            organization_id=mock_organization.id,
+            settings={},
+            tracker_configurations={"repo": "test/repo"},
+        )
+
+        with patch.object(
+            projects.crud_organization, "get", return_value=mock_organization
+        ):
+            with patch.object(
+                projects.crud_project,
+                "get_by_identifier",
+                autospec=True,
+                return_value=None,
+            ):
+                with patch.object(
+                    projects.crud_project, "create", return_value=mock_project
+                ):
+                    result = call_endpoint(
+                        projects.create_project,
+                        project=project_create,
+                        db=mock_db_session,
+                        current_user=mock_user,
+                    )
+
+                    assert result["identifier"] == "test-project"
+
     def test_create_project_organization_not_found(self, mock_user, mock_db_session):
         """Test 404 when organization is not found."""
         project_create = ProjectCreate(

--- a/backend/tests/models/crud/test_project.py
+++ b/backend/tests/models/crud/test_project.py
@@ -112,6 +112,36 @@ def test_get_by_identifier(crud_project, mock_db_session):
     assert result.identifier == identifier
 
 
+def test_get_by_identifier_with_organization_id(crud_project, mock_db_session):
+    """Test retrieving a project by identifier scoped to an organization.
+
+    Regression: get_by_identifier did not accept organization_id, so
+    endpoint call sites passing it (e.g. create_project's duplicate check)
+    raised TypeError and returned 500.
+    """
+    # Arrange
+    identifier = "test-project"
+    organization_id = str(uuid4())
+    mock_project = Project(
+        id=str(uuid4()), identifier=identifier, organization_id=organization_id
+    )
+
+    mock_query = MagicMock()
+    mock_db_session.query.return_value = mock_query
+    mock_query.filter.return_value = mock_query
+    mock_query.first.return_value = mock_project
+
+    # Act
+    result = crud_project.get_by_identifier(
+        mock_db_session, identifier=identifier, organization_id=organization_id
+    )
+
+    # Assert
+    assert result.identifier == identifier
+    # Both the identifier filter and the organization filter must be applied.
+    assert mock_query.filter.call_count == 2
+
+
 def test_get_for_tracker(crud_project, mock_db_session):
     """Test retrieving projects for a tracker."""
     # Arrange

--- a/backend/tests/services/test_policy_evaluator.py
+++ b/backend/tests/services/test_policy_evaluator.py
@@ -216,6 +216,36 @@ class TestEvaluatePolicyWithRules:
         assert action == "allow"
         assert approval_id is None
 
+    def test_allow_rule_with_true_literal_returns_allow(self, mock_audit_logging):
+        """An allow rule with condition_expression='true' must allow.
+
+        Regression: the 'true' literal raised ValueError during simple
+        expression parsing, so the rule failed closed to require_approval
+        instead of allowing.
+        """
+        workflow_id = uuid4()
+        mock_config = MagicMock()
+        mock_config.id = uuid4()
+        mock_config.approval_workflow_id = workflow_id
+
+        rule = self._make_rule(action="allow", condition_expression="true")
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_config
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+            rule
+        ]
+
+        action, approval_id, desc = evaluate_policy(
+            db=mock_db,
+            tool_name="test_tool",
+            tool_args={"anything": "goes"},
+            account_id=uuid4(),
+        )
+
+        assert action == "allow"
+        assert approval_id is None
+
     def test_matching_deny_rule_returns_deny(self, mock_audit_logging):
         """First matching rule with action=deny returns deny."""
         mock_config = MagicMock()
@@ -486,6 +516,24 @@ class TestEvaluateSimpleExpression:
         # evaluate_simple_expression. evaluate_simple_expression requires
         # a non-empty expression. So we test a valid expression.
         assert evaluate_simple_expression("args.x == 'y'", {"x": "y"})
+
+    def test_boolean_literal_true(self):
+        """A bare 'true' literal (any case) always matches.
+
+        Regression: 'true' was normalised to 'args.true', which failed to
+        parse and raised ValueError, so allow rules configured with a
+        catch-all 'true' condition failed closed to require_approval.
+        """
+        assert evaluate_simple_expression("true", {})
+        assert evaluate_simple_expression("True", {"amount": 100})
+        assert evaluate_simple_expression("TRUE", {})
+        assert evaluate_simple_expression("  true  ", {})
+
+    def test_boolean_literal_false(self):
+        """A bare 'false' literal (any case) never matches."""
+        assert not evaluate_simple_expression("false", {})
+        assert not evaluate_simple_expression("False", {"amount": 100})
+        assert not evaluate_simple_expression("FALSE", {})
 
     def test_invalid_expression_raises(self):
         """Unsupported expression format raises ValueError."""


### PR DESCRIPTION
## Summary

Fixes two production bugs surfaced by GlitchTip:

1. **#213 — policy_evaluator: simple expression `'true'` fails to parse.** The `args.` normalisation turned a bare `true` into `args.true`, which raised `ValueError`, so allow rules with a catch-all `true` condition failed closed to `require_approval`. Boolean literals `true`/`false` (case-insensitive) are now handled before normalisation: `true` always matches, `false` never matches.

2. **#214 — create_project 500s with `TypeError: get_by_identifier() got an unexpected keyword argument 'organization_id'`.** The endpoint's duplicate check (and two tool call sites: `create_issue`, project `test_connection`) passed `organization_id=` to `CRUDProject.get_by_identifier`, which only accepted `(identifier, account_id)`. The CRUD method now accepts an optional `organization_id` filter, so the duplicate check is correctly scoped to the target organization and the broken tool call sites work again.

Fixes #213
Fixes #214

## Test plan

- Red/green: added failing tests first for each bug, then fixed.
  - `backend/tests/services/test_policy_evaluator.py`: boolean-literal unit tests + end-to-end `evaluate_policy` test that an allow rule with `condition_expression='true'` returns `allow`.
  - `backend/tests/endpoints/test_projects.py`: duplicate-check test with `autospec=True` so the mock enforces the real CRUD signature (reproduced the `TypeError`).
  - `backend/tests/models/crud/test_project.py`: `get_by_identifier` with `organization_id` applies both filters.
- Full backend suite passes except pre-existing failures unrelated to this change (DB-trigger/gateway-attribution tests that also fail on `main`).
- pre-commit passes on all changed files.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Well-scoped bugfix PR with regression tests for both defects; no security implications found.
>
> **Overview**
> Handles bare `true`/`false` literals in policy simple expressions so catch-all rules no longer fail closed, and extends `CRUDProject.get_by_identifier` with an optional `organization_id` filter so `create_project` and the affected tools stop 500ing. One LOW documentation suggestion (docstring listing) noted.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 1047eefc. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->