### PR TITLE
fix: scope unpriced-model dedup key to the upstream provider

### DIFF
--- a/backend/preloop/services/unpriced_model_alert.py
+++ b/backend/preloop/services/unpriced_model_alert.py
@@ -33,6 +33,7 @@ from sqlalchemy.orm import Session
 
 from preloop.models.crud import crud_audit_log
 from preloop.models.models.ai_model import AIModel
+from preloop.services.litellm_routing import is_openrouter_endpoint
 from preloop.services.model_runtime_resolver import gateway_model_alias_candidates
 from preloop.sync.tasks import notify_admins
 
@@ -59,9 +60,8 @@ def _upstream_provider(ai_model: AIModel, provider_name: Optional[str]) -> str:
     keeps those spellings on one dedup key while still separating true
     different upstreams (e.g. OpenRouter-routed vs direct-vendor).
     """
-    endpoint = (ai_model.api_endpoint or "").strip().lower()
     provider = (ai_model.provider_name or provider_name or "unknown").strip().lower()
-    if provider == "openrouter" or "openrouter.ai" in endpoint:
+    if provider == "openrouter" or is_openrouter_endpoint(ai_model.api_endpoint):
         return "openrouter"
     return provider
 

--- a/backend/preloop/services/unpriced_model_alert.py
+++ b/backend/preloop/services/unpriced_model_alert.py
@@ -49,6 +49,23 @@ _local_lock = threading.Lock()
 _local_recent: dict[str, float] = {}
 
 
+def _upstream_provider(ai_model: AIModel, provider_name: Optional[str]) -> str:
+    """Best-effort name of the upstream actually serving the model.
+
+    Different AIModel configs for one upstream model can carry different
+    provider names — the production Auto Router incident had it registered as
+    both ``openrouter`` and ``openai-compatible`` (pointed at the OpenRouter
+    endpoint). Normalising every OpenRouter-fronted config to ``openrouter``
+    keeps those spellings on one dedup key while still separating true
+    different upstreams (e.g. OpenRouter-routed vs direct-vendor).
+    """
+    endpoint = (ai_model.api_endpoint or "").strip().lower()
+    provider = (ai_model.provider_name or provider_name or "unknown").strip().lower()
+    if provider == "openrouter" or "openrouter.ai" in endpoint:
+        return "openrouter"
+    return provider
+
+
 def _dedupe_key(
     model_alias: str,
     provider_name: Optional[str],
@@ -66,6 +83,13 @@ def _dedupe_key(
     candidate, which by the resolver's suffix-match rule is the bare tail all
     spellings share — so every spelling lands on one cooldown marker.
 
+    The canonical key is prefixed with the (normalised) upstream provider so
+    two genuinely different models that happen to share a bare alias tail
+    across providers (``openrouter/deepseek/deepseek-chat`` vs a direct
+    ``deepseek/deepseek-chat`` config) do not swallow each other's alerts.
+    OpenRouter-fronted configs are normalised to one prefix regardless of
+    their recorded provider name (see :func:`_upstream_provider`).
+
     Args:
         model_alias: Recorded model alias that could not be priced.
         provider_name: Provider that served the request.
@@ -81,7 +105,8 @@ def _dedupe_key(
             candidates = set()
         if candidates:
             canonical = min(candidates, key=lambda c: (len(c), c))
-            return f"model|{canonical.strip().lower()}"
+            upstream = _upstream_provider(ai_model, provider_name)
+            return f"model|{upstream}|{canonical.strip().lower()}"
     return f"{(provider_name or 'unknown').strip().lower()}|{model_alias.strip()}"
 
 

--- a/backend/tests/services/test_unpriced_model_alert.py
+++ b/backend/tests/services/test_unpriced_model_alert.py
@@ -239,3 +239,52 @@ def test_alert_without_ai_model_still_dedupes_on_raw_alias(db_session, test_user
 
     assert first is True and second is False
     assert mock_notify.call_count == 1
+
+
+def test_different_models_sharing_a_bare_tail_alert_independently(
+    db_session, test_user
+):
+    """A shared alias tail across providers must not swallow the second alert.
+
+    ``openrouter/deepseek/deepseek-chat`` (OpenRouter routing to DeepSeek) and
+    a direct ``deepseek-chat`` model both expose the bare tail
+    ``deepseek-chat`` among their alias candidates. They are different
+    provider configurations needing different price-catalog fixes, so the
+    second model's admin alert must not be suppressed by the first model's
+    cooldown.
+    """
+    from preloop.models.models.ai_model import AIModel
+
+    account_id = str(test_user.account_id)
+    via_openrouter = AIModel(
+        provider_name="openrouter",
+        model_identifier="deepseek/deepseek-chat",
+        api_endpoint="https://openrouter.ai/api/v1",
+    )
+    direct = AIModel(
+        provider_name="deepseek",
+        model_identifier="deepseek-chat",
+        api_endpoint="https://api.deepseek.com/v1",
+    )
+
+    with patch.object(unpriced_model_alert, "notify_admins") as mock_notify:
+        first = notify_unpriced_model(
+            db_session,
+            account_id=account_id,
+            model_alias="deepseek/deepseek-chat",
+            provider_name="openrouter",
+            total_tokens=100,
+            ai_model=via_openrouter,
+        )
+        second = notify_unpriced_model(
+            db_session,
+            account_id=account_id,
+            model_alias="deepseek-chat",
+            provider_name="deepseek",
+            total_tokens=100,
+            ai_model=direct,
+        )
+
+    assert first is True
+    assert second is True
+    assert mock_notify.call_count == 2

--- a/backend/tests/services/test_unpriced_model_alert.py
+++ b/backend/tests/services/test_unpriced_model_alert.py
@@ -288,3 +288,50 @@ def test_different_models_sharing_a_bare_tail_alert_independently(
     assert first is True
     assert second is True
     assert mock_notify.call_count == 2
+
+
+def test_endpoint_containing_openrouter_string_is_not_classified_openrouter(
+    db_session, test_user
+):
+    """Provider classification must anchor on the URL host, not a substring.
+
+    An unrelated upstream whose endpoint URL merely contains the string
+    ``openrouter.ai`` (e.g. a path segment on a proxy) must NOT collapse into
+    the ``openrouter`` dedup class: that would let a genuinely different
+    upstream suppress OpenRouter's alert (or vice versa) within the cooldown.
+    """
+    from preloop.models.models.ai_model import AIModel
+
+    account_id = str(test_user.account_id)
+    via_openrouter = AIModel(
+        provider_name="openrouter",
+        model_identifier="deepseek/deepseek-chat",
+        api_endpoint="https://openrouter.ai/api/v1",
+    )
+    lookalike = AIModel(
+        provider_name="custom-proxy",
+        model_identifier="deepseek/deepseek-chat",
+        api_endpoint="https://llm.example.com/openrouter.ai/api/v1",
+    )
+
+    with patch.object(unpriced_model_alert, "notify_admins") as mock_notify:
+        first = notify_unpriced_model(
+            db_session,
+            account_id=account_id,
+            model_alias="deepseek/deepseek-chat",
+            provider_name="openrouter",
+            total_tokens=100,
+            ai_model=via_openrouter,
+        )
+        second = notify_unpriced_model(
+            db_session,
+            account_id=account_id,
+            model_alias="deepseek/deepseek-chat",
+            provider_name="custom-proxy",
+            total_tokens=100,
+            ai_model=lookalike,
+        )
+
+    assert first is True
+    assert second is True
+    assert mock_notify.call_count == 2


### PR DESCRIPTION
Follow-up to #208, addressing the LOW review finding on `unpriced_model_alert.py` (https://github.com/preloop/preloop/pull/208#discussion_r3751427991) — the PR merged before the fix landed on the branch.

## Problem
The alias-canonical dedup key collapsed to the bare alias tail, so two genuinely different models sharing a tail across providers (`openrouter/deepseek/deepseek-chat` vs a direct `deepseek/deepseek-chat` config) conflated onto one cooldown marker: the second model's admin alert was suppressed for the 24h cooldown.

## Fix
The canonical key now carries a normalised upstream-provider prefix (`model|<provider>|<tail>`). OpenRouter-fronted configs normalise to a single `openrouter` prefix regardless of recorded provider name (the production Auto Router was registered under both `openrouter` and `openai-compatible`), preserving the intended one-alert-per-model collapse across alias spellings. The raw-key fallback for callers without a resolved model is unchanged.

## Testing
- Red/green: new test `test_different_models_sharing_a_bare_tail_alert_independently` fails against the tail-only key, passes with the provider-scoped key.
- All 9 tests in `test_unpriced_model_alert.py` pass; mypy clean on the touched file.

## Review follow-ups (a8a9eafa)
- Host-anchored OpenRouter classification via `litellm_routing.is_openrouter_endpoint` (was substring match); regression test added.

## Deploy note
Dedup markers written before this deploy use the old `model|<tail>` key. A model that alerted within the last 24h may fire **one** extra admin alert right after rollout; the new key's cooldown then holds for all spellings. No action needed.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Focused, well-tested bug fix with no security implications; the dedup-key change is internal and low-risk.
>
> **Overview**
> Scopes the unpriced-model admin-alert dedup key to a normalised upstream-provider prefix (`model|<provider>|<tail>`), so distinct models sharing a bare alias tail across providers no longer suppress each other's alert during the cooldown. OpenRouter-fronted configs normalise to one `openrouter` prefix; the raw-alias fallback is unchanged. Includes a red/green regression test.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit c9deda53. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
