### PR TITLE
fix: stop rollouts from severing in-flight agent LLM streams (and retry when they do)

### DIFF
--- a/backend/preloop/agents/base.py
+++ b/backend/preloop/agents/base.py
@@ -4,7 +4,10 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+if TYPE_CHECKING:
+    from .failure_analysis import AgentFailureAnalysis
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +34,11 @@ class AgentExecutionResult:
     actions_taken: Optional[list] = None
     artifacts: Optional[Dict[str, Any]] = None  # Generated files, logs, etc.
     exit_code: Optional[int] = None
+    # First-pass failure classification made against the FULL container logs
+    # (set when status is FAILED and logs were analysed). ``error_message``
+    # keeps only the generated sentence, which cannot encode the
+    # transient/terminal verdict — this carries it to the retry decision.
+    failure_analysis: Optional["AgentFailureAnalysis"] = None
 
 
 class AgentExecutor(ABC):

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -688,10 +688,16 @@ class ContainerAgentExecutor(AgentExecutor):
                         "Logs contain benign messages (e.g., 'no commits'), not marking as failed."
                     )
 
+            failure_analysis = None
             if status == AgentStatus.FAILED:
+                # Analyse the full logs once and keep the whole verdict:
+                # only the message survives into FlowExecution.error_message,
+                # so the transient/terminal classification must travel on the
+                # result itself for the orchestrator's retry decision.
+                failure_analysis = analyze_agent_failure(logs_text)
                 error_message = (
                     info["State"].get("Error")
-                    or self._extract_error_from_logs(logs_text)
+                    or failure_analysis.message
                     or f"Container exited with code {exit_code}"
                 )
 
@@ -701,6 +707,7 @@ class ContainerAgentExecutor(AgentExecutor):
                 output_summary=output_summary,
                 error_message=error_message,
                 exit_code=exit_code,
+                failure_analysis=failure_analysis,
             )
 
         except DockerError as e:
@@ -768,10 +775,13 @@ class ContainerAgentExecutor(AgentExecutor):
             except Exception as e:
                 self.logger.warning(f"Could not get exit code for Job {job_name}: {e}")
 
+            failure_analysis = None
             if status == AgentStatus.FAILED:
-                error_message = (
-                    self._extract_error_from_logs(logs_text)
-                    or f"Job exited with code {exit_code}"
+                # Same as the Docker path: keep the full-log verdict on the
+                # result, not just the message.
+                failure_analysis = analyze_agent_failure(logs_text)
+                error_message = failure_analysis.message or (
+                    f"Job exited with code {exit_code}"
                     if exit_code is not None
                     else "Job failed"
                 )
@@ -782,6 +792,7 @@ class ContainerAgentExecutor(AgentExecutor):
                 output_summary=output_summary,
                 error_message=error_message,
                 exit_code=exit_code,
+                failure_analysis=failure_analysis,
             )
 
         except ApiException as e:
@@ -932,6 +943,10 @@ class ContainerAgentExecutor(AgentExecutor):
         returning whatever the last error-shaped line happened to be. The tail
         of a failed run is usually a stack trace or a stringified error object
         (``[object Object]``), which names no cause.
+
+        Message-only view: ``get_result`` calls :func:`analyze_agent_failure`
+        directly so the full classification (``transient`` verdict, evidence)
+        can travel on the ``AgentExecutionResult``.
 
         Args:
             logs_text: Full log text

--- a/backend/preloop/agents/failure_analysis.py
+++ b/backend/preloop/agents/failure_analysis.py
@@ -98,6 +98,14 @@ _STATUS_RE = re.compile(
 # closed`` and ``TypeError: terminated``. The latter is anchored to the
 # ``TypeError:`` prefix on purpose — a bare "terminated" also appears in
 # terminal failures ("run terminated by policy") that must never retry.
+#
+# These patterns are matched against *any* content line, not only "attempt N
+# failed" lines: a CLI that crashes on a severed stream without running its
+# own retry loop leaves nothing but a raw stack (``TypeError: terminated`` /
+# ``[cause]: SocketError: other side closed``), and that shape must still be
+# classified transient. The asymmetry is deliberate — a false positive costs
+# one bounded, side-effect-safe flow retry, while a false negative terminally
+# fails a recoverable run.
 _TRANSIENT_NETWORK_RE = re.compile(
     r"\b(?:connection\s+(?:reset|refused|closed|aborted|error)"
     r"|econnreset|econnrefused|epipe|etimedout"
@@ -118,10 +126,13 @@ _TRANSIENT_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504, 520, 522, 52
 
 # Opening of the sentence this module generates for an upstream failure.
 # The generated message is the only thing that survives into
-# ``FlowExecution.error_message``, so it is also the input the orchestrator
-# re-analyses when deciding whether to retry. Recognising our own phrasing
-# makes ``analyze_agent_failure`` idempotent: analysing its output reproduces
-# the same classification.
+# ``FlowExecution.error_message``. The full analysis (including the
+# transient verdict) now travels on the agent result itself, but legacy
+# results carry only the message — recognising our own phrasing keeps
+# re-analysis of that message as faithful as possible. Note the message alone
+# cannot encode every verdict (a no-status sentence loses the
+# transient/terminal distinction), which is exactly why the attached verdict
+# is authoritative when present.
 _UPSTREAM_SENTENCE_PREFIX = "Upstream model provider"
 _GENERATED_ATTEMPTS_RE = re.compile(r"after\s+(\d{1,3})\s+attempts?\b", re.IGNORECASE)
 _GENERATED_EXHAUSTED_RE = re.compile(r"exhausted its retries", re.IGNORECASE)
@@ -181,6 +192,9 @@ class AgentFailureAnalysis:
     retry_exhausted: bool = False
     transient: bool = False
     error_class: Optional[str] = None
+    # Raw log lines the classification was derived from (scrubbed, capped).
+    # Travels with the agent result so the retry decision can be audited.
+    evidence: str = ""
 
 
 def _content_lines(logs_text: str) -> list[str]:
@@ -233,7 +247,8 @@ def _scan_upstream_retry_signal(lines: list[str]) -> _RetrySignal:
 
     for line in lines:
         is_attempt_line = bool(_ATTEMPT_LINE_RE.search(line))
-        if _EXHAUSTED_RE.search(line):
+        is_exhausted_line = bool(_EXHAUSTED_RE.search(line))
+        if is_exhausted_line:
             exhausted = True
             evidence.append(line)
 
@@ -249,8 +264,14 @@ def _scan_upstream_retry_signal(lines: list[str]) -> _RetrySignal:
             status_match = _STATUS_RE.search(line)
             if status_match:
                 statuses.append(int(status_match.group(1)))
-            if _TRANSIENT_NETWORK_RE.search(line):
-                saw_network_failure = True
+
+        # Checked on every content line, not only attempt lines: a severed
+        # stream that crashed the CLI outright surfaces as a raw stack with
+        # no retry-loop phrasing (see the _TRANSIENT_NETWORK_RE comment).
+        if _TRANSIENT_NETWORK_RE.search(line):
+            saw_network_failure = True
+            if not is_attempt_line and not is_exhausted_line:
+                evidence.append(line)
 
     return _RetrySignal(
         # The last reported attempt is the one that ended the run.
@@ -332,10 +353,14 @@ def _fallback_message(lines: list[str]) -> str:
 def _reanalyze_generated_message(text: str) -> Optional[AgentFailureAnalysis]:
     """Re-derive an analysis from a message this module previously generated.
 
-    The orchestrator stores only the generated sentence, then re-analyses it
-    to decide whether to retry. Parsing our own output keeps that decision
-    identical to the one made from the full logs, instead of silently
-    downgrading a known-transient failure to "not transient".
+    This is the *legacy* retry-decision path: agent results that predate the
+    attached first-pass verdict carry only the stored sentence, so the
+    orchestrator falls back to re-analysing it. Parsing our own output keeps
+    that fallback as close as possible to the full-log classification —
+    though not identical: a no-status sentence ("was unreachable") cannot
+    distinguish a severed stream from a terminal failure that also exhausted
+    attempts, so it is treated as transient here. Results carrying the
+    first-pass verdict do not take this path.
     """
     stripped = text.strip()
     if not stripped.startswith(_UPSTREAM_SENTENCE_PREFIX):
@@ -425,6 +450,16 @@ def analyze_agent_failure(logs_text: str) -> AgentFailureAnalysis:
             retry_exhausted=signal.exhausted,
             transient=transient,
             error_class=error_class,
+            evidence=_finalize(signal.evidence),
         )
 
-    return AgentFailureAnalysis(message=_finalize(_fallback_message(lines)))
+    # Fallback path: no retry loop and no HTTP status anywhere. A raw
+    # transport-failure stack (undici "TypeError: terminated" with
+    # "[cause]: SocketError: other side closed") lands here, and it is
+    # exactly as retryable as the attempt-line shapes above — the verdict
+    # comes from the same _TRANSIENT_NETWORK_RE scan of the full log.
+    return AgentFailureAnalysis(
+        message=_finalize(_fallback_message(lines)),
+        transient=signal.saw_network_failure,
+        evidence=_finalize(signal.evidence),
+    )

--- a/backend/preloop/agents/failure_analysis.py
+++ b/backend/preloop/agents/failure_analysis.py
@@ -92,11 +92,19 @@ _STATUS_RE = re.compile(
 )
 
 # Transport-level failures that never produced an HTTP status but are just as
-# retryable as a 504.
+# retryable as a 504. The undici entries are what Node's fetch reports when
+# the server side of an in-flight stream goes away (observed when a gateway
+# pod was cycled mid-response during a rollout): ``SocketError: other side
+# closed`` and ``TypeError: terminated``. The latter is anchored to the
+# ``TypeError:`` prefix on purpose — a bare "terminated" also appears in
+# terminal failures ("run terminated by policy") that must never retry.
 _TRANSIENT_NETWORK_RE = re.compile(
     r"\b(?:connection\s+(?:reset|refused|closed|aborted|error)"
     r"|econnreset|econnrefused|epipe|etimedout"
     r"|socket\s+hang\s+up"
+    r"|other\s+side\s+closed"
+    r"|typeerror:\s*terminated"
+    r"|fetch\s+(?:failed|terminated)"
     r"|network\s+error"
     r"|(?:request|read|socket)\s+timed?\s*out"
     r"|timeout\s+(?:of\s+)?\d+\s*ms\s+exceeded)\b",

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -3,6 +3,7 @@ import uuid
 import json
 import asyncio
 import shlex
+from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 import re
@@ -2277,6 +2278,16 @@ class FlowExecutionOrchestrator:
                         "actions_taken": self.execution_logger.get_actions_taken(),
                         "mcp_usage_logs": self.execution_logger.get_mcp_usage_logs(),
                         "exit_code": result.exit_code,
+                        # First-pass failure classification made against the
+                        # FULL container logs. error_message keeps only the
+                        # generated sentence, which cannot encode the
+                        # transient/terminal verdict — _retry_decision needs
+                        # this to survive.
+                        "failure_analysis": (
+                            asdict(result.failure_analysis)
+                            if result.failure_analysis is not None
+                            else None
+                        ),
                     }
 
                 # Check if the success sentinel was seen in logs while
@@ -2465,11 +2476,31 @@ class FlowExecutionOrchestrator:
         if self.execution_logger.get_actions_taken():
             return "the agent already recorded actions; retrying could repeat them"
 
-        analysis = analyze_agent_failure(agent_result.get("error_message") or "")
-        if not analysis.transient:
+        if not self._failure_is_transient(agent_result):
             return "the failure is not a transient upstream failure"
 
         return None
+
+    @staticmethod
+    def _failure_is_transient(agent_result: Dict[str, Any]) -> bool:
+        """Whether the failed attempt is worth retrying.
+
+        Prefers the first-pass verdict the agent executor classified against
+        the FULL container logs (``failure_analysis`` on the result). The
+        stored ``error_message`` is a lossy summary — a raw severed-stream
+        stack yields a fallback message that re-analyses as non-transient,
+        and a no-status "unreachable" sentence re-analyses as transient even
+        for a policy-terminated run — so the message is only consulted for
+        legacy results that carry no attached verdict.
+        """
+        analysis_payload = agent_result.get("failure_analysis")
+        if isinstance(analysis_payload, dict) and "transient" in analysis_payload:
+            return bool(analysis_payload["transient"])
+        if analysis_payload is not None and hasattr(analysis_payload, "transient"):
+            # Tolerate an un-serialised AgentFailureAnalysis instance.
+            return bool(analysis_payload.transient)
+
+        return analyze_agent_failure(agent_result.get("error_message") or "").transient
 
     async def _run_agent_with_retries(
         self, execution_context: Dict[str, Any]

--- a/backend/tests/agents/test_failure_analysis.py
+++ b/backend/tests/agents/test_failure_analysis.py
@@ -168,17 +168,83 @@ class TestTransience:
         assert analysis.transient is True
         assert analysis.retry_exhausted is True
 
+    def test_undici_fetch_failed_is_transient(self):
+        """undici wraps most transport failures as ``TypeError: fetch failed``.
+
+        This is the most common shape Node's fetch produces for a connection
+        that never completed; it deserves a retry exactly like an explicit
+        socket error.
+        """
+        logs = "\n".join(
+            [
+                "Attempt 1 failed: TypeError: fetch failed. Retrying...",
+                "Attempt 2 failed: TypeError: fetch failed.",
+                "Max attempts reached.",
+            ]
+        )
+
+        analysis = analyze_agent_failure(logs)
+
+        assert analysis.transient is True
+        assert analysis.retry_exhausted is True
+
+    def test_raw_severed_stream_stack_is_transient(self):
+        """The incident shape: a raw undici stack with no retry-loop phrasing.
+
+        A CLI that crashes outright on a severed stream never prints
+        "attempt N failed" — the only signal is the stack itself, on the
+        fallback (non-attempt-line) path. It must still classify transient,
+        and the matched lines must be carried as evidence.
+        """
+        logs = "\n".join(
+            [
+                "Streaming model response...",
+                "TypeError: terminated",
+                "    at Fetch.onAborted (node:internal/deps/undici/undici:11190:53)",
+                "  [cause]: SocketError: other side closed",
+                "      at TLSSocket.onSocketEnd (node:internal/deps/undici/undici:8117:26)",
+            ]
+        )
+
+        analysis = analyze_agent_failure(logs)
+
+        assert analysis.transient is True
+        assert "other side closed" in analysis.evidence
+
     def test_generic_terminated_wording_is_not_transient(self):
         """Only undici's error shape may match — not any use of 'terminated'.
 
         An agent killed by policy or by an operator also says "terminated";
         retrying those burns money and can never succeed.
+
+        Contract note: this first-pass ``transient=False`` verdict is what
+        production actually enforces — the executor attaches the analysis to
+        the agent result and ``_retry_decision`` consults it directly. The
+        generated *message* for this shape ("was unreachable after 2
+        attempts") re-analyses as transient, which is why the verdict must
+        travel with the result; the end-to-end guarantee is pinned by
+        ``TestRetryVerdictWiring`` in
+        ``tests/services/test_flow_orchestrator_retry.py``.
         """
         logs = "\n".join(
             [
                 "Attempt 1 failed: run terminated by policy",
                 "Attempt 2 failed: run terminated by policy",
                 "Giving up.",
+            ]
+        )
+
+        analysis = analyze_agent_failure(logs)
+
+        assert analysis.transient is False
+
+    def test_raw_policy_termination_is_not_transient(self):
+        """The fallback path must not over-match either: a bare policy kill."""
+        logs = "\n".join(
+            [
+                "Reviewing diff...",
+                "ERROR: run terminated by policy",
+                "Shutting down.",
             ]
         )
 

--- a/backend/tests/agents/test_failure_analysis.py
+++ b/backend/tests/agents/test_failure_analysis.py
@@ -132,6 +132,60 @@ class TestTransience:
         assert analysis.transient is True
         assert analysis.retry_exhausted is True
 
+    def test_undici_other_side_closed_is_transient(self):
+        """A gateway pod cycling mid-stream severs the agent's socket.
+
+        Observed during a rollout: the pod was SIGKILLed while the agent was
+        mid-response, and undici surfaced ``SocketError: other side closed``.
+        This is exactly as retryable as a connection reset.
+        """
+        logs = "\n".join(
+            [
+                "Attempt 1 failed: SocketError: other side closed. Retrying...",
+                "Attempt 2 failed: SocketError: other side closed. Retrying...",
+                "Attempt 3 failed: SocketError: other side closed.",
+                "Max attempts reached.",
+            ]
+        )
+
+        analysis = analyze_agent_failure(logs)
+
+        assert analysis.transient is True
+        assert analysis.retry_exhausted is True
+
+    def test_undici_fetch_terminated_is_transient(self):
+        """undici's fetch reports a severed stream as ``TypeError: terminated``."""
+        logs = "\n".join(
+            [
+                "Attempt 1 failed: TypeError: terminated. Retrying with backoff...",
+                "Attempt 2 failed: TypeError: terminated. Retrying with backoff...",
+                "Giving up.",
+            ]
+        )
+
+        analysis = analyze_agent_failure(logs)
+
+        assert analysis.transient is True
+        assert analysis.retry_exhausted is True
+
+    def test_generic_terminated_wording_is_not_transient(self):
+        """Only undici's error shape may match — not any use of 'terminated'.
+
+        An agent killed by policy or by an operator also says "terminated";
+        retrying those burns money and can never succeed.
+        """
+        logs = "\n".join(
+            [
+                "Attempt 1 failed: run terminated by policy",
+                "Attempt 2 failed: run terminated by policy",
+                "Giving up.",
+            ]
+        )
+
+        analysis = analyze_agent_failure(logs)
+
+        assert analysis.transient is False
+
     def test_plain_agent_error_is_not_transient(self):
         """No upstream signal at all must never be treated as retryable."""
         logs = "\n".join(

--- a/backend/tests/helm/chart_helpers.py
+++ b/backend/tests/helm/chart_helpers.py
@@ -1,0 +1,72 @@
+"""Shared helpers for the helm chart guard tests.
+
+Both suites in this directory need the same primitives: the chart's default
+values, dotted ``.Values`` lookup, and a way to run a real ``helm template``
+without network access. They live here so the suites cannot drift apart.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Iterator, List
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHART_DIR = REPO_ROOT / "helm" / "preloop"
+CHART_VALUES = CHART_DIR / "values.yaml"
+
+
+def load_values() -> Dict:
+    """Return the chart's default values."""
+    return yaml.safe_load(CHART_VALUES.read_text())
+
+
+def resolve_values_path(values: Dict, dotted: str):
+    """Look up a dotted ``.Values`` path, returning None when absent."""
+    node = values
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+@contextmanager
+def offline_chart() -> Iterator[Path]:
+    """Yield a copy of the chart that renders without fetching dependencies.
+
+    ``helm template`` refuses to run while a declared subchart is missing from
+    ``charts/``, which would make these tests require network access. The
+    subcharts are irrelevant to the templates under test, so the copy simply
+    declares none.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        chart_copy = Path(tmp) / CHART_DIR.name
+        shutil.copytree(CHART_DIR, chart_copy)
+        chart_yaml = chart_copy / "Chart.yaml"
+        metadata = yaml.safe_load(chart_yaml.read_text())
+        metadata.pop("dependencies", None)
+        chart_yaml.write_text(yaml.safe_dump(metadata))
+        yield chart_copy
+
+
+def helm_template(template: str, overrides: List[str] | None = None) -> str:
+    """Render one chart template, skipping when helm is unavailable."""
+    helm = shutil.which("helm")
+    if helm is None:  # pragma: no cover - depends on the local toolchain
+        pytest.skip("helm binary not available")
+
+    with offline_chart() as chart_dir:
+        command = [helm, "template", "preloop", str(chart_dir), "--show-only", template]
+        for override in overrides or []:
+            command += ["--set", override]
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    return result.stdout

--- a/backend/tests/helm/test_deployment_termination_grace.py
+++ b/backend/tests/helm/test_deployment_termination_grace.py
@@ -20,19 +20,12 @@ These tests exist so a future edit that drops either value back to the
 
 from __future__ import annotations
 
-import shutil
-import subprocess
-import tempfile
-from contextlib import contextmanager
-from pathlib import Path
-from typing import Dict, Iterator, List
+from typing import Dict, List
 
 import pytest
 import yaml
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-CHART_DIR = REPO_ROOT / "helm" / "preloop"
-CHART_VALUES = CHART_DIR / "values.yaml"
+from tests.helm.chart_helpers import helm_template, load_values, resolve_values_path
 
 # Deployments that hold long-lived streaming/long-poll connections, with the
 # dotted values path each one's grace period must come from.
@@ -46,24 +39,9 @@ STREAMING_DEPLOYMENTS = [
 MIN_STREAMING_TIMEOUT_SECONDS = 300
 
 
-def _load_values() -> Dict:
-    """Return the chart's default values."""
-    return yaml.safe_load(CHART_VALUES.read_text())
-
-
-def _resolve_values_path(values: Dict, dotted: str):
-    """Look up a dotted ``.Values`` path, returning None when absent."""
-    node = values
-    for part in dotted.split("."):
-        if not isinstance(node, dict) or part not in node:
-            return None
-        node = node[part]
-    return node
-
-
 def _proxy_read_timeout(values: Dict) -> int:
     """Seconds the proxies in front of the gateway allow between reads."""
-    read_timeout = _resolve_values_path(values, "gateway.proxy.readTimeout")
+    read_timeout = resolve_values_path(values, "gateway.proxy.readTimeout")
     assert read_timeout is not None, "gateway.proxy.readTimeout missing"
     return int(read_timeout)
 
@@ -73,8 +51,8 @@ def test_values_declare_a_stream_covering_grace_period(
     template: str, component: str
 ) -> None:
     """values.yaml must pin a grace period long enough for a full stream."""
-    values = _load_values()
-    grace = _resolve_values_path(values, f"{component}.terminationGracePeriodSeconds")
+    values = load_values()
+    grace = resolve_values_path(values, f"{component}.terminationGracePeriodSeconds")
 
     assert grace is not None, (
         f"{component}.terminationGracePeriodSeconds is not set; the pod falls "
@@ -87,54 +65,17 @@ def test_values_declare_a_stream_covering_grace_period(
     )
 
 
-@contextmanager
-def _offline_chart() -> Iterator[Path]:
-    """Yield a copy of the chart that renders without fetching dependencies.
-
-    ``helm template`` refuses to run while a declared subchart is missing from
-    ``charts/``, which would make these tests require network access. The
-    subcharts are irrelevant to the templates under test, so the copy simply
-    declares none.
-    """
-    with tempfile.TemporaryDirectory() as tmp:
-        chart_copy = Path(tmp) / CHART_DIR.name
-        shutil.copytree(CHART_DIR, chart_copy)
-        chart_yaml = chart_copy / "Chart.yaml"
-        metadata = yaml.safe_load(chart_yaml.read_text())
-        metadata.pop("dependencies", None)
-        chart_yaml.write_text(yaml.safe_dump(metadata))
-        yield chart_copy
-
-
-def _helm_template(template: str, overrides: List[str] | None = None) -> str:
-    """Render one chart template, skipping when helm is unavailable."""
-    helm = shutil.which("helm")
-    if helm is None:  # pragma: no cover - depends on the local toolchain
-        pytest.skip("helm binary not available")
-
-    with _offline_chart() as chart_dir:
-        command = [helm, "template", "preloop", str(chart_dir), "--show-only", template]
-        for override in overrides or []:
-            command += ["--set", override]
-        result = subprocess.run(command, capture_output=True, text=True, check=False)
-
-    assert result.returncode == 0, result.stderr
-    return result.stdout
-
-
 def _rendered_pod_spec(template: str, overrides: List[str] | None = None) -> Dict:
     """Render a deployment template and return its pod spec."""
-    rendered = yaml.safe_load(_helm_template(template, overrides))
+    rendered = yaml.safe_load(helm_template(template, overrides))
     return rendered["spec"]["template"]["spec"]
 
 
 @pytest.mark.parametrize("template,component", STREAMING_DEPLOYMENTS)
 def test_helm_render_sets_the_grace_period(template: str, component: str) -> None:
     """The rendered pod spec must carry the values.yaml grace period."""
-    values = _load_values()
-    expected = _resolve_values_path(
-        values, f"{component}.terminationGracePeriodSeconds"
-    )
+    values = load_values()
+    expected = resolve_values_path(values, f"{component}.terminationGracePeriodSeconds")
     assert expected is not None
 
     pod_spec = _rendered_pod_spec(template)

--- a/backend/tests/helm/test_deployment_termination_grace.py
+++ b/backend/tests/helm/test_deployment_termination_grace.py
@@ -1,0 +1,172 @@
+"""Guards on the termination grace period of the streaming deployments.
+
+The gateway proxies streaming LLM responses that routinely run for minutes.
+Rollouts use surge-first RollingUpdate plus a preStop sleep, so endpoint
+drain is fine — but ``terminationGracePeriodSeconds`` used to be the k8s
+default of 30, so kubelet SIGKILLed the pod ~20s after preStop while uvicorn
+was still draining in-flight streams. Agents saw the socket die mid-response
+("other side closed" / undici "terminated") and their flow executions failed
+during every deploy window.
+
+The grace period must therefore cover at least as long as the proxies in
+front of the gateway are willing to keep a stream open
+(``gateway.proxy.readTimeout``), plus the preStop sleep. The api deployment
+serves MCP sessions and long-polls with the same 10s preStop, so it gets the
+same treatment.
+
+These tests exist so a future edit that drops either value back to the
+30s default fails CI instead of shipping.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Iterator, List
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHART_DIR = REPO_ROOT / "helm" / "preloop"
+CHART_VALUES = CHART_DIR / "values.yaml"
+
+# Deployments that hold long-lived streaming/long-poll connections, with the
+# dotted values path each one's grace period must come from.
+STREAMING_DEPLOYMENTS = [
+    pytest.param("templates/gateway-deployment.yaml", "gateway", id="gateway"),
+    pytest.param("templates/api-deployment.yaml", "api", id="api"),
+]
+
+# A drain window at or below this cannot cover even the minimum streaming
+# window the proxy guards (test_gateway_proxy_timeouts.py) insist on.
+MIN_STREAMING_TIMEOUT_SECONDS = 300
+
+
+def _load_values() -> Dict:
+    """Return the chart's default values."""
+    return yaml.safe_load(CHART_VALUES.read_text())
+
+
+def _resolve_values_path(values: Dict, dotted: str):
+    """Look up a dotted ``.Values`` path, returning None when absent."""
+    node = values
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def _proxy_read_timeout(values: Dict) -> int:
+    """Seconds the proxies in front of the gateway allow between reads."""
+    read_timeout = _resolve_values_path(values, "gateway.proxy.readTimeout")
+    assert read_timeout is not None, "gateway.proxy.readTimeout missing"
+    return int(read_timeout)
+
+
+@pytest.mark.parametrize("template,component", STREAMING_DEPLOYMENTS)
+def test_values_declare_a_stream_covering_grace_period(
+    template: str, component: str
+) -> None:
+    """values.yaml must pin a grace period long enough for a full stream."""
+    values = _load_values()
+    grace = _resolve_values_path(values, f"{component}.terminationGracePeriodSeconds")
+
+    assert grace is not None, (
+        f"{component}.terminationGracePeriodSeconds is not set; the pod falls "
+        "back to the k8s default of 30s and kubelet SIGKILLs in-flight "
+        "streams ~20s after preStop"
+    )
+    assert int(grace) >= _proxy_read_timeout(values), (
+        f"{component}.terminationGracePeriodSeconds={grace} is shorter than "
+        "the stream window the proxies allow (gateway.proxy.readTimeout)"
+    )
+
+
+@contextmanager
+def _offline_chart() -> Iterator[Path]:
+    """Yield a copy of the chart that renders without fetching dependencies.
+
+    ``helm template`` refuses to run while a declared subchart is missing from
+    ``charts/``, which would make these tests require network access. The
+    subcharts are irrelevant to the templates under test, so the copy simply
+    declares none.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        chart_copy = Path(tmp) / CHART_DIR.name
+        shutil.copytree(CHART_DIR, chart_copy)
+        chart_yaml = chart_copy / "Chart.yaml"
+        metadata = yaml.safe_load(chart_yaml.read_text())
+        metadata.pop("dependencies", None)
+        chart_yaml.write_text(yaml.safe_dump(metadata))
+        yield chart_copy
+
+
+def _helm_template(template: str, overrides: List[str] | None = None) -> str:
+    """Render one chart template, skipping when helm is unavailable."""
+    helm = shutil.which("helm")
+    if helm is None:  # pragma: no cover - depends on the local toolchain
+        pytest.skip("helm binary not available")
+
+    with _offline_chart() as chart_dir:
+        command = [helm, "template", "preloop", str(chart_dir), "--show-only", template]
+        for override in overrides or []:
+            command += ["--set", override]
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def _rendered_pod_spec(template: str, overrides: List[str] | None = None) -> Dict:
+    """Render a deployment template and return its pod spec."""
+    rendered = yaml.safe_load(_helm_template(template, overrides))
+    return rendered["spec"]["template"]["spec"]
+
+
+@pytest.mark.parametrize("template,component", STREAMING_DEPLOYMENTS)
+def test_helm_render_sets_the_grace_period(template: str, component: str) -> None:
+    """The rendered pod spec must carry the values.yaml grace period."""
+    values = _load_values()
+    expected = _resolve_values_path(
+        values, f"{component}.terminationGracePeriodSeconds"
+    )
+    assert expected is not None
+
+    pod_spec = _rendered_pod_spec(template)
+    assert pod_spec.get("terminationGracePeriodSeconds") == int(expected), (
+        f"{template} does not wire {component}.terminationGracePeriodSeconds "
+        "into the pod spec, so the k8s default of 30s applies"
+    )
+
+
+@pytest.mark.parametrize("template,component", STREAMING_DEPLOYMENTS)
+def test_helm_render_grace_period_stays_overridable(
+    template: str, component: str
+) -> None:
+    """An operator's own value must win over the chart default."""
+    pod_spec = _rendered_pod_spec(
+        template, [f"{component}.terminationGracePeriodSeconds=1234"]
+    )
+    assert pod_spec.get("terminationGracePeriodSeconds") == 1234
+
+
+@pytest.mark.parametrize("template,component", STREAMING_DEPLOYMENTS)
+def test_grace_period_outlives_the_prestop_sleep(template: str, component: str) -> None:
+    """The preStop sleep spends grace budget; the drain window is the rest."""
+    pod_spec = _rendered_pod_spec(template)
+    container = pod_spec["containers"][0]
+
+    prestop = container["lifecycle"]["preStop"]["exec"]["command"]
+    sleep_seconds = int(prestop[-1])
+    grace = pod_spec.get("terminationGracePeriodSeconds") or 30
+
+    assert grace - sleep_seconds >= MIN_STREAMING_TIMEOUT_SECONDS, (
+        f"{template}: after the {sleep_seconds}s preStop sleep, the remaining "
+        f"drain window ({grace - sleep_seconds}s) is shorter than the minimum "
+        "streaming window the proxy guards insist on"
+    )

--- a/backend/tests/helm/test_gateway_proxy_timeouts.py
+++ b/backend/tests/helm/test_gateway_proxy_timeouts.py
@@ -15,20 +15,21 @@ instead of shipping.
 from __future__ import annotations
 
 import re
-import shutil
-import subprocess
-import tempfile
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, Iterator, List
+from typing import Dict, List
 
 import pytest
 import yaml
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-CHART_DIR = REPO_ROOT / "helm" / "preloop"
+from tests.helm.chart_helpers import (
+    CHART_DIR,
+    REPO_ROOT,
+    helm_template,
+    load_values,
+    resolve_values_path,
+)
+
 NGINX_CONFIGMAP = CHART_DIR / "templates" / "configmap-nginx.yaml"
-CHART_VALUES = CHART_DIR / "values.yaml"
 DOCKER_NGINX_TEMPLATE = REPO_ROOT / "frontend" / "docker" / "nginx.conf.template"
 
 # The gateway route prefixes that carry streaming model traffic.
@@ -39,21 +40,6 @@ GATEWAY_LOCATIONS = ("^~ /openai/", "^~ /anthropic/", "^~ /gemini/")
 MIN_STREAMING_TIMEOUT_SECONDS = 300
 
 
-def _load_values() -> Dict:
-    """Return the chart's default values."""
-    return yaml.safe_load(CHART_VALUES.read_text())
-
-
-def _resolve_values_path(values: Dict, dotted: str):
-    """Look up a dotted ``.Values`` path, returning None when absent."""
-    node = values
-    for part in dotted.split("."):
-        if not isinstance(node, dict) or part not in node:
-            return None
-        node = node[part]
-    return node
-
-
 def _render_with_default_values(template_text: str) -> str:
     """Substitute ``.Values`` references so the config can be parsed.
 
@@ -62,13 +48,13 @@ def _render_with_default_values(template_text: str) -> str:
     lets the assertions run in a test environment that has no ``helm``
     binary; when helm *is* available a separate test checks the real render.
     """
-    values = _load_values()
+    values = load_values()
 
     def _replace(match: re.Match) -> str:
         expression = match.group(1).strip()
         values_ref = re.fullmatch(r"\.Values\.([\w.]+)", expression)
         if values_ref:
-            resolved = _resolve_values_path(values, values_ref.group(1))
+            resolved = resolve_values_path(values, values_ref.group(1))
             if resolved is not None:
                 return str(resolved)
         return ""
@@ -161,9 +147,9 @@ def test_gateway_location_streams_tokens_through(
 
 def test_ingress_annotations_match_the_console_timeout() -> None:
     """The ingress is the second 60s proxy in front of the gateway."""
-    values = _load_values()
-    read_timeout = _resolve_values_path(values, "gateway.proxy.readTimeout")
-    send_timeout = _resolve_values_path(values, "gateway.proxy.sendTimeout")
+    values = load_values()
+    read_timeout = resolve_values_path(values, "gateway.proxy.readTimeout")
+    send_timeout = resolve_values_path(values, "gateway.proxy.sendTimeout")
 
     assert read_timeout is not None and int(read_timeout) >= (
         MIN_STREAMING_TIMEOUT_SECONDS
@@ -196,44 +182,9 @@ def test_ingress_annotations_stay_overridable() -> None:
     assert "cert-manager.io/cluster-issuer" in annotations
 
 
-@contextmanager
-def _offline_chart() -> Iterator[Path]:
-    """Yield a copy of the chart that renders without fetching dependencies.
-
-    ``helm template`` refuses to run while a declared subchart is missing from
-    ``charts/``, which would make these tests require network access. The
-    subcharts are irrelevant to the templates under test, so the copy simply
-    declares none.
-    """
-    with tempfile.TemporaryDirectory() as tmp:
-        chart_copy = Path(tmp) / CHART_DIR.name
-        shutil.copytree(CHART_DIR, chart_copy)
-        chart_yaml = chart_copy / "Chart.yaml"
-        metadata = yaml.safe_load(chart_yaml.read_text())
-        metadata.pop("dependencies", None)
-        chart_yaml.write_text(yaml.safe_dump(metadata))
-        yield chart_copy
-
-
-def _helm_template(template: str, overrides: List[str] | None = None) -> str:
-    """Render one chart template, skipping when helm is unavailable."""
-    helm = shutil.which("helm")
-    if helm is None:  # pragma: no cover - depends on the local toolchain
-        pytest.skip("helm binary not available")
-
-    with _offline_chart() as chart_dir:
-        command = [helm, "template", "preloop", str(chart_dir), "--show-only", template]
-        for override in overrides or []:
-            command += ["--set", override]
-        result = subprocess.run(command, capture_output=True, text=True, check=False)
-
-    assert result.returncode == 0, result.stderr
-    return result.stdout
-
-
 def _render_ingress(overrides: List[str] | None = None) -> Dict:
     """Render the ingress template with the chart's default values."""
-    rendered = _helm_template(
+    rendered = helm_template(
         "templates/ingress.yaml",
         ["ingress.enabled=true", *(overrides or [])],
     )
@@ -243,7 +194,7 @@ def _render_ingress(overrides: List[str] | None = None) -> Dict:
 @pytest.mark.parametrize("location", GATEWAY_LOCATIONS)
 def test_helm_render_keeps_the_gateway_timeouts(location: str) -> None:
     """The same guard, against a real ``helm template`` render."""
-    rendered = _helm_template("templates/configmap-nginx.yaml")
+    rendered = helm_template("templates/configmap-nginx.yaml")
 
     body = _location_body(_nginx_config_from_configmap(rendered), location)
     assert _directive_seconds(body, "proxy_read_timeout") >= (

--- a/backend/tests/services/test_flow_orchestrator_retry.py
+++ b/backend/tests/services/test_flow_orchestrator_retry.py
@@ -7,6 +7,8 @@ more importantly, the safety boundary that keeps a retry from double-posting
 external side effects (pull-request comments, commit statuses, pushes).
 """
 
+import dataclasses
+
 import pytest
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -14,6 +16,7 @@ from uuid import uuid4
 from sqlalchemy.orm import Session
 
 from preloop.agents.base import AgentExecutionResult, AgentStatus
+from preloop.agents.container import ContainerAgentExecutor
 from preloop.models.crud import crud_account, crud_flow, crud_user
 from preloop.models.models import Account, Flow
 from preloop.models.models.user import User
@@ -461,3 +464,218 @@ class TestSideEffectSafety:
             f"final failure status; got {states}"
         )
         assert states[-1] == "success"
+
+
+# The raw log shape from the rollout incident: the agent CLI crashed on a
+# severed LLM stream *without* running its own retry loop, so the logs carry
+# no "attempt N failed" phrasing at all — only undici's stack. This is the
+# one shape the stored error MESSAGE cannot classify on its own; the verdict
+# has to travel with the agent result.
+SEVERED_STREAM_STACK_LOGS = [
+    "[Agent Status] running",
+    "Streaming model response...",
+    "TypeError: terminated",
+    "    at Fetch.onAborted (node:internal/deps/undici/undici:11190:53)",
+    "    at Fetch.emit (node:events:518:28)",
+    "  [cause]: SocketError: other side closed",
+    "      at TLSSocket.onSocketEnd (node:internal/deps/undici/undici:8117:26)",
+]
+
+
+async def _agent_result_via_container(logs: list[str]) -> dict:
+    """Build the agent-result payload the way production actually does.
+
+    The real ``ContainerAgentExecutor.get_result`` (Docker mocked away)
+    produces the ``AgentExecutionResult`` from the logs; the returned dict
+    mirrors the terminal-result payload ``_monitor_agent_execution`` hands to
+    ``_retry_decision``. Going through the real extraction path is the point:
+    these tests pin the *wiring* from full-log analysis to retry decision,
+    not any single component.
+    """
+    executor = ContainerAgentExecutor(
+        agent_type="codex",
+        config={},
+        image="test-image:latest",
+        use_kubernetes=False,
+    )
+
+    mock_docker = AsyncMock()
+    mock_container = AsyncMock()
+    mock_container.show.return_value = {"State": {"ExitCode": 1, "Error": ""}}
+    mock_docker.containers.get.return_value = mock_container
+
+    with (
+        patch.object(ContainerAgentExecutor, "get_logs", AsyncMock(return_value=logs)),
+        patch.object(
+            ContainerAgentExecutor,
+            "get_status",
+            AsyncMock(return_value=AgentStatus.FAILED),
+        ),
+        patch.object(
+            ContainerAgentExecutor,
+            "_get_docker_client",
+            AsyncMock(return_value=mock_docker),
+        ),
+    ):
+        result = await executor.get_result("container-under-test")
+
+    # ``getattr`` keeps this helper runnable against pre-wiring results, the
+    # same tolerance _retry_decision itself must have for legacy payloads.
+    analysis = getattr(result, "failure_analysis", None)
+    return {
+        "status": result.status.value,
+        "output_summary": result.output_summary,
+        "error_message": result.error_message,
+        "actions_taken": [],
+        "mcp_usage_logs": [],
+        "exit_code": result.exit_code,
+        "failure_analysis": (
+            dataclasses.asdict(analysis) if analysis is not None else None
+        ),
+    }
+
+
+@pytest.mark.asyncio
+class TestRetryVerdictWiring:
+    """The full-log verdict, not the stored message, drives the retry.
+
+    ``container.get_result`` analyses the complete container logs;
+    ``FlowExecution.error_message`` keeps only the generated sentence. These
+    tests pin the contract that the transient/terminal verdict survives that
+    lossy step by travelling on the agent result itself.
+    """
+
+    async def test_severed_stream_stack_is_retried_end_to_end(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        """The incident shape: a raw undici stack must schedule a retry.
+
+        The fallback error message is the stack text, which re-analysis of
+        the message alone classifies as non-transient. Only the verdict
+        attached to the agent result can carry "this was a severed stream —
+        retry it" across the message bottleneck.
+        """
+        agent_result = await _agent_result_via_container(SEVERED_STREAM_STACK_LOGS)
+
+        orchestrator = _build_orchestrator(
+            db_session, test_flow, event_data, mock_nats_client
+        )
+
+        assert orchestrator._retry_decision(agent_result) is None, (
+            "a stream severed mid-response (undici 'TypeError: terminated' / "
+            "'other side closed') is transient and must be retried"
+        )
+
+    async def test_policy_terminated_attempts_are_not_retried_end_to_end(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        """A policy kill with retry-loop phrasing must never retry.
+
+        The generated message for this shape is 'Upstream model provider was
+        unreachable after 2 attempts.', which message-only re-analysis calls
+        transient. The first-pass verdict (terminal: no transport failure in
+        the logs) must win.
+        """
+        agent_result = await _agent_result_via_container(
+            [
+                "Attempt 1 failed: run terminated by policy",
+                "Attempt 2 failed: run terminated by policy",
+                "Giving up.",
+            ]
+        )
+
+        orchestrator = _build_orchestrator(
+            db_session, test_flow, event_data, mock_nats_client
+        )
+
+        assert orchestrator._retry_decision(agent_result) is not None, (
+            "a run terminated by policy can never succeed on retry; the "
+            "full-log verdict must override the message's phrasing"
+        )
+
+    async def test_plain_crash_stays_non_retryable_end_to_end(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        """Guard against over-matching: an ordinary crash must not retry."""
+        agent_result = await _agent_result_via_container(
+            [
+                "Traceback (most recent call last):",
+                '  File "agent.py", line 10, in run',
+                "ValueError: prompt template rendered empty",
+            ]
+        )
+
+        orchestrator = _build_orchestrator(
+            db_session, test_flow, event_data, mock_nats_client
+        )
+
+        assert orchestrator._retry_decision(agent_result) is not None
+
+    async def test_attached_verdict_wins_over_message_phrasing(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        """Through the retry loop: a terminal verdict beats a transient-looking message."""
+        calls = []
+
+        async def monitor(session_reference, agent_executor):
+            calls.append(session_reference)
+            return {
+                "status": "FAILED",
+                # Message-only re-analysis would call this transient
+                # (no-status branch of _reanalyze_generated_message).
+                "error_message": "Upstream model provider was unreachable "
+                "after 2 attempts.",
+                "exit_code": 1,
+                "actions_taken": [],
+                "mcp_usage_logs": [],
+                "failure_analysis": {
+                    "message": "Upstream model provider was unreachable "
+                    "after 2 attempts.",
+                    "transient": False,
+                },
+            }
+
+        executor = AsyncMock()
+        executor.start = AsyncMock(return_value="session-under-test")
+        executor.cleanup = AsyncMock()
+
+        with (
+            patch(
+                "preloop.services.flow_orchestrator.create_agent_executor",
+                return_value=executor,
+            ),
+            patch.object(
+                FlowExecutionOrchestrator,
+                "_monitor_agent_execution",
+                side_effect=monitor,
+            ),
+            patch("preloop.services.flow_orchestrator.asyncio.sleep", AsyncMock()),
+        ):
+            orchestrator = _build_orchestrator(
+                db_session, test_flow, event_data, mock_nats_client
+            )
+            await orchestrator.run()
+
+        assert len(calls) == 1, (
+            "the first-pass terminal verdict travels with the result and "
+            "must not be overridden by re-analysing the message"
+        )
+
+    async def test_legacy_result_without_verdict_still_retries_on_message(
+        self, db_session, test_flow, event_data, mock_nats_client
+    ):
+        """Backward compat: no attached verdict → fall back to the message."""
+        agent_result = {
+            "status": "FAILED",
+            "error_message": "Upstream model provider timed out (HTTP 504) "
+            "after 3 attempts.",
+            "exit_code": 1,
+            "actions_taken": [],
+            "mcp_usage_logs": [],
+        }
+
+        orchestrator = _build_orchestrator(
+            db_session, test_flow, event_data, mock_nats_client
+        )
+
+        assert orchestrator._retry_decision(agent_result) is None

--- a/helm/preloop/templates/api-deployment.yaml
+++ b/helm/preloop/templates/api-deployment.yaml
@@ -31,6 +31,11 @@ spec:
         {{- include "preloop.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: api
     spec:
+      # Long-lived MCP sessions/long-polls and websockets must be allowed to
+      # drain before kubelet SIGKILLs the pod; the k8s default of 30s cuts
+      # them off ~20s after preStop. See api.terminationGracePeriodSeconds
+      # in values.yaml.
+      terminationGracePeriodSeconds: {{ .Values.api.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/preloop/templates/gateway-deployment.yaml
+++ b/helm/preloop/templates/gateway-deployment.yaml
@@ -32,6 +32,11 @@ spec:
         {{- include "preloop.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: gateway
     spec:
+      # In-flight streaming LLM responses must be allowed to finish before
+      # kubelet SIGKILLs the pod. With the k8s default of 30s, rollouts
+      # severed multi-minute agent streams ~20s after preStop began. See
+      # gateway.terminationGracePeriodSeconds in values.yaml.
+      terminationGracePeriodSeconds: {{ .Values.gateway.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -227,8 +232,10 @@ spec:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
           # Delay SIGTERM so ingress/kube-proxy endpoint updates propagate
           # before the server stops accepting; avoids 502s during rollouts.
-          # Long-lived SSE/streaming requests then drain within the pod's
-          # termination grace period.
+          # Long-lived SSE/streaming requests then drain during the rest of
+          # terminationGracePeriodSeconds (set on the pod spec above from
+          # gateway.terminationGracePeriodSeconds; the sleep spends part of
+          # that budget, and uvicorn drains until the last stream closes).
           lifecycle:
             preStop:
               exec:

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -137,6 +137,12 @@ api:
   # When unset, falls back to top-level replicaCount.
   # Staging/prod set this to 2 independently of gateway/console.
   replicaCount: null
+  # Same rationale as gateway.terminationGracePeriodSeconds: the api holds
+  # long-lived MCP sessions/long-polls and websockets behind the same 10s
+  # preStop sleep, so the 30s k8s default SIGKILLs them mid-rollout too.
+  # A generous ceiling costs nothing when connections have drained — uvicorn
+  # exits as soon as the last one closes.
+  terminationGracePeriodSeconds: 900
   resources:
     requests:
       cpu: "50m"
@@ -205,6 +211,15 @@ gateway:
     # Agent requests carry whole file trees and diffs as context, which
     # comfortably exceeds the ingress default of 1m.
     bodySize: "32m"
+  # Seconds kubelet waits after starting the preStop hook before SIGKILL.
+  # The k8s default of 30 is far too short for this pod: a rollout SIGKILLed
+  # in-flight streaming LLM responses ~20s after preStop (10s sleep + uvicorn
+  # still draining), and agents mid-review saw the socket die ("other side
+  # closed"), failing their flow executions. This is a ceiling, not a delay:
+  # uvicorn exits as soon as the last in-flight request completes, so an idle
+  # pod still terminates in ~10s. Aligned with proxy.readTimeout above — any
+  # stream the proxies are still willing to carry must be allowed to finish.
+  terminationGracePeriodSeconds: 900
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
## Symptom

During the 2026-08-10 22:45 prod deploy window, two flow executions failed the moment the gateway pods cycled. The agents logged undici transport errors (`SocketError: other side closed`, `TypeError: terminated`) — their in-flight streaming LLM responses were cut mid-stream — and no flow-level retry fired.

## Root cause

Two independent gaps:

1. **Pods are SIGKILLed while streams are still draining.** The gateway (and api) deployments use surge-first RollingUpdate + a 10s `preStop` sleep, and uvicorn drains in-flight connections indefinitely on SIGTERM — but `terminationGracePeriodSeconds` was the k8s default of **30**. Kubelet SIGKILLs ~20s after preStop starts, killing multi-minute review streams. The template's own comment promised streams "drain within the pod's termination grace period", which was silently untrue.
2. **The resulting error was classified as terminal.** `failure_analysis`'s transient network patterns cover `econnreset`/`socket hang up`/timeouts, but not undici's `other side closed` / `TypeError: terminated`, so the orchestrator never scheduled a retry that would have succeeded against the replacement pod.

## Changes

**Commit 1 (helm):**
- New `gateway.terminationGracePeriodSeconds` / `api.terminationGracePeriodSeconds` values (default **900**, aligned with `gateway.proxy.readTimeout`: any stream the proxies are still willing to carry must be allowed to finish), wired into both deployments.
- The grace period is a **ceiling, not a delay** — uvicorn exits as soon as the last connection closes, so idle pods still terminate in ~10s.
- **api gets the same value** because it sits behind the identical preStop/rollout setup and holds long-lived MCP sessions/long-polls and websockets; the cost of the ceiling is zero when drained, while 30s cuts those connections off the same way.
- Fixed the misleading preStop comment.
- Helm-template tests (`backend/tests/helm/test_deployment_termination_grace.py`, following the `test_gateway_proxy_timeouts.py` pattern) guard: values exist and cover the proxy read timeout, rendered pod specs carry them, operator overrides win, and the post-preStop drain window stays above the minimum streaming window.

**Commit 2 (failure_analysis):**
- Added `other side closed`, `typeerror:\s*terminated`, and `fetch failed/terminated` to `_TRANSIENT_NETWORK_RE`.
- The `terminated` match is deliberately anchored to undici's `TypeError:` prefix; a regression test pins that generic wording like "run terminated by policy" stays non-transient.

## Testing

- Red/green: the two new transience tests fail on `main`'s classifier and pass with the fix; the helm tests fail against the un-wired templates and pass after wiring.
- `backend/tests/helm/` (25 passed, real `helm template` render included) and `backend/tests/agents/test_failure_analysis.py` + `backend/tests/services/test_flow_orchestrator_retry.py` (29 passed).

<!-- PRELOOM_SUMMARY -->
> [!NOTE]
> **[Low]**
> All previously raised review issues are resolved: the full-log transient verdict is now wired into the orchestrator's retry decision and verified end-to-end, and the helm grace-period fix is well-tested.
>
> **Overview**
> Adds a 900s `terminationGracePeriodSeconds` to the gateway/api deployments so rollouts stop SIGKILLing in-flight agent LLM streams, and wires the full-log failure classification (including undici transport errors) into the retry decision so severed streams get a bounded flow-level retry.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit c326a09. Updates automatically on new commits.</sup>
<!-- /PRELOOM_SUMMARY -->