### PR TITLE
fix(agents): pin gemini-cli helper models to the flow model; capture OpenCode stderr

### DIFF
--- a/backend/preloop/agents/gemini.py
+++ b/backend/preloop/agents/gemini.py
@@ -16,6 +16,36 @@ from .container import ContainerAgentExecutor
 
 logger = logging.getLogger(__name__)
 
+# gemini-cli internal helper aliases that must be pinned to the flow's model
+# when running behind the Preloop gateway.  Stock gemini-cli resolves these to
+# hardcoded Google model names (gemini-2.5-flash / gemini-3-flash-preview via
+# the `gemini-*-flash-base` alias chain), which do not exist behind the
+# gateway and 404 (issue #212).  The failing calls are swallowed by the CLI,
+# silently degrading loop detection, the next-speaker (auto-continue) check,
+# tool-output summarization and chat compression — and a run whose
+# continuation check dies mid-review exits 0 without the success sentinel.
+#
+# Deliberately NOT pinned: `web-fetch` and `web-search`.  Their primary path
+# requires Google server-side tools (urlContext / googleSearch) that no
+# gateway model provides; pinning them would make the flow model hallucinate
+# page content instead of failing over to `web-fetch-fallback`, which fetches
+# the page locally and IS pinned to the flow model below.
+GEMINI_CLI_HELPER_ALIASES = (
+    "loop-detection",
+    "loop-detection-double-check",
+    "next-speaker-checker",
+    "web-fetch-fallback",
+    "summarizer-default",
+    "summarizer-shell",
+    "edit-corrector",
+    "llm-edit-fixer",
+    "chat-compression-default",
+    "classifier",
+    "prompt-completion",
+    "fast-ack-helper",
+    "context-snapshotter",
+)
+
 
 def _gemini_cli_base_url(endpoint: str) -> str:
     """Return the Gemini CLI base URL before the SDK-appended API version."""
@@ -282,6 +312,45 @@ class GeminiAgent(ContainerAgentExecutor):
             )
             raise RuntimeError(f"Failed to start Gemini CLI container: {e}")
 
+    def _build_gateway_helper_settings(self, model: str) -> Dict[str, Any]:
+        """
+        Build gemini-cli settings pinning internal helper models to the flow model.
+
+        Only used for Preloop-gateway runs.  Two things are configured:
+
+        - ``modelConfigs.customAliases``: every internal helper alias
+          (loop detection, next-speaker check, web-fetch fallback,
+          summarizers, chat compression, ...) is pointed at the flow's
+          gateway model alias.  Stock gemini-cli resolves these helpers to
+          hardcoded Google models that the gateway does not serve, so every
+          helper call 404s and is silently swallowed (issue #212).  The
+          next-speaker check failing this way is what lets the CLI stop
+          mid-task with exit code 0 and no success sentinel.
+        - ``model.disableLoopDetection``: the CLI's own loop detection is
+          redundant here — the orchestrator has its own MCP tool-loop
+          backstop and execution timeouts — and its LLM-based check both
+          costs gateway tokens (it ships recent history every ~30 turns) and
+          can false-positive on legitimately repetitive review workloads,
+          aborting the run without the sentinel.
+
+        ``web-fetch`` and ``web-search`` primaries are intentionally NOT
+        pinned: they rely on Google server-side tools (urlContext /
+        googleSearch) that gateway models cannot provide.  Left alone, their
+        404 makes web_fetch fail over to the local ``web-fetch-fallback``
+        path, which IS pinned and works with any model.
+        """
+        return {
+            "model": {
+                "disableLoopDetection": True,
+            },
+            "modelConfigs": {
+                "customAliases": {
+                    alias: {"modelConfig": {"model": model}}
+                    for alias in GEMINI_CLI_HELPER_ALIASES
+                }
+            },
+        }
+
     def _build_gemini_script(self, execution_context: Dict[str, Any]) -> str:
         """
         Build the Gemini initialization and execution script.
@@ -333,6 +402,25 @@ fi
         # Convert timeout from seconds to milliseconds for Gemini CLI
         mcp_timeout_ms = execution_context.get("_mcp_tool_timeout", 600) * 1000
 
+        # For Preloop-gateway runs, write a settings.json that pins gemini-cli's
+        # internal helper models to the flow's model and disables the CLI's own
+        # loop detection (see _build_gateway_helper_settings).  Base64-encoded
+        # for safe shell embedding.  Written BEFORE `gemini mcp add`, which
+        # merges the MCP server into the same user settings file.
+        gateway_settings_block = ""
+        if execution_context.get("model_gateway_enabled"):
+            settings_json = json.dumps(
+                self._build_gateway_helper_settings(model), indent=2
+            )
+            settings_b64 = base64.b64encode(settings_json.encode()).decode()
+            gateway_settings_block = f"""
+# Pin gemini-cli internal helper models (loop detection, next-speaker check,
+# web-fetch fallback, summarizers, compression) to the flow's gateway model.
+# Stock gemini-cli calls hardcoded Google models for these, which the Preloop
+# gateway does not serve (404 -> silent helper degradation, issue #212).
+echo '{settings_b64}' | base64 -d > "$HOME/.gemini/settings.json"
+"""
+
         # Create the full script
         script = f"""
 set -e
@@ -381,7 +469,7 @@ fi
 
 # Configure Gemini CLI MCP servers
 mkdir -p ~/.gemini
-
+{gateway_settings_block}
 # Register the Preloop MCP server via `gemini mcp add`.
 # Flags: -t http (HTTP transport), -s user (user scope),
 #         --trust (auto-approve), -H (custom header).

--- a/backend/preloop/agents/opencode.py
+++ b/backend/preloop/agents/opencode.py
@@ -509,8 +509,13 @@ echo "PRELOOP_AGENT_EXEC_START"
 # directly, we should switch to that instead of positional args $(cat ...) to avoid E2BIG on very large prompts.
 # Auto-approve all permission requests to avoid hangs.
 # We use '--' to prevent argument injection if the prompt starts with a hyphen.
+# --print-logs/--log-level WARN: surface opencode's internal logs on stderr —
+# without this, fatal errors only land in log files inside the container and
+# failures are undiagnosable from the captured log stream (issue #212).
+# 2>&1 merges stderr into the filter pipe; the filter passes non-JSON lines
+# through verbatim, so stderr text reaches the execution log in order.
 set +e
-opencode run --format json --model {opencode_model_arg} --dangerously-skip-permissions -- "$(cat /tmp/prompt.txt)" | node /tmp/opencode-json-log-filter.js
+opencode run --format json --print-logs --log-level WARN --model {opencode_model_arg} --dangerously-skip-permissions -- "$(cat /tmp/prompt.txt)" 2>&1 | node /tmp/opencode-json-log-filter.js
 PIPE_CODES=("${{PIPESTATUS[@]}}")
 OPENCODE_EXIT_CODE=${{PIPE_CODES[0]}}
 FILTER_EXIT_CODE=${{PIPE_CODES[1]:-0}}

--- a/backend/tests/agents/test_agent_gemini.py
+++ b/backend/tests/agents/test_agent_gemini.py
@@ -308,3 +308,111 @@ class TestGeminiKubernetesStartup:
             assert call_ctx["_container_command"] == ["/bin/bash"]
             assert call_ctx["_container_args"][0] == "-c"
             assert len(call_ctx["_container_args"]) == 2
+
+
+class TestGeminiGatewayHelperModelSettings:
+    """Gateway mode must pin gemini-cli's internal helper models to the flow model.
+
+    gemini-cli's utility subsystems (loop detection, next-speaker check,
+    web-fetch fallback, summarizers, chat compression) default to hardcoded
+    Google model names (e.g. gemini-2.5-flash). Behind the Preloop gateway only
+    the flow's configured alias exists, so those calls 404 and silently degrade
+    — including the auto-continuation check whose failure lets the CLI exit 0
+    without the success sentinel (issue #212).
+    """
+
+    def _gateway_context(self, **overrides):
+        context = {
+            "prompt": "review the PR",
+            "gemini_model": "openrouter/auto-beta",
+            "model_gateway_enabled": True,
+            "execution_id": "exec-1",
+            "flow_name": "test-flow",
+        }
+        context.update(overrides)
+        return context
+
+    def test_gateway_mode_writes_settings_json_before_mcp_add(self):
+        """Script writes ~/.gemini/settings.json (helper pins) before gemini mcp add."""
+        agent = GeminiAgent({})
+        script = agent._build_gemini_script(self._gateway_context())
+        assert "settings.json" in script
+        # Settings must land before `gemini mcp add` merges into the same file.
+        assert script.index("settings.json") < script.index("gemini mcp add")
+
+    def test_gateway_helper_settings_pin_helper_aliases_to_flow_model(self):
+        """customAliases must point every helper alias at the flow's model."""
+        agent = GeminiAgent({})
+        settings = agent._build_gateway_helper_settings("openrouter/auto-beta")
+        aliases = settings["modelConfigs"]["customAliases"]
+        for alias in (
+            "loop-detection",
+            "loop-detection-double-check",
+            "next-speaker-checker",
+            "web-fetch-fallback",
+            "summarizer-default",
+            "summarizer-shell",
+            "edit-corrector",
+            "llm-edit-fixer",
+            "chat-compression-default",
+        ):
+            assert aliases[alias]["modelConfig"]["model"] == "openrouter/auto-beta"
+
+    def test_gateway_helper_settings_do_not_override_url_context_tools(self):
+        """web-fetch / web-search primaries need Google server-side tools.
+
+        They must NOT be pinned to a non-Google model: web_fetch has a local
+        fallback path (web-fetch-fallback) that works with any model, and
+        overriding the primary would make the model hallucinate page content.
+        """
+        agent = GeminiAgent({})
+        settings = agent._build_gateway_helper_settings("openrouter/auto-beta")
+        aliases = settings["modelConfigs"]["customAliases"]
+        assert "web-fetch" not in aliases
+        assert "web-search" not in aliases
+
+    def test_gateway_helper_settings_disable_loop_detection(self):
+        """CLI loop detection must be disabled for gateway runs.
+
+        The deterministic tool-call loop detector aborts the run (exit 0, no
+        sentinel) on bursts of identical malformed tool calls; the orchestrator
+        has its own MCP tool-loop backstop and execution timeouts.
+        """
+        agent = GeminiAgent({})
+        settings = agent._build_gateway_helper_settings("openrouter/auto-beta")
+        assert settings["model"]["disableLoopDetection"] is True
+
+    def test_gateway_settings_embedded_base64_decodes_to_valid_json(self):
+        """The script embeds the settings as base64 that decodes to valid JSON."""
+        import base64
+        import json as jsonlib
+        import re
+
+        agent = GeminiAgent({})
+        script = agent._build_gemini_script(self._gateway_context())
+        match = re.search(
+            r"echo '([A-Za-z0-9+/=]+)' \| base64 -d > \"\$HOME/.gemini/settings.json\"",
+            script,
+        )
+        assert match, "settings.json base64 write not found in script"
+        decoded = jsonlib.loads(base64.b64decode(match.group(1)))
+        assert decoded["model"]["disableLoopDetection"] is True
+        aliases = decoded["modelConfigs"]["customAliases"]
+        assert (
+            aliases["next-speaker-checker"]["modelConfig"]["model"]
+            == "openrouter/auto-beta"
+        )
+
+    def test_direct_mode_does_not_write_helper_settings(self):
+        """Direct-provider runs keep stock gemini-cli behavior (helpers work)."""
+        agent = GeminiAgent({})
+        context = {
+            "prompt": "review the PR",
+            "gemini_model": "gemini-3-pro-preview",
+            "model_gateway_enabled": False,
+            "execution_id": "exec-1",
+            "flow_name": "test-flow",
+        }
+        script = agent._build_gemini_script(context)
+        assert "settings.json" not in script
+        assert "disableLoopDetection" not in script

--- a/backend/tests/agents/test_agent_opencode.py
+++ b/backend/tests/agents/test_agent_opencode.py
@@ -494,3 +494,39 @@ class TestOpenCodeKubernetesStartup:
             assert call_ctx["_container_command"] == ["/bin/bash"]
             assert call_ctx["_container_args"][0] == "-c"
             assert len(call_ctx["_container_args"]) == 2
+
+
+class TestOpenCodeStderrCapture:
+    """OpenCode failures must be diagnosable from the execution log.
+
+    Staging PR-reviewer runs died with "OpenCode CLI exited with code: 1" and
+    nothing else: opencode's internal logger writes to log files (not stderr)
+    unless --print-logs is passed, and stderr was not routed through the JSON
+    log filter, so fatal errors never reached the captured log stream
+    (issue #212).
+    """
+
+    def _context(self):
+        return {
+            "prompt": "test",
+            "opencode_model": "model-1",
+            "execution_id": "exec-1",
+            "flow_name": "test-flow",
+        }
+
+    def test_script_enables_opencode_logging(self):
+        """opencode run must print its internal logs to stderr."""
+        agent = OpenCodeAgent({})
+        script = agent._build_opencode_script(self._context())
+        assert "--print-logs" in script
+        assert "--log-level WARN" in script
+
+    def test_script_routes_stderr_through_log_filter(self):
+        """stderr must be merged into the pipe feeding the JSON log filter.
+
+        The filter passes non-JSON lines through verbatim, so plain-text
+        stderr log lines reach the captured log stream in order.
+        """
+        agent = OpenCodeAgent({})
+        script = agent._build_opencode_script(self._context())
+        assert "2>&1 | node /tmp/opencode-json-log-filter.js" in script


### PR DESCRIPTION
Fixes #212.

## Problem

Since the token-optimised PR-reviewer preset propagated (2026-08-10 ~15:20 UTC), gateway-backed review executions complete the review but end FAILED: the agent exits without printing the `FLOW_EXECUTION_SUCCESS` sentinel (prod: 0/30 failed before, 9/32 after; model unchanged).

## Root cause (verified against prod logs, read-only)

**Gemini CLI (prod failures).** Behind the Preloop model gateway only the flow's configured alias exists, but gemini-cli's internal helper subsystems resolve to hardcoded Google models (`gemini-2.5-flash` via the `gemini-*-flash-base` alias chains): loop detection, the **next-speaker (auto-continue) check**, web-fetch, summarizers, chat compression. Every helper call 404s (`ModelNotFoundError` from our gateway) and is swallowed by the CLI (`catch { return null; }`).

The sentinel-killing mechanism is the next-speaker check: in non-interactive mode, when a model turn ends with no pending tool calls, `checkNextSpeaker` decides whether to send "Please continue.". When that call 404s it returns `null`, the run ends mid-task — exit code 0, no sentinel — and the orchestrator's sentinel-missing override correctly marks the run FAILED. Failed prod runs consistently show: review chatter → helper 404 stack traces (`LoopDetectionService.checkForLoopWithLLM`, `web-fetch`) → `Gemini CLI exited with code: 0` with no sentinel. The preset change triggered this by making runs longer/more repetitive (≥30 turns arms the LLM loop check; verification greps + malformed-tool-call bursts add turns), not by breaking the contract itself.

**OpenCode (staging failures).** `opencode run` exited 1 with a blank tail in the execution log: its internal logger writes to log files unless `--print-logs` is set, and stderr was not routed through the JSON log filter, so the fatal error never reached the captured log stream.

## Fix (least-magical option chosen)

**Gemini, gateway runs only:** write `~/.gemini/settings.json` (before `gemini mcp add`, which merges into the same file) that:
- pins every internal helper alias to the flow's gateway model via `modelConfigs.customAliases` — this is gemini-cli's documented settings surface for exactly this (`Custom named presets for model configs... merged with (and override) the built-in aliases`), supported by the CLI version in the sandbox image (0.53.1, verified);
- sets `model.disableLoopDetection: true` — redundant with the orchestrator's own MCP tool-loop backstop and execution timeouts, and its LLM check both costs gateway tokens (ships recent history every ~30 turns) and can false-positive on legitimately repetitive review workloads, aborting the run without the sentinel.

`web-fetch`/`web-search` primaries are deliberately **not** pinned: they require Google server-side tools (`urlContext`/`googleSearch`) that no gateway model provides; pinning them would make the flow model hallucinate page content. Left alone, their 404 makes web_fetch fail over to the local `web-fetch-fallback` path, which IS pinned and model-agnostic.

Rejected alternatives: gateway-side aliasing of `gemini-2.5-flash` for gemini runtime sessions silently double-serves one alias under an unrelated Google name and misattributes usage; per-run flags don't exist for these helpers. Settings-file pinning keeps the mapping explicit, per-run, and agent-local. Direct-provider Gemini runs are untouched.

**OpenCode:** pass `--print-logs --log-level WARN` and merge stderr into the log-filter pipe (`2>&1 |`); the filter passes non-JSON lines through verbatim, so stderr reaches the execution log in order.

**Preset:** unchanged. Failed runs were mostly FULL-scope first reviews, so Step 3.2's re-read loop is not the implicated mechanism; no accuracy guardrails were touched.

The sentinel contract is unchanged.

## Red/green

- `TestGeminiGatewayHelperModelSettings` (6 tests): settings written before `gemini mcp add`, helper aliases pinned, web-fetch/web-search not pinned, loop detection disabled, embedded base64 decodes to valid JSON, direct-provider runs untouched — red before, green after.
- `TestOpenCodeStderrCapture` (2 tests): `--print-logs --log-level WARN` present, stderr routed through the filter — red before, green after.
- Full `backend/tests/agents/` suite: 274 passed.
- Sandbox smoke test (prod image `docker/sandbox-templates:gemini`): settings survive the `gemini mcp add` merge and the CLI starts cleanly with them.