### PR TITLE
fix(gateway): recover OpenRouter cost fields dropped by litellm's streaming transcode

### DIFF
--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -240,6 +240,27 @@ class LiteLLMModelGatewayBackend:
         return litellm.completion(**kwargs)
 
 
+class _PrefetchedUpstreamStream:
+    """Iterator over a prefetched upstream stream keeping the raw handle.
+
+    ``_prefetch_upstream_stream`` used to return a bare ``chain`` iterator,
+    which hid the underlying litellm ``CustomStreamWrapper``. The accounting
+    path needs that wrapper after the stream is drained to recover the
+    provider-reported cost fields litellm's transcode drops from the yielded
+    chunks (issue #219), so the raw stream object is exposed as ``.raw``.
+    """
+
+    def __init__(self, iterator: Iterator[Any], *, raw: Any) -> None:
+        self._iterator = iterator
+        self.raw = raw
+
+    def __iter__(self) -> "_PrefetchedUpstreamStream":
+        return self
+
+    def __next__(self) -> Any:
+        return next(self._iterator)
+
+
 def get_model_gateway_backend(
     backend_name: Optional[str] = None,
 ) -> ModelGatewayBackend:
@@ -1361,6 +1382,13 @@ class OpenAIGatewayService:
                         self._extract_finish_reason(chunk_dict) or last_finish_reason
                     )
 
+                # Recover the OpenRouter usage-accounting cost fields litellm
+                # drops from the transcoded chunks (#219).
+                final_usage_details = self._merge_usage_dicts(
+                    final_usage_details,
+                    self._provider_cost_fields(upstream_stream),
+                )
+
                 response_id = response_id or f"msg_{int(time.time())}"
                 if not emitted_text_start:
                     yield self._anthropic_sse_event(
@@ -1678,6 +1706,13 @@ class OpenAIGatewayService:
                         ):
                             continue
                     yield self._sse_event(event_payload)
+
+                # Recover the OpenRouter usage-accounting cost fields litellm
+                # drops from the transcoded chunks (#219).
+                final_usage_details = self._merge_usage_dicts(
+                    final_usage_details,
+                    self._provider_cost_fields(upstream_stream),
+                )
 
                 assistant_message = {
                     "role": "assistant",
@@ -2012,6 +2047,14 @@ class OpenAIGatewayService:
                             "output_tokens": usage["completion_tokens"],
                             "total_tokens": usage["total_tokens"],
                         }
+
+                # litellm's transcoded chunks never carry the OpenRouter
+                # usage-accounting cost fields; recover them from the raw
+                # stream so the persisted usage_details price the row (#219).
+                final_usage_details = self._merge_usage_dicts(
+                    final_usage_details,
+                    self._provider_cost_fields(upstream_stream),
+                )
 
                 full_text = "".join(assistant_parts)
                 if text_output_index is not None:
@@ -4474,7 +4517,7 @@ class OpenAIGatewayService:
 
     def _prefetch_upstream_stream(
         self, upstream_stream: Any, *, provider: GatewayProvider
-    ) -> Iterator[Any]:
+    ) -> "_PrefetchedUpstreamStream":
         """Pull the first upstream chunk before SSE headers are committed.
 
         ``StreamingResponse`` sends the HTTP 200 status line before iterating
@@ -4488,7 +4531,10 @@ class OpenAIGatewayService:
             provider: Gateway provider used to shape normalized errors.
 
         Returns:
-            An iterator yielding the prefetched chunk followed by the rest.
+            An iterator yielding the prefetched chunk followed by the rest. It
+            keeps a handle on the raw upstream stream object (``.raw``) so the
+            accounting path can recover fields litellm's transcode drops from
+            the yielded chunks (issue #219).
 
         Raises:
             ModelGatewayAPIError: When the first chunk cannot be obtained.
@@ -4497,13 +4543,63 @@ class OpenAIGatewayService:
         try:
             first_chunk = next(iterator)
         except StopIteration:
-            return iter(())
+            return _PrefetchedUpstreamStream(iter(()), raw=upstream_stream)
         except ModelGatewayAPIError:
             raise
         except Exception as exc:
             self._capture_rate_limit_headers(headers_from_exception(exc))
             raise self._normalize_upstream_error(provider, exc) from exc
-        return chain([first_chunk], iterator)
+        return _PrefetchedUpstreamStream(
+            chain([first_chunk], iterator), raw=upstream_stream
+        )
+
+    @staticmethod
+    def _provider_cost_fields(upstream_stream: Any) -> Dict[str, Any]:
+        """Recover provider-reported cost fields from the raw litellm stream.
+
+        OpenRouter's usage accounting puts the request's actual charge on the
+        final streamed chunk (``usage.cost`` / ``usage.cost_details``), but
+        litellm's ``CustomStreamWrapper`` never delivers those fields to its
+        consumer: the synthetic final usage chunk it emits for
+        ``stream_options.include_usage`` is rebuilt from token counts only
+        (``stream_chunk_builder`` -> ``calculate_usage``), and mid-stream
+        chunks have their usage stripped. The wrapper does retain every
+        pre-strip chunk on ``.chunks`` (the list it feeds to
+        ``stream_chunk_builder``), so the cost fields are recovered from
+        there after the stream is drained (issue #219).
+
+        Fail-open by design: when the stream is not a litellm wrapper (codex,
+        passthrough, tests) or litellm's internals change shape, this returns
+        ``{}`` and accounting proceeds without provider cost, exactly as
+        before.
+
+        Args:
+            upstream_stream: The (possibly prefetch-wrapped) upstream stream.
+
+        Returns:
+            Dict with any recovered ``cost`` / ``cost_details`` values, else
+            empty.
+        """
+        raw = getattr(upstream_stream, "raw", upstream_stream)
+        chunks = getattr(raw, "chunks", None)
+        if not isinstance(chunks, list):
+            return {}
+        recovered: Dict[str, Any] = {}
+        for chunk in chunks:
+            usage = getattr(chunk, "usage", None)
+            if usage is None and isinstance(chunk, dict):
+                usage = chunk.get("usage")
+            if usage is None:
+                continue
+            if hasattr(usage, "model_dump"):
+                usage = usage.model_dump()
+            if not isinstance(usage, dict):
+                continue
+            for key in ("cost", "cost_details"):
+                value = usage.get(key)
+                if value is not None:
+                    recovered[key] = value
+        return recovered
 
     def _stream_error(
         self, provider: GatewayProvider, exc: Exception

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -4599,6 +4599,16 @@ class OpenAIGatewayService:
                 value = usage.get(key)
                 if value is not None:
                     recovered[key] = value
+        if not recovered:
+            # A litellm stream retained chunks but none carried cost fields.
+            # Either the upstream did not return usage accounting, or a
+            # litellm upgrade changed the retained-chunk shape - log so the
+            # invisible-failure mode #219 fixed cannot silently return.
+            logger.debug(
+                "Provider cost recovery found no cost fields in %d retained "
+                "stream chunks",
+                len(chunks),
+            )
         return recovered
 
     def _stream_error(

--- a/backend/tests/services/test_openai_gateway.py
+++ b/backend/tests/services/test_openai_gateway.py
@@ -3237,3 +3237,225 @@ def test_responses_endpoint_records_provider_cost_and_requests_accounting(
     assert usage_row is not None
     assert usage_row.cost_source == "provider"
     assert usage_row.estimated_cost == pytest.approx(0.0000305)
+
+
+# ---------------------------------------------------------------------------
+# #219: provider-reported cost must survive litellm's STREAMING transcode.
+#
+# litellm's CustomStreamWrapper rebuilds the final usage chunk from token
+# counts only (stream_chunk_builder.calculate_usage), so OpenRouter's
+# usage-accounting fields (usage.cost / usage.cost_details) are dropped from
+# the transcoded stream even though the raw provider chunk carried them. The
+# tests below drive the REAL litellm streaming pipeline (mocked HTTP
+# transport, no network) so the transcode is exercised as in production --
+# the #208 tests mocked litellm.completion with plain dicts and missed this.
+# ---------------------------------------------------------------------------
+
+_OPENROUTER_STREAM_USAGE = {
+    "prompt_tokens": 973,
+    "completion_tokens": 15,
+    "total_tokens": 988,
+    "prompt_tokens_details": {"cached_tokens": 100},
+    "cost": 0.0000305,
+    "cost_details": {"upstream_inference_cost": 0.00001946},
+}
+
+# provider_reported_cost sums the OpenRouter charge and the BYOK upstream
+# vendor charge (both are paid by the customer).
+_OPENROUTER_EXPECTED_TOTAL = 0.0000305 + 0.00001946
+
+
+def _real_litellm_openrouter_stream(raw_usage):
+    """Build a real litellm CustomStreamWrapper over raw OpenRouter SSE chunks.
+
+    Uses litellm's own HTTP handler with a mocked httpx transport, so the
+    chunks flow through the genuine OpenRouter chunk parser and streaming
+    transcode -- exactly what the gateway consumes in production.
+    """
+    import httpx
+    import litellm
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    def sse(data):
+        return f"data: {json.dumps(data)}\n\n".encode()
+
+    body = b"".join(
+        [
+            sse(
+                {
+                    "id": "gen-stream-1",
+                    "object": "chat.completion.chunk",
+                    "created": 1710000000,
+                    "model": "openrouter/auto-beta",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": "Hel"},
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+            ),
+            sse(
+                {
+                    "id": "gen-stream-1",
+                    "object": "chat.completion.chunk",
+                    "created": 1710000000,
+                    "model": "openrouter/auto-beta",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": "lo"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                }
+            ),
+            # OpenRouter's final usage-accounting chunk: empty choices, usage
+            # with cost + cost_details (per their usage accounting docs).
+            sse(
+                {
+                    "id": "gen-stream-1",
+                    "object": "chat.completion.chunk",
+                    "created": 1710000000,
+                    "model": "openrouter/auto-beta",
+                    "choices": [],
+                    "usage": raw_usage,
+                }
+            ),
+            b"data: [DONE]\n\n",
+        ]
+    )
+
+    def handler(request: "httpx.Request") -> "httpx.Response":
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=body,
+        )
+
+    client = HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(handler)))
+    return litellm.completion(
+        model="openrouter/openrouter/auto-beta",
+        messages=[{"role": "user", "content": "Hello"}],
+        api_key="sk-or-test",
+        stream=True,
+        stream_options={"include_usage": True},
+        extra_body={"usage": {"include": True}},
+        client=client,
+    )
+
+
+def _create_openrouter_gateway_model(db_session, test_user):
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "OpenRouter Auto",
+            "provider_name": "openrouter",
+            "model_identifier": "openrouter/auto-beta",
+            "api_endpoint": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-key",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "openrouter/auto-beta",
+                    "provider_adapter": "preloop",
+                }
+            },
+            "is_default": True,
+        },
+        account_id=test_user.account_id,
+    )
+
+
+def _latest_usage_row(db_session, endpoint):
+    return (
+        db_session.query(ApiUsage)
+        .filter(ApiUsage.endpoint == endpoint)
+        .order_by(ApiUsage.timestamp.desc())
+        .first()
+    )
+
+
+def test_responses_stream_persists_openrouter_provider_cost(db_session, test_user):
+    """Streaming /responses via OpenRouter prices the row from usage.cost.
+
+    Regression for #219: all post-#208 prod rows (streaming /responses) stayed
+    unpriced because litellm's synthetic final usage chunk drops the cost
+    fields.
+    """
+    _create_openrouter_gateway_model(db_session, test_user)
+    service = OpenAIGatewayService(
+        db_session, ModelGatewayAuthContext(token="t", user=test_user)
+    )
+    stream = _real_litellm_openrouter_stream(dict(_OPENROUTER_STREAM_USAGE))
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=stream,
+    ):
+        events = list(
+            service.stream_response(
+                {"model": "openrouter/auto-beta", "input": "Hello", "stream": True}
+            )
+        )
+    assert any('"response.completed"' in event for event in events)
+
+    usage_row = _latest_usage_row(db_session, "/openai/v1/responses")
+    assert usage_row is not None
+    usage_details = (usage_row.meta_data or {}).get("usage_details") or {}
+    # Token detail must be intact...
+    assert usage_details.get("prompt_tokens") == 973
+    assert usage_details.get("prompt_tokens_details", {}).get("cached_tokens") == 100
+    # ...AND the provider-reported cost fields must survive persistence.
+    assert usage_details.get("cost") == pytest.approx(0.0000305)
+    assert usage_details.get("cost_details", {}).get(
+        "upstream_inference_cost"
+    ) == pytest.approx(0.00001946)
+    assert usage_row.cost_source == "provider"
+    assert usage_row.estimated_cost == pytest.approx(_OPENROUTER_EXPECTED_TOTAL)
+
+
+def test_chat_completions_stream_persists_openrouter_provider_cost(
+    db_session, test_user
+):
+    """Streaming /chat/completions shares the same recovery path."""
+    _create_openrouter_gateway_model(db_session, test_user)
+    service = OpenAIGatewayService(
+        db_session, ModelGatewayAuthContext(token="t", user=test_user)
+    )
+    stream = _real_litellm_openrouter_stream(dict(_OPENROUTER_STREAM_USAGE))
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=stream,
+    ):
+        events = list(
+            service.stream_chat_completion(
+                {
+                    "model": "openrouter/auto-beta",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "stream": True,
+                }
+            )
+        )
+    assert events  # stream produced output
+
+    usage_row = _latest_usage_row(db_session, "/openai/v1/chat/completions")
+    assert usage_row is not None
+    usage_details = (usage_row.meta_data or {}).get("usage_details") or {}
+    assert usage_details.get("cost") == pytest.approx(0.0000305)
+    assert usage_details.get("cost_details", {}).get(
+        "upstream_inference_cost"
+    ) == pytest.approx(0.00001946)
+    assert usage_row.cost_source == "provider"
+    assert usage_row.estimated_cost == pytest.approx(_OPENROUTER_EXPECTED_TOTAL)
+
+
+def test_provider_cost_fields_recovery_is_fail_open():
+    """Absent litellm internals must never break the stream accounting."""
+    assert OpenAIGatewayService._provider_cost_fields(iter([])) == {}
+    assert OpenAIGatewayService._provider_cost_fields(None) == {}
+    assert (
+        OpenAIGatewayService._provider_cost_fields(SimpleNamespace(chunks="nope")) == {}
+    )


### PR DESCRIPTION
Fixes #219 (follow-up to #208).

## Root cause: hypothesis (b) — litellm's streaming usage assembly drops the cost fields

Verified without touching prod, by driving litellm's **real** streaming pipeline (v1.81.13) over a mocked httpx transport with the raw OpenRouter final chunk per their usage-accounting docs (`usage.cost`, `usage.cost_details`):

- **The flag IS sent** on the wire: outbound body carries `"usage": {"include": true}` alongside `stream_options.include_usage` (rules out hypothesis (a)).
- **litellm never delivers the cost fields to its consumer** on streams:
  - mid-stream chunks have their `usage` stripped ("remove usage from chunk, only send on final chunk", `streaming_handler.py`), and the usage-bearing OpenRouter chunk (empty `choices`) is then discarded as empty;
  - the synthetic final usage chunk emitted for `stream_options.include_usage` is **rebuilt from token counts only** (`stream_chunk_builder` → `calculate_usage` constructs a fresh `Usage` with tokens + token details, no extras).
- The gateway-visible final usage in the repro is byte-for-byte the shape of the 716 unpriced prod rows: full token detail (`prompt_tokens_details.cached_tokens`, `completion_tokens_details.*`) and **no `cost`/`cost_details` keys**.
- Non-streaming responses preserve the cost fields fine (litellm's `Usage` keeps extra keys on direct construction) — which is why the ~6 historical priced rows were all non-streaming, and why #208's non-streaming/request-side verification passed while production (streaming Codex `/responses`) failed.

## Fix

litellm's `CustomStreamWrapper` retains every pre-strip chunk on `.chunks` (the list it feeds to `stream_chunk_builder`), including the raw OpenRouter usage with cost. Per the issue's suggested direction, the gateway now recovers the cost fields from there instead of patching litellm:

- `_prefetch_upstream_stream` returns a thin `_PrefetchedUpstreamStream` wrapper that keeps a handle (`.raw`) on the litellm stream object (previously an anonymous `chain` iterator hid it).
- New `OpenAIGatewayService._provider_cost_fields()` recovers `cost`/`cost_details` from the retained raw chunks after the stream is drained. Strictly fail-open: non-litellm streams (codex, passthrough) or changed litellm internals yield `{}` and accounting proceeds exactly as before.
- All three streaming paths (`/openai/v1/responses`, `/openai/v1/chat/completions`, `/anthropic/v1/messages`) merge the recovered fields into `final_usage_details` right after stream drain, so they land in `meta_data.usage_details` and `provider_reported_cost()` prices the row (`cost_source='provider'`, spend recorded).

Client-facing SSE payloads are unchanged; the recovery only feeds persistence/accounting.

## Tests (red → green)

- `test_responses_stream_persists_openrouter_provider_cost` / `test_chat_completions_stream_persists_openrouter_provider_cost`: end-to-end through the **real** litellm transcode (mocked transport, no network) into DB persistence — assert token detail intact **and** `usage_details.cost` + `cost_details.upstream_inference_cost` present, `cost_source='provider'`, `estimated_cost == cost + upstream_inference_cost`. Both fail on main with `cost=None` (and reproduce the exact "no pricing for model openrouter/auto-beta" unpriced admin alert).
- `test_provider_cost_fields_recovery_is_fail_open`: pins the fail-open contract.
- Full `test_openai_gateway.py` (73) plus 15 related gateway/pricing/usage suites (175) pass.

## Live verification

No dev-environment OpenRouter key exists (checked env, gateway container env, dev DB) so no live call was made, per the brief. Note the fix is required regardless of whether OpenRouter honors the flag on this path: even when cost IS returned, litellm demonstrably drops it before the gateway sees it.

## Post-deploy confirmation SQL (prod, read-only)

```sql
SELECT cost_source, count(*),
       count(*) FILTER (WHERE meta_data->'usage_details' ? 'cost') AS with_cost
FROM api_usage
WHERE action_type = 'model_gateway'
  AND provider_name = 'openrouter'
  AND timestamp > '<deploy timestamp>'
GROUP BY cost_source;
```

Expect new rows to show `cost_source='provider'` with `with_cost = count`.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Risk Level] Low**
> No security issues. Focused bug fix with a strict fail-open path, verification against the real litellm transcode via mocked transport, and end-to-end regression tests. The prior low-priority observability suggestion was addressed in a follow-up commit (guarded debug log for silent recovery failure).
>
> **Overview**
> Recovers OpenRouter usage-accounting `cost`/`cost_details` fields that litellm's streaming transcode drops, so streaming `/responses`, `/chat/completions`, and `/anthropic/v1/messages` rows are priced from the provider-reported cost instead of being silently unpriced. The gateway keeps a handle on the raw litellm stream and merges the recovered fields into persisted `usage_details` after drain, fail-open for non-litellm streams, without changing client-facing SSE payloads.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit e0bc6dca. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->