### PR TITLE
fix: stop OpenCode's 120s LLM timeout from being fatal and meter abandoned-response usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,13 @@ PRODUCT_TEAM_EMAIL="product@preloop.ai"
 # SKIP_EXECUTION_RECOVERY=false  # Set to true to skip recovering orphaned executions on startup
                                  # Useful for debugging startup issues when stuck executions cause problems
 
+# Agent Runtime Options
+# OPENCODE_LLM_TIMEOUT_SEC=600  # Whole-request LLM timeout for OpenCode agents
+                                # (seconds). Keep below the gateway proxy read
+                                # timeout (900s) so gateway-side timeouts still
+                                # surface as retryable HTTP errors instead of
+                                # fatal client aborts.
+
 # Model Gateway Cost Accounting
 # OPENROUTER_USAGE_ACCOUNTING=true  # Ask OpenRouter to include the request's actual
                                     # cost in the response usage payload (recorded as

--- a/backend/preloop/agents/failure_analysis.py
+++ b/backend/preloop/agents/failure_analysis.py
@@ -114,7 +114,11 @@ _TRANSIENT_NETWORK_RE = re.compile(
     r"|typeerror:\s*terminated"
     r"|fetch\s+(?:failed|terminated)"
     r"|network\s+error"
-    r"|(?:request|read|socket)\s+timed?\s*out"
+    # "operation timed out" is OpenCode's client-side LLM abort: its provider
+    # options.timeout fires AbortSignal.timeout and the CLI dies with
+    # `error="The operation timed out."` while the request was still
+    # completing upstream — the canonical recoverable shape.
+    r"|(?:request|read|socket|operation)\s+timed?\s*out"
     r"|timeout\s+(?:of\s+)?\d+\s*ms\s+exceeded)\b",
     re.IGNORECASE,
 )

--- a/backend/preloop/agents/opencode.py
+++ b/backend/preloop/agents/opencode.py
@@ -17,6 +17,30 @@ from .container import ContainerAgentExecutor
 logger = logging.getLogger(__name__)
 
 
+def _opencode_llm_timeout_ms() -> int:
+    """
+    Whole-request LLM timeout injected into OpenCode's provider options.
+
+    OpenCode aborts any in-flight LLM request once ``provider.<id>.options.
+    timeout`` (milliseconds) elapses — the value is wrapped in an
+    ``AbortSignal.timeout`` around every provider fetch
+    (packages/opencode/src/provider/provider.ts, present in v1.2.6 baked into
+    the sandbox image and in the ``opencode-ai@latest`` build the runtime
+    script installs). The previous hardcoded 120_000 ms sat far below the rest
+    of the stack — the gateway proxy readTimeout is 900 s and the MCP tool
+    timeout is 600 s — so real-but-slow upstream calls (30k+ token prompts
+    observed completing 20-35 s *after* OpenCode had already aborted at ~120 s)
+    became fatal "The operation timed out." mid-review failures while the
+    tokens were still billed upstream.
+
+    Aligned with the MCP tool timeout (600 s) and kept under the gateway
+    proxy's 900 s so gateway-side timeouts still surface as HTTP errors
+    (retryable) rather than client aborts. Override via
+    ``OPENCODE_LLM_TIMEOUT_SEC``.
+    """
+    return int(os.getenv("OPENCODE_LLM_TIMEOUT_SEC", "600")) * 1000
+
+
 def _opencode_provider_local_model_id(model: str, provider: str) -> str:
     """
     Return the model id used inside OpenCode's provider.models map.
@@ -625,6 +649,12 @@ exit $OPENCODE_EXIT_CODE
         #   npm   – AI SDK adapter package (e.g. "@ai-sdk/openai-compatible")
         #   options.baseURL – API endpoint
         #   models – map of model-id → {name}
+        # ``timeout`` is OpenCode's whole-request LLM abort (see
+        # _opencode_llm_timeout_ms); ``chunkTimeout`` is the SSE inter-chunk
+        # inactivity abort in opencode >= 1.18 (ignored by older builds) and
+        # gets the same budget so a long silent reasoning phase between
+        # chunks is not treated as a dead stream.
+        llm_timeout_ms = _opencode_llm_timeout_ms()
         if model_endpoint:
             if gateway_enabled and model_provider in ("google", "gemini"):
                 config["provider"] = {
@@ -633,8 +663,8 @@ exit $OPENCODE_EXIT_CODE
                         "options": {
                             "baseURL": model_endpoint,
                             "apiKey": "$OPENAI_API_KEY",
-                            "timeout": 120000,
-                            "chunkTimeout": 120000,
+                            "timeout": llm_timeout_ms,
+                            "chunkTimeout": llm_timeout_ms,
                         },
                         "models": {
                             model_local_id: {"name": model},
@@ -648,8 +678,8 @@ exit $OPENCODE_EXIT_CODE
                         "options": {
                             "baseURL": model_endpoint,
                             "apiKey": "$GOOGLE_API_KEY",
-                            "timeout": 120000,
-                            "chunkTimeout": 120000,
+                            "timeout": llm_timeout_ms,
+                            "chunkTimeout": llm_timeout_ms,
                         },
                         "models": {
                             model_local_id: {"name": model},
@@ -663,8 +693,8 @@ exit $OPENCODE_EXIT_CODE
                         "options": {
                             "baseURL": model_endpoint,
                             "apiKey": "$OPENAI_API_KEY",
-                            "timeout": 120000,
-                            "chunkTimeout": 120000,
+                            "timeout": llm_timeout_ms,
+                            "chunkTimeout": llm_timeout_ms,
                         },
                         "models": {
                             model_local_id: {"name": model},

--- a/backend/preloop/agents/opencode.py
+++ b/backend/preloop/agents/opencode.py
@@ -36,9 +36,20 @@ def _opencode_llm_timeout_ms() -> int:
     Aligned with the MCP tool timeout (600 s) and kept under the gateway
     proxy's 900 s so gateway-side timeouts still surface as HTTP errors
     (retryable) rather than client aborts. Override via
-    ``OPENCODE_LLM_TIMEOUT_SEC``.
+    ``OPENCODE_LLM_TIMEOUT_SEC``. A malformed override falls back to the
+    default rather than failing the whole run at config-build time.
     """
-    return int(os.getenv("OPENCODE_LLM_TIMEOUT_SEC", "600")) * 1000
+    raw = os.getenv("OPENCODE_LLM_TIMEOUT_SEC", "600")
+    try:
+        seconds = int(raw)
+        if seconds <= 0:
+            raise ValueError
+    except ValueError:
+        logging.getLogger(__name__).warning(
+            "Invalid OPENCODE_LLM_TIMEOUT_SEC=%r; using default 600s", raw
+        )
+        seconds = 600
+    return seconds * 1000
 
 
 def _opencode_provider_local_model_id(model: str, provider: str) -> str:

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -5736,6 +5736,11 @@ class OpenAIGatewayService:
 
         Never raises — it runs during response teardown.
         """
+        # Teardown can outlive the request scope: by the time an abandoned
+        # stream is closed the session may be closed and ``ai_model`` detached
+        # (even the log line below would raise DetachedInstanceError).
+        # Re-fetch by identity before touching any attribute.
+        ai_model = self._reattach_for_recording(ai_model)
         logger.warning(
             "Gateway stream abandoned before first chunk: "
             "endpoint=%s provider=%s model=%s",
@@ -5822,6 +5827,26 @@ class OpenAIGatewayService:
         wrapper rather than each site wrapping itself and one being forgotten.
         """
         try:
+            # A streaming disconnect runs this during response teardown, and
+            # the request scope may already have closed the session by then:
+            # every ORM instance the service holds (the AIModel, the auth
+            # user, the ApiKey) is detached with expired attributes, and the
+            # first attribute read raises DetachedInstanceError. Before this
+            # reattachment, that skipped the whole record — tokens billed by
+            # the provider were never metered (observed in staging as
+            # "Skipped gateway usage recording after DetachedInstanceError").
+            # The identity key survives detachment, so re-fetch by primary
+            # key; the session itself stays usable after close (a new
+            # transaction begins on next use).
+            ai_model = self._reattach_for_recording(ai_model)
+            auth_context = getattr(self, "auth_context", None)
+            if auth_context is not None:
+                user = self._reattach_for_recording(auth_context.user)
+                if user is not None and user is not auth_context.user:
+                    auth_context.user = user
+                api_key = self._reattach_for_recording(auth_context.api_key)
+                if api_key is not None and api_key is not auth_context.api_key:
+                    auth_context.api_key = api_key
             self._record_gateway_request_inner(
                 endpoint=endpoint,
                 method=method,
@@ -5841,6 +5866,36 @@ class OpenAIGatewayService:
             )
         except Exception as exc:
             self._rollback_activity_recording(exc, context="gateway usage recording")
+
+    def _reattach_for_recording(self, instance: Any) -> Any:
+        """Return an attached equivalent of a possibly-detached ORM instance.
+
+        Usage recording reads attributes off instances loaded earlier in the
+        request (AIModel, User, ApiKey). When it runs during response
+        teardown — a client disconnect, an abandoned stream — the request
+        session may already be closed, leaving those instances detached with
+        expired attributes; any attribute read then raises
+        DetachedInstanceError. The primary-key identity survives detachment,
+        so a detached instance is re-fetched by identity on ``self.db``.
+
+        Falls back to the original instance when nothing better exists (never
+        loaded / row since deleted); the caller's defensive except still
+        applies.
+        """
+        if instance is None:
+            return None
+        try:
+            state = inspect(instance)
+            if not state.detached:
+                return instance
+            identity = state.identity
+            if identity is not None:
+                refreshed = self.db.get(type(instance), identity)
+                if refreshed is not None:
+                    return refreshed
+        except SQLAlchemyError:  # pragma: no cover - defensive
+            pass
+        return instance
 
     def _record_gateway_request_inner(
         self,

--- a/backend/tests/agents/test_agent_opencode.py
+++ b/backend/tests/agents/test_agent_opencode.py
@@ -355,6 +355,19 @@ class TestOpenCodeBuildConfig:
         assert options["timeout"] == 750000
         assert options["chunkTimeout"] == 750000
 
+    def test_llm_request_timeout_invalid_override_falls_back(self):
+        """A malformed OPENCODE_LLM_TIMEOUT_SEC must not fail the run."""
+        agent = OpenCodeAgent({})
+        context = {"model_endpoint": "https://custom.api.com/v1"}
+        for bad in ("ninety", "", "-5", "0"):
+            with patch.dict(os.environ, {"OPENCODE_LLM_TIMEOUT_SEC": bad}):
+                config = agent._build_opencode_config(
+                    "model-1", "customllm", context, 600000
+                )
+            options = config["provider"]["customllm"]["options"]
+            assert options["timeout"] == 600000, bad
+            assert options["chunkTimeout"] == 600000, bad
+
     def test_gateway_endpoint_uses_preloop_provider(self):
         """Gateway-enabled config uses gateway provider and URL."""
         agent = OpenCodeAgent({})

--- a/backend/tests/agents/test_agent_opencode.py
+++ b/backend/tests/agents/test_agent_opencode.py
@@ -327,6 +327,34 @@ class TestOpenCodeBuildConfig:
         assert provider["options"]["apiKey"] == "$OPENAI_API_KEY"
         assert "model-1" in provider["models"]
 
+    def test_llm_request_timeout_aligned_with_gateway_stack(self):
+        """The provider LLM timeout must sit at 600s, not OpenCode-fatal 120s.
+
+        OpenCode aborts any LLM request after ``provider.options.timeout`` ms
+        ("The operation timed out."). 120s was below real upstream latency
+        (slow-but-successful gateway calls finished after the CLI had already
+        exited), so the timeout must align with the MCP tool timeout (600s)
+        and stay under the gateway proxy readTimeout (900s).
+        """
+        agent = OpenCodeAgent({})
+        context = {"model_endpoint": "https://custom.api.com/v1"}
+        config = agent._build_opencode_config("model-1", "customllm", context, 600000)
+        options = config["provider"]["customllm"]["options"]
+        assert options["timeout"] == 600000
+        assert options["chunkTimeout"] == 600000
+
+    def test_llm_request_timeout_env_override(self):
+        """OPENCODE_LLM_TIMEOUT_SEC overrides the 600s default."""
+        agent = OpenCodeAgent({})
+        context = {"model_endpoint": "https://custom.api.com/v1"}
+        with patch.dict(os.environ, {"OPENCODE_LLM_TIMEOUT_SEC": "750"}):
+            config = agent._build_opencode_config(
+                "model-1", "customllm", context, 600000
+            )
+        options = config["provider"]["customllm"]["options"]
+        assert options["timeout"] == 750000
+        assert options["chunkTimeout"] == 750000
+
     def test_gateway_endpoint_uses_preloop_provider(self):
         """Gateway-enabled config uses gateway provider and URL."""
         agent = OpenCodeAgent({})

--- a/backend/tests/agents/test_failure_analysis.py
+++ b/backend/tests/agents/test_failure_analysis.py
@@ -221,13 +221,11 @@ class TestTransience:
         lines, no HTTP status. The gateway later completed the same request
         upstream, so another attempt can plausibly succeed.
         """
-        logs = "\n".join(
-            [
-                "Reviewing diff...",
-                "timestamp=2026-08-10T14:03:22Z level=ERROR "
-                'message=process service=session error="The operation timed out."',
-            ]
+        error_line = (
+            "timestamp=2026-08-10T14:03:22Z level=ERROR "
+            'message=process service=session error="The operation timed out."'
         )
+        logs = "\n".join(["Reviewing diff...", error_line])
 
         analysis = analyze_agent_failure(logs)
 

--- a/backend/tests/agents/test_failure_analysis.py
+++ b/backend/tests/agents/test_failure_analysis.py
@@ -211,6 +211,44 @@ class TestTransience:
         assert analysis.transient is True
         assert "other side closed" in analysis.evidence
 
+    def test_opencode_operation_timed_out_is_transient(self):
+        """OpenCode's client-side LLM timeout abort must classify transient.
+
+        The staging incident shape (executions 5fe6ee91/ddd8123a/cca8dc29/
+        ffbdd25d): OpenCode's provider ``options.timeout`` fires
+        ``AbortSignal.timeout`` after ~120s, the CLI exits 1, and the only
+        stderr signal is its exact structured-log phrasing — no retry-loop
+        lines, no HTTP status. The gateway later completed the same request
+        upstream, so another attempt can plausibly succeed.
+        """
+        logs = "\n".join(
+            [
+                "Reviewing diff...",
+                "timestamp=2026-08-10T14:03:22Z level=ERROR "
+                'message=process service=session error="The operation timed out."',
+            ]
+        )
+
+        analysis = analyze_agent_failure(logs)
+
+        assert analysis.transient is True
+        assert "operation timed out" in analysis.evidence.lower()
+
+    def test_plain_operation_timed_out_wording_is_transient(self):
+        """The generic 'operation timed out' phrasing also classifies transient."""
+        logs = "\n".join(
+            [
+                "Attempt 1 failed: operation timed out",
+                "Attempt 2 failed: operation timed out",
+                "Giving up.",
+            ]
+        )
+
+        analysis = analyze_agent_failure(logs)
+
+        assert analysis.transient is True
+        assert analysis.retry_exhausted is True
+
     def test_generic_terminated_wording_is_not_transient(self):
         """Only undici's error shape may match — not any use of 'terminated'.
 

--- a/backend/tests/services/test_gateway_stream_abandonment.py
+++ b/backend/tests/services/test_gateway_stream_abandonment.py
@@ -193,6 +193,59 @@ def test_abandoned_gemini_stream_is_recorded(db_session, test_user):
     assert rows[0].error_class == ERROR_CLASS_STREAM_ABANDONED
 
 
+def test_abandoned_stream_records_usage_after_session_teardown_detached_orm(
+    db_session, test_user
+):
+    """A detached ORM graph at teardown time must not lose the usage row.
+
+    In production the client disconnect (e.g. OpenCode's 120s LLM abort)
+    tears down the FastAPI dependency scope before the stream observer's
+    abandonment accounting runs: the request session closes, its instances
+    are expired and detached, and the first attribute read inside the
+    recording path raises DetachedInstanceError. The gateway then logged
+    "Skipped gateway usage recording after DetachedInstanceError; returning
+    the upstream response unchanged" — and tokens billed by the provider were
+    never metered. Recording must survive detachment by re-fetching the
+    instances by identity.
+    """
+    ai_model = _create_gateway_model(db_session, test_user.account_id, "abandon-det")
+    ai_model_id = ai_model.id
+    service = _service(db_session, test_user)
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value=_upstream_chunks(),
+    ) as mock_completion:
+        stream = service.stream_response({"model": "abandon-det", "input": "Hello"})
+        assert mock_completion.called
+        # Simulate request-scope teardown racing the disconnect accounting:
+        # every instance the service holds (ai_model, auth user) becomes
+        # detached with expired attributes, exactly what Session.close() on
+        # the request session produces.
+        db_session.expire_all()
+        db_session.expunge_all()
+        stream.close()
+
+    rows = (
+        db_session.query(ApiUsage)
+        .filter(
+            ApiUsage.action_type == "model_gateway",
+            ApiUsage.ai_model_id == ai_model_id,
+        )
+        .order_by(ApiUsage.timestamp.asc())
+        .all()
+    )
+    assert len(rows) == 1, (
+        f"expected exactly one usage row despite detached ORM instances, "
+        f"got {len(rows)}"
+    )
+    assert rows[0].status_code == 499
+    assert rows[0].error_class == ERROR_CLASS_STREAM_ABANDONED
+    assert (rows[0].prompt_tokens or 0) > 0, (
+        "abandoned-request usage must still be estimated and metered"
+    )
+
+
 def test_fully_consumed_stream_records_one_success_row(db_session, test_user):
     """The happy path must stay a single 200 row with provider tokens.
 


### PR DESCRIPTION
## Problem

All 4 OpenCode reviewer failures in staging (5fe6ee91, ddd8123a, cca8dc29, ffbdd25d) show exactly 122-123s between the last successful gateway call and CLI exit 1, with stderr (captured since #218):

```
timestamp=... level=ERROR message=process ... error="The operation timed out."
```

In each case the gateway completed the request upstream 20-35s **after** the CLI had exited, then logged `Skipped gateway usage recording after DetachedInstanceError; returning the upstream response unchanged` — so the tokens were paid to OpenRouter and never metered. Slow calls are real, not pathological: the same run had 34s and 62s successful calls (flash-0731 via OpenRouter, ~30k+ token prompts).

## Root cause

Our generated `opencode.json` hardcodes `provider.<id>.options.timeout: 120000`. OpenCode wraps every provider fetch in `AbortSignal.timeout(options.timeout)` (`packages/opencode/src/provider/provider.ts`) — verified in **v1.2.6** (baked into `docker/sandbox-templates:opencode`) and **v1.18.16** (`opencode-ai@latest`, which the runtime script installs over it). When it fires, Bun reports `The operation timed out.` and the CLI exits 1.

## Fixes (one commit each)

1. **`agents/opencode.py`** — raise the whole-request LLM timeout to 600s (aligned with the MCP tool timeout; under the gateway proxy readTimeout of 900s so gateway failures still surface as retryable HTTP errors). `chunkTimeout` (SSE inter-chunk inactivity, opencode ≥ 1.18, ignored by 1.2.6) gets the same budget. Override via `OPENCODE_LLM_TIMEOUT_SEC`.
2. **`agents/failure_analysis.py`** — classify `operation timed out` (incl. OpenCode's exact `The operation timed out.` phrasing) as transient, so the retry verdict wired in #217 rescues these runs when side-effect-safe. Red/green.
3. **`services/openai_gateway.py`** — abandoned/aborted-stream usage recording now survives a detached ORM graph: `_reattach_for_recording` re-fetches AIModel/User/ApiKey by identity when request-scope teardown closed the session before accounting ran. Previously those rows were silently dropped. Red/green.

## Tests

- `test_agent_opencode.py`: provider options carry 600000ms (red on main: `assert 120000 == 600000`), plus env override.
- `test_failure_analysis.py`: OpenCode's exact stderr line and generic phrasing classify transient (both red on main); policy-termination/quota guards untouched.
- `test_gateway_stream_abandonment.py`: expire+expunge the whole session state between stream start and close → 0 rows on main, one estimated 499/`stream_abandoned` row with this fix.
- Full `backend/tests/agents/` (284) and all gateway suites green; the only local failures are pre-existing env issues in `test_openai_gateway_attribution_sessions.py`, identical with and without this change.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Risk Level] Low**
> No security impact; a bug fix plus config tuning with regression tests. The transient reclassification is bounded and side-effect-safe.
>
> **Overview**
> This PR fixes OpenCode reviewer runs that were failing on slow-but-successful LLM calls by raising the provider timeout from 120s to 600s, wiring OpenCode's "operation timed out" abort into the transient/retry classification, and making abandoned-stream usage recording survive a detached ORM graph at teardown so billed tokens are correctly metered. The previously-flagged env-var parse robustness LOW is fixed in the latest commits; the transient-regex breadth note remains awareness-only.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 3f4b9a57. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->