### PR TITLE
fix(flows): stop failing exit-0 runs on missing model-printed sentinel

### DIFF
--- a/backend/preloop/agents/codex.py
+++ b/backend/preloop/agents/codex.py
@@ -427,6 +427,10 @@ echo "PRELOOP_AGENT_EXEC_START"
 # Run codex in non-interactive mode with the prompt
 echo "{escaped_prompt}" | codex exec --skip-git-repo-check --model "{model}" --sandbox workspace-write --yolo
 CODEX_EXIT_CODE=$?
+# Wrapper-emitted completion marker: pairs with PRELOOP_AGENT_EXEC_START.
+# The orchestrator treats this marker with exit code 0 as success without
+# requiring any model-printed sentinel.
+echo "PRELOOP_AGENT_EXEC_END:$CODEX_EXIT_CODE"
 {post_exec_block}
 # Exit with codex's exit code
 exit $CODEX_EXIT_CODE

--- a/backend/preloop/agents/gemini.py
+++ b/backend/preloop/agents/gemini.py
@@ -507,6 +507,10 @@ echo ""
 echo "=================================================="
 echo "Gemini CLI exited with code: $GEMINI_EXIT_CODE"
 echo "=================================================="
+# Wrapper-emitted completion marker: pairs with PRELOOP_AGENT_EXEC_START.
+# The orchestrator treats this marker with exit code 0 as success without
+# requiring any model-printed sentinel.
+echo "PRELOOP_AGENT_EXEC_END:$GEMINI_EXIT_CODE"
 {post_exec_block}
 # Exit with gemini's exit code
 exit $GEMINI_EXIT_CODE

--- a/backend/preloop/agents/opencode.py
+++ b/backend/preloop/agents/opencode.py
@@ -566,6 +566,10 @@ echo ""
 echo "=================================================="
 echo "OpenCode CLI exited with code: $OPENCODE_EXIT_CODE"
 echo "=================================================="
+# Wrapper-emitted completion marker: pairs with PRELOOP_AGENT_EXEC_START.
+# The orchestrator treats this marker with exit code 0 as success without
+# requiring any model-printed sentinel.
+echo "PRELOOP_AGENT_EXEC_END:$OPENCODE_EXIT_CODE"
 {post_exec_block}
 # Exit with opencode's exit code
 exit $OPENCODE_EXIT_CODE

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -66,6 +66,14 @@ FLOW_SUCCESS_SENTINEL = "FLOW_EXECUTION_SUCCESS"
 # preventing false positives from the prompt echo that contains the sentinel
 # instruction text.
 AGENT_EXEC_START_MARKER = "PRELOOP_AGENT_EXEC_START"
+
+# Marker printed by the agent wrapper script immediately after the agent CLI
+# exits, suffixed with the CLI's exit code (e.g. "PRELOOP_AGENT_EXEC_END:0").
+# Emitted by the same wrapper code that prints AGENT_EXEC_START_MARKER, so it
+# does not depend on the model following instructions.  Wrapper-end with exit
+# code 0 is a first-class success signal: model output is never required for
+# success.
+AGENT_EXEC_END_MARKER = "PRELOOP_AGENT_EXEC_END"
 MCP_TOOL_LOOP_PATTERN_MAX_LENGTH = 3
 MCP_TOOL_LOOP_MIN_REPETITIONS = 3
 MCP_TOOL_LOOP_SINGLE_CALL_REPETITIONS = 4
@@ -100,6 +108,31 @@ def _exception_message(exc: BaseException) -> str:
     return str(exc) or exc.__class__.__name__
 
 
+def _result_artifact_verdict(artifact: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Interpret a result.json artifact's ``status`` as a success signal.
+
+    Returns ``"success"``, ``"failure"``, or ``None`` when the artifact is
+    absent or carries no recognizable status.  Capture-error wrappers
+    (``{"error": "result_artifact_fetch_failed", ...}``) have no ``status``
+    key and yield None — an infra fetch problem must not flip an otherwise
+    successful run.
+
+    Schema: preloop.eval.result/v1 uses ``pass | fail | error``; common
+    synonyms are accepted defensively.
+    """
+    if not isinstance(artifact, dict):
+        return None
+    status = artifact.get("status")
+    if not isinstance(status, str):
+        return None
+    normalized = status.strip().lower()
+    if normalized in ("pass", "passed", "success", "succeeded", "ok"):
+        return "success"
+    if normalized in ("fail", "failed", "failure", "error"):
+        return "failure"
+    return None
+
+
 class FlowExecutionOrchestrator:
     """Manages the end-to-end lifecycle of a single Flow invocation."""
 
@@ -130,6 +163,9 @@ class FlowExecutionOrchestrator:
         self._agent_exec_started = (
             False  # Set when AGENT_EXEC_START_MARKER seen in logs
         )
+        # Exit code parsed from the wrapper's AGENT_EXEC_END_MARKER line
+        # (None until the marker is seen in logs).
+        self._agent_exec_end_exit_code: Optional[int] = None
         self._user_messages: asyncio.Queue = asyncio.Queue()
 
         # Execution metrics tracked during execution
@@ -1699,9 +1735,34 @@ class FlowExecutionOrchestrator:
                         f"Agent exec start marker seen at log line #{log_count}"
                     )
 
+                # Detect the wrapper-emitted end marker with the CLI's exit
+                # code (e.g. "PRELOOP_AGENT_EXEC_END:0").  Printed by the
+                # wrapper script itself, so it cannot appear in prompt echo
+                # with a valid exit-code suffix and does not depend on model
+                # behavior.
+                stripped_line = log_line.strip()
+                if (
+                    self._agent_exec_started
+                    and self._agent_exec_end_exit_code is None
+                    and stripped_line.startswith(f"{AGENT_EXEC_END_MARKER}:")
+                ):
+                    suffix = stripped_line[len(AGENT_EXEC_END_MARKER) + 1 :]
+                    try:
+                        self._agent_exec_end_exit_code = int(suffix)
+                    except ValueError:
+                        logger.warning(
+                            f"[ExecEnd] Malformed end marker at line #{log_count}: "
+                            f"{stripped_line!r}"
+                        )
+                    else:
+                        logger.info(
+                            f"[ExecEnd] Agent exec end marker seen at line "
+                            f"#{log_count} with exit code "
+                            f"{self._agent_exec_end_exit_code}"
+                        )
+
                 # Detect success sentinel — but ONLY after the agent exec
                 # start marker has been seen (to ignore prompt echo).
-                stripped_line = log_line.strip()
                 if stripped_line == FLOW_SUCCESS_SENTINEL:
                     if not self._agent_exec_started:
                         logger.warning(
@@ -2307,41 +2368,89 @@ class FlowExecutionOrchestrator:
                         {"status": status.value, "exit_code": result.exit_code},
                     )
 
-                    # Sentinel-based status override:
-                    # If the container reports SUCCEEDED (exit code 0) but the
-                    # FLOW_EXECUTION_SUCCESS sentinel was NOT found in logs,
-                    # treat it as FAILED.  This catches agents (e.g. OpenCode)
-                    # that error out but still exit with code 0.
-                    # Guard: only apply the override when the agent-exec-start
-                    # marker was actually seen in logs.  If we never streamed
-                    # real logs (e.g. mocks, or the log stream failed before
-                    # any output), the sentinel's absence is not meaningful.
+                    # Structured result artifact (/workspace/result.json)
+                    # captured first-class from the workspace — the
+                    # eval/observe contract surface (no log scraping).
+                    # Captured BEFORE the status decision so it can act as
+                    # the authoritative success/failure signal (PR #231).
+                    result_artifact = await self._capture_result_artifact(
+                        agent_executor, session_reference
+                    )
+
+                    # Success decision, in order of authority:
+                    # 1. result.json artifact status (pass|fail|error) — the
+                    #    explicit contract surface; a failure status fails
+                    #    the run even on exit code 0.
+                    # 2. Container exit code (result.status from the
+                    #    executor, which already folds in log-based critical
+                    #    error detection).
+                    # 3. The model-printed FLOW_EXECUTION_SUCCESS sentinel is
+                    #    a LEGACY signal only: its absence alone never fails
+                    #    an exit-0 run (models routinely skip printing it,
+                    #    and some prompts never contain the instruction —
+                    #    execution ff1294e1).  The wrapper-emitted
+                    #    PRELOOP_AGENT_EXEC_END:<code> marker confirms clean
+                    #    CLI completion without requiring model output.
                     final_status = result.status.value
                     error_message = result.error_message
 
+                    artifact_verdict = _result_artifact_verdict(result_artifact)
                     if (
-                        result.status == AgentStatus.SUCCEEDED
-                        and self._agent_exec_started
-                        and not self._success_sentinel_seen.is_set()
+                        artifact_verdict == "failure"
+                        and result.status == AgentStatus.SUCCEEDED
                     ):
+                        artifact_status = (result_artifact or {}).get("status")
                         logger.warning(
-                            f"Agent exited with SUCCEEDED status (exit_code={result.exit_code}) "
-                            f"but success sentinel was NOT found in logs. "
+                            f"Agent exited with SUCCEEDED status "
+                            f"(exit_code={result.exit_code}) but result.json "
+                            f"reports status={artifact_status!r}. "
                             f"Overriding status to FAILED."
                         )
                         self.execution_logger.log_milestone(
-                            "sentinel_missing_override",
+                            "result_artifact_failure_override",
                             {
                                 "original_status": result.status.value,
+                                "artifact_status": artifact_status,
                                 "exit_code": result.exit_code,
                             },
                         )
                         final_status = "FAILED"
-                        error_message = (
-                            result.error_message
-                            or "Agent exited with code 0 but did not produce "
-                            "the success sentinel — likely encountered an error."
+                        error_message = result.error_message or (
+                            f"Result artifact reported status "
+                            f"{artifact_status!r} despite exit code 0."
                         )
+                    elif (
+                        result.status == AgentStatus.SUCCEEDED
+                        and self._agent_exec_started
+                        and not self._success_sentinel_seen.is_set()
+                    ):
+                        if self._agent_exec_end_exit_code == 0:
+                            logger.info(
+                                "Success sentinel not printed by the model, "
+                                "but the wrapper end marker confirmed clean "
+                                "CLI exit (code 0) — treating as SUCCEEDED."
+                            )
+                            self.execution_logger.log_milestone(
+                                "agent_exec_end_confirmed_success",
+                                {"exit_code": result.exit_code},
+                            )
+                        else:
+                            # Legacy-only signal missing: warn, do not fail.
+                            logger.warning(
+                                f"Agent exited with SUCCEEDED status "
+                                f"(exit_code={result.exit_code}) but neither "
+                                f"the success sentinel nor the wrapper end "
+                                f"marker was seen in logs. Keeping SUCCEEDED "
+                                f"(sentinel is a legacy signal; its absence "
+                                f"alone is not a failure)."
+                            )
+                            self.execution_logger.log_milestone(
+                                "sentinel_missing_warning",
+                                {
+                                    "original_status": result.status.value,
+                                    "exit_code": result.exit_code,
+                                },
+                            )
 
                     return {
                         "status": final_status,
@@ -2349,12 +2458,7 @@ class FlowExecutionOrchestrator:
                         "error_message": error_message,
                         "actions_taken": self.execution_logger.get_actions_taken(),
                         "mcp_usage_logs": self.execution_logger.get_mcp_usage_logs(),
-                        # Structured result artifact (/workspace/result.json)
-                        # captured first-class from the workspace — the
-                        # eval/observe contract surface (no log scraping).
-                        "result": await self._capture_result_artifact(
-                            agent_executor, session_reference
-                        ),
+                        "result": result_artifact,
                         "exit_code": result.exit_code,
                         # First-pass failure classification made against the
                         # FULL container logs. error_message keeps only the
@@ -2368,21 +2472,26 @@ class FlowExecutionOrchestrator:
                         ),
                     }
 
-                # Check if the success sentinel was seen in logs while
-                # the container is still running (post-exec commands).
-                # The sentinel is only armed after AGENT_EXEC_START_MARKER is
-                # seen, so prompt echoes cannot trigger it.
-                if self._success_sentinel_seen.is_set():
+                # Check if a completion signal was seen in logs while the
+                # container is still running (post-exec commands): either the
+                # legacy model-printed sentinel or the wrapper-emitted end
+                # marker with exit code 0.  Both are only armed after
+                # AGENT_EXEC_START_MARKER, so prompt echoes cannot trigger
+                # them.
+                if (
+                    self._success_sentinel_seen.is_set()
+                    or self._agent_exec_end_exit_code == 0
+                ):
                     if sentinel_seen_at is None:
                         sentinel_seen_at = elapsed
                         logger.info(
-                            f"Success sentinel seen at {elapsed}s, "
+                            f"Completion signal seen at {elapsed}s, "
                             f"allowing {post_sentinel_grace}s grace period"
                         )
                     elif elapsed - sentinel_seen_at >= post_sentinel_grace:
                         logger.info(
                             f"Grace period expired ({post_sentinel_grace}s) "
-                            f"after success sentinel — treating as SUCCEEDED"
+                            f"after completion signal — treating as SUCCEEDED"
                         )
                         self.execution_logger.log_milestone(
                             "sentinel_grace_period_expired",

--- a/backend/tests/test_flow_orchestrator.py
+++ b/backend/tests/test_flow_orchestrator.py
@@ -1150,6 +1150,216 @@ class TestFlowExecutionOrchestrator:
             )
             assert persisted.result == artifact
 
+    @staticmethod
+    def _make_streaming_executor(
+        log_lines,
+        *,
+        exit_code=0,
+        result_status=AgentStatus.SUCCEEDED,
+        error_message=None,
+    ):
+        """Build a mock executor that streams real log lines before finishing.
+
+        get_status returns RUNNING on the first poll so the orchestrator's
+        monitor loop yields to the log-streaming task (via the patched
+        asyncio.sleep) and the exec-start/end markers are actually consumed
+        before the terminal status decision is made.
+        """
+        mock_executor = AsyncMock()
+        mock_executor.start = AsyncMock(return_value="session-123")
+
+        # First poll returns RUNNING (so the monitor loop sleeps and yields
+        # to the log-streaming task); every later poll returns the terminal
+        # status.
+        statuses = [AgentStatus.RUNNING]
+        mock_executor.get_status = AsyncMock(
+            side_effect=lambda ref: (statuses.pop(0) if statuses else result_status)
+        )
+        mock_executor.get_result = AsyncMock(
+            return_value=AgentExecutionResult(
+                status=result_status,
+                session_reference="session-123",
+                output_summary="done",
+                error_message=error_message,
+                exit_code=exit_code,
+            )
+        )
+        mock_executor.get_result_artifact = AsyncMock(return_value=None)
+        mock_executor.stop = AsyncMock()
+        mock_executor.cleanup = AsyncMock()
+
+        async def stream_logs(session_ref):
+            for line in log_lines:
+                yield line
+
+        mock_executor.stream_logs = stream_logs
+        return mock_executor
+
+    async def _run_with_streaming_executor(
+        self, db_session, test_flow, mock_nats_client, event_data, mock_executor
+    ):
+        """Run the orchestrator with a yielding fake sleep so the background
+        log-streaming task processes all lines between status polls."""
+        import asyncio as _asyncio
+
+        real_sleep = _asyncio.sleep
+
+        async def yielding_sleep(seconds):
+            await real_sleep(0)
+
+        with (
+            patch(
+                "preloop.services.flow_orchestrator.create_agent_executor",
+                return_value=mock_executor,
+            ),
+            patch(
+                "preloop.services.flow_orchestrator.asyncio.sleep",
+                side_effect=yielding_sleep,
+            ),
+        ):
+            orchestrator = FlowExecutionOrchestrator(
+                db=db_session,
+                flow_id=test_flow.id,
+                trigger_event_data=event_data,
+                nats_client=mock_nats_client,
+            )
+            await orchestrator.run()
+            return orchestrator
+
+    @pytest.mark.asyncio
+    async def test_exit_zero_without_sentinel_succeeds(
+        self,
+        db_session: Session,
+        test_flow: Flow,
+        mock_nats_client,
+        event_data,
+    ):
+        """Exit 0 with NO model-printed sentinel must succeed.
+
+        Regression for execution ff1294e1-8e26-435d-b37f-e3a85a44b310: the
+        PR-reviewer agent completed all work, the CLI exited 0, the runner
+        reported SUCCEEDED — and the platform flipped it to FAILED solely
+        because FLOW_EXECUTION_SUCCESS was never printed.  The sentinel is a
+        legacy signal; its absence alone is a warning, not a failure.
+        """
+        mock_executor = self._make_streaming_executor(
+            [
+                "PRELOOP_AGENT_EXEC_START",
+                "review approved and posted",
+                "OpenCode CLI exited with code: 0",
+                # Note: deliberately NO PRELOOP_AGENT_EXEC_END line either —
+                # the staging wrapper predates the end marker.
+            ],
+            exit_code=0,
+        )
+
+        orchestrator = await self._run_with_streaming_executor(
+            db_session, test_flow, mock_nats_client, event_data, mock_executor
+        )
+
+        assert orchestrator._agent_exec_started is True
+        assert orchestrator._success_sentinel_seen.is_set() is False
+        assert orchestrator.execution_log.status == "SUCCEEDED"
+
+    @pytest.mark.asyncio
+    async def test_exit_zero_with_wrapper_end_marker_succeeds(
+        self,
+        db_session: Session,
+        test_flow: Flow,
+        mock_nats_client,
+        event_data,
+    ):
+        """Wrapper-emitted PRELOOP_AGENT_EXEC_END:0 + exit 0 is success,
+        with no model-printed sentinel required."""
+        mock_executor = self._make_streaming_executor(
+            [
+                "PRELOOP_AGENT_EXEC_START",
+                "agent output without any sentinel",
+                "PRELOOP_AGENT_EXEC_END:0",
+            ],
+            exit_code=0,
+        )
+
+        orchestrator = await self._run_with_streaming_executor(
+            db_session, test_flow, mock_nats_client, event_data, mock_executor
+        )
+
+        assert orchestrator._agent_exec_end_exit_code == 0
+        assert orchestrator.execution_log.status == "SUCCEEDED"
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_fails(
+        self,
+        db_session: Session,
+        test_flow: Flow,
+        mock_nats_client,
+        event_data,
+    ):
+        """A non-zero CLI exit still fails the run — leniency about the
+        missing sentinel must not weaken real failure detection."""
+        mock_executor = self._make_streaming_executor(
+            [
+                "PRELOOP_AGENT_EXEC_START",
+                "OpenCode CLI exited with code: 2",
+                "PRELOOP_AGENT_EXEC_END:2",
+            ],
+            exit_code=2,
+            result_status=AgentStatus.FAILED,
+            error_message="Agent execution failed with exit code 2",
+        )
+
+        orchestrator = await self._run_with_streaming_executor(
+            db_session, test_flow, mock_nats_client, event_data, mock_executor
+        )
+
+        assert orchestrator._agent_exec_end_exit_code == 2
+        assert orchestrator.execution_log.status == "FAILED"
+
+    @pytest.mark.asyncio
+    async def test_result_artifact_failure_overrides_exit_zero(
+        self,
+        db_session: Session,
+        test_flow: Flow,
+        mock_nats_client,
+        event_data,
+    ):
+        """result.json with a failure status fails the run even on exit 0.
+
+        The artifact (PR #231) is the explicit contract surface and outranks
+        both the exit code and any log sentinel.
+        """
+        from preloop.models.models.flow_execution import FlowExecution
+
+        artifact = {
+            "schema": "preloop.eval.result/v1",
+            "status": "fail",
+            "summary": "2 of 5 checks failed",
+        }
+        mock_executor = self._make_streaming_executor(
+            [
+                "PRELOOP_AGENT_EXEC_START",
+                "eval run complete",
+                "PRELOOP_AGENT_EXEC_END:0",
+            ],
+            exit_code=0,
+        )
+        mock_executor.get_result_artifact = AsyncMock(return_value=artifact)
+
+        orchestrator = await self._run_with_streaming_executor(
+            db_session, test_flow, mock_nats_client, event_data, mock_executor
+        )
+
+        assert orchestrator.execution_log.status == "FAILED"
+        assert "fail" in (orchestrator.execution_log.error_message or "")
+
+        # The artifact itself must still be persisted alongside the failure.
+        persisted = (
+            db_session.query(FlowExecution)
+            .filter(FlowExecution.id == orchestrator.execution_log.id)
+            .one()
+        )
+        assert persisted.result == artifact
+
     @pytest.mark.asyncio
     async def test_user_stop_command(
         self,


### PR DESCRIPTION
## Problem

Staging execution `ff1294e1-8e26-435d-b37f-e3a85a44b310` (internal id): the PR-reviewer agent completed all work (review approved and posted), the harness logged `OpenCode CLI exited with code: 0`, the runner emitted `agent_status SUCCEEDED` — and the platform then marked the execution FAILED with *"Agent exited with code 0 but did not produce the success sentinel"*.

The contract was one-sided: the wrapper scripts emit `PRELOOP_AGENT_EXEC_START` but no end marker, and success depended on the **model** printing `FLOW_EXECUTION_SUCCESS` — a signal models routinely skip, and which the resolved prompt in this run never even contained.

## Fix

Success decision in `_monitor_agent_execution` is now, in order of authority:

1. **result.json artifact** (`preloop.eval.result/v1`, first-class capture from #231): a `fail`/`error` status fails the run even on exit code 0 (`result_artifact_failure_override` milestone). Capture-error wrappers (`{"error": ...}`) carry no `status` and cannot flip a run.
2. **Container exit code** — unchanged, including the executor's log-based critical-error detection.
3. **Wrapper-emitted `PRELOOP_AGENT_EXEC_END:<exit_code>`** (new): printed by the same wrapper code that prints `PRELOOP_AGENT_EXEC_START`, right after the CLI exits (opencode/codex/gemini). END + exit 0 confirms clean completion — model output is never required for success. The model-printed sentinel is demoted to a legacy fallback: when it is the only signal missing, we log `sentinel_missing_warning` and keep SUCCEEDED.

Also: the post-completion grace-period path (container lingering on git push / PR creation) now arms on wrapper END:0 as well, not just the sentinel. `aider`/`openhands` are untouched — they never emitted EXEC_START, so the old override never applied to them (`_agent_exec_started` guard preserved).

Prior related work checked to avoid regressions: #212-class gemini exit-0 mitigations (helper alias pinning kept intact) and #231 artifact capture (now honored as the top-priority signal).

## Tests

- `test_exit_zero_without_sentinel_succeeds` — regression for ff1294e1 (exec start seen, no sentinel, no END marker → SUCCEEDED with warning)
- `test_exit_zero_with_wrapper_end_marker_succeeds` — END:0 → SUCCEEDED
- `test_nonzero_exit_fails` — leniency does not weaken real failure detection
- `test_result_artifact_failure_overrides_exit_zero` — artifact `status: fail` fails the run on exit 0 and is still persisted

Tests stream real log lines through the background log-streaming task (async generator + yielding fake sleep) so the markers are consumed before the status decision.

Validation: ruff check/format clean; local test DB (alembic upgrade head) — `test_flow_orchestrator.py` + `tests/agents` 329 passed / 5 skipped; matrix, retry, commit-status and flows endpoint suites 80 passed.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> The change is a well-scoped, well-tested reliability fix that removes a false-failure path without weakening real failure detection (executor critical-error detection and the artifact override are preserved). No security impact.
>
> **Overview**
> Demotes the model-printed `FLOW_EXECUTION_SUCCESS` sentinel from an exit-0 failure condition to a legacy fallback, adding a wrapper-emitted `PRELOOP_AGENT_EXEC_END:<code>` marker and honoring the result.json artifact as the authoritative signal. One medium finding: the artifact failure override is not applied on the grace-period/completion-signal path.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 5053651e. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->