### PR TITLE
feat(flows): schedules UI for flow schedule triggers

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2469,6 +2469,58 @@ export async function deleteFlow(flowId: string) {
   }
 }
 
+export interface SchedulePreview {
+  type: string;
+  description: string;
+  timezone: string;
+  next_run_times: string[];
+}
+
+/**
+ * Preview a flow schedule trigger configuration.
+ *
+ * Returns a human-readable description and the next few run times.
+ * Invalid configurations (bad cron, below the minimum interval, unknown
+ * timezone) are rejected by the backend with a 422; the validation
+ * message is surfaced as the thrown Error's message so callers can show
+ * it inline.
+ */
+export async function previewFlowSchedule(
+  scheduleConfig: unknown
+): Promise<SchedulePreview> {
+  const response = await fetchWithAuth('/api/v1/flows/schedule/preview', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ schedule_config: scheduleConfig }),
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(extractValidationMessage(errorData));
+  }
+  return response.json();
+}
+
+/**
+ * Extract a readable message from a FastAPI error body.
+ *
+ * 422 validation errors carry `detail` as a list of {loc, msg, ...};
+ * other errors carry `detail` as a string.
+ */
+function extractValidationMessage(errorData: any): string {
+  const detail = errorData?.detail;
+  if (typeof detail === 'string') {
+    return detail;
+  }
+  if (Array.isArray(detail) && detail.length > 0) {
+    return detail
+      .map((item: any) =>
+        String(item?.msg || 'Invalid value').replace(/^Value error,\s*/, '')
+      )
+      .join('; ');
+  }
+  return 'Invalid schedule configuration';
+}
+
 export async function getFlowPresets(): Promise<any[]> {
   const response = await fetchWithAuth('/api/v1/flows/presets');
   if (!response.ok) {

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -16,6 +16,8 @@ import { getTrackerEventOptions } from '../constants/tracker-event-types';
 import consoleStyles from '../styles/console-styles.css?inline';
 import './add-tracker-modal';
 import './add-ai-model-modal';
+import './schedule-config-editor';
+import { defaultScheduleConfig } from './schedule-config-editor';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
@@ -122,7 +124,7 @@ export class PreloopFlowForm extends LitElement {
   flow: any = {};
 
   @state()
-  private triggerType: 'webhook' | 'tracker' = 'webhook';
+  private triggerType: 'webhook' | 'tracker' | 'schedule' = 'webhook';
 
   @state()
   private flowExecutionPath: 'ephemeral' | 'persistent' = 'ephemeral';
@@ -355,6 +357,8 @@ export class PreloopFlowForm extends LitElement {
 
     if (source === 'webhook') {
       this.triggerType = 'webhook';
+    } else if (source === 'schedule') {
+      this.triggerType = 'schedule';
     } else if (source) {
       this.triggerType = 'tracker';
     } else if (this.flow?.webhook_config) {
@@ -426,13 +430,21 @@ export class PreloopFlowForm extends LitElement {
     this.requestUpdate();
   }
 
-  private handleTriggerTypeChange(newType: 'webhook' | 'tracker') {
+  private handleTriggerTypeChange(newType: 'webhook' | 'tracker' | 'schedule') {
     this.triggerType = newType;
     if (newType === 'webhook') {
       this.flow.trigger_event_source = 'webhook';
       this.flow.trigger_event_types = ['webhook'];
       this.flow.trigger_organization_id = undefined;
       this.flow.trigger_project_ids = undefined;
+    } else if (newType === 'schedule') {
+      this.flow.trigger_event_source = 'schedule';
+      this.flow.trigger_event_types = ['schedule'];
+      this.flow.trigger_organization_id = undefined;
+      this.flow.trigger_project_ids = undefined;
+      if (!this.flow.schedule_config) {
+        this.flow.schedule_config = defaultScheduleConfig();
+      }
     } else {
       this.flow.trigger_event_source = undefined;
       this.flow.trigger_event_types = undefined;
@@ -581,6 +593,10 @@ export class PreloopFlowForm extends LitElement {
         trigger_event_types: this.flow.trigger_event_types || ['webhook'],
         trigger_organization_id: this.flow.trigger_organization_id || undefined,
         trigger_project_ids: this.flow.trigger_project_ids || undefined,
+        schedule_config:
+          this.triggerType === 'schedule'
+            ? this.flow.schedule_config || defaultScheduleConfig()
+            : undefined,
         git_clone_config: this.flow.git_clone_config || { enabled: false },
         max_iterations: this.flow.max_iterations || undefined,
         max_budget: this.flow.max_budget || undefined,
@@ -927,6 +943,7 @@ export class PreloopFlowForm extends LitElement {
             >
               <sl-radio value="webhook">Webhook</sl-radio>
               <sl-radio value="tracker">Tracker Event</sl-radio>
+              <sl-radio value="schedule">Schedule</sl-radio>
             </sl-radio-group>
           </div>
 
@@ -943,97 +960,114 @@ export class PreloopFlowForm extends LitElement {
                     </p>
                   </div>
                 `
-              : html`
-                  <div class="form-grid">
-                    <div
-                      style="display: flex; flex-direction: column; gap: var(--sl-spacing-2x-small);"
-                    >
-                      <sl-select
-                        label="Tracker"
-                        placeholder="Select tracking source"
-                        .value=${this.flow.trigger_event_source || ''}
-                        @sl-change=${this.handleTrackerChange}
-                        style="margin-bottom: 0;"
+              : this.triggerType === 'schedule'
+                ? html`
+                    <div>
+                      <p
+                        style="color: var(--sl-color-neutral-600); margin-bottom: var(--sl-spacing-medium);"
                       >
-                        ${this.trackers.map(
-                          (t) =>
-                            html`<sl-option .value=${t.id}
-                              >${t.name} (${t.tracker_type})</sl-option
+                        This flow runs automatically on the schedule below.
+                        Pausing the flow suspends the schedule.
+                      </p>
+                      <schedule-config-editor
+                        .value=${this.flow.schedule_config}
+                        @schedule-change=${(e: CustomEvent) => {
+                          this.flow.schedule_config = e.detail.value;
+                        }}
+                      ></schedule-config-editor>
+                    </div>
+                  `
+                : html`
+                    <div class="form-grid">
+                      <div
+                        style="display: flex; flex-direction: column; gap: var(--sl-spacing-2x-small);"
+                      >
+                        <sl-select
+                          label="Tracker"
+                          placeholder="Select tracking source"
+                          .value=${this.flow.trigger_event_source || ''}
+                          @sl-change=${this.handleTrackerChange}
+                          style="margin-bottom: 0;"
+                        >
+                          ${this.trackers.map(
+                            (t) =>
+                              html`<sl-option .value=${t.id}
+                                >${t.name} (${t.tracker_type})</sl-option
+                              >`
+                          )}
+                        </sl-select>
+                        <sl-button
+                          size="small"
+                          variant="text"
+                          @click=${this.openAddTrackerDialog}
+                          style="align-self: flex-start; margin-top: -0.25rem; height: auto; padding: 0;"
+                        >
+                          <sl-icon slot="prefix" name="plus-lg"></sl-icon> Add
+                          New Tracker
+                        </sl-button>
+                      </div>
+
+                      <sl-select
+                        label="Organization"
+                        placeholder="Select organization"
+                        .value=${this.flow.trigger_organization_id || ''}
+                        @sl-change=${this.handleOrganizationChange}
+                        ?disabled=${
+                          this.isPollingOrganizations ||
+                          !this.flow.trigger_event_source
+                        }
+                      >
+                        ${this.organizations.map(
+                          (org) =>
+                            html`<sl-option .value=${org.id}
+                              >${org.name}</sl-option
                             >`
                         )}
                       </sl-select>
-                      <sl-button
-                        size="small"
-                        variant="text"
-                        @click=${this.openAddTrackerDialog}
-                        style="align-self: flex-start; margin-top: -0.25rem; height: auto; padding: 0;"
+
+                      <sl-select
+                        label="Projects (Optional)"
+                        placeholder="All projects"
+                        multiple
+                        clearable
+                        .value=${this.flow.trigger_project_ids || []}
+                        @sl-change=${(e: any) => {
+                          this.flow.trigger_project_ids = e.target.value;
+                        }}
+                        ?disabled=${!this.flow.trigger_organization_id}
                       >
-                        <sl-icon slot="prefix" name="plus-lg"></sl-icon> Add New
-                        Tracker
-                      </sl-button>
-                    </div>
+                        ${this.projects
+                          .filter(
+                            (p) =>
+                              p.organization_id ===
+                              this.flow.trigger_organization_id
+                          )
+                          .map(
+                            (p) =>
+                              html`<sl-option .value=${p.id}
+                                >${p.name || p.identifier || p.key}</sl-option
+                              >`
+                          )}
+                      </sl-select>
 
-                    <sl-select
-                      label="Organization"
-                      placeholder="Select organization"
-                      .value=${this.flow.trigger_organization_id || ''}
-                      @sl-change=${this.handleOrganizationChange}
-                      ?disabled=${
-                        this.isPollingOrganizations ||
-                        !this.flow.trigger_event_source
-                      }
-                    >
-                      ${this.organizations.map(
-                        (org) =>
-                          html`<sl-option .value=${org.id}
-                            >${org.name}</sl-option
-                          >`
-                      )}
-                    </sl-select>
-
-                    <sl-select
-                      label="Projects (Optional)"
-                      placeholder="All projects"
-                      multiple
-                      clearable
-                      .value=${this.flow.trigger_project_ids || []}
-                      @sl-change=${(e: any) => {
-                        this.flow.trigger_project_ids = e.target.value;
-                      }}
-                      ?disabled=${!this.flow.trigger_organization_id}
-                    >
-                      ${this.projects
-                        .filter(
-                          (p) =>
-                            p.organization_id ===
-                            this.flow.trigger_organization_id
-                        )
-                        .map(
-                          (p) =>
-                            html`<sl-option .value=${p.id}
-                              >${p.name || p.identifier || p.key}</sl-option
+                      <sl-select
+                        label="Events"
+                        placeholder="Select trigger event kinds"
+                        multiple
+                        .value=${this.flow.trigger_event_types || []}
+                        @sl-change=${(e: any) => {
+                          this.flow.trigger_event_types = e.target.value;
+                        }}
+                      >
+                        ${this.getEventOptions().map(
+                          (ev) =>
+                            html`<sl-option .value=${ev.value}
+                              >${ev.name}</sl-option
                             >`
                         )}
-                    </sl-select>
-
-                    <sl-select
-                      label="Events"
-                      placeholder="Select trigger event kinds"
-                      multiple
-                      .value=${this.flow.trigger_event_types || []}
-                      @sl-change=${(e: any) => {
-                        this.flow.trigger_event_types = e.target.value;
-                      }}
-                    >
-                      ${this.getEventOptions().map(
-                        (ev) =>
-                          html`<sl-option .value=${ev.value}
-                            >${ev.name}</sl-option
-                          >`
-                      )}
-                    </sl-select>
-                  </div>
-                `
+                      </sl-select>
+                    </div>
+                  `
           }
         </sl-card>
 

--- a/frontend/src/components/schedule-config-editor.test.ts
+++ b/frontend/src/components/schedule-config-editor.test.ts
@@ -1,0 +1,211 @@
+import { html, fixture, expect, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
+
+import './schedule-config-editor.ts';
+import type {
+  ScheduleConfigEditor,
+  ScheduleConfig,
+} from './schedule-config-editor';
+import { browserTimezone } from './schedule-config-editor';
+import { invalidateApiCaches } from '../api';
+
+describe('ScheduleConfigEditor', () => {
+  let fetchStub: sinon.SinonStub;
+
+  function stubPreview(
+    handler: (config: any) => { status: number; body: unknown }
+  ) {
+    return sinon
+      .stub(window, 'fetch')
+      .callsFake(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/api/v1/flows/schedule/preview')) {
+          const payload = JSON.parse(String(init?.body || '{}'));
+          const { status, body } = handler(payload.schedule_config);
+          return new Response(JSON.stringify(body), {
+            status,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({ detail: `Unhandled: ${url}` }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+  }
+
+  function okPreview(config: any) {
+    return {
+      status: 200,
+      body: {
+        type: config.type,
+        description: `Preview of ${config.type}`,
+        timezone: config.timezone,
+        next_run_times: [
+          '2026-08-17T09:00:00+00:00',
+          '2026-08-18T09:00:00+00:00',
+          '2026-08-19T09:00:00+00:00',
+        ],
+      },
+    };
+  }
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+  });
+
+  afterEach(() => {
+    fetchStub?.restore();
+    localStorage.clear();
+    invalidateApiCaches();
+  });
+
+  it('defaults to a daily schedule in the browser timezone', async () => {
+    fetchStub = stubPreview(okPreview);
+    const element = (await fixture(
+      html`<schedule-config-editor></schedule-config-editor>`
+    )) as ScheduleConfigEditor;
+
+    expect(element.value).to.deep.equal({
+      type: 'daily',
+      at: '09:00',
+      timezone: browserTimezone(),
+    });
+  });
+
+  it('shows the next run times from the backend preview endpoint', async () => {
+    fetchStub = stubPreview(okPreview);
+    const element = (await fixture(
+      html`<schedule-config-editor></schedule-config-editor>`
+    )) as ScheduleConfigEditor;
+
+    await waitUntil(
+      () =>
+        element.shadowRoot?.querySelector('[data-testid="schedule-preview"]'),
+      'preview never rendered',
+      { timeout: 4000 }
+    );
+
+    const preview = element.shadowRoot?.querySelector(
+      '[data-testid="schedule-preview"]'
+    );
+    expect(preview?.textContent).to.contain('Preview of daily');
+    const runs = preview?.querySelectorAll('li');
+    expect(runs?.length).to.equal(3);
+  });
+
+  it('emits an interval config when switching mode', async () => {
+    fetchStub = stubPreview(okPreview);
+    const changes: ScheduleConfig[] = [];
+    const element = (await fixture(
+      html`<schedule-config-editor
+        @schedule-change=${(e: CustomEvent) => changes.push(e.detail.value)}
+      ></schedule-config-editor>`
+    )) as ScheduleConfigEditor;
+
+    const radioGroup = element.shadowRoot?.querySelector('sl-radio-group');
+    expect(radioGroup).to.exist;
+    (radioGroup as any).value = 'interval';
+    radioGroup?.dispatchEvent(new CustomEvent('sl-change', { bubbles: true }));
+    await element.updateComplete;
+
+    const latest = changes[changes.length - 1] as any;
+    expect(latest.type).to.equal('interval');
+    expect(latest.every).to.equal(1);
+    expect(latest.unit).to.equal('hours');
+    expect(latest.timezone).to.equal(browserTimezone());
+  });
+
+  it('switches to cron behind the Advanced toggle', async () => {
+    fetchStub = stubPreview(okPreview);
+    const changes: ScheduleConfig[] = [];
+    const element = (await fixture(
+      html`<schedule-config-editor
+        @schedule-change=${(e: CustomEvent) => changes.push(e.detail.value)}
+      ></schedule-config-editor>`
+    )) as ScheduleConfigEditor;
+
+    const toggle = element.shadowRoot?.querySelector('sl-switch');
+    expect(toggle).to.exist;
+    (toggle as any).checked = true;
+    toggle?.dispatchEvent(new CustomEvent('sl-change', { bubbles: true }));
+    await element.updateComplete;
+
+    const latest = changes[changes.length - 1] as any;
+    expect(latest.type).to.equal('cron');
+    expect(latest.expr).to.equal('0 9 * * *');
+    // Friendly mode radios are hidden in cron mode
+    expect(element.shadowRoot?.querySelector('sl-radio-group')).to.not.exist;
+  });
+
+  it('surfaces backend min-interval validation errors inline', async () => {
+    fetchStub = stubPreview(() => ({
+      status: 422,
+      body: {
+        detail: [
+          {
+            loc: ['body', 'schedule_config', 'interval'],
+            msg: 'Value error, Interval of 1 minutes is below the minimum interval of 5 minutes',
+            type: 'value_error',
+          },
+        ],
+      },
+    }));
+    const element = (await fixture(
+      html`<schedule-config-editor
+        .value=${{
+          type: 'interval',
+          every: 1,
+          unit: 'minutes',
+          timezone: 'UTC',
+        }}
+      ></schedule-config-editor>`
+    )) as ScheduleConfigEditor;
+
+    await waitUntil(
+      () =>
+        element.shadowRoot?.querySelector(
+          '[data-testid="schedule-preview-error"]'
+        ),
+      'error never rendered',
+      { timeout: 4000 }
+    );
+
+    expect(
+      element.shadowRoot?.querySelector(
+        '[data-testid="schedule-preview-error"]'
+      )?.textContent
+    ).to.contain('below the minimum interval of 5 minutes');
+  });
+
+  it('rejects a weekly schedule without days client-side', async () => {
+    fetchStub = stubPreview(okPreview);
+    const element = (await fixture(
+      html`<schedule-config-editor
+        .value=${{ type: 'weekly', days: [], at: '09:00', timezone: 'UTC' }}
+      ></schedule-config-editor>`
+    )) as ScheduleConfigEditor;
+
+    await waitUntil(
+      () =>
+        element.shadowRoot?.querySelector(
+          '[data-testid="schedule-preview-error"]'
+        ),
+      'error never rendered',
+      { timeout: 4000 }
+    );
+
+    expect(
+      element.shadowRoot?.querySelector(
+        '[data-testid="schedule-preview-error"]'
+      )?.textContent
+    ).to.contain('Select at least one day');
+    const previewCalls = fetchStub
+      .getCalls()
+      .filter((call) =>
+        String(call.args[0]).includes('/flows/schedule/preview')
+      );
+    expect(previewCalls.length).to.equal(0);
+  });
+});

--- a/frontend/src/components/schedule-config-editor.ts
+++ b/frontend/src/components/schedule-config-editor.ts
@@ -1,0 +1,480 @@
+import { LitElement, html, css, unsafeCSS, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { previewFlowSchedule, type SchedulePreview } from '../api';
+import { formatLocalDateTime } from '../utils/date';
+import consoleStyles from '../styles/console-styles.css?inline';
+import '@shoelace-style/shoelace/dist/components/input/input.js';
+import '@shoelace-style/shoelace/dist/components/select/select.js';
+import '@shoelace-style/shoelace/dist/components/option/option.js';
+import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
+import '@shoelace-style/shoelace/dist/components/radio/radio.js';
+import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
+import '@shoelace-style/shoelace/dist/components/switch/switch.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
+
+export type ScheduleUnit = 'minutes' | 'hours' | 'days';
+export type Weekday = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
+
+export type ScheduleConfig =
+  | { type: 'interval'; every: number; unit: ScheduleUnit; timezone: string }
+  | { type: 'daily'; at: string; timezone: string }
+  | { type: 'weekly'; days: Weekday[]; at: string; timezone: string }
+  | { type: 'cron'; expr: string; timezone: string };
+
+const WEEKDAYS: { value: Weekday; label: string }[] = [
+  { value: 'mon', label: 'Mon' },
+  { value: 'tue', label: 'Tue' },
+  { value: 'wed', label: 'Wed' },
+  { value: 'thu', label: 'Thu' },
+  { value: 'fri', label: 'Fri' },
+  { value: 'sat', label: 'Sat' },
+  { value: 'sun', label: 'Sun' },
+];
+
+/** The browser's IANA timezone, falling back to UTC. */
+export function browserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+function supportedTimezones(): string[] {
+  const zones: string[] =
+    typeof (Intl as any).supportedValuesOf === 'function'
+      ? (Intl as any).supportedValuesOf('timeZone')
+      : [];
+  const set = new Set(zones);
+  set.add('UTC');
+  set.add(browserTimezone());
+  return [...set].sort();
+}
+
+/** Sensible default when the user first picks the Schedule trigger. */
+export function defaultScheduleConfig(): ScheduleConfig {
+  return { type: 'daily', at: '09:00', timezone: browserTimezone() };
+}
+
+/**
+ * Editor for a flow schedule trigger configuration.
+ *
+ * Friendly forms first (interval / daily / weekly); raw cron is behind
+ * an "Advanced" toggle. Emits `schedule-change` with `{ value }` on
+ * every edit and shows a live preview of the next run times computed by
+ * the backend preview endpoint (min-interval and cron validation errors
+ * are surfaced inline from the same call).
+ */
+@customElement('schedule-config-editor')
+export class ScheduleConfigEditor extends LitElement {
+  static styles = [
+    unsafeCSS(consoleStyles),
+    css`
+      :host {
+        display: block;
+      }
+      .schedule-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--sl-spacing-medium);
+      }
+      @media (max-width: 768px) {
+        .schedule-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .weekday-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sl-spacing-medium);
+      }
+      .field-label {
+        display: block;
+        margin-bottom: 0.5rem;
+        font-weight: 500;
+      }
+      .advanced-toggle {
+        margin: var(--sl-spacing-medium) 0;
+      }
+      .preview {
+        margin-top: var(--sl-spacing-medium);
+        padding: var(--sl-spacing-medium);
+        background: var(--sl-color-neutral-50);
+        border: 1px solid var(--sl-color-neutral-200);
+        border-radius: var(--sl-border-radius-medium);
+        font-size: var(--sl-font-size-small);
+      }
+      .preview-description {
+        font-weight: 600;
+        margin-bottom: var(--sl-spacing-x-small);
+      }
+      .preview-runs {
+        margin: 0;
+        padding-left: 1.25rem;
+        color: var(--sl-color-neutral-700);
+      }
+      .preview-error {
+        color: var(--sl-color-danger-600);
+      }
+      .preview-hint {
+        color: var(--sl-color-neutral-500);
+        margin-top: var(--sl-spacing-x-small);
+      }
+    `,
+  ];
+
+  /** The current schedule config value (discriminated on `type`). */
+  @property({ type: Object })
+  value: ScheduleConfig | undefined;
+
+  @state()
+  private previewResult: SchedulePreview | null = null;
+
+  @state()
+  private previewError: string | null = null;
+
+  @state()
+  private previewLoading = false;
+
+  private previewDebounce?: number;
+  private previewSeq = 0;
+  private needsDefaultEmit = false;
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this.previewDebounce) clearTimeout(this.previewDebounce);
+  }
+
+  willUpdate(changed: Map<string | number | symbol, unknown>) {
+    // Initialize here (not connectedCallback) so a `.value` binding
+    // applied during upgrade is never clobbered by the default.
+    if (!this.value) {
+      this.value = defaultScheduleConfig();
+      this.needsDefaultEmit = true;
+    }
+    if (!this.hasUpdated || changed.has('value')) {
+      this.schedulePreview();
+    }
+  }
+
+  firstUpdated() {
+    if (this.needsDefaultEmit) {
+      this.needsDefaultEmit = false;
+      this.emitChange();
+    }
+  }
+
+  private get config(): ScheduleConfig {
+    return this.value || defaultScheduleConfig();
+  }
+
+  private patchConfig(patch: Partial<ScheduleConfig>) {
+    this.value = { ...this.config, ...patch } as ScheduleConfig;
+    this.emitChange();
+    this.schedulePreview();
+  }
+
+  private switchType(type: ScheduleConfig['type']) {
+    const timezone = this.config.timezone || browserTimezone();
+    const prev = this.config as any;
+    let next: ScheduleConfig;
+    switch (type) {
+      case 'interval':
+        next = { type, every: 1, unit: 'hours', timezone };
+        break;
+      case 'daily':
+        next = { type, at: prev.at || '09:00', timezone };
+        break;
+      case 'weekly':
+        next = { type, days: ['mon'], at: prev.at || '09:00', timezone };
+        break;
+      case 'cron':
+      default:
+        next = { type: 'cron', expr: '0 9 * * *', timezone };
+        break;
+    }
+    this.value = next;
+    this.emitChange();
+    this.schedulePreview();
+  }
+
+  private emitChange() {
+    this.dispatchEvent(
+      new CustomEvent('schedule-change', {
+        bubbles: true,
+        composed: true,
+        detail: { value: this.value },
+      })
+    );
+  }
+
+  /** Client-side guard for shapes the backend would reject as incomplete. */
+  private localValidationError(): string | null {
+    const config = this.config;
+    if (config.type === 'weekly' && config.days.length === 0) {
+      return 'Select at least one day of the week.';
+    }
+    if (config.type === 'cron' && !config.expr.trim()) {
+      return 'Enter a cron expression (minute hour day month day-of-week).';
+    }
+    if (
+      (config.type === 'daily' || config.type === 'weekly') &&
+      !/^([01]\d|2[0-3]):([0-5]\d)$/.test(config.at)
+    ) {
+      return 'Enter a time of day in 24h HH:MM format.';
+    }
+    if (config.type === 'interval' && (!config.every || config.every < 1)) {
+      return 'Enter how often the flow should run (at least 1).';
+    }
+    return null;
+  }
+
+  private schedulePreview() {
+    if (this.previewDebounce) clearTimeout(this.previewDebounce);
+    const localError = this.localValidationError();
+    if (localError) {
+      this.previewResult = null;
+      this.previewError = localError;
+      this.previewLoading = false;
+      return;
+    }
+    this.previewLoading = true;
+    this.previewDebounce = window.setTimeout(() => {
+      void this.fetchPreview();
+    }, 350);
+  }
+
+  private async fetchPreview() {
+    const seq = ++this.previewSeq;
+    try {
+      const preview = await previewFlowSchedule(this.config);
+      if (seq !== this.previewSeq) return;
+      this.previewResult = preview;
+      this.previewError = null;
+    } catch (error) {
+      if (seq !== this.previewSeq) return;
+      this.previewResult = null;
+      this.previewError =
+        error instanceof Error ? error.message : 'Invalid schedule.';
+    } finally {
+      if (seq === this.previewSeq) {
+        this.previewLoading = false;
+      }
+    }
+  }
+
+  private toggleWeekday(day: Weekday, checked: boolean) {
+    const config = this.config;
+    if (config.type !== 'weekly') return;
+    const days = checked
+      ? [...config.days, day]
+      : config.days.filter((d) => d !== day);
+    const ordered = WEEKDAYS.map((d) => d.value).filter((d) =>
+      days.includes(d)
+    );
+    this.patchConfig({ days: ordered } as Partial<ScheduleConfig>);
+  }
+
+  private renderIntervalFields() {
+    const config = this.config;
+    if (config.type !== 'interval') return nothing;
+    return html`
+      <div class="schedule-grid">
+        <sl-input
+          type="number"
+          label="Every"
+          min="1"
+          .value=${String(config.every)}
+          @sl-input=${(e: any) =>
+            this.patchConfig({
+              every: Number(e.target.value) || 0,
+            } as Partial<ScheduleConfig>)}
+        ></sl-input>
+        <sl-select
+          label="Unit"
+          .value=${config.unit}
+          @sl-change=${(e: any) =>
+            this.patchConfig({
+              unit: e.target.value,
+            } as Partial<ScheduleConfig>)}
+        >
+          <sl-option value="minutes">Minutes</sl-option>
+          <sl-option value="hours">Hours</sl-option>
+          <sl-option value="days">Days</sl-option>
+        </sl-select>
+      </div>
+    `;
+  }
+
+  private renderDailyFields() {
+    const config = this.config;
+    if (config.type !== 'daily') return nothing;
+    return html`
+      <sl-input
+        type="time"
+        label="At time"
+        .value=${config.at}
+        @sl-input=${(e: any) =>
+          this.patchConfig({ at: e.target.value } as Partial<ScheduleConfig>)}
+      ></sl-input>
+    `;
+  }
+
+  private renderWeeklyFields() {
+    const config = this.config;
+    if (config.type !== 'weekly') return nothing;
+    return html`
+      <div style="margin-bottom: var(--sl-spacing-medium);">
+        <label class="field-label">On days</label>
+        <div class="weekday-row">
+          ${WEEKDAYS.map(
+            (day) => html`
+              <sl-checkbox
+                .checked=${config.days.includes(day.value)}
+                @sl-change=${(e: any) =>
+                  this.toggleWeekday(day.value, e.target.checked)}
+              >
+                ${day.label}
+              </sl-checkbox>
+            `
+          )}
+        </div>
+      </div>
+      <sl-input
+        type="time"
+        label="At time"
+        .value=${config.at}
+        @sl-input=${(e: any) =>
+          this.patchConfig({ at: e.target.value } as Partial<ScheduleConfig>)}
+      ></sl-input>
+    `;
+  }
+
+  private renderCronFields() {
+    const config = this.config;
+    if (config.type !== 'cron') return nothing;
+    return html`
+      <sl-input
+        label="Cron expression"
+        help-text="5-field crontab: minute hour day-of-month month day-of-week (e.g. '0 9 * * mon-fri')"
+        .value=${config.expr}
+        @sl-input=${(e: any) =>
+          this.patchConfig({ expr: e.target.value } as Partial<ScheduleConfig>)}
+      ></sl-input>
+    `;
+  }
+
+  private renderPreview() {
+    if (this.previewError) {
+      return html`
+        <div class="preview">
+          <div class="preview-error" data-testid="schedule-preview-error">
+            <sl-icon
+              name="exclamation-triangle"
+              style="vertical-align: -0.125em;"
+            ></sl-icon>
+            ${this.previewError}
+          </div>
+        </div>
+      `;
+    }
+    if (this.previewLoading && !this.previewResult) {
+      return html`
+        <div class="preview">
+          <sl-spinner style="font-size: 1rem;"></sl-spinner>
+          Computing next run times...
+        </div>
+      `;
+    }
+    if (!this.previewResult) return nothing;
+    return html`
+      <div class="preview" data-testid="schedule-preview">
+        <div class="preview-description">
+          <sl-icon
+            name="calendar-check"
+            style="vertical-align: -0.125em;"
+          ></sl-icon>
+          ${this.previewResult.description}
+        </div>
+        ${
+          this.previewResult.next_run_times.length > 0
+            ? html`
+                <div>Next runs (your local time):</div>
+                <ol class="preview-runs">
+                  ${this.previewResult.next_run_times
+                    .slice(0, 3)
+                    .map((t) => html`<li>${formatLocalDateTime(t)}</li>`)}
+                </ol>
+              `
+            : html`<div>This schedule never fires.</div>`
+        }
+        <div class="preview-hint">
+          Evaluated in ${this.previewResult.timezone}. Runs are skipped while a
+          previous run is still in progress; paused flows do not fire.
+        </div>
+      </div>
+    `;
+  }
+
+  render() {
+    const config = this.config;
+    const isCron = config.type === 'cron';
+    return html`
+      <div>
+        ${
+          !isCron
+            ? html`
+                <div style="margin-bottom: var(--sl-spacing-medium);">
+                  <label class="field-label">Repeats</label>
+                  <sl-radio-group
+                    value=${config.type}
+                    @sl-change=${(e: any) => this.switchType(e.target.value)}
+                    style="display: flex; gap: var(--sl-spacing-large);"
+                  >
+                    <sl-radio value="interval">Interval</sl-radio>
+                    <sl-radio value="daily">Daily</sl-radio>
+                    <sl-radio value="weekly">Weekly</sl-radio>
+                  </sl-radio-group>
+                </div>
+              `
+            : nothing
+        }
+        ${this.renderIntervalFields()} ${this.renderDailyFields()}
+        ${this.renderWeeklyFields()} ${this.renderCronFields()}
+
+        <sl-select
+          label="Timezone"
+          .value=${config.timezone}
+          @sl-change=${(e: any) =>
+            this.patchConfig({
+              timezone: e.target.value,
+            } as Partial<ScheduleConfig>)}
+          style="margin-top: var(--sl-spacing-medium);"
+        >
+          ${supportedTimezones().map(
+            (tz) => html`<sl-option .value=${tz}>${tz}</sl-option>`
+          )}
+        </sl-select>
+
+        <div class="advanced-toggle">
+          <sl-switch
+            .checked=${isCron}
+            @sl-change=${(e: any) =>
+              this.switchType(e.target.checked ? 'cron' : 'daily')}
+          >
+            Advanced: cron expression
+          </sl-switch>
+        </div>
+
+        ${this.renderPreview()}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'schedule-config-editor': ScheduleConfigEditor;
+  }
+}

--- a/frontend/src/views/authed/flow-view.test.ts
+++ b/frontend/src/views/authed/flow-view.test.ts
@@ -36,3 +36,48 @@ describe('FlowView model selection', () => {
     );
   });
 });
+
+describe('FlowView trigger summary', () => {
+  function createElement(): any {
+    return document.createElement('flow-view') as FlowView as any;
+  }
+
+  it('describes webhook triggers', () => {
+    const element = createElement();
+    element.flow = { name: 'Test', trigger_event_source: 'webhook' };
+    expect(element.getTriggerSummary()).to.equal('Webhook');
+  });
+
+  it('describes schedule triggers with the backend summary', () => {
+    const element = createElement();
+    element.flow = {
+      name: 'Test',
+      trigger_event_source: 'schedule',
+      schedule_config: {
+        type: 'daily',
+        at: '09:00',
+        timezone: 'Europe/Athens',
+      },
+      schedule_state: {
+        active: true,
+        type: 'daily',
+        description: 'Daily at 09:00 (Europe/Athens)',
+        timezone: 'Europe/Athens',
+        next_run_at: '2026-08-17T06:00:00+00:00',
+      },
+    };
+    expect(element.getTriggerSummary()).to.equal(
+      'Daily at 09:00 (Europe/Athens)'
+    );
+  });
+
+  it('falls back to a generic label when schedule state is missing', () => {
+    const element = createElement();
+    element.flow = {
+      name: 'Test',
+      trigger_event_source: 'schedule',
+      schedule_config: { type: 'daily', at: '09:00', timezone: 'UTC' },
+    };
+    expect(element.getTriggerSummary()).to.equal('Schedule');
+  });
+});

--- a/frontend/src/views/authed/flow-view.ts
+++ b/frontend/src/views/authed/flow-view.ts
@@ -13,6 +13,7 @@ import {
   getAllTools,
   getMCPServers,
   getAccountAgents,
+  previewFlowSchedule,
 } from '../../api';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import { parseUTCDate, formatLocalDateTime } from '../../utils/date';
@@ -66,6 +67,15 @@ interface WebhookConfig {
   webhook_secret: string;
 }
 
+interface ScheduleState {
+  active: boolean;
+  type: string;
+  description: string;
+  timezone: string;
+  next_run_at: string | null;
+  cron?: string;
+}
+
 interface Flow {
   id?: string;
   name: string;
@@ -79,6 +89,8 @@ interface Flow {
   trigger_project_ids?: string[];
   trigger_config?: any;
   webhook_config?: WebhookConfig;
+  schedule_config?: any;
+  schedule_state?: ScheduleState | null;
   ai_model_id?: string;
   prompt_template?: string;
   allowed_mcp_servers?: string[];
@@ -238,7 +250,11 @@ export class FlowView extends LitElement {
   private isAdmin = false;
 
   @state()
-  private triggerType: 'webhook' | 'tracker' = 'webhook';
+  private triggerType: 'webhook' | 'tracker' | 'schedule' = 'webhook';
+
+  /** Next run times (ISO strings) for schedule-triggered flows. */
+  @state()
+  private scheduleNextRuns: string[] = [];
 
   @state()
   private isPollingOrganizations = false;
@@ -307,7 +323,13 @@ export class FlowView extends LitElement {
       this.flow = await getFlow(this.flowId);
 
       this.triggerType =
-        this.flow.trigger_event_source === 'webhook' ? 'webhook' : 'tracker';
+        this.flow.trigger_event_source === 'webhook'
+          ? 'webhook'
+          : this.flow.trigger_event_source === 'schedule'
+            ? 'schedule'
+            : 'tracker';
+
+      void this.loadScheduleNextRuns();
 
       const allExecutions = await import('../../api').then((m) =>
         m.getFlowExecutions({ flowId: this.flowId, limit: 10 })
@@ -626,13 +648,7 @@ export class FlowView extends LitElement {
               }
 
               <strong>Trigger:</strong>
-              <span>
-                ${
-                  this.flow.trigger_event_source === 'webhook'
-                    ? 'Webhook'
-                    : `${this.getTrackerName(this.flow.trigger_event_source)} - ${this.flow.trigger_event_types?.join(', ') || 'No events'}`
-                }
-              </span>
+              <span>${this.getTriggerSummary()}</span>
 
               ${
                 this.flow.trigger_organization_id
@@ -701,6 +717,7 @@ ${this.flow.prompt_template}</pre>
                 `
               : ''
           }
+          ${this.renderScheduleCard()}
           ${
             this.flow.trigger_event_source === 'webhook' &&
             this.flow.webhook_config
@@ -917,6 +934,124 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre>
     `;
   }
 
+  /** One-line trigger summary for the flow details grid. */
+  getTriggerSummary(): string {
+    if (this.flow.trigger_event_source === 'webhook') {
+      return 'Webhook';
+    }
+    if (this.flow.trigger_event_source === 'schedule') {
+      return this.flow.schedule_state?.description || 'Schedule';
+    }
+    return `${this.getTrackerName(this.flow.trigger_event_source)} - ${
+      this.flow.trigger_event_types?.join(', ') || 'No events'
+    }`;
+  }
+
+  /** Fetch the next few run times for a schedule-triggered flow. */
+  private async loadScheduleNextRuns() {
+    if (
+      this.flow?.trigger_event_source !== 'schedule' ||
+      !this.flow.schedule_config
+    ) {
+      this.scheduleNextRuns = [];
+      return;
+    }
+    try {
+      const preview = await previewFlowSchedule(this.flow.schedule_config);
+      this.scheduleNextRuns = preview.next_run_times.slice(0, 3);
+    } catch (error) {
+      console.error('Failed to preview flow schedule:', error);
+      this.scheduleNextRuns = [];
+    }
+  }
+
+  /**
+   * Schedule summary card for schedule-triggered flows: human-readable
+   * cadence, paused state (paused flow = schedule suspended), the next
+   * runs, and the status of the most recent run.
+   */
+  renderScheduleCard() {
+    if (
+      this.flow.trigger_event_source !== 'schedule' ||
+      !this.flow.schedule_config
+    ) {
+      return '';
+    }
+    const schedule = this.flow.schedule_state;
+    const paused = !this.flow.is_enabled;
+    const lastRun = this.recentExecutions[0];
+    return html`
+      <sl-card>
+        <div slot="header">
+          <sl-icon name="clock"></sl-icon>
+          Schedule
+        </div>
+        <div
+          style="display: grid; grid-template-columns: 150px 1fr; gap: var(--sl-spacing-medium);"
+        >
+          <strong>Runs:</strong>
+          <span>${schedule?.description || 'Schedule'}</span>
+
+          <strong>Status:</strong>
+          <span>
+            ${
+              paused
+                ? html`
+                    <sl-badge variant="warning">Paused</sl-badge>
+                    <span
+                      style="color: var(--sl-color-neutral-600); margin-left: var(--sl-spacing-x-small);"
+                    >
+                      Schedule suspended — enable the flow to resume runs.
+                    </span>
+                  `
+                : html`<sl-badge variant="success">Active</sl-badge>`
+            }
+          </span>
+
+          ${
+            !paused
+              ? html`
+                  <strong>Next runs:</strong>
+                  <span>
+                    ${
+                      this.scheduleNextRuns.length > 0
+                        ? html`
+                            <ol
+                              style="margin: 0; padding-left: 1.25rem; display: flex; flex-direction: column; gap: var(--sl-spacing-2x-small);"
+                            >
+                              ${this.scheduleNextRuns.map(
+                                (t) => html`<li>${formatLocalDateTime(t)}</li>`
+                              )}
+                            </ol>
+                          `
+                        : 'No upcoming runs'
+                    }
+                  </span>
+                `
+              : ''
+          }
+          ${
+            lastRun
+              ? html`
+                  <strong>Last run:</strong>
+                  <span>
+                    <sl-badge variant=${this.getStatusVariant(lastRun.status)}>
+                      ${lastRun.status}
+                    </sl-badge>
+                    <span
+                      style="color: var(--sl-color-neutral-600); margin-left: var(--sl-spacing-x-small);"
+                    >
+                      ${formatLocalDateTime(lastRun.start_time)}
+                    </span>
+                  </span>
+                `
+              : ''
+          }
+        </div>
+      </sl-card>
+    `;
+  }
+
   getStatusVariant(status: string) {
     switch (status) {
       case 'SUCCEEDED':
@@ -973,14 +1108,16 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre>
       // Toggle the enabled state
       const newEnabledState = !this.flow.is_enabled;
 
-      // Update the flow on the backend
-      await updateFlow(this.flowId, {
+      // Update the flow on the backend; use the response so computed
+      // fields (e.g. schedule_state for scheduled flows) stay fresh.
+      const updated = await updateFlow(this.flowId, {
         is_enabled: newEnabledState,
       });
 
       // Update local state
       this.flow = {
         ...this.flow,
+        ...(updated && typeof updated === 'object' ? updated : {}),
         is_enabled: newEnabledState,
       };
 
@@ -1165,6 +1302,7 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre>
       'trigger_project_ids',
       'trigger_config',
       'webhook_config',
+      'schedule_config',
       'ai_model_id',
       'agent_type',
       'git_clone_config',

--- a/frontend/src/views/authed/flows-view.test.ts
+++ b/frontend/src/views/authed/flows-view.test.ts
@@ -151,6 +151,79 @@ describe('FlowsView', () => {
     expect(urls.some((u) => u.includes('/api/v1/flows'))).to.be.true;
   });
 
+  describe('schedule indicators', () => {
+    async function renderFlows(flows: unknown[]) {
+      fetchStub = createFetchStub(flows, []);
+      const element = (await fixture(
+        html`<flows-view></flows-view>`
+      )) as FlowsView;
+      await waitUntil(
+        () => !(element as any).isLoading,
+        'Flows view did not finish loading'
+      );
+      await element.updateComplete;
+      return element;
+    }
+
+    it('shows the next run time for scheduled flows', async () => {
+      const element = await renderFlows([
+        {
+          id: 'flow-sched',
+          name: 'Nightly Report',
+          trigger_event_source: 'schedule',
+          is_enabled: true,
+          schedule_state: {
+            active: true,
+            type: 'daily',
+            description: 'Daily at 09:00 (Europe/Athens)',
+            timezone: 'Europe/Athens',
+            next_run_at: '2026-08-17T06:00:00+00:00',
+          },
+        },
+      ]);
+
+      const card = element.shadowRoot?.querySelector('.flow-card');
+      expect(card?.textContent).to.contain('Next run');
+      expect(card?.textContent).to.not.contain('Schedule paused');
+    });
+
+    it('shows a paused badge when a scheduled flow is disabled', async () => {
+      const element = await renderFlows([
+        {
+          id: 'flow-paused',
+          name: 'Paused Report',
+          trigger_event_source: 'schedule',
+          is_enabled: false,
+          schedule_state: {
+            active: false,
+            type: 'daily',
+            description: 'Daily at 09:00 (Europe/Athens)',
+            timezone: 'Europe/Athens',
+            next_run_at: null,
+          },
+        },
+      ]);
+
+      const card = element.shadowRoot?.querySelector('.flow-card');
+      expect(card?.textContent).to.contain('Schedule paused');
+      expect(card?.textContent).to.not.contain('Next run');
+    });
+
+    it('shows no schedule indicator for non-scheduled flows', async () => {
+      const element = await renderFlows([
+        {
+          id: 'flow-hook',
+          name: 'Webhook Flow',
+          trigger_event_source: 'webhook',
+        },
+      ]);
+
+      const card = element.shadowRoot?.querySelector('.flow-card');
+      expect(card?.textContent).to.not.contain('Next run');
+      expect(card?.textContent).to.not.contain('Schedule paused');
+    });
+  });
+
   describe('recent execution duration', () => {
     async function renderItem(exec: Record<string, unknown>) {
       fetchStub = createFetchStub([], []);

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -19,12 +19,24 @@ import { formatLocalDateTime } from '../../utils/date';
 import { executionDurationText } from '../../utils/execution';
 import consoleStyles from '../../styles/console-styles.css?inline';
 
+interface ScheduleState {
+  active: boolean;
+  type: string;
+  description: string;
+  timezone: string;
+  next_run_at: string | null;
+  cron?: string;
+}
+
 interface Flow {
   id: string;
   name: string;
   description?: string;
   icon?: string;
   account_id?: string;
+  trigger_event_source?: string;
+  is_enabled?: boolean;
+  schedule_state?: ScheduleState | null;
   execution_stats?: {
     total_execs?: number;
     running_execs?: number;
@@ -531,6 +543,7 @@ export class FlowsView extends LitElement {
             <sl-icon name="play-circle"></sl-icon>
             <span>${totalCount} executions</span>
           </div>
+          ${this.renderScheduleStat(flow)}
         </div>
 
         <div slot="footer" class="flow-footer">
@@ -633,6 +646,38 @@ export class FlowsView extends LitElement {
         <sl-button size="small">
           <sl-icon name="arrow-right"></sl-icon>
         </sl-button>
+      </div>
+    `;
+  }
+
+  /**
+   * Next-run/paused indicator for scheduled flows on the flow card.
+   *
+   * Paused flows (schedule suspended) get a warning badge; active
+   * schedules show the next run time in local time.
+   */
+  renderScheduleStat(flow: Flow) {
+    const schedule = flow.schedule_state;
+    if (flow.trigger_event_source !== 'schedule' || !schedule) {
+      return '';
+    }
+    if (!schedule.active) {
+      return html`
+        <div class="stat-item" title=${schedule.description}>
+          <sl-badge variant="warning">Schedule paused</sl-badge>
+        </div>
+      `;
+    }
+    return html`
+      <div class="stat-item" title=${schedule.description}>
+        <sl-icon name="clock"></sl-icon>
+        <span>
+          ${
+            schedule.next_run_at
+              ? html`Next run ${formatLocalDateTime(schedule.next_run_at)}`
+              : 'No upcoming runs'
+          }
+        </span>
       </div>
     `;
   }


### PR DESCRIPTION
Stacked on #229 (`feat/alex-schedules`). **Base is `feat/alex-schedules`; retarget to `main` once #229 merges.** Contains only frontend changes plus one backend commit (4944266f) that lands the #229 discriminated-union schema + preview endpoint the UI builds against (that commit is part of the #229 branch and will disappear from this diff when #229 merges).

## What

Schedules UI for flow schedule triggers. Schedules live **under Flows** — a schedule is a property of a flow; there is no separate Schedules page.

### 1. Flow editor — "Schedule" trigger type
- New `Schedule` radio alongside `Webhook` / `Tracker Event` in the trigger section of `preloop-flow-form`.
- Friendly-first forms: **Interval** (every N minutes/hours/days), **Daily** (time), **Weekly** (days + time). Raw **cron** is behind an "Advanced: cron expression" toggle.
- Timezone picker (IANA list via `Intl.supportedValuesOf`) defaulting to the browser timezone.
- Live preview of the next 3 run times using the backend `POST /api/v1/flows/schedule/preview` endpoint (not client-side computation), debounced. Backend 422 validation errors — min-interval violations, bad cron, unknown timezone — are surfaced inline in the preview box; trivially-invalid shapes (weekly with no days, malformed HH:MM) are caught client-side without a round trip.

### 2. Flows list — next-run indicator
- Scheduled flow cards show `Next run <local time>` (from `schedule_state.next_run_at`), or a warning badge `Schedule paused` when the flow is disabled.

### 3. Flow detail — schedule summary card
- Cadence summary from the backend (`"Daily at 09:00 (Europe/Athens)"`), Active/Paused badge (paused flow = schedule suspended, stated explicitly), the next 3 runs (via the preview endpoint), and the most recent run's status.
- Trigger row in Flow Details reuses the same summary.

## Component tree (no headless console-screenshot pattern in repo; visual tests only cover landing/pricing)

```
preloop-flow-form
└─ Trigger Configuration (sl-card)
   ├─ sl-radio-group: Webhook | Tracker Event | Schedule   ← new option
   └─ schedule-config-editor                               ← new component
      ├─ sl-radio-group: Interval | Daily | Weekly (hidden in cron mode)
      ├─ interval: sl-input[number] + sl-select[unit]
      ├─ daily:    sl-input[type=time]
      ├─ weekly:   7× sl-checkbox + sl-input[type=time]
      ├─ cron:     sl-input[expr] (help text: 5-field crontab)
      ├─ sl-select: Timezone (defaults to browser tz)
      ├─ sl-switch: "Advanced: cron expression"
      └─ preview box: description + next 3 runs (local time) | inline 422 error

flows-view › flow-card › .flow-stats
└─ renderScheduleStat: "Next run …" | sl-badge[warning] "Schedule paused"

flow-view › renderFlowDetails
├─ Trigger row: getTriggerSummary() → schedule_state.description
└─ renderScheduleCard (sl-card "Schedule")
   ├─ Runs: description
   ├─ Status: Active | Paused ("Schedule suspended — enable the flow to resume runs.")
   ├─ Next runs: next 3 (preview endpoint, local time)
   └─ Last run: status badge + start time
```

## Tests
- `schedule-config-editor.test.ts`: default daily/browser-tz config, backend preview rendering, mode switching, Advanced cron toggle, inline 422 min-interval error, client-side weekly-days guard (asserts no preview request).
- `flows-view.test.ts`: next-run indicator, paused badge, absence for non-scheduled flows.
- `flow-view.test.ts`: trigger summary for webhook/schedule/fallback.
- Full suite: **88 files / 666 tests passing**; `npm run format:check` clean.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Medium]**
> Well-tested frontend-only UI for flow schedule triggers; one MEDIUM race in the preview error handling and two LOW polish items. No security issues.
>
> **Overview**
> Adds the "Schedule" trigger type to the flow editor with friendly interval/daily/weekly/cron forms and a debounced backend preview, plus a next-run indicator in the flows list and a schedule summary card in flow detail. Strong test coverage across the editor, flows view, and flow view.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 49fda2f5. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->