### PR TITLE
fix(flows): workspace seed cap check before decode (completes #236 review)

### DIFF
--- a/backend/preloop/utils/workspace_seed.py
+++ b/backend/preloop/utils/workspace_seed.py
@@ -155,16 +155,11 @@ def parse_workspace_files(
                 "(URLs are not supported)"
             )
         content = "".join(content.split())  # tolerate wrapped base64
-        try:
-            base64.b64decode(content, validate=True)
-        except (binascii.Error, ValueError) as exc:
-            raise WorkspaceSeedError(
-                f"workspace_files[{index}] content_base64 is not valid base64: {exc}"
-            ) from exc
 
-        # Cap the ENCODED size: the base64 text is what is embedded in the
-        # container launch command (K8s Job spec / etcd limit), so that is
-        # the size that matters for the transport.
+        # Cap the ENCODED size BEFORE decoding: the base64 text is what is
+        # embedded in the container launch command (K8s Job spec / etcd
+        # limit), so that is the size that matters for the transport, and
+        # oversized payloads should be rejected without decode work.
         total_bytes += len(content)
         if total_bytes > MAX_TOTAL_SEED_ENCODED_BYTES:
             raise WorkspaceSeedError(
@@ -173,6 +168,12 @@ def parse_workspace_files(
                 "cap (the encoded form is embedded in the container launch "
                 "command); use fewer/smaller files"
             )
+        try:
+            base64.b64decode(content, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise WorkspaceSeedError(
+                f"workspace_files[{index}] content_base64 is not valid base64: {exc}"
+            ) from exc
         files.append(WorkspaceSeedFile(path=path, content_base64=content))
     return files
 


### PR DESCRIPTION
Addresses the two unresolved post-merge review findings on #236 (HIGH: double-counted cap, MEDIUM: dead/duplicated lines). The duplication itself was already reverted in #238; this PR completes the review intent by moving the encoded-size cap check before the base64 decode, so oversized payloads are rejected without decode work and at-cap payloads are accepted. All 52 workspace-seed tests pass.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> A clean, well-tested reordering with no security implications; the encoded-size cap is now enforced before any base64 decode work.

> **Overview**
> Reorders `parse_workspace_files` so the base64-encoded size cap is checked before decoding, resolving the #236 review findings. Behavior is covered by boundary tests for over-cap, at-cap, and decoded-size rejection.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 18882c98. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->