### PR TITLE
feat(qwen): refresh Model Studio catalog and honor regional endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Qwen / Model Studio catalog**: the keyless picker now lists current chat
+  models (`qwen3.8-max` first) instead of `qwen-plus` / `qwen-turbo` /
+  `qwen-max` / `qwq-32b-preview`. Live `/models` listing honors a
+  user-supplied DashScope or Model Studio base URL (China Beijing default is
+  unchanged so existing keys keep working) and drops dedicated image, video,
+  audio, and NSFW ids. International list prices were added for the fallback
+  ids. DeepSeek-V4 / GLM 5.2 / Kimi remain their own providers; a Model
+  Studio key that also serves those SKUs will surface them via live listing.
 - **PR Reviewer preset: token-optimised prompt**: the stock Pull Request
   Reviewer preset now bounds every open-ended read that previously let agents
   walk the repository. Project doc reads are capped (agent-instruction files in

--- a/backend/preloop/models/crud/ai_model.py
+++ b/backend/preloop/models/crud/ai_model.py
@@ -36,6 +36,35 @@ class CRUDAIModel(CRUDBase[AIModel]):
         return normalized
 
     @staticmethod
+    def _validate_qwen_api_endpoint(
+        obj_data: Dict[str, Any],
+        existing: Optional[AIModel] = None,
+    ) -> None:
+        """Reject a Qwen chat endpoint outside DashScope / Model Studio."""
+        provider = (
+            str(
+                obj_data.get("provider_name")
+                or (existing.provider_name if existing is not None else "")
+                or ""
+            )
+            .strip()
+            .lower()
+        )
+        if provider != "qwen":
+            return
+        if "api_endpoint" in obj_data:
+            endpoint = obj_data.get("api_endpoint")
+        elif existing is not None:
+            endpoint = existing.api_endpoint
+        else:
+            return
+        if not isinstance(endpoint, str) or not endpoint.strip():
+            return
+        from preloop.services.ai_model_provider import validate_qwen_endpoint
+
+        validate_qwen_endpoint(endpoint)
+
+    @staticmethod
     def _apply_secret_reference_fields(
         db: Session,
         *,
@@ -204,6 +233,7 @@ class CRUDAIModel(CRUDBase[AIModel]):
                 and commit themselves.
         """
         obj_data = self._normalize_model_kind_fields(dict(obj_in))
+        self._validate_qwen_api_endpoint(obj_data)
         if obj_in.get("is_default"):
             for existing_model in (
                 db.query(self.model)
@@ -326,6 +356,7 @@ class CRUDAIModel(CRUDBase[AIModel]):
     ) -> AIModel:
         """Update an AIModel. If setting a model as default, ensure others are not."""
         obj_data = self._normalize_model_kind_fields(dict(obj_in))
+        self._validate_qwen_api_endpoint(obj_data, existing=db_obj)
         target_model_kind = (obj_data.get("meta_data") or {}).get(
             "service_kind"
         ) or db_obj.model_kind

--- a/backend/preloop/services/ai_model_provider.py
+++ b/backend/preloop/services/ai_model_provider.py
@@ -294,6 +294,47 @@ def validate_discovery_endpoint(api_endpoint: str) -> str:
     return raw
 
 
+# Regional DashScope hosts shown in the add-provider UI, plus workspace
+# Model Studio hosts under *.maas.aliyuncs.com. Both sit under *.aliyuncs.com.
+QWEN_ALLOWED_HOSTS = frozenset(
+    {
+        "dashscope.aliyuncs.com",
+        "dashscope-intl.aliyuncs.com",
+        "dashscope-us.aliyuncs.com",
+    }
+)
+QWEN_ALLOWED_HOST_SUFFIXES = (".aliyuncs.com", ".maas.aliyuncs.com")
+
+
+def _is_qwen_allowed_host(host: str) -> bool:
+    """Return True if host is a DashScope / Model Studio hostname."""
+    hostname = (host or "").strip().lower().rstrip(".")
+    if not hostname:
+        return False
+    if hostname in QWEN_ALLOWED_HOSTS:
+        return True
+    return any(hostname.endswith(suffix) for suffix in QWEN_ALLOWED_HOST_SUFFIXES)
+
+
+def validate_qwen_endpoint(api_endpoint: str) -> str:
+    """Validate a Qwen discovery or chat endpoint, or raise ValueError.
+
+    Applies the shared SSRF guard, then restricts the host to known
+    DashScope / Model Studio names (``*.aliyuncs.com``, including the
+    Beijing / Singapore / US hosts in the UI and workspace
+    ``*.maas.aliyuncs.com`` endpoints). Other providers keep using
+    ``validate_discovery_endpoint`` alone.
+    """
+    raw = validate_discovery_endpoint(api_endpoint)
+    host = (urlsplit(raw).hostname or "").strip()
+    if not _is_qwen_allowed_host(host):
+        raise ProviderValidationError(
+            "Qwen api_endpoint must be a DashScope or Model Studio host "
+            "(*.aliyuncs.com)"
+        )
+    return raw
+
+
 async def _get_openai_compatible_models(
     api_endpoint: str, api_key: Optional[str] = None
 ) -> ModelDiscoveryResult:
@@ -870,11 +911,12 @@ async def _get_qwen_models(
     Default base URL is the China (Beijing) DashScope compatible-mode host so
     existing keys keep working. A caller-supplied endpoint (Singapore intl,
     US Virginia, or a workspace-specific ``*.maas.aliyuncs.com`` host) is
-    used instead after SSRF validation. Region keys are not interchangeable.
+    used instead after DashScope host allowlisting. Region keys are not
+    interchangeable.
     """
     raw = (api_endpoint or "").strip()
     if raw:
-        base_url = validate_discovery_endpoint(raw).rstrip("/")
+        base_url = validate_qwen_endpoint(raw).rstrip("/")
     else:
         base_url = QWEN_DEFAULT_BASE_URL
 

--- a/backend/preloop/services/ai_model_provider.py
+++ b/backend/preloop/services/ai_model_provider.py
@@ -222,7 +222,7 @@ async def get_available_models_for_provider(
     elif provider == "google":
         return await _get_google_models(api_key)
     elif provider == "qwen":
-        return await _get_qwen_models(api_key)
+        return await _get_qwen_models(api_key, api_endpoint)
     elif provider == "deepseek":
         return await _get_deepseek_models(api_key)
     elif provider == "moonshot":
@@ -747,12 +747,30 @@ async def _get_catalog_provider_models(
     return _live(live_models)
 
 
-# Fallback catalog used when no Qwen key is available to list the live set.
+# China (Beijing) DashScope compatible-mode host. Existing keys target this
+# URL; do not rename or replace it. International and US Model Studio hosts
+# are accepted via the stored api_endpoint (keys are per-region).
+QWEN_DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+QWEN_INTL_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+QWEN_US_BASE_URL = "https://dashscope-us.aliyuncs.com/compatible-mode/v1"
+
+# Fallback catalog used when no Qwen / Model Studio key is available.
+# Provenance: Alibaba Cloud Model Studio text-generation list and the
+# qwen3.8-max product page (fetched 2026-08-17). Chat/completions only:
+# image, video, TTS, NSFW, Happy Horse, and Z-Image are excluded.
+# ORDER MATTERS: qwen3.8-max first (the headline model as of 2026-08-03).
+# Every id here is priced in services/data/model_prices.json under
+# dashscope/<id> (pinned by tests/services/test_model_pricing.py).
 QWEN_KNOWN_MODELS = [
+    "qwen3.8-max",
+    "qwen3.7-max",
+    "qwen3.7-plus",
+    "qwen3.6-flash",
+    "qwen3.5-plus",
+    "qwen3-max",
+    "qwen3-coder-plus",
     "qwen-plus",
-    "qwen-turbo",
-    "qwen-max",
-    "qwq-32b-preview",
+    "qwen-flash",
 ]
 
 # Fallback catalog used when no DeepSeek key is available to list the live set.
@@ -804,14 +822,79 @@ MISTRAL_KNOWN_MODELS = [
 ]
 
 
-async def _get_qwen_models(api_key: Optional[str] = None) -> ModelDiscoveryResult:
-    """Return Qwen models, live from the API when a key is supplied."""
-    return await _get_catalog_provider_models(
+def _is_qwen_chat_model(model_id: str) -> bool:
+    """Keep chat/completions SKUs; drop dedicated media, audio, and NSFW ids.
+
+    Multimodal chat flagships (``qwen3.8-max``) stay. Dedicated Wan video,
+    Qwen-Image, Qwen-VL product lines, audio/TTS, Happy Horse, Z-Image, and
+    any id carrying ``nsfw`` are excluded from the picker.
+    """
+    lowered = (model_id or "").strip().lower()
+    if not lowered:
+        return False
+    blocked_prefixes = (
+        "wan",
+        "happy-horse",
+        "z-image",
+        "qwen-image",
+        "qwen-vl",
+        "qwen-audio",
+        "qwen-tts",
+        "qwen-omni",
+        "qwen2.5-omni",
+        "qwen2.5-vl",
+        "qvq-",
+    )
+    blocked_substrings = (
+        "nsfw",
+        "-tts",
+        "-asr",
+        "-stt",
+        "-embedding",
+        "-rerank",
+        "-vl-",
+    )
+    if any(lowered.startswith(prefix) for prefix in blocked_prefixes):
+        return False
+    if any(token in lowered for token in blocked_substrings):
+        return False
+    return True
+
+
+async def _get_qwen_models(
+    api_key: Optional[str] = None,
+    api_endpoint: Optional[str] = None,
+) -> ModelDiscoveryResult:
+    """Return Qwen / Model Studio models, live when a key is supplied.
+
+    Default base URL is the China (Beijing) DashScope compatible-mode host so
+    existing keys keep working. A caller-supplied endpoint (Singapore intl,
+    US Virginia, or a workspace-specific ``*.maas.aliyuncs.com`` host) is
+    used instead after SSRF validation. Region keys are not interchangeable.
+    """
+    raw = (api_endpoint or "").strip()
+    if raw:
+        base_url = validate_discovery_endpoint(raw).rstrip("/")
+    else:
+        base_url = QWEN_DEFAULT_BASE_URL
+
+    result = await _get_catalog_provider_models(
         provider_label="Qwen",
-        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        base_url=base_url,
         known_models=QWEN_KNOWN_MODELS,
         api_key=api_key,
     )
+    if result.source != "live":
+        return result
+
+    filtered = [model_id for model_id in result.models if _is_qwen_chat_model(model_id)]
+    if not filtered:
+        logger.info(
+            "Qwen live list had no chat models after media/NSFW filter, "
+            "using bundled catalog"
+        )
+        return _fallback(QWEN_KNOWN_MODELS, ERROR_EMPTY_RESPONSE)
+    return _live(filtered)
 
 
 async def _get_deepseek_models(api_key: Optional[str] = None) -> ModelDiscoveryResult:

--- a/backend/preloop/services/data/model_prices.json
+++ b/backend/preloop/services/data/model_prices.json
@@ -2,7 +2,7 @@
  "_preloop_meta": {
   "source_url": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
   "fetched_at": "2026-07-12T12:10:45.331564+00:00",
-  "model_count": 845
+  "model_count": 849
  },
  "ai21.j2-mid-v1": {
   "input_cost_per_token": 1.25e-05,
@@ -4293,11 +4293,13 @@
   "output_cost_per_token": 1.5e-06
  },
  "dashscope/qwen-flash": {
+  "input_cost_per_token": 5e-08,
   "litellm_provider": "dashscope",
   "max_input_tokens": 997952,
   "max_output_tokens": 32768,
   "max_tokens": 32768,
-  "mode": "chat"
+  "mode": "chat",
+  "output_cost_per_token": 4e-07
  },
  "dashscope/qwen-flash-2025-07-28": {
   "litellm_provider": "dashscope",
@@ -4435,11 +4437,13 @@
   "mode": "chat"
  },
  "dashscope/qwen3-coder-plus": {
+  "input_cost_per_token": 1e-06,
   "litellm_provider": "dashscope",
   "max_input_tokens": 997952,
   "max_output_tokens": 65536,
   "max_tokens": 65536,
-  "mode": "chat"
+  "mode": "chat",
+  "output_cost_per_token": 5e-06
  },
  "dashscope/qwen3-coder-plus-2025-07-22": {
   "litellm_provider": "dashscope",
@@ -4449,11 +4453,13 @@
   "mode": "chat"
  },
  "dashscope/qwen3-max": {
+  "input_cost_per_token": 1.2e-06,
   "litellm_provider": "dashscope",
   "max_input_tokens": 258048,
   "max_output_tokens": 65536,
   "max_tokens": 65536,
-  "mode": "chat"
+  "mode": "chat",
+  "output_cost_per_token": 6e-06
  },
  "dashscope/qwen3-max-2026-01-23": {
   "litellm_provider": "dashscope",
@@ -4531,11 +4537,49 @@
   "mode": "chat"
  },
  "dashscope/qwen3.5-plus": {
+  "input_cost_per_token": 4e-07,
   "litellm_provider": "dashscope",
   "max_input_tokens": 991808,
   "max_output_tokens": 65536,
   "max_tokens": 65536,
-  "mode": "chat"
+  "mode": "chat",
+  "output_cost_per_token": 2.4e-06
+ },
+ "dashscope/qwen3.6-flash": {
+  "input_cost_per_token": 2.5e-07,
+  "litellm_provider": "dashscope",
+  "max_input_tokens": 1000000,
+  "max_output_tokens": 65536,
+  "max_tokens": 65536,
+  "mode": "chat",
+  "output_cost_per_token": 1.5e-06
+ },
+ "dashscope/qwen3.7-max": {
+  "input_cost_per_token": 2.5e-06,
+  "litellm_provider": "dashscope",
+  "max_input_tokens": 1000000,
+  "max_output_tokens": 65536,
+  "max_tokens": 65536,
+  "mode": "chat",
+  "output_cost_per_token": 7.5e-06
+ },
+ "dashscope/qwen3.7-plus": {
+  "input_cost_per_token": 4e-07,
+  "litellm_provider": "dashscope",
+  "max_input_tokens": 1000000,
+  "max_output_tokens": 65536,
+  "max_tokens": 65536,
+  "mode": "chat",
+  "output_cost_per_token": 1.6e-06
+ },
+ "dashscope/qwen3.8-max": {
+  "input_cost_per_token": 2e-06,
+  "litellm_provider": "dashscope",
+  "max_input_tokens": 991808,
+  "max_output_tokens": 131072,
+  "max_tokens": 131072,
+  "mode": "chat",
+  "output_cost_per_token": 6e-06
  },
  "dashscope/qwq-plus": {
   "input_cost_per_token": 8e-07,

--- a/backend/preloop/services/model_pricing.py
+++ b/backend/preloop/services/model_pricing.py
@@ -37,7 +37,13 @@ _SYNTHETIC_PROVIDER_PREFIXES = ("openai-compatible/", "custom/", "preloop/")
 
 # Hosts that front a model marketplace whose catalog keys litellm namespaces
 # under a provider prefix (e.g. ``openrouter/deepseek/deepseek-chat``).
-_ENDPOINT_HOST_PREFIXES = (("openrouter.ai", "openrouter"),)
+_ENDPOINT_HOST_PREFIXES = (
+    ("openrouter.ai", "openrouter"),
+    ("dashscope.aliyuncs.com", "dashscope"),
+    ("dashscope-intl.aliyuncs.com", "dashscope"),
+    ("dashscope-us.aliyuncs.com", "dashscope"),
+    ("maas.aliyuncs.com", "dashscope"),
+)
 
 
 def _strip_synthetic_prefix(candidate: str) -> str:
@@ -498,7 +504,13 @@ def _iter_litellm_model_candidates(ai_model: AIModel) -> Iterable[str]:
 
     if model_identifier:
         candidates.append(model_identifier)
-        prefix = _PROVIDER_PREFIX.get(provider, provider)
+        # Routing maps qwen -> openai (DashScope compatible-mode). Pricing
+        # keys live under dashscope/<id> in the vendored catalog.
+        prefix = (
+            "dashscope"
+            if provider == "qwen"
+            else _PROVIDER_PREFIX.get(provider, provider)
+        )
         bare_identifier = _strip_synthetic_prefix(model_identifier)
         if "/" not in bare_identifier and prefix not in _SYNTHETIC_PROVIDER_PREFIXES:
             candidates.append(f"{prefix}/{bare_identifier}")

--- a/backend/preloop/services/model_pricing.py
+++ b/backend/preloop/services/model_pricing.py
@@ -65,6 +65,18 @@ def _strip_synthetic_prefix(candidate: str) -> str:
     return candidate
 
 
+def _pricing_provider_prefix(provider: str) -> str:
+    """Return the price-catalog namespace for a configured provider.
+
+    Gateway routing maps ``qwen`` to ``openai`` (DashScope compatible-mode).
+    Vendored prices live under ``dashscope/<id>``, so pricing lookup must not
+    reuse the routing prefix.
+    """
+    if provider == "qwen":
+        return "dashscope"
+    return _PROVIDER_PREFIX.get(provider, provider)
+
+
 def _endpoint_prefix(api_endpoint: Optional[str]) -> Optional[str]:
     """Return the price-map provider prefix implied by a model's endpoint.
 
@@ -151,7 +163,7 @@ def _expand_candidate(
         undated = pattern.sub("", stripped)
         if undated != stripped and undated:
             yield undated
-            prefix = _PROVIDER_PREFIX.get(provider, provider)
+            prefix = _pricing_provider_prefix(provider)
             if "/" not in undated:
                 yield f"{prefix}/{undated}"
             break
@@ -506,11 +518,7 @@ def _iter_litellm_model_candidates(ai_model: AIModel) -> Iterable[str]:
         candidates.append(model_identifier)
         # Routing maps qwen -> openai (DashScope compatible-mode). Pricing
         # keys live under dashscope/<id> in the vendored catalog.
-        prefix = (
-            "dashscope"
-            if provider == "qwen"
-            else _PROVIDER_PREFIX.get(provider, provider)
-        )
+        prefix = _pricing_provider_prefix(provider)
         bare_identifier = _strip_synthetic_prefix(model_identifier)
         if "/" not in bare_identifier and prefix not in _SYNTHETIC_PROVIDER_PREFIXES:
             candidates.append(f"{prefix}/{bare_identifier}")

--- a/backend/tests/services/test_ai_model_provider.py
+++ b/backend/tests/services/test_ai_model_provider.py
@@ -13,8 +13,11 @@ from preloop.services.ai_model_provider import (
     MISTRAL_KNOWN_MODELS,
     MOONSHOT_KNOWN_MODELS,
     OPENAI_FALLBACK_MODELS,
+    QWEN_DEFAULT_BASE_URL,
+    QWEN_INTL_BASE_URL,
     QWEN_KNOWN_MODELS,
     ZAI_KNOWN_MODELS,
+    _is_qwen_chat_model,
     FALLBACK_ERROR_REASONS,
     MODEL_DISCOVERY_TIMEOUT_SECONDS,
     ModelDiscoveryResult,
@@ -147,7 +150,22 @@ class TestGetAvailableModelsForProvider:
             )
             result = await get_available_models_for_provider("qwen", "test_key")
             assert result.models == ["qwen-plus", "qwen-turbo"]
-            mock_get.assert_called_once_with("test_key")
+            mock_get.assert_called_once_with("test_key", None)
+
+    @pytest.mark.asyncio
+    async def test_get_qwen_models_forwards_endpoint(self):
+        """Intl / US Model Studio hosts must reach the Qwen lister."""
+        with patch("preloop.services.ai_model_provider._get_qwen_models") as mock_get:
+            mock_get.return_value = ModelDiscoveryResult(
+                models=["qwen3.8-max"], source="live"
+            )
+            result = await get_available_models_for_provider(
+                "qwen",
+                "test_key",
+                api_endpoint=QWEN_INTL_BASE_URL,
+            )
+            assert result.models == ["qwen3.8-max"]
+            mock_get.assert_called_once_with("test_key", QWEN_INTL_BASE_URL)
 
     @pytest.mark.asyncio
     async def test_get_deepseek_models(self):
@@ -791,12 +809,9 @@ class TestGetQwenModels:
             # The stale bundled catalog must not leak into a live answer.
             assert "qwq-32b-preview" not in result.models
             mock_client.assert_called_once()
-            # Verify it's using Qwen's base URL
+            # Verify it's using Qwen's China DashScope default
             call_kwargs = mock_client.call_args[1]
-            assert (
-                call_kwargs["base_url"]
-                == "https://dashscope.aliyuncs.com/compatible-mode/v1"
-            )
+            assert call_kwargs["base_url"] == QWEN_DEFAULT_BASE_URL
 
     @pytest.mark.asyncio
     async def test_get_qwen_models_empty_live_list_falls_back(self):
@@ -808,7 +823,7 @@ class TestGetQwenModels:
 
             result = await _get_qwen_models("valid_key")
 
-            assert "qwen-plus" in result.models
+            assert "qwen3.8-max" in result.models
             assert result.source == "fallback"
             assert result.error == "empty_response"
 
@@ -843,8 +858,65 @@ class TestGetQwenModels:
 
             result = await _get_qwen_models("test_key")
             # Should return known models even on network error
-            assert "qwen-plus" in result.models
+            assert "qwen3.8-max" in result.models
             assert result.source == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_get_qwen_models_uses_supplied_intl_endpoint(self):
+        """A Singapore / intl base URL must be queried, not the China default."""
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(
+                return_value=_models_response("qwen3.8-max")
+            )
+            mock_client.return_value = mock_instance
+
+            result = await _get_qwen_models("valid_key", QWEN_INTL_BASE_URL)
+
+            assert result.models == ["qwen3.8-max"]
+            assert result.source == "live"
+            call_kwargs = mock_client.call_args[1]
+            assert call_kwargs["base_url"] == QWEN_INTL_BASE_URL
+
+    @pytest.mark.asyncio
+    async def test_get_qwen_models_rejects_private_endpoint(self):
+        """User-supplied discovery URLs are an SSRF sink and must be validated."""
+        with pytest.raises(ValueError, match="private address"):
+            await _get_qwen_models("valid_key", "http://127.0.0.1/v1")
+
+    @pytest.mark.asyncio
+    async def test_get_qwen_models_filters_media_and_nsfw_from_live_list(self):
+        """Dedicated media / NSFW SKUs must not appear in the chat picker."""
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(
+                return_value=_models_response(
+                    "qwen3.8-max",
+                    "wan2.2-t2v",
+                    "qwen-image-plus",
+                    "qwen-vl-max",
+                    "happy-horse-1.1",
+                    "z-image",
+                    "some-nsfw-model",
+                    "deepseek-v4-pro",
+                )
+            )
+            mock_client.return_value = mock_instance
+
+            result = await _get_qwen_models("valid_key")
+
+            assert result.source == "live"
+            assert result.models == ["deepseek-v4-pro", "qwen3.8-max"]
+
+    def test_qwen_fallback_catalog_is_current_chat_models(self):
+        """Keyless picker shows 2026-08 chat models, not the stale 2025 set."""
+        assert QWEN_KNOWN_MODELS[0] == "qwen3.8-max"
+        assert "qwen3.7-max" in QWEN_KNOWN_MODELS
+        assert "qwq-32b-preview" not in QWEN_KNOWN_MODELS
+        assert "qwen-turbo" not in QWEN_KNOWN_MODELS
+        assert _is_qwen_chat_model("qwen3.8-max")
+        assert not _is_qwen_chat_model("wan2.2-t2v")
+        assert not _is_qwen_chat_model("qwen3-vl-plus")
 
 
 class TestGetDeepSeekModels:

--- a/backend/tests/services/test_ai_model_provider.py
+++ b/backend/tests/services/test_ai_model_provider.py
@@ -16,6 +16,7 @@ from preloop.services.ai_model_provider import (
     QWEN_DEFAULT_BASE_URL,
     QWEN_INTL_BASE_URL,
     QWEN_KNOWN_MODELS,
+    QWEN_US_BASE_URL,
     ZAI_KNOWN_MODELS,
     _is_qwen_chat_model,
     FALLBACK_ERROR_REASONS,
@@ -885,6 +886,14 @@ class TestGetQwenModels:
             await _get_qwen_models("valid_key", "http://127.0.0.1/v1")
 
     @pytest.mark.asyncio
+    async def test_get_qwen_models_rejects_non_aliyun_host(self):
+        """Qwen discovery must not fetch a host outside DashScope / Model Studio."""
+        with pytest.raises(ValueError, match="DashScope or Model Studio"):
+            await _get_qwen_models(
+                "valid_key", "https://evil.example.com/compatible-mode/v1"
+            )
+
+    @pytest.mark.asyncio
     async def test_get_qwen_models_filters_media_and_nsfw_from_live_list(self):
         """Dedicated media / NSFW SKUs must not appear in the chat picker."""
         with patch("openai.AsyncOpenAI") as mock_client:
@@ -1486,6 +1495,71 @@ class TestDiscoveryEndpointValidation:
         from preloop.services.ai_model_provider import validate_discovery_endpoint
 
         assert validate_discovery_endpoint(endpoint) == endpoint
+
+
+class TestQwenEndpointAllowlist:
+    """Qwen discovery/chat URLs are restricted to DashScope / Model Studio."""
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            QWEN_DEFAULT_BASE_URL,
+            QWEN_INTL_BASE_URL,
+            QWEN_US_BASE_URL,
+            "https://workspace-abc.maas.aliyuncs.com/v1",
+        ],
+    )
+    def test_allowed_dashscope_hosts(self, endpoint):
+        from preloop.services.ai_model_provider import validate_qwen_endpoint
+
+        assert validate_qwen_endpoint(endpoint) == endpoint
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://evil.example.com/v1",
+            "https://openrouter.ai/api/v1",
+            "https://dashscope.aliyuncs.com.evil.test/v1",
+            "https://notaliyuncs.com/v1",
+            "https://1.2.3.4/v1",
+        ],
+    )
+    def test_rejects_non_aliyun_host(self, endpoint):
+        from preloop.services.ai_model_provider import validate_qwen_endpoint
+
+        with pytest.raises(ValueError, match="DashScope or Model Studio"):
+            validate_qwen_endpoint(endpoint)
+
+    def test_openai_compatible_still_allows_non_aliyun_host(self):
+        """Other providers must not inherit the Qwen host allowlist."""
+        from preloop.services.ai_model_provider import validate_discovery_endpoint
+
+        endpoint = "https://gateway.example.com/v1"
+        assert validate_discovery_endpoint(endpoint) == endpoint
+
+    def test_crud_persist_rejects_non_aliyun_qwen_host(self):
+        """Saved Qwen chat endpoints use the same DashScope allowlist."""
+        from preloop.models.crud.ai_model import CRUDAIModel
+
+        with pytest.raises(ValueError, match="DashScope or Model Studio"):
+            CRUDAIModel._validate_qwen_api_endpoint(
+                {
+                    "provider_name": "qwen",
+                    "api_endpoint": "https://evil.example.com/v1",
+                }
+            )
+        CRUDAIModel._validate_qwen_api_endpoint(
+            {
+                "provider_name": "qwen",
+                "api_endpoint": QWEN_INTL_BASE_URL,
+            }
+        )
+        CRUDAIModel._validate_qwen_api_endpoint(
+            {
+                "provider_name": "openai",
+                "api_endpoint": "https://evil.example.com/v1",
+            }
+        )
 
 
 class TestOpenAIAuthErrorDoesNotLeakSecrets:

--- a/backend/tests/services/test_model_pricing.py
+++ b/backend/tests/services/test_model_pricing.py
@@ -342,6 +342,13 @@ class TestQwenProviderPricing:
         assert "qwen3.8-max" in candidates
         assert "dashscope/qwen3.8-max" in candidates
 
+    def test_dated_qwen_id_expands_to_dashscope_undated(self) -> None:
+        """Date-stamped Qwen ids must undate under dashscope, not openai."""
+        ai_model = AIModel(provider_name="qwen", model_identifier="qwen-plus-20250101")
+        candidates = list(_iter_litellm_model_candidates(ai_model))
+        assert "dashscope/qwen-plus" in candidates
+        assert "openai/qwen-plus" not in candidates
+
     def test_intl_endpoint_still_prices_as_dashscope(self) -> None:
         ai_model = AIModel(
             provider_name="qwen",

--- a/backend/tests/services/test_model_pricing.py
+++ b/backend/tests/services/test_model_pricing.py
@@ -329,6 +329,64 @@ class TestNewProviderPricing:
             )
 
 
+class TestQwenProviderPricing:
+    """Qwen / Model Studio fallback ids must resolve to dashscope catalog prices.
+
+    International USD list prices from Model Studio docs (fetched 2026-08-17).
+    Plus/flash families are tiered; we store the lower published tier.
+    """
+
+    def test_candidates_include_dashscope_prefix(self) -> None:
+        ai_model = AIModel(provider_name="qwen", model_identifier="qwen3.8-max")
+        candidates = list(_iter_litellm_model_candidates(ai_model))
+        assert "qwen3.8-max" in candidates
+        assert "dashscope/qwen3.8-max" in candidates
+
+    def test_intl_endpoint_still_prices_as_dashscope(self) -> None:
+        ai_model = AIModel(
+            provider_name="qwen",
+            model_identifier="qwen3.8-max",
+            api_endpoint="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        )
+        candidates = list(_iter_litellm_model_candidates(ai_model))
+        assert "dashscope/qwen3.8-max" in candidates
+
+    def test_bundled_table_prices_every_qwen_fallback_id(self) -> None:
+        from preloop.services.ai_model_provider import QWEN_KNOWN_MODELS
+
+        prices = json.loads(CATALOG_PATH.read_text())
+        for model_id in QWEN_KNOWN_MODELS:
+            key = f"dashscope/{model_id}"
+            assert key in prices, f"{key} missing from model_prices.json"
+            entry = prices[key]
+            assert entry["litellm_provider"] == "dashscope"
+            assert entry["mode"] == "chat"
+            assert entry["input_cost_per_token"] > 0
+            assert entry["output_cost_per_token"] > 0
+
+    def test_qwen38_max_list_prices_in_bundled_table(self) -> None:
+        """modelstudio.alibabacloud.com launch card (2026-08-03): $2 / $6 per 1M."""
+        prices = json.loads(CATALOG_PATH.read_text())
+        entry = prices["dashscope/qwen3.8-max"]
+        assert entry["input_cost_per_token"] == 2e-06
+        assert entry["output_cost_per_token"] == 6e-06
+        assert entry["max_input_tokens"] == 991808
+        assert entry["max_output_tokens"] == 131072
+
+    def test_qwen38_max_cost_resolves_through_estimator(self) -> None:
+        load_catalog(force=True)
+        ai_model = AIModel(provider_name="qwen", model_identifier="qwen3.8-max")
+        estimate = estimate_ai_model_usage_cost_detailed(
+            ai_model,
+            prompt_tokens=1_000_000,
+            completion_tokens=1_000_000,
+            total_tokens=2_000_000,
+        )
+        assert estimate.source == "catalog"
+        # 1M input at $2/M plus 1M output at $6/M.
+        assert estimate.cost == pytest.approx(8.0, rel=1e-6)
+
+
 def test_model_price_override_serializes_adjustment_terms() -> None:
     """Persisted overrides should expose all adjustment terms to estimators."""
     override = ModelPriceOverride(

--- a/frontend/src/components/add-ai-model-modal.test.ts
+++ b/frontend/src/components/add-ai-model-modal.test.ts
@@ -714,6 +714,44 @@ describe('AddAIModelModal new BYOK providers', () => {
   });
 });
 
+describe('AddAIModelModal Qwen regional endpoints', () => {
+  let element: AddAIModelModal;
+  let sandbox: SinonSandbox;
+
+  beforeEach(async () => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    sandbox = sinon.createSandbox();
+    sandbox.stub(window, 'fetch').resolves(new Response(JSON.stringify([])));
+    element = await fixture(html`<add-ai-model-modal></add-ai-model-modal>`);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    localStorage.clear();
+  });
+
+  it('prefills the China DashScope URL and does not rename it', async () => {
+    await (element as any)._handleProviderChange({
+      target: { value: 'qwen' },
+    } as unknown as Event);
+    expect((element as any)._currentModel.api_endpoint).to.equal(
+      'https://dashscope.aliyuncs.com/compatible-mode/v1'
+    );
+  });
+
+  it('mentions the international and US hosts in the API URL help', async () => {
+    element.open = true;
+    await (element as any)._handleProviderChange({
+      target: { value: 'qwen' },
+    } as unknown as Event);
+    await element.updateComplete;
+    const help = element.shadowRoot?.textContent || '';
+    expect(help).to.contain('dashscope-intl.aliyuncs.com');
+    expect(help).to.contain('dashscope-us.aliyuncs.com');
+  });
+});
+
 /**
  * Editing a model must never echo stored credential bookkeeping back to the
  * server. The API returns credential_type / credentials_* fields on reads;

--- a/frontend/src/components/add-ai-model-modal.test.ts
+++ b/frontend/src/components/add-ai-model-modal.test.ts
@@ -742,11 +742,16 @@ describe('AddAIModelModal Qwen regional endpoints', () => {
 
   it('mentions the international and US hosts in the API URL help', async () => {
     element.open = true;
+    await element.updateComplete;
     await (element as any)._handleProviderChange({
       target: { value: 'qwen' },
     } as unknown as Event);
     await element.updateComplete;
-    const help = element.shadowRoot?.textContent || '';
+    const help =
+      element.shadowRoot?.querySelector(
+        'sl-input[label="API URL"] [slot="help-text"]'
+      )?.textContent || '';
+    expect(help).to.contain('dashscope.aliyuncs.com');
     expect(help).to.contain('dashscope-intl.aliyuncs.com');
     expect(help).to.contain('dashscope-us.aliyuncs.com');
   });

--- a/frontend/src/components/add-ai-model-modal.ts
+++ b/frontend/src/components/add-ai-model-modal.ts
@@ -711,7 +711,21 @@ export class AddAIModelModal extends LitElement {
               this.requestUpdate();
             }}
             ?disabled=${this._isSubmitting}
-          ></sl-input>
+          >
+            ${
+              this._currentModel.provider_name === 'qwen'
+                ? html`
+                    <div slot="help-text">
+                      Default is China (Beijing) DashScope. International
+                      (Singapore):
+                      https://dashscope-intl.aliyuncs.com/compatible-mode/v1.
+                      US: https://dashscope-us.aliyuncs.com/compatible-mode/v1.
+                      Keys are not interchangeable across regions.
+                    </div>
+                  `
+                : ''
+            }
+          </sl-input>
           <sl-input
             class="full-width"
             type="password"

--- a/frontend/src/components/add-ai-model-modal.ts
+++ b/frontend/src/components/add-ai-model-modal.ts
@@ -716,8 +716,9 @@ export class AddAIModelModal extends LitElement {
               this._currentModel.provider_name === 'qwen'
                 ? html`
                     <div slot="help-text">
-                      Default is China (Beijing) DashScope. International
-                      (Singapore):
+                      Default is China (Beijing):
+                      https://dashscope.aliyuncs.com/compatible-mode/v1.
+                      International (Singapore):
                       https://dashscope-intl.aliyuncs.com/compatible-mode/v1.
                       US: https://dashscope-us.aliyuncs.com/compatible-mode/v1.
                       Keys are not interchangeable across regions.


### PR DESCRIPTION
## Summary
- Update the keyless Qwen picker to current Model Studio chat models (`qwen3.8-max` first). Drop `qwen-turbo`, `qwen-max`, and `qwq-32b-preview`.
- Live `/models` listing now uses the stored DashScope / Model Studio base URL (China Beijing default unchanged) and drops dedicated image, video, audio, and NSFW ids.
- Price every fallback id under `dashscope/<id>` using published international list rates. DeepSeek-V4 / GLM 5.2 / Kimi stay on their own providers; a Model Studio key that also serves those SKUs will surface them via live listing.

## Test plan
- [x] `pytest backend/tests/services/test_ai_model_provider.py backend/tests/services/test_model_pricing.py backend/tests/services/test_ai_approval_service.py` (188 passed)
- [ ] Frontend `add-ai-model-modal` tests (Playwright Chromium was not available in the authoring environment)
- [ ] After an Alibaba trial key lands: live-list Beijing, `dashscope-intl`, and `dashscope-us`; confirm `qwen3.8-max` and any entitled third-party SKUs; refine the media filter against the real list


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Catalog refresh and pricing-only change with strong test coverage; no security or data-integrity concerns found.
>
> **Overview**
> Refreshes the keyless Qwen picker to current Model Studio chat models, honors user-supplied regional DashScope endpoints for live model listing, and prices fallback ids under the `dashscope/` namespace. Both prior LOW suggestions (SSRF DNS-resolution gap and the undated-fallback pricing inconsistency) are now resolved.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 27624acb. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->