### PR TITLE
feat(cli): add preloop update and interactive upgrade prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Update now? [y/N]" when stdin is a TTY and the running binary is
   writable. If the binary cannot be replaced, the CLI stays silent (no
   nag, no sudo hint).
+- **`preloop flow trigger`**: CI-native trigger for an existing flow by id
+  or name. Posts to `POST /api/v1/flows/{flow_id}/trigger`, accepts
+  `--payload JSON` or `--payload -` (stdin), and waits for a terminal
+  status when stdin is not a TTY (override with `--wait=false`). Logs are
+  polled from `GET /api/v1/flows/executions/{id}/logs` and printed to
+  stdout. Non-zero exit on FAILED, STOPPED, or TIMEOUT. `--runner` errors
+  until self-hosted runners land. See `docs/guide/flows/ci-trigger.md`.
 - **Native scheduled (cron) flow triggers**: flows can now run on a schedule
   without an external cron caller hitting the webhook endpoint. Create or
   update a flow with `trigger_event_source: "schedule"` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`preloop update`**: download the matching GitHub release asset for this
+  OS/architecture and replace the current binary in place. `--check` prints
+  the latest version and exits; `--yes` / `-y` skips the confirmation
+  prompt. Version lookup honors `PRELOOP_DISABLE_TELEMETRY` the same way
+  `preloop version --check` does. The daily update notice now asks
+  "Update now? [y/N]" when stdin is a TTY and the running binary is
+  writable. If the binary cannot be replaced, the CLI stays silent (no
+  nag, no sudo hint).
 - **Native scheduled (cron) flow triggers**: flows can now run on a schedule
   without an external cron caller hitting the webhook endpoint. Create or
   update a flow with `trigger_event_source: "schedule"` and

--- a/cli/README.md
+++ b/cli/README.md
@@ -188,7 +188,16 @@ Both flags default to `ask`. With `--yes` alone, the CLI skips the main offboard
 ```bash
 preloop version                        # Show version info
 preloop version --check                # Check for updates
+preloop update                         # Install the latest CLI release
+preloop update --check                 # Print current vs latest and exit
+preloop update --yes                   # Install without prompting
 ```
+
+`preloop update` downloads the GitHub release asset for this OS/architecture
+(the same URL as `scripts/install-cli.sh`) and replaces the current binary
+in place. The daily update notice asks whether to upgrade when stdin is a
+TTY and the binary is writable; otherwise it stays silent. Version lookup
+is skipped when `PRELOOP_DISABLE_TELEMETRY` is set.
 
 ## Configuration
 
@@ -264,11 +273,13 @@ cli/
 │   │   ├── policy.go        # policy validate/apply/diff/export/list
 │   │   ├── tools.go         # tools list/describe/exec
 │   │   ├── approvals.go     # approvals list/pending/approve/deny
-│   │   └── version.go       # version command
+│   │   ├── version.go       # version command
+│   │   └── update.go        # update command
 │   ├── mcpclient/
 │   │   └── client.go        # Minimal MCP HTTP client
 │   └── version/
-│       └── check.go         # Daily version check logic
+│       ├── check.go         # Daily version check logic
+│       └── update.go        # In-place GitHub release installer
 ├── go.mod
 ├── go.sum
 ├── Makefile

--- a/cli/README.md
+++ b/cli/README.md
@@ -183,6 +183,21 @@ Both flags default to `ask`. With `--yes` alone, the CLI skips the main offboard
 - MCP servers are kept if they are still referenced by another managed agent
 - Recently active shared resources are also skipped
 
+### Flows
+
+```bash
+preloop flow trigger <flow-id-or-name>
+preloop flow trigger nightly-review --payload '{"ref":"main"}'
+cat event.json | preloop flow trigger nightly-review --payload -
+preloop flow trigger nightly-review --wait --timeout 30m
+```
+
+In CI (stdin is not a TTY) the command waits by default and streams
+execution logs to stdout. The same logs remain in the console execution
+view. Exit status is non-zero on FAILED, STOPPED, or TIMEOUT. Auth is
+`--token`, `PRELOOP_TOKEN`, or the saved login. See
+[docs/guide/flows/ci-trigger.md](../docs/guide/flows/ci-trigger.md).
+
 ### Version
 
 ```bash
@@ -274,7 +289,8 @@ cli/
 │   │   ├── tools.go         # tools list/describe/exec
 │   │   ├── approvals.go     # approvals list/pending/approve/deny
 │   │   ├── version.go       # version command
-│   │   └── update.go        # update command
+│   │   ├── update.go        # update command
+│   │   └── flow.go          # flow trigger
 │   ├── mcpclient/
 │   │   └── client.go        # Minimal MCP HTTP client
 │   └── version/

--- a/cli/internal/cmd/auth.go
+++ b/cli/internal/cmd/auth.go
@@ -534,7 +534,9 @@ func conversionEventName() string {
 	return "Login"
 }
 
-func stdinIsTerminal() bool {
+var stdinIsTerminal = defaultStdinIsTerminal
+
+func defaultStdinIsTerminal() bool {
 	stat, err := os.Stdin.Stat()
 	if err != nil {
 		return false

--- a/cli/internal/cmd/flow.go
+++ b/cli/internal/cmd/flow.go
@@ -1,0 +1,283 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+const (
+	flowsPath              = "/api/v1/flows"
+	defaultFlowWaitTimeout = 60 * time.Minute
+	flowPollInitial        = time.Second
+	flowPollMax            = 5 * time.Second
+)
+
+var uuidPattern = regexp.MustCompile(
+	`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+)
+
+var (
+	flowSleep = time.Sleep
+	flowNow   = time.Now
+)
+
+var terminalFailureStatuses = map[string]bool{
+	"FAILED":  true,
+	"STOPPED": true,
+	"TIMEOUT": true,
+}
+
+// flowCmd is the parent for flow operations.
+var flowCmd = &cobra.Command{
+	Use:   "flow",
+	Short: "Trigger and inspect Preloop flows",
+	Long:  `Trigger flow executions from CI or the command line.`,
+}
+
+// flowTriggerCmd implements `preloop flow trigger`.
+var flowTriggerCmd = &cobra.Command{
+	Use:   "trigger <flow-id-or-name>",
+	Short: "Trigger a flow execution",
+	Long: `Trigger a flow by id or name via POST /api/v1/flows/{flow_id}/trigger.
+
+In CI (stdin is not a TTY) the command waits for a terminal status by default
+and streams execution logs to stdout. The same logs remain visible in the
+console execution view. Exit status is non-zero on FAILED, STOPPED, or TIMEOUT.
+
+Examples:
+  preloop flow trigger pull-request-reviewer
+  preloop flow trigger 11111111-2222-4333-8444-555555555555 --payload '{"ref":"main"}'
+  cat event.json | preloop flow trigger pull-request-reviewer --payload -`,
+	Args: cobra.ExactArgs(1),
+	RunE: runFlowTrigger,
+}
+
+func init() {
+	flowCmd.AddCommand(flowTriggerCmd)
+	flowTriggerCmd.Flags().String("payload", "", "JSON trigger payload, or - to read stdin")
+	flowTriggerCmd.Flags().Bool("wait", false, "stream logs until the execution finishes (default on when stdin is not a TTY)")
+	flowTriggerCmd.Flags().String("runner", "", "pin the execution to a self-hosted runner (not yet available)")
+	flowTriggerCmd.Flags().Duration("timeout", defaultFlowWaitTimeout, "how long --wait will poll before exiting")
+}
+
+func runFlowTrigger(cmd *cobra.Command, args []string) error {
+	runner, err := cmd.Flags().GetString("runner")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(runner) != "" {
+		return fmt.Errorf("self-hosted runner targeting is not available yet; omit --runner")
+	}
+
+	payloadFlag, err := cmd.Flags().GetString("payload")
+	if err != nil {
+		return err
+	}
+	payload, err := parseTriggerPayload(payloadFlag, os.Stdin)
+	if err != nil {
+		return err
+	}
+
+	waitFlag, err := cmd.Flags().GetBool("wait")
+	if err != nil {
+		return err
+	}
+	wait := shouldWaitDefault(cmd.Flags().Changed("wait"), waitFlag, stdinIsTerminal())
+	timeout, err := cmd.Flags().GetDuration("timeout")
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClient(FlagToken, FlagURL)
+	if err != nil {
+		return err
+	}
+
+	flowID, err := resolveFlowID(client, args[0])
+	if err != nil {
+		return err
+	}
+
+	var result flowTriggerResult
+	if err := client.Post(flowsPath+"/"+flowID+"/trigger", payload, &result); err != nil {
+		return fmt.Errorf("failed to trigger flow: %w", err)
+	}
+	if result.ID == "" {
+		return fmt.Errorf("trigger response did not include an execution id")
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Triggered flow %s (execution %s, status %s)\n",
+		flowID, result.ID, result.Status)
+
+	if !wait {
+		return nil
+	}
+	return waitForExecution(client, result.ID, timeout, cmd.OutOrStdout())
+}
+
+type flowTriggerResult struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	FlowID string `json:"flow_id"`
+}
+
+type flowExecutionStatus struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+type flowLogsResponse struct {
+	Logs    []flowLogEntry `json:"logs"`
+	Source  string         `json:"source"`
+	HasMore bool           `json:"has_more"`
+}
+
+type flowLogEntry struct {
+	Type    string         `json:"type"`
+	Payload map[string]any `json:"payload"`
+}
+
+func parseTriggerPayload(raw string, stdin io.Reader) (map[string]any, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var r io.Reader
+	if raw == "-" {
+		r = stdin
+	} else {
+		r = strings.NewReader(raw)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read payload: %w", err)
+	}
+	data = bytesTrimSpace(data)
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("payload must be a JSON object: %w", err)
+	}
+	return payload, nil
+}
+
+func bytesTrimSpace(data []byte) []byte {
+	return []byte(strings.TrimSpace(string(data)))
+}
+
+func resolveFlowID(client *api.Client, nameOrID string) (string, error) {
+	nameOrID = strings.TrimSpace(nameOrID)
+	if nameOrID == "" {
+		return "", fmt.Errorf("flow id or name is required")
+	}
+	if uuidPattern.MatchString(nameOrID) {
+		var flow flowSummaryResponse
+		if err := client.Get(flowsPath+"/"+nameOrID, &flow); err == nil && flow.ID != "" {
+			return flow.ID, nil
+		}
+	}
+
+	var flows []flowSummaryResponse
+	if err := client.Get(flowsPath+"?limit=1000", &flows); err != nil {
+		return "", fmt.Errorf("failed to list flows: %w", err)
+	}
+	var matches []flowSummaryResponse
+	for _, flow := range flows {
+		if strings.EqualFold(flow.ID, nameOrID) || strings.EqualFold(flow.Name, nameOrID) {
+			matches = append(matches, flow)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0].ID, nil
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("multiple flows match %q", nameOrID)
+	}
+	return "", fmt.Errorf("flow %q not found", nameOrID)
+}
+
+func shouldWaitDefault(flagChanged, flagValue, isTTY bool) bool {
+	if flagChanged {
+		return flagValue
+	}
+	return !isTTY
+}
+
+func extractLogLine(entry flowLogEntry) string {
+	if entry.Payload == nil {
+		return ""
+	}
+	if line, ok := entry.Payload["line"].(string); ok && line != "" {
+		return line
+	}
+	if msg, ok := entry.Payload["message"].(string); ok && msg != "" {
+		return msg
+	}
+	return ""
+}
+
+func newLogLines(source string, alreadyPrinted int, entries []flowLogEntry) []string {
+	lines := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if line := extractLogLine(entry); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if strings.EqualFold(source, "container") && alreadyPrinted > 0 && len(lines) >= alreadyPrinted {
+		return lines[alreadyPrinted:]
+	}
+	return lines
+}
+
+func waitForExecution(client *api.Client, executionID string, timeout time.Duration, out io.Writer) error {
+	deadline := flowNow().Add(timeout)
+	printed := 0
+	backoff := flowPollInitial
+
+	for {
+		var exec flowExecutionStatus
+		if err := client.Get("/api/v1/flows/executions/"+executionID, &exec); err != nil {
+			return fmt.Errorf("failed to read execution: %w", err)
+		}
+
+		var logs flowLogsResponse
+		path := fmt.Sprintf("/api/v1/flows/executions/%s/logs?skip=%d&limit=500", executionID, printed)
+		if err := client.Get(path, &logs); err != nil {
+			return fmt.Errorf("failed to read execution logs: %w", err)
+		}
+		for _, line := range newLogLines(logs.Source, printed, logs.Logs) {
+			fmt.Fprintln(out, line)
+			printed++
+		}
+
+		status := strings.ToUpper(strings.TrimSpace(exec.Status))
+		if status == "SUCCEEDED" {
+			return nil
+		}
+		if terminalFailureStatuses[status] {
+			return fmt.Errorf("execution %s %s", executionID, status)
+		}
+		if flowNow().After(deadline) {
+			return fmt.Errorf("execution %s timed out after %s (last status %s)", executionID, timeout, exec.Status)
+		}
+
+		flowSleep(backoff)
+		if backoff < flowPollMax {
+			backoff *= 2
+			if backoff > flowPollMax {
+				backoff = flowPollMax
+			}
+		}
+	}
+}

--- a/cli/internal/cmd/flow.go
+++ b/cli/internal/cmd/flow.go
@@ -19,6 +19,10 @@ const (
 	defaultFlowWaitTimeout = 60 * time.Minute
 	flowPollInitial        = time.Second
 	flowPollMax            = 5 * time.Second
+	flowLogPageSize        = 500
+	flowLogMaxPages        = 100
+	flowListPageSize       = 1000
+	flowListMaxPages       = 10
 )
 
 var uuidPattern = regexp.MustCompile(
@@ -189,8 +193,16 @@ func resolveFlowID(client *api.Client, nameOrID string) (string, error) {
 	}
 
 	var flows []flowSummaryResponse
-	if err := client.Get(flowsPath+"?limit=1000", &flows); err != nil {
-		return "", fmt.Errorf("failed to list flows: %w", err)
+	for page := 0; page < flowListMaxPages; page++ {
+		var batch []flowSummaryResponse
+		path := fmt.Sprintf("%s?skip=%d&limit=%d", flowsPath, page*flowListPageSize, flowListPageSize)
+		if err := client.Get(path, &batch); err != nil {
+			return "", fmt.Errorf("failed to list flows: %w", err)
+		}
+		flows = append(flows, batch...)
+		if len(batch) < flowListPageSize {
+			break
+		}
 	}
 	var matches []flowSummaryResponse
 	for _, flow := range flows {
@@ -240,6 +252,24 @@ func newLogLines(source string, alreadyPrinted int, entries []flowLogEntry) []st
 	return lines
 }
 
+func drainExecutionLogs(client *api.Client, executionID string, printed int, out io.Writer) (int, error) {
+	for page := 0; page < flowLogMaxPages; page++ {
+		var logs flowLogsResponse
+		path := fmt.Sprintf("/api/v1/flows/executions/%s/logs?skip=%d&limit=%d", executionID, printed, flowLogPageSize)
+		if err := client.Get(path, &logs); err != nil {
+			return printed, fmt.Errorf("failed to read execution logs: %w", err)
+		}
+		for _, line := range newLogLines(logs.Source, printed, logs.Logs) {
+			fmt.Fprintln(out, line)
+			printed++
+		}
+		if !logs.HasMore {
+			return printed, nil
+		}
+	}
+	return printed, nil
+}
+
 func waitForExecution(client *api.Client, executionID string, timeout time.Duration, out io.Writer) error {
 	deadline := flowNow().Add(timeout)
 	printed := 0
@@ -251,15 +281,11 @@ func waitForExecution(client *api.Client, executionID string, timeout time.Durat
 			return fmt.Errorf("failed to read execution: %w", err)
 		}
 
-		var logs flowLogsResponse
-		path := fmt.Sprintf("/api/v1/flows/executions/%s/logs?skip=%d&limit=500", executionID, printed)
-		if err := client.Get(path, &logs); err != nil {
-			return fmt.Errorf("failed to read execution logs: %w", err)
+		nextPrinted, err := drainExecutionLogs(client, executionID, printed, out)
+		if err != nil {
+			return err
 		}
-		for _, line := range newLogLines(logs.Source, printed, logs.Logs) {
-			fmt.Fprintln(out, line)
-			printed++
-		}
+		printed = nextPrinted
 
 		status := strings.ToUpper(strings.TrimSpace(exec.Status))
 		if status == "SUCCEEDED" {

--- a/cli/internal/cmd/flow_test.go
+++ b/cli/internal/cmd/flow_test.go
@@ -1,0 +1,273 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/preloop/preloop/cli/internal/api"
+	"github.com/preloop/preloop/cli/internal/testenv"
+)
+
+func TestParseTriggerPayload(t *testing.T) {
+	got, err := parseTriggerPayload(`{"ref":"main"}`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["ref"] != "main" {
+		t.Fatalf("got %#v", got)
+	}
+
+	empty, err := parseTriggerPayload("", nil)
+	if err != nil || empty != nil {
+		t.Fatalf("empty payload: %#v %v", empty, err)
+	}
+
+	fromStdin, err := parseTriggerPayload("-", strings.NewReader(`{"n":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fromStdin["n"].(float64) != 1 {
+		t.Fatalf("stdin payload: %#v", fromStdin)
+	}
+
+	if _, err := parseTriggerPayload(`["not","object"]`, nil); err == nil {
+		t.Fatal("expected error for non-object JSON")
+	}
+}
+
+func TestShouldWaitDefault(t *testing.T) {
+	if !shouldWaitDefault(false, false, false) {
+		t.Fatal("CI (no TTY, flag unset) should wait")
+	}
+	if shouldWaitDefault(false, false, true) {
+		t.Fatal("interactive TTY should not wait by default")
+	}
+	if shouldWaitDefault(true, false, false) {
+		t.Fatal("explicit --wait=false must win in CI")
+	}
+	if !shouldWaitDefault(true, true, true) {
+		t.Fatal("explicit --wait must win on a TTY")
+	}
+}
+
+func TestExtractAndDedupeLogLines(t *testing.T) {
+	entries := []flowLogEntry{
+		{Payload: map[string]any{"line": "one"}},
+		{Payload: map[string]any{"message": "two"}},
+		{Payload: map[string]any{}},
+	}
+	if got := newLogLines("database", 0, entries); strings.Join(got, ",") != "one,two" {
+		t.Fatalf("database lines = %#v", got)
+	}
+	if got := newLogLines("container", 1, entries); strings.Join(got, ",") != "two" {
+		t.Fatalf("container dedupe = %#v", got)
+	}
+}
+
+func TestResolveFlowIDByNameAndUUID(t *testing.T) {
+	const flowID = "11111111-2222-4333-8444-555555555555"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/flows/"+flowID:
+			_ = json.NewEncoder(w).Encode(flowSummaryResponse{ID: flowID, Name: "Nightly Review"})
+		case r.URL.Path == "/api/v1/flows":
+			_ = json.NewEncoder(w).Encode([]flowSummaryResponse{
+				{ID: flowID, Name: "Nightly Review"},
+				{ID: "22222222-2222-4333-8444-555555555555", Name: "Other"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client := api.NewClientWithToken(server.URL, "tok")
+
+	got, err := resolveFlowID(client, "Nightly Review")
+	if err != nil || got != flowID {
+		t.Fatalf("by name: %q %v", got, err)
+	}
+	got, err = resolveFlowID(client, flowID)
+	if err != nil || got != flowID {
+		t.Fatalf("by id: %q %v", got, err)
+	}
+	if _, err := resolveFlowID(client, "missing"); err == nil {
+		t.Fatal("expected not found")
+	}
+}
+
+func TestFlowTriggerPostsAndPrintsID(t *testing.T) {
+	const flowID = "11111111-2222-4333-8444-555555555555"
+	var gotPath string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.Method + " " + r.URL.Path
+		switch {
+		case r.URL.Path == "/api/v1/flows":
+			_ = json.NewEncoder(w).Encode([]flowSummaryResponse{
+				{ID: flowID, Name: "Nightly Review"},
+			})
+		case r.URL.Path == "/api/v1/flows/"+flowID+"/trigger":
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_ = json.NewEncoder(w).Encode(flowTriggerResult{
+				ID:     "exec-1",
+				Status: "PENDING",
+				FlowID: flowID,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	testenv.SetHome(t, t.TempDir())
+	oldToken, oldURL := FlagToken, FlagURL
+	FlagToken, FlagURL = "tok", server.URL
+	t.Cleanup(func() { FlagToken, FlagURL = oldToken, oldURL })
+
+	if err := flowTriggerCmd.Flags().Set("payload", `{"ref":"main"}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := flowTriggerCmd.Flags().Set("wait", "false"); err != nil {
+		t.Fatal(err)
+	}
+	if err := flowTriggerCmd.Flags().Set("runner", ""); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = flowTriggerCmd.Flags().Set("payload", "")
+		_ = flowTriggerCmd.Flags().Set("wait", "false")
+		_ = flowTriggerCmd.Flags().Set("runner", "")
+	})
+
+	var out bytes.Buffer
+	flowTriggerCmd.SetOut(&out)
+	if err := runFlowTrigger(flowTriggerCmd, []string{"Nightly Review"}); err != nil {
+		t.Fatalf("runFlowTrigger: %v", err)
+	}
+	if gotPath != "POST /api/v1/flows/"+flowID+"/trigger" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotBody["ref"] != "main" {
+		t.Fatalf("body = %#v", gotBody)
+	}
+	if !strings.Contains(out.String(), "exec-1") {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestFlowTriggerRunnerFlagErrors(t *testing.T) {
+	if err := flowTriggerCmd.Flags().Set("runner", "buildkite"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = flowTriggerCmd.Flags().Set("runner", "") })
+	err := runFlowTrigger(flowTriggerCmd, []string{"any"})
+	if err == nil || !strings.Contains(err.Error(), "not available yet") {
+		t.Fatalf("expected runner error, got %v", err)
+	}
+}
+
+func TestWaitForExecutionStreamsLogsAndFails(t *testing.T) {
+	polls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/flows/executions/exec-1/logs"):
+			line := "hello from agent"
+			if polls > 1 {
+				line = "done"
+			}
+			_ = json.NewEncoder(w).Encode(flowLogsResponse{
+				Source: "database",
+				Logs:   []flowLogEntry{{Payload: map[string]any{"line": line}}},
+			})
+		case r.URL.Path == "/api/v1/flows/executions/exec-1":
+			polls++
+			status := "RUNNING"
+			if polls >= 2 {
+				status = "FAILED"
+			}
+			_ = json.NewEncoder(w).Encode(flowExecutionStatus{ID: "exec-1", Status: status})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	oldSleep := flowSleep
+	flowSleep = func(time.Duration) {}
+	t.Cleanup(func() { flowSleep = oldSleep })
+
+	var out bytes.Buffer
+	client := api.NewClientWithToken(server.URL, "tok")
+	err := waitForExecution(client, "exec-1", time.Minute, &out)
+	if err == nil || !strings.Contains(err.Error(), "FAILED") {
+		t.Fatalf("expected FAILED, got %v", err)
+	}
+	if !strings.Contains(out.String(), "hello from agent") {
+		t.Fatalf("logs not streamed: %q", out.String())
+	}
+}
+
+func TestWaitForExecutionSucceeds(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/logs") || strings.Contains(r.URL.Path, "/logs") {
+			_ = json.NewEncoder(w).Encode(flowLogsResponse{
+				Source: "database",
+				Logs:   []flowLogEntry{{Payload: map[string]any{"message": "ok"}}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(flowExecutionStatus{ID: "exec-2", Status: "SUCCEEDED"})
+	}))
+	defer server.Close()
+
+	oldSleep := flowSleep
+	flowSleep = func(time.Duration) {}
+	t.Cleanup(func() { flowSleep = oldSleep })
+
+	var out bytes.Buffer
+	if err := waitForExecution(api.NewClientWithToken(server.URL, "tok"), "exec-2", time.Minute, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "ok") {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestWaitForExecutionTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/logs") {
+			_ = json.NewEncoder(w).Encode(flowLogsResponse{Logs: []flowLogEntry{}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(flowExecutionStatus{ID: "exec-3", Status: "RUNNING"})
+	}))
+	defer server.Close()
+
+	oldSleep := flowSleep
+	oldNow := flowNow
+	calls := 0
+	start := time.Unix(0, 0)
+	flowNow = func() time.Time {
+		calls++
+		if calls > 2 {
+			return start.Add(2 * time.Hour)
+		}
+		return start
+	}
+	flowSleep = func(time.Duration) {}
+	t.Cleanup(func() {
+		flowSleep = oldSleep
+		flowNow = oldNow
+	})
+
+	err := waitForExecution(api.NewClientWithToken(server.URL, "tok"), "exec-3", time.Minute, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout, got %v", err)
+	}
+}

--- a/cli/internal/cmd/flow_test.go
+++ b/cli/internal/cmd/flow_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -236,6 +237,93 @@ func TestWaitForExecutionSucceeds(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "ok") {
 		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestWaitForExecutionDrainsHasMoreBeforeTerminal(t *testing.T) {
+	var skips []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/logs") {
+			skips = append(skips, r.URL.Query().Get("skip"))
+			switch r.URL.Query().Get("skip") {
+			case "0":
+				_ = json.NewEncoder(w).Encode(flowLogsResponse{
+					Source:  "database",
+					HasMore: true,
+					Logs: []flowLogEntry{
+						{Payload: map[string]any{"line": "page-one"}},
+						{Payload: map[string]any{"line": "page-one-b"}},
+					},
+				})
+			case "2":
+				_ = json.NewEncoder(w).Encode(flowLogsResponse{
+					Source:  "database",
+					HasMore: false,
+					Logs: []flowLogEntry{
+						{Payload: map[string]any{"line": "error: boom"}},
+					},
+				})
+			default:
+				t.Errorf("unexpected skip=%q", r.URL.Query().Get("skip"))
+				_ = json.NewEncoder(w).Encode(flowLogsResponse{Source: "database"})
+			}
+			return
+		}
+		_ = json.NewEncoder(w).Encode(flowExecutionStatus{ID: "exec-4", Status: "FAILED"})
+	}))
+	defer server.Close()
+
+	oldSleep := flowSleep
+	flowSleep = func(time.Duration) {}
+	t.Cleanup(func() { flowSleep = oldSleep })
+
+	var out bytes.Buffer
+	err := waitForExecution(api.NewClientWithToken(server.URL, "tok"), "exec-4", time.Minute, &out)
+	if err == nil || !strings.Contains(err.Error(), "FAILED") {
+		t.Fatalf("expected FAILED, got %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "page-one") || !strings.Contains(got, "error: boom") {
+		t.Fatalf("dropped tail logs: %q", got)
+	}
+	if len(skips) < 2 || skips[0] != "0" || skips[1] != "2" {
+		t.Fatalf("expected skip=0 then skip=2, got %#v", skips)
+	}
+}
+
+func TestResolveFlowIDPaginatesList(t *testing.T) {
+	const lateID = "33333333-2222-4333-8444-555555555555"
+	pages := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/flows" {
+			http.NotFound(w, r)
+			return
+		}
+		pages++
+		skip := r.URL.Query().Get("skip")
+		if skip == "0" {
+			first := make([]flowSummaryResponse, flowListPageSize)
+			for i := range first {
+				first[i] = flowSummaryResponse{
+					ID:   fmt.Sprintf("11111111-2222-4333-8444-%012d", i),
+					Name: fmt.Sprintf("flow-%d", i),
+				}
+			}
+			_ = json.NewEncoder(w).Encode(first)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]flowSummaryResponse{
+			{ID: lateID, Name: "Late Flow"},
+		})
+	}))
+	defer server.Close()
+
+	got, err := resolveFlowID(api.NewClientWithToken(server.URL, "tok"), "Late Flow")
+	if err != nil || got != lateID {
+		t.Fatalf("paginated name resolve: %q %v", got, err)
+	}
+	if pages < 2 {
+		t.Fatalf("expected a second list page, got %d", pages)
 	}
 }
 

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -58,11 +58,15 @@ suppressed too, as they depend on the check-in response.`,
 		// dump the full usage/flags help after the error message.
 		silenceUsageForRuntimeErrors(cmd)
 
-		// Check for updates on each invocation (cached daily)
-		if err := version.CheckForUpdate(); err != nil {
-			// Silently ignore update check errors
-			if verbose {
-				fmt.Fprintf(os.Stderr, "Warning: failed to check for updates: %v\n", err)
+		// Check for updates on each invocation (cached daily). Skip the
+		// daily prompt on `preloop update` itself so the command owns the
+		// confirmation and we do not ask twice.
+		if cmd.Name() != "update" {
+			if err := version.CheckForUpdate(); err != nil {
+				// Silently ignore update check errors
+				if verbose {
+					fmt.Fprintf(os.Stderr, "Warning: failed to check for updates: %v\n", err)
+				}
 			}
 		}
 	},
@@ -112,4 +116,5 @@ func init() {
 	rootCmd.AddCommand(agentsCmd)
 	rootCmd.AddCommand(usageCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(updateCmd)
 }

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -117,4 +117,5 @@ func init() {
 	rootCmd.AddCommand(usageCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(updateCmd)
+	rootCmd.AddCommand(flowCmd)
 }

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/preloop/preloop/cli/internal/version"
+)
+
+// updateCmd implements `preloop update`.
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update the preloop CLI to the latest release",
+	Long: `Download the matching GitHub release asset for this OS/architecture
+and replace the current binary in place.
+
+Use --check to print the latest version and exit without installing.
+Use --yes to skip the confirmation prompt (required when stdin is not a TTY).
+
+Version lookup uses the same check-in as 'preloop version --check' and is
+skipped when PRELOOP_DISABLE_TELEMETRY is set.`,
+	RunE: runUpdate,
+}
+
+func init() {
+	updateCmd.Flags().BoolP("yes", "y", false, "install without prompting")
+	updateCmd.Flags().Bool("check", false, "print the latest version and exit")
+}
+
+func runUpdate(cmd *cobra.Command, args []string) error {
+	checkOnly, err := cmd.Flags().GetBool("check")
+	if err != nil {
+		return err
+	}
+	autoYes, err := cmd.Flags().GetBool("yes")
+	if err != nil {
+		return err
+	}
+
+	info, err := version.ForceCheck()
+	if err != nil {
+		return err
+	}
+
+	current := version.NormalizeVersion(version.Version)
+	latest := version.NormalizeVersion(info.LatestVersion)
+	fmt.Printf("preloop %s\n", version.Version)
+	if latest == "" {
+		return fmt.Errorf("version check returned no latest_version")
+	}
+	fmt.Printf("latest %s\n", info.LatestVersion)
+
+	if current == latest {
+		fmt.Println("up to date")
+		return nil
+	}
+
+	fmt.Println("update available")
+	if checkOnly {
+		return nil
+	}
+
+	dest, err := version.CurrentBinaryPath()
+	if err != nil {
+		return err
+	}
+	if !version.CanReplaceBinary(dest) {
+		return fmt.Errorf("cannot replace %s: binary or its directory is not writable", dest)
+	}
+
+	if !autoYes {
+		if !stdinIsTerminal() {
+			return fmt.Errorf("refusing to update without --yes when stdin is not a TTY")
+		}
+		fmt.Print("Update now? [y/N] ")
+		var answer string
+		if _, scanErr := fmt.Scanln(&answer); scanErr != nil {
+			return nil
+		}
+		switch answer {
+		case "y", "Y", "yes", "YES", "Yes":
+		default:
+			fmt.Println("Update cancelled")
+			return nil
+		}
+	}
+
+	fmt.Printf("Updating to %s...\n", info.LatestVersion)
+	if err := version.ApplyUpdate(context.Background(), info.LatestVersion, dest); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "Updated to %s. Restart preloop to use the new binary.\n", info.LatestVersion)
+	return nil
+}

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -45,7 +45,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	current := version.NormalizeVersion(version.Version)
 	latest := version.NormalizeVersion(info.LatestVersion)
 	fmt.Printf("preloop %s\n", version.Version)
 	if latest == "" {
@@ -53,8 +52,12 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("latest %s\n", info.LatestVersion)
 
-	if current == latest {
-		fmt.Println("up to date")
+	if !version.UpdateAvailable(version.Version, info.LatestVersion) {
+		if cmp, ok := version.CompareVersions(version.Version, info.LatestVersion); ok && cmp > 0 {
+			fmt.Println("newer than latest release")
+		} else {
+			fmt.Println("up to date")
+		}
 		return nil
 	}
 
@@ -72,17 +75,10 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if !autoYes {
-		if !stdinIsTerminal() {
+		if !version.StdinIsTerminal() {
 			return fmt.Errorf("refusing to update without --yes when stdin is not a TTY")
 		}
-		fmt.Print("Update now? [y/N] ")
-		var answer string
-		if _, scanErr := fmt.Scanln(&answer); scanErr != nil {
-			return nil
-		}
-		switch answer {
-		case "y", "Y", "yes", "YES", "Yes":
-		default:
+		if !version.PromptUpdateYes() {
 			fmt.Println("Update cancelled")
 			return nil
 		}

--- a/cli/internal/cmd/update_test.go
+++ b/cli/internal/cmd/update_test.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/testenv"
+	"github.com/preloop/preloop/cli/internal/version"
+)
+
+func resetUpdateFlags(t *testing.T) {
+	t.Helper()
+	if err := updateCmd.Flags().Set("check", "false"); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateCmd.Flags().Set("yes", "false"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func withVersionCheckServer(t *testing.T, latest string) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"latest_version": latest})
+	}))
+	t.Cleanup(server.Close)
+	old := version.VersionCheckOrigin
+	version.VersionCheckOrigin = server.URL
+	t.Cleanup(func() { version.VersionCheckOrigin = old })
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv("PRELOOP_DISABLE_TELEMETRY", "")
+	t.Setenv("DISABLE_VERSION_CHECK", "")
+}
+
+func captureUpdateStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	runErr := fn()
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String(), runErr
+}
+
+func TestUpdateCheckPrintsAndExits(t *testing.T) {
+	resetUpdateFlags(t)
+	oldVersion := version.Version
+	version.Version = "0.1.0"
+	t.Cleanup(func() { version.Version = oldVersion })
+	withVersionCheckServer(t, "9.9.9")
+	if err := updateCmd.Flags().Set("check", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureUpdateStdout(t, func() error {
+		return runUpdate(updateCmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("runUpdate --check: %v", err)
+	}
+	if !strings.Contains(out, "preloop 0.1.0") {
+		t.Fatalf("missing current version, got %q", out)
+	}
+	if !strings.Contains(out, "latest 9.9.9") {
+		t.Fatalf("missing latest, got %q", out)
+	}
+	if !strings.Contains(out, "update available") {
+		t.Fatalf("missing availability line, got %q", out)
+	}
+}
+
+func TestUpdateCheckUpToDate(t *testing.T) {
+	resetUpdateFlags(t)
+	oldVersion := version.Version
+	version.Version = "1.2.3"
+	t.Cleanup(func() { version.Version = oldVersion })
+	withVersionCheckServer(t, "1.2.3")
+	if err := updateCmd.Flags().Set("check", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureUpdateStdout(t, func() error {
+		return runUpdate(updateCmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("runUpdate --check: %v", err)
+	}
+	if !strings.Contains(out, "up to date") {
+		t.Fatalf("expected up to date, got %q", out)
+	}
+}
+
+func TestUpdateHonorsTelemetryOptOut(t *testing.T) {
+	resetUpdateFlags(t)
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv("PRELOOP_DISABLE_TELEMETRY", "true")
+	if err := updateCmd.Flags().Set("check", "true"); err != nil {
+		t.Fatal(err)
+	}
+	err := runUpdate(updateCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when telemetry is disabled")
+	}
+	if !strings.Contains(err.Error(), "PRELOOP_DISABLE_TELEMETRY") {
+		t.Fatalf("error should name the env var, got %v", err)
+	}
+}
+
+func TestUpdateRequiresYesWhenNotTTY(t *testing.T) {
+	resetUpdateFlags(t)
+	oldVersion := version.Version
+	version.Version = "0.1.0"
+	t.Cleanup(func() { version.Version = oldVersion })
+	withVersionCheckServer(t, "9.9.9")
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "preloop")
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	restore := version.OverrideExecutablePathForTest(func() (string, error) {
+		return dest, nil
+	})
+	t.Cleanup(restore)
+	oldTerm := stdinIsTerminal
+	stdinIsTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsTerminal = oldTerm })
+
+	_, err := captureUpdateStdout(t, func() error {
+		return runUpdate(updateCmd, nil)
+	})
+	if err == nil || !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("expected --yes requirement, got %v", err)
+	}
+}
+
+func TestUpdateYesReplacesBinary(t *testing.T) {
+	resetUpdateFlags(t)
+	oldVersion := version.Version
+	version.Version = "0.1.0"
+	t.Cleanup(func() { version.Version = oldVersion })
+	withVersionCheckServer(t, "9.9.9")
+
+	asset := version.ReleaseAssetName(runtime.GOOS, runtime.GOARCH)
+	payload := []byte("brand-new-cli")
+	dl := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/"+asset) {
+			_, _ = w.Write(payload)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(dl.Close)
+	oldBase := version.ReleaseDownloadBase
+	version.ReleaseDownloadBase = dl.URL
+	t.Cleanup(func() { version.ReleaseDownloadBase = oldBase })
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "preloop")
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	restore := version.OverrideExecutablePathForTest(func() (string, error) {
+		return dest, nil
+	})
+	t.Cleanup(restore)
+
+	if err := updateCmd.Flags().Set("yes", "true"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureUpdateStdout(t, func() error {
+		return runUpdate(updateCmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("runUpdate --yes: %v\n%s", err, out)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("installed %q", got)
+	}
+	if !strings.Contains(out, "Updated to 9.9.9") {
+		t.Fatalf("missing success line, got %q", out)
+	}
+}

--- a/cli/internal/cmd/update_test.go
+++ b/cli/internal/cmd/update_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -138,9 +140,8 @@ func TestUpdateRequiresYesWhenNotTTY(t *testing.T) {
 		return dest, nil
 	})
 	t.Cleanup(restore)
-	oldTerm := stdinIsTerminal
-	stdinIsTerminal = func() bool { return false }
-	t.Cleanup(func() { stdinIsTerminal = oldTerm })
+	restoreTerm := version.OverrideStdinIsTerminalForTest(func() bool { return false })
+	t.Cleanup(restoreTerm)
 
 	_, err := captureUpdateStdout(t, func() error {
 		return runUpdate(updateCmd, nil)
@@ -159,12 +160,17 @@ func TestUpdateYesReplacesBinary(t *testing.T) {
 
 	asset := version.ReleaseAssetName(runtime.GOOS, runtime.GOARCH)
 	payload := []byte("brand-new-cli")
+	sum := sha256.Sum256(payload)
+	checksums := hex.EncodeToString(sum[:]) + "  " + asset + "\n"
 	dl := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/"+asset) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/"+asset):
 			_, _ = w.Write(payload)
-			return
+		case strings.HasSuffix(r.URL.Path, "/SHA256SUMS"):
+			_, _ = w.Write([]byte(checksums))
+		default:
+			http.NotFound(w, r)
 		}
-		http.NotFound(w, r)
 	}))
 	t.Cleanup(dl.Close)
 	oldBase := version.ReleaseDownloadBase
@@ -199,5 +205,29 @@ func TestUpdateYesReplacesBinary(t *testing.T) {
 	}
 	if !strings.Contains(out, "Updated to 9.9.9") {
 		t.Fatalf("missing success line, got %q", out)
+	}
+}
+
+func TestUpdateCheckNewerThanLatest(t *testing.T) {
+	resetUpdateFlags(t)
+	oldVersion := version.Version
+	version.Version = "9.9.9"
+	t.Cleanup(func() { version.Version = oldVersion })
+	withVersionCheckServer(t, "1.2.3")
+	if err := updateCmd.Flags().Set("check", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureUpdateStdout(t, func() error {
+		return runUpdate(updateCmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("runUpdate --check: %v", err)
+	}
+	if strings.Contains(out, "update available") {
+		t.Fatalf("newer local build must not offer an update, got %q", out)
+	}
+	if !strings.Contains(out, "newer than latest release") {
+		t.Fatalf("expected newer-than-latest line, got %q", out)
 	}
 }

--- a/cli/internal/version/check.go
+++ b/cli/internal/version/check.go
@@ -331,21 +331,6 @@ func fetchLegacyVersionInfo(client *http.Client) (*VersionInfo, error) {
 	return &info, nil
 }
 
-// displayUpdatePrompt shows a message about the available update.
-func displayUpdatePrompt(info *VersionInfo) {
-	fmt.Println()
-	fmt.Println("╭─────────────────────────────────────────────────────────╮")
-	fmt.Printf("│  A new version of preloop is available: %s → %s  │\n", Version, info.LatestVersion)
-	fmt.Println("│                                                         │")
-	if info.DownloadURL != "" {
-		fmt.Printf("│  Download: %-45s │\n", info.DownloadURL)
-	} else {
-		fmt.Println("│  Run 'preloop update' to upgrade                        │")
-	}
-	fmt.Println("╰─────────────────────────────────────────────────────────╯")
-	fmt.Println()
-}
-
 // ForceCheck forces a version check regardless of the last check time.
 // Even a forced check respects the telemetry opt-out: the check-in POST is
 // the telemetry, so there is no way to check without emitting it.

--- a/cli/internal/version/check.go
+++ b/cli/internal/version/check.go
@@ -122,8 +122,7 @@ func CheckForUpdate() error {
 		_ = err
 	}
 
-	// Compare versions
-	if info.LatestVersion != "" && info.LatestVersion != Version && Version != "dev" {
+	if UpdateAvailable(Version, info.LatestVersion) {
 		displayUpdatePrompt(info)
 	}
 

--- a/cli/internal/version/update.go
+++ b/cli/internal/version/update.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -53,6 +54,110 @@ var applyUpdateFn = ApplyUpdate
 // NormalizeVersion strips a leading "v" so "v0.14.0" and "0.14.0" compare equal.
 func NormalizeVersion(v string) string {
 	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+// parsedVersion is a numeric X.Y.Z with an optional prerelease suffix.
+type parsedVersion struct {
+	parts []int
+	pre   string
+}
+
+func parseSemver(v string) (parsedVersion, bool) {
+	s := strings.TrimSpace(v)
+	s = strings.TrimPrefix(s, "v")
+	s = strings.TrimPrefix(s, "V")
+	if s == "" || s == "dev" {
+		return parsedVersion{}, false
+	}
+	core, pre, _ := strings.Cut(s, "-")
+	core, _, _ = strings.Cut(core, "+")
+	pre, _, _ = strings.Cut(pre, "+")
+	fields := strings.Split(core, ".")
+	if len(fields) == 0 || len(fields) > 4 {
+		return parsedVersion{}, false
+	}
+	parts := make([]int, len(fields))
+	for i, field := range fields {
+		n, err := strconv.Atoi(field)
+		if err != nil || n < 0 {
+			return parsedVersion{}, false
+		}
+		parts[i] = n
+	}
+	return parsedVersion{parts: parts, pre: pre}, true
+}
+
+func compareParsed(a, b parsedVersion) int {
+	n := len(a.parts)
+	if len(b.parts) > n {
+		n = len(b.parts)
+	}
+	for i := 0; i < n; i++ {
+		av, bv := 0, 0
+		if i < len(a.parts) {
+			av = a.parts[i]
+		}
+		if i < len(b.parts) {
+			bv = b.parts[i]
+		}
+		if av < bv {
+			return -1
+		}
+		if av > bv {
+			return 1
+		}
+	}
+	aPre, bPre := a.pre != "", b.pre != ""
+	if aPre && !bPre {
+		return -1
+	}
+	if !aPre && bPre {
+		return 1
+	}
+	switch {
+	case a.pre < b.pre:
+		return -1
+	case a.pre > b.pre:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// CompareVersions compares [v]X.Y.Z strings (optional prerelease after '-').
+// Returns -1 if a < b, 0 if a == b, 1 if a > b. ok is false when either
+// side is not a parseable version (for example "dev").
+func CompareVersions(a, b string) (cmp int, ok bool) {
+	pa, oka := parseSemver(a)
+	pb, okb := parseSemver(b)
+	if !oka || !okb {
+		return 0, false
+	}
+	return compareParsed(pa, pb), true
+}
+
+// UpdateAvailable reports whether latest is a newer release than current.
+// A local build that is already newer than latest, or an unparseable
+// version such as "dev", is not treated as an available update.
+func UpdateAvailable(current, latest string) bool {
+	if strings.TrimSpace(latest) == "" {
+		return false
+	}
+	cmp, ok := CompareVersions(current, latest)
+	return ok && cmp < 0
+}
+
+// StdinIsTerminal reports whether stdin is a TTY. Overridable in tests
+// via OverrideStdinIsTerminalForTest.
+func StdinIsTerminal() bool {
+	return stdinIsTerminal()
+}
+
+// OverrideStdinIsTerminalForTest swaps TTY detection. Tests only.
+func OverrideStdinIsTerminalForTest(fn func() bool) func() {
+	prev := stdinIsTerminal
+	stdinIsTerminal = fn
+	return func() { stdinIsTerminal = prev }
 }
 
 // ReleaseTag returns the GitHub release tag for a version string.
@@ -140,7 +245,7 @@ func ApplyUpdate(ctx context.Context, ver, destPath string) error {
 	if err != nil {
 		return err
 	}
-	if err := verifyOptionalChecksum(ctx, ver, runtime.GOOS, runtime.GOARCH, body); err != nil {
+	if err := verifyChecksum(ctx, ver, runtime.GOOS, runtime.GOARCH, body); err != nil {
 		return err
 	}
 	return ReplaceBinary(destPath, body)
@@ -175,6 +280,10 @@ func ReplaceBinary(destPath string, newBytes []byte) error {
 	if err := tmp.Chmod(mode); err != nil {
 		_ = tmp.Close()
 		return fmt.Errorf("chmod temp binary: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp binary: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close temp binary: %w", err)
@@ -232,35 +341,31 @@ func downloadReleaseAsset(ctx context.Context, ver, goos, goarch string) ([]byte
 	return body, nil
 }
 
-func verifyOptionalChecksum(ctx context.Context, ver, goos, goarch string, body []byte) error {
+func verifyChecksum(ctx context.Context, ver, goos, goarch string, body []byte) error {
 	url := ChecksumsURL(ver)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil
+		return fmt.Errorf("build checksum request: %w", err)
 	}
 	SetClientIdentityHeaders(req.Header)
 	client := &http.Client{Timeout: 15 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Fprintln(promptWriter, "Warning: could not download SHA256SUMS; continuing without verification.")
-		return nil
+		return fmt.Errorf("download SHA256SUMS: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode != http.StatusOK {
-		fmt.Fprintln(promptWriter, "Warning: could not download SHA256SUMS; continuing without verification.")
-		return nil
+		return fmt.Errorf("download SHA256SUMS: HTTP %d", resp.StatusCode)
 	}
 	sums, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Fprintln(promptWriter, "Warning: could not read SHA256SUMS; continuing without verification.")
-		return nil
+		return fmt.Errorf("read SHA256SUMS: %w", err)
 	}
 
 	asset := ReleaseAssetName(goos, goarch)
 	expected := checksumForAsset(string(sums), asset)
 	if expected == "" {
-		fmt.Fprintf(promptWriter, "Warning: could not find a SHA256 checksum for %s; continuing without verification.\n", asset)
-		return nil
+		return fmt.Errorf("SHA256SUMS has no entry for %s", asset)
 	}
 	sum := sha256.Sum256(body)
 	actual := hex.EncodeToString(sum[:])
@@ -292,8 +397,8 @@ func defaultStdinIsTerminal() bool {
 	return stat.Mode()&os.ModeCharDevice != 0
 }
 
-// promptUpdateYes prints "Update now? [y/N]" and returns whether the user accepted.
-func promptUpdateYes() bool {
+// PromptUpdateYes prints "Update now? [y/N]" and returns whether the user accepted.
+func PromptUpdateYes() bool {
 	fmt.Fprint(promptWriter, "Update now? [y/N] ")
 	scanner := bufio.NewScanner(promptReader)
 	if !scanner.Scan() {
@@ -323,7 +428,7 @@ func displayUpdatePrompt(info *VersionInfo) {
 	fmt.Fprintln(promptWriter, "╰─────────────────────────────────────────────────────────╯")
 	fmt.Fprintln(promptWriter)
 
-	if !promptUpdateYes() {
+	if !PromptUpdateYes() {
 		return
 	}
 	fmt.Fprintf(promptWriter, "Updating to %s...\n", info.LatestVersion)

--- a/cli/internal/version/update.go
+++ b/cli/internal/version/update.go
@@ -1,0 +1,335 @@
+package version
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultReleaseRepo is the GitHub repo that publishes CLI assets.
+	DefaultReleaseRepo = "preloop/preloop"
+
+	defaultReleaseDownloadBase = "https://github.com/" + DefaultReleaseRepo + "/releases/download"
+
+	updateDownloadTimeout = 2 * time.Minute
+)
+
+// ReleaseDownloadBase is the prefix for GitHub release asset URLs.
+// Tests override it to point at a local httptest server.
+var ReleaseDownloadBase = defaultReleaseDownloadBase
+
+// executablePath is os.Executable, overridable in tests.
+var executablePath = os.Executable
+
+// OverrideExecutablePathForTest swaps the binary-path lookup. Tests only.
+func OverrideExecutablePathForTest(fn func() (string, error)) func() {
+	prev := executablePath
+	executablePath = fn
+	return func() { executablePath = prev }
+}
+
+// stdinIsTerminal reports whether stdin is a TTY. Overridable in tests.
+var stdinIsTerminal = defaultStdinIsTerminal
+
+// promptReader is the source for the interactive "Update now?" answer.
+var promptReader io.Reader = os.Stdin
+
+// promptWriter is where the update box and prompt are written.
+var promptWriter io.Writer = os.Stdout
+
+// applyUpdateFn is the in-place installer used by the interactive prompt.
+var applyUpdateFn = ApplyUpdate
+
+// NormalizeVersion strips a leading "v" so "v0.14.0" and "0.14.0" compare equal.
+func NormalizeVersion(v string) string {
+	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+// ReleaseTag returns the GitHub release tag for a version string.
+func ReleaseTag(v string) string {
+	return "v" + NormalizeVersion(v)
+}
+
+// ReleaseAssetName is the GitHub release asset for GOOS/GOARCH, matching
+// scripts/install-cli.sh (preloop-<os>-<arch>[.exe]).
+func ReleaseAssetName(goos, goarch string) string {
+	name := fmt.Sprintf("preloop-%s-%s", goos, goarch)
+	if goos == "windows" {
+		name += ".exe"
+	}
+	return name
+}
+
+// ReleaseDownloadURL is the GitHub release asset URL for a version and platform.
+func ReleaseDownloadURL(ver, goos, goarch string) string {
+	return strings.TrimRight(ReleaseDownloadBase, "/") + "/" + ReleaseTag(ver) + "/" + ReleaseAssetName(goos, goarch)
+}
+
+// ChecksumsURL is the SHA256SUMS asset for a release tag.
+func ChecksumsURL(ver string) string {
+	return strings.TrimRight(ReleaseDownloadBase, "/") + "/" + ReleaseTag(ver) + "/SHA256SUMS"
+}
+
+// CurrentBinaryPath returns the resolved path of the running CLI binary.
+func CurrentBinaryPath() (string, error) {
+	path, err := executablePath()
+	if err != nil {
+		return "", fmt.Errorf("failed to locate current binary: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		// The binary may have been deleted mid-run; use the raw path.
+		return path, nil
+	}
+	return resolved, nil
+}
+
+// CanReplaceBinary reports whether this user can replace path in place:
+// the file itself is writable, and its directory accepts a sibling file
+// that can be renamed onto path.
+func CanReplaceBinary(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return false
+	}
+	_ = file.Close()
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".preloop-write-test-*")
+	if err != nil {
+		return false
+	}
+	name := tmp.Name()
+	_ = tmp.Close()
+	_ = os.Remove(name)
+	return true
+}
+
+// ApplyUpdate downloads the release asset for ver / GOOS / GOARCH and
+// replaces destPath in place, preserving destPath's file mode.
+func ApplyUpdate(ctx context.Context, ver, destPath string) error {
+	if destPath == "" {
+		var err error
+		destPath, err = CurrentBinaryPath()
+		if err != nil {
+			return err
+		}
+	}
+	if !CanReplaceBinary(destPath) {
+		return fmt.Errorf("cannot replace %s: binary or its directory is not writable", destPath)
+	}
+
+	body, err := downloadReleaseAsset(ctx, ver, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return err
+	}
+	if err := verifyOptionalChecksum(ctx, ver, runtime.GOOS, runtime.GOARCH, body); err != nil {
+		return err
+	}
+	return ReplaceBinary(destPath, body)
+}
+
+// ReplaceBinary writes newBytes to destPath via a same-directory tempfile
+// and an atomic rename, preserving destPath's mode.
+func ReplaceBinary(destPath string, newBytes []byte) error {
+	info, err := os.Stat(destPath)
+	if err != nil {
+		return fmt.Errorf("stat current binary: %w", err)
+	}
+	mode := info.Mode()
+
+	dir := filepath.Dir(destPath)
+	tmp, err := os.CreateTemp(dir, ".preloop-update-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(newBytes); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp binary: %w", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp binary: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp binary: %w", err)
+	}
+
+	if runtime.GOOS == "windows" {
+		// Windows cannot overwrite a running executable. Move the current
+		// binary aside, then rename the new file into place.
+		backup := destPath + ".old"
+		_ = os.Remove(backup)
+		if err := os.Rename(destPath, backup); err != nil {
+			return fmt.Errorf("rename current binary aside: %w", err)
+		}
+		if err := os.Rename(tmpName, destPath); err != nil {
+			_ = os.Rename(backup, destPath)
+			return fmt.Errorf("install new binary: %w", err)
+		}
+		_ = os.Remove(backup)
+		cleanup = false
+		return nil
+	}
+
+	if err := os.Rename(tmpName, destPath); err != nil {
+		return fmt.Errorf("install new binary: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+func downloadReleaseAsset(ctx context.Context, ver, goos, goarch string) ([]byte, error) {
+	url := ReleaseDownloadURL(ver, goos, goarch)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build download request: %w", err)
+	}
+	SetClientIdentityHeaders(req.Header)
+
+	client := &http.Client{Timeout: updateDownloadTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download %s: HTTP %d", url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read download: %w", err)
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf("download %s: empty body", url)
+	}
+	return body, nil
+}
+
+func verifyOptionalChecksum(ctx context.Context, ver, goos, goarch string, body []byte) error {
+	url := ChecksumsURL(ver)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil
+	}
+	SetClientIdentityHeaders(req.Header)
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintln(promptWriter, "Warning: could not download SHA256SUMS; continuing without verification.")
+		return nil
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintln(promptWriter, "Warning: could not download SHA256SUMS; continuing without verification.")
+		return nil
+	}
+	sums, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Fprintln(promptWriter, "Warning: could not read SHA256SUMS; continuing without verification.")
+		return nil
+	}
+
+	asset := ReleaseAssetName(goos, goarch)
+	expected := checksumForAsset(string(sums), asset)
+	if expected == "" {
+		fmt.Fprintf(promptWriter, "Warning: could not find a SHA256 checksum for %s; continuing without verification.\n", asset)
+		return nil
+	}
+	sum := sha256.Sum256(body)
+	actual := hex.EncodeToString(sum[:])
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("SHA256 mismatch for %s: got %s, want %s", asset, actual, expected)
+	}
+	return nil
+}
+
+func checksumForAsset(sums, asset string) string {
+	for _, line := range strings.Split(sums, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		name := strings.TrimPrefix(fields[1], "*")
+		if name == asset {
+			return fields[0]
+		}
+	}
+	return ""
+}
+
+func defaultStdinIsTerminal() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return stat.Mode()&os.ModeCharDevice != 0
+}
+
+// promptUpdateYes prints "Update now? [y/N]" and returns whether the user accepted.
+func promptUpdateYes() bool {
+	fmt.Fprint(promptWriter, "Update now? [y/N] ")
+	scanner := bufio.NewScanner(promptReader)
+	if !scanner.Scan() {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(scanner.Text()))
+	return answer == "y" || answer == "yes"
+}
+
+// displayUpdatePrompt asks whether to upgrade when stdin is a TTY and the
+// running binary can be replaced. If the binary is not writable, it prints
+// nothing (no nag, no sudo hint, no download URL).
+func displayUpdatePrompt(info *VersionInfo) {
+	path, err := CurrentBinaryPath()
+	if err != nil || !CanReplaceBinary(path) {
+		return
+	}
+	if !stdinIsTerminal() {
+		return
+	}
+
+	fmt.Fprintln(promptWriter)
+	fmt.Fprintln(promptWriter, "╭─────────────────────────────────────────────────────────╮")
+	fmt.Fprintf(promptWriter, "│  A new version of preloop is available: %s → %s\n", Version, info.LatestVersion)
+	fmt.Fprintln(promptWriter, "│                                                         │")
+	fmt.Fprintln(promptWriter, "│  Run 'preloop update' to upgrade                        │")
+	fmt.Fprintln(promptWriter, "╰─────────────────────────────────────────────────────────╯")
+	fmt.Fprintln(promptWriter)
+
+	if !promptUpdateYes() {
+		return
+	}
+	fmt.Fprintf(promptWriter, "Updating to %s...\n", info.LatestVersion)
+	if err := applyUpdateFn(context.Background(), info.LatestVersion, path); err != nil {
+		fmt.Fprintf(promptWriter, "Update failed: %v\n", err)
+		return
+	}
+	fmt.Fprintf(promptWriter, "Updated to %s. Restart preloop to use the new binary.\n", info.LatestVersion)
+}

--- a/cli/internal/version/update.go
+++ b/cli/internal/version/update.go
@@ -114,14 +114,65 @@ func compareParsed(a, b parsedVersion) int {
 	if !aPre && bPre {
 		return 1
 	}
+	if !aPre && !bPre {
+		return 0
+	}
+	return comparePrerelease(a.pre, b.pre)
+}
+
+func comparePrerelease(a, b string) int {
+	aIDs := strings.Split(a, ".")
+	bIDs := strings.Split(b, ".")
+	n := len(aIDs)
+	if len(bIDs) > n {
+		n = len(bIDs)
+	}
+	for i := 0; i < n; i++ {
+		if i >= len(aIDs) {
+			return -1
+		}
+		if i >= len(bIDs) {
+			return 1
+		}
+		if cmp := comparePrereleaseIdent(aIDs[i], bIDs[i]); cmp != 0 {
+			return cmp
+		}
+	}
+	return 0
+}
+
+func comparePrereleaseIdent(a, b string) int {
+	aNum, aOK := parsePrereleaseInt(a)
+	bNum, bOK := parsePrereleaseInt(b)
+	if aOK && bOK {
+		switch {
+		case aNum < bNum:
+			return -1
+		case aNum > bNum:
+			return 1
+		default:
+			return 0
+		}
+	}
 	switch {
-	case a.pre < b.pre:
+	case a < b:
 		return -1
-	case a.pre > b.pre:
+	case a > b:
 		return 1
 	default:
 		return 0
 	}
+}
+
+func parsePrereleaseInt(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
 }
 
 // CompareVersions compares [v]X.Y.Z strings (optional prerelease after '-').

--- a/cli/internal/version/update_test.go
+++ b/cli/internal/version/update_test.go
@@ -68,6 +68,13 @@ func TestReplaceBinaryPreservesMode(t *testing.T) {
 	if err := os.WriteFile(dest, []byte("old-binary"), 0o750); err != nil {
 		t.Fatal(err)
 	}
+	// NTFS does not store Unix 0750; Stat after WriteFile is the mode
+	// ReplaceBinary can actually preserve on this OS.
+	before, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantMode := before.Mode().Perm()
 
 	if err := ReplaceBinary(dest, []byte("new-binary")); err != nil {
 		t.Fatalf("ReplaceBinary: %v", err)
@@ -83,8 +90,8 @@ func TestReplaceBinaryPreservesMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0o750 {
-		t.Errorf("mode = %o, want 0750", info.Mode().Perm())
+	if info.Mode().Perm() != wantMode {
+		t.Errorf("mode = %o, want %o (OS-stored mode of the original file)", info.Mode().Perm(), wantMode)
 	}
 }
 

--- a/cli/internal/version/update_test.go
+++ b/cli/internal/version/update_test.go
@@ -49,6 +49,58 @@ func TestNormalizeVersionAndReleaseURLs(t *testing.T) {
 	}
 }
 
+func TestCompareVersionsAndUpdateAvailable(t *testing.T) {
+	cmp := func(a, b string) int {
+		t.Helper()
+		got, ok := CompareVersions(a, b)
+		if !ok {
+			t.Fatalf("CompareVersions(%q, %q) unparseable", a, b)
+		}
+		return got
+	}
+
+	if got := cmp("0.14.0", "0.14.0"); got != 0 {
+		t.Errorf("equal = %d", got)
+	}
+	if got := cmp("v0.14.0", "0.14.0"); got != 0 {
+		t.Errorf("v-prefix equal = %d", got)
+	}
+	if got := cmp("0.14.0", "0.14.1"); got != -1 {
+		t.Errorf("patch older = %d", got)
+	}
+	if got := cmp("0.15.0", "0.14.9"); got != 1 {
+		t.Errorf("minor newer = %d", got)
+	}
+	if got := cmp("0.14.0-rc.1", "0.14.0"); got != -1 {
+		t.Errorf("prerelease < release = %d", got)
+	}
+	if got := cmp("1.0.0", "0.14.0"); got != 1 {
+		t.Errorf("major newer = %d", got)
+	}
+
+	if _, ok := CompareVersions("dev", "0.14.0"); ok {
+		t.Fatal("dev must be unparseable")
+	}
+	if UpdateAvailable("0.14.0", "0.14.0") {
+		t.Fatal("equal is not an update")
+	}
+	if UpdateAvailable("0.15.0", "0.14.0") {
+		t.Fatal("newer local build must not offer an update")
+	}
+	if UpdateAvailable("dev", "0.14.0") {
+		t.Fatal("dev must not offer an update")
+	}
+	if UpdateAvailable("0.14.0", "") {
+		t.Fatal("empty latest is not an update")
+	}
+	if !UpdateAvailable("0.14.0", "0.14.1") {
+		t.Fatal("expected update 0.14.0 -> 0.14.1")
+	}
+	if !UpdateAvailable("v0.13.9", "0.14.0") {
+		t.Fatal("expected update v0.13.9 -> 0.14.0")
+	}
+}
+
 func TestChecksumForAsset(t *testing.T) {
 	sums := "abc123  preloop-darwin-arm64\ndef456 *preloop-linux-amd64\n"
 	if got := checksumForAsset(sums, "preloop-darwin-arm64"); got != "abc123" {
@@ -105,12 +157,24 @@ func TestCanReplaceBinary(t *testing.T) {
 		t.Fatal("expected writable binary to be replaceable")
 	}
 
-	readonly := filepath.Join(dir, "readonly")
-	if err := os.WriteFile(readonly, []byte("x"), 0o444); err != nil {
+	if os.Geteuid() == 0 {
+		t.Log("skipping 0o444 assertion: permission bits are not enforced as root")
+	} else {
+		readonly := filepath.Join(dir, "readonly")
+		if err := os.WriteFile(readonly, []byte("x"), 0o444); err != nil {
+			t.Fatal(err)
+		}
+		if CanReplaceBinary(readonly) {
+			t.Fatal("expected read-only binary not to be replaceable")
+		}
+	}
+
+	dirPath := filepath.Join(dir, "not-a-binary")
+	if err := os.Mkdir(dirPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if CanReplaceBinary(readonly) {
-		t.Fatal("expected read-only binary not to be replaceable")
+	if CanReplaceBinary(dirPath) {
+		t.Fatal("directory must not be replaceable")
 	}
 
 	if CanReplaceBinary(filepath.Join(dir, "missing")) {
@@ -161,6 +225,69 @@ func TestApplyUpdateDownloadsMatchingAsset(t *testing.T) {
 	}
 }
 
+func TestApplyUpdateFailsWhenChecksumsUnavailable(t *testing.T) {
+	asset := ReleaseAssetName(runtime.GOOS, runtime.GOARCH)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/"+asset) {
+			_, _ = w.Write([]byte("updated-cli-bytes"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	oldBase := ReleaseDownloadBase
+	ReleaseDownloadBase = server.URL
+	defer func() { ReleaseDownloadBase = oldBase }()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "preloop")
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := ApplyUpdate(context.Background(), "9.9.9", dest)
+	if err == nil || !strings.Contains(err.Error(), "SHA256SUMS") {
+		t.Fatalf("expected fail-closed checksum error, got %v", err)
+	}
+	got, readErr := os.ReadFile(dest)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "old" {
+		t.Fatalf("binary must be unchanged when checksums are missing, got %q", got)
+	}
+}
+
+func TestApplyUpdateFailsWhenChecksumEntryMissing(t *testing.T) {
+	asset := ReleaseAssetName(runtime.GOOS, runtime.GOARCH)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/SHA256SUMS") {
+			_, _ = w.Write([]byte("abc123  some-other-asset\n"))
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/"+asset) {
+			_, _ = w.Write([]byte("updated-cli-bytes"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	oldBase := ReleaseDownloadBase
+	ReleaseDownloadBase = server.URL
+	defer func() { ReleaseDownloadBase = oldBase }()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "preloop")
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := ApplyUpdate(context.Background(), "9.9.9", dest)
+	if err == nil || !strings.Contains(err.Error(), "no entry") {
+		t.Fatalf("expected missing checksum entry error, got %v", err)
+	}
+}
+
 func TestApplyUpdateRejectsChecksumMismatch(t *testing.T) {
 	asset := ReleaseAssetName(runtime.GOOS, runtime.GOARCH)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -189,15 +316,14 @@ func TestApplyUpdateRejectsChecksumMismatch(t *testing.T) {
 
 func TestDisplayUpdatePromptSilentWhenNotWritable(t *testing.T) {
 	dir := t.TempDir()
-	readonly := filepath.Join(dir, "preloop")
-	if err := os.WriteFile(readonly, []byte("x"), 0o444); err != nil {
-		t.Fatal(err)
-	}
+	// A missing path is a reliable "cannot replace" signal, including as
+	// root (mode bits are not enforced for uid 0).
+	missing := filepath.Join(dir, "missing-preloop")
 	oldExec := executablePath
 	oldTerm := stdinIsTerminal
 	oldWriter := promptWriter
 	var out bytes.Buffer
-	executablePath = func() (string, error) { return readonly, nil }
+	executablePath = func() (string, error) { return missing, nil }
 	stdinIsTerminal = func() bool { return true }
 	promptWriter = &out
 	defer func() {

--- a/cli/internal/version/update_test.go
+++ b/cli/internal/version/update_test.go
@@ -74,6 +74,12 @@ func TestCompareVersionsAndUpdateAvailable(t *testing.T) {
 	if got := cmp("0.14.0-rc.1", "0.14.0"); got != -1 {
 		t.Errorf("prerelease < release = %d", got)
 	}
+	if got := cmp("0.14.0-rc.2", "0.14.0-rc.10"); got != -1 {
+		t.Errorf("rc.2 < rc.10 = %d", got)
+	}
+	if got := cmp("0.14.0-rc.10", "0.14.0-rc.2"); got != 1 {
+		t.Errorf("rc.10 > rc.2 = %d", got)
+	}
 	if got := cmp("1.0.0", "0.14.0"); got != 1 {
 		t.Errorf("major newer = %d", got)
 	}

--- a/cli/internal/version/update_test.go
+++ b/cli/internal/version/update_test.go
@@ -1,0 +1,337 @@
+package version
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/testenv"
+)
+
+func TestNormalizeVersionAndReleaseURLs(t *testing.T) {
+	if got := NormalizeVersion("v0.14.0"); got != "0.14.0" {
+		t.Errorf("NormalizeVersion(v0.14.0) = %q", got)
+	}
+	if got := NormalizeVersion("0.14.0"); got != "0.14.0" {
+		t.Errorf("NormalizeVersion(0.14.0) = %q", got)
+	}
+	if got := ReleaseTag("0.14.0"); got != "v0.14.0" {
+		t.Errorf("ReleaseTag = %q", got)
+	}
+	if got := ReleaseTag("v0.14.0"); got != "v0.14.0" {
+		t.Errorf("ReleaseTag of tagged version = %q", got)
+	}
+
+	if got := ReleaseAssetName("darwin", "arm64"); got != "preloop-darwin-arm64" {
+		t.Errorf("darwin/arm64 asset = %q", got)
+	}
+	if got := ReleaseAssetName("windows", "amd64"); got != "preloop-windows-amd64.exe" {
+		t.Errorf("windows/amd64 asset = %q", got)
+	}
+
+	oldBase := ReleaseDownloadBase
+	ReleaseDownloadBase = "https://github.com/preloop/preloop/releases/download"
+	defer func() { ReleaseDownloadBase = oldBase }()
+
+	want := "https://github.com/preloop/preloop/releases/download/v0.14.0/preloop-linux-amd64"
+	if got := ReleaseDownloadURL("0.14.0", "linux", "amd64"); got != want {
+		t.Errorf("ReleaseDownloadURL = %q, want %q", got, want)
+	}
+}
+
+func TestChecksumForAsset(t *testing.T) {
+	sums := "abc123  preloop-darwin-arm64\ndef456 *preloop-linux-amd64\n"
+	if got := checksumForAsset(sums, "preloop-darwin-arm64"); got != "abc123" {
+		t.Errorf("got %q", got)
+	}
+	if got := checksumForAsset(sums, "preloop-linux-amd64"); got != "def456" {
+		t.Errorf("star-prefixed name: got %q", got)
+	}
+	if got := checksumForAsset(sums, "missing"); got != "" {
+		t.Errorf("missing asset should be empty, got %q", got)
+	}
+}
+
+func TestReplaceBinaryPreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "preloop")
+	if err := os.WriteFile(dest, []byte("old-binary"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReplaceBinary(dest, []byte("new-binary")); err != nil {
+		t.Fatalf("ReplaceBinary: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new-binary" {
+		t.Errorf("contents = %q", got)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o750 {
+		t.Errorf("mode = %o, want 0750", info.Mode().Perm())
+	}
+}
+
+func TestCanReplaceBinary(t *testing.T) {
+	dir := t.TempDir()
+	writable := filepath.Join(dir, "writable")
+	if err := os.WriteFile(writable, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !CanReplaceBinary(writable) {
+		t.Fatal("expected writable binary to be replaceable")
+	}
+
+	readonly := filepath.Join(dir, "readonly")
+	if err := os.WriteFile(readonly, []byte("x"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if CanReplaceBinary(readonly) {
+		t.Fatal("expected read-only binary not to be replaceable")
+	}
+
+	if CanReplaceBinary(filepath.Join(dir, "missing")) {
+		t.Fatal("missing path must not be replaceable")
+	}
+	if CanReplaceBinary("") {
+		t.Fatal("empty path must not be replaceable")
+	}
+}
+
+func TestApplyUpdateDownloadsMatchingAsset(t *testing.T) {
+	asset := ReleaseAssetName(runtime.GOOS, runtime.GOARCH)
+	payload := []byte("updated-cli-bytes")
+	sum := sha256.Sum256(payload)
+	checksums := hex.EncodeToString(sum[:]) + "  " + asset + "\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/"+asset):
+			_, _ = w.Write(payload)
+		case strings.HasSuffix(r.URL.Path, "/SHA256SUMS"):
+			_, _ = w.Write([]byte(checksums))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	oldBase := ReleaseDownloadBase
+	ReleaseDownloadBase = server.URL
+	defer func() { ReleaseDownloadBase = oldBase }()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "preloop")
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ApplyUpdate(context.Background(), "9.9.9", dest); err != nil {
+		t.Fatalf("ApplyUpdate: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("installed bytes = %q", got)
+	}
+}
+
+func TestApplyUpdateRejectsChecksumMismatch(t *testing.T) {
+	asset := ReleaseAssetName(runtime.GOOS, runtime.GOARCH)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/SHA256SUMS") {
+			_, _ = w.Write([]byte("0000000000000000000000000000000000000000000000000000000000000000  " + asset + "\n"))
+			return
+		}
+		_, _ = w.Write([]byte("tampered"))
+	}))
+	defer server.Close()
+
+	oldBase := ReleaseDownloadBase
+	ReleaseDownloadBase = server.URL
+	defer func() { ReleaseDownloadBase = oldBase }()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "preloop")
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := ApplyUpdate(context.Background(), "9.9.9", dest)
+	if err == nil || !strings.Contains(err.Error(), "SHA256 mismatch") {
+		t.Fatalf("expected checksum mismatch, got %v", err)
+	}
+}
+
+func TestDisplayUpdatePromptSilentWhenNotWritable(t *testing.T) {
+	dir := t.TempDir()
+	readonly := filepath.Join(dir, "preloop")
+	if err := os.WriteFile(readonly, []byte("x"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	oldExec := executablePath
+	oldTerm := stdinIsTerminal
+	oldWriter := promptWriter
+	var out bytes.Buffer
+	executablePath = func() (string, error) { return readonly, nil }
+	stdinIsTerminal = func() bool { return true }
+	promptWriter = &out
+	defer func() {
+		executablePath = oldExec
+		stdinIsTerminal = oldTerm
+		promptWriter = oldWriter
+	}()
+
+	displayUpdatePrompt(&VersionInfo{LatestVersion: "9.9.9"})
+	if out.Len() != 0 {
+		t.Fatalf("expected no output when binary is not writable, got %q", out.String())
+	}
+}
+
+func TestDisplayUpdatePromptSilentWhenNotTTY(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "preloop")
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldExec := executablePath
+	oldTerm := stdinIsTerminal
+	oldWriter := promptWriter
+	var out bytes.Buffer
+	executablePath = func() (string, error) { return bin, nil }
+	stdinIsTerminal = func() bool { return false }
+	promptWriter = &out
+	defer func() {
+		executablePath = oldExec
+		stdinIsTerminal = oldTerm
+		promptWriter = oldWriter
+	}()
+
+	displayUpdatePrompt(&VersionInfo{LatestVersion: "9.9.9"})
+	if out.Len() != 0 {
+		t.Fatalf("expected no output when stdin is not a TTY, got %q", out.String())
+	}
+}
+
+func TestDisplayUpdatePromptAppliesOnYes(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "preloop")
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldExec := executablePath
+	oldTerm := stdinIsTerminal
+	oldReader := promptReader
+	oldWriter := promptWriter
+	oldApply := applyUpdateFn
+	var out bytes.Buffer
+	var appliedVersion, appliedDest string
+	executablePath = func() (string, error) { return bin, nil }
+	stdinIsTerminal = func() bool { return true }
+	promptReader = strings.NewReader("y\n")
+	promptWriter = io.MultiWriter(&out)
+	applyUpdateFn = func(ctx context.Context, ver, dest string) error {
+		appliedVersion = ver
+		appliedDest = dest
+		return nil
+	}
+	defer func() {
+		executablePath = oldExec
+		stdinIsTerminal = oldTerm
+		promptReader = oldReader
+		promptWriter = oldWriter
+		applyUpdateFn = oldApply
+	}()
+
+	displayUpdatePrompt(&VersionInfo{LatestVersion: "9.9.9"})
+	if appliedVersion != "9.9.9" {
+		t.Fatalf("expected apply of 9.9.9, got %q", appliedVersion)
+	}
+	resolved, err := filepath.EvalSymlinks(bin)
+	if err != nil {
+		resolved = bin
+	}
+	if appliedDest != bin && appliedDest != resolved {
+		t.Fatalf("applied dest = %q, want %q", appliedDest, bin)
+	}
+	if !strings.Contains(out.String(), "Update now? [y/N]") {
+		t.Fatalf("expected prompt, got %q", out.String())
+	}
+}
+
+func TestDisplayUpdatePromptSkipsOnNo(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "preloop")
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldExec := executablePath
+	oldTerm := stdinIsTerminal
+	oldReader := promptReader
+	oldWriter := promptWriter
+	oldApply := applyUpdateFn
+	applied := false
+	executablePath = func() (string, error) { return bin, nil }
+	stdinIsTerminal = func() bool { return true }
+	promptReader = strings.NewReader("n\n")
+	promptWriter = io.Discard
+	applyUpdateFn = func(ctx context.Context, ver, dest string) error {
+		applied = true
+		return nil
+	}
+	defer func() {
+		executablePath = oldExec
+		stdinIsTerminal = oldTerm
+		promptReader = oldReader
+		promptWriter = oldWriter
+		applyUpdateFn = oldApply
+	}()
+
+	displayUpdatePrompt(&VersionInfo{LatestVersion: "9.9.9"})
+	if applied {
+		t.Fatal("did not expect apply on n")
+	}
+}
+
+func TestForceCheckStillUsedByUpdateLookup(t *testing.T) {
+	// Sanity: the update command's version lookup is ForceCheck, which
+	// posts to the rich endpoint. Keep a local server so this file does
+	// not depend on the network.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"latest_version": "1.2.3"})
+	}))
+	defer server.Close()
+	oldOrigin := VersionCheckOrigin
+	VersionCheckOrigin = server.URL
+	defer func() { VersionCheckOrigin = oldOrigin }()
+
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv("PRELOOP_DISABLE_TELEMETRY", "")
+	t.Setenv("DISABLE_VERSION_CHECK", "")
+	info, err := ForceCheck()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.LatestVersion != "1.2.3" {
+		t.Fatalf("latest = %q", info.LatestVersion)
+	}
+}

--- a/docs/guide/flows/ci-trigger.md
+++ b/docs/guide/flows/ci-trigger.md
@@ -1,0 +1,29 @@
+# Trigger a flow from CI
+
+GitHub Actions and GitLab CI call the Preloop CLI. Preloop does not dispatch
+into your CI APIs. The CLI blocks (when stdin is not a TTY), streams
+execution logs to the job, and exits non-zero on FAILED, STOPPED, or TIMEOUT.
+The same logs stay visible in the Preloop console.
+
+```yaml
+# .github/workflows/preloop-flow.yml
+name: Preloop flow
+on:
+  pull_request:
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Preloop flow
+        env:
+          PRELOOP_TOKEN: ${{ secrets.PRELOOP_TOKEN }}
+          PRELOOP_URL: https://preloop.example.com
+        run: |
+          curl -fsSL https://preloop.ai/install/cli | sh
+          preloop flow trigger pull-request-reviewer \
+            --payload '{"pull_request":{"url":"https://github.com/example/repo/pull/1"}}'
+```
+
+`PRELOOP_TOKEN` is an account API token. OIDC exchange is not part of this
+command yet. Use `--payload -` to pipe a JSON event file from a previous step.
+Omit `--wait` in CI; waiting is the default when stdin is not a TTY.


### PR DESCRIPTION
## Summary
- Add `preloop update` to download the matching GitHub release asset for this OS/architecture and replace the current binary in place (`--check`, `--yes` / `-y`).
- Version lookup uses the existing check-in path and honors `PRELOOP_DISABLE_TELEMETRY` the same way `version.ForceCheck` does.
- The daily update notice now asks "Update now? [y/N]" only when stdin is a TTY and the running binary (plus its directory) is writable. Otherwise it stays silent: no nag, no sudo hint, no download URL.

## Test plan
- [ ] `cd cli && go test ./internal/version/ ./internal/cmd/ -run 'TestUpdate|TestDisplayUpdate|TestNormalize|TestReplace|TestCanReplace|TestApplyUpdate|TestChecksum'`
- [ ] `preloop update --check` against a logged-in install (telemetry enabled)
- [ ] `PRELOOP_DISABLE_TELEMETRY=true preloop update --check` errors without phoning home
- [ ] Interactive `preloop` invocation on a user-writable binary asks to upgrade; a root-owned `/usr/local/bin/preloop` stays silent


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> All previously reported findings (semver ordering, fail-open checksums, root-incompatible tests, prerelease ordering) are resolved; the self-update path is clean and well-tested.
>
> **Overview**
> Adds `preloop update` (downloads the matching GitHub release asset and replaces the running binary in place) plus an interactive upgrade prompt on the daily version check, honoring the telemetry opt-out. Follow-up commits `ba6b7acd` and `92278bf3` harden semver comparison, make checksum verification fail closed, and fix prerelease ordering.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 92278bf3. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->