### PR TITLE
feat(cli): add preloop flow trigger for CI-native runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Update now? [y/N]" when stdin is a TTY and the running binary is
   writable. If the binary cannot be replaced, the CLI stays silent (no
   nag, no sudo hint).
+- **`preloop flow trigger`**: CI-native trigger for an existing flow by id
+  or name. Posts to `POST /api/v1/flows/{flow_id}/trigger`, accepts
+  `--payload JSON` or `--payload -` (stdin), and waits for a terminal
+  status when stdin is not a TTY (override with `--wait=false`). Logs are
+  polled from `GET /api/v1/flows/executions/{id}/logs` and printed to
+  stdout. Non-zero exit on FAILED, STOPPED, or TIMEOUT. `--runner` errors
+  until self-hosted runners land. See `docs/guide/flows/ci-trigger.md`.
 - **Native scheduled (cron) flow triggers**: flows can now run on a schedule
   without an external cron caller hitting the webhook endpoint. Create or
   update a flow with `trigger_event_source: "schedule"` and

--- a/cli/README.md
+++ b/cli/README.md
@@ -183,6 +183,21 @@ Both flags default to `ask`. With `--yes` alone, the CLI skips the main offboard
 - MCP servers are kept if they are still referenced by another managed agent
 - Recently active shared resources are also skipped
 
+### Flows
+
+```bash
+preloop flow trigger <flow-id-or-name>
+preloop flow trigger nightly-review --payload '{"ref":"main"}'
+cat event.json | preloop flow trigger nightly-review --payload -
+preloop flow trigger nightly-review --wait --timeout 30m
+```
+
+In CI (stdin is not a TTY) the command waits by default and streams
+execution logs to stdout. The same logs remain in the console execution
+view. Exit status is non-zero on FAILED, STOPPED, or TIMEOUT. Auth is
+`--token`, `PRELOOP_TOKEN`, or the saved login. See
+[docs/guide/flows/ci-trigger.md](../docs/guide/flows/ci-trigger.md).
+
 ### Version
 
 ```bash
@@ -274,7 +289,8 @@ cli/
 │   │   ├── tools.go         # tools list/describe/exec
 │   │   ├── approvals.go     # approvals list/pending/approve/deny
 │   │   ├── version.go       # version command
-│   │   └── update.go        # update command
+│   │   ├── update.go        # update command
+│   │   └── flow.go          # flow trigger
 │   ├── mcpclient/
 │   │   └── client.go        # Minimal MCP HTTP client
 │   └── version/

--- a/cli/internal/cmd/flow.go
+++ b/cli/internal/cmd/flow.go
@@ -1,0 +1,283 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+const (
+	flowsPath              = "/api/v1/flows"
+	defaultFlowWaitTimeout = 60 * time.Minute
+	flowPollInitial        = time.Second
+	flowPollMax            = 5 * time.Second
+)
+
+var uuidPattern = regexp.MustCompile(
+	`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+)
+
+var (
+	flowSleep = time.Sleep
+	flowNow   = time.Now
+)
+
+var terminalFailureStatuses = map[string]bool{
+	"FAILED":  true,
+	"STOPPED": true,
+	"TIMEOUT": true,
+}
+
+// flowCmd is the parent for flow operations.
+var flowCmd = &cobra.Command{
+	Use:   "flow",
+	Short: "Trigger and inspect Preloop flows",
+	Long:  `Trigger flow executions from CI or the command line.`,
+}
+
+// flowTriggerCmd implements `preloop flow trigger`.
+var flowTriggerCmd = &cobra.Command{
+	Use:   "trigger <flow-id-or-name>",
+	Short: "Trigger a flow execution",
+	Long: `Trigger a flow by id or name via POST /api/v1/flows/{flow_id}/trigger.
+
+In CI (stdin is not a TTY) the command waits for a terminal status by default
+and streams execution logs to stdout. The same logs remain visible in the
+console execution view. Exit status is non-zero on FAILED, STOPPED, or TIMEOUT.
+
+Examples:
+  preloop flow trigger pull-request-reviewer
+  preloop flow trigger 11111111-2222-4333-8444-555555555555 --payload '{"ref":"main"}'
+  cat event.json | preloop flow trigger pull-request-reviewer --payload -`,
+	Args: cobra.ExactArgs(1),
+	RunE: runFlowTrigger,
+}
+
+func init() {
+	flowCmd.AddCommand(flowTriggerCmd)
+	flowTriggerCmd.Flags().String("payload", "", "JSON trigger payload, or - to read stdin")
+	flowTriggerCmd.Flags().Bool("wait", false, "stream logs until the execution finishes (default on when stdin is not a TTY)")
+	flowTriggerCmd.Flags().String("runner", "", "pin the execution to a self-hosted runner (not yet available)")
+	flowTriggerCmd.Flags().Duration("timeout", defaultFlowWaitTimeout, "how long --wait will poll before exiting")
+}
+
+func runFlowTrigger(cmd *cobra.Command, args []string) error {
+	runner, err := cmd.Flags().GetString("runner")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(runner) != "" {
+		return fmt.Errorf("self-hosted runner targeting is not available yet; omit --runner")
+	}
+
+	payloadFlag, err := cmd.Flags().GetString("payload")
+	if err != nil {
+		return err
+	}
+	payload, err := parseTriggerPayload(payloadFlag, os.Stdin)
+	if err != nil {
+		return err
+	}
+
+	waitFlag, err := cmd.Flags().GetBool("wait")
+	if err != nil {
+		return err
+	}
+	wait := shouldWaitDefault(cmd.Flags().Changed("wait"), waitFlag, stdinIsTerminal())
+	timeout, err := cmd.Flags().GetDuration("timeout")
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClient(FlagToken, FlagURL)
+	if err != nil {
+		return err
+	}
+
+	flowID, err := resolveFlowID(client, args[0])
+	if err != nil {
+		return err
+	}
+
+	var result flowTriggerResult
+	if err := client.Post(flowsPath+"/"+flowID+"/trigger", payload, &result); err != nil {
+		return fmt.Errorf("failed to trigger flow: %w", err)
+	}
+	if result.ID == "" {
+		return fmt.Errorf("trigger response did not include an execution id")
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Triggered flow %s (execution %s, status %s)\n",
+		flowID, result.ID, result.Status)
+
+	if !wait {
+		return nil
+	}
+	return waitForExecution(client, result.ID, timeout, cmd.OutOrStdout())
+}
+
+type flowTriggerResult struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	FlowID string `json:"flow_id"`
+}
+
+type flowExecutionStatus struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+type flowLogsResponse struct {
+	Logs    []flowLogEntry `json:"logs"`
+	Source  string         `json:"source"`
+	HasMore bool           `json:"has_more"`
+}
+
+type flowLogEntry struct {
+	Type    string         `json:"type"`
+	Payload map[string]any `json:"payload"`
+}
+
+func parseTriggerPayload(raw string, stdin io.Reader) (map[string]any, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var r io.Reader
+	if raw == "-" {
+		r = stdin
+	} else {
+		r = strings.NewReader(raw)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read payload: %w", err)
+	}
+	data = bytesTrimSpace(data)
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("payload must be a JSON object: %w", err)
+	}
+	return payload, nil
+}
+
+func bytesTrimSpace(data []byte) []byte {
+	return []byte(strings.TrimSpace(string(data)))
+}
+
+func resolveFlowID(client *api.Client, nameOrID string) (string, error) {
+	nameOrID = strings.TrimSpace(nameOrID)
+	if nameOrID == "" {
+		return "", fmt.Errorf("flow id or name is required")
+	}
+	if uuidPattern.MatchString(nameOrID) {
+		var flow flowSummaryResponse
+		if err := client.Get(flowsPath+"/"+nameOrID, &flow); err == nil && flow.ID != "" {
+			return flow.ID, nil
+		}
+	}
+
+	var flows []flowSummaryResponse
+	if err := client.Get(flowsPath+"?limit=1000", &flows); err != nil {
+		return "", fmt.Errorf("failed to list flows: %w", err)
+	}
+	var matches []flowSummaryResponse
+	for _, flow := range flows {
+		if strings.EqualFold(flow.ID, nameOrID) || strings.EqualFold(flow.Name, nameOrID) {
+			matches = append(matches, flow)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0].ID, nil
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("multiple flows match %q", nameOrID)
+	}
+	return "", fmt.Errorf("flow %q not found", nameOrID)
+}
+
+func shouldWaitDefault(flagChanged, flagValue, isTTY bool) bool {
+	if flagChanged {
+		return flagValue
+	}
+	return !isTTY
+}
+
+func extractLogLine(entry flowLogEntry) string {
+	if entry.Payload == nil {
+		return ""
+	}
+	if line, ok := entry.Payload["line"].(string); ok && line != "" {
+		return line
+	}
+	if msg, ok := entry.Payload["message"].(string); ok && msg != "" {
+		return msg
+	}
+	return ""
+}
+
+func newLogLines(source string, alreadyPrinted int, entries []flowLogEntry) []string {
+	lines := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if line := extractLogLine(entry); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if strings.EqualFold(source, "container") && alreadyPrinted > 0 && len(lines) >= alreadyPrinted {
+		return lines[alreadyPrinted:]
+	}
+	return lines
+}
+
+func waitForExecution(client *api.Client, executionID string, timeout time.Duration, out io.Writer) error {
+	deadline := flowNow().Add(timeout)
+	printed := 0
+	backoff := flowPollInitial
+
+	for {
+		var exec flowExecutionStatus
+		if err := client.Get("/api/v1/flows/executions/"+executionID, &exec); err != nil {
+			return fmt.Errorf("failed to read execution: %w", err)
+		}
+
+		var logs flowLogsResponse
+		path := fmt.Sprintf("/api/v1/flows/executions/%s/logs?skip=%d&limit=500", executionID, printed)
+		if err := client.Get(path, &logs); err != nil {
+			return fmt.Errorf("failed to read execution logs: %w", err)
+		}
+		for _, line := range newLogLines(logs.Source, printed, logs.Logs) {
+			fmt.Fprintln(out, line)
+			printed++
+		}
+
+		status := strings.ToUpper(strings.TrimSpace(exec.Status))
+		if status == "SUCCEEDED" {
+			return nil
+		}
+		if terminalFailureStatuses[status] {
+			return fmt.Errorf("execution %s %s", executionID, status)
+		}
+		if flowNow().After(deadline) {
+			return fmt.Errorf("execution %s timed out after %s (last status %s)", executionID, timeout, exec.Status)
+		}
+
+		flowSleep(backoff)
+		if backoff < flowPollMax {
+			backoff *= 2
+			if backoff > flowPollMax {
+				backoff = flowPollMax
+			}
+		}
+	}
+}

--- a/cli/internal/cmd/flow.go
+++ b/cli/internal/cmd/flow.go
@@ -19,6 +19,10 @@ const (
 	defaultFlowWaitTimeout = 60 * time.Minute
 	flowPollInitial        = time.Second
 	flowPollMax            = 5 * time.Second
+	flowLogPageSize        = 500
+	flowLogMaxPages        = 100
+	flowListPageSize       = 1000
+	flowListMaxPages       = 10
 )
 
 var uuidPattern = regexp.MustCompile(
@@ -189,8 +193,16 @@ func resolveFlowID(client *api.Client, nameOrID string) (string, error) {
 	}
 
 	var flows []flowSummaryResponse
-	if err := client.Get(flowsPath+"?limit=1000", &flows); err != nil {
-		return "", fmt.Errorf("failed to list flows: %w", err)
+	for page := 0; page < flowListMaxPages; page++ {
+		var batch []flowSummaryResponse
+		path := fmt.Sprintf("%s?skip=%d&limit=%d", flowsPath, page*flowListPageSize, flowListPageSize)
+		if err := client.Get(path, &batch); err != nil {
+			return "", fmt.Errorf("failed to list flows: %w", err)
+		}
+		flows = append(flows, batch...)
+		if len(batch) < flowListPageSize {
+			break
+		}
 	}
 	var matches []flowSummaryResponse
 	for _, flow := range flows {
@@ -240,6 +252,24 @@ func newLogLines(source string, alreadyPrinted int, entries []flowLogEntry) []st
 	return lines
 }
 
+func drainExecutionLogs(client *api.Client, executionID string, printed int, out io.Writer) (int, error) {
+	for page := 0; page < flowLogMaxPages; page++ {
+		var logs flowLogsResponse
+		path := fmt.Sprintf("/api/v1/flows/executions/%s/logs?skip=%d&limit=%d", executionID, printed, flowLogPageSize)
+		if err := client.Get(path, &logs); err != nil {
+			return printed, fmt.Errorf("failed to read execution logs: %w", err)
+		}
+		for _, line := range newLogLines(logs.Source, printed, logs.Logs) {
+			fmt.Fprintln(out, line)
+			printed++
+		}
+		if !logs.HasMore {
+			return printed, nil
+		}
+	}
+	return printed, nil
+}
+
 func waitForExecution(client *api.Client, executionID string, timeout time.Duration, out io.Writer) error {
 	deadline := flowNow().Add(timeout)
 	printed := 0
@@ -251,15 +281,11 @@ func waitForExecution(client *api.Client, executionID string, timeout time.Durat
 			return fmt.Errorf("failed to read execution: %w", err)
 		}
 
-		var logs flowLogsResponse
-		path := fmt.Sprintf("/api/v1/flows/executions/%s/logs?skip=%d&limit=500", executionID, printed)
-		if err := client.Get(path, &logs); err != nil {
-			return fmt.Errorf("failed to read execution logs: %w", err)
+		nextPrinted, err := drainExecutionLogs(client, executionID, printed, out)
+		if err != nil {
+			return err
 		}
-		for _, line := range newLogLines(logs.Source, printed, logs.Logs) {
-			fmt.Fprintln(out, line)
-			printed++
-		}
+		printed = nextPrinted
 
 		status := strings.ToUpper(strings.TrimSpace(exec.Status))
 		if status == "SUCCEEDED" {

--- a/cli/internal/cmd/flow_test.go
+++ b/cli/internal/cmd/flow_test.go
@@ -1,0 +1,273 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/preloop/preloop/cli/internal/api"
+	"github.com/preloop/preloop/cli/internal/testenv"
+)
+
+func TestParseTriggerPayload(t *testing.T) {
+	got, err := parseTriggerPayload(`{"ref":"main"}`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["ref"] != "main" {
+		t.Fatalf("got %#v", got)
+	}
+
+	empty, err := parseTriggerPayload("", nil)
+	if err != nil || empty != nil {
+		t.Fatalf("empty payload: %#v %v", empty, err)
+	}
+
+	fromStdin, err := parseTriggerPayload("-", strings.NewReader(`{"n":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fromStdin["n"].(float64) != 1 {
+		t.Fatalf("stdin payload: %#v", fromStdin)
+	}
+
+	if _, err := parseTriggerPayload(`["not","object"]`, nil); err == nil {
+		t.Fatal("expected error for non-object JSON")
+	}
+}
+
+func TestShouldWaitDefault(t *testing.T) {
+	if !shouldWaitDefault(false, false, false) {
+		t.Fatal("CI (no TTY, flag unset) should wait")
+	}
+	if shouldWaitDefault(false, false, true) {
+		t.Fatal("interactive TTY should not wait by default")
+	}
+	if shouldWaitDefault(true, false, false) {
+		t.Fatal("explicit --wait=false must win in CI")
+	}
+	if !shouldWaitDefault(true, true, true) {
+		t.Fatal("explicit --wait must win on a TTY")
+	}
+}
+
+func TestExtractAndDedupeLogLines(t *testing.T) {
+	entries := []flowLogEntry{
+		{Payload: map[string]any{"line": "one"}},
+		{Payload: map[string]any{"message": "two"}},
+		{Payload: map[string]any{}},
+	}
+	if got := newLogLines("database", 0, entries); strings.Join(got, ",") != "one,two" {
+		t.Fatalf("database lines = %#v", got)
+	}
+	if got := newLogLines("container", 1, entries); strings.Join(got, ",") != "two" {
+		t.Fatalf("container dedupe = %#v", got)
+	}
+}
+
+func TestResolveFlowIDByNameAndUUID(t *testing.T) {
+	const flowID = "11111111-2222-4333-8444-555555555555"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/flows/"+flowID:
+			_ = json.NewEncoder(w).Encode(flowSummaryResponse{ID: flowID, Name: "Nightly Review"})
+		case r.URL.Path == "/api/v1/flows":
+			_ = json.NewEncoder(w).Encode([]flowSummaryResponse{
+				{ID: flowID, Name: "Nightly Review"},
+				{ID: "22222222-2222-4333-8444-555555555555", Name: "Other"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client := api.NewClientWithToken(server.URL, "tok")
+
+	got, err := resolveFlowID(client, "Nightly Review")
+	if err != nil || got != flowID {
+		t.Fatalf("by name: %q %v", got, err)
+	}
+	got, err = resolveFlowID(client, flowID)
+	if err != nil || got != flowID {
+		t.Fatalf("by id: %q %v", got, err)
+	}
+	if _, err := resolveFlowID(client, "missing"); err == nil {
+		t.Fatal("expected not found")
+	}
+}
+
+func TestFlowTriggerPostsAndPrintsID(t *testing.T) {
+	const flowID = "11111111-2222-4333-8444-555555555555"
+	var gotPath string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.Method + " " + r.URL.Path
+		switch {
+		case r.URL.Path == "/api/v1/flows":
+			_ = json.NewEncoder(w).Encode([]flowSummaryResponse{
+				{ID: flowID, Name: "Nightly Review"},
+			})
+		case r.URL.Path == "/api/v1/flows/"+flowID+"/trigger":
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_ = json.NewEncoder(w).Encode(flowTriggerResult{
+				ID:     "exec-1",
+				Status: "PENDING",
+				FlowID: flowID,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	testenv.SetHome(t, t.TempDir())
+	oldToken, oldURL := FlagToken, FlagURL
+	FlagToken, FlagURL = "tok", server.URL
+	t.Cleanup(func() { FlagToken, FlagURL = oldToken, oldURL })
+
+	if err := flowTriggerCmd.Flags().Set("payload", `{"ref":"main"}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := flowTriggerCmd.Flags().Set("wait", "false"); err != nil {
+		t.Fatal(err)
+	}
+	if err := flowTriggerCmd.Flags().Set("runner", ""); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = flowTriggerCmd.Flags().Set("payload", "")
+		_ = flowTriggerCmd.Flags().Set("wait", "false")
+		_ = flowTriggerCmd.Flags().Set("runner", "")
+	})
+
+	var out bytes.Buffer
+	flowTriggerCmd.SetOut(&out)
+	if err := runFlowTrigger(flowTriggerCmd, []string{"Nightly Review"}); err != nil {
+		t.Fatalf("runFlowTrigger: %v", err)
+	}
+	if gotPath != "POST /api/v1/flows/"+flowID+"/trigger" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotBody["ref"] != "main" {
+		t.Fatalf("body = %#v", gotBody)
+	}
+	if !strings.Contains(out.String(), "exec-1") {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestFlowTriggerRunnerFlagErrors(t *testing.T) {
+	if err := flowTriggerCmd.Flags().Set("runner", "buildkite"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = flowTriggerCmd.Flags().Set("runner", "") })
+	err := runFlowTrigger(flowTriggerCmd, []string{"any"})
+	if err == nil || !strings.Contains(err.Error(), "not available yet") {
+		t.Fatalf("expected runner error, got %v", err)
+	}
+}
+
+func TestWaitForExecutionStreamsLogsAndFails(t *testing.T) {
+	polls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/flows/executions/exec-1/logs"):
+			line := "hello from agent"
+			if polls > 1 {
+				line = "done"
+			}
+			_ = json.NewEncoder(w).Encode(flowLogsResponse{
+				Source: "database",
+				Logs:   []flowLogEntry{{Payload: map[string]any{"line": line}}},
+			})
+		case r.URL.Path == "/api/v1/flows/executions/exec-1":
+			polls++
+			status := "RUNNING"
+			if polls >= 2 {
+				status = "FAILED"
+			}
+			_ = json.NewEncoder(w).Encode(flowExecutionStatus{ID: "exec-1", Status: status})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	oldSleep := flowSleep
+	flowSleep = func(time.Duration) {}
+	t.Cleanup(func() { flowSleep = oldSleep })
+
+	var out bytes.Buffer
+	client := api.NewClientWithToken(server.URL, "tok")
+	err := waitForExecution(client, "exec-1", time.Minute, &out)
+	if err == nil || !strings.Contains(err.Error(), "FAILED") {
+		t.Fatalf("expected FAILED, got %v", err)
+	}
+	if !strings.Contains(out.String(), "hello from agent") {
+		t.Fatalf("logs not streamed: %q", out.String())
+	}
+}
+
+func TestWaitForExecutionSucceeds(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/logs") || strings.Contains(r.URL.Path, "/logs") {
+			_ = json.NewEncoder(w).Encode(flowLogsResponse{
+				Source: "database",
+				Logs:   []flowLogEntry{{Payload: map[string]any{"message": "ok"}}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(flowExecutionStatus{ID: "exec-2", Status: "SUCCEEDED"})
+	}))
+	defer server.Close()
+
+	oldSleep := flowSleep
+	flowSleep = func(time.Duration) {}
+	t.Cleanup(func() { flowSleep = oldSleep })
+
+	var out bytes.Buffer
+	if err := waitForExecution(api.NewClientWithToken(server.URL, "tok"), "exec-2", time.Minute, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "ok") {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestWaitForExecutionTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/logs") {
+			_ = json.NewEncoder(w).Encode(flowLogsResponse{Logs: []flowLogEntry{}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(flowExecutionStatus{ID: "exec-3", Status: "RUNNING"})
+	}))
+	defer server.Close()
+
+	oldSleep := flowSleep
+	oldNow := flowNow
+	calls := 0
+	start := time.Unix(0, 0)
+	flowNow = func() time.Time {
+		calls++
+		if calls > 2 {
+			return start.Add(2 * time.Hour)
+		}
+		return start
+	}
+	flowSleep = func(time.Duration) {}
+	t.Cleanup(func() {
+		flowSleep = oldSleep
+		flowNow = oldNow
+	})
+
+	err := waitForExecution(api.NewClientWithToken(server.URL, "tok"), "exec-3", time.Minute, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout, got %v", err)
+	}
+}

--- a/cli/internal/cmd/flow_test.go
+++ b/cli/internal/cmd/flow_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -236,6 +237,93 @@ func TestWaitForExecutionSucceeds(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "ok") {
 		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestWaitForExecutionDrainsHasMoreBeforeTerminal(t *testing.T) {
+	var skips []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/logs") {
+			skips = append(skips, r.URL.Query().Get("skip"))
+			switch r.URL.Query().Get("skip") {
+			case "0":
+				_ = json.NewEncoder(w).Encode(flowLogsResponse{
+					Source:  "database",
+					HasMore: true,
+					Logs: []flowLogEntry{
+						{Payload: map[string]any{"line": "page-one"}},
+						{Payload: map[string]any{"line": "page-one-b"}},
+					},
+				})
+			case "2":
+				_ = json.NewEncoder(w).Encode(flowLogsResponse{
+					Source:  "database",
+					HasMore: false,
+					Logs: []flowLogEntry{
+						{Payload: map[string]any{"line": "error: boom"}},
+					},
+				})
+			default:
+				t.Errorf("unexpected skip=%q", r.URL.Query().Get("skip"))
+				_ = json.NewEncoder(w).Encode(flowLogsResponse{Source: "database"})
+			}
+			return
+		}
+		_ = json.NewEncoder(w).Encode(flowExecutionStatus{ID: "exec-4", Status: "FAILED"})
+	}))
+	defer server.Close()
+
+	oldSleep := flowSleep
+	flowSleep = func(time.Duration) {}
+	t.Cleanup(func() { flowSleep = oldSleep })
+
+	var out bytes.Buffer
+	err := waitForExecution(api.NewClientWithToken(server.URL, "tok"), "exec-4", time.Minute, &out)
+	if err == nil || !strings.Contains(err.Error(), "FAILED") {
+		t.Fatalf("expected FAILED, got %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "page-one") || !strings.Contains(got, "error: boom") {
+		t.Fatalf("dropped tail logs: %q", got)
+	}
+	if len(skips) < 2 || skips[0] != "0" || skips[1] != "2" {
+		t.Fatalf("expected skip=0 then skip=2, got %#v", skips)
+	}
+}
+
+func TestResolveFlowIDPaginatesList(t *testing.T) {
+	const lateID = "33333333-2222-4333-8444-555555555555"
+	pages := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/flows" {
+			http.NotFound(w, r)
+			return
+		}
+		pages++
+		skip := r.URL.Query().Get("skip")
+		if skip == "0" {
+			first := make([]flowSummaryResponse, flowListPageSize)
+			for i := range first {
+				first[i] = flowSummaryResponse{
+					ID:   fmt.Sprintf("11111111-2222-4333-8444-%012d", i),
+					Name: fmt.Sprintf("flow-%d", i),
+				}
+			}
+			_ = json.NewEncoder(w).Encode(first)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]flowSummaryResponse{
+			{ID: lateID, Name: "Late Flow"},
+		})
+	}))
+	defer server.Close()
+
+	got, err := resolveFlowID(api.NewClientWithToken(server.URL, "tok"), "Late Flow")
+	if err != nil || got != lateID {
+		t.Fatalf("paginated name resolve: %q %v", got, err)
+	}
+	if pages < 2 {
+		t.Fatalf("expected a second list page, got %d", pages)
 	}
 }
 

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -117,4 +117,5 @@ func init() {
 	rootCmd.AddCommand(usageCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(updateCmd)
+	rootCmd.AddCommand(flowCmd)
 }

--- a/cli/internal/version/update_test.go
+++ b/cli/internal/version/update_test.go
@@ -68,6 +68,13 @@ func TestReplaceBinaryPreservesMode(t *testing.T) {
 	if err := os.WriteFile(dest, []byte("old-binary"), 0o750); err != nil {
 		t.Fatal(err)
 	}
+	// NTFS does not store Unix 0750; Stat after WriteFile is the mode
+	// ReplaceBinary can actually preserve on this OS.
+	before, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantMode := before.Mode().Perm()
 
 	if err := ReplaceBinary(dest, []byte("new-binary")); err != nil {
 		t.Fatalf("ReplaceBinary: %v", err)
@@ -83,8 +90,8 @@ func TestReplaceBinaryPreservesMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0o750 {
-		t.Errorf("mode = %o, want 0750", info.Mode().Perm())
+	if info.Mode().Perm() != wantMode {
+		t.Errorf("mode = %o, want %o (OS-stored mode of the original file)", info.Mode().Perm(), wantMode)
 	}
 }
 

--- a/docs/guide/flows/ci-trigger.md
+++ b/docs/guide/flows/ci-trigger.md
@@ -1,0 +1,29 @@
+# Trigger a flow from CI
+
+GitHub Actions and GitLab CI call the Preloop CLI. Preloop does not dispatch
+into your CI APIs. The CLI blocks (when stdin is not a TTY), streams
+execution logs to the job, and exits non-zero on FAILED, STOPPED, or TIMEOUT.
+The same logs stay visible in the Preloop console.
+
+```yaml
+# .github/workflows/preloop-flow.yml
+name: Preloop flow
+on:
+  pull_request:
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Preloop flow
+        env:
+          PRELOOP_TOKEN: ${{ secrets.PRELOOP_TOKEN }}
+          PRELOOP_URL: https://preloop.example.com
+        run: |
+          curl -fsSL https://preloop.ai/install/cli | sh
+          preloop flow trigger pull-request-reviewer \
+            --payload '{"pull_request":{"url":"https://github.com/example/repo/pull/1"}}'
+```
+
+`PRELOOP_TOKEN` is an account API token. OIDC exchange is not part of this
+command yet. Use `--payload -` to pipe a JSON event file from a previous step.
+Omit `--wait` in CI; waiting is the default when stdin is not a TTY.


### PR DESCRIPTION
## Summary
- Add `preloop flow trigger <flow-id-or-name>` so CI jobs call Preloop instead of Preloop dispatching into GitHub or GitLab.
- Posts to the existing `POST /api/v1/flows/{flow_id}/trigger`. `--payload JSON` or `--payload -` (stdin). Auth is `--token` / `PRELOOP_TOKEN` / config.
- `--wait` defaults on when stdin is not a TTY. Logs are polled from `GET /api/v1/flows/executions/{id}/logs` (same store the console uses) and printed to stdout. Non-zero exit on FAILED, STOPPED, or TIMEOUT.
- `--runner` returns a clear error until the self-hosted runner slice lands.
- GitHub Actions snippet: `docs/guide/flows/ci-trigger.md`.

Stacked on #242 (`feat/cli-self-update`). Retarget to `main` after that merges.

## Test plan
- [ ] `cd cli && go test ./internal/cmd/ -run 'TestParseTriggerPayload|TestShouldWaitDefault|TestExtractAndDedupeLogLines|TestResolveFlowID|TestFlowTrigger|TestWaitForExecution'`
- [ ] Against local compose: `preloop flow trigger <name> --payload '{\"hello\":\"ci\"}' --wait=false` prints an execution id
- [ ] `preloop flow trigger <name> --wait --timeout 2m` streams logs and exits 0 on SUCCEEDED
- [ ] `preloop flow trigger <name> --runner anything` errors with \"not available yet\"
- [ ] `cat event.json | preloop flow trigger <name> --payload -` accepts stdin JSON


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low risk**
> Additive CLI feature with strong test coverage and no security implications. Both previously reported issues (log-tail truncation and flow-list pagination) are now resolved.
>
> **Overview**
> Adds `preloop flow trigger <flow-id-or-name>` so CI jobs trigger flows directly via the CLI instead of Preloop dispatching into GitHub/GitLab. Posts to the existing trigger endpoint, supports `--payload` (JSON or stdin), defaults to waiting and streaming logs when stdin is not a TTY, and exits non-zero on FAILED/STOPPED/TIMEOUT. Includes tests, docs, and CHANGELOG updates.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 25f09f1. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->