### PR TITLE
Enable Claude Code Agent Control and attach native session ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent Control for Claude Code (G1) and native session targeting (G2)**:
+  `claude_code` is now a supported Agent Control kind. `control_enabled`
+  still requires sidecar/capability flags, not a blanket true. When a
+  command targets an existing session, the persisted outbound envelope
+  includes that session's `session_source_id` and `session_reference`.
+  Clients keep sending the Preloop `target_session_id` UUID.
 - **Native scheduled (cron) flow triggers**: flows can now run on a schedule
   without an external cron caller hitting the webhook endpoint. Create or
   update a flow with `trigger_event_source: "schedule"` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still requires sidecar/capability flags, not a blanket true. When a
   command targets an existing session, the persisted outbound envelope
   includes that session's `session_source_id` and `session_reference`.
-  Clients keep sending the Preloop `target_session_id` UUID.
+  Clients keep sending the Preloop `target_session_id` UUID. Those
+  native fields are response-only: request models ignore any
+  client-supplied value. `start_new_session` responses also return
+  the minted history session's native identity.
 - **Native scheduled (cron) flow triggers**: flows can now run on a schedule
   without an external cron caller hitting the webhook endpoint. Create or
   update a flow with `trigger_event_source: "schedule"` and

--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -120,7 +120,7 @@ AGENT_CONTROL_CAPABILITIES = [
 ]
 AGENT_CONTROL_INPUT_MODES = ["text", "voice_transcript"]
 AGENT_CONTROL_OUTPUT_MODES = ["event", "status", "text"]
-AGENT_CONTROL_SUPPORTED_AGENT_KINDS = {"hermes", "openclaw"}
+AGENT_CONTROL_SUPPORTED_AGENT_KINDS = {"hermes", "openclaw", "claude_code"}
 AGENT_CONTROL_STATE_UNSUPPORTED = "unsupported"
 AGENT_CONTROL_STATE_INSTALL_PENDING = "install_pending"
 AGENT_CONTROL_STATE_PLUGIN_CONFIGURED = "plugin_configured"

--- a/backend/preloop/api/endpoints/agent_control.py
+++ b/backend/preloop/api/endpoints/agent_control.py
@@ -85,7 +85,7 @@ _SERIALIZATION_ERRORS = (
 )
 
 HEARTBEAT_TOUCH_INTERVAL = timedelta(seconds=15)
-SUPPORTED_CONTROL_AGENT_KINDS = {"hermes", "openclaw"}
+SUPPORTED_CONTROL_AGENT_KINDS = {"hermes", "openclaw", "claude_code"}
 
 
 @dataclass(frozen=True)
@@ -899,11 +899,11 @@ def _resolve_session_mode(
     account_id: str,
     agent: Any,
     request: AgentControlSendMessageRequest,
-) -> AgentControlSessionMode:
+) -> tuple[AgentControlSessionMode, Optional[models.RuntimeSession]]:
     if request.start_new_session:
-        return "new"
+        return "new", None
     if request.target_session_id is None:
-        return "current"
+        return "current", None
 
     target_session = crud_runtime_session.get_account_session(
         db,
@@ -928,7 +928,24 @@ def _resolve_session_mode(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Target runtime session does not belong to this managed agent",
         )
-    return "existing"
+    return "existing", target_session
+
+
+def _existing_session_identity(
+    target_session: Optional[models.RuntimeSession],
+) -> dict[str, Any]:
+    """Native resume fields for a targeted existing session.
+
+    Clients address sessions by Preloop UUID. Sidecars such as Claude Code
+    resume by ``session_source_id``. Attach the stored identity so plugins
+    do not have to map UUIDs themselves.
+    """
+    if target_session is None:
+        return {}
+    return {
+        "session_source_id": target_session.session_source_id,
+        "session_reference": target_session.session_reference,
+    }
 
 
 def _command_history_session(
@@ -998,26 +1015,28 @@ async def _route_managed_agent_prompt(
             detail="Managed agent does not have an Agent Control plugin configured",
         )
 
-    session_mode = _resolve_session_mode(
+    session_mode, target_session = _resolve_session_mode(
         db,
         account_id=str(current_user.account_id),
         agent=agent,
         request=request,
     )
+    payload: dict[str, Any] = {
+        "text": request.message,
+        "metadata": request.metadata,
+        "input_mode": request.input_mode,
+        "session_mode": session_mode,
+        "target_session_id": str(request.target_session_id)
+        if request.target_session_id
+        else None,
+        "start_new_session": request.start_new_session,
+        "voice": request.voice,
+    }
+    payload.update(_existing_session_identity(target_session))
     envelope = _operator_command_envelope(
         agent,
         name="send_message",
-        payload={
-            "text": request.message,
-            "metadata": request.metadata,
-            "input_mode": request.input_mode,
-            "session_mode": session_mode,
-            "target_session_id": str(request.target_session_id)
-            if request.target_session_id
-            else None,
-            "start_new_session": request.start_new_session,
-            "voice": request.voice,
-        },
+        payload=payload,
     )
     # Persist the command durably BEFORE any delivery attempt so agents that
     # reconnect after downtime can recover missed instructions.
@@ -1124,6 +1143,12 @@ async def _route_managed_agent_prompt(
             history_session.id
             if request.start_new_session and history_session is not None
             else request.target_session_id
+        ),
+        session_source_id=(
+            target_session.session_source_id if target_session is not None else None
+        ),
+        session_reference=(
+            target_session.session_reference if target_session is not None else None
         ),
         session_mode=session_mode,
         subject=subject,

--- a/backend/preloop/api/endpoints/agent_control.py
+++ b/backend/preloop/api/endpoints/agent_control.py
@@ -1135,6 +1135,9 @@ async def _route_managed_agent_prompt(
             else None,
         )
     )
+    identity_session = target_session
+    if identity_session is None and request.start_new_session:
+        identity_session = history_session
     return AgentControlCommandResponse(
         command_id=envelope.message_id,
         managed_agent_id=agent.id,
@@ -1145,10 +1148,10 @@ async def _route_managed_agent_prompt(
             else request.target_session_id
         ),
         session_source_id=(
-            target_session.session_source_id if target_session is not None else None
+            identity_session.session_source_id if identity_session is not None else None
         ),
         session_reference=(
-            target_session.session_reference if target_session is not None else None
+            identity_session.session_reference if identity_session is not None else None
         ),
         session_mode=session_mode,
         subject=subject,

--- a/backend/preloop/schemas/agent_control.py
+++ b/backend/preloop/schemas/agent_control.py
@@ -43,22 +43,6 @@ class AgentControlSendMessageRequest(BaseModel):
     message: str = Field(..., min_length=1)
     metadata: dict[str, Any] = Field(default_factory=dict)
     target_session_id: Optional[UUID] = None
-    session_source_id: Optional[str] = Field(
-        default=None,
-        max_length=255,
-        description=(
-            "Native id of the target runtime session. Clients send "
-            "target_session_id; the server fills this on the outbound envelope."
-        ),
-    )
-    session_reference: Optional[str] = Field(
-        default=None,
-        max_length=255,
-        description=(
-            "Human-readable reference of the target runtime session. Filled "
-            "by the server on the outbound envelope."
-        ),
-    )
     start_new_session: bool = False
     input_mode: AgentControlInputMode = "text"
     voice: dict[str, Any] = Field(default_factory=dict)
@@ -79,8 +63,6 @@ class AgentControlVoiceTranscriptRequest(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     voice: dict[str, Any] = Field(default_factory=dict)
     target_session_id: Optional[UUID] = None
-    session_source_id: Optional[str] = Field(default=None, max_length=255)
-    session_reference: Optional[str] = Field(default=None, max_length=255)
     start_new_session: bool = False
 
 

--- a/backend/preloop/schemas/agent_control.py
+++ b/backend/preloop/schemas/agent_control.py
@@ -43,6 +43,22 @@ class AgentControlSendMessageRequest(BaseModel):
     message: str = Field(..., min_length=1)
     metadata: dict[str, Any] = Field(default_factory=dict)
     target_session_id: Optional[UUID] = None
+    session_source_id: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description=(
+            "Native id of the target runtime session. Clients send "
+            "target_session_id; the server fills this on the outbound envelope."
+        ),
+    )
+    session_reference: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description=(
+            "Human-readable reference of the target runtime session. Filled "
+            "by the server on the outbound envelope."
+        ),
+    )
     start_new_session: bool = False
     input_mode: AgentControlInputMode = "text"
     voice: dict[str, Any] = Field(default_factory=dict)
@@ -63,6 +79,8 @@ class AgentControlVoiceTranscriptRequest(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     voice: dict[str, Any] = Field(default_factory=dict)
     target_session_id: Optional[UUID] = None
+    session_source_id: Optional[str] = Field(default=None, max_length=255)
+    session_reference: Optional[str] = Field(default=None, max_length=255)
     start_new_session: bool = False
 
 
@@ -73,6 +91,8 @@ class AgentControlCommandResponse(BaseModel):
     managed_agent_id: UUID
     runtime_session_id: Optional[UUID] = None
     target_session_id: Optional[UUID] = None
+    session_source_id: Optional[str] = None
+    session_reference: Optional[str] = None
     session_mode: AgentControlSessionMode
     subject: Optional[str] = None
     local_delivery: bool = False

--- a/backend/tests/endpoints/test_account_agents.py
+++ b/backend/tests/endpoints/test_account_agents.py
@@ -123,6 +123,74 @@ def test_managed_agent_control_fields_merge_runtime_plugin_evidence():
     assert fields["control_capabilities"]
 
 
+def test_managed_agent_control_fields_enable_claude_code_with_sidecar_flags():
+    """claude_code is a supported kind; control_enabled still needs sidecar flags."""
+    connected = _managed_agent_control_fields(
+        {
+            "agent_kind": "claude_code",
+            "session_source_type": "claude_code",
+            "lifecycle_state": "active",
+            "runtime_session_id": "runtime-claude",
+            "ended_at": None,
+        },
+        {
+            "validation_result": {
+                "control_channel_configured": True,
+                "control_plugin_verified": True,
+                "control_ws_url_ok": True,
+                "control_bearer_token_ok": True,
+            },
+            "managed_config": {},
+        },
+    )
+
+    assert connected["control_enabled"] is True
+    assert connected["control_online"] is True
+    assert connected["control_state"] == "plugin_connected"
+    assert connected["control_capabilities"]
+
+    no_sidecar = _managed_agent_control_fields(
+        {
+            "agent_kind": "claude_code",
+            "session_source_type": "claude_code",
+            "lifecycle_state": "active",
+            "runtime_session_id": "runtime-claude",
+            "ended_at": None,
+        },
+        None,
+    )
+
+    assert no_sidecar["control_enabled"] is False
+    assert no_sidecar["control_online"] is False
+    assert no_sidecar["control_state"] == "unsupported"
+    assert no_sidecar["control_capabilities"] == []
+
+
+def test_managed_agent_control_fields_keep_unknown_kinds_unsupported():
+    """Sidecar flags must not enable Agent Control for an unsupported kind."""
+    fields = _managed_agent_control_fields(
+        {
+            "agent_kind": "cursor",
+            "session_source_type": "cursor",
+            "lifecycle_state": "active",
+            "runtime_session_id": "runtime-cursor",
+            "ended_at": None,
+        },
+        {
+            "validation_result": {
+                "control_channel_configured": True,
+                "control_plugin_verified": True,
+                "control_ws_url_ok": True,
+                "control_bearer_token_ok": True,
+            },
+            "managed_config": {},
+        },
+    )
+
+    assert fields["control_enabled"] is False
+    assert fields["control_state"] == "unsupported"
+
+
 def test_onboarding_flags_downgrade_failed_live_gateway_to_mcp_only():
     """Failed gateway validation must not leave the UI showing fully onboarded."""
     mcp_configured, gateway_configured, state = _managed_agent_onboarding_flags(

--- a/backend/tests/endpoints/test_agent_control.py
+++ b/backend/tests/endpoints/test_agent_control.py
@@ -14,6 +14,7 @@ from preloop.models.crud import (
     crud_runtime_session,
     crud_runtime_session_activity,
 )
+from preloop.schemas.agent_control import AgentControlSendMessageRequest
 
 
 def _issue_runtime_token(client, *, session_source_id: str = "openclaw-live"):
@@ -768,15 +769,22 @@ def test_agent_control_existing_session_envelope_includes_native_ids(
     mock_nats.publish = AsyncMock()
     mock_get_nats_client.return_value = mock_nats
 
+    request_json = {
+        "message": "Resume the ended investigation",
+        "target_session_id": str(native_session.id),
+        "session_source_id": "client-must-not-win",
+        "session_reference": "client-supplied-ref",
+        "metadata": {"source": "ios"},
+    }
+    parsed = AgentControlSendMessageRequest.model_validate(request_json)
+    assert "session_source_id" not in AgentControlSendMessageRequest.model_fields
+    assert "session_reference" not in AgentControlSendMessageRequest.model_fields
+    assert "session_source_id" not in parsed.model_dump()
+    assert "session_reference" not in parsed.model_dump()
+
     response = client.post(
         f"/api/v1/agents/{managed_agent.id}/control/commands",
-        json={
-            "message": "Resume the ended investigation",
-            "target_session_id": str(native_session.id),
-            "session_source_id": "client-must-not-win",
-            "session_reference": "client-supplied-ref",
-            "metadata": {"source": "ios"},
-        },
+        json=request_json,
     )
 
     assert response.status_code == 202
@@ -839,6 +847,16 @@ def test_agent_control_prompt_can_request_new_session(
     assert body["session_mode"] == "new"
     assert body["target_session_id"] is not None
     assert body["target_session_id"] != body["runtime_session_id"]
+    history_session = crud_runtime_session.get_account_session(
+        db_session,
+        account_id=str(test_user.account_id),
+        runtime_session_id=body["target_session_id"],
+    )
+    assert history_session is not None
+    assert body["session_source_id"] == history_session.session_source_id
+    assert body["session_reference"] == history_session.session_reference
+    assert history_session.session_source_id.startswith("openclaw-new-session-")
+    assert history_session.session_reference == "Agent Control new session"
     payload = body["command_envelope"]["payload"]
     assert payload["session_mode"] == "new"
     assert payload["start_new_session"] is True

--- a/backend/tests/endpoints/test_agent_control.py
+++ b/backend/tests/endpoints/test_agent_control.py
@@ -8,6 +8,7 @@ import pytest
 from starlette.websockets import WebSocketDisconnect
 
 from preloop.models.crud import (
+    crud_agent_control_command,
     crud_managed_agent,
     crud_managed_agent_enrollment,
     crud_runtime_session,
@@ -695,7 +696,11 @@ def test_agent_control_prompt_targets_existing_session(
     payload = body["command_envelope"]["payload"]
     assert payload["session_mode"] == "existing"
     assert payload["target_session_id"] == str(runtime_session.id)
+    assert payload["session_source_id"] == runtime_session.session_source_id
+    assert payload["session_reference"] == runtime_session.session_reference
     assert payload["start_new_session"] is False
+    assert body["session_source_id"] == runtime_session.session_source_id
+    assert body["session_reference"] == runtime_session.session_reference
 
     activity = crud_runtime_session_activity.list_for_runtime_session(
         db_session,
@@ -709,6 +714,92 @@ def test_agent_control_prompt_targets_existing_session(
     assert command_activity[0].summary == "Continue the current task"
     assert command_activity[0].metadata_["session_mode"] == "existing"
     assert command_activity[0].metadata_["target_session_id"] == str(runtime_session.id)
+
+
+@patch("preloop.api.endpoints.agent_control.get_nats_client")
+def test_agent_control_existing_session_envelope_includes_native_ids(
+    mock_get_nats_client,
+    client,
+    db_session,
+    test_user,
+):
+    """Existing-session commands persist the target's native resume identity.
+
+    Clients keep sending the Preloop runtime-session UUID. The sidecar
+    resumes by session_source_id, so the outbound envelope must carry that
+    native id (and session_reference) even when they differ from the
+    managed agent's durable source id.
+    """
+    token_response = client.post(
+        "/api/v1/auth/runtime-sessions/token",
+        json={
+            "session_source_type": "claude_code",
+            "session_source_id": "claude-principal-host",
+            "session_reference": "/tmp/claude.json",
+            "runtime_principal_name": "Claude Code",
+        },
+    )
+    assert token_response.status_code == 201
+    managed_agent = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="claude-principal-host",
+    )
+    assert managed_agent is not None
+    _mark_agent_control_configured(db_session, test_user, managed_agent)
+
+    native_session = crud_runtime_session.upsert_by_source(
+        db_session,
+        account_id=test_user.account_id,
+        session_source_type="claude_code",
+        session_source_id="ses_native_abc123",
+        session_reference="resume:ses_native_abc123",
+        runtime_principal_type="claude_code",
+        runtime_principal_id="claude-principal-host",
+        runtime_principal_name="Claude Code",
+        started_at=datetime.now(UTC),
+        last_activity_at=datetime.now(UTC),
+    )
+    db_session.commit()
+
+    mock_nats = MagicMock()
+    mock_nats.is_connected = True
+    mock_nats.publish = AsyncMock()
+    mock_get_nats_client.return_value = mock_nats
+
+    response = client.post(
+        f"/api/v1/agents/{managed_agent.id}/control/commands",
+        json={
+            "message": "Resume the ended investigation",
+            "target_session_id": str(native_session.id),
+            "session_source_id": "client-must-not-win",
+            "session_reference": "client-supplied-ref",
+            "metadata": {"source": "ios"},
+        },
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["session_mode"] == "existing"
+    assert body["target_session_id"] == str(native_session.id)
+    assert body["session_source_id"] == "ses_native_abc123"
+    assert body["session_reference"] == "resume:ses_native_abc123"
+    payload = body["command_envelope"]["payload"]
+    assert payload["target_session_id"] == str(native_session.id)
+    assert payload["session_source_id"] == "ses_native_abc123"
+    assert payload["session_reference"] == "resume:ses_native_abc123"
+
+    record = crud_agent_control_command.get_by_command_id(
+        db_session,
+        account_id=test_user.account_id,
+        command_id=body["command_id"],
+    )
+    assert record is not None
+    persisted = record.envelope["payload"]
+    assert persisted["target_session_id"] == str(native_session.id)
+    assert persisted["session_source_id"] == "ses_native_abc123"
+    assert persisted["session_reference"] == "resume:ses_native_abc123"
 
 
 @patch("preloop.api.endpoints.agent_control.get_nats_client")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9207,6 +9207,16 @@ components:
             format: uuid
           - type: 'null'
           title: Target Session Id
+        session_source_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Session Source Id
+        session_reference:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Session Reference
         session_mode:
           type: string
           enum:
@@ -9326,6 +9336,22 @@ components:
             format: uuid
           - type: 'null'
           title: Target Session Id
+        session_source_id:
+          anyOf:
+          - type: string
+            maxLength: 255
+          - type: 'null'
+          title: Session Source Id
+          description: Native id of the target runtime session. Clients send target_session_id;
+            the server fills this on the outbound envelope.
+        session_reference:
+          anyOf:
+          - type: string
+            maxLength: 255
+          - type: 'null'
+          title: Session Reference
+          description: Human-readable reference of the target runtime session. Filled
+            by the server on the outbound envelope.
         start_new_session:
           type: boolean
           title: Start New Session
@@ -9366,6 +9392,18 @@ components:
             format: uuid
           - type: 'null'
           title: Target Session Id
+        session_source_id:
+          anyOf:
+          - type: string
+            maxLength: 255
+          - type: 'null'
+          title: Session Source Id
+        session_reference:
+          anyOf:
+          - type: string
+            maxLength: 255
+          - type: 'null'
+          title: Session Reference
         start_new_session:
           type: boolean
           title: Start New Session

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9336,22 +9336,6 @@ components:
             format: uuid
           - type: 'null'
           title: Target Session Id
-        session_source_id:
-          anyOf:
-          - type: string
-            maxLength: 255
-          - type: 'null'
-          title: Session Source Id
-          description: Native id of the target runtime session. Clients send target_session_id;
-            the server fills this on the outbound envelope.
-        session_reference:
-          anyOf:
-          - type: string
-            maxLength: 255
-          - type: 'null'
-          title: Session Reference
-          description: Human-readable reference of the target runtime session. Filled
-            by the server on the outbound envelope.
         start_new_session:
           type: boolean
           title: Start New Session
@@ -9392,18 +9376,6 @@ components:
             format: uuid
           - type: 'null'
           title: Target Session Id
-        session_source_id:
-          anyOf:
-          - type: string
-            maxLength: 255
-          - type: 'null'
-          title: Session Source Id
-        session_reference:
-          anyOf:
-          - type: string
-            maxLength: 255
-          - type: 'null'
-          title: Session Reference
         start_new_session:
           type: boolean
           title: Start New Session


### PR DESCRIPTION
## Summary
- G1: add `claude_code` to `AGENT_CONTROL_SUPPORTED_AGENT_KINDS` (and the command-routing kind set). `control_enabled` still follows sidecar/capability flags, not a blanket true.
- G2: when a control command targets an existing session, the persisted/outbound envelope includes that session's `session_source_id` and `session_reference`. Clients keep sending the Preloop `target_session_id` UUID.
- Does not merge or depend on merging PR #161. Full Claude steer still needs the sidecar.

## Test plan
- [x] `pytest` on `_managed_agent_control_fields` for `claude_code` with and without sidecar flags
- [x] `pytest` on existing-session command envelope + persisted row for a native `session_source_id` that differs from the agent id
- [x] Existing Agent Control command/persistence tests still pass


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, well-tested additive change: a new supported agent kind plus native session identity fields on existing-session command envelopes. No open findings; both prior low-severity suggestions were addressed.
>
> **Overview**
> Enables `claude_code` as a supported Agent Control kind (gated behind sidecar/capability flags) and attaches the target session's native `session_source_id`/`session_reference` to existing-session command envelopes, persisted rows, and responses. Native identity fields are response-only, and `start_new_session` responses now return the minted session's identity.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 4aaa5245. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->