### PR TITLE
fix(gateway): suppress unpriced alerts for accounted $0 and empty completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Unpriced-model admin alert on accounted $0 and empty completions**:
+  when OpenRouter usage accounting was requested, an explicit `usage.cost`
+  of `0` is now recorded as provider $0 (`cost_source=provider`) instead of
+  treated as "not accounted". A response with `completion_tokens == 0` and
+  no `cost` / `cost_details` fields may still land unpriced, but it no
+  longer pages admins to add catalog pricing. `cost: -1` stays the catalog
+  sentinel (not accounted). Prompt plus completion with no cost and no
+  catalog price still alerts.
+
 - **Per-execution cost rollup understated real gateway spend (#209)**:
   `flow_execution.estimated_cost` is written once when the run finishes, but
   most gateway usage rows are priced *later* — the live price lookup and the

--- a/backend/preloop/services/model_pricing.py
+++ b/backend/preloop/services/model_pricing.py
@@ -188,9 +188,10 @@ def provider_reported_cost(
     for BYOK, ``cost`` alone otherwise. Without the flag, fall back to the
     magnitude heuristic: sum only when ``cost < upstream_inference_cost``
     (BYOK: a small fee next to the vendor charge); otherwise ``cost`` alone
-    is the total. Zero and negative values mean "not accounted" (the Auto
-    Router's catalog price is literally ``-1``), never a real charge, so
-    they are treated as absent.
+    is the total. An explicit ``usage.cost`` of ``0`` (key present) is a
+    real provider $0 charge. Negative values (the Auto Router catalog
+    sentinel ``-1``) still mean "not accounted" and are treated as absent.
+    A zero ``upstream_inference_cost`` alone is also treated as absent.
 
     Args:
         usage_details: Raw provider usage dict from the response, if any.
@@ -207,13 +208,24 @@ def provider_reported_cost(
             return None
         return float(value) if value > 0 else None
 
+    def _accounted_cost(value: Any) -> Optional[float]:
+        # Explicit 0 is a real $0 charge. Negative is the catalog
+        # sentinel (Auto Router list price is -1), not a charge.
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        if value < 0:
+            return None
+        return float(value)
+
     cost_details = usage_details.get("cost_details")
     upstream_cost = (
         _positive_number(cost_details.get("upstream_inference_cost"))
         if isinstance(cost_details, dict)
         else None
     )
-    gateway_cost = _positive_number(usage_details.get("cost"))
+    gateway_cost = (
+        _accounted_cost(usage_details["cost"]) if "cost" in usage_details else None
+    )
 
     if upstream_cost is None and gateway_cost is None:
         return None

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -86,7 +86,10 @@ from preloop.services.upstream_errors import (
     classify_upstream_error,
 )
 from preloop.services.model_price_catalog import schedule_price_lookup
-from preloop.services.unpriced_model_alert import notify_unpriced_model
+from preloop.services.unpriced_model_alert import (
+    notify_unpriced_model,
+    should_notify_unpriced_model,
+)
 from preloop.services.rate_limit_telemetry import (
     RateLimitSnapshot,
     classify_rate_limit_subtype,
@@ -6230,17 +6233,28 @@ class OpenAIGatewayService:
             # Tell an admin the catalog is missing this model. Deduplicated
             # per (model_alias, provider) via a persisted marker, so hot-path
             # traffic yields one actionable alert, not one per request.
-            try:
-                notify_unpriced_model(
-                    self.db,
-                    account_id=str(self.auth_context.user.account_id),
-                    model_alias=model_alias,
-                    provider_name=ai_model.provider_name,
-                    total_tokens=int(total_tokens or 0),
-                    ai_model=ai_model,
-                )
-            except Exception:  # noqa: BLE001 - never break recording
-                logger.debug("Unpriced-model admin alert failed", exc_info=True)
+            # Skip when usage accounting was on and the response has no
+            # completion and no cost fields (empty routed completion).
+            usage_accounting_requested = (
+                _is_openrouter_upstream(ai_model)
+                and _openrouter_usage_accounting_enabled()
+            )
+            if should_notify_unpriced_model(
+                usage_accounting_requested=usage_accounting_requested,
+                usage_details=usage_details,
+                completion_tokens=int(completion_tokens or 0),
+            ):
+                try:
+                    notify_unpriced_model(
+                        self.db,
+                        account_id=str(self.auth_context.user.account_id),
+                        model_alias=model_alias,
+                        provider_name=ai_model.provider_name,
+                        total_tokens=int(total_tokens or 0),
+                        ai_model=ai_model,
+                    )
+                except Exception:  # noqa: BLE001 - never break recording
+                    logger.debug("Unpriced-model admin alert failed", exc_info=True)
 
         log_model_gateway_request(
             self.db,

--- a/backend/preloop/services/unpriced_model_alert.py
+++ b/backend/preloop/services/unpriced_model_alert.py
@@ -27,7 +27,7 @@ import os
 import threading
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from sqlalchemy.orm import Session
 
@@ -108,6 +108,40 @@ def _dedupe_key(
             upstream = _upstream_provider(ai_model, provider_name)
             return f"model|{upstream}|{canonical.strip().lower()}"
     return f"{(provider_name or 'unknown').strip().lower()}|{model_alias.strip()}"
+
+
+def should_notify_unpriced_model(
+    *,
+    usage_accounting_requested: bool,
+    usage_details: Optional[Dict[str, Any]],
+    completion_tokens: int,
+) -> bool:
+    """Return False when an unpriced row should not page admins.
+
+    When we asked OpenRouter for usage accounting and the response has
+    no completion tokens and no ``cost`` / ``cost_details`` fields, the
+    request produced no billable output. The row may stay unpriced; do
+    not ask an admin to add catalog pricing. Prompt plus completion
+    with no cost and no catalog still alerts.
+
+    Args:
+        usage_accounting_requested: True when this request asked
+            OpenRouter for usage accounting.
+        usage_details: Raw provider usage dict from the response.
+        completion_tokens: Completion tokens on the recorded row.
+
+    Returns:
+        True when ``notify_unpriced_model`` should still run.
+    """
+    if not usage_accounting_requested:
+        return True
+    if int(completion_tokens or 0) != 0:
+        return True
+    if isinstance(usage_details, dict) and (
+        "cost" in usage_details or "cost_details" in usage_details
+    ):
+        return True
+    return False
 
 
 def reset_alert_state_for_tests() -> None:

--- a/backend/tests/services/test_model_pricing.py
+++ b/backend/tests/services/test_model_pricing.py
@@ -588,21 +588,61 @@ def test_absent_provider_cost_still_unpriced_for_uncatalogued_model() -> None:
     assert estimate.cost is None
 
 
-def test_zero_or_negative_provider_cost_is_ignored() -> None:
-    """cost=0/-1 mean 'not accounted', never a real $0 charge."""
-    for bogus in (
-        {"cost": 0},
-        {"cost": -1},
-        {"cost_details": {"upstream_inference_cost": 0}},
+def test_explicit_zero_provider_cost_is_accounted() -> None:
+    """usage.cost=0 (key present) is a real provider $0 charge."""
+    for usage_details in (
+        {"prompt_tokens": 10, "completion_tokens": 5, "cost": 0},
+        {"prompt_tokens": 10, "completion_tokens": 5, "cost": 0.0},
+        {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "cost": 0,
+            "cost_details": {
+                "upstream_inference_cost": 0,
+                "upstream_inference_prompt_cost": 0,
+                "upstream_inference_completions_cost": 0,
+            },
+        },
     ):
         estimate = estimate_ai_model_usage_cost_detailed(
             _openrouter_auto_model(),
             prompt_tokens=10,
             completion_tokens=5,
             total_tokens=15,
-            usage_details={"prompt_tokens": 10, "completion_tokens": 5, **bogus},
+            usage_details=usage_details,
         )
-        assert estimate.source == "unpriced", bogus
+        assert estimate.source == "provider", usage_details
+        assert estimate.cost == 0.0, usage_details
+
+
+def test_negative_provider_cost_is_ignored() -> None:
+    """cost=-1 is the catalog sentinel, not an accounted charge."""
+    estimate = estimate_ai_model_usage_cost_detailed(
+        _openrouter_auto_model(),
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+        usage_details={"prompt_tokens": 10, "completion_tokens": 5, "cost": -1},
+    )
+    assert estimate.source == "unpriced"
+    assert estimate.cost is None
+
+
+def test_zero_upstream_inference_cost_alone_is_ignored() -> None:
+    """A zero upstream_inference_cost without usage.cost is not accounted."""
+    estimate = estimate_ai_model_usage_cost_detailed(
+        _openrouter_auto_model(),
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+        usage_details={
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "cost_details": {"upstream_inference_cost": 0},
+        },
+    )
+    assert estimate.source == "unpriced"
+    assert estimate.cost is None
 
 
 def test_explicit_price_override_still_wins_over_provider_cost() -> None:

--- a/backend/tests/services/test_openai_gateway.py
+++ b/backend/tests/services/test_openai_gateway.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -3108,6 +3109,192 @@ def test_gateway_records_provider_reported_cost_as_authoritative(db_session, tes
     )
     assert spend is not None
     assert float(spend.spend_usd) == pytest.approx(0.00001946)
+
+
+def _openrouter_auto_gateway(db_session, test_user):
+    """Provision Auto Router and return a gateway service for recording tests."""
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "OpenRouter Auto",
+            "provider_name": "openrouter",
+            "model_identifier": "openrouter/auto-beta",
+            "api_endpoint": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-key",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "openrouter/auto-beta",
+                    "provider_adapter": "preloop",
+                }
+            },
+            "is_default": True,
+        },
+        account_id=test_user.account_id,
+    )
+    return OpenAIGatewayService(
+        db_session, ModelGatewayAuthContext(token="t", user=test_user)
+    )
+
+
+def _auto_beta_chat_response(usage):
+    return {
+        "id": "gen-abc",
+        "created": 1710000000,
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "routed answer"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": usage,
+    }
+
+
+@contextmanager
+def _patch_gateway_secrets():
+    """Stub credential resolution so recording tests do not need a live key."""
+    creds = SimpleNamespace(
+        credential_type="api_key",
+        value="sk-or-key",
+        backend_type="local_encrypted",
+        payload=None,
+    )
+    secret_service = SimpleNamespace(
+        resolve_ai_model_credentials=lambda *_args, **_kwargs: creds
+    )
+    with (
+        patch(
+            "preloop.services.model_runtime_resolver.get_secret_service",
+            return_value=secret_service,
+        ),
+        patch(
+            "preloop.services.openai_gateway.get_secret_service",
+            return_value=secret_service,
+        ),
+    ):
+        yield
+
+
+def test_gateway_records_explicit_zero_cost_as_provider(db_session, test_user):
+    """usage.cost=0 with accounting on records provider $0 and does not alert."""
+    service = _openrouter_auto_gateway(db_session, test_user)
+    litellm_response = _auto_beta_chat_response(
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 5,
+            "total_tokens": 105,
+            "cost": 0,
+            "cost_details": {
+                "upstream_inference_cost": 0,
+                "upstream_inference_prompt_cost": 0,
+                "upstream_inference_completions_cost": 0,
+            },
+        }
+    )
+
+    with (
+        _patch_gateway_secrets(),
+        patch(
+            "preloop.services.openai_gateway.litellm.completion",
+            return_value=litellm_response,
+        ),
+        patch("preloop.services.openai_gateway.notify_unpriced_model") as mock_notify,
+    ):
+        service.create_chat_completion(
+            {
+                "model": "openrouter/auto-beta",
+                "messages": [{"role": "user", "content": "Hello"}],
+            }
+        )
+
+    usage_row = (
+        db_session.query(ApiUsage)
+        .filter(ApiUsage.endpoint == "/openai/v1/chat/completions")
+        .order_by(ApiUsage.timestamp.desc())
+        .first()
+    )
+    assert usage_row is not None
+    assert usage_row.cost_source == "provider"
+    assert usage_row.estimated_cost == 0.0
+    mock_notify.assert_not_called()
+
+
+def test_gateway_empty_completion_without_cost_skips_unpriced_alert(
+    db_session, test_user
+):
+    """0 completion and no cost fields: row may stay unpriced, no admin page."""
+    service = _openrouter_auto_gateway(db_session, test_user)
+    litellm_response = _auto_beta_chat_response(
+        {
+            "prompt_tokens": 4800,
+            "completion_tokens": 0,
+            "total_tokens": 4800,
+        }
+    )
+
+    with (
+        _patch_gateway_secrets(),
+        patch(
+            "preloop.services.openai_gateway.litellm.completion",
+            return_value=litellm_response,
+        ),
+        patch("preloop.services.openai_gateway.notify_unpriced_model") as mock_notify,
+    ):
+        service.create_chat_completion(
+            {
+                "model": "openrouter/auto-beta",
+                "messages": [{"role": "user", "content": "Hello"}],
+            }
+        )
+
+    usage_row = (
+        db_session.query(ApiUsage)
+        .filter(ApiUsage.endpoint == "/openai/v1/chat/completions")
+        .order_by(ApiUsage.timestamp.desc())
+        .first()
+    )
+    assert usage_row is not None
+    assert usage_row.cost_source == "unpriced"
+    assert usage_row.completion_tokens == 0
+    mock_notify.assert_not_called()
+
+
+def test_gateway_unpriced_prompt_and_completion_still_alerts(db_session, test_user):
+    """Prompt+completion, no cost, no catalog: still notify admins."""
+    service = _openrouter_auto_gateway(db_session, test_user)
+    litellm_response = _auto_beta_chat_response(
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "total_tokens": 120,
+        }
+    )
+
+    with (
+        _patch_gateway_secrets(),
+        patch(
+            "preloop.services.openai_gateway.litellm.completion",
+            return_value=litellm_response,
+        ),
+        patch("preloop.services.openai_gateway.notify_unpriced_model") as mock_notify,
+    ):
+        service.create_chat_completion(
+            {
+                "model": "openrouter/auto-beta",
+                "messages": [{"role": "user", "content": "Hello"}],
+            }
+        )
+
+    usage_row = (
+        db_session.query(ApiUsage)
+        .filter(ApiUsage.endpoint == "/openai/v1/chat/completions")
+        .order_by(ApiUsage.timestamp.desc())
+        .first()
+    )
+    assert usage_row is not None
+    assert usage_row.cost_source == "unpriced"
+    mock_notify.assert_called_once()
 
 
 def test_gateway_without_provider_cost_keeps_catalog_pricing(db_session, test_user):

--- a/backend/tests/services/test_unpriced_model_alert.py
+++ b/backend/tests/services/test_unpriced_model_alert.py
@@ -17,7 +17,10 @@ from unittest.mock import patch
 import pytest
 
 from preloop.services import unpriced_model_alert
-from preloop.services.unpriced_model_alert import notify_unpriced_model
+from preloop.services.unpriced_model_alert import (
+    notify_unpriced_model,
+    should_notify_unpriced_model,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -26,6 +29,62 @@ def _clear_alert_cache():
     unpriced_model_alert.reset_alert_state_for_tests()
     yield
     unpriced_model_alert.reset_alert_state_for_tests()
+
+
+def test_empty_completion_without_cost_fields_suppresses_alert():
+    """Usage accounting on + 0 completion + no cost fields: do not page."""
+    assert (
+        should_notify_unpriced_model(
+            usage_accounting_requested=True,
+            usage_details={"prompt_tokens": 4800, "completion_tokens": 0},
+            completion_tokens=0,
+        )
+        is False
+    )
+    assert (
+        should_notify_unpriced_model(
+            usage_accounting_requested=True,
+            usage_details=None,
+            completion_tokens=0,
+        )
+        is False
+    )
+
+
+def test_prompt_and_completion_without_cost_still_alerts():
+    """Real unpriced spend (prompt+completion, no cost) still pages."""
+    assert (
+        should_notify_unpriced_model(
+            usage_accounting_requested=True,
+            usage_details={"prompt_tokens": 100, "completion_tokens": 20},
+            completion_tokens=20,
+        )
+        is True
+    )
+
+
+def test_empty_completion_without_accounting_still_alerts():
+    """Do not suppress when we did not ask for usage accounting."""
+    assert (
+        should_notify_unpriced_model(
+            usage_accounting_requested=False,
+            usage_details={"prompt_tokens": 4800, "completion_tokens": 0},
+            completion_tokens=0,
+        )
+        is True
+    )
+
+
+def test_empty_completion_with_cost_sentinel_still_alerts():
+    """cost=-1 is present, so this is not the empty-completion skip."""
+    assert (
+        should_notify_unpriced_model(
+            usage_accounting_requested=True,
+            usage_details={"prompt_tokens": 10, "completion_tokens": 0, "cost": -1},
+            completion_tokens=0,
+        )
+        is True
+    )
 
 
 def test_first_unpriced_model_notifies_admins(db_session, test_user):


### PR DESCRIPTION
## Summary
- Treat an explicit OpenRouter `usage.cost` of `0` (key present) as a real provider $0 charge (`cost_source=provider`, `estimated_cost=0`). `cost: -1` stays the catalog sentinel and is still not accounted.
- When usage accounting was requested and the response has `completion_tokens == 0` with no `cost` / `cost_details` fields, the row may stay unpriced but admins are not paged to add catalog pricing.
- Prompt plus completion with no cost and no catalog price still alerts. Split the old "0 and -1 both ignored" pricing test.

## Test plan
- [x] `test_explicit_zero_provider_cost_is_accounted` (int 0, float 0.0, zeroed `cost_details`)
- [x] `test_negative_provider_cost_is_ignored` (`cost: -1` stays unpriced)
- [x] `test_zero_upstream_inference_cost_alone_is_ignored`
- [x] `should_notify_unpriced_model` cases: empty completion suppress, prompt+completion still alerts, accounting off still alerts, `cost: -1` still alerts
- [x] Gateway recording: explicit $0 does not notify; empty completion does not notify; prompt+completion still notifies
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-scoped bug fix to unpriced-model alerting with no security implications, no breaking changes, and thorough test coverage.
>
> **Overview**
> Treats an explicit OpenRouter `usage.cost` of `0` as a real provider $0 charge and suppresses unpriced-model admin alerts for empty, non-billable completions when usage accounting is on, while keeping `cost: -1` as the catalog sentinel and still alerting on genuine unpriced prompt+completion spend.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 0b443497. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->