### PR TITLE
fix(ci): pin MCP v1 and stop CLI tests posting telemetry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -432,6 +432,9 @@ test:unit:cli:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
   variables:
     CGO_ENABLED: "1"
+    # Match GitHub CLI CI and EE GitLab. Login tests POST events/batch
+    # unless telemetry is off.
+    PRELOOP_DISABLE_TELEMETRY: "true"
 
 # Install script + e2e-rig pure-python logic. The installer's shell helpers
 # (architecture detection, the already-signed-in check) and the rig helpers
@@ -791,7 +794,7 @@ test:integration:ui:
   extends: .test:integration:template
   image: python:3.12-alpine
   before_script:
-    - pip install pytest httpx certifi dotenv mcp
+    - pip install pytest httpx certifi dotenv "mcp>=1.0.0,<2"
     - cd backend
 
 test:integration:api:github:
@@ -812,7 +815,7 @@ test:integration:api:jira:
 test:integration:api:mcp:
   extends: .test:integration:api:template
   before_script:
-    - pip install pytest pytest-asyncio httpx certifi dotenv mcp
+    - pip install pytest pytest-asyncio httpx certifi dotenv "mcp>=1.0.0,<2"
     - cd backend
   script:
     - pytest --confcutdir=tests/integration tests/integration/test_mcp.py -v -s
@@ -820,7 +823,7 @@ test:integration:api:mcp:
 test:integration:api:hermes:
   extends: .test:integration:api:template
   before_script:
-    - pip install pytest pytest-asyncio httpx certifi dotenv mcp
+    - pip install pytest pytest-asyncio httpx certifi dotenv "mcp>=1.0.0,<2"
     - cd backend
   script:
     - pytest --confcutdir=tests/integration tests/integration/test_hermes_onboarding.py -v -s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **GitLab CI against MCP Python SDK v2 and CLI telemetry**: integration
+  jobs now pin `mcp>=1.0.0,<2` (`pip install mcp` was pulling v2, which
+  removed `streamablehttp_client`). CLI unit tests disable adoption
+  telemetry so `preloop login --token` does not POST `/api/v1/events/batch`
+  at hermetic httptest servers. The frontend e2e seeder looks up the admin
+  account through ``User`` CRUD; ``CRUDAccount.get_by_email`` is gone.
+
 - **Unpriced-model admin alert on accounted $0 and empty completions**:
   when OpenRouter usage accounting was requested, an explicit `usage.cost`
   of `0` is now recorded as provider $0 (`cost_source=provider`) instead of

--- a/backend/tests/e2e_support/seed_gateway_model.py
+++ b/backend/tests/e2e_support/seed_gateway_model.py
@@ -37,11 +37,9 @@ import logging
 import os
 import sys
 
-from preloop.models.crud.account import CRUDAccount
 from preloop.models.crud.ai_model import ai_model as crud_ai_model
 from preloop.models.crud.user import CRUDUser
 from preloop.models.db.session import get_db_session
-from preloop.models.models.account import Account
 from preloop.models.models.user import User
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
@@ -62,9 +60,9 @@ def _resolve_account_id(db) -> str:
     The credential-mint endpoint anchors the agent to the same account. So the
     seeded model must live under the SAME account the admin login resolves to.
 
-    Prefer the ``User`` row's ``account_id`` (matches the login principal); fall
-    back to the ``Account`` looked up by email for INIT_TEST_DATA setups where
-    the admin is provisioned as an Account.
+    Prefer the ``User`` row's ``account_id`` (matches the login principal).
+    Email and username live on ``User`` now; ``CRUDAccount`` no longer
+    exposes ``get_by_email``.
 
     Raises:
         RuntimeError: If no admin principal can be found.
@@ -75,11 +73,6 @@ def _resolve_account_id(db) -> str:
     )
     if user is not None and getattr(user, "account_id", None):
         return str(user.account_id)
-
-    crud_account = CRUDAccount(Account)
-    account = crud_account.get_by_email(db, email=ADMIN_EMAIL)
-    if account is not None:
-        return str(account.id)
 
     raise RuntimeError(
         f"No admin principal found (username={ADMIN_USERNAME!r}, "

--- a/cli/internal/cmd/auth_test.go
+++ b/cli/internal/cmd/auth_test.go
@@ -292,6 +292,13 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
+	// GitHub CLI CI sets this; GitLab OSS did not. Successful login posts
+	// /api/v1/events/batch unless telemetry is off, which fails hermetic
+	// httptest servers that only expect the user-info path.
+	if err := os.Setenv("PRELOOP_DISABLE_TELEMETRY", "true"); err != nil {
+		panic(err)
+	}
+
 	// Scrub ambient agent/model env vars so upstream-resolution tests see a
 	// hermetic environment. When the test suite itself runs inside a managed
 	// agent session (e.g. Preloop-managed Claude Code exporting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ dev = [
     "httpx>=0.24.1",
     "playwright>=1.30.0",
     "pytest-playwright>=0.4.0",
-    "mcp>=1.0.0",  # MCP client for integration tests
+    "mcp>=1.0.0,<2",  # MCP client for integration tests; v2 dropped streamablehttp_client
     "PyYAML>=6.0",  # test_nginx_route_parity imports yaml
 ]
 ai-providers = [


### PR DESCRIPTION
## Summary
- Pin GitLab integration jobs and `pyproject.toml` to `mcp>=1.0.0,<2`. Unpinned `pip install mcp` now installs SDK v2, which removed `streamablehttp_client` and broke MCP/Hermes integration collection.
- Disable adoption telemetry in CLI `TestMain` and the GitLab `test:unit:cli` job so `preloop login --token` does not POST `/api/v1/events/batch` at hermetic httptest servers.
- Frontend e2e seeder resolves the admin account through User CRUD (`CRUDAccount.get_by_email` is gone).

Companion GitLab MR: https://gitlab.spacecode.ai/spacecode/preloop/-/merge_requests/41

## Test plan
- [ ] `cd cli && go test ./internal/cmd -run TestRunAuthLoginTokenBypassesPreCheck`
- [ ] GitLab `test:unit:cli`, `test:integration:api:mcp`, `test:integration:api:hermes` green

Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> CI/test-only changes with no security implications; small, well-scoped, and correct.
>
> **Overview**
> Pins the MCP Python SDK to v1 to fix MCP/Hermes integration collection, disables adoption telemetry in CLI unit tests and the GitLab CLI job, and removes a dead `CRUDAccount` fallback in the frontend e2e seeder.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 95a7a1c. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->