### PR TITLE
feat: usage ingest push API (usage_source external spend)

### DIFF
--- a/backend/preloop/api/endpoints/usage_import.py
+++ b/backend/preloop/api/endpoints/usage_import.py
@@ -26,7 +26,6 @@ from preloop.schemas.usage_import import (
     UsageImportCsvResponse,
     UsageImportRequest,
     UsageImportResponse,
-    UsageIngestRecordResult,
     UsageIngestRequest,
     UsageIngestResponse,
 )
@@ -114,13 +113,21 @@ def ingest_usage_records(
     """Push a batch of external usage records into the cost ledger.
 
     The continuous-push evolution of ``POST /usage/import``: a harness
-    posts sanitized spend records as they occur instead of batch CSV.
-    Each record is identified by (source, external_id) per account, so
-    replaying a batch — e.g. a retry after a network timeout — returns
-    200 with the replayed records flagged ``deduplicated`` and never
-    double-counts spend. Records carry ``conversation_id`` /
-    ``parent_conversation_id`` so subagent workers billed on separate
-    conversations can be rolled up under their parent thread.
+    posts sanitized spend records — or hook-shaped lifecycle events
+    (``event_type``) — as they occur instead of batch CSV. Each record is
+    identified by (source, external_id) per account, so replaying a batch
+    — e.g. a retry after a network timeout — returns 200 with the
+    replayed records flagged ``deduplicated`` and never double-counts
+    spend; a replay whose payload differs from the stored record is
+    additionally flagged ``conflict`` (first write wins, never a 409).
+    Records carry ``conversation_id`` / ``parent_conversation_id`` so
+    subagent workers billed on separate conversations can be rolled up
+    under their parent thread, and ``cost_basis`` so reconciled
+    billing-export records supersede hook-derived estimates in cost
+    summaries. Attribution precedence: explicit ``agent_id`` (must belong
+    to the account) wins; otherwise the account's single managed agent
+    whose kind equals ``source`` is used, and zero or multiple candidates
+    is a 422.
     """
     get_account_or_404(db, current_user)
     try:
@@ -130,7 +137,7 @@ def ingest_usage_records(
             agent_id=str(payload.agent_id) if payload.agent_id else None,
             default_agent_kind=payload.source,
         )
-        flags = ingest_push_records(
+        results = ingest_push_records(
             db,
             account_id=str(current_user.account_id),
             user_id=str(current_user.id),
@@ -140,18 +147,14 @@ def ingest_usage_records(
         )
     except UsageImportError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    results = [
-        UsageIngestRecordResult(
-            external_id=record.external_id, deduplicated=deduplicated
-        )
-        for record, deduplicated in zip(payload.records, flags, strict=True)
-    ]
-    accepted = sum(1 for flag in flags if not flag)
+    accepted = sum(1 for result in results if not result.deduplicated)
+    conflicts = sum(1 for result in results if result.conflict)
     logger.info(
-        "Ingested %d usage records (%d deduplicated) for agent %s "
-        "(source=%s, account=%s)",
+        "Ingested %d usage records (%d deduplicated, %d conflicts) for "
+        "agent %s (source=%s, account=%s)",
         accepted,
-        len(flags) - accepted,
+        len(results) - accepted,
+        conflicts,
         agent.id,
         payload.source,
         current_user.account_id,
@@ -161,7 +164,8 @@ def ingest_usage_records(
         agent_id=UUID(str(agent.id)),
         agent_display_name=agent.display_name,
         accepted=accepted,
-        deduplicated=len(flags) - accepted,
+        deduplicated=len(results) - accepted,
+        conflicts=conflicts,
         results=results,
     )
 

--- a/backend/preloop/api/endpoints/usage_import.py
+++ b/backend/preloop/api/endpoints/usage_import.py
@@ -26,11 +26,15 @@ from preloop.schemas.usage_import import (
     UsageImportCsvResponse,
     UsageImportRequest,
     UsageImportResponse,
+    UsageIngestRecordResult,
+    UsageIngestRequest,
+    UsageIngestResponse,
 )
 from preloop.services.usage_import import (
     MAX_CSV_BYTES,
     UsageImportError,
     ingest_events,
+    ingest_push_records,
     parse_cursor_usage_csv,
     resolve_target_agent,
 )
@@ -97,6 +101,68 @@ def import_usage_events(
         agent_id=UUID(str(agent.id)),
         agent_display_name=agent.display_name,
         source=payload.source,
+    )
+
+
+@router.post("/ingest", response_model=UsageIngestResponse)
+@require_permission("import_usage")
+def ingest_usage_records(
+    payload: UsageIngestRequest,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_active_user),
+) -> UsageIngestResponse:
+    """Push a batch of external usage records into the cost ledger.
+
+    The continuous-push evolution of ``POST /usage/import``: a harness
+    posts sanitized spend records as they occur instead of batch CSV.
+    Each record is identified by (source, external_id) per account, so
+    replaying a batch — e.g. a retry after a network timeout — returns
+    200 with the replayed records flagged ``deduplicated`` and never
+    double-counts spend. Records carry ``conversation_id`` /
+    ``parent_conversation_id`` so subagent workers billed on separate
+    conversations can be rolled up under their parent thread.
+    """
+    get_account_or_404(db, current_user)
+    try:
+        agent = resolve_target_agent(
+            db,
+            account_id=str(current_user.account_id),
+            agent_id=str(payload.agent_id) if payload.agent_id else None,
+            default_agent_kind=payload.source,
+        )
+        flags = ingest_push_records(
+            db,
+            account_id=str(current_user.account_id),
+            user_id=str(current_user.id),
+            agent=agent,
+            records=payload.records,
+            source=payload.source,
+        )
+    except UsageImportError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    results = [
+        UsageIngestRecordResult(
+            external_id=record.external_id, deduplicated=deduplicated
+        )
+        for record, deduplicated in zip(payload.records, flags, strict=True)
+    ]
+    accepted = sum(1 for flag in flags if not flag)
+    logger.info(
+        "Ingested %d usage records (%d deduplicated) for agent %s "
+        "(source=%s, account=%s)",
+        accepted,
+        len(flags) - accepted,
+        agent.id,
+        payload.source,
+        current_user.account_id,
+    )
+    return UsageIngestResponse(
+        source=payload.source,
+        agent_id=UUID(str(agent.id)),
+        agent_display_name=agent.display_name,
+        accepted=accepted,
+        deduplicated=len(flags) - accepted,
+        results=results,
     )
 
 

--- a/backend/preloop/models/alembic/versions/20260818_usage_ingest_conversations.py
+++ b/backend/preloop/models/alembic/versions/20260818_usage_ingest_conversations.py
@@ -1,0 +1,92 @@
+"""Usage ingest round 2: conversation rollup columns and cost_basis.
+
+Revision ID: 20260818_usage_ingest_conv
+Revises: 20260817_add_flow_runners
+Create Date: 2026-08-18
+
+The usage push API (issue #123 evolution) rolls subagent workers billed on
+separate conversations up under their parent thread, tracks message/tool
+growth tripwires, and lets billing-export ("reconciled") records supersede
+hook-derived ("estimated") cost without double-counting. That needs real
+indexed columns instead of JSONB-only storage:
+
+- ``conversation_id`` / ``parent_conversation_id``: worker->parent rollup,
+  partially indexed for imported usage only.
+- ``message_count`` / ``tool_call_count``: growth tripwires, never derived
+  from tokens.
+- ``cost_basis``: 'estimated' | 'reconciled'; NULL on legacy rows, which
+  never participate in supersession.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "20260818_usage_ingest_conv"
+down_revision: Union[str, None] = "20260817_add_flow_runners"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+# Alembic reads these module globals by name; keep a local reference so static
+# analysis treats them as used.
+_ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)
+assert _ALEMBIC_IDENTIFIERS, "Alembic revision metadata must be defined"
+
+
+def upgrade() -> None:
+    """Add rollup/tripwire/cost-basis columns and their partial indexes."""
+    op.add_column(
+        "api_usage", sa.Column("conversation_id", sa.String(255), nullable=True)
+    )
+    op.add_column(
+        "api_usage", sa.Column("parent_conversation_id", sa.String(255), nullable=True)
+    )
+    op.add_column("api_usage", sa.Column("message_count", sa.Integer(), nullable=True))
+    op.add_column(
+        "api_usage", sa.Column("tool_call_count", sa.Integer(), nullable=True)
+    )
+    op.add_column("api_usage", sa.Column("cost_basis", sa.String(16), nullable=True))
+    op.create_check_constraint(
+        "ck_api_usage_cost_basis",
+        "api_usage",
+        "cost_basis IS NULL OR cost_basis IN ('estimated', 'reconciled')",
+    )
+    op.create_index(
+        "ix_api_usage_imported_conversation",
+        "api_usage",
+        ["account_id", "conversation_id"],
+        postgresql_where=text(
+            "action_type = 'imported_usage' AND conversation_id IS NOT NULL"
+        ),
+    )
+    op.create_index(
+        "ix_api_usage_imported_parent_conv",
+        "api_usage",
+        ["account_id", "parent_conversation_id"],
+        postgresql_where=text(
+            "action_type = 'imported_usage' AND parent_conversation_id IS NOT NULL"
+        ),
+    )
+    # Backfill: pre-round-2 push-ingested rows stored conversation ids in
+    # meta_data only. Scoped to imported usage; gateway rows are untouched.
+    op.execute(
+        "UPDATE api_usage SET "
+        "conversation_id = meta_data->>'conversation_id', "
+        "parent_conversation_id = meta_data->>'parent_conversation_id' "
+        "WHERE action_type = 'imported_usage' AND meta_data IS NOT NULL "
+        "AND (meta_data ? 'conversation_id' OR meta_data ? 'parent_conversation_id')"
+    )
+
+
+def downgrade() -> None:
+    """Drop the round-2 columns, indexes, and CHECK constraint."""
+    op.drop_index("ix_api_usage_imported_parent_conv", table_name="api_usage")
+    op.drop_index("ix_api_usage_imported_conversation", table_name="api_usage")
+    op.drop_constraint("ck_api_usage_cost_basis", "api_usage", type_="check")
+    op.drop_column("api_usage", "cost_basis")
+    op.drop_column("api_usage", "tool_call_count")
+    op.drop_column("api_usage", "message_count")
+    op.drop_column("api_usage", "parent_conversation_id")
+    op.drop_column("api_usage", "conversation_id")

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -5,9 +5,9 @@ import logging
 from types import SimpleNamespace
 import uuid
 from typing import Any, Dict, List, Optional, Sequence, Union
-from sqlalchemy import Float, String, and_, case, cast, func, or_
+from sqlalchemy import Float, String, and_, case, cast, func, or_, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, aliased
 
 from ..models.api_usage import ApiUsage
 from ..models.flow import Flow
@@ -2313,6 +2313,25 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         )
         return exists is not None
 
+    def get_imported_row_by_fingerprint(
+        self, db: Session, *, account_id: str, import_fingerprint: str
+    ) -> Optional[ApiUsage]:
+        """Return the account's imported row with this fingerprint, if any.
+
+        Used by the push-ingest path to flag conflicting replays: the
+        stored row's ``meta_data.ingest_content_hash`` is compared with the
+        incoming record's payload hash (first write wins either way).
+        """
+        return (
+            db.query(ApiUsage)
+            .filter(
+                ApiUsage.account_id == account_id,
+                ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,
+                ApiUsage.meta_data["import_fingerprint"].astext == import_fingerprint,
+            )
+            .first()
+        )
+
     def log_imported_usage_event(
         self,
         db: Session,
@@ -2320,7 +2339,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         account_id: str,
         user_id: Optional[str] = None,
         timestamp: datetime,
-        model_alias: str,
+        model_alias: Optional[str],
         source: str,
         prompt_tokens: Optional[int] = None,
         completion_tokens: Optional[int] = None,
@@ -2328,6 +2347,11 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         cache_read_tokens: Optional[int] = None,
         cache_creation_tokens: Optional[int] = None,
         cost_usd: Optional[float] = None,
+        cost_basis: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+        parent_conversation_id: Optional[str] = None,
+        message_count: Optional[int] = None,
+        tool_call_count: Optional[int] = None,
         runtime_principal_type: Optional[str] = None,
         runtime_principal_id: Optional[str] = None,
         runtime_principal_name: Optional[str] = None,
@@ -2342,7 +2366,8 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             account_id: Owning account id.
             user_id: Importing user's id, for audit.
             timestamp: When the usage occurred at the source vendor.
-            model_alias: Source-reported model name (e.g. ``composer``).
+            model_alias: Source-reported model name (e.g. ``composer``);
+                NULL for lifecycle events pushed without one.
             source: Origin label (e.g. ``cursor``); stored in
                 ``meta_data.import_source``.
             prompt_tokens: Input tokens reported by the source.
@@ -2353,6 +2378,15 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             cache_creation_tokens: Cache-write tokens reported by the source.
             cost_usd: Amount the source vendor charged, in USD. Stored in
                 ``estimated_cost`` with ``cost_source='imported'``.
+            cost_basis: ``estimated`` or ``reconciled``; reconciled rows
+                supersede estimated rows with the same (account, source,
+                conversation_id) in imported-cost sums. NULL rows never
+                participate in supersession.
+            conversation_id: Source-side conversation the record belongs to.
+            parent_conversation_id: Conversation it was spawned from, for
+                worker->parent rollup.
+            message_count: Conversation message count (growth tripwire).
+            tool_call_count: Conversation tool-call count (growth tripwire).
             runtime_principal_type: Managed-agent principal type attribution.
             runtime_principal_id: Managed-agent principal id attribution.
             runtime_principal_name: Managed-agent display name attribution.
@@ -2401,6 +2435,11 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             estimated_cost=cost_usd,
             currency="USD" if cost_usd is not None else None,
             cost_source="imported" if cost_usd is not None else None,
+            cost_basis=cost_basis,
+            conversation_id=conversation_id,
+            parent_conversation_id=parent_conversation_id,
+            message_count=message_count,
+            tool_call_count=tool_call_count,
             usage_source="imported",
             runtime_principal_type=runtime_principal_type,
             runtime_principal_id=runtime_principal_id,
@@ -2424,6 +2463,42 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             db.refresh(db_obj)
         return db_obj
 
+    def _imported_cost_sum(self):
+        """SUM of imported cost with reconciled-over-estimated precedence.
+
+        A ``cost_basis='reconciled'`` row (billing export) supersedes ALL
+        ``cost_basis='estimated'`` rows (hook/transcript-derived) with the
+        same (account, provider_name, conversation_id): superseded rows
+        contribute $0, so the two bases are never summed for one scope.
+        Supersession deliberately ignores the query time-window — billing
+        exports are coarser-grained than hooks, and window-matching would
+        silently double-count. Rows without a conversation_id or with a
+        NULL cost_basis (legacy/CSV imports) never participate.
+        """
+        reconciled = aliased(ApiUsage)
+        superseded = and_(
+            ApiUsage.cost_basis == "estimated",
+            ApiUsage.conversation_id.isnot(None),
+            select(reconciled.id)
+            .where(
+                reconciled.account_id == ApiUsage.account_id,
+                reconciled.action_type == self.IMPORTED_USAGE_ACTION_TYPE,
+                reconciled.cost_basis == "reconciled",
+                reconciled.provider_name == ApiUsage.provider_name,
+                reconciled.conversation_id == ApiUsage.conversation_id,
+            )
+            .exists(),
+        )
+        return func.coalesce(
+            func.sum(
+                case(
+                    (superseded, 0.0),
+                    else_=func.coalesce(ApiUsage.estimated_cost, 0.0),
+                )
+            ),
+            0.0,
+        )
+
     def get_imported_usage_summary(
         self,
         db: Session,
@@ -2435,6 +2510,9 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         source: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Aggregate imported usage totals for an account in a window.
+
+        ``imported_cost`` applies reconciled-over-estimated precedence (see
+        :meth:`_imported_cost_sum`); event/token totals count all rows.
 
         Args:
             db: Database session.
@@ -2450,9 +2528,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         query = db.query(
             func.count(ApiUsage.id).label("event_count"),
             func.coalesce(func.sum(ApiUsage.total_tokens), 0).label("total_tokens"),
-            func.coalesce(func.sum(ApiUsage.estimated_cost), 0.0).label(
-                "imported_cost"
-            ),
+            self._imported_cost_sum().label("imported_cost"),
         ).filter(
             ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,
             ApiUsage.account_id == account_id,
@@ -2483,6 +2559,9 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
     ) -> List[Dict[str, Any]]:
         """Group imported usage by source-reported model.
 
+        ``imported_cost`` applies reconciled-over-estimated precedence (see
+        :meth:`_imported_cost_sum`); event/token totals count all rows.
+
         Args:
             db: Database session.
             account_id: Account whose imported usage is aggregated.
@@ -2501,9 +2580,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             import_source.label("source"),
             func.count(ApiUsage.id).label("request_count"),
             func.coalesce(func.sum(ApiUsage.total_tokens), 0).label("total_tokens"),
-            func.coalesce(func.sum(ApiUsage.estimated_cost), 0.0).label(
-                "imported_cost"
-            ),
+            self._imported_cost_sum().label("imported_cost"),
             func.max(ApiUsage.timestamp).label("last_event_at"),
         ).filter(
             ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -2332,6 +2332,37 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             .first()
         )
 
+    def get_imported_rows_by_fingerprints(
+        self,
+        db: Session,
+        *,
+        account_id: str,
+        fingerprints: Sequence[str],
+    ) -> Dict[str, ApiUsage]:
+        """Return imported rows keyed by fingerprint for a batch lookup.
+
+        Used by push-ingest to replace per-record existence SELECTs with one
+        ``IN`` query. Missing fingerprints are omitted from the result.
+        """
+        unique = list(dict.fromkeys(fp for fp in fingerprints if fp))
+        if not unique:
+            return {}
+        rows = (
+            db.query(ApiUsage)
+            .filter(
+                ApiUsage.account_id == account_id,
+                ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,
+                ApiUsage.meta_data["import_fingerprint"].astext.in_(unique),
+            )
+            .all()
+        )
+        found: Dict[str, ApiUsage] = {}
+        for row in rows:
+            fingerprint = (row.meta_data or {}).get("import_fingerprint")
+            if isinstance(fingerprint, str):
+                found[fingerprint] = row
+        return found
+
     def log_imported_usage_event(
         self,
         db: Session,
@@ -2357,6 +2388,8 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         runtime_principal_name: Optional[str] = None,
         import_fingerprint: Optional[str] = None,
         meta_data: Optional[Dict[str, Any]] = None,
+        endpoint: Optional[str] = None,
+        skip_fingerprint_lookup: bool = False,
         commit: bool = True,
     ) -> Optional[ApiUsage]:
         """Record one imported usage event in the cost ledger.
@@ -2397,13 +2430,23 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
                 index ``ix_api_usage_imported_fingerprint_uniq``, so two
                 concurrent imports of the same event cannot both land.
             meta_data: Extra keys merged into the stored ``meta_data``.
+            endpoint: Ledger endpoint label. Defaults to
+                ``/usage/import/{source}`` (CSV/JSON import). Push-ingest
+                passes ``/usage/ingest/{source}``.
+            skip_fingerprint_lookup: When True, skip the fast-path SELECT
+                (the caller already bulk-loaded existing fingerprints). The
+                unique index remains the concurrent-insert guard.
             commit: When False, flush only so callers can batch commits.
 
         Returns:
             The created row, or ``None`` when skipped as a duplicate.
         """
-        if import_fingerprint and self._imported_fingerprint_exists(
-            db, account_id=account_id, import_fingerprint=import_fingerprint
+        if (
+            import_fingerprint
+            and not skip_fingerprint_lookup
+            and self._imported_fingerprint_exists(
+                db, account_id=account_id, import_fingerprint=import_fingerprint
+            )
         ):
             return None
 
@@ -2420,7 +2463,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         db_obj = ApiUsage(
             user_id=user_id,
             account_id=account_id,
-            endpoint=f"/usage/import/{source}",
+            endpoint=endpoint or f"/usage/import/{source}",
             method="POST",
             status_code=200,
             duration=0.0,
@@ -2463,17 +2506,18 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             db.refresh(db_obj)
         return db_obj
 
-    def _imported_cost_sum(self):
+    def _imported_cost_sum(self, *, start_date: datetime, end_date: datetime):
         """SUM of imported cost with reconciled-over-estimated precedence.
 
         A ``cost_basis='reconciled'`` row (billing export) supersedes ALL
         ``cost_basis='estimated'`` rows (hook/transcript-derived) with the
-        same (account, provider_name, conversation_id): superseded rows
-        contribute $0, so the two bases are never summed for one scope.
-        Supersession deliberately ignores the query time-window — billing
-        exports are coarser-grained than hooks, and window-matching would
-        silently double-count. Rows without a conversation_id or with a
-        NULL cost_basis (legacy/CSV imports) never participate.
+        same (account, provider_name, conversation_id) **in the queried
+        window**: superseded rows contribute $0, so the two bases are never
+        summed for one scope. The EXISTS is bounded to
+        ``start_date <= timestamp < end_date`` so a reconciled row outside
+        the window cannot zero in-window estimates while contributing $0
+        itself. Rows without a conversation_id or with a NULL cost_basis
+        (legacy/CSV imports) never participate.
         """
         reconciled = aliased(ApiUsage)
         superseded = and_(
@@ -2486,6 +2530,8 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
                 reconciled.cost_basis == "reconciled",
                 reconciled.provider_name == ApiUsage.provider_name,
                 reconciled.conversation_id == ApiUsage.conversation_id,
+                reconciled.timestamp >= start_date,
+                reconciled.timestamp < end_date,
             )
             .exists(),
         )
@@ -2513,6 +2559,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
 
         ``imported_cost`` applies reconciled-over-estimated precedence (see
         :meth:`_imported_cost_sum`); event/token totals count all rows.
+        Supersession is bounded to this same window.
 
         Args:
             db: Database session.
@@ -2528,7 +2575,9 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         query = db.query(
             func.count(ApiUsage.id).label("event_count"),
             func.coalesce(func.sum(ApiUsage.total_tokens), 0).label("total_tokens"),
-            self._imported_cost_sum().label("imported_cost"),
+            self._imported_cost_sum(start_date=start_date, end_date=end_date).label(
+                "imported_cost"
+            ),
         ).filter(
             ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,
             ApiUsage.account_id == account_id,
@@ -2561,6 +2610,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
 
         ``imported_cost`` applies reconciled-over-estimated precedence (see
         :meth:`_imported_cost_sum`); event/token totals count all rows.
+        Supersession is bounded to this same window.
 
         Args:
             db: Database session.
@@ -2580,7 +2630,9 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             import_source.label("source"),
             func.count(ApiUsage.id).label("request_count"),
             func.coalesce(func.sum(ApiUsage.total_tokens), 0).label("total_tokens"),
-            self._imported_cost_sum().label("imported_cost"),
+            self._imported_cost_sum(start_date=start_date, end_date=end_date).label(
+                "imported_cost"
+            ),
             func.max(ApiUsage.timestamp).label("last_event_at"),
         ).filter(
             ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,

--- a/backend/preloop/models/models/api_usage.py
+++ b/backend/preloop/models/models/api_usage.py
@@ -135,6 +135,21 @@ class ApiUsage(Base):
     runtime_principal_name: Mapped[Optional[str]] = mapped_column(
         String(255), nullable=True
     )
+    # Source-side conversation attribution for imported usage (issue #123
+    # push API): subagent workers billed on separate conversation ids roll
+    # up under parent_conversation_id in Cost analytics.
+    conversation_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    parent_conversation_id: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True
+    )
+    # Growth tripwires reported by the source; never derived from tokens.
+    message_count: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    tool_call_count: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    # estimated (hook/transcript-derived) | reconciled (billing export).
+    # Reconciled rows supersede estimated rows with the same
+    # (account, provider_name, conversation_id) in imported-cost sums; NULL
+    # (legacy/CSV) rows never participate in supersession.
+    cost_basis: Mapped[Optional[str]] = mapped_column(String(16), nullable=True)
     meta_data: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
     timestamp: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False, index=True
@@ -171,6 +186,10 @@ class ApiUsage(Base):
             "('provider', 'estimated', 'partial', 'imported')",
             name="ck_api_usage_usage_source",
         ),
+        CheckConstraint(
+            "cost_basis IS NULL OR cost_basis IN ('estimated', 'reconciled')",
+            name="ck_api_usage_cost_basis",
+        ),
         Index(
             "ix_api_usage_account_action_ts",
             "account_id",
@@ -203,6 +222,25 @@ class ApiUsage(Base):
             text("(meta_data->>'import_fingerprint')"),
             unique=True,
             postgresql_where=text("action_type = 'imported_usage'"),
+        ),
+        # Worker->parent conversation rollup for imported usage: partial
+        # indexes scoped to imported rows keep the gateway hot path
+        # unaffected while making per-thread aggregation indexable.
+        Index(
+            "ix_api_usage_imported_conversation",
+            "account_id",
+            "conversation_id",
+            postgresql_where=text(
+                "action_type = 'imported_usage' AND conversation_id IS NOT NULL"
+            ),
+        ),
+        Index(
+            "ix_api_usage_imported_parent_conv",
+            "account_id",
+            "parent_conversation_id",
+            postgresql_where=text(
+                "action_type = 'imported_usage' AND parent_conversation_id IS NOT NULL"
+            ),
         ),
     )
 

--- a/backend/preloop/schemas/usage_import.py
+++ b/backend/preloop/schemas/usage_import.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -25,6 +25,26 @@ MAX_INGEST_RECORDS_PER_REQUEST = 1000
 
 #: Hard cap on the serialized size of one record's ``metadata`` object.
 MAX_INGEST_METADATA_BYTES = 8 * 1024
+
+#: Hook-shaped lifecycle event types accepted alongside plain usage
+#: records. Lifecycle events may carry zero token/cost data; they exist so
+#: analytics can count fan-out (e.g. ``subagent_start`` per
+#: ``parent_conversation_id``) in near-real-time.
+IngestEventType = Literal[
+    "session_start",
+    "session_end",
+    "subagent_start",
+    "subagent_stop",
+    "response",
+    "compaction",
+    "usage",
+]
+
+#: How the record's charged_cost was determined. Reconciled records
+#: (billing export) supersede estimated records (hook/transcript-derived)
+#: with the same (source, conversation_id) scope in cost summaries — the
+#: two are never summed together.
+IngestCostBasis = Literal["estimated", "reconciled"]
 
 
 class UsageImportEvent(BaseModel):
@@ -149,13 +169,35 @@ class UsageIngestRecord(BaseModel):
         ),
     )
     timestamp: datetime
-    model: str = Field(..., min_length=1, max_length=255)
+    event_type: IngestEventType = Field(
+        default="usage",
+        description=(
+            "Hook-shaped lifecycle marker. 'usage' (default) requires a "
+            "model and at least one measurement; lifecycle events "
+            "(session/subagent start/stop, response, compaction) may carry "
+            "zero token/cost data and no model."
+        ),
+    )
+    model: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description="Source-reported model name. Required for event_type='usage'.",
+    )
     charged_cost: Optional[Decimal] = Field(
         default=None,
         ge=0,
         description=(
             "Amount the source vendor charged, in USD. The billing truth; "
             "never derived from tokens."
+        ),
+    )
+    cost_basis: IngestCostBasis = Field(
+        default="estimated",
+        description=(
+            "'estimated' (hook/transcript-derived) or 'reconciled' (billing "
+            "export). Reconciled records supersede estimated records with "
+            "the same (source, conversation_id) in cost summaries; the two "
+            "are never summed together."
         ),
     )
     input_tokens: Optional[int] = Field(default=None, ge=0)
@@ -167,6 +209,16 @@ class UsageIngestRecord(BaseModel):
             "Cache-read tokens, reported distinctly; never summed into "
             "charged spend or total tokens."
         ),
+    )
+    message_count: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Messages in the conversation so far (growth tripwire).",
+    )
+    tool_call_count: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Tool calls in the conversation so far (growth tripwire).",
     )
     metadata: Optional[Dict[str, Any]] = None
 
@@ -203,9 +255,26 @@ class UsageIngestRecord(BaseModel):
             )
         return value
 
+    @field_validator("model")
+    @classmethod
+    def strip_model(cls, value: Optional[str]) -> Optional[str]:
+        """Normalize the model name; empty strings collapse to None."""
+        if value is None:
+            return None
+        return value.strip() or None
+
     @model_validator(mode="after")
-    def validate_measurement_present(self) -> "UsageIngestRecord":
-        """Require at least one measurable quantity (tokens or money)."""
+    def validate_usage_event_shape(self) -> "UsageIngestRecord":
+        """Require model + a measurable quantity for plain usage records.
+
+        Lifecycle events (``event_type != 'usage'``) may carry zero
+        token/cost data and no model — they exist so analytics can count
+        fan-out in near-real-time.
+        """
+        if self.event_type != "usage":
+            return self
+        if self.model is None:
+            raise ValueError("Usage records must carry a model name")
         has_measurement = any(
             value is not None
             for value in (
@@ -256,13 +325,23 @@ class UsageIngestRecordResult(BaseModel):
 
     external_id: str
     deduplicated: bool = False
+    conflict: bool = Field(
+        default=False,
+        description=(
+            "True when a deduplicated replay carried a DIFFERENT payload "
+            "than the stored record (first write wins; the batch still "
+            "returns 200 so shippers can retry blindly)."
+        ),
+    )
 
 
 class UsageIngestResponse(BaseModel):
     """Result of a push-ingest request.
 
     Replays return 200 with the replayed records flagged
-    ``deduplicated`` — spend is never double-counted.
+    ``deduplicated`` — spend is never double-counted. Replays whose
+    payload differs from the stored record are additionally flagged
+    ``conflict`` (first write wins; never a 409).
     """
 
     source: str
@@ -270,6 +349,7 @@ class UsageIngestResponse(BaseModel):
     agent_display_name: Optional[str] = None
     accepted: int = 0
     deduplicated: int = 0
+    conflicts: int = 0
     results: List[UsageIngestRecordResult] = Field(default_factory=list)
 
 

--- a/backend/preloop/schemas/usage_import.py
+++ b/backend/preloop/schemas/usage_import.py
@@ -8,7 +8,9 @@ analytics without ever mixing into gateway budget accounting.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
+from decimal import Decimal
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -16,6 +18,13 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 #: Hard cap on events per ingest request; callers must batch beyond this.
 MAX_EVENTS_PER_REQUEST = 5000
+
+#: Hard cap on records per push-ingest request; harnesses stream small
+#: continuous batches, so this bounds request size without hurting them.
+MAX_INGEST_RECORDS_PER_REQUEST = 1000
+
+#: Hard cap on the serialized size of one record's ``metadata`` object.
+MAX_INGEST_METADATA_BYTES = 8 * 1024
 
 
 class UsageImportEvent(BaseModel):
@@ -112,6 +121,156 @@ class UsageImportResponse(BaseModel):
     agent_id: Optional[UUID] = None
     agent_display_name: Optional[str] = None
     source: str = "cursor"
+
+
+class UsageIngestRecord(BaseModel):
+    """One usage record pushed continuously by an external harness.
+
+    Unlike ``UsageImportEvent`` (batch CSV/JSON import, content-hash
+    dedupe), a pushed record carries a caller-supplied ``external_id`` so
+    replays after network timeouts are idempotent, plus conversation ids so
+    subagent workers billed on separate conversations can be rolled up
+    under their parent thread in Cost analytics.
+    """
+
+    external_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Source-side record/turn id; dedupe key with `source`.",
+    )
+    conversation_id: Optional[str] = Field(default=None, max_length=255)
+    parent_conversation_id: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description=(
+            "Conversation this record's conversation was spawned from "
+            "(e.g. a subagent worker's parent thread), for cost rollup."
+        ),
+    )
+    timestamp: datetime
+    model: str = Field(..., min_length=1, max_length=255)
+    charged_cost: Optional[Decimal] = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Amount the source vendor charged, in USD. The billing truth; "
+            "never derived from tokens."
+        ),
+    )
+    input_tokens: Optional[int] = Field(default=None, ge=0)
+    output_tokens: Optional[int] = Field(default=None, ge=0)
+    cache_read_tokens: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Cache-read tokens, reported distinctly; never summed into "
+            "charged spend or total tokens."
+        ),
+    )
+    metadata: Optional[Dict[str, Any]] = None
+
+    @field_validator("external_id")
+    @classmethod
+    def strip_external_id(cls, value: str) -> str:
+        """Normalize the dedupe key; blank values are invalid."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("external_id must not be blank")
+        return stripped
+
+    @field_validator("conversation_id", "parent_conversation_id")
+    @classmethod
+    def strip_conversation_ids(cls, value: Optional[str]) -> Optional[str]:
+        """Normalize conversation ids; empty strings collapse to None."""
+        if value is None:
+            return None
+        return value.strip() or None
+
+    @field_validator("metadata")
+    @classmethod
+    def cap_metadata_size(
+        cls, value: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """Reject metadata objects larger than the serialized cap."""
+        if value is None:
+            return None
+        size = len(json.dumps(value, default=str).encode("utf-8"))
+        if size > MAX_INGEST_METADATA_BYTES:
+            raise ValueError(
+                f"metadata exceeds {MAX_INGEST_METADATA_BYTES} bytes "
+                f"serialized ({size} bytes)"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def validate_measurement_present(self) -> "UsageIngestRecord":
+        """Require at least one measurable quantity (tokens or money)."""
+        has_measurement = any(
+            value is not None
+            for value in (
+                self.charged_cost,
+                self.input_tokens,
+                self.output_tokens,
+                self.cache_read_tokens,
+            )
+        )
+        if not has_measurement:
+            raise ValueError("Record must carry token counts and/or a charged_cost")
+        return self
+
+
+class UsageIngestRequest(BaseModel):
+    """Batch of pushed usage records to ingest."""
+
+    records: List[UsageIngestRecord] = Field(
+        ..., min_length=1, max_length=MAX_INGEST_RECORDS_PER_REQUEST
+    )
+    agent_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "Managed agent to attribute the records to. When omitted, the "
+            "account's single managed agent whose kind matches `source` is "
+            "used if exactly resolvable."
+        ),
+    )
+    source: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Origin label stored on each row (e.g. 'cursor').",
+    )
+
+    @field_validator("source")
+    @classmethod
+    def normalize_source(cls, value: str) -> str:
+        """Normalize the source label for stable filtering and dedupe."""
+        normalized = value.strip().lower()
+        if not normalized:
+            raise ValueError("source must not be blank")
+        return normalized
+
+
+class UsageIngestRecordResult(BaseModel):
+    """Per-record outcome of a push-ingest request."""
+
+    external_id: str
+    deduplicated: bool = False
+
+
+class UsageIngestResponse(BaseModel):
+    """Result of a push-ingest request.
+
+    Replays return 200 with the replayed records flagged
+    ``deduplicated`` — spend is never double-counted.
+    """
+
+    source: str
+    agent_id: Optional[UUID] = None
+    agent_display_name: Optional[str] = None
+    accepted: int = 0
+    deduplicated: int = 0
+    results: List[UsageIngestRecordResult] = Field(default_factory=list)
 
 
 class UsageImportCsvResponse(UsageImportResponse):

--- a/backend/preloop/schemas/usage_import.py
+++ b/backend/preloop/schemas/usage_import.py
@@ -188,7 +188,8 @@ class UsageIngestRecord(BaseModel):
         ge=0,
         description=(
             "Amount the source vendor charged, in USD. The billing truth; "
-            "never derived from tokens."
+            "never derived from tokens. Stored as a float on the ledger "
+            "(estimated_cost is a Float column), matching the CSV import path."
         ),
     )
     cost_basis: IngestCostBasis = Field(

--- a/backend/preloop/services/usage_import.py
+++ b/backend/preloop/services/usage_import.py
@@ -287,15 +287,18 @@ def ingest_push_records(
         differs from the stored one (first write wins either way).
         Committed once at the end.
     """
+    fingerprints = [
+        push_record_fingerprint(source=source, external_id=record.external_id)
+        for record in records
+    ]
+    existing_by_fp = crud_api_usage.get_imported_rows_by_fingerprints(
+        db, account_id=account_id, fingerprints=fingerprints
+    )
+    ingest_endpoint = f"/usage/ingest/{source}"
     results: List[UsageIngestRecordResult] = []
-    for record in records:
-        fingerprint = push_record_fingerprint(
-            source=source, external_id=record.external_id
-        )
+    for record, fingerprint in zip(records, fingerprints, strict=True):
         content_hash = push_record_content_hash(record)
-        existing = crud_api_usage.get_imported_row_by_fingerprint(
-            db, account_id=account_id, import_fingerprint=fingerprint
-        )
+        existing = existing_by_fp.get(fingerprint)
         if existing is None:
             timestamp = record.timestamp
             if timestamp.tzinfo is not None:
@@ -320,6 +323,7 @@ def ingest_push_records(
                 completion_tokens=record.output_tokens,
                 cache_read_tokens=record.cache_read_tokens,
                 cost_usd=(
+                    # estimated_cost is a Float column; Decimal is request-only.
                     float(record.charged_cost)
                     if record.charged_cost is not None
                     else None
@@ -334,9 +338,12 @@ def ingest_push_records(
                 runtime_principal_name=agent.display_name,
                 import_fingerprint=fingerprint,
                 meta_data=meta,
+                endpoint=ingest_endpoint,
+                skip_fingerprint_lookup=True,
                 commit=False,
             )
             if row is not None:
+                existing_by_fp[fingerprint] = row
                 results.append(UsageIngestRecordResult(external_id=record.external_id))
                 continue
             # A concurrent request landed this fingerprint between the

--- a/backend/preloop/services/usage_import.py
+++ b/backend/preloop/services/usage_import.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import csv
 import hashlib
 import io
+import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -31,7 +32,11 @@ from sqlalchemy.orm import Session
 
 from preloop.models.crud import crud_api_usage, crud_managed_agent
 from preloop.models.models.managed_agent import ManagedAgent
-from preloop.schemas.usage_import import UsageImportEvent, UsageIngestRecord
+from preloop.schemas.usage_import import (
+    UsageImportEvent,
+    UsageIngestRecord,
+    UsageIngestRecordResult,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +239,20 @@ def push_record_fingerprint(*, source: str, external_id: str) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def push_record_content_hash(record: UsageIngestRecord) -> str:
+    """Compute the canonical payload hash of one pushed usage record.
+
+    Stored as ``meta_data.ingest_content_hash`` so a replay of the same
+    (source, external_id) with a DIFFERENT payload can be flagged
+    ``conflict`` in the response. First write still wins — the marker is a
+    heuristic for the shipper's operator, never a rejection.
+    """
+    canonical = json.dumps(
+        record.model_dump(mode="json"), sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 def ingest_push_records(
     db: Session,
     *,
@@ -242,7 +261,7 @@ def ingest_push_records(
     agent: ManagedAgent,
     records: List[UsageIngestRecord],
     source: str,
-) -> List[bool]:
+) -> List[UsageIngestRecordResult]:
     """Write pushed usage records into the cost ledger, deduplicated.
 
     Reuses the imported-usage normalization chokepoint
@@ -250,6 +269,9 @@ def ingest_push_records(
     rows land as ``action_type='imported_usage'`` / ``usage_source='imported'``,
     ``total_tokens`` derives from input+output only, and cache-read tokens
     stay in their own column — never summed into totals or charged spend.
+    Conversation ids, message/tool counts, and cost_basis land in their
+    first-class columns; lifecycle events (``event_type != 'usage'``) land
+    as zero-cost rows unless explicitly priced.
 
     Args:
         db: Database session.
@@ -260,50 +282,85 @@ def ingest_push_records(
         source: Origin label (e.g. ``cursor``); scopes the dedupe key.
 
     Returns:
-        Per-record flags, ``True`` when the record was skipped as a
-        duplicate of (source, external_id). Committed once at the end.
+        Per-record results: ``deduplicated`` when the (source, external_id)
+        was already stored, plus ``conflict`` when the replayed payload
+        differs from the stored one (first write wins either way).
+        Committed once at the end.
     """
-    deduplicated: List[bool] = []
+    results: List[UsageIngestRecordResult] = []
     for record in records:
-        timestamp = record.timestamp
-        if timestamp.tzinfo is not None:
-            timestamp = timestamp.astimezone(timezone.utc).replace(tzinfo=None)
-        meta: Dict[str, Any] = {
-            "managed_agent_id": str(agent.id),
-            "external_id": record.external_id,
-        }
-        if record.conversation_id:
-            meta["conversation_id"] = record.conversation_id
-        if record.parent_conversation_id:
-            meta["parent_conversation_id"] = record.parent_conversation_id
-        if record.metadata:
-            for key, value in record.metadata.items():
-                meta.setdefault(key, value)
-        row = crud_api_usage.log_imported_usage_event(
-            db,
-            account_id=account_id,
-            user_id=user_id,
-            timestamp=timestamp,
-            model_alias=record.model,
-            source=source,
-            prompt_tokens=record.input_tokens,
-            completion_tokens=record.output_tokens,
-            cache_read_tokens=record.cache_read_tokens,
-            cost_usd=(
-                float(record.charged_cost) if record.charged_cost is not None else None
-            ),
-            runtime_principal_type=agent.session_source_type,
-            runtime_principal_id=agent.session_source_id,
-            runtime_principal_name=agent.display_name,
-            import_fingerprint=push_record_fingerprint(
-                source=source, external_id=record.external_id
-            ),
-            meta_data=meta,
-            commit=False,
+        fingerprint = push_record_fingerprint(
+            source=source, external_id=record.external_id
         )
-        deduplicated.append(row is None)
+        content_hash = push_record_content_hash(record)
+        existing = crud_api_usage.get_imported_row_by_fingerprint(
+            db, account_id=account_id, import_fingerprint=fingerprint
+        )
+        if existing is None:
+            timestamp = record.timestamp
+            if timestamp.tzinfo is not None:
+                timestamp = timestamp.astimezone(timezone.utc).replace(tzinfo=None)
+            meta: Dict[str, Any] = {
+                "managed_agent_id": str(agent.id),
+                "external_id": record.external_id,
+                "event_type": record.event_type,
+                "ingest_content_hash": content_hash,
+            }
+            if record.metadata:
+                for key, value in record.metadata.items():
+                    meta.setdefault(key, value)
+            row = crud_api_usage.log_imported_usage_event(
+                db,
+                account_id=account_id,
+                user_id=user_id,
+                timestamp=timestamp,
+                model_alias=record.model,
+                source=source,
+                prompt_tokens=record.input_tokens,
+                completion_tokens=record.output_tokens,
+                cache_read_tokens=record.cache_read_tokens,
+                cost_usd=(
+                    float(record.charged_cost)
+                    if record.charged_cost is not None
+                    else None
+                ),
+                cost_basis=record.cost_basis,
+                conversation_id=record.conversation_id,
+                parent_conversation_id=record.parent_conversation_id,
+                message_count=record.message_count,
+                tool_call_count=record.tool_call_count,
+                runtime_principal_type=agent.session_source_type,
+                runtime_principal_id=agent.session_source_id,
+                runtime_principal_name=agent.display_name,
+                import_fingerprint=fingerprint,
+                meta_data=meta,
+                commit=False,
+            )
+            if row is not None:
+                results.append(UsageIngestRecordResult(external_id=record.external_id))
+                continue
+            # A concurrent request landed this fingerprint between the
+            # existence check and the insert; re-read it for the conflict
+            # comparison below.
+            existing = crud_api_usage.get_imported_row_by_fingerprint(
+                db, account_id=account_id, import_fingerprint=fingerprint
+            )
+        stored_hash = (
+            (existing.meta_data or {}).get("ingest_content_hash")
+            if existing is not None
+            else None
+        )
+        results.append(
+            UsageIngestRecordResult(
+                external_id=record.external_id,
+                deduplicated=True,
+                # Rows written before content hashing (or by the CSV path)
+                # have no stored hash and are non-comparable: no conflict.
+                conflict=bool(stored_hash and stored_hash != content_hash),
+            )
+        )
     db.commit()
-    return deduplicated
+    return results
 
 
 # ---------------------------------------------------------------------------

--- a/backend/preloop/services/usage_import.py
+++ b/backend/preloop/services/usage_import.py
@@ -31,7 +31,7 @@ from sqlalchemy.orm import Session
 
 from preloop.models.crud import crud_api_usage, crud_managed_agent
 from preloop.models.models.managed_agent import ManagedAgent
-from preloop.schemas.usage_import import UsageImportEvent
+from preloop.schemas.usage_import import UsageImportEvent, UsageIngestRecord
 
 logger = logging.getLogger(__name__)
 
@@ -219,6 +219,91 @@ def ingest_events(
             imported += 1
     db.commit()
     return imported, skipped
+
+
+def push_record_fingerprint(*, source: str, external_id: str) -> str:
+    """Compute the dedupe fingerprint for one pushed usage record.
+
+    Pushed records are identified by (account, source, external_id): the
+    caller supplies a stable source-side id, so a harness retrying a batch
+    after a network timeout cannot double-count spend. The ``ingest|``
+    prefix keeps this namespace disjoint from the content-hash fingerprints
+    of the CSV/JSON import path, which share the same unique index.
+    """
+    payload = f"ingest|{source}|{external_id}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def ingest_push_records(
+    db: Session,
+    *,
+    account_id: str,
+    user_id: Optional[str],
+    agent: ManagedAgent,
+    records: List[UsageIngestRecord],
+    source: str,
+) -> List[bool]:
+    """Write pushed usage records into the cost ledger, deduplicated.
+
+    Reuses the imported-usage normalization chokepoint
+    (:meth:`~preloop.models.crud.api_usage.CRUDApiUsage.log_imported_usage_event`):
+    rows land as ``action_type='imported_usage'`` / ``usage_source='imported'``,
+    ``total_tokens`` derives from input+output only, and cache-read tokens
+    stay in their own column — never summed into totals or charged spend.
+
+    Args:
+        db: Database session.
+        account_id: Owning account id.
+        user_id: Pushing user's id, for audit.
+        agent: Managed agent the records are attributed to.
+        records: Pushed usage records.
+        source: Origin label (e.g. ``cursor``); scopes the dedupe key.
+
+    Returns:
+        Per-record flags, ``True`` when the record was skipped as a
+        duplicate of (source, external_id). Committed once at the end.
+    """
+    deduplicated: List[bool] = []
+    for record in records:
+        timestamp = record.timestamp
+        if timestamp.tzinfo is not None:
+            timestamp = timestamp.astimezone(timezone.utc).replace(tzinfo=None)
+        meta: Dict[str, Any] = {
+            "managed_agent_id": str(agent.id),
+            "external_id": record.external_id,
+        }
+        if record.conversation_id:
+            meta["conversation_id"] = record.conversation_id
+        if record.parent_conversation_id:
+            meta["parent_conversation_id"] = record.parent_conversation_id
+        if record.metadata:
+            for key, value in record.metadata.items():
+                meta.setdefault(key, value)
+        row = crud_api_usage.log_imported_usage_event(
+            db,
+            account_id=account_id,
+            user_id=user_id,
+            timestamp=timestamp,
+            model_alias=record.model,
+            source=source,
+            prompt_tokens=record.input_tokens,
+            completion_tokens=record.output_tokens,
+            cache_read_tokens=record.cache_read_tokens,
+            cost_usd=(
+                float(record.charged_cost) if record.charged_cost is not None else None
+            ),
+            runtime_principal_type=agent.session_source_type,
+            runtime_principal_id=agent.session_source_id,
+            runtime_principal_name=agent.display_name,
+            import_fingerprint=push_record_fingerprint(
+                source=source, external_id=record.external_id
+            ),
+            meta_data=meta,
+            commit=False,
+        )
+        deduplicated.append(row is None)
+    db.commit()
+    return deduplicated
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/endpoints/test_usage_ingest.py
+++ b/backend/tests/endpoints/test_usage_ingest.py
@@ -95,6 +95,7 @@ class TestIngestRecords:
         assert worker.parent_conversation_id == "conv-parent"
         assert worker.cost_basis == "estimated"
         assert worker.meta_data["event_type"] == "usage"
+        assert worker.endpoint == "/usage/ingest/cursor"
 
     def test_replay_returns_200_with_deduplicated_flag(
         self, client, db_session, test_user

--- a/backend/tests/endpoints/test_usage_ingest.py
+++ b/backend/tests/endpoints/test_usage_ingest.py
@@ -1,0 +1,326 @@
+"""Endpoint tests for the usage push-ingest API (evolution of issue #123).
+
+Covers POST /api/v1/usage/ingest: continuous push of externally observed
+spend records, idempotent on (source, external_id) per account, with
+conversation ids stored so subagent workers billed on separate
+conversations can be rolled up under their parent thread. Cache-read
+tokens are reported distinctly and never treated as charged spend.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import Integer, distinct, func
+
+from preloop.models.crud import crud_managed_agent
+from preloop.models.models.api_usage import ApiUsage
+
+INGEST_URL = "/api/v1/usage/ingest"
+COST_SUMMARY_URL = "/api/v1/cost/summary"
+
+
+def _make_cursor_agent(db, account_id, *, source_id="cursor-ws-1", name="Cursor"):
+    """Register a managed Cursor agent like `preloop agents onboard Cursor`."""
+    return crud_managed_agent.upsert_from_runtime_session(
+        db,
+        account_id=account_id,
+        runtime_session_id=None,
+        session_source_type="desktop_agent",
+        session_source_id=source_id,
+        display_name=name,
+        agent_kind="cursor",
+    )
+
+
+def _record(**overrides):
+    """Build one valid ingest record."""
+    record = {
+        "external_id": "turn-0001",
+        "timestamp": (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
+        "model": "composer",
+        "charged_cost": "0.42",
+        "input_tokens": 1200,
+        "output_tokens": 850,
+        "cache_read_tokens": 4500,
+    }
+    record.update(overrides)
+    return record
+
+
+def _payload(records=None, **overrides):
+    """Build a minimal valid ingest payload."""
+    payload = {"source": "cursor", "records": records or [_record()]}
+    payload.update(overrides)
+    return payload
+
+
+class TestIngestRecords:
+    """POST /api/v1/usage/ingest."""
+
+    def test_ingest_accepts_batch(self, client, db_session, test_user):
+        """Records land on the default agent with per-record results."""
+        agent = _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        records = [
+            _record(external_id="turn-1"),
+            _record(
+                external_id="turn-2",
+                conversation_id="conv-w1",
+                parent_conversation_id="conv-parent",
+            ),
+        ]
+        response = client.post(INGEST_URL, json=_payload(records))
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["accepted"] == 2
+        assert body["deduplicated"] == 0
+        assert body["agent_id"] == str(agent.id)
+        assert body["source"] == "cursor"
+        assert body["results"] == [
+            {"external_id": "turn-1", "deduplicated": False},
+            {"external_id": "turn-2", "deduplicated": False},
+        ]
+
+        rows = (
+            db_session.query(ApiUsage)
+            .filter(ApiUsage.action_type == "imported_usage")
+            .all()
+        )
+        assert len(rows) == 2
+        by_ext = {row.meta_data["external_id"]: row for row in rows}
+        worker = by_ext["turn-2"]
+        assert worker.usage_source == "imported"
+        assert worker.meta_data["conversation_id"] == "conv-w1"
+        assert worker.meta_data["parent_conversation_id"] == "conv-parent"
+
+    def test_replay_returns_200_with_deduplicated_flag(
+        self, client, db_session, test_user
+    ):
+        """Replaying the same batch never double-counts spend."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        payload = _payload([_record(external_id="turn-1")])
+
+        first = client.post(INGEST_URL, json=payload)
+        second = client.post(INGEST_URL, json=payload)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json()["accepted"] == 1
+        body = second.json()
+        assert body["accepted"] == 0
+        assert body["deduplicated"] == 1
+        assert body["results"] == [{"external_id": "turn-1", "deduplicated": True}]
+
+        total_cost = (
+            db_session.query(func.sum(ApiUsage.estimated_cost))
+            .filter(ApiUsage.action_type == "imported_usage")
+            .scalar()
+        )
+        assert total_cost is not None
+        assert abs(total_cost - 0.42) < 1e-9
+
+    def test_duplicates_within_one_batch_are_deduplicated(
+        self, client, db_session, test_user
+    ):
+        """The same external_id twice in one request lands only once."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        records = [_record(external_id="turn-1"), _record(external_id="turn-1")]
+        body = client.post(INGEST_URL, json=_payload(records)).json()
+
+        assert body["accepted"] == 1
+        assert body["deduplicated"] == 1
+
+    def test_same_external_id_from_two_sources_both_land(
+        self, client, db_session, test_user
+    ):
+        """Dedupe is scoped by source: ids from different vendors differ."""
+        agent = _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        first = client.post(INGEST_URL, json=_payload([_record(external_id="turn-1")]))
+        second = client.post(
+            INGEST_URL,
+            json=_payload(
+                [_record(external_id="turn-1")],
+                source="other-vendor",
+                agent_id=str(agent.id),
+            ),
+        )
+
+        assert first.json()["accepted"] == 1
+        assert second.status_code == 200
+        assert second.json()["accepted"] == 1
+
+    def test_cache_read_tokens_are_never_charged(self, client, db_session, test_user):
+        """Cache reads are reported distinctly, never counted as spend."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        records = [
+            # Cache-read-only record: reported, but carries no charge.
+            _record(
+                external_id="turn-cache-only",
+                charged_cost=None,
+                input_tokens=None,
+                output_tokens=None,
+                cache_read_tokens=250_000,
+            ),
+            # Charged record: cost must equal charged_cost exactly, and
+            # total tokens must exclude the cache reads.
+            _record(
+                external_id="turn-charged",
+                charged_cost="1.25",
+                input_tokens=100,
+                output_tokens=50,
+                cache_read_tokens=90_000,
+            ),
+        ]
+        response = client.post(INGEST_URL, json=_payload(records))
+        assert response.status_code == 200
+        assert response.json()["accepted"] == 2
+
+        rows = (
+            db_session.query(ApiUsage)
+            .filter(ApiUsage.action_type == "imported_usage")
+            .all()
+        )
+        by_ext = {row.meta_data["external_id"]: row for row in rows}
+
+        cache_only = by_ext["turn-cache-only"]
+        assert cache_only.estimated_cost is None
+        assert cache_only.cost_source is None
+        assert cache_only.cache_read_tokens == 250_000
+        assert cache_only.total_tokens in (None, 0)
+
+        charged = by_ext["turn-charged"]
+        assert abs(charged.estimated_cost - 1.25) < 1e-9
+        assert charged.cost_source == "imported"
+        assert charged.total_tokens == 150  # input + output only
+        assert charged.cache_read_tokens == 90_000
+
+        summary = client.get(COST_SUMMARY_URL).json()
+        imported = summary["imported_usage"]
+        assert abs(imported["imported_cost"] - 1.25) < 1e-9
+
+    def test_parent_worker_rollup_query_is_possible(
+        self, client, db_session, test_user
+    ):
+        """Workers billed on separate conversations roll up under the parent.
+
+        The motivating scenario: a parent thread spawns many subagent
+        workers, each billed on its own conversation id; reading only the
+        parent's conversation misses the combined spend. The stored data
+        model must answer: charged dollars and worker count per thread.
+        """
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        records = [
+            _record(
+                external_id="turn-parent",
+                conversation_id="conv-parent",
+                charged_cost="0.10",
+            )
+        ]
+        for i in range(3):
+            records.append(
+                _record(
+                    external_id=f"turn-worker-{i}",
+                    conversation_id=f"conv-worker-{i}",
+                    parent_conversation_id="conv-parent",
+                    charged_cost="2.00",
+                )
+            )
+        assert client.post(INGEST_URL, json=_payload(records)).json()["accepted"] == 4
+
+        thread = func.coalesce(
+            ApiUsage.meta_data["parent_conversation_id"].astext,
+            ApiUsage.meta_data["conversation_id"].astext,
+        )
+        rollup = (
+            db_session.query(
+                thread.label("thread"),
+                func.sum(ApiUsage.estimated_cost).label("charged"),
+                func.count(distinct(ApiUsage.meta_data["conversation_id"].astext))
+                .cast(Integer)
+                .label("worker_count"),
+            )
+            .filter(
+                ApiUsage.account_id == test_user.account_id,
+                ApiUsage.action_type == "imported_usage",
+            )
+            .group_by(thread)
+            .all()
+        )
+        assert len(rollup) == 1
+        row = rollup[0]
+        assert row.thread == "conv-parent"
+        assert abs(row.charged - 6.10) < 1e-9
+        assert row.worker_count == 4  # parent conversation + 3 workers
+
+    def test_without_matching_agent_returns_422(self, client, db_session, test_user):
+        """No managed agent of the source's kind and no agent_id: 422."""
+        response = client.post(INGEST_URL, json=_payload())
+
+        assert response.status_code == 422
+        assert "onboard" in response.json()["detail"].lower()
+
+    def test_validation_errors_are_field_scoped(self, client, db_session, test_user):
+        """Shape violations return 422 with per-field error locations."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        response = client.post(
+            INGEST_URL,
+            json=_payload(
+                [
+                    _record(external_id="", input_tokens=-5),
+                ]
+            ),
+        )
+
+        assert response.status_code == 422
+        locs = [tuple(err["loc"]) for err in response.json()["detail"]]
+        assert ("body", "records", 0, "external_id") in locs
+        assert ("body", "records", 0, "input_tokens") in locs
+
+    def test_record_without_any_measurement_returns_422(
+        self, client, db_session, test_user
+    ):
+        """A record with neither tokens nor charged_cost is rejected."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        response = client.post(
+            INGEST_URL,
+            json=_payload(
+                [
+                    _record(
+                        charged_cost=None,
+                        input_tokens=None,
+                        output_tokens=None,
+                        cache_read_tokens=None,
+                    )
+                ]
+            ),
+        )
+
+        assert response.status_code == 422
+        assert "charged_cost" in response.text
+
+    def test_oversized_metadata_returns_422(self, client, db_session, test_user):
+        """Metadata beyond the serialized size cap is rejected."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        response = client.post(
+            INGEST_URL,
+            json=_payload([_record(metadata={"blob": "x" * 9000})]),
+        )
+
+        assert response.status_code == 422
+        assert "metadata" in response.text

--- a/backend/tests/endpoints/test_usage_ingest.py
+++ b/backend/tests/endpoints/test_usage_ingest.py
@@ -78,8 +78,8 @@ class TestIngestRecords:
         assert body["agent_id"] == str(agent.id)
         assert body["source"] == "cursor"
         assert body["results"] == [
-            {"external_id": "turn-1", "deduplicated": False},
-            {"external_id": "turn-2", "deduplicated": False},
+            {"external_id": "turn-1", "deduplicated": False, "conflict": False},
+            {"external_id": "turn-2", "deduplicated": False, "conflict": False},
         ]
 
         rows = (
@@ -91,8 +91,10 @@ class TestIngestRecords:
         by_ext = {row.meta_data["external_id"]: row for row in rows}
         worker = by_ext["turn-2"]
         assert worker.usage_source == "imported"
-        assert worker.meta_data["conversation_id"] == "conv-w1"
-        assert worker.meta_data["parent_conversation_id"] == "conv-parent"
+        assert worker.conversation_id == "conv-w1"
+        assert worker.parent_conversation_id == "conv-parent"
+        assert worker.cost_basis == "estimated"
+        assert worker.meta_data["event_type"] == "usage"
 
     def test_replay_returns_200_with_deduplicated_flag(
         self, client, db_session, test_user
@@ -111,7 +113,10 @@ class TestIngestRecords:
         body = second.json()
         assert body["accepted"] == 0
         assert body["deduplicated"] == 1
-        assert body["results"] == [{"external_id": "turn-1", "deduplicated": True}]
+        assert body["conflicts"] == 0
+        assert body["results"] == [
+            {"external_id": "turn-1", "deduplicated": True, "conflict": False}
+        ]
 
         total_cost = (
             db_session.query(func.sum(ApiUsage.estimated_cost))
@@ -238,14 +243,13 @@ class TestIngestRecords:
         assert client.post(INGEST_URL, json=_payload(records)).json()["accepted"] == 4
 
         thread = func.coalesce(
-            ApiUsage.meta_data["parent_conversation_id"].astext,
-            ApiUsage.meta_data["conversation_id"].astext,
+            ApiUsage.parent_conversation_id, ApiUsage.conversation_id
         )
         rollup = (
             db_session.query(
                 thread.label("thread"),
                 func.sum(ApiUsage.estimated_cost).label("charged"),
-                func.count(distinct(ApiUsage.meta_data["conversation_id"].astext))
+                func.count(distinct(ApiUsage.conversation_id))
                 .cast(Integer)
                 .label("worker_count"),
             )
@@ -324,3 +328,183 @@ class TestIngestRecords:
 
         assert response.status_code == 422
         assert "metadata" in response.text
+
+    def test_conflicting_replay_is_flagged_first_write_wins(
+        self, client, db_session, test_user
+    ):
+        """A replay with a different payload gets conflict=true, not a 409.
+
+        Shippers must be retry-dumb: the batch still returns 200 with the
+        record deduplicated, the stored row is unchanged (first write
+        wins), and the per-item conflict marker plus the top-level count
+        tell the operator the source re-emitted the id with new data.
+        """
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        first = client.post(INGEST_URL, json=_payload([_record(external_id="turn-1")]))
+        conflicting = client.post(
+            INGEST_URL,
+            json=_payload([_record(external_id="turn-1", charged_cost="9.99")]),
+        )
+
+        assert first.status_code == 200
+        assert conflicting.status_code == 200
+        body = conflicting.json()
+        assert body["accepted"] == 0
+        assert body["deduplicated"] == 1
+        assert body["conflicts"] == 1
+        assert body["results"] == [
+            {"external_id": "turn-1", "deduplicated": True, "conflict": True}
+        ]
+
+        # First write wins: the stored charge is the original one.
+        row = (
+            db_session.query(ApiUsage)
+            .filter(ApiUsage.action_type == "imported_usage")
+            .one()
+        )
+        assert abs(row.estimated_cost - 0.42) < 1e-9
+
+    def test_lifecycle_events_count_fanout_without_spend(
+        self, client, db_session, test_user
+    ):
+        """Hook-shaped lifecycle events land cost-free and count fan-out."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        base = {
+            "timestamp": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
+            "parent_conversation_id": "conv-parent",
+        }
+        records = [
+            {
+                **base,
+                "external_id": f"gen-start-{i}",
+                "event_type": "subagent_start",
+                "conversation_id": f"conv-worker-{i}",
+            }
+            for i in range(3)
+        ]
+        records.append(
+            {
+                **base,
+                "external_id": "gen-compaction",
+                "event_type": "compaction",
+                "conversation_id": "conv-parent",
+            }
+        )
+        response = client.post(INGEST_URL, json=_payload(records))
+
+        assert response.status_code == 200
+        assert response.json()["accepted"] == 4
+
+        rows = (
+            db_session.query(ApiUsage)
+            .filter(ApiUsage.action_type == "imported_usage")
+            .all()
+        )
+        assert all(row.estimated_cost is None for row in rows)
+        assert all(row.model_alias is None for row in rows)
+
+        # Near-real-time fan-out: subagent_start count per parent thread.
+        fanout = (
+            db_session.query(func.count(ApiUsage.id))
+            .filter(
+                ApiUsage.account_id == test_user.account_id,
+                ApiUsage.action_type == "imported_usage",
+                ApiUsage.parent_conversation_id == "conv-parent",
+                ApiUsage.meta_data["event_type"].astext == "subagent_start",
+            )
+            .scalar()
+        )
+        assert fanout == 3
+
+        # Lifecycle events never contribute charged spend.
+        summary = client.get(COST_SUMMARY_URL).json()
+        imported = summary["imported_usage"]
+        assert imported["imported_cost"] == 0
+        assert imported["event_count"] == 4
+
+    def test_usage_event_requires_model(self, client, db_session, test_user):
+        """event_type='usage' (the default) still requires a model name."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        response = client.post(INGEST_URL, json=_payload([_record(model=None)]))
+
+        assert response.status_code == 422
+        assert "model" in response.text
+
+    def test_growth_tripwire_counts_are_stored(self, client, db_session, test_user):
+        """message_count / tool_call_count land in first-class columns."""
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        records = [_record(external_id="turn-1", message_count=41, tool_call_count=7)]
+        assert client.post(INGEST_URL, json=_payload(records)).status_code == 200
+
+        row = (
+            db_session.query(ApiUsage)
+            .filter(ApiUsage.action_type == "imported_usage")
+            .one()
+        )
+        assert row.message_count == 41
+        assert row.tool_call_count == 7
+
+    def test_reconciled_supersedes_estimated_in_cost_summary(
+        self, client, db_session, test_user
+    ):
+        """Reconciled billing rows replace estimates for the same scope.
+
+        conv-1 has two hook-derived estimates ($2.00 + $0.30) and one
+        reconciled billing-export record ($1.80): only the reconciled
+        dollars count. conv-2 has an un-reconciled estimate ($0.50): it
+        keeps counting. Estimated and reconciled dollars are never summed
+        for the same conversation; event/token totals still include all
+        rows (billing exports rarely carry tokens).
+        """
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        records = [
+            _record(
+                external_id="turn-a",
+                conversation_id="conv-1",
+                charged_cost="2.00",
+                input_tokens=1000,
+                output_tokens=200,
+            ),
+            _record(
+                external_id="turn-b",
+                conversation_id="conv-1",
+                charged_cost="0.30",
+                input_tokens=300,
+                output_tokens=100,
+            ),
+            _record(
+                external_id="billing-conv-1",
+                conversation_id="conv-1",
+                charged_cost="1.80",
+                cost_basis="reconciled",
+                input_tokens=None,
+                output_tokens=None,
+                cache_read_tokens=None,
+            ),
+            _record(
+                external_id="turn-c",
+                conversation_id="conv-2",
+                charged_cost="0.50",
+                input_tokens=100,
+                output_tokens=50,
+            ),
+        ]
+        assert client.post(INGEST_URL, json=_payload(records)).json()["accepted"] == 4
+
+        summary = client.get(COST_SUMMARY_URL).json()
+        imported = summary["imported_usage"]
+        # 1.80 (reconciled, conv-1) + 0.50 (estimated, conv-2). NOT 4.60.
+        assert abs(imported["imported_cost"] - 2.30) < 1e-9
+        # Event and token truth stays with all rows.
+        assert imported["event_count"] == 4
+        assert imported["total_tokens"] == 1750

--- a/backend/tests/models/crud/test_imported_usage_crud.py
+++ b/backend/tests/models/crud/test_imported_usage_crud.py
@@ -64,6 +64,7 @@ def test_log_imported_usage_event_writes_labeled_ledger_row(
     assert row.provider_name == "cursor"
     assert row.runtime_principal_id == "cursor-ws-1"
     assert row.meta_data["import_source"] == "cursor"
+    assert row.endpoint == "/usage/import/cursor"
     assert row.meta_data["import_fingerprint"] == "fp-write-1"
     assert row.meta_data["source_kind"] == "Usage-based"
 
@@ -305,3 +306,47 @@ def test_gateway_aggregations_are_blind_to_imported_rows(
     assert gateway["request_count"] == 0
     assert gateway["estimated_cost"] == 0.0
     assert gateway["total_tokens"] == 0
+
+
+def test_out_of_window_reconciled_does_not_zero_in_window_estimates(
+    db_session, create_account
+):
+    """A later billing export must not hide spend that fell in this window."""
+    account = create_account()
+    window_start = datetime(2026, 8, 1, tzinfo=timezone.utc).replace(tzinfo=None)
+    window_end = datetime(2026, 8, 8, tzinfo=timezone.utc).replace(tzinfo=None)
+
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        timestamp=datetime(2026, 8, 3, tzinfo=timezone.utc).replace(tzinfo=None),
+        cost_usd=2.00,
+        cost_basis="estimated",
+        conversation_id="conv-1",
+        import_fingerprint="fp-est-aug",
+    )
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        timestamp=datetime(2026, 8, 10, tzinfo=timezone.utc).replace(tzinfo=None),
+        cost_usd=1.80,
+        cost_basis="reconciled",
+        conversation_id="conv-1",
+        import_fingerprint="fp-rec-aug",
+    )
+
+    in_window = crud_api_usage.get_imported_usage_summary(
+        db_session,
+        account_id=str(account.id),
+        start_date=window_start,
+        end_date=window_end,
+    )
+    later = crud_api_usage.get_imported_usage_summary(
+        db_session,
+        account_id=str(account.id),
+        start_date=window_end,
+        end_date=datetime(2026, 8, 15, tzinfo=timezone.utc).replace(tzinfo=None),
+    )
+
+    assert abs(in_window["imported_cost"] - 2.00) < 1e-9
+    assert abs(later["imported_cost"] - 1.80) < 1e-9

--- a/backend/tests/models/test_alembic_single_head.py
+++ b/backend/tests/models/test_alembic_single_head.py
@@ -76,8 +76,10 @@ def test_alembic_head_is_reachable_from_base() -> None:
 
 
 def test_flow_runners_revision_chains_onto_approval_rule_context() -> None:
-    """Self-hosted runners must parent the current main migration head."""
+    """Self-hosted runners parent the previous main head; ingest is current."""
     script = _script_directory()
-    revision = script.get_revision("20260817_add_flow_runners")
-    assert revision.down_revision == "20260806_approval_rule_ctx"
-    assert script.get_heads() == ["20260817_add_flow_runners"]
+    runners = script.get_revision("20260817_add_flow_runners")
+    assert runners.down_revision == "20260806_approval_rule_ctx"
+    ingest = script.get_revision("20260818_usage_ingest_conv")
+    assert ingest.down_revision == "20260817_add_flow_runners"
+    assert script.get_heads() == ["20260818_usage_ingest_conv"]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6330,6 +6330,52 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
       security:
       - bearerAuth: []
+  /api/v1/usage/ingest:
+    post:
+      tags:
+      - Usage Import
+      - Usage Import
+      summary: Ingest Usage Records
+      description: 'Push a batch of external usage records into the cost ledger.
+
+
+        The continuous-push evolution of ``POST /usage/import``: a harness
+
+        posts sanitized spend records as they occur instead of batch CSV.
+
+        Each record is identified by (source, external_id) per account, so
+
+        replaying a batch — e.g. a retry after a network timeout — returns
+
+        200 with the replayed records flagged ``deduplicated`` and never
+
+        double-counts spend. Records carry ``conversation_id`` /
+
+        ``parent_conversation_id`` so subagent workers billed on separate
+
+        conversations can be rolled up under their parent thread.'
+      operationId: ingest_usage_records_api_v1_usage_ingest_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsageIngestRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageIngestResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
   /api/v1/usage/import/csv:
     post:
       tags:
@@ -18805,6 +18851,174 @@ components:
       type: object
       title: UsageImportResponse
       description: Result of an ingest request.
+    UsageIngestRecord:
+      properties:
+        external_id:
+          type: string
+          maxLength: 255
+          minLength: 1
+          title: External Id
+          description: Source-side record/turn id; dedupe key with `source`.
+        conversation_id:
+          anyOf:
+          - type: string
+            maxLength: 255
+          - type: 'null'
+          title: Conversation Id
+        parent_conversation_id:
+          anyOf:
+          - type: string
+            maxLength: 255
+          - type: 'null'
+          title: Parent Conversation Id
+          description: Conversation this record's conversation was spawned from (e.g.
+            a subagent worker's parent thread), for cost rollup.
+        timestamp:
+          type: string
+          format: date-time
+          title: Timestamp
+        model:
+          type: string
+          maxLength: 255
+          minLength: 1
+          title: Model
+        charged_cost:
+          anyOf:
+          - type: number
+            minimum: 0.0
+          - type: string
+            pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          - type: 'null'
+          title: Charged Cost
+          description: Amount the source vendor charged, in USD. The billing truth;
+            never derived from tokens.
+        input_tokens:
+          anyOf:
+          - type: integer
+            minimum: 0.0
+          - type: 'null'
+          title: Input Tokens
+        output_tokens:
+          anyOf:
+          - type: integer
+            minimum: 0.0
+          - type: 'null'
+          title: Output Tokens
+        cache_read_tokens:
+          anyOf:
+          - type: integer
+            minimum: 0.0
+          - type: 'null'
+          title: Cache Read Tokens
+          description: Cache-read tokens, reported distinctly; never summed into charged
+            spend or total tokens.
+        metadata:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Metadata
+      type: object
+      required:
+      - external_id
+      - timestamp
+      - model
+      title: UsageIngestRecord
+      description: 'One usage record pushed continuously by an external harness.
+
+
+        Unlike ``UsageImportEvent`` (batch CSV/JSON import, content-hash
+
+        dedupe), a pushed record carries a caller-supplied ``external_id`` so
+
+        replays after network timeouts are idempotent, plus conversation ids so
+
+        subagent workers billed on separate conversations can be rolled up
+
+        under their parent thread in Cost analytics.'
+    UsageIngestRecordResult:
+      properties:
+        external_id:
+          type: string
+          title: External Id
+        deduplicated:
+          type: boolean
+          title: Deduplicated
+          default: false
+      type: object
+      required:
+      - external_id
+      title: UsageIngestRecordResult
+      description: Per-record outcome of a push-ingest request.
+    UsageIngestRequest:
+      properties:
+        records:
+          items:
+            $ref: '#/components/schemas/UsageIngestRecord'
+          type: array
+          maxItems: 1000
+          minItems: 1
+          title: Records
+        agent_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Agent Id
+          description: Managed agent to attribute the records to. When omitted, the
+            account's single managed agent whose kind matches `source` is used if
+            exactly resolvable.
+        source:
+          type: string
+          maxLength: 64
+          minLength: 1
+          title: Source
+          description: Origin label stored on each row (e.g. 'cursor').
+      type: object
+      required:
+      - records
+      - source
+      title: UsageIngestRequest
+      description: Batch of pushed usage records to ingest.
+    UsageIngestResponse:
+      properties:
+        source:
+          type: string
+          title: Source
+        agent_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Agent Id
+        agent_display_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Agent Display Name
+        accepted:
+          type: integer
+          title: Accepted
+          default: 0
+        deduplicated:
+          type: integer
+          title: Deduplicated
+          default: 0
+        results:
+          items:
+            $ref: '#/components/schemas/UsageIngestRecordResult'
+          type: array
+          title: Results
+      type: object
+      required:
+      - source
+      title: UsageIngestResponse
+      description: 'Result of a push-ingest request.
+
+
+        Replays return 200 with the replayed records flagged
+
+        ``deduplicated`` — spend is never double-counted.'
     ValidationError:
       properties:
         loc:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6341,19 +6341,35 @@ paths:
 
         The continuous-push evolution of ``POST /usage/import``: a harness
 
-        posts sanitized spend records as they occur instead of batch CSV.
+        posts sanitized spend records — or hook-shaped lifecycle events
 
-        Each record is identified by (source, external_id) per account, so
+        (``event_type``) — as they occur instead of batch CSV. Each record is
 
-        replaying a batch — e.g. a retry after a network timeout — returns
+        identified by (source, external_id) per account, so replaying a batch
 
-        200 with the replayed records flagged ``deduplicated`` and never
+        — e.g. a retry after a network timeout — returns 200 with the
 
-        double-counts spend. Records carry ``conversation_id`` /
+        replayed records flagged ``deduplicated`` and never double-counts
 
-        ``parent_conversation_id`` so subagent workers billed on separate
+        spend; a replay whose payload differs from the stored record is
 
-        conversations can be rolled up under their parent thread.'
+        additionally flagged ``conflict`` (first write wins, never a 409).
+
+        Records carry ``conversation_id`` / ``parent_conversation_id`` so
+
+        subagent workers billed on separate conversations can be rolled up
+
+        under their parent thread, and ``cost_basis`` so reconciled
+
+        billing-export records supersede hook-derived estimates in cost
+
+        summaries. Attribution precedence: explicit ``agent_id`` (must belong
+
+        to the account) wins; otherwise the account''s single managed agent
+
+        whose kind equals ``source`` is used, and zero or multiple candidates
+
+        is a 422.'
       operationId: ingest_usage_records_api_v1_usage_ingest_post
       requestBody:
         content:
@@ -18877,11 +18893,29 @@ components:
           type: string
           format: date-time
           title: Timestamp
-        model:
+        event_type:
           type: string
-          maxLength: 255
-          minLength: 1
+          enum:
+          - session_start
+          - session_end
+          - subagent_start
+          - subagent_stop
+          - response
+          - compaction
+          - usage
+          title: Event Type
+          description: Hook-shaped lifecycle marker. 'usage' (default) requires a
+            model and at least one measurement; lifecycle events (session/subagent
+            start/stop, response, compaction) may carry zero token/cost data and no
+            model.
+          default: usage
+        model:
+          anyOf:
+          - type: string
+            maxLength: 255
+          - type: 'null'
           title: Model
+          description: Source-reported model name. Required for event_type='usage'.
         charged_cost:
           anyOf:
           - type: number
@@ -18892,6 +18926,17 @@ components:
           title: Charged Cost
           description: Amount the source vendor charged, in USD. The billing truth;
             never derived from tokens.
+        cost_basis:
+          type: string
+          enum:
+          - estimated
+          - reconciled
+          title: Cost Basis
+          description: '''estimated'' (hook/transcript-derived) or ''reconciled''
+            (billing export). Reconciled records supersede estimated records with
+            the same (source, conversation_id) in cost summaries; the two are never
+            summed together.'
+          default: estimated
         input_tokens:
           anyOf:
           - type: integer
@@ -18912,6 +18957,20 @@ components:
           title: Cache Read Tokens
           description: Cache-read tokens, reported distinctly; never summed into charged
             spend or total tokens.
+        message_count:
+          anyOf:
+          - type: integer
+            minimum: 0.0
+          - type: 'null'
+          title: Message Count
+          description: Messages in the conversation so far (growth tripwire).
+        tool_call_count:
+          anyOf:
+          - type: integer
+            minimum: 0.0
+          - type: 'null'
+          title: Tool Call Count
+          description: Tool calls in the conversation so far (growth tripwire).
         metadata:
           anyOf:
           - additionalProperties: true
@@ -18922,7 +18981,6 @@ components:
       required:
       - external_id
       - timestamp
-      - model
       title: UsageIngestRecord
       description: 'One usage record pushed continuously by an external harness.
 
@@ -18944,6 +19002,13 @@ components:
         deduplicated:
           type: boolean
           title: Deduplicated
+          default: false
+        conflict:
+          type: boolean
+          title: Conflict
+          description: True when a deduplicated replay carried a DIFFERENT payload
+            than the stored record (first write wins; the batch still returns 200
+            so shippers can retry blindly).
           default: false
       type: object
       required:
@@ -19004,6 +19069,10 @@ components:
           type: integer
           title: Deduplicated
           default: 0
+        conflicts:
+          type: integer
+          title: Conflicts
+          default: 0
         results:
           items:
             $ref: '#/components/schemas/UsageIngestRecordResult'
@@ -19018,7 +19087,11 @@ components:
 
         Replays return 200 with the replayed records flagged
 
-        ``deduplicated`` — spend is never double-counted.'
+        ``deduplicated`` — spend is never double-counted. Replays whose
+
+        payload differs from the stored record are additionally flagged
+
+        ``conflict`` (first write wins; never a 409).'
     ValidationError:
       properties:
         loc:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18925,7 +18925,8 @@ components:
           - type: 'null'
           title: Charged Cost
           description: Amount the source vendor charged, in USD. The billing truth;
-            never derived from tokens.
+            never derived from tokens. Stored as a float on the ledger (estimated_cost
+            is a Float column), matching the CSV import path.
         cost_basis:
           type: string
           enum:


### PR DESCRIPTION
## Summary

Evolution of the issue #123 CSV usage import: an authenticated **push** API so a harness can post sanitized external/bundled-model spend continuously instead of batch CSV.

Adds `POST /api/v1/usage/ingest` (same router, tag, and `import_usage` permission as the existing import routes; works with API keys because `get_current_active_user` already accepts them). Free-tier feature — cost overview is OSS.

## Spec

**Request**: `{source, agent_id?, records[1..1000]}`, each record:

| field | notes |
|---|---|
| `external_id` (required) | source-side record/turn id; dedupe key with `source` |
| `conversation_id`, `parent_conversation_id` (nullable) | stored in `meta_data` so workers billed on separate conversations roll up under their parent thread |
| `timestamp`, `model` (required) | normalized to naive UTC |
| `charged_cost` (Decimal ≥ 0, USD) | the billing truth; stored in `estimated_cost` with `cost_source='imported'`, never derived from tokens |
| `input_tokens`, `output_tokens`, `cache_read_tokens` | cache reads kept in their own column — **never** summed into totals or charged spend |
| `metadata` | optional object, 8 KiB serialized cap |

At least one measurable quantity (tokens or `charged_cost`) is required; shape violations return **422 with per-field errors**.

**Dedupe semantics**: record identity is **(account, source, external_id)**, implemented as `sha256("ingest|{source}|{external_id}")` in the existing `meta_data->>'import_fingerprint'` partial unique index (`ix_api_usage_imported_fingerprint_uniq`) — **no migration needed**; the `ingest|` prefix keeps the namespace disjoint from the CSV content-hash fingerprints. Replays (e.g. harness retry after a network timeout) return **200** with per-record `deduplicated: true` flags and never double-count spend; within-batch duplicates and concurrent replays (savepoint-per-row + unique index) are covered. First write wins — payload content is not compared on replay.

**Rollup (data model only; UI out of scope)**: aggregating by `COALESCE(meta_data->>'parent_conversation_id', meta_data->>'conversation_id')` yields per-thread charged dollars, record counts, and distinct worker counts — so a parent thread that fans out to many separately-billed subagent workers reports its combined spend. Demonstrated by a test.

**Normalization is reused, not duplicated**: rows flow through the same `log_imported_usage_event` chokepoint as the CSV path (`action_type='imported_usage'`, `usage_source='imported'`), so they appear in the separate `imported_usage` block of `GET /cost/summary` and stay out of gateway budget accounting.

## Open design questions (flagged for the design call, not guessed at)

1. Promote conversation ids to first-class indexed columns (needs a migration) once a rollup endpoint/UI exists, vs. JSONB as now?
2. Replay with same `(source, external_id)` but different payload: first-write-wins + `deduplicated` today; alternatively detect the conflict (409/flag)?
3. Default agent attribution for non-`cursor` sources currently resolves an agent of kind = source label; allow account-level rows without a managed agent instead?
4. First-class `message_count`/`tool_call_count` fields for growth tripwires, or is capped `metadata` enough?

## Test plan

- `backend/tests/endpoints/test_usage_ingest.py` (10 new tests): idempotency replay, within-batch dedupe, cross-source non-collision, **cache-read-not-charged** (incl. `/cost/summary` integration), parent/worker rollup aggregation, field-scoped 422s, metadata size cap, attribution failure.
- Related suites still green (62 passed: usage import endpoints/service/fingerprint/CRUD + cost health) against a fresh DB migrated with `alembic upgrade head` (single head verified: `20260817_add_flow_runners`).
- `ruff check`/`format` clean; `openapi.yaml` regenerated.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Adds an authenticated push API that writes directly to the cost ledger (round 2 adds first-class conversation rollup columns, lifecycle events, and reconciled-vs-estimated cost supersession); mitigated by account-scoped agent resolution, the `import_usage` permission, DB-level dedupe, and thorough test coverage. All prior review findings are now resolved.
>
> **Overview**
> `POST /api/v1/usage/ingest` lets a harness push sanitized external/bundled-model spend continuously, idempotent on `(account, source, external_id)`, rolling subagent workers up under parent conversations via indexed columns, flagging conflicting replays (first write wins), and letting reconciled billing-export rows supersede hook-derived estimates in cost summaries. The latest commit bounds supersession to the query window and batches fingerprint existence checks into a single lookup. Records flow through the same `log_imported_usage_event` chokepoint as the CSV import path, keeping them out of gateway budget accounting.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit d2f5da69. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->