### PR TITLE
fix: cost reprice row selection + provider daily-ledger backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (not `0`) when the run was dispatched to a background worker, so an async
   submission is no longer indistinguishable from "the window contained no
   rows".
+- **Ledger CSV parser rejects non-finite totals**: `nan` / `inf` in
+  `total_usage` are skipped like negatives, so they cannot land in
+  `estimated_cost`.
 
 - **Agent Control for Claude Code (G1) and native session targeting (G2)**:
   `claude_code` is now a supported Agent Control kind. `control_enabled`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Provider daily-ledger CSV backfill**: `POST /api/v1/cost/ledger-backfill/csv`
+  (permission `manage_budgets`) and `scripts/backfill_openrouter_ledger.py
+  --csv` accept an OpenRouter Activity → Explore daily export
+  (`date__day,model,total_usage`) and distribute each (day × model) total
+  across that account's still-unpriced gateway rows for the day — pro-rata
+  by tokens, equal split when the bucket recorded no tokens. Display names
+  are matched to recorded aliases via a shared family key; the export's
+  "Other" bucket names no model, so its spend is reported as a residual and
+  never allocated. Allocated rows are tagged `cost_source='reconciled'`
+  (never mixed with estimates), re-runs are idempotent (only still-unpriced
+  rows are ever written), and the default is a dry run that returns the full
+  allocation plan. CSV mode needs no management API key and has no 30-day
+  activity-endpoint horizon.
+- **Synchronous reprice endpoint**: `POST /api/v1/cost/reprice` (permission
+  `manage_budgets`) scans the requested window in-request — keyset-paginated,
+  up to 92 days — and returns real examined/updated counters, avoiding the
+  billing plugin's 7-day async cliff whose acknowledgement serialized as
+  "examined 0 rows".
+
+### Fixed
+
+- **Reprice row selection**: `only_unpriced` repricing now also examines rows
+  tagged `cost_source='unpriced'` that carry a stray stored cost (legacy $0
+  writes), and the ledger backfill additionally admits legacy rows recorded
+  before cost provenance existed (`cost_source IS NULL` with a NULL cost).
+- **Estimates can no longer overwrite actuals**: repricing (bulk and
+  single-row) refuses to touch `provider`, `reconciled`, and `imported`
+  cost sources even with `only_unpriced=false` — provider-reported and
+  ledger-reconciled figures are never replaced by catalog estimates.
+- **Async reprice acknowledgements**: `RepriceResponse` counters are `null`
+  (not `0`) when the run was dispatched to a background worker, so an async
+  submission is no longer indistinguishable from "the window contained no
+  rows".
+
 - **Agent Control for Claude Code (G1) and native session targeting (G2)**:
   `claude_code` is now a supported Agent Control kind. `control_enabled`
   still requires sidecar/capability flags, not a blanket true. When a

--- a/backend/preloop/api/endpoints/cost.py
+++ b/backend/preloop/api/endpoints/cost.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    UploadFile,
+)
 from sqlalchemy.orm import Session
 
 from preloop.api.auth.jwt import get_current_active_user
@@ -18,13 +26,34 @@ from preloop.schemas.cost_analytics import (
     CostHealthResponse,
     ImportedUsageByModel,
     ImportedUsageSummary,
+    LedgerBackfillBucket,
+    LedgerBackfillResidual,
+    LedgerBackfillResponse,
+    LedgerBackfillUnmatched,
     PriceCatalogInfo,
+    RepriceRequest,
+    RepriceResponse,
 )
 from preloop.services.gateway_accounting_check import run_accounting_checks
+from preloop.services.ledger_backfill import (
+    apply_ledger_backfill,
+    load_unpriced_rows,
+    parse_explorer_csv,
+    plan_ledger_allocation,
+)
 from preloop.services.model_gateway_usage import ModelGatewayUsageService
+from preloop.services.usage_repricing import reprice_gateway_usage
 from preloop.utils.permissions import require_permission
 
 router = APIRouter(prefix="/cost", tags=["Cost Analytics"])
+
+#: Hard cap for one synchronous reprice request. Keyset pagination keeps
+#: memory flat, but a bound keeps one HTTP request from scanning unbounded
+#: history — split longer backfills into consecutive calls.
+REPRICE_MAX_WINDOW_DAYS = 92
+
+#: Explore exports are one row per (day, model); even a year is tiny.
+MAX_LEDGER_CSV_BYTES = 2 * 1024 * 1024
 
 
 def _price_catalog_info() -> Optional[PriceCatalogInfo]:
@@ -135,3 +164,160 @@ def get_cost_health(
     account = get_account_or_404(db, current_user)
     result = run_accounting_checks(db, account_id=str(account.id), window_hours=hours)
     return CostHealthResponse(**result)
+
+
+@router.post("/reprice", response_model=RepriceResponse)
+@require_permission("manage_budgets")
+def reprice_account_gateway_usage(
+    reprice_in: RepriceRequest,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_active_user),
+) -> RepriceResponse:
+    """Re-price historical gateway usage synchronously and report real counts.
+
+    Unlike the billing plugin's ``/billing/cost/reprice`` (which dispatches
+    windows over 7 days to a background worker and acknowledges with empty
+    counters), this endpoint always scans in-request — keyset-paginated, so
+    an operator backfilling weeks of history gets actual examined/updated
+    numbers instead of an ambiguous async ack. Budget-spend buckets are never
+    rewritten; provider-side actuals (``provider``/``reconciled``/
+    ``imported``) and ``subscription`` rows are never touched.
+    """
+    get_account_or_404(db, current_user)
+    window = reprice_in.end_date - reprice_in.start_date
+    if window > timedelta(days=REPRICE_MAX_WINDOW_DAYS):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Window exceeds {REPRICE_MAX_WINDOW_DAYS} days; split the "
+                "backfill into smaller ranges"
+            ),
+        )
+    result = reprice_gateway_usage(
+        db,
+        account_id=current_user.account_id,
+        start=reprice_in.start_date,
+        end=reprice_in.end_date,
+        only_unpriced=reprice_in.only_unpriced,
+        dry_run=reprice_in.dry_run,
+    )
+    return RepriceResponse(
+        submitted_async=False,
+        rows_examined=result.rows_examined,
+        rows_updated=result.rows_updated,
+        rows_skipped=result.rows_skipped,
+        cost_before=result.cost_before,
+        cost_after=result.cost_after,
+        dry_run=result.dry_run,
+    )
+
+
+@router.post("/ledger-backfill/csv", response_model=LedgerBackfillResponse)
+@require_permission("manage_budgets")
+async def backfill_from_provider_ledger_csv(
+    file: UploadFile = File(
+        ...,
+        description=(
+            "OpenRouter Activity -> Explore daily export "
+            "(columns: date__day, model, total_usage)"
+        ),
+    ),
+    provider: str = Form(default="openrouter"),
+    start: Optional[date] = Form(
+        default=None, description="First UTC day (inclusive); default: CSV min."
+    ),
+    end: Optional[date] = Form(
+        default=None, description="Last UTC day (inclusive); default: CSV max."
+    ),
+    apply: bool = Form(
+        default=False,
+        description="Persist the allocation. Default is a dry run.",
+    ),
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_active_user),
+) -> LedgerBackfillResponse:
+    """Reconcile unpriced gateway rows against a provider daily-usage export.
+
+    Distributes each (day x model) ledger total across this account's
+    still-unpriced gateway rows for that day — pro-rata by tokens, equal
+    split when the bucket recorded no tokens — and tags them
+    ``cost_source='reconciled'`` so provider actuals never mix with catalog
+    estimates. Only rows without a resolved cost are ever touched, which
+    also makes re-running the same export idempotent. The export's "Other"
+    bucket is reported as an unallocatable residual, never distributed.
+
+    Defaults to a dry run that returns the full allocation plan; pass
+    ``apply=true`` to persist it.
+    """
+    get_account_or_404(db, current_user)
+    raw = await file.read(MAX_LEDGER_CSV_BYTES + 1)
+    if len(raw) > MAX_LEDGER_CSV_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"CSV exceeds the {MAX_LEDGER_CSV_BYTES // (1024 * 1024)} MiB limit"
+            ),
+        )
+    try:
+        ledger = parse_explorer_csv(raw.decode("utf-8-sig"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    ledger_days = [entry.day for entry in ledger.entries] + [
+        day for day, _ in ledger.other_by_day
+    ]
+    if not ledger_days:
+        raise HTTPException(
+            status_code=422, detail="The export contains no usable ledger rows"
+        )
+    start = start or min(ledger_days)
+    end = end or max(ledger_days)
+    if end < start:
+        raise HTTPException(status_code=422, detail="end must not be before start")
+
+    entries = [entry for entry in ledger.entries if start <= entry.day <= end]
+    other_residual = sum(usd for day, usd in ledger.other_by_day if start <= day <= end)
+    rows = load_unpriced_rows(
+        db,
+        account_id=str(current_user.account_id),
+        provider_name=provider.strip().lower(),
+        start=start,
+        end=end,
+    )
+    plan = plan_ledger_allocation(entries, rows)
+    rows_updated = apply_ledger_backfill(db, plan) if apply else None
+
+    return LedgerBackfillResponse(
+        dry_run=not apply,
+        provider=provider.strip().lower(),
+        start=start,
+        end=end,
+        ledger_entries=len(entries),
+        eligible_rows=len(rows),
+        rows_to_reconcile=len(plan.allocations),
+        total_allocated=round(
+            sum(allocation.allocated_cost for allocation in plan.allocations), 12
+        ),
+        rows_updated=rows_updated,
+        other_residual_usd=round(other_residual, 12),
+        buckets=[
+            LedgerBackfillBucket(
+                day=bucket.day,
+                family=bucket.family,
+                ledger_total=bucket.ledger_total,
+                row_count=bucket.row_count,
+                allocated_total=bucket.allocated_total,
+                ledger_models=list(bucket.ledger_models),
+            )
+            for bucket in plan.buckets
+        ],
+        unallocated_ledger=[
+            LedgerBackfillResidual(day=day, family=family, amount_usd=usd)
+            for day, family, usd in plan.unallocated_ledger
+        ],
+        unmatched_rows=[
+            LedgerBackfillUnmatched(day=day, family=family, row_count=count)
+            for day, family, count in plan.unmatched_rows
+        ],
+        skipped_csv_rows=ledger.skipped,
+    )

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -360,7 +360,10 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             account_id: Account scope.
             start: Window start (inclusive).
             end: Window end (exclusive).
-            only_unpriced: Restrict to rows without a stored cost.
+            only_unpriced: Restrict to rows without a resolved cost: NULL
+                ``estimated_cost`` (however tagged) plus rows explicitly
+                tagged ``cost_source='unpriced'`` that carry a stray numeric
+                cost (legacy $0 writes), so those anomalies heal too.
             batch_size: Rows fetched per query.
 
         Yields:
@@ -375,7 +378,12 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
                 ApiUsage.timestamp < end,
             )
             if only_unpriced:
-                query = query.filter(ApiUsage.estimated_cost.is_(None))
+                query = query.filter(
+                    or_(
+                        ApiUsage.estimated_cost.is_(None),
+                        ApiUsage.cost_source == "unpriced",
+                    )
+                )
             if last_id is not None:
                 query = query.filter(ApiUsage.id > last_id)
             batch = query.order_by(ApiUsage.id).limit(batch_size).all()
@@ -397,9 +405,11 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         """Yield unpriced gateway rows for one provider, keyset-paginated.
 
         Deliberately narrower than :meth:`iter_gateway_rows_for_repricing`:
-        only rows explicitly tagged ``cost_source='unpriced'`` for the given
-        provider are eligible, so a ledger backfill can never touch rows the
-        catalog (or the provider itself) already priced.
+        only rows explicitly tagged ``cost_source='unpriced'`` — plus legacy
+        rows recorded before provenance existed (``cost_source IS NULL`` with
+        a NULL cost, i.e. before the 20260712 accuracy-columns migration) —
+        are eligible for the given provider, so a ledger backfill can never
+        touch rows the catalog (or the provider itself) already priced.
 
         Args:
             db: Database session.
@@ -418,7 +428,13 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
                 ApiUsage.account_id == account_id,
                 ApiUsage.action_type == "model_gateway",
                 ApiUsage.provider_name == provider_name,
-                ApiUsage.cost_source == "unpriced",
+                or_(
+                    ApiUsage.cost_source == "unpriced",
+                    and_(
+                        ApiUsage.cost_source.is_(None),
+                        ApiUsage.estimated_cost.is_(None),
+                    ),
+                ),
                 ApiUsage.timestamp >= start,
                 ApiUsage.timestamp < end,
             )

--- a/backend/preloop/schemas/cost_analytics.py
+++ b/backend/preloop/schemas/cost_analytics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import List, Optional
 from uuid import UUID
 
@@ -277,15 +277,75 @@ class RepriceRequest(BaseModel):
 
 
 class RepriceResponse(BaseModel):
-    """Result of a repricing run (or async submission)."""
+    """Result of a repricing run (or async submission).
+
+    The counters are ``None`` — not ``0`` — when the run was dispatched to a
+    background worker (``submitted_async=True``): nothing has been scanned in
+    this request, so reporting zeros would be indistinguishable from "the
+    window really contained no rows" (the exact confusion behind "reprice
+    examined 0 rows" on large windows).
+    """
 
     submitted_async: bool = False
-    rows_examined: int = 0
-    rows_updated: int = 0
-    rows_skipped: int = 0
-    cost_before: float = 0.0
-    cost_after: float = 0.0
+    rows_examined: Optional[int] = None
+    rows_updated: Optional[int] = None
+    rows_skipped: Optional[int] = None
+    cost_before: Optional[float] = None
+    cost_after: Optional[float] = None
     dry_run: bool = False
+
+
+class LedgerBackfillBucket(BaseModel):
+    """One (day x model family) allocation bucket of a ledger backfill."""
+
+    day: date
+    family: str
+    ledger_total: float
+    row_count: int
+    allocated_total: float
+    ledger_models: List[str] = Field(default_factory=list)
+
+
+class LedgerBackfillResidual(BaseModel):
+    """Ledger spend with no eligible usage rows to receive it."""
+
+    day: date
+    family: str
+    amount_usd: float
+
+
+class LedgerBackfillUnmatched(BaseModel):
+    """Unpriced usage rows whose family had no ledger spend that day."""
+
+    day: date
+    family: str
+    row_count: int
+
+
+class LedgerBackfillResponse(BaseModel):
+    """Outcome (or dry-run preview) of a provider daily-ledger backfill.
+
+    ``rows_updated`` is ``None`` on a dry run — nothing was written, which is
+    different from "wrote 0 rows". ``other_residual_usd`` is the export's
+    "Other" bucket inside the window: the provider does not say which models
+    it covers, so that spend is reported but never allocated and the matching
+    rows stay unpriced.
+    """
+
+    dry_run: bool = True
+    provider: str
+    start: date
+    end: date
+    ledger_entries: int = 0
+    eligible_rows: int = 0
+    rows_to_reconcile: int = 0
+    total_allocated: float = 0.0
+    rows_updated: Optional[int] = None
+    other_residual_usd: float = 0.0
+    buckets: List[LedgerBackfillBucket] = Field(default_factory=list)
+    unallocated_ledger: List[LedgerBackfillResidual] = Field(default_factory=list)
+    unmatched_rows: List[LedgerBackfillUnmatched] = Field(default_factory=list)
+    skipped_csv_rows: List[str] = Field(default_factory=list)
 
 
 class CostHealthCheck(BaseModel):

--- a/backend/preloop/services/ledger_backfill.py
+++ b/backend/preloop/services/ledger_backfill.py
@@ -28,6 +28,8 @@ by the provider itself are untouched.
 
 from __future__ import annotations
 
+import csv
+import io
 import logging
 import re
 import uuid
@@ -84,6 +86,29 @@ def alias_family(name: Optional[str]) -> Optional[str]:
     return family or None
 
 
+def display_name_family(name: Optional[str]) -> Optional[str]:
+    """Reduce a provider-UI model display name to the shared family key.
+
+    The Activity -> Explore export names models for humans ("Acme Z9 Mini
+    0731"), while our usage rows record slugs
+    ("openrouter/acme/acme-z9-mini-0731"). Matching rule: collapse
+    whitespace to single hyphens, lowercase, then apply the same
+    prefix/variant/date normalization :func:`alias_family` applies to slugs,
+    so both sides land on one comparable key ("acme-z9-mini-0731").
+
+    Args:
+        name: A display name from the Explore export (or a raw slug, which
+            passes through :func:`alias_family` unchanged).
+
+    Returns:
+        The normalized family key, or None for empty input.
+    """
+    if not isinstance(name, str) or not name.strip():
+        return None
+    slugified = "-".join(name.strip().lower().split())
+    return alias_family(slugified)
+
+
 @dataclass(frozen=True)
 class LedgerEntry:
     """One (day, model) aggregate from the provider's activity ledger."""
@@ -91,6 +116,95 @@ class LedgerEntry:
     day: date
     model: str
     usage_usd: float
+
+
+#: Column headers of the OpenRouter Activity -> Explore daily export.
+EXPLORER_COLUMNS = ("date__day", "model", "total_usage")
+
+#: The export's aggregate bucket for long-tail models. It names no model, so
+#: its spend can only be reported as an unallocatable residual — inventing a
+#: split for it would assign money to rows the provider never priced.
+EXPLORER_OTHER_LABEL = "other"
+
+
+@dataclass
+class ExplorerLedger:
+    """A parsed Activity -> Explore export, ready for allocation."""
+
+    entries: List[LedgerEntry] = field(default_factory=list)
+    #: "Other"-bucket spend per day: reported as residual, never allocated.
+    other_by_day: List[Tuple[date, float]] = field(default_factory=list)
+    #: Human-readable reasons for rows the parser refused (dry-run report).
+    skipped: List[str] = field(default_factory=list)
+
+    @property
+    def other_total(self) -> float:
+        """Total USD in the export's "Other" bucket (left unpriced)."""
+        return sum(usd for _, usd in self.other_by_day)
+
+
+def parse_explorer_csv(text: str) -> ExplorerLedger:
+    """Parse an OpenRouter Activity -> Explore daily usage export.
+
+    Expected columns (extra columns are ignored): ``date__day`` (YYYY-MM-DD),
+    ``model`` (display name), ``total_usage`` (USD). Malformed rows are
+    collected in :attr:`ExplorerLedger.skipped` rather than aborting the
+    import, so the operator sees exactly what a run would and would not use.
+
+    Args:
+        text: The CSV file content (a UTF-8 BOM is tolerated).
+
+    Returns:
+        The parsed ledger, with "Other" rows split out as residual.
+
+    Raises:
+        ValueError: When the header does not contain the expected columns.
+    """
+    reader = csv.DictReader(io.StringIO(text.lstrip("\ufeff")))
+    header = [name.strip().lower() for name in reader.fieldnames or []]
+    missing = [column for column in EXPLORER_COLUMNS if column not in header]
+    if missing:
+        raise ValueError(
+            "Not an OpenRouter Explore export: missing column(s) "
+            f"{', '.join(missing)} (expected {', '.join(EXPLORER_COLUMNS)})"
+        )
+
+    ledger = ExplorerLedger()
+    for line_number, raw in enumerate(reader, start=2):
+        row = {
+            (key or "").strip().lower(): (value or "").strip()
+            for key, value in raw.items()
+            if key is not None
+        }
+        if not any(row.values()):
+            continue
+        try:
+            day = date.fromisoformat(row["date__day"])
+        except ValueError:
+            ledger.skipped.append(
+                f"line {line_number}: bad date__day {row['date__day']!r}"
+            )
+            continue
+        try:
+            usage_usd = float(row["total_usage"])
+        except ValueError:
+            ledger.skipped.append(
+                f"line {line_number}: bad total_usage {row['total_usage']!r}"
+            )
+            continue
+        if usage_usd < 0:
+            ledger.skipped.append(f"line {line_number}: negative total_usage")
+            continue
+        model_name = row["model"]
+        if model_name.lower() == EXPLORER_OTHER_LABEL:
+            ledger.other_by_day.append((day, usage_usd))
+            continue
+        family = display_name_family(model_name)
+        if family is None:
+            ledger.skipped.append(f"line {line_number}: empty model name")
+            continue
+        ledger.entries.append(LedgerEntry(day=day, model=family, usage_usd=usage_usd))
+    return ledger
 
 
 @dataclass(frozen=True)
@@ -386,6 +500,20 @@ def load_unpriced_rows(
     return rows
 
 
+def _row_is_still_unpriced(row) -> bool:
+    """True when a usage row is still eligible to receive a ledger share.
+
+    Mirrors :meth:`crud_api_usage.iter_unpriced_provider_rows` eligibility:
+    explicitly tagged ``unpriced``, or a legacy row from before cost
+    provenance existed (NULL ``cost_source`` AND NULL cost). Anything else —
+    catalog/override estimates, provider actuals, an earlier reconciliation —
+    must never be overwritten by an allocation.
+    """
+    if row.cost_source == "unpriced":
+        return True
+    return row.cost_source is None and row.estimated_cost is None
+
+
 def apply_ledger_backfill(db: Session, plan: BackfillPlan) -> int:
     """Write a plan's allocations and refresh affected execution rollups.
 
@@ -406,7 +534,7 @@ def apply_ledger_backfill(db: Session, plan: BackfillPlan) -> int:
     touched_executions = set()
     for allocation in plan.allocations:
         row = crud_api_usage.get(db, id=allocation.api_usage_id)
-        if row is None or row.cost_source != "unpriced":
+        if row is None or not _row_is_still_unpriced(row):
             logger.info("Skipping row %s: no longer unpriced", allocation.api_usage_id)
             continue
         crud_api_usage.update_cost_fields(

--- a/backend/preloop/services/ledger_backfill.py
+++ b/backend/preloop/services/ledger_backfill.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import csv
 import io
 import logging
+import math
 import re
 import uuid
 from collections import defaultdict
@@ -190,6 +191,11 @@ def parse_explorer_csv(text: str) -> ExplorerLedger:
         except ValueError:
             ledger.skipped.append(
                 f"line {line_number}: bad total_usage {row['total_usage']!r}"
+            )
+            continue
+        if not math.isfinite(usage_usd):
+            ledger.skipped.append(
+                f"line {line_number}: non-finite total_usage {row['total_usage']!r}"
             )
             continue
         if usage_usd < 0:

--- a/backend/preloop/services/usage_repricing.py
+++ b/backend/preloop/services/usage_repricing.py
@@ -10,7 +10,12 @@ account overrides. It exists to:
 
 Budget-spend buckets are deliberately NOT rewritten: spend was charged at
 request time and repricing is analytics-only. Rows priced as ``subscription``
-are skipped — their $0 cost is correct by construction.
+are skipped — their $0 cost is correct by construction. Rows whose cost came
+from the provider itself are equally off-limits: ``provider`` (the upstream
+reported the request's actual cost), ``reconciled`` (backfilled from the
+provider's daily activity ledger) and ``imported`` (external spend ingested
+as-is) are actuals, and a catalog ESTIMATE must never overwrite an actual —
+not even on a full ``only_unpriced=False`` recompute.
 """
 
 from __future__ import annotations
@@ -34,6 +39,12 @@ from preloop.services.pricing_overrides import resolve_pricing_override
 
 logger = logging.getLogger(__name__)
 
+#: Cost sources a catalog estimate must never overwrite. ``subscription`` is
+#: correct-by-construction $0; the rest are provider-side actuals.
+PROTECTED_COST_SOURCES = frozenset(
+    {"subscription", "provider", "reconciled", "imported"}
+)
+
 
 @dataclass
 class RepriceResult:
@@ -55,8 +66,9 @@ def reprice_single_row(
     """Re-price one gateway usage row against current prices/overrides.
 
     Used by the live price lookup to fix the row that triggered it. Follows
-    the same rules as the bulk path: subscription rows are left alone and
-    budget spend is never rewritten.
+    the same rules as the bulk path: rows with a protected cost source
+    (subscription $0s and provider-side actuals) are left alone and budget
+    spend is never rewritten.
 
     Args:
         db: Database session.
@@ -66,7 +78,9 @@ def reprice_single_row(
         True when the row was updated with a new cost/source.
     """
     row = crud_api_usage.get(db, id=api_usage_id)
-    if row is None or row.cost_source == "subscription" or not row.ai_model_id:
+    if row is None or row.cost_source in PROTECTED_COST_SOURCES:
+        return False
+    if not row.ai_model_id:
         return False
     ai_model = crud_ai_model.get(db, id=str(row.ai_model_id))
     if ai_model is None or row.account_id is None:
@@ -166,9 +180,12 @@ def reprice_gateway_usage(
         account_id: Account whose rows are repriced.
         start: Window start (inclusive).
         end: Window end (exclusive).
-        only_unpriced: When True (default), only rows with NULL cost are
-            touched; when False every row is recomputed against current
-            pricing (retroactive override application).
+        only_unpriced: When True (default), only rows without a resolved
+            cost are touched (NULL cost, or tagged ``unpriced`` with a stray
+            stored cost); when False every non-protected row is recomputed
+            against current pricing (retroactive override application).
+            Rows whose ``cost_source`` is in :data:`PROTECTED_COST_SOURCES`
+            are never rewritten in either mode.
         dry_run: Compute and report without persisting.
         batch_size: Rows fetched per query page.
 
@@ -195,7 +212,7 @@ def reprice_gateway_usage(
         result.rows_examined += 1
         result.cost_before += float(row.estimated_cost or 0.0)
 
-        if row.cost_source == "subscription":
+        if row.cost_source in PROTECTED_COST_SOURCES:
             result.rows_skipped += 1
             result.cost_after += float(row.estimated_cost or 0.0)
             continue

--- a/backend/tests/endpoints/test_cost_reprice_backfill.py
+++ b/backend/tests/endpoints/test_cost_reprice_backfill.py
@@ -1,0 +1,246 @@
+"""Endpoint tests for the OSS synchronous reprice + CSV ledger backfill.
+
+Covers POST /api/v1/cost/reprice (real counters, window cap) and
+POST /api/v1/cost/ledger-backfill/csv (dry-run vs apply, idempotency,
+"Other" residual reporting, estimate-vs-reconciled separation). All CSV
+content is synthetic fixture data in the Explore export's shape.
+"""
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+from preloop.models.crud import crud_ai_model, crud_api_usage
+
+REPRICE = "/api/v1/cost/reprice"
+LEDGER_CSV = "/api/v1/cost/ledger-backfill/csv"
+
+DAY = date(2026, 8, 5)
+
+FIXTURE_CSV = (
+    "date__day,model,total_usage\n"
+    "2026-08-05,Acme Z9 Mini 0731,0.30\n"
+    "2026-08-05,Other,0.05\n"
+)
+
+
+def _create_model(db_session, test_user, *, pricing=None, provider="openrouter"):
+    meta = {}
+    if pricing:
+        meta["pricing"] = pricing
+    return crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Acme Z9 Mini",
+            "provider_name": provider,
+            "model_identifier": "acme/acme-z9-mini-0731",
+            "api_endpoint": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-key",
+            "meta_data": meta,
+        },
+        account_id=test_user.account_id,
+    )
+
+
+def _log_unpriced_row(db_session, test_user, ai_model, *, tokens, day=DAY):
+    row = crud_api_usage.log_gateway_request(
+        db_session,
+        endpoint="/openai/v1/chat/completions",
+        method="POST",
+        status_code=200,
+        duration=0.4,
+        account_id=str(test_user.account_id),
+        user_id=str(test_user.id),
+        ai_model_id=str(ai_model.id),
+        model_alias="openrouter/acme/acme-z9-mini-0731",
+        provider_name="openrouter",
+        prompt_tokens=tokens,
+        completion_tokens=0,
+        total_tokens=tokens,
+        estimated_cost=None,
+        cost_source="unpriced",
+    )
+    row.timestamp = datetime(day.year, day.month, day.day, 12, 0, 0)
+    db_session.commit()
+    return row
+
+
+def _upload(client, *, apply=False, csv_text=FIXTURE_CSV, **form):
+    data = {"apply": "true" if apply else "false", **form}
+    return client.post(
+        LEDGER_CSV,
+        files={"file": ("export.csv", csv_text, "text/csv")},
+        data=data,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /cost/reprice
+# ---------------------------------------------------------------------------
+
+
+def test_reprice_endpoint_returns_real_counts_synchronously(
+    client, db_session, test_user
+):
+    """No async cliff: a multi-day window is scanned in-request and the
+    response carries actual examined/updated counters."""
+    ai_model = _create_model(
+        db_session,
+        test_user,
+        pricing={"input_price_per_1k": 0.01},
+    )
+    row = _log_unpriced_row(db_session, test_user, ai_model, tokens=1000)
+    now = datetime.now(timezone.utc)
+    row.timestamp = now - timedelta(days=3)
+    db_session.commit()
+
+    response = client.post(
+        REPRICE,
+        json={
+            "start_date": (now - timedelta(days=14)).isoformat(),
+            "end_date": now.isoformat(),
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["submitted_async"] is False
+    assert body["rows_examined"] == 1
+    assert body["rows_updated"] == 1
+    db_session.expire_all()
+    refreshed = crud_api_usage.get(db_session, id=row.id)
+    assert refreshed.estimated_cost == 0.01
+    assert refreshed.cost_source == "model_config"
+
+
+def test_reprice_endpoint_rejects_oversized_windows(client, db_session, test_user):
+    now = datetime.now(timezone.utc)
+    response = client.post(
+        REPRICE,
+        json={
+            "start_date": (now - timedelta(days=200)).isoformat(),
+            "end_date": now.isoformat(),
+        },
+    )
+    assert response.status_code == 422
+    assert "92 days" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# POST /cost/ledger-backfill/csv
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_csv_dry_run_reports_plan_and_writes_nothing(
+    client, db_session, test_user
+):
+    ai_model = _create_model(db_session, test_user)
+    row_a = _log_unpriced_row(db_session, test_user, ai_model, tokens=100)
+    row_b = _log_unpriced_row(db_session, test_user, ai_model, tokens=300)
+
+    response = _upload(client, apply=False)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["dry_run"] is True
+    assert body["rows_updated"] is None
+    assert body["start"] == "2026-08-05"
+    assert body["end"] == "2026-08-05"
+    assert body["eligible_rows"] == 2
+    assert body["rows_to_reconcile"] == 2
+    assert body["total_allocated"] == pytest.approx(0.30)
+    # The export's "Other" bucket is residual — reported, never allocated.
+    assert body["other_residual_usd"] == pytest.approx(0.05)
+    assert len(body["buckets"]) == 1
+    assert body["buckets"][0]["family"] == "acme-z9-mini-0731"
+
+    db_session.expire_all()
+    for row in (row_a, row_b):
+        refreshed = crud_api_usage.get(db_session, id=row.id)
+        assert refreshed.estimated_cost is None
+        assert refreshed.cost_source == "unpriced"
+
+
+def test_ledger_csv_apply_reconciles_pro_rata_and_is_idempotent(
+    client, db_session, test_user
+):
+    ai_model = _create_model(db_session, test_user)
+    row_a = _log_unpriced_row(db_session, test_user, ai_model, tokens=100)
+    row_b = _log_unpriced_row(db_session, test_user, ai_model, tokens=300)
+
+    response = _upload(client, apply=True)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["dry_run"] is False
+    assert body["rows_updated"] == 2
+
+    db_session.expire_all()
+    refreshed_a = crud_api_usage.get(db_session, id=row_a.id)
+    refreshed_b = crud_api_usage.get(db_session, id=row_b.id)
+    assert refreshed_a.cost_source == "reconciled"
+    assert refreshed_b.cost_source == "reconciled"
+    assert refreshed_a.estimated_cost == pytest.approx(0.075)
+    assert refreshed_b.estimated_cost == pytest.approx(0.225)
+    assert (refreshed_a.meta_data or {})["reconciled"]["ledger_day"] == "2026-08-05"
+
+    # Re-uploading the same export changes nothing: the rows are no longer
+    # unpriced, so they are no longer eligible.
+    second = _upload(client, apply=True)
+    assert second.status_code == 200
+    second_body = second.json()
+    assert second_body["eligible_rows"] == 0
+    assert second_body["rows_updated"] == 0
+    db_session.expire_all()
+    refreshed_a = crud_api_usage.get(db_session, id=row_a.id)
+    assert refreshed_a.estimated_cost == pytest.approx(0.075)
+
+
+def test_reconciled_costs_survive_a_full_reprice(client, db_session, test_user):
+    """Estimate-vs-reconciled separation end to end: after a ledger apply,
+    even only_unpriced=false repricing leaves the reconciled figures alone."""
+    ai_model = _create_model(
+        db_session,
+        test_user,
+        pricing={"input_price_per_1k": 0.01},
+    )
+    row = _log_unpriced_row(db_session, test_user, ai_model, tokens=100)
+    assert _upload(client, apply=True).status_code == 200
+    db_session.expire_all()
+    reconciled_cost = crud_api_usage.get(db_session, id=row.id).estimated_cost
+
+    response = client.post(
+        REPRICE,
+        json={
+            "start_date": "2026-08-01T00:00:00+00:00",
+            "end_date": "2026-08-10T00:00:00+00:00",
+            "only_unpriced": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["rows_skipped"] >= 1
+    db_session.expire_all()
+    refreshed = crud_api_usage.get(db_session, id=row.id)
+    assert refreshed.cost_source == "reconciled"
+    assert refreshed.estimated_cost == pytest.approx(reconciled_cost)
+
+
+def test_ledger_csv_rejects_non_explorer_exports(client, db_session, test_user):
+    response = _upload(client, csv_text="Date,Kind,Cost\n2026-08-05,usage,1\n")
+    assert response.status_code == 422
+    assert "missing column" in response.json()["detail"]
+
+
+def test_ledger_csv_unmatched_ledger_spend_is_reported_not_invented(
+    client, db_session, test_user
+):
+    """Ledger lines with no matching unpriced rows surface as residual."""
+    response = _upload(client)  # no usage rows exist at all
+    assert response.status_code == 200
+    body = response.json()
+    assert body["eligible_rows"] == 0
+    assert body["rows_to_reconcile"] == 0
+    assert body["unallocated_ledger"] == [
+        {"day": "2026-08-05", "family": "acme-z9-mini-0731", "amount_usd": 0.30}
+    ]

--- a/backend/tests/services/test_ledger_csv_backfill.py
+++ b/backend/tests/services/test_ledger_csv_backfill.py
@@ -105,14 +105,18 @@ def test_parse_explorer_csv_collects_malformed_rows_instead_of_aborting():
         "not-a-date,Acme Z9,0.10\n"
         "2026-08-05,Acme Z9,not-a-number\n"
         "2026-08-05,Acme Z9,-0.10\n"
+        "2026-08-05,Acme Z9,nan\n"
+        "2026-08-05,Acme Z9,inf\n"
         "2026-08-05,Acme Z9,0.10\n"
     )
     ledger = parse_explorer_csv(text)
     assert len(ledger.entries) == 1
-    assert len(ledger.skipped) == 3
+    assert len(ledger.skipped) == 5
     assert "line 2" in ledger.skipped[0]
     assert "line 3" in ledger.skipped[1]
     assert "negative" in ledger.skipped[2]
+    assert "non-finite" in ledger.skipped[3]
+    assert "non-finite" in ledger.skipped[4]
 
 
 def test_parsed_entries_allocate_against_display_named_rows():

--- a/backend/tests/services/test_ledger_csv_backfill.py
+++ b/backend/tests/services/test_ledger_csv_backfill.py
@@ -1,0 +1,263 @@
+"""Tests for the provider daily-ledger CSV backfill (Explore-export mode).
+
+All ledger figures here are synthetic fixtures shaped like an OpenRouter
+Activity -> Explore export (``date__day,model,total_usage``); no real
+provider data appears in this repository.
+"""
+
+import uuid
+from datetime import date, datetime
+
+import pytest
+
+from preloop.models.crud import crud_ai_model, crud_api_usage
+from preloop.services.ledger_backfill import (
+    UsageRowInfo,
+    alias_family,
+    apply_ledger_backfill,
+    display_name_family,
+    load_unpriced_rows,
+    parse_explorer_csv,
+    plan_ledger_allocation,
+)
+
+DAY = date(2026, 8, 5)
+
+
+# ---------------------------------------------------------------------------
+# display_name_family: the export names models for humans; our rows record
+# slugs. Both must land on the same family key.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("display_name", "family"),
+    [
+        # Dated display name matches the dated slug (dates are separate SKUs).
+        ("Acme Z9 Mini 0731", "acme-z9-mini-0731"),
+        ("Gemma 9.9 Flash Lite", "gemma-9.9-flash-lite"),
+        # Already-sluggy names pass through unchanged.
+        ("gpt-test-120b", "gpt-test-120b"),
+        # Extra whitespace collapses; case folds.
+        ("  Acme   Z9  ", "acme-z9"),
+        # Slugs with org paths defer to the slug normalizer.
+        ("acme/acme-z9-mini", "acme-z9-mini"),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_display_name_family(display_name, family):
+    assert display_name_family(display_name) == family
+
+
+def test_display_name_family_agrees_with_alias_family():
+    """The invariant the whole CSV mode rests on: display name and recorded
+    alias reduce to the same key."""
+    assert display_name_family("Acme Z9 Mini 0731") == alias_family(
+        "openrouter/acme/acme-z9-mini-0731"
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_explorer_csv: fixture CSV in the export's exact shape.
+# ---------------------------------------------------------------------------
+
+FIXTURE_CSV = (
+    "date__day,model,total_usage\n"
+    "2026-08-05,Acme Z9 Mini 0731,0.30\n"
+    "2026-08-05,Other,0.05\n"
+    "2026-08-06,Gemma 9.9 Flash,0.12\n"
+    "2026-08-06,Other,4.4e-16\n"
+)
+
+
+def test_parse_explorer_csv_splits_entries_and_other_bucket():
+    ledger = parse_explorer_csv(FIXTURE_CSV)
+
+    assert [(e.day, e.model, e.usage_usd) for e in ledger.entries] == [
+        (DAY, "acme-z9-mini-0731", pytest.approx(0.30)),
+        (date(2026, 8, 6), "gemma-9.9-flash", pytest.approx(0.12)),
+    ]
+    # "Other" names no model: reported per-day as residual, never allocated.
+    assert ledger.other_by_day == [
+        (DAY, pytest.approx(0.05)),
+        (date(2026, 8, 6), pytest.approx(4.4e-16)),
+    ]
+    assert ledger.other_total == pytest.approx(0.05, rel=1e-6)
+    assert ledger.skipped == []
+
+
+def test_parse_explorer_csv_tolerates_bom_blank_lines_and_extra_columns():
+    text = "﻿date__day,model,total_usage,requests\n2026-08-05,Acme Z9,0.10,42\n\n"
+    ledger = parse_explorer_csv(text)
+    assert len(ledger.entries) == 1
+    assert ledger.entries[0].model == "acme-z9"
+
+
+def test_parse_explorer_csv_rejects_wrong_header():
+    with pytest.raises(ValueError, match="missing column"):
+        parse_explorer_csv("Date,Kind,Cost\n2026-08-05,included,1\n")
+
+
+def test_parse_explorer_csv_collects_malformed_rows_instead_of_aborting():
+    text = (
+        "date__day,model,total_usage\n"
+        "not-a-date,Acme Z9,0.10\n"
+        "2026-08-05,Acme Z9,not-a-number\n"
+        "2026-08-05,Acme Z9,-0.10\n"
+        "2026-08-05,Acme Z9,0.10\n"
+    )
+    ledger = parse_explorer_csv(text)
+    assert len(ledger.entries) == 1
+    assert len(ledger.skipped) == 3
+    assert "line 2" in ledger.skipped[0]
+    assert "line 3" in ledger.skipped[1]
+    assert "negative" in ledger.skipped[2]
+
+
+def test_parsed_entries_allocate_against_display_named_rows():
+    """End-to-end (pure): a display-named ledger line finds slug-aliased
+    rows, pro-rata by tokens."""
+    ledger = parse_explorer_csv(
+        "date__day,model,total_usage\n2026-08-05,Acme Z9 Mini 0731,0.30\n"
+    )
+    rows = [
+        UsageRowInfo(
+            api_usage_id=uuid.uuid4(),
+            day=DAY,
+            model_alias="openrouter/acme/acme-z9-mini-0731",
+            weight_tokens=100,
+        ),
+        UsageRowInfo(
+            api_usage_id=uuid.uuid4(),
+            day=DAY,
+            model_alias="openrouter/acme/acme-z9-mini-0731",
+            weight_tokens=300,
+        ),
+    ]
+
+    plan = plan_ledger_allocation(ledger.entries, rows)
+
+    assert [a.allocated_cost for a in plan.allocations] == [
+        pytest.approx(0.075),
+        pytest.approx(0.225),
+    ]
+    assert not plan.unallocated_ledger
+    assert not plan.unmatched_rows
+
+
+# ---------------------------------------------------------------------------
+# DB round-trip: legacy pre-provenance rows are eligible; re-runs are inert.
+# ---------------------------------------------------------------------------
+
+
+def _create_model(db_session, test_user):
+    return crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Acme Z9 Mini",
+            "provider_name": "openrouter",
+            "model_identifier": "acme/acme-z9-mini-0731",
+            "api_endpoint": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-key",
+        },
+        account_id=test_user.account_id,
+    )
+
+
+def _log_row(db_session, test_user, ai_model, *, cost_source, estimated_cost, tokens):
+    row = crud_api_usage.log_gateway_request(
+        db_session,
+        endpoint="/openai/v1/chat/completions",
+        method="POST",
+        status_code=200,
+        duration=0.4,
+        account_id=str(test_user.account_id),
+        user_id=str(test_user.id),
+        ai_model_id=str(ai_model.id),
+        model_alias="openrouter/acme/acme-z9-mini-0731",
+        provider_name="openrouter",
+        prompt_tokens=tokens,
+        completion_tokens=0,
+        total_tokens=tokens,
+        estimated_cost=estimated_cost,
+        cost_source=cost_source,
+    )
+    row.timestamp = datetime(DAY.year, DAY.month, DAY.day, 12, 0, 0)
+    db_session.commit()
+    return row
+
+
+def test_legacy_rows_without_provenance_are_eligible_and_reconciled(
+    db_session, test_user
+):
+    """Rows from before the cost_source column existed (NULL/NULL) receive
+    ledger shares alongside explicitly 'unpriced' rows."""
+    ai_model = _create_model(db_session, test_user)
+    legacy = _log_row(
+        db_session,
+        test_user,
+        ai_model,
+        cost_source=None,
+        estimated_cost=None,
+        tokens=100,
+    )
+    tagged = _log_row(
+        db_session,
+        test_user,
+        ai_model,
+        cost_source="unpriced",
+        estimated_cost=None,
+        tokens=300,
+    )
+    # A catalog-priced row must stay untouched.
+    priced = _log_row(
+        db_session,
+        test_user,
+        ai_model,
+        cost_source="catalog",
+        estimated_cost=0.9,
+        tokens=100,
+    )
+
+    ledger = parse_explorer_csv(
+        "date__day,model,total_usage\n2026-08-05,Acme Z9 Mini 0731,0.40\n"
+    )
+    rows = load_unpriced_rows(
+        db_session,
+        account_id=str(test_user.account_id),
+        provider_name="openrouter",
+        start=DAY,
+        end=DAY,
+    )
+    assert {r.api_usage_id for r in rows} == {legacy.id, tagged.id}
+
+    plan = plan_ledger_allocation(ledger.entries, rows)
+    updated = apply_ledger_backfill(db_session, plan)
+    assert updated == 2
+
+    db_session.refresh(legacy)
+    db_session.refresh(tagged)
+    db_session.refresh(priced)
+    assert legacy.cost_source == "reconciled"
+    assert tagged.cost_source == "reconciled"
+    assert legacy.estimated_cost + tagged.estimated_cost == pytest.approx(0.40)
+    assert (legacy.meta_data or {})["reconciled"]["method"] == (
+        "ledger_daily_proportional"
+    )
+    assert priced.cost_source == "catalog"
+    assert priced.estimated_cost == 0.9
+
+    # Idempotency: a second run finds nothing eligible and writes nothing.
+    rows_again = load_unpriced_rows(
+        db_session,
+        account_id=str(test_user.account_id),
+        provider_name="openrouter",
+        start=DAY,
+        end=DAY,
+    )
+    assert rows_again == []
+    plan_again = plan_ledger_allocation(ledger.entries, rows_again)
+    assert apply_ledger_backfill(db_session, plan_again) == 0
+    db_session.refresh(tagged)
+    assert tagged.cost_source == "reconciled"

--- a/backend/tests/services/test_usage_repricing.py
+++ b/backend/tests/services/test_usage_repricing.py
@@ -436,3 +436,114 @@ def test_reprice_single_row_does_not_double_count_credits_shape(db_session, test
     db_session.refresh(row)
     assert row.cost_source == "provider"
     assert row.estimated_cost == pytest.approx(0.000001979964)
+
+
+def test_reprice_examines_zero_cost_rows_tagged_unpriced(db_session, test_user):
+    """A row tagged 'unpriced' but carrying a stray $0 cost (legacy write) is
+    selected by only_unpriced and healed — previously invisible because the
+    filter matched NULL costs only."""
+    ai_model = _create_model(
+        db_session,
+        test_user,
+        pricing={"input_price_per_1k": 0.01, "output_price_per_1k": 0.02},
+    )
+    row = crud_api_usage.log_gateway_request(
+        db_session,
+        endpoint="/openai/v1/chat/completions",
+        method="POST",
+        status_code=200,
+        duration=0.4,
+        account_id=str(test_user.account_id),
+        user_id=str(test_user.id),
+        ai_model_id=str(ai_model.id),
+        model_alias="openai/gpt-5",
+        provider_name="openai",
+        prompt_tokens=1000,
+        completion_tokens=100,
+        total_tokens=1100,
+        estimated_cost=0.0,
+        cost_source="unpriced",
+    )
+    start, end = _window()
+
+    result = reprice_gateway_usage(
+        db_session, account_id=test_user.account_id, start=start, end=end
+    )
+
+    assert result.rows_examined == 1
+    assert result.rows_updated == 1
+    db_session.refresh(row)
+    assert row.estimated_cost == 0.012
+    assert row.cost_source == "model_config"
+
+
+@pytest.mark.parametrize("source", ["provider", "reconciled", "imported"])
+def test_reprice_never_overwrites_provider_side_actuals(db_session, test_user, source):
+    """provider/reconciled/imported costs are actuals; even a full
+    only_unpriced=False recompute must not replace them with estimates."""
+    ai_model = _create_model(
+        db_session,
+        test_user,
+        pricing={"input_price_per_1k": 0.01, "output_price_per_1k": 0.02},
+    )
+    row = crud_api_usage.log_gateway_request(
+        db_session,
+        endpoint="/openai/v1/chat/completions",
+        method="POST",
+        status_code=200,
+        duration=0.4,
+        account_id=str(test_user.account_id),
+        user_id=str(test_user.id),
+        ai_model_id=str(ai_model.id),
+        model_alias="openai/gpt-5",
+        provider_name="openai",
+        prompt_tokens=1000,
+        completion_tokens=100,
+        total_tokens=1100,
+        estimated_cost=0.5,
+        cost_source=source,
+    )
+    start, end = _window()
+
+    result = reprice_gateway_usage(
+        db_session,
+        account_id=test_user.account_id,
+        start=start,
+        end=end,
+        only_unpriced=False,
+    )
+
+    assert result.rows_skipped >= 1
+    db_session.refresh(row)
+    assert row.estimated_cost == 0.5
+    assert row.cost_source == source
+
+
+@pytest.mark.parametrize("source", ["provider", "reconciled", "imported"])
+def test_reprice_single_row_refuses_protected_sources(db_session, test_user, source):
+    """The single-row heal path honors the same protection as the bulk pass."""
+    ai_model = _create_model(
+        db_session, test_user, pricing={"input_price_per_1k": 0.01}
+    )
+    row = crud_api_usage.log_gateway_request(
+        db_session,
+        endpoint="/openai/v1/chat/completions",
+        method="POST",
+        status_code=200,
+        duration=0.4,
+        account_id=str(test_user.account_id),
+        user_id=str(test_user.id),
+        ai_model_id=str(ai_model.id),
+        model_alias="openai/gpt-5",
+        provider_name="openai",
+        prompt_tokens=1000,
+        completion_tokens=100,
+        total_tokens=1100,
+        estimated_cost=0.5,
+        cost_source=source,
+    )
+
+    assert usage_repricing.reprice_single_row(db_session, api_usage_id=row.id) is False
+    db_session.refresh(row)
+    assert row.estimated_cost == 0.5
+    assert row.cost_source == source

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1036,11 +1036,13 @@ export interface CostReconciliationResponse {
 
 export interface RepriceResponse {
   submitted_async: boolean;
-  rows_examined: number;
-  rows_updated: number;
-  rows_skipped: number;
-  cost_before: number;
-  cost_after: number;
+  // Null when submitted_async: nothing was scanned in-request, which is
+  // different from "the window contained 0 rows".
+  rows_examined: number | null;
+  rows_updated: number | null;
+  rows_skipped: number | null;
+  cost_before: number | null;
+  cost_after: number | null;
   dry_run: boolean;
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6292,6 +6292,101 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/cost/reprice:
+    post:
+      tags:
+      - Cost Analytics
+      - Cost Analytics
+      summary: Reprice Account Gateway Usage
+      description: 'Re-price historical gateway usage synchronously and report real
+        counts.
+
+
+        Unlike the billing plugin''s ``/billing/cost/reprice`` (which dispatches
+
+        windows over 7 days to a background worker and acknowledges with empty
+
+        counters), this endpoint always scans in-request — keyset-paginated, so
+
+        an operator backfilling weeks of history gets actual examined/updated
+
+        numbers instead of an ambiguous async ack. Budget-spend buckets are never
+
+        rewritten; provider-side actuals (``provider``/``reconciled``/
+
+        ``imported``) and ``subscription`` rows are never touched.'
+      operationId: reprice_account_gateway_usage_api_v1_cost_reprice_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RepriceRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepriceResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /api/v1/cost/ledger-backfill/csv:
+    post:
+      tags:
+      - Cost Analytics
+      - Cost Analytics
+      summary: Backfill From Provider Ledger Csv
+      description: 'Reconcile unpriced gateway rows against a provider daily-usage
+        export.
+
+
+        Distributes each (day x model) ledger total across this account''s
+
+        still-unpriced gateway rows for that day — pro-rata by tokens, equal
+
+        split when the bucket recorded no tokens — and tags them
+
+        ``cost_source=''reconciled''`` so provider actuals never mix with catalog
+
+        estimates. Only rows without a resolved cost are ever touched, which
+
+        also makes re-running the same export idempotent. The export''s "Other"
+
+        bucket is reported as an unallocatable residual, never distributed.
+
+
+        Defaults to a dry run that returns the full allocation plan; pass
+
+        ``apply=true`` to persist it.'
+      operationId: backfill_from_provider_ledger_csv_api_v1_cost_ledger_backfill_csv_post
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Body_backfill_from_provider_ledger_csv_api_v1_cost_ledger_backfill_csv_post'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerBackfillResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
   /api/v1/usage/import:
     post:
       tags:
@@ -11071,6 +11166,41 @@ components:
       - by_status
       title: BatchRollup
       description: Aggregate metrics over the executions of one batch.
+    Body_backfill_from_provider_ledger_csv_api_v1_cost_ledger_backfill_csv_post:
+      properties:
+        file:
+          type: string
+          contentMediaType: application/octet-stream
+          title: File
+          description: 'OpenRouter Activity -> Explore daily export (columns: date__day,
+            model, total_usage)'
+        provider:
+          type: string
+          title: Provider
+          default: openrouter
+        start:
+          anyOf:
+          - type: string
+            format: date
+          - type: 'null'
+          title: Start
+          description: 'First UTC day (inclusive); default: CSV min.'
+        end:
+          anyOf:
+          - type: string
+            format: date
+          - type: 'null'
+          title: End
+          description: 'Last UTC day (inclusive); default: CSV max.'
+        apply:
+          type: boolean
+          title: Apply
+          description: Persist the allocation. Default is a dry run.
+          default: false
+      type: object
+      required:
+      - file
+      title: Body_backfill_from_provider_ledger_csv_api_v1_cost_ledger_backfill_csv_post
     Body_diff_policy_api_v1_policies_diff_post:
       properties:
         file:
@@ -13623,6 +13753,156 @@ components:
       type: object
       title: IssueUpdate
       description: Model for updating an issue.
+    LedgerBackfillBucket:
+      properties:
+        day:
+          type: string
+          format: date
+          title: Day
+        family:
+          type: string
+          title: Family
+        ledger_total:
+          type: number
+          title: Ledger Total
+        row_count:
+          type: integer
+          title: Row Count
+        allocated_total:
+          type: number
+          title: Allocated Total
+        ledger_models:
+          items:
+            type: string
+          type: array
+          title: Ledger Models
+      type: object
+      required:
+      - day
+      - family
+      - ledger_total
+      - row_count
+      - allocated_total
+      title: LedgerBackfillBucket
+      description: One (day x model family) allocation bucket of a ledger backfill.
+    LedgerBackfillResidual:
+      properties:
+        day:
+          type: string
+          format: date
+          title: Day
+        family:
+          type: string
+          title: Family
+        amount_usd:
+          type: number
+          title: Amount Usd
+      type: object
+      required:
+      - day
+      - family
+      - amount_usd
+      title: LedgerBackfillResidual
+      description: Ledger spend with no eligible usage rows to receive it.
+    LedgerBackfillResponse:
+      properties:
+        dry_run:
+          type: boolean
+          title: Dry Run
+          default: true
+        provider:
+          type: string
+          title: Provider
+        start:
+          type: string
+          format: date
+          title: Start
+        end:
+          type: string
+          format: date
+          title: End
+        ledger_entries:
+          type: integer
+          title: Ledger Entries
+          default: 0
+        eligible_rows:
+          type: integer
+          title: Eligible Rows
+          default: 0
+        rows_to_reconcile:
+          type: integer
+          title: Rows To Reconcile
+          default: 0
+        total_allocated:
+          type: number
+          title: Total Allocated
+          default: 0.0
+        rows_updated:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rows Updated
+        other_residual_usd:
+          type: number
+          title: Other Residual Usd
+          default: 0.0
+        buckets:
+          items:
+            $ref: '#/components/schemas/LedgerBackfillBucket'
+          type: array
+          title: Buckets
+        unallocated_ledger:
+          items:
+            $ref: '#/components/schemas/LedgerBackfillResidual'
+          type: array
+          title: Unallocated Ledger
+        unmatched_rows:
+          items:
+            $ref: '#/components/schemas/LedgerBackfillUnmatched'
+          type: array
+          title: Unmatched Rows
+        skipped_csv_rows:
+          items:
+            type: string
+          type: array
+          title: Skipped Csv Rows
+      type: object
+      required:
+      - provider
+      - start
+      - end
+      title: LedgerBackfillResponse
+      description: 'Outcome (or dry-run preview) of a provider daily-ledger backfill.
+
+
+        ``rows_updated`` is ``None`` on a dry run — nothing was written, which is
+
+        different from "wrote 0 rows". ``other_residual_usd`` is the export''s
+
+        "Other" bucket inside the window: the provider does not say which models
+
+        it covers, so that spend is reported but never allocated and the matching
+
+        rows stay unpriced.'
+    LedgerBackfillUnmatched:
+      properties:
+        day:
+          type: string
+          format: date
+          title: Day
+        family:
+          type: string
+          title: Family
+        row_count:
+          type: integer
+          title: Row Count
+      type: object
+      required:
+      - day
+      - family
+      - row_count
+      title: LedgerBackfillUnmatched
+      description: Unpriced usage rows whose family had no ledger spend that day.
     LoginRequest:
       properties:
         username:
@@ -15955,6 +16235,79 @@ components:
       - challenge_token
       title: RegistrationVerifyRequest
       description: Authenticator response for the registration ceremony.
+    RepriceRequest:
+      properties:
+        start_date:
+          type: string
+          format: date-time
+          title: Start Date
+        end_date:
+          type: string
+          format: date-time
+          title: End Date
+        only_unpriced:
+          type: boolean
+          title: Only Unpriced
+          default: true
+        dry_run:
+          type: boolean
+          title: Dry Run
+          default: false
+      type: object
+      required:
+      - start_date
+      - end_date
+      title: RepriceRequest
+      description: Request body for re-pricing historical gateway usage.
+    RepriceResponse:
+      properties:
+        submitted_async:
+          type: boolean
+          title: Submitted Async
+          default: false
+        rows_examined:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rows Examined
+        rows_updated:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rows Updated
+        rows_skipped:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rows Skipped
+        cost_before:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Cost Before
+        cost_after:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Cost After
+        dry_run:
+          type: boolean
+          title: Dry Run
+          default: false
+      type: object
+      title: RepriceResponse
+      description: 'Result of a repricing run (or async submission).
+
+
+        The counters are ``None`` — not ``0`` — when the run was dispatched to a
+
+        background worker (``submitted_async=True``): nothing has been scanned in
+
+        this request, so reporting zeros would be indistinguishable from "the
+
+        window really contained no rows" (the exact confusion behind "reprice
+
+        examined 0 rows" on large windows).'
     RollbackRequest:
       properties:
         preview_only:

--- a/scripts/backfill_openrouter_ledger.py
+++ b/scripts/backfill_openrouter_ledger.py
@@ -12,16 +12,28 @@ Defaults to a DRY RUN: it prints, per day and model family, the ledger
 total, our eligible row count and the allocation sum, plus the per-flow-
 execution cost deltas — and writes nothing until ``--apply`` is passed.
 
-The OpenRouter key is read from the OPENROUTER_ACTIVITY_KEY environment
-variable, never from code or the database. Note the activity endpoint
-requires a management/provisioning key and only serves the last 30
-completed UTC days.
+Two ledger sources:
+
+- API mode (default): the OpenRouter key is read from the
+  OPENROUTER_ACTIVITY_KEY environment variable, never from code or the
+  database. Note the activity endpoint requires a management/provisioning
+  key and only serves the last 30 completed UTC days.
+- CSV mode (``--csv``): an OpenRouter Activity -> Explore daily export
+  (columns ``date__day,model,total_usage``), e.g. provided by the account
+  owner. Needs no API key and has no horizon limit. The export's "Other"
+  bucket names no model, so its spend is reported as a residual and never
+  allocated; matching rows stay unpriced.
 
 Usage:
     OPENROUTER_ACTIVITY_KEY=... python scripts/backfill_openrouter_ledger.py \\
         --account-id <uuid> --start 2026-08-04 --end 2026-08-11
 
-    # After reviewing the dry-run output:
+    # From a provider-side Explore export instead of the API:
+    python scripts/backfill_openrouter_ledger.py \\
+        --account-id <uuid> --start 2026-08-04 --end 2026-08-18 \\
+        --csv /path/to/explore_export.csv
+
+    # After reviewing the dry-run output, add --apply to either form:
     OPENROUTER_ACTIVITY_KEY=... python scripts/backfill_openrouter_ledger.py \\
         --account-id <uuid> --start 2026-08-04 --end 2026-08-11 --apply
 
@@ -46,6 +58,7 @@ from preloop.services.ledger_backfill import (
     apply_ledger_backfill,
     fetch_openrouter_activity,
     load_unpriced_rows,
+    parse_explorer_csv,
     plan_ledger_allocation,
 )
 
@@ -77,25 +90,47 @@ def _parse_day(value: str, label: str) -> date:
     default=False,
     help="Persist the allocation. Without this the run is a dry run.",
 )
-def main(account_id: str, start_str: str, end_str: str, apply_changes: bool) -> None:
+@click.option(
+    "--csv",
+    "csv_path",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help=(
+        "Use an OpenRouter Activity -> Explore daily export "
+        "(date__day,model,total_usage) as the ledger instead of calling the "
+        "activity API. No API key needed and no 30-day horizon: the export "
+        "carries its own history. The 'Other' bucket is reported as an "
+        "unallocatable residual, never distributed."
+    ),
+)
+def main(
+    account_id: str,
+    start_str: str,
+    end_str: str,
+    apply_changes: bool,
+    csv_path: str | None,
+) -> None:
     """Reconcile unpriced OpenRouter usage against the provider's daily ledger."""
     start = _parse_day(start_str, "start")
     end = _parse_day(end_str, "end")
     if end < start:
         raise click.UsageError("--end must not be before --start.")
-    if (end - start).days > 31:
-        raise click.UsageError(
-            "Window exceeds 31 days; the activity ledger only serves the "
-            "last 30 completed UTC days."
-        )
     today_utc = datetime.now(timezone.utc).date()
-    oldest_served = today_utc - timedelta(days=30)
-    if start < oldest_served:
-        raise click.UsageError(
-            f"--start {start.isoformat()} is older than the activity "
-            f"ledger's horizon ({oldest_served.isoformat()}: the API serves "
-            "only the last 30 completed UTC days). Narrow the window."
-        )
+    if csv_path is None:
+        # API mode only: the activity endpoint serves a rolling 30-day window.
+        if (end - start).days > 31:
+            raise click.UsageError(
+                "Window exceeds 31 days; the activity ledger only serves the "
+                "last 30 completed UTC days. Use --csv for older history."
+            )
+        oldest_served = today_utc - timedelta(days=30)
+        if start < oldest_served:
+            raise click.UsageError(
+                f"--start {start.isoformat()} is older than the activity "
+                f"ledger's horizon ({oldest_served.isoformat()}: the API serves "
+                "only the last 30 completed UTC days). Narrow the window or "
+                "pass an Explore export via --csv."
+            )
     if end >= today_utc:
         click.echo(
             f"Note: {end.isoformat()} is not a completed UTC day yet; its "
@@ -103,17 +138,44 @@ def main(account_id: str, start_str: str, end_str: str, apply_changes: bool) -> 
             "safe to re-run later (only still-unpriced rows are touched)."
         )
 
-    api_key = os.environ.get("OPENROUTER_ACTIVITY_KEY", "").strip()
-    if not api_key:
-        raise click.UsageError(
-            "Set OPENROUTER_ACTIVITY_KEY to the OpenRouter key to query the "
-            "activity ledger with (a management/provisioning key)."
+    if csv_path is not None:
+        with open(csv_path, encoding="utf-8-sig") as handle:
+            explorer = parse_explorer_csv(handle.read())
+        for reason in explorer.skipped:
+            click.echo(f"Skipped CSV row: {reason}")
+        in_window = [e for e in explorer.entries if start <= e.day <= end]
+        outside = len(explorer.entries) - len(in_window)
+        if outside:
+            click.echo(
+                f"Ignoring {outside} ledger row(s) outside "
+                f"{start.isoformat()}..{end.isoformat()}."
+            )
+        other_in_window = sum(
+            usd for day, usd in explorer.other_by_day if start <= day <= end
         )
+        if other_in_window > 0:
+            click.echo(
+                f"'Other' bucket in window: ${other_in_window:.6f} — the export "
+                "does not say which models this covers, so it is left "
+                "unallocated (matching rows stay unpriced)."
+            )
+        ledger_entries = in_window
+        click.echo(f"Ledger rows from CSV: {len(ledger_entries)}")
+    else:
+        api_key = os.environ.get("OPENROUTER_ACTIVITY_KEY", "").strip()
+        if not api_key:
+            raise click.UsageError(
+                "Set OPENROUTER_ACTIVITY_KEY to the OpenRouter key to query "
+                "the activity ledger with (a management/provisioning key), or "
+                "pass an Explore export via --csv."
+            )
 
-    days = [start + timedelta(days=offset) for offset in range((end - start).days + 1)]
-    click.echo(f"Fetching OpenRouter activity for {len(days)} day(s)…")
-    ledger_entries = fetch_openrouter_activity(api_key, days)
-    click.echo(f"Ledger rows: {len(ledger_entries)}")
+        days = [
+            start + timedelta(days=offset) for offset in range((end - start).days + 1)
+        ]
+        click.echo(f"Fetching OpenRouter activity for {len(days)} day(s)…")
+        ledger_entries = fetch_openrouter_activity(api_key, days)
+        click.echo(f"Ledger rows: {len(ledger_entries)}")
 
     db = next(get_db_session())
     try:


### PR DESCRIPTION
## Problem

Accounts with pre-catalog gateway history can be left with large blocks of UNPRICED usage that neither the reprice endpoint nor reconciliation ever heals:

1. **"Examined 0 rows" on large windows.** `POST /billing/cost/reprice` (billing plugin) dispatches windows > 7 days to a background worker and acknowledges with `RepriceResponse` whose counters default to `0` — indistinguishable from "the window contained no rows". The publish ack is also unchecked, so "scheduled" can silently mean "dropped", and the worker's result is only visible in logs.
2. **Row-selection gaps.** `only_unpriced` repricing selected `estimated_cost IS NULL` only, missing rows tagged `cost_source='unpriced'` that carry a stray stored cost (legacy \$0 writes). The ledger backfill required `cost_source='unpriced'` exactly, missing legacy rows recorded before cost provenance existed (NULL/NULL).
3. **Estimates could overwrite actuals.** A full `only_unpriced=false` recompute skipped only `subscription` rows — it would replace `provider`-reported and ledger-`reconciled` costs with catalog estimates.
4. **No offline ledger source.** Historical models (dated marketplace SKUs, Auto-Router traffic) are not catalog-priceable even on re-examination; the provider's daily ledger is the only honest source. The existing backfill needs a management API key and only serves the last 30 completed UTC days.

## Changes

- `RepriceResponse` counters are nullable: async submissions serialize `null`, never fake zeros (console already branches on `submitted_async`).
- New **`POST /api/v1/cost/reprice`** (permission `manage_budgets`): always synchronous, keyset-paginated, up to 92 days per call — real examined/updated counters for operator backfills.
- Broadened unpriced-row selection on both the reprice and ledger-backfill paths (see above); apply-time re-check mirrors the same eligibility.
- `PROTECTED_COST_SOURCES = {subscription, provider, reconciled, imported}`: repricing (bulk + single-row) never touches them, in either mode.
- New **provider daily-ledger CSV backfill** — `POST /api/v1/cost/ledger-backfill/csv` (permission `manage_budgets`, multipart upload, `apply=false` dry-run by default) and `scripts/backfill_openrouter_ledger.py --csv` (operator path, `--apply` gated):
  - Accepts the OpenRouter Activity → Explore daily export (`date__day,model,total_usage`); strict header validation, malformed rows collected and reported, BOM/extra columns tolerated.
  - Display names are matched to recorded aliases via a shared family key (`display_name_family` ∘ `alias_family`).
  - Each (day × model) total is distributed across that account's still-unpriced rows for the day, pro-rata by tokens, equal split when the bucket recorded no tokens.
  - The **"Other"** bucket names no model: reported as an unallocatable residual, never distributed; unmatched ledger spend and unmatched rows are likewise reported, never invented.
  - Allocated rows get `cost_source='reconciled'` + `meta_data["reconciled"]` marker; re-runs are idempotent (only still-unpriced rows are ever written); execution cost rollups are resynced.

## Tests

- `tests/services/test_ledger_csv_backfill.py` (14): matching rules, parser, allocation, DB round-trip incl. legacy-row eligibility and idempotency.
- `tests/endpoints/test_cost_reprice_backfill.py` (7): sync reprice counters + window cap; CSV dry-run vs apply, idempotent re-apply, reconciled costs surviving a full reprice, header validation, residual reporting.
- `tests/services/test_usage_repricing.py` (+7): zero-cost unpriced rows examined; protected sources refused in bulk + single-row paths.
- All fixture data is synthetic. `ruff check`/`format` clean; `openapi.yaml` regenerated (additive).
<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Additive operator-facing backfill tooling with strong test coverage and no security concerns; the sole input-validation finding (non-finite CSV totals) is now resolved.
>
> **Overview**
> Fixes unpriced-cost healing gaps by broadening row selection (legacy `unpriced`/NULL-provenance rows), protecting provider-side actuals from estimate overwrites, adding a synchronous `POST /api/v1/cost/reprice` endpoint with real counters, and a provider daily-ledger CSV backfill (dry-run by default, idempotent, pro-rata allocation).
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 671dbeb. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->