### PR TITLE
fix: skip the console hop for OSS TLS and Helm gateway routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Update now? [y/N]" when stdin is a TTY and the running binary is
   writable. If the binary cannot be replaced, the CLI stays silent (no
   nag, no sudo hint).
+- **Gateway overhead script**: `scripts/measure_gateway_overhead.py`
+  (Python 3 stdlib) times streaming TTFB and time-to-close through the
+  gateway versus an optional same-model direct upstream. Keys stay in
+  the environment. See the script docstring for the env vars.
 - **`preloop flow trigger`**: CI-native trigger for an existing flow by id
   or name. Posts to `POST /api/v1/flows/{flow_id}/trigger`, accepts
   `--payload JSON` or `--payload -` (stdin), and waits for a terminal
@@ -100,6 +104,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Model gateway stream close**: the gateway now yields the terminal SSE
+  event (`message_stop` / `[DONE]`) before writing the usage row, so
+  bookkeeping no longer holds the last event on the client-visible stream.
+- **OSS TLS proxy skips the console hop for the model gateway**:
+  `/openai/`, `/anthropic/`, and `/gemini/` now proxy straight to the
+  gateway container instead of hairpinning through console nginx. Re-run
+  `scripts/measure_gateway_overhead.py` against a public install to
+  confirm the TTFB delta.
 - **Qwen / Model Studio catalog**: the keyless picker now lists current chat
   models (`qwen3.8-max` first) instead of `qwen-plus` / `qwen-turbo` /
   `qwen-max` / `qwq-32b-preview`. Live `/models` listing honors a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Model gateway stream close**: the gateway now yields the terminal SSE
   event (`message_stop` / `[DONE]`) before writing the usage row, so
   bookkeeping no longer holds the last event on the client-visible stream.
+  A client that disconnects after that terminal event is recorded as 200
+  with captured usage, not 499/partial.
 - **OSS TLS proxy skips the console hop for the model gateway**:
   `/openai/`, `/anthropic/`, and `/gemini/` now proxy straight to the
   gateway container instead of hairpinning through console nginx. Re-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,9 +109,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bookkeeping no longer holds the last event on the client-visible stream.
   A client that disconnects after that terminal event is recorded as 200
   with captured usage, not 499/partial.
-- **OSS TLS proxy skips the console hop for the model gateway**:
-  `/openai/`, `/anthropic/`, and `/gemini/` now proxy straight to the
-  gateway container instead of hairpinning through console nginx. Re-run
+- **OSS TLS proxy and Helm ingress skip the console hop for the model
+  gateway**: `/openai`, `/anthropic`, and `/gemini` now proxy straight to
+  the gateway instead of hairpinning through console nginx. Helm does
+  this with a second Ingress on the same host so SSE buffering can stay
+  off on those prefixes without changing `/`. Usage accounting is
+  unchanged: the gateway process still writes the request row. Re-run
   `scripts/measure_gateway_overhead.py` against a public install to
   confirm the TTFB delta.
 - **Qwen / Model Studio catalog**: the keyless picker now lists current chat

--- a/README.md
+++ b/README.md
@@ -275,6 +275,20 @@ curl -fsSL https://preloop.ai/install/oss | \
 
 `preloop.example.com` must already resolve to the machine, and ports 80/443 must be free. Certificates are only requested for public DNS names — `localhost`, bare IPs and `.local` hosts are left on plain HTTP. Useful knobs: `PRELOOP_TLS_STAGING=1` (rehearse against the Let's Encrypt staging CA), `PRELOOP_SKIP_TLS=1` (keep the https URL but terminate TLS yourself, e.g. behind a load balancer), `PRELOOP_SKIP_SMTP=1` (never prompt for email).
 
+On a public TLS install, `/openai/`, `/anthropic/`, and `/gemini/` go from the edge proxy straight to the gateway. To measure the hop your agents actually see:
+
+```bash
+export PRELOOP_DISABLE_TELEMETRY=true
+export PRELOOP_BASE_URL=https://preloop.example.com
+export PRELOOP_API_KEY=...          # a gateway-capable API key
+export PRELOOP_MODEL=...            # the alias the gateway expects
+# optional same-model pair (bypass Preloop):
+# export DIRECT_BASE_URL=... DIRECT_API_KEY=... DIRECT_MODEL=...
+python3 scripts/measure_gateway_overhead.py --n 30 --json /tmp/gateway-overhead.json
+```
+
+The script is stdlib only. It prints p50/p95 time-to-first-SSE-byte and time-to-stream-close for the gateway path, and the delta when `DIRECT_*` is set.
+
 **Email is not optional in practice**: approval requests, invitations and password resets are delivered by email, so an instance without SMTP cannot notify approvers. Everything the installer writes lives in `~/.preloop-oss/.env` — edit it and run `docker compose up -d` to change any setting later.
 
 **Passkeys (WebAuthn)**: passkey sign-in is enabled by default; set `PASSKEYS_ENABLED=false` to turn it off. Behind a proxy or on a non-standard domain setup, pin the relying party and origin explicitly with `WEBAUTHN_RP_ID` (the registrable domain, e.g. `preloop.example.com`) and `WEBAUTHN_ORIGIN` (e.g. `https://preloop.example.com`); by default both are derived from the request. `WEBAUTHN_CHALLENGE_RATE_LIMIT` (default `30`) caps challenge requests per IP per minute.

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -139,7 +139,11 @@ _ANTHROPIC_PASSTHROUGH_TIMEOUT_SECONDS = 600
 # when the caller has no running loop (sync StreamingResponse / tests).
 # Matches the billing plugin entitlements notify pattern: create_task when
 # a loop exists, otherwise a single-worker executor. wait=False so an
-# in-flight publish cannot block interpreter exit.
+# in-flight publish cannot block interpreter exit. Cap pending work and
+# drop-on-full: started events are telemetry, not billing.
+_GATEWAY_STARTED_EMIT_MAX_PENDING = 32
+_GATEWAY_STARTED_EMIT_PENDING = 0
+_GATEWAY_STARTED_EMIT_PENDING_LOCK = threading.Lock()
 _GATEWAY_STARTED_EMIT_EXECUTOR = ThreadPoolExecutor(
     max_workers=1, thread_name_prefix="gateway-started-emit"
 )
@@ -194,9 +198,33 @@ def _emit_account_event_nonblocking(event: Dict[str, Any]) -> None:
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        _GATEWAY_STARTED_EMIT_EXECUTOR.submit(emit_account_event, event)
+        _submit_gateway_started_emit(event)
         return
     emit_account_event(event)
+
+
+def _submit_gateway_started_emit(event: Dict[str, Any]) -> None:
+    """Queue a started-event publish, dropping it if the worker is backed up."""
+    global _GATEWAY_STARTED_EMIT_PENDING
+    with _GATEWAY_STARTED_EMIT_PENDING_LOCK:
+        if _GATEWAY_STARTED_EMIT_PENDING >= _GATEWAY_STARTED_EMIT_MAX_PENDING:
+            logger.debug("Dropping gateway request-started event; emit queue full")
+            return
+        _GATEWAY_STARTED_EMIT_PENDING += 1
+
+    def _run() -> None:
+        global _GATEWAY_STARTED_EMIT_PENDING
+        try:
+            emit_account_event(event)
+        finally:
+            with _GATEWAY_STARTED_EMIT_PENDING_LOCK:
+                _GATEWAY_STARTED_EMIT_PENDING -= 1
+
+    try:
+        _GATEWAY_STARTED_EMIT_EXECUTOR.submit(_run)
+    except RuntimeError:
+        with _GATEWAY_STARTED_EMIT_PENDING_LOCK:
+            _GATEWAY_STARTED_EMIT_PENDING -= 1
 
 
 def _supports_ambient_provider_credentials(ai_model: AIModel) -> bool:
@@ -1295,6 +1323,7 @@ class OpenAIGatewayService:
             emitted_text_start = False
             emitted_text_stop = False
             recorded = False
+            terminal_sent = False
             tool_call_states: Dict[int, Dict[str, Any]] = {}
             content_index = 0
 
@@ -1524,9 +1553,10 @@ class OpenAIGatewayService:
                     },
                 )
                 # Terminal event first so usage bookkeeping cannot hold
-                # message_stop on the client-visible stream. Recording is
-                # fail-open (_record_gateway_request); GeneratorExit at this
-                # yield still bills via the finally abort path.
+                # message_stop on the client-visible stream. Mark complete
+                # before the yield so a client close at message_stop records
+                # 200 with captured usage, not 499/partial.
+                terminal_sent = True
                 yield self._anthropic_sse_event(
                     "message_stop",
                     {"type": "message_stop"},
@@ -1595,6 +1625,7 @@ class OpenAIGatewayService:
                         usage_details=final_usage_details or final_usage,
                         budget_result=budget_result,
                         accumulated_output_text="".join(assistant_parts),
+                        stream_completed=terminal_sent,
                     )
 
         return self._observe_stream(
@@ -1709,6 +1740,7 @@ class OpenAIGatewayService:
             response_id: Optional[str] = None
             created_at: Optional[int] = None
             recorded = False
+            terminal_sent = False
             tool_call_states: Dict[int, Dict[str, Any]] = {}
             try:
                 for chunk in upstream_stream:
@@ -1806,9 +1838,10 @@ class OpenAIGatewayService:
                     "usage": final_usage,
                 }
                 # Terminal event first so usage bookkeeping cannot hold
-                # [DONE] on the client-visible stream. Recording is
-                # fail-open (_record_gateway_request); GeneratorExit at this
-                # yield still bills via the finally abort path.
+                # [DONE] on the client-visible stream. Mark complete before
+                # the yield so a client close at [DONE] records 200 with
+                # captured usage, not 499/partial.
+                terminal_sent = True
                 yield self._sse_done()
                 self._record_gateway_request(
                     endpoint="/openai/v1/chat/completions",
@@ -1875,6 +1908,7 @@ class OpenAIGatewayService:
                         usage_details=final_usage_details or final_usage,
                         budget_result=budget_result,
                         accumulated_output_text="".join(assistant_parts),
+                        stream_completed=terminal_sent,
                     )
 
         return self._observe_stream(
@@ -1973,6 +2007,7 @@ class OpenAIGatewayService:
             final_usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
             final_usage_details: Dict[str, Any] = {}
             recorded = False
+            terminal_sent = False
             text_output_index: Optional[int] = None
             output_items: List[Dict[str, Any]] = []
             tool_call_states: Dict[int, Dict[str, Any]] = {}
@@ -2226,9 +2261,10 @@ class OpenAIGatewayService:
                     }
                 )
                 # Terminal event first so usage bookkeeping cannot hold
-                # [DONE] on the client-visible stream. Recording is
-                # fail-open (_record_gateway_request); GeneratorExit at this
-                # yield still bills via the finally abort path.
+                # [DONE] on the client-visible stream. Mark complete before
+                # the yield so a client close at [DONE] records 200 with
+                # captured usage, not 499/partial.
+                terminal_sent = True
                 yield self._sse_done()
                 self._record_gateway_request(
                     endpoint="/openai/v1/responses",
@@ -2293,6 +2329,7 @@ class OpenAIGatewayService:
                         usage_details=final_usage_details or final_usage,
                         budget_result=budget_result,
                         accumulated_output_text="".join(assistant_parts),
+                        stream_completed=terminal_sent,
                     )
 
         return self._observe_stream(
@@ -3402,6 +3439,7 @@ class OpenAIGatewayService:
             )
             text_output_index = output_items.index(text_item) if text_item else None
             recorded = False
+            terminal_sent = False
             try:
                 yield self._sse_event(
                     {
@@ -3478,7 +3516,10 @@ class OpenAIGatewayService:
                     }
                 )
                 # Terminal event first so usage bookkeeping cannot hold
-                # [DONE] on the client-visible stream.
+                # [DONE] on the client-visible stream. Mark complete before
+                # the yield so a client close at [DONE] records 200 with
+                # captured usage, not 499/partial.
+                terminal_sent = True
                 yield "data: [DONE]\n\n"
                 self._record_gateway_request(
                     endpoint="/openai/v1/responses",
@@ -3536,6 +3577,7 @@ class OpenAIGatewayService:
                         usage_details=response_payload.get("usage"),
                         budget_result=budget_result,
                         accumulated_output_text=assistant_text,
+                        stream_completed=terminal_sent,
                     )
 
         return self._observe_stream(
@@ -3599,6 +3641,7 @@ class OpenAIGatewayService:
 
         def event_stream() -> Iterator[str]:
             recorded = False
+            terminal_sent = False
             assistant_text = ""
             usage: Dict[str, Any] = {}
             try:
@@ -3715,9 +3758,10 @@ class OpenAIGatewayService:
                     "usage": usage,
                 }
                 # Terminal event first so usage bookkeeping cannot hold
-                # [DONE] on the client-visible stream. Recording is
-                # fail-open (_record_gateway_request); GeneratorExit at this
-                # yield still bills via the finally abort path.
+                # [DONE] on the client-visible stream. Mark complete before
+                # the yield so a client close at [DONE] records 200 with
+                # captured usage, not 499/partial.
+                terminal_sent = True
                 yield self._sse_done()
                 self._record_gateway_request(
                     endpoint="/openai/v1/chat/completions",
@@ -3775,6 +3819,7 @@ class OpenAIGatewayService:
                         usage_details=usage,
                         budget_result=budget_result,
                         accumulated_output_text=assistant_text,
+                        stream_completed=terminal_sent,
                     )
 
         return self._observe_stream(
@@ -4322,6 +4367,8 @@ class OpenAIGatewayService:
                     and isinstance(delta.get("text"), str)
                 ):
                     state["text_parts"].append(delta["text"])
+            elif event_type == "message_stop":
+                state["saw_stop"] = True
 
         def event_stream() -> Iterator[str]:
             state: Dict[str, Any] = {
@@ -4329,20 +4376,26 @@ class OpenAIGatewayService:
                 "stop_reason": None,
                 "usage": {},
                 "text_parts": [],
+                "saw_stop": False,
             }
             buffer = ""
             recorded = False
+            terminal_sent = False
             try:
                 for chunk in upstream_response.iter_text():
                     if not chunk:
                         continue
-                    yield chunk
                     buffer += chunk
                     while "\n" in buffer:
                         line, buffer = buffer.split("\n", 1)
                         _consume_sse_line(line, state)
+                    if state["saw_stop"]:
+                        terminal_sent = True
+                    yield chunk
                 if buffer:
                     _consume_sse_line(buffer, state)
+                    if state["saw_stop"]:
+                        terminal_sent = True
 
                 response_id = state["response_id"] or f"msg_{int(time.time())}"
                 normalized_usage = self._normalize_usage(
@@ -4421,6 +4474,7 @@ class OpenAIGatewayService:
                         usage_details=state["usage"],
                         budget_result=budget_result,
                         accumulated_output_text="".join(state["text_parts"]),
+                        stream_completed=terminal_sent,
                     )
                 upstream_response.close()
                 # Shared process-level client: do not close.
@@ -5844,16 +5898,45 @@ class OpenAIGatewayService:
         usage_details: Optional[Dict[str, Any]],
         budget_result: Optional[BudgetCheckResult],
         accumulated_output_text: Optional[str] = None,
+        stream_completed: bool = False,
     ) -> None:
-        """Best-effort usage record when a streaming client disconnects early.
+        """Best-effort usage record when a streaming client disconnects.
 
         Called from a ``finally`` during GeneratorExit, so it must never raise —
-        a failure here would replace a clean disconnect with an error. Status
-        499 ("client closed request") flags the partial record. Usage captured
-        so far is recorded as ``partial``; when no usage chunk arrived yet the
-        record path falls back to a local token estimate over the request and
-        accumulated output text.
+        a failure here would replace a clean disconnect with an error.
+
+        If the terminal SSE event already went out (``stream_completed``), the
+        stream finished successfully: record status 200 with captured usage.
+        499/partial would mark completed spend as client-cancelled. Mid-stream
+        disconnects still use 499 and ``usage_source="partial"``.
         """
+        if stream_completed:
+            try:
+                self._record_gateway_request(
+                    endpoint=endpoint,
+                    method="POST",
+                    status_code=200,
+                    duration=time.perf_counter() - started_at,
+                    ai_model=ai_model,
+                    requested_model=payload.get("model"),
+                    response_payload=None,
+                    upstream_response={"usage": usage_details}
+                    if isinstance(usage_details, dict)
+                    else None,
+                    endpoint_kind=endpoint_kind,
+                    budget_result=budget_result,
+                    request_payload=payload,
+                    accumulated_output_text=accumulated_output_text,
+                )
+            except (
+                Exception
+            ) as exc:  # pragma: no cover - defensive; never break teardown
+                self._rollback_activity_recording(
+                    exc,
+                    context="gateway usage recording after completed stream disconnect",
+                )
+            return
+
         has_partial_usage = isinstance(usage_details, dict) and any(
             usage_details.get(key)
             for key in (

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import atexit
+import asyncio
 import hashlib
 import json
 import logging
@@ -9,6 +11,7 @@ import os
 import re
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from itertools import chain
@@ -131,6 +134,69 @@ ANTHROPIC_OAUTH_PASSTHROUGH_BASE_URL = "https://api.anthropic.com"
 ANTHROPIC_OAUTH_BETA_FLAG = "oauth-2025-04-20"
 ANTHROPIC_DEFAULT_API_VERSION = "2023-06-01"
 _ANTHROPIC_PASSTHROUGH_TIMEOUT_SECONDS = 600
+
+# Best-effort "request started" NATS publish must not sit on the TTFB path
+# when the caller has no running loop (sync StreamingResponse / tests).
+# Matches the billing plugin entitlements notify pattern: create_task when
+# a loop exists, otherwise a single-worker executor. wait=False so an
+# in-flight publish cannot block interpreter exit.
+_GATEWAY_STARTED_EMIT_EXECUTOR = ThreadPoolExecutor(
+    max_workers=1, thread_name_prefix="gateway-started-emit"
+)
+atexit.register(_GATEWAY_STARTED_EMIT_EXECUTOR.shutdown, wait=False)
+
+# Process-level Anthropic OAuth passthrough client. A fresh httpx.Client
+# per request pays a new TLS handshake; reuse keeps the connection warm.
+_ANTHROPIC_PASSTHROUGH_CLIENT: Optional[httpx.Client] = None
+_ANTHROPIC_PASSTHROUGH_CLIENT_LOCK = threading.Lock()
+
+
+def _anthropic_passthrough_http_client() -> httpx.Client:
+    """Return the process-level Anthropic passthrough httpx client."""
+    global _ANTHROPIC_PASSTHROUGH_CLIENT
+    client = _ANTHROPIC_PASSTHROUGH_CLIENT
+    if client is not None and not client.is_closed:
+        return client
+    with _ANTHROPIC_PASSTHROUGH_CLIENT_LOCK:
+        client = _ANTHROPIC_PASSTHROUGH_CLIENT
+        if client is None or client.is_closed:
+            client = httpx.Client(
+                timeout=_ANTHROPIC_PASSTHROUGH_TIMEOUT_SECONDS,
+                limits=httpx.Limits(
+                    max_keepalive_connections=20,
+                    max_connections=40,
+                ),
+            )
+            _ANTHROPIC_PASSTHROUGH_CLIENT = client
+        return client
+
+
+def _close_anthropic_passthrough_http_client() -> None:
+    """Close the process-level passthrough client (interpreter exit)."""
+    global _ANTHROPIC_PASSTHROUGH_CLIENT
+    with _ANTHROPIC_PASSTHROUGH_CLIENT_LOCK:
+        client = _ANTHROPIC_PASSTHROUGH_CLIENT
+        _ANTHROPIC_PASSTHROUGH_CLIENT = None
+        if client is not None and not client.is_closed:
+            client.close()
+
+
+atexit.register(_close_anthropic_passthrough_http_client)
+
+
+def _emit_account_event_nonblocking(event: Dict[str, Any]) -> None:
+    """Publish an account realtime event without blocking TTFB on NATS.
+
+    ``emit_account_event`` is already create_task when a loop is running.
+    The sync fallback uses ``run_async`` and waits for the publish. Started
+    events are telemetry: queue that sync path on a worker instead.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        _GATEWAY_STARTED_EMIT_EXECUTOR.submit(emit_account_event, event)
+        return
+    emit_account_event(event)
 
 
 def _supports_ambient_provider_credentials(ai_model: AIModel) -> bool:
@@ -686,15 +752,12 @@ class OpenAIGatewayService:
     ) -> None:
         from datetime import datetime, timezone
         from preloop.services.model_gateway_events import build_account_event
-        from preloop.services.account_realtime import (
-            emit_account_event,
-            ACCOUNT_TOPIC_GATEWAY_ACTIVITY,
-        )
+        from preloop.services.account_realtime import ACCOUNT_TOPIC_GATEWAY_ACTIVITY
 
         runtime_session_id = self._resolve_runtime_session()
         managed_agent_id = self._resolve_managed_agent_id()
 
-        emit_account_event(
+        _emit_account_event_nonblocking(
             build_account_event(
                 account_id=str(self.auth_context.user.account_id),
                 topic=ACCOUNT_TOPIC_GATEWAY_ACTIVITY,
@@ -1460,6 +1523,14 @@ class OpenAIGatewayService:
                         },
                     },
                 )
+                # Terminal event first so usage bookkeeping cannot hold
+                # message_stop on the client-visible stream. Recording is
+                # fail-open (_record_gateway_request); GeneratorExit at this
+                # yield still bills via the finally abort path.
+                yield self._anthropic_sse_event(
+                    "message_stop",
+                    {"type": "message_stop"},
+                )
                 self._record_gateway_request(
                     endpoint="/anthropic/v1/messages",
                     method="POST",
@@ -1479,10 +1550,6 @@ class OpenAIGatewayService:
                     accumulated_output_text="".join(assistant_parts),
                 )
                 recorded = True
-                yield self._anthropic_sse_event(
-                    "message_stop",
-                    {"type": "message_stop"},
-                )
             except Exception as exc:
                 gateway_error = self._stream_error("anthropic", exc)
                 if not recorded:
@@ -1738,6 +1805,11 @@ class OpenAIGatewayService:
                     ],
                     "usage": final_usage,
                 }
+                # Terminal event first so usage bookkeeping cannot hold
+                # [DONE] on the client-visible stream. Recording is
+                # fail-open (_record_gateway_request); GeneratorExit at this
+                # yield still bills via the finally abort path.
+                yield self._sse_done()
                 self._record_gateway_request(
                     endpoint="/openai/v1/chat/completions",
                     method="POST",
@@ -1756,7 +1828,6 @@ class OpenAIGatewayService:
                     accumulated_output_text="".join(assistant_parts),
                 )
                 recorded = True
-                yield self._sse_done()
             except Exception as exc:
                 gateway_error = self._stream_error("openai", exc)
                 if not recorded:
@@ -2154,6 +2225,11 @@ class OpenAIGatewayService:
                         "response": response_payload,
                     }
                 )
+                # Terminal event first so usage bookkeeping cannot hold
+                # [DONE] on the client-visible stream. Recording is
+                # fail-open (_record_gateway_request); GeneratorExit at this
+                # yield still bills via the finally abort path.
+                yield self._sse_done()
                 self._record_gateway_request(
                     endpoint="/openai/v1/responses",
                     method="POST",
@@ -2172,7 +2248,6 @@ class OpenAIGatewayService:
                     accumulated_output_text="".join(assistant_parts),
                 )
                 recorded = True
-                yield self._sse_done()
             except Exception as exc:
                 gateway_error = self._stream_error("openai", exc)
                 if not recorded:
@@ -3326,6 +3401,7 @@ class OpenAIGatewayService:
                 None,
             )
             text_output_index = output_items.index(text_item) if text_item else None
+            recorded = False
             try:
                 yield self._sse_event(
                     {
@@ -3401,6 +3477,9 @@ class OpenAIGatewayService:
                         "response": response_payload,
                     }
                 )
+                # Terminal event first so usage bookkeeping cannot hold
+                # [DONE] on the client-visible stream.
+                yield "data: [DONE]\n\n"
                 self._record_gateway_request(
                     endpoint="/openai/v1/responses",
                     method="POST",
@@ -3414,24 +3493,26 @@ class OpenAIGatewayService:
                     budget_result=budget_result,
                     request_payload=payload,
                 )
-                yield "data: [DONE]\n\n"
+                recorded = True
             except Exception as exc:
                 gateway_error = self._stream_error("openai", exc)
-                self._record_gateway_request(
-                    endpoint="/openai/v1/responses",
-                    method="POST",
-                    status_code=gateway_error.status_code,
-                    duration=time.perf_counter() - started_at,
-                    ai_model=ai_model,
-                    requested_model=payload.get("model"),
-                    response_payload=None,
-                    upstream_response=None,
-                    endpoint_kind="responses_stream",
-                    budget_result=budget_result,
-                    error_detail=gateway_error.message,
-                    error_class=gateway_error.error_class,
-                    request_payload=payload,
-                )
+                if not recorded:
+                    self._record_gateway_request(
+                        endpoint="/openai/v1/responses",
+                        method="POST",
+                        status_code=gateway_error.status_code,
+                        duration=time.perf_counter() - started_at,
+                        ai_model=ai_model,
+                        requested_model=payload.get("model"),
+                        response_payload=None,
+                        upstream_response=None,
+                        endpoint_kind="responses_stream",
+                        budget_result=budget_result,
+                        error_detail=gateway_error.message,
+                        error_class=gateway_error.error_class,
+                        request_payload=payload,
+                    )
+                    recorded = True
                 # Status 200 is already on the wire; emit an SSE error event
                 # + [DONE] instead of truncating silently (#109, #117).
                 logger.warning(
@@ -3444,6 +3525,18 @@ class OpenAIGatewayService:
                 )
                 yield self._responses_stream_error_event(exc)
                 yield "data: [DONE]\n\n"
+            finally:
+                if not recorded:
+                    self._record_stream_abort(
+                        endpoint="/openai/v1/responses",
+                        endpoint_kind="responses_stream",
+                        started_at=started_at,
+                        ai_model=ai_model,
+                        payload=payload,
+                        usage_details=response_payload.get("usage"),
+                        budget_result=budget_result,
+                        accumulated_output_text=assistant_text,
+                    )
 
         return self._observe_stream(
             event_stream(),
@@ -3506,6 +3599,8 @@ class OpenAIGatewayService:
 
         def event_stream() -> Iterator[str]:
             recorded = False
+            assistant_text = ""
+            usage: Dict[str, Any] = {}
             try:
                 response_id = response_dict.get("id", f"chatcmpl_{int(time.time())}")
                 created_at = int(response_dict.get("created", time.time()))
@@ -3619,6 +3714,11 @@ class OpenAIGatewayService:
                     ],
                     "usage": usage,
                 }
+                # Terminal event first so usage bookkeeping cannot hold
+                # [DONE] on the client-visible stream. Recording is
+                # fail-open (_record_gateway_request); GeneratorExit at this
+                # yield still bills via the finally abort path.
+                yield self._sse_done()
                 self._record_gateway_request(
                     endpoint="/openai/v1/chat/completions",
                     method="POST",
@@ -3633,7 +3733,6 @@ class OpenAIGatewayService:
                     request_payload=payload,
                 )
                 recorded = True
-                yield self._sse_done()
             except Exception as exc:
                 gateway_error = self._stream_error("openai", exc)
                 if not recorded:
@@ -3652,6 +3751,7 @@ class OpenAIGatewayService:
                         error_class=gateway_error.error_class,
                         request_payload=payload,
                     )
+                    recorded = True
                 # Status 200 is already on the wire; emit an SSE error event
                 # + [DONE] instead of truncating silently (#109, #117).
                 logger.warning(
@@ -3664,6 +3764,18 @@ class OpenAIGatewayService:
                 )
                 yield self._openai_stream_error_event(exc)
                 yield self._sse_done()
+            finally:
+                if not recorded:
+                    self._record_stream_abort(
+                        endpoint="/openai/v1/chat/completions",
+                        endpoint_kind="chat_completions_stream",
+                        started_at=started_at,
+                        ai_model=ai_model,
+                        payload=payload,
+                        usage_details=usage,
+                        budget_result=budget_result,
+                        accumulated_output_text=assistant_text,
+                    )
 
         return self._observe_stream(
             event_stream(),
@@ -4073,11 +4185,10 @@ class OpenAIGatewayService:
             ModelGatewayAPIError: On transport failure or upstream >=400.
         """
         try:
-            response = httpx.post(
+            response = _anthropic_passthrough_http_client().post(
                 url,
                 headers=headers,
                 json=body,
-                timeout=_ANTHROPIC_PASSTHROUGH_TIMEOUT_SECONDS,
             )
         except httpx.HTTPError as exc:
             raise ModelGatewayAPIError(
@@ -4085,28 +4196,33 @@ class OpenAIGatewayService:
                 status_code=502,
                 message=f"Gateway upstream error: {exc}",
             ) from exc
-        # Anthropic sends ratelimit headers on successes too; that success
-        # signal is the subscription headroom observation (#136).
-        self._capture_rate_limit_headers(response.headers)
-        if response.status_code >= 400:
-            raise self._anthropic_passthrough_upstream_error(
-                response.status_code, response.text
-            )
         try:
-            response_payload = response.json()
-        except ValueError as exc:
-            raise ModelGatewayAPIError(
-                provider="anthropic",
-                status_code=502,
-                message="Gateway upstream error: invalid JSON from upstream",
-            ) from exc
-        if not isinstance(response_payload, dict):
-            raise ModelGatewayAPIError(
-                provider="anthropic",
-                status_code=502,
-                message="Gateway upstream error: unexpected upstream response shape",
-            )
-        return response_payload
+            # Anthropic sends ratelimit headers on successes too; that success
+            # signal is the subscription headroom observation (#136).
+            self._capture_rate_limit_headers(response.headers)
+            if response.status_code >= 400:
+                raise self._anthropic_passthrough_upstream_error(
+                    response.status_code, response.text
+                )
+            try:
+                response_payload = response.json()
+            except ValueError as exc:
+                raise ModelGatewayAPIError(
+                    provider="anthropic",
+                    status_code=502,
+                    message="Gateway upstream error: invalid JSON from upstream",
+                ) from exc
+            if not isinstance(response_payload, dict):
+                raise ModelGatewayAPIError(
+                    provider="anthropic",
+                    status_code=502,
+                    message=(
+                        "Gateway upstream error: unexpected upstream response shape"
+                    ),
+                )
+            return response_payload
+        finally:
+            response.close()
 
     def _open_anthropic_oauth_passthrough_stream(
         self, *, url: str, headers: Dict[str, str], body: Dict[str, Any]
@@ -4118,17 +4234,17 @@ class OpenAIGatewayService:
         gateway errors (and get recorded) instead of dying mid-stream.
 
         Returns:
-            Tuple of (client, response); the caller owns closing both.
+            Tuple of (shared client, response). Close the response after
+            use; the client is process-level and must stay open.
 
         Raises:
             ModelGatewayAPIError: On transport failure or upstream >=400.
         """
-        client = httpx.Client(timeout=_ANTHROPIC_PASSTHROUGH_TIMEOUT_SECONDS)
+        client = _anthropic_passthrough_http_client()
         try:
             request = client.build_request("POST", url, headers=headers, json=body)
             response = client.send(request, stream=True)
         except httpx.HTTPError as exc:
-            client.close()
             raise ModelGatewayAPIError(
                 provider="anthropic",
                 status_code=502,
@@ -4142,7 +4258,6 @@ class OpenAIGatewayService:
                 body_text = ""
             finally:
                 response.close()
-                client.close()
             raise self._anthropic_passthrough_upstream_error(
                 response.status_code, body_text
             )
@@ -4308,11 +4423,13 @@ class OpenAIGatewayService:
                         accumulated_output_text="".join(state["text_parts"]),
                     )
                 upstream_response.close()
-                upstream_client.close()
+                # Shared process-level client: do not close.
 
-        # The upstream HTTP response and client are closed in the generator's
-        # finally, which never runs for a stream nobody consumed — hand them to
-        # the observer so an abandoned passthrough does not leak a connection.
+        # The upstream HTTP response is closed in the generator's finally,
+        # which never runs for a stream nobody consumed — hand it to the
+        # observer so an abandoned passthrough does not leak a connection.
+        # The httpx client is process-level and must not be closed here.
+        _ = upstream_client
         return self._observe_stream(
             event_stream(),
             endpoint="/anthropic/v1/messages",
@@ -4321,7 +4438,7 @@ class OpenAIGatewayService:
             ai_model=ai_model,
             payload=payload,
             budget_result=budget_result,
-            closes=(upstream_response, upstream_client),
+            closes=(upstream_response,),
         )
 
     def _build_completion_kwargs(

--- a/backend/tests/helm/test_gateway_proxy_timeouts.py
+++ b/backend/tests/helm/test_gateway_proxy_timeouts.py
@@ -115,6 +115,26 @@ def _read_nginx_config(path: Path, is_configmap: bool) -> str:
     return _nginx_config_from_configmap(text) if is_configmap else text
 
 
+@pytest.mark.parametrize("location", GATEWAY_LOCATIONS)
+def test_install_oss_tls_proxy_sends_gateway_routes_direct(location: str) -> None:
+    """The OSS TLS edge proxy must not hairpin /openai through the console.
+
+    A 2026-08-18 co-located bench showed ~70ms extra TTFB when public nginx
+    sent every path to console nginx, which then proxied to the gateway.
+    Helm and the console nginx template already skip that hop; the installer
+    TLS overlay must match.
+    """
+    text = (REPO_ROOT / "scripts" / "install-oss.sh").read_text()
+    marker = f"location {location} {{"
+    assert marker in text, f"install-oss.sh missing `{marker}`"
+    body = _location_body(text, location)
+    assert "proxy_pass http://gateway:8000;" in body
+    assert re.search(r"^\s*proxy_buffering\s+off\s*;", body, re.MULTILINE)
+    assert _directive_seconds(body, "proxy_read_timeout") >= (
+        MIN_STREAMING_TIMEOUT_SECONDS
+    )
+
+
 @pytest.mark.parametrize("config_path,is_configmap", _gateway_nginx_configs())
 @pytest.mark.parametrize("location", GATEWAY_LOCATIONS)
 def test_gateway_location_survives_a_slow_first_token(

--- a/backend/tests/helm/test_gateway_proxy_timeouts.py
+++ b/backend/tests/helm/test_gateway_proxy_timeouts.py
@@ -6,10 +6,11 @@ for well over a minute before the first token appears, and nginx's default
 ``proxy_read_timeout`` is 60s — so a route without an explicit override kills
 the connection and hands the client a 504 that never reaches the application.
 
-Both proxy layers in front of the gateway (the console nginx and the ingress)
-default to 60s, so both need the override; fixing one still leaves the other
-at 60s. These tests exist so a future edit that drops either one fails CI
-instead of shipping.
+Helm ingress sends those prefixes to the gateway Service. Console nginx still
+proxies them for callers that hit the console Service directly. Both of those
+proxies default to 60s, so both need the override; fixing one still leaves
+the other at 60s for the traffic that still uses it. These tests exist so a
+future edit that drops either one fails CI instead of shipping.
 """
 
 from __future__ import annotations
@@ -121,8 +122,8 @@ def test_install_oss_tls_proxy_sends_gateway_routes_direct(location: str) -> Non
 
     A 2026-08-18 co-located bench showed ~70ms extra TTFB when public nginx
     sent every path to console nginx, which then proxied to the gateway.
-    Helm and the console nginx template already skip that hop; the installer
-    TLS overlay must match.
+    Helm ingress and this installer overlay both skip that hop; console
+    nginx still proxies the prefixes for in-cluster callers.
     """
     text = (REPO_ROOT / "scripts" / "install-oss.sh").read_text()
     marker = f"location {location} {{"
@@ -166,7 +167,7 @@ def test_gateway_location_streams_tokens_through(
 
 
 def test_ingress_annotations_match_the_console_timeout() -> None:
-    """The ingress is the second 60s proxy in front of the gateway."""
+    """The console Ingress still carries the streaming timeout budget."""
     values = load_values()
     read_timeout = resolve_values_path(values, "gateway.proxy.readTimeout")
     send_timeout = resolve_values_path(values, "gateway.proxy.sendTimeout")
@@ -178,7 +179,7 @@ def test_ingress_annotations_match_the_console_timeout() -> None:
         MIN_STREAMING_TIMEOUT_SECONDS
     )
 
-    rendered = _render_ingress()
+    rendered = _render_console_ingress()
     annotations = rendered["metadata"]["annotations"]
     assert annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] == str(
         read_timeout
@@ -190,7 +191,7 @@ def test_ingress_annotations_match_the_console_timeout() -> None:
 
 def test_ingress_annotations_stay_overridable() -> None:
     """An operator's own annotation value must win over the chart default."""
-    rendered = _render_ingress(
+    rendered = _render_console_ingress(
         overrides=[
             "ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/proxy-read-timeout=1200"
         ]
@@ -202,13 +203,75 @@ def test_ingress_annotations_stay_overridable() -> None:
     assert "cert-manager.io/cluster-issuer" in annotations
 
 
-def _render_ingress(overrides: List[str] | None = None) -> Dict:
-    """Render the ingress template with the chart's default values."""
+def test_ingress_sends_gateway_prefixes_to_gateway_service() -> None:
+    """Public /openai traffic must not hairpin through the console Service."""
+    gateway = _render_gateway_ingress()
+    assert gateway["metadata"]["name"] == "preloop-gateway"
+    paths = {
+        item["path"]: item["backend"]["service"]["name"]
+        for item in gateway["spec"]["rules"][0]["http"]["paths"]
+    }
+    assert paths == {
+        "/openai": "preloop-gateway",
+        "/anthropic": "preloop-gateway",
+        "/gemini": "preloop-gateway",
+    }
+
+    console_paths = {
+        item["path"]
+        for item in _render_console_ingress()["spec"]["rules"][0]["http"]["paths"]
+    }
+    assert "/openai" not in console_paths
+    assert "/anthropic" not in console_paths
+    assert "/gemini" not in console_paths
+
+
+def test_gateway_ingress_disables_buffering_and_keeps_timeouts() -> None:
+    """SSE must not buffer at ingress once console nginx is no longer in path."""
+    values = load_values()
+    read_timeout = str(resolve_values_path(values, "gateway.proxy.readTimeout"))
+    gateway = _render_gateway_ingress()
+    annotations = gateway["metadata"]["annotations"]
+    assert annotations["nginx.ingress.kubernetes.io/proxy-buffering"] == "off"
+    assert annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] == read_timeout
+    assert "cert-manager.io/cluster-issuer" not in annotations
+    console = _render_console_ingress()
+    assert (
+        "nginx.ingress.kubernetes.io/proxy-buffering"
+        not in console["metadata"]["annotations"]
+    )
+    assert "cert-manager.io/cluster-issuer" in console["metadata"]["annotations"]
+
+
+def _render_ingress_docs(overrides: List[str] | None = None) -> List[Dict]:
+    """Render every Ingress document in the chart template."""
     rendered = helm_template(
         "templates/ingress.yaml",
         ["ingress.enabled=true", *(overrides or [])],
     )
-    return yaml.safe_load(rendered)
+    return [doc for doc in yaml.safe_load_all(rendered) if doc]
+
+
+def _render_console_ingress(overrides: List[str] | None = None) -> Dict:
+    """Render the console Ingress (first document, name without -gateway)."""
+    docs = _render_ingress_docs(overrides)
+    console = next(
+        doc
+        for doc in docs
+        if doc["kind"] == "Ingress" and not doc["metadata"]["name"].endswith("-gateway")
+    )
+    return console
+
+
+def _render_gateway_ingress(overrides: List[str] | None = None) -> Dict:
+    """Render the gateway Ingress that owns /openai /anthropic /gemini."""
+    docs = _render_ingress_docs(overrides)
+    gateway = next(
+        doc
+        for doc in docs
+        if doc["kind"] == "Ingress" and doc["metadata"]["name"].endswith("-gateway")
+    )
+    return gateway
 
 
 @pytest.mark.parametrize("location", GATEWAY_LOCATIONS)

--- a/backend/tests/services/test_anthropic_oauth_passthrough.py
+++ b/backend/tests/services/test_anthropic_oauth_passthrough.py
@@ -61,6 +61,14 @@ def _oauth_credentials():
     )
 
 
+def _patch_passthrough_http_client(client: MagicMock):
+    """Passthrough uses a process-level client, not module-level httpx.post."""
+    return patch(
+        "preloop.services.openai_gateway._anthropic_passthrough_http_client",
+        return_value=client,
+    )
+
+
 def _claude_code_payload():
     """A representative Claude Code request: system array + cache_control."""
     return {
@@ -125,15 +133,14 @@ def test_oauth_passthrough_preserves_system_array_and_cache_control(
     upstream_response = MagicMock()
     upstream_response.status_code = 200
     upstream_response.json.return_value = _upstream_message_response()
+    upstream_client = MagicMock()
+    upstream_client.post.return_value = upstream_response
 
     with (
         patch(
             "preloop.services.openai_gateway.get_secret_service"
         ) as mock_secret_service,
-        patch(
-            "preloop.services.openai_gateway.httpx.post",
-            return_value=upstream_response,
-        ) as mock_post,
+        _patch_passthrough_http_client(upstream_client),
         patch("preloop.services.openai_gateway.litellm.completion") as mock_completion,
     ):
         mock_secret_service.return_value.resolve_ai_model_credentials.return_value = (
@@ -146,9 +153,12 @@ def test_oauth_passthrough_preserves_system_array_and_cache_control(
         )
 
     mock_completion.assert_not_called()
-    mock_post.assert_called_once()
-    call_kwargs = mock_post.call_args.kwargs
-    assert mock_post.call_args.args[0] == "https://api.anthropic.com/v1/messages"
+    upstream_client.post.assert_called_once()
+    call_kwargs = upstream_client.post.call_args.kwargs
+    assert (
+        upstream_client.post.call_args.args[0]
+        == "https://api.anthropic.com/v1/messages"
+    )
 
     body = call_kwargs["json"]
     # System survives as an ARRAY of blocks, sentinel first, byte-faithful.
@@ -235,6 +245,8 @@ def test_oauth_passthrough_governance_strip_keeps_system_untouched(
     upstream_response = MagicMock()
     upstream_response.status_code = 200
     upstream_response.json.return_value = _upstream_message_response()
+    upstream_client = MagicMock()
+    upstream_client.post.return_value = upstream_response
 
     with (
         patch(
@@ -244,17 +256,14 @@ def test_oauth_passthrough_governance_strip_keeps_system_untouched(
             "preloop.services.openai_gateway.get_cached_account_meta_data",
             return_value=governance_meta,
         ),
-        patch(
-            "preloop.services.openai_gateway.httpx.post",
-            return_value=upstream_response,
-        ) as mock_post,
+        _patch_passthrough_http_client(upstream_client),
     ):
         mock_secret_service.return_value.resolve_ai_model_credentials.return_value = (
             _oauth_credentials()
         )
         service.create_message(request_payload)
 
-    body = mock_post.call_args.kwargs["json"]
+    body = upstream_client.post.call_args.kwargs["json"]
     # The disabled tool is stripped; the surviving tool is untouched
     # (including its cache_control breakpoint).
     assert [tool["name"] for tool in body["tools"]] == ["Bash"]
@@ -301,10 +310,9 @@ def test_api_key_anthropic_path_still_uses_litellm(db_session, test_user):
         db_session, ModelGatewayAuthContext(token="t", user=test_user)
     )
 
+    unused_passthrough_client = MagicMock()
     with (
-        patch(
-            "preloop.services.openai_gateway.httpx.post",
-        ) as mock_post,
+        _patch_passthrough_http_client(unused_passthrough_client),
         patch(
             "preloop.services.openai_gateway.litellm.completion",
             return_value={
@@ -332,7 +340,7 @@ def test_api_key_anthropic_path_still_uses_litellm(db_session, test_user):
             }
         )
 
-    mock_post.assert_not_called()
+    unused_passthrough_client.post.assert_not_called()
     mock_completion.assert_called_once()
     assert payload["content"][0]["text"] == "ok"
 
@@ -356,14 +364,14 @@ def test_oauth_passthrough_maps_upstream_error(db_session, test_user):
         }
     )
 
+    upstream_client = MagicMock()
+    upstream_client.post.return_value = upstream_response
+
     with (
         patch(
             "preloop.services.openai_gateway.get_secret_service"
         ) as mock_secret_service,
-        patch(
-            "preloop.services.openai_gateway.httpx.post",
-            return_value=upstream_response,
-        ),
+        _patch_passthrough_http_client(upstream_client),
     ):
         mock_secret_service.return_value.resolve_ai_model_credentials.return_value = (
             _oauth_credentials()
@@ -427,10 +435,7 @@ def test_oauth_passthrough_stream_relays_sse_verbatim(db_session, test_user):
         patch(
             "preloop.services.openai_gateway.get_secret_service"
         ) as mock_secret_service,
-        patch(
-            "preloop.services.openai_gateway.httpx.Client",
-            return_value=upstream_client,
-        ),
+        _patch_passthrough_http_client(upstream_client),
         patch("preloop.services.openai_gateway.litellm.completion") as mock_completion,
     ):
         mock_secret_service.return_value.resolve_ai_model_credentials.return_value = (
@@ -448,7 +453,7 @@ def test_oauth_passthrough_stream_relays_sse_verbatim(db_session, test_user):
     assert body["system"][0]["text"] == CLAUDE_CODE_SENTINEL
     assert body["stream"] is True
     upstream_response.close.assert_called_once()
-    upstream_client.close.assert_called_once()
+    upstream_client.close.assert_not_called()
 
     usage_row = (
         db_session.query(ApiUsage)
@@ -486,10 +491,7 @@ def test_oauth_passthrough_stream_upstream_error_raises_before_stream(
         patch(
             "preloop.services.openai_gateway.get_secret_service"
         ) as mock_secret_service,
-        patch(
-            "preloop.services.openai_gateway.httpx.Client",
-            return_value=upstream_client,
-        ),
+        _patch_passthrough_http_client(upstream_client),
     ):
         mock_secret_service.return_value.resolve_ai_model_credentials.return_value = (
             _oauth_credentials()
@@ -500,4 +502,4 @@ def test_oauth_passthrough_stream_upstream_error_raises_before_stream(
     assert exc_info.value.status_code == 429
     assert exc_info.value.error_type == "rate_limit_error"
     upstream_response.close.assert_called_once()
-    upstream_client.close.assert_called_once()
+    upstream_client.close.assert_not_called()

--- a/backend/tests/services/test_gateway_rate_limit_capture.py
+++ b/backend/tests/services/test_gateway_rate_limit_capture.py
@@ -71,6 +71,14 @@ def _oauth_credentials():
     )
 
 
+def _patch_passthrough_http_client(client: MagicMock):
+    """Passthrough uses a process-level client, not module-level httpx.post."""
+    return patch(
+        "preloop.services.openai_gateway._anthropic_passthrough_http_client",
+        return_value=client,
+    )
+
+
 def _claude_code_payload():
     return {
         "model": "anthropic/claude-sonnet-4-5",
@@ -114,14 +122,14 @@ def test_passthrough_429_records_rate_limit_telemetry(db_session, test_user):
         }
     )
 
+    upstream_client = MagicMock()
+    upstream_client.post.return_value = upstream_response
+
     with (
         patch(
             "preloop.services.openai_gateway.get_secret_service"
         ) as mock_secret_service,
-        patch(
-            "preloop.services.openai_gateway.httpx.post",
-            return_value=upstream_response,
-        ),
+        _patch_passthrough_http_client(upstream_client),
     ):
         mock_secret_service.return_value.resolve_ai_model_credentials.return_value = (
             _oauth_credentials()
@@ -170,14 +178,14 @@ def test_passthrough_success_records_headroom_snapshot(db_session, test_user):
         "usage": {"input_tokens": 3, "output_tokens": 2},
     }
 
+    upstream_client = MagicMock()
+    upstream_client.post.return_value = upstream_response
+
     with (
         patch(
             "preloop.services.openai_gateway.get_secret_service"
         ) as mock_secret_service,
-        patch(
-            "preloop.services.openai_gateway.httpx.post",
-            return_value=upstream_response,
-        ),
+        _patch_passthrough_http_client(upstream_client),
     ):
         mock_secret_service.return_value.resolve_ai_model_credentials.return_value = (
             _oauth_credentials()

--- a/backend/tests/services/test_openai_gateway_stream_eos.py
+++ b/backend/tests/services/test_openai_gateway_stream_eos.py
@@ -1,0 +1,303 @@
+"""Client-visible EOS must not wait on gateway usage recording.
+
+The stream generators used to call ``_record_gateway_request`` (DB +
+activity bookkeeping) *before* yielding ``message_stop`` / ``[DONE]``.
+That held the last SSE event for the duration of recording. These tests
+pin the new order: the terminal event is yielded first, then recording
+runs on the subsequent pull. Disconnect at that yield still bills via
+the ``finally`` abort path.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from contextlib import ExitStack, contextmanager
+from types import SimpleNamespace
+from typing import Iterator
+from unittest.mock import MagicMock, patch
+
+from preloop.services.model_gateway_auth import ModelGatewayAuthContext
+from preloop.services.openai_gateway import (
+    OpenAIGatewayService,
+    _anthropic_passthrough_http_client,
+    _close_anthropic_passthrough_http_client,
+)
+
+
+def _parse_sse_payload(event: str):
+    data_line = next(line for line in event.splitlines() if line.startswith("data: "))
+    payload = data_line.removeprefix("data: ")
+    if payload == "[DONE]":
+        return payload
+    return json.loads(payload)
+
+
+def _service() -> OpenAIGatewayService:
+    auth_context = ModelGatewayAuthContext(
+        token="token",
+        user=SimpleNamespace(id="user-1", account_id="account-1"),
+    )
+    return OpenAIGatewayService(MagicMock(), auth_context)
+
+
+def _openai_model() -> SimpleNamespace:
+    return SimpleNamespace(id="model-1", provider_name="openai")
+
+
+def _chat_upstream() -> list[dict]:
+    return [
+        {"choices": [{"delta": {"content": "Hello"}}]},
+        {
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 3,
+                "completion_tokens": 1,
+                "total_tokens": 4,
+            },
+        },
+    ]
+
+
+def _responses_upstream() -> list[dict]:
+    return [
+        {"choices": [{"delta": {"content": "Hello"}}]},
+        {
+            "choices": [{"delta": {"content": " world"}}],
+            "usage": {
+                "prompt_tokens": 3,
+                "completion_tokens": 2,
+                "total_tokens": 5,
+            },
+        },
+    ]
+
+
+def _anthropic_upstream() -> list[dict]:
+    return [
+        {
+            "id": "msg_123",
+            "choices": [{"index": 0, "delta": {"content": "Hello"}}],
+        },
+        {
+            "id": "msg_123",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 1,
+                "total_tokens": 6,
+            },
+        },
+    ]
+
+
+@contextmanager
+def _stream_patches(
+    service: OpenAIGatewayService, upstream: list[dict]
+) -> Iterator[None]:
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(
+                service, "_resolve_requested_model", return_value=_openai_model()
+            )
+        )
+        stack.enter_context(patch.object(service, "_check_budget", return_value=None))
+        stack.enter_context(
+            patch.object(service, "_call_litellm", return_value=iter(upstream))
+        )
+        stack.enter_context(patch.object(service, "_emit_gateway_request_started"))
+        stack.enter_context(
+            patch.object(
+                service, "_anthropic_oauth_passthrough_token", return_value=None
+            )
+        )
+        yield
+
+
+def test_chat_stream_emits_done_before_recording():
+    """``[DONE]`` is yielded before ``_record_gateway_request`` runs."""
+    service = _service()
+    order: list[str] = []
+
+    def _record(*_args, **_kwargs) -> None:
+        order.append("record")
+
+    with (
+        _stream_patches(service, _chat_upstream()),
+        patch.object(service, "_record_gateway_request", side_effect=_record),
+    ):
+        stream = service.stream_chat_completion(
+            {
+                "model": "openai/gpt-5",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": True,
+            }
+        )
+        for event in stream:
+            if _parse_sse_payload(event) == "[DONE]":
+                order.append("done")
+                break
+        try:
+            next(stream)
+        except StopIteration:
+            pass
+
+    assert order == ["done", "record"]
+
+
+def test_chat_stream_emits_done_even_if_recording_is_slow():
+    """A slow record must not delay the client-visible ``[DONE]``."""
+    service = _service()
+    recorded: list[str] = []
+
+    def _slow_record(*_args, **_kwargs) -> None:
+        time.sleep(0.15)
+        recorded.append("record")
+
+    with (
+        _stream_patches(service, _chat_upstream()),
+        patch.object(service, "_record_gateway_request", side_effect=_slow_record),
+    ):
+        stream = service.stream_chat_completion(
+            {
+                "model": "openai/gpt-5",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": True,
+            }
+        )
+        started = time.perf_counter()
+        saw_done = False
+        for event in stream:
+            if _parse_sse_payload(event) == "[DONE]":
+                saw_done = True
+                elapsed = time.perf_counter() - started
+                break
+        remainder = list(stream)
+
+    assert saw_done
+    assert elapsed < 0.1
+    assert recorded == ["record"]
+    assert remainder == []
+
+
+def test_chat_stream_disconnect_after_done_still_records():
+    """GeneratorExit at the terminal yield still bills via the abort path."""
+    service = _service()
+
+    with (
+        _stream_patches(service, _chat_upstream()),
+        patch.object(service, "_record_gateway_request") as mock_record,
+        patch.object(
+            service, "_record_stream_abort", wraps=service._record_stream_abort
+        ) as mock_abort,
+    ):
+        stream = service.stream_chat_completion(
+            {
+                "model": "openai/gpt-5",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": True,
+            }
+        )
+        for event in stream:
+            if _parse_sse_payload(event) == "[DONE]":
+                stream.close()
+                break
+
+    mock_abort.assert_called_once()
+    assert mock_record.call_args.kwargs["status_code"] == 499
+
+
+def test_responses_stream_emits_done_before_recording():
+    service = _service()
+    order: list[str] = []
+
+    def _record(*_args, **_kwargs) -> None:
+        order.append("record")
+
+    with (
+        _stream_patches(service, _responses_upstream()),
+        patch.object(service, "_record_gateway_request", side_effect=_record),
+    ):
+        stream = service.stream_response(
+            {"model": "openai/gpt-5", "input": "Hi", "stream": True}
+        )
+        for event in stream:
+            if _parse_sse_payload(event) == "[DONE]":
+                order.append("done")
+                break
+        try:
+            next(stream)
+        except StopIteration:
+            pass
+
+    assert order == ["done", "record"]
+
+
+def test_anthropic_stream_emits_message_stop_before_recording():
+    service = _service()
+    order: list[str] = []
+
+    def _record(*_args, **_kwargs) -> None:
+        order.append("record")
+
+    with (
+        _stream_patches(service, _anthropic_upstream()),
+        patch.object(service, "_record_gateway_request", side_effect=_record),
+    ):
+        stream = service.stream_message(
+            {
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 64,
+                "stream": True,
+            }
+        )
+        for event in stream:
+            if "event: message_stop" in event:
+                order.append("message_stop")
+                break
+        try:
+            next(stream)
+        except StopIteration:
+            pass
+
+    assert order == ["message_stop", "record"]
+
+
+def test_anthropic_stream_disconnect_after_stop_still_records():
+    service = _service()
+
+    with (
+        _stream_patches(service, _anthropic_upstream()),
+        patch.object(service, "_record_gateway_request") as mock_record,
+        patch.object(
+            service, "_record_stream_abort", wraps=service._record_stream_abort
+        ) as mock_abort,
+    ):
+        stream = service.stream_message(
+            {
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 64,
+                "stream": True,
+            }
+        )
+        for event in stream:
+            if "event: message_stop" in event:
+                stream.close()
+                break
+
+    mock_abort.assert_called_once()
+    assert mock_record.call_args.kwargs["status_code"] == 499
+
+
+def test_anthropic_passthrough_http_client_is_reused():
+    """OAuth passthrough must reuse one process-level httpx client."""
+    _close_anthropic_passthrough_http_client()
+    first = _anthropic_passthrough_http_client()
+    second = _anthropic_passthrough_http_client()
+    try:
+        assert first is second
+        assert not first.is_closed
+    finally:
+        _close_anthropic_passthrough_http_client()

--- a/backend/tests/services/test_openai_gateway_stream_eos.py
+++ b/backend/tests/services/test_openai_gateway_stream_eos.py
@@ -4,8 +4,8 @@ The stream generators used to call ``_record_gateway_request`` (DB +
 activity bookkeeping) *before* yielding ``message_stop`` / ``[DONE]``.
 That held the last SSE event for the duration of recording. These tests
 pin the new order: the terminal event is yielded first, then recording
-runs on the subsequent pull. Disconnect at that yield still bills via
-the ``finally`` abort path.
+runs on the subsequent pull. Disconnect at that yield still bills, but
+as a completed 200 with captured usage rather than 499/partial.
 """
 
 from __future__ import annotations
@@ -18,10 +18,13 @@ from typing import Iterator
 from unittest.mock import MagicMock, patch
 
 from preloop.services.model_gateway_auth import ModelGatewayAuthContext
+import preloop.services.openai_gateway as openai_gateway
 from preloop.services.openai_gateway import (
+    _GATEWAY_STARTED_EMIT_MAX_PENDING,
     OpenAIGatewayService,
     _anthropic_passthrough_http_client,
     _close_anthropic_passthrough_http_client,
+    _emit_account_event_nonblocking,
 )
 
 
@@ -181,7 +184,7 @@ def test_chat_stream_emits_done_even_if_recording_is_slow():
 
 
 def test_chat_stream_disconnect_after_done_still_records():
-    """GeneratorExit at the terminal yield still bills via the abort path."""
+    """GeneratorExit at the terminal yield records 200 with captured usage."""
     service = _service()
 
     with (
@@ -204,7 +207,43 @@ def test_chat_stream_disconnect_after_done_still_records():
                 break
 
     mock_abort.assert_called_once()
+    assert mock_abort.call_args.kwargs["stream_completed"] is True
+    assert mock_record.call_args.kwargs["status_code"] == 200
+    assert mock_record.call_args.kwargs.get("usage_source") is None
+    assert mock_record.call_args.kwargs.get("error_class") is None
+    usage = mock_record.call_args.kwargs["upstream_response"]["usage"]
+    assert usage["prompt_tokens"] == 3
+    assert usage["completion_tokens"] == 1
+
+
+def test_chat_stream_disconnect_before_done_records_abort():
+    """A mid-stream disconnect still records 499/partial."""
+    service = _service()
+
+    with (
+        _stream_patches(service, _chat_upstream()),
+        patch.object(service, "_record_gateway_request") as mock_record,
+        patch.object(
+            service, "_record_stream_abort", wraps=service._record_stream_abort
+        ) as mock_abort,
+    ):
+        stream = service.stream_chat_completion(
+            {
+                "model": "openai/gpt-5",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": True,
+            }
+        )
+        next(stream)
+        stream.close()
+
+    mock_abort.assert_called_once()
+    assert mock_abort.call_args.kwargs["stream_completed"] is False
     assert mock_record.call_args.kwargs["status_code"] == 499
+    assert (
+        mock_record.call_args.kwargs["error_detail"]
+        == "client disconnected before stream completion"
+    )
 
 
 def test_responses_stream_emits_done_before_recording():
@@ -288,7 +327,10 @@ def test_anthropic_stream_disconnect_after_stop_still_records():
                 break
 
     mock_abort.assert_called_once()
-    assert mock_record.call_args.kwargs["status_code"] == 499
+    assert mock_abort.call_args.kwargs["stream_completed"] is True
+    assert mock_record.call_args.kwargs["status_code"] == 200
+    assert mock_record.call_args.kwargs.get("usage_source") is None
+    assert mock_record.call_args.kwargs.get("error_class") is None
 
 
 def test_anthropic_passthrough_http_client_is_reused():
@@ -301,3 +343,52 @@ def test_anthropic_passthrough_http_client_is_reused():
         assert not first.is_closed
     finally:
         _close_anthropic_passthrough_http_client()
+
+
+def test_oauth_passthrough_complete_posts_via_shared_client():
+    """Non-streaming OAuth passthrough must use the process-level httpx client."""
+    service = _service()
+    upstream = MagicMock()
+    upstream.status_code = 200
+    upstream.headers = {}
+    upstream.json.return_value = {"id": "msg_1", "type": "message"}
+    client = MagicMock()
+    client.post.return_value = upstream
+
+    with patch(
+        "preloop.services.openai_gateway._anthropic_passthrough_http_client",
+        return_value=client,
+    ):
+        payload = service._anthropic_oauth_passthrough_complete(
+            url="https://api.anthropic.com/v1/messages",
+            headers={"authorization": "Bearer token"},
+            body={"model": "claude-sonnet-4-5", "max_tokens": 16},
+        )
+
+    client.post.assert_called_once()
+    assert client.post.call_args.args[0] == "https://api.anthropic.com/v1/messages"
+    assert payload == {"id": "msg_1", "type": "message"}
+    upstream.close.assert_called_once()
+
+
+def test_started_emit_drops_when_queue_is_full():
+    """Started-event telemetry must not queue unbounded work."""
+    with (
+        patch(
+            "preloop.services.openai_gateway.asyncio.get_running_loop",
+            side_effect=RuntimeError,
+        ),
+        patch.object(
+            openai_gateway,
+            "_GATEWAY_STARTED_EMIT_PENDING",
+            _GATEWAY_STARTED_EMIT_MAX_PENDING,
+        ),
+        patch.object(
+            openai_gateway._GATEWAY_STARTED_EMIT_EXECUTOR, "submit"
+        ) as mock_submit,
+        patch.object(openai_gateway, "emit_account_event") as mock_emit,
+    ):
+        _emit_account_event_nonblocking({"type": "test"})
+
+    mock_submit.assert_not_called()
+    mock_emit.assert_not_called()

--- a/helm/preloop/README.md
+++ b/helm/preloop/README.md
@@ -240,7 +240,11 @@ environment:
 
 ### Ingress Configuration
 
-To enable ingress, set `ingress.enabled=true` and configure the ingress hosts:
+To enable ingress, set `ingress.enabled=true` and configure the ingress hosts.
+The chart renders two Ingress objects on that host: one sending `/` to the
+console Service, and one sending `/openai`, `/anthropic`, and `/gemini` to
+the gateway Service so streaming model traffic does not hairpin through
+console nginx.
 
 ```yaml
 ingress:

--- a/helm/preloop/templates/ingress.yaml
+++ b/helm/preloop/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "preloop.fullname" . -}}
 {{- $svcPort := 80 -}}
+{{- $proxy := .Values.gateway.proxy | default dict }}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -19,22 +20,20 @@ metadata:
   labels:
     {{- include "preloop.labels" . | nindent 4 }}
   {{- /*
-    The ingress is the outermost of the two proxies in front of the model
-    gateway, and it enforces its own timeouts independently of the console
-    nginx config. Its defaults are 60s, which is shorter than a streaming
-    model response can legitimately take to produce its first token, so a
-    long-running generation is terminated here with a 504 before the
-    application is ever aware of it. These annotations carry the same budget
-    the console nginx uses (see `gateway.proxy` in values.yaml) so that a
-    default install is correct without extra flags — a chart that fixed only
-    the inner proxy would still fail at 60s.
+    The ingress is the outermost proxy in front of the model gateway, and it
+    enforces its own timeouts independently of the console nginx config. Its
+    defaults are 60s, which is shorter than a streaming model response can
+    legitimately take to produce its first token, so a long-running generation
+    is terminated here with a 504 before the application is ever aware of it.
+    These annotations carry the same budget the console nginx uses (see
+    `gateway.proxy` in values.yaml) so that a default install is correct
+    without extra flags.
 
     The controller runs with `allow-snippet-annotations: false` in many
     deployments, so this must use the first-class annotations rather than a
     configuration snippet. Operator-supplied `ingress.annotations` are merged
     last and therefore win.
   */}}
-  {{- $proxy := .Values.gateway.proxy | default dict }}
   {{- $annotations := dict
         "nginx.ingress.kubernetes.io/proxy-read-timeout" $proxy.readTimeout
         "nginx.ingress.kubernetes.io/proxy-send-timeout" $proxy.sendTimeout
@@ -80,6 +79,82 @@ spec:
                   number: {{ $svcPort }}
               {{- else }}
               serviceName: {{ $fullName }}-console
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+---
+{{ if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-gateway
+  labels:
+    {{- include "preloop.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+  {{- /*
+    Streaming model traffic used to hairpin through console nginx
+    (ingress → console → gateway). That extra hop is only a proxy; usage
+    accounting still happens in the gateway process. Sending /openai,
+    /anthropic, and /gemini to the gateway Service from this Ingress drops
+    the hop without changing bookkeeping.
+
+    A second Ingress is required because nginx-ingress annotations apply
+    to every path on the object. proxy-buffering must be off for SSE, but
+    must not be forced onto `/` (the SPA and /api). Timeouts stay the same
+    `gateway.proxy` budget so a slow first token still cannot 504 at 60s.
+  */}}
+  {{- $gatewayAnnotations := dict
+        "nginx.ingress.kubernetes.io/proxy-read-timeout" $proxy.readTimeout
+        "nginx.ingress.kubernetes.io/proxy-send-timeout" $proxy.sendTimeout
+        "nginx.ingress.kubernetes.io/proxy-connect-timeout" $proxy.connectTimeout
+        "nginx.ingress.kubernetes.io/proxy-body-size" $proxy.bodySize
+        "nginx.ingress.kubernetes.io/proxy-buffering" "off" }}
+  {{- $gatewayAnnotations = merge (deepCopy (.Values.ingress.annotations | default dict)) $gatewayAnnotations }}
+  {{- /* cert-manager must issue once, from the console Ingress. Duplicating
+       the issuer annotation on this object races the same TLS secret. */}}
+  {{- range $cmKey := tuple "cert-manager.io/cluster-issuer" "cert-manager.io/issuer" "cert-manager.io/issuer-kind" "cert-manager.io/issuer-group" }}
+  {{- $_ := unset $gatewayAnnotations $cmKey }}
+  {{- end }}
+  {{- $gatewayRendered := dict }}
+  {{- range $key, $value := $gatewayAnnotations }}
+  {{- if not (kindIs "invalid" $value) }}
+  {{- $_ := set $gatewayRendered $key (toString $value) }}
+  {{- end }}
+  {{- end }}
+  {{- with $gatewayRendered }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range $path := tuple "/openai" "/anthropic" "/gemini" }}
+          - path: {{ $path }}
+            pathType: Prefix
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-gateway
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}-gateway
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -192,13 +192,16 @@ healthMonitor:
 # Gateway resources
 gateway:
   # Proxy settings applied to the model-gateway routes (/openai, /anthropic,
-  # /gemini) at BOTH proxy layers in front of the gateway: the console nginx
-  # and the ingress. These routes relay streaming LLM responses, where the
-  # upstream model can spend minutes reasoning over a large prompt before the
-  # first token exists — nginx's 60s default read timeout is a ceiling on how
-  # long a model is allowed to think, and hitting it returns a 504 the
-  # application never sees. Both layers default to 60s, so both are set here;
-  # raising only one leaves the other cutting the stream.
+  # /gemini) at every proxy in front of the gateway. Helm ingress sends those
+  # prefixes to the gateway Service (skipping console nginx). Console nginx
+  # still proxies the same prefixes for callers that hit the console Service
+  # directly, and the OSS installer TLS overlay does the same at the edge.
+  # These routes relay streaming LLM responses, where the upstream model can
+  # spend minutes reasoning over a large prompt before the first token exists.
+  # nginx's 60s default read timeout is a ceiling on how long a model is
+  # allowed to think, and hitting it returns a 504 the application never sees.
+  # Every remaining proxy layer defaults to 60s, so all of them are set here;
+  # raising only one leaves another cutting the stream.
   proxy:
     # Seconds. Generous rather than exact: the cost of waiting is an idle
     # connection, the cost of being short is a failed request plus whatever

--- a/scripts/install-oss.sh
+++ b/scripts/install-oss.sh
@@ -21,9 +21,11 @@ INSTALL_DIR="${INSTALL_DIR:-${HOME}/.preloop-oss}"
 # the terminal; the happy path prints a few curated lines and this path.
 LOG_FILE="${INSTALL_DIR}/install.log"
 
-# Public base URL this instance is reached at. Everything (console, API, MCP,
-# gateway) is served through one origin: the console container reverse-proxies
-# /api, /mcp, /openai, /anthropic and /gemini to the backend services.
+# Public base URL this instance is reached at. Console, API and MCP share one
+# origin: the TLS proxy (or the console nginx on plain HTTP) reverse-proxies
+# /api and /mcp. Model-gateway routes (/openai, /anthropic, /gemini) go
+# straight to the gateway container so streaming TTFB does not pay an extra
+# hop through the console.
 #
 #   PRELOOP_URL=https://preloop.example.com  -> public deploy, TLS via certbot
 #   PRELOOP_URL=http://localhost:3000        -> local (default)
@@ -580,6 +582,59 @@ caa_forbids_letsencrypt() {
   return 0
 }
 
+# Nginx locations that terminate /openai /anthropic /gemini on the gateway
+# container (port 8000 on the compose network). Used by both the HTTP bootstrap
+# config and the HTTPS config so streaming traffic never hairpins through the
+# console. proxy_buffering must stay off (SSE).
+gateway_proxy_locations() {
+  cat <<'GATE'
+    location ^~ /openai/ {
+        proxy_pass http://gateway:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+        proxy_buffering off;
+        proxy_cache off;
+        client_max_body_size 32m;
+    }
+
+    location ^~ /anthropic/ {
+        proxy_pass http://gateway:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+        proxy_buffering off;
+        proxy_cache off;
+        client_max_body_size 32m;
+    }
+
+    location ^~ /gemini/ {
+        proxy_pass http://gateway:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+        proxy_buffering off;
+        proxy_cache off;
+        client_max_body_size 32m;
+    }
+GATE
+}
+
 write_tls_assets() {
   host="$1"
   mkdir -p "${INSTALL_DIR}/tls" "${INSTALL_DIR}/certbot/www" "${INSTALL_DIR}/certbot/conf"
@@ -594,6 +649,8 @@ server {
     location ^~ /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
+
+$(gateway_proxy_locations)
 
     location / {
         proxy_pass http://console:80;
@@ -637,6 +694,10 @@ server {
     ssl_session_timeout 1d;
 
     # Streaming (SSE) and WebSocket traffic must not be buffered or cut short.
+    # Gateway routes are listed first so /openai /anthropic /gemini skip the
+    # console hop (measured extra TTFB on the hairpin path).
+$(gateway_proxy_locations)
+
     location / {
         proxy_pass http://console:80;
         proxy_http_version 1.1;
@@ -663,6 +724,7 @@ services:
     restart: unless-stopped
     depends_on:
       - console
+      - gateway
     ports:
       - "80:80"
       - "443:443"

--- a/scripts/measure_gateway_overhead.py
+++ b/scripts/measure_gateway_overhead.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""Measure Preloop gateway streaming overhead (TTFB, TTLB, EOS-gap).
+
+Stdlib only. Keys stay in the environment; nothing is written to the
+script or to default output.
+
+Environment
+-----------
+PRELOOP_BASE_URL    Gateway origin, e.g. https://host or http://127.0.0.1:8001
+PRELOOP_API_KEY     Preloop API key
+PRELOOP_MODEL       Model alias as the gateway expects it
+PRELOOP_PROTOCOL    openai (default) or anthropic
+
+Optional paired direct-upstream (same model, bypasses Preloop):
+DIRECT_BASE_URL     Upstream origin (OpenAI-compatible or Anthropic)
+DIRECT_API_KEY      Upstream key
+DIRECT_MODEL        Upstream model id
+DIRECT_PROTOCOL     openai (default) or anthropic
+
+Every request sets PRELOOP_DISABLE_TELEMETRY=true in the process
+environment and as a request header (the product may only honor the
+server-side env; the header is harmless).
+
+Examples
+--------
+  PRELOOP_BASE_URL=https://preloop.example.com \\
+  PRELOOP_API_KEY=... PRELOOP_MODEL=your-gateway-alias \\
+  python3 scripts/measure_gateway_overhead.py --n 30 --json /tmp/samples.json
+
+  # paired same-model upstream (bypass Preloop)
+  DIRECT_BASE_URL=https://api.example.com/v1 \\
+  DIRECT_API_KEY=... DIRECT_MODEL=your-upstream-id \\
+  python3 scripts/measure_gateway_overhead.py --n 30 --json /tmp/samples.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import ssl
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+from urllib.parse import urljoin
+
+PROMPT = "Reply with the single word ping."
+
+
+def _env(name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    return value
+
+
+def percentile(values: list[float], p: float) -> float | None:
+    """Nearest-rank percentile. p in 0..100. None if empty."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = max(1, int(round((p / 100.0) * len(ordered))))
+    return ordered[rank - 1]
+
+
+def fmt_ms(seconds: float | None) -> str:
+    if seconds is None:
+        return "n/a"
+    return f"{seconds * 1000.0:.1f}ms"
+
+
+def _extract_openai_text(payload: dict[str, Any]) -> str:
+    choices = payload.get("choices") or []
+    if not choices:
+        return ""
+    delta = choices[0].get("delta") or {}
+    content = delta.get("content")
+    if isinstance(content, str):
+        return content
+    message = choices[0].get("message") or {}
+    msg_content = message.get("content")
+    if isinstance(msg_content, str):
+        return msg_content
+    return ""
+
+
+def _extract_anthropic_text(payload: dict[str, Any]) -> str:
+    if payload.get("type") == "content_block_delta":
+        delta = payload.get("delta") or {}
+        text = delta.get("text")
+        if isinstance(text, str):
+            return text
+    block = payload.get("content_block") or {}
+    text = block.get("text")
+    if isinstance(text, str):
+        return text
+    return ""
+
+
+def _is_eos_openai(data_line: str) -> bool:
+    return data_line.strip() == "[DONE]"
+
+
+def _is_eos_anthropic(payload: dict[str, Any] | None, data_line: str) -> bool:
+    if data_line.strip() == "[DONE]":
+        return True
+    if payload and payload.get("type") == "message_stop":
+        return True
+    return False
+
+
+def measure_stream(
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    protocol: str,
+    max_tokens: int,
+    timeout_s: float,
+    insecure: bool,
+) -> dict[str, Any]:
+    """POST one streaming completion and time TTFB / last-content / EOS."""
+    protocol = protocol.lower().strip()
+    origin = base_url.rstrip("/") + "/"
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "PRELOOP_DISABLE_TELEMETRY": "true",
+    }
+
+    if protocol == "anthropic":
+        url = urljoin(origin, "anthropic/v1/messages")
+        # Some Anthropic-compatible hosts (and Preloop) also accept Bearer.
+        headers["x-api-key"] = api_key
+        headers["Authorization"] = f"Bearer {api_key}"
+        headers["anthropic-version"] = "2023-06-01"
+        body = {
+            "model": model,
+            "stream": True,
+            "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": PROMPT}],
+        }
+    elif protocol == "openai":
+        # Support either a full origin (https://host) or an OpenAI-compat
+        # prefix already ending at /openai or /v1.
+        if origin.rstrip("/").endswith("/v1"):
+            url = urljoin(origin, "chat/completions")
+        elif origin.rstrip("/").endswith("/openai"):
+            url = urljoin(origin.rstrip("/") + "/", "v1/chat/completions")
+        else:
+            url = urljoin(origin, "openai/v1/chat/completions")
+        headers["Authorization"] = f"Bearer {api_key}"
+        body = {
+            "model": model,
+            "stream": True,
+            "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": PROMPT}],
+        }
+    else:
+        raise ValueError(f"unknown protocol: {protocol}")
+
+    payload = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+    context = (
+        ssl._create_unverified_context() if insecure else ssl.create_default_context()
+    )
+
+    t0 = time.perf_counter()
+    ttfb_data: float | None = None
+    ttfb_content: float | None = None
+    last_content: float | None = None
+    last_data: float | None = None
+    eos: float | None = None
+    status = None
+    first_data_preview = ""
+    content_chars = 0
+    data_events = 0
+    error = None
+
+    try:
+        with urllib.request.urlopen(
+            request, timeout=timeout_s, context=context
+        ) as resp:
+            status = getattr(resp, "status", None)
+            buf = b""
+            while True:
+                chunk = resp.read(256)
+                if not chunk:
+                    break
+                buf += chunk
+                while b"\n" in buf:
+                    raw_line, buf = buf.split(b"\n", 1)
+                    line = raw_line.decode("utf-8", errors="replace").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    data_line = line[5:].lstrip()
+                    if data_line == "":
+                        continue
+                    now = time.perf_counter()
+                    data_events += 1
+                    if ttfb_data is None:
+                        ttfb_data = now - t0
+                        first_data_preview = data_line[:80]
+
+                    parsed: dict[str, Any] | None = None
+                    if data_line != "[DONE]":
+                        try:
+                            loaded = json.loads(data_line)
+                            if isinstance(loaded, dict):
+                                parsed = loaded
+                        except json.JSONDecodeError:
+                            parsed = None
+
+                    if protocol == "anthropic":
+                        done = _is_eos_anthropic(parsed, data_line)
+                    else:
+                        done = _is_eos_openai(data_line)
+                    if done:
+                        eos = now - t0
+                        buf = b""
+                        break
+
+                    # Non-EOS events only. Counting [DONE]/message_stop here
+                    # would force eos_gap to 0.
+                    last_data = now - t0
+                    text = ""
+                    if parsed is not None:
+                        if protocol == "anthropic":
+                            text = _extract_anthropic_text(parsed)
+                        else:
+                            text = _extract_openai_text(parsed)
+                    if text:
+                        content_chars += len(text)
+                        if ttfb_content is None:
+                            ttfb_content = now - t0
+                        last_content = now - t0
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        try:
+            err_body = exc.read().decode("utf-8", errors="replace")[:300]
+        except Exception:
+            err_body = str(exc)
+        error = f"HTTP {exc.code}: {err_body}"
+    except Exception as exc:  # noqa: BLE001 - surface any transport failure
+        error = f"{type(exc).__name__}: {exc}"
+
+    gap_from = last_content if last_content is not None else last_data
+    gap = None
+    if eos is not None and gap_from is not None:
+        gap = eos - gap_from
+
+    return {
+        "ok": error is None and eos is not None,
+        "status": status,
+        "error": error,
+        "ttfb_s": ttfb_data,
+        "ttfb_content_s": ttfb_content,
+        "ttlb_s": eos,
+        "eos_gap_s": gap,
+        "last_content_s": last_content,
+        "last_data_s": last_data,
+        "content_chars": content_chars,
+        "data_events": data_events,
+        "first_data_preview": first_data_preview,
+        "protocol": protocol,
+        "model": model,
+        "url_host_path": _redact_url(url),
+    }
+
+
+def _redact_url(url: str) -> str:
+    # Drop query strings (some providers put keys there). Keep host+path.
+    if "?" in url:
+        url = url.split("?", 1)[0]
+    return url
+
+
+def run_series(
+    label: str,
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    protocol: str,
+    n: int,
+    warmup: int,
+    max_tokens: int,
+    timeout_s: float,
+    insecure: bool,
+) -> dict[str, Any]:
+    print(
+        f"\n== {label}  {protocol}  model={model}  n={n} warmup={warmup} ==", flush=True
+    )
+    print(f"   base={base_url}", flush=True)
+    warmup_errors = 0
+    for i in range(warmup):
+        sample = measure_stream(
+            base_url=base_url,
+            api_key=api_key,
+            model=model,
+            protocol=protocol,
+            max_tokens=max_tokens,
+            timeout_s=timeout_s,
+            insecure=insecure,
+        )
+        if not sample["ok"]:
+            warmup_errors += 1
+            print(f"   warmup {i + 1}/{warmup} FAIL {sample.get('error')}", flush=True)
+        else:
+            print(
+                f"   warmup {i + 1}/{warmup} ttfb={fmt_ms(sample['ttfb_s'])} "
+                f"ttlb={fmt_ms(sample['ttlb_s'])} gap={fmt_ms(sample['eos_gap_s'])}",
+                flush=True,
+            )
+
+    samples: list[dict[str, Any]] = []
+    for i in range(n):
+        sample = measure_stream(
+            base_url=base_url,
+            api_key=api_key,
+            model=model,
+            protocol=protocol,
+            max_tokens=max_tokens,
+            timeout_s=timeout_s,
+            insecure=insecure,
+        )
+        samples.append(sample)
+        flag = "ok" if sample["ok"] else "FAIL"
+        print(
+            f"   {i + 1:02d}/{n} {flag} ttfb={fmt_ms(sample['ttfb_s'])} "
+            f"ttfb_text={fmt_ms(sample['ttfb_content_s'])} "
+            f"ttlb={fmt_ms(sample['ttlb_s'])} gap={fmt_ms(sample['eos_gap_s'])} "
+            f"chars={sample['content_chars']}",
+            flush=True,
+        )
+        if not sample["ok"]:
+            print(f"      {sample.get('error')}", flush=True)
+
+    ok = [s for s in samples if s["ok"] and s["ttfb_s"] is not None]
+    summary = {
+        "label": label,
+        "base_url": base_url,
+        "model": model,
+        "protocol": protocol,
+        "n_requested": n,
+        "n_ok": len(ok),
+        "warmup": warmup,
+        "warmup_errors": warmup_errors,
+        "max_tokens": max_tokens,
+        "ttfb_p50_s": percentile([s["ttfb_s"] for s in ok], 50),
+        "ttfb_p95_s": percentile([s["ttfb_s"] for s in ok], 95),
+        "ttfb_content_p50_s": percentile(
+            [s["ttfb_content_s"] for s in ok if s["ttfb_content_s"] is not None], 50
+        ),
+        "ttfb_content_p95_s": percentile(
+            [s["ttfb_content_s"] for s in ok if s["ttfb_content_s"] is not None], 95
+        ),
+        "ttlb_p50_s": percentile(
+            [s["ttlb_s"] for s in ok if s["ttlb_s"] is not None], 50
+        ),
+        "ttlb_p95_s": percentile(
+            [s["ttlb_s"] for s in ok if s["ttlb_s"] is not None], 95
+        ),
+        "eos_gap_p50_s": percentile(
+            [s["eos_gap_s"] for s in ok if s["eos_gap_s"] is not None], 50
+        ),
+        "eos_gap_p95_s": percentile(
+            [s["eos_gap_s"] for s in ok if s["eos_gap_s"] is not None], 95
+        ),
+        "stream_tail_p50_s": percentile(
+            [
+                s["ttlb_s"] - s["ttfb_s"]
+                for s in ok
+                if s["ttlb_s"] is not None and s["ttfb_s"] is not None
+            ],
+            50,
+        ),
+        "stream_tail_p95_s": percentile(
+            [
+                s["ttlb_s"] - s["ttfb_s"]
+                for s in ok
+                if s["ttlb_s"] is not None and s["ttfb_s"] is not None
+            ],
+            95,
+        ),
+        "mean_content_chars": (
+            statistics.mean([s["content_chars"] for s in ok]) if ok else None
+        ),
+        "samples": samples,
+    }
+    print(
+        f"   SUMMARY n_ok={summary['n_ok']}/{n} "
+        f"ttfb p50={fmt_ms(summary['ttfb_p50_s'])} p95={fmt_ms(summary['ttfb_p95_s'])} "
+        f"ttlb p50={fmt_ms(summary['ttlb_p50_s'])} p95={fmt_ms(summary['ttlb_p95_s'])} "
+        f"gap p50={fmt_ms(summary['eos_gap_p50_s'])} p95={fmt_ms(summary['eos_gap_p95_s'])} "
+        f"tail p50={fmt_ms(summary['stream_tail_p50_s'])} p95={fmt_ms(summary['stream_tail_p95_s'])}",
+        flush=True,
+    )
+    return summary
+
+
+def _delta(a: float | None, b: float | None) -> float | None:
+    if a is None or b is None:
+        return None
+    return a - b
+
+
+def print_table(rows: list[dict[str, Any]]) -> None:
+    headers = [
+        "series",
+        "n_ok",
+        "ttfb_p50",
+        "ttfb_p95",
+        "ttlb_p50",
+        "ttlb_p95",
+        "gap_p50",
+        "gap_p95",
+        "tail_p50",
+        "tail_p95",
+    ]
+    print("\n" + "  ".join(f"{h:>12}" for h in headers))
+    for row in rows:
+        cells = [
+            row["series"],
+            str(row["n_ok"]),
+            fmt_ms(row.get("ttfb_p50_s")),
+            fmt_ms(row.get("ttfb_p95_s")),
+            fmt_ms(row.get("ttlb_p50_s")),
+            fmt_ms(row.get("ttlb_p95_s")),
+            fmt_ms(row.get("eos_gap_p50_s")),
+            fmt_ms(row.get("eos_gap_p95_s")),
+            fmt_ms(row.get("stream_tail_p50_s")),
+            fmt_ms(row.get("stream_tail_p95_s")),
+        ]
+        print("  ".join(f"{c:>12}" for c in cells))
+
+
+def main() -> int:
+    os.environ["PRELOOP_DISABLE_TELEMETRY"] = "true"
+
+    parser = argparse.ArgumentParser(description=__doc__.split("Stdlib")[0].strip())
+    parser.add_argument(
+        "--n", type=int, default=30, help="measured requests after warmup"
+    )
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--max-tokens", type=int, default=8)
+    parser.add_argument("--timeout", type=float, default=60.0)
+    parser.add_argument(
+        "--protocol",
+        default=_env("PRELOOP_PROTOCOL", "openai"),
+        choices=("openai", "anthropic"),
+    )
+    parser.add_argument("--json", dest="json_path", help="write raw samples JSON here")
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="skip TLS verify (not for customer-real numbers)",
+    )
+    args = parser.parse_args()
+
+    base = _env("PRELOOP_BASE_URL")
+    key = _env("PRELOOP_API_KEY")
+    model = _env("PRELOOP_MODEL")
+    if not base or not key or not model:
+        print(
+            "PRELOOP_BASE_URL, PRELOOP_API_KEY, and PRELOOP_MODEL are required",
+            file=sys.stderr,
+        )
+        return 2
+
+    gateway = run_series(
+        "gateway",
+        base_url=base,
+        api_key=key,
+        model=model,
+        protocol=args.protocol,
+        n=args.n,
+        warmup=args.warmup,
+        max_tokens=args.max_tokens,
+        timeout_s=args.timeout,
+        insecure=args.insecure,
+    )
+
+    direct = None
+    d_base = _env("DIRECT_BASE_URL")
+    d_key = _env("DIRECT_API_KEY")
+    d_model = _env("DIRECT_MODEL")
+    d_proto = _env("DIRECT_PROTOCOL", "openai") or "openai"
+    if d_base and d_key and d_model:
+        direct = run_series(
+            "direct",
+            base_url=d_base,
+            api_key=d_key,
+            model=d_model,
+            protocol=d_proto,
+            n=args.n,
+            warmup=args.warmup,
+            max_tokens=args.max_tokens,
+            timeout_s=args.timeout,
+            insecure=args.insecure,
+        )
+    else:
+        print("\nNo DIRECT_* env set; skipping paired upstream.", flush=True)
+
+    rows = [
+        {
+            "series": "gateway",
+            "n_ok": gateway["n_ok"],
+            "ttfb_p50_s": gateway["ttfb_p50_s"],
+            "ttfb_p95_s": gateway["ttfb_p95_s"],
+            "ttlb_p50_s": gateway["ttlb_p50_s"],
+            "ttlb_p95_s": gateway["ttlb_p95_s"],
+            "eos_gap_p50_s": gateway["eos_gap_p50_s"],
+            "eos_gap_p95_s": gateway["eos_gap_p95_s"],
+            "stream_tail_p50_s": gateway["stream_tail_p50_s"],
+            "stream_tail_p95_s": gateway["stream_tail_p95_s"],
+        }
+    ]
+    if direct:
+        rows.append(
+            {
+                "series": "direct",
+                "n_ok": direct["n_ok"],
+                "ttfb_p50_s": direct["ttfb_p50_s"],
+                "ttfb_p95_s": direct["ttfb_p95_s"],
+                "ttlb_p50_s": direct["ttlb_p50_s"],
+                "ttlb_p95_s": direct["ttlb_p95_s"],
+                "eos_gap_p50_s": direct["eos_gap_p50_s"],
+                "eos_gap_p95_s": direct["eos_gap_p95_s"],
+                "stream_tail_p50_s": direct["stream_tail_p50_s"],
+                "stream_tail_p95_s": direct["stream_tail_p95_s"],
+            }
+        )
+        rows.append(
+            {
+                "series": "delta (g-d)",
+                "n_ok": f"{gateway['n_ok']}/{direct['n_ok']}",
+                "ttfb_p50_s": _delta(gateway["ttfb_p50_s"], direct["ttfb_p50_s"]),
+                "ttfb_p95_s": _delta(gateway["ttfb_p95_s"], direct["ttfb_p95_s"]),
+                "ttlb_p50_s": _delta(gateway["ttlb_p50_s"], direct["ttlb_p50_s"]),
+                "ttlb_p95_s": _delta(gateway["ttlb_p95_s"], direct["ttlb_p95_s"]),
+                "eos_gap_p50_s": _delta(
+                    gateway["eos_gap_p50_s"], direct["eos_gap_p50_s"]
+                ),
+                "eos_gap_p95_s": _delta(
+                    gateway["eos_gap_p95_s"], direct["eos_gap_p95_s"]
+                ),
+                "stream_tail_p50_s": _delta(
+                    gateway["stream_tail_p50_s"], direct["stream_tail_p50_s"]
+                ),
+                "stream_tail_p95_s": _delta(
+                    gateway["stream_tail_p95_s"], direct["stream_tail_p95_s"]
+                ),
+            }
+        )
+    print_table(rows)
+
+    if args.json_path:
+        dump = {
+            "prompt_word": "ping",
+            "max_tokens": args.max_tokens,
+            "n": args.n,
+            "warmup": args.warmup,
+            "gateway": _strip_samples_host_only(gateway),
+            "direct": _strip_samples_host_only(direct) if direct else None,
+        }
+        with open(args.json_path, "w", encoding="utf-8") as fh:
+            json.dump(dump, fh, indent=2)
+            fh.write("\n")
+        print(f"\nWrote {args.json_path}")
+    return 0 if gateway["n_ok"] == args.n else 1
+
+
+def _strip_samples_host_only(summary: dict[str, Any]) -> dict[str, Any]:
+    """Copy summary; drop any accidental secret-shaped fields (none expected)."""
+    copy = dict(summary)
+    clean = []
+    for sample in copy.get("samples") or []:
+        item = dict(sample)
+        item.pop("error_body", None)
+        item.pop("first_data_preview", None)
+        if item.get("error") and "Bearer" in str(item["error"]):
+            item["error"] = "redacted HTTP error"
+        clean.append(item)
+    copy["samples"] = clean
+    return copy
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- OSS TLS nginx was sending `/openai/`, `/anthropic/`, and `/gemini/` through the console, which added about 70ms TTFB on a co-located self-host (public path vs loopback to the gateway). Those locations now proxy straight to the gateway, matching Helm and the console nginx template.
- Streaming responses yield `message_stop` / `[DONE]` before usage recording, so bookkeeping no longer holds the last SSE event.
- `scripts/measure_gateway_overhead.py` (Python 3 stdlib) times TTFB and time-to-close through the gateway vs an optional same-model direct upstream. Keys stay in the environment.

## Test plan
- [ ] `PRELOOP_DISABLE_TELEMETRY=true pytest backend/tests/helm/test_gateway_proxy_timeouts.py backend/tests/services/test_openai_gateway_stream_eos.py`
- [ ] Confirm `scripts/install-oss.sh` TLS config contains `location ^~ /openai/` with `proxy_pass http://gateway:8000` and `proxy_buffering off`
- [ ] On a TLS OSS install, run:

```bash
export PRELOOP_DISABLE_TELEMETRY=true
export PRELOOP_BASE_URL=https://your-preloop-host
export PRELOOP_API_KEY=...
export PRELOOP_MODEL=...
python3 scripts/measure_gateway_overhead.py --n 30 --json /tmp/gateway-overhead.json
```

- [ ] Optional pair: set `DIRECT_BASE_URL`, `DIRECT_API_KEY`, `DIRECT_MODEL` to the same upstream the gateway uses. Public TTFB should sit close to loopback (`PRELOOP_BASE_URL=http://127.0.0.1:8001`) rather than ~70ms above it.


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low risk**
> Follow-up commit adds a second Helm Ingress routing `/openai`, `/anthropic`, `/gemini` straight to the gateway Service. Config-only, render-verified, with matching tests; no security impact.
>
> **Overview**
> Routes `/openai`, `/anthropic`, `/gemini` now skip the ~70ms console hop in both the OSS TLS edge proxy and the Helm chart (second Ingress with `proxy-buffering: off`, shared TLS secret issued once). Streams yield terminal SSE events before usage recording so completed streams record 200 on disconnect, and a stdlib gateway-overhead measurement script plus regression tests are included.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 5778ddd. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->