### PR TITLE
feat: CNPG scheduled backups (prod+staging) replacing deploy-time pg_dump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,16 @@ jobs:
       - name: Run ruff
         run: ruff check .
 
+  helm-lint:
+    name: Helm Chart Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      # helm is preinstalled on ubuntu-latest runners
+      - name: Helm render checks (chart lint + CNPG backup wiring)
+        run: sh scripts/helm-render-check.sh
+
   test-backend:
     name: Backend Tests
     runs-on: ubuntu-latest

--- a/helm/preloop/README.md
+++ b/helm/preloop/README.md
@@ -348,6 +348,133 @@ LIMIT 10;
 SELECT pg_stat_statements_reset();
 ```
 
+### Continuous Backups (CNPG WAL archiving + scheduled base backups)
+
+The chart can configure CloudNativePG continuous backups to any S3-compatible
+object store. Enabling `database.cnpg.backup.enabled`:
+
+- turns on **continuous WAL archiving** on the Cluster (recovery point is
+  typically under 5 minutes — no need for deploy-time `pg_dump` backups), and
+- creates a **`ScheduledBackup`** CR for periodic base backups (bounds WAL
+  replay time on restore and anchors the retention policy).
+
+**1. Create the credentials secret** (once per namespace):
+
+```bash
+kubectl create secret generic preloop-db-backup-s3 -n <namespace> \
+  --from-literal=ACCESS_KEY_ID=<access-key> \
+  --from-literal=SECRET_ACCESS_KEY=<secret-key>
+```
+
+**2. Enable via values** (see `values-backup-prod.yaml` /
+`values-backup-staging.yaml` for complete profiles):
+
+```yaml
+database:
+  cnpg:
+    backup:
+      enabled: true
+      destinationPath: "s3://my-bucket/cnpg/my-cluster"  # required
+      endpointURL: ""       # set for MinIO/R2/Ceph; empty for AWS S3
+      retentionPolicy: "30d"
+      s3Credentials:
+        secretName: "preloop-db-backup-s3"
+      scheduled:
+        enabled: true
+        schedule: "0 0 2 * * *"  # CNPG cron: SIX fields, seconds first
+        immediate: true          # take a base backup right away
+```
+
+Notes:
+
+- The CNPG cron `schedule` has **six** fields (`seconds minutes hours
+  day-of-month month day-of-week`), unlike standard Kubernetes CronJobs.
+- Enabling backups on a running cluster is a configuration reload, not a
+  restart (CNPG always runs with `archive_mode=on`).
+- Each cluster must own a **unique** `destinationPath`+`serverName`
+  combination. Never point two live clusters at the same path.
+
+**Verify** after enabling:
+
+```bash
+# WAL archiving healthy? (continuousArchiving condition should be True)
+kubectl -n <ns> get cluster <cluster-name> \
+  -o jsonpath='{.status.conditions[?(@.type=="ContinuousArchiving")]}'
+
+# First base backup completed?
+kubectl -n <ns> get backups
+kubectl -n <ns> get scheduledbackup
+```
+
+You can also trigger an on-demand base backup at any time (e.g. before a
+risky migration) without touching the deploy pipeline:
+
+```bash
+kubectl -n <ns> create -f - <<'EOF'
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  generateName: preloop-db-ondemand-
+spec:
+  cluster:
+    name: <cluster-name>  # e.g. preloop-db
+EOF
+```
+
+#### Restore procedure
+
+Restores bootstrap a **new** Cluster from the object store (optionally to a
+point in time), they do not restore in place:
+
+1. Create a recovery manifest (adjust names, storage and credentials to match
+   the environment; the `externalClusters.serverName` must match the name the
+   backups were written under — by default the old cluster's name):
+
+   ```yaml
+   apiVersion: postgresql.cnpg.io/v1
+   kind: Cluster
+   metadata:
+     name: preloop-db-restore
+   spec:
+     instances: 1
+     storage:
+       size: 10Gi  # >= original
+     superuserSecret:
+       name: preloop-db-superuser
+     enableSuperuserAccess: true
+     bootstrap:
+       recovery:
+         source: origin
+         # Optional point-in-time recovery:
+         # recoveryTarget:
+         #   targetTime: "2026-08-19 10:00:00+00"
+     externalClusters:
+       - name: origin
+         barmanObjectStore:
+           destinationPath: "s3://my-bucket/cnpg/my-cluster"
+           # endpointURL: "https://..."  # if S3-compatible
+           serverName: preloop-db  # folder the backups were written under
+           s3Credentials:
+             accessKeyId:
+               name: preloop-db-backup-s3
+               key: ACCESS_KEY_ID
+             secretAccessKey:
+               name: preloop-db-backup-s3
+               key: SECRET_ACCESS_KEY
+           wal:
+             compression: gzip
+   ```
+
+2. `kubectl apply -n <ns> -f restore.yaml` and wait for the cluster to become
+   `Cluster in healthy state` (`kubectl -n <ns> get cluster preloop-db-restore -w`).
+3. Validate the data (connect via `kubectl -n <ns> exec -it preloop-db-restore-1 -- psql`).
+4. Cut over: either repoint the application `database.host` at the restored
+   cluster's `-rw` service, or (cleaner) redeploy the chart with
+   `database.cnpg.name=preloop-db-restore` **and** a fresh
+   `backup.serverName`/`destinationPath` so the restored cluster archives to
+   a new location instead of overwriting the archive it recovered from.
+5. Decommission the old cluster only after the new one is verified.
+
 ## Upgrading the Chart
 
 ### To 1.0.0

--- a/helm/preloop/README.md
+++ b/helm/preloop/README.md
@@ -383,6 +383,10 @@ database:
         enabled: true
         schedule: "0 0 2 * * *"  # CNPG cron: SIX fields, seconds first
         immediate: true          # take a base backup right away
+        # none: base backups survive ScheduledBackup deletion (helm
+        # upgrade with scheduled.enabled=false, helm uninstall). self
+        # would garbage-collect every backup the schedule created.
+        backupOwnerReference: none
 ```
 
 Notes:
@@ -393,6 +397,10 @@ Notes:
   restart (CNPG always runs with `archive_mode=on`).
 - Each cluster must own a **unique** `destinationPath`+`serverName`
   combination. Never point two live clusters at the same path.
+- `backupOwnerReference` defaults to `none` so base backups are not
+  garbage-collected when the `ScheduledBackup` is removed (a helm
+  upgrade that sets `scheduled.enabled=false`, or `helm uninstall`).
+  Set `self` only if you want that cascade.
 
 **Verify** after enabling:
 

--- a/helm/preloop/templates/postgresql-scheduledbackup.yaml
+++ b/helm/preloop/templates/postgresql-scheduledbackup.yaml
@@ -1,0 +1,26 @@
+{{- /*
+Scheduled base backups for the CNPG cluster. Requires
+database.cnpg.backup.enabled (which configures the barmanObjectStore on the
+Cluster) — a Backup/ScheduledBackup without an object store target fails.
+WAL archiving is continuous; this CR only controls periodic base backups
+which bound restore (WAL replay) time and anchor the retention policy.
+*/ -}}
+{{- if and .Values.database.enabled (not .Values.database.external) }}
+{{- $backup := .Values.database.cnpg.backup }}
+{{- if and $backup.enabled $backup.scheduled.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: {{ .Values.database.cnpg.name | default (printf "%s-db" (include "preloop.fullname" .)) }}-scheduled-backup
+  labels:
+    {{- include "preloop.labels" . | nindent 4 }}
+spec:
+  # CNPG cron format: SIX fields, seconds first ("sec min hour dom mon dow")
+  schedule: {{ $backup.scheduled.schedule | quote }}
+  backupOwnerReference: {{ $backup.scheduled.backupOwnerReference | default "self" }}
+  immediate: {{ $backup.scheduled.immediate | default false }}
+  suspend: {{ $backup.scheduled.suspend | default false }}
+  cluster:
+    name: {{ .Values.database.cnpg.name | default (printf "%s-db" (include "preloop.fullname" .)) }}
+{{- end }}
+{{- end }}

--- a/helm/preloop/templates/postgresql-scheduledbackup.yaml
+++ b/helm/preloop/templates/postgresql-scheduledbackup.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   # CNPG cron format: SIX fields, seconds first ("sec min hour dom mon dow")
   schedule: {{ $backup.scheduled.schedule | quote }}
-  backupOwnerReference: {{ $backup.scheduled.backupOwnerReference | default "self" }}
+  backupOwnerReference: {{ $backup.scheduled.backupOwnerReference | default "none" }}
   immediate: {{ $backup.scheduled.immediate | default false }}
   suspend: {{ $backup.scheduled.suspend | default false }}
   cluster:

--- a/helm/preloop/templates/postgresql.yaml
+++ b/helm/preloop/templates/postgresql.yaml
@@ -95,22 +95,34 @@ spec:
     disableDefaultQueries: false
 
   {{- if .Values.database.cnpg.backup.enabled }}
-  # Continuous backup to object storage
+  {{- $backup := .Values.database.cnpg.backup }}
+  {{- if not $backup.destinationPath }}
+  {{- fail "database.cnpg.backup.destinationPath is required when database.cnpg.backup.enabled is true" }}
+  {{- end }}
+  # Continuous backup to object storage (WAL archiving + base backups)
   backup:
     barmanObjectStore:
-      destinationPath: {{ .Values.database.cnpg.backup.destinationPath }}
-      {{- if .Values.database.cnpg.backup.s3Credentials }}
+      destinationPath: {{ $backup.destinationPath }}
+      {{- with $backup.endpointURL }}
+      endpointURL: {{ . }}
+      {{- end }}
+      {{- with $backup.serverName }}
+      serverName: {{ . }}
+      {{- end }}
+      {{- if and $backup.s3Credentials $backup.s3Credentials.secretName }}
       s3Credentials:
         accessKeyId:
-          name: {{ .Values.database.cnpg.backup.s3Credentials.secretName }}
-          key: {{ .Values.database.cnpg.backup.s3Credentials.accessKeyIdKey | default "ACCESS_KEY_ID" }}
+          name: {{ $backup.s3Credentials.secretName }}
+          key: {{ $backup.s3Credentials.accessKeyIdKey | default "ACCESS_KEY_ID" }}
         secretAccessKey:
-          name: {{ .Values.database.cnpg.backup.s3Credentials.secretName }}
-          key: {{ .Values.database.cnpg.backup.s3Credentials.secretAccessKeyKey | default "SECRET_ACCESS_KEY" }}
+          name: {{ $backup.s3Credentials.secretName }}
+          key: {{ $backup.s3Credentials.secretAccessKeyKey | default "SECRET_ACCESS_KEY" }}
       {{- end }}
       wal:
-        compression: {{ .Values.database.cnpg.backup.walCompression | default "gzip" }}
-    retentionPolicy: {{ .Values.database.cnpg.backup.retentionPolicy | default "30d" | quote }}
+        compression: {{ $backup.walCompression | default "gzip" }}
+      data:
+        compression: {{ $backup.dataCompression | default "gzip" }}
+    retentionPolicy: {{ $backup.retentionPolicy | default "30d" | quote }}
   {{- end }}
 
   # Storage configuration

--- a/helm/preloop/values-backup-prod.yaml
+++ b/helm/preloop/values-backup-prod.yaml
@@ -1,0 +1,33 @@
+# Production backup profile — apply on top of the normal prod values/flags:
+#   helm upgrade --install preloop ./helm/preloop -n preloop-prod \
+#     <existing flags...> -f helm/preloop/values-backup-prod.yaml
+#
+# Prerequisite (once per namespace): an S3(-compatible) credentials secret:
+#   kubectl create secret generic preloop-db-backup-s3 -n preloop-prod \
+#     --from-literal=ACCESS_KEY_ID=<key> \
+#     --from-literal=SECRET_ACCESS_KEY=<secret>
+#
+# Replace bucket/endpoint with the real values before use.
+database:
+  cnpg:
+    backup:
+      enabled: true
+      # Keep the CNPG archive under a dedicated prefix, separate from the
+      # legacy pg_dump uploads (s3://$S3_BUCKET/db/...)
+      destinationPath: "s3://preloop-backups/cnpg/preloop-prod"
+      # Set for S3-compatible stores (MinIO/R2/Ceph); leave empty for AWS S3
+      endpointURL: ""
+      retentionPolicy: "30d"
+      walCompression: "gzip"
+      dataCompression: "gzip"
+      s3Credentials:
+        secretName: "preloop-db-backup-s3"
+        accessKeyIdKey: "ACCESS_KEY_ID"
+        secretAccessKeyKey: "SECRET_ACCESS_KEY"
+      scheduled:
+        enabled: true
+        # Daily base backup at 02:00 UTC (low-traffic window)
+        schedule: "0 0 2 * * *"
+        immediate: true
+        suspend: false
+        backupOwnerReference: self

--- a/helm/preloop/values-backup-prod.yaml
+++ b/helm/preloop/values-backup-prod.yaml
@@ -30,4 +30,4 @@ database:
         schedule: "0 0 2 * * *"
         immediate: true
         suspend: false
-        backupOwnerReference: self
+        backupOwnerReference: none

--- a/helm/preloop/values-backup-staging.yaml
+++ b/helm/preloop/values-backup-staging.yaml
@@ -1,0 +1,32 @@
+# Staging backup profile — apply on top of the normal staging values/flags:
+#   helm upgrade --install preloop ./helm/preloop -n preloop-staging \
+#     <existing flags...> -f helm/preloop/values-backup-staging.yaml
+#
+# Prerequisite (once per namespace): an S3(-compatible) credentials secret:
+#   kubectl create secret generic preloop-db-backup-s3 -n preloop-staging \
+#     --from-literal=ACCESS_KEY_ID=<key> \
+#     --from-literal=SECRET_ACCESS_KEY=<secret>
+#
+# Replace bucket/endpoint with the real values before use.
+database:
+  cnpg:
+    backup:
+      enabled: true
+      destinationPath: "s3://preloop-backups/cnpg/preloop-staging"
+      endpointURL: ""
+      # Shorter retention than prod — staging data is disposable
+      retentionPolicy: "7d"
+      walCompression: "gzip"
+      dataCompression: "gzip"
+      s3Credentials:
+        secretName: "preloop-db-backup-s3"
+        accessKeyIdKey: "ACCESS_KEY_ID"
+        secretAccessKeyKey: "SECRET_ACCESS_KEY"
+      scheduled:
+        enabled: true
+        # Daily base backup at 03:00 UTC (offset from prod to spread load
+        # on shared object storage)
+        schedule: "0 0 3 * * *"
+        immediate: true
+        suspend: false
+        backupOwnerReference: self

--- a/helm/preloop/values-backup-staging.yaml
+++ b/helm/preloop/values-backup-staging.yaml
@@ -29,4 +29,4 @@ database:
         schedule: "0 0 3 * * *"
         immediate: true
         suspend: false
-        backupOwnerReference: self
+        backupOwnerReference: none

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -402,16 +402,40 @@ database:
     # Monitoring - expose PostgreSQL metrics to Prometheus via PodMonitor
     monitoring:
       enablePodMonitor: false  # Set to true if Prometheus is deployed
-    # Continuous backup to object storage (WAL archiving + base backups)
+    # Continuous backup to object storage (WAL archiving + base backups).
+    # Enabling this turns on continuous WAL archiving on the Cluster and
+    # (via scheduled.enabled) a ScheduledBackup CR for periodic base backups.
+    # This replaces any deploy-time pg_dump: recovery point is determined by
+    # WAL archiving (typically < 5 min), not by deploy frequency.
     backup:
-      enabled: false  # Set to true in production
+      enabled: false  # Set to true in production and staging
       destinationPath: ""  # e.g. s3://bucket/cnpg/preloop-prod
+      # Endpoint for S3-compatible object stores (MinIO, R2, Ceph, ...).
+      # Leave empty for AWS S3.
+      endpointURL: ""
+      # Folder name inside destinationPath. Defaults to the cluster name.
+      # Must be changed (or destinationPath moved) when bootstrapping a new
+      # cluster that recovers from an existing backup, so the new cluster
+      # does not overwrite the archive it is restoring from.
+      serverName: ""
       retentionPolicy: "30d"
       walCompression: "gzip"
+      dataCompression: "gzip"  # Compression for base backup data files
       s3Credentials:
         secretName: ""  # K8s secret containing ACCESS_KEY_ID and SECRET_ACCESS_KEY
         accessKeyIdKey: "ACCESS_KEY_ID"
         secretAccessKeyKey: "SECRET_ACCESS_KEY"
+      # Scheduled base backups (CNPG ScheduledBackup CR)
+      scheduled:
+        enabled: true  # Effective only when backup.enabled is true
+        # CNPG cron format has SIX fields (seconds first):
+        # "sec min hour day month weekday" — default: daily at 02:00 UTC
+        schedule: "0 0 2 * * *"
+        # Take a first base backup as soon as the ScheduledBackup is created
+        immediate: true
+        suspend: false
+        # Owner of Backup objects created by the schedule: none|self|cluster
+        backupOwnerReference: self
     # Slow query logging - enable to monitor query performance
     logging:
       enabled: false  # Set to true to enable slow query logging

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -434,8 +434,11 @@ database:
         # Take a first base backup as soon as the ScheduledBackup is created
         immediate: true
         suspend: false
-        # Owner of Backup objects created by the schedule: none|self|cluster
-        backupOwnerReference: self
+        # Owner of Backup objects created by the schedule: none|self|cluster.
+        # Default none: deleting/recreating the ScheduledBackup (helm upgrade
+        # with scheduled.enabled=false, or helm uninstall) must not garbage-
+        # collect the base backups. `self` would cascade-delete them.
+        backupOwnerReference: none
     # Slow query logging - enable to monitor query performance
     logging:
       enabled: false  # Set to true to enable slow query logging

--- a/scripts/helm-render-check.sh
+++ b/scripts/helm-render-check.sh
@@ -26,12 +26,14 @@ echo "$out" | grep -q "kind: ScheduledBackup" || fail "ScheduledBackup missing (
 echo "$out" | grep -q "barmanObjectStore" || fail "barmanObjectStore missing (prod profile)"
 echo "$out" | grep -q 'retentionPolicy: "30d"' || fail "prod retention wrong"
 echo "$out" | grep -q 'schedule: "0 0 2 \* \* \*"' || fail "prod schedule wrong"
+echo "$out" | grep -q "backupOwnerReference: none" || fail "prod backupOwnerReference should be none"
 
 echo "==> staging profile: backup + ScheduledBackup ON"
 out=$(helm template t "$CHART" -f "$CHART/values-backup-staging.yaml")
 echo "$out" | grep -q "kind: ScheduledBackup" || fail "ScheduledBackup missing (staging profile)"
 echo "$out" | grep -q 'retentionPolicy: "7d"' || fail "staging retention wrong"
 echo "$out" | grep -q 'schedule: "0 0 3 \* \* \*"' || fail "staging schedule wrong"
+echo "$out" | grep -q "backupOwnerReference: none" || fail "staging backupOwnerReference should be none"
 
 echo "==> backup.enabled without destinationPath must fail fast"
 if helm template t "$CHART" --set database.cnpg.backup.enabled=true >/dev/null 2>&1; then

--- a/scripts/helm-render-check.sh
+++ b/scripts/helm-render-check.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+# Helm chart render checks for the preloop chart, focused on the CNPG backup
+# wiring. Run from the repo root. Requires helm 3 and network access for
+# `helm dependency build` (nats subchart).
+set -eu
+
+CHART=./helm/preloop
+
+echo "==> helm dependency build"
+helm repo add nats https://nats-io.github.io/k8s/helm/charts >/dev/null 2>&1 || true
+helm dependency build "$CHART" >/dev/null
+
+echo "==> helm lint"
+helm lint "$CHART"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+echo "==> defaults: backup must be OFF"
+out=$(helm template t "$CHART")
+echo "$out" | grep -q "kind: ScheduledBackup" && fail "ScheduledBackup rendered with defaults"
+echo "$out" | grep -q "barmanObjectStore" && fail "barmanObjectStore rendered with defaults"
+
+echo "==> prod profile: backup + ScheduledBackup ON"
+out=$(helm template t "$CHART" -f "$CHART/values-backup-prod.yaml")
+echo "$out" | grep -q "kind: ScheduledBackup" || fail "ScheduledBackup missing (prod profile)"
+echo "$out" | grep -q "barmanObjectStore" || fail "barmanObjectStore missing (prod profile)"
+echo "$out" | grep -q 'retentionPolicy: "30d"' || fail "prod retention wrong"
+echo "$out" | grep -q 'schedule: "0 0 2 \* \* \*"' || fail "prod schedule wrong"
+
+echo "==> staging profile: backup + ScheduledBackup ON"
+out=$(helm template t "$CHART" -f "$CHART/values-backup-staging.yaml")
+echo "$out" | grep -q "kind: ScheduledBackup" || fail "ScheduledBackup missing (staging profile)"
+echo "$out" | grep -q 'retentionPolicy: "7d"' || fail "staging retention wrong"
+echo "$out" | grep -q 'schedule: "0 0 3 \* \* \*"' || fail "staging schedule wrong"
+
+echo "==> backup.enabled without destinationPath must fail fast"
+if helm template t "$CHART" --set database.cnpg.backup.enabled=true >/dev/null 2>&1; then
+  fail "template rendered despite missing destinationPath"
+fi
+
+echo "==> scheduled.enabled=false suppresses ScheduledBackup only"
+out=$(helm template t "$CHART" -f "$CHART/values-backup-prod.yaml" \
+  --set database.cnpg.backup.scheduled.enabled=false)
+echo "$out" | grep -q "kind: ScheduledBackup" && fail "ScheduledBackup rendered when scheduled.enabled=false"
+echo "$out" | grep -q "barmanObjectStore" || fail "WAL archiving suppressed by scheduled.enabled=false"
+
+echo "==> endpointURL / serverName render when set"
+out=$(helm template t "$CHART" -f "$CHART/values-backup-prod.yaml" \
+  --set database.cnpg.backup.endpointURL=https://minio.example.com \
+  --set database.cnpg.backup.serverName=preloop-db-v2)
+echo "$out" | grep -q "endpointURL: https://minio.example.com" || fail "endpointURL not rendered"
+echo "$out" | grep -q "serverName: preloop-db-v2" || fail "serverName not rendered"
+
+echo "All helm render checks passed."


### PR DESCRIPTION
## Why

Prod deploys are slow because `deploy:prod` (enterprise pipeline) runs a synchronous `pg_dump` inside the DB pod, copies it to the runner, xz-compresses it and uploads it to S3 — all before `helm upgrade` starts. This PR wires proper continuous backups via CloudNativePG so that deploy-time backup can be removed: WAL archiving gives a recovery point measured in minutes (vs. one dump per deploy), and scheduled base backups bound restore time and anchor retention.

## What

**Chart (`helm/preloop`)**
- `Cluster` template: `endpointURL` for S3-compatible stores (MinIO/R2/Ceph), optional `serverName` override (needed for safe restores), base-backup `data.compression`, and a fail-fast `fail` when `backup.enabled` is set without `destinationPath`.
- New `ScheduledBackup` CR template, gated on `database.cnpg.backup.enabled` + `backup.scheduled.enabled`, with values for schedule (CNPG 6-field cron), `immediate`, `suspend`, `backupOwnerReference`.
- `values-backup-prod.yaml` / `values-backup-staging.yaml`: ready-to-use overlay profiles (30d/7d retention, 02:00/03:00 UTC base backups, `preloop-db-backup-s3` secret pattern with `ACCESS_KEY_ID`/`SECRET_ACCESS_KEY` keys, matching the existing chart secret conventions).

**Docs**
- Chart README: enablement steps, verification commands, on-demand `Backup` CR (replacement for pre-migration safety dumps), and a full restore procedure (bootstrap recovery from object store, incl. PITR and the serverName/destinationPath rules that prevent overwriting the archive you restore from).

**Tests/CI**
- `scripts/helm-render-check.sh`: helm lint + render assertions — backup off by default, prod/staging profiles render Cluster backup block + ScheduledBackup with correct retention/schedule, missing `destinationPath` fails fast, `scheduled.enabled=false` suppresses only the ScheduledBackup, `endpointURL`/`serverName` render.
- New non-gating `helm-lint` CI job running that script.

## Enterprise pipeline follow-up (separate repo)

Once this ships and backups are verified healthy, delete the entire `before_script` of `deploy:prod` in `preloop-ee/.gitlab-ci.yml` (the pg_dump/kubectl cp/xz/aws-s3 block) and pass the new `database.cnpg.backup.*` flags from `.deploy:template`. Exact spec and operator commands (cancel in-flight deploy backup, enable on prod/staging) are in the ops runbook accompanying this change.

## Validation

- `helm lint`: pass
- `sh scripts/helm-render-check.sh`: all assertions pass
- No live clusters touched.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Addressed the prior data-safety concern: `backupOwnerReference` now defaults to `none`, so base backups survive `ScheduledBackup` deletion.
>
> **Overview**
> Adds CNPG continuous backups (WAL archiving + a new `ScheduledBackup` template), fail-fast `destinationPath` validation, prod/staging overlay profiles, thorough restore docs, and a helm render-check CI job — replacing deploy-time `pg_dump`.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 510e2f9e. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->