### PR TITLE
feat: security audit preset pack (SBOM verify, exploit check, release audit)

### DIFF
--- a/backend/presets/004-sbom-verify.yaml
+++ b/backend/presets/004-sbom-verify.yaml
@@ -1,0 +1,152 @@
+name: SBOM Verify
+description: >-
+  Verify and audit a CI-emitted SBOM (SPDX or CycloneDX) instead of
+  generating one. Checks format validity, NTIA/CRA minimum elements,
+  completeness and consistency against build manifests when present, and
+  license policy flags. Read-only: writes a structured verdict to
+  /workspace/result.json (preloop.cra.sbomaudit/v1) plus an evidence pack
+  under /workspace/evidence/. Wire a CI webhook trigger that delivers the
+  SBOM via the payload's workspace_files seed or artifact URLs.
+icon: shield-check
+trigger_event_source: null
+trigger_event_types: null
+prompt_template: |
+  You are running an SBOM VERIFICATION AUDIT. You have NO write tools: do
+  not create issues, post comments, push commits, or mutate any external
+  system. Work read-only against the workspace and your sandbox. Scratch
+  space is /tmp; the evidence pack goes under /workspace/evidence/.
+
+  You VERIFY SBOMs, you never GENERATE them. SBOM creation belongs to the
+  build toolchain (Yocto/OpenEmbedded create-spdx, AOSP SBOM tooling,
+  CycloneDX build plugins). If no SBOM artifact was delivered to this run,
+  do not invent or reconstruct one: finish with status "error" and explain
+  exactly what input was missing.
+
+  Trigger payload (from CI webhook or manual trigger):
+  {{trigger_event.payload}}
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 0: LOCATE INPUTS
+  ═══════════════════════════════════════════════════════════
+  Inputs arrive via the webhook payload and the workspace seed:
+  - SBOM file(s): SPDX 2.x/3.0 (JSON/tag-value) or CycloneDX (JSON/XML),
+    either materialized under /workspace by the payload's workspace_files
+    seed (payload fields like sbom.paths point at them) or referenced by
+    URL (payload fields like sbom.urls) for you to download with curl.
+  - Optional build evidence for cross-checks: a license manifest
+    (e.g. Yocto license.manifest) and/or image/package manifests.
+  - Optional license policy file (allow/deny/flag lists).
+  - Optional build metadata: release ref, image name/hash, toolchain and
+    version.
+  Inventory what you actually received; record it later under
+  inputs_declared. Payload field names may vary — search /workspace for
+  SBOM-looking files (*.spdx.json, *.cdx.json, bom.json, *.spdx,
+  sbom*.xml) before concluding nothing was delivered.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 1: DETERMINISTIC CHECKS
+  ═══════════════════════════════════════════════════════════
+  Prefer deterministic tooling over judgment. You may pip/npm install
+  validators in the sandbox (e.g. ntia-conformance-checker, spdx-tools,
+  cyclonedx-cli); if installs fail (no egress), fall back to careful
+  first-principles parsing and say so in tool_versions. Record the name
+  and version of every tool you used.
+
+  1. FORMAT VALIDITY — detect format and spec version; parse; validate
+     schema/spec conformance and internal referential integrity (SPDX
+     relationships reference existing elements, CycloneDX bom-refs
+     resolve, no duplicate identifiers).
+  2. MINIMUM ELEMENTS (NTIA / CRA Annex I Part II) — per component:
+     supplier, name, version, unique identifier, relationships;
+     document-level: author/creator and timestamp. List what is missing
+     and for how many components.
+  3. COVERAGE QUALITY — percentage of components with a version, with a
+     concluded license (count NOASSERTION/missing separately), and with a
+     machine-matchable identifier (purl or CPE). Missing purl/CPE silently
+     breaks downstream CVE matching — report it as a finding, never
+     ignore it.
+  4. BUILD CROSS-CHECK (only if build manifests were provided) —
+     components present in the build manifests but absent from the SBOM,
+     and version disagreements. If no manifests were provided, mark the
+     check "skipped: no build evidence delivered" — do not guess.
+  5. LICENSE FLAGS (only if a policy file was provided; otherwise flag
+     only components with no license at all) — denylist hits and
+     flag-list matches, per component.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 2: EVIDENCE PACK
+  ═══════════════════════════════════════════════════════════
+  Write to /workspace/evidence/:
+  - audit-report.md — human-readable audit: what SBOM was verified,
+    against which build evidence, with which tools/versions, every check
+    with its outcome, and the findings register.
+  - findings.json — the full machine-readable findings list (no size
+    limit here; result.json stays small and references this file).
+  Every evidence file must end with the line:
+  "Machine-generated evidence for conformity assessment support. Not a
+  conformity assessment, certification, or legal advice."
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 3: REPORT (MANDATORY)
+  ═══════════════════════════════════════════════════════════
+  As your FINAL action, write /workspace/result.json: valid JSON, a
+  single top-level object, no comments, no trailing output after it. Do
+  not paste the JSON into chat; the file is the deliverable.
+
+  Required shape (preloop.cra.sbomaudit/v1):
+
+  {
+    "schema": "preloop.cra.sbomaudit/v1",
+    "flow": "sbom-verify",
+    "run_at": "<ISO 8601 UTC>",
+    "git": null,
+    "tool_versions": { "<tool>": "<version or 'unavailable: reason'>" },
+    "inputs_declared": { "<what the payload/seed actually delivered>": "..." },
+    "runner": { "kind": null, "id": null },
+    "regime_profile": "cra",
+    "source": {
+      "format": "spdx" | "cyclonedx",
+      "spec_version": "<e.g. SPDX-2.3, CycloneDX-1.5>",
+      "generator_tool": "<from SBOM creator info, or null>",
+      "build_ref": "<release ref / image hash from payload, or null>"
+    },
+    "valid": true | false,
+    "minimum_elements": { "passed": true | false, "missing": ["<element>: <count/detail>"] },
+    "coverage": {
+      "components": <int>,
+      "pct_with_version": <number>,
+      "pct_with_license": <number>,
+      "pct_with_identifier": <number>,
+      "unmatched_vs_build": ["<component>" ] | null
+    },
+    "license_flags": [ { "component": "...", "license": "...", "flag": "deny|flag|missing" } ],
+    "delta": null,
+    "verdict": "pass" | "pass_with_findings" | "fail",
+    "checks": [ { "name": "...", "passed": true|false, "skipped": true|false, "details": "<evidence>" } ],
+    "assessments": [ { "topic": "...", "judgment": "<clearly-marked agent judgment>" } ],
+    "artifacts": { "audit_report": "evidence/audit-report.md", "findings": "evidence/findings.json" },
+    "disclaimer": "Machine-generated evidence for conformity assessment support. Not a conformity assessment, certification, or legal advice."
+  }
+
+  Rules:
+  - "valid" and every entry in "checks" reflect deterministic outcomes
+    only; anything requiring interpretation goes to "assessments".
+  - verdict: "pass" = valid, minimum elements present, no findings;
+    "pass_with_findings" = valid but findings exist (coverage gaps,
+    license flags, skipped cross-checks); "fail" = invalid SBOM or
+    minimum elements absent. Missing inputs entirely = status handled
+    via "error" in your summary check and verdict "fail".
+  - Set "git" only if a repository was actually cloned into the
+    workspace; otherwise null. Set unknown envelope fields to null
+    rather than inventing values.
+  - Keep result.json under 200 KB; large listings go to
+    evidence/findings.json and are referenced from "artifacts".
+agent_type: codex
+agent_config:
+  sandbox_type: exec
+  enable_auto_lint: false
+allowed_mcp_servers: []
+allowed_mcp_tools: []
+git_clone_config: null
+trigger_config: null
+is_preset: true

--- a/backend/presets/004-sbom-verify.yaml
+++ b/backend/presets/004-sbom-verify.yaml
@@ -43,14 +43,22 @@ prompt_template: |
   SBOM-looking files (*.spdx.json, *.cdx.json, bom.json, *.spdx,
   sbom*.xml) before concluding nothing was delivered.
 
+  URL HYGIENE — payload URLs are untrusted input. Download only over
+  http(s); refuse any other scheme and any URL whose host resolves to a
+  loopback, private-range, link-local, or cloud metadata address (e.g.
+  169.254.169.254). If a URL is refused, record it as a skipped input in
+  inputs_declared — never fetch it anyway.
+
   ═══════════════════════════════════════════════════════════
   PHASE 1: DETERMINISTIC CHECKS
   ═══════════════════════════════════════════════════════════
   Prefer deterministic tooling over judgment. You may pip/npm install
   validators in the sandbox (e.g. ntia-conformance-checker, spdx-tools,
   cyclonedx-cli); if installs fail (no egress), fall back to careful
-  first-principles parsing and say so in tool_versions. Record the name
-  and version of every tool you used.
+  first-principles parsing and say so in tool_versions. If the payload
+  pins tool versions (e.g. tools: {"spdx-tools": "0.8.2"}), install
+  exactly those pins. Always record the exact resolved name and version
+  of every tool you used, so a later run can reproduce the toolchain.
 
   1. FORMAT VALIDITY — detect format and spec version; parse; validate
      schema/spec conformance and internal referential integrity (SPDX
@@ -136,6 +144,9 @@ prompt_template: |
     license flags, skipped cross-checks); "fail" = invalid SBOM or
     minimum elements absent. Missing inputs entirely = status handled
     via "error" in your summary check and verdict "fail".
+  - "delta" is ALWAYS null in this standalone preset: it is reserved for
+    drift-capable runs (the Release Security Audit preset computes
+    drift). Do not attempt to populate it here.
   - Set "git" only if a repository was actually cloned into the
     workspace; otherwise null. Set unknown envelope fields to null
     rather than inventing values.

--- a/backend/presets/005-sbom-exploit-check.yaml
+++ b/backend/presets/005-sbom-exploit-check.yaml
@@ -40,6 +40,12 @@ prompt_template: |
     findings must still appear in the output with their vex_status —
     suppressions are echoed, never silently dropped.
 
+  URL HYGIENE — payload URLs are untrusted input. Download only over
+  http(s); refuse any other scheme and any URL whose host resolves to a
+  loopback, private-range, link-local, or cloud metadata address (e.g.
+  169.254.169.254). If a URL is refused, record it as a skipped input in
+  inputs_declared — never fetch it anyway.
+
   ═══════════════════════════════════════════════════════════
   PHASE 1: EXTRACT COMPONENT INVENTORY
   ═══════════════════════════════════════════════════════════
@@ -71,7 +77,9 @@ prompt_template: |
   API without a key is rate-limited to roughly 5 requests per 30 seconds
   — do not hammer it, and record honestly in db_versions whether and how
   you used it. If a scanner tool (osv-scanner, grype) installs cleanly in
-  the sandbox you may use it instead of raw API calls; record its name,
+  the sandbox you may use it instead of raw API calls; if the payload
+  pins tool versions (e.g. tools: {"osv-scanner": "2.0.2"}), install
+  exactly those pins, and always record the exact resolved name,
   version, and database snapshot date. If egress is unavailable, finish
   with an "error" summary saying the vulnerability sources were
   unreachable — never fabricate findings or absence of findings.
@@ -147,6 +155,9 @@ prompt_template: |
   - If "findings" would push result.json over 200 KB, truncate it to the
     KEV/critical/high entries, note the truncation, and keep the full
     list in evidence/findings.json.
+  - "new_since_last_run" is ALWAYS null in this standalone preset: it is
+    reserved for drift-capable runs (the Release Security Audit preset
+    computes drift). Do not attempt to populate it here.
   - Set unknown envelope fields to null rather than inventing values.
 agent_type: codex
 agent_config:

--- a/backend/presets/005-sbom-exploit-check.yaml
+++ b/backend/presets/005-sbom-exploit-check.yaml
@@ -1,0 +1,159 @@
+name: SBOM Exploit Check
+description: >-
+  Match the components of a CI-emitted SBOM against public vulnerability
+  sources — OSV.dev as primary, the CISA Known Exploited Vulnerabilities
+  catalog for actively-exploited flags, EPSS scores best-effort — and gate
+  on a severity policy. Read-only: writes a structured verdict to
+  /workspace/result.json (preloop.cra.vulnscan/v1) plus an evidence pack
+  under /workspace/evidence/. Wire a CI webhook trigger that delivers the
+  SBOM via the payload's workspace_files seed or artifact URLs; attach a
+  schedule to re-check a released SBOM periodically.
+icon: bug
+trigger_event_source: null
+trigger_event_types: null
+prompt_template: |
+  You are running an SBOM EXPLOIT/VULNERABILITY CHECK. You have NO write
+  tools: do not create issues, post comments, push commits, or mutate any
+  external system. Work read-only against the workspace and your sandbox.
+  Scratch space is /tmp; the evidence pack goes under /workspace/evidence/.
+
+  The delivered SBOM is the source of truth for the component inventory.
+  You never generate or extend an SBOM. If no SBOM artifact was delivered
+  to this run, do not invent one: finish with an "error" summary and
+  explain exactly what input was missing.
+
+  Trigger payload (from CI webhook, schedule, or manual trigger):
+  {{trigger_event.payload}}
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 0: LOCATE INPUTS
+  ═══════════════════════════════════════════════════════════
+  - SBOM file(s): SPDX 2.x/3.0 or CycloneDX, materialized under
+    /workspace by the payload's workspace_files seed or referenced by URL
+    in the payload for you to download with curl. Search /workspace for
+    SBOM-looking files (*.spdx.json, *.cdx.json, bom.json, *.spdx,
+    sbom*.xml) before concluding nothing was delivered.
+  - Optional severity gate policy in the payload (e.g.
+    gate.fail_on_kev: true, gate.fail_on_cvss_gte: 7.0). Default when
+    absent: fail on any KEV-listed finding or CVSS >= 9.0.
+  - Optional VEX statements file (OpenVEX or CycloneDX VEX): suppressed
+    findings must still appear in the output with their vex_status —
+    suppressions are echoed, never silently dropped.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 1: EXTRACT COMPONENT INVENTORY
+  ═══════════════════════════════════════════════════════════
+  Parse the SBOM and build the component list (name, version, purl/CPE
+  where present). Components with no version or no machine-matchable
+  identifier cannot be reliably matched: count them and report them as an
+  "unmatchable components" finding — an honest coverage statement, not an
+  omission.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 2: QUERY PUBLIC VULNERABILITY SOURCES
+  ═══════════════════════════════════════════════════════════
+  Primary: OSV.dev — POST https://api.osv.dev/v1/querybatch with purl (or
+  name+ecosystem+version) queries, then /v1/vulns/{id} for details of the
+  hits. No API key needed. Batch requests; be a polite client.
+
+  Known-exploited flags: download the CISA KEV catalog JSON
+  (https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json)
+  and match findings by CVE id. Record the catalog's dateReleased as
+  kev_snapshot_date. KEV hits are flagged as potential CRA Article 14
+  reporting candidates — a prioritisation signal for a human, not legal
+  advice and not a report filing.
+
+  Prioritisation (best-effort): EPSS scores from
+  https://api.first.org/data/v1/epss?cve=... — if unreachable, set epss
+  to null and note it.
+
+  NVD is a FALLBACK ONLY (e.g. for CVSS scores OSV lacks): the public NVD
+  API without a key is rate-limited to roughly 5 requests per 30 seconds
+  — do not hammer it, and record honestly in db_versions whether and how
+  you used it. If a scanner tool (osv-scanner, grype) installs cleanly in
+  the sandbox you may use it instead of raw API calls; record its name,
+  version, and database snapshot date. If egress is unavailable, finish
+  with an "error" summary saying the vulnerability sources were
+  unreachable — never fabricate findings or absence of findings.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 3: GATE + EVIDENCE PACK
+  ═══════════════════════════════════════════════════════════
+  Apply the severity gate to the non-suppressed findings and record the
+  policy applied and the outcome. Write to /workspace/evidence/:
+  - findings.json — full machine-readable findings (all of them).
+  - vuln-report.md — human-readable report: inventory size, match
+    coverage, sources queried with snapshot dates/timestamps, findings by
+    severity, KEV hits called out, VEX suppressions echoed with their
+    justification, gate outcome.
+  Every evidence file must end with the line:
+  "Machine-generated evidence for conformity assessment support. Not a
+  conformity assessment, certification, or legal advice."
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 4: REPORT (MANDATORY)
+  ═══════════════════════════════════════════════════════════
+  As your FINAL action, write /workspace/result.json: valid JSON, a
+  single top-level object, no trailing output after it. Do not paste the
+  JSON into chat; the file is the deliverable.
+
+  Required shape (preloop.cra.vulnscan/v1):
+
+  {
+    "schema": "preloop.cra.vulnscan/v1",
+    "flow": "sbom-exploit-check",
+    "run_at": "<ISO 8601 UTC>",
+    "git": null,
+    "tool_versions": { "<tool>": "<version or 'unavailable: reason'>" },
+    "inputs_declared": { "<what the payload/seed actually delivered>": "..." },
+    "runner": { "kind": null, "id": null },
+    "regime_profile": "cra",
+    "source_sbom": { "path": "...", "format": "spdx" | "cyclonedx", "spec_version": "...", "build_ref": "<or null>" },
+    "db_versions": {
+      "osv_queried_at": "<ISO 8601 UTC>",
+      "kev_snapshot_date": "<from catalog, or null>",
+      "epss_queried_at": "<ISO 8601 UTC or null>",
+      "nvd": "<'not used' or honest usage note>"
+    },
+    "inventory": { "components": <int>, "matchable": <int>, "unmatchable": <int> },
+    "findings": [
+      {
+        "id": "<CVE/GHSA/OSV id>",
+        "pkg": "...", "version": "...",
+        "severity": "critical|high|medium|low|unknown",
+        "cvss": <number|null>, "epss": <number|null>,
+        "kev": true | false,
+        "fix_version": "<or null>",
+        "vex_status": "<null, or not_affected/false_positive/accepted with justification>"
+      }
+    ],
+    "counts_by_severity": { "critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0 },
+    "art14_candidates": [ "<CVE ids of KEV-listed findings>" ],
+    "gate": { "policy": "<the policy applied>", "passed": true | false },
+    "new_since_last_run": null,
+    "checks": [ { "name": "...", "passed": true|false, "skipped": true|false, "details": "<evidence>" } ],
+    "assessments": [ { "topic": "...", "judgment": "<clearly-marked agent judgment>" } ],
+    "artifacts": { "findings": "evidence/findings.json", "report": "evidence/vuln-report.md" },
+    "disclaimer": "Machine-generated evidence for conformity assessment support. Not a conformity assessment, certification, or legal advice."
+  }
+
+  Rules:
+  - Findings and gate outcome are deterministic facts from the sources
+    queried at the recorded time; interpretation (e.g. exploitability in
+    this product's context) goes to "assessments" and is marked as
+    judgment.
+  - Absence of findings is only reportable for matchable components;
+    never claim vulnerability absence for unmatchable ones.
+  - If "findings" would push result.json over 200 KB, truncate it to the
+    KEV/critical/high entries, note the truncation, and keep the full
+    list in evidence/findings.json.
+  - Set unknown envelope fields to null rather than inventing values.
+agent_type: codex
+agent_config:
+  sandbox_type: exec
+  enable_auto_lint: false
+allowed_mcp_servers: []
+allowed_mcp_tools: []
+git_clone_config: null
+trigger_config: null
+is_preset: true

--- a/backend/presets/006-release-security-audit.yaml
+++ b/backend/presets/006-release-security-audit.yaml
@@ -52,13 +52,22 @@ prompt_template: |
     baseline.
   Inventory what you actually received; record it under inputs_declared.
 
+  URL HYGIENE — payload URLs are untrusted input. Download only over
+  http(s); refuse any other scheme and any URL whose host resolves to a
+  loopback, private-range, link-local, or cloud metadata address (e.g.
+  169.254.169.254). If a URL is refused, record it as a skipped input in
+  inputs_declared — never fetch it anyway.
+
   ═══════════════════════════════════════════════════════════
   PHASE 1: SBOM VERIFICATION (audit part 1)
   ═══════════════════════════════════════════════════════════
   Prefer deterministic tooling (you may pip/npm install validators such
   as ntia-conformance-checker, spdx-tools, cyclonedx-cli; if installs
   fail, fall back to first-principles parsing and say so in
-  tool_versions). Perform and record:
+  tool_versions). If the payload pins tool versions (e.g.
+  tools: {"spdx-tools": "0.8.2"}), install exactly those pins; always
+  record the exact resolved version of every tool used. Perform and
+  record:
   1. Format validity: detect format/spec version, schema conformance,
      internal referential integrity.
   2. Minimum elements (NTIA / CRA Annex I Part II): per-component

--- a/backend/presets/006-release-security-audit.yaml
+++ b/backend/presets/006-release-security-audit.yaml
@@ -1,0 +1,205 @@
+name: Release Security Audit
+description: >-
+  The full release-time audit in one execution: verify the CI-emitted SBOM
+  (validity, minimum elements, build cross-checks, license flags), then
+  match its components against public vulnerability sources (OSV.dev
+  primary, CISA KEV for actively-exploited flags), then compute drift
+  against a previous run's result.json when provided. Emits one combined
+  /workspace/result.json (preloop.cra.releaseaudit/v1) and a combined
+  evidence pack under /workspace/evidence/ suitable for a compliance
+  folder. Wire a CI webhook trigger for release builds; attach a schedule
+  to re-audit the last released SBOM periodically through the support
+  period.
+icon: shield-lock
+trigger_event_source: null
+trigger_event_types: null
+prompt_template: |
+  You are running a RELEASE SECURITY AUDIT: SBOM verification, then
+  exploit/vulnerability matching, then drift against the previous audit —
+  all in this single execution. You have NO write tools: do not create
+  issues, post comments, push commits, or mutate any external system.
+  Work read-only against the workspace and your sandbox. Scratch space is
+  /tmp; the evidence pack goes under /workspace/evidence/.
+
+  You VERIFY SBOMs, you never GENERATE them. SBOM creation belongs to the
+  build toolchain (Yocto/OpenEmbedded create-spdx, AOSP SBOM tooling,
+  CycloneDX build plugins). If no SBOM artifact was delivered to this
+  run, do not invent or reconstruct one: finish with an "error" summary
+  explaining exactly what input was missing.
+
+  Trigger payload (from CI webhook, schedule, or manual trigger):
+  {{trigger_event.payload}}
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 0: LOCATE INPUTS
+  ═══════════════════════════════════════════════════════════
+  Inputs arrive via the webhook payload and the workspace seed
+  (workspace_files) or by URL for you to download with curl:
+  - SBOM file(s): SPDX 2.x/3.0 or CycloneDX. Search /workspace for
+    SBOM-looking files (*.spdx.json, *.cdx.json, bom.json, *.spdx,
+    sbom*.xml) before concluding nothing was delivered.
+  - Optional build evidence: license manifest (e.g. Yocto
+    license.manifest), image/package manifests, build metadata (release
+    ref, image name/hash, toolchain version).
+  - Optional license policy file (allow/deny/flag lists).
+  - Optional VEX statements file (OpenVEX or CycloneDX VEX).
+  - Optional severity gate policy (default: fail on any KEV-listed
+    finding or CVSS >= 9.0).
+  - Optional PREVIOUS RESULT: a prior run's result.json
+    (preloop.cra.releaseaudit/v1 or preloop.cra.vulnscan/v1), delivered
+    in the seed (e.g. previous/result.json) or by URL. If absent, drift
+    is null and the corresponding check is marked skipped — never guess a
+    baseline.
+  Inventory what you actually received; record it under inputs_declared.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 1: SBOM VERIFICATION (audit part 1)
+  ═══════════════════════════════════════════════════════════
+  Prefer deterministic tooling (you may pip/npm install validators such
+  as ntia-conformance-checker, spdx-tools, cyclonedx-cli; if installs
+  fail, fall back to first-principles parsing and say so in
+  tool_versions). Perform and record:
+  1. Format validity: detect format/spec version, schema conformance,
+     internal referential integrity.
+  2. Minimum elements (NTIA / CRA Annex I Part II): per-component
+     supplier, name, version, unique identifier, relationships;
+     document-level author and timestamp.
+  3. Coverage quality: pct of components with version, with concluded
+     license (NOASSERTION counted separately), with purl/CPE. Missing
+     identifiers silently break CVE matching — report as findings.
+  4. Build cross-check (only if build manifests provided): components in
+     the build but missing from the SBOM, version disagreements;
+     otherwise mark skipped.
+  5. License flags (only if a policy file provided; otherwise flag only
+     components with no license at all).
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 2: EXPLOIT / VULNERABILITY MATCH (audit part 2)
+  ═══════════════════════════════════════════════════════════
+  The SBOM is the source of truth for the inventory. Extract components
+  (name, version, purl/CPE); count unmatchable ones honestly.
+  - Primary source: OSV.dev — POST https://api.osv.dev/v1/querybatch
+    (purl or name+ecosystem+version), then /v1/vulns/{id} for details.
+  - Known-exploited: CISA KEV catalog JSON
+    (https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json);
+    record its dateReleased as kev_snapshot_date. KEV hits are flagged as
+    potential CRA Article 14 reporting candidates — a signal for a human,
+    not legal advice and not a report filing.
+  - EPSS best-effort via https://api.first.org/data/v1/epss?cve=...;
+    null if unreachable.
+  - NVD is a fallback only; the public API without a key is rate-limited
+    to roughly 5 requests per 30 seconds — do not hammer it and record
+    honest usage in db_versions. A cleanly-installing scanner
+    (osv-scanner, grype) may substitute for raw API calls; record its
+    version and DB snapshot date.
+  - If egress is unavailable, report the vulnerability phase as "error:
+    sources unreachable" — never fabricate findings or their absence.
+  Apply VEX suppressions (echoed, never silently dropped) and the
+  severity gate.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 3: DRIFT VS PREVIOUS RESULT (audit part 3)
+  ═══════════════════════════════════════════════════════════
+  Only if a previous result.json was delivered:
+  - Component drift: added / removed / upgraded components, license
+    changes, coverage-quality regressions vs the previous sbom_audit.
+  - Vulnerability drift: findings new since the previous run, newly
+    KEV-listed ids, findings resolved.
+  - Gate transitions: pass -> fail (or reverse).
+  Set drift.alert = true if there are new KEV hits, new critical/high
+  findings, or a pass -> fail transition.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 4: COMBINED EVIDENCE PACK
+  ═══════════════════════════════════════════════════════════
+  Write a compliance-folder-ready pack to /workspace/evidence/:
+  - audit-report.md — the combined human-readable audit: what SBOM was
+    verified against which build evidence, with which tools and source
+    snapshot dates; every check and its outcome; findings by severity
+    with KEV hits called out; VEX suppressions echoed; drift summary;
+    gate outcome.
+  - findings.json — full machine-readable vulnerability findings.
+  - sbom-findings.json — full SBOM verification findings register.
+  - drift-report.md — the delta vs the previous run (only when a
+    baseline was provided).
+  Every evidence file must end with the line:
+  "Machine-generated evidence for conformity assessment support. Not a
+  conformity assessment, certification, or legal advice."
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 5: REPORT (MANDATORY)
+  ═══════════════════════════════════════════════════════════
+  As your FINAL action, write /workspace/result.json: valid JSON, a
+  single top-level object, no trailing output after it. Do not paste the
+  JSON into chat; the file is the deliverable.
+
+  Required shape (preloop.cra.releaseaudit/v1):
+
+  {
+    "schema": "preloop.cra.releaseaudit/v1",
+    "flow": "release-security-audit",
+    "run_at": "<ISO 8601 UTC>",
+    "git": null,
+    "tool_versions": { "<tool>": "<version or 'unavailable: reason'>" },
+    "inputs_declared": { "<what the payload/seed actually delivered>": "..." },
+    "runner": { "kind": null, "id": null },
+    "regime_profile": "cra",
+    "sbom_audit": {
+      "source": { "format": "spdx"|"cyclonedx", "spec_version": "...", "generator_tool": "<or null>", "build_ref": "<or null>" },
+      "valid": true|false,
+      "minimum_elements": { "passed": true|false, "missing": ["..."] },
+      "coverage": { "components": <int>, "pct_with_version": <n>, "pct_with_license": <n>, "pct_with_identifier": <n>, "unmatched_vs_build": [...] | null },
+      "license_flags": [ { "component": "...", "license": "...", "flag": "deny|flag|missing" } ],
+      "verdict": "pass" | "pass_with_findings" | "fail"
+    },
+    "vuln_scan": {
+      "db_versions": { "osv_queried_at": "...", "kev_snapshot_date": "<or null>", "epss_queried_at": "<or null>", "nvd": "<'not used' or honest usage note>" },
+      "inventory": { "components": <int>, "matchable": <int>, "unmatchable": <int> },
+      "findings": [ { "id": "...", "pkg": "...", "version": "...", "severity": "...", "cvss": <n|null>, "epss": <n|null>, "kev": true|false, "fix_version": "<or null>", "vex_status": "<or null>" } ],
+      "counts_by_severity": { "critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0 },
+      "art14_candidates": [ "<CVE ids of KEV-listed findings>" ],
+      "gate": { "policy": "<the policy applied>", "passed": true|false }
+    },
+    "drift": null | {
+      "baseline": { "schema": "<of previous result>", "run_at": "<or null>", "build_ref": "<or null>" },
+      "sbom_changes": { "added": [...], "removed": [...], "upgraded": [...], "license_changes": [...] },
+      "new_vulns": [ "<ids>" ],
+      "resolved_vulns": [ "<ids>" ],
+      "new_kev": [ "<ids>" ],
+      "gate_transitions": [ "<e.g. 'gate: pass -> fail'>" ],
+      "alert": true|false
+    },
+    "verdict": "pass" | "pass_with_findings" | "fail",
+    "checks": [ { "name": "...", "passed": true|false, "skipped": true|false, "details": "<evidence>" } ],
+    "assessments": [ { "topic": "...", "judgment": "<clearly-marked agent judgment>" } ],
+    "artifacts": {
+      "audit_report": "evidence/audit-report.md",
+      "findings": "evidence/findings.json",
+      "sbom_findings": "evidence/sbom-findings.json",
+      "drift_report": "evidence/drift-report.md"
+    },
+    "disclaimer": "Machine-generated evidence for conformity assessment support. Not a conformity assessment, certification, or legal advice."
+  }
+
+  Rules:
+  - Overall verdict: "fail" if the SBOM audit failed OR the severity gate
+    failed; "pass_with_findings" if everything gated passed but findings
+    or skipped cross-checks exist; "pass" only when clean.
+  - Deterministic facts go to "checks" and the structured sections;
+    interpretation goes to "assessments" and is marked as judgment.
+  - Never claim vulnerability absence for unmatchable components, and
+    never claim SBOM completeness beyond what the delivered build
+    evidence allowed you to cross-check.
+  - Keep result.json under 200 KB: truncate "vuln_scan.findings" to
+    KEV/critical/high entries if needed, note the truncation, and keep
+    the full list in evidence/findings.json.
+  - Set unknown envelope fields to null rather than inventing values.
+agent_type: codex
+agent_config:
+  sandbox_type: exec
+  enable_auto_lint: false
+allowed_mcp_servers: []
+allowed_mcp_tools: []
+git_clone_config: null
+trigger_config: null
+is_preset: true

--- a/backend/tests/fixtures/sbom/sample.cdx.json
+++ b/backend/tests/fixtures/sbom/sample.cdx.json
@@ -1,0 +1,58 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-08-01T12:00:00Z",
+    "tools": [
+      {
+        "vendor": "Example",
+        "name": "example-cdx-generator",
+        "version": "1.0.0"
+      }
+    ],
+    "component": {
+      "bom-ref": "pkg:generic/example-app@2.1.0",
+      "type": "application",
+      "name": "example-app",
+      "version": "2.1.0"
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:generic/openssl@3.0.13",
+      "type": "library",
+      "name": "openssl",
+      "version": "3.0.13",
+      "supplier": {
+        "name": "Example Embedded Vendor (synthetic fixture)"
+      },
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:generic/openssl@3.0.13"
+    },
+    {
+      "bom-ref": "urn:example:component:no-version",
+      "type": "library",
+      "name": "legacy-blob",
+      "supplier": {
+        "name": "NOASSERTION"
+      }
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:generic/example-app@2.1.0",
+      "dependsOn": [
+        "pkg:generic/openssl@3.0.13",
+        "urn:example:component:no-version"
+      ]
+    }
+  ]
+}

--- a/backend/tests/fixtures/sbom/sample.spdx.json
+++ b/backend/tests/fixtures/sbom/sample.spdx.json
@@ -1,0 +1,74 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "example-image-1.0.0",
+  "documentNamespace": "https://sbom.example.invalid/spdxdocs/example-image-1.0.0-9f2c7a30-synthetic",
+  "creationInfo": {
+    "created": "2026-08-01T12:00:00Z",
+    "creators": [
+      "Tool: example-build-toolchain-1.0",
+      "Organization: Example Embedded Vendor (synthetic fixture)"
+    ]
+  },
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-busybox",
+      "name": "busybox",
+      "versionInfo": "1.36.1",
+      "supplier": "Organization: Example Embedded Vendor (synthetic fixture)",
+      "downloadLocation": "NOASSERTION",
+      "licenseConcluded": "GPL-2.0-only",
+      "licenseDeclared": "GPL-2.0-only",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:generic/busybox@1.36.1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zlib",
+      "name": "zlib",
+      "versionInfo": "1.3.1",
+      "supplier": "Organization: Example Embedded Vendor (synthetic fixture)",
+      "downloadLocation": "NOASSERTION",
+      "licenseConcluded": "Zlib",
+      "licenseDeclared": "Zlib",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:generic/zlib@1.3.1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-examplelib",
+      "name": "examplelib",
+      "versionInfo": "0.9.0",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-busybox"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-busybox",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-zlib"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-busybox",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-examplelib"
+    }
+  ]
+}

--- a/backend/tests/test_security_audit_presets.py
+++ b/backend/tests/test_security_audit_presets.py
@@ -1,0 +1,228 @@
+"""Tests for the security audit preset pack (SBOM verify / exploit check /
+release audit).
+
+Validates the shipped preset YAMLs against the Observe/Eval pattern
+invariants (read-only toolset, mandatory result.json contract, versioned
+schema ids) and sanity-checks the synthetic SBOM fixtures used to
+document the input path.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+PRESETS_DIR = Path(__file__).resolve().parents[1] / "presets"
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "sbom"
+
+DISCLAIMER = "Machine-generated evidence for conformity assessment support. Not a"
+
+PRESET_FILES = {
+    "SBOM Verify": "004-sbom-verify.yaml",
+    "SBOM Exploit Check": "005-sbom-exploit-check.yaml",
+    "Release Security Audit": "006-release-security-audit.yaml",
+}
+
+SCHEMA_IDS = {
+    "SBOM Verify": "preloop.cra.sbomaudit/v1",
+    "SBOM Exploit Check": "preloop.cra.vulnscan/v1",
+    "Release Security Audit": "preloop.cra.releaseaudit/v1",
+}
+
+
+def _norm(text: str) -> str:
+    """Collapse whitespace so asserts survive YAML line wrapping."""
+    return " ".join(text.split())
+
+
+def _load_preset(filename: str) -> dict:
+    path = PRESETS_DIR / filename
+    assert path.exists(), f"Missing preset file: {path}"
+    data = yaml.safe_load(path.read_text())
+    assert isinstance(data, dict)
+    return data
+
+
+@pytest.fixture(params=sorted(PRESET_FILES))
+def preset(request):
+    return request.param, _load_preset(PRESET_FILES[request.param])
+
+
+class TestSecurityAuditPresetInvariants:
+    """Observe/Eval-pattern invariants shared by all three presets."""
+
+    def test_name_matches_file(self, preset):
+        name, data = preset
+        assert data["name"] == name
+
+    def test_read_only_toolset(self, preset):
+        """No MCP servers/tools: the flows are read-only by construction."""
+        _, data = preset
+        assert data["allowed_mcp_servers"] == []
+        assert data["allowed_mcp_tools"] == []
+
+    def test_no_git_clone_or_baked_trigger(self, preset):
+        """Presets ship trigger-agnostic, like 003-observe-eval."""
+        _, data = preset
+        assert data["git_clone_config"] is None
+        assert data["trigger_config"] is None
+        assert data["trigger_event_source"] is None
+        assert data["trigger_event_types"] is None
+
+    def test_agent_config(self, preset):
+        _, data = preset
+        assert data["agent_type"] == "codex"
+        assert data["agent_config"]["sandbox_type"] == "exec"
+        assert data["agent_config"]["enable_auto_lint"] is False
+        assert data["is_preset"] is True
+        assert data.get("description")
+        assert data.get("icon")
+
+    def test_prompt_declares_result_json_contract(self, preset):
+        name, data = preset
+        prompt = data["prompt_template"]
+        assert "/workspace/result.json" in prompt
+        assert SCHEMA_IDS[name] in prompt
+        # Payload templating is the input path.
+        assert "{{trigger_event.payload}}" in prompt
+
+    def test_prompt_carries_disclaimer(self, preset):
+        """Every artifact must carry the evidence-not-assessment line."""
+        _, data = preset
+        assert DISCLAIMER in data["prompt_template"]
+
+    def test_prompt_forbids_writes(self, preset):
+        _, data = preset
+        assert "NO write tools" in _norm(data["prompt_template"])
+
+    def test_prompt_separates_facts_from_judgment(self, preset):
+        _, data = preset
+        prompt = data["prompt_template"]
+        assert '"checks"' in prompt
+        assert '"assessments"' in prompt
+
+    def test_verify_not_generate(self, preset):
+        """The pack verifies SBOMs; generation is explicitly out of scope."""
+        name, data = preset
+        prompt = data["prompt_template"]
+        assert "never" in prompt and "invent" in prompt
+        if name != "SBOM Exploit Check":
+            assert "GENERATE" in prompt
+
+
+class TestSbomVerifyPreset:
+    def test_deterministic_check_catalogue(self):
+        prompt = _load_preset(PRESET_FILES["SBOM Verify"])["prompt_template"]
+        for marker in [
+            "FORMAT VALIDITY",
+            "MINIMUM ELEMENTS",
+            "COVERAGE QUALITY",
+            "BUILD CROSS-CHECK",
+            "LICENSE FLAGS",
+        ]:
+            assert marker in prompt
+        # Missing build evidence must be reported as skipped, not guessed.
+        assert "skipped: no build evidence delivered" in prompt
+
+
+class TestSbomExploitCheckPreset:
+    def test_vuln_sources_and_honest_limits(self):
+        prompt = _load_preset(PRESET_FILES["SBOM Exploit Check"])["prompt_template"]
+        assert "api.osv.dev/v1/querybatch" in prompt
+        assert "known_exploited_vulnerabilities.json" in prompt
+        # NVD rate limits stated honestly; NVD is fallback only.
+        assert "FALLBACK ONLY" in prompt
+        assert "5 requests per 30 seconds" in prompt
+        assert "art14_candidates" in prompt
+        assert "kev_snapshot_date" in prompt
+        # Never claim absence for unmatchable components.
+        assert "unmatchable" in prompt
+
+
+class TestReleaseSecurityAuditPreset:
+    def test_combines_both_audits_plus_drift(self):
+        prompt = _load_preset(PRESET_FILES["Release Security Audit"])["prompt_template"]
+        assert '"sbom_audit"' in prompt
+        assert '"vuln_scan"' in prompt
+        assert '"drift"' in prompt
+        # Drift only against a delivered baseline, never a guessed one.
+        assert "never guess a baseline" in _norm(prompt)
+        assert "api.osv.dev/v1/querybatch" in prompt
+        assert "known_exploited_vulnerabilities.json" in prompt
+
+    def test_designed_for_schedules(self):
+        data = _load_preset(PRESET_FILES["Release Security Audit"])
+        assert "schedule" in data["description"].lower()
+
+
+class TestPresetsLoadThroughLoader:
+    def test_loader_picks_up_all_three(self):
+        from unittest.mock import patch
+
+        from preloop.flow_presets import load_flow_presets
+
+        load_flow_presets.cache_clear()
+        try:
+            with patch("preloop.flow_presets.PRESETS_DIR", PRESETS_DIR):
+                names = [p["name"] for p in load_flow_presets()]
+            for name in PRESET_FILES:
+                assert name in names
+            # Ordering: after the existing 001-003 presets.
+            assert names.index("SBOM Verify") > names.index("Observe / Eval")
+        finally:
+            load_flow_presets.cache_clear()
+
+
+class TestSbomFixtures:
+    """The synthetic SPDX + CycloneDX samples used as documented inputs."""
+
+    def test_spdx_fixture_minimum_elements(self):
+        doc = json.loads((FIXTURES_DIR / "sample.spdx.json").read_text())
+        assert doc["spdxVersion"] == "SPDX-2.3"
+        assert doc["creationInfo"]["created"]
+        assert doc["creationInfo"]["creators"]
+        packages = doc["packages"]
+        assert len(packages) == 3
+        for pkg in packages:
+            assert pkg["name"]
+            assert pkg["versionInfo"]
+        # Relationships reference existing elements (referential integrity).
+        ids = {doc["SPDXID"]} | {pkg["SPDXID"] for pkg in packages}
+        for rel in doc["relationships"]:
+            assert rel["spdxElementId"] in ids
+            assert rel["relatedSpdxElement"] in ids
+        # The fixture deliberately contains quality gaps for the audit to
+        # find: one package with NOASSERTION license and no purl.
+        gaps = [
+            p
+            for p in packages
+            if p.get("licenseConcluded") == "NOASSERTION" and not p.get("externalRefs")
+        ]
+        assert len(gaps) == 1
+
+    def test_cyclonedx_fixture_shape(self):
+        doc = json.loads((FIXTURES_DIR / "sample.cdx.json").read_text())
+        assert doc["bomFormat"] == "CycloneDX"
+        assert doc["specVersion"] == "1.5"
+        assert doc["metadata"]["timestamp"]
+        components = doc["components"]
+        assert len(components) == 2
+        # One fully-identified component, one deliberate quality gap
+        # (no version, no purl) for the audit to find.
+        assert components[0]["purl"] == "pkg:generic/openssl@3.0.13"
+        assert "version" not in components[1]
+        assert "purl" not in components[1]
+        # Dependency refs resolve to declared bom-refs.
+        declared = {c["bom-ref"] for c in components}
+        declared.add(doc["metadata"]["component"]["bom-ref"])
+        for dep in doc["dependencies"]:
+            assert dep["ref"] in declared
+            for ref in dep["dependsOn"]:
+                assert ref in declared
+
+    def test_fixtures_are_synthetic(self):
+        """Confidentiality: fixtures carry no real vendor/customer identity."""
+        for name in ("sample.spdx.json", "sample.cdx.json"):
+            text = (FIXTURES_DIR / name).read_text()
+            assert "synthetic fixture" in text

--- a/docs/guide/flows/security-audit-presets.md
+++ b/docs/guide/flows/security-audit-presets.md
@@ -1,0 +1,218 @@
+# Security audit presets (SBOM verify, exploit check, release audit)
+
+Three flow presets turn a CI release build into audit-grade security
+evidence. They **verify** SBOMs emitted by your build toolchain
+(Yocto/OpenEmbedded `create-spdx`, AOSP SBOM tooling, CycloneDX build
+plugins) — they never generate one. Each run is a single execution that
+ends by writing `/workspace/result.json` with a versioned schema, captured
+as a first-class execution artifact and retrievable via
+`GET /api/v1/flows/executions/{execution_id}/result`, plus a
+human-readable evidence pack under `/workspace/evidence/`.
+
+| Preset | What it does | result.json schema |
+| --- | --- | --- |
+| SBOM Verify | Format validity, NTIA/CRA minimum elements, completeness vs build manifests, license flags | `preloop.cra.sbomaudit/v1` |
+| SBOM Exploit Check | Components → CVEs via OSV.dev, known-exploited flags via CISA KEV, severity gate | `preloop.cra.vulnscan/v1` |
+| Release Security Audit | Both of the above in one execution, plus drift vs a previous run's result.json | `preloop.cra.releaseaudit/v1` |
+
+All three follow the Observe/Eval pattern: read-only toolset (no MCP
+servers or tools), deterministic checks separated from agent judgment
+(`checks[]` vs `assessments[]`), and every artifact carries the line:
+
+> Machine-generated evidence for conformity assessment support. Not a
+> conformity assessment, certification, or legal advice.
+
+## Wiring a CI build to a preset
+
+1. Clone the preset into a flow and configure a webhook trigger. Your CI
+   job calls `POST /webhooks/flows/{flow_id}/{webhook_secret}` after the
+   build; the response carries `execution_id` so the pipeline can poll
+   `/flows/executions/{execution_id}/result` and gate the release on the
+   verdict.
+2. Deliver the SBOM either **inline** via the payload's
+   [`workspace_files` seed](../../webhook-triggers.md) (base64, 1 MiB
+   encoded cap across files) or **by pointer**: put URLs in the payload
+   and the agent downloads them at run start.
+
+Example payload (field names are conventions the prompt understands; the
+agent also searches `/workspace` for SBOM-shaped files):
+
+```json
+{
+  "release_ref": "v1.2.3",
+  "build": {"image_name": "example-image", "image_hash": "sha256:…", "toolchain": "yocto-5.0"},
+  "sbom": {"paths": ["sbom/image.spdx.json"]},
+  "manifests": {"license_manifest_path": "manifests/license.manifest"},
+  "license_policy_path": "policy/licenses.yaml",
+  "gate": {"fail_on_kev": true, "fail_on_cvss_gte": 7.0},
+  "previous_result_path": "previous/result.json",
+  "workspace_files": [
+    {"path": "sbom/image.spdx.json", "content_base64": "…"},
+    {"path": "manifests/license.manifest", "content_base64": "…"},
+    {"path": "previous/result.json", "content_base64": "…"}
+  ]
+}
+```
+
+Recommended CI job outputs to retain and deliver: the SPDX/CycloneDX
+file(s), the license manifest (e.g. Yocto `license.manifest`), image or
+package manifests for cross-checks, and the previous audit's
+`result.json` if you want drift.
+
+### Scheduled re-audits
+
+CRA vulnerability handling continues through the support period even when
+you ship nothing. Attach a schedule trigger (cron/interval) to a cloned
+**Release Security Audit** or **SBOM Exploit Check** flow that re-delivers
+the *last released* SBOM (plus the previous `result.json` for drift). Each
+run produces a dated evidence pack; the run-over-run trail is the
+auditable record.
+
+## Vulnerability sources (honest notes)
+
+- **OSV.dev** is the primary source: `POST https://api.osv.dev/v1/querybatch`
+  with purl or name+ecosystem+version, no API key required. Results record
+  `osv_queried_at`.
+- **CISA KEV** catalog supplies known-exploited flags; the catalog release
+  date is recorded as `kev_snapshot_date`. KEV hits appear in
+  `art14_candidates` as a prioritisation signal for a human — not legal
+  advice, and Preloop does not file Article 14 reports.
+- **EPSS** scores are best-effort (`api.first.org`); `null` when
+  unreachable.
+- **NVD** is a fallback only: the public API without a key is rate-limited
+  to roughly 5 requests per 30 seconds, so runs do not enumerate NVD for a
+  whole SBOM. How (and whether) NVD was used is recorded in
+  `db_versions.nvd`.
+- Components without a version or a purl/CPE identifier cannot be reliably
+  matched; they are counted as `unmatchable` and results never claim
+  vulnerability absence for them.
+- If the sandbox has no egress to these sources, the run reports an error
+  rather than fabricating findings or their absence.
+
+## result.json schemas
+
+### Common evidence envelope (all three schemas)
+
+```json
+{
+  "schema": "preloop.cra.sbomaudit/v1 | preloop.cra.vulnscan/v1 | preloop.cra.releaseaudit/v1",
+  "flow": "sbom-verify | sbom-exploit-check | release-security-audit",
+  "run_at": "ISO 8601 UTC",
+  "git": {"remote": "…", "commit": "…", "branch": "…", "dirty": false},
+  "tool_versions": {"<tool>": "<version or 'unavailable: reason'>"},
+  "inputs_declared": {"<input>": "<what was actually delivered>"},
+  "runner": {"kind": "hosted | self_hosted | null", "id": null},
+  "regime_profile": "cra",
+  "checks": [{"name": "…", "passed": true, "skipped": false, "details": "evidence"}],
+  "assessments": [{"topic": "…", "judgment": "agent judgment, marked as such"}],
+  "artifacts": {"<name>": "<workspace-relative path>"},
+  "disclaimer": "Machine-generated evidence for conformity assessment support. Not a conformity assessment, certification, or legal advice."
+}
+```
+
+`git` is `null` unless a repository was cloned into the workspace.
+Unknown envelope fields are `null`, never invented. `checks[]` are
+deterministic facts; `assessments[]` are agent judgment. `result.json`
+stays under 200 KB; large listings live in `/workspace/evidence/` files
+referenced from `artifacts`.
+
+### `preloop.cra.sbomaudit/v1` (SBOM Verify)
+
+Envelope plus:
+
+```json
+{
+  "source": {"format": "spdx | cyclonedx", "spec_version": "SPDX-2.3", "generator_tool": null, "build_ref": null},
+  "valid": true,
+  "minimum_elements": {"passed": false, "missing": ["supplier: 12 components"]},
+  "coverage": {
+    "components": 214,
+    "pct_with_version": 99.1,
+    "pct_with_license": 92.5,
+    "pct_with_identifier": 88.3,
+    "unmatched_vs_build": ["kernel-module-foo"]
+  },
+  "license_flags": [{"component": "…", "license": "…", "flag": "deny | flag | missing"}],
+  "delta": null,
+  "verdict": "pass | pass_with_findings | fail"
+}
+```
+
+Verdict semantics: `fail` = invalid SBOM or minimum elements absent;
+`pass_with_findings` = valid but findings exist (coverage gaps, license
+flags, skipped cross-checks); `pass` = clean. Build cross-checks are
+marked `skipped` when no build manifests were delivered — absence of
+evidence is reported, not papered over.
+
+### `preloop.cra.vulnscan/v1` (SBOM Exploit Check)
+
+Envelope plus:
+
+```json
+{
+  "source_sbom": {"path": "sbom/image.spdx.json", "format": "spdx", "spec_version": "SPDX-2.3", "build_ref": null},
+  "db_versions": {"osv_queried_at": "…", "kev_snapshot_date": "…", "epss_queried_at": null, "nvd": "not used"},
+  "inventory": {"components": 214, "matchable": 189, "unmatchable": 25},
+  "findings": [
+    {"id": "CVE-…", "pkg": "…", "version": "…", "severity": "high", "cvss": 8.1,
+     "epss": 0.42, "kev": true, "fix_version": "…", "vex_status": null}
+  ],
+  "counts_by_severity": {"critical": 0, "high": 1, "medium": 3, "low": 2, "unknown": 1},
+  "art14_candidates": ["CVE-…"],
+  "gate": {"policy": "fail on KEV or CVSS >= 9.0 (default)", "passed": false},
+  "new_since_last_run": null
+}
+```
+
+Default gate when the payload provides none: fail on any KEV-listed
+finding or CVSS ≥ 9.0. VEX suppressions (OpenVEX or CycloneDX VEX) are
+applied to the gate but always echoed in `findings` with their
+`vex_status` — auditors ask what was suppressed and why.
+
+### `preloop.cra.releaseaudit/v1` (Release Security Audit)
+
+Envelope plus `sbom_audit` (the `sbomaudit` body above, minus envelope),
+`vuln_scan` (the `vulnscan` body above, minus envelope), and:
+
+```json
+{
+  "drift": {
+    "baseline": {"schema": "preloop.cra.releaseaudit/v1", "run_at": "…", "build_ref": "…"},
+    "sbom_changes": {"added": [], "removed": [], "upgraded": [], "license_changes": []},
+    "new_vulns": ["CVE-…"],
+    "resolved_vulns": [],
+    "new_kev": [],
+    "gate_transitions": ["gate: pass -> fail"],
+    "alert": true
+  },
+  "verdict": "pass | pass_with_findings | fail"
+}
+```
+
+`drift` is `null` when no previous `result.json` was delivered. Overall
+verdict: `fail` if the SBOM audit failed or the severity gate failed;
+`pass_with_findings` if gated-clean but findings or skipped checks exist.
+
+## Evidence pack layout
+
+```
+/workspace/evidence/
+  audit-report.md      # human-readable audit (all presets)
+  findings.json        # full vulnerability findings (exploit check / release audit)
+  sbom-findings.json   # full SBOM verification findings (release audit)
+  vuln-report.md       # human-readable vuln report (exploit check)
+  drift-report.md      # delta vs previous run (release audit, when baseline given)
+```
+
+## Honest limits
+
+- Verification is bounded by delivered build evidence: these flows cannot
+  prove an SBOM is complete beyond cross-checks against the manifests you
+  provide, and cannot guarantee vulnerability absence.
+- No Declaration of Conformity, CE marking decision, "compliant" verdict,
+  legal product classification, or Article 14 filing. Evidence in, human
+  assessment out.
+- Evidence files live in the execution workspace; `result.json` is the
+  artifact persisted by the platform. Long-horizon retention/export of the
+  full evidence pack and artifact signing are open platform questions —
+  not claimed by these presets.

--- a/docs/guide/flows/security-audit-presets.md
+++ b/docs/guide/flows/security-audit-presets.md
@@ -27,12 +27,23 @@ servers or tools), deterministic checks separated from agent judgment
 1. Clone the preset into a flow and configure a webhook trigger. Your CI
    job calls `POST /webhooks/flows/{flow_id}/{webhook_secret}` after the
    build; the response carries `execution_id` so the pipeline can poll
-   `/flows/executions/{execution_id}/result` and gate the release on the
-   verdict.
+   `/api/v1/flows/executions/{execution_id}/result` and gate the release
+   on the verdict.
 2. Deliver the SBOM either **inline** via the payload's
    [`workspace_files` seed](../../webhook-triggers.md) (base64, 1 MiB
    encoded cap across files) or **by pointer**: put URLs in the payload
    and the agent downloads them at run start.
+
+> **Trust and egress for URL delivery.** Payload URLs are treated as
+> hostile input: anyone holding the webhook secret can inject them, and
+> the exec sandbox needs egress to the vulnerability sources, so the
+> runner does **not** guarantee egress filtering. The prompts instruct
+> the agent to fetch only http(s) URLs and to refuse targets resolving
+> to loopback, private-range, link-local, or cloud metadata addresses
+> (e.g. `169.254.169.254`), but this is prompt-level hardening, not a
+> network policy. Prefer inline `workspace_files` delivery where
+> integrity matters; a platform-level egress allowlist is an open
+> question.
 
 Example payload (field names are conventions the prompt understands; the
 agent also searches `/workspace` for SBOM-shaped files):
@@ -142,7 +153,9 @@ Verdict semantics: `fail` = invalid SBOM or minimum elements absent;
 `pass_with_findings` = valid but findings exist (coverage gaps, license
 flags, skipped cross-checks); `pass` = clean. Build cross-checks are
 marked `skipped` when no build manifests were delivered — absence of
-evidence is reported, not papered over.
+evidence is reported, not papered over. `delta` is **always `null`** in
+this standalone preset: the field is reserved for drift-capable runs
+(only the Release Security Audit preset computes drift).
 
 ### `preloop.cra.vulnscan/v1` (SBOM Exploit Check)
 
@@ -168,6 +181,9 @@ Default gate when the payload provides none: fail on any KEV-listed
 finding or CVSS ≥ 9.0. VEX suppressions (OpenVEX or CycloneDX VEX) are
 applied to the gate but always echoed in `findings` with their
 `vex_status` — auditors ask what was suppressed and why.
+`new_since_last_run` is **always `null`** in this standalone preset: the
+field is reserved for drift-capable runs (only the Release Security
+Audit preset computes drift).
 
 ### `preloop.cra.releaseaudit/v1` (Release Security Audit)
 
@@ -216,3 +232,12 @@ verdict: `fail` if the SBOM audit failed or the severity gate failed;
   artifact persisted by the platform. Long-horizon retention/export of the
   full evidence pack and artifact signing are open platform questions —
   not claimed by these presets.
+- Validators/scanners are installed at run time, so the toolchain is not
+  bit-for-bit fixed across runs. Every run records the exact resolved
+  tool versions (`tool_versions`) and source snapshot dates
+  (`db_versions`), and the payload can pin versions (e.g.
+  `"tools": {"spdx-tools": "0.8.2"}`) which the prompt honors. Shipping
+  pinned tools in the runner image is the stronger fix and an open
+  platform question. Note that for vulnerability results, database churn
+  — not tool versions — is the dominant source of run-to-run variance,
+  which is why snapshot dates are always recorded.

--- a/docs/webhook-triggers.md
+++ b/docs/webhook-triggers.md
@@ -70,3 +70,9 @@ where `/workspace` resolves through a symlink work normally.
 - Full-event prompt embeds (`{{trigger_event}}` /
   `{{trigger_event.payload}}`) redact each `content_base64` so fixture
   blobs never inflate prompts.
+
+### See also
+
+- [Security audit presets](guide/flows/security-audit-presets.md) — CI-fed
+  SBOM verification, exploit checking, and release audits that consume
+  `workspace_files`-seeded artifacts.


### PR DESCRIPTION
## What

Three new global flow presets that turn a CI release build into audit-grade security evidence, following the Observe/Eval preset pattern (#231): read-only toolset, mandatory versioned `/workspace/result.json` captured as a first-class execution artifact, evidence files under `/workspace/evidence/`.

| Preset | File | result.json schema |
| --- | --- | --- |
| SBOM Verify | `backend/presets/004-sbom-verify.yaml` | `preloop.cra.sbomaudit/v1` |
| SBOM Exploit Check | `backend/presets/005-sbom-exploit-check.yaml` | `preloop.cra.vulnscan/v1` |
| Release Security Audit | `backend/presets/006-release-security-audit.yaml` | `preloop.cra.releaseaudit/v1` |

## Spec summary

- **Verify, not generate.** SBOM creation belongs to the build toolchain (Yocto/OpenEmbedded `create-spdx`, AOSP SBOM tooling, CycloneDX build plugins). These presets ingest CI-emitted SPDX 2.x/3.0 or CycloneDX artifacts — delivered via the webhook payload's `workspace_files` seed or by URL pointer — and audit them. A run with no SBOM delivered errors with an explanation; it never synthesizes one.
- **SBOM Verify:** format validity + internal referential integrity, NTIA/CRA-minimum-elements presence, coverage quality (versions, licenses incl. NOASSERTION rate, purl/CPE identifiers — missing identifiers are findings because they silently break downstream CVE matching), completeness cross-checks against build manifests *when delivered* (skipped-and-said-so otherwise), license policy flags.
- **SBOM Exploit Check:** components → CVEs via OSV.dev `querybatch` (primary, keyless), known-exploited flags via the CISA KEV catalog (surfaced as `art14_candidates` — a prioritisation signal for a human, explicitly not legal advice or a report filing), EPSS best-effort, NVD **fallback only** with its unauthenticated rate limit (~5 req/30 s) stated honestly and usage recorded in `db_versions`. Severity gate (default: fail on KEV or CVSS ≥ 9.0; payload-overridable). VEX suppressions applied to the gate but always echoed. Unmatchable components counted; no absence claims made for them.
- **Release Security Audit (flagship):** both audits in **one execution** (no flow chaining), plus drift vs a previous run's `result.json` when the payload provides one (component/vuln/KEV drift, gate transitions, alert flag). Emits a combined evidence pack suitable for a compliance folder; intended for webhook-fed release builds and cron-scheduled re-audits of the last released SBOM through the support period.
- **Shared contract:** common evidence envelope (`schema, flow, run_at, git, tool_versions, inputs_declared, runner, regime_profile`), deterministic `checks[]` separated from agent `assessments[]`, ≤200 KB result.json with large listings in referenced evidence files, and every artifact carries: *"Machine-generated evidence for conformity assessment support. Not a conformity assessment, certification, or legal advice."*

## Docs & tests

- `docs/guide/flows/security-audit-presets.md`: CI wiring (webhook + seed/pointer, example payload, recommended CI job outputs), scheduled re-audit guidance, all three JSON schemas, vulnerability-source notes, honest limits. Cross-linked from `docs/webhook-triggers.md`.
- `backend/tests/test_security_audit_presets.py`: preset invariants (read-only, trigger-agnostic like 003, schema ids, disclaimer, facts-vs-judgment, verify-not-generate), per-preset content checks, loader pickup/ordering, fixture sanity.
- Synthetic fixtures: `backend/tests/fixtures/sbom/sample.spdx.json` (SPDX 2.3) and `sample.cdx.json` (CycloneDX 1.5), each with a deliberate quality gap for audits to find; marked synthetic in-file.

No migrations, no model/API changes — presets are data synced by `scripts/sync_flow_presets.py` (verified the sync script needs no changes; `--dry-run` not executed here as it needs a live DB).

## Open questions (flagged, not guessed)

1. **New schema id** `preloop.cra.releaseaudit/v1`: the revised spec defines `sbomaudit/v1` + `vulnscan/v1` + `drift/v1` but no combined schema; the flagship needed one, so it embeds the two bodies plus a `drift` block shaped after `drift/v1`. Happy to rename/reshape.
2. **Evidence signing** (cosign/minisign, runner identity): not implemented or claimed; needed later to compete on evidence integrity.
3. **Evidence-pack persistence & retention:** only `result.json` is platform-persisted today; the `/workspace/evidence/` pack's retrieval/retention story (10-year technical files, multi-year watch) is a platform question the docs deliberately do not overpromise on.
4. **Preset-shipped schedules:** presets stay trigger-agnostic per repo convention (001–003); "designed for schedules" is delivered via description + docs. If we want a schedule baked into the preset (`trigger_config`), that's a convention change to decide explicitly.
5. **Per-client gate/license policy files** (vs inline payload fields) and OpenVEX vs CycloneDX VEX as the recommended suppression format.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Data-only flow preset additions (no code/model/migration changes); well-tested and documented. All four review-round-1 LOW-severity findings (URL egress hygiene, drift-field intent, endpoint path mismatch, toolchain pinning) were addressed in `e7586c1e`.
>
> **Overview**
> Adds three read-only security-audit flow presets (SBOM Verify, SBOM Exploit Check, Release Security Audit) following the Observe/Eval pattern, each writing a versioned result.json plus an evidence pack. Ships synthetic SBOM fixtures, preset-invariant tests, and a security-audit-presets guide cross-linked from the webhook docs.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit e7586c1e. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->