### PR TITLE
fix: price moonshotai/kimi-k3 as moonshot/kimi-k3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **OpenRouter Kimi slug is unpriced under provider `openai`**: traffic
+  recorded as `moonshotai/kimi-k3` is the same SKU as bundled
+  `moonshot/kimi-k3` ($3/$15 per million). Lookup now maps the OpenRouter
+  org slug onto the Moonshot catalog key so those rows get a cost instead
+  of `$0`. Reprice still-unpriced historical rows after deploy
+  (`POST /api/v1/cost/reprice` with `only_unpriced=true`).
 - **Reprice row selection**: `only_unpriced` repricing now also examines rows
   tagged `cost_source='unpriced'` that carry a stray stored cost (legacy $0
   writes), and the ledger backfill additionally admits legacy rows recorded

--- a/backend/preloop/services/model_pricing.py
+++ b/backend/preloop/services/model_pricing.py
@@ -45,6 +45,14 @@ _ENDPOINT_HOST_PREFIXES = (
     ("maas.aliyuncs.com", "dashscope"),
 )
 
+# OpenRouter (and some OpenAI-compatible configs) use the vendor's org slug
+# as the first path segment. LiteLLM's price map uses the provider namespace.
+# ``moonshotai/kimi-k3`` is the same SKU as ``moonshot/kimi-k3``; without this
+# rewrite the vendored Moonshot prices never match and the row stays unpriced.
+_VENDOR_NAMESPACE_ALIASES = {
+    "moonshotai": "moonshot",
+}
+
 
 def _strip_synthetic_prefix(candidate: str) -> str:
     """Remove Preloop's routing-only provider prefixes from a model name.
@@ -142,6 +150,14 @@ def _expand_candidate(
     if endpoint_prefix and not normalized.lower().startswith(f"{endpoint_prefix}/"):
         yield f"{endpoint_prefix}/{normalized}"
     yield normalized
+
+    vendor, separator, rest = normalized.partition("/")
+    if separator and rest:
+        canonical_vendor = _VENDOR_NAMESPACE_ALIASES.get(vendor.lower())
+        if canonical_vendor:
+            aliased = f"{canonical_vendor}/{rest}"
+            if aliased.lower() != normalized.lower():
+                yield aliased
 
     stripped = normalized
     for region_prefix in _BEDROCK_REGION_PREFIXES:

--- a/backend/tests/services/test_model_pricing.py
+++ b/backend/tests/services/test_model_pricing.py
@@ -440,6 +440,33 @@ def test_candidates_strip_openai_compatible_provider_prefix() -> None:
     assert "openai-compatible/deepseek/deepseek-v4-flash-0731" not in candidates
 
 
+def test_moonshotai_slug_maps_to_moonshot_catalog_key() -> None:
+    """OpenRouter's moonshotai/ org slug must hit the vendored moonshot/ prices.
+
+    The unpriced-model alert fired for provider=openai, alias=moonshotai/kimi-k3
+    because candidates never included moonshot/kimi-k3, which is the bundled
+    key. Same SKU, same $3/$15 per million.
+    """
+    ai_model = AIModel(
+        provider_name="openai",
+        model_identifier="moonshotai/kimi-k3",
+        meta_data={"gateway": {"model_alias": "moonshotai/kimi-k3"}},
+    )
+    candidates = list(_iter_litellm_model_candidates(ai_model))
+    assert "moonshotai/kimi-k3" in candidates
+    assert "moonshot/kimi-k3" in candidates
+
+    load_catalog(force=True)
+    estimate = estimate_ai_model_usage_cost_detailed(
+        ai_model,
+        prompt_tokens=1_000_000,
+        completion_tokens=1_000_000,
+        total_tokens=2_000_000,
+    )
+    assert estimate.source == "catalog"
+    assert estimate.cost == pytest.approx(18.0, rel=1e-6)
+
+
 def test_candidates_add_openrouter_prefix_for_openrouter_endpoint() -> None:
     """A model served via openrouter.ai gains ``openrouter/`` catalog keys.
 


### PR DESCRIPTION
## Summary
- Gateway traffic recorded as `moonshotai/kimi-k3` with provider `openai` stayed unpriced because the bundled catalog keys the same SKU as `moonshot/kimi-k3`.
- Lookup now maps the OpenRouter org slug onto the Moonshot namespace so those rows get the $3/$15 per million catalog price.
- After deploy, reprice still-unpriced historical rows (`POST /api/v1/cost/reprice`, `only_unpriced=true`) for the affected account.

## Test plan
- [x] `pytest backend/tests/services/test_model_pricing.py` (47 passed)
- [ ] After deploy, confirm new `moonshotai/kimi-k3` usage is `cost_source=catalog`
- [ ] Reprice the dogfood account window that triggered the unpriced-model alert


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Minimal, well-tested pricing fix that maps a single OpenRouter org slug onto an existing catalog key; no security or API-contract changes.
>
> **Overview**
> Maps `moonshotai/kimi-k3` to the bundled `moonshot/kimi-k3` catalog key via a small vendor-namespace alias in `_expand_candidate`, with a regression test asserting the resolved $3/$15 per-million price.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 6f2c75e. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->