### PR TITLE
feat: layered preset directories with by-identity override

### DIFF
--- a/backend/preloop/flow_presets.py
+++ b/backend/preloop/flow_presets.py
@@ -1,4 +1,23 @@
-"""Flow preset configurations loaded from YAML files."""
+"""Flow preset configurations loaded from layered YAML preset directories.
+
+``PRELOOP_PRESETS_PATH`` accepts an ``os.pathsep``-separated list of
+directories (e.g. ``/app/backend/presets:/app/presets`` on Linux). Directories
+are loaded in order and merged with union semantics:
+
+* Each preset has a stable identity: the explicit ``slug`` key in its YAML,
+  falling back to the filename stem minus the numeric order prefix
+  (``004-documentation-generator.yaml`` -> ``documentation-generator``).
+* On slug collision, the preset from the LATER directory fully replaces the
+  earlier one (by-identity override); presets without a collision all appear.
+* A preset with ``disabled: true`` in a later directory is a tombstone: it
+  suppresses the same-slug preset from earlier directories and is itself not
+  included in the catalog.
+* The catalog is stably sorted by (numeric filename prefix, slug); on
+  override, the overriding file's numeric prefix determines the position.
+
+A single-directory value (the default) preserves the historical behavior of
+loading exactly one presets directory.
+"""
 
 from __future__ import annotations
 
@@ -12,9 +31,16 @@ import yaml
 BASE_DIR = Path(__file__).resolve().parents[1]
 DEFAULT_PRESETS_DIR = BASE_DIR / "presets"
 
-# Allow overriding presets directory via environment variable
-# This is used by EE to load enterprise-specific presets
-PRESETS_DIR = Path(os.environ.get("PRELOOP_PRESETS_PATH", str(DEFAULT_PRESETS_DIR)))
+# Allow overriding preset directories via environment variable. This is used
+# by EE to layer enterprise presets on top of the open-source ones (see module
+# docstring for merge semantics).
+PRESETS_DIRS: List[Path] = [
+    Path(part)
+    for part in os.environ.get("PRELOOP_PRESETS_PATH", str(DEFAULT_PRESETS_DIR)).split(
+        os.pathsep
+    )
+    if part
+]
 
 
 def _extract_order(filename: str) -> int:
@@ -27,6 +53,15 @@ def _extract_order(filename: str) -> int:
         return 9999
 
 
+def _derive_slug(stem: str) -> str:
+    """Derive a fallback slug from a filename stem, minus the numeric prefix."""
+
+    prefix, sep, rest = stem.partition("-")
+    if sep and prefix.isdigit() and rest:
+        return rest
+    return stem
+
+
 def _load_yaml_file(path: Path) -> Dict[str, Any]:
     try:
         data = yaml.safe_load(path.read_text())
@@ -36,6 +71,10 @@ def _load_yaml_file(path: Path) -> Dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"Preset file {path} must define a mapping")
 
+    slug = data.get("slug")
+    if slug is not None and (not isinstance(slug, str) or not slug.strip()):
+        raise ValueError(f"Preset file {path} has an invalid 'slug' value")
+
     # Ensure presets default to being marked as presets unless explicitly overridden
     data.setdefault("is_preset", True)
     return data
@@ -43,19 +82,33 @@ def _load_yaml_file(path: Path) -> Dict[str, Any]:
 
 @lru_cache()
 def load_flow_presets() -> List[Dict[str, Any]]:
-    """Load flow preset configurations from YAML files."""
+    """Load flow preset configurations from the layered preset directories.
 
-    if not PRESETS_DIR.exists():
-        # Return empty list if presets directory doesn't exist (open source default)
-        return []
+    Directories in ``PRESETS_DIRS`` are merged in order: presets are keyed by
+    slug (explicit ``slug`` key, or filename-derived fallback); a same-slug
+    preset in a later directory overrides the earlier one, and ``disabled:
+    true`` tombstones suppress the preset entirely. The result is stably
+    sorted by (numeric filename prefix, slug). Missing directories are
+    skipped; an empty catalog is the open-source default.
+    """
 
-    preset_entries: List[Tuple[int, Dict[str, Any]]] = []
-    for path in sorted(PRESETS_DIR.glob("*.yml")) + sorted(PRESETS_DIR.glob("*.yaml")):
-        order = _extract_order(path.stem)
-        preset_entries.append((order, _load_yaml_file(path)))
+    merged: Dict[str, Tuple[int, Dict[str, Any]]] = {}
+    for directory in PRESETS_DIRS:
+        if not directory.exists():
+            continue
+        for path in sorted(directory.glob("*.yml")) + sorted(directory.glob("*.yaml")):
+            config = _load_yaml_file(path)
+            slug = config.get("slug") or _derive_slug(path.stem)
+            config["slug"] = slug
+            # Later directories override earlier ones on slug collision.
+            merged[slug] = (_extract_order(path.stem), config)
 
-    preset_entries.sort(key=lambda entry: entry[0])
-    return [config for _, config in preset_entries]
+    catalog: List[Dict[str, Any]] = []
+    for _, config in sorted(merged.values(), key=lambda e: (e[0], e[1]["slug"])):
+        if config.pop("disabled", False):
+            continue  # Tombstone: suppress this slug entirely.
+        catalog.append(config)
+    return catalog
 
 
 FLOW_PRESETS: List[Dict[str, Any]] = load_flow_presets()

--- a/backend/preloop/flow_presets.py
+++ b/backend/preloop/flow_presets.py
@@ -15,18 +15,26 @@ are loaded in order and merged with union semantics:
 * The catalog is stably sorted by (numeric filename prefix, slug); on
   override, the overriding file's numeric prefix determines the position.
 
-A single-directory value (the default) preserves the historical behavior of
-loading exactly one presets directory.
+The ``slug`` is loader-internal identity: it is stripped from the returned
+catalog dicts and never reaches downstream consumers.
+
+A single-directory value (the default) matches the historical loader except
+that presets are now de-duplicated by slug even within one directory: two
+files in the same directory resolving to the same slug (e.g. ``001-triage.yaml``
+and ``002-triage.yaml``) collide, the later file wins, and a warning is logged.
 """
 
 from __future__ import annotations
 
+import logging
 import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 DEFAULT_PRESETS_DIR = BASE_DIR / "presets"
@@ -87,24 +95,41 @@ def load_flow_presets() -> List[Dict[str, Any]]:
     Directories in ``PRESETS_DIRS`` are merged in order: presets are keyed by
     slug (explicit ``slug`` key, or filename-derived fallback); a same-slug
     preset in a later directory overrides the earlier one, and ``disabled:
-    true`` tombstones suppress the preset entirely. The result is stably
-    sorted by (numeric filename prefix, slug). Missing directories are
+    true`` tombstones suppress the preset entirely. A same-slug collision
+    within a single directory is almost certainly a mistake: the later file
+    wins and a warning is logged. The result is stably sorted by (numeric
+    filename prefix, slug); the loader-internal ``slug`` and ``disabled``
+    keys are stripped from the returned dicts. Missing directories are
     skipped; an empty catalog is the open-source default.
     """
 
-    merged: Dict[str, Tuple[int, Dict[str, Any]]] = {}
+    # slug -> (numeric order, slug, source path, config)
+    merged: Dict[str, Tuple[int, str, Path, Dict[str, Any]]] = {}
     for directory in PRESETS_DIRS:
         if not directory.exists():
             continue
         for path in sorted(directory.glob("*.yml")) + sorted(directory.glob("*.yaml")):
             config = _load_yaml_file(path)
-            slug = config.get("slug") or _derive_slug(path.stem)
-            config["slug"] = slug
+            # The slug is loader-internal identity; pop it so it never leaks
+            # into the catalog dicts handed to downstream consumers.
+            slug = config.pop("slug", None) or _derive_slug(path.stem)
+            previous = merged.get(slug)
+            if previous is not None and previous[2].parent == directory:
+                # Cross-directory collisions are the override feature; a
+                # collision within one directory silently drops a preset,
+                # so surface it.
+                logger.warning(
+                    "Preset slug collision within %s: %s overrides %s (slug %r)",
+                    directory,
+                    path.name,
+                    previous[2].name,
+                    slug,
+                )
             # Later directories override earlier ones on slug collision.
-            merged[slug] = (_extract_order(path.stem), config)
+            merged[slug] = (_extract_order(path.stem), slug, path, config)
 
     catalog: List[Dict[str, Any]] = []
-    for _, config in sorted(merged.values(), key=lambda e: (e[0], e[1]["slug"])):
+    for _, _, _, config in sorted(merged.values(), key=lambda e: (e[0], e[1])):
         if config.pop("disabled", False):
             continue  # Tombstone: suppress this slug entirely.
         catalog.append(config)

--- a/backend/presets/001-issue-triage-assistant.yaml
+++ b/backend/presets/001-issue-triage-assistant.yaml
@@ -1,3 +1,4 @@
+slug: issue-triage-assistant
 name: Issue Triage Assistant
 description: >-
   Automatically analyze new issues, suggest labels, priority, and potential

--- a/backend/presets/002-pull-request-reviewer.yaml
+++ b/backend/presets/002-pull-request-reviewer.yaml
@@ -1,3 +1,4 @@
+slug: pull-request-reviewer
 name: Pull Request Reviewer
 description: >-
   Automatically review pull requests for code quality, potential bugs, security

--- a/backend/presets/003-observe-eval.yaml
+++ b/backend/presets/003-observe-eval.yaml
@@ -1,3 +1,4 @@
+slug: observe-eval
 name: Observe / Eval
 description: >-
   Run-measure-report evaluation runs with no write tools by default. The agent

--- a/backend/presets/004-sbom-verify.yaml
+++ b/backend/presets/004-sbom-verify.yaml
@@ -1,3 +1,4 @@
+slug: sbom-verify
 name: SBOM Verify
 description: >-
   Verify and audit a CI-emitted SBOM (SPDX or CycloneDX) instead of

--- a/backend/presets/005-sbom-exploit-check.yaml
+++ b/backend/presets/005-sbom-exploit-check.yaml
@@ -1,3 +1,4 @@
+slug: sbom-exploit-check
 name: SBOM Exploit Check
 description: >-
   Match the components of a CI-emitted SBOM against public vulnerability

--- a/backend/presets/006-release-security-audit.yaml
+++ b/backend/presets/006-release-security-audit.yaml
@@ -1,3 +1,4 @@
+slug: release-security-audit
 name: Release Security Audit
 description: >-
   The full release-time audit in one execution: verify the CI-emitted SBOM

--- a/backend/presets/README.md
+++ b/backend/presets/README.md
@@ -17,6 +17,7 @@ Preset files should be named with a numeric prefix to control the order they app
 Each YAML file should define a single flow preset:
 
 ```yaml
+slug: "issue-triage-assistant"   # Stable identity used for layering/override
 name: "Issue Triage Assistant"
 description: "Automatically analyze new issues..."
 icon: "funnel"
@@ -41,6 +42,28 @@ is_preset: true
 > **Note:** Use `trigger_event_types` (plural, array) not the legacy
 > `trigger_event_type` (singular). The singular form is ignored by the
 > schema and flows created with it will never match events.
+
+## Layered Preset Directories
+
+`PRELOOP_PRESETS_PATH` accepts an `os.pathsep`-separated list of directories
+(e.g. `/app/backend/presets:/app/presets` on Linux), loaded in order and
+merged with union semantics:
+
+- **Identity**: every preset has a stable `slug`. Declare it explicitly in
+  the YAML (recommended); otherwise it is derived from the filename stem
+  minus the numeric prefix (`004-docs-generator.yaml` -> `docs-generator`).
+- **Union**: presets with distinct slugs from all directories appear in the
+  catalog.
+- **Override**: on slug collision, the preset from the *later* directory
+  fully replaces the earlier one. Its numeric filename prefix determines the
+  catalog position.
+- **Tombstone**: a preset with `disabled: true` in a later directory
+  suppresses the same-slug preset from earlier directories and is itself not
+  shown.
+- **Ordering**: the catalog is stably sorted by (numeric prefix, slug).
+
+A single-directory value (the default) behaves exactly like the historical
+single-directory loader.
 
 ## Notes
 

--- a/backend/presets/README.md
+++ b/backend/presets/README.md
@@ -62,8 +62,14 @@ merged with union semantics:
   shown.
 - **Ordering**: the catalog is stably sorted by (numeric prefix, slug).
 
-A single-directory value (the default) behaves exactly like the historical
-single-directory loader.
+The `slug` is loader-internal identity only: it is stripped from the loaded
+preset data before the catalog is handed to the rest of the application.
+
+A single-directory value (the default) behaves like the historical
+single-directory loader, except that presets are now de-duplicated by slug
+even within one directory: two files in the same directory that resolve to
+the same slug (e.g. `001-triage.yaml` and `002-triage.yaml`) collide — the
+later file wins and a warning is logged at startup.
 
 ## Notes
 

--- a/backend/tests/test_flow_presets.py
+++ b/backend/tests/test_flow_presets.py
@@ -249,7 +249,8 @@ class TestLayeredLoading:
         )
         result = _load_from([oss])
         assert [p["name"] for p in result] == ["First", "Second"]
-        assert [p["slug"] for p in result] == ["first", "second"]
+        # The loader-internal slug identity never leaks into the catalog.
+        assert all("slug" not in p for p in result)
 
     def test_union_of_distinct_slugs(self, tmp_path: Path):
         """Presets with distinct slugs from all dirs appear (union)."""
@@ -299,6 +300,8 @@ class TestLayeredLoading:
         result = _load_from([oss, ee])
         assert len(result) == 1
         assert result[0]["name"] == "EE Triage"
+        # The explicit slug key is stripped before the catalog is returned.
+        assert "slug" not in result[0]
 
     def test_tombstone_suppresses_earlier_preset(self, tmp_path: Path):
         """`disabled: true` in a later dir hides the same-slug preset entirely."""
@@ -346,6 +349,57 @@ class TestLayeredLoading:
         with pytest.raises(ValueError, match="invalid 'slug'"):
             _load_yaml_file(yaml_file)
 
+    def test_same_dir_collision_warns_and_later_file_wins(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        """Two files in ONE directory resolving to the same slug is almost
+        certainly a mistake: the later file wins, but a warning is logged so
+        the drop is surfaced instead of silently swallowed."""
+        oss = self._make_dir(
+            tmp_path,
+            "oss",
+            {
+                "001-triage.yaml": "name: Old Triage\n",
+                "002-triage.yaml": "name: New Triage\n",
+            },
+        )
+        with caplog.at_level("WARNING", logger="preloop.flow_presets"):
+            result = _load_from([oss])
+        assert [p["name"] for p in result] == ["New Triage"]
+        warnings = [r for r in caplog.records if "slug collision" in r.message]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "002-triage.yaml" in message
+        assert "001-triage.yaml" in message
+        assert "'triage'" in message
+
+    def test_cross_dir_override_does_not_warn(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        """Cross-directory same-slug override is the intended layering
+        feature and must stay silent."""
+        oss = self._make_dir(tmp_path, "oss", {"001-triage.yaml": "name: OSS\n"})
+        ee = self._make_dir(tmp_path, "ee", {"001-triage.yaml": "name: EE\n"})
+        with caplog.at_level("WARNING", logger="preloop.flow_presets"):
+            result = _load_from([oss, ee])
+        assert [p["name"] for p in result] == ["EE"]
+        assert not [r for r in caplog.records if "slug collision" in r.message]
+
+    def test_slug_never_leaks_into_catalog(self, tmp_path: Path):
+        """Neither explicit nor filename-derived slugs appear in catalog
+        dicts; the loader is the sole owner of the identity."""
+        oss = self._make_dir(
+            tmp_path,
+            "oss",
+            {
+                "001-explicit.yaml": "slug: my-explicit\nname: Explicit\n",
+                "002-derived.yaml": "name: Derived\n",
+            },
+        )
+        result = _load_from([oss])
+        assert len(result) == 2
+        assert all("slug" not in p for p in result)
+
 
 class TestSyncPropagationOnDirChange:
     """When a preset's source dir changes (EE override), the loaded content
@@ -369,11 +423,13 @@ class TestSyncPropagationOnDirChange:
         oss_hash = compute_content_hash(oss_only[0]["prompt_template"])
         layered_hash = compute_content_hash(layered[0]["prompt_template"])
 
-        # Same identity, different content: sync (which compares
+        # Same identity (both files derive slug "triage", so the EE layer
+        # overrides), different content: sync (which compares
         # source_prompt_hash against the current preset hash in
         # sync_preset_to_derived_flows) will auto-update non-customized
         # derived flows and notify customized ones.
-        assert oss_only[0]["slug"] == layered[0]["slug"] == "triage"
+        assert oss_only[0]["name"] == layered[0]["name"] == "Triage"
+        assert len(layered) == 1
         assert oss_hash != layered_hash
 
     def test_content_hash_stable_without_override(self, tmp_path: Path):

--- a/backend/tests/test_flow_presets.py
+++ b/backend/tests/test_flow_presets.py
@@ -7,10 +7,22 @@ import pytest
 import yaml
 
 from preloop.flow_presets import (
+    _derive_slug,
     _extract_order,
     _load_yaml_file,
     load_flow_presets,
 )
+from preloop.utils.hashing import compute_content_hash
+
+
+def _load_from(dirs: list[Path]):
+    """Load presets from the given directory layers with a fresh cache."""
+
+    with patch("preloop.flow_presets.PRESETS_DIRS", dirs):
+        load_flow_presets.cache_clear()
+        result = load_flow_presets()
+    load_flow_presets.cache_clear()
+    return result
 
 
 class TestExtractOrder:
@@ -88,7 +100,7 @@ class TestLoadFlowPresets:
         presets_dir = tmp_path / "presets"
         presets_dir.mkdir()
 
-        with patch("preloop.flow_presets.PRESETS_DIR", presets_dir):
+        with patch("preloop.flow_presets.PRESETS_DIRS", [presets_dir]):
             # Clear the lru_cache
             load_flow_presets.cache_clear()
             result = load_flow_presets()
@@ -98,7 +110,7 @@ class TestLoadFlowPresets:
         """Test that missing presets directory returns empty list (open source default)."""
         nonexistent_dir = tmp_path / "nonexistent"
 
-        with patch("preloop.flow_presets.PRESETS_DIR", nonexistent_dir):
+        with patch("preloop.flow_presets.PRESETS_DIRS", [nonexistent_dir]):
             load_flow_presets.cache_clear()
             result = load_flow_presets()
             assert result == []
@@ -112,7 +124,7 @@ class TestLoadFlowPresets:
         (presets_dir / "01-first.yml").write_text("name: First Flow\n")
         (presets_dir / "02-second.yaml").write_text("name: Second Flow\n")
 
-        with patch("preloop.flow_presets.PRESETS_DIR", presets_dir):
+        with patch("preloop.flow_presets.PRESETS_DIRS", [presets_dir]):
             load_flow_presets.cache_clear()
             result = load_flow_presets()
 
@@ -130,7 +142,7 @@ class TestLoadFlowPresets:
         (presets_dir / "01-first.yml").write_text("name: First\n")
         (presets_dir / "05-middle.yml").write_text("name: Middle\n")
 
-        with patch("preloop.flow_presets.PRESETS_DIR", presets_dir):
+        with patch("preloop.flow_presets.PRESETS_DIRS", [presets_dir]):
             load_flow_presets.cache_clear()
             result = load_flow_presets()
 
@@ -169,7 +181,7 @@ class TestFlowPresetSchema:
         }
         (presets_dir / "01-test.yml").write_text(yaml.dump(valid_preset))
 
-        with patch("preloop.flow_presets.PRESETS_DIR", presets_dir):
+        with patch("preloop.flow_presets.PRESETS_DIRS", [presets_dir]):
             load_flow_presets.cache_clear()
             presets = load_flow_presets()
 
@@ -196,3 +208,205 @@ class TestFlowPresetSchema:
             assert preset.get("is_preset", True) is True or preset.get("is_preset"), (
                 f"Preset should have is_preset=True: {preset.get('name')}"
             )
+
+
+class TestDeriveSlug:
+    """Tests for _derive_slug fallback identity derivation."""
+
+    def test_strips_numeric_prefix(self):
+        assert _derive_slug("001-issue-triage-assistant") == "issue-triage-assistant"
+        assert _derive_slug("42-pr-reviewer") == "pr-reviewer"
+
+    def test_no_numeric_prefix(self):
+        assert _derive_slug("observe-eval") == "observe-eval"
+        assert _derive_slug("custom") == "custom"
+
+    def test_bare_numeric_stem(self):
+        assert _derive_slug("001") == "001"
+        assert _derive_slug("001-") == "001-"
+
+
+class TestLayeredLoading:
+    """Tests for union/override/tombstone semantics across preset dirs."""
+
+    @staticmethod
+    def _make_dir(tmp_path: Path, name: str, files: dict) -> Path:
+        directory = tmp_path / name
+        directory.mkdir()
+        for filename, content in files.items():
+            (directory / filename).write_text(content)
+        return directory
+
+    def test_single_dir_compat(self, tmp_path: Path):
+        """A single directory keeps the exact current behavior."""
+        oss = self._make_dir(
+            tmp_path,
+            "oss",
+            {
+                "01-first.yml": "name: First\n",
+                "02-second.yaml": "name: Second\n",
+            },
+        )
+        result = _load_from([oss])
+        assert [p["name"] for p in result] == ["First", "Second"]
+        assert [p["slug"] for p in result] == ["first", "second"]
+
+    def test_union_of_distinct_slugs(self, tmp_path: Path):
+        """Presets with distinct slugs from all dirs appear (union)."""
+        oss = self._make_dir(
+            tmp_path,
+            "oss",
+            {
+                "001-triage.yaml": "name: Triage\n",
+                "004-docs-generator.yaml": "name: Docs Generator\n",
+            },
+        )
+        ee = self._make_dir(tmp_path, "ee", {"007-scanner.yaml": "name: Scanner\n"})
+        result = _load_from([oss, ee])
+        assert [p["name"] for p in result] == ["Triage", "Docs Generator", "Scanner"]
+
+    def test_override_on_slug_collision(self, tmp_path: Path):
+        """A later dir overrides an earlier one when slugs collide."""
+        oss = self._make_dir(
+            tmp_path,
+            "oss",
+            {"003-observe-eval.yaml": "name: Observe / Eval\nprompt_template: oss\n"},
+        )
+        ee = self._make_dir(
+            tmp_path,
+            "ee",
+            {
+                "008-observe-eval.yaml": "name: Observe / Eval (EE)\nprompt_template: ee\n"
+            },
+        )
+        result = _load_from([oss, ee])
+        assert len(result) == 1
+        assert result[0]["name"] == "Observe / Eval (EE)"
+        assert result[0]["prompt_template"] == "ee"
+
+    def test_override_via_explicit_slug(self, tmp_path: Path):
+        """Explicit slug keys collide even when filenames differ entirely."""
+        oss = self._make_dir(
+            tmp_path,
+            "oss",
+            {"001-triage.yaml": "slug: issue-triage\nname: OSS Triage\n"},
+        )
+        ee = self._make_dir(
+            tmp_path,
+            "ee",
+            {"050-enterprise-triage.yaml": "slug: issue-triage\nname: EE Triage\n"},
+        )
+        result = _load_from([oss, ee])
+        assert len(result) == 1
+        assert result[0]["name"] == "EE Triage"
+
+    def test_tombstone_suppresses_earlier_preset(self, tmp_path: Path):
+        """`disabled: true` in a later dir hides the same-slug preset entirely."""
+        oss = self._make_dir(
+            tmp_path,
+            "oss",
+            {
+                "001-triage.yaml": "name: Triage\n",
+                "002-reviewer.yaml": "name: Reviewer\n",
+            },
+        )
+        ee = self._make_dir(
+            tmp_path,
+            "ee",
+            {"001-triage.yaml": "name: Triage\ndisabled: true\n"},
+        )
+        result = _load_from([oss, ee])
+        assert [p["name"] for p in result] == ["Reviewer"]
+        # The tombstone marker itself never leaks into the catalog
+        assert all("disabled" not in p for p in result)
+
+    def test_stable_ordering_numeric_prefix_then_slug(self, tmp_path: Path):
+        """Catalog is sorted by (numeric prefix, slug) across dirs."""
+        oss = self._make_dir(
+            tmp_path,
+            "oss",
+            {
+                "010-zeta.yaml": "name: Zeta\n",
+                "010-alpha.yaml": "name: Alpha\n",
+            },
+        )
+        ee = self._make_dir(tmp_path, "ee", {"005-mid.yaml": "name: Mid\n"})
+        result = _load_from([oss, ee])
+        assert [p["name"] for p in result] == ["Mid", "Alpha", "Zeta"]
+
+    def test_missing_later_dir_ignored(self, tmp_path: Path):
+        """A nonexistent layer is skipped without error."""
+        oss = self._make_dir(tmp_path, "oss", {"001-triage.yaml": "name: Triage\n"})
+        result = _load_from([oss, tmp_path / "nonexistent"])
+        assert [p["name"] for p in result] == ["Triage"]
+
+    def test_invalid_slug_rejected(self, tmp_path: Path):
+        yaml_file = tmp_path / "001-bad.yaml"
+        yaml_file.write_text("name: Bad\nslug: ''\n")
+        with pytest.raises(ValueError, match="invalid 'slug'"):
+            _load_yaml_file(yaml_file)
+
+
+class TestSyncPropagationOnDirChange:
+    """When a preset's source dir changes (EE override), the loaded content
+    changes and the content-hash based sync detects it for propagation."""
+
+    def test_content_hash_changes_when_override_dir_added(self, tmp_path: Path):
+        oss = tmp_path / "oss"
+        oss.mkdir()
+        (oss / "001-triage.yaml").write_text(
+            "name: Triage\nprompt_template: oss prompt\n"
+        )
+        ee = tmp_path / "ee"
+        ee.mkdir()
+        (ee / "001-triage.yaml").write_text(
+            "name: Triage\nprompt_template: ee prompt\n"
+        )
+
+        oss_only = _load_from([oss])
+        layered = _load_from([oss, ee])
+
+        oss_hash = compute_content_hash(oss_only[0]["prompt_template"])
+        layered_hash = compute_content_hash(layered[0]["prompt_template"])
+
+        # Same identity, different content: sync (which compares
+        # source_prompt_hash against the current preset hash in
+        # sync_preset_to_derived_flows) will auto-update non-customized
+        # derived flows and notify customized ones.
+        assert oss_only[0]["slug"] == layered[0]["slug"] == "triage"
+        assert oss_hash != layered_hash
+
+    def test_content_hash_stable_without_override(self, tmp_path: Path):
+        oss = tmp_path / "oss"
+        oss.mkdir()
+        (oss / "001-triage.yaml").write_text(
+            "name: Triage\nprompt_template: oss prompt\n"
+        )
+        empty = tmp_path / "ee"
+        empty.mkdir()
+
+        oss_only = _load_from([oss])
+        layered = _load_from([oss, empty])
+
+        assert compute_content_hash(
+            oss_only[0]["prompt_template"]
+        ) == compute_content_hash(layered[0]["prompt_template"])
+
+
+class TestRealPresetSlugs:
+    """The shipped preset files must declare unique explicit slugs."""
+
+    def test_shipped_presets_declare_unique_slugs(self):
+        from preloop.flow_presets import DEFAULT_PRESETS_DIR
+
+        if not DEFAULT_PRESETS_DIR.exists():
+            pytest.skip("no shipped presets")
+
+        slugs = []
+        for path in sorted(DEFAULT_PRESETS_DIR.glob("*.y*ml")):
+            data = yaml.safe_load(path.read_text())
+            assert isinstance(data.get("slug"), str) and data["slug"].strip(), (
+                f"{path.name} must declare an explicit slug"
+            )
+            slugs.append(data["slug"])
+        assert len(slugs) == len(set(slugs)), f"duplicate slugs: {slugs}"

--- a/backend/tests/test_security_audit_presets.py
+++ b/backend/tests/test_security_audit_presets.py
@@ -164,7 +164,7 @@ class TestPresetsLoadThroughLoader:
 
         load_flow_presets.cache_clear()
         try:
-            with patch("preloop.flow_presets.PRESETS_DIR", PRESETS_DIR):
+            with patch("preloop.flow_presets.PRESETS_DIRS", [PRESETS_DIR]):
                 names = [p["name"] for p in load_flow_presets()]
             for name in PRESET_FILES:
                 assert name in names

--- a/scripts/sync_flow_presets.py
+++ b/scripts/sync_flow_presets.py
@@ -19,9 +19,12 @@ Usage:
     python scripts/sync_flow_presets.py --cleanup --dry-run
 
 Environment Variables:
-    PRELOOP_PRESETS_PATH: Path to the presets directory. Defaults to the
-                          open-source presets directory. Set to /app/presets
-                          in the EE Docker image.
+    PRELOOP_PRESETS_PATH: os.pathsep-separated list of preset directories,
+                          loaded in order (later dirs override earlier ones
+                          on slug collision; union otherwise). Defaults to
+                          the open-source presets directory. Set to
+                          "/app/backend/presets:/app/presets" in the EE
+                          Docker image to layer EE presets on top of OSS.
 """
 
 import argparse
@@ -37,7 +40,7 @@ from preloop.models.db.session import get_db_session
 from preloop.models.crud.flow import CRUDFlow
 from preloop.models.models.flow import Flow
 from preloop.models import schemas
-from preloop.flow_presets import FLOW_PRESETS, PRESETS_DIR
+from preloop.flow_presets import FLOW_PRESETS, PRESETS_DIRS
 from preloop.services.flow_presets_service import (
     compute_content_hash,
     link_unlinked_flows_by_content,
@@ -52,7 +55,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-logger.info(f"Loading presets from: {PRESETS_DIR}")
+logger.info(f"Loading presets from: {[str(d) for d in PRESETS_DIRS]}")
 logger.info(f"Found {len(FLOW_PRESETS)} preset definitions")
 
 


### PR DESCRIPTION
## Problem

The EE overlay sets `PRELOOP_PRESETS_PATH` to its own presets directory, which **replaces** the OSS preset directory wholesale. New OSS presets (e.g. 004-006 from #259) therefore never appear on Cloud unless manually copied into the EE tree.

## Spec (founder decision)

Union semantics with by-identity override: an EE preset overrides an OSS preset only when both declare the same identity; otherwise both appear.

## Changes

- **Stable `slug` identity**: preset YAML gains an explicit `slug` key. Fallback for backward compat: derived from the filename stem minus the numeric prefix (`004-docs-generator.yaml` → `docs-generator`). The three shipped presets now declare explicit slugs.
- **Layered loading**: `PRELOOP_PRESETS_PATH` accepts an `os.pathsep`-separated list of directories, loaded in order:
  - *union*: distinct slugs from all dirs appear;
  - *override*: on slug collision the later dir fully replaces the earlier preset (its numeric filename prefix determines catalog position);
  - *tombstone*: `disabled: true` in a later dir suppresses the same-slug preset from earlier dirs and is itself not shown.
  - A single-directory value keeps the exact current behavior.
- **Catalog ordering**: stable sort by (numeric prefix, slug); collision behavior documented in the loader docstring and `backend/presets/README.md`.
- **Sync script**: logs the full directory list; docstring documents the layered env var. Content-hash propagation to derived flows is unchanged and picks up overrides automatically (same name, new prompt → auto-update / notify).

## Tests

`backend/tests/test_flow_presets.py` (28 pass): union, override (filename-derived and explicit-slug collisions), tombstone, single-dir compat, ordering across dirs, missing-layer tolerance, invalid slug rejection, content-hash change when a preset's source dir changes (sync propagation trigger), and shipped-preset slug uniqueness. Preset service tests (61) still pass.

## EE-side follow-up (not in this PR)

One-line change in the EE Dockerfile:

```dockerfile
ENV PRELOOP_PRESETS_PATH=/app/backend/presets:/app/presets
```

(OSS presets first, EE overlay second, so EE overrides on slug collision.) EE preset files should also gain explicit `slug` keys matching the OSS slugs where an override is intended.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Core preset loading change, but well-tested with no security issues and all review findings now addressed.
>
> **Overview**
> Adds layered preset directories via `PRELOOP_PRESETS_PATH` (os.pathsep-separated), with a stable `slug` identity supporting union, by-identity override, and `disabled: true` tombstones. Merge logic is correct and well-tested; both prior findings (same-directory slug collision warning, slug metadata leakage) are resolved.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit c9a02281. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->