### PR TITLE
fix: open the edit-model dialog from the detail page

### DIFF
--- a/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
@@ -467,4 +467,61 @@ describe('AIModelDetailView', () => {
     expect(message).to.not.contain('https://');
     expect(message).to.not.match(/sk-[A-Za-z0-9]/);
   });
+
+  it('opens the shared edit dialog from the header Edit action', async () => {
+    const element = (await fixture(
+      html`<ai-model-detail-view .modelId=${'model-1'}></ai-model-detail-view>`
+    )) as AIModelDetailView;
+
+    await waitUntil(
+      () => !(element as any).loading,
+      'AI model detail view did not finish loading',
+      { timeout: 5000 }
+    );
+    await element.updateComplete;
+
+    const actions = element.shadowRoot?.querySelector('resource-actions');
+    expect(actions).to.exist;
+    const clickable = Array.from(
+      actions!.shadowRoot?.querySelectorAll('sl-button, sl-menu-item') || []
+    ).find((el) => (el.textContent || '').includes('Edit'));
+    expect(clickable).to.exist;
+    (clickable as HTMLElement).click();
+    await element.updateComplete;
+
+    const modal = element.shadowRoot?.querySelector(
+      'add-ai-model-modal'
+    ) as HTMLElement & { open: boolean; model: { id?: string } | null };
+    expect(modal).to.exist;
+    expect(modal.open).to.equal(true);
+    expect(modal.model?.id).to.equal('model-1');
+  });
+
+  it('opens a delete confirmation from the header Delete action', async () => {
+    const element = (await fixture(
+      html`<ai-model-detail-view .modelId=${'model-1'}></ai-model-detail-view>`
+    )) as AIModelDetailView;
+
+    await waitUntil(
+      () => !(element as any).loading,
+      'AI model detail view did not finish loading',
+      { timeout: 5000 }
+    );
+    await element.updateComplete;
+
+    const actions = element.shadowRoot?.querySelector('resource-actions');
+    const clickable = Array.from(
+      actions!.shadowRoot?.querySelectorAll('sl-button, sl-menu-item') || []
+    ).find((el) => (el.textContent || '').includes('Delete'));
+    expect(clickable).to.exist;
+    (clickable as HTMLElement).click();
+    await element.updateComplete;
+
+    expect((element as any).isDeleteConfirmOpen).to.equal(true);
+    const dialog = element.shadowRoot?.querySelector('sl-dialog');
+    expect(dialog).to.exist;
+    expect(dialog?.getAttribute('label') || (dialog as any).label).to.contain(
+      'Delete Model'
+    );
+  });
 });

--- a/frontend/src/views/authed/settings/ai-model-detail-view.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.ts
@@ -1,10 +1,12 @@
 import { LitElement, html, css, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { Router } from '@vaadin/router';
 
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
+import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
@@ -15,7 +17,9 @@ import '../../../components/view-header.ts';
 import '../../../components/resource-actions.ts';
 import '../../../components/budget-policy-editor.ts';
 import '../../../components/preloop-session-observer.ts';
+import '../../../components/add-ai-model-modal';
 import {
+  deleteAIModel,
   extractErrorMessage,
   fetchWithAuth,
   getAIModel,
@@ -89,6 +93,12 @@ export class AIModelDetailView extends LitElement {
 
   @state()
   private gatewayEnableInFlight = false;
+
+  @state()
+  private isEditModalOpen = false;
+
+  @state()
+  private isDeleteConfirmOpen = false;
 
   private initialized = false;
   private unsubscribeRealtime?: () => void;
@@ -666,6 +676,44 @@ export class AIModelDetailView extends LitElement {
     return Boolean(this.getGatewayConfig()?.enabled);
   }
 
+  private openEditModal = () => {
+    if (!this.model) {
+      return;
+    }
+    this.isEditModalOpen = true;
+  };
+
+  private closeEditModal = () => {
+    this.isEditModalOpen = false;
+  };
+
+  private async handleModelUpdated() {
+    this.closeEditModal();
+    await this.loadData({ preserveLoadingState: true });
+  }
+
+  private openDeleteConfirm = () => {
+    if (!this.model) {
+      return;
+    }
+    this.isDeleteConfirmOpen = true;
+  };
+
+  private async confirmDelete() {
+    if (!this.model) {
+      return;
+    }
+    try {
+      await deleteAIModel(this.model.id);
+      this.isDeleteConfirmOpen = false;
+      Router.go('/console/ai-models');
+    } catch (error) {
+      this.isDeleteConfirmOpen = false;
+      this.error =
+        error instanceof Error ? error.message : 'Failed to delete model';
+    }
+  }
+
   private async enableGatewayRouting() {
     if (!this.model?.id || !this.model.has_api_key) {
       this.validationError =
@@ -1068,7 +1116,14 @@ export class AIModelDetailView extends LitElement {
                             </sl-button>
                           `
                         : html`
-                            Add upstream API credentials (edit this model)
+                            Add upstream API credentials
+                            <sl-button
+                              variant="text"
+                              size="small"
+                              @click=${this.openEditModal}
+                            >
+                              (edit this model)
+                            </sl-button>
                             before enabling gateway routing.
                           `
                     }
@@ -1117,13 +1172,20 @@ export class AIModelDetailView extends LitElement {
         </div>
         <div slot="main-column" class="header-actions">
           <resource-actions
+            .collapseOverflow=${false}
             .actions=${[
-              { id: 'edit', label: 'Edit', icon: 'pencil' },
+              {
+                id: 'edit',
+                label: 'Edit',
+                icon: 'pencil',
+                onClick: this.openEditModal,
+              },
               {
                 id: 'delete',
                 label: 'Delete',
                 icon: 'trash',
                 variant: 'danger',
+                onClick: this.openDeleteConfirm,
               },
             ]}
           ></resource-actions>
@@ -1369,6 +1431,27 @@ export class AIModelDetailView extends LitElement {
           </div>
         </div>
       </div>
+      <add-ai-model-modal
+        ?open=${this.isEditModalOpen}
+        .model=${this.model}
+        @model-updated=${this.handleModelUpdated}
+        @close-modal=${this.closeEditModal}
+      ></add-ai-model-modal>
+      <sl-dialog
+        label="Delete Model"
+        .open=${this.isDeleteConfirmOpen}
+        @sl-hide=${() => (this.isDeleteConfirmOpen = false)}
+      >
+        Are you sure you want to delete the model "${this.model?.name}"?
+        <sl-button
+          slot="footer"
+          @click=${() => (this.isDeleteConfirmOpen = false)}
+          >Cancel</sl-button
+        >
+        <sl-button slot="footer" variant="danger" @click=${this.confirmDelete}
+          >Delete</sl-button
+        >
+      </sl-dialog>
     `;
   }
 }


### PR DESCRIPTION
## Summary
- Header Edit and Delete on the single-model page were labels with no `onClick`, and `add-ai-model-modal` was never mounted. The models list already opened the shared dialog.
- Wire those actions the same way as tracker detail: Edit opens the shared modal, Delete confirms then `deleteAIModel`, credentials CTA also opens edit.
- Keep both header actions visible (`collapseOverflow=false`).

## Test plan
- [ ] From AI Models list, Edit still opens the shared dialog
- [ ] From a single model page, header Edit opens the same dialog with that model
- [ ] Header Delete asks for confirmation, then returns to `/console/ai-models`
- [ ] `npx web-test-runner src/views/authed/settings/ai-model-detail-view.test.ts` (5 passed locally)


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> No security issues, a small well-scoped UI wiring fix with regression tests.
>
> **Overview**
> Wires the previously inert header Edit/Delete actions on the single AI-model page to the shared edit dialog and a new delete confirmation, mirroring the existing models-list pattern. Tests cover both the edit and delete paths.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 4e9b890. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->