### PR TITLE
fix(flows): auto-generate webhook secret when a flow is switched to a webhook trigger

### DIFF
--- a/backend/preloop/api/endpoints/flows.py
+++ b/backend/preloop/api/endpoints/flows.py
@@ -1225,6 +1225,20 @@ def update_flow(
         if flow_in.trigger_event_source == "schedule":
             flow_in.trigger_event_types = ["schedule"]
 
+    # Webhook triggers need a secret to build the trigger URL. The create
+    # path auto-generates one, but flows switched to a webhook trigger
+    # later (e.g. cloned presets, which start with no trigger) ended up
+    # with webhook_config=None: the console never shows a webhook URL and
+    # the flow is untriggerable. Mirror the create-path behavior here.
+    if (
+        effective_source == "webhook"
+        and not flow.webhook_config
+        and not flow_in.webhook_config
+    ):
+        flow_in.webhook_config = schemas.WebhookConfig(
+            webhook_secret=secrets.token_urlsafe(32)
+        )
+
     # Detect customization for template-tracked flows
     # If the user modifies the prompt or tools, mark them as customized
     # so they won't be auto-updated when the source preset changes

--- a/backend/tests/endpoints/test_flows.py
+++ b/backend/tests/endpoints/test_flows.py
@@ -1631,6 +1631,92 @@ async def test_update_flow_schedule_config_on_webhook_flow_rejected(
 
 
 @pytest.mark.asyncio
+async def test_update_flow_switch_to_webhook_generates_secret(
+    mock_account: Account, mocker: MockerFixture
+):
+    """Switching a flow with no webhook_config to a webhook trigger
+    auto-generates a webhook secret (mirrors the create path; cloned
+    presets start with trigger_event_source=None and no secret)."""
+    mock_crud_flow = _mock_crud_flow_no_conflicts(mocker)
+    flow_id = uuid.uuid4()
+    mock_flow = MagicMock()
+    mock_flow.name = "Cloned Preset Flow"
+    mock_flow.trigger_event_source = None
+    mock_flow.webhook_config = None
+    mock_flow.schedule_config = None
+    mock_flow.source_preset_id = None
+    mock_flow.is_enabled = True
+    mock_crud_flow.get.return_value = mock_flow
+
+    flow_update = schemas.FlowUpdate(
+        trigger_event_source="webhook",
+        trigger_event_types=["webhook"],
+    )
+    mock_crud_flow.update.return_value = schemas.FlowResponse(
+        id=flow_id,
+        name="Cloned Preset Flow",
+        trigger_event_source="webhook",
+        trigger_event_types=["webhook"],
+        prompt_template="p",
+        created_at=datetime.now(ZoneInfo("UTC")),
+        updated_at=datetime.now(ZoneInfo("UTC")),
+    )
+
+    await maybe_await(
+        flows.update_flow(
+            db=MagicMock(),
+            flow_id=flow_id,
+            flow_in=flow_update,
+            current_user=mock_account,
+        )
+    )
+
+    assert flow_update.webhook_config is not None
+    assert flow_update.webhook_config.webhook_secret
+    assert len(flow_update.webhook_config.webhook_secret) >= 32
+
+
+@pytest.mark.asyncio
+async def test_update_flow_webhook_keeps_existing_secret(
+    mock_account: Account, mocker: MockerFixture
+):
+    """Updating a webhook flow that already has a secret does not
+    overwrite it."""
+    mock_crud_flow = _mock_crud_flow_no_conflicts(mocker)
+    flow_id = uuid.uuid4()
+    mock_flow = MagicMock()
+    mock_flow.name = "Webhook Flow"
+    mock_flow.trigger_event_source = "webhook"
+    mock_flow.webhook_config = {"webhook_secret": "existing-secret"}
+    mock_flow.schedule_config = None
+    mock_flow.source_preset_id = None
+    mock_flow.is_enabled = True
+    mock_crud_flow.get.return_value = mock_flow
+
+    flow_update = schemas.FlowUpdate(name="Renamed Webhook Flow")
+    mock_crud_flow.update.return_value = schemas.FlowResponse(
+        id=flow_id,
+        name="Renamed Webhook Flow",
+        trigger_event_source="webhook",
+        trigger_event_types=["webhook"],
+        prompt_template="p",
+        created_at=datetime.now(ZoneInfo("UTC")),
+        updated_at=datetime.now(ZoneInfo("UTC")),
+    )
+
+    await maybe_await(
+        flows.update_flow(
+            db=MagicMock(),
+            flow_id=flow_id,
+            flow_in=flow_update,
+            current_user=mock_account,
+        )
+    )
+
+    assert flow_update.webhook_config is None
+
+
+@pytest.mark.asyncio
 async def test_update_flow_switch_to_schedule_forces_event_types(
     mock_account: Account, mocker: MockerFixture
 ):


### PR DESCRIPTION
## Problem
Cloned presets start with `trigger_event_source=None` and no `webhook_config`. The create path auto-generates a webhook secret, but `update_flow` did not. So the documented path for the security-audit preset pack (clone preset, wire a CI webhook trigger) produced a flow with `webhook_config=None`: the console never renders a webhook URL and the flow cannot be triggered by CI at all.

Found in the 2026-08-21 security-preset smoke test: all three cloned SBOM/security-audit preset flows were untriggerable out of the box.

## Fix
Mirror the create-path behavior in `update_flow`: when the effective trigger source is `webhook` and neither the stored flow nor the update payload carries a `webhook_config`, generate a `secrets.token_urlsafe(32)` secret.

Existing secrets are never overwritten; callers may still supply their own `webhook_config`.

## Tests
- `test_update_flow_switch_to_webhook_generates_secret`
- `test_update_flow_webhook_keeps_existing_secret`
- Full `tests/endpoints/test_flows.py`: 51 passed

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, focused bug fix with no security implications, mirroring existing create-path behavior and covered by new tests.
>
> **Overview**
> Auto-generates a webhook secret in `update_flow` when a flow is switched to a webhook trigger with no existing `webhook_config`, fixing cloned presets that were untriggerable out of the box. Existing secrets are never overwritten.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 83e8fd1. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->