### PR TITLE
fix: gateway model alias collision (routing + attribution)

### DIFF
--- a/backend/preloop/api/endpoints/openai_gateway.py
+++ b/backend/preloop/api/endpoints/openai_gateway.py
@@ -22,6 +22,31 @@ from preloop.services.openai_gateway import OpenAIGatewayService
 router = APIRouter(include_in_schema=False)
 
 
+_WARNING_HEADER_MAX_LEN = 256
+
+
+def _sanitize_header_value(value: str, max_len: int = _WARNING_HEADER_MAX_LEN) -> str:
+    """Make an arbitrary string safe to emit as an HTTP header value.
+
+    The warning text embeds client-controlled input (the requested model
+    spelling) and model names that may contain anything a user or an
+    agent-onboarding import wrote. Three hazards are neutralized:
+
+    * CR/LF would split the header (response-splitting/injection class);
+    * non-latin-1 characters (CJK/emoji in a model name) raise
+      ``UnicodeEncodeError`` inside Starlette's ``Response.init_headers``,
+      turning a successful completion into a 500 on exactly the collision
+      path this header exists to make visible;
+    * unbounded model inventories could inflate the header past proxy
+      limits, so the value is capped.
+    """
+    cleaned = value.replace("\r", " ").replace("\n", " ")
+    cleaned = cleaned.encode("ascii", "replace").decode("ascii")
+    if len(cleaned) > max_len:
+        cleaned = cleaned[: max_len - 3] + "..."
+    return cleaned
+
+
 def _with_alias_collision_warning(
     result: Dict[str, Any], service: OpenAIGatewayService
 ) -> Any:
@@ -34,7 +59,11 @@ def _with_alias_collision_warning(
     if service.alias_collision_warning:
         return JSONResponse(
             content=result,
-            headers={"X-Preloop-Warning": service.alias_collision_warning},
+            headers={
+                "X-Preloop-Warning": _sanitize_header_value(
+                    service.alias_collision_warning
+                )
+            },
         )
     return result
 

--- a/backend/preloop/api/endpoints/openai_gateway.py
+++ b/backend/preloop/api/endpoints/openai_gateway.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Body, Depends, Header, Request
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from preloop.models.db.session import get_db_session
@@ -19,6 +20,23 @@ from preloop.services.gateway_streaming import GatewayStreamingResponse
 from preloop.services.openai_gateway import OpenAIGatewayService
 
 router = APIRouter(include_in_schema=False)
+
+
+def _with_alias_collision_warning(
+    result: Dict[str, Any], service: OpenAIGatewayService
+) -> Any:
+    """Attach the alias-collision warning header to a non-streaming result.
+
+    When the requested model alias matched more than one binding the service
+    records a warning; surfacing it as ``X-Preloop-Warning`` keeps the body
+    OpenAI-compatible while making the collision visible to the caller.
+    """
+    if service.alias_collision_warning:
+        return JSONResponse(
+            content=result,
+            headers={"X-Preloop-Warning": service.alias_collision_warning},
+        )
+    return result
 
 
 async def get_model_gateway_auth_context(
@@ -84,7 +102,9 @@ def create_chat_completion(
             media_type="text/event-stream",
             on_complete=service.flush_deferred_stream_record,
         )
-    return service.create_chat_completion(payload)
+    return _with_alias_collision_warning(
+        service.create_chat_completion(payload), service
+    )
 
 
 @router.post("/responses")
@@ -116,4 +136,4 @@ def create_response(
             media_type="text/event-stream",
             on_complete=service.flush_deferred_stream_record,
         )
-    return service.create_response(payload)
+    return _with_alias_collision_warning(service.create_response(payload), service)

--- a/backend/preloop/models/alembic/versions/20260822_gateway_alias_collision_audit.py
+++ b/backend/preloop/models/alembic/versions/20260822_gateway_alias_collision_audit.py
@@ -129,8 +129,15 @@ def upgrade() -> None:
             gateway = dict(meta.get("gateway") or {})
             gateway["model_alias"] = new_alias
             meta["gateway"] = gateway
+            # ``meta_data`` is JSONB and the bound value is a Python str;
+            # PostgreSQL has no implicit text -> jsonb assignment cast, so
+            # the cast must be explicit or the UPDATE raises at deploy time.
             connection.execute(
-                sa.text("UPDATE ai_model SET meta_data = :meta_data WHERE id = :id"),
+                sa.text(
+                    "UPDATE ai_model "
+                    "SET meta_data = CAST(:meta_data AS jsonb) "
+                    "WHERE id = :id"
+                ),
                 {"meta_data": json.dumps(meta), "id": entry["id"]},
             )
             logger.warning(

--- a/backend/preloop/models/alembic/versions/20260822_gateway_alias_collision_audit.py
+++ b/backend/preloop/models/alembic/versions/20260822_gateway_alias_collision_audit.py
@@ -1,0 +1,148 @@
+"""Audit and resolve per-account gateway alias collisions.
+
+Revision ID: 20260822_alias_collision_audit
+Revises: 20260821_flow_exec_evidence
+Create Date: 2026-08-22
+
+Two gateway-enabled ai_model rows in one account answering to the same
+effective alias make routing and usage attribution ambiguous: the gateway
+resolves an alias to exactly one ``ai_model_id``, so one binding silently
+serves (and is billed for) the other's traffic. Write-time validation now
+prevents new collisions; this data migration audits existing rows.
+
+Resolution rule (same as the gateway's runtime preference):
+
+* The explicitly user-created binding (no ``meta_data.managed_by``) keeps
+  the alias; agent-onboarding imports (``managed_by`` set) that collide
+  with it are re-aliased with the first free ``-N`` suffix.
+* Collisions consisting only of user-created bindings are REPORTED but
+  never rewritten — re-aliasing a user's explicit configuration silently
+  is exactly the failure mode this migration exists to remove. Runtime
+  resolution keeps them deterministic (stable creation order) until the
+  user renames one.
+
+Every detected collision and every rewrite is emitted as a
+``gateway_alias_collision_audit`` log line, forming the audit report.
+"""
+
+import json
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260822_alias_collision_audit"
+down_revision: Union[str, None] = "20260821_flow_exec_evidence"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+# Alembic reads these module globals by name; keep a local reference so static
+# analysis treats them as used.
+_ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)
+assert _ALEMBIC_IDENTIFIERS, "Alembic revision metadata must be defined"
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def _effective_alias(provider_name, model_identifier, meta_data) -> str | None:
+    """Effective gateway alias of a row, or None when not gateway-enabled."""
+    gateway = meta_data.get("gateway") if isinstance(meta_data, dict) else None
+    if not isinstance(gateway, dict) or not gateway.get("enabled"):
+        return None
+    alias = gateway.get("model_alias")
+    if isinstance(alias, str) and alias.strip():
+        return alias.strip()
+    provider = (provider_name or "openai").strip().lower()
+    identifier = (model_identifier or "").strip()
+    return f"{provider}/{identifier}" if identifier else provider
+
+
+def upgrade() -> None:
+    """Detect collisions, re-alias colliding imports, report the rest."""
+    connection = op.get_bind()
+    rows = (
+        connection.execute(
+            sa.text("""
+            SELECT id, account_id, name, provider_name, model_identifier,
+                   meta_data
+            FROM ai_model
+            WHERE account_id IS NOT NULL
+            ORDER BY account_id, created_at ASC, id ASC
+            """)
+        )
+        .mappings()
+        .all()
+    )
+
+    by_account_alias: dict[tuple, list[dict]] = {}
+    taken_by_account: dict[str, set[str]] = {}
+    for row in rows:
+        meta = row["meta_data"]
+        if isinstance(meta, str):
+            meta = json.loads(meta or "{}")
+        alias = _effective_alias(row["provider_name"], row["model_identifier"], meta)
+        if not alias:
+            continue
+        entry = {**row, "meta_data": meta, "alias": alias}
+        by_account_alias.setdefault((str(row["account_id"]), alias), []).append(entry)
+        taken_by_account.setdefault(str(row["account_id"]), set()).add(alias)
+
+    for (account_id, alias), entries in sorted(by_account_alias.items()):
+        if len(entries) < 2:
+            continue
+        user_created = [
+            e
+            for e in entries
+            if not str((e["meta_data"] or {}).get("managed_by") or "").strip()
+        ]
+        imported = [e for e in entries if e not in user_created]
+        logger.warning(
+            "gateway_alias_collision_audit account=%s alias=%r bindings=%s",
+            account_id,
+            alias,
+            [(str(e["id"]), e["name"]) for e in entries],
+        )
+        if not user_created:
+            # Only imports collide: the oldest keeps the alias (matches the
+            # runtime stable order), later ones get suffixed.
+            user_created, imported = [imported[0]], imported[1:]
+        elif len(user_created) > 1:
+            logger.warning(
+                "gateway_alias_collision_audit account=%s alias=%r "
+                "UNRESOLVED: %d user-created bindings share this alias; "
+                "not rewriting user configuration — rename one of: %s",
+                account_id,
+                alias,
+                len(user_created),
+                [(str(e["id"]), e["name"]) for e in user_created],
+            )
+
+        taken = taken_by_account[account_id]
+        for entry in imported:
+            suffix = 2
+            while f"{alias}-{suffix}" in taken:
+                suffix += 1
+            new_alias = f"{alias}-{suffix}"
+            taken.add(new_alias)
+            meta = dict(entry["meta_data"] or {})
+            gateway = dict(meta.get("gateway") or {})
+            gateway["model_alias"] = new_alias
+            meta["gateway"] = gateway
+            connection.execute(
+                sa.text("UPDATE ai_model SET meta_data = :meta_data WHERE id = :id"),
+                {"meta_data": json.dumps(meta), "id": entry["id"]},
+            )
+            logger.warning(
+                "gateway_alias_collision_audit account=%s alias=%r "
+                "re-aliased import %s (%r) -> %r",
+                account_id,
+                alias,
+                entry["id"],
+                entry["name"],
+                new_alias,
+            )
+
+
+def downgrade() -> None:
+    """No-op: the audit rewrites cannot be meaningfully reversed."""

--- a/backend/preloop/models/crud/ai_model.py
+++ b/backend/preloop/models/crud/ai_model.py
@@ -1,6 +1,8 @@
 """CRUD operations for AIModel model."""
 
+import copy
 import json
+import logging
 import uuid
 from typing import Any, Dict, Optional, Sequence
 
@@ -11,6 +13,30 @@ from preloop.models.models.ai_model import AIModel
 from preloop.models.crud.secret_reference import crud_secret_reference
 from preloop.services.secret_service import get_secret_service
 from .base import CRUDBase
+
+logger = logging.getLogger(__name__)
+
+
+def _effective_gateway_alias_from_fields(
+    provider_name: Optional[str],
+    model_identifier: Optional[str],
+    meta_data: Optional[Dict],
+) -> Optional[str]:
+    """Compute the alias a would-be model row answers to on the gateway.
+
+    Mirrors ``model_runtime_resolver.effective_gateway_alias`` but works on
+    raw field values so create/update payloads can be validated before a row
+    exists. ``None`` when the row is not gateway-enabled.
+    """
+    gateway = meta_data.get("gateway") if isinstance(meta_data, dict) else None
+    if not isinstance(gateway, dict) or not gateway.get("enabled"):
+        return None
+    alias = gateway.get("model_alias")
+    if isinstance(alias, str) and alias.strip():
+        return alias.strip()
+    provider = (provider_name or "openai").strip().lower()
+    identifier = (model_identifier or "").strip()
+    return f"{provider}/{identifier}" if identifier else provider
 
 
 class CRUDAIModel(CRUDBase[AIModel]):
@@ -214,6 +240,91 @@ class CRUDAIModel(CRUDBase[AIModel]):
                 return ai_model
         return candidates[0]
 
+    def _enforce_unique_gateway_alias(
+        self,
+        db: Session,
+        *,
+        obj_data: Dict,
+        provider_name: Optional[str],
+        model_identifier: Optional[str],
+        account_id,
+        exclude_id: Optional[uuid.UUID] = None,
+    ) -> None:
+        """Keep gateway aliases unique per account at write time.
+
+        Two bindings answering to the same alias make routing and usage
+        attribution ambiguous (an alias resolves to exactly one
+        ``ai_model_id``). Explicit user writes that would collide are
+        rejected; agent-onboarding imports (rows carrying
+        ``meta_data.managed_by``) are auto-suffixed instead — an import must
+        never fail onboarding, but it must never silently take over a user's
+        alias either.
+
+        Args:
+            db: Active session.
+            obj_data: Normalized column values about to be written. Mutated
+                in place (deep-copied ``meta_data``) when auto-suffixing.
+            provider_name: Effective provider for default-alias computation.
+            model_identifier: Effective identifier for default-alias
+                computation.
+            account_id: Owning account; ``None`` (system rows) is exempt.
+            exclude_id: Row being updated, excluded from the taken-alias set.
+
+        Raises:
+            ValueError: When a non-import write would create a collision.
+        """
+        if account_id is None:
+            return
+        meta_data = obj_data.get("meta_data")
+        alias = _effective_gateway_alias_from_fields(
+            provider_name, model_identifier, meta_data
+        )
+        if not alias:
+            return
+
+        from preloop.services.model_runtime_resolver import effective_gateway_alias
+
+        taken: set[str] = set()
+        for existing in (
+            db.query(self.model).filter(self.model.account_id == account_id).all()
+        ):
+            if exclude_id is not None and existing.id == exclude_id:
+                continue
+            existing_alias = effective_gateway_alias(existing)
+            if existing_alias:
+                taken.add(existing_alias)
+        if alias not in taken:
+            return
+
+        managed_by = (
+            str((meta_data or {}).get("managed_by") or "").strip()
+            if isinstance(meta_data, dict)
+            else ""
+        )
+        if not managed_by:
+            raise ValueError(
+                f"Gateway alias '{alias}' is already used by another AI model "
+                "in this account. Choose a different alias (or remove the "
+                "other binding) so gateway routing and usage attribution stay "
+                "unambiguous."
+            )
+
+        suffix = 2
+        while f"{alias}-{suffix}" in taken:
+            suffix += 1
+        suffixed = f"{alias}-{suffix}"
+        new_meta = copy.deepcopy(meta_data)
+        new_meta.setdefault("gateway", {})["model_alias"] = suffixed
+        obj_data["meta_data"] = new_meta
+        logger.warning(
+            "gateway_alias_collision_autosuffix account=%s managed_by=%r "
+            "requested_alias=%r assigned_alias=%r",
+            account_id,
+            managed_by,
+            alias,
+            suffixed,
+        )
+
     def create_with_account(
         self,
         db: Session,
@@ -234,6 +345,13 @@ class CRUDAIModel(CRUDBase[AIModel]):
         """
         obj_data = self._normalize_model_kind_fields(dict(obj_in))
         self._validate_qwen_api_endpoint(obj_data)
+        self._enforce_unique_gateway_alias(
+            db,
+            obj_data=obj_data,
+            provider_name=obj_data.get("provider_name"),
+            model_identifier=obj_data.get("model_identifier"),
+            account_id=account_id,
+        )
         if obj_in.get("is_default"):
             for existing_model in (
                 db.query(self.model)
@@ -357,6 +475,34 @@ class CRUDAIModel(CRUDBase[AIModel]):
         """Update an AIModel. If setting a model as default, ensure others are not."""
         obj_data = self._normalize_model_kind_fields(dict(obj_in))
         self._validate_qwen_api_endpoint(obj_data, existing=db_obj)
+
+        # Enforce alias uniqueness only when this update changes the effective
+        # gateway alias; pre-existing rows (including legacy collisions being
+        # cleaned up) must remain updatable for unrelated fields.
+        from preloop.services.model_runtime_resolver import effective_gateway_alias
+
+        merged_provider = obj_data.get("provider_name", db_obj.provider_name)
+        merged_identifier = obj_data.get("model_identifier", db_obj.model_identifier)
+        merged_meta = (
+            obj_data["meta_data"] if "meta_data" in obj_data else db_obj.meta_data
+        )
+        new_alias = _effective_gateway_alias_from_fields(
+            merged_provider, merged_identifier, merged_meta
+        )
+        if new_alias and new_alias != effective_gateway_alias(db_obj):
+            check_data = {"meta_data": merged_meta}
+            self._enforce_unique_gateway_alias(
+                db,
+                obj_data=check_data,
+                provider_name=merged_provider,
+                model_identifier=merged_identifier,
+                account_id=db_obj.account_id,
+                exclude_id=db_obj.id,
+            )
+            if check_data["meta_data"] is not merged_meta:
+                # Import row was auto-suffixed; persist the rewritten alias.
+                obj_data["meta_data"] = check_data["meta_data"]
+
         target_model_kind = (obj_data.get("meta_data") or {}).get(
             "service_kind"
         ) or db_obj.model_kind

--- a/backend/preloop/models/crud/ai_model.py
+++ b/backend/preloop/models/crud/ai_model.py
@@ -260,6 +260,21 @@ class CRUDAIModel(CRUDBase[AIModel]):
         never fail onboarding, but it must never silently take over a user's
         alias either.
 
+        This is deliberately an application-level read-then-write check with
+        no backing DB constraint, so two writes racing each other can both
+        pass and land a collision. A partial unique index cannot express the
+        *effective* alias — it is a conditional over
+        ``meta_data->'gateway'->>'model_alias'`` and the computed
+        ``provider/model_identifier`` default (an indexed expression would
+        need a backfilled generated column) — and creating one would abort
+        ``alembic upgrade`` on accounts holding legacy user-created
+        collisions, which the audit migration intentionally reports but
+        never rewrites. The residual race is tolerated because the runtime
+        resolver keeps colliding aliases deterministic (user-created wins,
+        else stable inventory order) and every multi-match is logged and
+        surfaced via ``X-Preloop-Warning``, so a raced-in collision is
+        visible instead of silently misrouting.
+
         Args:
             db: Active session.
             obj_data: Normalized column values about to be written. Mutated
@@ -284,6 +299,9 @@ class CRUDAIModel(CRUDBase[AIModel]):
 
         from preloop.services.model_runtime_resolver import effective_gateway_alias
 
+        # NOTE: read-then-write without a DB-level uniqueness guard; see the
+        # docstring for why no partial unique index backs this and why the
+        # concurrent-write window is acceptable.
         taken: set[str] = set()
         for existing in (
             db.query(self.model).filter(self.model.account_id == account_id).all()

--- a/backend/preloop/services/model_runtime_resolver.py
+++ b/backend/preloop/services/model_runtime_resolver.py
@@ -227,8 +227,14 @@ def resolve_ai_model_runtime(
 
     if gateway_enabled:
         gateway_url = gateway_config.get("url") or default_model_gateway_url()
-        gateway_model_alias = gateway_config.get(
-            "model_alias"
+        # effective_gateway_alias is the single definition of the alias a
+        # binding answers to (it strips whitespace); using it here keeps
+        # runtime resolution in agreement with write-time uniqueness
+        # validation and the collision audit. The fallback is defensive:
+        # inside this branch the gateway is enabled, so the helper cannot
+        # return None.
+        gateway_model_alias = effective_gateway_alias(
+            ai_model
         ) or _build_default_gateway_alias(ai_model)
         gateway_provider = (
             gateway_config.get("provider_adapter") or DEFAULT_GATEWAY_PROVIDER

--- a/backend/preloop/services/model_runtime_resolver.py
+++ b/backend/preloop/services/model_runtime_resolver.py
@@ -73,6 +73,34 @@ def _get_gateway_config(ai_model: AIModel) -> Dict[str, Any]:
     return gateway_config if isinstance(gateway_config, dict) else {}
 
 
+def effective_gateway_alias(ai_model: AIModel) -> Optional[str]:
+    """Return the single alias a gateway-enabled model answers to.
+
+    This is the value alias-uniqueness is enforced against: the configured
+    ``meta_data.gateway.model_alias`` when set, otherwise the default
+    ``provider/model_identifier`` spelling. ``None`` for models that are not
+    gateway-enabled (they cannot collide because they are never resolved).
+    """
+    gateway_config = _get_gateway_config(ai_model)
+    if not gateway_config.get("enabled"):
+        return None
+    configured_alias = gateway_config.get("model_alias")
+    if isinstance(configured_alias, str) and configured_alias.strip():
+        return configured_alias.strip()
+    return _build_default_gateway_alias(ai_model)
+
+
+def is_agent_managed_model(ai_model: AIModel) -> bool:
+    """True when the model row was imported/managed by agent tooling.
+
+    Agent onboarding (``preloop agents onboard``) and gateway autoregistration
+    stamp ``meta_data.managed_by``; explicitly user-created models never carry
+    it. Collision handling prefers user-created rows over these imports.
+    """
+    meta_data = ai_model.meta_data if isinstance(ai_model.meta_data, dict) else {}
+    return bool(str(meta_data.get("managed_by") or "").strip())
+
+
 def gateway_url_for_api(gateway_url: Optional[str], api: str) -> Optional[str]:
     """Return the sibling gateway URL for the requested client API shape."""
     if not gateway_url:

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -117,7 +117,10 @@ from preloop.services.model_pricing import (
 )
 from preloop.services.litellm_routing import is_openrouter_endpoint, to_litellm_model
 from preloop.services.pricing_overrides import resolve_pricing_override
-from preloop.services.model_runtime_resolver import resolve_ai_model_runtime
+from preloop.services.model_runtime_resolver import (
+    is_agent_managed_model,
+    resolve_ai_model_runtime,
+)
 from preloop.services.gateway_usage_search import GatewayUsageSearchService
 from preloop.services.secret_service import (
     ANTHROPIC_CLAUDE_CODE_OAUTH_CREDENTIAL_TYPE,
@@ -543,6 +546,11 @@ class OpenAIGatewayService:
         # Computed once from the account inventory on first use so listing,
         # alias resolution, and default selection all consume the same set.
         self._authorized_model_ids_cache: Optional[frozenset[str]] = None
+        # Human-readable warning set when the requested model alias matched
+        # more than one binding. Endpoints surface it to the caller (e.g. as
+        # an X-Preloop-Warning response header) so a silent misroute like the
+        # zai/glm-5.3 collision is visible at the client, not just in logs.
+        self.alias_collision_warning: Optional[str] = None
         # Usage row stashed until the ASGI body has been finished
         # (``GatewayStreamingResponse.on_complete``). None when the generator
         # is still mid-stream or recording already ran.
@@ -2424,20 +2432,55 @@ class OpenAIGatewayService:
             # verbatim on the Anthropic OAuth passthrough, so the user's 1M
             # selection keeps working while authorization and pricing key on
             # the base model.
+            # On a tie (two bindings answering to the same spelling — e.g. a
+            # user-created model and an agent-onboarding import that silently
+            # took the same alias) the explicitly user-created binding wins:
+            # it encodes routing intent, while imports are bookkeeping. Ties
+            # within the same class fall back to the stable inventory order,
+            # and every tie is logged + surfaced as a client warning.
             normalized_requested = self._strip_claude_variant_marker(
                 str(requested_model)
             )
-            suffix_match: Optional[AIModel] = None
+            exact_matches: List[AIModel] = []
+            suffix_matches: List[AIModel] = []
             for ai_model, alias in gateway_enabled_models:
                 if alias == requested_model or alias == normalized_requested:
-                    return ai_model
-                if suffix_match is None and (
-                    alias.endswith(f"/{requested_model}")
-                    or alias.endswith(f"/{normalized_requested}")
+                    exact_matches.append(ai_model)
+                elif alias.endswith(f"/{requested_model}") or alias.endswith(
+                    f"/{normalized_requested}"
                 ):
-                    suffix_match = ai_model
-            if suffix_match is not None:
-                return suffix_match
+                    suffix_matches.append(ai_model)
+            for candidates in (exact_matches, suffix_matches):
+                if not candidates:
+                    continue
+                if len(candidates) == 1:
+                    return candidates[0]
+                user_created = [
+                    model for model in candidates if not is_agent_managed_model(model)
+                ]
+                chosen = (user_created or candidates)[0]
+                shadowed = [
+                    f"{model.id} ({model.name!r})"
+                    for model in candidates
+                    if model.id != chosen.id
+                ]
+                self.alias_collision_warning = (
+                    f"gateway alias collision: '{requested_model}' matches "
+                    f"{len(candidates)} model bindings; served by "
+                    f"{chosen.id} ({chosen.name!r}), shadowing "
+                    f"{', '.join(shadowed)}. Re-alias or remove the "
+                    "duplicate binding(s)."
+                )
+                logger.warning(
+                    "gateway_alias_collision account=%s requested=%r "
+                    "chosen=%s chosen_name=%r shadowed=%s",
+                    self.auth_context.user.account_id,
+                    requested_model,
+                    chosen.id,
+                    chosen.name,
+                    shadowed,
+                )
+                return chosen
             for _, alias in unauthorized_gateway_models:
                 if alias == requested_model or alias.endswith(f"/{requested_model}"):
                     available = (

--- a/backend/tests/endpoints/test_openai_gateway.py
+++ b/backend/tests/endpoints/test_openai_gateway.py
@@ -797,3 +797,111 @@ def test_responses_stream_midstream_failure_emits_sse_error_event(
     assert error_events[-1].get("code") == "upstream_disconnect"
     assert "upstream connection reset" in error_events[-1]["message"]
     assert "data: [DONE]" in response.text
+
+
+def test_alias_collision_warning_header_present_and_sanitized(
+    app, client, db_session, test_user
+):
+    """A collision surfaces ``X-Preloop-Warning`` on the real HTTP response.
+
+    The shadowed import carries a non-latin-1 name (CJK + emoji): without
+    sanitization Starlette's latin-1 header encoding raises
+    ``UnicodeEncodeError`` and the completion 500s on exactly the path this
+    header exists to make visible.
+    """
+    user_created = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "glm-5.3",
+            "provider_name": "zai",
+            "model_identifier": "glm-5.3",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "zai/glm-5.3",
+                    "provider_adapter": "preloop",
+                }
+            },
+        },
+        account_id=test_user.account_id,
+    )
+    imported = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "OpenCode 评审模型 🚀",
+            "provider_name": "zai",
+            "model_identifier": "glm-5.3",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "managed_by": "preloop agents onboard",
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "zai/glm-5.3-tmp",
+                    "provider_adapter": "preloop",
+                },
+            },
+        },
+        account_id=test_user.account_id,
+    )
+    # Force the legacy collision (write-time validation auto-suffixes new
+    # imports, so recreate the pre-fix data shape directly).
+    imported.meta_data = {
+        **imported.meta_data,
+        "gateway": {**imported.meta_data["gateway"], "model_alias": "zai/glm-5.3"},
+    }
+    db_session.flush()
+
+    app.dependency_overrides[get_model_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token="runtime-token", user=test_user)
+    )
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value={
+            "id": "chatcmpl_123",
+            "created": 1710000000,
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        },
+    ):
+        response = client.post(
+            "/openai/v1/chat/completions",
+            headers={"Authorization": "Bearer ignored"},
+            json={
+                "model": "zai/glm-5.3",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+
+    assert response.status_code == 200
+    warning = response.headers.get("X-Preloop-Warning")
+    assert warning, "collision warning header must be present on the response"
+    assert str(user_created.id) in warning
+    assert str(imported.id) in warning
+    # Sanitized: single-line, pure ASCII, bounded.
+    assert "\r" not in warning and "\n" not in warning
+    warning.encode("ascii")  # must not raise
+    assert len(warning) <= 256
+
+
+def test_sanitize_header_value_strips_crlf_and_caps_length():
+    """CR/LF are neutralized (header-injection class) and length is capped."""
+    from preloop.api.endpoints.openai_gateway import _sanitize_header_value
+
+    injected = "evil\r\nX-Injected: 1\nrest"
+    cleaned = _sanitize_header_value(injected)
+    assert "\r" not in cleaned and "\n" not in cleaned
+    assert "X-Injected" in cleaned  # content kept, structure neutralized
+
+    long_value = "a" * 10_000
+    capped = _sanitize_header_value(long_value)
+    assert len(capped) == 256
+    assert capped.endswith("...")
+
+    # Non-latin-1 characters become ASCII replacements, never raise.
+    assert _sanitize_header_value("模型🚀") == "???"

--- a/backend/tests/models/test_alembic_single_head.py
+++ b/backend/tests/models/test_alembic_single_head.py
@@ -86,4 +86,6 @@ def test_flow_runners_revision_chains_onto_approval_rule_context() -> None:
     assert toggles.down_revision == "20260818_usage_ingest_conv"
     evidence = script.get_revision("20260821_flow_exec_evidence")
     assert evidence.down_revision == "20260818_notify_toggles"
-    assert script.get_heads() == ["20260821_flow_exec_evidence"]
+    alias_audit = script.get_revision("20260822_alias_collision_audit")
+    assert alias_audit.down_revision == "20260821_flow_exec_evidence"
+    assert script.get_heads() == ["20260822_alias_collision_audit"]

--- a/backend/tests/models/test_alias_collision_migration.py
+++ b/backend/tests/models/test_alias_collision_migration.py
@@ -1,0 +1,167 @@
+"""Execute the alias-collision audit migration against a real Postgres DB.
+
+`test_alembic_single_head.py` only checks the revision graph; nothing there
+runs `upgrade()`. This matters because the migration's data-rewrite path
+binds a JSON string into the JSONB ``meta_data`` column — a statement that
+only executes when a collision exists, i.e. on exactly the accounts the
+migration was written to fix — so a driver-level type error (text -> jsonb
+needs an explicit cast) would abort ``alembic upgrade head`` at deploy time
+while every graph test stayed green. These tests seed a collision and run
+the migration's ``upgrade()`` through the psycopg driver used in production.
+"""
+
+import importlib.util
+from datetime import datetime
+from pathlib import Path
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from preloop.models.crud import crud_ai_model
+from preloop.services.model_runtime_resolver import effective_gateway_alias
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "preloop"
+    / "models"
+    / "alembic"
+    / "versions"
+    / "20260822_gateway_alias_collision_audit.py"
+)
+
+
+def _load_migration():
+    """Import the migration module by path (its name starts with digits)."""
+    spec = importlib.util.spec_from_file_location(
+        "alias_collision_audit_migration", MIGRATION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_upgrade(db_session) -> None:
+    """Run the migration's ``upgrade()`` inside the test transaction."""
+    migration = _load_migration()
+    context = MigrationContext.configure(db_session.connection())
+    with Operations.context(context):
+        migration.upgrade()
+
+
+def _payload(name: str, *, alias: str, managed_by: str | None = None) -> dict:
+    meta: dict = {
+        "gateway": {
+            "enabled": True,
+            "model_alias": alias,
+            "provider_adapter": "preloop",
+        }
+    }
+    if managed_by:
+        meta["managed_by"] = managed_by
+    return {
+        "name": name,
+        "provider_name": "zai",
+        "model_identifier": "glm-5.3",
+        "api_key": "test-key",
+        "meta_data": meta,
+    }
+
+
+def _force_alias(db_session, model, alias: str) -> None:
+    """Recreate the legacy collision shape (write-time checks now prevent it)."""
+    model.meta_data = {
+        **model.meta_data,
+        "gateway": {**model.meta_data["gateway"], "model_alias": alias},
+    }
+    db_session.flush()
+
+
+def test_upgrade_realiases_colliding_import_on_postgres(db_session, test_user):
+    """User keeps the alias; the import is rewritten via a real JSONB UPDATE."""
+    user_created = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_payload("glm-5.3", alias="zai/glm-5.3"),
+        account_id=test_user.account_id,
+    )
+    imported = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_payload(
+            "OpenCode zai/glm-5-3-turbo",
+            alias="zai/glm-5.3-tmp",
+            managed_by="preloop agents onboard",
+        ),
+        account_id=test_user.account_id,
+    )
+    _force_alias(db_session, imported, "zai/glm-5.3")
+
+    _run_upgrade(db_session)
+
+    db_session.expire_all()
+    assert effective_gateway_alias(user_created) == "zai/glm-5.3"
+    assert effective_gateway_alias(imported) == "zai/glm-5.3-2"
+    # The rewrite must only touch the alias, not the rest of meta_data.
+    assert imported.meta_data["managed_by"] == "preloop agents onboard"
+    assert imported.meta_data["gateway"]["enabled"] is True
+
+
+def test_upgrade_import_only_collision_keeps_oldest_on_postgres(db_session, test_user):
+    """With no user-created row the oldest import keeps the alias."""
+    first_import = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_payload(
+            "import one", alias="zai/glm-5.3", managed_by="preloop agents onboard"
+        ),
+        account_id=test_user.account_id,
+    )
+    second_import = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_payload(
+            "import two",
+            alias="zai/glm-5.3-tmp",
+            managed_by="preloop agents onboard",
+        ),
+        account_id=test_user.account_id,
+    )
+    _force_alias(db_session, second_import, "zai/glm-5.3")
+    # Rows created inside one test transaction share a transaction-fixed
+    # ``now()`` timestamp, which would leave "oldest" to the random-UUID
+    # tiebreak. Real onboarding runs produce distinct timestamps, so pin
+    # them explicitly to make "oldest import" deterministic here.
+    first_import.created_at = datetime(2026, 8, 1, 12, 0, 0)
+    second_import.created_at = datetime(2026, 8, 2, 12, 0, 0)
+    db_session.flush()
+
+    _run_upgrade(db_session)
+
+    db_session.expire_all()
+    assert effective_gateway_alias(first_import) == "zai/glm-5.3"
+    assert effective_gateway_alias(second_import) == "zai/glm-5.3-2"
+
+
+def test_upgrade_reports_but_never_rewrites_user_only_collision_on_postgres(
+    db_session, test_user, caplog
+):
+    """User-vs-user collisions are audited, not silently renamed."""
+    first = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_payload("user one", alias="zai/glm-5.3"),
+        account_id=test_user.account_id,
+    )
+    second = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_payload("user two", alias="zai/glm-5.3-tmp"),
+        account_id=test_user.account_id,
+    )
+    _force_alias(db_session, second, "zai/glm-5.3")
+
+    with caplog.at_level("WARNING"):
+        _run_upgrade(db_session)
+
+    db_session.expire_all()
+    assert effective_gateway_alias(first) == "zai/glm-5.3"
+    assert effective_gateway_alias(second) == "zai/glm-5.3"
+    assert any(
+        "gateway_alias_collision_audit" in record.message
+        and "UNRESOLVED" in (record.getMessage())
+        for record in caplog.records
+    )

--- a/backend/tests/services/test_gateway_alias_collision.py
+++ b/backend/tests/services/test_gateway_alias_collision.py
@@ -285,3 +285,43 @@ def test_import_update_into_collision_is_auto_suffixed(db_session, test_user):
         },
     )
     assert effective_gateway_alias(updated) == "zai/glm-5.3-2"
+
+
+# ---------------------------------------------------------------------------
+# Effective-alias consistency (validation vs runtime)
+# ---------------------------------------------------------------------------
+
+
+def test_whitespace_padded_alias_agrees_between_validation_and_runtime(
+    db_session, test_user
+):
+    """One alias definition everywhere: a padded ``model_alias`` strips.
+
+    Regression: write-time validation and the audit used the stripped
+    ``effective_gateway_alias`` while ``resolve_ai_model_runtime`` used the
+    raw configured string, so a whitespace-padded alias was a collision at
+    write time yet a *distinct* alias at runtime (false-positive 400,
+    unroutable spelling).
+    """
+    from preloop.services.model_runtime_resolver import resolve_ai_model_runtime
+
+    padded = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("padded", alias=" zai/glm-5.3 "),
+        account_id=test_user.account_id,
+    )
+    assert effective_gateway_alias(padded) == "zai/glm-5.3"
+    # Runtime resolution must agree with the write-time/audit definition.
+    assert resolve_ai_model_runtime(padded).model_gateway_model_alias == "zai/glm-5.3"
+    # ... which makes the padded row reachable by its stripped spelling.
+    service = _service(db_session, test_user)
+    resolved = service._resolve_requested_model("zai/glm-5.3", provider="openai")
+    assert resolved.id == padded.id
+    assert service.alias_collision_warning is None
+    # And a second write on the stripped spelling is a real collision.
+    with pytest.raises(ValueError, match="already used"):
+        crud_ai_model.create_with_account(
+            db=db_session,
+            obj_in=_model_payload("collides"),
+            account_id=test_user.account_id,
+        )

--- a/backend/tests/services/test_gateway_alias_collision.py
+++ b/backend/tests/services/test_gateway_alias_collision.py
@@ -1,0 +1,287 @@
+"""Gateway alias collision handling: create, import, and resolve paths.
+
+Regression tests for the routing/attribution bug where an agent-onboarding
+import silently took a user-created binding's gateway alias (two bindings
+answering to ``zai/glm-5.3``) and the gateway resolved — and billed — the
+import instead of the model the user explicitly added.
+"""
+
+import pytest
+
+from preloop.models.crud import crud_ai_model
+from preloop.services.model_gateway_auth import ModelGatewayAuthContext
+from preloop.services.model_runtime_resolver import effective_gateway_alias
+from preloop.services.openai_gateway import OpenAIGatewayService
+
+
+def _model_payload(
+    name: str,
+    *,
+    alias: str = "zai/glm-5.3",
+    identifier: str = "glm-5.3",
+    provider: str = "zai",
+    managed_by: str | None = None,
+):
+    meta = {
+        "gateway": {
+            "enabled": True,
+            "model_alias": alias,
+            "provider_adapter": "preloop",
+        }
+    }
+    if managed_by:
+        meta["managed_by"] = managed_by
+        meta["source_agent"] = "opencode"
+    return {
+        "name": name,
+        "provider_name": provider,
+        "model_identifier": identifier,
+        "api_key": "test-key",
+        "meta_data": meta,
+    }
+
+
+def _service(db_session, test_user) -> OpenAIGatewayService:
+    return OpenAIGatewayService(
+        db_session, ModelGatewayAuthContext(token="t", user=test_user)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resolve path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_prefers_user_created_binding_on_alias_collision(
+    db_session, test_user, caplog
+):
+    """On an exact-alias tie the explicit user binding wins over the import."""
+    imported = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload(
+            "OpenCode zai/glm-5-3-turbo", managed_by="preloop agents onboard"
+        ),
+        account_id=test_user.account_id,
+    )
+    # Simulate the legacy collision (write-time validation now auto-suffixes
+    # imports, so force the clash directly as it exists in old data).
+    user_created = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("glm-5.3", alias="zai/glm-5.3-tmp"),
+        account_id=test_user.account_id,
+    )
+    user_created.meta_data = {
+        **user_created.meta_data,
+        "gateway": {**user_created.meta_data["gateway"], "model_alias": "zai/glm-5.3"},
+    }
+    imported.meta_data = {
+        **imported.meta_data,
+        "gateway": {**imported.meta_data["gateway"], "model_alias": "zai/glm-5.3"},
+    }
+    db_session.flush()
+
+    service = _service(db_session, test_user)
+    with caplog.at_level("WARNING"):
+        resolved = service._resolve_requested_model("zai/glm-5.3", provider="openai")
+
+    assert resolved.id == user_created.id
+    assert service.alias_collision_warning is not None
+    assert "zai/glm-5.3" in service.alias_collision_warning
+    assert str(imported.id) in service.alias_collision_warning
+    assert any("gateway_alias_collision" in r.message for r in caplog.records)
+
+
+def test_resolve_prefers_user_created_binding_on_suffix_collision(
+    db_session, test_user
+):
+    """Bare-suffix requests apply the same user-over-import preference."""
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload(
+            "OpenCode import",
+            alias="zai-agent/glm-5.3",
+            managed_by="preloop agents onboard",
+        ),
+        account_id=test_user.account_id,
+    )
+    user_created = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("glm-5.3", alias="zai/glm-5.3"),
+        account_id=test_user.account_id,
+    )
+
+    service = _service(db_session, test_user)
+    resolved = service._resolve_requested_model("glm-5.3", provider="openai")
+
+    assert resolved.id == user_created.id
+    assert service.alias_collision_warning is not None
+
+
+def test_resolve_without_collision_sets_no_warning(db_session, test_user):
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("glm-5.3"),
+        account_id=test_user.account_id,
+    )
+    service = _service(db_session, test_user)
+    resolved = service._resolve_requested_model("zai/glm-5.3", provider="openai")
+    assert resolved.name == "glm-5.3"
+    assert service.alias_collision_warning is None
+
+
+# ---------------------------------------------------------------------------
+# Create path (explicit user writes)
+# ---------------------------------------------------------------------------
+
+
+def test_user_create_with_colliding_alias_is_rejected(db_session, test_user):
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("glm-5.3"),
+        account_id=test_user.account_id,
+    )
+    with pytest.raises(ValueError, match="already used"):
+        crud_ai_model.create_with_account(
+            db=db_session,
+            obj_in=_model_payload("glm-5.3 duplicate"),
+            account_id=test_user.account_id,
+        )
+
+
+def test_user_create_default_alias_collision_is_rejected(db_session, test_user):
+    """The default provider/identifier alias collides with an explicit one."""
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("glm-5.3"),
+        account_id=test_user.account_id,
+    )
+    payload = _model_payload("implicit alias")
+    del payload["meta_data"]["gateway"]["model_alias"]  # defaults to zai/glm-5.3
+    with pytest.raises(ValueError, match="already used"):
+        crud_ai_model.create_with_account(
+            db=db_session, obj_in=payload, account_id=test_user.account_id
+        )
+
+
+def test_user_update_into_colliding_alias_is_rejected(db_session, test_user):
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("glm-5.3"),
+        account_id=test_user.account_id,
+    )
+    other = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("other", alias="zai/glm-4.6"),
+        account_id=test_user.account_id,
+    )
+    with pytest.raises(ValueError, match="already used"):
+        crud_ai_model.update(
+            db=db_session,
+            db_obj=other,
+            obj_in={
+                "meta_data": {
+                    **other.meta_data,
+                    "gateway": {
+                        **other.meta_data["gateway"],
+                        "model_alias": "zai/glm-5.3",
+                    },
+                }
+            },
+        )
+
+
+def test_unrelated_update_on_legacy_collision_still_allowed(db_session, test_user):
+    """Rows that already collide stay editable for non-alias fields."""
+    first = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("glm-5.3"),
+        account_id=test_user.account_id,
+    )
+    second = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("legacy dup", alias="zai/glm-5.3-tmp"),
+        account_id=test_user.account_id,
+    )
+    second.meta_data = {
+        **second.meta_data,
+        "gateway": {**second.meta_data["gateway"], "model_alias": "zai/glm-5.3"},
+    }
+    db_session.flush()
+    assert effective_gateway_alias(first) == effective_gateway_alias(second)
+
+    updated = crud_ai_model.update(
+        db=db_session, db_obj=second, obj_in={"description": "still editable"}
+    )
+    assert updated.description == "still editable"
+
+
+# ---------------------------------------------------------------------------
+# Import path (agent onboarding)
+# ---------------------------------------------------------------------------
+
+
+def test_import_with_colliding_alias_is_auto_suffixed(db_session, test_user):
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("glm-5.3"),
+        account_id=test_user.account_id,
+    )
+    imported = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload(
+            "OpenCode zai/glm-5-3-turbo", managed_by="preloop agents onboard"
+        ),
+        account_id=test_user.account_id,
+    )
+    assert effective_gateway_alias(imported) == "zai/glm-5.3-2"
+
+    second_import = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("OpenCode another", managed_by="preloop agents onboard"),
+        account_id=test_user.account_id,
+    )
+    assert effective_gateway_alias(second_import) == "zai/glm-5.3-3"
+
+
+def test_import_without_collision_keeps_requested_alias(db_session, test_user):
+    imported = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload(
+            "OpenCode zai/glm-5-3-turbo",
+            alias="zai/glm-5-3-turbo",
+            managed_by="preloop agents onboard",
+        ),
+        account_id=test_user.account_id,
+    )
+    assert effective_gateway_alias(imported) == "zai/glm-5-3-turbo"
+
+
+def test_import_update_into_collision_is_auto_suffixed(db_session, test_user):
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload("glm-5.3"),
+        account_id=test_user.account_id,
+    )
+    imported = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in=_model_payload(
+            "OpenCode zai/glm-5-3-turbo",
+            alias="zai/glm-5-3-turbo",
+            managed_by="preloop agents onboard",
+        ),
+        account_id=test_user.account_id,
+    )
+    updated = crud_ai_model.update(
+        db=db_session,
+        db_obj=imported,
+        obj_in={
+            "meta_data": {
+                **imported.meta_data,
+                "gateway": {
+                    **imported.meta_data["gateway"],
+                    "model_alias": "zai/glm-5.3",
+                },
+            }
+        },
+    )
+    assert effective_gateway_alias(updated) == "zai/glm-5.3-2"


### PR DESCRIPTION
## Problem

On a staging account, two ai-model bindings shared the gateway alias `zai/glm-5.3`:

- the model the user **explicitly added** (`glm-5.3`), and
- an OpenCode-onboarded import (`OpenCode zai/glm-5-3-turbo`, `meta_data.managed_by: "preloop agents onboard"`) that silently took the same alias.

`_resolve_requested_model`'s first-exact-match rule resolved the alias to the *import* (it sorts earlier in the stable inventory order), so requests the user sent "to glm-5.3" were served **and billed** against the turbo binding. That corrupts both routing intent and cost/usage attribution.

## Fix

**Resolution rule (deterministic + intention-preserving).** When a requested spelling matches more than one binding (exact-alias tie, or bare-suffix tie when no exact match exists):

1. Prefer the **explicitly user-created** binding (no `meta_data.managed_by`) over agent-onboarding / autoregister imports — an explicit add encodes routing intent; imports are bookkeeping.
2. Ties within the same class fall back to the existing stable order (`get_all_for_account`: account rows before system, oldest first).
3. Every tie emits a `gateway_alias_collision` warning log and is surfaced to the caller via an `X-Preloop-Warning` response header on non-streaming OpenAI-gateway responses (body stays OpenAI-compatible).

**Preventing new collisions.** `crud_ai_model.create_with_account` / `update` now enforce per-account uniqueness of the *effective* gateway alias (`meta_data.gateway.model_alias`, else the `provider/model_identifier` default):

- Explicit user writes that would collide are rejected (`ValueError` → HTTP 400 at the endpoint).
- Agent-onboarding imports (`managed_by` set) are **auto-suffixed** (`alias-2`, `-3`, …) — onboarding never fails, and never silently takes over a user's alias. Clients receive the created row (with the assigned alias) in the response.
- Updates only validate when they *change* the effective alias, so rows in legacy collided state remain editable for unrelated fields.

**Backfill audit** (`20260822_alias_collision_audit`, chained onto the single head `20260821_flow_exec_evidence`):

- Detects existing per-account collisions among gateway-enabled rows.
- Re-aliases **only colliding imports** by the same preference rule (first free `-N` suffix; when only imports collide, the oldest keeps the alias, matching runtime order).
- Emits a `gateway_alias_collision_audit` report line for every collision and every rewrite. Collisions consisting solely of user-created bindings are reported but **never rewritten** — runtime resolution keeps them deterministic until the user renames one.

## Edge cases considered

- **Default-alias collisions**: a row with no configured `model_alias` still answers to `provider/model_identifier`; validation and audit compute this same effective alias.
- **Bare-suffix overlap** (e.g. `custom/x/y` vs `x/y` both ending in `/y`): not treated as a write-time collision (exact aliases differ), but resolve-time ties get the same preference + warning.
- **System models** (`account_id IS NULL`) are exempt from write-time uniqueness and skipped by the audit; account rows already shadow them via inventory order.
- **All-import collisions**: oldest import keeps the alias (mirrors previous behavior), later ones are suffixed.
- **Suffix availability**: the suffixer probes `-2, -3, …` against the account's full taken-alias set, so repeated imports converge instead of ping-ponging.

## Tests

`backend/tests/services/test_gateway_alias_collision.py` — 10 tests covering the create (reject), import (auto-suffix, incl. default-alias and update paths), and resolve (exact tie, suffix tie, no-collision no-warning, legacy-row editability) paths. Extended `test_alembic_single_head.py` for the new revision. Full `tests/services`, `tests/endpoints`, `tests/models` suites pass (4037 passed, 1 skipped).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Deterministic, intention-preserving gateway alias resolution plus a data migration to backfill existing collisions. The migration's JSONB cast is now explicit and covered by a real-Postgres test; the remaining write-time uniqueness check is app-level (documented race window) but no longer a silent misroute.
>
> **Overview**
> Adds deterministic, intention-preserving gateway alias resolution (user-created bindings win over agent-onboarding imports), write-time per-account alias uniqueness (reject user collisions, auto-suffix imports), and an audit migration to backfill existing collisions. Resolution ties log a `gateway_alias_collision` warning and surface it via an `X-Preloop-Warning` header on non-streaming OpenAI-gateway responses.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit c1e68b95. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->