### PR TITLE
fix: drop unsupported LiteLLM params and identify traffic as Preloop

### DIFF
--- a/backend/preloop/agents/failure_analysis.py
+++ b/backend/preloop/agents/failure_analysis.py
@@ -119,7 +119,15 @@ _TRANSIENT_NETWORK_RE = re.compile(
     # `error="The operation timed out."` while the request was still
     # completing upstream — the canonical recoverable shape.
     r"|(?:request|read|socket|operation)\s+timed?\s*out"
-    r"|timeout\s+(?:of\s+)?\d+\s*ms\s+exceeded)\b",
+    r"|timeout\s+(?:of\s+)?\d+\s*ms\s+exceeded"
+    # OpenRouter / LiteLLM mid-stream provider drop. The gateway remaps this
+    # to HTTP 502 upstream_disconnect; agent logs often carry the raw
+    # signature without a "status: 502" token.
+    r"|provider_unavailable"
+    r"|upstream_disconnect"
+    r"|disconnected mid-stream"
+    r"|midstreamfallbackerror"
+    r"|json error injected into sse stream)\b",
     re.IGNORECASE,
 )
 

--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -244,6 +244,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Initialize Sentry if DSN is configured
     init_sentry()
 
+    # Stamp LiteLLM env defaults before any httpx client is cached so
+    # provider dashboards do not attribute traffic to LiteLLM.
+    from preloop.services.litellm_routing import ensure_preloop_client_identity
+
+    ensure_preloop_client_identity()
+
     # Register the vendored model-price catalog so gateway cost estimates are
     # deterministic per release (independent of the installed litellm version).
     # load_catalog() already handles missing/corrupt files; this catch is only

--- a/backend/preloop/services/litellm_routing.py
+++ b/backend/preloop/services/litellm_routing.py
@@ -38,8 +38,9 @@ of the stored provider/endpoint sent live traffic to the wrong vendor with a
 truncated model id (issue #172).
 """
 
+import os
 from functools import lru_cache
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from urllib.parse import urlsplit
 
 import litellm
@@ -82,6 +83,86 @@ OPENAI_COMPATIBLE_PROVIDERS = frozenset({"openai-compatible", "custom"})
 OPENROUTER_HOSTS = frozenset({"openrouter.ai"})
 
 OPENROUTER_PREFIX = "openrouter/"
+
+# LiteLLM's HTTP client defaults User-Agent to ``litellm/{version}`` (overridable
+# via ``LITELLM_USER_AGENT``). Its OpenRouter adapter also defaults
+# ``HTTP-Referer`` / ``X-Title`` to ``https://litellm.ai`` / ``liteLLM``
+# (``OR_SITE_URL`` / ``OR_APP_NAME``). Provider dashboards attribute traffic
+# from those headers, so Preloop must replace them on every completion.
+PRELOOP_APP_NAME = "Preloop"
+PRELOOP_SITE_URL = "https://preloop.ai"
+OPENROUTER_APP_NAME = PRELOOP_APP_NAME
+OPENROUTER_SITE_URL = PRELOOP_SITE_URL
+
+
+def preloop_user_agent() -> str:
+    """User-Agent sent on every LiteLLM completion.
+
+    LiteLLM otherwise stamps ``litellm/{version}``, which is what provider
+    dashboards (OpenRouter, z.ai, OpenAI, ...) display as the client app.
+    """
+    from preloop import __version__
+
+    return f"Preloop/{__version__}"
+
+
+def preloop_client_headers() -> Dict[str, str]:
+    """LiteLLM-default client headers replaced on every upstream."""
+    return {"User-Agent": preloop_user_agent()}
+
+
+def openrouter_app_headers() -> Dict[str, str]:
+    """OpenRouter app-attribution headers (HTTP-Referer / X-Title)."""
+    return {
+        "HTTP-Referer": PRELOOP_SITE_URL,
+        "X-Title": PRELOOP_APP_NAME,
+    }
+
+
+def is_openrouter_model(ai_model: Any) -> bool:
+    """Whether this model's traffic terminates at OpenRouter.
+
+    True for the explicit ``openrouter`` provider and for any model whose
+    ``api_endpoint`` points at openrouter.ai (e.g. an ``openai-compatible``
+    provider with an OpenRouter base URL). Mirrors the routing decision in
+    :func:`to_litellm_model`.
+    """
+    provider = (getattr(ai_model, "provider_name", None) or "").strip().lower()
+    if provider == "openrouter":
+        return True
+    return is_openrouter_endpoint(getattr(ai_model, "api_endpoint", None))
+
+
+def apply_preloop_client_headers(
+    kwargs: Dict[str, Any], ai_model: Any = None
+) -> Dict[str, Any]:
+    """Replace LiteLLM client branding on every completion kwargs dict.
+
+    User-Agent is always Preloop (not gated on OpenRouter). OpenRouter
+    attribution headers are added when the request terminates there.
+    Merges into existing ``extra_headers`` so provider-specific headers
+    (Claude Code OAuth betas, etc.) are kept.
+    """
+    extra = dict(kwargs.get("extra_headers") or {})
+    extra.update(preloop_client_headers())
+    if ai_model is not None and is_openrouter_model(ai_model):
+        extra.update(openrouter_app_headers())
+    kwargs["extra_headers"] = extra
+    return kwargs
+
+
+def ensure_preloop_client_identity() -> None:
+    """Fill LiteLLM env defaults so its HTTP client is not ``litellm/...``.
+
+    ``LITELLM_USER_AGENT`` is the supported override for the default
+    ``User-Agent: litellm/{version}`` header baked into LiteLLM's httpx
+    client. ``OR_SITE_URL`` / ``OR_APP_NAME`` override the OpenRouter
+    adapter's ``liteLLM`` attribution. Does not clobber an operator-set
+    value.
+    """
+    os.environ.setdefault("LITELLM_USER_AGENT", preloop_user_agent())
+    os.environ.setdefault("OR_SITE_URL", OPENROUTER_SITE_URL)
+    os.environ.setdefault("OR_APP_NAME", OPENROUTER_APP_NAME)
 
 
 @lru_cache(maxsize=1)

--- a/backend/preloop/services/litellm_routing.py
+++ b/backend/preloop/services/litellm_routing.py
@@ -151,9 +151,7 @@ def apply_preloop_client_headers(
     return kwargs
 
 
-_PRELOOP_CLIENT_IDENTITY_APPLIED = False
-
-
+@lru_cache(maxsize=1)
 def ensure_preloop_client_identity() -> None:
     """Fill LiteLLM env defaults once so new HTTP clients are not ``litellm/...``.
 
@@ -163,19 +161,16 @@ def ensure_preloop_client_identity() -> None:
     adapter's ``liteLLM`` attribution. Does not clobber an operator-set
     value.
 
-    Call this at process startup, not per request. LiteLLM caches httpx
-    clients, so an env change after the first client is created is a
-    no-op. ``apply_preloop_client_headers`` is the source of truth for
-    branding on every completion.
+    Call this at process startup, not per request. Cached so later calls
+    are a no-op. LiteLLM caches httpx clients, so an env change after the
+    first client is created is also a no-op.
+    ``apply_preloop_client_headers`` is the source of truth for branding
+    on every completion.
     """
-    global _PRELOOP_CLIENT_IDENTITY_APPLIED
-    if _PRELOOP_CLIENT_IDENTITY_APPLIED:
-        return
     if "LITELLM_USER_AGENT" not in os.environ:
         os.environ["LITELLM_USER_AGENT"] = preloop_user_agent()
     os.environ.setdefault("OR_SITE_URL", OPENROUTER_SITE_URL)
     os.environ.setdefault("OR_APP_NAME", OPENROUTER_APP_NAME)
-    _PRELOOP_CLIENT_IDENTITY_APPLIED = True
 
 
 @lru_cache(maxsize=1)

--- a/backend/preloop/services/litellm_routing.py
+++ b/backend/preloop/services/litellm_routing.py
@@ -151,18 +151,31 @@ def apply_preloop_client_headers(
     return kwargs
 
 
+_PRELOOP_CLIENT_IDENTITY_APPLIED = False
+
+
 def ensure_preloop_client_identity() -> None:
-    """Fill LiteLLM env defaults so its HTTP client is not ``litellm/...``.
+    """Fill LiteLLM env defaults once so new HTTP clients are not ``litellm/...``.
 
     ``LITELLM_USER_AGENT`` is the supported override for the default
     ``User-Agent: litellm/{version}`` header baked into LiteLLM's httpx
     client. ``OR_SITE_URL`` / ``OR_APP_NAME`` override the OpenRouter
     adapter's ``liteLLM`` attribution. Does not clobber an operator-set
     value.
+
+    Call this at process startup, not per request. LiteLLM caches httpx
+    clients, so an env change after the first client is created is a
+    no-op. ``apply_preloop_client_headers`` is the source of truth for
+    branding on every completion.
     """
-    os.environ.setdefault("LITELLM_USER_AGENT", preloop_user_agent())
+    global _PRELOOP_CLIENT_IDENTITY_APPLIED
+    if _PRELOOP_CLIENT_IDENTITY_APPLIED:
+        return
+    if "LITELLM_USER_AGENT" not in os.environ:
+        os.environ["LITELLM_USER_AGENT"] = preloop_user_agent()
     os.environ.setdefault("OR_SITE_URL", OPENROUTER_SITE_URL)
     os.environ.setdefault("OR_APP_NAME", OPENROUTER_APP_NAME)
+    _PRELOOP_CLIENT_IDENTITY_APPLIED = True
 
 
 @lru_cache(maxsize=1)

--- a/backend/preloop/services/model_credentials.py
+++ b/backend/preloop/services/model_credentials.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 
 from preloop.models.crud.ai_model import ai_model as crud_ai_model
 from preloop.models.models.ai_model import AIModel
+from preloop.services.litellm_routing import apply_preloop_client_headers
 from preloop.services.secret_service import get_secret_service
 
 logger = logging.getLogger(__name__)
@@ -263,6 +264,9 @@ def build_aux_kwargs(
     ``call_site_kwargs`` keeps the call-site value. ``extra_body`` dicts are
     deep-merged so a default thinking-disable knob is not clobbered by an
     unrelated extra_body key in a higher layer.
+
+    Preloop client branding is applied last: User-Agent is always Preloop
+    (never LiteLLM). OpenRouter also gets ``X-Title`` / ``HTTP-Referer``.
     """
     # Layer 4: safety defaults (capability-checked, not blanket).
     merged: dict[str, Any] = {"drop_params": True}
@@ -279,6 +283,7 @@ def build_aux_kwargs(
     # Layer 1: call-site explicit args (always win).
     _merge_extra_body(merged, call_site_kwargs)
 
+    apply_preloop_client_headers(merged, model)
     return merged
 
 

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -115,7 +115,12 @@ from preloop.services.model_pricing import (
     _iter_litellm_model_candidates,
     estimate_ai_model_usage_cost_detailed,
 )
-from preloop.services.litellm_routing import is_openrouter_endpoint, to_litellm_model
+from preloop.services.litellm_routing import (
+    apply_preloop_client_headers,
+    ensure_preloop_client_identity,
+    is_openrouter_model,
+    to_litellm_model,
+)
 from preloop.services.pricing_overrides import resolve_pricing_override
 from preloop.services.model_runtime_resolver import resolve_ai_model_runtime
 from preloop.services.gateway_usage_search import GatewayUsageSearchService
@@ -261,18 +266,8 @@ def _openrouter_usage_accounting_enabled() -> bool:
 
 
 def _is_openrouter_upstream(ai_model: AIModel) -> bool:
-    """Whether this model's traffic terminates at OpenRouter.
-
-    True for the explicit ``openrouter`` provider and for any model whose
-    ``api_endpoint`` points at openrouter.ai (e.g. an ``openai-compatible``
-    provider with an OpenRouter base URL). Mirrors the routing decision in
-    :func:`preloop.services.litellm_routing.to_litellm_model` so the
-    usage-accounting flag is sent exactly when the request goes to OpenRouter.
-    """
-    provider = (getattr(ai_model, "provider_name", None) or "").strip().lower()
-    if provider == "openrouter":
-        return True
-    return is_openrouter_endpoint(getattr(ai_model, "api_endpoint", None))
+    """Whether this model's traffic terminates at OpenRouter."""
+    return is_openrouter_model(ai_model)
 
 
 def _bedrock_region(ai_model: AIModel) -> Optional[str]:
@@ -341,6 +336,11 @@ def _anthropic_oauth_environment(auth_token: str) -> Iterator[None]:
 
 class LiteLLMModelGatewayBackend:
     def completion(self, **kwargs: Any) -> Any:
+        # Belt-and-suspenders: LiteLLM's httpx client defaults User-Agent to
+        # ``litellm/{version}`` unless LITELLM_USER_AGENT is set, and will
+        # also re-stamp liteLLM on OpenRouter if extra_headers are dropped.
+        ensure_preloop_client_identity()
+        apply_preloop_client_headers(kwargs)
         anthropic_auth_token = kwargs.pop("_preloop_anthropic_auth_token", None)
         if anthropic_auth_token:
             with _anthropic_oauth_environment(str(anthropic_auth_token)):
@@ -4640,6 +4640,14 @@ class OpenAIGatewayService:
                 kwargs[target_key] = payload[source_key]
         if payload.get("stop") is not None:
             kwargs["stop"] = payload["stop"]
+        # LiteLLM fallback metadata for unlisted models (e.g. zai/glm-5.3)
+        # forwards client flags the provider rejects. Drop those instead of
+        # failing the whole request. Aux generation already does this.
+        kwargs["drop_params"] = True
+        # Identify as Preloop on every upstream. User-Agent is global so
+        # provider dashboards do not attribute traffic to LiteLLM.
+        # OpenRouter also gets HTTP-Referer / X-Title.
+        apply_preloop_client_headers(kwargs, ai_model)
 
         return kwargs
 

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -4695,8 +4695,9 @@ class OpenAIGatewayService:
 
         Retries 502 / provider_unavailable / upstream_disconnect /
         MidStreamFallbackError / network / overload. Does not retry 4xx
-        unsupported-params, auth, or quota. Intermediate failures are not
-        admin-alerted; only the final mapped error notifies.
+        unsupported-params, auth, quota, or opaque generic exceptions.
+        Intermediate failures are not admin-alerted; only the final mapped
+        error notifies.
 
         Args:
             provider: Gateway provider used to shape the final error.

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -117,7 +117,6 @@ from preloop.services.model_pricing import (
 )
 from preloop.services.litellm_routing import (
     apply_preloop_client_headers,
-    ensure_preloop_client_identity,
     is_openrouter_model,
     to_litellm_model,
 )
@@ -336,10 +335,8 @@ def _anthropic_oauth_environment(auth_token: str) -> Iterator[None]:
 
 class LiteLLMModelGatewayBackend:
     def completion(self, **kwargs: Any) -> Any:
-        # Belt-and-suspenders: LiteLLM's httpx client defaults User-Agent to
-        # ``litellm/{version}`` unless LITELLM_USER_AGENT is set, and will
-        # also re-stamp liteLLM on OpenRouter if extra_headers are dropped.
-        ensure_preloop_client_identity()
+        # extra_headers is the source of truth for Preloop branding.
+        # LITELLM_USER_AGENT is set once at process startup.
         apply_preloop_client_headers(kwargs)
         anthropic_auth_token = kwargs.pop("_preloop_anthropic_auth_token", None)
         if anthropic_auth_token:
@@ -4640,9 +4637,10 @@ class OpenAIGatewayService:
                 kwargs[target_key] = payload[source_key]
         if payload.get("stop") is not None:
             kwargs["stop"] = payload["stop"]
+        # Intentional global default, not zai-only. Matches aux generation.
         # LiteLLM fallback metadata for unlisted models (e.g. zai/glm-5.3)
         # forwards client flags the provider rejects. Drop those instead of
-        # failing the whole request. Aux generation already does this.
+        # failing the whole request.
         kwargs["drop_params"] = True
         # Identify as Preloop on every upstream. User-Agent is global so
         # provider dashboards do not attribute traffic to LiteLLM.

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -319,20 +319,42 @@ class ModelGatewayBackend(Protocol):
 # Not LiteLLM Router fallbacks; those would require a model list.
 _UPSTREAM_RETRY_MAX_ATTEMPTS = 3
 _UPSTREAM_RETRY_BASE_SECONDS = 0.2
+# Cap provider Retry-After so a 429 hint cannot stall the gateway.
+_UPSTREAM_RETRY_AFTER_CAP_SECONDS = 8.0
 
 
-def _upstream_retry_delay_seconds(attempt: int) -> float:
-    """Exponential backoff plus jitter for one gateway upstream retry.
+def _upstream_retry_after_hint_seconds(exc: Exception) -> Optional[int]:
+    """Provider Retry-After from a mapped error or the raw exception."""
+    hinted = getattr(exc, "retry_after_seconds", None)
+    if isinstance(hinted, int) and hinted >= 0:
+        return hinted
+    classified = classify_upstream_error(exc)
+    if classified is None:
+        return None
+    return classified.retry_after_seconds
+
+
+def _upstream_retry_delay_seconds(
+    attempt: int,
+    retry_after_seconds: Optional[int] = None,
+) -> float:
+    """Exponential backoff plus jitter, raised to a capped Retry-After hint.
 
     Args:
         attempt: Zero-based index of the failure that just happened.
+        retry_after_seconds: Provider Retry-After when the exception
+            exposed one. Honored up to ``_UPSTREAM_RETRY_AFTER_CAP_SECONDS``.
 
     Returns:
         Seconds to wait before the next attempt.
     """
-    return (_UPSTREAM_RETRY_BASE_SECONDS * (2**attempt)) + random.uniform(
+    backoff = (_UPSTREAM_RETRY_BASE_SECONDS * (2**attempt)) + random.uniform(
         0, _UPSTREAM_RETRY_BASE_SECONDS
     )
+    if retry_after_seconds is None:
+        return backoff
+    hinted = min(float(max(retry_after_seconds, 0)), _UPSTREAM_RETRY_AFTER_CAP_SECONDS)
+    return max(backoff, hinted)
 
 
 def _sleep_before_upstream_retry(seconds: float) -> None:
@@ -4721,7 +4743,10 @@ class OpenAIGatewayService:
                     or not is_retryable_upstream_failure(exc)
                 ):
                     break
-                delay = _upstream_retry_delay_seconds(attempt)
+                delay = _upstream_retry_delay_seconds(
+                    attempt,
+                    retry_after_seconds=_upstream_retry_after_hint_seconds(exc),
+                )
                 logger.warning(
                     "Retrying gateway upstream call after transient failure "
                     "(attempt %s/%s, delay=%.2fs, error=%s)",

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import logging
 import os
+import random
 import re
 import sys
 import threading
@@ -98,6 +99,7 @@ from preloop.services.upstream_errors import (
     ERROR_CLASS_UPSTREAM_QUOTA_EXHAUSTED,
     classify_recorded_error,
     classify_upstream_error,
+    is_retryable_upstream_failure,
 )
 from preloop.services.model_price_catalog import schedule_price_lookup
 from preloop.services.unpriced_model_alert import (
@@ -310,6 +312,32 @@ def _bedrock_credential_kwargs(secret_value: Optional[str]) -> Dict[str, Any]:
 class ModelGatewayBackend(Protocol):
     def completion(self, **kwargs: Any) -> Any:
         pass
+
+
+# Bounded retries for transient 502 / provider_unavailable /
+# upstream_disconnect / MidStreamFallbackError. 1 initial + 2 retries.
+# Not LiteLLM Router fallbacks; those would require a model list.
+_UPSTREAM_RETRY_MAX_ATTEMPTS = 3
+_UPSTREAM_RETRY_BASE_SECONDS = 0.2
+
+
+def _upstream_retry_delay_seconds(attempt: int) -> float:
+    """Exponential backoff plus jitter for one gateway upstream retry.
+
+    Args:
+        attempt: Zero-based index of the failure that just happened.
+
+    Returns:
+        Seconds to wait before the next attempt.
+    """
+    return (_UPSTREAM_RETRY_BASE_SECONDS * (2**attempt)) + random.uniform(
+        0, _UPSTREAM_RETRY_BASE_SECONDS
+    )
+
+
+def _sleep_before_upstream_retry(seconds: float) -> None:
+    """Sleep hook tests can patch without freezing the suite."""
+    time.sleep(seconds)
 
 
 _ANTHROPIC_OAUTH_ENV_LOCK = threading.Lock()
@@ -1278,14 +1306,10 @@ class OpenAIGatewayService:
                     url=url, headers=headers, body=body
                 )
             else:
-                upstream_stream = self._prefetch_upstream_stream(
-                    self._call_litellm(
-                        model,
-                        messages=messages,
-                        payload=payload,
-                        stream=True,
-                        provider="anthropic",
-                    ),
+                upstream_stream = self._open_upstream_stream(
+                    model,
+                    messages=messages,
+                    payload=payload,
                     provider="anthropic",
                 )
         except ModelGatewayAPIError as exc:
@@ -1703,14 +1727,10 @@ class OpenAIGatewayService:
                     started_at=started_at,
                     budget_result=budget_result,
                 )
-            upstream_stream = self._prefetch_upstream_stream(
-                self._call_litellm(
-                    model,
-                    messages=messages,
-                    payload=payload,
-                    stream=True,
-                    provider="openai",
-                ),
+            upstream_stream = self._open_upstream_stream(
+                model,
+                messages=messages,
+                payload=payload,
                 provider="openai",
             )
         except ModelGatewayAPIError as exc:
@@ -1978,14 +1998,10 @@ class OpenAIGatewayService:
                     started_at=started_at,
                     budget_result=budget_result,
                 )
-            upstream_stream = self._prefetch_upstream_stream(
-                self._call_litellm(
-                    model,
-                    messages=messages,
-                    payload=payload,
-                    stream=True,
-                    provider="openai",
-                ),
+            upstream_stream = self._open_upstream_stream(
+                model,
+                messages=messages,
+                payload=payload,
                 provider="openai",
             )
         except ModelGatewayAPIError as exc:
@@ -4670,6 +4686,56 @@ class OpenAIGatewayService:
     # attribution is not lost. Codex requests are not governance-stripped, so
     # every codex tool reports ``stripped=False`` (correct).
     # ------------------------------------------------------------------
+    def _run_with_upstream_retries(
+        self,
+        provider: GatewayProvider,
+        operation: Callable[[], Any],
+    ) -> Any:
+        """Run ``operation`` with bounded retries for transient upstream faults.
+
+        Retries 502 / provider_unavailable / upstream_disconnect /
+        MidStreamFallbackError / network / overload. Does not retry 4xx
+        unsupported-params, auth, or quota. Intermediate failures are not
+        admin-alerted; only the final mapped error notifies.
+
+        Args:
+            provider: Gateway provider used to shape the final error.
+            operation: Zero-arg callable to invoke.
+
+        Returns:
+            The value returned by ``operation``.
+
+        Raises:
+            ModelGatewayAPIError: When retries are exhausted or the error
+                is not retryable.
+        """
+        last_exc: Optional[Exception] = None
+        for attempt in range(_UPSTREAM_RETRY_MAX_ATTEMPTS):
+            try:
+                return operation()
+            except Exception as exc:
+                last_exc = exc
+                if (
+                    attempt >= _UPSTREAM_RETRY_MAX_ATTEMPTS - 1
+                    or not is_retryable_upstream_failure(exc)
+                ):
+                    break
+                delay = _upstream_retry_delay_seconds(attempt)
+                logger.warning(
+                    "Retrying gateway upstream call after transient failure "
+                    "(attempt %s/%s, delay=%.2fs, error=%s)",
+                    attempt + 1,
+                    _UPSTREAM_RETRY_MAX_ATTEMPTS,
+                    delay,
+                    exc,
+                )
+                _sleep_before_upstream_retry(delay)
+        assert last_exc is not None
+        self._capture_rate_limit_headers(headers_from_exception(last_exc))
+        if isinstance(last_exc, ModelGatewayAPIError):
+            raise last_exc
+        raise self._normalize_upstream_error(provider, last_exc) from last_exc
+
     def _call_litellm(
         self,
         ai_model: AIModel,
@@ -4678,6 +4744,7 @@ class OpenAIGatewayService:
         payload: Dict[str, Any],
         stream: bool = False,
         provider: GatewayProvider,
+        retry_transient: bool = True,
     ):
         # Capture the ORIGINAL tools before optimization strips any of them so
         # per-tool attribution covers the request as the client sent it.
@@ -4699,16 +4766,65 @@ class OpenAIGatewayService:
             provider=provider,
         )
 
-        try:
-            response = self.upstream_backend.completion(**kwargs)
-        except Exception as exc:
-            self._capture_rate_limit_headers(headers_from_exception(exc))
-            raise self._normalize_upstream_error(provider, exc) from exc
+        def _invoke() -> Any:
+            return self.upstream_backend.completion(**kwargs)
+
+        if retry_transient:
+            response = self._run_with_upstream_retries(provider, _invoke)
+        else:
+            response = _invoke()
         if not stream:
             # LiteLLM relays provider headers in _hidden_params; best effort,
             # absent headers simply record no snapshot.
             self._capture_rate_limit_headers(headers_from_litellm_response(response))
         return response
+
+    def _open_upstream_stream(
+        self,
+        ai_model: AIModel,
+        *,
+        messages: List[Dict[str, Any]],
+        payload: Dict[str, Any],
+        provider: GatewayProvider,
+    ) -> "_PrefetchedUpstreamStream":
+        """Open a streaming completion and prefetch the first chunk, with retry.
+
+        Covers the founder 502 signature: LiteLLM raises
+        ``MidStreamFallbackError`` wrapping OpenRouter
+        ``provider_unavailable`` / ``upstream_disconnect`` on the first
+        SSE event (or the completion handshake). A later disconnect after
+        tokens have already been forwarded cannot be stitched onto the
+        same SSE response without duplicating billed tokens; that case
+        stays an SSE error and the flow-level retry may recover the run.
+
+        Args:
+            ai_model: Resolved model row.
+            messages: Chat messages for the completion.
+            payload: Client request payload.
+            provider: Gateway provider used to shape errors.
+
+        Returns:
+            A prefetched stream ready to iterate.
+
+        Raises:
+            ModelGatewayAPIError: When retries are exhausted or the error
+                is not retryable.
+        """
+
+        def _attempt() -> "_PrefetchedUpstreamStream":
+            return self._prefetch_upstream_stream(
+                self._call_litellm(
+                    ai_model,
+                    messages=messages,
+                    payload=payload,
+                    stream=True,
+                    provider=provider,
+                    retry_transient=False,
+                ),
+                provider=provider,
+            )
+
+        return self._run_with_upstream_retries(provider, _attempt)
 
     def _prefetch_upstream_stream(
         self, upstream_stream: Any, *, provider: GatewayProvider
@@ -4742,8 +4858,11 @@ class OpenAIGatewayService:
         except ModelGatewayAPIError:
             raise
         except Exception as exc:
+            # Leave the exception raw so ``_open_upstream_stream`` can retry
+            # MidStreamFallbackError / 502 without admin-alerting each
+            # attempt. The retry wrapper maps the final failure.
             self._capture_rate_limit_headers(headers_from_exception(exc))
-            raise self._normalize_upstream_error(provider, exc) from exc
+            raise
         return _PrefetchedUpstreamStream(
             chain([first_chunk], iterator), raw=upstream_stream
         )

--- a/backend/preloop/services/upstream_errors.py
+++ b/backend/preloop/services/upstream_errors.py
@@ -273,6 +273,101 @@ _DISCONNECT_DETAIL_MARKERS = (
     "peer closed connection",
 )
 
+# Transient provider faults the gateway should retry (bounded). Includes the
+# OpenRouter mid-stream signature: MidStreamFallbackError wrapping
+# provider_unavailable / upstream_disconnect / HTTP 502.
+_RETRYABLE_MARKERS = (
+    "provider_unavailable",
+    "upstream_disconnect",
+    "disconnected mid-stream",
+    "json error injected into sse stream",
+    "midstreamfallbackerror",
+)
+
+# Client / model-capability errors. Retrying these cannot succeed and burns
+# quota (glm-5.3 parallel_tool_calls, auth, bad params).
+_NON_RETRYABLE_MARKERS = (
+    "does not support parameters",
+    "unsupported parameter",
+    "unsupported_parameter",
+    "parallel_tool_calls",
+    "invalid_request",
+    "invalid api key",
+    "incorrect api key",
+    "authentication",
+)
+
+_RETRYABLE_ERROR_CLASSES = frozenset(
+    {
+        ERROR_CLASS_NETWORK,
+        ERROR_CLASS_UPSTREAM_DISCONNECT,
+        ERROR_CLASS_UPSTREAM_OVERLOADED,
+        ERROR_CLASS_UPSTREAM_ERROR,
+        ERROR_CLASS_UPSTREAM_RATE_LIMITED,
+    }
+)
+
+_NON_RETRYABLE_ERROR_CLASSES = frozenset(
+    {
+        ERROR_CLASS_UPSTREAM_AUTH,
+        ERROR_CLASS_UPSTREAM_QUOTA_EXHAUSTED,
+        ERROR_CLASS_CLIENT_CANCELLED,
+        ERROR_CLASS_STREAM_ABANDONED,
+    }
+)
+
+_RETRYABLE_STATUS_CODES = frozenset(
+    {408, 425, 429, 500, 502, 503, 504, 520, 522, 524, 529}
+)
+
+
+def is_retryable_upstream_failure(exc: Exception) -> bool:
+    """Whether the gateway should retry this upstream failure.
+
+    Retries transient 502 / provider_unavailable / upstream_disconnect /
+    MidStreamFallbackError / network / overload. Does not retry 4xx
+    validation, auth, quota, or unsupported-parameter errors
+    (``parallel_tool_calls``).
+
+    Args:
+        exc: Raw LiteLLM/httpx exception or a mapped ``ModelGatewayAPIError``.
+
+    Returns:
+        True when another bounded attempt could plausibly succeed.
+    """
+    text = _exception_text(exc)
+    if _contains(text, _NON_RETRYABLE_MARKERS):
+        return False
+
+    if bool(getattr(exc, "terminal", False)):
+        return False
+
+    error_class = getattr(exc, "error_class", None)
+    if error_class in _NON_RETRYABLE_ERROR_CLASSES:
+        return False
+
+    classified = classify_upstream_error(exc)
+    if classified is not None:
+        if classified.terminal:
+            return False
+        if classified.error_class in _NON_RETRYABLE_ERROR_CLASSES:
+            return False
+        if classified.error_class in _RETRYABLE_ERROR_CLASSES:
+            return True
+        if classified.status_code in _RETRYABLE_STATUS_CODES:
+            return True
+
+    if error_class in _RETRYABLE_ERROR_CLASSES:
+        return True
+
+    status = _status_code(exc)
+    if status in _RETRYABLE_STATUS_CODES:
+        return True
+    if status is not None and 400 <= status < 500:
+        return False
+
+    return _contains(text, _RETRYABLE_MARKERS)
+
 
 def classify_recorded_error(
     status_code: int, error_detail: Optional[str]

--- a/backend/preloop/services/upstream_errors.py
+++ b/backend/preloop/services/upstream_errors.py
@@ -365,7 +365,11 @@ def is_retryable_upstream_failure(exc: Exception) -> bool:
         return True
 
     status = _status_code(exc)
-    if status in _RETRYABLE_STATUS_CODES:
+    # Mapped ModelGatewayAPIError.status_code is a client-presentation
+    # mapping (#116), not a provider status. Trust the class decision
+    # and skip this fallback when error_class is already set. Raw
+    # exceptions with a real 502/500/503 stay retryable (#109).
+    if error_class is None and status in _RETRYABLE_STATUS_CODES:
         return True
     if status is not None and 400 <= status < 500:
         return False

--- a/backend/preloop/services/upstream_errors.py
+++ b/backend/preloop/services/upstream_errors.py
@@ -297,12 +297,15 @@ _NON_RETRYABLE_MARKERS = (
     "authentication",
 )
 
+# Known-transient classes only. ``upstream_error`` is the presentation
+# bucket for opaque failures (mapped to HTTP 502 for the client, #116);
+# retrying those without a real 5xx / marker turns a first-chunk raise
+# into an empty HTTP 200 stream when the retry sees StopIteration (#109).
 _RETRYABLE_ERROR_CLASSES = frozenset(
     {
         ERROR_CLASS_NETWORK,
         ERROR_CLASS_UPSTREAM_DISCONNECT,
         ERROR_CLASS_UPSTREAM_OVERLOADED,
-        ERROR_CLASS_UPSTREAM_ERROR,
         ERROR_CLASS_UPSTREAM_RATE_LIMITED,
     }
 )
@@ -326,8 +329,9 @@ def is_retryable_upstream_failure(exc: Exception) -> bool:
 
     Retries transient 502 / provider_unavailable / upstream_disconnect /
     MidStreamFallbackError / network / overload. Does not retry 4xx
-    validation, auth, quota, or unsupported-parameter errors
-    (``parallel_tool_calls``).
+    validation, auth, quota, unsupported-parameter errors
+    (``parallel_tool_calls``), or opaque generic exceptions. Those last
+    are presented as 502 to the client (#116) but are not retried.
 
     Args:
         exc: Raw LiteLLM/httpx exception or a mapped ``ModelGatewayAPIError``.
@@ -354,8 +358,8 @@ def is_retryable_upstream_failure(exc: Exception) -> bool:
             return False
         if classified.error_class in _RETRYABLE_ERROR_CLASSES:
             return True
-        if classified.status_code in _RETRYABLE_STATUS_CODES:
-            return True
+        # Do not use classified.status_code: opaque errors are mapped to
+        # 502 for client presentation, not because the provider returned 502.
 
     if error_class in _RETRYABLE_ERROR_CLASSES:
         return True

--- a/backend/tests/agents/test_failure_analysis.py
+++ b/backend/tests/agents/test_failure_analysis.py
@@ -376,3 +376,22 @@ class TestIdempotence:
 
         assert second.transient is False
         assert second.upstream_status == 401
+
+
+class TestOpenRouterMidStreamDisconnect:
+    """Gateway 502 signature must be retryable at flow level too."""
+
+    def test_provider_unavailable_midstream_is_transient(self):
+        logs = (
+            "Upstream provider disconnected mid-stream: APIError: "
+            "OpenrouterException - Message: JSON error injected into SSE "
+            "stream, Metadata: {'error_type': 'provider_unavailable'}\n"
+            "litellm.MidStreamFallbackError wrapping litellm.APIError"
+        )
+        analysis = analyze_agent_failure(logs)
+        assert analysis.transient is True
+
+    def test_unsupported_parallel_tool_calls_is_not_transient(self):
+        logs = "ERROR: zai does not support parameters: ['parallel_tool_calls']"
+        analysis = analyze_agent_failure(logs)
+        assert analysis.transient is False

--- a/backend/tests/services/test_aux_reasoning_model.py
+++ b/backend/tests/services/test_aux_reasoning_model.py
@@ -125,6 +125,43 @@ class TestBuildAuxKwargsPrecedence:
 
         assert result["drop_params"] is True
 
+    def test_user_agent_is_preloop_for_non_openrouter(self):
+        """Aux completions must not identify as LiteLLM on any upstream."""
+        model = _make_model()
+        result = build_aux_kwargs(model, {}, call_site_kwargs={"model": "test"})
+        ua = result["extra_headers"]["User-Agent"]
+        assert "litellm" not in ua.lower()
+        assert ua.lower().startswith("preloop/")
+        assert result["extra_headers"].get("X-Title") is None
+
+    def test_user_agent_is_preloop_for_openrouter(self):
+        model = _make_model(
+            provider_name="openrouter",
+            model_identifier="anthropic/claude-opus-4.6",
+            api_endpoint="https://openrouter.ai/api/v1",
+        )
+        result = build_aux_kwargs(model, {}, call_site_kwargs={"model": "test"})
+        extra = result["extra_headers"]
+        ua = extra["User-Agent"]
+        assert "litellm" not in ua.lower()
+        assert ua.lower().startswith("preloop/")
+        assert extra["X-Title"] == "Preloop"
+        assert extra["HTTP-Referer"] == "https://preloop.ai"
+
+    def test_user_agent_preserves_existing_extra_headers(self):
+        model = _make_model()
+        result = build_aux_kwargs(
+            model,
+            {},
+            call_site_kwargs={
+                "model": "test",
+                "extra_headers": {"X-Custom": "keep-me"},
+            },
+        )
+        extra = result["extra_headers"]
+        assert extra["X-Custom"] == "keep-me"
+        assert "litellm" not in extra["User-Agent"].lower()
+
     def test_none_model_parameters_handled(self):
         """model_parameters=None does not crash."""
         model = _make_model(model_parameters=None)

--- a/backend/tests/services/test_litellm_routing.py
+++ b/backend/tests/services/test_litellm_routing.py
@@ -150,16 +150,14 @@ class TestPreloopClientIdentity:
         assert extra.get("HTTP-Referer") is None
 
     def test_ensure_identity_is_idempotent_and_skips_eval_when_set(self, monkeypatch):
-        import preloop.services.litellm_routing as routing
-
         monkeypatch.setenv("LITELLM_USER_AGENT", "already-set")
         monkeypatch.setenv("OR_SITE_URL", "https://already.example")
         monkeypatch.setenv("OR_APP_NAME", "already")
-        monkeypatch.setattr(routing, "_PRELOOP_CLIENT_IDENTITY_APPLIED", False)
+        ensure_preloop_client_identity.cache_clear()
 
-        with patch.object(routing, "preloop_user_agent") as mock_ua:
-            routing.ensure_preloop_client_identity()
-            routing.ensure_preloop_client_identity()
+        with patch("preloop.services.litellm_routing.preloop_user_agent") as mock_ua:
+            ensure_preloop_client_identity()
+            ensure_preloop_client_identity()
             mock_ua.assert_not_called()
 
         assert os.environ["LITELLM_USER_AGENT"] == "already-set"
@@ -167,12 +165,10 @@ class TestPreloopClientIdentity:
         assert os.environ["OR_APP_NAME"] == "already"
 
     def test_ensure_identity_sets_missing_env_once(self, monkeypatch):
-        import preloop.services.litellm_routing as routing
-
         monkeypatch.delenv("LITELLM_USER_AGENT", raising=False)
         monkeypatch.delenv("OR_SITE_URL", raising=False)
         monkeypatch.delenv("OR_APP_NAME", raising=False)
-        monkeypatch.setattr(routing, "_PRELOOP_CLIENT_IDENTITY_APPLIED", False)
+        ensure_preloop_client_identity.cache_clear()
 
         ensure_preloop_client_identity()
         first_ua = os.environ["LITELLM_USER_AGENT"]

--- a/backend/tests/services/test_litellm_routing.py
+++ b/backend/tests/services/test_litellm_routing.py
@@ -8,8 +8,12 @@ not a routing instruction when the stored provider says otherwise).
 
 from preloop.models.models.ai_model import AIModel
 from preloop.services.litellm_routing import (
+    PRELOOP_APP_NAME,
+    PRELOOP_SITE_URL,
     PROVIDER_PREFIX,
+    apply_preloop_client_headers,
     known_litellm_providers,
+    preloop_user_agent,
     to_litellm_model,
 )
 
@@ -82,3 +86,61 @@ class TestSlashPrefixHeuristicNoRegression:
             endpoint="https://my-gateway.example.com/v1",
         )
         assert to_litellm_model(model) == "openai/moonshot/kimi-k3"
+
+
+class TestPreloopClientIdentity:
+    """LiteLLM client branding is Preloop on every upstream, not just OpenRouter."""
+
+    def test_user_agent_never_contains_litellm(self):
+        assert "litellm" not in preloop_user_agent().lower()
+        assert preloop_user_agent().lower().startswith("preloop/")
+
+    def test_apply_stamps_user_agent_on_openai(self):
+        kwargs: dict = {}
+        apply_preloop_client_headers(kwargs, _model("openai", "gpt-5"))
+        ua = kwargs["extra_headers"]["User-Agent"]
+        assert "litellm" not in ua.lower()
+        assert ua.lower().startswith("preloop/")
+
+    def test_apply_stamps_user_agent_on_zai(self):
+        kwargs: dict = {}
+        apply_preloop_client_headers(kwargs, _model("zai", "glm-5.3"))
+        ua = kwargs["extra_headers"]["User-Agent"]
+        assert "litellm" not in ua.lower()
+        assert ua.lower().startswith("preloop/")
+
+    def test_apply_stamps_user_agent_on_anthropic(self):
+        kwargs: dict = {}
+        apply_preloop_client_headers(kwargs, _model("anthropic", "claude-opus-4-6"))
+        ua = kwargs["extra_headers"]["User-Agent"]
+        assert "litellm" not in ua.lower()
+        assert ua.lower().startswith("preloop/")
+
+    def test_apply_preserves_existing_extra_headers(self):
+        kwargs = {"extra_headers": {"anthropic-beta": "oauth-2025-04-20"}}
+        apply_preloop_client_headers(kwargs, _model("anthropic", "claude-opus-4-6"))
+        assert kwargs["extra_headers"]["anthropic-beta"] == "oauth-2025-04-20"
+        assert "litellm" not in kwargs["extra_headers"]["User-Agent"].lower()
+
+    def test_openrouter_also_gets_attribution_headers(self):
+        kwargs: dict = {}
+        apply_preloop_client_headers(
+            kwargs,
+            _model(
+                "openrouter",
+                "anthropic/claude-opus-4.6",
+                endpoint="https://openrouter.ai/api/v1",
+            ),
+        )
+        extra = kwargs["extra_headers"]
+        assert extra["X-Title"] == PRELOOP_APP_NAME == "Preloop"
+        assert extra["HTTP-Referer"] == PRELOOP_SITE_URL == "https://preloop.ai"
+        assert "litellm" not in extra["User-Agent"].lower()
+
+    def test_non_openrouter_does_not_require_xtitle(self):
+        kwargs: dict = {}
+        apply_preloop_client_headers(kwargs, _model("openai", "gpt-5"))
+        extra = kwargs["extra_headers"]
+        assert "User-Agent" in extra
+        assert extra.get("X-Title") is None
+        assert extra.get("HTTP-Referer") is None

--- a/backend/tests/services/test_litellm_routing.py
+++ b/backend/tests/services/test_litellm_routing.py
@@ -6,12 +6,16 @@ heuristic must not regress issue #172 (a vendor prefix inside a model id is
 not a routing instruction when the stored provider says otherwise).
 """
 
+import os
+from unittest.mock import patch
+
 from preloop.models.models.ai_model import AIModel
 from preloop.services.litellm_routing import (
     PRELOOP_APP_NAME,
     PRELOOP_SITE_URL,
     PROVIDER_PREFIX,
     apply_preloop_client_headers,
+    ensure_preloop_client_identity,
     known_litellm_providers,
     preloop_user_agent,
     to_litellm_model,
@@ -144,3 +148,39 @@ class TestPreloopClientIdentity:
         assert "User-Agent" in extra
         assert extra.get("X-Title") is None
         assert extra.get("HTTP-Referer") is None
+
+    def test_ensure_identity_is_idempotent_and_skips_eval_when_set(self, monkeypatch):
+        import preloop.services.litellm_routing as routing
+
+        monkeypatch.setenv("LITELLM_USER_AGENT", "already-set")
+        monkeypatch.setenv("OR_SITE_URL", "https://already.example")
+        monkeypatch.setenv("OR_APP_NAME", "already")
+        monkeypatch.setattr(routing, "_PRELOOP_CLIENT_IDENTITY_APPLIED", False)
+
+        with patch.object(routing, "preloop_user_agent") as mock_ua:
+            routing.ensure_preloop_client_identity()
+            routing.ensure_preloop_client_identity()
+            mock_ua.assert_not_called()
+
+        assert os.environ["LITELLM_USER_AGENT"] == "already-set"
+        assert os.environ["OR_SITE_URL"] == "https://already.example"
+        assert os.environ["OR_APP_NAME"] == "already"
+
+    def test_ensure_identity_sets_missing_env_once(self, monkeypatch):
+        import preloop.services.litellm_routing as routing
+
+        monkeypatch.delenv("LITELLM_USER_AGENT", raising=False)
+        monkeypatch.delenv("OR_SITE_URL", raising=False)
+        monkeypatch.delenv("OR_APP_NAME", raising=False)
+        monkeypatch.setattr(routing, "_PRELOOP_CLIENT_IDENTITY_APPLIED", False)
+
+        ensure_preloop_client_identity()
+        first_ua = os.environ["LITELLM_USER_AGENT"]
+        assert "litellm" not in first_ua.lower()
+        assert first_ua.lower().startswith("preloop/")
+        assert os.environ["OR_SITE_URL"] == PRELOOP_SITE_URL
+        assert os.environ["OR_APP_NAME"] == PRELOOP_APP_NAME
+
+        monkeypatch.setenv("LITELLM_USER_AGENT", "should-not-replace")
+        ensure_preloop_client_identity()
+        assert os.environ["LITELLM_USER_AGENT"] == "should-not-replace"

--- a/backend/tests/services/test_openai_gateway.py
+++ b/backend/tests/services/test_openai_gateway.py
@@ -14,6 +14,7 @@ from preloop.models.crud import (
     crud_runtime_session,
 )
 from preloop.models.crud import crud_api_key
+from preloop.services.litellm_routing import preloop_user_agent
 from preloop.services.model_gateway_auth import ModelGatewayAuthContext
 from preloop.services.model_gateway_errors import ModelGatewayAPIError
 from preloop.services.openai_gateway import OpenAIGatewayService
@@ -61,6 +62,8 @@ def test_call_litellm_uses_injected_upstream_backend():
         api_key="provider-secret",
         timeout=600,
         temperature=0.2,
+        drop_params=True,
+        extra_headers={"User-Agent": preloop_user_agent()},
     )
 
 
@@ -98,6 +101,8 @@ def test_call_litellm_allows_bedrock_ambient_credentials():
         messages=[{"role": "user", "content": "Hello"}],
         timeout=600,
         aws_region_name="us-east-1",
+        drop_params=True,
+        extra_headers={"User-Agent": preloop_user_agent()},
     )
 
 
@@ -148,6 +153,8 @@ def test_call_litellm_passes_imported_bedrock_credentials():
         aws_secret_access_key="secret-test",
         aws_session_token="session-test",
         aws_region_name="eu-central-1",
+        drop_params=True,
+        extra_headers={"User-Agent": preloop_user_agent()},
     )
 
 
@@ -195,8 +202,10 @@ def test_call_litellm_uses_claude_code_oauth_headers():
         extra_headers={
             "anthropic-beta": "oauth-2025-04-20",
             "anthropic-client-platform": "claude-code",
+            "User-Agent": preloop_user_agent(),
         },
         max_tokens=1,
+        drop_params=True,
     )
 
 

--- a/backend/tests/services/test_openai_gateway_drop_params.py
+++ b/backend/tests/services/test_openai_gateway_drop_params.py
@@ -1,0 +1,106 @@
+"""Gateway LiteLLM kwargs: drop unsupported params and identify as Preloop."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from preloop.services.model_gateway_auth import ModelGatewayAuthContext
+from preloop.services.openai_gateway import OpenAIGatewayService
+from preloop.services.secret_service import ResolvedModelCredentials
+
+
+def _service() -> OpenAIGatewayService:
+    auth_context = ModelGatewayAuthContext(
+        token="token",
+        user=SimpleNamespace(id="user-1", account_id="account-1"),
+    )
+    return OpenAIGatewayService(MagicMock(), auth_context)
+
+
+def _creds() -> ResolvedModelCredentials:
+    return ResolvedModelCredentials(
+        credential_type="api_key",
+        backend_type="local",
+        value="sk-test",
+    )
+
+
+def _build_kwargs(model: SimpleNamespace, payload: dict | None = None) -> dict:
+    service = _service()
+    with patch("preloop.services.openai_gateway.get_secret_service") as mock_secrets:
+        mock_secrets.return_value.resolve_ai_model_credentials.return_value = _creds()
+        return service._build_completion_kwargs(
+            model,
+            messages=[{"role": "user", "content": "hi"}],
+            payload=payload or {},
+            stream=False,
+            provider="openai",
+        )
+
+
+def _assert_user_agent_is_preloop(headers: dict) -> None:
+    user_agent = headers.get("User-Agent") or headers.get("user-agent") or ""
+    assert user_agent, "User-Agent must be set on LiteLLM extra_headers"
+    assert "litellm" not in user_agent.lower()
+    assert user_agent.lower().startswith("preloop/")
+
+
+def test_build_completion_kwargs_sets_drop_params_for_zai():
+    """z.ai rejects parallel_tool_calls; fallback metadata still forwards it."""
+    model = SimpleNamespace(
+        provider_name="zai",
+        model_identifier="glm-5.3",
+        api_endpoint="https://api.z.ai/api/paas/v4",
+    )
+    kwargs = _build_kwargs(model, payload={"parallel_tool_calls": True})
+    assert kwargs["drop_params"] is True
+    assert kwargs.get("api_key") == "sk-test"
+
+
+def test_build_completion_kwargs_user_agent_is_preloop_for_zai():
+    """Non-OpenRouter upstreams must not identify as LiteLLM."""
+    model = SimpleNamespace(
+        provider_name="zai",
+        model_identifier="glm-5.3",
+        api_endpoint="https://api.z.ai/api/paas/v4",
+    )
+    kwargs = _build_kwargs(model)
+    extra = kwargs["extra_headers"]
+    _assert_user_agent_is_preloop(extra)
+
+
+def test_build_completion_kwargs_user_agent_is_preloop_for_openai():
+    """OpenAI-native completions also replace LiteLLM's default User-Agent."""
+    model = SimpleNamespace(
+        provider_name="openai",
+        model_identifier="gpt-5",
+        api_endpoint=None,
+    )
+    kwargs = _build_kwargs(model)
+    _assert_user_agent_is_preloop(kwargs["extra_headers"])
+
+
+def test_build_completion_kwargs_user_agent_is_preloop_for_openrouter():
+    """OpenRouter dashboards attribute by User-Agent / X-Title / HTTP-Referer."""
+    model = SimpleNamespace(
+        provider_name="openrouter",
+        model_identifier="openrouter/auto-beta",
+        api_endpoint="https://openrouter.ai/api/v1",
+    )
+    kwargs = _build_kwargs(model)
+    extra = kwargs["extra_headers"]
+    _assert_user_agent_is_preloop(extra)
+    assert extra["X-Title"] == "Preloop"
+    assert extra["HTTP-Referer"] == "https://preloop.ai"
+
+
+def test_openai_compatible_openrouter_base_url_gets_attribution_headers():
+    model = SimpleNamespace(
+        provider_name="openai-compatible",
+        model_identifier="anthropic/claude-opus-4.6",
+        api_endpoint="https://openrouter.ai/api/v1",
+    )
+    kwargs = _build_kwargs(model)
+    extra = kwargs["extra_headers"]
+    _assert_user_agent_is_preloop(extra)
+    assert extra["X-Title"] == "Preloop"
+    assert extra["HTTP-Referer"] == "https://preloop.ai"

--- a/backend/tests/services/test_openai_gateway_drop_params.py
+++ b/backend/tests/services/test_openai_gateway_drop_params.py
@@ -56,6 +56,17 @@ def test_build_completion_kwargs_sets_drop_params_for_zai():
     assert kwargs.get("api_key") == "sk-test"
 
 
+def test_build_completion_kwargs_sets_drop_params_globally():
+    """drop_params is the gateway default for every provider, not only zai."""
+    model = SimpleNamespace(
+        provider_name="openai",
+        model_identifier="gpt-5",
+        api_endpoint=None,
+    )
+    kwargs = _build_kwargs(model, payload={"parallel_tool_calls": True})
+    assert kwargs["drop_params"] is True
+
+
 def test_build_completion_kwargs_user_agent_is_preloop_for_zai():
     """Non-OpenRouter upstreams must not identify as LiteLLM."""
     model = SimpleNamespace(

--- a/backend/tests/services/test_openai_gateway_retry.py
+++ b/backend/tests/services/test_openai_gateway_retry.py
@@ -1,0 +1,136 @@
+"""Bounded gateway retries for transient 502 / mid-stream disconnect."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from preloop.services.model_gateway_auth import ModelGatewayAuthContext
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
+from preloop.services.openai_gateway import OpenAIGatewayService
+
+
+class _MidStreamFallbackError(Exception):
+    """Name-matched stand-in for litellm.exceptions.MidStreamFallbackError."""
+
+    def __init__(self, message: str, *, is_pre_first_chunk: bool = True) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = 502
+        self.error_type = "provider_unavailable"
+        self.is_pre_first_chunk = is_pre_first_chunk
+        self.generated_content = ""
+
+
+class _UnsupportedParamsError(Exception):
+    def __init__(self) -> None:
+        message = "zai does not support parameters: ['parallel_tool_calls']"
+        super().__init__(message)
+        self.message = message
+        self.status_code = 400
+
+
+_FOUNDER_502 = (
+    "Upstream provider disconnected mid-stream: APIError: OpenrouterException "
+    "- Message: JSON error injected into SSE stream, "
+    "Metadata: {'error_type': 'provider_unavailable'}"
+)
+
+
+def _service_and_model():
+    auth_context = ModelGatewayAuthContext(
+        token="token",
+        user=SimpleNamespace(id="user-1", account_id="account-1"),
+    )
+    upstream_backend = MagicMock()
+    service = OpenAIGatewayService(
+        MagicMock(), auth_context, upstream_backend=upstream_backend
+    )
+    ai_model = SimpleNamespace(
+        provider_name="openai",
+        model_identifier="gpt-5",
+        api_endpoint=None,
+        meta_data={},
+    )
+    return service, ai_model, upstream_backend
+
+
+def _call(service, ai_model):
+    with patch("preloop.services.openai_gateway.get_secret_service") as secrets:
+        secrets.return_value.resolve_ai_model_credentials.return_value = (
+            SimpleNamespace(credential_type="api_key", value="sk-test")
+        )
+        return service._call_litellm(
+            ai_model,
+            messages=[{"role": "user", "content": "Hello"}],
+            payload={},
+            provider="openai",
+        )
+
+
+def _open_stream(service, ai_model):
+    with patch("preloop.services.openai_gateway.get_secret_service") as secrets:
+        secrets.return_value.resolve_ai_model_credentials.return_value = (
+            SimpleNamespace(credential_type="api_key", value="sk-test")
+        )
+        return service._open_upstream_stream(
+            ai_model,
+            messages=[{"role": "user", "content": "Hello"}],
+            payload={},
+            provider="openai",
+        )
+
+
+def test_call_litellm_retries_midstream_502_then_succeeds():
+    service, ai_model, backend = _service_and_model()
+    backend.completion.side_effect = [
+        _MidStreamFallbackError(_FOUNDER_502),
+        {"ok": True},
+    ]
+    with patch("preloop.services.openai_gateway._sleep_before_upstream_retry"):
+        result = _call(service, ai_model)
+    assert result == {"ok": True}
+    assert backend.completion.call_count == 2
+
+
+def test_call_litellm_does_not_retry_unsupported_params_400():
+    service, ai_model, backend = _service_and_model()
+    backend.completion.side_effect = _UnsupportedParamsError()
+    with patch("preloop.services.openai_gateway._sleep_before_upstream_retry") as sleep:
+        with pytest.raises(ModelGatewayAPIError) as exc_info:
+            _call(service, ai_model)
+    assert exc_info.value.status_code == 400
+    assert backend.completion.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_call_litellm_exhausts_retries_on_persistent_502():
+    service, ai_model, backend = _service_and_model()
+    backend.completion.side_effect = _MidStreamFallbackError(_FOUNDER_502)
+    with patch("preloop.services.openai_gateway._sleep_before_upstream_retry"):
+        with pytest.raises(ModelGatewayAPIError) as exc_info:
+            _call(service, ai_model)
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.error_class == "upstream_disconnect"
+    assert backend.completion.call_count == 3
+
+
+def test_open_upstream_stream_retries_first_chunk_disconnect():
+    service, ai_model, backend = _service_and_model()
+
+    class _FailThenOk:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __iter__(self):
+            self.calls += 1
+            if self.calls == 1:
+                raise _MidStreamFallbackError(_FOUNDER_502)
+            return iter([{"delta": "hi"}])
+
+    stream = _FailThenOk()
+    backend.completion.return_value = stream
+    with patch("preloop.services.openai_gateway._sleep_before_upstream_retry"):
+        prefetched = _open_stream(service, ai_model)
+    assert list(prefetched) == [{"delta": "hi"}]
+    assert backend.completion.call_count == 2

--- a/backend/tests/services/test_openai_gateway_retry.py
+++ b/backend/tests/services/test_openai_gateway_retry.py
@@ -115,6 +115,23 @@ def test_call_litellm_exhausts_retries_on_persistent_502():
     assert backend.completion.call_count == 3
 
 
+def test_open_upstream_stream_does_not_retry_generic_first_chunk_error():
+    """Opaque first-chunk failures stay 502; retrying them can become HTTP 200."""
+    service, ai_model, backend = _service_and_model()
+
+    def _failing_stream():
+        raise Exception("upstream rejected the tools payload")
+        yield  # pragma: no cover
+
+    backend.completion.return_value = _failing_stream()
+    with patch("preloop.services.openai_gateway._sleep_before_upstream_retry") as sleep:
+        with pytest.raises(ModelGatewayAPIError) as exc_info:
+            _open_stream(service, ai_model)
+    assert exc_info.value.status_code == 502
+    assert backend.completion.call_count == 1
+    sleep.assert_not_called()
+
+
 def test_open_upstream_stream_retries_first_chunk_disconnect():
     service, ai_model, backend = _service_and_model()
 

--- a/backend/tests/services/test_openai_gateway_retry.py
+++ b/backend/tests/services/test_openai_gateway_retry.py
@@ -7,7 +7,11 @@ import pytest
 
 from preloop.services.model_gateway_auth import ModelGatewayAuthContext
 from preloop.services.model_gateway_errors import ModelGatewayAPIError
-from preloop.services.openai_gateway import OpenAIGatewayService
+from preloop.services.openai_gateway import (
+    OpenAIGatewayService,
+    _UPSTREAM_RETRY_AFTER_CAP_SECONDS,
+    _upstream_retry_delay_seconds,
+)
 
 
 class _MidStreamFallbackError(Exception):
@@ -28,6 +32,16 @@ class _UnsupportedParamsError(Exception):
         super().__init__(message)
         self.message = message
         self.status_code = 400
+
+
+class _TransientRateLimitError(Exception):
+    """Non-terminal 429 with a provider Retry-After header."""
+
+    def __init__(self, retry_after: int) -> None:
+        super().__init__("rate limited")
+        self.message = "rate limited"
+        self.status_code = 429
+        self.response = SimpleNamespace(headers={"retry-after": str(retry_after)})
 
 
 _FOUNDER_502 = (
@@ -151,3 +165,46 @@ def test_open_upstream_stream_retries_first_chunk_disconnect():
         prefetched = _open_stream(service, ai_model)
     assert list(prefetched) == [{"delta": "hi"}]
     assert backend.completion.call_count == 2
+
+
+def test_retry_delay_honors_capped_retry_after():
+    """Backoff is raised to Retry-After, but a large hint stays bounded."""
+    with patch("preloop.services.openai_gateway.random.uniform", return_value=0.0):
+        assert _upstream_retry_delay_seconds(0) == 0.2
+        assert _upstream_retry_delay_seconds(0, retry_after_seconds=5) == 5.0
+        assert (
+            _upstream_retry_delay_seconds(0, retry_after_seconds=60)
+            == _UPSTREAM_RETRY_AFTER_CAP_SECONDS
+        )
+        assert _upstream_retry_delay_seconds(1, retry_after_seconds=0) == 0.4
+
+
+def test_call_litellm_honors_retry_after_on_transient_429():
+    service, ai_model, backend = _service_and_model()
+    backend.completion.side_effect = [
+        _TransientRateLimitError(5),
+        {"ok": True},
+    ]
+    with (
+        patch("preloop.services.openai_gateway._sleep_before_upstream_retry") as sleep,
+        patch("preloop.services.openai_gateway.random.uniform", return_value=0.0),
+    ):
+        result = _call(service, ai_model)
+    assert result == {"ok": True}
+    assert backend.completion.call_count == 2
+    sleep.assert_called_once_with(5.0)
+
+
+def test_call_litellm_caps_large_retry_after_on_transient_429():
+    service, ai_model, backend = _service_and_model()
+    backend.completion.side_effect = [
+        _TransientRateLimitError(600),
+        {"ok": True},
+    ]
+    with (
+        patch("preloop.services.openai_gateway._sleep_before_upstream_retry") as sleep,
+        patch("preloop.services.openai_gateway.random.uniform", return_value=0.0),
+    ):
+        result = _call(service, ai_model)
+    assert result == {"ok": True}
+    sleep.assert_called_once_with(_UPSTREAM_RETRY_AFTER_CAP_SECONDS)

--- a/backend/tests/services/test_upstream_errors.py
+++ b/backend/tests/services/test_upstream_errors.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import pytest
 
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
 from preloop.services.upstream_errors import (
     ERROR_CLASS_NETWORK,
     ERROR_CLASS_UPSTREAM_AUTH,
@@ -189,6 +190,17 @@ def test_actual_502_status_is_retryable():
     """A real provider 502 (not a mapped opaque error) is retried."""
     exc = _FakeHTTPError("bad gateway", status_code=502)
     assert is_retryable_upstream_failure(exc) is True
+
+
+def test_mapped_upstream_error_502_is_not_retryable():
+    """#109: presentation 502 on a mapped opaque error is not a retry."""
+    exc = ModelGatewayAPIError(
+        provider="openai",
+        status_code=502,
+        message="upstream exploded",
+        error_class=ERROR_CLASS_UPSTREAM_ERROR,
+    )
+    assert is_retryable_upstream_failure(exc) is False
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/services/test_upstream_errors.py
+++ b/backend/tests/services/test_upstream_errors.py
@@ -18,6 +18,7 @@ from preloop.services.upstream_errors import (
     ERROR_CLASS_CLIENT_CANCELLED,
     classify_recorded_error,
     classify_upstream_error,
+    is_retryable_upstream_failure,
 )
 
 
@@ -134,6 +135,39 @@ def test_client_shaped_4xx_returns_none():
     """Validation-style 4xx keep existing passthrough handling."""
     exc = _FakeHTTPError("messages must be a non-empty list", status_code=400)
     assert classify_upstream_error(exc) is None
+
+
+def test_midstream_provider_unavailable_is_retryable():
+    """Founder 502 signature: OpenRouter JSON error injected mid-stream."""
+    exc = _MidStreamFallbackError(
+        "Upstream provider disconnected mid-stream: APIError: "
+        "OpenrouterException - Message: JSON error injected into SSE stream, "
+        "Metadata: {'error_type': 'provider_unavailable'}"
+    )
+    assert is_retryable_upstream_failure(exc) is True
+
+
+def test_unsupported_parallel_tool_calls_is_not_retryable():
+    """glm-5.3 4xx must not be retried; drop_params is the fix, not retry."""
+    exc = _FakeHTTPError(
+        "zai does not support parameters: ['parallel_tool_calls']",
+        status_code=400,
+    )
+    assert is_retryable_upstream_failure(exc) is False
+
+
+def test_auth_401_is_not_retryable():
+    exc = _FakeHTTPError("Invalid API key", status_code=401)
+    assert is_retryable_upstream_failure(exc) is False
+
+
+def test_quota_exhausted_is_not_retryable():
+    exc = _FakeHTTPError(
+        "HTTP 429: request reached organization TPD rate limit",
+        status_code=429,
+        error_type="rate_limit_reached_error",
+    )
+    assert is_retryable_upstream_failure(exc) is False
 
 
 def test_opaque_failure_maps_to_upstream_error_502():

--- a/backend/tests/services/test_upstream_errors.py
+++ b/backend/tests/services/test_upstream_errors.py
@@ -178,6 +178,19 @@ def test_opaque_failure_maps_to_upstream_error_502():
     assert result.status_code == 502
 
 
+def test_opaque_generic_exception_is_not_retryable():
+    """#109: first-chunk ``Exception`` is a 502 to the client, not a retry."""
+    rejected = Exception("upstream rejected the request")
+    assert is_retryable_upstream_failure(rejected) is False
+    assert is_retryable_upstream_failure(Exception("upstream exploded")) is False
+
+
+def test_actual_502_status_is_retryable():
+    """A real provider 502 (not a mapped opaque error) is retried."""
+    exc = _FakeHTTPError("bad gateway", status_code=502)
+    assert is_retryable_upstream_failure(exc) is True
+
+
 @pytest.mark.parametrize(
     "status_code,detail,expected",
     [


### PR DESCRIPTION
## Summary
- Set LiteLLM `drop_params` on OpenAI-compatible gateway completions so models like zai/glm-5.3 are not sent `parallel_tool_calls`
- OpenRouter attribution: send Preloop User-Agent / X-Title / HTTP-Referer so the dashboard does not label requests LiteLLM
- The User-Agent / client branding override is **global** (OpenRouter, z.ai, OpenAI, Anthropic, and every other LiteLLM completion). OpenRouter-specific `HTTP-Referer` and `X-Title` are still set when the request terminates at OpenRouter
- Staging evidence: execs 195b35f6 and ee897af5 FAILED in ~15-20s, 0 tokens, error `zai does not support parameters: ['parallel_tool_calls']`

### Why the earlier branding fix did not stick
- `45f3114f` / `19bbaeed` / `c3811c4e` on `fix/openrouter-app-identity` stamped `X-Title` and `HTTP-Referer` only. That branch never merged to `main`, so staging never got it
- Even if it had landed, LiteLLM's HTTP client still defaults `User-Agent: litellm/{version}` unless `LITELLM_USER_AGENT` is set. Provider dashboards attribute traffic by User-Agent, so traffic would still show as LiteLLM

### Transient 502 / MidStreamFallbackError retry
Staging is still seeing OpenRouter 502s of this class (not the glm-5.3 4xx):

- Provider: openai
- Status: 502
- Message: Upstream provider disconnected mid-stream: APIError: OpenrouterException JSON error injected into SSE stream, error_type provider_unavailable
- Type/Code/Class: upstream_disconnect
- Trace: litellm.MidStreamFallbackError wrapping litellm.APIError

**What we already did before this commit:** classify MidStreamFallbackError as `upstream_disconnect` / HTTP 502 and emit an SSE error. No gateway retry. LiteLLM `num_retries` / `fallbacks` were not set. Flow execution can retry the whole agent session (max 2) only when the failure is classified transient and the attempt recorded no side effects. That is not a per-request gateway retry, and the agent-local "Reconnecting... 1/5" string is the CLI, not the platform.

**What this PR adds (`0f59ee92`):** bounded gateway retry (1 initial + 2 retries, exponential backoff + jitter) on:

- HTTP 502 / 503 / 504 / 529
- `provider_unavailable`, `upstream_disconnect`, MidStreamFallbackError
- network / overload / transient 429

No retry on 4xx unsupported params (`parallel_tool_calls`), auth, or quota. Intermediate attempts do not fire the admin 502 alert; only the final mapped error does.

**Remaining gap (not boiled into this PR):** if tokens have already been forwarded on the SSE response, the gateway cannot restart the completion on the same stream without duplicating billed tokens and garbled output. That case still emits the SSE error. Flow-level retry may recover the run when the attempt is side-effect-free. Do not treat staging 502s as fixed until this is deployed.

## Test plan
- [x] unit test `test_openai_gateway_drop_params` (`drop_params=True` for zai/glm-5.3)
- [x] unit tests: User-Agent must not contain `litellm` (case-insensitive) for OpenRouter **and** non-OpenRouter (z.ai, OpenAI, Anthropic)
- [x] existing `_call_litellm` assertions updated for global `drop_params` + Preloop User-Agent (CI Backend Tests)
- [x] retry tests: MidStreamFallbackError / provider_unavailable retries; 400 unsupported params does not
- [ ] after deploy to staging, re-trigger throwaway flow 8092271d with glm-5.3 and confirm it no longer dies before first token
- [ ] after deploy, confirm OpenRouter request log attributes Preloop, not LiteLLM
- [ ] after deploy, watch whether OpenRouter mid-stream 502s recover on the gateway retry (do not claim fixed until then)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Well-tested reliability hardening: mapped opaque gateway failures are no longer retried on their presentation status while real provider 5xx stays retryable (`ab1a0131`), transient 429s honor the capped `Retry-After` hint, and all previously raised findings are resolved; one LOW robustness note on the gate predicate remains.
>
> **Overview**
> Since `0f59ee92`, the branch de-retries opaque first-chunk exceptions (`9cd8d58f`), raises retry backoff to `max(backoff, min(Retry-After, 8s))` for transient 429s (`e4b53c52`), and gates the status-code fallback in `is_retryable_upstream_failure` so mapped `upstream_error` 502s are not retried as if they were provider statuses (`ab1a0131`). Streaming and non-streaming retries share one bounded loop with regression tests pinning each behavior.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit ab1a0131. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->