### PR TITLE
fix: hide Qwen omni and translate SKUs from the chat picker

### DIFF
--- a/backend/preloop/services/ai_model_provider.py
+++ b/backend/preloop/services/ai_model_provider.py
@@ -867,8 +867,9 @@ def _is_qwen_chat_model(model_id: str) -> bool:
     """Keep chat/completions SKUs; drop dedicated media, audio, and NSFW ids.
 
     Multimodal chat flagships (``qwen3.8-max``) stay. Dedicated Wan video,
-    Qwen-Image, Qwen-VL product lines, audio/TTS, Happy Horse, Z-Image, and
-    any id carrying ``nsfw`` are excluded from the picker.
+    Qwen-Image, Qwen-VL product lines, audio/TTS, Happy Horse, Z-Image,
+    hyphen-delimited omni/MT/s2s families, live-translate SKUs, and any id
+    carrying ``nsfw`` are excluded from the picker.
     """
     lowered = (model_id or "").strip().lower()
     if not lowered:
@@ -881,14 +882,6 @@ def _is_qwen_chat_model(model_id: str) -> bool:
         "qwen-vl",
         "qwen-audio",
         "qwen-tts",
-        "qwen-omni",
-        "qwen2.5-omni",
-        "qwen3-omni",
-        "qwen3.5-omni",
-        "qwen3-s2s",
-        "qwen-mt",
-        "qwen3-livetranslate",
-        "qwen3.5-livetranslate",
         "qwen2.5-vl",
         "qvq-",
         "tongyi-tingwu",
@@ -901,12 +894,17 @@ def _is_qwen_chat_model(model_id: str) -> bool:
         "-embedding",
         "-rerank",
         "-vl-",
-        "-s2s-",
         "livetranslate",
     )
+    # Hyphen-delimited families so a qwen4-omni / qwen3-mt-plus bump stays
+    # hidden without another prefix edit. Tokens, not bare substrings, so
+    # a third-party id like omnilingual-chat would still list.
+    blocked_family_tokens = frozenset({"omni", "mt", "s2s"})
     if any(lowered.startswith(prefix) for prefix in blocked_prefixes):
         return False
     if any(token in lowered for token in blocked_substrings):
+        return False
+    if any(part in blocked_family_tokens for part in lowered.split("-")):
         return False
     return True
 

--- a/backend/preloop/services/ai_model_provider.py
+++ b/backend/preloop/services/ai_model_provider.py
@@ -883,8 +883,15 @@ def _is_qwen_chat_model(model_id: str) -> bool:
         "qwen-tts",
         "qwen-omni",
         "qwen2.5-omni",
+        "qwen3-omni",
+        "qwen3.5-omni",
+        "qwen3-s2s",
+        "qwen-mt",
+        "qwen3-livetranslate",
+        "qwen3.5-livetranslate",
         "qwen2.5-vl",
         "qvq-",
+        "tongyi-tingwu",
     )
     blocked_substrings = (
         "nsfw",
@@ -894,6 +901,8 @@ def _is_qwen_chat_model(model_id: str) -> bool:
         "-embedding",
         "-rerank",
         "-vl-",
+        "-s2s-",
+        "livetranslate",
     )
     if any(lowered.startswith(prefix) for prefix in blocked_prefixes):
         return False

--- a/backend/tests/services/test_ai_model_provider.py
+++ b/backend/tests/services/test_ai_model_provider.py
@@ -904,10 +904,18 @@ class TestGetQwenModels:
                     "wan2.2-t2v",
                     "qwen-image-plus",
                     "qwen-vl-max",
+                    "qwen3-omni-flash",
+                    "qwen3.5-omni-plus",
+                    "qwen3-s2s-flash-realtime",
+                    "qwen3-livetranslate-flash",
+                    "qwen-mt-plus",
+                    "tongyi-tingwu-slp",
                     "happy-horse-1.1",
                     "z-image",
                     "some-nsfw-model",
                     "deepseek-v4-pro",
+                    "glm-5.2",
+                    "kimi-k2.7-code",
                 )
             )
             mock_client.return_value = mock_instance
@@ -915,7 +923,12 @@ class TestGetQwenModels:
             result = await _get_qwen_models("valid_key")
 
             assert result.source == "live"
-            assert result.models == ["deepseek-v4-pro", "qwen3.8-max"]
+            assert result.models == [
+                "deepseek-v4-pro",
+                "glm-5.2",
+                "kimi-k2.7-code",
+                "qwen3.8-max",
+            ]
 
     def test_qwen_fallback_catalog_is_current_chat_models(self):
         """Keyless picker shows 2026-08 chat models, not the stale 2025 set."""
@@ -924,8 +937,14 @@ class TestGetQwenModels:
         assert "qwq-32b-preview" not in QWEN_KNOWN_MODELS
         assert "qwen-turbo" not in QWEN_KNOWN_MODELS
         assert _is_qwen_chat_model("qwen3.8-max")
+        assert _is_qwen_chat_model("deepseek-v4-pro")
+        assert _is_qwen_chat_model("glm-5.2")
+        assert _is_qwen_chat_model("kimi-k2.7-code")
         assert not _is_qwen_chat_model("wan2.2-t2v")
         assert not _is_qwen_chat_model("qwen3-vl-plus")
+        assert not _is_qwen_chat_model("qwen3-omni-flash")
+        assert not _is_qwen_chat_model("qwen3.5-omni-plus")
+        assert not _is_qwen_chat_model("qwen-mt-plus")
 
 
 class TestGetDeepSeekModels:

--- a/backend/tests/services/test_ai_model_provider.py
+++ b/backend/tests/services/test_ai_model_provider.py
@@ -906,9 +906,11 @@ class TestGetQwenModels:
                     "qwen-vl-max",
                     "qwen3-omni-flash",
                     "qwen3.5-omni-plus",
+                    "qwen4-omni-flash",
                     "qwen3-s2s-flash-realtime",
                     "qwen3-livetranslate-flash",
                     "qwen-mt-plus",
+                    "qwen3-mt-plus",
                     "tongyi-tingwu-slp",
                     "happy-horse-1.1",
                     "z-image",
@@ -944,7 +946,10 @@ class TestGetQwenModels:
         assert not _is_qwen_chat_model("qwen3-vl-plus")
         assert not _is_qwen_chat_model("qwen3-omni-flash")
         assert not _is_qwen_chat_model("qwen3.5-omni-plus")
+        assert not _is_qwen_chat_model("qwen4-omni-flash")
         assert not _is_qwen_chat_model("qwen-mt-plus")
+        assert not _is_qwen_chat_model("qwen3-mt-plus")
+        assert not _is_qwen_chat_model("qwen4-s2s-flash")
 
 
 class TestGetDeepSeekModels:


### PR DESCRIPTION
## Summary
- Block Qwen omni, speech-to-speech, live-translate, and machine-translation SKUs from the chat model picker.
- Keep third-party chat models that Studio also lists (DeepSeek, GLM, Kimi) visible.

## Test plan
- [x] `pytest backend/tests/services/test_ai_model_provider.py` (120 passed)
- [ ] On staging: open the Qwen/DashScope model picker and confirm omni / MT / livetranslate models do not appear
- [ ] Confirm `qwen3.8-max` and other chat models still appear


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Small, well-tested tightening of a deny-list filter; no security, data-flow, or API impact beyond which models appear in the Qwen chat picker.
>
> **Overview**
> Blocks Qwen omni, speech-to-speech, machine-translation, and live-translate SKUs from the chat model picker via hyphen-delimited family tokens (`omni`, `mt`, `s2s`) plus the existing `livetranslate` substring, keeping third-party chat models (DeepSeek, GLM, Kimi) visible. Regression tests cover future-version ids for each blocked family.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit d7bf5d0. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->