### PR TITLE
feat: post Mattermost DMs with a bot token

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -507,7 +507,7 @@ graph TD
 2. `DynamicMCPServer` checks if the tool requires approval via `_check_approval_required()`
 3. If approval is required:
    - `ApprovalService.create_and_notify()` creates an `ApprovalRequest` record
-   - Webhook notifications are sent to configured channels (Slack, Mattermost, custom endpoints)
+   - Webhook notifications are sent to configured channels (Slack, Mattermost, custom endpoints). Mattermost incoming webhooks cannot target DMs (403). When `approval_config` includes bot credentials (`bot_token` or `mattermost_token`, `mattermost_url` or `base_url`, and `channel_id`), Preloop posts via `/api/v4/posts` instead. A `standard` workflow with those keys uses the bot path; one without them stays silent. `http://` base URLs are accepted for internal instances but log a warning because the bearer token then travels in plaintext.
    - The service waits for approval with configurable timeout
 4. Approver reviews request and responds via:
    - Public approval API endpoint (`/approval/{request_id}/decide`)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ answer yes when interactive onboarding offers it for supported agents.
 
 ### Access Policies & Approval Workflows
 Define fine-grained access controls for any AI tool or operation. Tools support multiple ordered access rules that evaluate in priority order. When an AI attempts a protected operation, Preloop pauses and notifies you:
-- **Instant notifications** via mobile app, email, Slack, Mattermost, or custom webhook.
+- **Instant notifications** via mobile app, email, Slack, Mattermost, or custom webhook. Mattermost incoming webhooks cannot target DMs (they return 403). To post a DM or channel message from a `standard` workflow, set `approval_config` with `bot_token` (alias `mattermost_token`), `mattermost_url` (alias `base_url`, must start with `https://` or `http://`), and `channel_id`. Preloop then posts via the Mattermost Posts API. A `standard` workflow without those keys stays silent. Existing `mattermost` / `slack` / `webhook` workflows that already use `webhook_url` are unchanged.
 - **One-tap approvals** from your phone, watch, or desktop — for any onboarded agent's tool calls, including native `Bash`/`Edit` actions, not just MCP tools.
 - **Async approval mode** lets the agent poll for status instead of blocking network hooks.
 - **Agent questions** — beyond allow/deny, agents can call the built-in `ask_user` tool to ask the operator a question with multiple-choice options and/or a free-text reply, and get the answer back. Rendered as option buttons + an answer field in the mobile and watch apps.

--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -43,6 +43,57 @@ def _approval_config_dict(workflow: ApprovalWorkflow) -> Dict[str, Any]:
     return cfg if isinstance(cfg, dict) else {}
 
 
+def _parse_mattermost_bot_target(
+    workflow: ApprovalWorkflow,
+) -> tuple[Optional[tuple[str, str, str]], Optional[str]]:
+    """Return ``(target, error)`` for a Mattermost bot post.
+
+    Incoming webhooks cannot target direct messages (Mattermost returns 403).
+    The bot-token Posts API can. Both values are None when no bot keys were
+    supplied so empty standard workflows and MagicMock fixtures stay silent.
+    """
+    cfg = _approval_config_dict(workflow)
+    raw_token = cfg.get("bot_token") or cfg.get("mattermost_token")
+    raw_url = cfg.get("mattermost_url") or cfg.get("base_url")
+    raw_channel = cfg.get("channel_id")
+    if not isinstance(raw_channel, str) or not raw_channel.strip():
+        fallback = getattr(workflow, "channel", None)
+        raw_channel = fallback if isinstance(fallback, str) else ""
+
+    token_ok = isinstance(raw_token, str) and bool(raw_token.strip())
+    url_ok = isinstance(raw_url, str) and bool(raw_url.strip())
+    if not token_ok and not url_ok:
+        return None, None
+
+    missing: List[str] = []
+    if not token_ok:
+        missing.append("bot_token (or mattermost_token)")
+    if not url_ok:
+        missing.append("mattermost_url (or base_url)")
+    channel = raw_channel.strip() if isinstance(raw_channel, str) else ""
+    if not channel:
+        missing.append("channel_id")
+    if missing:
+        return None, (
+            "Mattermost bot configuration incomplete: missing " + ", ".join(missing)
+        )
+
+    token = str(raw_token).strip()
+    url = str(raw_url).strip().rstrip("/")
+    if not url.startswith(("https://", "http://")):
+        return None, (
+            "Mattermost bot configuration incomplete: "
+            "mattermost_url must start with https:// or http://"
+        )
+    if url.startswith("http://"):
+        logger.warning(
+            "Mattermost bot token will be sent over plaintext HTTP (%s). "
+            "Prefer https:// unless this is a trusted internal instance.",
+            url,
+        )
+    return (url, token, channel), None
+
+
 def mattermost_bot_target(
     workflow: ApprovalWorkflow,
 ) -> Optional[tuple[str, str, str]]:
@@ -52,23 +103,14 @@ def mattermost_bot_target(
     The bot-token Posts API can. Non-string fields return None so empty
     standard workflows and MagicMock fixtures stay silent.
     """
-    cfg = _approval_config_dict(workflow)
-    token = cfg.get("bot_token") or cfg.get("mattermost_token")
-    url = cfg.get("mattermost_url") or cfg.get("base_url")
-    channel = cfg.get("channel_id")
-    if not isinstance(channel, str) or not channel.strip():
-        raw = getattr(workflow, "channel", None)
-        channel = raw if isinstance(raw, str) else ""
-    if not isinstance(token, str) or not isinstance(url, str):
-        return None
-    token = token.strip()
-    url = url.strip().rstrip("/")
-    channel = channel.strip()
-    if not token or not url or not channel:
-        return None
-    if not url.startswith(("https://", "http://")):
-        return None
-    return (url, token, channel)
+    target, _error = _parse_mattermost_bot_target(workflow)
+    return target
+
+
+def mattermost_bot_config_error(workflow: ApprovalWorkflow) -> Optional[str]:
+    """Return why bot credentials were rejected, or None if none were set."""
+    _target, error = _parse_mattermost_bot_target(workflow)
+    return error
 
 
 def _operator_present_at_machine(db, approval_request: ApprovalRequest) -> bool:
@@ -1580,7 +1622,10 @@ class ApprovalService:
         bot_target = mattermost_bot_target(approval_workflow)
 
         if not webhook_url and not bot_target:
-            error_msg = "No webhook URL configured in approval workflow"
+            error_msg = (
+                mattermost_bot_config_error(approval_workflow)
+                or "No webhook URL configured in approval workflow"
+            )
             await self.update_approval_request(
                 approval_request.id,
                 ApprovalRequestUpdate(webhook_error=error_msg),
@@ -2216,7 +2261,10 @@ class ApprovalService:
         if not any(
             channel in ("slack", "mattermost", "webhook")
             for channel in workflow_channels
-        ) and mattermost_bot_target(approval_workflow):
+        ) and (
+            mattermost_bot_target(approval_workflow)
+            or mattermost_bot_config_error(approval_workflow)
+        ):
             workflow_channels.append("mattermost")
         for channel in workflow_channels:
             if channel in ["slack", "mattermost", "webhook"]:

--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -37,6 +37,40 @@ logger = logging.getLogger(__name__)
 _LOCAL_PRESENCE_WINDOW = timedelta(seconds=20)
 
 
+def _approval_config_dict(workflow: ApprovalWorkflow) -> Dict[str, Any]:
+    """Return ``approval_config`` only when it is a real dict."""
+    cfg = getattr(workflow, "approval_config", None)
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def mattermost_bot_target(
+    workflow: ApprovalWorkflow,
+) -> Optional[tuple[str, str, str]]:
+    """Return ``(base_url, token, channel_id)`` for a Mattermost bot post.
+
+    Incoming webhooks cannot target direct messages (Mattermost returns 403).
+    The bot-token Posts API can. Non-string fields return None so empty
+    standard workflows and MagicMock fixtures stay silent.
+    """
+    cfg = _approval_config_dict(workflow)
+    token = cfg.get("bot_token") or cfg.get("mattermost_token")
+    url = cfg.get("mattermost_url") or cfg.get("base_url")
+    channel = cfg.get("channel_id")
+    if not isinstance(channel, str) or not channel.strip():
+        raw = getattr(workflow, "channel", None)
+        channel = raw if isinstance(raw, str) else ""
+    if not isinstance(token, str) or not isinstance(url, str):
+        return None
+    token = token.strip()
+    url = url.strip().rstrip("/")
+    channel = channel.strip()
+    if not token or not url or not channel:
+        return None
+    if not url.startswith(("https://", "http://")):
+        return None
+    return (url, token, channel)
+
+
 def _operator_present_at_machine(db, approval_request: ApprovalRequest) -> bool:
     """True only when the operator is at the local TTY.
 
@@ -1537,12 +1571,15 @@ class ApprovalService:
         Returns:
             True if successful, False otherwise
         """
-        # Get webhook URL from workflow
-        webhook_url = None
-        if approval_workflow.approval_config:
-            webhook_url = approval_workflow.approval_config.get("webhook_url")
+        cfg = _approval_config_dict(approval_workflow)
+        webhook_url = cfg.get("webhook_url")
+        if not isinstance(webhook_url, str) or not webhook_url.strip():
+            webhook_url = None
+        else:
+            webhook_url = webhook_url.strip()
+        bot_target = mattermost_bot_target(approval_workflow)
 
-        if not webhook_url:
+        if not webhook_url and not bot_target:
             error_msg = "No webhook URL configured in approval workflow"
             await self.update_approval_request(
                 approval_request.id,
@@ -1571,8 +1608,14 @@ class ApprovalService:
         ask_text = (approval_request.summary or "").strip() or None
         headline = ask_text or f"Approval Required: {approval_request.tool_name}"
 
-        # Create message based on approval type
-        if approval_workflow.approval_type in ["slack", "mattermost"]:
+        # Create message based on approval type. Bot-token Mattermost
+        # posts use the same chat markdown even when approval_type is
+        # still ``standard`` (incoming DM webhooks 403).
+        use_chat_payload = (
+            approval_workflow.approval_type in ["slack", "mattermost"]
+            or bot_target is not None
+        )
+        if use_chat_payload:
             # Build message text with all details — summary first when present
             if ask_text:
                 message_text = f"⚠️ **{ask_text}**\n\n"
@@ -1672,14 +1715,36 @@ class ApprovalService:
                 },
             }
 
-        # Post to webhook
+        # Incoming webhook when configured; otherwise Mattermost bot Posts API.
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
-                response = await client.post(
-                    webhook_url,
-                    json=message,
-                    headers={"Content-Type": "application/json"},
-                )
+                if webhook_url:
+                    response = await client.post(
+                        webhook_url,
+                        json=message,
+                        headers={"Content-Type": "application/json"},
+                    )
+                else:
+                    assert bot_target is not None
+                    base_url, token, channel_id = bot_target
+                    post_body: Dict[str, Any] = {
+                        "channel_id": channel_id,
+                        "message": (
+                            message["text"]
+                            if isinstance(message, dict) and "text" in message
+                            else json.dumps(message)
+                        ),
+                    }
+                    if isinstance(message, dict) and message.get("attachments"):
+                        post_body["props"] = {"attachments": message["attachments"]}
+                    response = await client.post(
+                        f"{base_url}/api/v4/posts",
+                        json=post_body,
+                        headers={
+                            "Content-Type": "application/json",
+                            "Authorization": f"Bearer {token}",
+                        },
+                    )
                 response.raise_for_status()
 
             # Mark as posted
@@ -2142,10 +2207,17 @@ class ApprovalService:
             )
 
         # Handle webhook-based notifications (these are workflow-level, not per-user)
-        # Derive notification channels from approval_type (the model field)
+        # Derive notification channels from approval_type (the model field).
+        # A ``standard`` workflow with Mattermost bot credentials still
+        # posts: DMs reject incoming webhooks, so type alone is not enough.
         workflow_channels = (
             [approval_workflow.approval_type] if approval_workflow.approval_type else []
         )
+        if not any(
+            channel in ("slack", "mattermost", "webhook")
+            for channel in workflow_channels
+        ) and mattermost_bot_target(approval_workflow):
+            workflow_channels.append("mattermost")
         for channel in workflow_channels:
             if channel in ["slack", "mattermost", "webhook"]:
                 try:

--- a/backend/tests/services/test_approval_service.py
+++ b/backend/tests/services/test_approval_service.py
@@ -9,7 +9,7 @@ import pytest
 from preloop.models.models import ApprovalWorkflow, ApprovalRequest
 from preloop.models.schemas.approval_request import ApprovalRequestUpdate
 
-from preloop.services.approval_service import ApprovalService
+from preloop.services.approval_service import ApprovalService, mattermost_bot_target
 
 pytestmark = pytest.mark.asyncio
 
@@ -1121,6 +1121,61 @@ class TestPostWebhookNotification:
             ]
             assert len(reasoning_fields) > 0
 
+    @patch("preloop.services.approval_service.httpx.AsyncClient")
+    async def test_post_webhook_mattermost_bot_token_success(
+        self,
+        mock_client_class,
+        approval_service,
+        sample_approval_request,
+        sample_approval_workflow,
+    ):
+        """DM incoming webhooks 403. Bot-token Posts API is the working path."""
+        sample_approval_workflow.approval_type = "standard"
+        sample_approval_workflow.channel = None
+        sample_approval_workflow.approval_config = {
+            "mattermost_url": "https://mm.example.com/",
+            "channel_id": "abcdefghijklmnopqrstuvwxyz",
+            "bot_token": "bot-token-test-value",
+        }
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        with patch.object(approval_service, "update_approval_request") as mock_update:
+            result = await approval_service.post_webhook_notification(
+                sample_approval_request, sample_approval_workflow
+            )
+
+        assert result is True
+        mock_client.post.assert_called_once()
+        args, kwargs = mock_client.post.call_args
+        assert args[0] == "https://mm.example.com/api/v4/posts"
+        assert kwargs["headers"]["Authorization"] == "Bearer bot-token-test-value"
+        assert kwargs["json"]["channel_id"] == "abcdefghijklmnopqrstuvwxyz"
+        assert "message" in kwargs["json"]
+        update = mock_update.call_args[0][1]
+        assert update.webhook_posted_at is not None
+
+    async def test_mattermost_bot_target_ignores_non_string_channel(
+        self, sample_approval_workflow
+    ):
+        """MagicMock.channel must not be treated as a channel id."""
+        sample_approval_workflow.approval_type = "standard"
+        sample_approval_workflow.approval_config = {
+            "mattermost_url": "https://mm.example.com",
+            "bot_token": "bot-token-test-value",
+        }
+        sample_approval_workflow.channel = MagicMock()
+        assert mattermost_bot_target(sample_approval_workflow) is None
+
+        sample_approval_workflow.channel = "abcdefghijklmnopqrstuvwxyz"
+        target = mattermost_bot_target(sample_approval_workflow)
+        assert target is not None
+        assert target[2] == "abcdefghijklmnopqrstuvwxyz"
+
 
 class TestSendNotifications:
     """Test send_notifications method."""
@@ -1293,6 +1348,79 @@ class TestSendNotifications:
 
                     assert result["slack"]["success"] is False
                     assert "error" in result["slack"]
+
+    async def test_send_notifications_standard_with_bot_config(
+        self, approval_service, sample_approval_request, sample_approval_workflow
+    ):
+        """Founder Mattermost ping is approval_type=standard with bot creds."""
+        sample_approval_request.requested_at = datetime.utcnow()
+        sample_approval_workflow.approval_type = "standard"
+        sample_approval_workflow.channel = "abcdefghijklmnopqrstuvwxyz"
+        sample_approval_workflow.approval_config = {
+            "mattermost_url": "https://mm.example.com",
+            "channel_id": "abcdefghijklmnopqrstuvwxyz",
+            "bot_token": "bot-token-test-value",
+        }
+
+        with patch.object(
+            approval_service,
+            "_send_email_notification",
+            new_callable=AsyncMock,
+            return_value={"success": True, "sent": 0, "failed": 0, "skipped": 0},
+        ):
+            with patch.object(
+                approval_service,
+                "_send_push_notification",
+                new_callable=AsyncMock,
+                return_value={"success": True, "sent": 0, "failed": 0},
+            ):
+                with patch.object(
+                    approval_service,
+                    "post_webhook_notification",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                ) as mock_webhook:
+                    result = await approval_service.send_notifications(
+                        sample_approval_request, sample_approval_workflow
+                    )
+
+                    mock_webhook.assert_called_once()
+                    assert result["mattermost"]["success"] is True
+
+    async def test_send_notifications_standard_without_bot_skips_mattermost(
+        self, approval_service, sample_approval_request, sample_approval_workflow
+    ):
+        """Default standard workflow has no bot creds, so no Mattermost post."""
+        sample_approval_request.requested_at = datetime.utcnow()
+        sample_approval_request.tool_name = "shell"
+        sample_approval_workflow.approval_type = "standard"
+        sample_approval_workflow.channel = None
+        sample_approval_workflow.approval_config = None
+
+        with patch.object(
+            approval_service,
+            "_send_email_notification",
+            new_callable=AsyncMock,
+            return_value={"success": True, "sent": 0, "failed": 0, "skipped": 0},
+        ):
+            with patch.object(
+                approval_service,
+                "_send_push_notification",
+                new_callable=AsyncMock,
+                return_value={"success": True, "sent": 0, "failed": 0},
+            ):
+                with patch.object(
+                    approval_service,
+                    "post_webhook_notification",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                ) as mock_webhook:
+                    result = await approval_service.send_notifications(
+                        sample_approval_request, sample_approval_workflow
+                    )
+
+                    mock_webhook.assert_not_called()
+                    assert "mattermost" not in result
 
 
 class TestGetAllApproverUserIds:

--- a/backend/tests/services/test_approval_service.py
+++ b/backend/tests/services/test_approval_service.py
@@ -1,6 +1,7 @@
 """Tests for approval service."""
 
 import json
+import logging
 import uuid
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1176,6 +1177,109 @@ class TestPostWebhookNotification:
         assert target is not None
         assert target[2] == "abcdefghijklmnopqrstuvwxyz"
 
+    @pytest.mark.parametrize(
+        "config,channel,expect_target",
+        [
+            (
+                {
+                    "mattermost_url": "mm.example.com",
+                    "bot_token": "bot-token-test-value",
+                    "channel_id": "abcdefghijklmnopqrstuvwxyz",
+                },
+                None,
+                None,
+            ),
+            (
+                {
+                    "mattermost_url": "https://mm.example.com",
+                    "bot_token": "   ",
+                    "channel_id": "abcdefghijklmnopqrstuvwxyz",
+                },
+                None,
+                None,
+            ),
+            (
+                {
+                    "mattermost_url": "   ",
+                    "bot_token": "bot-token-test-value",
+                    "channel_id": "abcdefghijklmnopqrstuvwxyz",
+                },
+                None,
+                None,
+            ),
+            (
+                {
+                    "mattermost_url": "https://mm.example.com",
+                    "bot_token": "bot-token-test-value",
+                    "channel_id": "   ",
+                },
+                None,
+                None,
+            ),
+            (
+                {
+                    "mattermost_url": "https://mm.example.com",
+                    "bot_token": "bot-token-test-value",
+                    "channel_id": "from-config",
+                },
+                "from-workflow",
+                ("https://mm.example.com", "bot-token-test-value", "from-config"),
+            ),
+        ],
+        ids=[
+            "url-missing-scheme",
+            "whitespace-token",
+            "whitespace-url",
+            "whitespace-channel",
+            "channel-id-precedes-workflow-channel",
+        ],
+    )
+    async def test_mattermost_bot_target_validation_branches(
+        self, sample_approval_workflow, config, channel, expect_target
+    ):
+        sample_approval_workflow.approval_type = "standard"
+        sample_approval_workflow.approval_config = config
+        sample_approval_workflow.channel = channel
+        assert mattermost_bot_target(sample_approval_workflow) == expect_target
+
+    async def test_mattermost_bot_target_warns_on_plaintext_http(
+        self, sample_approval_workflow, caplog
+    ):
+        sample_approval_workflow.approval_type = "standard"
+        sample_approval_workflow.approval_config = {
+            "mattermost_url": "http://mm.example.com",
+            "bot_token": "bot-token-test-value",
+            "channel_id": "abcdefghijklmnopqrstuvwxyz",
+        }
+        with caplog.at_level(logging.WARNING):
+            target = mattermost_bot_target(sample_approval_workflow)
+        assert target == (
+            "http://mm.example.com",
+            "bot-token-test-value",
+            "abcdefghijklmnopqrstuvwxyz",
+        )
+        assert "plaintext HTTP" in caplog.text
+
+    async def test_post_webhook_incomplete_bot_config_names_field(
+        self, approval_service, sample_approval_request, sample_approval_workflow
+    ):
+        sample_approval_workflow.approval_type = "standard"
+        sample_approval_workflow.approval_config = {
+            "mattermost_url": "mm.example.com",
+            "bot_token": "bot-token-test-value",
+            "channel_id": "abcdefghijklmnopqrstuvwxyz",
+        }
+
+        with patch.object(approval_service, "update_approval_request") as mock_update:
+            result = await approval_service.post_webhook_notification(
+                sample_approval_request, sample_approval_workflow
+            )
+
+        assert result is False
+        update = mock_update.call_args[0][1]
+        assert "https://" in (update.webhook_error or "")
+        assert "No webhook URL configured" not in (update.webhook_error or "")
+
 
 class TestSendNotifications:
     """Test send_notifications method."""
@@ -1421,6 +1525,44 @@ class TestSendNotifications:
 
                     mock_webhook.assert_not_called()
                     assert "mattermost" not in result
+
+    async def test_send_notifications_standard_invalid_bot_still_posts(
+        self, approval_service, sample_approval_request, sample_approval_workflow
+    ):
+        """A typo'd scheme must not stay silent; record the config error."""
+        sample_approval_request.requested_at = datetime.utcnow()
+        sample_approval_workflow.approval_type = "standard"
+        sample_approval_workflow.channel = None
+        sample_approval_workflow.approval_config = {
+            "mattermost_url": "mm.example.com",
+            "channel_id": "abcdefghijklmnopqrstuvwxyz",
+            "bot_token": "bot-token-test-value",
+        }
+
+        with patch.object(
+            approval_service,
+            "_send_email_notification",
+            new_callable=AsyncMock,
+            return_value={"success": True, "sent": 0, "failed": 0, "skipped": 0},
+        ):
+            with patch.object(
+                approval_service,
+                "_send_push_notification",
+                new_callable=AsyncMock,
+                return_value={"success": True, "sent": 0, "failed": 0},
+            ):
+                with patch.object(
+                    approval_service,
+                    "post_webhook_notification",
+                    new_callable=AsyncMock,
+                    return_value=False,
+                ) as mock_webhook:
+                    result = await approval_service.send_notifications(
+                        sample_approval_request, sample_approval_workflow
+                    )
+
+                    mock_webhook.assert_called_once()
+                    assert result["mattermost"]["success"] is False
 
 
 class TestGetAllApproverUserIds:


### PR DESCRIPTION
## Summary
- Incoming Mattermost webhooks cannot target DMs (403). If a workflow has bot-token credentials, post via the Posts API instead.
- Standard workflows without bot credentials stay silent; no webhook is invented.

## Test plan
- [x] `pytest backend/tests/services/test_approval_service.py` (116 passed)
- [ ] On staging: a standard workflow with `mattermost_url`, `channel_id`, and `bot_token` posts the approval to that channel
- [ ] A standard workflow with no bot credentials does not attempt a Mattermost post


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> All previously raised issues are resolved in `4aa5ecd1`: docs cover the new config keys, plaintext-http tokens warn at config time, misconfiguration errors name the missing field, and validation branches have direct tests.
>
> **Overview**
> When an approval workflow's config carries Mattermost bot credentials, notifications are posted via the Posts API (`/api/v4/posts`) instead of an incoming webhook, which is the only way to target DMs. Standard workflows without credentials keep their current silent behavior, and existing webhook-based workflows are unchanged.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 4aa5ecd1. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->