### PR TITLE
fix(cli): onboard Codex via config.toml only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Codex onboarding is config-only**: `preloop agents onboard` no longer
-  installs a `~/.local/bin/codex` PATH wrapper. MCP auth, model routing,
-  and the durable token already live in `~/.codex/config.toml`; native
-  tool approvals go through `~/.codex/hooks.json`. Re-onboarding removes
-  leftover Preloop wrappers from older installs. Gemini CLI still uses a
-  wrapper because it reads gateway credentials from the environment.
+  installs a `~/.local/bin/codex` PATH wrapper. Codex only requires a
+  process environment variable when `env_key` or `bearer_token_env_var` is
+  set; if `env_key` is set and the var is missing, Codex errors and never
+  falls back to an inline token. Desktop onboarding writes
+  `experimental_bearer_token` and inlined MCP `http_headers` instead, so
+  Homebrew's `codex` can run without a wrapper. The flow runner still uses
+  `env_key` because it launches Codex as a subprocess. Re-onboarding
+  removes leftover Preloop wrappers. Gemini CLI still uses a wrapper
+  because it reads gateway credentials from the environment.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `issue_unlabeled`). Filter field `added_labels` is set on GitHub and
   GitLab.
 
+### Changed
+
+- **Codex onboarding is config-only**: `preloop agents onboard` no longer
+  installs a `~/.local/bin/codex` PATH wrapper. MCP auth, model routing,
+  and the durable token already live in `~/.codex/config.toml`; native
+  tool approvals go through `~/.codex/hooks.json`. Re-onboarding removes
+  leftover Preloop wrappers from older installs. Gemini CLI still uses a
+  wrapper because it reads gateway credentials from the environment.
+
 ### Fixed
 
 - **Preloop-bot label events were dropped**: `_is_preloop_triggered_event`

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -3949,6 +3949,20 @@ func applyCodexManagedGateway(plan managedMCPEnrollmentPlan, baseURL, token, mod
 		providers = make(map[string]interface{})
 		plan.ManagedDocument["model_providers"] = providers
 	}
+	// Codex reads custom-provider credentials in this order
+	// (codex-rs model-provider/src/auth.rs bearer_auth_for_provider):
+	//  1. env_key → os.Getenv; if the key is set and the var is empty/unset,
+	//     Codex returns EnvVarError and never reaches step 2.
+	//  2. experimental_bearer_token (inline Authorization: Bearer).
+	//  3. otherwise ChatGPT/API-key auth from ~/.codex/auth.json.
+	//
+	// Desktop onboarding therefore inlines experimental_bearer_token and
+	// must not write env_key. The flow runner can use env_key because it
+	// launches Codex as a subprocess and injects PRELOOP_API_KEY into that
+	// process (backend/preloop/agents/codex.py). A PATH wrapper that only
+	// exports PRELOOP_TOKEN does not satisfy env_key unless config also
+	// names that variable — and naming it without guaranteeing the export
+	// would fail closed.
 	providers["preloop"] = map[string]interface{}{
 		"name":                      "Preloop",
 		"base_url":                  strings.TrimRight(baseURL, "/") + openClawGatewayPath,

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -6218,13 +6218,14 @@ func syncManagedAgentRuntimeArtifacts(agent AgentConfig, baseURL, token string) 
 			},
 		)
 	case "codex cli":
-		// Codex is config-file only: MCP auth, model routing, and the
-		// durable token already live in ~/.codex/config.toml
-		// (http_headers + model_providers.preloop.experimental_bearer_token).
-		// Native-tool approvals go through ~/.codex/hooks.json. A
-		// ~/.local/bin/codex PATH wrapper is unnecessary, fails when that
-		// directory is missing, and is shadowed by Homebrew's
-		// /opt/homebrew/bin/codex. Drop leftovers from older onboardings.
+		// Codex desktop onboarding is config-file only. Model routing uses
+		// experimental_bearer_token (not env_key); MCP uses inlined
+		// http_headers. Codex only requires a process env var when env_key
+		// or bearer_token_env_var is set — see applyCodexManagedGateway.
+		// A ~/.local/bin/codex wrapper that exported PRELOOP_TOKEN was a
+		// leftover of the Gemini launcher and of the flow runner's env_key
+		// pattern; it did not feed model auth, failed when ~/.local/bin was
+		// missing, and was shadowed by Homebrew. Remove leftovers.
 		return removeManagedAgentLauncher("codex", "codex-cli.env")
 	default:
 		return nil

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -6204,6 +6204,10 @@ func detectWSLEnvironment(getenv func(string) string, procVersionPath string) bo
 func syncManagedAgentRuntimeArtifacts(agent AgentConfig, baseURL, token string) error {
 	switch strings.ToLower(strings.TrimSpace(agent.Name)) {
 	case "gemini cli":
+		// Gemini CLI still honors GEMINI_API_KEY / GOOGLE_GEMINI_BASE_URL
+		// from the process environment even when settings.json is rewritten,
+		// so a PATH wrapper is the only way to inject gateway routing without
+		// asking the operator to export those variables in every shell.
 		return syncManagedAgentLauncher(
 			"gemini",
 			"gemini-cli.env",
@@ -6214,13 +6218,14 @@ func syncManagedAgentRuntimeArtifacts(agent AgentConfig, baseURL, token string) 
 			},
 		)
 	case "codex cli":
-		return syncManagedAgentLauncher(
-			"codex",
-			"codex-cli.env",
-			map[string]string{
-				"PRELOOP_TOKEN": token,
-			},
-		)
+		// Codex is config-file only: MCP auth, model routing, and the
+		// durable token already live in ~/.codex/config.toml
+		// (http_headers + model_providers.preloop.experimental_bearer_token).
+		// Native-tool approvals go through ~/.codex/hooks.json. A
+		// ~/.local/bin/codex PATH wrapper is unnecessary, fails when that
+		// directory is missing, and is shadowed by Homebrew's
+		// /opt/homebrew/bin/codex. Drop leftovers from older onboardings.
+		return removeManagedAgentLauncher("codex", "codex-cli.env")
 	default:
 		return nil
 	}

--- a/cli/internal/cmd/agents_test.go
+++ b/cli/internal/cmd/agents_test.go
@@ -3661,15 +3661,10 @@ func TestSyncManagedAgentRuntimeArtifactsReplacesLegacyGeminiLauncher(t *testing
 	}
 }
 
-func TestSyncManagedAgentRuntimeArtifactsInstallsCodexLauncher(t *testing.T) {
-	skipManagedLauncherOnWindows(t, "installing the Codex managed launcher")
+func TestSyncManagedAgentRuntimeArtifactsSkipsCodexLauncher(t *testing.T) {
 	home := t.TempDir()
 	testenv.SetHome(t, home)
 
-	launcherDir := filepath.Join(home, ".local", "bin")
-	if err := os.MkdirAll(launcherDir, 0o755); err != nil {
-		t.Fatalf("failed to create launcher dir: %v", err)
-	}
 	originalDir := filepath.Join(home, "orig-bin")
 	if err := os.MkdirAll(originalDir, 0o755); err != nil {
 		t.Fatalf("failed to create original bin dir: %v", err)
@@ -3682,26 +3677,64 @@ func TestSyncManagedAgentRuntimeArtifactsInstallsCodexLauncher(t *testing.T) {
 	); err != nil {
 		t.Fatalf("failed to write fake codex executable: %v", err)
 	}
-	t.Setenv(
-		"PATH",
-		launcherDir+string(os.PathListSeparator)+originalDir+string(os.PathListSeparator)+os.Getenv("PATH"),
-	)
+	t.Setenv("PATH", originalDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	if err := syncManagedAgentRuntimeArtifacts(
 		AgentConfig{Name: "Codex CLI"},
 		"https://preloop.example",
 		"codex-durable-token",
 	); err != nil {
-		t.Fatalf("unexpected codex launcher install error: %v", err)
+		t.Fatalf("unexpected Codex runtime sync error: %v", err)
 	}
 
-	wrapperPath := filepath.Join(launcherDir, "codex")
-	output, err := exec.Command(wrapperPath).CombinedOutput()
-	if err != nil {
-		t.Fatalf("managed codex launcher failed: %v (%s)", err, string(output))
+	wrapperPath := filepath.Join(home, ".local", "bin", "codex")
+	if _, err := os.Stat(wrapperPath); !os.IsNotExist(err) {
+		t.Fatalf("expected Codex onboarding not to write a PATH wrapper, stat err=%v", err)
 	}
-	if got := string(output); got != "codex-durable-token" {
-		t.Fatalf("unexpected codex launcher env output: %q", got)
+	envPath := filepath.Join(home, ".preloop", "agents", "runtime", "codex-cli.env")
+	if _, err := os.Stat(envPath); !os.IsNotExist(err) {
+		t.Fatalf("expected Codex onboarding not to write a runtime env file, stat err=%v", err)
+	}
+}
+
+func TestSyncManagedAgentRuntimeArtifactsRemovesLegacyCodexLauncher(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+
+	runtimeDir := filepath.Join(home, ".preloop", "agents", "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatalf("failed to create runtime dir: %v", err)
+	}
+	envPath := filepath.Join(runtimeDir, "codex-cli.env")
+	if err := os.WriteFile(envPath, []byte("export PRELOOP_TOKEN='legacy'\n"), 0o600); err != nil {
+		t.Fatalf("failed to write runtime env file: %v", err)
+	}
+
+	launcherDir := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(launcherDir, 0o755); err != nil {
+		t.Fatalf("failed to create launcher dir: %v", err)
+	}
+	wrapperPath := filepath.Join(launcherDir, "codex")
+	if err := os.WriteFile(
+		wrapperPath,
+		[]byte("#!/usr/bin/env bash\n"+preloopManagedLauncherMarker+"\nexec /usr/bin/env true\n"),
+		0o755,
+	); err != nil {
+		t.Fatalf("failed to write legacy Codex wrapper: %v", err)
+	}
+
+	if err := syncManagedAgentRuntimeArtifacts(
+		AgentConfig{Name: "Codex CLI"},
+		"https://preloop.example",
+		"codex-durable-token",
+	); err != nil {
+		t.Fatalf("unexpected Codex runtime sync error: %v", err)
+	}
+	if _, err := os.Stat(wrapperPath); !os.IsNotExist(err) {
+		t.Fatalf("expected leftover Codex wrapper to be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(envPath); !os.IsNotExist(err) {
+		t.Fatalf("expected leftover Codex runtime env file to be removed, got err=%v", err)
 	}
 }
 

--- a/cli/internal/cmd/agents_test.go
+++ b/cli/internal/cmd/agents_test.go
@@ -2584,6 +2584,9 @@ func TestApplyCodexManagedGatewayConfiguresCustomProvider(t *testing.T) {
 	if preloop["experimental_bearer_token"] != "codex-durable-token" {
 		t.Fatalf("unexpected codex gateway token: %#v", preloop)
 	}
+	if _, hasEnvKey := preloop["env_key"]; hasEnvKey {
+		t.Fatalf("Codex desktop onboarding must not set env_key; unset PRELOOP_TOKEN would fail closed: %#v", preloop)
+	}
 	if preloop["wire_api"] != "responses" {
 		t.Fatalf("unexpected codex gateway wire_api: %#v", preloop)
 	}
@@ -2595,6 +2598,28 @@ func TestApplyCodexManagedGatewayConfiguresCustomProvider(t *testing.T) {
 	legacyHeaders := legacyPreloop["http_headers"].(map[string]interface{})
 	if legacyHeaders["Authorization"] != "Bearer codex-durable-token" {
 		t.Fatalf("unexpected Codex legacy Authorization header: %#v", legacyPreloop)
+	}
+	if _, hasBearerEnv := legacyPreloop["bearer_token_env_var"]; hasBearerEnv {
+		t.Fatalf("tokenful Codex MCP entry must not require bearer_token_env_var, got %#v", legacyPreloop)
+	}
+
+	agent := AgentConfig{Name: "Codex CLI", ConfigPath: configPath}
+	if err := writeAgentConfigDocument(agent, plan.ManagedDocument); err != nil {
+		t.Fatalf("failed to write Codex config: %v", err)
+	}
+	written, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read written Codex config: %v", err)
+	}
+	body := string(written)
+	if !strings.Contains(body, "experimental_bearer_token") {
+		t.Fatalf("expected experimental_bearer_token in written config, got:\n%s", body)
+	}
+	if strings.Contains(body, "env_key") {
+		t.Fatalf("written Codex config must not contain env_key, got:\n%s", body)
+	}
+	if strings.Contains(body, "bearer_token_env_var") {
+		t.Fatalf("written Codex config must not require bearer_token_env_var when a token is present, got:\n%s", body)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Codex onboarding no longer installs a `~/.local/bin/codex` PATH wrapper.

Codex only requires a process environment variable when config names one (`env_key` or `bearer_token_env_var`). If `env_key` is set and that variable is missing, Codex 0.149.0 errors with `Missing environment variable: PRELOOP_TOKEN` and never falls back to an inline token. That is a good reason to wrap the binary **if** we used `env_key`.

Desktop onboarding does not. It writes:

- `[model_providers.preloop] experimental_bearer_token` + `base_url` (model routing)
- `[mcp_servers.preloop]` with inlined `Authorization` (MCP)
- `~/.codex/hooks.json` for native tool approvals

The flow runner still uses `env_key` because it launches Codex as a subprocess and injects `PRELOOP_API_KEY`. The old desktop wrapper exported `PRELOOP_TOKEN` without setting `env_key`, so it did not feed model auth, and it failed when `~/.local/bin` was missing or Homebrew's binary took PATH precedence.

Re-onboarding removes leftover Preloop wrappers. Gemini CLI still uses a wrapper because it reads gateway credentials from the environment.

## Testing

- [x] CLI unit tests: generated `config.toml` has `experimental_bearer_token` and does not contain `env_key` / `bearer_token_env_var` when a token is present
- [x] Codex 0.149.0 `doctor --strict-config`: Preloop-shaped config loads; OpenAI auth is not required
- [x] Codex 0.149.0 `exec`: `env_key = PRELOOP_TOKEN` with the var unset fails closed; `experimental_bearer_token` with no env starts as `provider: preloop`
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Manual validation on a Homebrew machine without `~/.local/bin`

## Checklist

- [x] Docs updated if needed (changelog)
- [x] Changelog updated if needed
- [x] No secrets included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href=\"https://cursor.com/agents/bc-47ff3b40-f939-4a26-b607-574095c48c97?cursor_ref=pr_footer&cursor_cta=open_in_web\"><picture><source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cursor.com/assets/images/open-in-web-dark.png\"><source media=\"(prefers-color-scheme: light)\" srcset=\"https://cursor.com/assets/images/open-in-web-light.png\"><img alt=\"Open in Web\" width=\"114\" height=\"28\" src=\"https://cursor.com/assets/images/open-in-web-dark.png\"></picture></a>&nbsp;<a href=\"https://cursor.com/background-agent?bcId=bc-47ff3b40-f939-4a26-b607-574095c48c97&cursor_ref=pr_footer&cursor_cta=open_in_cursor\"><picture><source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cursor.com/assets/images/open-in-cursor-dark.png\"><source media=\"(prefers-color-scheme: light)\" srcset=\"https://cursor.com/assets/images/open-in-cursor-light.png\"><img alt=\"Open in Cursor\" width=\"131\" height=\"28\" src=\"https://cursor.com/assets/images/open-in-cursor-dark.png\"></picture></a>&nbsp;</div>

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Safe, well-scoped CLI change: the Codex wrapper removal is guarded by Preloop-marker checks so cleanup can't touch user-installed binaries, token delivery already lives in config.toml, and both new behaviors are covered by passing unit tests.
>
> **Overview**
> Codex onboarding becomes config-only by dropping the `~/.local/bin/codex` PATH wrapper (whose only job was exporting a redundant `PRELOOP_TOKEN`) and instead removes leftover wrappers from older installs via the existing managed-launcher teardown path. Gemini CLI keeps its wrapper since it still needs environment-based credential injection.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 3553487d. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->