### PR TITLE
fix: preloop claude sidecar startup and plugin discovery

### DIFF
--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -4438,6 +4438,20 @@ func installAgentControlRuntimePlugin(agent AgentConfig, writer io.Writer) map[s
 		ctx, cancel = context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 		args = []string{"install", "-g", installTarget}
+		// npm install -g <source folder> symlinks the folder as-is: it does
+		// not install the folder's devDependencies, so the TypeScript build
+		// (prepare script) cannot run and npm silently skips creating the
+		// preloop-claude-plugin bin link because dist/index.js is missing.
+		// Build the source first so the global install links a working bin.
+		if buildErr := buildClaudePluginSourceIfNeeded(installerPath, installTarget, writer); buildErr != nil {
+			result["control_plugin_install_status"] = "plugin_source_build_failed"
+			result["control_plugin_install_target"] = installTarget
+			result["control_plugin_install_error"] = buildErr.Error()
+			if writer != nil {
+				fmt.Fprintf(writer, "  Warning: Agent Control plugin source build failed: %s\n", buildErr) //nolint:errcheck
+			}
+			return mergeStringMaps(result, ensureManagedAgentControlSidecar(agent, writer))
+		}
 	}
 	output, err := exec.CommandContext(ctx, installerPath, args...).CombinedOutput()
 	result["control_plugin_install_status"] = "install_attempted"
@@ -4661,6 +4675,50 @@ func agentControlPluginSourceCandidates(startPath, dirName string) []string {
 		startPath = parent
 	}
 	return candidates
+}
+
+// buildClaudePluginSourceIfNeeded prepares a local claude-preloop source
+// checkout for a global npm install. It is a no-op when the install target is
+// the published package name or when dist/index.js is already built. For an
+// unbuilt source folder it installs the folder's dependencies (including
+// devDependencies, which hold the TypeScript compiler) and runs the build so
+// that npm install -g links the preloop-claude-plugin bin against a real
+// entry point.
+func buildClaudePluginSourceIfNeeded(npmPath, installTarget string, writer io.Writer) error {
+	info, err := os.Stat(installTarget)
+	if err != nil || !info.IsDir() {
+		// Registry package name, not a local source folder.
+		return nil
+	}
+	entry := filepath.Join(installTarget, "dist", "index.js")
+	if entryInfo, entryErr := os.Stat(entry); entryErr == nil && !entryInfo.IsDir() {
+		return nil
+	}
+	if writer != nil {
+		fmt.Fprintf(writer, "  Building Claude Agent Control plugin from source (%s)...\n", installTarget) //nolint:errcheck
+	}
+	steps := [][]string{
+		{"install", "--no-audit", "--no-fund"},
+		{"run", "build"},
+	}
+	for _, stepArgs := range steps {
+		ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+		command := exec.CommandContext(ctx, npmPath, stepArgs...)
+		command.Dir = installTarget
+		output, runErr := command.CombinedOutput()
+		cancel()
+		if runErr != nil {
+			message := strings.TrimSpace(string(output))
+			if message == "" {
+				message = runErr.Error()
+			}
+			return fmt.Errorf("npm %s in %s failed: %s", strings.Join(stepArgs, " "), installTarget, message)
+		}
+	}
+	if entryInfo, entryErr := os.Stat(entry); entryErr != nil || entryInfo.IsDir() {
+		return fmt.Errorf("build completed but %s is still missing", entry)
+	}
+	return nil
 }
 
 func existingAgentControlPluginSource(path string) (string, bool) {

--- a/cli/internal/cmd/claude.go
+++ b/cli/internal/cmd/claude.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -101,8 +103,11 @@ func claudeControlConfigPath() string {
 }
 
 func runClaudeLauncher(cmd *cobra.Command, args []string) error {
+	// The sidecar owns the control socket; without it there is no remote
+	// control and the dial below can never succeed. Stop with one actionable
+	// error instead of warning and then failing on the dial.
 	if err := ensureClaudeSidecarRunning(cmd.OutOrStdout()); err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: sidecar: %v\n", err)
+		return fmt.Errorf("cannot start the Claude Code sidecar: %w", err)
 	}
 	printClaudePairingHint(cmd.OutOrStdout())
 
@@ -112,7 +117,12 @@ func runClaudeLauncher(cmd *cobra.Command, args []string) error {
 	}
 	conn, err := dialClaudeControlSocket(8 * time.Second)
 	if err != nil {
-		return fmt.Errorf("claude sidecar is not listening (%s): %w", claudeControlSocketPath(), err)
+		return fmt.Errorf(
+			"claude sidecar started but did not open %s: %w (check %s)",
+			claudeControlSocketPath(),
+			err,
+			claudeSidecarLogPath(),
+		)
 	}
 	defer conn.Close()
 
@@ -320,15 +330,15 @@ func ensureClaudeSidecarRunning(out io.Writer) error {
 }
 
 func startClaudeSidecarProcess() error {
-	bin, err := resolveRuntimeExecutable("preloop-claude-plugin")
+	invocation, err := resolveClaudeSidecarInvocation()
 	if err != nil {
-		return fmt.Errorf("preloop-claude-plugin not found; run preloop agents onboard \"Claude Code\"")
+		return err
 	}
-	cmd := exec.Command(bin, "run", "--config", claudeControlConfigPath())
+	cmd := exec.Command(invocation.bin, append(invocation.args, "run", "--config", claudeControlConfigPath())...)
 	cmd.SysProcAttr = claudeSysProcAttr()
-	logDir := filepath.Join(filepath.Dir(claudeControlSocketPath()), "logs")
+	logDir := filepath.Dir(claudeSidecarLogPath())
 	_ = os.MkdirAll(logDir, 0o700)
-	stdout, err := os.OpenFile(filepath.Join(logDir, "claude-sidecar.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	stdout, err := os.OpenFile(claudeSidecarLogPath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return err
 	}
@@ -343,6 +353,118 @@ func startClaudeSidecarProcess() error {
 		_ = stdout.Close()
 	}()
 	return nil
+}
+
+func claudeSidecarLogPath() string {
+	return filepath.Join(filepath.Dir(claudeControlSocketPath()), "logs", "claude-sidecar.log")
+}
+
+// claudeSidecarInvocation describes how to start the sidecar: either the
+// preloop-claude-plugin bin directly, or node with the package entry point
+// when npm never linked the bin.
+type claudeSidecarInvocation struct {
+	bin  string
+	args []string
+}
+
+// resolveClaudeSidecarInvocation locates the sidecar executable. npm skips
+// creating the preloop-claude-plugin bin link when the package was installed
+// from a source checkout whose dist/ was not built yet, so a missing bin does
+// not mean the package is missing. Fall back to the package entry point under
+// the npm global root before telling the user to onboard.
+func resolveClaudeSidecarInvocation() (claudeSidecarInvocation, error) {
+	if bin, err := resolveRuntimeExecutable("preloop-claude-plugin"); err == nil {
+		return claudeSidecarInvocation{bin: bin}, nil
+	}
+	entry, found, err := findClaudeSidecarPackageEntry(claudeNpmGlobalRoots())
+	if err != nil {
+		return claudeSidecarInvocation{}, err
+	}
+	if found {
+		node, nodeErr := resolveRuntimeExecutable("node")
+		if nodeErr != nil {
+			return claudeSidecarInvocation{}, fmt.Errorf(
+				"found the Claude sidecar at %s but node was not found on %s",
+				entry,
+				runtimeExecutableSearchDescription("node"),
+			)
+		}
+		return claudeSidecarInvocation{bin: node, args: []string{entry}}, nil
+	}
+	return claudeSidecarInvocation{}, fmt.Errorf(
+		"preloop-claude-plugin was not found on %s or in the npm global directory; "+
+			"run: preloop agents onboard \"Claude Code\"",
+		runtimeExecutableSearchDescription("preloop-claude-plugin"),
+	)
+}
+
+// findClaudeSidecarPackageEntry looks for @preloop-ai/claude-plugin under the
+// given npm global node_modules roots. Returns the dist entry point when the
+// package is installed and built. When the package directory exists but the
+// build output is missing (a source-folder install that never ran a build),
+// return an error that names the broken install instead of a generic
+// not-found message.
+func findClaudeSidecarPackageEntry(roots []string) (string, bool, error) {
+	for _, root := range roots {
+		pkgDir := filepath.Join(root, "@preloop-ai", "claude-plugin")
+		info, err := os.Stat(pkgDir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		entry := filepath.Join(pkgDir, "dist", "index.js")
+		if entryInfo, entryErr := os.Stat(entry); entryErr == nil && !entryInfo.IsDir() {
+			return entry, true, nil
+		}
+		return "", false, fmt.Errorf(
+			"@preloop-ai/claude-plugin is installed at %s but its dist/index.js build output is missing; "+
+				"rerun preloop agents onboard \"Claude Code\" to rebuild it, "+
+				"or run: npm install -g @preloop-ai/claude-plugin",
+			pkgDir,
+		)
+	}
+	return "", false, nil
+}
+
+// claudeNpmGlobalRoots returns candidate npm global node_modules directories:
+// whatever npm itself reports, plus common prefixes for machines where npm is
+// unavailable or misconfigured.
+func claudeNpmGlobalRoots() []string {
+	roots := []string{}
+	if npmBin, err := resolveRuntimeExecutable("npm"); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		output, cmdErr := exec.CommandContext(ctx, npmBin, "root", "-g").Output()
+		cancel()
+		if cmdErr == nil {
+			if root := strings.TrimSpace(string(output)); root != "" {
+				roots = append(roots, root)
+			}
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		roots = append(roots,
+			filepath.Join(home, ".npm-global", "lib", "node_modules"),
+		)
+		if matches, globErr := filepath.Glob(
+			filepath.Join(home, ".nvm", "versions", "node", "*", "lib", "node_modules"),
+		); globErr == nil {
+			sort.Sort(sort.Reverse(sort.StringSlice(matches)))
+			roots = append(roots, matches...)
+		}
+	}
+	roots = append(roots,
+		"/opt/homebrew/lib/node_modules",
+		"/usr/local/lib/node_modules",
+	)
+	seen := map[string]bool{}
+	unique := roots[:0]
+	for _, root := range roots {
+		if root == "" || seen[root] {
+			continue
+		}
+		seen[root] = true
+		unique = append(unique, root)
+	}
+	return unique
 }
 
 func claudeSidecarLaunchdPath() string {
@@ -404,11 +526,11 @@ func runClaudeSidecarStatus(cmd *cobra.Command, args []string) error {
 }
 
 func runClaudeSidecarForeground(cmd *cobra.Command, args []string) error {
-	bin, err := resolveRuntimeExecutable("preloop-claude-plugin")
+	invocation, err := resolveClaudeSidecarInvocation()
 	if err != nil {
-		return fmt.Errorf("preloop-claude-plugin not found: %w", err)
+		return err
 	}
-	child := exec.Command(bin, "run", "--config", claudeControlConfigPath())
+	child := exec.Command(invocation.bin, append(invocation.args, "run", "--config", claudeControlConfigPath())...)
 	child.Stdout = cmd.OutOrStdout()
 	child.Stderr = cmd.ErrOrStderr()
 	return child.Run()

--- a/cli/internal/cmd/claude.go
+++ b/cli/internal/cmd/claude.go
@@ -376,7 +376,7 @@ func resolveClaudeSidecarInvocation() (claudeSidecarInvocation, error) {
 	if bin, err := resolveRuntimeExecutable("preloop-claude-plugin"); err == nil {
 		return claudeSidecarInvocation{bin: bin}, nil
 	}
-	entry, found, err := findClaudeSidecarPackageEntry(claudeNpmGlobalRoots())
+	entry, found, err := findClaudeSidecarPackageEntry(claudeNpmGlobalRootsFunc())
 	if err != nil {
 		return claudeSidecarInvocation{}, err
 	}
@@ -424,6 +424,12 @@ func findClaudeSidecarPackageEntry(roots []string) (string, bool, error) {
 	}
 	return "", false, nil
 }
+
+// claudeNpmGlobalRootsFunc is a seam for tests: claudeNpmGlobalRoots probes
+// fixed absolute prefixes (for example /opt/homebrew/lib/node_modules), so a
+// machine with the plugin genuinely installed there would leak into tests
+// that pin PATH and HOME to temp dirs.
+var claudeNpmGlobalRootsFunc = claudeNpmGlobalRoots
 
 // claudeNpmGlobalRoots returns candidate npm global node_modules directories:
 // whatever npm itself reports, plus common prefixes for machines where npm is

--- a/cli/internal/cmd/claude_plugin_build_test.go
+++ b/cli/internal/cmd/claude_plugin_build_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/testenv"
+)
+
+// writeFakeNpm creates an npm shim in dir that prints message and exits with
+// the given code, returning the shim path. Cross-platform for the same reason
+// as writeFakeExecutable: Windows resolves executables via PATHEXT.
+func writeFakeNpm(t *testing.T, dir, message string, exitCode int) string {
+	t.Helper()
+	path := filepath.Join(dir, "npm")
+	code := strconv.Itoa(exitCode)
+	body := "#!/bin/sh\necho \"" + message + "\"\nexit " + code + "\n"
+	if runtime.GOOS == "windows" {
+		path += ".bat"
+		body = "@echo off\r\necho " + message + "\r\nexit /b " + code + "\r\n"
+	}
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestBuildClaudePluginSourceFailingBuildNamesStepAndFolder(t *testing.T) {
+	// An unbuilt source checkout whose npm step fails must produce an error
+	// that names the exact npm invocation and the folder it ran in, so the
+	// user can rerun it by hand.
+	source := t.TempDir()
+	npmPath := writeFakeNpm(t, t.TempDir(), "tsc exploded", 1)
+
+	err := buildClaudePluginSourceIfNeeded(npmPath, source, nil)
+	if err == nil {
+		t.Fatal("expected the failing npm step to surface as an error")
+	}
+	for _, want := range []string{"npm install --no-audit --no-fund", source, "tsc exploded"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+	if strings.ContainsRune(err.Error(), '—') {
+		t.Fatalf("error contains an em dash: %q", err.Error())
+	}
+}
+
+func TestBuildClaudePluginSourceAlreadyBuiltSkipsNpm(t *testing.T) {
+	// dist/index.js already exists, so the function must return nil without
+	// running npm at all. The npm path points at nothing runnable: any
+	// invocation would fail the build and fail this test.
+	source := t.TempDir()
+	distDir := filepath.Join(source, "dist")
+	if err := os.MkdirAll(distDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(distDir, "index.js"), []byte("// built"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bogusNpm := filepath.Join(t.TempDir(), "npm-that-does-not-exist")
+
+	if err := buildClaudePluginSourceIfNeeded(bogusNpm, source, nil); err != nil {
+		t.Fatalf("already-built source must be a no-op, got %v", err)
+	}
+}
+
+func TestBuildClaudePluginSourceRegistryPackageNameIsNoOp(t *testing.T) {
+	// A registry package name is not a directory on disk; the pre-build must
+	// not run. Same bogus-npm trick: invoking npm would return an error.
+	bogusNpm := filepath.Join(t.TempDir(), "npm-that-does-not-exist")
+
+	if err := buildClaudePluginSourceIfNeeded(bogusNpm, "@preloop-ai/claude-plugin", nil); err != nil {
+		t.Fatalf("registry package name must be a no-op, got %v", err)
+	}
+}
+
+func TestBuildClaudePluginSourceBuildSucceedsButEntryStillMissing(t *testing.T) {
+	// npm exits 0 for both steps but never produces dist/index.js; the
+	// function must not report success against a bin target that still does
+	// not exist.
+	source := t.TempDir()
+	npmPath := writeFakeNpm(t, t.TempDir(), "ok", 0)
+
+	err := buildClaudePluginSourceIfNeeded(npmPath, source, nil)
+	if err == nil {
+		t.Fatal("expected an error when the build output is still missing")
+	}
+	if !strings.Contains(err.Error(), "build completed but") || !strings.Contains(err.Error(), "still missing") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), filepath.Join(source, "dist", "index.js")) {
+		t.Fatalf("error %q must name the missing entry point", err.Error())
+	}
+}
+
+func TestInstallAgentControlRuntimePluginRecordsSourceBuildFailure(t *testing.T) {
+	// The installer-side pre-build is the root-cause fix for the broken
+	// source-folder install: when it fails, onboarding must record
+	// plugin_source_build_failed instead of attempting npm install -g.
+	testenv.SetTempHome(t)
+	npmDir := t.TempDir()
+	writeFakeNpm(t, npmDir, "tsc exploded", 1)
+	t.Setenv("PATH", npmDir)
+
+	pluginsRoot := t.TempDir()
+	source := filepath.Join(pluginsRoot, "claude-preloop")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRELOOP_RUNTIME_PLUGINS_DIR", pluginsRoot)
+
+	var out strings.Builder
+	result := installAgentControlRuntimePlugin(AgentConfig{Name: "Claude Code"}, &out)
+
+	if got := result["control_plugin_install_status"]; got != "plugin_source_build_failed" {
+		t.Fatalf("control_plugin_install_status = %v, want plugin_source_build_failed", got)
+	}
+	if got := result["control_plugin_install_target"]; got != source {
+		t.Fatalf("control_plugin_install_target = %v, want %q", got, source)
+	}
+	installError, _ := result["control_plugin_install_error"].(string)
+	for _, want := range []string{"npm install --no-audit --no-fund", source, "tsc exploded"} {
+		if !strings.Contains(installError, want) {
+			t.Fatalf("install error %q missing %q", installError, want)
+		}
+	}
+	if !strings.Contains(out.String(), "plugin source build failed") {
+		t.Fatalf("user-facing output %q must mention the failed build", out.String())
+	}
+}

--- a/cli/internal/cmd/claude_test.go
+++ b/cli/internal/cmd/claude_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -172,5 +173,138 @@ func TestWaitForStdinOrReleaseConsumesKey(t *testing.T) {
 	}
 	if ready {
 		t.Fatal("key should have been consumed")
+	}
+}
+
+func TestFindClaudeSidecarPackageEntryFound(t *testing.T) {
+	root := t.TempDir()
+	distDir := filepath.Join(root, "@preloop-ai", "claude-plugin", "dist")
+	if err := os.MkdirAll(distDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entryPath := filepath.Join(distDir, "index.js")
+	if err := os.WriteFile(entryPath, []byte("// stub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entry, found, err := findClaudeSidecarPackageEntry([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || entry != entryPath {
+		t.Fatalf("found=%v entry=%q, want %q", found, entry, entryPath)
+	}
+}
+
+func TestFindClaudeSidecarPackageEntryUnbuiltInstallIsActionable(t *testing.T) {
+	// Repro of the founder's machine: npm install -g <source folder> symlinks
+	// the package without building dist/ and never links the bin. The lookup
+	// must name the broken install instead of claiming the plugin is missing.
+	root := t.TempDir()
+	pkgDir := filepath.Join(root, "@preloop-ai", "claude-plugin", "src")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, found, err := findClaudeSidecarPackageEntry([]string{root})
+	if found {
+		t.Fatal("unbuilt install must not be reported as usable")
+	}
+	if err == nil {
+		t.Fatal("expected an actionable error for an unbuilt install")
+	}
+	for _, want := range []string{"dist/index.js", "preloop agents onboard", "npm install -g @preloop-ai/claude-plugin"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+	if strings.ContainsRune(err.Error(), '—') {
+		t.Fatalf("error contains an em dash: %q", err.Error())
+	}
+}
+
+func TestFindClaudeSidecarPackageEntryMissingEverywhere(t *testing.T) {
+	entry, found, err := findClaudeSidecarPackageEntry([]string{t.TempDir(), filepath.Join(t.TempDir(), "nope")})
+	if err != nil || found || entry != "" {
+		t.Fatalf("want clean miss, got entry=%q found=%v err=%v", entry, found, err)
+	}
+}
+
+func TestResolveClaudeSidecarInvocationPrefersBinOnPath(t *testing.T) {
+	binDir := t.TempDir()
+	plugin := filepath.Join(binDir, "preloop-claude-plugin")
+	if err := os.WriteFile(plugin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	t.Setenv("HOME", t.TempDir())
+	invocation, err := resolveClaudeSidecarInvocation()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if invocation.bin != plugin || len(invocation.args) != 0 {
+		t.Fatalf("unexpected invocation %+v", invocation)
+	}
+}
+
+func TestResolveClaudeSidecarInvocationErrorIsActionable(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	_, err := resolveClaudeSidecarInvocation()
+	if err == nil {
+		t.Fatal("expected an error with no plugin anywhere")
+	}
+	if !strings.Contains(err.Error(), "preloop agents onboard \"Claude Code\"") {
+		t.Fatalf("error %q must tell the user to onboard", err.Error())
+	}
+	if strings.ContainsRune(err.Error(), '—') {
+		t.Fatalf("error contains an em dash: %q", err.Error())
+	}
+}
+
+func TestRunClaudeLauncherFailsFastWithoutSidecar(t *testing.T) {
+	// The bug: a missing plugin produced a warning, then the launcher dialed a
+	// socket nothing had created and failed 8 seconds later with a confusing
+	// message. The launcher must stop with one actionable error instead.
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	var out, errOut strings.Builder
+	cmd := claudeCmd
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	start := time.Now()
+	err := runClaudeLauncher(cmd, nil)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected launcher to fail without a sidecar")
+	}
+	if !strings.Contains(err.Error(), "cannot start the Claude Code sidecar") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "preloop agents onboard") {
+		t.Fatalf("error %q must include the onboard remediation", err.Error())
+	}
+	if strings.Contains(errOut.String(), "Warning: sidecar") {
+		t.Fatalf("launcher must not warn and continue: %q", errOut.String())
+	}
+	if strings.Contains(err.Error(), "is not listening") {
+		t.Fatalf("dial failure leaked through: %v", err)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("fail-fast took %s; the launcher must not sit in the dial loop", elapsed)
+	}
+}
+
+func TestClaudeNpmGlobalRootsDeduplicatesAndSkipsEmpty(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	roots := claudeNpmGlobalRoots()
+	seen := map[string]bool{}
+	for _, root := range roots {
+		if root == "" {
+			t.Fatal("empty root returned")
+		}
+		if seen[root] {
+			t.Fatalf("duplicate root %q", root)
+		}
+		seen[root] = true
 	}
 }

--- a/cli/internal/cmd/claude_test.go
+++ b/cli/internal/cmd/claude_test.go
@@ -6,7 +6,20 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/preloop/preloop/cli/internal/testenv"
 )
+
+// pinClaudeNpmGlobalRoots overrides the npm global root probe for the duration
+// of a test. Without this, a machine that really has the plugin installed
+// under a fixed prefix such as /opt/homebrew/lib/node_modules would satisfy
+// the package lookup even though PATH and HOME point at temp dirs.
+func pinClaudeNpmGlobalRoots(t *testing.T, roots []string) {
+	t.Helper()
+	previous := claudeNpmGlobalRootsFunc
+	claudeNpmGlobalRootsFunc = func() []string { return roots }
+	t.Cleanup(func() { claudeNpmGlobalRootsFunc = previous })
+}
 
 func TestSupportsAgentControlChannelIncludesClaudeCode(t *testing.T) {
 	if !supportsAgentControlChannel(AgentConfig{Name: "Claude Code"}) {
@@ -230,12 +243,10 @@ func TestFindClaudeSidecarPackageEntryMissingEverywhere(t *testing.T) {
 
 func TestResolveClaudeSidecarInvocationPrefersBinOnPath(t *testing.T) {
 	binDir := t.TempDir()
-	plugin := filepath.Join(binDir, "preloop-claude-plugin")
-	if err := os.WriteFile(plugin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	plugin := writeFakeExecutable(t, binDir, "preloop-claude-plugin")
 	t.Setenv("PATH", binDir)
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetTempHome(t)
+	pinClaudeNpmGlobalRoots(t, []string{t.TempDir()})
 	invocation, err := resolveClaudeSidecarInvocation()
 	if err != nil {
 		t.Fatal(err)
@@ -247,7 +258,8 @@ func TestResolveClaudeSidecarInvocationPrefersBinOnPath(t *testing.T) {
 
 func TestResolveClaudeSidecarInvocationErrorIsActionable(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetTempHome(t)
+	pinClaudeNpmGlobalRoots(t, []string{t.TempDir()})
 	_, err := resolveClaudeSidecarInvocation()
 	if err == nil {
 		t.Fatal("expected an error with no plugin anywhere")
@@ -265,7 +277,8 @@ func TestRunClaudeLauncherFailsFastWithoutSidecar(t *testing.T) {
 	// socket nothing had created and failed 8 seconds later with a confusing
 	// message. The launcher must stop with one actionable error instead.
 	t.Setenv("PATH", t.TempDir())
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetTempHome(t)
+	pinClaudeNpmGlobalRoots(t, []string{t.TempDir()})
 	var out, errOut strings.Builder
 	cmd := claudeCmd
 	cmd.SetOut(&out)

--- a/runtime-plugins/claude-preloop/package.json
+++ b/runtime-plugins/claude-preloop/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepare": "npm run build",
     "verify": "node dist/index.js verify",
     "test": "npm run build && node --test",
     "test:e2e": "npm run build && PRELOOP_LIVE_CLAUDE_SDK=1 node --test test/live-sdk.e2e.mjs"

--- a/runtime-plugins/claude-preloop/src/index.ts
+++ b/runtime-plugins/claude-preloop/src/index.ts
@@ -14,6 +14,8 @@
 // Design memo: factory/roadmap/claude-code-remote-control.md §4 (issue #131).
 
 import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
 
 import WebSocket from "ws";
 
@@ -571,7 +573,25 @@ function parseArgs(): { command: string; configPath?: string } {
   };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Detect direct CLI invocation. npm installs the bin as a SYMLINK
+// (bin/preloop-claude-plugin -> .../dist/index.js) and Node resolves
+// import.meta.url to the realpath of the entry module, while process.argv[1]
+// keeps the symlink path. A naive string comparison therefore fails for every
+// npm-installed bin and the sidecar would exit 0 without ever listening.
+// Realpath argv[1] and compare file URLs instead.
+function invokedAsCli(): boolean {
+  const argv1 = process.argv[1];
+  if (!argv1) {
+    return false;
+  }
+  try {
+    return import.meta.url === pathToFileURL(fs.realpathSync(argv1)).href;
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsCli()) {
   const args = parseArgs();
   const sidecar = new PreloopClaudeSidecar(args.configPath);
   sidecar.setLogger((message) => console.error(message));

--- a/runtime-plugins/claude-preloop/test/cli-entry.test.mjs
+++ b/runtime-plugins/claude-preloop/test/cli-entry.test.mjs
@@ -1,0 +1,59 @@
+// CLI entry detection. npm installs the bin as a symlink
+// (bin/preloop-claude-plugin -> dist/index.js) and Node resolves
+// import.meta.url to the realpath while process.argv[1] keeps the symlink,
+// so the entry guard must realpath argv[1] before comparing. Regression for
+// the sidecar exiting 0 without listening when started through the npm bin.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const entry = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "dist",
+  "index.js",
+);
+
+const validConfig = {
+  enabled: true,
+  protocol: "preloop.agent_control.v1",
+  runtime: "claude_code",
+  control_ws_url: "wss://example.preloop.ai/api/v1/agents/control/ws",
+  bearer_token: "agt_secret",
+  runtime_principal_id: "claude-code-1",
+};
+
+function writeTempConfig() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "preloop-claude-cli-"));
+  const file = path.join(dir, "preloop-control.json");
+  fs.writeFileSync(file, JSON.stringify(validConfig));
+  return { dir, file };
+}
+
+test("verify works when invoked directly", () => {
+  const { file } = writeTempConfig();
+  const result = spawnSync(process.execPath, [entry, "verify", "--config", file], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /verified/);
+});
+
+test("verify works when invoked through a bin-style symlink", () => {
+  const { dir, file } = writeTempConfig();
+  const link = path.join(dir, "preloop-claude-plugin");
+  fs.symlinkSync(entry, link);
+  const result = spawnSync(process.execPath, [link, "verify", "--config", file], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /verified/,
+    "symlinked bin must dispatch the CLI instead of exiting silently",
+  );
+});


### PR DESCRIPTION
## Bug

    $ preloop claude
    Starting Claude Code sidecar...
    Warning: sidecar: preloop-claude-plugin not found; run preloop agents onboard "Claude Code"
    Preloop Claude Control
    Pair: https://preloop.ai/console/agents
    Error: claude sidecar is not listening (~/.preloop/claude-control.sock): dial unix ...: connect: no such file or directory

The CLI warned that the plugin was missing, then proceeded to dial a socket nothing had created and failed again 8 seconds later.

## Root causes (three, stacked)

1. **Launcher swallowed the fatal error.** `runClaudeLauncher` demoted the sidecar start failure to a `Warning:` and continued into `dialClaudeControlSocket`, producing a second, confusing error. The sidecar owns the control socket; without it the dial can never succeed.

2. **Source-folder install produced a package with no executable.** On a dev machine, onboarding prefers the local `runtime-plugins/claude-preloop` checkout and runs `npm install -g <folder>`. npm symlinks the folder as-is: it does not install devDependencies, never builds `dist/`, and then **silently skips creating the `preloop-claude-plugin` bin link** because the declared bin target `dist/index.js` does not exist. Result on the reporting machine: `npm ls -g` showed `@preloop-ai/claude-plugin@0.1.0 -> .../runtime-plugins/claude-preloop` (looks installed) while no executable existed on PATH or anywhere else. That is why the plugin was "not found" despite onboarding having run.

3. **Even a correct install could not create the socket.** `dist/index.js` guarded its CLI dispatch with `import.meta.url === `file://${process.argv[1]}``. Node resolves the ESM entry to its realpath while `argv[1]` keeps the npm bin symlink path, so a properly linked bin failed the guard and exited 0 without ever listening.

## Fix

- `cli/internal/cmd/claude.go`: `preloop claude` now stops with one actionable error when the sidecar cannot start (intended behavior: the sidecar is required; running without it is what raw `claude` is for). The dial-failed error (sidecar started but socket absent) now points at `~/.preloop/logs/claude-sidecar.log`.
- `cli/internal/cmd/claude.go`: discovery is robust to the missing bin link. If `preloop-claude-plugin` is not on PATH or the known fallbacks, the CLI looks for `@preloop-ai/claude-plugin/dist/index.js` under the npm global roots (`npm root -g` plus common prefixes) and runs it with `node`. An installed-but-unbuilt package yields an error naming the broken install and both repair paths.
- `cli/internal/cmd/agents_openclaw.go`: before `npm install -g <source folder>` for Claude Code, the installer builds the source (`npm install` + `npm run build`) so npm links a working bin. Failure is reported as `plugin_source_build_failed` instead of silently installing a broken package.
- `runtime-plugins/claude-preloop/package.json`: added `"prepare": "npm run build"` so git/pack/folder installs build `dist/` themselves.
- `runtime-plugins/claude-preloop/src/index.ts`: CLI entry guard realpaths `argv[1]` and compares file URLs, so npm bin symlinks dispatch correctly.

## Repro / test plan

- Reproduced the exact transcript with a scratch `HOME=/tmp/sidecar-home` and a PATH without the plugin.
- Reproduced the broken install: `npm install -g <source folder>` into a scratch prefix -> symlink, no `dist/`, no bin link.
- After fix: pre-build + global install creates the `preloop-claude-plugin` bin link; `preloop claude` in the scratch HOME starts the sidecar through the symlinked bin, the socket appears, and the launcher proceeds to spawn `claude`.
- Missing plugin now: single error, exit 1, no 8 second dial loop:
  `Error: cannot start the Claude Code sidecar: preloop-claude-plugin was not found on PATH ... run: preloop agents onboard "Claude Code"`
- Installed-but-unbuilt now: `... installed at <dir> but its dist/index.js build output is missing; rerun preloop agents onboard "Claude Code" to rebuild it, or run: npm install -g @preloop-ai/claude-plugin`
- `go test ./cli/...` green (new regression tests for fail-fast, package-entry discovery, actionable errors).
- `npm test` in `runtime-plugins/claude-preloop` green (44 tests, incl. new bin-symlink CLI dispatch regression test).

Do not merge without conductor verification.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Incremental re-review of commit 374c156 found no security issues and no open defects: both previously flagged test-infrastructure gaps are closed with regression tests that were verified green during review, and the full cli/internal suite plus go vet/gofmt are clean.
>
> **Overview**
> Fixes the `preloop claude` startup transcript where a missing or unbuilt sidecar plugin produced a warning followed by a confusing socket dial error. The launcher now fails fast with one actionable message, sidecar discovery falls back to running the package entry under `node`, onboarding builds the source checkout before `npm install -g`, and the CLI entry guard realpaths `argv[1]` so npm bin symlinks dispatch correctly.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 374c156. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->