### PR TITLE
fix: claude sidecar config schema mismatch and silent startup

### DIFF
--- a/cli/internal/cmd/claude.go
+++ b/cli/internal/cmd/claude.go
@@ -126,8 +126,6 @@ func runClaudeLauncher(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 
-	sessionID := ""
-	mode := "local"
 	incoming := make(chan claudeIPCMessage, 8)
 	go readClaudeIPC(conn, incoming)
 
@@ -138,53 +136,79 @@ func runClaudeLauncher(cmd *cobra.Command, args []string) error {
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(signals)
 
+	return runClaudeLauncherLoop(claudeLauncherLoop{
+		out:        cmd.OutOrStdout(),
+		conn:       conn,
+		incoming:   incoming,
+		signals:    signals,
+		spawn:      startClaudeTUI,
+		args:       args,
+		waitRemote: waitForAnyKeyOrRelease,
+	})
+}
+
+// claudeLauncherLoop wires the launcher event loop to its environment so the
+// loop itself is testable without a terminal or a real claude binary.
+type claudeLauncherLoop struct {
+	out        io.Writer
+	conn       net.Conn
+	incoming   chan claudeIPCMessage
+	signals    chan os.Signal
+	spawn      func(extra []string, resumeSessionID string) (*exec.Cmd, error)
+	args       []string
+	waitRemote func(incoming <-chan claudeIPCMessage, signals <-chan os.Signal)
+}
+
+// runClaudeLauncherLoop owns exactly one live TUI child at a time. The TUI is
+// respawned only after this loop itself terminated the previous child (switch
+// to remote, or an explicit release). Informational IPC frames ("status",
+// "session") must NOT respawn: the sidecar sends a status broadcast for every
+// hello/local_ready, and respawning per frame stacked up multiple `claude`
+// children that all stopped on SIGTTIN (the silent-launcher bug).
+func runClaudeLauncherLoop(loop claudeLauncherLoop) error {
+	sessionID := ""
 	for {
-		child, startErr := startClaudeTUI(args, sessionID)
+		child, startErr := loop.spawn(loop.args, sessionID)
 		if startErr != nil {
 			return startErr
 		}
 		childDone := make(chan error, 1)
 		go func() { childDone <- child.Wait() }()
 
-		select {
-		case <-signals:
-			_ = terminateProcess(child, childDone)
-			return nil
-		case waitErr := <-childDone:
-			if waitErr != nil && !isExpectedClaudeExit(waitErr) {
-				return waitErr
-			}
-			return nil
-		case msg := <-incoming:
-			switch msg.Type {
-			case "switch":
+		respawn := false
+		for !respawn {
+			select {
+			case <-loop.signals:
 				_ = terminateProcess(child, childDone)
-				_ = writeClaudeIPC(conn, claudeIPCMessage{Type: "switched", SessionID: sessionID})
-				mode = "remote"
-				if msg.SessionID != "" {
-					sessionID = msg.SessionID
+				return nil
+			case waitErr := <-childDone:
+				if waitErr != nil && !isExpectedClaudeExit(waitErr) {
+					return waitErr
 				}
-				fmt.Fprintln(cmd.OutOrStdout(), "Remote. Press any key to return.")
-				waitForAnyKeyOrRelease(incoming, signals)
-				_ = writeClaudeIPC(conn, claudeIPCMessage{Type: "release", SessionID: sessionID})
-				mode = "local"
-			case "release":
-				_ = terminateProcess(child, childDone)
-				if msg.SessionID != "" {
-					sessionID = msg.SessionID
-				}
-				mode = "local"
-			case "status":
-				if msg.SessionID != "" {
-					sessionID = msg.SessionID
-				}
-				if msg.Mode != "" {
-					mode = msg.Mode
-				}
-				_ = mode
-			case "session":
-				if msg.SessionID != "" {
-					sessionID = msg.SessionID
+				return nil
+			case msg := <-loop.incoming:
+				switch msg.Type {
+				case "switch":
+					_ = terminateProcess(child, childDone)
+					_ = writeClaudeIPC(loop.conn, claudeIPCMessage{Type: "switched", SessionID: sessionID})
+					if msg.SessionID != "" {
+						sessionID = msg.SessionID
+					}
+					fmt.Fprintln(loop.out, "Remote. Press any key to return.")
+					loop.waitRemote(loop.incoming, loop.signals)
+					_ = writeClaudeIPC(loop.conn, claudeIPCMessage{Type: "release", SessionID: sessionID})
+					respawn = true
+				case "release":
+					_ = terminateProcess(child, childDone)
+					if msg.SessionID != "" {
+						sessionID = msg.SessionID
+					}
+					respawn = true
+				case "status", "session":
+					// Bookkeeping only; the current TUI keeps running.
+					if msg.SessionID != "" {
+						sessionID = msg.SessionID
+					}
 				}
 			}
 		}
@@ -204,7 +228,11 @@ func startClaudeTUI(extra []string, resumeSessionID string) (*exec.Cmd, error) {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = claudeSysProcAttr()
+	// No SysProcAttr on purpose: the TUI must inherit the launcher's process
+	// group, which is the terminal's foreground group. Spawning it with
+	// Setpgid put it in a BACKGROUND group, so its first tty read delivered
+	// SIGTTIN and the TUI sat stopped (state T) forever while the launcher
+	// waited silently. Detaching is only for the sidecar daemon.
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}
@@ -335,13 +363,23 @@ func startClaudeSidecarProcess() error {
 		return err
 	}
 	cmd := exec.Command(invocation.bin, append(invocation.args, "run", "--config", claudeControlConfigPath())...)
-	cmd.SysProcAttr = claudeSysProcAttr()
+	cmd.SysProcAttr = claudeSidecarSysProcAttr()
 	logDir := filepath.Dir(claudeSidecarLogPath())
 	_ = os.MkdirAll(logDir, 0o700)
 	stdout, err := os.OpenFile(claudeSidecarLogPath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return err
 	}
+	// A 0-byte log after a real run is indistinguishable from "never ran";
+	// that ambiguity burned a whole debugging session. Record the launch here
+	// so the log is non-empty even if the sidecar dies before its first line.
+	fmt.Fprintf(
+		stdout,
+		"[%s] launcher: starting Claude sidecar: %s %s\n",
+		time.Now().Format(time.RFC3339),
+		invocation.bin,
+		strings.Join(append(invocation.args, "run", "--config", claudeControlConfigPath()), " "),
+	)
 	cmd.Stdout = stdout
 	cmd.Stderr = stdout
 	if err := cmd.Start(); err != nil {

--- a/cli/internal/cmd/claude_launcher_loop_test.go
+++ b/cli/internal/cmd/claude_launcher_loop_test.go
@@ -1,0 +1,173 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// launcherLoopHarness runs runClaudeLauncherLoop against a fake spawner whose
+// children are real processes (sleep), so Wait/terminate semantics are real.
+type launcherLoopHarness struct {
+	spawns   atomic.Int32
+	exited   atomic.Bool
+	incoming chan claudeIPCMessage
+	signals  chan os.Signal
+	done     chan error
+	conn     net.Conn
+	peer     net.Conn
+}
+
+func startLauncherLoopHarness(t *testing.T) *launcherLoopHarness {
+	t.Helper()
+	h := &launcherLoopHarness{
+		incoming: make(chan claudeIPCMessage, 8),
+		signals:  make(chan os.Signal, 1),
+		done:     make(chan error, 1),
+	}
+	h.conn, h.peer = net.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, h.peer) }()
+	t.Cleanup(func() {
+		_ = h.conn.Close()
+		_ = h.peer.Close()
+	})
+	spawn := func(extra []string, resume string) (*exec.Cmd, error) {
+		h.spawns.Add(1)
+		child := exec.Command("sleep", "30")
+		if err := child.Start(); err != nil {
+			return nil, err
+		}
+		return child, nil
+	}
+	go func() {
+		err := runClaudeLauncherLoop(claudeLauncherLoop{
+			out:        io.Discard,
+			conn:       h.conn,
+			incoming:   h.incoming,
+			signals:    h.signals,
+			spawn:      spawn,
+			waitRemote: func(<-chan claudeIPCMessage, <-chan os.Signal) {},
+		})
+		h.exited.Store(true)
+		h.done <- err
+	}()
+	t.Cleanup(func() {
+		if h.exited.Load() {
+			return
+		}
+		select {
+		case h.signals <- syscall.SIGTERM:
+		default:
+		}
+		select {
+		case <-h.done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+	return h
+}
+
+func (h *launcherLoopHarness) waitSpawns(t *testing.T, want int32, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if h.spawns.Load() >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("wanted %d spawns within %s, got %d", want, within, h.spawns.Load())
+}
+
+// The founder bug: every status broadcast from the sidecar respawned a fresh
+// TUI child that immediately stopped on SIGTTIN, leaving several stopped
+// `claude` processes and a silent terminal. Informational frames must never
+// respawn the TUI.
+func TestRunClaudeLauncherLoopDoesNotRespawnOnStatusOrSession(t *testing.T) {
+	h := startLauncherLoopHarness(t)
+	h.waitSpawns(t, 1, 2*time.Second)
+	h.incoming <- claudeIPCMessage{Type: "status", Mode: "local", SessionID: "s1"}
+	h.incoming <- claudeIPCMessage{Type: "session", SessionID: "s2"}
+	h.incoming <- claudeIPCMessage{Type: "status", Mode: "local"}
+	time.Sleep(300 * time.Millisecond)
+	if got := h.spawns.Load(); got != 1 {
+		t.Fatalf("status/session frames respawned the TUI: %d spawns", got)
+	}
+	h.signals <- syscall.SIGTERM
+	select {
+	case err := <-h.done:
+		if err != nil {
+			t.Fatalf("loop returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not exit on signal")
+	}
+}
+
+// A release terminates the current child and respawns exactly one new TUI.
+func TestRunClaudeLauncherLoopRespawnsOnceOnRelease(t *testing.T) {
+	h := startLauncherLoopHarness(t)
+	h.waitSpawns(t, 1, 2*time.Second)
+	h.incoming <- claudeIPCMessage{Type: "release", SessionID: "s9"}
+	h.waitSpawns(t, 2, 3*time.Second)
+	time.Sleep(200 * time.Millisecond)
+	if got := h.spawns.Load(); got != 2 {
+		t.Fatalf("release must respawn exactly once, got %d spawns", got)
+	}
+}
+
+// The TUI must stay in the launcher's process group: that group is the
+// terminal's foreground group, and only foreground processes may read the
+// tty. Setpgid on the TUI child put it in a background group and it stopped
+// on SIGTTIN before drawing anything.
+func TestStartClaudeTUIStaysInLauncherProcessGroup(t *testing.T) {
+	binDir := t.TempDir()
+	script := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	child, err := startClaudeTUI(nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	childDone := make(chan error, 1)
+	go func() { childDone <- child.Wait() }()
+	defer func() { _ = terminateProcess(child, childDone) }()
+
+	pgid, err := syscall.Getpgid(child.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pgid != syscall.Getpgrp() {
+		t.Fatalf(
+			"TUI child pgid %d differs from launcher pgid %d; it would stop on SIGTTIN",
+			pgid,
+			syscall.Getpgrp(),
+		)
+	}
+
+	// Terminating a same-group child must signal only the child, and must
+	// not take down this (launcher) process with a group-wide SIGTERM.
+	if err := terminateProcess(child, childDone); err != nil {
+		t.Fatalf("terminate: %v", err)
+	}
+}
+
+// The sidecar spawn stays detached (its own process group) so Ctrl+C at the
+// launcher terminal never kills the daemon.
+func TestClaudeSidecarSysProcAttrDetaches(t *testing.T) {
+	attr := claudeSidecarSysProcAttr()
+	if attr == nil || !attr.Setpgid {
+		t.Fatalf("sidecar must start in its own process group, got %+v", attr)
+	}
+}

--- a/cli/internal/cmd/claude_test.go
+++ b/cli/internal/cmd/claude_test.go
@@ -321,3 +321,29 @@ func TestClaudeNpmGlobalRootsDeduplicatesAndSkipsEmpty(t *testing.T) {
 		seen[root] = true
 	}
 }
+
+func TestStartClaudeSidecarProcessLogsLaunch(t *testing.T) {
+	// A 0-byte sidecar log after a real run left "sidecar never ran" and
+	// "sidecar ran fine" indistinguishable. The launcher itself must record
+	// every launch in the log, even if the sidecar dies before its first line.
+	binDir := t.TempDir()
+	writeFakeExecutable(t, binDir, "preloop-claude-plugin")
+	t.Setenv("PATH", binDir)
+	testenv.SetTempHome(t)
+	pinClaudeNpmGlobalRoots(t, []string{t.TempDir()})
+
+	if err := startClaudeSidecarProcess(); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		data, err := os.ReadFile(claudeSidecarLogPath())
+		if err == nil && strings.Contains(string(data), "starting Claude sidecar") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sidecar log missing the launch line: err=%v data=%q", err, data)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/cli/internal/cmd/claude_unix.go
+++ b/cli/internal/cmd/claude_unix.go
@@ -36,13 +36,20 @@ func consumeStdinByte(fd int) {
 	_ = syscall.SetNonblock(fd, false)
 }
 
-func claudeSysProcAttr() *syscall.SysProcAttr {
+// claudeSidecarSysProcAttr detaches the sidecar daemon into its own process
+// group so terminal signals (Ctrl+C) never reach it. It must NOT be applied
+// to the TUI child: a new pgroup is a background group on the controlling
+// tty, and the TUI stops on SIGTTIN the moment it reads stdin.
+func claudeSidecarSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setpgid: true}
 }
 
 func terminateClaudeProcess(cmd *exec.Cmd, wait <-chan error) error {
+	// The TUI child shares the launcher's (foreground) process group. Never
+	// signal that group: kill(-pgid) would SIGTERM the launcher itself. Group
+	// signalling is only safe when the child truly has its own group.
 	pgid, err := syscall.Getpgid(cmd.Process.Pid)
-	if err == nil {
+	if err == nil && pgid != syscall.Getpgrp() {
 		_ = syscall.Kill(-pgid, syscall.SIGTERM)
 	} else {
 		_ = cmd.Process.Signal(syscall.SIGTERM)

--- a/cli/internal/cmd/claude_windows.go
+++ b/cli/internal/cmd/claude_windows.go
@@ -118,7 +118,7 @@ func consumeStdinByte(fd int) {
 	_, _ = syscall.Read(syscall.Handle(fd), b[:])
 }
 
-func claudeSysProcAttr() *syscall.SysProcAttr {
+func claudeSidecarSysProcAttr() *syscall.SysProcAttr {
 	return nil
 }
 

--- a/runtime-plugins/claude-preloop/README.md
+++ b/runtime-plugins/claude-preloop/README.md
@@ -47,19 +47,25 @@ Control WebSocket and drives Claude Code through the
 ## Configuration
 
 The sidecar reads `~/.claude/preloop-control.json` (its own file;
-`~/.claude/settings.json` stays reserved for Claude Code's own schema):
+`~/.claude/settings.json` stays reserved for Claude Code's own schema).
+`preloop agents onboard "Claude Code"` writes the settings nested under a
+top-level `"control"` key; a flat file (all keys at the top level) is
+accepted too. A file with neither shape yields no usable settings and the
+sidecar logs a loud warning instead of idling silently.
 
 ```json
 {
-  "enabled": true,
-  "protocol": "preloop.agent_control.v1",
-  "runtime": "claude_code",
-  "control_ws_url": "wss://app.preloop.ai/api/v1/agents/control/ws",
-  "bearer_token": "agt_...",
-  "managed_agent_id": "...",
-  "runtime_principal_id": "claude-code-...",
-  "runtime_principal_name": "Claude Code",
-  "workspace_root": "/path/to/default/workspace"
+  "control": {
+    "enabled": true,
+    "protocol": "preloop.agent_control.v1",
+    "runtime": "claude_code",
+    "control_ws_url": "wss://app.preloop.ai/api/v1/agents/control/ws",
+    "bearer_token": "agt_...",
+    "managed_agent_id": "...",
+    "runtime_principal_id": "claude-code-...",
+    "runtime_principal_name": "Claude Code",
+    "workspace_root": "/path/to/default/workspace"
+  }
 }
 ```
 

--- a/runtime-plugins/claude-preloop/src/config.ts
+++ b/runtime-plugins/claude-preloop/src/config.ts
@@ -43,15 +43,53 @@ export function defaultTranscriptDir(): string {
   return path.join(os.homedir(), ".claude", "projects");
 }
 
-export function loadConfig(configPath?: string): ControlConfig {
+/**
+ * Where the usable settings were found. `preloop agents onboard` writes a
+ * nested `{"control": {...}}` block; the README long documented the flat
+ * shape. Both are accepted on read, and the source is reported so a config
+ * that yields NOTHING usable is loudly distinguishable from a good one
+ * (a silently-empty config idles the sidecar forever).
+ */
+export type ConfigSource = "control-block" | "flat" | "empty";
+
+export type LoadedConfig = {
+  config: ControlConfig;
+  source: ConfigSource;
+  path: string;
+};
+
+/** Keys that mark a config object as carrying real control settings. */
+const USABLE_KEYS: (keyof ControlConfig)[] = [
+  "enabled",
+  "protocol",
+  "runtime",
+  "control_ws_url",
+  "bearer_token",
+  "runtime_principal_id",
+];
+
+export function loadConfigDetailed(configPath?: string): LoadedConfig {
   const resolvedPath = configPath ?? defaultConfigPath();
   const raw = JSON.parse(fs.readFileSync(resolvedPath, "utf8")) as Record<
     string,
     unknown
   >;
   // Accept either a flat file or a nested `control` block.
-  const config = (raw.control ?? raw) as ControlConfig;
-  return config;
+  const nested = raw.control;
+  if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+    return {
+      config: nested as ControlConfig,
+      source: "control-block",
+      path: resolvedPath,
+    };
+  }
+  const flat = raw as ControlConfig;
+  const usable = USABLE_KEYS.some((key) => flat[key] !== undefined);
+  return { config: flat, source: usable ? "flat" : "empty", path: resolvedPath };
+}
+
+export function loadConfig(configPath?: string): ControlConfig {
+  return loadConfigDetailed(configPath).config;
 }
 
 export function verifyConfig(config: ControlConfig): void {

--- a/runtime-plugins/claude-preloop/src/config.ts
+++ b/runtime-plugins/claude-preloop/src/config.ts
@@ -77,9 +77,15 @@ export function loadConfigDetailed(configPath?: string): LoadedConfig {
   // Accept either a flat file or a nested `control` block.
   const nested = raw.control;
   if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+    const nestedCfg = nested as ControlConfig;
+    // A control block with no usable keys is the same ambiguous case as an
+    // empty flat file: classify it "empty" so the loud warning fires.
+    const nestedUsable = USABLE_KEYS.some(
+      (key) => nestedCfg[key] !== undefined,
+    );
     return {
-      config: nested as ControlConfig,
-      source: "control-block",
+      config: nestedCfg,
+      source: nestedUsable ? "control-block" : "empty",
       path: resolvedPath,
     };
   }

--- a/runtime-plugins/claude-preloop/src/index.ts
+++ b/runtime-plugins/claude-preloop/src/index.ts
@@ -196,7 +196,9 @@ export class PreloopClaudeSidecar {
 
     // The URL is loggable (the bearer token travels in a header, never in
     // the URL). The token itself must never be logged.
-    this.log(`Agent Control: connecting to ${wsUrl.href}`);
+    // Log origin + pathname only: control_ws_url is user-supplied and could
+    // embed credentials in its query string; those must never reach the log.
+    this.log(`Agent Control: connecting to ${wsUrl.origin}${wsUrl.pathname}`);
     let socket: WebSocket;
     try {
       socket = new WebSocket(wsUrl, {

--- a/runtime-plugins/claude-preloop/src/index.ts
+++ b/runtime-plugins/claude-preloop/src/index.ts
@@ -23,15 +23,22 @@ import {
   ControlConfig,
   PROTOCOL,
   RUNTIME,
+  defaultConfigPath,
   defaultTranscriptDir,
-  loadConfig,
+  loadConfigDetailed,
   verifyConfig,
 } from "./config.js";
 import { QueryFactory, SessionManager, sdkQueryFactory } from "./sessions.js";
 import { SessionActivity, TranscriptObserver } from "./observer.js";
 import { LauncherBridge, OwnershipMode } from "./mode.js";
 
-export { ControlConfig, loadConfig, verifyConfig } from "./config.js";
+export {
+  ControlConfig,
+  loadConfig,
+  loadConfigDetailed,
+  verifyConfig,
+} from "./config.js";
+export type { ConfigSource, LoadedConfig } from "./config.js";
 export { SessionManager } from "./sessions.js";
 export type { QueryFactory, SdkQueryHandle, SdkMessage, SdkUserMessage } from "./sessions.js";
 export { TranscriptObserver } from "./observer.js";
@@ -108,7 +115,26 @@ export class PreloopClaudeSidecar {
   }
 
   verify(): ControlConfig {
-    const config = this.controlConfig ?? loadConfig(this.configPath);
+    let config = this.controlConfig;
+    if (!config) {
+      const loaded = loadConfigDetailed(this.configPath);
+      this.log(
+        `config: ${loaded.path} (${loaded.source === "control-block" ? 'nested "control" block' : loaded.source + " schema"})`,
+      );
+      if (loaded.source === "empty") {
+        // The whole bug pattern of this saga is silent idling. A config that
+        // yields nothing usable must be LOUD, on stderr, before verifyConfig
+        // fails with a narrower message.
+        const warning =
+          `preloop-control config at ${loaded.path} contains no usable control settings ` +
+          '(expected flat keys or a top-level "control" object); ' +
+          "the sidecar cannot connect to Agent Control. " +
+          'Re-run: preloop agents onboard "Claude Code"';
+        this.log(warning);
+        console.error(warning);
+      }
+      config = loaded.config;
+    }
     verifyConfig(config);
     this.controlConfig = config;
     return config;
@@ -116,6 +142,9 @@ export class PreloopClaudeSidecar {
 
   async start(): Promise<void> {
     this.stopped = false;
+    this.log(
+      `sidecar starting (pid ${process.pid}, config ${this.configPath ?? defaultConfigPath()})`,
+    );
     const config = this.verify();
     if (config.enabled === false) {
       throw new Error("preloop-control is disabled (enabled=false)");
@@ -126,6 +155,7 @@ export class PreloopClaudeSidecar {
       void this.sessions?.release();
     });
     await this.launcher.listen();
+    this.log("launcher control socket listening");
     if (config.observer_enabled !== false) {
       this.observer = new TranscriptObserver(
         config.transcript_dir ?? defaultTranscriptDir(),
@@ -164,6 +194,9 @@ export class PreloopClaudeSidecar {
     // upgrade. That is the scheme Agent Control already prefers; the token
     // stays out of the URL and out of access-log query strings.
 
+    // The URL is loggable (the bearer token travels in a header, never in
+    // the URL). The token itself must never be logged.
+    this.log(`Agent Control: connecting to ${wsUrl.href}`);
     let socket: WebSocket;
     try {
       socket = new WebSocket(wsUrl, {
@@ -179,6 +212,7 @@ export class PreloopClaudeSidecar {
     this.socket = socket;
 
     socket.on("open", () => {
+      this.log("Agent Control: connected; announcing capabilities");
       this.reconnectAttempts = 0;
       this.sendEnvelope({
         type: "presence",
@@ -213,16 +247,19 @@ export class PreloopClaudeSidecar {
       void this.handleFrame(socket, websocketDataToString(data));
     });
 
-    socket.on("close", () => {
+    socket.on("close", (code) => {
+      this.log(`Agent Control: connection closed (code ${code})`);
       this.stopHeartbeat();
       if (this.socket === socket) {
         this.socket = undefined;
       }
       this.scheduleReconnect();
     });
-    socket.on("error", () => {
+    socket.on("error", (error) => {
       // 'error' is followed by 'close'; log and let close drive reconnect.
-      this.log("Preloop Agent Control websocket error");
+      this.log(
+        `Preloop Agent Control websocket error: ${errorMessage(error)}`,
+      );
     });
   }
 
@@ -457,6 +494,7 @@ export class PreloopClaudeSidecar {
       RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempts,
     );
     this.reconnectAttempts += 1;
+    this.log(`Agent Control: reconnecting in ${delay}ms`);
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = undefined;
       this.connect();
@@ -594,7 +632,12 @@ function invokedAsCli(): boolean {
 if (invokedAsCli()) {
   const args = parseArgs();
   const sidecar = new PreloopClaudeSidecar(args.configPath);
-  sidecar.setLogger((message) => console.error(message));
+  // Timestamped stderr: launchd/the launcher redirect stderr to
+  // ~/.preloop/logs/claude-sidecar.log, and a log line without a time is
+  // useless when correlating with launcher runs.
+  sidecar.setLogger((message) =>
+    console.error(`[${new Date().toISOString()}] ${message}`),
+  );
   if (args.command === "verify") {
     sidecar.verify();
     console.log("@preloop-ai/claude-plugin verified");

--- a/runtime-plugins/claude-preloop/test/config.test.mjs
+++ b/runtime-plugins/claude-preloop/test/config.test.mjs
@@ -90,6 +90,17 @@ test("loadConfigDetailed flags a config with no usable settings as empty", () =>
   assert.equal(loaded.source, "empty");
 });
 
+test("a nested control block with no usable keys is empty, not control-block", () => {
+  // Review follow-up on #280: {"control": {}} and {"control": {"unrelated":
+  // true}} are the same ambiguous case as an empty flat file; the loud
+  // warning must fire for them too.
+  for (const control of [{}, { unrelated: true }]) {
+    const file = writeTempConfig({ control });
+    const loaded = loadConfigDetailed(file);
+    assert.equal(loaded.source, "empty");
+  }
+});
+
 test("a nested control block that is an array is not treated as settings", () => {
   const file = writeTempConfig({ control: ["nope"] });
   const loaded = loadConfigDetailed(file);

--- a/runtime-plugins/claude-preloop/test/config.test.mjs
+++ b/runtime-plugins/claude-preloop/test/config.test.mjs
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { loadConfig, verifyConfig } from "../dist/config.js";
+import { loadConfig, loadConfigDetailed, verifyConfig } from "../dist/config.js";
 
 const validConfig = {
   enabled: true,
@@ -65,4 +65,33 @@ test("verify rejects an unknown protocol", () => {
     () => verifyConfig({ ...validConfig, protocol: "preloop.v999" }),
     /Unsupported protocol/,
   );
+});
+
+test("loadConfigDetailed reports the nested control-block source", () => {
+  const file = writeTempConfig({ control: validConfig });
+  const loaded = loadConfigDetailed(file);
+  assert.equal(loaded.source, "control-block");
+  assert.equal(loaded.path, file);
+  assert.equal(loaded.config.runtime, "claude_code");
+});
+
+test("loadConfigDetailed reports the flat source", () => {
+  const file = writeTempConfig(validConfig);
+  const loaded = loadConfigDetailed(file);
+  assert.equal(loaded.source, "flat");
+  assert.equal(loaded.config.bearer_token, "agt_secret");
+});
+
+test("loadConfigDetailed flags a config with no usable settings as empty", () => {
+  // The silent-idle bug: a file that parses fine but carries no control
+  // settings under either shape must be distinguishable from a good one.
+  const file = writeTempConfig({ something_else: true });
+  const loaded = loadConfigDetailed(file);
+  assert.equal(loaded.source, "empty");
+});
+
+test("a nested control block that is an array is not treated as settings", () => {
+  const file = writeTempConfig({ control: ["nope"] });
+  const loaded = loadConfigDetailed(file);
+  assert.equal(loaded.source, "empty");
 });

--- a/runtime-plugins/claude-preloop/test/logging.test.mjs
+++ b/runtime-plugins/claude-preloop/test/logging.test.mjs
@@ -119,6 +119,12 @@ test("start logs startup, socket listen, and WS connect results against a fake s
     assert.match(joined, new RegExp(`connecting to ws://127\\.0\\.0\\.1:${port}/control`));
     assert.match(joined, /Agent Control: connected/);
     assert.ok(!joined.includes(TOKEN), "log must never contain the token");
+    for (const line of lines.filter((l) => l.includes("connecting to"))) {
+      assert.ok(
+        !line.includes("?"),
+        "connect log must carry origin + pathname only, never a query string",
+      );
+    }
   } finally {
     sidecar.stop();
     server.close();

--- a/runtime-plugins/claude-preloop/test/logging.test.mjs
+++ b/runtime-plugins/claude-preloop/test/logging.test.mjs
@@ -1,0 +1,167 @@
+// Sidecar observability: the log must never stay empty across a real run.
+// Startup, config source, and WS connect attempts/results are all logged
+// (never the bearer token), and a config with no usable settings warns
+// loudly instead of idling silently. The WS side runs against a loopback
+// fake server; no live network.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+
+import { WebSocketServer } from "ws";
+
+import { PreloopClaudeSidecar } from "../dist/index.js";
+
+const TOKEN = "agt_fake_token_for_tests";
+
+function writeTempConfig(value) {
+  const dir = fs.mkdtempSync("/tmp/plc-");
+  const file = path.join(dir, "preloop-control.json");
+  fs.writeFileSync(file, JSON.stringify(value));
+  return { dir, file };
+}
+
+function baseConfig(overrides = {}) {
+  return {
+    enabled: true,
+    protocol: "preloop.agent_control.v1",
+    runtime: "claude_code",
+    control_ws_url: "wss://example.preloop.ai/api/v1/agents/control/ws",
+    bearer_token: TOKEN,
+    runtime_principal_id: "claude-code-1",
+    observer_enabled: false,
+    ...overrides,
+  };
+}
+
+test("verify logs the config path and nested schema source", () => {
+  const { file } = writeTempConfig({ control: baseConfig() });
+  const lines = [];
+  const sidecar = new PreloopClaudeSidecar(file);
+  sidecar.setLogger((message) => lines.push(message));
+  sidecar.verify();
+  const joined = lines.join("\n");
+  assert.match(joined, /config: .*preloop-control\.json/);
+  assert.match(joined, /nested "control" block/);
+  assert.ok(!joined.includes(TOKEN), "log must never contain the token");
+});
+
+test("verify logs the flat schema source", () => {
+  const { file } = writeTempConfig(baseConfig());
+  const lines = [];
+  const sidecar = new PreloopClaudeSidecar(file);
+  sidecar.setLogger((message) => lines.push(message));
+  sidecar.verify();
+  assert.match(lines.join("\n"), /flat schema/);
+});
+
+test("a config with no usable settings warns loudly on logger and stderr", () => {
+  const { file } = writeTempConfig({ unrelated: true });
+  const lines = [];
+  const stderrLines = [];
+  const originalError = console.error;
+  console.error = (message) => stderrLines.push(String(message));
+  try {
+    const sidecar = new PreloopClaudeSidecar(file);
+    sidecar.setLogger((message) => lines.push(message));
+    assert.throws(() => sidecar.verify(), /Expected runtime/);
+  } finally {
+    console.error = originalError;
+  }
+  const joined = lines.join("\n");
+  assert.match(joined, /no usable control settings/);
+  assert.match(joined, /preloop agents onboard/);
+  assert.match(stderrLines.join("\n"), /no usable control settings/);
+});
+
+test("start logs startup, socket listen, and WS connect results against a fake server", async () => {
+  // Keep the launcher IPC socket out of the real HOME.
+  const scratchHome = fs.mkdtempSync("/tmp/plc-home-");
+  const originalHome = process.env.HOME;
+  process.env.HOME = scratchHome;
+
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise((resolve) => server.on("listening", resolve));
+  const port = server.address().port;
+  const firstFrame = new Promise((resolve) => {
+    server.on("connection", (socket) => {
+      socket.on("message", (data) => resolve(JSON.parse(String(data))));
+    });
+  });
+
+  const { file } = writeTempConfig({
+    control: baseConfig({
+      control_ws_url: `ws://127.0.0.1:${port}/control`,
+    }),
+  });
+  const lines = [];
+  const sidecar = new PreloopClaudeSidecar(file, async () => {
+    throw new Error("no sessions in this test");
+  });
+  sidecar.setLogger((message) => lines.push(message));
+  try {
+    await sidecar.start();
+    const frame = await firstFrame;
+    assert.equal(frame.type, "presence");
+    assert.equal(frame.name, "capabilities");
+
+    const deadline = Date.now() + 5000;
+    while (
+      !lines.some((line) => line.includes("Agent Control: connected")) &&
+      Date.now() < deadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    const joined = lines.join("\n");
+    assert.match(joined, /sidecar starting \(pid \d+/);
+    assert.match(joined, /nested "control" block/);
+    assert.match(joined, /launcher control socket listening/);
+    assert.match(joined, new RegExp(`connecting to ws://127\\.0\\.0\\.1:${port}/control`));
+    assert.match(joined, /Agent Control: connected/);
+    assert.ok(!joined.includes(TOKEN), "log must never contain the token");
+  } finally {
+    sidecar.stop();
+    server.close();
+    process.env.HOME = originalHome;
+  }
+});
+
+test("a refused WS connection logs the failure and schedules a reconnect", async () => {
+  const scratchHome = fs.mkdtempSync("/tmp/plc-home-");
+  const originalHome = process.env.HOME;
+  process.env.HOME = scratchHome;
+
+  // Grab a port with nothing listening on it.
+  const probe = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise((resolve) => probe.on("listening", resolve));
+  const deadPort = probe.address().port;
+  await new Promise((resolve) => probe.close(resolve));
+
+  const { file } = writeTempConfig({
+    control: baseConfig({
+      control_ws_url: `ws://127.0.0.1:${deadPort}/control`,
+    }),
+  });
+  const lines = [];
+  const sidecar = new PreloopClaudeSidecar(file, async () => {
+    throw new Error("no sessions in this test");
+  });
+  sidecar.setLogger((message) => lines.push(message));
+  try {
+    await sidecar.start();
+    const deadline = Date.now() + 5000;
+    while (
+      !lines.some((line) => line.includes("reconnecting in")) &&
+      Date.now() < deadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    const joined = lines.join("\n");
+    assert.match(joined, /websocket error: .*ECONNREFUSED/);
+    assert.match(joined, /connection closed/);
+    assert.match(joined, /reconnecting in \d+ms/);
+  } finally {
+    sidecar.stop();
+    process.env.HOME = originalHome;
+  }
+});


### PR DESCRIPTION
## Symptoms (founder machine, macOS)

`preloop claude` printed the banner and pairing hint, then nothing: no TUI, no CLI control, agent absent from the console. `~/.preloop/logs/claude-sidecar.log` was 0 bytes; `~/.claude/preloop-control.json` nests everything under a top-level `control` key while the README documented a flat schema.

## Root causes

**1. TUI stopped on SIGTTIN (the silence).** `startClaudeTUI` spawned `claude` with `Setpgid: true`, placing it in a *background* process group on the controlling tty. Its first stdin read delivered SIGTTIN and the TUI sat stopped (state `T`) forever; `child.Wait()` never returned, so the launcher hung silently. Verified live: the hung run had claude children with `PGID != TPGID`, state `T`.

**2. TUI respawn per IPC frame.** The launcher loop spawned a fresh TUI for every informational frame. The sidecar sends one `status` broadcast per `hello`/`local_ready`, so exactly three stopped `claude` children stacked up per run (reproduced).

**3. Silent sidecar.** The sidecar logged nothing on any successful path, and nothing on WS connect attempts. A 0-byte log could mean "never ran" or "ran fine" - undebuggable. A config with no usable settings (neither flat keys nor a `control` block) failed with a cryptic message and no loud warning.

**4. Schema docs mismatch.** `preloop agents onboard` writes `{"control": {...}}` (nested); the plugin README documented flat. The reader already accepts both since #278; the docs and the empty-config behavior did not.

## Fixes

- TUI spawns with **no** `SysProcAttr`: it inherits the launcher's foreground process group. Only the sidecar daemon detaches (`claudeSidecarSysProcAttr`).
- `terminateClaudeProcess` signals a same-group child directly; `kill(-pgid)` is only used when the child truly owns its group (it would otherwise SIGTERM the launcher itself).
- Launcher loop restructured (`runClaudeLauncherLoop`, now testable): exactly one live TUI; `status`/`session` frames update bookkeeping without respawning; respawn only after switch->release or release.
- The Go launcher records every sidecar launch in `~/.preloop/logs/claude-sidecar.log`; the sidecar logs startup, config path + schema source, launcher-socket listen, every WS connect attempt/result, close codes, and reconnect backoff - with timestamps and never the bearer token.
- `loadConfigDetailed` reports the config source (`control-block` / `flat` / `empty`); an empty config warns loudly on the logger and stderr before verification fails.
- README now documents the nested shape onboard writes; flat stays accepted.

## Tests

- Go: `runClaudeLauncherLoop` no-respawn-on-status + respawn-once-on-release against real child processes; TUI stays in launcher pgroup (fake `claude`); same-group terminate safety; sidecar detach attr; launch line lands in the log. `go test ./...` green.
- Plugin: `loadConfigDetailed` sources incl. empty and array-`control`; verify-time schema logging; loud empty-config warning; full WS lifecycle logging against a loopback `WebSocketServer` and a refused-connection port (no live network). `npm test` green (49 pass, 4 pre-existing skips).

End-to-end verified in a scratch HOME with a synthesized config and fake token: one TUI child, foreground pgroup, reads the tty fine; sidecar log fully populated.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, well-tested fix restoring Claude TUI foreground process-group membership, single-TUI respawn semantics, and sidecar observability; no security issues, both prior review suggestions addressed.
>
> **Overview**
> Fixes the silent `preloop claude` launcher (TUI stopped on SIGTTIN + respawn-per-status-frame) and the silent sidecar (no logs, cryptic empty-config failure), aligns the plugin README with the nested `control` config schema, and adds regression tests. Follow-up commit 8b272d75 addressed both review suggestions (query-free connect log, empty nested `control` detection).
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 8b272d75. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->