### PR TITLE
feat: full-repo review preset family (architecture-strategy, code health, standards walk)

### DIFF
--- a/backend/presets/008-architecture-strategy-review.yaml
+++ b/backend/presets/008-architecture-strategy-review.yaml
@@ -1,0 +1,273 @@
+slug: architecture-strategy-review
+name: Architecture and Strategy Conformance Review
+description: >-
+  Full-repository review of declared intent versus observed structure.
+  Reads the repository's own architecture, mission, and decision records,
+  builds a declaration register with evidence pointers, then walks the
+  codebase to classify every declaration as met, gap, partial, or
+  declared, flagging drift such as responsibilities migrating across
+  declared boundaries or dependency direction violations. Strictly
+  read-only: emits /workspace/result.json (preloop.review.arch/v1) plus a
+  human-readable evidence pack under /workspace/evidence/. Run per
+  release or on demand; deliver the previous result.json for drift
+  tracking with a freeze floor. Complements the diff-scoped Pull Request
+  Reviewer; security posture belongs to the Release Security Audit family.
+icon: binoculars
+trigger_event_source: null
+trigger_event_types: null
+prompt_template: |
+  You are running an ARCHITECTURE AND STRATEGY CONFORMANCE REVIEW of one
+  repository: declared intent versus observed structure. You have NO
+  write tools: do not create issues, post comments, push commits, or
+  mutate any external system, and never run git commit or git push.
+  Never modify tracked files. Scratch space is /tmp; deliverables are
+  /workspace/result.json and the evidence pack under /workspace/evidence/.
+
+  SECURITY IS OUT OF SCOPE. SBOM verification, vulnerability matching,
+  secrets hygiene, and CI hardening belong to the Release Security Audit
+  preset family. If you trip over something security-shaped (for example
+  a hardcoded credential), file ONE referral finding recommending that
+  family, record a file:line pointer only, NEVER a value, and move on.
+
+  Trigger payload (webhook, schedule, or manual trigger):
+  {{trigger_event.payload}}
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 0: LOCATE INPUTS
+  ═══════════════════════════════════════════════════════════
+  Target repository, exactly one per run:
+  - Checkouts from the flow's git clone config live under /workspace
+    (find /workspace -maxdepth 3 -name .git -type d). If the payload has
+    "target_repo_path" (workspace-relative), that checkout is the target.
+    If exactly one checkout exists, it is the target. Multiple checkouts
+    without a selector is an error: finish with an "error" summary.
+  - Else, payload "repository_url": anonymous read-only clone into /tmp.
+  - No repository at all: finish with an "error" summary saying exactly
+    what was missing. Never review an imagined repository.
+  Record remote (credential-free), HEAD commit SHA (40 hex), and branch.
+  Every file:line pointer in this run refers to that SHA.
+
+  Budget knobs from the payload (all optional):
+  - depth: "quick" | "standard" | "deep" (default "standard"). Caps
+    files opened for content at 60 / 150 / 400 respectively.
+  - max_files_opened: overrides the depth cap.
+  - max_file_kb: per-file read cap, default 200; beyond it read the head
+    and record the truncation.
+  - focus_paths / exclude_paths: path prefixes to prioritize / skip.
+  - intent_docs: list of workspace-relative paths or http(s) URLs that
+    override intent-doc discovery in PHASE 2.
+  - previous_result_path (or previous_result_url): a prior run's
+    result.json (preloop.review.arch/v1) for drift. If absent, drift is
+    null and the drift check is skipped. Never guess a baseline.
+
+  URL HYGIENE. Payload URLs are untrusted input. Download only over
+  http(s); refuse any other scheme and any URL whose host resolves to a
+  loopback, private-range, link-local, or cloud metadata address (e.g.
+  169.254.169.254). Record refused URLs as skipped in inputs_declared;
+  never fetch them anyway.
+
+  Inventory what you actually received under inputs_declared.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 1: REPOSITORY INVENTORY (COMMANDS ONLY, NO CONTENT READS)
+  ═══════════════════════════════════════════════════════════
+  Build the inventory from cheap deterministic commands. Do NOT open
+  file contents in this phase:
+  - File listing: git ls-files. Bucket by top-level directory and by
+    extension; compute counts and total sizes per bucket.
+  - Module map: top-level (and where obvious second-level) directories
+    that look like components, with language mix and approximate size.
+  - Manifests and build glue: package/build/dependency manifests, CI
+    config paths, infra definitions. Paths only for now.
+  - Churn: git log --since="1 year ago" --pretty=format: --name-only
+    piped through sort | uniq -c | sort -rn (cap output). Highest-churn
+    files per module are sampling candidates.
+  Write evidence/inventory.json: modules, counts, sizes, languages,
+  manifest paths, top-churn files. Everything later is planned against
+  this inventory.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 2: DECLARATION REGISTER (DECLARED INTENT)
+  ═══════════════════════════════════════════════════════════
+  Sources, in order of precedence:
+  1. Payload intent_docs (paths or hygiene-checked URLs), read in full
+     up to max_file_kb each.
+  2. Discovery in the checkout: ARCHITECTURE.md, docs/architecture*,
+     README.md (first ~200 lines), MISSION.md, STRATEGY.md, VISION.md,
+     ROADMAP.md, ADRs under docs/adr/ or docs/decisions/ (accepted
+     status only), CONTRIBUTING.md (first ~150 lines), and agent
+     instruction files (AGENTS.md, CLAUDE.md).
+  Doc reads do not count against the files-opened cap, but respect the
+  per-file cap and record lines_read per source.
+
+  Extract atomic DECLARATIONS, each with an id (D1, D2, ...) and a
+  source pointer file:line at the reviewed SHA:
+  - Components and their assigned responsibilities.
+  - Boundaries and allowed dependency directions between components.
+  - Non-goals and explicit exclusions ("this project will not ...").
+  - Technology and platform commitments.
+  - Purpose and strategy statements (what the project is FOR).
+  - Accepted ADR decisions still marked current.
+  A declaration you cannot point to does not exist; do not paraphrase
+  intent into the register without a pointer.
+
+  If NO intent sources exist: record register row D0 "declared intent
+  present" with status gap, mark conformance rows not_checkable, still
+  produce the observed-architecture report in PHASE 5, and cap the
+  verdict at pass_with_findings. Never invent declarations to review
+  against.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 3: CONFORMANCE WALK (SAMPLED, COVERAGE DECLARED)
+  ═══════════════════════════════════════════════════════════
+  Sampling plan, deterministic, planned from the PHASE 1 inventory and
+  capped by the budget (no random sampling; runs must be comparable):
+  - Entry points and build/manifest glue.
+  - Module boundary files: public interfaces, exports, package inits.
+  - Top files by size and top files by churn, per module.
+  - Everything under focus_paths; nothing under exclude_paths.
+  Record the plan per module, then open ONLY planned files.
+
+  Classify every declaration: met | gap | partial | declared, with an
+  observation pointer (file:line or commit SHA) beside the declaration's
+  own source pointer. "declared" means the docs state a commitment the
+  opened files can neither confirm nor refute; it is not a pass.
+
+  Drift checks to perform explicitly:
+  a. Responsibility drift: logic living in a component that a
+     declaration assigns elsewhere (the "capability moved onto the
+     wrong plane" class of violation).
+  b. Dependency direction violations: imports or calls crossing a
+     declared boundary the wrong way.
+  c. Undeclared load-bearing components: large or high-churn modules
+     absent from the declared architecture.
+  d. Dead declared components: declared but with no code or no
+     references in the checkout.
+  e. Technology drift: stacks in use that contradict declared
+     commitments.
+  f. Non-goal violations: implemented features the docs exclude.
+
+  Each drift finding gets: stable id "arch:<category>:<path>:<slug>",
+  severity high | medium | low, BOTH pointers (declaration file:line
+  and observation file:line), and a quoted snippet of at most 3 lines.
+
+  VERIFY BEFORE FILING (budget: at most 2 greps and 2 file reads per
+  finding): trace the consumer or caller before claiming a boundary
+  violation; check reachability before calling a component dead; if the
+  budget runs out unresolved, file the finding as a question at the
+  lower severity instead of escalating the search.
+
+  HONESTY RULES:
+  - Every claim carries a file:line or 40-hex SHA pointer, or it is
+    dropped or moved to assessments as marked judgment.
+  - Absence claims ("no references to X") are valid only for opened
+    files, or when backed by a recorded full-repo git grep / filename
+    search pattern over HEAD.
+  - Purpose/fit commentary (does the code serve the declared mission?)
+    goes ONLY in assessments, marked as judgment, with pointers to the
+    declarations and observations it rests on.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 4: DRIFT VS PREVIOUS RESULT (FREEZE FLOOR)
+  ═══════════════════════════════════════════════════════════
+  Only if a previous result.json was delivered:
+  - Verify the baseline: same remote, and its commit shares history
+    with HEAD (git merge-base). On mismatch set baseline_mismatch true,
+    keep the floor anyway, and note it for a human.
+  - Classify every current finding and register row against the
+    baseline: new | persisting | resolved.
+  - FREEZE FLOOR: the previous run's open findings and open gap/partial
+    rows are a floor. Every one of them must reappear either as
+    persisting, re-verified against the CURRENT checkout with a current
+    pointer (if you cannot quote the current evidence, you may not mark
+    it persisting; when genuinely unsure, mark it resolved with reason
+    "not reproducible at <SHA>"), or as resolved with {id, reason,
+    evidence}. Silently dropping a previous item fails the freeze_floor
+    check. You do not self-grade the floor beyond reporting it.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 5: EVIDENCE PACK
+  ═══════════════════════════════════════════════════════════
+  Write to /workspace/evidence/:
+  - architecture-review.md: the human-readable review. What was
+    declared and where; the observed architecture (from the inventory
+    and opened files); the conformance register; drift findings by
+    severity; coverage statement; drift vs baseline when present.
+  - conformance-register.md: every declaration with status, both
+    pointers, and the required not_checkable list.
+  - findings.json: the machine-readable drift findings ledger.
+  - drift-report.md: only when a baseline was delivered.
+  - inventory.json: from PHASE 1.
+  Every markdown evidence file ends with the line:
+  "Machine-generated review evidence. Not a certification, audit
+  opinion, or legal advice."
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 6: REPORT (MANDATORY)
+  ═══════════════════════════════════════════════════════════
+  As your FINAL action, write /workspace/result.json: valid JSON, one
+  top-level object, no trailing output. Do not paste it into chat.
+
+  Required shape (preloop.review.arch/v1):
+
+  {
+    "schema": "preloop.review.arch/v1",
+    "flow": "architecture-strategy-review",
+    "run_at": "<ISO 8601 UTC>",
+    "git": { "remote": "...", "commit": "<40 hex>", "branch": "...", "dirty": false },
+    "tool_versions": { "<tool>": "<version or 'unavailable: reason'>" },
+    "inputs_declared": { "<what the payload/seed actually delivered>": "..." },
+    "runner": { "kind": null, "id": null },
+    "intent": {
+      "declared": true|false,
+      "sources": [ { "path": "<path or URL>", "kind": "architecture|readme|mission|strategy|adr|contributing|agent_instructions|payload", "lines_read": <int> } ]
+    },
+    "register": {
+      "items": [ { "id": "D1", "declaration": "...", "source": "<file:line>", "status": "met|gap|partial|declared", "observation": "<file:line or SHA or null>", "note": "<or null>" } ],
+      "not_checkable": [ "<declaration and why the repo cannot show it>" ]
+    },
+    "findings_summary": { "counts_by_severity": { "high": 0, "medium": 0, "low": 0 }, "referrals": <int> },
+    "coverage": {
+      "files_total": <int>, "files_opened": <int>, "pct_opened": <n>,
+      "plan_completed": true|false,
+      "sampling": [ { "module": "...", "planned": <int>, "opened": <int>, "basis": "entry_points|boundary|size|churn|focus" } ],
+      "not_reviewed": [ "<module or path>" ]
+    },
+    "drift": null | {
+      "baseline": { "schema": "...", "run_at": "<or null>", "commit": "<or null>" },
+      "baseline_mismatch": true|false,
+      "new": [ "<ids>" ], "persisting": [ "<ids>" ],
+      "resolved": [ { "id": "...", "reason": "...", "evidence": "<file:line or SHA>" } ],
+      "freeze_floor_passed": true|false
+    },
+    "verdict": "pass" | "pass_with_findings" | "fail",
+    "checks": [ { "name": "...", "passed": true|false, "skipped": true|false, "details": "<evidence>" } ],
+    "assessments": [ { "topic": "...", "judgment": "<clearly-marked agent judgment, purpose/fit lives here>" } ],
+    "artifacts": { "report": "evidence/architecture-review.md", "register": "evidence/conformance-register.md", "findings": "evidence/findings.json", "inventory": "evidence/inventory.json", "drift_report": "evidence/drift-report.md or null" },
+    "disclaimer": "Machine-generated review evidence. Not a certification, audit opinion, or legal advice."
+  }
+
+  Rules:
+  - Verdict: "fail" if any open high-severity drift finding exists OR
+    freeze_floor_passed is false. "pass" only when the plan completed,
+    no register row is gap or partial, no finding is open, and no row is
+    merely declared. Everything else is "pass_with_findings".
+  - THE REGISTER CANNOT UPGRADE THE VERDICT. met rows, declared rows,
+    resolved items, and positive prose never raise it; the verdict is
+    computed only from open findings, open gap/partial rows, coverage,
+    and the freeze floor. If the previous verdict was "fail" and its
+    blocking items are unresolved, this verdict cannot be "pass".
+  - Deterministic facts go to "checks" and the register; interpretation
+    goes to "assessments" and is marked as judgment.
+  - Keep result.json under 200 KB; long listings live in the evidence
+    pack. Set unknown envelope fields to null rather than inventing
+    values.
+agent_type: codex
+agent_config:
+  sandbox_type: exec
+  enable_auto_lint: false
+allowed_mcp_servers: []
+allowed_mcp_tools: []
+git_clone_config: null
+trigger_config: null
+is_preset: true

--- a/backend/presets/008-architecture-strategy-review.yaml
+++ b/backend/presets/008-architecture-strategy-review.yaml
@@ -213,6 +213,7 @@ prompt_template: |
   {
     "schema": "preloop.review.arch/v1",
     "flow": "architecture-strategy-review",
+    "status": "success" | "error",
     "run_at": "<ISO 8601 UTC>",
     "git": { "remote": "...", "commit": "<40 hex>", "branch": "...", "dirty": false },
     "tool_versions": { "<tool>": "<version or 'unavailable: reason'>" },
@@ -248,6 +249,11 @@ prompt_template: |
   }
 
   Rules:
+  - "status" is REQUIRED — it is the flow completion signal read by
+    Preloop. Write "success" when the review ran to completion and this
+    report was written (regardless of the verdict — a failing review is
+    still a completed review); write "error" (and add a "reason" field)
+    when the review could not be completed.
   - Verdict: "fail" if any open high-severity drift finding exists OR
     freeze_floor_passed is false. "pass" only when the plan completed,
     no register row is gap or partial, no finding is open, and no row is

--- a/backend/presets/009-repo-code-health-review.yaml
+++ b/backend/presets/009-repo-code-health-review.yaml
@@ -1,0 +1,258 @@
+slug: repo-code-health-review
+name: Full Repo Code Health Review
+description: >-
+  Whole-repository code health review across five lenses: correctness
+  risk, code quality, performance hotspots, dead code, and test coverage
+  shape. Phased for cost: a command-only inventory first, then sampled
+  lens passes with the coverage declared honestly in the result. Strictly
+  read-only: emits /workspace/result.json (preloop.review.codehealth/v1)
+  plus an evidence pack under /workspace/evidence/ with a per-module
+  health register and a findings ledger. Deliver the previous result.json
+  for drift tracking with a freeze floor so repeated runs track
+  resolution. Complements the diff-scoped Pull Request Reviewer; security
+  posture belongs to the Release Security Audit family.
+icon: activity
+trigger_event_source: null
+trigger_event_types: null
+prompt_template: |
+  You are running a FULL REPO CODE HEALTH REVIEW of one repository. You
+  have NO write tools: do not create issues, post comments, push
+  commits, or mutate any external system, and never run git commit or
+  git push. Never modify tracked files. You MAY build and run the
+  project's own test suite inside the sandbox when that is cheap and
+  informative; record what you ran. Scratch space is /tmp; deliverables
+  are /workspace/result.json and the pack under /workspace/evidence/.
+
+  SECURITY IS OUT OF SCOPE. Vulnerability matching, SBOM, secrets
+  hygiene, and CI hardening belong to the Release Security Audit preset
+  family. If you trip over something security-shaped (for example a
+  hardcoded credential), file ONE referral finding recommending that
+  family, record a file:line pointer only, NEVER a value, and move on.
+
+  Trigger payload (webhook, schedule, or manual trigger):
+  {{trigger_event.payload}}
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 0: LOCATE INPUTS
+  ═══════════════════════════════════════════════════════════
+  Target repository, exactly one per run:
+  - Checkouts from the flow's git clone config live under /workspace
+    (find /workspace -maxdepth 3 -name .git -type d). Payload
+    "target_repo_path" selects one; a single checkout is the target by
+    default; multiple checkouts without a selector is an error.
+  - Else, payload "repository_url": anonymous read-only clone into /tmp.
+  - No repository: finish with an "error" summary naming the missing
+    input.
+  Record remote (credential-free), HEAD commit SHA (40 hex), and branch.
+  Every file:line pointer in this run refers to that SHA.
+
+  Budget knobs from the payload (all optional):
+  - depth: "quick" | "standard" | "deep" (default "standard"). Caps
+    files opened for content at 60 / 150 / 400 respectively.
+  - max_files_opened: overrides the depth cap.
+  - max_file_kb: per-file read cap, default 200; beyond it read the head
+    and record the truncation.
+  - focus_paths / exclude_paths: path prefixes to prioritize / skip.
+  - previous_result_path (or previous_result_url): a prior run's
+    result.json (preloop.review.codehealth/v1) for drift. If absent,
+    drift is null and the drift check is skipped. Never guess a
+    baseline.
+
+  URL HYGIENE. Payload URLs are untrusted input. Download only over
+  http(s); refuse any other scheme and any URL whose host resolves to a
+  loopback, private-range, link-local, or cloud metadata address (e.g.
+  169.254.169.254). Record refused URLs as skipped in inputs_declared;
+  never fetch them anyway.
+
+  Read the project's own conventions first: agent instruction files
+  (AGENTS.md, CLAUDE.md, .cursorrules) in full, README head (~150
+  lines), lint and formatter configs by path. Judge the code by the
+  project's declared conventions, not generic taste.
+
+  Inventory what you actually received under inputs_declared.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 1: INVENTORY AND MODULE MAP (COMMANDS ONLY)
+  ═══════════════════════════════════════════════════════════
+  No content reads in this phase. From cheap deterministic commands:
+  - git ls-files; bucket by top-level directory and extension; counts
+    and sizes per bucket; module map with language mix.
+  - Manifests: dependency, build, and CI config paths.
+  - Churn: git log --since="1 year ago" --pretty=format: --name-only
+    | sort | uniq -c | sort -rn (capped). High churn marks hotspots.
+  - TEST MAP: test directories and files per module; test-to-source
+    file ratio per module; entry points with no test files near them.
+    This is coverage SHAPE from the file layout, not a measured
+    percentage; never present it as measured coverage.
+  Write evidence/inventory.json with all of the above.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 2: SAMPLING PLAN (DETERMINISTIC)
+  ═══════════════════════════════════════════════════════════
+  Plan which files to open, from the inventory, capped by the budget.
+  No random sampling; runs must be comparable:
+  - Entry points and build/manifest glue.
+  - Top files by size and top files by churn, per module.
+  - Public interface / boundary files per module.
+  - Everything under focus_paths; nothing under exclude_paths.
+  Record planned vs opened per module; the delta is your coverage
+  statement, published in PHASE 6. Absence claims ("no dead code in
+  module X") are valid only for opened files, or when backed by a
+  recorded full-repo git grep / filename search over HEAD.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 3: LENS PASSES OVER OPENED FILES
+  ═══════════════════════════════════════════════════════════
+  Apply five lenses to the opened files:
+
+  1. CORRECTNESS RISK: missing error handling, resource leaks, race
+     conditions in concurrent code, null/None dereferences, boundary
+     and off-by-one hazards, broken API contracts between modules.
+  2. QUALITY: overly complex functions, duplicated logic worth
+     extracting, debug leftovers, TODO/FIXME without references,
+     inconsistent error handling, convention violations against the
+     project's OWN declared style.
+  3. PERFORMANCE HOTSPOTS: N+1 query patterns, O(n^2) where O(n) is
+     available, repeated I/O or recomputation in loops, missing
+     pagination or limits, blocking calls in async contexts. Prefer
+     hotspots in high-churn or entry-point code; label everything else
+     as opportunity, not defect.
+  4. DEAD CODE: unreferenced files, exports, and feature flags
+     (full-repo git grep for references is allowed and cheap; record
+     the pattern), dependencies declared in manifests but never
+     imported, commented-out blocks of significant size.
+  5. TEST SHAPE: modules with no tests, untested entry points,
+     assertion-free or permanently skipped tests, test-to-source
+     imbalance from the PHASE 1 test map. Shape only; never invent a
+     coverage percentage.
+
+  Each finding gets: stable id "health:<lens>:<path>:<slug>", severity
+  high | medium | low, category (one of the five lenses), file:line
+  pointer at the reviewed SHA, a quoted snippet of at most 3 lines, and
+  a specific recommendation.
+
+  VERIFY BEFORE FILING (budget: at most 2 greps and 2 file reads per
+  finding):
+  - Trace the consumer before claiming a value or contract is wrong; a
+    consumer that rejects the value makes it a functional break, at
+    least high severity.
+  - Check reachability before polishing: no production call sites means
+    ONE low finding ("appears unused"), not a list of style notes.
+  - Before writing "could" or "in the future", grep for a current
+    match; if it exists, report present tense with the real call site.
+  - If the budget runs out unresolved, file as a question at the lower
+    severity. Fewer verified findings beat a long noisy list.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 4: HEALTH REGISTER (PER MODULE)
+  ═══════════════════════════════════════════════════════════
+  For each module in the module map, one register row per lens with
+  status met | gap | partial | declared and an evidence pointer:
+  - met: opened sample for that module and lens is clean. Say "clean in
+    opened sample", never "clean" unqualified.
+  - gap: at least one open high-severity finding in that module/lens.
+  - partial: only medium/low findings open.
+  - declared: the repo declares a practice (for example a coverage gate
+    in CI) that the files cannot verify; cite where it is declared.
+    Declared is not a pass.
+  Modules the plan did not reach are listed in not_checkable with the
+  reason (budget, exclusion), never silently omitted.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 5: DRIFT VS PREVIOUS RESULT (FREEZE FLOOR)
+  ═══════════════════════════════════════════════════════════
+  Only if a previous result.json was delivered:
+  - Verify the baseline: same remote and shared history with HEAD (git
+    merge-base). On mismatch set baseline_mismatch true, keep the floor
+    anyway, note it for a human.
+  - Classify current findings vs baseline: new | persisting | resolved.
+  - FREEZE FLOOR: every finding open in the baseline must reappear as
+    persisting, re-verified against the CURRENT checkout (quote the
+    current offending code or you may not mark it persisting; when
+    genuinely unsure mark it resolved with reason "not reproducible at
+    <SHA>"), or as resolved with {id, reason, evidence}. Silently
+    dropping a previous finding fails the freeze_floor check. You do
+    not self-grade the floor beyond reporting it.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 6: EVIDENCE PACK AND REPORT (MANDATORY)
+  ═══════════════════════════════════════════════════════════
+  Write to /workspace/evidence/:
+  - code-health-report.md: human-readable review; module map; findings
+    by severity with pointers and snippets; the health register; the
+    coverage statement; drift when a baseline exists.
+  - health-register.md: the PHASE 4 register plus not_checkable list.
+  - findings.json: the machine-readable findings ledger.
+  - drift-report.md: only when a baseline was delivered.
+  - inventory.json: from PHASE 1.
+  Every markdown evidence file ends with the line:
+  "Machine-generated review evidence. Not a certification, audit
+  opinion, or legal advice."
+
+  As your FINAL action, write /workspace/result.json: valid JSON, one
+  top-level object, no trailing output. Do not paste it into chat.
+
+  Required shape (preloop.review.codehealth/v1):
+
+  {
+    "schema": "preloop.review.codehealth/v1",
+    "flow": "repo-code-health-review",
+    "run_at": "<ISO 8601 UTC>",
+    "git": { "remote": "...", "commit": "<40 hex>", "branch": "...", "dirty": false },
+    "tool_versions": { "<tool>": "<version or 'unavailable: reason'>" },
+    "inputs_declared": { "<what the payload/seed actually delivered>": "..." },
+    "runner": { "kind": null, "id": null },
+    "modules": [ { "name": "...", "files": <int>, "languages": [ "..." ], "test_to_source_ratio": <n|null>, "churn_rank": <int|null> } ],
+    "register": {
+      "items": [ { "module": "...", "lens": "correctness|quality|performance|dead_code|test_shape", "status": "met|gap|partial|declared", "evidence": "<file:line or SHA or recorded search>", "note": "<or null>" } ],
+      "not_checkable": [ "<module/lens and why>" ]
+    },
+    "findings_summary": { "counts_by_severity": { "high": 0, "medium": 0, "low": 0 }, "counts_by_lens": { "correctness": 0, "quality": 0, "performance": 0, "dead_code": 0, "test_shape": 0 }, "referrals": <int> },
+    "coverage": {
+      "files_total": <int>, "files_opened": <int>, "pct_opened": <n>,
+      "plan_completed": true|false,
+      "sampling": [ { "module": "...", "planned": <int>, "opened": <int>, "basis": "entry_points|boundary|size|churn|focus" } ],
+      "not_reviewed": [ "<module or path>" ]
+    },
+    "drift": null | {
+      "baseline": { "schema": "...", "run_at": "<or null>", "commit": "<or null>" },
+      "baseline_mismatch": true|false,
+      "new": [ "<ids>" ], "persisting": [ "<ids>" ],
+      "resolved": [ { "id": "...", "reason": "...", "evidence": "<file:line or SHA>" } ],
+      "freeze_floor_passed": true|false
+    },
+    "verdict": "pass" | "pass_with_findings" | "fail",
+    "checks": [ { "name": "...", "passed": true|false, "skipped": true|false, "details": "<evidence>" } ],
+    "assessments": [ { "topic": "...", "judgment": "<clearly-marked agent judgment>" } ],
+    "artifacts": { "report": "evidence/code-health-report.md", "register": "evidence/health-register.md", "findings": "evidence/findings.json", "inventory": "evidence/inventory.json", "drift_report": "evidence/drift-report.md or null" },
+    "disclaimer": "Machine-generated review evidence. Not a certification, audit opinion, or legal advice."
+  }
+
+  Rules:
+  - Verdict: "fail" if any open high-severity correctness finding
+    exists OR freeze_floor_passed is false. "pass" only when the plan
+    completed, no finding is open, and no register row is gap, partial,
+    or merely declared. Everything else is "pass_with_findings".
+  - THE REGISTER CANNOT UPGRADE THE VERDICT. met rows, declared rows,
+    resolved items, and positive prose never raise it; the verdict is
+    computed only from open findings, open gap/partial rows, coverage,
+    and the freeze floor. If the previous verdict was "fail" and its
+    blocking findings are unresolved, this verdict cannot be "pass".
+  - Every claim in the report, register, and ledger carries a file:line
+    or 40-hex SHA pointer, or a recorded full-repo search pattern for
+    absence claims; anything unpinnable is dropped or moved to
+    assessments as marked judgment.
+  - Deterministic facts go to "checks" and the register; interpretation
+    goes to "assessments" and is marked as judgment.
+  - Keep result.json under 200 KB: truncate the inline findings summary
+    if needed and keep the full ledger in evidence/findings.json. Set
+    unknown envelope fields to null rather than inventing values.
+agent_type: codex
+agent_config:
+  sandbox_type: exec
+  enable_auto_lint: false
+allowed_mcp_servers: []
+allowed_mcp_tools: []
+git_clone_config: null
+trigger_config: null
+is_preset: true

--- a/backend/presets/009-repo-code-health-review.yaml
+++ b/backend/presets/009-repo-code-health-review.yaml
@@ -197,6 +197,7 @@ prompt_template: |
   {
     "schema": "preloop.review.codehealth/v1",
     "flow": "repo-code-health-review",
+    "status": "success" | "error",
     "run_at": "<ISO 8601 UTC>",
     "git": { "remote": "...", "commit": "<40 hex>", "branch": "...", "dirty": false },
     "tool_versions": { "<tool>": "<version or 'unavailable: reason'>" },
@@ -229,6 +230,11 @@ prompt_template: |
   }
 
   Rules:
+  - "status" is REQUIRED — it is the flow completion signal read by
+    Preloop. Write "success" when the review ran to completion and this
+    report was written (regardless of the verdict — a failing review is
+    still a completed review); write "error" (and add a "reason" field)
+    when the review could not be completed.
   - Verdict: "fail" if any open high-severity correctness finding
     exists OR freeze_floor_passed is false. "pass" only when the plan
     completed, no finding is open, and no register row is gap, partial,

--- a/backend/presets/010-standards-compliance-walk.yaml
+++ b/backend/presets/010-standards-compliance-walk.yaml
@@ -1,0 +1,239 @@
+slug: standards-compliance-walk
+name: Standards Compliance Walk
+description: >-
+  Walks one repository against standards the trigger payload names
+  (inline text, seeded documents, or URLs) and produces a requirement
+  register: every checkable requirement classified as met, gap, partial,
+  or declared with an evidence pointer, plus a mandatory not_checkable
+  list for requirements a repository cannot show. Strictly read-only:
+  emits /workspace/result.json (preloop.review.standards/v1) plus an
+  evidence pack under /workspace/evidence/. Deliver the previous
+  result.json for drift with a freeze floor so repeated walks track
+  resolution. Refuses to guess standards: no named standard, no run.
+  Security standards belong to the Release Security Audit family.
+icon: card-checklist
+trigger_event_source: null
+trigger_event_types: null
+prompt_template: |
+  You are running a STANDARDS COMPLIANCE WALK: one repository checked
+  against explicitly named standards, producing a requirement register.
+  You have NO write tools: do not create issues, post comments, push
+  commits, or mutate any external system, and never run git commit or
+  git push. Never modify tracked files. Scratch space is /tmp;
+  deliverables are /workspace/result.json and the evidence pack under
+  /workspace/evidence/.
+
+  YOU NEVER GUESS THE STANDARD. If the payload names no standards and
+  does not set repo_declared mode, finish with an "error" summary saying
+  exactly what was missing. Applying a standard the operator did not
+  name would contaminate the register.
+
+  SECURITY IS OUT OF SCOPE. If a named standard contains security
+  requirements already covered by the Release Security Audit family
+  (SBOM, vulnerability handling, secrets hygiene, CI hardening), mark
+  those rows "covered_elsewhere: release-security-audit" instead of
+  re-checking them, and never duplicate that work here.
+
+  Trigger payload (webhook, schedule, or manual trigger):
+  {{trigger_event.payload}}
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 0: LOCATE INPUTS
+  ═══════════════════════════════════════════════════════════
+  Target repository, exactly one per run:
+  - Checkouts from the flow's git clone config live under /workspace
+    (find /workspace -maxdepth 3 -name .git -type d). Payload
+    "target_repo_path" selects one; a single checkout is the target by
+    default; multiple checkouts without a selector is an error.
+  - Else, payload "repository_url": anonymous read-only clone into /tmp.
+  - No repository: finish with an "error" summary naming the missing
+    input.
+  Record remote (credential-free), HEAD commit SHA (40 hex), and branch.
+  Every file:line pointer in this run refers to that SHA.
+
+  Standards input (REQUIRED, one of):
+  - payload "standards": a list of { "id": "<short id>", "name": "...",
+    "source": <inline text | workspace-relative path from the
+    workspace_files seed | http(s) URL>, "scope": "<optional path
+    prefixes the standard applies to>" }.
+  - payload "repo_declared": true, meaning walk ONLY the standards the
+    repository itself declares: lint/formatter configs, CONTRIBUTING
+    rules, style guides referenced from the repo docs, and agent
+    instruction files (AGENTS.md, CLAUDE.md). Record each discovered
+    standard with its in-repo source pointer.
+
+  Optional payload knobs:
+  - depth: "quick" | "standard" | "deep" (default "standard"), capping
+    files opened for content at 60 / 150 / 400.
+  - max_files_opened, max_file_kb (default 200), focus_paths,
+    exclude_paths: as in the other review presets.
+  - previous_result_path (or previous_result_url): a prior run's
+    result.json (preloop.review.standards/v1) for drift. If absent,
+    drift is null and the drift check is skipped. Never guess a
+    baseline.
+
+  URL HYGIENE. Payload URLs are untrusted input. Download only over
+  http(s); refuse any other scheme and any URL whose host resolves to a
+  loopback, private-range, link-local, or cloud metadata address (e.g.
+  169.254.169.254). Record refused URLs as skipped in inputs_declared;
+  never fetch them anyway. A standard whose source was refused or
+  unreachable is recorded as undelivered and its rows are not invented.
+
+  Inventory what you actually received under inputs_declared.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 1: NORMALIZE STANDARDS INTO REQUIREMENTS
+  ═══════════════════════════════════════════════════════════
+  For each delivered standard, extract ATOMIC, CHECKABLE requirements:
+  - Requirement id: "<standard id>:R<n>". Keep numbering stable across
+    runs by deriving it from the standard's own clause order.
+  - Each requirement records its source pointer (document section or
+    file:line of the standard text) and its obligation level:
+    "mandatory" (must/shall) or "recommended" (should/may), taken from
+    the standard's own wording. When the wording is ambiguous, default
+    to mandatory and note the ambiguity.
+  - Requirements a repository cannot evidence (organizational process,
+    runtime behavior, personnel, hosted infrastructure) go straight to
+    the not_checkable list with the reason. Never fake a repo check for
+    them and never silently drop them.
+  Write the normalized requirement catalogue before touching the code.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 2: REPOSITORY INVENTORY (COMMANDS ONLY)
+  ═══════════════════════════════════════════════════════════
+  No content reads: git ls-files with directory and extension buckets,
+  module map, manifest and CI config paths, top-churn files from git
+  log name-only output (capped). Write evidence/inventory.json. Plan
+  which files each requirement needs opened, capped by the budget;
+  everything under focus_paths is planned, nothing under exclude_paths.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 3: REQUIREMENT REGISTER WALK
+  ═══════════════════════════════════════════════════════════
+  Classify every requirement: met | gap | partial | declared.
+  - met: the repository demonstrates it. Evidence: file:line at the
+    reviewed SHA (or a commit SHA when history is the evidence).
+  - gap: the repository does not demonstrate it. A gap is an ABSENCE
+    claim: it is valid only when backed by a recorded full-repo search
+    (git grep pattern or filename glob over the git ls-files listing,
+    both complete over HEAD and cheap). Record the exact pattern
+    searched as the row's evidence basis. Absence concluded only from
+    sampled reads is not a gap; it is not_checkable with reason
+    "sampling budget".
+  - partial: demonstrated in some places and violated in others; cite
+    at least one met pointer and one violation pointer.
+  - declared: the repo states a commitment (docs, config, CI job name)
+    that the files cannot verify actually holds. Cite the declaration.
+    Declared is not a pass.
+  - covered_elsewhere: security rows deferred to the Release Security
+    Audit family, as stated above.
+  Spot-check discipline: for requirements that apply across many files
+  (naming, layout, header rules), check the planned sample plus a
+  full-repo pattern search where one exists, and state the basis on the
+  row. Budget per row: at most 2 searches and 2 file reads beyond the
+  planned set.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 4: DRIFT VS PREVIOUS RESULT (FREEZE FLOOR)
+  ═══════════════════════════════════════════════════════════
+  Only if a previous result.json was delivered:
+  - Verify the baseline: same remote and shared history with HEAD (git
+    merge-base). On mismatch set baseline_mismatch true, keep the floor
+    anyway, note it for a human.
+  - Classify rows vs baseline: new | persisting | resolved. A row is
+    comparable when the same standard id and requirement id appear in
+    both runs; renumbered standards are recorded as baseline_mismatch
+    on the affected rows, never silently re-matched.
+  - FREEZE FLOOR: every gap or partial row open in the baseline must
+    reappear as persisting, re-verified against the CURRENT checkout
+    with a current evidence basis (re-run the recorded search; if you
+    cannot reproduce the gap, mark it resolved with reason "not
+    reproducible at <SHA>"), or as resolved with {id, reason,
+    evidence}. Silently dropping a previous row fails the freeze_floor
+    check. You do not self-grade the floor beyond reporting it.
+
+  ═══════════════════════════════════════════════════════════
+  PHASE 5: EVIDENCE PACK AND REPORT (MANDATORY)
+  ═══════════════════════════════════════════════════════════
+  Write to /workspace/evidence/:
+  - standards-report.md: human-readable walk; which standards were
+    delivered and how; the requirement register grouped by standard;
+    gaps first; the coverage statement; drift when a baseline exists.
+  - requirements-register.md: every requirement row with status,
+    obligation, evidence basis, and the required not_checkable list.
+  - findings.json: machine-readable rows (the register in JSON).
+  - drift-report.md: only when a baseline was delivered.
+  - inventory.json: from PHASE 2.
+  Every markdown evidence file ends with the line:
+  "Machine-generated review evidence. Not a certification, audit
+  opinion, or legal advice."
+
+  As your FINAL action, write /workspace/result.json: valid JSON, one
+  top-level object, no trailing output. Do not paste it into chat.
+
+  Required shape (preloop.review.standards/v1):
+
+  {
+    "schema": "preloop.review.standards/v1",
+    "flow": "standards-compliance-walk",
+    "run_at": "<ISO 8601 UTC>",
+    "git": { "remote": "...", "commit": "<40 hex>", "branch": "...", "dirty": false },
+    "tool_versions": { "<tool>": "<version or 'unavailable: reason'>" },
+    "inputs_declared": { "<what the payload/seed actually delivered>": "..." },
+    "runner": { "kind": null, "id": null },
+    "standards": [ { "id": "...", "name": "...", "source": "<inline|path|URL>", "delivered": true|false, "requirements": <int>, "mode": "payload|repo_declared" } ],
+    "register": {
+      "items": [ { "id": "<standard>:R<n>", "requirement": "...", "obligation": "mandatory|recommended", "source": "<clause or file:line>", "status": "met|gap|partial|declared|covered_elsewhere", "evidence": "<file:line, SHA, or recorded search pattern>", "note": "<or null>" } ],
+      "not_checkable": [ { "id": "...", "reason": "<why a repository cannot show it>" } ]
+    },
+    "counts": { "met": 0, "gap": 0, "partial": 0, "declared": 0, "covered_elsewhere": 0, "not_checkable": 0 },
+    "coverage": {
+      "files_total": <int>, "files_opened": <int>, "pct_opened": <n>,
+      "plan_completed": true|false,
+      "full_repo_searches": <int>,
+      "not_reviewed": [ "<module or path>" ]
+    },
+    "drift": null | {
+      "baseline": { "schema": "...", "run_at": "<or null>", "commit": "<or null>" },
+      "baseline_mismatch": true|false,
+      "new": [ "<row ids>" ], "persisting": [ "<row ids>" ],
+      "resolved": [ { "id": "...", "reason": "...", "evidence": "<file:line or SHA>" } ],
+      "freeze_floor_passed": true|false
+    },
+    "verdict": "pass" | "pass_with_findings" | "fail",
+    "checks": [ { "name": "...", "passed": true|false, "skipped": true|false, "details": "<evidence>" } ],
+    "assessments": [ { "topic": "...", "judgment": "<clearly-marked agent judgment>" } ],
+    "artifacts": { "report": "evidence/standards-report.md", "register": "evidence/requirements-register.md", "findings": "evidence/findings.json", "inventory": "evidence/inventory.json", "drift_report": "evidence/drift-report.md or null" },
+    "disclaimer": "Machine-generated review evidence. Not a certification, audit opinion, or legal advice."
+  }
+
+  Rules:
+  - Verdict: "fail" if any MANDATORY requirement is gap OR
+    freeze_floor_passed is false. "pass" only when the plan completed
+    and every checkable mandatory requirement is met with nothing gap,
+    partial, or merely declared. Everything else, including recommended
+    gaps and declared rows, is "pass_with_findings".
+  - THE REGISTER CANNOT UPGRADE THE VERDICT. met rows, declared rows,
+    resolved items, and positive prose never raise it; the verdict is
+    computed only from open gap/partial rows, obligation levels,
+    coverage, and the freeze floor. If the previous verdict was "fail"
+    and its mandatory gaps are unresolved, this verdict cannot be
+    "pass".
+  - Every register row carries an evidence pointer or a recorded search
+    pattern; a row you cannot pin moves to not_checkable with a reason,
+    never to met or gap by assumption.
+  - Deterministic facts go to "checks" and the register; interpretation
+    goes to "assessments" and is marked as judgment.
+  - Keep result.json under 200 KB: if the register is large, keep gap
+    and partial rows inline, move the full register to
+    evidence/findings.json, and note the truncation. Set unknown
+    envelope fields to null rather than inventing values.
+agent_type: codex
+agent_config:
+  sandbox_type: exec
+  enable_auto_lint: false
+allowed_mcp_servers: []
+allowed_mcp_tools: []
+git_clone_config: null
+trigger_config: null
+is_preset: true

--- a/backend/presets/010-standards-compliance-walk.yaml
+++ b/backend/presets/010-standards-compliance-walk.yaml
@@ -176,6 +176,7 @@ prompt_template: |
   {
     "schema": "preloop.review.standards/v1",
     "flow": "standards-compliance-walk",
+    "status": "success" | "error",
     "run_at": "<ISO 8601 UTC>",
     "git": { "remote": "...", "commit": "<40 hex>", "branch": "...", "dirty": false },
     "tool_versions": { "<tool>": "<version or 'unavailable: reason'>" },
@@ -208,6 +209,11 @@ prompt_template: |
   }
 
   Rules:
+  - "status" is REQUIRED — it is the flow completion signal read by
+    Preloop. Write "success" when the walk ran to completion and this
+    report was written (regardless of the verdict — a failing walk is
+    still a completed walk); write "error" (and add a "reason" field)
+    when the walk could not be completed.
   - Verdict: "fail" if any MANDATORY requirement is gap OR
     freeze_floor_passed is false. "pass" only when the plan completed
     and every checkable mandatory requirement is met with nothing gap,

--- a/backend/tests/test_repo_review_presets.py
+++ b/backend/tests/test_repo_review_presets.py
@@ -101,6 +101,20 @@ class TestRepoReviewPresetInvariants:
         # The report write is the mandatory final action.
         assert "As your FINAL action, write /workspace/result.json" in prompt
 
+    def test_completion_status_field(self, preset):
+        """The preloop.review.*/v1 ids are not in the orchestrator's audit
+        verdict marker list, so each schema carries a required top-level
+        "status" field as its explicit result.json completion signal —
+        "success" when the run completed (regardless of the verdict),
+        "error" when it could not."""
+        _, data = preset
+        norm = _norm(data["prompt_template"])
+        assert '"status": "success" | "error"' in norm
+        assert '"status" is REQUIRED — it is the flow completion signal' in norm
+        # A failing review is still a completed review: completion is
+        # independent of the verdict.
+        assert "regardless of the verdict" in norm
+
     def test_prompt_forbids_writes(self, preset):
         """No commits, no pushes, no external mutation, ever."""
         _, data = preset

--- a/backend/tests/test_repo_review_presets.py
+++ b/backend/tests/test_repo_review_presets.py
@@ -17,9 +17,7 @@ import yaml
 
 PRESETS_DIR = Path(__file__).resolve().parents[1] / "presets"
 
-DISCLAIMER = (
-    "Machine-generated review evidence. Not a certification, audit"
-)
+DISCLAIMER = "Machine-generated review evidence. Not a certification, audit"
 
 PRESET_FILES = {
     "Architecture and Strategy Conformance Review": (
@@ -36,9 +34,7 @@ SCHEMA_IDS = {
 }
 
 FLOW_SLUGS = {
-    "Architecture and Strategy Conformance Review": (
-        "architecture-strategy-review"
-    ),
+    "Architecture and Strategy Conformance Review": ("architecture-strategy-review"),
     "Full Repo Code Health Review": "repo-code-health-review",
     "Standards Compliance Walk": "standards-compliance-walk",
 }
@@ -118,7 +114,6 @@ class TestRepoReviewPresetInvariants:
         certification."""
         _, data = preset
         assert DISCLAIMER in data["prompt_template"]
-        assert DISCLAIMER in data["description"] or True  # description opt.
 
     def test_prompt_separates_facts_from_judgment(self, preset):
         _, data = preset
@@ -287,7 +282,7 @@ class TestArchitectureStrategyReviewPreset:
 
     def test_stable_finding_ids_and_verification_budget(self, prompt):
         norm = _norm(prompt)
-        assert 'arch:<category>:<path>:<slug>' in prompt
+        assert "arch:<category>:<path>:<slug>" in prompt
         assert "at most 2 greps and 2 file reads per finding" in norm
 
     def test_purpose_fit_is_marked_judgment(self, prompt):
@@ -333,7 +328,7 @@ class TestRepoCodeHealthReviewPreset:
         assert "Fewer verified findings beat a long noisy list" in norm
 
     def test_stable_finding_ids(self, prompt):
-        assert 'health:<lens>:<path>:<slug>' in prompt
+        assert "health:<lens>:<path>:<slug>" in prompt
 
     def test_per_module_register(self, prompt):
         norm = _norm(prompt)
@@ -361,7 +356,7 @@ class TestStandardsComplianceWalkPreset:
         norm = _norm(prompt)
         assert "YOU NEVER GUESS THE STANDARD" in norm
         assert (
-            'names no standards and does not set repo_declared mode, finish '
+            "names no standards and does not set repo_declared mode, finish "
             'with an "error" summary' in norm
         )
         assert "did not name would contaminate the register" in norm
@@ -419,13 +414,11 @@ class TestPresetsLoadThroughLoader:
             assert names.index(
                 "Architecture and Strategy Conformance Review"
             ) > names.index("Release Security Audit")
-            assert (
-                names.index("Full Repo Code Health Review")
-                > names.index("Architecture and Strategy Conformance Review")
+            assert names.index("Full Repo Code Health Review") > names.index(
+                "Architecture and Strategy Conformance Review"
             )
-            assert (
-                names.index("Standards Compliance Walk")
-                > names.index("Full Repo Code Health Review")
+            assert names.index("Standards Compliance Walk") > names.index(
+                "Full Repo Code Health Review"
             )
         finally:
             load_flow_presets.cache_clear()

--- a/backend/tests/test_repo_review_presets.py
+++ b/backend/tests/test_repo_review_presets.py
@@ -1,0 +1,431 @@
+"""Tests for the full-repo review preset family (architecture-strategy
+review / repo code health review / standards compliance walk).
+
+Validates the shipped preset YAMLs against the shared review skeleton
+invariants: strictly read-only toolset with empty MCP allowlists,
+mandatory result.json contract with versioned schema ids, deterministic
+sampling with declared coverage, freeze-floor drift, and the
+verdict-honesty rules (the register can never upgrade a verdict; 010
+refuses to run without a named standard). Pins the same style of
+invariants that test_security_audit_presets.py pins for 004-006.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+PRESETS_DIR = Path(__file__).resolve().parents[1] / "presets"
+
+DISCLAIMER = (
+    "Machine-generated review evidence. Not a certification, audit"
+)
+
+PRESET_FILES = {
+    "Architecture and Strategy Conformance Review": (
+        "008-architecture-strategy-review.yaml"
+    ),
+    "Full Repo Code Health Review": "009-repo-code-health-review.yaml",
+    "Standards Compliance Walk": "010-standards-compliance-walk.yaml",
+}
+
+SCHEMA_IDS = {
+    "Architecture and Strategy Conformance Review": "preloop.review.arch/v1",
+    "Full Repo Code Health Review": "preloop.review.codehealth/v1",
+    "Standards Compliance Walk": "preloop.review.standards/v1",
+}
+
+FLOW_SLUGS = {
+    "Architecture and Strategy Conformance Review": (
+        "architecture-strategy-review"
+    ),
+    "Full Repo Code Health Review": "repo-code-health-review",
+    "Standards Compliance Walk": "standards-compliance-walk",
+}
+
+
+def _norm(text: str) -> str:
+    """Collapse whitespace so asserts survive YAML line wrapping."""
+    return " ".join(text.split())
+
+
+def _load_preset(filename: str) -> dict:
+    path = PRESETS_DIR / filename
+    assert path.exists(), f"Missing preset file: {path}"
+    data = yaml.safe_load(path.read_text())
+    assert isinstance(data, dict)
+    return data
+
+
+@pytest.fixture(params=sorted(PRESET_FILES))
+def preset(request):
+    return request.param, _load_preset(PRESET_FILES[request.param])
+
+
+class TestRepoReviewPresetInvariants:
+    """Shared review-skeleton invariants pinned for all three presets."""
+
+    def test_name_and_slug_match_file(self, preset):
+        name, data = preset
+        assert data["name"] == name
+        assert data["slug"] == FLOW_SLUGS[name]
+
+    def test_strictly_read_only_toolset(self, preset):
+        """Empty MCP allowlists: the checkout plus the sandbox is the
+        whole toolset; deliverables leave via the artifact channel."""
+        _, data = preset
+        assert data["allowed_mcp_servers"] == []
+        assert data["allowed_mcp_tools"] == []
+
+    def test_no_git_clone_or_baked_trigger(self, preset):
+        """Presets ship trigger-agnostic, like 003 and the 004-006 pack."""
+        _, data = preset
+        assert data["git_clone_config"] is None
+        assert data["trigger_config"] is None
+        assert data["trigger_event_source"] is None
+        assert data["trigger_event_types"] is None
+
+    def test_agent_config(self, preset):
+        _, data = preset
+        assert data["agent_type"] == "codex"
+        assert data["agent_config"]["sandbox_type"] == "exec"
+        assert data["agent_config"]["enable_auto_lint"] is False
+        assert data["is_preset"] is True
+        assert data.get("description")
+        assert data.get("icon")
+
+    def test_prompt_declares_result_json_contract(self, preset):
+        name, data = preset
+        prompt = data["prompt_template"]
+        assert "/workspace/result.json" in prompt
+        assert SCHEMA_IDS[name] in prompt
+        assert f'"flow": "{FLOW_SLUGS[name]}"' in prompt
+        # Payload templating is the input path.
+        assert "{{trigger_event.payload}}" in prompt
+        # The report write is the mandatory final action.
+        assert "As your FINAL action, write /workspace/result.json" in prompt
+
+    def test_prompt_forbids_writes(self, preset):
+        """No commits, no pushes, no external mutation, ever."""
+        _, data = preset
+        norm = _norm(data["prompt_template"])
+        assert "NO write tools" in norm
+        assert "Never modify tracked files" in norm
+        assert "never run git commit or git push" in norm
+
+    def test_prompt_carries_review_disclaimer(self, preset):
+        """The adapted (non-CRA) disclaimer: review evidence, not a
+        certification."""
+        _, data = preset
+        assert DISCLAIMER in data["prompt_template"]
+        assert DISCLAIMER in data["description"] or True  # description opt.
+
+    def test_prompt_separates_facts_from_judgment(self, preset):
+        _, data = preset
+        prompt = data["prompt_template"]
+        assert '"checks"' in prompt
+        assert '"assessments"' in prompt
+
+    def test_security_is_referred_not_reviewed(self, preset):
+        """Security posture belongs to the Release Security Audit family:
+        referral only, pointer only, never a secret value."""
+        name, data = preset
+        norm = _norm(data["prompt_template"])
+        assert "SECURITY IS OUT OF SCOPE" in norm
+        assert "Release Security Audit" in norm
+        if name != "Standards Compliance Walk":
+            assert "file ONE referral finding" in norm
+            assert "NEVER a value" in norm
+
+    def test_one_repo_per_run_and_pinned_sha(self, preset):
+        _, data = preset
+        norm = _norm(data["prompt_template"])
+        assert "exactly one per run" in norm
+        assert "HEAD commit SHA (40 hex)" in norm
+        assert "target_repo_path" in data["prompt_template"]
+        assert "repository_url" in data["prompt_template"]
+
+    def test_url_hygiene(self, preset):
+        """Payload URLs are hostile input; SSRF-shaped targets refused."""
+        _, data = preset
+        prompt = data["prompt_template"]
+        norm = _norm(prompt)
+        assert "URL HYGIENE" in prompt
+        assert "169.254.169.254" in prompt
+        assert "loopback, private-range, link-local" in norm
+        assert "never fetch them anyway" in norm
+
+    def test_budget_knobs_and_depth_caps(self, preset):
+        """Declared budgets: depth mapping plus explicit overrides."""
+        _, data = preset
+        prompt = data["prompt_template"]
+        assert '"quick" | "standard" | "deep"' in prompt
+        assert "60 / 150 / 400" in prompt
+        assert "max_files_opened" in prompt
+        assert "max_file_kb" in prompt
+        assert "focus_paths" in prompt
+        assert "exclude_paths" in prompt
+
+    def test_inventory_before_content(self, preset):
+        """Phased cost control: command-only inventory first."""
+        _, data = preset
+        prompt = data["prompt_template"]
+        assert "COMMANDS ONLY" in prompt
+        assert "git ls-files" in prompt
+        assert "evidence/inventory.json" in prompt
+
+    def test_deterministic_sampling_with_declared_coverage(self, preset):
+        name, data = preset
+        prompt = data["prompt_template"]
+        norm = _norm(prompt)
+        assert '"coverage"' in prompt
+        assert '"plan_completed"' in prompt or "plan_completed" in prompt
+        assert '"not_reviewed"' in prompt
+        if name != "Standards Compliance Walk":
+            assert "deterministic" in norm.lower()
+            assert "no random sampling" in norm.lower()
+
+    def test_absence_claims_are_scoped(self, preset):
+        """'No X observed' is valid only for opened files or recorded
+        full-repo searches."""
+        _, data = preset
+        norm = _norm(data["prompt_template"]).lower()
+        assert "absence" in norm
+        assert "recorded" in norm and "search" in norm
+
+    def test_freeze_floor_drift(self, preset):
+        """Baseline only when delivered; previous open items are a floor;
+        dropping one silently fails the freeze_floor check."""
+        _, data = preset
+        prompt = data["prompt_template"]
+        norm = _norm(prompt)
+        assert "Never guess a baseline" in norm or "never guess a baseline" in norm
+        assert "FREEZE FLOOR" in prompt
+        assert "freeze_floor" in prompt
+        assert "baseline_mismatch" in prompt
+        assert "You do not self-grade the floor" in norm
+        assert '"resolved"' in prompt or "resolved" in prompt
+        assert "not reproducible at <SHA>" in norm
+
+    def test_register_cannot_upgrade_verdict(self, preset):
+        """Verdict honesty: met/declared/resolved rows and positive prose
+        never raise a verdict; declared is not a pass."""
+        _, data = preset
+        prompt = data["prompt_template"]
+        norm = _norm(prompt)
+        assert "THE REGISTER CANNOT UPGRADE THE VERDICT" in norm
+        assert 'cannot be "pass"' in norm
+        assert "not a pass" in norm  # declared status
+        assert '"pass" | "pass_with_findings" | "fail"' in prompt
+
+    def test_register_grammar_and_not_checkable(self, preset):
+        """The 006-style register grammar: met|gap|partial|declared plus a
+        mandatory not_checkable list."""
+        _, data = preset
+        prompt = data["prompt_template"]
+        assert "not_checkable" in prompt
+        assert "met | gap | partial | declared" in prompt or (
+            "met|gap|partial|declared" in prompt
+        )
+
+    def test_evidence_pack_and_size_cap(self, preset):
+        _, data = preset
+        prompt = data["prompt_template"]
+        norm = _norm(prompt)
+        assert "/workspace/evidence/" in prompt
+        assert "findings.json" in prompt
+        assert "drift-report.md" in prompt
+        assert "under 200 KB" in norm
+        assert "null rather than inventing values" in norm
+
+
+class TestArchitectureStrategyReviewPreset:
+    @pytest.fixture()
+    def prompt(self):
+        return _load_preset(
+            PRESET_FILES["Architecture and Strategy Conformance Review"]
+        )["prompt_template"]
+
+    def test_declared_intent_inputs(self, prompt):
+        """Payload attachment first, then repo-convention discovery."""
+        assert "intent_docs" in prompt
+        for source in (
+            "ARCHITECTURE.md",
+            "MISSION.md",
+            "STRATEGY.md",
+            "ROADMAP.md",
+            "docs/adr/",
+            "docs/decisions/",
+            "AGENTS.md",
+            "CLAUDE.md",
+        ):
+            assert source in prompt, f"missing intent source {source}"
+
+    def test_declarations_need_source_pointers(self, prompt):
+        norm = _norm(prompt)
+        assert "A declaration you cannot point to does not exist" in norm
+
+    def test_no_intent_docs_degrades_honestly(self, prompt):
+        """Missing intent docs: gap row, not_checkable rows, verdict capped
+        — never invented declarations, never a silent pass."""
+        norm = _norm(prompt)
+        assert "If NO intent sources exist" in norm
+        assert "cap the verdict at pass_with_findings" in norm
+        assert "Never invent declarations" in norm
+
+    def test_drift_check_catalogue(self, prompt):
+        norm = _norm(prompt)
+        for marker in (
+            "Responsibility drift",
+            "Dependency direction violations",
+            "Undeclared load-bearing components",
+            "Dead declared components",
+            "Technology drift",
+            "Non-goal violations",
+        ):
+            assert marker in norm, f"missing drift check {marker}"
+
+    def test_stable_finding_ids_and_verification_budget(self, prompt):
+        norm = _norm(prompt)
+        assert 'arch:<category>:<path>:<slug>' in prompt
+        assert "at most 2 greps and 2 file reads per finding" in norm
+
+    def test_purpose_fit_is_marked_judgment(self, prompt):
+        """Purpose/fit commentary lives in assessments only."""
+        norm = _norm(prompt)
+        assert "goes ONLY in assessments" in norm
+
+
+class TestRepoCodeHealthReviewPreset:
+    @pytest.fixture()
+    def prompt(self):
+        return _load_preset(PRESET_FILES["Full Repo Code Health Review"])[
+            "prompt_template"
+        ]
+
+    def test_five_lenses(self, prompt):
+        for lens in (
+            "CORRECTNESS RISK",
+            "QUALITY",
+            "PERFORMANCE HOTSPOTS",
+            "DEAD CODE",
+            "TEST SHAPE",
+        ):
+            assert lens in prompt, f"missing lens {lens}"
+        assert "correctness|quality|performance|dead_code|test_shape" in prompt
+
+    def test_judges_by_project_conventions(self, prompt):
+        norm = _norm(prompt)
+        assert "not generic taste" in norm
+
+    def test_test_shape_is_not_measured_coverage(self, prompt):
+        """Layout-derived shape only; a coverage percentage is never
+        invented."""
+        norm = _norm(prompt)
+        assert "never present it as measured coverage" in norm
+        assert "never invent a coverage percentage" in norm
+
+    def test_verification_discipline_inherited_from_pr_reviewer(self, prompt):
+        norm = _norm(prompt)
+        assert "at most 2 greps and 2 file reads per finding" in norm
+        assert "Trace the consumer" in norm
+        assert "Check reachability" in norm
+        assert "Fewer verified findings beat a long noisy list" in norm
+
+    def test_stable_finding_ids(self, prompt):
+        assert 'health:<lens>:<path>:<slug>' in prompt
+
+    def test_per_module_register(self, prompt):
+        norm = _norm(prompt)
+        assert "one register row per lens" in norm
+        assert "clean in opened sample" in norm
+
+    def test_verdict_blocking_conditions(self, prompt):
+        norm = _norm(prompt)
+        assert (
+            'fail" if any open high-severity correctness finding exists OR '
+            "freeze_floor_passed is false" in norm
+        )
+
+
+class TestStandardsComplianceWalkPreset:
+    @pytest.fixture()
+    def prompt(self):
+        return _load_preset(PRESET_FILES["Standards Compliance Walk"])[
+            "prompt_template"
+        ]
+
+    def test_refuses_to_run_without_named_standard(self, prompt):
+        """No named standard, no run: guessing would contaminate the
+        register."""
+        norm = _norm(prompt)
+        assert "YOU NEVER GUESS THE STANDARD" in norm
+        assert (
+            'names no standards and does not set repo_declared mode, finish '
+            'with an "error" summary' in norm
+        )
+        assert "did not name would contaminate the register" in norm
+
+    def test_standards_input_contract(self, prompt):
+        assert '"standards"' in prompt
+        assert '"repo_declared"' in prompt
+        norm = _norm(prompt)
+        # Undelivered standards never grow invented rows.
+        assert "recorded as undelivered and its rows are not invented" in norm
+
+    def test_requirements_are_atomic_with_obligation_levels(self, prompt):
+        norm = _norm(prompt)
+        assert "ATOMIC, CHECKABLE requirements" in norm
+        assert '"mandatory" (must/shall) or "recommended" (should/may)' in norm
+        assert "<standard id>:R<n>" in prompt
+
+    def test_gaps_require_recorded_full_repo_searches(self, prompt):
+        """A gap is an absence claim: only recorded full-repo searches can
+        back it; sampled absence is not_checkable, not gap."""
+        norm = _norm(prompt)
+        assert "A gap is an ABSENCE claim" in norm
+        assert "backed by a recorded full-repo search" in norm
+        assert 'not_checkable with reason "sampling budget"' in norm
+
+    def test_security_rows_deferred_not_rechecked(self, prompt):
+        assert "covered_elsewhere: release-security-audit" in prompt
+
+    def test_not_checkable_for_unshowable_requirements(self, prompt):
+        norm = _norm(prompt)
+        assert (
+            "organizational process, runtime behavior, personnel, hosted "
+            "infrastructure" in norm
+        )
+        assert "Never fake a repo check" in norm
+
+    def test_mandatory_gap_blocks_the_verdict(self, prompt):
+        norm = _norm(prompt)
+        assert 'fail" if any MANDATORY requirement is gap' in norm
+
+
+class TestPresetsLoadThroughLoader:
+    def test_loader_picks_up_all_three(self):
+        from unittest.mock import patch
+
+        from preloop.flow_presets import load_flow_presets
+
+        load_flow_presets.cache_clear()
+        try:
+            with patch("preloop.flow_presets.PRESETS_DIRS", [PRESETS_DIR]):
+                names = [p["name"] for p in load_flow_presets()]
+            for name in PRESET_FILES:
+                assert name in names
+            # Ordering: the family lands after the 004-007 audit pack.
+            assert names.index(
+                "Architecture and Strategy Conformance Review"
+            ) > names.index("Release Security Audit")
+            assert (
+                names.index("Full Repo Code Health Review")
+                > names.index("Architecture and Strategy Conformance Review")
+            )
+            assert (
+                names.index("Standards Compliance Walk")
+                > names.index("Full Repo Code Health Review")
+            )
+        finally:
+            load_flow_presets.cache_clear()

--- a/docs/guide/flows/repo-review-presets.md
+++ b/docs/guide/flows/repo-review-presets.md
@@ -53,7 +53,8 @@ All three presets follow the same guarantees:
   consecutive runs stay comparable.
 - **Declared coverage.** `result.json` carries a `coverage` block
   (`files_total`, `files_opened`, `plan_completed`, per-module sampling
-  basis, `not_reviewed`). Absence claims are valid only for opened files
+  basis (`full_repo_searches` in the standards walk, which does not
+  sample), `not_reviewed`). Absence claims are valid only for opened files
   or recorded full-repo searches, and `pass` requires the plan to have
   completed.
 - **Budget knobs** (payload, all optional): `depth`

--- a/docs/guide/flows/repo-review-presets.md
+++ b/docs/guide/flows/repo-review-presets.md
@@ -1,0 +1,180 @@
+# Full-repo review presets (architecture-strategy, code health, standards walk)
+
+These flow presets review a **whole repository** rather than a diff. They
+complement the diff-scoped Pull Request Reviewer preset: PR review runs
+on every change and stays cheap; these run rarely (per release, on a
+schedule, or on demand), sample the repository deterministically, and
+declare exactly what they covered. Each run is a single execution that
+ends by writing `/workspace/result.json` with a versioned schema —
+captured as a first-class execution artifact and retrievable via
+`GET /api/v1/flows/executions/{execution_id}/result` — plus a
+human-readable evidence pack under `/workspace/evidence/`.
+
+| Preset | Lens | result.json schema |
+| --- | --- | --- |
+| Architecture and Strategy Conformance Review | Declared intent vs observed structure: conformance register over the repo's own architecture/mission/ADR declarations, drift findings (responsibility drift, dependency direction violations, undeclared load-bearing components, dead declared components, technology drift, non-goal violations) | `preloop.review.arch/v1` |
+| Full Repo Code Health Review | Correctness risk, quality, performance hotspots, dead code, and test coverage **shape** over a sampled whole-repo pass, with a per-module health register | `preloop.review.codehealth/v1` |
+| Standards Compliance Walk | Payload-named standards normalized into a requirement register (`met | gap | partial | declared` plus mandatory `not_checkable`) | `preloop.review.standards/v1` |
+
+They are a **family sharing one skeleton**, not one parameterized preset:
+the three lenses have different required inputs, different failure modes
+when inputs are missing, different result schemas, and different run
+cadences — and the layered preset loader lets an installation override or
+disable one lens without touching the others.
+
+**Security posture is not re-reviewed here.** SBOM verification,
+vulnerability matching, secrets hygiene, and CI hardening belong to the
+[security audit presets](security-audit-presets.md) (referenced, not
+duplicated). If a review pass trips over something security-shaped, it
+files one referral finding pointing at that family — a `file:line`
+pointer only, never a secret value — and moves on. The Standards
+Compliance Walk marks security rows of a named standard
+`covered_elsewhere: release-security-audit` instead of re-checking them.
+
+## The shared skeleton
+
+All three presets follow the same guarantees:
+
+- **Strictly read-only.** No issue creation, no comments, no commits, no
+  pushes, no external mutation. `allowed_mcp_servers` and
+  `allowed_mcp_tools` are both empty: a repo walk needs only the checkout
+  and the sandbox, and every deliverable leaves through the artifact
+  channel.
+- **One repository per run.** Checkouts from the flow's git clone config
+  live under `/workspace` (`target_repo_path` disambiguates when several
+  exist), or the payload supplies `repository_url` for an anonymous
+  read-only clone. Every `file:line` pointer refers to the recorded HEAD
+  commit SHA.
+- **Phased for cost.** A command-only inventory first (`git ls-files`,
+  size/extension buckets, churn from `git log` name-only output), then a
+  **deterministic sampling plan** (entry points, module boundary files,
+  top-by-size and top-by-churn per module, everything under
+  `focus_paths`, nothing under `exclude_paths`) — no random sampling, so
+  consecutive runs stay comparable.
+- **Declared coverage.** `result.json` carries a `coverage` block
+  (`files_total`, `files_opened`, `plan_completed`, per-module sampling
+  basis, `not_reviewed`). Absence claims are valid only for opened files
+  or recorded full-repo searches, and `pass` requires the plan to have
+  completed.
+- **Budget knobs** (payload, all optional): `depth`
+  (`quick | standard | deep` → 60 / 150 / 400 files opened),
+  `max_files_opened`, `max_file_kb`, `focus_paths` / `exclude_paths`,
+  plus a per-finding verification budget (at most 2 greps and 2 file
+  reads) inherited from the Pull Request Reviewer.
+- **Freeze-floor drift.** Deliver a previous run's `result.json`
+  (`previous_result_path` in the seed, or a hygiene-checked URL) and the
+  run classifies everything as new / persisting / resolved. Previous open
+  items are a floor: each must reappear re-verified against the current
+  checkout or be resolved with a reason and evidence; silently dropping
+  one fails the `freeze_floor` check. No baseline delivered → `drift` is
+  `null`; a baseline is never guessed.
+- **Verdict honesty.** Verdicts (`pass | pass_with_findings | fail`) are
+  computed only from open findings, open gap/partial rows, coverage, and
+  the freeze floor. **The register can never upgrade a verdict**: `met`
+  rows, `declared` rows, resolved items, and positive prose never raise
+  it, and `declared` (a stated commitment the files cannot verify) is
+  not a pass. `not_checkable` is required, never empty by assumption.
+- **Evidence envelope.** Same `checks[]` (deterministic facts) vs
+  `assessments[]` (marked judgment) split as the Observe/Eval and
+  security presets; every artifact carries the line:
+
+> Machine-generated review evidence. Not a certification, audit opinion,
+> or legal advice.
+
+Payload URLs are treated as hostile input, with the same hygiene rule as
+the security presets: http(s) only, refusing loopback, private-range,
+link-local, and cloud-metadata targets, with refused URLs recorded as
+skipped inputs.
+
+## Input contracts per lens
+
+### Architecture and Strategy Conformance Review
+
+Declared intent is attached or discovered — in order of precedence:
+
+1. Payload `intent_docs`: workspace-relative paths (deliverable inline
+   via the standard [`workspace_files` seed](../../webhook-triggers.md))
+   or hygiene-checked URLs.
+2. Repository conventions: `ARCHITECTURE.md`, `docs/architecture*`,
+   `README.md` (head), `MISSION.md`, `STRATEGY.md`, `VISION.md`,
+   `ROADMAP.md`, accepted ADRs under `docs/adr/` or `docs/decisions/`,
+   `CONTRIBUTING.md` (head), and agent instruction files (`AGENTS.md`,
+   `CLAUDE.md`).
+
+Every declaration entering the conformance register carries a
+`file:line` source pointer — a declaration the agent cannot point to
+does not exist. **No intent docs is not a failure**: the run records "no
+declared intent" as a gap row, marks conformance rows `not_checkable`,
+still reports the observed architecture, and caps the verdict at
+`pass_with_findings`. Purpose/fit commentary (does the code serve the
+declared mission?) appears only in `assessments`, marked as judgment.
+
+### Full Repo Code Health Review
+
+Needs nothing beyond the checkout. It reads the project's own
+conventions first (agent instruction files, README head, lint/formatter
+configs) and judges the code by those, not generic taste. Five lenses:
+correctness risk, quality, performance hotspots, dead code, and test
+**shape** — the test map is derived from file layout (test-to-source
+ratios, untested entry points) and is never presented as measured
+coverage. Output includes a per-module health register (one row per
+lens) and a findings ledger with stable ids
+(`health:<lens>:<path>:<slug>`).
+
+### Standards Compliance Walk
+
+The payload must name the standards — the preset **refuses to run
+without one** (guessing which standard applies would contaminate the
+register):
+
+```json
+{
+  "standards": [
+    {"id": "styleguide", "name": "Example in-house style guide", "source": "docs/styleguide.md"}
+  ],
+  "depth": "standard",
+  "previous_result_path": "previous/result.json"
+}
+```
+
+`source` is inline text, a seeded workspace path, or a hygiene-checked
+URL. Alternatively `"repo_declared": true` walks only the standards the
+repository itself declares (lint configs, CONTRIBUTING rules, referenced
+style guides, agent instruction files). With neither, the run ends with
+an `error` verdict naming the missing input. Standards are normalized
+into atomic requirements (`<standard>:R<n>`) with obligation levels
+(`mandatory` vs `recommended`) taken from the standard's own wording; a
+`gap` is an absence claim and must be backed by a recorded full-repo
+search pattern, and requirements a repository cannot evidence
+(organizational process, runtime behavior, personnel, hosted
+infrastructure) land in `not_checkable`, never faked. Any `mandatory`
+gap fails the run.
+
+## Evidence pack layout
+
+```
+/workspace/evidence/
+  inventory.json               # phase-1 command-only inventory (all three)
+  findings.json                # machine-readable findings/register ledger (all three)
+  drift-report.md              # only when a baseline was delivered (all three)
+  architecture-review.md       # human-readable review (architecture-strategy)
+  conformance-register.md      # declaration register (architecture-strategy)
+  code-health-report.md        # human-readable review (code health)
+  health-register.md           # per-module register (code health)
+  standards-report.md          # human-readable walk (standards walk)
+  requirements-register.md     # requirement register (standards walk)
+```
+
+`result.json` stays under 200 KB; long listings live in the pack and are
+referenced from `artifacts`.
+
+## Honest limits
+
+- Coverage is sampled and declared, not total: a clean register row
+  means "clean in the opened sample", and the `coverage` block is the
+  scope of every claim.
+- These are engineering reviews, not conformity assessments: no
+  regime profile, no certification, and the standards walk checks only
+  what a repository can show.
+- Freeze-floor enforcement is reported by the run and owned by
+  downstream validation; the agent never self-grades the floor.


### PR DESCRIPTION
Lands the full-repo review preset family designed in the repo-review brief: three read-only, whole-repository review presets sharing one skeleton, plus their invariant test suite and a guide page.

| # | Preset | Lens | Schema |
|---|--------|------|--------|
| 008 | `architecture-strategy-review` | Declared intent vs observed structure, purpose/fit, drift | `preloop.review.arch/v1` |
| 009 | `repo-code-health-review` | Correctness, quality, performance hotspots, dead code, test shape | `preloop.review.codehealth/v1` |
| 010 | `standards-compliance-walk` | Payload-named standards to a requirement register | `preloop.review.standards/v1` |

## Why separate from the diff-scoped Pull Request Reviewer

002 is diff-scoped **for cost** and runs on every PR; it stays lean. These presets are the opposite trade: whole-repo scope, run rarely (per release, on a schedule, or on demand), with an explicit token budget (`depth` → 60/150/400 files opened, `max_files_opened`, `max_file_kb`, `focus_paths`/`exclude_paths`) and phased execution — a command-only inventory first, then a deterministic sampling plan, then lens passes over planned files only. They reuse 002's verification discipline (trace the consumer, check reachability, at most 2 greps + 2 file reads per finding) but apply it to sampled whole-repo passes with the coverage declared in the result.

## Family, not one parameterized preset

From the design doc:

- The three lenses have **different required inputs and different failure modes** when inputs are missing: 008 discovers intent docs and degrades honestly when none exist (gap row, `not_checkable` conformance, verdict capped at `pass_with_findings`); 010 **refuses to run without a named standard** (guessing which standard applies would contaminate the register); 009 needs nothing beyond the checkout.
- The **result schemas differ**: a conformance register keyed by declaration, a findings ledger keyed by file, and a requirement register keyed by standard clause don't merge without a discriminated union every consumer would have to unpack.
- **Cost and cadence differ**: code health on a schedule, the conformance review per release, the standards walk on demand — separate flows mean separate triggers, budgets, and drift baselines.
- The layered preset loader (slug union/override/tombstone) makes a family cheap to ship and lets an installation override or disable one lens without touching the others.

Rejected alternatives: a single `lens`-switched preset (prompt becomes a three-way branch — exactly where agents drift off protocol), a fourth purpose-and-fit preset (judgment over the same inputs 008 already reads; lives in 008's `assessments`), and folding into 002.

## Shared skeleton guarantees (identical across the three prompts)

- **Strictly read-only**: no commits, pushes, comments, or external mutation; **empty MCP allowlists** (`allowed_mcp_servers: []`, `allowed_mcp_tools: []`) — the checkout plus the sandbox is the whole toolset, deliverables leave via the artifact channel (`/workspace/result.json` + `/workspace/evidence/`).
- **One repo per run**, every pointer pinned to the recorded HEAD SHA; payload URL hygiene identical to the security presets.
- **Deterministic sampling with declared coverage**: no random sampling; `coverage` block with `plan_completed`, per-module sampling basis, and `not_reviewed`; absence claims scoped to opened files or recorded full-repo searches; `pass` requires the plan to have completed.
- **006-style register grammar** (`met | gap | partial | declared` + mandatory `not_checkable`) and evidence pack shape.
- **Freeze-floor drift**: previous open items must reappear re-verified against the current checkout or be resolved with reason + evidence; silent drops fail the `freeze_floor` check; baselines are never guessed; the agent doesn't self-grade the floor.
- **Verdict honesty**: the register can never upgrade a verdict; `declared` is not a pass; a previous `fail` with unresolved blockers cannot become `pass`.
- **Security referenced, not duplicated**: SBOM/vulns/secrets/CI hardening stay with the 004–006 audit family; review passes file a single referral finding (pointer only, never a value), and 010 marks security rows of a named standard `covered_elsewhere: release-security-audit`.

## Adaptations made vs the reviewed drafts

- Icons `telescope`/`pulse`/`checklist` → `binoculars`/`activity`/`card-checklist` (valid Shoelace/Bootstrap icon names; the catalog renders `<sl-icon name=${preset.icon}>`).
- Final-action wording normalized to 006's "As your FINAL action, write /workspace/result.json".
- 009 gained the missing "Declared is not a pass." sentence (design honesty rule 3 is enforced in every prompt; 008/010 already carried it).

## Tests

`backend/tests/test_repo_review_presets.py` pins the invariants the way `test_security_audit_presets.py` does for 004–006: loader pickup + catalog ordering, exact schema/flow ids, read-only + empty allowlists, trigger-agnostic shipping, disclaimer, checks-vs-assessments split, budget knobs, deterministic sampling, freeze floor, verdict-honesty sentences, and the 010 refusal rule.

```
backend/tests/test_repo_review_presets.py + test_flow_presets.py +
test_security_audit_presets.py + test_component_due_diligence_preset.py +
tests/security: 207 passed
```

## Docs

`docs/guide/flows/repo-review-presets.md` — the three lenses, the shared skeleton, per-lens input contracts, evidence pack layout, honest limits; cross-links the security preset guide (security lenses remain in 004–006, referenced, not duplicated).

001–007 are untouched. Presets are model-agnostic (agent_type `codex` for catalog parity; nothing model-specific in the prompts).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Read-only whole-repo review presets plus tests and docs; no executable logic, no security-sensitive code, no dependency changes.
>
> **Overview**
> Adds presets 008–010 (architecture-strategy, code-health, standards-walk) sharing a strict read-only skeleton with empty MCP allowlists, deterministic sampled coverage, and freeze-floor drift. `2a2bf784` adds a required top-level `status` field (`success | error`) to the three result schemas as the completion signal, pinned by a new invariant test. Both prior LOW notes resolved in `3c4a691f`; one minor doc wording nit flagged.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 2a2bf784. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->