### PR TITLE
fix: recognize the audit verdict contract as a flow completion channel

### DIFF
--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -2499,9 +2499,11 @@ class FlowExecutionOrchestrator:
                             "Agent exited with code 0 but did not confirm "
                             "success on either channel: the "
                             f"{FLOW_SUCCESS_SENTINEL} sentinel was not printed "
-                            'and no result.json with {"status": "success"} was '
-                            "written. The work may have completed without "
-                            "confirmation, or the agent died mid-task."
+                            "and no result.json with a recognized completion "
+                            'status (top-level {"status": "success"} or an '
+                            "audit verdict such as pass, pass_with_findings, "
+                            "or fail) was written. The work may have completed "
+                            "without confirmation, or the agent died mid-task."
                         )
                     elif (
                         result.status == AgentStatus.SUCCEEDED

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -95,6 +95,34 @@ FLOW_EVAL_SUCCESS_INSTRUCTION = """
 IMPORTANT: Your existing structured /workspace/result.json report is the flow confirmation channel. Preserve its schema and all rich report fields; do not overwrite it with a bare status object. The `pass` and `fail` verdicts confirm that the flow completed. An `error` verdict means the evaluation could not complete. Do not print sentinel markers.
 ---"""
 
+# Instruction for audit flows (CRA/RSA preset family) whose result contract
+# uses a top-level "verdict" instead of "status". Mirrors the eval precedent:
+# the structured result.json IS the confirmation channel, and a failing audit
+# is a completed flow. Unlike the eval instruction, the sentinel is not
+# forbidden — printing it additionally is harmless, and it stays REQUIRED for
+# contracts without a top-level "verdict" (e.g. preloop.cra.vulnscan/v1),
+# which otherwise have no result.json confirmation at all.
+# NOTE: the sentinel is kept INLINE (see FLOW_SUCCESS_INSTRUCTION) so the
+# prompt echo cannot trigger the exact-line detector.
+FLOW_AUDIT_SUCCESS_INSTRUCTION = f"""
+
+---
+IMPORTANT: Your structured /workspace/result.json report is the flow confirmation channel: a top-level "verdict" of "pass", "pass_with_findings", or "fail" confirms that the flow ran to completion (a failing audit is still a completed audit); a verdict of "error" means the audit itself could not complete. Preserve the exact result schema your instructions require and all rich report fields; never overwrite the file with a bare status object. Additionally printing the success marker on a line by itself (no other text on that line) after writing the file is allowed and harmless: {FLOW_SUCCESS_SENTINEL}
+If your required result shape has NO top-level "verdict" field, you MUST print that marker after writing the file — without it the run is marked FAILED.
+---"""
+
+# Schema ids of the audit result contracts (presets 004-006) whose top-level
+# "verdict" vocabulary is pass | pass_with_findings | fail (+ error). The
+# due-diligence contract (preloop.cra.duediligence/v1, verdict
+# "recorded" | "error") is deliberately NOT listed: its verdict vocabulary is
+# not a recognized completion confirmation, so those flows keep the generic
+# sentinel instruction.
+AUDIT_RESULT_SCHEMA_MARKERS = (
+    "preloop.cra.sbomaudit/v1",
+    "preloop.cra.vulnscan/v1",
+    "preloop.cra.releaseaudit/v1",
+)
+
 
 def _success_instruction_for_prompt(prompt: str) -> str:
     """Select the completion instruction matching the prompt's result contract."""
@@ -104,6 +132,8 @@ def _success_instruction_for_prompt(prompt: str) -> str:
         or "do not print sentinel markers" in normalized_prompt
     ):
         return FLOW_EVAL_SUCCESS_INSTRUCTION
+    if any(marker in normalized_prompt for marker in AUDIT_RESULT_SCHEMA_MARKERS):
+        return FLOW_AUDIT_SUCCESS_INSTRUCTION
     return FLOW_SUCCESS_INSTRUCTION
 
 
@@ -118,6 +148,16 @@ RESULT_ARTIFACT_SUCCESS_STATUSES = frozenset(
 )
 RESULT_ARTIFACT_FAILURE_STATUSES = frozenset({"failure", "failed", "error"})
 
+# Audit vocabulary (preloop.cra.sbomaudit/v1, preloop.cra.releaseaudit/v1):
+# the top-level field is "verdict", never "status". As with eval, "fail" and
+# "pass_with_findings" are completed-run verdicts — the audit ran to
+# completion and reported its outcome — so they confirm the FLOW succeeded;
+# only "error" means the audit itself could not complete.
+RESULT_ARTIFACT_VERDICT_SUCCESSES = frozenset(
+    {"pass", "passed", "pass_with_findings", "fail"}
+)
+RESULT_ARTIFACT_VERDICT_FAILURES = frozenset({"error"})
+
 
 def _result_artifact_confirmation(artifact: Optional[Dict[str, Any]]) -> Optional[str]:
     """Classify a result.json artifact as an explicit completion verdict.
@@ -125,17 +165,29 @@ def _result_artifact_confirmation(artifact: Optional[Dict[str, Any]]) -> Optiona
     Returns ``"success"`` or ``"failure"`` when the artifact carries an
     explicit ``status`` verdict, else ``None`` (no artifact, no status field,
     or an unrecognised value — none of which is a confirmation).
+
+    ``status`` is authoritative when it carries a recognized value. When it
+    is absent or unrecognized, the audit contracts' top-level ``verdict`` is
+    consulted as a fallback so audit runs that honour their result schema are
+    recognized as completed (channel 2) instead of being overridden to FAILED
+    for a missing success confirmation.
     """
     if not isinstance(artifact, dict):
         return None
     status = artifact.get("status")
-    if not isinstance(status, str):
-        return None
-    normalized = status.strip().lower()
-    if normalized in RESULT_ARTIFACT_SUCCESS_STATUSES:
-        return "success"
-    if normalized in RESULT_ARTIFACT_FAILURE_STATUSES:
-        return "failure"
+    if isinstance(status, str):
+        normalized = status.strip().lower()
+        if normalized in RESULT_ARTIFACT_SUCCESS_STATUSES:
+            return "success"
+        if normalized in RESULT_ARTIFACT_FAILURE_STATUSES:
+            return "failure"
+    verdict = artifact.get("verdict")
+    if isinstance(verdict, str):
+        normalized = verdict.strip().lower()
+        if normalized in RESULT_ARTIFACT_VERDICT_SUCCESSES:
+            return "success"
+        if normalized in RESULT_ARTIFACT_VERDICT_FAILURES:
+            return "failure"
     return None
 
 

--- a/backend/tests/test_flow_orchestrator.py
+++ b/backend/tests/test_flow_orchestrator.py
@@ -7,10 +7,12 @@ from uuid import uuid4
 from sqlalchemy.orm import Session
 
 from preloop.services.flow_orchestrator import (
+    FLOW_AUDIT_SUCCESS_INSTRUCTION,
     FLOW_EVAL_SUCCESS_INSTRUCTION,
     FLOW_SUCCESS_INSTRUCTION,
     FlowExecutionOrchestrator,
     _result_artifact_confirmation,
+    _success_instruction_for_prompt,
 )
 from preloop.agents.base import AgentStatus, AgentExecutionResult
 from preloop.models.models import Flow, Account
@@ -311,6 +313,69 @@ class TestFlowExecutionOrchestrator:
         assert "/workspace/result.json" in resolved_prompt
         assert "`pass` and `fail`" in resolved_prompt
         assert "`error`" in resolved_prompt
+
+    @pytest.mark.parametrize(
+        "audit_schema_marker",
+        [
+            # The schema ids actually present in the preset prompt texts:
+            "preloop.cra.sbomaudit/v1",  # 004-sbom-verify
+            "preloop.cra.vulnscan/v1",  # 005-sbom-exploit-check
+            "preloop.cra.releaseaudit/v1",  # 006-release-security-audit
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_prompt_resolution_audit_uses_verdict_instruction(
+        self,
+        audit_schema_marker: str,
+    ):
+        """Audit prompts get the verdict-contract confirmation instruction."""
+        orchestrator = FlowExecutionOrchestrator(
+            db=MagicMock(spec=Session),
+            flow_id=uuid4(),
+            trigger_event_data={},
+            nats_client=MagicMock(),
+        )
+        orchestrator.flow = MagicMock(
+            prompt_template=(
+                "As your FINAL action, write /workspace/result.json.\n"
+                f'Required shape ({audit_schema_marker}): {{ "schema": '
+                f'"{audit_schema_marker}", "verdict": "pass" }}'
+            )
+        )
+
+        resolved_prompt = await orchestrator._resolve_prompt()
+
+        assert resolved_prompt.endswith(FLOW_AUDIT_SUCCESS_INSTRUCTION)
+        # result.json + verdict is the confirmation channel...
+        assert '"verdict"' in resolved_prompt
+        assert '"pass_with_findings"' in resolved_prompt
+        # ...but the sentinel is NOT forbidden (unlike eval): it stays
+        # available, and required for shapes without a top-level verdict.
+        assert "FLOW_EXECUTION_SUCCESS" in resolved_prompt
+        assert "allowed and harmless" in resolved_prompt
+        assert "bare status object" in resolved_prompt
+
+    def test_instruction_selection_audit_vs_eval_vs_generic(self):
+        """Contract routing: eval wins first, then audit, else generic."""
+        assert (
+            _success_instruction_for_prompt("shape: preloop.eval.result/v1")
+            is FLOW_EVAL_SUCCESS_INSTRUCTION
+        )
+        assert (
+            _success_instruction_for_prompt("shape: preloop.cra.releaseaudit/v1")
+            is FLOW_AUDIT_SUCCESS_INSTRUCTION
+        )
+        assert (
+            _success_instruction_for_prompt("Fix the bug and open a PR.")
+            is FLOW_SUCCESS_INSTRUCTION
+        )
+        # The due-diligence contract's verdict vocabulary
+        # ("recorded" | "error") is not a recognized completion
+        # confirmation, so it keeps the generic sentinel instruction.
+        assert (
+            _success_instruction_for_prompt("shape: preloop.cra.duediligence/v1")
+            is FLOW_SUCCESS_INSTRUCTION
+        )
 
     @pytest.mark.asyncio
     async def test_prompt_resolution_nested(
@@ -1991,6 +2056,71 @@ class TestSuccessConfirmationChannels:
         assert result["result"] == artifact
 
     @pytest.mark.asyncio
+    async def test_audit_fail_verdict_does_not_fail_the_flow(
+        self, mock_nats_client, event_data
+    ):
+        """Audit ``verdict: fail`` (no sentinel) confirms flow completion.
+
+        Per the preloop.cra.* contracts, a failing audit is a completed
+        audit — channel 2 must recognize the verdict vocabulary even though
+        the artifact carries no "status" key.
+        """
+        artifact = {
+            "schema": "preloop.cra.releaseaudit/v1",
+            "verdict": "fail",
+            "checks": [{"name": "severity gate", "passed": False}],
+        }
+        orchestrator = self._monitor_orchestrator(
+            mock_nats_client, event_data, sentinel_seen=False
+        )
+        result = await orchestrator._monitor_agent_execution(
+            "session-confirmation-123",
+            _confirmation_executor(artifact=artifact),
+        )
+
+        assert result["status"] == "SUCCEEDED"
+        assert result["result"] == artifact
+
+    @pytest.mark.asyncio
+    async def test_audit_error_verdict_overrides_to_failed(
+        self, mock_nats_client, event_data
+    ):
+        """Audit ``verdict: error`` means the audit could not complete."""
+        artifact = {
+            "schema": "preloop.cra.sbomaudit/v1",
+            "verdict": "error",
+            "checks": [{"name": "inputs", "passed": False}],
+        }
+        orchestrator = self._monitor_orchestrator(
+            mock_nats_client, event_data, sentinel_seen=True
+        )
+        result = await orchestrator._monitor_agent_execution(
+            "session-confirmation-123",
+            _confirmation_executor(artifact=artifact),
+        )
+
+        assert result["status"] == "FAILED"
+        assert "result.json" in result["error_message"]
+        assert result["result"] == artifact
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_verdict_without_sentinel_still_fails(
+        self, mock_nats_client, event_data
+    ):
+        """Neither channel: an unrecognized verdict is not a confirmation."""
+        artifact = {"schema": "preloop.cra.duediligence/v1", "verdict": "recorded"}
+        orchestrator = self._monitor_orchestrator(
+            mock_nats_client, event_data, sentinel_seen=False
+        )
+        result = await orchestrator._monitor_agent_execution(
+            "session-confirmation-123",
+            _confirmation_executor(artifact=artifact),
+        )
+
+        assert result["status"] == "FAILED"
+        assert "FLOW_EXECUTION_SUCCESS" in result["error_message"]
+
+    @pytest.mark.asyncio
     async def test_result_artifact_error_overrides_to_failed(
         self, mock_nats_client, event_data
     ):
@@ -2085,3 +2215,67 @@ class TestResultArtifactConfirmation:
 
     def test_pass_is_success_confirmation(self):
         assert _result_artifact_confirmation({"status": "pass"}) == "success"
+
+
+class TestResultArtifactVerdictConfirmation:
+    """Audit contracts confirm completion via top-level ``verdict``.
+
+    Vocabulary (preloop.cra.sbomaudit/v1, preloop.cra.releaseaudit/v1):
+    pass | pass_with_findings | fail are completed-run verdicts — a failing
+    audit is a completed flow (same semantics as eval) — while ``error``
+    means the audit itself could not complete.
+    """
+
+    @pytest.mark.parametrize(
+        "verdict", ["pass", "passed", "pass_with_findings", "fail"]
+    )
+    def test_completed_verdicts_confirm_success(self, verdict):
+        artifact = {"schema": "preloop.cra.releaseaudit/v1", "verdict": verdict}
+        assert _result_artifact_confirmation(artifact) == "success"
+
+    def test_verdict_is_normalized(self):
+        assert (
+            _result_artifact_confirmation({"verdict": "  Pass_With_Findings "})
+            == "success"
+        )
+
+    def test_error_verdict_is_failure_confirmation(self):
+        artifact = {"schema": "preloop.cra.releaseaudit/v1", "verdict": "error"}
+        assert _result_artifact_confirmation(artifact) == "failure"
+
+    def test_unrecognized_verdict_is_no_confirmation(self):
+        # e.g. the due-diligence contract's "recorded" — not a completion
+        # confirmation; the sentinel remains required for those flows.
+        assert _result_artifact_confirmation({"verdict": "recorded"}) is None
+
+    def test_non_string_verdict_is_no_confirmation(self):
+        assert _result_artifact_confirmation({"verdict": True}) is None
+
+    def test_neither_status_nor_verdict_is_no_confirmation(self):
+        assert _result_artifact_confirmation({"schema": "x", "checks": []}) is None
+
+    def test_recognized_status_wins_over_verdict(self):
+        # status stays authoritative: an explicit failure status is not
+        # softened by a passing verdict...
+        assert (
+            _result_artifact_confirmation({"status": "error", "verdict": "pass"})
+            == "failure"
+        )
+        # ...and a recognized success status is not overridden by an
+        # error verdict.
+        assert (
+            _result_artifact_confirmation({"status": "success", "verdict": "error"})
+            == "success"
+        )
+
+    def test_unrecognized_status_falls_back_to_verdict(self):
+        assert (
+            _result_artifact_confirmation(
+                {"status": "wat", "verdict": "pass_with_findings"}
+            )
+            == "success"
+        )
+        assert (
+            _result_artifact_confirmation({"status": None, "verdict": "error"})
+            == "failure"
+        )


### PR DESCRIPTION
## Problem: two completion contracts colliding

`flow_orchestrator.py` enforces a fail-closed positive-confirmation contract: an agent that exits 0 is only SUCCEEDED when it either

1. prints the `FLOW_EXECUTION_SUCCESS` sentinel on a line by itself (instructed by the appended `FLOW_SUCCESS_INSTRUCTION`), or
2. writes `/workspace/result.json` with a top-level `status` in `RESULT_ARTIFACT_SUCCESS_STATUSES`.

Neither channel → overridden to FAILED (`success_confirmation_missing` milestone).

The audit preset family (004 `sbom-verify`, 005 `sbom-exploit-check`, 006 `release-security-audit`) has a result contract that uses a top-level **`verdict`** (`pass | pass_with_findings | fail`), never `status` — so channel 2 can never fire for those flows. Worse, the presets instruct "As your FINAL action, write /workspace/result.json", which contradicts the appended print-a-marker instruction: strict models honour the FINAL-action contract, skip the sentinel, and complete-but-FAIL. Observed on staging: RSA runs terminate with

> Agent exited with code 0 but did not confirm success on either channel: the FLOW_EXECUTION_SUCCESS sentinel was not printed and no result.json with {"status": "success"} was written.

## Fix (mirrors the eval precedent)

This follows the existing `FLOW_EVAL_SUCCESS_INSTRUCTION` / `preloop.eval.result/v1` precedent, where `fail` is a completed-run verdict and only `error` means the run itself could not complete:

- **`_result_artifact_confirmation`**: the existing `status` handling comes first and is unchanged (`status` stays authoritative when recognized). When `status` is absent or unrecognized, the top-level `verdict` is consulted: `pass` / `passed` / `pass_with_findings` / `fail` → success confirmation (a failing audit is a completed audit); `error` → explicit flow failure.
- **`FLOW_AUDIT_SUCCESS_INSTRUCTION`**: selected by `_success_instruction_for_prompt` when the prompt carries one of the audit schema ids actually present in the preset texts (`preloop.cra.sbomaudit/v1`, `preloop.cra.vulnscan/v1`, `preloop.cra.releaseaudit/v1`). It tells the agent the structured result.json with its `verdict` is the confirmation channel, to preserve the required schema (never overwrite with a bare status object), that additionally printing the sentinel is allowed and harmless — and that it is REQUIRED when the result shape has no top-level `verdict` (the `vulnscan/v1` contract), so 005 cannot regress into a confirmation gap.

## Explicitly out of scope / unchanged

- **The sentinel requirement for generic flows is untouched.** Prompts without an audit/eval contract still get `FLOW_SUCCESS_INSTRUCTION`, and exit 0 with neither channel still fails (`success_confirmation_missing`).
- The due-diligence contract (`preloop.cra.duediligence/v1`, verdict `recorded | error`) deliberately keeps the generic sentinel instruction: its vocabulary is not a completion confirmation.
- An explicit failure (`status` or `verdict: error`) still wins over a printed sentinel.

## Tests

- `_result_artifact_confirmation`: all verdict values incl. `pass_with_findings` and `error`; normalization; `status` precedence over `verdict` (both directions); unrecognized-`status` fallback; neither-field → no confirmation.
- Monitor path: audit `verdict: fail` without sentinel → SUCCEEDED; `verdict: error` → FAILED even with sentinel; unrecognized verdict without sentinel → still FAILED.
- Instruction selection: audit (all three schema ids) vs eval vs generic vs due-diligence.

`backend/tests/test_flow_orchestrator.py` (73 passed, 5 skipped), container agent files (159 passed), preset suites (112 passed). Ruff clean.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Well-scoped bug fix to the flow confirmation logic; no security surface, thorough test coverage, and correctly preserves existing contracts.
>
> **Overview**
> Recognizes the audit preset family's top-level `verdict` result contract as a flow completion channel (mirroring the eval precedent), so audit runs that honour their result schema are no longer overridden to FAILED for a missing sentinel. Adds a `verdict` fallback to `_result_artifact_confirmation` and an audit-specific success instruction selected by schema markers.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit bec4f6ac. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->