### PR TITLE
fix: give every shipped preset an explicit result.json completion contract

### DIFF
--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -100,8 +100,11 @@ IMPORTANT: Your existing structured /workspace/result.json report is the flow co
 # the structured result.json IS the confirmation channel, and a failing audit
 # is a completed flow. Unlike the eval instruction, the sentinel is not
 # forbidden — printing it additionally is harmless, and it stays REQUIRED for
-# contracts without a top-level "verdict" (e.g. preloop.cra.vulnscan/v1),
-# which otherwise have no result.json confirmation at all.
+# contracts without a top-level "verdict" AND without a top-level "status"
+# field, which otherwise have no result.json confirmation at all.
+# (preloop.cra.vulnscan/v1 carries a top-level "status" completion field
+# since preset revision #283, so it uses the generic instruction, whose
+# result.json-status branch matches its contract.)
 # NOTE: the sentinel is kept INLINE (see FLOW_SUCCESS_INSTRUCTION) so the
 # prompt echo cannot trigger the exact-line detector.
 FLOW_AUDIT_SUCCESS_INSTRUCTION = f"""
@@ -119,7 +122,6 @@ If your required result shape has NO top-level "verdict" field, you MUST print t
 # sentinel instruction.
 AUDIT_RESULT_SCHEMA_MARKERS = (
     "preloop.cra.sbomaudit/v1",
-    "preloop.cra.vulnscan/v1",
     "preloop.cra.releaseaudit/v1",
 )
 

--- a/backend/presets/001-issue-triage-assistant.yaml
+++ b/backend/presets/001-issue-triage-assistant.yaml
@@ -578,6 +578,25 @@ prompt_template: |
   **Step 10.1: Post the Triage Comment**
   Use the `add_comment` tool to post your comprehensive triage report under the updated issue.
 
+  **Step 10.2: Record Completion (MANDATORY FINAL ACT)**
+
+  As your very last action, write /workspace/result.json — this file is how
+  Preloop confirms the triage completed. It must be valid JSON, a single
+  top-level object:
+
+  {
+    "status": "success",
+    "comment_posted": true | false,
+    "issue_type": "<the classification from Step 3.1>",
+    "suggested_priority": "<P0-P4, or null if not determined>"
+  }
+
+  Use "status": "success" when the run completed — whether you posted the
+  triage comment (comment_posted: true) or deliberately decided not to
+  post one (comment_posted: false). If you hit an unrecoverable error and
+  could not complete the triage, write "status": "error" instead and add
+  a "reason" field. Be honest: never report success for work you did not do.
+
 
   ═══════════════════════════════════════════════════════════
   CRITICAL GUIDELINES

--- a/backend/presets/002-pull-request-reviewer.yaml
+++ b/backend/presets/002-pull-request-reviewer.yaml
@@ -758,14 +758,18 @@ prompt_template: |
 
   {
     "status": "success",
+    "review_posted": true | false,
     "risk_level": "low" | "medium" | "high",
     "findings_count": <total issues reported in this review>,
-    "review_action": "approve" | "request_changes" | "comment"
+    "review_action": "approve" | "request_changes" | "comment" | null
   }
 
-  Use "status": "success" only if the review was submitted (Step 4.4). If you
-  could not complete the review, write "status": "failure" instead and add a
-  "reason" field.
+  Use "status": "success" when the run completed — whether the review was
+  submitted (review_posted: true, Step 4.4) or you deliberately decided not
+  to post one (review_posted: false, review_action: null). If you hit an
+  unrecoverable error and could not complete the review, write
+  "status": "error" instead and add a "reason" field. Be honest: never
+  report success for work you did not do.
 
   ═══════════════════════════════════════════════════════════
   CRITICAL GUIDELINES

--- a/backend/presets/005-sbom-exploit-check.yaml
+++ b/backend/presets/005-sbom-exploit-check.yaml
@@ -111,6 +111,7 @@ prompt_template: |
   {
     "schema": "preloop.cra.vulnscan/v1",
     "flow": "sbom-exploit-check",
+    "status": "success" | "error",
     "run_at": "<ISO 8601 UTC>",
     "git": null,
     "tool_versions": { "<tool>": "<version or 'unavailable: reason'>" },
@@ -147,6 +148,10 @@ prompt_template: |
   }
 
   Rules:
+  - "status" is REQUIRED — it is the flow completion signal read by
+    Preloop. Write "success" when the scan completed and this report was
+    written (regardless of the gate outcome or findings); write "error"
+    (and add a "reason" field) when the scan could not be completed.
   - Findings and gate outcome are deterministic facts from the sources
     queried at the recorded time; interpretation (e.g. exploitability in
     this product's context) goes to "assessments" and is marked as

--- a/backend/presets/007-component-due-diligence.yaml
+++ b/backend/presets/007-component-due-diligence.yaml
@@ -179,6 +179,7 @@ prompt_template: |
       "note": "Reviewer identity and decision timestamp are in the Preloop approval audit trail for this execution."
     },
     "record": { "compliance_repo": "<remote or null>", "repo_commit": "<HEAD SHA or null>", "path": "<record path in repo, or null>", "committed": true|false },
+    "status": "success" | "error",
     "verdict": "recorded" | "error",
     "checks": [ { "name": "...", "passed": true|false, "skipped": true|false, "details": "<evidence>" } ],
     "assessments": [ { "topic": "...", "judgment": "<clearly-marked agent judgment — factual characterization only, never the risk decision>" } ],
@@ -187,6 +188,12 @@ prompt_template: |
   }
 
   Rules:
+  - "status" is REQUIRED — it is the flow completion signal read by
+    Preloop. The "verdict" vocabulary (recorded|error) is deliberately
+    NOT a completion signal; "status" carries that role. Write
+    "status": "success" when the run completed and the decision was
+    captured (verdict "recorded"); write "status": "error" (and add a
+    "reason" field) when it could not (verdict "error").
   - "verdict" is "recorded" only when the legwork completed AND a human
     decision (accepted or rejected) was captured; otherwise "error".
     A "rejected" decision is still a successfully RECORDED decision.

--- a/backend/tests/test_component_due_diligence_preset.py
+++ b/backend/tests/test_component_due_diligence_preset.py
@@ -64,6 +64,16 @@ class TestPresetInvariants:
         assert SCHEMA_ID in prompt
         assert "{{trigger_event.payload}}" in prompt
 
+    def test_completion_status_alongside_verdict(self, preset):
+        """The verdict vocabulary (recorded|error) is deliberately NOT a flow
+        completion signal; a required top-level "status" field carries the
+        completion contract alongside it."""
+        norm = _norm(preset["prompt_template"])
+        assert '"status": "success" | "error"' in norm
+        assert '"verdict": "recorded" | "error"' in norm
+        assert '"status" is REQUIRED — it is the flow completion signal' in norm
+        assert "NOT a completion signal" in norm
+
     def test_disclaimer(self, preset):
         assert DISCLAIMER in preset["prompt_template"]
 

--- a/backend/tests/test_flow_orchestrator.py
+++ b/backend/tests/test_flow_orchestrator.py
@@ -319,8 +319,10 @@ class TestFlowExecutionOrchestrator:
         [
             # The schema ids actually present in the preset prompt texts:
             "preloop.cra.sbomaudit/v1",  # 004-sbom-verify
-            "preloop.cra.vulnscan/v1",  # 005-sbom-exploit-check
             "preloop.cra.releaseaudit/v1",  # 006-release-security-audit
+            # preloop.cra.vulnscan/v1 (005) deliberately absent: since its
+            # prompt carries a top-level "status" completion field it uses
+            # the generic instruction (see test below).
         ],
     )
     @pytest.mark.asyncio
@@ -367,6 +369,15 @@ class TestFlowExecutionOrchestrator:
         )
         assert (
             _success_instruction_for_prompt("Fix the bug and open a PR.")
+            is FLOW_SUCCESS_INSTRUCTION
+        )
+        # 005's vulnscan contract carries a top-level "status" completion
+        # field (preset revision #283), so it routes to the GENERIC
+        # instruction whose result.json-status branch matches its contract;
+        # the audit instruction's no-verdict sentinel fallback would be
+        # misleading for it.
+        assert (
+            _success_instruction_for_prompt("shape: preloop.cra.vulnscan/v1")
             is FLOW_SUCCESS_INSTRUCTION
         )
         # The due-diligence contract's verdict vocabulary

--- a/backend/tests/test_flow_presets.py
+++ b/backend/tests/test_flow_presets.py
@@ -466,3 +466,79 @@ class TestRealPresetSlugs:
             )
             slugs.append(data["slug"])
         assert len(slugs) == len(set(slugs)), f"duplicate slugs: {slugs}"
+
+
+# Every shipped preset must declare an explicit result.json completion
+# channel in its prompt. Flows confirm completion either by printing the
+# FLOW_EXECUTION_SUCCESS sentinel or by writing /workspace/result.json with
+# a recognized completion status; presets must not rely on the model
+# remembering the sentinel (regression guard for exec 31613e46, where the
+# PR reviewer completed a full review then FAILED on the missing sentinel).
+# Maps preset file -> the exact status/verdict vocabulary line its prompt
+# documents (whitespace-normalized).
+PRESET_COMPLETION_MARKERS = {
+    "001-issue-triage-assistant.yaml": '"status": "success"',
+    "002-pull-request-reviewer.yaml": '"status": "success"',
+    "003-observe-eval.yaml": '"status": "pass" | "fail" | "error"',
+    "004-sbom-verify.yaml": '"verdict": "pass" | "pass_with_findings" | "fail"',
+    "005-sbom-exploit-check.yaml": '"status": "success" | "error"',
+    "006-release-security-audit.yaml": (
+        '"verdict": "pass" | "pass_with_findings" | "fail"'
+    ),
+    "007-component-due-diligence.yaml": '"status": "success" | "error"',
+}
+
+
+class TestShippedPresetCompletionContracts:
+    """Each shipped preset prompt pins its result.json completion contract."""
+
+    def _shipped_preset_files(self):
+        from preloop.flow_presets import DEFAULT_PRESETS_DIR
+
+        if not DEFAULT_PRESETS_DIR.exists():
+            pytest.skip("no shipped presets")
+        return sorted(DEFAULT_PRESETS_DIR.glob("*.y*ml"))
+
+    def test_every_shipped_preset_has_a_known_completion_marker(self):
+        """New presets must register their completion vocabulary here."""
+        names = [path.name for path in self._shipped_preset_files()]
+        assert names == sorted(PRESET_COMPLETION_MARKERS), (
+            "shipped presets and PRESET_COMPLETION_MARKERS out of sync — "
+            "every shipped preset needs an explicit result.json completion "
+            "contract and a marker entry in this test"
+        )
+
+    @pytest.mark.parametrize("filename", sorted(PRESET_COMPLETION_MARKERS))
+    def test_prompt_documents_result_json_completion_status(self, filename):
+        from preloop.flow_presets import DEFAULT_PRESETS_DIR
+
+        path = DEFAULT_PRESETS_DIR / filename
+        if not path.exists():
+            pytest.skip(f"{filename} not shipped in this layout")
+        prompt = yaml.safe_load(path.read_text())["prompt_template"]
+        norm = " ".join(prompt.split())
+        assert "/workspace/result.json" in norm, (
+            f"{filename} prompt must instruct writing /workspace/result.json"
+        )
+        assert PRESET_COMPLETION_MARKERS[filename] in norm, (
+            f"{filename} prompt must document its completion status vocabulary"
+        )
+
+    @pytest.mark.parametrize(
+        "filename",
+        ["001-issue-triage-assistant.yaml", "002-pull-request-reviewer.yaml"],
+    )
+    def test_success_and_error_paths_are_both_instructed(self, filename):
+        """001/002 use the plain status contract: success on completion,
+        error (with a reason) on unrecoverable failure."""
+        from preloop.flow_presets import DEFAULT_PRESETS_DIR
+
+        prompt = yaml.safe_load((DEFAULT_PRESETS_DIR / filename).read_text())[
+            "prompt_template"
+        ]
+        norm = " ".join(prompt.split())
+        assert '"status": "success"' in norm
+        assert '"status": "error"' in norm
+        assert '"reason"' in norm
+        # The final act framing: writing result.json is the last action.
+        assert "Record Completion (MANDATORY FINAL ACT)" in norm

--- a/backend/tests/test_flow_presets.py
+++ b/backend/tests/test_flow_presets.py
@@ -486,7 +486,23 @@ PRESET_COMPLETION_MARKERS = {
         '"verdict": "pass" | "pass_with_findings" | "fail"'
     ),
     "007-component-due-diligence.yaml": '"status": "success" | "error"',
+    "008-architecture-strategy-review.yaml": '"status": "success" | "error"',
+    "009-repo-code-health-review.yaml": '"status": "success" | "error"',
+    "010-standards-compliance-walk.yaml": '"status": "success" | "error"',
 }
+
+
+def _parse_completion_marker(marker: str) -> tuple[str, list[str]]:
+    """Split a marker line into its result.json field and value vocabulary.
+
+    ``'"status": "pass" | "fail" | "error"'`` -> ``("status", ["pass",
+    "fail", "error"])``.
+    """
+    field_part, _, values_part = marker.partition(":")
+    field = field_part.strip().strip('"')
+    values = [value.strip().strip('"') for value in values_part.split("|")]
+    assert field and all(values), f"malformed completion marker: {marker!r}"
+    return field, values
 
 
 class TestShippedPresetCompletionContracts:
@@ -542,3 +558,41 @@ class TestShippedPresetCompletionContracts:
         assert '"reason"' in norm
         # The final act framing: writing result.json is the last action.
         assert "Record Completion (MANDATORY FINAL ACT)" in norm
+
+
+class TestCompletionMarkersAreRecognizedByOrchestrator:
+    """PRESET_COMPLETION_MARKERS must match the real consumer.
+
+    The orchestrator's ``_result_artifact_confirmation`` is the code that
+    actually reads result.json and decides whether a flow confirmed
+    completion (channel 2). A preset whose documented vocabulary the
+    orchestrator does not recognize would complete its work and still be
+    marked FAILED — so an unrecognized contract must fail this suite.
+    """
+
+    @pytest.mark.parametrize("filename", sorted(PRESET_COMPLETION_MARKERS), ids=str)
+    def test_marker_vocabulary_is_classified_by_the_orchestrator(self, filename):
+        from preloop.services.flow_orchestrator import (
+            _result_artifact_confirmation,
+        )
+
+        field, values = _parse_completion_marker(PRESET_COMPLETION_MARKERS[filename])
+        assert field in {"status", "verdict"}, (
+            f"{filename}: completion field {field!r} is not a channel the "
+            "orchestrator reads (status or verdict)"
+        )
+        classifications = {
+            value: _result_artifact_confirmation({field: value}) for value in values
+        }
+        unrecognized = [v for v, c in classifications.items() if c is None]
+        assert not unrecognized, (
+            f"{filename}: documented {field} value(s) {unrecognized} are not "
+            "recognized by _result_artifact_confirmation — the preset would "
+            "write its contract and still be failed for a missing "
+            "confirmation"
+        )
+        assert "success" in classifications.values(), (
+            f"{filename}: no documented {field} value classifies as a "
+            "success confirmation — the preset can never confirm completion "
+            f"via result.json ({classifications})"
+        )

--- a/backend/tests/test_security_audit_presets.py
+++ b/backend/tests/test_security_audit_presets.py
@@ -140,6 +140,17 @@ class TestSbomExploitCheckPreset:
         # Never claim absence for unmatchable components.
         assert "unmatchable" in prompt
 
+    def test_completion_status_contract(self):
+        """The vulnscan schema has no top-level verdict, so a required
+        top-level "status" field is its flow completion signal: "success"
+        when the scan completed, "error" when it could not."""
+        prompt = _load_preset(PRESET_FILES["SBOM Exploit Check"])["prompt_template"]
+        norm = _norm(prompt)
+        assert '"status": "success" | "error"' in norm
+        assert '"status" is REQUIRED — it is the flow completion signal' in norm
+        # Completion is about the scan finishing, not the gate outcome.
+        assert "regardless of the gate outcome or findings" in norm
+
 
 class TestReleaseSecurityAuditPreset:
     def test_combines_both_audits_plus_drift(self):

--- a/docs/guide/flows/security-audit-presets.md
+++ b/docs/guide/flows/security-audit-presets.md
@@ -172,6 +172,7 @@ Envelope plus:
 
 ```json
 {
+  "status": "success | error",
   "source_sbom": {"path": "sbom/image.spdx.json", "format": "spdx", "spec_version": "SPDX-2.3", "build_ref": null},
   "db_versions": {"osv_queried_at": "…", "kev_snapshot_date": "…", "epss_queried_at": null, "nvd": "not used"},
   "inventory": {"components": 214, "matchable": 189, "unmatchable": 25},
@@ -185,6 +186,13 @@ Envelope plus:
   "new_since_last_run": null
 }
 ```
+
+`status` is the **required** top-level flow completion signal read by
+Preloop: `success` when the scan completed and the report was written
+(regardless of gate outcome or findings), `error` (plus a `reason`
+field) when the scan could not be completed. It is independent of the
+severity gate — a failed gate on a completed scan is still
+`"status": "success"`.
 
 Default gate when the payload provides none: fail on any KEV-listed
 finding or CVSS ≥ 9.0. VEX suppressions (OpenVEX or CycloneDX VEX) are
@@ -417,10 +425,16 @@ Trigger it manually or by webhook, one component per run:
 }
 ```
 
-A `rejected` decision is still a successfully **recorded** decision —
-the point is the trail. A granted approval means one reviewer accepted
-the component's risk for this product at this time; it is not a
-certification, and the record says so.
+The record carries a required top-level `status` (`success | error`) —
+the flow completion signal read by Preloop. `status` is `success` when
+the run completed and the decision was captured; the record's own
+`verdict` vocabulary (`recorded | error`) and the human outcome
+(`decision.outcome`: `accepted | rejected | pending`) are deliberately
+**not** completion signals. A `rejected` decision is still a
+successfully **recorded** decision — the point is the trail. A granted
+approval means one reviewer accepted the component's risk for this
+product at this time; it is not a certification, and the record says
+so.
 
 ## Honest limits
 


### PR DESCRIPTION
## Why

Flows confirm completion through one of two channels:

1. the printed `FLOW_EXECUTION_SUCCESS` sentinel in the logs, or
2. a `/workspace/result.json` artifact carrying a recognized completion status.

A preset that relies only on channel 1 fails whenever the model forgets the magic string, even when the work fully completed. That is exactly what happened in staging exec `31613e46`: the PR-reviewer flow finished a complete review and was then marked FAILED for a missing sentinel, because preset 002 had no reliable result.json contract to fall back on.

This PR gives every shipped preset an explicit result.json completion contract, so no shipped preset depends on the model remembering the sentinel. The sentinel requirement itself stays untouched: custom flows without a result contract still get the appended platform instruction and must confirm via sentinel or a recognized result.json status.

## Per-preset changes

| Preset | Change |
|---|---|
| 001 issue-triage-assistant | New Step 10.2 (mandatory final act): write result.json with `status: success/error` plus an honest summary (`comment_posted`, `issue_type`, `suggested_priority`). |
| 002 pull-request-reviewer | Step 8.2 now reports `success` whenever the run completed — review posted or deliberately not posted (`review_posted` bool, `findings_count`) — and reserves `status: error` (with `reason`) for unrecoverable failures. Review-posting logic untouched. |
| 003 observe-eval | Unchanged — `preloop.eval.result/v1` statuses are already recognized. |
| 004 sbom-verify / 006 release-security-audit | Unchanged — covered by the #282 audit verdict recognition. |
| 005 sbom-exploit-check | Its `preloop.cra.vulnscan/v1` schema has no top-level verdict, so it gains a required top-level `status` field: `success` when the scan completed (regardless of gate outcome), `error` when it could not. |
| 007 component-due-diligence | Its verdict vocabulary (`recorded`\|`error`) is deliberately NOT a completion signal per #282, so a top-level `status` field now carries the completion contract alongside the verdict. |

## Tests

- `test_flow_presets.py`: new invariant class mapping every shipped preset file to its completion vocabulary — fails when a new preset ships without registering an explicit completion contract; plus success/error-path pins for 001/002.
- `test_security_audit_presets.py`: pins 005's required top-level `status` field and its scan-completion (not gate-outcome) semantics.
- `test_component_due_diligence_preset.py`: pins 007's `status` field alongside the non-completion-signal verdict.

Related: #282 (audit verdict recognition), #281 (repo-review family — gets the same `status` field in its own branch).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Gives every shipped preset an explicit result.json completion contract; all previously raised issues are now resolved, including the 005 vulnscan routing inconsistency.
>
> **Overview**
> Every shipped preset now declares an explicit result.json completion contract, verified against the orchestrator's real `_result_artifact_confirmation` consumer. The #282 audit-verdict recognition has merged, so 004/006 are no longer sentinel-dependent, and 005's `vulnscan/v1` contract now routes to the generic instruction whose result.json-status branch matches its top-level `status` field.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 8510cef0. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->