### PR TITLE
ci: parallelize GitHub backend tests across four shards

### DIFF
--- a/.github/requirements/app-dev.txt
+++ b/.github/requirements/app-dev.txt
@@ -3305,6 +3305,7 @@ pytest==9.1.1 \
     #   pytest-cov
     #   pytest-mock
     #   pytest-playwright
+    #   pytest-split
 pytest-asyncio==1.4.0 \
     --hash=sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1 \
     --hash=sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42
@@ -3324,6 +3325,10 @@ pytest-mock==3.15.1 \
 pytest-playwright==0.9.0 \
     --hash=sha256:9d9dc74e335c647944cecfffa706cc9e6e4bf4c25e84592c128b584d494d4471 \
     --hash=sha256:bd44daa852b0fb8b0e55a2f88b727507dedda0e350bea5d09420647252f2454b
+    # via preloop (pyproject.toml)
+pytest-split==0.11.0 \
+    --hash=sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382 \
+    --hash=sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5
     # via preloop (pyproject.toml)
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,6 @@ jobs:
 
       - name: Upload coverage data
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
         with:
           name: backend-coverage-${{ matrix.group }}
           path: coverage-data.${{ matrix.group }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,11 @@ jobs:
   # Four shards, each with its own Postgres. GitLab splits this suite into
   # dozens of per-file jobs; that is a poor fit here because each GitHub
   # runner spends ~1.5m on checkout/pip/migrations before pytest starts.
-  # pytest-split keeps new tests in the partition automatically. The 60%
+  # pytest-split keeps new tests in the partition automatically. Use
+  # duration_based_chunks (not least_duration): without a timings file,
+  # least_duration round-robins individual tests across shards and breaks
+  # unittest setUp isolation plus tests that share a process-wide DB
+  # session. Chunks keep collection order, so files stay together. The 60%
   # coverage floor is applied after shards are combined -- a single shard
   # only sees part of the tree.
   test-backend:
@@ -142,7 +146,7 @@ jobs:
             -m "not integration" \
             --splits 4 \
             --group ${{ matrix.group }} \
-            --splitting-algorithm=least_duration \
+            --splitting-algorithm=duration_based_chunks \
             --cov=preloop \
             --cov-report= \
             --junitxml=test-results.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,19 @@ jobs:
       - name: Helm render checks (chart lint + CNPG backup wiring)
         run: sh scripts/helm-render-check.sh
 
+  # Four shards, each with its own Postgres. GitLab splits this suite into
+  # dozens of per-file jobs; that is a poor fit here because each GitHub
+  # runner spends ~1.5m on checkout/pip/migrations before pytest starts.
+  # pytest-split keeps new tests in the partition automatically. The 60%
+  # coverage floor is applied after shards are combined -- a single shard
+  # only sees part of the tree.
   test-backend:
-    name: Backend Tests
+    name: Backend Tests (${{ matrix.group }}/4)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4]
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -97,6 +107,8 @@ jobs:
       DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
       OPENAI_API_KEY: mock_key
       ANTHROPIC_API_KEY: mock_key
+      PRELOOP_DISABLE_TELEMETRY: "true"
+      COVERAGE_FILE: coverage-data.${{ matrix.group }}
 
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -128,10 +140,72 @@ jobs:
         run: |
           pytest -v \
             -m "not integration" \
+            --splits 4 \
+            --group ${{ matrix.group }} \
+            --splitting-algorithm=least_duration \
             --cov=preloop \
-            --cov-report=xml \
-            --cov-fail-under=60 \
+            --cov-report= \
             --junitxml=test-results.xml
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: backend-coverage-${{ matrix.group }}
+          path: coverage-data.${{ matrix.group }}
+          if-no-files-found: error
+
+      - name: Upload test results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: backend-test-results-${{ matrix.group }}
+          path: test-results.xml
+
+  test-backend-coverage:
+    name: Backend Coverage
+    runs-on: ubuntu-latest
+    needs: test-backend
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Cache pip
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('.github/requirements/app-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # Same lock as the shards so coverage.py can combine their data files.
+      - name: Install coverage
+        run: |
+          pip install --require-hashes -r .github/requirements/app-dev.txt
+          pip install --no-deps -e .
+
+      - name: Download shard coverage data
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: backend-coverage-*
+          path: coverage-shards
+          merge-multiple: true
+
+      - name: Combine coverage and enforce floor
+        run: |
+          mapfile -t coverage_files < <(find coverage-shards -name 'coverage-data.*' -type f | sort)
+          if [ ${#coverage_files[@]} -ne 4 ]; then
+            echo "Expected 4 shard coverage files, found ${#coverage_files[@]}"
+            find coverage-shards -type f -print
+            exit 1
+          fi
+          coverage combine "${coverage_files[@]}"
+          coverage xml -o coverage.xml
+          coverage report --fail-under=60
 
       - name: Upload coverage
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
@@ -140,13 +214,6 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
-        with:
-          name: backend-test-results
-          path: test-results.xml
 
   # ==========================================================================
   # Frontend Tests
@@ -318,7 +385,7 @@ jobs:
   build-and-push:
     name: Build & Push Docker Images
     runs-on: ubuntu-latest
-    needs: [lint, test-backend, test-frontend, test-runtime-plugins]
+    needs: [lint, test-backend-coverage, test-frontend, test-runtime-plugins]
     permissions:
       contents: read
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ ENV/
 .coverage
 htmlcov/
 .pytest_cache/
+.test_durations
 
 # Logs
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **GitHub CI backend tests run in parallel**: the backend unit suite is
+  sharded across four GitHub Actions jobs with pytest-split, each with
+  its own Postgres, so PRs are no longer gated on a single ~12-minute
+  pytest process. Coverage from the shards is combined before the 60%
+  floor is applied.
+
 - **Codex onboarding is config-only**: `preloop agents onboard` no longer
   installs a `~/.local/bin/codex` PATH wrapper. Codex only requires a
   process environment variable when `env_key` or `bearer_token_env_var` is

--- a/TESTING.md
+++ b/TESTING.md
@@ -92,7 +92,17 @@ Significant progress has been made in increasing unit test coverage for the back
 
 ### CI/CD Integration
 
-All backend unit tests are organized into separate jobs in the `.gitlab-ci.yml` pipeline. This allows for parallel execution and clear reporting on the test status of each component, such as `test:unit:spacemodels`, `test:unit:preloop-sync`, and individual endpoint tests like `test:unit:preloop-endpoints-mcp`.
+GitHub Actions (`.github/workflows/ci.yml`) shards backend unit tests
+(`pytest -m "not integration"`) across four jobs with
+[pytest-split](https://pypi.org/project/pytest-split/). Each shard has
+its own Postgres service. Coverage data is combined in a follow-up
+**Backend Coverage** job before the 60% floor is applied; a single shard
+only exercises part of the tree, so `--cov-fail-under` cannot run there.
+
+GitLab CI (`.gitlab-ci.yml`) splits the same suite into per-component
+jobs for parallel execution and reporting, such as
+`test:unit:preloop-sync` and individual endpoint tests like
+`test:unit:preloop-endpoints-mcp`.
 
 ### Mutation Testing
 

--- a/backend/tests/sync/trackers/test_jira.py
+++ b/backend/tests/sync/trackers/test_jira.py
@@ -159,7 +159,17 @@ class TestJiraTrackerWebhooks(unittest.IsolatedAsyncioTestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = mock_webhooks_data
         self.mock_jira_client._session.get.return_value = mock_response
-        result = self.tracker.cleanup_stale_webhooks(preloop_url)
+        with (
+            patch(
+                "preloop.models.crud.crud_webhook.get_by_external_id",
+                return_value=None,
+            ),
+            patch(
+                "preloop.models.db.session.get_db_session",
+                side_effect=lambda: iter([MagicMock()]),
+            ),
+        ):
+            result = self.tracker.cleanup_stale_webhooks(preloop_url)
         self.assertEqual(result, {"unregistered": 2, "failed": 0})
         self.mock_jira_client._session.get.assert_called_once_with(
             "https://myjira.atlassian.net/rest/webhooks/1.0/webhook"
@@ -186,7 +196,17 @@ class TestJiraTrackerWebhooks(unittest.IsolatedAsyncioTestCase):
             MagicMock(status_code=204),
             JIRAError(status_code=500, text="Internal Server Error"),
         ]
-        result = self.tracker.cleanup_stale_webhooks(preloop_url)
+        with (
+            patch(
+                "preloop.models.crud.crud_webhook.get_by_external_id",
+                return_value=None,
+            ),
+            patch(
+                "preloop.models.db.session.get_db_session",
+                side_effect=lambda: iter([MagicMock()]),
+            ),
+        ):
+            result = self.tracker.cleanup_stale_webhooks(preloop_url)
         self.assertEqual(result, {"unregistered": 1, "failed": 1})
         self.mock_jira_client._session.get.assert_called_once_with(
             "https://myjira.atlassian.net/rest/webhooks/1.0/webhook"

--- a/backend/tests/test_api_key_creation_bug.py
+++ b/backend/tests/test_api_key_creation_bug.py
@@ -12,16 +12,6 @@ from sqlalchemy.orm import Session
 from preloop.models.models.api_key import ApiKey
 from preloop.models.models.user import User
 from preloop.models.models.account import Account
-from preloop.models.db.session import get_db_session
-
-
-@pytest.fixture
-def db_session():
-    """Get a real database session."""
-    session_generator = get_db_session()
-    session = next(session_generator)
-    yield session
-    session.close()
 
 
 def test_api_key_creation_with_user_id(db_session: Session):
@@ -30,9 +20,10 @@ def test_api_key_creation_with_user_id(db_session: Session):
     This test would have immediately failed if the code tried to use
     'created_by' instead of 'user_id', catching the bug before deployment.
     """
+    suffix = uuid.uuid4().hex[:8]
     # Create a test account
     test_account = Account(
-        organization_name="Test Organization",
+        organization_name=f"Test Organization {suffix}",
         email_verified=True,
         is_active=True,
         is_superuser=False,
@@ -42,8 +33,8 @@ def test_api_key_creation_with_user_id(db_session: Session):
 
     # Create a test user
     test_user = User(
-        username=f"testuser_{uuid.uuid4().hex[:8]}",
-        email="test_user@example.com",
+        username=f"testuser_{suffix}",
+        email=f"test_user_{suffix}@example.com",
         hashed_password="hashed_password",
         account_id=test_account.id,
         is_active=True,
@@ -64,7 +55,7 @@ def test_api_key_creation_with_user_id(db_session: Session):
             is_active=True,
         )
         db_session.add(api_key)
-        db_session.commit()
+        db_session.flush()
 
         # Verify the key was created with the correct user_id
         assert api_key.id is not None
@@ -88,9 +79,6 @@ def test_api_key_creation_with_user_id(db_session: Session):
                 f"This indicates the created_by vs user_id bug: {e}"
             )
         raise
-    finally:
-        # Clean up
-        db_session.rollback()
 
 
 def test_api_key_creation_fails_with_created_by(db_session: Session):
@@ -98,9 +86,10 @@ def test_api_key_creation_fails_with_created_by(db_session: Session):
 
     This explicitly tests that the old field name is no longer accepted.
     """
+    suffix = uuid.uuid4().hex[:8]
     # Create a test account
     test_account = Account(
-        organization_name="Test Organization 2",
+        organization_name=f"Test Organization 2 {suffix}",
         email_verified=True,
         is_active=True,
         is_superuser=False,
@@ -110,8 +99,8 @@ def test_api_key_creation_fails_with_created_by(db_session: Session):
 
     # Create a test user
     test_user = User(
-        username=f"testuser2_{uuid.uuid4().hex[:8]}",
-        email="test_user2@example.com",
+        username=f"testuser2_{suffix}",
+        email=f"test_user2_{suffix}@example.com",
         hashed_password="hashed_password",
         account_id=test_account.id,
         is_active=True,
@@ -134,8 +123,6 @@ def test_api_key_creation_fails_with_created_by(db_session: Session):
 
     # Verify the error message mentions the invalid parameter
     assert "created_by" in str(exc_info.value).lower()
-
-    db_session.rollback()
 
 
 def test_api_key_response_schema_compatibility():

--- a/backend/tests/test_github_ci_backend_shards.py
+++ b/backend/tests/test_github_ci_backend_shards.py
@@ -60,6 +60,10 @@ def test_backend_shards_partition_with_pytest_split() -> None:
     assert "--splitting-algorithm=duration_based_chunks" in script
     assert "--splitting-algorithm=least_duration" not in script
     assert "--cov-fail-under" not in script
+    coverage_upload = next(
+        step for step in backend["steps"] if step.get("name") == "Upload coverage data"
+    )
+    assert "always()" not in str(coverage_upload.get("if", ""))
     assert backend["env"]["COVERAGE_FILE"] == "coverage-data.${{ matrix.group }}"
     assert backend["env"]["PRELOOP_DISABLE_TELEMETRY"] == "true"
 

--- a/backend/tests/test_github_ci_backend_shards.py
+++ b/backend/tests/test_github_ci_backend_shards.py
@@ -57,7 +57,8 @@ def test_backend_shards_partition_with_pytest_split() -> None:
     script = _step_script(backend, "Run tests")
     assert f"--splits {BACKEND_TEST_SPLITS}" in script
     assert "--group ${{ matrix.group }}" in script
-    assert "--splitting-algorithm=least_duration" in script
+    assert "--splitting-algorithm=duration_based_chunks" in script
+    assert "--splitting-algorithm=least_duration" not in script
     assert "--cov-fail-under" not in script
     assert backend["env"]["COVERAGE_FILE"] == "coverage-data.${{ matrix.group }}"
     assert backend["env"]["PRELOOP_DISABLE_TELEMETRY"] == "true"

--- a/backend/tests/test_github_ci_backend_shards.py
+++ b/backend/tests/test_github_ci_backend_shards.py
@@ -1,0 +1,86 @@
+"""Guard GitHub Actions backend test sharding against config drift.
+
+The suite is split with pytest-split across a matrix of jobs, then coverage
+is combined before the 60% floor. ``--splits`` and the matrix group list
+must stay in lockstep, and the floor must not run on a single shard.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+BACKEND_TEST_SPLITS = 4
+
+
+def _load_ci_jobs() -> dict[str, Any]:
+    """Return the jobs mapping from the GitHub CI workflow."""
+    with CI_WORKFLOW.open(encoding="utf-8") as handle:
+        doc = yaml.safe_load(handle)
+    jobs = doc["jobs"]
+    assert isinstance(jobs, dict)
+    return jobs
+
+
+def _step_script(job: dict[str, Any], name: str) -> str:
+    """Return the run script for a named workflow step."""
+    for step in job["steps"]:
+        if step.get("name") == name:
+            script = step["run"]
+            assert isinstance(script, str)
+            return script
+    raise AssertionError(f"No step named {name!r}")
+
+
+def test_pytest_split_is_a_dev_dependency() -> None:
+    """CI installs ``.[dev]`` from the hash-pinned lock, so the plugin must be there."""
+    with PYPROJECT.open("rb") as handle:
+        data = tomllib.load(handle)
+    dev = data["project"]["optional-dependencies"]["dev"]
+    assert any(item.startswith("pytest-split") for item in dev)
+
+
+def test_backend_shards_partition_with_pytest_split() -> None:
+    """Each matrix group must match ``--splits N --group`` in the pytest invocation."""
+    backend = _load_ci_jobs()["test-backend"]
+    groups = backend["strategy"]["matrix"]["group"]
+    assert groups == list(range(1, BACKEND_TEST_SPLITS + 1))
+    assert backend["strategy"]["fail-fast"] is False
+
+    script = _step_script(backend, "Run tests")
+    assert f"--splits {BACKEND_TEST_SPLITS}" in script
+    assert "--group ${{ matrix.group }}" in script
+    assert "--splitting-algorithm=least_duration" in script
+    assert "--cov-fail-under" not in script
+    assert backend["env"]["COVERAGE_FILE"] == "coverage-data.${{ matrix.group }}"
+    assert backend["env"]["PRELOOP_DISABLE_TELEMETRY"] == "true"
+
+
+def test_backend_coverage_job_combines_shards_before_floor() -> None:
+    """The 60% floor applies only to the combined coverage data."""
+    jobs = _load_ci_jobs()
+    coverage = jobs["test-backend-coverage"]
+    assert coverage["needs"] == "test-backend"
+
+    install = _step_script(coverage, "Install coverage")
+    assert ".github/requirements/app-dev.txt" in install
+
+    script = _step_script(coverage, "Combine coverage and enforce floor")
+    assert "coverage combine" in script
+    assert "--fail-under=60" in script
+    assert f"-ne {BACKEND_TEST_SPLITS}" in script
+    assert "coverage-data.*" in script
+
+
+def test_build_and_push_waits_for_combined_backend_coverage() -> None:
+    """Image publish must not proceed on a shard pass with incomplete coverage."""
+    needs = _load_ci_jobs()["build-and-push"]["needs"]
+    assert "test-backend-coverage" in needs
+    assert "test-backend" not in needs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-asyncio>=0.21.1",
     "pytest-mock>=3.12.0",
+    "pytest-split>=0.10.0",
     "python-dotenv>=0.21.0", # Added python-dotenv
     "black>=23.7.0",
     "isort>=5.12.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

GitHub CI ran the whole backend unit suite in one job (~12.5 minutes of pytest, ~14 minutes wall clock). That job was the long pole: lint, frontend, and plugin tests finish in about two minutes, then Docker build waits on backend.

This shards `pytest -m "not integration"` across **four GitHub Actions jobs** with [pytest-split](https://pypi.org/project/pytest-split/), each with its own Postgres. New tests are included automatically; we do not copy GitLab's per-file job list (that would repeat ~1.5 minutes of checkout/pip/migrations dozens of times).

A follow-up **Backend Coverage** job combines the shard data files and applies the existing 60% floor. Image publish now depends on that combined result, not on a single shard passing.

The first CI run on this PR showed the speedup (shards finished in ~4–6 minutes) but shard 4 failed: `least_duration` without timings round-robins individual tests, which interleaved unittest classes and a process-wide DB session. Follow-up commits switch to `duration_based_chunks` (collection-order chunks; pytest-split has no `count_based_chunks` algorithm), mock the live DB in the Jira stale-webhook tests, use the transactional fixture for API key tests, skip coverage-artifact upload on failed shards, and gitignore `.test_durations`.

## Testing

- [x] Backend tests (`backend/tests/test_github_ci_backend_shards.py`, Jira cleanup tests)
- [ ] Frontend tests (not affected)
- [x] Manual validation: pytest-split `--collect-only` partition of the unit suite; `coverage combine` with the `coverage-data.N` filenames CI uses; first GitHub run confirmed four parallel backend jobs

## Checklist

- [x] Docs updated if needed (`TESTING.md`)
- [x] Changelog updated if needed
- [x] No secrets included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a81e796b-564b-4fec-850d-86b838d6fcce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a81e796b-564b-4fec-850d-86b838d6fcce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low** — CI-only change with a defensive guard test; no security or correctness concerns.
>
> **Overview**
> Parallelizes the GitHub backend test suite across four pytest-split shards with a follow-up job that combines coverage data before enforcing the 60% floor. Well-scoped and guarded by a dedicated drift test.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit dcb502a2. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->