### PR TITLE
fix: price z.ai GLM-5.3 from the public list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **z.ai GLM-5.3 was unpriced**: first-party list prices from docs.z.ai
+  are now in the vendored catalog ($1.4 input, $0.26 cached input, $4.4
+  output per 1M). z.ai has no price API, so
+  `scripts/update_model_prices.py` refreshes those rows from the public
+  pricing page alongside the litellm map.
 - **Preloop-bot label events were dropped**: `_is_preloop_triggered_event`
   no longer skips `issue_labeled` / `issue_unlabeled`, so
   `update_issue` adding `agent-ready` can start an implementation flow.

--- a/backend/preloop/services/ai_model_provider.py
+++ b/backend/preloop/services/ai_model_provider.py
@@ -838,10 +838,13 @@ MOONSHOT_KNOWN_MODELS = [
 ]
 
 # Fallback catalog used when no Z.ai key is available to list the live set.
-# Provenance: the zai/* entries in the pinned litellm price map (litellm
-# 1.82.1 prices glm-5 and glm-5.1, so they are included). Every id resolves
-# to zai/<id> in litellm's map (pinned by tests/services/test_model_pricing.py).
+# Provenance: live GET https://api.z.ai/api/paas/v4/models (2026-08-22)
+# plus the zai/* entries in the pinned litellm price map. glm-5.3 is on
+# the live list and on docs.z.ai/guides/overview/pricing; litellm's map
+# does not carry it yet. Priced under zai/<id> in model_prices.json
+# (pinned by tests/services/test_model_pricing.py).
 ZAI_KNOWN_MODELS = [
+    "glm-5.3",
     "glm-5.1",
     "glm-5",
     "glm-4.7",

--- a/backend/preloop/services/data/model_prices.json
+++ b/backend/preloop/services/data/model_prices.json
@@ -2,7 +2,14 @@
  "_preloop_meta": {
   "source_url": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
   "fetched_at": "2026-07-12T12:10:45.331564+00:00",
-  "model_count": 849
+  "model_count": 868,
+  "overlay_sources": [
+   {
+    "url": "https://docs.z.ai/guides/overview/pricing.md",
+    "fetched_at": "2026-08-24T11:30:00+00:00",
+    "section": "Text Models"
+   }
+  ]
  },
  "ai21.j2-mid-v1": {
   "input_cost_per_token": 1.25e-05,
@@ -10020,5 +10027,111 @@
   "max_output_tokens": 128000,
   "max_tokens": 128000,
   "mode": "chat"
+ },
+ "zai/glm-4-32b-0414-128k": {
+  "input_cost_per_token": 1e-07,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 1e-07
+ },
+ "zai/glm-4.5": {
+  "cache_read_input_token_cost": 1.1e-07,
+  "input_cost_per_token": 6e-07,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 2.2e-06
+ },
+ "zai/glm-4.5-air": {
+  "cache_read_input_token_cost": 3e-08,
+  "input_cost_per_token": 2e-07,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 1.1e-06
+ },
+ "zai/glm-4.5-airx": {
+  "cache_read_input_token_cost": 2.2e-07,
+  "input_cost_per_token": 1.1e-06,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 4.5e-06
+ },
+ "zai/glm-4.5-flash": {
+  "cache_read_input_token_cost": 0.0,
+  "input_cost_per_token": 0.0,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 0.0
+ },
+ "zai/glm-4.5-x": {
+  "cache_read_input_token_cost": 4.5e-07,
+  "input_cost_per_token": 2.2e-06,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 8.9e-06
+ },
+ "zai/glm-4.6": {
+  "cache_read_input_token_cost": 1.1e-07,
+  "input_cost_per_token": 6e-07,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 2.2e-06
+ },
+ "zai/glm-4.7": {
+  "cache_read_input_token_cost": 1.1e-07,
+  "input_cost_per_token": 6e-07,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 2.2e-06
+ },
+ "zai/glm-4.7-flash": {
+  "cache_read_input_token_cost": 0.0,
+  "input_cost_per_token": 0.0,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 0.0
+ },
+ "zai/glm-4.7-flashx": {
+  "cache_read_input_token_cost": 1e-08,
+  "input_cost_per_token": 7e-08,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 4e-07
+ },
+ "zai/glm-5": {
+  "cache_read_input_token_cost": 2e-07,
+  "input_cost_per_token": 1e-06,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 3.2e-06
+ },
+ "zai/glm-5-turbo": {
+  "cache_read_input_token_cost": 2.4e-07,
+  "input_cost_per_token": 1.2e-06,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 4e-06
+ },
+ "zai/glm-5.1": {
+  "cache_read_input_token_cost": 2.6e-07,
+  "input_cost_per_token": 1.4e-06,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 4.4e-06
+ },
+ "zai/glm-5.2": {
+  "cache_read_input_token_cost": 2.6e-07,
+  "input_cost_per_token": 1.4e-06,
+  "litellm_provider": "zai",
+  "mode": "chat",
+  "output_cost_per_token": 4.4e-06
+ },
+ "zai/glm-5.3": {
+  "cache_read_input_token_cost": 2.6e-07,
+  "input_cost_per_token": 1.4e-06,
+  "litellm_provider": "zai",
+  "max_input_tokens": 1000000,
+  "max_output_tokens": 128000,
+  "mode": "chat",
+  "output_cost_per_token": 4.4e-06
  }
 }

--- a/backend/preloop/services/model_price_catalog.py
+++ b/backend/preloop/services/model_price_catalog.py
@@ -63,6 +63,12 @@ OPENROUTER_MODELS_URL = os.getenv(
     "OPENROUTER_MODELS_URL", "https://openrouter.ai/api/v1/models"
 )
 _OPENROUTER_PREFIX = "openrouter/"
+# Z.ai has no equivalent. Probed 2026-08-22 with a live key:
+# GET /api/paas/v4/models -> 200 {data, object}; item keys
+# created/id/object/owned_by (no pricing). GET /api/paas/v4/pricing,
+# /prices, /price -> 404 {error, path, status, timestamp}.
+# GET /api/v1/pricing -> HTTP 200 {code: 500, success: false,
+# msg: "404 NOT_FOUND"}. Do not invent a live z.ai price fetch.
 
 _lock = threading.Lock()
 _loaded = False

--- a/backend/tests/services/fixtures/zai_text_models_pricing.md
+++ b/backend/tests/services/fixtures/zai_text_models_pricing.md
@@ -1,0 +1,24 @@
+# Pricing fixture (docs.z.ai Text Models shape, not a live fetch)
+
+## Models
+
+### Text Models
+
+Prices per 1M tokens.
+
+| Model | Input | Cached Input | Cached Input Storage | Output |
+| :------------------ | :----- | :----------- | :------------------- | :----- |
+| GLM-5.3 | $1.4 | $0.26 | Limited-time Free | $4.4 |
+| GLM-5.2 | $1.4 | $0.26 | Limited-time Free | $4.4 |
+| GLM-5-Turbo | $1.2 | $0.24 | Limited-time Free | $4.0 |
+| GLM-4-32B-0414-128K | $0.1 | - | - | $0.1 |
+| GLM-Skip-Me | - | - | - | - |
+| GLM-4.7-Flash | Free | Free | Free | Free |
+
+### Vision Models
+
+Prices per 1M tokens.
+
+| Model | Input | Cached Input | Cached Input Storage | Output |
+| :-------------- | :----- | :----------- | :------------------- | :----- |
+| GLM-5V-Turbo | $1.2 | $0.24 | Limited-time Free | $4 |

--- a/backend/tests/services/test_ai_model_provider.py
+++ b/backend/tests/services/test_ai_model_provider.py
@@ -1144,6 +1144,7 @@ class TestGetZaiModels:
     async def test_without_key_returns_fallback(self):
         result = await _get_zai_models(None)
         assert result.models == ZAI_KNOWN_MODELS
+        assert "glm-5.3" in result.models
         assert "glm-5" in result.models
         assert "glm-4.7" in result.models
         assert result.source == "fallback"

--- a/backend/tests/services/test_model_pricing.py
+++ b/backend/tests/services/test_model_pricing.py
@@ -1,6 +1,9 @@
 """Tests for model pricing estimation."""
 
+import importlib.util
 import json
+from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -12,6 +15,20 @@ from preloop.services.model_pricing import (
     estimate_ai_model_usage_cost,
     estimate_ai_model_usage_cost_detailed,
 )
+
+_ZAI_PRICING_FIXTURE = (
+    Path(__file__).resolve().parent / "fixtures" / "zai_text_models_pricing.md"
+)
+
+
+def _load_update_model_prices() -> Any:
+    """Load scripts/update_model_prices.py by path (not the shared install)."""
+    script = Path(__file__).resolve().parents[3] / "scripts" / "update_model_prices.py"
+    spec = importlib.util.spec_from_file_location("update_model_prices", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_candidates_normalize_bedrock_region_prefix() -> None:
@@ -223,7 +240,9 @@ class TestNewProviderPricing:
 
     moonshot ids are priced from Preloop's bundled snapshot (official
     Moonshot prices; the pinned litellm map lacks kimi-k3 and the k2.7-code
-    family). zai and mistral ids are priced from the pinned litellm map.
+    family). glm-5.3 is likewise bundled from docs.z.ai pricing (litellm
+    has no zai/glm-5.3 key). Other zai and mistral ids are priced from
+    the pinned litellm map.
     """
 
     def test_candidates_include_moonshot_prefix(self) -> None:
@@ -236,6 +255,41 @@ class TestNewProviderPricing:
         ai_model = AIModel(provider_name="zai", model_identifier="glm-5")
         candidates = list(_iter_litellm_model_candidates(ai_model))
         assert "zai/glm-5" in candidates
+
+    def test_candidates_include_zai_glm_53(self) -> None:
+        ai_model = AIModel(provider_name="zai", model_identifier="glm-5.3")
+        candidates = list(_iter_litellm_model_candidates(ai_model))
+        assert "zai/glm-5.3" in candidates
+
+    def test_glm_53_official_prices_in_bundled_table(self) -> None:
+        """Official prices from docs.z.ai/guides/overview/pricing.md
+        (fetched 2026-08-24): input $1.4, cached input $0.26, output $4.4
+        per 1M. Context/output limits from docs.z.ai/guides/llm/glm-5.3
+        (1M context, 128K max output)."""
+        prices = json.loads(CATALOG_PATH.read_text())
+        entry = prices["zai/glm-5.3"]
+        assert entry["litellm_provider"] == "zai"
+        assert entry["mode"] == "chat"
+        assert entry["input_cost_per_token"] == 1.4e-06
+        assert entry["output_cost_per_token"] == 4.4e-06
+        assert entry["cache_read_input_token_cost"] == 2.6e-07
+        assert entry["max_input_tokens"] == 1_000_000
+        assert entry["max_output_tokens"] == 128_000
+        assert "cache_creation_input_token_cost" not in entry
+
+    def test_glm_53_cost_resolves_through_estimator(self) -> None:
+        """An AIModel row for glm-5.3 produces a catalog price."""
+        load_catalog(force=True)
+        ai_model = AIModel(provider_name="zai", model_identifier="glm-5.3")
+        estimate = estimate_ai_model_usage_cost_detailed(
+            ai_model,
+            prompt_tokens=1_000_000,
+            completion_tokens=1_000_000,
+            total_tokens=2_000_000,
+        )
+        assert estimate.source == "catalog"
+        # 1M input at $1.4/M plus 1M output at $4.4/M.
+        assert estimate.cost == pytest.approx(5.8, rel=1e-6)
 
     def test_candidates_include_mistral_prefix(self) -> None:
         ai_model = AIModel(
@@ -299,6 +353,8 @@ class TestNewProviderPricing:
     def test_zai_fallback_ids_resolve_via_litellm_map(self) -> None:
         from preloop.services.ai_model_provider import ZAI_KNOWN_MODELS
 
+        # glm-5.3 is in the vendored snapshot, not litellm's published map.
+        load_catalog(force=True)
         for model_id in ZAI_KNOWN_MODELS:
             ai_model = AIModel(provider_name="zai", model_identifier=model_id)
             estimate = estimate_ai_model_usage_cost_detailed(
@@ -749,3 +805,103 @@ def test_explicit_price_override_still_wins_over_provider_cost() -> None:
     )
     assert estimate.source == "override"
     assert estimate.cost == pytest.approx(0.01)
+
+
+class TestUpdateModelPriceOverlays:
+    """update_model_prices.py overlay parser and merge (no network)."""
+
+    def test_update_model_parser_reads_text_models_fixture(self) -> None:
+        script = _load_update_model_prices()
+        rows = script.parse_zai_text_models(_ZAI_PRICING_FIXTURE.read_text())
+        assert "glm-5.3" in rows
+        assert rows["glm-5.3"]["input_cost_per_token"] == 1.4e-06
+        assert rows["glm-5.3"]["output_cost_per_token"] == 4.4e-06
+        assert rows["glm-5.3"]["cache_read_input_token_cost"] == 2.6e-07
+        assert "glm-5-turbo" in rows
+        assert rows["glm-5-turbo"]["input_cost_per_token"] == 1.2e-06
+        assert rows["glm-4.7-flash"]["input_cost_per_token"] == 0.0
+        assert rows["glm-4.7-flash"]["output_cost_per_token"] == 0.0
+        # Cached input was "-": field omitted, row kept.
+        assert "glm-4-32b-0414-128k" in rows
+        assert "cache_read_input_token_cost" not in rows["glm-4-32b-0414-128k"]
+        # Dash input/output: skip the row.
+        assert "glm-skip-me" not in rows
+        # Vision table must not leak into the overlay.
+        assert "glm-5v-turbo" not in rows
+
+    def test_update_model_moonshot_keys_survive_stub_litellm_merge(self) -> None:
+        script = _load_update_model_prices()
+        current = {
+            "gpt-4o": {
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "input_cost_per_token": 2.5e-06,
+                "output_cost_per_token": 1.0e-05,
+            },
+            "moonshot/kimi-k3": {
+                "litellm_provider": "moonshot",
+                "mode": "chat",
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "cache_read_input_token_cost": 3e-07,
+            },
+            "zai/glm-5-turbo": {
+                "litellm_provider": "zai",
+                "mode": "chat",
+                "input_cost_per_token": 9.9e-06,
+                "output_cost_per_token": 9.9e-06,
+                "max_input_tokens": 200000,
+            },
+        }
+        stub_litellm = {
+            "gpt-4o": {
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "input_cost_per_token": 1.0e-06,
+                "output_cost_per_token": 4.0e-06,
+            }
+        }
+        zai_rows = script.parse_zai_text_models(_ZAI_PRICING_FIXTURE.read_text())
+        merged = script.apply_overlays(stub_litellm, current, zai_rows)
+        assert merged["moonshot/kimi-k3"]["input_cost_per_token"] == 3e-06
+        assert merged["zai/glm-5.3"]["input_cost_per_token"] == 1.4e-06
+        assert merged["zai/glm-5.3"]["max_input_tokens"] == 1_000_000
+        assert merged["zai/glm-5.3"]["max_output_tokens"] == 128_000
+        # Other z.ai rows keep existing max_* and do not invent new ones.
+        assert merged["zai/glm-5-turbo"]["input_cost_per_token"] == 1.2e-06
+        assert merged["zai/glm-5-turbo"]["max_input_tokens"] == 200000
+        assert "max_output_tokens" not in merged["zai/glm-5.2"]
+        assert "zai/glm-5v-turbo" not in merged
+
+    def test_update_model_compare_remote_excludes_overlay_prefixes(self) -> None:
+        script = _load_update_model_prices()
+        current = {
+            "_preloop_meta": {"source_url": "https://example.com/litellm.json"},
+            "gpt-4o": {
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "input_cost_per_token": 1.0e-06,
+            },
+            "moonshot/kimi-k3": {
+                "litellm_provider": "moonshot",
+                "mode": "chat",
+                "input_cost_per_token": 3e-06,
+            },
+            "zai/glm-5.3": {
+                "litellm_provider": "zai",
+                "mode": "chat",
+                "input_cost_per_token": 1.4e-06,
+            },
+        }
+        upstream = {
+            "gpt-4o": {
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "input_cost_per_token": 1.0e-06,
+            }
+        }
+        sourced = script.litellm_sourced_catalog(current)
+        assert "moonshot/kimi-k3" not in sourced
+        assert "zai/glm-5.3" not in sourced
+        assert "gpt-4o" in sourced
+        assert script.diff_catalogs(sourced, upstream) == []

--- a/backend/tests/services/test_model_pricing.py
+++ b/backend/tests/services/test_model_pricing.py
@@ -2,6 +2,8 @@
 
 import importlib.util
 import json
+import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -905,3 +907,103 @@ class TestUpdateModelPriceOverlays:
         assert "zai/glm-5.3" not in sourced
         assert "gpt-4o" in sourced
         assert script.diff_catalogs(sourced, upstream) == []
+
+    def test_update_model_zai_fetch_failure_still_merges_litellm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """docs.z.ai 404 or parse failure must not abort the litellm write."""
+        script = _load_update_model_prices()
+        previous_overlay = {
+            "url": script.ZAI_PRICING_URL,
+            "fetched_at": "2026-01-15T00:00:00+00:00",
+            "section": "Text Models",
+        }
+        current = {
+            "_preloop_meta": {
+                "source_url": "https://example.com/litellm.json",
+                "fetched_at": "2026-01-15T00:00:00+00:00",
+                "overlay_sources": [previous_overlay],
+            },
+            "gpt-4o": {
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "input_cost_per_token": 2.5e-06,
+                "output_cost_per_token": 1.0e-05,
+            },
+            "moonshot/kimi-k3": {
+                "litellm_provider": "moonshot",
+                "mode": "chat",
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+            },
+            "zai/glm-5.3": {
+                "litellm_provider": "zai",
+                "mode": "chat",
+                "input_cost_per_token": 1.4e-06,
+                "output_cost_per_token": 4.4e-06,
+            },
+        }
+        written: dict[str, Any] = {}
+
+        def fake_fetch_remote(url: str = script.SOURCE_URL) -> dict[str, Any]:
+            return {
+                "gpt-4o": {
+                    "litellm_provider": "openai",
+                    "mode": "chat",
+                    "input_cost_per_token": 1.0e-06,
+                    "output_cost_per_token": 4.0e-06,
+                }
+            }
+
+        def fake_fetch_text(url: str) -> str:
+            raise OSError("HTTP Error 404: Not Found")
+
+        def fake_write_catalog(
+            filtered: dict[str, Any],
+            source_url: str,
+            overlay_sources: list[dict[str, Any]] | None = None,
+        ) -> None:
+            written["filtered"] = filtered
+            written["source_url"] = source_url
+            written["overlay_sources"] = overlay_sources
+
+        monkeypatch.setattr(script, "fetch_remote", fake_fetch_remote)
+        monkeypatch.setattr(script, "fetch_text", fake_fetch_text)
+        monkeypatch.setattr(script, "load_current", lambda: current)
+        monkeypatch.setattr(script, "write_catalog", fake_write_catalog)
+        monkeypatch.setattr(sys, "argv", ["update_model_prices.py"])
+
+        assert script.main() == 0
+        merged = written["filtered"]
+        assert merged["gpt-4o"]["input_cost_per_token"] == 1.0e-06
+        assert merged["moonshot/kimi-k3"]["input_cost_per_token"] == 3e-06
+        assert merged["zai/glm-5.3"]["input_cost_per_token"] == 1.4e-06
+        assert written["overlay_sources"] == [previous_overlay]
+
+    def test_check_overlay_ages_uses_fixture_meta(self) -> None:
+        """--check ages overlay_sources from meta without fetching docs.z.ai."""
+        script = _load_update_model_prices()
+        now = datetime(2026, 8, 24, tzinfo=timezone.utc)
+        fresh_meta = {
+            "overlay_sources": [
+                {
+                    "url": "https://docs.z.ai/guides/overview/pricing.md",
+                    "fetched_at": "2026-08-20T00:00:00+00:00",
+                    "section": "Text Models",
+                }
+            ]
+        }
+        stale_meta = {
+            "overlay_sources": [
+                {
+                    "url": "https://docs.z.ai/guides/overview/pricing.md",
+                    "fetched_at": "2026-01-01T00:00:00+00:00",
+                    "section": "Text Models",
+                }
+            ]
+        }
+        assert script.overlay_sources_over_max_age(fresh_meta, 30, now=now) == []
+        stale = script.overlay_sources_over_max_age(stale_meta, 30, now=now)
+        assert len(stale) == 1
+        assert "older than 30 days" in stale[0]
+        assert script.overlay_sources_over_max_age({}, 30, now=now) == []

--- a/scripts/update_model_prices.py
+++ b/scripts/update_model_prices.py
@@ -399,6 +399,59 @@ def write_catalog(
     CATALOG_PATH.write_text(json.dumps(payload, indent=1, sort_keys=False) + "\n")
 
 
+def overlay_sources_over_max_age(
+    meta: Dict[str, Any],
+    max_age_days: int,
+    now: Optional[datetime] = None,
+) -> List[str]:
+    """Return FAIL reasons for overlay_sources older than max_age_days.
+
+    Missing overlay_sources is not a failure (older catalogs). Does not
+    fetch any remote URL; callers pass a meta dict, including fixtures.
+    """
+    clock = now or datetime.now(timezone.utc)
+    sources = meta.get("overlay_sources")
+    if not isinstance(sources, list):
+        return []
+    failures: List[str] = []
+    for source in sources:
+        if not isinstance(source, dict):
+            failures.append("FAIL: overlay_sources entry is not an object")
+            continue
+        raw = source.get("fetched_at")
+        url = source.get("url") or "overlay"
+        if not raw:
+            failures.append(f"FAIL: overlay {url} has no fetched_at provenance")
+            continue
+        try:
+            fetched_at = datetime.fromisoformat(str(raw))
+        except ValueError:
+            failures.append(f"FAIL: overlay {url} has invalid fetched_at")
+            continue
+        if fetched_at.tzinfo is None:
+            fetched_at = fetched_at.replace(tzinfo=timezone.utc)
+        age_days = (clock - fetched_at).days
+        if age_days > max_age_days:
+            failures.append(
+                f"FAIL: overlay {url} older than {max_age_days} days "
+                f"(age={age_days}d): rerun this script"
+            )
+    return failures
+
+
+def _previous_overlay_sources(
+    current: Dict[str, Any],
+) -> Optional[List[Dict[str, Any]]]:
+    """Return existing overlay_sources so a failed fetch is not stamped fresh."""
+    meta = current.get(META_KEY)
+    if not isinstance(meta, dict):
+        return None
+    sources = meta.get("overlay_sources")
+    if isinstance(sources, list) and sources:
+        return sources
+    return None
+
+
 def check(max_age_days: int, compare_remote: bool) -> int:
     """Freshness gate: non-zero exit when the snapshot is stale or drifted."""
     current = load_current()
@@ -418,6 +471,13 @@ def check(max_age_days: int, compare_remote: bool) -> int:
     if age_days > max_age_days:
         print(f"FAIL: catalog older than {max_age_days} days: rerun this script")
         return 1
+    overlay_failures = overlay_sources_over_max_age(meta, max_age_days)
+    if overlay_failures:
+        for line in overlay_failures:
+            print(line)
+        return 1
+    if isinstance(meta.get("overlay_sources"), list) and meta["overlay_sources"]:
+        print(f"overlay_sources={len(meta['overlay_sources'])} within {max_age_days}d")
     if compare_remote:
         filtered = filter_catalog(fetch_remote())
         drift = diff_catalogs(litellm_sourced_catalog(current), filtered)
@@ -459,9 +519,24 @@ def main() -> int:
     filtered = filter_catalog(fetch_remote(args.url))
     current = load_current()
     print(f"Fetching {ZAI_PRICING_URL} ...")
-    zai_rows = parse_zai_text_models(fetch_text(ZAI_PRICING_URL))
+    overlay_sources: Optional[List[Dict[str, Any]]] = None
+    try:
+        zai_rows = parse_zai_text_models(fetch_text(ZAI_PRICING_URL))
+    except (ValueError, OSError) as exc:
+        print(
+            f"WARNING: z.ai pricing overlay skipped ({exc}); keeping existing overlays"
+        )
+        zai_rows = {}
+        overlay_sources = _previous_overlay_sources(current)
+    else:
+        overlay_sources = [
+            {
+                "url": ZAI_PRICING_URL,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "section": "Text Models",
+            }
+        ]
     merged = apply_overlays(filtered, current, zai_rows)
-    overlay_fetched_at = datetime.now(timezone.utc).isoformat()
     changes = diff_catalogs({k: v for k, v in current.items() if k != META_KEY}, merged)
     if changes:
         print(f"{len(changes)} model change(s):")
@@ -469,17 +544,7 @@ def main() -> int:
             print("  " + line)
     else:
         print("No price/model changes; refreshing provenance only.")
-    write_catalog(
-        merged,
-        args.url,
-        overlay_sources=[
-            {
-                "url": ZAI_PRICING_URL,
-                "fetched_at": overlay_fetched_at,
-                "section": "Text Models",
-            }
-        ],
-    )
+    write_catalog(merged, args.url, overlay_sources=overlay_sources)
     print(f"Wrote {len(merged)} models to {CATALOG_PATH}")
     return 0
 

--- a/scripts/update_model_prices.py
+++ b/scripts/update_model_prices.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Refresh the vendored model-price catalog from litellm's public price map.
+"""Refresh the vendored model-price catalog from litellm plus first-party overlays.
 
 This is the standardized way to update Preloop's default model prices:
 
@@ -10,15 +10,22 @@ The catalog (``preloop/services/data/model_prices.json``) is a filtered
 snapshot of litellm's ``model_prices_and_context_window.json``:
 
 - providers limited to the ones Preloop routes,
-- modes limited to chat/responses (no image/audio/video/embedding models —
+- modes limited to chat/responses (no image/audio/video/embedding models:
   the gateway never bills those),
 - entries past their ``deprecation_date`` dropped,
 - fields stripped to what pricing needs (cost fields + provider/mode/limits;
-  capability flags are omitted — ``litellm.register_model`` merges per key,
+  capability flags are omitted. ``litellm.register_model`` merges per key,
   so bundled entries keep their flags).
 
+First-party overlays (``moonshot/*``, ``zai/*``) are preserved across a
+refresh and are not sourced from litellm. z.ai has no live price API
+(probed 2026-08-22: ``/api/paas/v4/models`` has ids only; ``/pricing``,
+``/prices``, ``/price`` 404; ``/api/v1/pricing`` is HTTP 200 with
+``success=false``). Text-model prices are scraped from the public docs
+page and upserted under ``zai/<slug>``. Do not invent a live z.ai fetch.
+
 Models missing from the snapshot are looked up live, once, at runtime (see
-``model_price_catalog.schedule_price_lookup``) — the snapshot is a warm,
+``model_price_catalog.schedule_price_lookup``). The snapshot is a warm,
 deterministic cache, not an exhaustive registry. It is loaded at startup via
 ``preloop.services.model_price_catalog.load_catalog`` so runtime pricing does
 not depend on the installed litellm version. Review the printed diff and
@@ -29,16 +36,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 SOURCE_URL = (
     "https://raw.githubusercontent.com/BerriAI/litellm/main/"
     "model_prices_and_context_window.json"
 )
+ZAI_PRICING_URL = "https://docs.z.ai/guides/overview/pricing.md"
 CATALOG_PATH = (
     Path(__file__).resolve().parents[1]
     / "backend"
@@ -50,7 +59,8 @@ CATALOG_PATH = (
 META_KEY = "_preloop_meta"
 
 # litellm_provider values Preloop routes (exact match, or prefix for the
-# vertex_ai-* families).
+# vertex_ai-* families). moonshot and zai are first-party overlays, not
+# this allowlist: a refresh must not drop them when litellm omits the keys.
 PROVIDER_ALLOWLIST = {
     "openai",
     "azure",
@@ -63,12 +73,15 @@ PROVIDER_ALLOWLIST = {
 }
 PROVIDER_PREFIXES = ("vertex_ai",)
 
+OVERLAY_KEY_PREFIXES = ("moonshot/", "zai/")
+OVERLAY_PROVIDERS = frozenset({"moonshot", "zai"})
+
 # Only modes the gateway can actually bill (chat completions / responses).
 MODE_ALLOWLIST = {"chat", "responses"}
 
 # Fields kept per entry: everything pricing-related plus routing/limit
 # metadata. Capability flags (supports_*), sources, and sample specs are
-# dropped — register_model merges per key, so litellm's bundled entries keep
+# dropped. register_model merges per key, so litellm's bundled entries keep
 # any field we omit.
 KEEP_FIELDS_EXACT = {
     "litellm_provider",
@@ -90,6 +103,18 @@ PRICE_FIELDS = (
     "output_cost_per_reasoning_token",
 )
 
+# Official GLM-5.3 limits from https://docs.z.ai/guides/llm/glm-5.3
+# ("1M-token context window and a maximum output length of 128K tokens").
+# Do not invent max_* for other z.ai rows.
+ZAI_GLM_53_LIMITS = {
+    "max_input_tokens": 1_000_000,
+    "max_output_tokens": 128_000,
+}
+
+_TEXT_MODELS_HEADING = re.compile(r"^###\s+Text Models\s*$", re.MULTILINE)
+_NEXT_H3 = re.compile(r"^###\s+", re.MULTILINE)
+_TABLE_SEP = re.compile(r"^:?-+:?$")
+
 
 def _provider_allowed(entry: Any) -> bool:
     if not isinstance(entry, dict):
@@ -98,23 +123,43 @@ def _provider_allowed(entry: Any) -> bool:
     return provider in PROVIDER_ALLOWLIST or provider.startswith(PROVIDER_PREFIXES)
 
 
-def fetch_remote(url: str = SOURCE_URL) -> Dict[str, Any]:
-    """Download and parse the upstream litellm price map."""
-    context = None
+def is_overlay_entry(key: str, entry: Any) -> bool:
+    """True for first-party overlay keys (moonshot/zai), not litellm-sourced."""
+    if key.startswith(OVERLAY_KEY_PREFIXES):
+        return True
+    if isinstance(entry, dict) and entry.get("litellm_provider") in OVERLAY_PROVIDERS:
+        return True
+    return False
+
+
+def _ssl_context() -> Any:
     try:
         import ssl
 
         import certifi
 
-        context = ssl.create_default_context(cafile=certifi.where())
+        return ssl.create_default_context(cafile=certifi.where())
     except ImportError:
         # certifi is optional: fall back to the system CA store via
         # urlopen's default SSL context when the package is not installed.
-        pass
+        return None
+
+
+def _urlopen_bytes(url: str) -> bytes:
     with urllib.request.urlopen(  # noqa: S310
-        url, timeout=60, context=context
+        url, timeout=60, context=_ssl_context()
     ) as response:
-        return json.loads(response.read().decode("utf-8"))
+        return response.read()
+
+
+def fetch_remote(url: str = SOURCE_URL) -> Dict[str, Any]:
+    """Download and parse the upstream litellm price map."""
+    return json.loads(_urlopen_bytes(url).decode("utf-8"))
+
+
+def fetch_text(url: str) -> str:
+    """Download a text document (used for the public z.ai pricing page)."""
+    return _urlopen_bytes(url).decode("utf-8")
 
 
 def _entry_relevant(entry: Any, today: str) -> bool:
@@ -155,6 +200,160 @@ def load_current() -> Dict[str, Any]:
     return json.loads(CATALOG_PATH.read_text())
 
 
+def preserve_overlays(current: Dict[str, Any]) -> Dict[str, Any]:
+    """Return first-party overlay rows from the current catalog."""
+    return {
+        key: value
+        for key, value in current.items()
+        if key != META_KEY and is_overlay_entry(key, value)
+    }
+
+
+def litellm_sourced_catalog(catalog: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop meta and first-party overlays so --compare-remote diffs litellm only."""
+    return {
+        key: value
+        for key, value in catalog.items()
+        if key != META_KEY and not is_overlay_entry(key, value)
+    }
+
+
+def _split_md_row(line: str) -> List[str]:
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def _is_separator_row(cells: List[str]) -> bool:
+    if not cells:
+        return False
+    return all(_TABLE_SEP.match(cell.replace(" ", "")) for cell in cells if cell)
+
+
+def zai_model_slug(name: str) -> str:
+    """GLM-5.3 -> glm-5.3, GLM-5-Turbo -> glm-5-turbo."""
+    return name.strip().lower()
+
+
+def parse_usd_per_million(cell: str) -> Optional[float]:
+    """Convert a Text Models cell ($/1M, Free, or -) to per-token cost.
+
+    Returns None for a dash / empty cell (caller skips the field or row).
+    Does not invent a storage-cost field for "Limited-time Free".
+    """
+    raw = cell.replace("\\", "").replace("$", "").replace(",", "").strip()
+    if raw in ("", "-"):
+        return None
+    if "free" in raw.lower():
+        return 0.0
+    # 8 significant digits is enough for $/1M / 1e6 and avoids binary noise
+    # such as 1.0000000000000001e-07.
+    return float(f"{(float(raw) / 1_000_000):.8g}")
+
+
+def parse_zai_text_models(markdown: str) -> Dict[str, Dict[str, Any]]:
+    """Parse the Text Models table only (not vision/image/video/audio/agents).
+
+    Args:
+        markdown: Full docs.z.ai pricing page (or a fixture snippet).
+
+    Returns:
+        Map of slug -> cost fields (per token). Rows with ``-`` for input
+        or output are skipped. Cached-input ``-`` omits that field only.
+
+    Raises:
+        ValueError: The Text Models table is missing or has no Model column.
+    """
+    heading = _TEXT_MODELS_HEADING.search(markdown)
+    if heading is None:
+        raise ValueError("z.ai pricing markdown has no Text Models section")
+    rest = markdown[heading.end() :]
+    next_heading = _NEXT_H3.search(rest)
+    section = rest[: next_heading.start()] if next_heading else rest
+
+    table_rows: List[List[str]] = []
+    for line in section.splitlines():
+        if "|" not in line:
+            continue
+        cells = _split_md_row(line)
+        if not cells or _is_separator_row(cells):
+            continue
+        table_rows.append(cells)
+    if len(table_rows) < 2:
+        raise ValueError("z.ai Text Models section has no data rows")
+
+    header = [cell.lower() for cell in table_rows[0]]
+    try:
+        model_idx = header.index("model")
+        input_idx = header.index("input")
+        output_idx = header.index("output")
+    except ValueError as exc:
+        raise ValueError("z.ai Text Models table is missing required columns") from exc
+    cache_idx = header.index("cached input") if "cached input" in header else None
+
+    parsed: Dict[str, Dict[str, Any]] = {}
+    for cells in table_rows[1:]:
+        if model_idx >= len(cells):
+            continue
+        slug = zai_model_slug(cells[model_idx])
+        if not slug:
+            continue
+        input_cell = cells[input_idx] if input_idx < len(cells) else ""
+        output_cell = cells[output_idx] if output_idx < len(cells) else ""
+        input_cost = parse_usd_per_million(input_cell)
+        output_cost = parse_usd_per_million(output_cell)
+        if input_cost is None or output_cost is None:
+            continue
+        entry: Dict[str, Any] = {
+            "input_cost_per_token": input_cost,
+            "output_cost_per_token": output_cost,
+        }
+        if cache_idx is not None and cache_idx < len(cells):
+            cache_cost = parse_usd_per_million(cells[cache_idx])
+            if cache_cost is not None:
+                entry["cache_read_input_token_cost"] = cache_cost
+        parsed[slug] = entry
+    return parsed
+
+
+def apply_overlays(
+    litellm_filtered: Dict[str, Any],
+    current: Dict[str, Any],
+    zai_rows: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Merge litellm rows with preserved overlays and upserted z.ai prices.
+
+    Existing ``moonshot/`` and ``zai/`` keys survive a stub or refreshed
+    litellm map. z.ai Text Models then overwrite ``zai/<slug>``. glm-5.3
+    gets documented max_* limits; other z.ai rows keep existing max_* only.
+    """
+    merged = dict(litellm_filtered)
+    for key, entry in preserve_overlays(current).items():
+        merged[key] = entry
+    for slug, costs in zai_rows.items():
+        key = f"zai/{slug}"
+        previous = current.get(key) if isinstance(current.get(key), dict) else {}
+        if not previous:
+            existing = merged.get(key)
+            previous = existing if isinstance(existing, dict) else {}
+        entry = {
+            "litellm_provider": "zai",
+            "mode": "chat",
+            **costs,
+        }
+        if slug == "glm-5.3":
+            entry.update(ZAI_GLM_53_LIMITS)
+        else:
+            for field in ("max_input_tokens", "max_output_tokens", "max_tokens"):
+                if field in previous:
+                    entry[field] = previous[field]
+        merged[key] = entry
+    return merged
+
+
 def diff_catalogs(current: Dict[str, Any], new: Dict[str, Any]) -> list[str]:
     """Return human-readable per-model changes between two snapshots."""
     lines: list[str] = []
@@ -176,15 +375,25 @@ def diff_catalogs(current: Dict[str, Any], new: Dict[str, Any]) -> list[str]:
     return lines
 
 
-def write_catalog(filtered: Dict[str, Any], source_url: str) -> None:
-    """Write the snapshot with provenance metadata."""
-    payload: Dict[str, Any] = {
-        META_KEY: {
-            "source_url": source_url,
-            "fetched_at": datetime.now(timezone.utc).isoformat(),
-            "model_count": len(filtered),
-        }
+def write_catalog(
+    filtered: Dict[str, Any],
+    source_url: str,
+    overlay_sources: Optional[List[Dict[str, Any]]] = None,
+) -> None:
+    """Write the snapshot with provenance metadata.
+
+    ``source_url`` stays the litellm map (CI / --check compatibility).
+    Overlay provenance lives in ``overlay_sources`` so first-party rows
+    are not claimed as litellm-sourced.
+    """
+    meta: Dict[str, Any] = {
+        "source_url": source_url,
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+        "model_count": len(filtered),
     }
+    if overlay_sources:
+        meta["overlay_sources"] = overlay_sources
+    payload: Dict[str, Any] = {META_KEY: meta}
     payload.update(dict(sorted(filtered.items())))
     CATALOG_PATH.parent.mkdir(parents=True, exist_ok=True)
     CATALOG_PATH.write_text(json.dumps(payload, indent=1, sort_keys=False) + "\n")
@@ -207,11 +416,11 @@ def check(max_age_days: int, compare_remote: bool) -> int:
         f"catalog fetched_at={fetched_at_raw} age={age_days}d models={meta.get('model_count')}"
     )
     if age_days > max_age_days:
-        print(f"FAIL: catalog older than {max_age_days} days — rerun this script")
+        print(f"FAIL: catalog older than {max_age_days} days: rerun this script")
         return 1
     if compare_remote:
         filtered = filter_catalog(fetch_remote())
-        drift = diff_catalogs(current, filtered)
+        drift = diff_catalogs(litellm_sourced_catalog(current), filtered)
         if drift:
             print(f"FAIL: catalog drifted from upstream ({len(drift)} changes):")
             for line in drift[:50]:
@@ -249,17 +458,29 @@ def main() -> int:
     print(f"Fetching {args.url} ...")
     filtered = filter_catalog(fetch_remote(args.url))
     current = load_current()
-    changes = diff_catalogs(
-        {k: v for k, v in current.items() if k != META_KEY}, filtered
-    )
+    print(f"Fetching {ZAI_PRICING_URL} ...")
+    zai_rows = parse_zai_text_models(fetch_text(ZAI_PRICING_URL))
+    merged = apply_overlays(filtered, current, zai_rows)
+    overlay_fetched_at = datetime.now(timezone.utc).isoformat()
+    changes = diff_catalogs({k: v for k, v in current.items() if k != META_KEY}, merged)
     if changes:
         print(f"{len(changes)} model change(s):")
         for line in changes:
             print("  " + line)
     else:
         print("No price/model changes; refreshing provenance only.")
-    write_catalog(filtered, args.url)
-    print(f"Wrote {len(filtered)} models to {CATALOG_PATH}")
+    write_catalog(
+        merged,
+        args.url,
+        overlay_sources=[
+            {
+                "url": ZAI_PRICING_URL,
+                "fetched_at": overlay_fetched_at,
+                "section": "Text Models",
+            }
+        ],
+    )
+    print(f"Wrote {len(merged)} models to {CATALOG_PATH}")
     return 0
 
 


### PR DESCRIPTION
## Summary
- Vendors first-party `zai/glm-5.3` prices from [docs.z.ai pricing](https://docs.z.ai/guides/overview/pricing.md) ($1.4 / $0.26 cached / $4.4 per 1M) so gateway usage is not recorded as unpriced. z.ai has no price API (unlike OpenRouter).
- `scripts/update_model_prices.py` now overlays that Text Models table and preserves moonshot/z.ai first-party rows, so a catalog refresh does not wipe them.
- Also overlays the other public Text Models under `zai/<slug>`. `ZAI_KNOWN_MODELS` leads with `glm-5.3`. Existing unpriced rows are not backfilled by this change.

## Test plan
- [x] `PYTHONPATH=backend pytest backend/tests/services/test_model_pricing.py backend/tests/services/test_ai_model_provider.py -k "zai or glm or NewProvider or update_model"` (25 passed; import resolved in this worktree)
- [ ] After deploy, a new `zai/glm-5.3` request records `cost_source=catalog` instead of `unpriced`
- [ ] Confirm a later `python scripts/update_model_prices.py` keeps `zai/glm-5.3` and `moonshot/kimi-k3`


Made with [Cursor](https://cursor.com)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Vendors first-party z.ai prices (including glm-5.3) and extends the catalog refresh script to scrape docs.z.ai. Well-tested, data-verified, and the z.ai scrape now degrades gracefully instead of being a hard dependency of the refresh.
>
> **Overview**
> Adds `zai/glm-5.3` (and other public Text Models) to the vendored price catalog so usage is recorded as `catalog` rather than `unpriced`, and makes `scripts/update_model_prices.py` overlay the docs.z.ai pricing table while preserving moonshot/z.ai rows. No security issues found.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 05d30de4. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->