### PR TITLE
fix(gateway): render MCP namespace tool calls in the form Codex's router routes

### DIFF
--- a/backend/preloop/services/codex_tool_compat.py
+++ b/backend/preloop/services/codex_tool_compat.py
@@ -72,7 +72,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -213,14 +213,21 @@ def sanitize_codex_tools(tools: Any) -> tuple[Any, Set[str]]:
             nested_tools, nested_freeform = sanitize_codex_tools(nested)
             if isinstance(nested_tools, list):
                 # MCP namespaces (``mcp__<server>``) advertise their nested
-                # tools under SHORT names, but Codex's tool router only
-                # routes the fully-qualified ``mcp__<server>__<tool>`` form:
-                # a model that calls the flattened short name gets
-                # ``unsupported call: <tool>`` back (staging execution
-                # 4ba5c5e7: 14 ``ask_user`` attempts, all rejected). Qualify
-                # the flattened names so what the model is declared is what
-                # the router routes. Non-MCP namespaces (multi_agent_v1)
-                # keep their nested names untouched.
+                # tools under SHORT names. Flattening them for the upstream
+                # requires globally unique model-facing names, so qualify
+                # them as ``mcp__<server>__<tool>``. NOTE this alone does
+                # NOT make the call routable: Codex's tool router accepts a
+                # namespace tool call ONLY as a ``function_call`` item that
+                # carries a separate ``namespace`` field plus the SHORT
+                # nested name (verified against the real binary: a plain
+                # function_call is rejected whether it uses the short name —
+                # staging exec 4ba5c5e7, 14 ``ask_user`` rejections — or the
+                # qualified name — staging exec 97c977f8,
+                # ``unsupported call: mcp__preloop__ask_user``). The
+                # response translation (:func:`restore_namespace_tool_calls`)
+                # renders the model's call back in that namespace form.
+                # Non-MCP namespaces (multi_agent_v1) keep their nested
+                # names untouched: their router names are not ours.
                 namespace_name = tool.get("name")
                 if isinstance(namespace_name, str) and namespace_name.startswith(
                     "mcp__"
@@ -384,3 +391,166 @@ def restore_custom_tool_calls(
             }
         )
     return restored
+
+
+def _nested_tool_name(tool: Any) -> Optional[str]:
+    """Return a nested namespace tool's declared name, any wire shape."""
+    if not isinstance(tool, dict):
+        return None
+    function = tool.get("function")
+    if isinstance(function, dict):
+        name = function.get("name")
+        if isinstance(name, str) and name:
+            return name
+    name = tool.get("name")
+    if isinstance(name, str) and name:
+        return name
+    return None
+
+
+def namespace_tool_aliases(tools: Any) -> Dict[str, Tuple[str, str]]:
+    """Map every model-callable alias to its ``(namespace, short_name)`` pair.
+
+    Codex's tool router accepts a call to an MCP namespace tool ONLY as a
+    ``function_call`` item carrying a separate ``namespace`` field and the
+    SHORT nested tool name (verified against the real binary; see
+    :func:`restore_namespace_tool_calls`). The model, however, is declared the
+    flattened ``mcp__<server>__<tool>`` name — and prompt text or older
+    transcripts may steer it to the bare short name instead. Both must route,
+    so both are registered as aliases of the same namespace call:
+
+    * the canonical qualified name (``mcp__preloop__ask_user``), always;
+    * the bare short name (``ask_user``), only while it is unambiguous — a
+      collision with another namespace's tool or with any top-level tool
+      name drops the bare alias rather than guessing.
+
+    Args:
+        tools: The ORIGINAL request ``tools`` value, before sanitization.
+
+    Returns:
+        Alias name -> ``(namespace, short_name)``. Empty when the request
+        declares no ``mcp__*`` namespace tools.
+    """
+    if not isinstance(tools, list):
+        return {}
+
+    aliases: Dict[str, Tuple[str, str]] = {}
+    ambiguous_short: Set[str] = set()
+    top_level_names: Set[str] = set()
+
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        if tool.get("type") == "namespace":
+            namespace = tool.get("name")
+            nested = tool.get("tools")
+            if (
+                not isinstance(namespace, str)
+                or not namespace.startswith("mcp__")
+                or not isinstance(nested, list)
+            ):
+                continue
+            for nested_tool in nested:
+                short = _nested_tool_name(nested_tool)
+                if not short:
+                    continue
+                prefix = f"{namespace}__"
+                if short.startswith(prefix):
+                    # Defensive: an already-qualified nested name still maps
+                    # to the short name the router expects.
+                    short = short[len(prefix) :]
+                    if not short:
+                        continue
+                qualified = f"{namespace}__{short}"
+                aliases[qualified] = (namespace, short)
+                if short in aliases and aliases[short] != (namespace, short):
+                    ambiguous_short.add(short)
+                elif short != qualified:
+                    aliases.setdefault(short, (namespace, short))
+        else:
+            name = _nested_tool_name(tool)
+            if name:
+                top_level_names.add(name)
+
+    for short in ambiguous_short:
+        aliases.pop(short, None)
+    for name in top_level_names:
+        # A top-level tool with the same name wins: Codex's router knows it
+        # as a plain function tool, so rewriting its calls to namespace form
+        # would break it. Never shadow one.
+        aliases.pop(name, None)
+    return aliases
+
+
+def restore_namespace_tool_calls(
+    output_items: List[Dict[str, Any]],
+    namespace_aliases: Dict[str, Tuple[str, str]],
+) -> List[Dict[str, Any]]:
+    """Render calls to flattened MCP namespace tools in the routable form.
+
+    Codex's tool router (``codex_core::tools::router``) routes a namespace
+    tool call ONLY when the ``function_call`` item carries the namespace in a
+    separate ``namespace`` field alongside the SHORT tool name. Verified
+    against the real binary: a plain ``function_call`` named ``ask_user``,
+    ``mcp__preloop__ask_user`` or ``mcp__preloop.ask_user`` is all
+    "unsupported call", while ``{"type": "function_call", "namespace":
+    "mcp__preloop", "name": "ask_user"}`` reaches the MCP server. This is the
+    response-side half of the namespace translation whose request-side half
+    (:func:`sanitize_codex_tools`) flattens and qualifies the declared names —
+    without this half every MCP tool call still fails after #286's
+    declaration fix (staging execution 97c977f8).
+
+    Args:
+        output_items: Responses-API output items built from the upstream
+            reply.
+        namespace_aliases: :func:`namespace_tool_aliases` of the request.
+
+    Returns:
+        The output items with matching calls rewritten in namespace form.
+        Returns the input unchanged when the request declared no MCP
+        namespace tools.
+    """
+    if not namespace_aliases or not isinstance(output_items, list):
+        return output_items
+
+    restored: List[Dict[str, Any]] = []
+    for item in output_items:
+        if not isinstance(item, dict) or item.get("type") != "function_call":
+            restored.append(item)
+            continue
+        target = namespace_aliases.get(item.get("name"))
+        if target is None:
+            restored.append(item)
+            continue
+        namespace, short = target
+        rewritten = dict(item)
+        rewritten["namespace"] = namespace
+        rewritten["name"] = short
+        restored.append(rewritten)
+    return restored
+
+
+def qualify_namespace_call_history_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Flatten a namespace-form ``function_call`` history item for upstreams.
+
+    Codex echoes the namespace-form call (``namespace`` field + short name)
+    back in the next turn's input history. Upstreams were declared the
+    flattened qualified name, so the history must use it too — and no
+    upstream accepts an unknown ``namespace`` field on a function call.
+
+    Args:
+        item: One Responses-API input item of type ``function_call``.
+
+    Returns:
+        The item with the qualified name and without the ``namespace`` field,
+        or the item unchanged when it carries no MCP namespace.
+    """
+    namespace = item.get("namespace")
+    if not isinstance(namespace, str) or not namespace.startswith("mcp__"):
+        return item
+    name = item.get("name")
+    flattened = dict(item)
+    flattened.pop("namespace", None)
+    if isinstance(name, str) and name and not name.startswith(f"{namespace}__"):
+        flattened["name"] = f"{namespace}__{name}"
+    return flattened

--- a/backend/preloop/services/codex_tool_compat.py
+++ b/backend/preloop/services/codex_tool_compat.py
@@ -465,8 +465,8 @@ def namespace_tool_aliases(tools: Any) -> Dict[str, Tuple[str, str]]:
                 aliases[qualified] = (namespace, short)
                 if short in aliases and aliases[short] != (namespace, short):
                     ambiguous_short.add(short)
-                elif short != qualified:
-                    aliases.setdefault(short, (namespace, short))
+                # Unambiguous bare alias so a model that calls the short name still routes.
+                aliases.setdefault(short, (namespace, short))
         else:
             name = _nested_tool_name(tool)
             if name:

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -2168,7 +2168,7 @@ class OpenAIGatewayService:
                             tool_call_states[index] = state
                             output_items.append(state["item"])
                         function_payload = tool_delta.get("function") or {}
-                        if function_payload.get("name"):
+                        if function_payload.get("name") and not state["announced"]:
                             state["item"]["name"] = function_payload["name"]
                         arguments_delta = function_payload.get("arguments")
                         if arguments_delta:

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -27,6 +27,7 @@ from typing import (
     Protocol,
     Sequence,
     Set,
+    Tuple,
 )
 from urllib import error as urllib_error
 from urllib import request as urllib_request
@@ -50,8 +51,11 @@ from preloop.models.crud.runtime_session import IDLE_GENERATION_INFIX
 from preloop.services.codex_tool_compat import (
     unwrap_freeform_arguments,
     custom_tool_call_output,
+    namespace_tool_aliases,
     normalize_custom_tool_call_item,
+    qualify_namespace_call_history_item,
     restore_custom_tool_calls,
+    restore_namespace_tool_calls,
     sanitize_codex_tools,
 )
 from preloop.models.models.ai_model import AIModel
@@ -575,6 +579,15 @@ class OpenAIGatewayService:
         # aborts the run on the function shape). Reset per request so a
         # translated turn never leaks into an untranslated one.
         self._codex_freeform_tool_names: Set[str] = set()
+        # Alias -> (namespace, short_name) for tools the client declared
+        # inside ``mcp__*`` namespace containers on THIS request. Set with
+        # the freeform names above, read when response output items are
+        # built: Codex's tool router routes a namespace tool call ONLY as a
+        # ``function_call`` carrying a separate ``namespace`` field plus the
+        # SHORT name, so the model's flat-named call must be rendered back in
+        # that form (staging execution 97c977f8: the flat qualified name is
+        # "unsupported call"). Reset per request alongside the freeform set.
+        self._codex_namespace_tool_aliases: Dict[str, Tuple[str, str]] = {}
         # Upstream credential type ("oauth" | "api_key" | "ambient") of the
         # credential used to call the provider on THIS request, captured at
         # resolution time and read into the usage row at log time. Powers
@@ -2176,6 +2189,22 @@ class OpenAIGatewayService:
                                     "input": "",
                                 }
                                 output_items[state["output_index"]] = state["item"]
+                            else:
+                                namespace_target = (
+                                    self._codex_namespace_tool_aliases.get(name)
+                                )
+                                if namespace_target is not None:
+                                    # Codex's router routes an MCP namespace
+                                    # tool call ONLY as a function_call with
+                                    # a separate `namespace` field and the
+                                    # SHORT name; the flat name the model was
+                                    # declared is "unsupported call" (staging
+                                    # execution 97c977f8). Same deferral as
+                                    # freeform tools: rewrite before the item
+                                    # is announced.
+                                    namespace, short = namespace_target
+                                    state["item"]["namespace"] = namespace
+                                    state["item"]["name"] = short
                             state["announced"] = True
                             yield self._sse_event(
                                 {
@@ -5320,7 +5349,14 @@ class OpenAIGatewayService:
     def _normalize_responses_tool_call_item(
         self, item: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
-        """Convert one Responses API function call into chat tool_call format."""
+        """Convert one Responses API function call into chat tool_call format.
+
+        Codex echoes MCP namespace tool calls back in the namespace form (a
+        ``namespace`` field plus the SHORT tool name). Upstreams were declared
+        the flattened ``mcp__<server>__<tool>`` name and reject unknown
+        fields, so the history item is flattened back first.
+        """
+        item = qualify_namespace_call_history_item(item)
         function_name = item.get("name")
         call_id = item.get("call_id")
         if not function_name or not call_id:
@@ -5665,9 +5701,12 @@ class OpenAIGatewayService:
         answered with an ordinary ``function_call`` for those tools. This is a
         no-op for every request that did not carry such a tool.
         """
-        return restore_custom_tool_calls(
-            self._build_response_output_items_raw(response_dict),
-            self._codex_freeform_tool_names,
+        return restore_namespace_tool_calls(
+            restore_custom_tool_calls(
+                self._build_response_output_items_raw(response_dict),
+                self._codex_freeform_tool_names,
+            ),
+            self._codex_namespace_tool_aliases,
         )
 
     def _build_response_output_items_raw(
@@ -5748,6 +5787,9 @@ class OpenAIGatewayService:
         :mod:`preloop.services.codex_tool_compat`. Requests without those
         shapes are returned by that step untouched.
         """
+        # Capture the namespace alias map BEFORE sanitizing: it needs the
+        # original ``namespace`` containers, which sanitization flattens.
+        self._codex_namespace_tool_aliases = namespace_tool_aliases(tools)
         tools, freeform_names = sanitize_codex_tools(tools)
         self._codex_freeform_tool_names = freeform_names
         if not isinstance(tools, list):

--- a/backend/tests/endpoints/test_openai_gateway.py
+++ b/backend/tests/endpoints/test_openai_gateway.py
@@ -58,9 +58,13 @@ def _assert_replay_tools_normalized(
             # flow's entire MCP toolset, so dropping it would leave the agent
             # silently toolless rather than visibly broken. MCP namespaces
             # (`mcp__<server>`) additionally QUALIFY the flattened short names
-            # with the namespace prefix, because Codex's tool router only
-            # routes the `mcp__<server>__<tool>` form — a model calling the
-            # short name gets `unsupported call: <tool>` back.
+            # with the namespace prefix so the model-facing names stay unique.
+            # NOTE the qualified name is NOT router-routable by itself: the
+            # response translation must render the model's call back as a
+            # `function_call` with a separate `namespace` field and the SHORT
+            # name (staging exec 97c977f8 proved the flat qualified name is
+            # `unsupported call` too) — asserted by the namespace-call tests
+            # below.
             namespace_name = tool.get("name")
             for nested_tool in tool.get("tools") or []:
                 if (
@@ -160,6 +164,140 @@ def test_openai_gateway_responses_codex_replay_normalizes_tools(
     _assert_replay_tools_normalized(
         payload["tools"], mock_completion.call_args.kwargs["tools"]
     )
+
+
+def _gateway_model_and_auth(app, db_session, test_user):
+    """Register a gateway model and bypass auth, as the replay test does."""
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Gateway Model",
+            "provider_name": "openai",
+            "model_identifier": "gpt-5",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "openai/gpt-5",
+                    "provider_adapter": "preloop",
+                }
+            },
+            "is_default": True,
+        },
+        account_id=test_user.account_id,
+    )
+    app.dependency_overrides[get_model_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token="gateway-token", user=test_user)
+    )
+
+
+def test_responses_namespace_tool_call_is_rendered_router_routable(
+    app, client, db_session, test_user
+):
+    """The exec 97c977f8 failure, end to end: the model calls the flat
+    qualified `mcp__preloop__ask_user` name it was declared, and the item
+    Codex receives back MUST carry the separate `namespace` field plus the
+    SHORT name — the only form `codex_core::tools::router` routes (a flat
+    function_call is `unsupported call` whether short or qualified, verified
+    against the real binary)."""
+    _gateway_model_and_auth(app, db_session, test_user)
+    payload = _load_codex_replay_payload()
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value={
+            "id": "chatcmpl_ns",
+            "created": 1710000000,
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_ns_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "mcp__preloop__preloop_get_goal",
+                                    "arguments": "{}",
+                                },
+                            }
+                        ],
+                    }
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        },
+    ):
+        response = client.post(
+            "/openai/v1/responses",
+            headers={"Authorization": "Bearer ignored"},
+            json=payload,
+        )
+
+    assert response.status_code == 200
+    calls = [
+        item
+        for item in response.json()["output"]
+        if item.get("type") == "function_call"
+    ]
+    assert len(calls) == 1
+    assert calls[0]["namespace"] == "mcp__preloop"
+    assert calls[0]["name"] == "preloop_get_goal"
+    assert calls[0]["call_id"] == "call_ns_1"
+
+
+def test_responses_namespace_history_echo_is_flattened_for_the_upstream(
+    app, client, db_session, test_user
+):
+    """Turn 2: Codex echoes the namespace-form call back in the input
+    history. The upstream was declared the flat qualified name and rejects an
+    unknown `namespace` field, so the history tool_call must be flattened."""
+    _gateway_model_and_auth(app, db_session, test_user)
+    payload = _load_codex_replay_payload()
+    payload["input"] = [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "collect waivers"}],
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_ns_1",
+            "namespace": "mcp__preloop",
+            "name": "preloop_get_goal",
+            "arguments": "{}",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_ns_1",
+            "output": "the goal",
+        },
+    ]
+
+    with patch(
+        "preloop.services.openai_gateway.litellm.completion",
+        return_value={
+            "id": "chatcmpl_ns2",
+            "created": 1710000000,
+            "choices": [{"message": {"role": "assistant", "content": "done"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        },
+    ) as mock_completion:
+        response = client.post(
+            "/openai/v1/responses",
+            headers={"Authorization": "Bearer ignored"},
+            json=payload,
+        )
+
+    assert response.status_code == 200
+    messages = mock_completion.call_args.kwargs["messages"]
+    tool_call_messages = [m for m in messages if m.get("tool_calls")]
+    assert len(tool_call_messages) == 1
+    tool_call = tool_call_messages[0]["tool_calls"][0]
+    assert tool_call["function"]["name"] == "mcp__preloop__preloop_get_goal"
+    assert "namespace" not in tool_call
+    assert "namespace" not in tool_call["function"]
 
 
 def test_list_models_endpoint_returns_gateway_models(

--- a/backend/tests/services/test_codex_tool_compat.py
+++ b/backend/tests/services/test_codex_tool_compat.py
@@ -16,8 +16,11 @@ a prod failure row, not invented:
 import json
 
 from preloop.services.codex_tool_compat import (
+    namespace_tool_aliases,
     normalize_custom_tool_call_item,
+    qualify_namespace_call_history_item,
     restore_custom_tool_calls,
+    restore_namespace_tool_calls,
     sanitize_codex_tools,
     unwrap_freeform_arguments,
 )
@@ -209,3 +212,162 @@ def test_unwrap_falls_back_to_raw_arguments_when_not_an_envelope():
     assert unwrap_freeform_arguments('{"patch": "y"}') == "y"
     # Multi-key JSON is ambiguous: keep it verbatim rather than guess.
     assert unwrap_freeform_arguments('{"a": "1", "b": "2"}') == '{"a": "1", "b": "2"}'
+
+
+NAMESPACE_REQUEST_TOOLS = [
+    {"type": "function", "name": "exec_command", "parameters": {}},
+    {
+        "type": "namespace",
+        "name": "multi_agent_v1",
+        "tools": [{"type": "function", "name": "spawn_agent"}],
+    },
+    {
+        "type": "namespace",
+        "name": "mcp__preloop",
+        "tools": [{"type": "function", "name": "ask_user", "parameters": {}}],
+    },
+]
+
+
+def test_namespace_aliases_register_canonical_and_bare_names():
+    """Both names the model may call must resolve to the SAME namespace call.
+
+    The declared (post-flattening) name is `mcp__preloop__ask_user`; preset
+    prompts and older transcripts steer some models to the bare `ask_user`.
+    The router accepts neither as a flat call, so both are aliases of the
+    namespace form.
+    """
+    aliases = namespace_tool_aliases(NAMESPACE_REQUEST_TOOLS)
+
+    assert aliases["mcp__preloop__ask_user"] == ("mcp__preloop", "ask_user")
+    assert aliases["ask_user"] == ("mcp__preloop", "ask_user")
+    # Codex-internal namespaces are not MCP: their router names are their own.
+    assert "spawn_agent" not in aliases
+    assert "multi_agent_v1__spawn_agent" not in aliases
+
+
+def test_namespace_bare_alias_is_dropped_on_cross_namespace_collision():
+    """An ambiguous short name must not be guessed into either namespace."""
+    tools = [
+        {
+            "type": "namespace",
+            "name": "mcp__alpha",
+            "tools": [{"type": "function", "name": "ask_user"}],
+        },
+        {
+            "type": "namespace",
+            "name": "mcp__beta",
+            "tools": [{"type": "function", "name": "ask_user"}],
+        },
+    ]
+
+    aliases = namespace_tool_aliases(tools)
+
+    assert "ask_user" not in aliases
+    assert aliases["mcp__alpha__ask_user"] == ("mcp__alpha", "ask_user")
+    assert aliases["mcp__beta__ask_user"] == ("mcp__beta", "ask_user")
+
+
+def test_namespace_bare_alias_never_shadows_a_top_level_tool():
+    """A plain function tool with the same name routes as itself."""
+    tools = [
+        {"type": "function", "name": "ask_user", "parameters": {}},
+        {
+            "type": "namespace",
+            "name": "mcp__preloop",
+            "tools": [{"type": "function", "name": "ask_user"}],
+        },
+    ]
+
+    aliases = namespace_tool_aliases(tools)
+
+    assert "ask_user" not in aliases
+    assert aliases["mcp__preloop__ask_user"] == ("mcp__preloop", "ask_user")
+
+
+def test_namespace_call_is_restored_to_the_router_routable_form():
+    """The live failure: a flat `mcp__preloop__ask_user` function_call gets
+    `ERROR codex_core::tools::router: error=unsupported call:
+    mcp__preloop__ask_user` (staging exec 97c977f8). Verified against the
+    real binary: the router routes ONLY `{"type": "function_call",
+    "namespace": "mcp__preloop", "name": "ask_user"}`."""
+    aliases = namespace_tool_aliases(NAMESPACE_REQUEST_TOOLS)
+    output_items = [
+        {
+            "id": "fc_1",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_1",
+            "name": "mcp__preloop__ask_user",
+            "arguments": json.dumps({"question": "waive CVE-X?"}),
+        }
+    ]
+
+    restored = restore_namespace_tool_calls(output_items, aliases)
+
+    assert restored[0]["namespace"] == "mcp__preloop"
+    assert restored[0]["name"] == "ask_user"
+    assert restored[0]["call_id"] == "call_1"
+    assert restored[0]["arguments"] == json.dumps({"question": "waive CVE-X?"})
+
+
+def test_namespace_call_by_bare_alias_is_restored_too():
+    """A model that calls the preset's bare `ask_user` still routes."""
+    aliases = namespace_tool_aliases(NAMESPACE_REQUEST_TOOLS)
+    output_items = [
+        {
+            "id": "fc_1",
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "ask_user",
+            "arguments": "{}",
+        }
+    ]
+
+    restored = restore_namespace_tool_calls(output_items, aliases)
+
+    assert restored[0]["namespace"] == "mcp__preloop"
+    assert restored[0]["name"] == "ask_user"
+
+
+def test_calls_to_non_namespace_tools_are_not_rewritten():
+    aliases = namespace_tool_aliases(NAMESPACE_REQUEST_TOOLS)
+    output_items = [
+        {
+            "id": "fc_1",
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "exec_command",
+            "arguments": "{}",
+        },
+        {"id": "m_1", "type": "message", "role": "assistant", "content": []},
+    ]
+
+    restored = restore_namespace_tool_calls(output_items, aliases)
+
+    assert restored == output_items
+
+
+def test_namespace_history_echo_is_flattened_for_upstreams():
+    """Codex echoes the namespace-form call back on the next turn; upstreams
+    know only the flat qualified name and reject unknown fields."""
+    item = {
+        "type": "function_call",
+        "call_id": "call_1",
+        "namespace": "mcp__preloop",
+        "name": "ask_user",
+        "arguments": "{}",
+    }
+
+    flattened = qualify_namespace_call_history_item(item)
+
+    assert flattened["name"] == "mcp__preloop__ask_user"
+    assert "namespace" not in flattened
+    # Codex-internal namespaces keep their own naming.
+    internal = {
+        "type": "function_call",
+        "call_id": "call_2",
+        "namespace": "multi_agent_v1",
+        "name": "spawn_agent",
+    }
+    assert qualify_namespace_call_history_item(internal) == internal

--- a/backend/tests/services/test_openai_gateway.py
+++ b/backend/tests/services/test_openai_gateway.py
@@ -2691,6 +2691,20 @@ def _codex_freeform_service() -> OpenAIGatewayService:
     return service
 
 
+def _codex_namespace_service() -> OpenAIGatewayService:
+    """A service whose current request declared the mcp__preloop ask_user tool."""
+    auth_context = ModelGatewayAuthContext(
+        token="token",
+        user=SimpleNamespace(id="user-1", account_id="account-1"),
+    )
+    service = OpenAIGatewayService(MagicMock(), auth_context)
+    service._codex_namespace_tool_aliases = {
+        "mcp__preloop__ask_user": ("mcp__preloop", "ask_user"),
+        "ask_user": ("mcp__preloop", "ask_user"),
+    }
+    return service
+
+
 def test_stream_response_emits_freeform_tool_call_as_custom_tool_call():
     """Codex aborts the run if its freeform tool is answered as a function_call.
 
@@ -2777,6 +2791,162 @@ def test_stream_response_emits_freeform_tool_call_as_custom_tool_call():
         if isinstance(event, dict)
         and event.get("type", "").startswith("response.function_call_arguments")
     ]
+
+
+def test_stream_response_emits_namespace_tool_call_with_short_name():
+    """Codex's router rejects a flat function_call whether short or qualified.
+
+    The streaming path must announce the item as namespace plus SHORT name
+    and keep that rewrite even if a later chunk re-sends the qualified
+    function.name the model was declared.
+    """
+    service = _codex_namespace_service()
+    ai_model = SimpleNamespace(id="model-1", provider_name="openai")
+    upstream_stream = iter(
+        [
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_1",
+                                    "function": {"name": "mcp__preloop__ask_user"},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "function": {
+                                        "name": "mcp__preloop__ask_user",
+                                        "arguments": '{"question":',
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {"index": 0, "function": {"arguments": ' "Ready?"}'}}
+                            ]
+                        }
+                    }
+                ]
+            },
+        ]
+    )
+
+    with (
+        patch.object(service, "_resolve_requested_model", return_value=ai_model),
+        patch.object(service, "_check_budget", return_value=None),
+        patch.object(service, "_call_litellm", return_value=upstream_stream),
+        patch.object(service, "_record_gateway_request"),
+    ):
+        events = [
+            _parse_sse_payload(event)
+            for event in service.stream_response(
+                {"model": "openai/gpt-5", "input": "Ask a question"}
+            )
+        ]
+
+    added = [
+        event
+        for event in events
+        if isinstance(event, dict) and event.get("type") == "response.output_item.added"
+    ]
+    assert len(added) == 1
+    assert added[0]["item"]["namespace"] == "mcp__preloop"
+    assert added[0]["item"]["name"] == "ask_user"
+
+    completed = events[-2]
+    output_item = completed["response"]["output"][0]
+    assert output_item["namespace"] == "mcp__preloop"
+    assert output_item["name"] == "ask_user"
+    assert output_item["type"] == "function_call"
+    assert output_item["call_id"] == "call_1"
+
+
+def test_stream_response_emits_namespace_tool_call_from_bare_alias():
+    """A first chunk that names the bare alias still announces namespace + short."""
+    service = _codex_namespace_service()
+    ai_model = SimpleNamespace(id="model-1", provider_name="openai")
+    upstream_stream = iter(
+        [
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_1",
+                                    "function": {"name": "ask_user"},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "function": {
+                                        "name": "mcp__preloop__ask_user",
+                                        "arguments": '{"question": "Ready?"}',
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+        ]
+    )
+
+    with (
+        patch.object(service, "_resolve_requested_model", return_value=ai_model),
+        patch.object(service, "_check_budget", return_value=None),
+        patch.object(service, "_call_litellm", return_value=upstream_stream),
+        patch.object(service, "_record_gateway_request"),
+    ):
+        events = [
+            _parse_sse_payload(event)
+            for event in service.stream_response(
+                {"model": "openai/gpt-5", "input": "Ask a question"}
+            )
+        ]
+
+    added = [
+        event
+        for event in events
+        if isinstance(event, dict) and event.get("type") == "response.output_item.added"
+    ]
+    assert len(added) == 1
+    assert added[0]["item"]["namespace"] == "mcp__preloop"
+    assert added[0]["item"]["name"] == "ask_user"
+
+    completed = events[-2]
+    output_item = completed["response"]["output"][0]
+    assert output_item["namespace"] == "mcp__preloop"
+    assert output_item["name"] == "ask_user"
 
 
 def test_stream_response_still_emits_plain_function_calls_normally():


### PR DESCRIPTION
## Live failure

Staging exec `97c977f8` (stock RSA preset, `waiver_collection: interactive`, codex runtime, post-#286 deploy):

```
ERROR codex_core::tools::router: error=unsupported call: mcp__preloop__ask_user
```

The founder was never asked; the run correctly failed closed (one attempt, recorded, unwaived). Same class as the W2 round-3 regression (`4ba5c5e7` / `094a5d1b`: `unsupported call: ask_user`) that #286 addressed.

## Root cause

Codex (≥ the namespace-shape versions) declares MCP tools as a `namespace` container (`mcp__preloop` + nested SHORT names). #286 correctly flattened and QUALIFIED the declared names for upstreams — but the router does not route **any** flat `function_call` name for a namespace tool. Probed against the real binary with staging's config shape (`[mcp_servers.preloop]`, `--yolo`):

| model's call item | router |
|---|---|
| `function_call` name=`ask_user` | ❌ `unsupported call` (= exec 4ba5c5e7) |
| `function_call` name=`mcp__preloop__ask_user` | ❌ `unsupported call` (= exec 97c977f8) |
| `function_call` name=`mcp__preloop.ask_user` / `preloop__ask_user` | ❌ `unsupported call` |
| `function_call` **`namespace="mcp__preloop"`** + name=`ask_user` | ✅ routes; MCP result returned |

So #286 fixed the request half of the translation (declarations) and left the response half broken: the gateway rendered the model's call back as a plain `function_call`, which the router rejects regardless of name. Every codex-runtime MCP call — including the RSA preset's sole interactive `ask_user` waiver call — still failed closed after deploy.

(Why #286's staging proof passed anyway: W2-final `28c5818d` ran on the **OpenCode** harness, where MCP tools are flat `preloop_ask_user` functions — it never exercised the codex router path. Details in the routing report.)

## Fix — symmetric namespace translation, mirroring the freeform-tool handling

- `namespace_tool_aliases()`: canonical qualified name **and** bare short name (while unambiguous; dropped on cross-namespace collision or when a top-level tool owns the name) → `(namespace, short_name)`.
- `restore_namespace_tool_calls()`: rewrites matching model calls into the router-routable namespace form — wired into both the non-streaming output builder and the streaming deferred-announce path (same hook that fixes freeform tools).
- `qualify_namespace_call_history_item()`: Codex echoes the namespace-form call in the next turn's history; flatten it back to the qualified name upstreams were declared (they reject an unknown `namespace` field).

The preset text is untouched: the catalog name it instructs (`mcp__preloop__ask_user`) is now genuinely routable, and the bare `ask_user` some models fall back to routes as an alias of the same call.

## Verification

- Unit tests at the mismatch layer (`test_codex_tool_compat.py`): alias registration, collision/shadowing rules, routable-form restore for canonical + bare names, history flattening.
- Endpoint tests (`test_openai_gateway.py`): full `/openai/v1/responses` replay — model calls the flat qualified name → response item carries `namespace` + short name; turn-2 history echo → upstream sees the flat qualified name, no `namespace` field.
- Real binary, end to end: local codex + local MCP server named `preloop` + mini-gateway running THIS branch's translation functions. Both `mcp__preloop__ask_user` and bare `ask_user` model calls now reach the MCP server and return the tool result (before: both `unsupported call`).
- `backend/tests/endpoints/test_openai_gateway.py` 17 passed, `backend/tests/services/test_codex_tool_compat.py` 20 passed, adjacent suites (mcp_config_service, ask_user_inband, security presets, approval_summary) 133 passed. ruff check/format clean.

## Deploy note

The fix lives in the API/gateway (`openai_gateway` + `codex_tool_compat`) — an **API redeploy suffices**; no runner/agent image rebuild is needed (the codex CLI is installed from npm at container start and is not modified). A live re-test of the RSA interactive waiver flow on staging should follow the deploy before this is called fixed.

Do NOT merge without the live staging re-test.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Medium]**
> Fixes the response half of MCP namespace tool-call routing (the #286 declaration fix's counterpart), making the RSA preset's interactive `ask_user` waiver call routable on the codex runtime. No security implications; well-tested at the unit, non-streaming endpoint, and streaming layers. All prior review findings resolved.
>
> **Overview**
> Adds symmetric namespace translation in the gateway: `namespace_tool_aliases` maps the flat qualified name (and unambiguous bare short name) to a `(namespace, short_name)` pair, `restore_namespace_tool_calls` renders the model's call in the namespace form `codex_core::tools::router` routes, and `qualify_namespace_call_history_item` flattens Codex's next-turn namespace echo back to the qualified name upstreams were declared.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit f35b0aaf. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->