### PR TITLE
fix(gateway): fail empty/error upstream Responses streams loudly (post-#289 turn-1 kill)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Empty upstream streams no longer complete "successfully"**: an
+  OpenAI-Responses stream whose upstream produced zero output items
+  (or reported an in-band `error` chunk) used to be folded into a
+  successful empty `response.completed`. Codex treats that as a
+  completed no-op turn and exits 0 without printing anything, which a
+  flow then fails as a missing success confirmation (staging
+  executions 1ded95c8 / ffb122bd: 18,268 prompt / 0 completion
+  tokens, agent silent). Such streams now emit an SSE `error` event
+  and are recorded as a 502 upstream failure, so Codex retries the
+  turn (verified against codex-cli 0.149.0: 5 retries, then a loud
+  stream error) instead of dying silently.
 - **z.ai GLM-5.3 was unpriced**: first-party list prices from docs.z.ai
   are now in the vendored catalog ($1.4 input, $0.26 cached input, $4.4
   output per 1M). z.ai has no price API, so

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -2098,6 +2098,24 @@ class OpenAIGatewayService:
 
                 for chunk in upstream_stream:
                     chunk_dict = self._response_to_dict(chunk)
+                    # Some upstreams (OpenRouter among them) report provider
+                    # failures as an in-band `error` field on an otherwise
+                    # well-formed chunk instead of failing the transport.
+                    # Ignoring it used to fold such streams into a successful
+                    # EMPTY `response.completed`, which Codex treats as a
+                    # completed no-op turn and exits 0 without printing
+                    # anything (staging executions 1ded95c8 / ffb122bd).
+                    # Surface it as a stream error instead.
+                    chunk_error = chunk_dict.get("error")
+                    if chunk_error:
+                        raise ModelGatewayAPIError(
+                            provider="openai",
+                            status_code=502,
+                            message=(
+                                "Upstream reported an in-stream error: "
+                                f"{json.dumps(chunk_error, default=str)[:500]}"
+                            ),
+                        )
                     delta_text = self._extract_stream_delta_text(chunk_dict)
                     if delta_text:
                         if text_output_index is None:
@@ -2251,6 +2269,28 @@ class OpenAIGatewayService:
                     final_usage_details,
                     self._provider_cost_fields(upstream_stream),
                 )
+
+                if not output_items:
+                    # The upstream stream ended without a single output item:
+                    # no text delta, no tool-call delta, nothing. A completed
+                    # Responses stream whose `output` is empty is not a usable
+                    # model turn — Codex renders nothing, makes no calls, and
+                    # exits 0 as if the task were done (staging executions
+                    # 1ded95c8 / ffb122bd: upstream billed 18,268 prompt /
+                    # 0 completion tokens and the agent died silently, which
+                    # the flow then failed as a missing success confirmation).
+                    # Fail the stream loudly instead so the client retries or
+                    # errors visibly; silent truncation is the #109/#117
+                    # failure mode this path already guards against.
+                    raise ModelGatewayAPIError(
+                        provider="openai",
+                        status_code=502,
+                        message=(
+                            "Upstream stream completed without any output "
+                            "items (usage: "
+                            f"{json.dumps(final_usage, default=str)})"
+                        ),
+                    )
 
                 full_text = "".join(assistant_parts)
                 if text_output_index is not None:

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -2108,12 +2108,17 @@ class OpenAIGatewayService:
                     # Surface it as a stream error instead.
                     chunk_error = chunk_dict.get("error")
                     if chunk_error:
+                        # Scrub before surfacing: upstream blobs can echo
+                        # URLs and keys (same convention as _stream_error).
+                        chunk_error_message = extract_upstream_error_detail(
+                            json.dumps(chunk_error, default=str)
+                        ).message
                         raise ModelGatewayAPIError(
                             provider="openai",
                             status_code=502,
                             message=(
                                 "Upstream reported an in-stream error: "
-                                f"{json.dumps(chunk_error, default=str)[:500]}"
+                                f"{chunk_error_message}"
                             ),
                         )
                     delta_text = self._extract_stream_delta_text(chunk_dict)

--- a/backend/tests/services/test_openai_gateway.py
+++ b/backend/tests/services/test_openai_gateway.py
@@ -3829,3 +3829,380 @@ def test_provider_cost_fields_recovery_is_fail_open():
     assert (
         OpenAIGatewayService._provider_cost_fields(SimpleNamespace(chunks="nope")) == {}
     )
+
+
+# ---------------------------------------------------------------------------
+# Codex turn-1 round-trip with MCP namespace tools declared (#289 follow-up).
+#
+# Staging executions 1ded95c8 / ffb122bd (flow fd6de770, codex + ox-alpha)
+# died on their FIRST model call after the #289 deploy: the upstream returned
+# a 200 stream with zero output items (18,268 prompt / 0 completion tokens)
+# and the gateway folded it into a successful EMPTY `response.completed`,
+# which Codex treats as a completed no-op turn and exits 0 silently. These
+# tests pin the full turn-1 path (real tools normalization, no preset alias
+# maps): plain text and tool calls pass through untouched, and an empty or
+# error-carrying upstream stream fails LOUDLY instead of succeeding empty.
+# ---------------------------------------------------------------------------
+
+
+_CODEX_NAMESPACE_REQUEST_TOOLS = [
+    {
+        "type": "function",
+        "name": "exec_command",
+        "description": "Run a command.",
+        "parameters": {"type": "object", "properties": {}},
+    },
+    {
+        # The shape the Codex CLI actually sends for an MCP server entry
+        # (captured from codex-cli 0.149.0 against a live [mcp_servers.preloop]).
+        "type": "namespace",
+        "name": "mcp__preloop",
+        "description": "Tools in the mcp__preloop namespace.",
+        "tools": [
+            {
+                "type": "function",
+                "name": "ask_user",
+                "description": "Ask the human a question and wait for their answer.",
+                "strict": False,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"question": {"type": "string"}},
+                    "required": ["question"],
+                    "additionalProperties": False,
+                },
+            }
+        ],
+    },
+]
+
+
+def _run_full_turn1_stream(upstream_chunks):
+    """Run stream_response through the REAL tools normalization path.
+
+    Unlike `_codex_namespace_service`, nothing is preset on the service: the
+    namespace alias map is captured by `_normalize_openai_tools` from the
+    request's own `tools`, exactly as in production. Only the litellm
+    boundary is stubbed.
+    """
+    auth_context = ModelGatewayAuthContext(
+        token="token",
+        user=SimpleNamespace(id="user-1", account_id="account-1"),
+    )
+    upstream_backend = MagicMock()
+    upstream_backend.completion.return_value = iter(upstream_chunks)
+    service = OpenAIGatewayService(
+        MagicMock(), auth_context, upstream_backend=upstream_backend
+    )
+    ai_model = SimpleNamespace(
+        id="model-1",
+        provider_name="openai",
+        model_identifier="ox-alpha",
+        api_endpoint=None,
+        meta_data={},
+        credentials_secret=None,
+        model_gateway_model_alias="ox-alpha",
+    )
+    record = MagicMock()
+    with (
+        patch.object(service, "_resolve_requested_model", return_value=ai_model),
+        patch.object(service, "_check_budget", return_value=None),
+        patch.object(service, "_record_gateway_request", record),
+        patch.object(
+            service,
+            "_optimize_request_context",
+            side_effect=lambda messages, payload: (messages, payload),
+        ),
+        patch(
+            "preloop.services.openai_gateway.get_secret_service"
+        ) as mock_secret_service,
+    ):
+        mock_secret_service.return_value.resolve_ai_model_credentials.return_value = (
+            SimpleNamespace(credential_type="api_key", value="provider-secret")
+        )
+        events = [
+            _parse_sse_payload(event)
+            for event in service.stream_response(
+                {
+                    "model": "ox-alpha",
+                    "input": "Run the audit",
+                    "tools": _CODEX_NAMESPACE_REQUEST_TOOLS,
+                    "stream": True,
+                }
+            )
+        ]
+    return events, record
+
+
+def test_stream_turn1_text_with_namespace_tools_passes_through():
+    """A plain first-turn text response is untouched by the namespace map."""
+    events, _ = _run_full_turn1_stream(
+        [
+            {"choices": [{"delta": {"role": "assistant", "content": None}}]},
+            # ox-alpha-style empty delta ahead of the visible text.
+            {"choices": [{"delta": {"content": ""}}]},
+            {"choices": [{"delta": {"content": "Plan ready."}}]},
+            {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 3,
+                    "total_tokens": 103,
+                },
+            },
+        ]
+    )
+
+    assert not [e for e in events if isinstance(e, dict) and e.get("type") == "error"]
+    completed = events[-2]
+    assert completed["type"] == "response.completed"
+    output = completed["response"]["output"]
+    assert len(output) == 1
+    assert output[0]["type"] == "message"
+    assert output[0]["content"] == [{"type": "output_text", "text": "Plan ready."}]
+
+
+def test_stream_turn1_namespace_tool_call_routes_via_captured_aliases():
+    """A first-turn ask_user call is rewritten to namespace + SHORT name.
+
+    The alias map here is captured from the request's own namespace
+    container by `_normalize_openai_tools`, not preset on the service: this
+    is the original mcp__preloop__ask_user routing case end to end.
+    """
+    events, _ = _run_full_turn1_stream(
+        [
+            {"choices": [{"delta": {"role": "assistant", "content": None}}]},
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_1",
+                                    "function": {"name": "mcp__preloop__ask_user"},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "function": {
+                                        "arguments": '{"question": "Proceed?"}'
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 20,
+                    "total_tokens": 120,
+                },
+            },
+        ]
+    )
+
+    assert not [e for e in events if isinstance(e, dict) and e.get("type") == "error"]
+    added = [
+        e
+        for e in events
+        if isinstance(e, dict) and e.get("type") == "response.output_item.added"
+    ]
+    assert len(added) == 1
+    assert added[0]["item"]["namespace"] == "mcp__preloop"
+    assert added[0]["item"]["name"] == "ask_user"
+    completed = events[-2]
+    output_item = completed["response"]["output"][0]
+    assert output_item["type"] == "function_call"
+    assert output_item["namespace"] == "mcp__preloop"
+    assert output_item["name"] == "ask_user"
+    assert output_item["call_id"] == "call_1"
+
+
+def test_stream_turn1_empty_upstream_stream_fails_loudly():
+    """An upstream stream with zero output items must NOT complete empty.
+
+    This is the staging 1ded95c8 / ffb122bd signature: role/finish/usage
+    chunks only, 0 completion tokens. Folding it into a successful empty
+    `response.completed` makes Codex exit 0 without printing anything.
+    """
+    events, record = _run_full_turn1_stream(
+        [
+            {"choices": [{"delta": {"role": "assistant", "content": None}}]},
+            {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 18268,
+                    "completion_tokens": 0,
+                    "total_tokens": 18268,
+                },
+            },
+        ]
+    )
+
+    errors = [e for e in events if isinstance(e, dict) and e.get("type") == "error"]
+    assert len(errors) == 1
+    assert "without any output" in errors[0]["message"]
+    assert not [
+        e
+        for e in events
+        if isinstance(e, dict) and e.get("type") == "response.completed"
+    ]
+    assert events[-1] == "[DONE]"
+    # The interaction is recorded as a failure, not a 200 success.
+    assert record.call_args.kwargs["status_code"] == 502
+
+
+def test_stream_turn1_upstream_error_chunk_surfaces_as_stream_error():
+    """An in-band upstream `error` chunk must not be swallowed silently."""
+    events, record = _run_full_turn1_stream(
+        [
+            {"choices": [{"delta": {"role": "assistant", "content": None}}]},
+            {"error": {"message": "Provider returned error", "code": 502}},
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 18268,
+                    "completion_tokens": 0,
+                    "total_tokens": 18268,
+                },
+            },
+        ]
+    )
+
+    errors = [e for e in events if isinstance(e, dict) and e.get("type") == "error"]
+    assert len(errors) == 1
+    assert "Provider returned error" in errors[0]["message"]
+    assert not [
+        e
+        for e in events
+        if isinstance(e, dict) and e.get("type") == "response.completed"
+    ]
+    assert record.call_args.kwargs["status_code"] == 502
+
+
+def test_stream_turn1_text_without_tools_still_passes():
+    """Control: the empty-stream guard never fires for a normal text turn."""
+    auth_context = ModelGatewayAuthContext(
+        token="token",
+        user=SimpleNamespace(id="user-1", account_id="account-1"),
+    )
+    service = OpenAIGatewayService(MagicMock(), auth_context)
+    ai_model = SimpleNamespace(id="model-1", provider_name="openai")
+    upstream_stream = iter(
+        [
+            {"choices": [{"delta": {"content": "Hello."}}]},
+            {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+        ]
+    )
+    with (
+        patch.object(service, "_resolve_requested_model", return_value=ai_model),
+        patch.object(service, "_check_budget", return_value=None),
+        patch.object(service, "_call_litellm", return_value=upstream_stream),
+        patch.object(service, "_record_gateway_request"),
+    ):
+        events = [
+            _parse_sse_payload(event)
+            for event in service.stream_response({"model": "gpt-5", "input": "Hi"})
+        ]
+    assert not [e for e in events if isinstance(e, dict) and e.get("type") == "error"]
+    completed = events[-2]
+    assert completed["response"]["output"][0]["content"] == [
+        {"type": "output_text", "text": "Hello."}
+    ]
+
+
+def test_create_response_turn1_with_namespace_tools_nonstreaming():
+    """Non-streaming: turn-1 text and tool call shapes with namespace tools."""
+    auth_context = ModelGatewayAuthContext(
+        token="token",
+        user=SimpleNamespace(id="user-1", account_id="account-1"),
+    )
+    upstream_backend = MagicMock()
+    service = OpenAIGatewayService(
+        MagicMock(), auth_context, upstream_backend=upstream_backend
+    )
+    ai_model = SimpleNamespace(
+        id="model-1",
+        provider_name="openai",
+        model_identifier="ox-alpha",
+        api_endpoint=None,
+        meta_data={},
+        credentials_secret=None,
+        model_gateway_model_alias="ox-alpha",
+    )
+
+    def _one_call(message):
+        upstream_backend.completion.return_value = {
+            "id": "chatcmpl-1",
+            "choices": [{"message": message, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        }
+        with (
+            patch.object(service, "_resolve_requested_model", return_value=ai_model),
+            patch.object(service, "_check_budget", return_value=None),
+            patch.object(service, "_record_gateway_request"),
+            patch.object(
+                service,
+                "_optimize_request_context",
+                side_effect=lambda messages, payload: (messages, payload),
+            ),
+            patch(
+                "preloop.services.openai_gateway.get_secret_service"
+            ) as mock_secret_service,
+        ):
+            mock_secret_service.return_value.resolve_ai_model_credentials.return_value = SimpleNamespace(
+                credential_type="api_key", value="provider-secret"
+            )
+            return service.create_response(
+                {
+                    "model": "ox-alpha",
+                    "input": "Run the audit",
+                    "tools": _CODEX_NAMESPACE_REQUEST_TOOLS,
+                }
+            )
+
+    # Turn-1 text response passes through untouched.
+    text_response = _one_call({"role": "assistant", "content": "Plan ready."})
+    assert [item["type"] for item in text_response["output"]] == ["message"]
+    assert text_response["output_text"] == "Plan ready."
+
+    # Turn-1 tool call is restored to namespace + SHORT name.
+    tool_response = _one_call(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "mcp__preloop__ask_user",
+                        "arguments": '{"question": "Proceed?"}',
+                    },
+                }
+            ],
+        }
+    )
+    calls = [i for i in tool_response["output"] if i["type"] == "function_call"]
+    assert len(calls) == 1
+    assert calls[0]["namespace"] == "mcp__preloop"
+    assert calls[0]["name"] == "ask_user"


### PR DESCRIPTION
## What happened on staging

Post-#289 deploy, waiver flow `fd6de770` (codex + ox-alpha) failed twice
deterministically (executions `1ded95c8`, `ffb122bd`): prompt echo, then
nothing, agent exit 0 at exactly **18,268 tokens**, missing-confirmation
override fired.

## Root cause — it is NOT the #289 namespace translation

Evidence (all captured in `/tmp/preloop-reports/289-regression-report.md`):

1. **Full-path reproduction with the real binary.** codex-cli 0.149.0 was run
   against the FULL `OpenAIGatewayService.stream_response` path from
   `origin/main` (real `_normalize_responses_input`, `_normalize_openai_tools`
   → `sanitize_codex_tools` + `namespace_tool_aliases`, real event stream
   builder; only `upstream_backend.completion` stubbed), with a live
   `[mcp_servers.preloop]` MCP server so codex declares a real
   `mcp__preloop` namespace container. Turn-1 text, qualified / bare /
   re-sent-name namespace tool calls, text+tool: **all pass**, the ask_user
   call routes (`mcp: preloop/ask_user started`).
2. **The upstream request is unchanged by #289.** Rebuilding the upstream
   request from the exact staging client payload (pulled from the execution's
   `model_gateway_call` log) through pre-#289 and post-#289 checkouts yields
   **byte-identical** kwargs (sha256 `aec50fdb9e3fff5a` both sides).
3. **What actually killed the run:** the execution's own gateway log shows the
   upstream answered the first call with a 200 stream containing **zero output
   items** (`output: []`, `output_text: \"\"`, usage 18,268 prompt / **0
   completion** tokens). The gateway folded that into a *successful empty*
   `response.completed`; codex 0.149.0 treats that as a completed no-op turn,
   prints nothing and exits 0 — reproduced identically with the real binary
   (empty-stream scenario: silent exit 0, \"tokens used 18,268\").

## The fix (minimal, response-side, streaming path)

- An upstream chunk carrying an in-band `error` field (how OpenRouter reports
  provider failures without failing the transport) now raises instead of being
  silently ignored.
- A stream that ends with **no output items at all** now raises instead of
  emitting a successful empty `response.completed`.

Both cases surface through the existing #109/#117 SSE `error` + `[DONE]` path
and are recorded as a 502 upstream failure. Verified against the real binary:
codex retries the turn 5× and then fails **loudly** (exit 1) instead of dying
silently; text and tool-call turns are unaffected.

## The three #289 behaviors survive

- aliases route / restore to namespace form / history flattening: existing
  #289 tests untouched and green.
- New full-path turn-1 regression tests (alias map captured from the request's
  own `namespace` container via `_normalize_openai_tools`, not preset):
  - turn-1 text with namespace tools declared (stream + non-stream) passes
    through untouched;
  - turn-1 `mcp__preloop__ask_user` call (stream + non-stream) renders
    namespace + SHORT name;
  - empty upstream stream → SSE error, recorded 502 (staging signature);
  - in-band upstream error chunk → SSE error, recorded 502;
  - control: text turn without tools never trips the guard.

## Tests

`backend/tests/services/test_openai_gateway.py` +
`test_codex_tool_compat.py` + `backend/tests/endpoints/test_openai_gateway.py`:
**121 passed** (fresh migrated DB). `backend/tests/agents`: **332 passed**.

## Deploy

**API-only deploy again.** After deploy, re-run the live retest
`/tmp/preloop-askuser/retest_askuser.py` (founder-run; this PR triggers no
staging runs). Note: since the upstream genuinely returned an empty
completion, the retest may now succeed via codex's automatic turn retries —
and if the upstream fault persists, the flow will fail with a real 502 error
message instead of a silent exit-0.

Do NOT merge — founder review first.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Correct, minimal fix that fails empty/in-band-error upstream streams loudly (502) instead of folding them into a silent exit-0. The in-band error blob is now scrubbed before surfacing; one LOW follow-up remains (empty-output parity for the non-streaming/Codex-OAuth paths, deferred).
>
> **Overview**
> Adds two guards to the OpenAI-Responses streaming path: raise on in-band `error` chunks and on streams that end with zero output items. Both surface via the existing #109/#117 SSE error path and are recorded as 502 upstream failures, so Codex retries and fails loudly instead of exiting 0 silently.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 32873e7. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->