### PR TITLE
fix(gateway): dedupe admin alert on mid-stream responses 5xx

### DIFF
--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -5119,6 +5119,16 @@ class OpenAIGatewayService:
     def _openai_stream_error_event(
         self, exc: Exception, error: ModelGatewayAPIError | None = None
     ) -> str:
+        """Render a mid-stream failure as an OpenAI-style SSE error event.
+
+        Args:
+            exc: The mid-stream exception.
+            error: Error already classified by ``_stream_error``; pass it so
+                the admin alert in ``_normalize_upstream_error`` fires once
+                per failure instead of twice (#210).
+        """
+        self, exc: Exception, error: ModelGatewayAPIError | None = None
+    ) -> str:
         """Render a mid-stream failure as an OpenAI-style SSE error event."""
         gateway_error = (
             error if error is not None else self._stream_error("openai", exc)

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -5127,23 +5127,6 @@ class OpenAIGatewayService:
                 the admin alert in ``_normalize_upstream_error`` fires once
                 per failure instead of twice (#210).
         """
-    def _openai_stream_error_event(
-        self, exc: Exception, error: ModelGatewayAPIError | None = None
-    ) -> str:
-        """Render a mid-stream failure as an OpenAI-style SSE error event.
-
-        Args:
-            exc: The mid-stream exception.
-            error: Error already classified by ``_stream_error``; pass it so
-                the admin alert in ``_normalize_upstream_error`` fires once
-                per failure instead of twice (#210).
-        """
-        gateway_error = (
-            error if error is not None else self._stream_error("openai", exc)
-        )
-        return self._sse_event(gateway_error.to_payload())
-    ) -> str:
-        """Render a mid-stream failure as an OpenAI-style SSE error event."""
         gateway_error = (
             error if error is not None else self._stream_error("openai", exc)
         )

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -5127,7 +5127,21 @@ class OpenAIGatewayService:
                 the admin alert in ``_normalize_upstream_error`` fires once
                 per failure instead of twice (#210).
         """
+    def _openai_stream_error_event(
         self, exc: Exception, error: ModelGatewayAPIError | None = None
+    ) -> str:
+        """Render a mid-stream failure as an OpenAI-style SSE error event.
+
+        Args:
+            exc: The mid-stream exception.
+            error: Error already classified by ``_stream_error``; pass it so
+                the admin alert in ``_normalize_upstream_error`` fires once
+                per failure instead of twice (#210).
+        """
+        gateway_error = (
+            error if error is not None else self._stream_error("openai", exc)
+        )
+        return self._sse_event(gateway_error.to_payload())
     ) -> str:
         """Render a mid-stream failure as an OpenAI-style SSE error event."""
         gateway_error = (

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -5158,7 +5158,15 @@ class OpenAIGatewayService:
     def _anthropic_stream_error_event(
         self, exc: Exception, error: ModelGatewayAPIError | None = None
     ) -> str:
-        """Render a mid-stream failure as an Anthropic-style SSE error event."""
+        """
+        Render a mid-stream failure as an Anthropic-style SSE error event.
+
+        Args:
+            exc: The mid-stream exception.
+            error: Error already classified by ``_stream_error``; pass it so
+                the admin alert in ``_normalize_upstream_error`` fires once
+                per failure instead of twice.
+        """
         gateway_error = (
             error if error is not None else self._stream_error("anthropic", exc)
         )

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -1687,7 +1687,7 @@ class OpenAIGatewayService:
                     payload.get("model"),
                     gateway_error.error_class,
                 )
-                yield self._anthropic_stream_error_event(exc)
+                yield self._anthropic_stream_error_event(exc, gateway_error)
             finally:
                 # Client disconnect raises GeneratorExit (a BaseException) at the
                 # paused yield, which the except above does not catch — so
@@ -1967,7 +1967,7 @@ class OpenAIGatewayService:
                     payload.get("model"),
                     gateway_error.error_class,
                 )
-                yield self._openai_stream_error_event(exc)
+                yield self._openai_stream_error_event(exc, gateway_error)
                 yield self._sse_done()
             finally:
                 # See stream_message: catch the client-disconnect GeneratorExit
@@ -2445,7 +2445,7 @@ class OpenAIGatewayService:
                     payload.get("model"),
                     gateway_error.error_class,
                 )
-                yield self._responses_stream_error_event(exc)
+                yield self._responses_stream_error_event(exc, gateway_error)
                 yield self._sse_done()
             finally:
                 # See stream_message: account for tokens consumed before a
@@ -3730,7 +3730,7 @@ class OpenAIGatewayService:
                     payload.get("model"),
                     gateway_error.error_class,
                 )
-                yield self._responses_stream_error_event(exc)
+                yield self._responses_stream_error_event(exc, gateway_error)
                 yield "data: [DONE]\n\n"
             finally:
                 if not recorded:
@@ -3972,7 +3972,7 @@ class OpenAIGatewayService:
                     payload.get("model"),
                     gateway_error.error_class,
                 )
-                yield self._openai_stream_error_event(exc)
+                yield self._openai_stream_error_event(exc, gateway_error)
                 yield self._sse_done()
             finally:
                 if not recorded:
@@ -4626,7 +4626,7 @@ class OpenAIGatewayService:
                     requested_model,
                     gateway_error.error_class,
                 )
-                yield self._anthropic_stream_error_event(exc)
+                yield self._anthropic_stream_error_event(exc, gateway_error)
             finally:
                 # GeneratorExit (client disconnect) bypasses the except above;
                 # bill already-consumed upstream tokens best-effort.
@@ -5116,27 +5116,46 @@ class OpenAIGatewayService:
             )
         return error
 
-    def _openai_stream_error_event(self, exc: Exception) -> str:
+    def _openai_stream_error_event(
+        self, exc: Exception, error: ModelGatewayAPIError | None = None
+    ) -> str:
         """Render a mid-stream failure as an OpenAI-style SSE error event."""
-        return self._sse_event(self._stream_error("openai", exc).to_payload())
+        gateway_error = (
+            error if error is not None else self._stream_error("openai", exc)
+        )
+        return self._sse_event(gateway_error.to_payload())
 
-    def _responses_stream_error_event(self, exc: Exception) -> str:
-        """Render a mid-stream failure as a Responses-API SSE error event."""
-        error = self._stream_error("openai", exc)
+    def _responses_stream_error_event(
+        self, exc: Exception, error: ModelGatewayAPIError | None = None
+    ) -> str:
+        """Render a mid-stream failure as a Responses-API SSE error event.
+
+        Args:
+            exc: The mid-stream exception.
+            error: Error already classified by ``_stream_error``; pass it so
+                the admin alert in ``_normalize_upstream_error`` fires once
+                per failure instead of twice (#210).
+        """
+        gateway_error = (
+            error if error is not None else self._stream_error("openai", exc)
+        )
         return self._sse_event(
             {
                 "type": "error",
-                "code": error.code or error.error_type,
-                "message": error.message,
-                "param": error.param,
+                "code": gateway_error.code or gateway_error.error_type,
+                "message": gateway_error.message,
+                "param": gateway_error.param,
             }
         )
 
-    def _anthropic_stream_error_event(self, exc: Exception) -> str:
+    def _anthropic_stream_error_event(
+        self, exc: Exception, error: ModelGatewayAPIError | None = None
+    ) -> str:
         """Render a mid-stream failure as an Anthropic-style SSE error event."""
-        return self._anthropic_sse_event(
-            "error", self._stream_error("anthropic", exc).to_payload()
+        gateway_error = (
+            error if error is not None else self._stream_error("anthropic", exc)
         )
+        return self._anthropic_sse_event("error", gateway_error.to_payload())
 
     def _capture_tools_meta(self, original_tools: Any) -> None:
         """Stash per-tool cost attribution for the usage row.

--- a/backend/tests/services/test_openai_gateway_upstream_errors.py
+++ b/backend/tests/services/test_openai_gateway_upstream_errors.py
@@ -50,6 +50,76 @@ def _service() -> OpenAIGatewayService:
     return OpenAIGatewayService(MagicMock(), auth_context)
 
 
+class TestMidStreamSingleAdminAlert:
+    """#210: one mid-stream 5xx must fire notify_admins exactly once.
+
+    The streaming except-blocks classify the exception once via
+    ``_stream_error`` and then reuse that error when rendering the SSE
+    event; re-running classification inside the render helpers would fire
+    a second admin alert for the same failure.
+    """
+
+    @staticmethod
+    def _capture_notify(captured_calls: list):
+        def _notify(*, subject: str, message: str) -> None:
+            captured_calls.append({"subject": subject, "message": message})
+
+        return _notify
+
+    def test_responses_stream_5xx_fires_single_admin_alert(self):
+        """Handler shape: _stream_error then render with the same error."""
+        from unittest.mock import patch as _patch
+
+        service = _service()
+        exc = _FakeHTTPError("upstream exploded mid-stream", status_code=502)
+
+        captured_calls: list = []
+        with _patch(
+            "preloop.sync.tasks.notify_admins",
+            side_effect=self._capture_notify(captured_calls),
+        ):
+            gateway_error = service._stream_error("openai", exc)
+            frame = service._responses_stream_error_event(exc, gateway_error)
+
+        assert len(captured_calls) == 1
+        assert frame.startswith("data: ")
+        assert '"type": "error"' in frame or '"type":"error"' in frame
+        assert "upstream exploded mid-stream" in frame
+
+    def test_chat_and_anthropic_streams_reuse_classified_error(self):
+        """Same dedupe applies to chat-completions and anthropic streams."""
+        from unittest.mock import patch as _patch
+
+        service = _service()
+        exc = _FakeHTTPError("upstream exploded mid-stream", status_code=500)
+
+        captured_calls: list = []
+        with _patch(
+            "preloop.sync.tasks.notify_admins",
+            side_effect=self._capture_notify(captured_calls),
+        ):
+            openai_error = service._stream_error("openai", exc)
+            openai_frame = service._openai_stream_error_event(exc, openai_error)
+            anthropic_error = service._stream_error("anthropic", exc)
+            anthropic_frame = service._anthropic_stream_error_event(
+                exc, anthropic_error
+            )
+
+        assert len(captured_calls) == 2  # once per provider stream, not twice
+        assert "upstream exploded mid-stream" in openai_frame
+        assert "upstream exploded mid-stream" in anthropic_frame
+
+    def test_render_helpers_without_precomputed_error_still_work(self):
+        """Direct calls (tests, non-stream paths) still classify on their own."""
+        service = _service()
+        exc = Exception("upstream connection reset")
+
+        responses_frame = service._responses_stream_error_event(exc)
+        assert '"code": "upstream_disconnect"' in responses_frame or (
+            '"code":"upstream_disconnect"' in responses_frame
+        )
+
+
 def test_normalize_connection_refused_returns_503_network():
     """#116: connection refused becomes 503 with a clear upstream message."""
     err = OpenAIGatewayService._normalize_upstream_error(


### PR DESCRIPTION
## Root cause

On the `/openai/v1/responses` streaming path, a mid-stream 5xx was classified twice: the except-block calls `_stream_error(exc)` directly (for request recording/logging) and then again inside `_responses_stream_error_event(exc)` when rendering the SSE error event. Each pass through `_normalize_upstream_error` fires `notify_admins` for status >= 500, so one upstream drop produced **two** admin alert emails (#210).

The same double-invoke shape existed on all six streaming handlers (chat completions, responses x2, codex chat, anthropic messages x2).

## Fix

Thread the already-classified error into the SSE render helpers instead of re-classifying:

- `_openai_stream_error_event`, `_responses_stream_error_event`, and `_anthropic_stream_error_event` now accept an optional pre-computed `ModelGatewayAPIError`; without it they classify as before (backward compatible).
- All six stream except-blocks pass their existing `gateway_error`, so `notify_admins` fires exactly once per failure and the SSE event is rendered from the identical error object.

## Test evidence

New regression tests in `backend/tests/services/test_openai_gateway_upstream_errors.py` (`TestMidStreamSingleAdminAlert`):
- one mid-stream 502 through the handler shape (`_stream_error` + render with reused error) => exactly **1** `notify_admins` call, SSE error event still emitted with correct payload
- same for chat-completions/anthropic helpers
- direct helper calls without a precomputed error still classify correctly

```
$ PRELOOP_DISABLE_TELEMETRY=true PYTHONPATH=<worktree>/backend pytest backend/tests/services/test_openai_gateway_upstream_errors.py -q
20 passed in 0.05s

$ PRELOOP_DISABLE_TELEMETRY=true PYTHONPATH=<worktree>/backend pytest backend/tests/services/test_openai_gateway.py backend/tests/services/test_openai_gateway_upstream_errors.py -q
13 failed, 91 passed   # 13 failures verified pre-existing on clean main via git stash
```

Ruff check + ruff format clean on touched files.

Fixes #210

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> All previously raised issues (the module-level syntax error and the docstring gap) are now fixed; the dedupe change is correct and well-tested.

> **Overview**
> Threads the already-classified `gateway_error` into the three SSE render helpers so `notify_admins` fires exactly once per mid-stream 5xx across all six streaming handlers.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 53eb6016. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->