### PR TITLE
fix(trackers): capture MR identity before approve/unapprove mutation

### DIFF
--- a/backend/preloop/sync/trackers/gitlab.py
+++ b/backend/preloop/sync/trackers/gitlab.py
@@ -1634,7 +1634,7 @@ class GitLabTracker(BaseTracker):
 
             # Return updated MR data
             return {
-                "id": str(mr.id),
+                "id": str(getattr(mr, "id", mr.iid)),
                 "iid": mr.iid,
                 "title": mr.title,
                 "description": mr.description or "",
@@ -1757,11 +1757,16 @@ class GitLabTracker(BaseTracker):
             project = await self._make_request(self.gl.projects.get, project_id)
             mr = await self._make_request(project.mergerequests.get, mr_iid)
 
+            # python-gitlab's approve()/unapprove() replace the object's
+            # attrs with the approvals payload, which has no `id` field.
+            # Capture the identity before mutating the object.
+            mr_id = str(getattr(mr, "id", mr.iid))
+
             # Approve the merge request
             approval = await self._make_request(mr.approve)
 
             return {
-                "id": str(mr.id),
+                "id": mr_id,
                 "iid": mr.iid,
                 "approved": True,
                 "approval_details": approval if approval else {},
@@ -1796,6 +1801,11 @@ class GitLabTracker(BaseTracker):
             raise TrackerResponseError(f"Failed to unapprove merge request: {e}")
 
         try:
+            # python-gitlab's unapprove() replaces the object's attrs with
+            # the approvals payload, which has no `id` field. Capture the
+            # identity before mutating the object.
+            mr_id = str(getattr(mr, "id", mr.iid))
+
             # Unapprove the merge request
             await self._make_request(mr.unapprove)
         except Exception as e:
@@ -1809,7 +1819,7 @@ class GitLabTracker(BaseTracker):
                     f"or approvals not available (404). Treating as no-op."
                 )
                 return {
-                    "id": str(mr.id),
+                    "id": str(getattr(mr, "id", mr.iid)),
                     "iid": mr.iid,
                     "approved": False,
                     "skipped": True,
@@ -1819,7 +1829,7 @@ class GitLabTracker(BaseTracker):
             raise TrackerResponseError(f"Failed to unapprove merge request: {e}")
 
         return {
-            "id": str(mr.id),
+            "id": mr_id,
             "iid": mr.iid,
             "approved": False,
         }

--- a/backend/preloop/sync/trackers/gitlab.py
+++ b/backend/preloop/sync/trackers/gitlab.py
@@ -1758,16 +1758,17 @@ class GitLabTracker(BaseTracker):
             mr = await self._make_request(project.mergerequests.get, mr_iid)
 
             # python-gitlab's approve()/unapprove() replace the object's
-            # attrs with the approvals payload, which has no `id` field.
-            # Capture the identity before mutating the object.
-            mr_id = str(getattr(mr, "id", mr.iid))
+            # attrs with the approvals payload, which has neither `id` nor
+            # `iid`. Capture the identity before mutating the object.
+            mr_id = str(getattr(mr, "id", mr_iid))
+            mr_identity_iid = getattr(mr, "iid", mr_iid)
 
             # Approve the merge request
             approval = await self._make_request(mr.approve)
 
             return {
                 "id": mr_id,
-                "iid": mr.iid,
+                "iid": mr_identity_iid,
                 "approved": True,
                 "approval_details": approval if approval else {},
             }
@@ -1802,9 +1803,10 @@ class GitLabTracker(BaseTracker):
 
         try:
             # python-gitlab's unapprove() replaces the object's attrs with
-            # the approvals payload, which has no `id` field. Capture the
-            # identity before mutating the object.
-            mr_id = str(getattr(mr, "id", mr.iid))
+            # the approvals payload, which has neither `id` nor `iid`.
+            # Capture the identity before mutating the object.
+            mr_id = str(getattr(mr, "id", mr_iid))
+            mr_identity_iid = getattr(mr, "iid", mr_iid)
 
             # Unapprove the merge request
             await self._make_request(mr.unapprove)
@@ -1819,8 +1821,8 @@ class GitLabTracker(BaseTracker):
                     f"or approvals not available (404). Treating as no-op."
                 )
                 return {
-                    "id": str(getattr(mr, "id", mr.iid)),
-                    "iid": mr.iid,
+                    "id": str(getattr(mr, "id", mr_iid)),
+                    "iid": getattr(mr, "iid", mr_iid),
                     "approved": False,
                     "skipped": True,
                     "reason": "no approval to revoke (404)",
@@ -1830,7 +1832,7 @@ class GitLabTracker(BaseTracker):
 
         return {
             "id": mr_id,
-            "iid": mr.iid,
+            "iid": mr_identity_iid,
             "approved": False,
         }
 

--- a/backend/tests/sync/trackers/test_gitlab_mr_review.py
+++ b/backend/tests/sync/trackers/test_gitlab_mr_review.py
@@ -16,6 +16,30 @@ from preloop.sync.trackers.gitlab import GitLabTracker
 from preloop.sync.exceptions import TrackerResponseError
 
 
+class _AttrsStrippingMR:
+    """Stands in for python-gitlab's ProjectMergeRequest post-approval.
+
+    approve()/unapprove() call ``_update_attrs`` with the approvals payload,
+    which carries no ``id`` field, so the attribute genuinely disappears
+    after a successful call (#246).
+    """
+
+    def __init__(self, mr_id: int, iid: int) -> None:
+        self.id = mr_id
+        self.iid = iid
+        self.approve_called = False
+        self.unapprove_called = False
+
+    def approve(self, *args, **kwargs):
+        self.approve_called = True
+        del self.id
+        return {"approved": True}
+
+    def unapprove(self, *args, **kwargs):
+        self.unapprove_called = True
+        del self.id
+
+
 class TestApproveMergeRequest(unittest.IsolatedAsyncioTestCase):
     """Tests for approve_merge_request method."""
 
@@ -77,6 +101,35 @@ class TestApproveMergeRequest(unittest.IsolatedAsyncioTestCase):
             await tracker.approve_merge_request("1")
 
         self.assertIn("Failed to approve merge request", str(context.exception))
+
+    @patch("preloop.sync.trackers.gitlab.gitlab.Gitlab")
+    async def test_approve_merge_request_survives_attrs_replacement(
+        self, mock_gitlab_constructor
+    ):
+        """Approving must not crash when python-gitlab replaces MR attrs.
+
+        python-gitlab's approve() updates the object's attrs with the
+        approvals payload, which carries no `id` field. The tracker captured
+        the identity before mutating so a successful approval does not blow
+        up afterwards with AttributeError (#246).
+        """
+        mock_gl_instance = MagicMock()
+        mock_gitlab_constructor.return_value = mock_gl_instance
+        mock_gl_instance.auth.return_value = None
+
+        mock_project = MagicMock()
+        mock_gl_instance.projects.get.return_value = mock_project
+
+        mock_mr = _AttrsStrippingMR(mr_id=12345, iid=6)
+        mock_project.mergerequests.get.return_value = mock_mr
+
+        tracker = GitLabTracker("tracker-1", "api-key", {"project_id": "proj-1"})
+        result = await tracker.approve_merge_request("6")
+
+        self.assertEqual(result["id"], "12345")
+        self.assertEqual(result["iid"], 6)
+        self.assertTrue(result["approved"])
+        self.assertTrue(mock_mr.approve_called)
 
 
 class TestUnapproveMergeRequest(unittest.IsolatedAsyncioTestCase):
@@ -149,6 +202,30 @@ class TestUnapproveMergeRequest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["iid"], 1)
         self.assertFalse(result["approved"])
         self.assertTrue(result["skipped"])
+
+    @patch("preloop.sync.trackers.gitlab.gitlab.Gitlab")
+    async def test_unapprove_merge_request_survives_attrs_replacement(
+        self, mock_gitlab_constructor
+    ):
+        """Unapproving must not crash when python-gitlab replaces MR attrs
+        with the approvals payload, which has no `id` field (#246)."""
+        mock_gl_instance = MagicMock()
+        mock_gitlab_constructor.return_value = mock_gl_instance
+        mock_gl_instance.auth.return_value = None
+
+        mock_project = MagicMock()
+        mock_gl_instance.projects.get.return_value = mock_project
+
+        mock_mr = _AttrsStrippingMR(mr_id=12345, iid=6)
+        mock_project.mergerequests.get.return_value = mock_mr
+
+        tracker = GitLabTracker("tracker-1", "api-key", {"project_id": "proj-1"})
+        result = await tracker.unapprove_merge_request("6")
+
+        self.assertEqual(result["id"], "12345")
+        self.assertEqual(result["iid"], 6)
+        self.assertFalse(result["approved"])
+        self.assertTrue(mock_mr.unapprove_called)
 
     @patch("preloop.sync.trackers.gitlab.gitlab.Gitlab")
     async def test_unapprove_merge_request_api_error(self, mock_gitlab_constructor):

--- a/backend/tests/sync/trackers/test_gitlab_mr_review.py
+++ b/backend/tests/sync/trackers/test_gitlab_mr_review.py
@@ -20,8 +20,8 @@ class _AttrsStrippingMR:
     """Stands in for python-gitlab's ProjectMergeRequest post-approval.
 
     approve()/unapprove() call ``_update_attrs`` with the approvals payload,
-    which carries no ``id`` field, so the attribute genuinely disappears
-    after a successful call (#246).
+    which carries neither ``id`` nor ``iid``, so both attributes genuinely
+    disappear after a successful call (#246).
     """
 
     def __init__(self, mr_id: int, iid: int) -> None:
@@ -30,14 +30,18 @@ class _AttrsStrippingMR:
         self.approve_called = False
         self.unapprove_called = False
 
+    def _strip_attrs(self) -> None:
+        del self.id
+        del self.iid
+
     def approve(self, *args, **kwargs):
         self.approve_called = True
-        del self.id
+        self._strip_attrs()
         return {"approved": True}
 
     def unapprove(self, *args, **kwargs):
         self.unapprove_called = True
-        del self.id
+        self._strip_attrs()
 
 
 class TestApproveMergeRequest(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Root cause

Staging errors `'ProjectMergeRequest' object has no attribute 'id'` when approving merge requests (GlitchTip 3326-3328) were not a missing-attribute bug at fetch time: python-gitlab's `ProjectMergeRequest.approve()` and `.unapprove()` call `_update_attrs(server_data)` with the **approvals payload**, which carries no `id` field. That call *replaces* the object's attrs, so reading `mr.id` on the line after a successful approval raises AttributeError and the whole review flow is marked failed even though the approval landed.

## Fix

Capture `mr_id` before mutating the object:

- `approve_merge_request`: identity captured before `mr.approve()`.
- `unapprove_merge_request`: captured before `mr.unapprove()` for both the normal return and the 404 no-op path.
- `update_merge_request` (`mr.save()` path): same defensive read, since `save()` uses the same `_update_attrs` mechanism.

## Tests

Regression tests in `test_gitlab_mr_review.py` use a fake MR whose attrs lose `id` when approve/unapprove is called (reproducing python-gitlab's behavior). Before the fix these raise `TrackerResponseError`; after, they return the captured identity. All 27 tests in the file pass.

Fixes #246

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Small, well-tested bug fix on the MR approval path that captures both `id` and `iid` before python-gitlab mutates the object.
>
> **Overview**
> Captures the MR `id` and `iid` before python-gitlab's `approve()`/`unapprove()` replace the object's attrs with the approvals payload (which has neither field), fixing `'ProjectMergeRequest' object has no attribute 'id'` (#246). Follow-up commit `7dae6fa` also captures `iid` and updates the regression fake to strip both attributes.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 7dae6fa. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->