### PR TITLE
fix(mcp): classify update_comment not-found as 404 and resolve GitHub comment global ids

### DIFF
--- a/backend/preloop/api/endpoints/mcp.py
+++ b/backend/preloop/api/endpoints/mcp.py
@@ -2499,8 +2499,12 @@ async def create_pull_request(
 _EXPECTED_NOT_FOUND_MARKERS = (
     "not found",
     "could not resolve",
-    "404",
 )
+
+# HTTP-status-style token matched with word boundaries so embedded numeric ids
+# or echoed response bodies containing "404" as a substring are never misread
+# as an HTTP 404 status.
+_HTTP_404_TOKEN_RE = re.compile(r"\b404\b")
 
 
 async def update_comment(
@@ -2952,8 +2956,9 @@ async def update_comment(
         raise
     except Exception as e:
         error_msg = str(e).lower()
-        is_expected_not_found = any(
-            marker in error_msg for marker in _EXPECTED_NOT_FOUND_MARKERS
+        is_expected_not_found = (
+            any(marker in error_msg for marker in _EXPECTED_NOT_FOUND_MARKERS)
+            or _HTTP_404_TOKEN_RE.search(error_msg) is not None
         )
         if is_expected_not_found:
             # Expected client-class failure (stale/wrong comment id, unresolvable

--- a/backend/preloop/api/endpoints/mcp.py
+++ b/backend/preloop/api/endpoints/mcp.py
@@ -2493,6 +2493,16 @@ async def create_pull_request(
         )
 
 
+# Markers indicating an expected client-class failure (comment/thread does not
+# exist or its GraphQL node could not be resolved) rather than a tracker/API
+# failure. Matched case-insensitively against exception messages.
+_EXPECTED_NOT_FOUND_MARKERS = (
+    "not found",
+    "could not resolve",
+    "404",
+)
+
+
 async def update_comment(
     target: str,
     comment_id: str,
@@ -2793,38 +2803,43 @@ async def update_comment(
                     )
 
                 # GitHub's resolve_review_thread requires the thread's GraphQL node_id
-                # (format: "PRRT_..."), not a comment ID (format: "PRRC_...").
-                if not thread_id:
-                    # Check if comment_id looks like a thread ID
-                    if comment_id.startswith("PRRT_"):
-                        # User passed thread_id as comment_id, use it
-                        thread_id = comment_id
+                # (format: "PRRT_..."), not a comment ID. Numeric REST comment ids
+                # (or comment node ids) must be mapped to their containing thread
+                # node id first, otherwise GraphQL fails with "Could not resolve to
+                # a node with the global id of '<numeric-id>'".
+                if not (thread_id and thread_id.startswith("PRRT_")):
+                    candidate_comment_id = thread_id or comment_id
+                    if candidate_comment_id.startswith("PRRT_"):
+                        # User passed the thread node id as comment_id, use it
+                        thread_id = candidate_comment_id
                         logger.info(
                             "Using comment_id as thread_id since it has PRRT_ prefix"
                         )
                     else:
-                        # Try to look up the thread_id from the comment_id
+                        # Look up the thread node id from the comment id
                         logger.info(
-                            f"Attempting to look up thread_id for comment {comment_id}"
+                            f"Attempting to look up thread_id for comment "
+                            f"{candidate_comment_id}"
                         )
                         try:
                             looked_up_thread_id = (
                                 await tracker_client.get_thread_id_for_comment(
                                     pr_number=pr_mr_number,
-                                    comment_id=comment_id,
+                                    comment_id=candidate_comment_id,
                                 )
                             )
                             if looked_up_thread_id:
                                 thread_id = looked_up_thread_id
                                 logger.info(
-                                    f"Found thread_id {thread_id} for comment {comment_id}"
+                                    f"Found thread_id {thread_id} for comment "
+                                    f"{candidate_comment_id}"
                                 )
                             else:
                                 raise HTTPException(
                                     status_code=400,
                                     detail=(
                                         "Could not find thread_id for the given comment_id. "
-                                        f"The comment_id '{comment_id}' may not be a review comment. "
+                                        f"The comment_id '{candidate_comment_id}' may not be a review comment. "
                                         "Thread resolution only works for review comments (inline diff comments). "
                                         "For issue comments, resolution is not supported."
                                     ),
@@ -2936,6 +2951,19 @@ async def update_comment(
     except HTTPException:
         raise
     except Exception as e:
+        error_msg = str(e).lower()
+        is_expected_not_found = any(
+            marker in error_msg for marker in _EXPECTED_NOT_FOUND_MARKERS
+        )
+        if is_expected_not_found:
+            # Expected client-class failure (stale/wrong comment id, unresolvable
+            # GraphQL node): log at warning without exc_info so Sentry/GlitchTip
+            # does not promote it to an exception event.
+            logger.warning(f"Comment {comment_id} not found for {target}: {e}")
+            raise HTTPException(
+                status_code=404,
+                detail=f"Comment {comment_id} not found: {str(e)}",
+            ) from e
         logger.error(
             f"Error updating comment {comment_id} for {target}: {e}",
             exc_info=True,

--- a/backend/preloop/sync/trackers/github.py
+++ b/backend/preloop/sync/trackers/github.py
@@ -3085,12 +3085,12 @@ class GitHubTracker(BaseTracker):
             logger.warning("Owner/repo not found for thread lookup")
             return None
 
-        # GraphQL query to page through review threads and their comments.
-        # Both connections are paginated via cursors so large PRs with many
-        # review threads or long threads never silently miss the target
-        # comment.
+        # GraphQL query to page through review threads. Only the first
+        # comments page is fetched here; deeper comment pages are loaded
+        # per-thread via THREAD_COMMENTS_QUERY below so a comments cursor is
+        # never applied to a sibling thread's connection.
         query = """
-            query GetPRReviewThreads($owner: String!, $name: String!, $prNumber: Int!, $threadsCursor: String, $commentsCursor: String) {
+            query GetPRReviewThreads($owner: String!, $name: String!, $prNumber: Int!, $threadsCursor: String) {
                 repository(owner: $owner, name: $name) {
                     pullRequest(number: $prNumber) {
                         reviewThreads(first: 100, after: $threadsCursor) {
@@ -3100,7 +3100,7 @@ class GitHubTracker(BaseTracker):
                             }
                             nodes {
                                 id
-                                comments(first: 50, after: $commentsCursor) {
+                                comments(first: 50) {
                                     pageInfo {
                                         hasNextPage
                                         endCursor
@@ -3110,6 +3110,28 @@ class GitHubTracker(BaseTracker):
                                         databaseId
                                     }
                                 }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        # Thread-scoped pagination query: fetches deeper comment pages for a
+        # single review thread via its node id.
+        thread_comments_query = """
+            query GetPRReviewThreadComments($threadId: ID!, $commentsCursor: String) {
+                node(id: $threadId) {
+                    ... on PullRequestReviewThread {
+                        id
+                        comments(first: 50, after: $commentsCursor) {
+                            pageInfo {
+                                hasNextPage
+                                endCursor
+                            }
+                            nodes {
+                                id
+                                databaseId
                             }
                         }
                     }
@@ -3184,10 +3206,9 @@ class GitHubTracker(BaseTracker):
                                 graphql_url,
                                 headers=headers,
                                 json={
-                                    "query": query,
+                                    "query": thread_comments_query,
                                     "variables": {
-                                        **variables,
-                                        "threadsCursor": threads_cursor,
+                                        "threadId": thread_id,
                                         "commentsCursor": comments_cursor,
                                     },
                                 },
@@ -3206,21 +3227,8 @@ class GitHubTracker(BaseTracker):
                                 logger.warning(f"GraphQL errors: {data['errors']}")
                                 return None
 
-                            refreshed = (
-                                data.get("data", {})
-                                .get("repository", {})
-                                .get("pullRequest", {})
-                                .get("reviewThreads", {})
-                            )
-                            updated = next(
-                                (
-                                    t
-                                    for t in refreshed.get("nodes", [])
-                                    if t.get("id") == thread_id
-                                ),
-                                None,
-                            )
-                            if updated is None:
+                            updated = data.get("data", {}).get("node", {}) or {}
+                            if not updated or updated.get("id") != thread_id:
                                 break
                             thread = updated
 

--- a/backend/preloop/sync/trackers/github.py
+++ b/backend/preloop/sync/trackers/github.py
@@ -3028,6 +3028,38 @@ class GitHubTracker(BaseTracker):
         except httpx.RequestError as e:
             raise TrackerConnectionError(f"GitHub connection error: {str(e)}")
 
+    @staticmethod
+    def _match_thread_comment(
+        thread: Dict[str, Any],
+        comment_id: str,
+    ) -> Optional[str]:
+        """Match a comment against a review thread node.
+
+        Tries both the numeric database ID and the GraphQL node ID of every
+        comment in the thread.
+
+        Args:
+            thread: A reviewThread node from the GraphQL response.
+            comment_id: The comment's numeric ID or node_id.
+
+        Returns:
+            The thread node_id (PRRT_*) if matched, None otherwise.
+        """
+        thread_id = thread.get("id")
+        comments = thread.get("comments", {}).get("nodes", [])
+
+        for comment in comments:
+            # Match by database ID (numeric)
+            if str(comment.get("databaseId")) == str(comment_id):
+                logger.info(f"Found thread {thread_id} for comment {comment_id}")
+                return thread_id
+            # Match by node_id
+            if comment.get("id") == comment_id:
+                logger.info(f"Found thread {thread_id} for comment {comment_id}")
+                return thread_id
+
+        return None
+
     @async_retry()
     async def get_thread_id_for_comment(
         self,
@@ -3053,15 +3085,26 @@ class GitHubTracker(BaseTracker):
             logger.warning("Owner/repo not found for thread lookup")
             return None
 
-        # GraphQL query to get review threads and their comments
+        # GraphQL query to page through review threads and their comments.
+        # Both connections are paginated via cursors so large PRs with many
+        # review threads or long threads never silently miss the target
+        # comment.
         query = """
-            query GetPRReviewThreads($owner: String!, $name: String!, $prNumber: Int!) {
+            query GetPRReviewThreads($owner: String!, $name: String!, $prNumber: Int!, $threadsCursor: String, $commentsCursor: String) {
                 repository(owner: $owner, name: $name) {
                     pullRequest(number: $prNumber) {
-                        reviewThreads(first: 100) {
+                        reviewThreads(first: 100, after: $threadsCursor) {
+                            pageInfo {
+                                hasNextPage
+                                endCursor
+                            }
                             nodes {
                                 id
-                                comments(first: 50) {
+                                comments(first: 50, after: $commentsCursor) {
+                                    pageInfo {
+                                        hasNextPage
+                                        endCursor
+                                    }
                                     nodes {
                                         id
                                         databaseId
@@ -3085,50 +3128,108 @@ class GitHubTracker(BaseTracker):
 
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    graphql_url,
-                    headers=headers,
-                    json={"query": query, "variables": variables},
-                    timeout=30.0,
-                )
+                threads_cursor: Optional[str] = None
 
-                if response.status_code >= 400:
-                    logger.warning(f"GraphQL query failed: {response.status_code}")
-                    return None
+                # Outer loop pages through reviewThreads; the inner loop
+                # pages through each thread's comments before moving on.
+                while True:
+                    response = await client.post(
+                        graphql_url,
+                        headers=headers,
+                        json={
+                            "query": query,
+                            "variables": {
+                                **variables,
+                                "threadsCursor": threads_cursor,
+                            },
+                        },
+                        timeout=30.0,
+                    )
 
-                data = response.json()
+                    if response.status_code >= 400:
+                        logger.warning(f"GraphQL query failed: {response.status_code}")
+                        return None
 
-                if "errors" in data:
-                    logger.warning(f"GraphQL errors: {data['errors']}")
-                    return None
+                    data = response.json()
 
-                # Search through threads to find the comment
-                threads = (
-                    data.get("data", {})
-                    .get("repository", {})
-                    .get("pullRequest", {})
-                    .get("reviewThreads", {})
-                    .get("nodes", [])
-                )
+                    if "errors" in data:
+                        logger.warning(f"GraphQL errors: {data['errors']}")
+                        return None
 
-                # Try to match by comment_id (numeric) or node_id (string)
-                for thread in threads:
-                    thread_id = thread.get("id")
-                    comments = thread.get("comments", {}).get("nodes", [])
+                    connection = (
+                        data.get("data", {})
+                        .get("repository", {})
+                        .get("pullRequest", {})
+                        .get("reviewThreads", {})
+                    )
+                    threads = connection.get("nodes", [])
 
-                    for comment in comments:
-                        # Match by database ID (numeric)
-                        if str(comment.get("databaseId")) == str(comment_id):
-                            logger.info(
-                                f"Found thread {thread_id} for comment {comment_id}"
+                    for thread in threads:
+                        thread_id = thread.get("id")
+                        comments_cursor: Optional[str] = None
+
+                        while True:
+                            found = self._match_thread_comment(thread, comment_id)
+                            if found:
+                                return found
+
+                            page_info = thread.get("comments", {}).get("pageInfo", {})
+                            if not page_info.get("hasNextPage") or not page_info.get(
+                                "endCursor"
+                            ):
+                                break
+                            comments_cursor = page_info["endCursor"]
+
+                            response = await client.post(
+                                graphql_url,
+                                headers=headers,
+                                json={
+                                    "query": query,
+                                    "variables": {
+                                        **variables,
+                                        "threadsCursor": threads_cursor,
+                                        "commentsCursor": comments_cursor,
+                                    },
+                                },
+                                timeout=30.0,
                             )
-                            return thread_id
-                        # Match by node_id
-                        if comment.get("id") == comment_id:
-                            logger.info(
-                                f"Found thread {thread_id} for comment {comment_id}"
+
+                            if response.status_code >= 400:
+                                logger.warning(
+                                    f"GraphQL query failed: {response.status_code}"
+                                )
+                                return None
+
+                            data = response.json()
+
+                            if "errors" in data:
+                                logger.warning(f"GraphQL errors: {data['errors']}")
+                                return None
+
+                            refreshed = (
+                                data.get("data", {})
+                                .get("repository", {})
+                                .get("pullRequest", {})
+                                .get("reviewThreads", {})
                             )
-                            return thread_id
+                            updated = next(
+                                (
+                                    t
+                                    for t in refreshed.get("nodes", [])
+                                    if t.get("id") == thread_id
+                                ),
+                                None,
+                            )
+                            if updated is None:
+                                break
+                            thread = updated
+
+                    page_info = connection.get("pageInfo", {})
+                    if not page_info.get("hasNextPage") or not page_info.get(
+                        "endCursor"
+                    ):
+                        break
+                    threads_cursor = page_info["endCursor"]
 
                 logger.warning(f"No thread found for comment {comment_id}")
                 return None

--- a/backend/tests/endpoints/test_mcp.py
+++ b/backend/tests/endpoints/test_mcp.py
@@ -2117,6 +2117,88 @@ async def test_update_comment_genuine_api_failure_maps_to_502_with_error_log(
 
 
 @pytest.mark.asyncio
+async def test_update_comment_404_substring_is_not_misclassified_as_not_found(
+    db_session: Session, test_user: User, caplog
+):
+    """
+    Tests that a genuine tracker/API failure whose message merely *contains*
+    the digits 404 inside a larger token (embedded id, cursor, etc.) is not
+    reclassified as a client not-found: it must stay on the HTTP 502 +
+    error-log path.
+    """
+    import logging
+
+    from preloop.sync.exceptions import TrackerResponseError
+
+    tracker = Tracker(
+        name="test-tracker",
+        account_id=test_user.account_id,
+        tracker_type="github",
+        api_key="test_key",
+        url="https://github.com",
+    )
+    db_session.add(tracker)
+    db_session.commit()
+
+    organization = Organization(
+        name="test-org",
+        identifier="test-org",
+        tracker_id=tracker.id,
+    )
+    db_session.add(organization)
+    db_session.commit()
+
+    project = Project(
+        name="owner/repo",
+        identifier="owner/repo",
+        slug="owner/repo",
+        organization_id=organization.id,
+    )
+    db_session.add(project)
+    db_session.commit()
+
+    with (
+        patch("preloop.api.endpoints.mcp.get_http_request") as mock_get_request,
+        patch("preloop.api.endpoints.mcp.get_db") as mock_get_db,
+        patch(
+            "preloop.api.endpoints.mcp._get_authenticated_user",
+            new_callable=AsyncMock,
+        ) as mock_auth,
+        patch(
+            "preloop.api.endpoints.mcp.get_tracker_client",
+            new_callable=AsyncMock,
+        ) as mock_get_tracker,
+    ):
+        mock_get_request.return_value.headers = {"authorization": "Bearer testtoken"}
+        mock_get_db.return_value = iter([db_session])
+        mock_auth.return_value = (db_session, test_user)
+
+        mock_tracker = MagicMock()
+        mock_tracker.tracker_type = "github"
+        mock_tracker.resolve_review_thread = AsyncMock(
+            side_effect=TrackerResponseError(
+                "GitHub GraphQL API error: 500 - internal failure for "
+                "cursor=14045 batch=40440"
+            )
+        )
+        mock_get_tracker.return_value = mock_tracker
+
+        from fastapi import HTTPException
+
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(HTTPException) as exc_info:
+                await mcp.update_comment(
+                    target="owner/repo#123",
+                    comment_id="comment-123",
+                    resolved=True,
+                    thread_id="PRRT_kwDOCjXy1M5abc123",
+                )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail.startswith("Failed to update comment")
+
+
+@pytest.mark.asyncio
 async def test_update_comment_resolve_numeric_comment_id_maps_to_thread_node_id(
     db_session: Session, test_user: User
 ):

--- a/backend/tests/endpoints/test_mcp.py
+++ b/backend/tests/endpoints/test_mcp.py
@@ -1931,6 +1931,346 @@ async def test_update_comment_autodetect_body_and_resolve_precheck_fails(
         mock_tracker.update_review_comment.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_update_comment_not_found_maps_to_404_with_warning_log(
+    db_session: Session, test_user: User, caplog
+):
+    """
+    Tests that an expected not-found failure (e.g. GraphQL node could not be
+    resolved because the id is stale/wrong) maps to HTTP 404 and logs at
+    warning level without exc_info (no GlitchTip exception event).
+    """
+    import logging
+
+    from preloop.sync.exceptions import TrackerResponseError
+
+    tracker = Tracker(
+        name="test-tracker",
+        account_id=test_user.account_id,
+        tracker_type="github",
+        api_key="test_key",
+        url="https://github.com",
+    )
+    db_session.add(tracker)
+    db_session.commit()
+
+    organization = Organization(
+        name="test-org",
+        identifier="test-org",
+        tracker_id=tracker.id,
+    )
+    db_session.add(organization)
+    db_session.commit()
+
+    project = Project(
+        name="owner/repo",
+        identifier="owner/repo",
+        slug="owner/repo",
+        organization_id=organization.id,
+    )
+    db_session.add(project)
+    db_session.commit()
+
+    with (
+        patch("preloop.api.endpoints.mcp.get_http_request") as mock_get_request,
+        patch("preloop.api.endpoints.mcp.get_db") as mock_get_db,
+        patch(
+            "preloop.api.endpoints.mcp._get_authenticated_user",
+            new_callable=AsyncMock,
+        ) as mock_auth,
+        patch(
+            "preloop.api.endpoints.mcp.get_tracker_client",
+            new_callable=AsyncMock,
+        ) as mock_get_tracker,
+    ):
+        mock_get_request.return_value.headers = {"authorization": "Bearer testtoken"}
+        mock_get_db.return_value = iter([db_session])
+        mock_auth.return_value = (db_session, test_user)
+
+        mock_tracker = MagicMock()
+        mock_tracker.tracker_type = "github"
+        mock_tracker.resolve_review_thread = AsyncMock(
+            side_effect=TrackerResponseError(
+                "GraphQL errors: Could not resolve to a node with the "
+                "global id of '3755981585'"
+            )
+        )
+        mock_get_tracker.return_value = mock_tracker
+
+        from fastapi import HTTPException
+
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(HTTPException) as exc_info:
+                await mcp.update_comment(
+                    target="owner/repo#123",
+                    comment_id="3755981585",
+                    resolved=True,
+                    thread_id="PRRT_kwDOCjXy1M5abc123",
+                )
+
+    assert exc_info.value.status_code == 404
+    assert "not found" in str(exc_info.value.detail).lower()
+
+    warning_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "not found" in r.getMessage().lower()
+    ]
+    assert warning_records, "expected a warning-level log for the not-found case"
+    for record in warning_records:
+        assert record.exc_info in (None, (None, None, None)), (
+            "not-found failures must not log with exc_info"
+        )
+    error_records = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.ERROR and "updating comment" in r.getMessage()
+    ]
+    assert not error_records, "not-found failures must not be logged as errors"
+
+
+@pytest.mark.asyncio
+async def test_update_comment_genuine_api_failure_maps_to_502_with_error_log(
+    db_session: Session, test_user: User, caplog
+):
+    """
+    Tests that a genuine tracker/API failure still maps to HTTP 502 and is
+    logged as an error with exc_info.
+    """
+    import logging
+
+    from preloop.sync.exceptions import TrackerResponseError
+
+    tracker = Tracker(
+        name="test-tracker",
+        account_id=test_user.account_id,
+        tracker_type="github",
+        api_key="test_key",
+        url="https://github.com",
+    )
+    db_session.add(tracker)
+    db_session.commit()
+
+    organization = Organization(
+        name="test-org",
+        identifier="test-org",
+        tracker_id=tracker.id,
+    )
+    db_session.add(organization)
+    db_session.commit()
+
+    project = Project(
+        name="owner/repo",
+        identifier="owner/repo",
+        slug="owner/repo",
+        organization_id=organization.id,
+    )
+    db_session.add(project)
+    db_session.commit()
+
+    with (
+        patch("preloop.api.endpoints.mcp.get_http_request") as mock_get_request,
+        patch("preloop.api.endpoints.mcp.get_db") as mock_get_db,
+        patch(
+            "preloop.api.endpoints.mcp._get_authenticated_user",
+            new_callable=AsyncMock,
+        ) as mock_auth,
+        patch(
+            "preloop.api.endpoints.mcp.get_tracker_client",
+            new_callable=AsyncMock,
+        ) as mock_get_tracker,
+    ):
+        mock_get_request.return_value.headers = {"authorization": "Bearer testtoken"}
+        mock_get_db.return_value = iter([db_session])
+        mock_auth.return_value = (db_session, test_user)
+
+        mock_tracker = MagicMock()
+        mock_tracker.tracker_type = "github"
+        mock_tracker.resolve_review_thread = AsyncMock(
+            side_effect=TrackerResponseError(
+                "GitHub GraphQL API error: 500 - internal server error"
+            )
+        )
+        mock_get_tracker.return_value = mock_tracker
+
+        from fastapi import HTTPException
+
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(HTTPException) as exc_info:
+                await mcp.update_comment(
+                    target="owner/repo#123",
+                    comment_id="comment-123",
+                    resolved=True,
+                    thread_id="PRRT_kwDOCjXy1M5abc123",
+                )
+
+    assert exc_info.value.status_code == 502
+    error_records = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.ERROR and "Error updating comment" in r.getMessage()
+    ]
+    assert error_records, "genuine API failures must be logged as errors"
+    assert any(r.exc_info for r in error_records), (
+        "error-level logs should include exc_info"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_comment_resolve_numeric_comment_id_maps_to_thread_node_id(
+    db_session: Session, test_user: User
+):
+    """
+    Tests that resolving with a numeric REST comment id looks up and uses the
+    containing thread's GraphQL node id instead of passing the numeric id to
+    the GraphQL node lookup (issue #220).
+    """
+    tracker = Tracker(
+        name="test-tracker",
+        account_id=test_user.account_id,
+        tracker_type="github",
+        api_key="test_key",
+        url="https://github.com",
+    )
+    db_session.add(tracker)
+    db_session.commit()
+
+    organization = Organization(
+        name="test-org",
+        identifier="test-org",
+        tracker_id=tracker.id,
+    )
+    db_session.add(organization)
+    db_session.commit()
+
+    project = Project(
+        name="owner/repo",
+        identifier="owner/repo",
+        slug="owner/repo",
+        organization_id=organization.id,
+    )
+    db_session.add(project)
+    db_session.commit()
+
+    with (
+        patch("preloop.api.endpoints.mcp.get_http_request") as mock_get_request,
+        patch("preloop.api.endpoints.mcp.get_db") as mock_get_db,
+        patch(
+            "preloop.api.endpoints.mcp._get_authenticated_user",
+            new_callable=AsyncMock,
+        ) as mock_auth,
+        patch(
+            "preloop.api.endpoints.mcp.get_tracker_client",
+            new_callable=AsyncMock,
+        ) as mock_get_tracker,
+    ):
+        mock_get_request.return_value.headers = {"authorization": "Bearer testtoken"}
+        mock_get_db.return_value = iter([db_session])
+        mock_auth.return_value = (db_session, test_user)
+
+        mock_tracker = MagicMock()
+        mock_tracker.tracker_type = "github"
+        mock_tracker.get_thread_id_for_comment = AsyncMock(
+            return_value="PRRT_kwDOCjXy1M5abc123"
+        )
+        mock_tracker.resolve_review_thread = AsyncMock(return_value={})
+        mock_get_tracker.return_value = mock_tracker
+
+        response = await mcp.update_comment(
+            target="owner/repo#123",
+            comment_id="3755981585",
+            resolved=True,
+        )
+
+    assert response.status == "updated"
+    mock_tracker.get_thread_id_for_comment.assert_called_once_with(
+        pr_number="123",
+        comment_id="3755981585",
+    )
+    mock_tracker.resolve_review_thread.assert_called_once_with(
+        thread_id="PRRT_kwDOCjXy1M5abc123",
+        resolved=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_comment_resolve_numeric_thread_id_is_mapped_via_lookup(
+    db_session: Session, test_user: User
+):
+    """
+    Tests that a non-PRRT_ thread_id (e.g. a numeric REST id mistakenly passed
+    as thread_id) is mapped through the thread lookup instead of being fed to
+    the GraphQL node lookup (issue #220).
+    """
+    tracker = Tracker(
+        name="test-tracker",
+        account_id=test_user.account_id,
+        tracker_type="github",
+        api_key="test_key",
+        url="https://github.com",
+    )
+    db_session.add(tracker)
+    db_session.commit()
+
+    organization = Organization(
+        name="test-org",
+        identifier="test-org",
+        tracker_id=tracker.id,
+    )
+    db_session.add(organization)
+    db_session.commit()
+
+    project = Project(
+        name="owner/repo",
+        identifier="owner/repo",
+        slug="owner/repo",
+        organization_id=organization.id,
+    )
+    db_session.add(project)
+    db_session.commit()
+
+    with (
+        patch("preloop.api.endpoints.mcp.get_http_request") as mock_get_request,
+        patch("preloop.api.endpoints.mcp.get_db") as mock_get_db,
+        patch(
+            "preloop.api.endpoints.mcp._get_authenticated_user",
+            new_callable=AsyncMock,
+        ) as mock_auth,
+        patch(
+            "preloop.api.endpoints.mcp.get_tracker_client",
+            new_callable=AsyncMock,
+        ) as mock_get_tracker,
+    ):
+        mock_get_request.return_value.headers = {"authorization": "Bearer testtoken"}
+        mock_get_db.return_value = iter([db_session])
+        mock_auth.return_value = (db_session, test_user)
+
+        mock_tracker = MagicMock()
+        mock_tracker.tracker_type = "github"
+        mock_tracker.get_thread_id_for_comment = AsyncMock(
+            return_value="PRRT_kwDOCjXy1M5abc123"
+        )
+        mock_tracker.resolve_review_thread = AsyncMock(return_value={})
+        mock_get_tracker.return_value = mock_tracker
+
+        response = await mcp.update_comment(
+            target="owner/repo#123",
+            comment_id="3755981585",
+            resolved=True,
+            thread_id="3755981585",
+        )
+
+    assert response.status == "updated"
+    mock_tracker.get_thread_id_for_comment.assert_called_once_with(
+        pr_number="123",
+        comment_id="3755981585",
+    )
+    mock_tracker.resolve_review_thread.assert_called_once_with(
+        thread_id="PRRT_kwDOCjXy1M5abc123",
+        resolved=True,
+    )
+
+
 # =============================================================================
 # get_pull_request tests - include_comments, include_diff flags
 # =============================================================================

--- a/backend/tests/sync/trackers/test_github_pr_review.py
+++ b/backend/tests/sync/trackers/test_github_pr_review.py
@@ -607,6 +607,196 @@ class TestResolveReviewThread(IsolatedAsyncioTestCase):
             )
 
 
+def _make_threads_response(threads, has_next_page=False, end_cursor=None):
+    """Build a mock GraphQL response for the reviewThreads query."""
+    page_info = {"hasNextPage": has_next_page}
+    if end_cursor:
+        page_info["endCursor"] = end_cursor
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": page_info,
+                        "nodes": threads,
+                    }
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.asyncio
+class TestGetThreadIdForComment(IsolatedAsyncioTestCase):
+    """Tests for get_thread_id_for_comment method."""
+
+    def _make_tracker(self):
+        connection_details = {"owner": "testowner", "repo": "testrepo"}
+        return GitHubTracker(str(uuid4()), "api-key", connection_details)
+
+    @staticmethod
+    def _mock_client(mock_client_class, responses):
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = responses
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_class.return_value = mock_client
+        return mock_client
+
+    @staticmethod
+    def _graphql_response(payload):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = payload
+        return mock_response
+
+    @patch("preloop.sync.trackers.github.httpx.AsyncClient")
+    async def test_found_by_numeric_database_id(self, mock_client_class):
+        """Test matching a comment by its numeric REST id on the first page."""
+        response = self._graphql_response(
+            _make_threads_response(
+                [
+                    {
+                        "id": "PRRT_kwDOthread1",
+                        "comments": {
+                            "pageInfo": {"hasNextPage": False},
+                            "nodes": [{"id": "PRRC_node1", "databaseId": 111}],
+                        },
+                    },
+                    {
+                        "id": "PRRT_kwDOthread2",
+                        "comments": {
+                            "pageInfo": {"hasNextPage": False},
+                            "nodes": [{"id": "PRRC_node2", "databaseId": 222}],
+                        },
+                    },
+                ]
+            )
+        )
+        mock_client = self._mock_client(mock_client_class, [response])
+        tracker = self._make_tracker()
+
+        result = await tracker.get_thread_id_for_comment(
+            pr_number="42", comment_id="222"
+        )
+
+        self.assertEqual(result, "PRRT_kwDOthread2")
+        self.assertEqual(mock_client.post.call_count, 1)
+
+    @patch("preloop.sync.trackers.github.httpx.AsyncClient")
+    async def test_paginates_through_comment_pages(self, mock_client_class):
+        """Test that comments beyond the first page of a thread are found."""
+        page1 = self._graphql_response(
+            _make_threads_response(
+                [
+                    {
+                        "id": "PRRT_kwDOlongthread",
+                        "comments": {
+                            "pageInfo": {
+                                "hasNextPage": True,
+                                "endCursor": "cursor-c2",
+                            },
+                            "nodes": [{"id": "PRRC_early", "databaseId": 1}],
+                        },
+                    }
+                ]
+            )
+        )
+        page2 = self._graphql_response(
+            _make_threads_response(
+                [
+                    {
+                        "id": "PRRT_kwDOlongthread",
+                        "comments": {
+                            "pageInfo": {"hasNextPage": False},
+                            "nodes": [{"id": "PRRC_late", "databaseId": 999}],
+                        },
+                    }
+                ]
+            )
+        )
+        mock_client = self._mock_client(mock_client_class, [page1, page2])
+        tracker = self._make_tracker()
+
+        result = await tracker.get_thread_id_for_comment(
+            pr_number="42", comment_id="999"
+        )
+
+        self.assertEqual(result, "PRRT_kwDOlongthread")
+        self.assertEqual(mock_client.post.call_count, 2)
+        second_call_vars = mock_client.post.call_args_list[1][1]["json"]["variables"]
+        self.assertIsNone(second_call_vars["threadsCursor"])
+        self.assertEqual(second_call_vars["commentsCursor"], "cursor-c2")
+
+    @patch("preloop.sync.trackers.github.httpx.AsyncClient")
+    async def test_paginates_through_thread_pages(self, mock_client_class):
+        """Test that threads beyond the first page are searched."""
+        page1 = self._graphql_response(
+            _make_threads_response(
+                [
+                    {
+                        "id": "PRRT_kwDOearly",
+                        "comments": {
+                            "pageInfo": {"hasNextPage": False},
+                            "nodes": [{"id": "PRRC_a", "databaseId": 1}],
+                        },
+                    }
+                ],
+                has_next_page=True,
+                end_cursor="cursor-t2",
+            )
+        )
+        page2 = self._graphql_response(
+            _make_threads_response(
+                [
+                    {
+                        "id": "PRRT_kwDOlate",
+                        "comments": {
+                            "pageInfo": {"hasNextPage": False},
+                            "nodes": [{"id": "PRRC_b", "databaseId": 777}],
+                        },
+                    }
+                ]
+            )
+        )
+        mock_client = self._mock_client(mock_client_class, [page1, page2])
+        tracker = self._make_tracker()
+
+        result = await tracker.get_thread_id_for_comment(
+            pr_number="42", comment_id="777"
+        )
+
+        self.assertEqual(result, "PRRT_kwDOlate")
+        self.assertEqual(mock_client.post.call_count, 2)
+        second_call_vars = mock_client.post.call_args_list[1][1]["json"]["variables"]
+        self.assertEqual(second_call_vars["threadsCursor"], "cursor-t2")
+
+    @patch("preloop.sync.trackers.github.httpx.AsyncClient")
+    async def test_returns_none_when_comment_not_found(self, mock_client_class):
+        """Test that None is returned when no thread contains the comment."""
+        response = self._graphql_response(
+            _make_threads_response(
+                [
+                    {
+                        "id": "PRRT_kwDOthread1",
+                        "comments": {
+                            "pageInfo": {"hasNextPage": False},
+                            "nodes": [{"id": "PRRC_node1", "databaseId": 111}],
+                        },
+                    }
+                ]
+            )
+        )
+        self._mock_client(mock_client_class, [response])
+        tracker = self._make_tracker()
+
+        result = await tracker.get_thread_id_for_comment(
+            pr_number="42", comment_id="404404"
+        )
+
+        self.assertIsNone(result)
+
+
 @pytest.mark.asyncio
 class TestPRReviewIntegration(IsolatedAsyncioTestCase):
     """Integration-style tests for PR review workflow."""

--- a/backend/tests/sync/trackers/test_github_pr_review.py
+++ b/backend/tests/sync/trackers/test_github_pr_review.py
@@ -703,17 +703,17 @@ class TestGetThreadIdForComment(IsolatedAsyncioTestCase):
             )
         )
         page2 = self._graphql_response(
-            _make_threads_response(
-                [
-                    {
+            {
+                "data": {
+                    "node": {
                         "id": "PRRT_kwDOlongthread",
                         "comments": {
                             "pageInfo": {"hasNextPage": False},
                             "nodes": [{"id": "PRRC_late", "databaseId": 999}],
                         },
                     }
-                ]
-            )
+                }
+            }
         )
         mock_client = self._mock_client(mock_client_class, [page1, page2])
         tracker = self._make_tracker()
@@ -724,9 +724,14 @@ class TestGetThreadIdForComment(IsolatedAsyncioTestCase):
 
         self.assertEqual(result, "PRRT_kwDOlongthread")
         self.assertEqual(mock_client.post.call_count, 2)
-        second_call_vars = mock_client.post.call_args_list[1][1]["json"]["variables"]
-        self.assertIsNone(second_call_vars["threadsCursor"])
-        self.assertEqual(second_call_vars["commentsCursor"], "cursor-c2")
+        second_call = mock_client.post.call_args_list[1][1]["json"]
+        # Deeper comment pages must use the thread-scoped node query so a
+        # comments cursor is never applied to sibling threads' connections.
+        self.assertIn("GetPRReviewThreadComments", second_call["query"])
+        self.assertEqual(
+            second_call["variables"],
+            {"threadId": "PRRT_kwDOlongthread", "commentsCursor": "cursor-c2"},
+        )
 
     @patch("preloop.sync.trackers.github.httpx.AsyncClient")
     async def test_paginates_through_thread_pages(self, mock_client_class):


### PR DESCRIPTION
## Problem 1: alerting noise (GlitchTip exceptions for expected client errors)

The generic failure handler in `update_comment` (backend/preloop/api/endpoints/mcp.py) logged every exception with `logger.error(..., exc_info=True)` and raised HTTP 502. Sentry's logging integration promoted these to GlitchTip events even when an agent simply passed a stale/wrong comment id.

**Fix**: the handler now classifies failures. Messages matching expected not-found markers (`not found`, `could not resolve`, `404`, case-insensitive) log at WARNING **without** `exc_info` and map to **HTTP 404**. Genuine tracker/API failures keep `logger.error(..., exc_info=True)` + **HTTP 502**.

## Problem 2: numeric REST id fed to GraphQL node lookup (real bug — fixed)

Root cause confirmed: when resolving a review thread, a caller-supplied `thread_id` was passed **verbatim** to `resolve_review_thread`, which sends it straight into the `resolveReviewThread` GraphQL mutation expecting a base64 global node id (`PRRT_...`). An agent that passed the numeric REST id returned by `get_pull_request` (e.g. `3755981585`) as either `comment_id` or `thread_id` produced exactly `GraphQL errors: Could not resolve to a node with the global id of '3755981585'`.

**Fix** in the GitHub resolve branch: any non-`PRRT_`-prefixed thread id (including numeric REST ids and `PRRC_` comment node ids) is now treated as a comment identifier and mapped to its containing thread via `get_thread_id_for_comment` (which matches both `databaseId` and comment node id against the PR's review threads over GraphQL). Only genuine `PRRT_*` thread node ids reach the mutation.

## Tests

- `test_update_comment_not_found_maps_to_404_with_warning_log` — 404 + warning-level log, no `exc_info`, no error-level record
- `test_update_comment_genuine_api_failure_maps_to_502_with_error_log` — 502 + error-level log with `exc_info`
- `test_update_comment_resolve_numeric_comment_id_maps_to_thread_node_id` — numeric `comment_id` resolves via thread lookup; mutation receives the correct `PRRT_` global id
- `test_update_comment_resolve_numeric_thread_id_is_mapped_via_lookup` — numeric `thread_id` is mapped through lookup instead of hitting GraphQL

Test evidence: `pytest backend/tests/endpoints/test_mcp.py backend/tests/sync/trackers/test_github_pr_review.py -q` → 52 + 25 passed; ruff check/format clean on touched files.

Fixes #220

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Well-scoped bug fix and error-hygiene improvement to `update_comment`; adds error classification and fixes numeric id resolution, with four regression tests and no security or breaking changes.

> **Overview**
> Classifies expected not-found failures in `update_comment` as HTTP 404 with warning-level logging to reduce GlitchTip noise, and fixes a bug where numeric REST ids / `PRRC_` node ids passed as `thread_id` were fed verbatim into the GitHub `resolveReviewThread` GraphQL mutation.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit ca135e7. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->