### PR TITLE
fix(gateway): scrub raw exception text and query-param credentials

### DIFF
--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -1682,7 +1682,7 @@ class OpenAIGatewayService:
                 logger.warning(
                     "Gateway anthropic-messages stream failed mid-stream: %s "
                     "provider=%s model=%s error_class=%s",
-                    exc,
+                    type(exc).__name__,
                     getattr(model, "provider_name", None),
                     payload.get("model"),
                     gateway_error.error_class,
@@ -1962,7 +1962,7 @@ class OpenAIGatewayService:
                 logger.warning(
                     "Gateway chat-completions stream failed mid-stream: %s "
                     "provider=%s model=%s error_class=%s",
-                    exc,
+                    type(exc).__name__,
                     getattr(model, "provider_name", None),
                     payload.get("model"),
                     gateway_error.error_class,
@@ -2440,7 +2440,7 @@ class OpenAIGatewayService:
                 logger.warning(
                     "Gateway responses stream failed mid-stream: %s "
                     "provider=%s model=%s error_class=%s",
-                    exc,
+                    type(exc).__name__,
                     getattr(model, "provider_name", None),
                     payload.get("model"),
                     gateway_error.error_class,
@@ -3725,7 +3725,7 @@ class OpenAIGatewayService:
                 logger.warning(
                     "Gateway codex responses stream failed mid-stream: %s "
                     "provider=%s model=%s error_class=%s",
-                    exc,
+                    type(exc).__name__,
                     getattr(ai_model, "provider_name", None),
                     payload.get("model"),
                     gateway_error.error_class,
@@ -3967,7 +3967,7 @@ class OpenAIGatewayService:
                 logger.warning(
                     "Gateway codex chat stream failed mid-stream: %s "
                     "provider=%s model=%s error_class=%s",
-                    exc,
+                    type(exc).__name__,
                     getattr(ai_model, "provider_name", None),
                     payload.get("model"),
                     gateway_error.error_class,
@@ -4621,7 +4621,7 @@ class OpenAIGatewayService:
                 logger.warning(
                     "Gateway anthropic passthrough stream failed mid-stream: %s "
                     "provider=%s model=%s error_class=%s",
-                    exc,
+                    type(exc).__name__,
                     getattr(ai_model, "provider_name", None),
                     requested_model,
                     gateway_error.error_class,

--- a/backend/preloop/utils/secret_scrubbing.py
+++ b/backend/preloop/utils/secret_scrubbing.py
@@ -30,6 +30,9 @@ _TOKEN_PATTERNS: List[Tuple[Pattern[str], str]] = [
         re.compile(r"\bgl(?:ptt|rt|soat|ft|imt|agent)-[A-Za-z0-9_\-]{16,}"),
         f"gl-token-{REDACTED}",
     ),
+    # Google API keys ("AIza" + 35 chars), used by Gemini/GCP and frequently
+    # echoed inside error text and URLs (issue #184).
+    (re.compile(r"\bAIza[0-9A-Za-z_\-]{35}\b"), f"AIza{REDACTED}"),
     # OpenAI and Anthropic keys, which flow through the same containers.
     (re.compile(r"\bsk-ant-[A-Za-z0-9_\-]{16,}"), f"sk-ant-{REDACTED}"),
     (re.compile(r"\bsk-[A-Za-z0-9_\-]{20,}"), f"sk-{REDACTED}"),
@@ -56,6 +59,19 @@ _URL_USERINFO_TOKEN_ONLY = re.compile(
     r"(?P<scheme>[A-Za-z][A-Za-z0-9+.\-]{0,63}://)"
     r"(?P<user>[^\s:/@]{1,4096})"
     r"(?=@[^\s/@]+)"
+)
+
+# Credentials passed as URL query parameters (issue #184), e.g. Gemini's
+#   https://generativelanguage.googleapis.com/...?key=AIza...
+# or xAI's ?api_key=..., OAuth-style ?access_token=.... The VALUE is redacted
+# while the parameter NAME is kept so operators know what to rotate. The
+# parameter name must directly follow "?" or "&" so ordinary words ending in
+# "key" (sort_key=, monkey=) never match.
+_QUERY_PARAM_SECRET = re.compile(
+    r"(?P<prefix>[?&])"
+    r"(?P<param>(?i:key|api_key|access_token))"
+    r"(?P<eq>=)"
+    r"(?P<value>[^\s&\"'<>]{1,4096})"
 )
 
 # Bearer/PRIVATE-TOKEN style headers, as produced by the PR/MR creation curls.
@@ -101,13 +117,26 @@ def _redact_url_credentials(text: str) -> str:
     return _URL_USERINFO_TOKEN_ONLY.sub(_token_only_sub, text)
 
 
+def _redact_query_param_secrets(text: str) -> str:
+    """Blank the value of credential-bearing URL query parameters."""
+
+    def _sub(match: Match[str]) -> str:
+        return (
+            f"{match.group('prefix')}{match.group('param')}"
+            f"{match.group('eq')}{REDACTED}"
+        )
+
+    return _QUERY_PARAM_SECRET.sub(_sub, text)
+
+
 def scrub_secrets(text: Optional[str]) -> Optional[str]:
     """Return ``text`` with known credential formats replaced by placeholders.
 
     Order matters: URL userinfo is blanked first so that a token inside a URL
     becomes ``https://[REDACTED]@host/...`` (hiding the fact that a credential
-    was present at all in that position), and remaining bare tokens elsewhere
-    in the line are then replaced by their prefix-preserving placeholder.
+    was present at all in that position), credential query parameters are then
+    blanked, and remaining bare tokens elsewhere in the line are replaced by
+    their prefix-preserving placeholder.
 
     ``None`` and empty input are passed through so callers can apply this
     without branching.
@@ -117,6 +146,7 @@ def scrub_secrets(text: Optional[str]) -> Optional[str]:
         return text
 
     scrubbed = _redact_url_credentials(text)
+    scrubbed = _redact_query_param_secrets(scrubbed)
 
     for header_pattern in _AUTH_HEADER_PATTERNS:
         scrubbed = header_pattern.sub(

--- a/backend/tests/services/test_openai_gateway_upstream_errors.py
+++ b/backend/tests/services/test_openai_gateway_upstream_errors.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+from contextlib import contextmanager
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from typing import Any, Iterator
+from unittest.mock import MagicMock, patch
 
+import pytest
+
+from preloop.models.crud import crud_ai_model
 from preloop.services.model_gateway_auth import ModelGatewayAuthContext
 from preloop.services.model_gateway_errors import ModelGatewayAPIError
 from preloop.services.openai_gateway import OpenAIGatewayService
@@ -390,3 +396,140 @@ class TestNotifyAdminsTraceScrubbing:
         assert len(trace_text) <= 400, (
             f"Trace length {len(trace_text)} exceeds 400-char cap"
         )
+
+
+# ---------------------------------------------------------------------------
+# Mid-stream handler log hygiene (issue #184).
+# ---------------------------------------------------------------------------
+
+_MIDSTREAM_SECRET = "sk-live-SUPERSECRETKEY1234567890abcdef"
+
+
+def _midstream_failure_chunks() -> Iterator[dict]:
+    """A stream that emits one chunk, then fails with a secret-bearing error."""
+    yield {"choices": [{"delta": {"content": "Hel"}}]}
+    raise RuntimeError(
+        f"upstream died at https://api.example.com/v1/chat?api_key={_MIDSTREAM_SECRET}"
+    )
+
+
+def _create_gateway_model(db_session: Any, account_id: str, alias: str) -> Any:
+    return crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": f"Gateway Model {alias}",
+            "provider_name": "openai",
+            "model_identifier": "test-model",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": alias,
+                    "provider_adapter": "preloop",
+                },
+                "pricing": {
+                    "input_price_per_1k": 0.01,
+                    "output_price_per_1k": 0.02,
+                },
+            },
+            "is_default": True,
+        },
+        account_id=account_id,
+    )
+
+
+@contextmanager
+def _captured_gateway_warnings(caplog: pytest.LogCaptureFixture) -> Iterator[Any]:
+    """Attach caplog's handler to the gateway logger directly.
+
+    The ``preloop`` logger is configured with ``propagate: False``, so records
+    never reach the root logger caplog attaches to by default; without this,
+    ``caplog.text`` is empty and the leak assertions below pass vacuously.
+    """
+    emitting_logger = logging.getLogger("preloop.services.openai_gateway")
+    emitting_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger="preloop.services.openai_gateway"):
+            yield
+    finally:
+        emitting_logger.removeHandler(caplog.handler)
+
+
+class TestMidStreamErrorLogHygiene:
+    """Issue #184: mid-stream handlers logged the raw exception object.
+
+    Upstream SDK exception text can embed endpoint URLs and credentials, so
+    the warning must carry ``type(exc).__name__`` plus the classified
+    ``error_class``, never ``str(exc)``.
+    """
+
+    def _assert_no_leak(self, caplog: pytest.LogCaptureFixture) -> None:
+        assert caplog.records, "log capture produced no records"
+        full_log = caplog.text
+        assert "mid-stream" in full_log
+        assert "RuntimeError" in full_log, "exception type name must be logged"
+        assert "error_class=" in full_log, "classified error_class must be logged"
+        assert _MIDSTREAM_SECRET not in full_log, (
+            "raw exception text leaked into the mid-stream warning log"
+        )
+        assert "https://api.example.com" not in full_log
+
+    def test_chat_completions_midstream_warning_scrubs_exception(
+        self, db_session, test_user, caplog
+    ):
+        _create_gateway_model(db_session, test_user.account_id, "hyg-chat")
+        service = OpenAIGatewayService(
+            db_session, ModelGatewayAuthContext(token="t", user=test_user)
+        )
+        with patch(
+            "preloop.services.openai_gateway.litellm.completion",
+            return_value=_midstream_failure_chunks(),
+        ):
+            with _captured_gateway_warnings(caplog):
+                list(
+                    service.stream_chat_completion(
+                        {
+                            "model": "hyg-chat",
+                            "messages": [{"role": "user", "content": "Hello"}],
+                        }
+                    )
+                )
+        self._assert_no_leak(caplog)
+
+    def test_anthropic_messages_midstream_warning_scrubs_exception(
+        self, db_session, test_user, caplog
+    ):
+        _create_gateway_model(db_session, test_user.account_id, "hyg-anth")
+        service = OpenAIGatewayService(
+            db_session, ModelGatewayAuthContext(token="t", user=test_user)
+        )
+        with patch(
+            "preloop.services.openai_gateway.litellm.completion",
+            return_value=_midstream_failure_chunks(),
+        ):
+            with _captured_gateway_warnings(caplog):
+                list(
+                    service.stream_message(
+                        {
+                            "model": "hyg-anth",
+                            "messages": [{"role": "user", "content": "Hello"}],
+                            "max_tokens": 64,
+                        }
+                    )
+                )
+        self._assert_no_leak(caplog)
+
+    def test_responses_midstream_warning_scrubs_exception(
+        self, db_session, test_user, caplog
+    ):
+        _create_gateway_model(db_session, test_user.account_id, "hyg-resp")
+        service = OpenAIGatewayService(
+            db_session, ModelGatewayAuthContext(token="t", user=test_user)
+        )
+        with patch(
+            "preloop.services.openai_gateway.litellm.completion",
+            return_value=_midstream_failure_chunks(),
+        ):
+            with _captured_gateway_warnings(caplog):
+                list(service.stream_response({"model": "hyg-resp", "input": "Hello"}))
+        self._assert_no_leak(caplog)

--- a/backend/tests/utils/test_secret_scrubbing.py
+++ b/backend/tests/utils/test_secret_scrubbing.py
@@ -218,6 +218,68 @@ class TestScrubStructure:
         assert GITHUB_PAT not in str(scrub_structure(data))
 
 
+class TestQueryParameterSecrets:
+    """Issue #184: API keys passed as URL query parameters were not redacted.
+
+    Gemini takes its key as ``?key=AIza...``; other providers use
+    ``?api_key=...`` or OAuth-style ``?access_token=....`` The value must be
+    redacted while the parameter name survives, so operators know what to
+    rotate.
+    """
+
+    GEMINI_KEY = "AIzaSyD-1234567890abcdefghijklmnopqrstu"
+
+    def test_gemini_key_query_param(self) -> None:
+        line = (
+            "https://generativelanguage.googleapis.com/v1beta/models"
+            f"?key={self.GEMINI_KEY}"
+        )
+        scrubbed = scrub_secrets(line)
+        assert self.GEMINI_KEY not in scrubbed
+        assert scrubbed.endswith("models?key=[REDACTED]")
+        assert "generativelanguage.googleapis.com" in scrubbed
+
+    def test_api_key_query_param(self) -> None:
+        secret = "abcdef1234567890abcdef1234567890"
+        line = f"https://api.x.com/v1/models?api_key={secret}"
+        scrubbed = scrub_secrets(line)
+        assert secret not in scrubbed
+        assert "?api_key=[REDACTED]" in scrubbed
+
+    def test_access_token_query_param(self) -> None:
+        token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.secret"
+        line = f"https://example.com/oauth/callback?access_token={token}"
+        scrubbed = scrub_secrets(line)
+        assert token not in scrubbed
+        assert "access_token=[REDACTED]" in scrubbed
+
+    def test_param_name_is_preserved_for_rotation(self) -> None:
+        line = f"https://host/v1/x?key={self.GEMINI_KEY}&alt=sse"
+        scrubbed = scrub_secrets(line)
+        assert "key=" in scrubbed
+        assert "&alt=sse" in scrubbed
+
+    def test_bare_google_key_format(self) -> None:
+        """The AIza format must also be caught outside any URL."""
+        assert self.GEMINI_KEY not in scrub_secrets(f"GEMINI_API_KEY={self.GEMINI_KEY}")
+        scrubbed = scrub_secrets(f"request failed for key {self.GEMINI_KEY} (403)")
+        assert "AIza[REDACTED]" in scrubbed
+
+    def test_second_query_param_after_redacted_one_survives(self) -> None:
+        line = "https://host/v1/x?api_key=supersecretvalue123&model=gemini-pro"
+        scrubbed = scrub_secrets(line)
+        assert "supersecretvalue123" not in scrubbed
+        assert "model=gemini-pro" in scrubbed
+
+    def test_non_credential_params_are_untouched(self) -> None:
+        line = "GET https://api.github.com/repos/a/b?sort=updated&direction=desc 200"
+        assert scrub_secrets(line) == line
+
+    def test_words_ending_in_key_are_not_matched(self) -> None:
+        line = "https://host/search?monkey=value&sort_key=abc"
+        assert scrub_secrets(line) == line
+
+
 class TestReDoSResistance:
     """The URL userinfo patterns are applied to every agent log line, so they
     must stay near-linear on adversarial input (CodeQL py/polynomial-redos,

--- a/backend/tests/utils/test_secret_scrubbing.py
+++ b/backend/tests/utils/test_secret_scrubbing.py
@@ -5,6 +5,8 @@ PAT embedded in a git remote URL, surfacing through ``git remote -v`` output
 captured into flow execution logs.
 """
 
+from urllib.parse import urlsplit
+
 from preloop.utils.secret_scrubbing import (
     REDACTED,
     scrub_secret_lines,
@@ -237,7 +239,7 @@ class TestQueryParameterSecrets:
         scrubbed = scrub_secrets(line)
         assert self.GEMINI_KEY not in scrubbed
         assert scrubbed.endswith("models?key=[REDACTED]")
-        assert "generativelanguage.googleapis.com" in scrubbed
+        assert urlsplit(scrubbed).hostname == "generativelanguage.googleapis.com"
 
     def test_api_key_query_param(self) -> None:
         secret = "abcdef1234567890abcdef1234567890"


### PR DESCRIPTION
Fixes #184 (round-3 follow-up to #181).

## Item 1: raw exception text in mid-stream error handlers

All mid-stream `logger.warning("Gateway ... stream failed mid-stream: %s ...", exc, ...)` handlers in `backend/preloop/services/openai_gateway.py` logged the exception object directly. Upstream SDK exception text can embed endpoint URLs and credentials.

The issue listed three handlers against an older base; the same pattern had since propagated to six (anthropic-messages, chat-completions, responses, codex responses, codex chat, anthropic passthrough). All six now log `type(exc).__name__` plus the already-computed `gateway_error.error_class`, matching the `notify_admins` trace-fix pattern from 01df0797 and every other scrubbed error path from #181 rounds 1–2. The SSE error events yielded to clients are unchanged.

## Item 2: query-parameter credentials not scrubbed

`scrub_secrets` had no coverage for keys passed as URL query parameters (verified repro in the issue):

```
https://generativelanguage.googleapis.com/v1beta/models?key=AIza... -> key intact
https://api.x.com/v1/models?api_key=...                             -> key intact
```

Added to `backend/preloop/utils/secret_scrubbing.py`:

- `_QUERY_PARAM_SECRET`: redacts the **value** of `?key=` / `?api_key=` / `?access_token=` while keeping the parameter name so operators know what to rotate (`?key=[REDACTED]`). The parameter name must directly follow `?` or `&`, so ordinary words ending in "key" (`sort_key=`, `monkey=`) never match; non-credential params like `?sort=updated` are untouched.
- An `AIza[0-9A-Za-z_\-]{35}` token pattern so Google's key format is caught both in URLs and as a bare token elsewhere in a log line.

## Tests

- `backend/tests/utils/test_secret_scrubbing.py`: new `TestQueryParameterSecrets` class — the two exact repro URLs from the issue, `access_token`, param-name preservation for rotation, bare AIza keys, adjacent-param survival, and false-positive guards.
- `backend/tests/services/test_openai_gateway_upstream_errors.py`: new `TestMidStreamErrorLogHygiene` class drives chat-completions, anthropic-messages, and responses streams into a real mid-stream failure with a secret-bearing exception message and asserts via caplog that the warning carries `RuntimeError` + `error_class=` but neither the secret nor the URL. The capture handler is attached directly to the emitting logger (the `preloop` logger does not propagate), per the pattern in `test_ai_model_provider.py`.

Mutation-checked: reverting one handler back to logging `exc` makes the hygiene test fail.

## Verification

```
pytest backend/tests/utils/test_secret_scrubbing.py \
       backend/tests/services/test_openai_gateway_upstream_errors.py -q
67 passed
```

Wider run (scrubbing, upstream errors, gateway endpoints): 125 passed; the only failures (`test_gateway_stream_abandonment.py`, one Gemini endpoint test) are pre-existing on unmodified `main` in this environment — local dev DB is missing the `api_usage.conversation_id` column (schema drift, unrelated). `ruff check` and `ruff format` clean on all touched files.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Well-scoped defense-in-depth fix: replaces raw exception logging with typed class names and redacts query-parameter credentials. No issues found.

> **Overview**
> This PR scrubs raw upstream exception text from six mid-stream gateway error handlers and adds `scrub_secrets` coverage for `?key=`/`?api_key=`/`?access_token=` query params plus a bare `AIza…` token pattern. Both changes are correct, safe, and backed by mutation-checked regression tests.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 9bc03bdc. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->