### PR TITLE
feat(runtime-plugins): add @preloop-ai/opencode-plugin

### DIFF
--- a/runtime-plugins/PUBLISHING.md
+++ b/runtime-plugins/PUBLISHING.md
@@ -38,9 +38,11 @@ ClawHub steps and smoke tests.
   - `openclaw-preloop/openclaw.plugin.json`
   - `hermes-preloop/pyproject.toml`
   - `hermes-preloop/preloop-plugin.json`
+  - `opencode-preloop/package.json`
 - Confirm the package names are final:
   - npm/OpenClaw: `@preloop-ai/openclaw-plugin`
   - PyPI/Hermes: `preloop-hermes-plugin`
+  - npm/OpenCode: `@preloop-ai/opencode-plugin`
 - Confirm Hermes entry points use the `hermes_agent.plugins` group and point at
   the module that exposes `register(ctx)` (`preloop_hermes_plugin.plugin`).
 - Confirm OpenClaw `package.json` includes ClawHub-required metadata:
@@ -201,6 +203,47 @@ token. Users should never have to hand-author runtime bearer tokens.
 Note: the OpenClaw plugin runtime id must be `preloop-plugin` (not
 `openclaw-plugin`) because ClawHub treats runtime ids as globally unique and
 `openclaw-plugin` is already claimed by another publisher.
+
+## OpenCode Plugin
+
+OpenCode has no central plugin marketplace: discovery is npm plus the
+`plugin` array in `opencode.json`. There is no ClawHub step and no manifest
+file — the only release artifact is the npm package.
+
+Build and validate the npm package:
+
+```bash
+cd preloop/runtime-plugins/opencode-preloop
+npm ci
+npm run build
+npm pack --dry-run
+npm publish --access public --dry-run
+```
+
+Publish to npm:
+
+```bash
+npm publish --access public
+```
+
+Manual smoke test on a machine without the Preloop CLI:
+
+```bash
+npm install -g @preloop-ai/opencode-plugin
+# add {"plugin": ["@preloop-ai/opencode-plugin"]} to ~/.config/opencode/opencode.json
+preloop-opencode-plugin verify --config ~/.config/opencode/opencode.json
+preloop-opencode-plugin run --config ~/.config/opencode/opencode.json
+```
+
+Marketplace UX requirement: if `~/.config/opencode/opencode.json` does not
+already contain `preloop.control`, a separate Preloop connect helper must
+prompt the user to log in or sign up to Preloop in a browser (same flow as
+the Hermes/OpenClaw plugins): use the existing OAuth CLI flow
+(`client_id=cli`, `redirect_uri=urn:ietf:wg:oauth:2.0:oob`) to obtain a
+Preloop API token, call the runtime-session bootstrap endpoint for the
+current OpenCode runtime, then write `preloop.control` with the generated
+runtime bearer token. Users should never have to hand-author runtime bearer
+tokens.
 
 ## Hermes Plugin
 

--- a/runtime-plugins/README.md
+++ b/runtime-plugins/README.md
@@ -25,4 +25,5 @@ Packages:
   Claude Code (no in-process plugin API; built on the Claude Agent SDK)
 - `opencode-preloop`: `@preloop-ai/opencode-plugin` (npm), in-process
   OpenCode plugin (permission prompts bridged via OpenCode's plugin
-  `event` hook)
+  `event` hook; remote steering via the SDK `session.chat`/`session.prompt`
+  and `session.abort` surfaces)

--- a/runtime-plugins/README.md
+++ b/runtime-plugins/README.md
@@ -23,3 +23,6 @@ Packages:
   OpenClaw plugin
 - `claude-preloop`: `@preloop-ai/claude-plugin` (npm), sidecar daemon for
   Claude Code (no in-process plugin API; built on the Claude Agent SDK)
+- `opencode-preloop`: `@preloop-ai/opencode-plugin` (npm), in-process
+  OpenCode plugin (permission prompts bridged via OpenCode's plugin
+  `event` hook)

--- a/runtime-plugins/opencode-preloop/README.md
+++ b/runtime-plugins/opencode-preloop/README.md
@@ -35,6 +35,38 @@ deduped by `message_id` (the backend replays undelivered commands on
 reconnect) and delivered into the targeted OpenCode session through the SDK
 `client.session.chat` surface.
 
+## Remote control
+
+The plugin also steers the local OpenCode agent from the Preloop console, so an
+operator can drive it remotely like `@preloop-ai/openclaw-plugin`,
+`@preloop-ai/claude-plugin` and `preloop-hermes-plugin`:
+
+- **Send a turn** — a `send_message` command is forwarded as a user prompt into
+  the targeted OpenCode session. The plugin prefers the async SDK
+  `client.session.chat(...)` surface and falls back to the documented blocking
+  [`client.session.prompt({ path, body })`](https://opencode.ai/docs/sdk/)
+  (`parts: [{ type: "text", text }]`), bounded by `turn_timeout_ms` (default
+  300 s) so a hung turn cannot stall the acknowledgement forever — the session
+  itself keeps running.
+- **Stop / interrupt** — a `stop` or `interrupt` command (or a `send_message`
+  with `payload.interrupt: true`) maps to
+  [`client.session.abort({ path })`](https://opencode.ai/docs/sdk/), which
+  aborts the running session.
+- **Session targeting** — the target session id comes from the envelope
+  (`target_session_id`, `session_reference`, `runtime_session_id`) with a
+  fallback to `preloop.control.session_reference`. OpenCode sessions are
+  addressed by their native session id; the plugin steers existing sessions and
+  does not create new ones (`new_session: false` in its presence payload).
+- **Status events** — every command emits a `command_result` frame on success
+  (which the backend accepts as the command ack) or `command_error` on
+  failure, mirroring the other runtime plugins. Replayed `message_id`s are
+  acknowledged as completed duplicates without re-executing.
+
+Remote steering can be disabled entirely by setting
+`remote_control_enabled: false`; presence then advertises `text: false` and
+`interrupt: false`, and steering commands are rejected while tool approvals keep
+working.
+
 ### A note on OpenCode's plugin API
 
 OpenCode documents a typed `permission.ask` hook, but as of 2026 the
@@ -77,7 +109,9 @@ Written by `preloop agents enroll` under `preloop.control` in
       "session_reference": "<optional default session>",
       "tool_approval_enabled": true,
       "tool_approval_fail_open": false,
-      "approval_timeout_ms": 310000
+      "approval_timeout_ms": 310000,
+      "remote_control_enabled": true,
+      "turn_timeout_ms": 300000
     }
   }
 }

--- a/runtime-plugins/opencode-preloop/README.md
+++ b/runtime-plugins/opencode-preloop/README.md
@@ -6,16 +6,19 @@ routes every tool-permission prompt OpenCode raises through Preloop's
 approval system, so operators can approve or deny tool calls from the Preloop
 console (web/mobile) while the agent keeps working.
 
-The plugin is standalone: it has zero runtime dependencies and mirrors the
-contract of the other Preloop runtime plugins (`@preloop-ai/openclaw-plugin`,
-`@preloop-ai/claude-plugin`, `preloop-hermes-plugin`).
+The plugin mirrors the contract of the other Preloop runtime plugins
+(`@preloop-ai/openclaw-plugin`, `@preloop-ai/claude-plugin`,
+`preloop-hermes-plugin`). Its only runtime dependency is the `ws` package,
+used to authenticate the control WebSocket with an `Authorization` header.
 
 ## How approvals flow
 
 1. The plugin reads the `preloop.control` block that
    `preloop agents enroll` writes into `~/.config/opencode/opencode.json`.
 2. It connects to `preloop.control.control_ws_url` with the durable runtime
-   bearer token, advertises presence/capabilities (`runtime: "opencode"`,
+   bearer token (sent as `Authorization: Bearer` on the WebSocket upgrade via
+   the `ws` package, so the token never appears in proxy/access-log query
+   strings), advertises presence/capabilities (`runtime: "opencode"`,
    `tool_approval: true`), sends heartbeats, and reconnects with backoff.
 3. When OpenCode's permission system raises a prompt, the plugin receives the
    `permission.asked` event through the plugin `event` hook, dedupes it by
@@ -65,7 +68,9 @@ operator can drive it remotely like `@preloop-ai/openclaw-plugin`,
 Remote steering can be disabled entirely by setting
 `remote_control_enabled: false`; presence then advertises `text: false` and
 `interrupt: false`, and steering commands are rejected while tool approvals keep
-working.
+working. Capabilities are advertised truthfully: `text: true` only when the SDK
+client exposes `session.chat` or `session.prompt`, and `interrupt: true` only
+when `session.abort` is available.
 
 ### A note on OpenCode's plugin API
 
@@ -77,7 +82,8 @@ the same integration path OpenCode's own ACP bridge uses.
 
 ## Install
 
-Add the package to `plugin` in your OpenCode config:
+The plugin is distributed via npm only (there is no OpenCode marketplace
+listing). Add the package to `plugin` in your OpenCode config:
 
 ```json
 {
@@ -106,6 +112,7 @@ Written by `preloop agents enroll` under `preloop.control` in
       "control_ws_url": "wss://example.preloop.ai/api/v1/agents/control/ws",
       "bearer_token": "<durable runtime token>",
       "runtime_principal_id": "<principal id>",
+      "permission_check_url": "<optional; overrides the derived permission-check endpoint>",
       "session_reference": "<optional default session>",
       "tool_approval_enabled": true,
       "tool_approval_fail_open": false,
@@ -118,6 +125,11 @@ Written by `preloop agents enroll` under `preloop.control` in
 ```
 
 Set `PRELOOP_OPENCODE_CONTROL_CONFIG` to point at an alternative config file.
+
+`permission_check_url` is optional: when unset, the plugin derives
+`<origin>/api/v1/agents/permission-check` from `control_ws_url`. Set it when a
+proxy or non-standard deployment serves the permission-check endpoint at a
+different URL.
 
 ## Manual Test Without Preloop CLI
 

--- a/runtime-plugins/opencode-preloop/README.md
+++ b/runtime-plugins/opencode-preloop/README.md
@@ -1,0 +1,107 @@
+# @preloop-ai/opencode-plugin
+
+Preloop Agent Control plugin for [OpenCode](https://opencode.ai). It keeps the
+Agent Control WebSocket connected from inside OpenCode's plugin host and
+routes every tool-permission prompt OpenCode raises through Preloop's
+approval system, so operators can approve or deny tool calls from the Preloop
+console (web/mobile) while the agent keeps working.
+
+The plugin is standalone: it has zero runtime dependencies and mirrors the
+contract of the other Preloop runtime plugins (`@preloop-ai/openclaw-plugin`,
+`@preloop-ai/claude-plugin`, `preloop-hermes-plugin`).
+
+## How approvals flow
+
+1. The plugin reads the `preloop.control` block that
+   `preloop agents enroll` writes into `~/.config/opencode/opencode.json`.
+2. It connects to `preloop.control.control_ws_url` with the durable runtime
+   bearer token, advertises presence/capabilities (`runtime: "opencode"`,
+   `tool_approval: true`), sends heartbeats, and reconnects with backoff.
+3. When OpenCode's permission system raises a prompt, the plugin receives the
+   `permission.asked` event through the plugin `event` hook, dedupes it by
+   request id, and POSTs it to Preloop's permission-check endpoint (tool
+   name, proposed patterns, session id).
+4. The backend parks that request until an operator decides. The decision is
+   applied by replying `"once"` (approved) or `"reject"` (denied) through the
+   OpenCode SDK client — OpenCode holds tool execution open until a reply,
+   so awaiting the operator genuinely blocks the tool call.
+5. If no decision arrives within `approval_timeout_ms` (default 310 s) or the
+   endpoint is unreachable, the configured fallback applies: fail closed
+   (reject, the default) or fail open (approve) via
+   `tool_approval_fail_open`.
+
+Operator `send_message` commands arriving over the control WebSocket are
+deduped by `message_id` (the backend replays undelivered commands on
+reconnect) and delivered into the targeted OpenCode session through the SDK
+`client.session.chat` surface.
+
+### A note on OpenCode's plugin API
+
+OpenCode documents a typed `permission.ask` hook, but as of 2026 the
+permission system never triggers it (see anomalyco/opencode issues #7006 and
+#9229). The supported surface — used here — is the generic `event` hook with
+`permission.asked` / `permission.replied` events plus an SDK reply, which is
+the same integration path OpenCode's own ACP bridge uses.
+
+## Install
+
+Add the package to `plugin` in your OpenCode config:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@preloop-ai/opencode-plugin"]
+}
+```
+
+Or drop a shim into `.opencode/plugins/preloop.ts`:
+
+```ts
+export { PreloopPlugin as default } from "@preloop-ai/opencode-plugin";
+```
+
+## Configuration
+
+Written by `preloop agents enroll` under `preloop.control` in
+`~/.config/opencode/opencode.json`:
+
+```json
+{
+  "preloop": {
+    "control": {
+      "runtime": "opencode",
+      "protocol": "preloop.agent_control.v1",
+      "control_ws_url": "wss://example.preloop.ai/api/v1/agents/control/ws",
+      "bearer_token": "<durable runtime token>",
+      "runtime_principal_id": "<principal id>",
+      "session_reference": "<optional default session>",
+      "tool_approval_enabled": true,
+      "tool_approval_fail_open": false,
+      "approval_timeout_ms": 310000
+    }
+  }
+}
+```
+
+Set `PRELOOP_OPENCODE_CONTROL_CONFIG` to point at an alternative config file.
+
+## Manual Test Without Preloop CLI
+
+```bash
+npm install -g @preloop-ai/opencode-plugin
+# add {"plugin": ["@preloop-ai/opencode-plugin"]} to ~/.config/opencode/opencode.json
+preloop-opencode-plugin verify --config ~/.config/opencode/opencode.json
+preloop-opencode-plugin run --config ~/.config/opencode/opencode.json
+```
+
+Then start `opencode`, trigger a permission-gated action, and approve/deny
+it from the Preloop console.
+
+## Development
+
+```bash
+npm install
+npm run build   # tsc -> dist/
+npm test        # builds, then runs node --test against dist/
+npx tsc --noEmit
+```

--- a/runtime-plugins/opencode-preloop/package-lock.json
+++ b/runtime-plugins/opencode-preloop/package-lock.json
@@ -8,11 +8,15 @@
       "name": "@preloop-ai/opencode-plugin",
       "version": "0.1.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "ws": "^8.18.3"
+      },
       "bin": {
         "preloop-opencode-plugin": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^22.19.19",
+        "@types/ws": "^8.18.1",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -27,6 +31,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/typescript": {
@@ -49,6 +63,27 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/runtime-plugins/opencode-preloop/package-lock.json
+++ b/runtime-plugins/opencode-preloop/package-lock.json
@@ -1,0 +1,54 @@
+{
+  "name": "@preloop-ai/opencode-plugin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@preloop-ai/opencode-plugin",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "bin": {
+        "preloop-opencode-plugin": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.19.19",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/runtime-plugins/opencode-preloop/package.json
+++ b/runtime-plugins/opencode-preloop/package.json
@@ -25,34 +25,9 @@
   "bin": {
     "preloop-opencode-plugin": "dist/cli.js"
   },
-  "opencode": {
-    "entrypoints": [
-      "./dist/index.js"
-    ],
-    "compat": {
-      "minVersion": ">=1.1.0"
-    },
-    "install": {
-      "npmSpec": "@preloop-ai/opencode-plugin"
-    },
-    "hooks": [
-      "event"
-    ],
-    "capabilities": {
-      "tool_approval": true
-    },
-    "permissions": [
-      "read_config:preloop.control",
-      "network:wss",
-      "network:https"
-    ],
-    "configPath": "preloop.control",
-    "verification": {
-      "command": "preloop-opencode-plugin verify --config ~/.config/opencode/opencode.json"
-    }
-  },
   "devDependencies": {
     "@types/node": "^22.19.19",
+    "@types/ws": "^8.18.1",
     "typescript": "^5.9.3"
   },
   "engines": {
@@ -66,5 +41,8 @@
   "homepage": "https://preloop.ai",
   "bugs": {
     "url": "https://github.com/preloop/preloop/issues"
+  },
+  "dependencies": {
+    "ws": "^8.18.3"
   }
 }

--- a/runtime-plugins/opencode-preloop/package.json
+++ b/runtime-plugins/opencode-preloop/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@preloop-ai/opencode-plugin",
+  "version": "0.1.0",
+  "description": "Preloop Agent Control plugin for OpenCode",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "verify": "node dist/cli.js verify",
+    "test": "npm run build && node --test"
+  },
+  "keywords": [
+    "preloop",
+    "opencode",
+    "agent-control",
+    "tool-approval",
+    "autonomous-agents"
+  ],
+  "bin": {
+    "preloop-opencode-plugin": "dist/cli.js"
+  },
+  "opencode": {
+    "entrypoints": [
+      "./dist/index.js"
+    ],
+    "compat": {
+      "minVersion": ">=1.1.0"
+    },
+    "install": {
+      "npmSpec": "@preloop-ai/opencode-plugin"
+    },
+    "hooks": [
+      "event"
+    ],
+    "capabilities": {
+      "tool_approval": true
+    },
+    "permissions": [
+      "read_config:preloop.control",
+      "network:wss",
+      "network:https"
+    ],
+    "configPath": "preloop.control",
+    "verification": {
+      "command": "preloop-opencode-plugin verify --config ~/.config/opencode/opencode.json"
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.19",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/preloop/preloop.git",
+    "directory": "runtime-plugins/opencode-preloop"
+  },
+  "homepage": "https://preloop.ai",
+  "bugs": {
+    "url": "https://github.com/preloop/preloop/issues"
+  }
+}

--- a/runtime-plugins/opencode-preloop/src/cli.ts
+++ b/runtime-plugins/opencode-preloop/src/cli.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { PreloopOpenCodePlugin } from "./index.js";
+
+function parseArgs(): { command: string; configPath?: string } {
+  const [, , command = "verify", ...rest] = process.argv;
+  const configIndex = rest.indexOf("--config");
+  return {
+    command,
+    configPath: configIndex >= 0 ? rest[configIndex + 1] : undefined,
+  };
+}
+
+const args = parseArgs();
+const instance = new PreloopOpenCodePlugin(args.configPath);
+if (args.command === "verify") {
+  instance.verify();
+  console.log("@preloop-ai/opencode-plugin verified");
+} else if (args.command === "run") {
+  void instance.start();
+} else {
+  throw new Error(`Unknown command: ${args.command}`);
+}

--- a/runtime-plugins/opencode-preloop/src/config.ts
+++ b/runtime-plugins/opencode-preloop/src/config.ts
@@ -22,6 +22,12 @@ export type ControlConfig = {
   /** Gate the permission-ask bridging. Defaults to enabled. */
   tool_approval_enabled?: boolean;
   /**
+   * Override for Preloop's permission-check endpoint. When set, approval
+   * round trips POST here instead of deriving
+   * `<origin>/api/v1/agents/permission-check` from `control_ws_url`.
+   */
+  permission_check_url?: string;
+  /**
    * When Preloop cannot be reached (or the operator has not decided within
    * the timeout), allow the tool to run instead of rejecting it. Defaults to
    * false (fail closed / reject on error).
@@ -62,6 +68,7 @@ const USABLE_KEYS: (keyof ControlConfig)[] = [
   "control_ws_url",
   "bearer_token",
   "runtime_principal_id",
+  "permission_check_url",
 ];
 
 export function defaultConfigPath(): string {

--- a/runtime-plugins/opencode-preloop/src/config.ts
+++ b/runtime-plugins/opencode-preloop/src/config.ts
@@ -33,6 +33,17 @@ export type ControlConfig = {
    * the permission-check request for up to ~300 s.
    */
   approval_timeout_ms?: number;
+  /**
+   * Gate remote steering (operator `send_message` / `stop` commands arriving
+   * on the Agent Control WebSocket). Defaults to enabled.
+   */
+  remote_control_enabled?: boolean;
+  /**
+   * Upper bound for waiting on OpenCode's blocking `session.prompt` surface
+   * before reporting a timeout for an operator turn. The session itself keeps
+   * running. Defaults to 300000 ms (mirrors the claude sidecar).
+   */
+  turn_timeout_ms?: number;
 };
 
 export const PROTOCOL = "preloop.agent_control.v1";
@@ -40,6 +51,9 @@ export const RUNTIME = "opencode";
 
 /** Upper bound for the blocking permission check; backend blocks up to ~300s. */
 export const DEFAULT_APPROVAL_TIMEOUT_MS = 310_000;
+
+/** Upper bound for one remote operator turn (mirrors the claude sidecar). */
+export const DEFAULT_TURN_TIMEOUT_MS = 300_000;
 
 const USABLE_KEYS: (keyof ControlConfig)[] = [
   "enabled",

--- a/runtime-plugins/opencode-preloop/src/config.ts
+++ b/runtime-plugins/opencode-preloop/src/config.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Control configuration, written by `preloop agents enroll` into OpenCode's
+ * own config file (`~/.config/opencode/opencode.json`) under the
+ * `preloop.control` key. A flat file containing only the control block is
+ * also accepted so a config can be staged by hand or pointed at via
+ * `PRELOOP_OPENCODE_CONTROL_CONFIG`.
+ */
+export type ControlConfig = {
+  enabled?: boolean;
+  protocol?: string;
+  runtime?: string;
+  control_ws_url?: string;
+  bearer_token?: string;
+  runtime_principal_id?: string;
+  runtime_principal_name?: string;
+  /** Preloop session to target when the operator does not specify one. */
+  session_reference?: string;
+  /** Gate the permission-ask bridging. Defaults to enabled. */
+  tool_approval_enabled?: boolean;
+  /**
+   * When Preloop cannot be reached (or the operator has not decided within
+   * the timeout), allow the tool to run instead of rejecting it. Defaults to
+   * false (fail closed / reject on error).
+   */
+  tool_approval_fail_open?: boolean;
+  /**
+   * How long to wait for the operator decision before applying the fallback
+   * (fail open or fail closed). Defaults to 310000 ms — the backend blocks
+   * the permission-check request for up to ~300 s.
+   */
+  approval_timeout_ms?: number;
+};
+
+export const PROTOCOL = "preloop.agent_control.v1";
+export const RUNTIME = "opencode";
+
+/** Upper bound for the blocking permission check; backend blocks up to ~300s. */
+export const DEFAULT_APPROVAL_TIMEOUT_MS = 310_000;
+
+const USABLE_KEYS: (keyof ControlConfig)[] = [
+  "enabled",
+  "protocol",
+  "runtime",
+  "control_ws_url",
+  "bearer_token",
+  "runtime_principal_id",
+];
+
+export function defaultConfigPath(): string {
+  return path.join(os.homedir(), ".config", "opencode", "opencode.json");
+}
+
+/**
+ * Extract the `preloop.control` block from an already-parsed OpenCode config.
+ *
+ * Accepted shapes, first match wins:
+ * - `preloop.control` (what the Preloop CLI writes)
+ * - a flat object that itself carries usable control keys
+ */
+export function extractControlConfig(raw: unknown): {
+  config: ControlConfig;
+  source: "control-block" | "flat" | "empty";
+} {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    const record = raw as Record<string, unknown>;
+    const nested = record["preloop"] as Record<string, unknown> | undefined;
+    if (
+      nested &&
+      typeof nested === "object" &&
+      !Array.isArray(nested) &&
+      nested["control"] &&
+      typeof nested["control"] === "object"
+    ) {
+      const block = nested["control"] as ControlConfig;
+      if (USABLE_KEYS.some((key) => block[key] !== undefined)) {
+        return { config: block, source: "control-block" };
+      }
+    }
+    const flat = raw as ControlConfig;
+    if (USABLE_KEYS.some((key) => flat[key] !== undefined)) {
+      return { config: flat, source: "flat" };
+    }
+  }
+  return { config: {}, source: "empty" };
+}
+
+export function loadControlConfig(configPath?: string): ControlConfig {
+  const resolvedPath =
+    process.env.PRELOOP_OPENCODE_CONTROL_CONFIG ?? configPath ?? defaultConfigPath();
+  const raw = JSON.parse(fs.readFileSync(resolvedPath, "utf8")) as unknown;
+  return extractControlConfig(raw).config;
+}
+
+export function verifyConfig(config: ControlConfig): void {
+  if (!USABLE_KEYS.some((key) => config[key] !== undefined)) {
+    throw new Error("no preloop.control settings found in opencode config");
+  }
+  if (config.runtime !== RUNTIME) {
+    throw new Error(
+      `Expected runtime "${RUNTIME}", got ${String(config.runtime)}`,
+    );
+  }
+  for (const key of [
+    "control_ws_url",
+    "bearer_token",
+    "runtime_principal_id",
+  ] as const) {
+    if (!config[key]) {
+      throw new Error(`preloop.control.${key} is required`);
+    }
+  }
+  if (config.protocol && config.protocol !== PROTOCOL) {
+    throw new Error(
+      `Unsupported protocol ${String(config.protocol)}; expected ${PROTOCOL}`,
+    );
+  }
+}

--- a/runtime-plugins/opencode-preloop/src/index.ts
+++ b/runtime-plugins/opencode-preloop/src/index.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import {
   DEFAULT_APPROVAL_TIMEOUT_MS,
+  DEFAULT_TURN_TIMEOUT_MS,
   PROTOCOL,
   RUNTIME,
   loadControlConfig,
@@ -54,10 +55,24 @@ export type OpenCodeClient = {
     }) => Promise<unknown>;
   };
   session?: {
+    /**
+     * Async prompt surface: enqueues the user message and resolves as soon
+     * as OpenCode accepts it. Present on recent SDK builds.
+     */
     chat?: (input: {
       path: { id: string };
       body: { parts: Array<{ type: "text"; text: string }> };
     }) => Promise<unknown>;
+    /**
+     * Blocking prompt surface (https://opencode.ai/docs/sdk/): resolves with
+     * the assistant's reply once the turn finishes.
+     */
+    prompt?: (input: {
+      path: { id: string };
+      body: { parts: Array<{ type: "text"; text: string }> };
+    }) => Promise<unknown>;
+    /** Abort a running session (https://opencode.ai/docs/sdk/). */
+    abort?: (input: { path: { id: string } }) => Promise<unknown>;
   };
 };
 
@@ -207,59 +222,7 @@ export class PreloopOpenCodePlugin {
     });
 
     socket.addEventListener("message", (event) => {
-      let command: OperatorCommand;
-      try {
-        command = JSON.parse(String(event.data)) as OperatorCommand;
-      } catch (error) {
-        this.sendStatus(socket, {
-          type: "status",
-          name: "command_error",
-          payload: {
-            status: "failed",
-            error: `invalid_json: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          },
-        });
-        return;
-      }
-      const outcome = this.handleCommand(command);
-      if (outcome.duplicate) {
-        // Already applied in a previous connection; acknowledge without
-        // re-executing so the backend can mark it delivered.
-        this.sendStatus(socket, {
-          type: "status",
-          name: "command_result",
-          message_id: command.message_id,
-          payload: {
-            command_id: command.message_id,
-            status: "completed",
-            duplicate: true,
-          },
-        });
-        return;
-      }
-      void Promise.resolve(outcome.result)
-        .then((result) => {
-          this.sendStatus(socket, {
-            type: "status",
-            name: "command_result",
-            message_id: command.message_id,
-            payload: { command_id: command.message_id, status: "completed", result },
-          });
-        })
-        .catch((error: unknown) => {
-          this.sendStatus(socket, {
-            type: "status",
-            name: "command_error",
-            message_id: command.message_id,
-            payload: {
-              command_id: command.message_id,
-              status: "failed",
-              error: error instanceof Error ? error.message : String(error),
-            },
-          });
-        });
+      void this.handleFrame(socket, String(event.data));
     });
 
     const onClose = (): void => {
@@ -278,6 +241,7 @@ export class PreloopOpenCodePlugin {
   }
 
   presenceMessage(config: ControlConfig): Record<string, unknown> {
+    const remoteControl = this.remoteControlEnabled(config);
     return {
       type: "presence",
       name: "capabilities",
@@ -287,17 +251,88 @@ export class PreloopOpenCodePlugin {
         protocol: PROTOCOL,
         runtime: this.runtime,
         capabilities: {
-          new_session: true,
+          // OpenCode sessions are addressed by their native session id; the
+          // plugin steers existing sessions rather than creating new ones.
+          new_session: false,
           existing_session: true,
-          text: true,
+          text: remoteControl,
           voice: false,
-          interrupt: true,
+          interrupt: remoteControl,
           tool_approval: this.toolApprovalEnabled(config),
         },
         runtime_principal_id: config.runtime_principal_id,
         runtime_principal_name: config.runtime_principal_name,
       },
     };
+  }
+
+  /**
+   * Process one inbound control frame. Exposed for tests.
+   *
+   * Emission mirrors the openclaw plugin exactly: a `command_result` frame on
+   * success (which the backend also accepts as the command ack) and a
+   * `command_error` frame on failure. Replayed `message_id`s are acknowledged
+   * as completed duplicates without re-executing.
+   */
+  async handleFrame(socket: WebSocket, data: string): Promise<void> {
+    let command: OperatorCommand;
+    try {
+      command = JSON.parse(data) as OperatorCommand;
+    } catch (error) {
+      this.sendStatus(socket, {
+        type: "status",
+        name: "command_error",
+        payload: {
+          status: "failed",
+          error: `invalid_json: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        },
+      });
+      return;
+    }
+    const outcome = this.handleCommand(command);
+    if (outcome.duplicate) {
+      // Already applied in a previous connection; acknowledge without
+      // re-executing so the backend can mark it delivered.
+      this.sendStatus(socket, {
+        type: "status",
+        name: "command_result",
+        message_id: command.message_id,
+        payload: {
+          command_id: command.message_id,
+          status: "completed",
+          duplicate: true,
+        },
+      });
+      return;
+    }
+    void Promise.resolve(outcome.result)
+      .then((result) => {
+        this.sendStatus(socket, {
+          type: "status",
+          name: "command_result",
+          message_id: command.message_id,
+          payload: {
+            command_id: command.message_id,
+            status: "completed",
+            result,
+            reply_text: this.resultToText(result),
+          },
+        });
+      })
+      .catch((error: unknown) => {
+        this.sendStatus(socket, {
+          type: "status",
+          name: "command_error",
+          message_id: command.message_id,
+          payload: {
+            command_id: command.message_id,
+            status: "failed",
+            error: error instanceof Error ? error.message : String(error),
+          },
+        });
+      });
   }
 
   private sendStatus(socket: WebSocket, frame: Record<string, unknown>): void {
@@ -430,25 +465,128 @@ export class PreloopOpenCodePlugin {
   }
 
   async dispatch(command: OperatorCommand): Promise<unknown> {
-    if (command.type !== "command" || command.name !== "send_message") {
+    if (command.type !== "command") {
       return undefined;
     }
     const payload = command.payload ?? {};
-    const text = payload.text ?? payload.message ?? "";
-    if (payload.interrupt) {
+    const isStop =
+      command.name === "stop" ||
+      command.name === "interrupt" ||
+      payload.interrupt === true;
+    if (!isStop && command.name !== "send_message") {
+      return undefined;
+    }
+    if (!this.remoteControlEnabled()) {
       throw new Error(
-        "OpenCode interrupt is not available over the SDK chat surface",
+        "Preloop remote control is disabled (preloop.control.remote_control_enabled)",
       );
     }
+    if (isStop) {
+      return this.abortSession(payload);
+    }
+    const text = payload.text ?? payload.message ?? "";
+    if (!text.trim()) {
+      throw new Error("send_message requires non-empty text");
+    }
+    return this.sendOperatorTurn(text, payload);
+  }
+
+  /**
+   * Forward an operator turn into the targeted OpenCode session.
+   *
+   * Prefers the async `session.chat` surface (resolves once OpenCode accepts
+   * the user message); falls back to the documented blocking
+   * `session.prompt` (https://opencode.ai/docs/sdk/), bounded by
+   * `turn_timeout_ms` so a hung session cannot stall the command ack forever.
+   */
+  private async sendOperatorTurn(
+    text: string,
+    payload: NonNullable<OperatorCommand["payload"]>,
+  ): Promise<unknown> {
     const sessionId = this.resolveSessionId(payload);
     const chat = this.client?.session?.chat;
-    if (!chat) {
-      throw new Error("OpenCode SDK client.session.chat is not available");
+    if (chat) {
+      return chat({
+        path: { id: sessionId },
+        body: { parts: [{ type: "text", text }] },
+      });
     }
-    return chat({
-      path: { id: sessionId },
-      body: { parts: [{ type: "text", text }] },
+    const prompt = this.client?.session?.prompt;
+    if (prompt) {
+      return this.withTurnTimeout(
+        prompt({
+          path: { id: sessionId },
+          body: { parts: [{ type: "text", text }] },
+        }),
+      );
+    }
+    throw new Error(
+      "OpenCode SDK client.session.chat / client.session.prompt is not available",
+    );
+  }
+
+  /** Map stop/interrupt commands onto OpenCode's `session.abort` API. */
+  private async abortSession(
+    payload: NonNullable<OperatorCommand["payload"]>,
+  ): Promise<"interrupted"> {
+    const sessionId = this.resolveSessionId(payload);
+    const abort = this.client?.session?.abort;
+    if (!abort) {
+      throw new Error("OpenCode SDK client.session.abort is not available");
+    }
+    await abort({ path: { id: sessionId } });
+    return "interrupted";
+  }
+
+  private withTurnTimeout<T>(promise: Promise<T>): Promise<T> {
+    const timeoutMs = this.turnTimeoutMs();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    return Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `OpenCode turn timed out after ${timeoutMs}ms; ` +
+                  "the session may still be running",
+              ),
+            ),
+          timeoutMs,
+        );
+      }),
+    ]).finally(() => {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
     });
+  }
+
+  remoteControlEnabled(config?: ControlConfig): boolean {
+    const resolved = config ?? this.controlConfig;
+    return resolved?.remote_control_enabled !== false;
+  }
+
+  turnTimeoutMs(config?: ControlConfig): number {
+    const resolved = config ?? this.controlConfig;
+    const value = resolved?.turn_timeout_ms;
+    return typeof value === "number" && value > 0
+      ? value
+      : DEFAULT_TURN_TIMEOUT_MS;
+  }
+
+  private resultToText(result: unknown): string {
+    if (typeof result === "string") return result;
+    if (result && typeof result === "object") {
+      const record = result as Record<string, unknown>;
+      for (const key of ["reply_text", "text", "message", "output"]) {
+        const value = record[key];
+        if (typeof value === "string" && value.trim()) {
+          return value;
+        }
+      }
+    }
+    return "";
   }
 
   resolveSessionId(payload: NonNullable<OperatorCommand["payload"]>): string {
@@ -646,7 +784,8 @@ export const plugin = new PreloopOpenCodePlugin();
  *
  * or drop a shim into `.opencode/plugins/preloop.ts`. OpenCode calls the
  * exported function once per project with an SDK context; we keep the Agent
- * Control websocket alive and bridge `permission.asked` events to Preloop.
+ * Control websocket alive, bridge `permission.asked` events to Preloop, and
+ * forward operator turns and stop commands from Preloop into OpenCode.
  */
 export const PreloopPlugin = async (ctx: {
   client?: OpenCodeClient;

--- a/runtime-plugins/opencode-preloop/src/index.ts
+++ b/runtime-plugins/opencode-preloop/src/index.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import path from "node:path";
+
+import WebSocket from "ws";
 
 import {
   DEFAULT_APPROVAL_TIMEOUT_MS,
@@ -197,13 +198,17 @@ export class PreloopOpenCodePlugin {
     }
     const config = this.controlConfig ?? this.loadConfig();
     const wsUrl = new URL(config.control_ws_url!);
-    // Node's global WebSocket has no header option, so the durable bearer
-    // token is passed as a query param. The backend accepts this form.
-    wsUrl.searchParams.set("token", config.bearer_token!);
+    // Node's global WebSocket cannot set headers, but the `ws` package can.
+    // The durable bearer token is therefore sent as `Authorization: Bearer`
+    // on the HTTP upgrade — the scheme Agent Control already prefers — so it
+    // never appears in proxy/access-log query strings. The URL is loggable;
+    // the token itself must never be logged.
 
     let socket: WebSocket;
     try {
-      socket = new WebSocket(wsUrl);
+      socket = new WebSocket(wsUrl, {
+        headers: { authorization: `Bearer ${config.bearer_token!}` },
+      });
     } catch (error) {
       this.log(
         `Preloop Agent Control connect failed: ${
@@ -240,8 +245,29 @@ export class PreloopOpenCodePlugin {
     });
   }
 
+  /**
+   * Steering capabilities actually available through the connected SDK
+   * client. Advertised truthfully in presence so the console never offers an
+   * operator a control the plugin cannot perform.
+   */
+  private steeringCapabilities(config: ControlConfig): {
+    text: boolean;
+    interrupt: boolean;
+  } {
+    if (!this.remoteControlEnabled(config)) {
+      return { text: false, interrupt: false };
+    }
+    const session = this.client?.session;
+    return {
+      text:
+        typeof session?.chat === "function" ||
+        typeof session?.prompt === "function",
+      interrupt: typeof session?.abort === "function",
+    };
+  }
+
   presenceMessage(config: ControlConfig): Record<string, unknown> {
-    const remoteControl = this.remoteControlEnabled(config);
+    const steering = this.steeringCapabilities(config);
     return {
       type: "presence",
       name: "capabilities",
@@ -255,9 +281,9 @@ export class PreloopOpenCodePlugin {
           // plugin steers existing sessions rather than creating new ones.
           new_session: false,
           existing_session: true,
-          text: remoteControl,
+          text: steering.text,
           voice: false,
-          interrupt: remoteControl,
+          interrupt: steering.interrupt,
           tool_approval: this.toolApprovalEnabled(config),
         },
         runtime_principal_id: config.runtime_principal_id,
@@ -367,7 +393,7 @@ export class PreloopOpenCodePlugin {
   private startHeartbeat(config: ControlConfig): void {
     this.stopHeartbeat();
     this.heartbeatTimer = setInterval(() => {
-      if (!this.socket || this.socket.readyState !== this.socket.OPEN) {
+      if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
         return;
       }
       this.socket.send(
@@ -426,9 +452,8 @@ export class PreloopOpenCodePlugin {
    * `wss://host/api/v1/agents/control/ws` -> `https://host`.
    */
   permissionCheckUrl(config: ControlConfig): string {
-    const cfg = config as ControlConfig & { permission_check_url?: string };
-    if (cfg.permission_check_url) {
-      return cfg.permission_check_url;
+    if (config.permission_check_url) {
+      return config.permission_check_url;
     }
     const wsUrl = new URL(config.control_ws_url!);
     const httpProtocol = wsUrl.protocol === "wss:" ? "https:" : "http:";
@@ -441,6 +466,11 @@ export class PreloopOpenCodePlugin {
    * Returns `{ duplicate: true }` when `message_id` was already applied (the
    * backend replays undelivered commands on reconnect), otherwise the result
    * promise from {@link dispatch}.
+   *
+   * The id is remembered only while the dispatch is in flight and after it
+   * succeeds; a failed turn (chat/prompt unavailable, remote control
+   * disabled, ...) forgets the id so a backend replay re-executes instead of
+   * being acked as a completed duplicate.
    */
   handleCommand(command: OperatorCommand): {
     duplicate: boolean;
@@ -453,15 +483,28 @@ export class PreloopOpenCodePlugin {
     if (this.seenCommandIds.has(messageId)) {
       return { duplicate: true };
     }
+    // Reserve the id synchronously so concurrent deliveries of the same
+    // command cannot double-execute while the first dispatch is pending.
     this.seenCommandIds.add(messageId);
     while (this.seenCommandIds.size > DEDUPE_MAX_ENTRIES) {
       const oldest = this.seenCommandIds.values().next().value;
       if (oldest === undefined) {
         break;
       }
+      if (oldest === messageId) {
+        break;
+      }
       this.seenCommandIds.delete(oldest);
     }
-    return { duplicate: false, result: this.dispatch(command) };
+    return {
+      duplicate: false,
+      result: Promise.resolve(this.dispatch(command)).catch((error) => {
+        // Release the reservation so reconnect replays of the same
+        // message_id re-execute instead of being dropped as duplicates.
+        this.seenCommandIds.delete(messageId);
+        throw error;
+      }),
+    };
   }
 
   async dispatch(command: OperatorCommand): Promise<unknown> {
@@ -620,42 +663,62 @@ export class PreloopOpenCodePlugin {
   async handlePermissionAsked(request: PermissionRequest): Promise<{
     replied: boolean;
     response?: PermissionResponse;
-    skipped?: "disabled" | "duplicate" | "no-reply-channel";
+    skipped?: "disabled" | "duplicate" | "missing-id" | "no-reply-channel";
     reason?: string;
   }> {
     const config = this.controlConfig ?? this.loadConfig();
     if (!this.toolApprovalEnabled(config)) {
       return { replied: false, skipped: "disabled" };
     }
-    if (!request.id || this.pendingApprovals.has(request.id)) {
+    if (!request.id || request.id.trim() === "") {
+      // Not a duplicate — there is nothing to dedupe on. Log loudly so a
+      // silently-dropped escalation is visible.
+      this.log(
+        "Preloop approval skipped: permission.asked event carried no request id",
+      );
+      return {
+        replied: false,
+        skipped: "missing-id",
+        reason: "permission.asked event had no request id",
+      };
+    }
+    if (this.pendingApprovals.has(request.id)) {
       return { replied: false, skipped: "duplicate" };
     }
     this.pendingApprovals.set(request.id, request);
     while (this.pendingApprovals.size > DEDUPE_MAX_ENTRIES) {
       const oldest = this.pendingApprovals.keys().next().value;
-      if (oldest === undefined) {
+      if (oldest === undefined || oldest === request.id) {
         break;
       }
       this.pendingApprovals.delete(oldest);
     }
 
-    const decision = await this.requestOperatorDecision(request);
-    let response: PermissionResponse;
-    if (decision.decision === "deny") {
-      response = "reject";
-    } else {
-      response = "once";
-    }
+    try {
+      const decision = await this.requestOperatorDecision(request);
+      let response: PermissionResponse;
+      if (decision.decision === "deny") {
+        response = "reject";
+      } else {
+        response = "once";
+      }
 
-    const reply = this.client?.permission?.reply;
-    if (!reply) {
-      this.log(
-        `Preloop decision "${decision.decision}" for ${request.id} could not be applied: no SDK reply channel`,
-      );
-      return { replied: false, skipped: "no-reply-channel", response };
+      const reply = this.client?.permission?.reply;
+      if (!reply) {
+        this.log(
+          `Preloop decision "${decision.decision}" for ${request.id} could not be applied: no SDK reply channel`,
+        );
+        return { replied: false, skipped: "no-reply-channel", response };
+      }
+      await reply({ path: { id: request.id }, body: { response } });
+      return { replied: true, response, reason: decision.reason };
+    } finally {
+      // The round trip has settled (replied, rejected for lack of a reply
+      // channel, or errored): forget the reservation so the map cannot leak
+      // entries. Late duplicate asks after settlement re-escalate rather
+      // than being silently dropped.
+      this.pendingApprovals.delete(request.id);
     }
-    await reply({ path: { id: request.id }, body: { response } });
-    return { replied: true, response, reason: decision.reason };
   }
 
   /**

--- a/runtime-plugins/opencode-preloop/src/index.ts
+++ b/runtime-plugins/opencode-preloop/src/index.ts
@@ -1,0 +1,684 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+import {
+  DEFAULT_APPROVAL_TIMEOUT_MS,
+  PROTOCOL,
+  RUNTIME,
+  loadControlConfig,
+  verifyConfig,
+  type ControlConfig,
+} from "./config.js";
+
+/**
+ * Structural mirror of OpenCode's permission-ask request
+ * (packages/opencode/src/permission/next.ts: PermissionNext.Request, delivered
+ * to plugins through the generic `event` hook as `{ type:
+ * "permission.asked", properties }`). Declared locally so the plugin keeps a
+ * zero runtime dependency on the `@opencode-ai/plugin` SDK.
+ *
+ * NOTE: OpenCode's documented `permission.ask` plugin hook is defined in the
+ * SDK types but never triggered by the permission system (anomalyco/opencode
+ * issues #7006 and #9229); the supported surface is the `permission.asked`
+ * bus event plus a reply through the SDK client.
+ */
+export type PermissionRequest = {
+  id: string;
+  sessionID?: string;
+  /** Permission action that matched an "ask" rule, e.g. "bash". */
+  permission?: string;
+  /** Resource patterns the tool proposed (e.g. command prefixes). */
+  patterns?: string[];
+  metadata?: Record<string, unknown>;
+  title?: string;
+  callID?: string;
+};
+
+export type PermissionEvent = {
+  type: "permission.asked" | "permission.replied";
+  properties?: Partial<PermissionRequest> & { id?: string };
+};
+
+/** Reply values accepted by OpenCode's permission reply endpoint. */
+export type PermissionResponse = "once" | "always" | "reject";
+
+/**
+ * Minimal structural view of the OpenCode SDK client handed to plugins. The
+ * real client is generated; only the members used here are declared.
+ */
+export type OpenCodeClient = {
+  permission?: {
+    reply: (input: {
+      path: { id: string };
+      body: { response: PermissionResponse };
+    }) => Promise<unknown>;
+  };
+  session?: {
+    chat?: (input: {
+      path: { id: string };
+      body: { parts: Array<{ type: "text"; text: string }> };
+    }) => Promise<unknown>;
+  };
+};
+
+type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+export type PermissionDecision = {
+  decision: "allow" | "deny";
+  reason?: string;
+  request_id?: string;
+};
+
+export type OperatorCommand = {
+  message_id?: string;
+  type?: string;
+  name?: string;
+  payload?: {
+    text?: string;
+    message?: string;
+    interrupt?: boolean;
+    target_session_id?: string;
+    session_reference?: string;
+    runtime_session_id?: string;
+    metadata?: Record<string, unknown>;
+  };
+};
+
+/** Reconnect backoff bounds and heartbeat cadence (mirror the Python client). */
+const RECONNECT_BASE_DELAY_MS = 2_000;
+const RECONNECT_MAX_DELAY_MS = 30_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+/** Upper bound on remembered command ids / pending approval ids. */
+const DEDUPE_MAX_ENTRIES = 512;
+
+export class PreloopOpenCodePlugin {
+  runtime = RUNTIME;
+  private controlConfig?: ControlConfig;
+  private socket?: WebSocket;
+  private client?: OpenCodeClient;
+  private stopped = false;
+  private reconnectAttempts = 0;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private heartbeatTimer?: ReturnType<typeof setInterval>;
+
+  /**
+   * Dedupe for inbound Agent Control commands. The backend persists commands
+   * before delivery and replays undelivered ones with their original ids on
+   * reconnect, so every envelope must be applied at most once.
+   */
+  private seenCommandIds: Set<string>;
+
+  /**
+   * Dedupe for OpenCode permission requests: repeated `permission.asked`
+   * events for the same request id must produce exactly one operator round
+   * trip and one reply.
+   */
+  private pendingApprovals: Map<string, PermissionRequest>;
+
+  private logger?: (message: string) => void;
+
+  constructor(
+    private readonly configPath?: string,
+    private readonly fetchImpl?: FetchLike,
+  ) {
+    this.seenCommandIds = new Set<string>();
+    this.pendingApprovals = new Map<string, PermissionRequest>();
+  }
+
+  setLogger(logger: (message: string) => void): void {
+    this.logger = logger;
+  }
+
+  setOpenCodeClient(client: OpenCodeClient): void {
+    this.client = client;
+  }
+
+  private log(message: string): void {
+    if (this.logger) {
+      this.logger(message);
+    }
+  }
+
+  configure(config: ControlConfig): void {
+    this.controlConfig = config;
+  }
+
+  loadConfig(): ControlConfig {
+    this.controlConfig = loadControlConfig(this.configPath);
+    return this.controlConfig;
+  }
+
+  verify(): void {
+    verifyConfig(this.loadConfig());
+  }
+
+  async start(client?: OpenCodeClient): Promise<void> {
+    this.stopped = false;
+    if (client) {
+      this.client = client;
+    }
+    // Resolve config once up front so a bad config surfaces to the caller
+    // instead of being retried forever.
+    this.controlConfig = this.controlConfig ?? this.loadConfig();
+    this.connect();
+  }
+
+  private connect(): void {
+    if (this.stopped) {
+      return;
+    }
+    const config = this.controlConfig ?? this.loadConfig();
+    const wsUrl = new URL(config.control_ws_url!);
+    // Node's global WebSocket has no header option, so the durable bearer
+    // token is passed as a query param. The backend accepts this form.
+    wsUrl.searchParams.set("token", config.bearer_token!);
+
+    let socket: WebSocket;
+    try {
+      socket = new WebSocket(wsUrl);
+    } catch (error) {
+      this.log(
+        `Preloop Agent Control connect failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      this.scheduleReconnect();
+      return;
+    }
+    this.socket = socket;
+
+    socket.addEventListener("open", () => {
+      this.reconnectAttempts = 0;
+      socket.send(JSON.stringify(this.presenceMessage(config)));
+      this.startHeartbeat(config);
+    });
+
+    socket.addEventListener("message", (event) => {
+      let command: OperatorCommand;
+      try {
+        command = JSON.parse(String(event.data)) as OperatorCommand;
+      } catch (error) {
+        this.sendStatus(socket, {
+          type: "status",
+          name: "command_error",
+          payload: {
+            status: "failed",
+            error: `invalid_json: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          },
+        });
+        return;
+      }
+      const outcome = this.handleCommand(command);
+      if (outcome.duplicate) {
+        // Already applied in a previous connection; acknowledge without
+        // re-executing so the backend can mark it delivered.
+        this.sendStatus(socket, {
+          type: "status",
+          name: "command_result",
+          message_id: command.message_id,
+          payload: {
+            command_id: command.message_id,
+            status: "completed",
+            duplicate: true,
+          },
+        });
+        return;
+      }
+      void Promise.resolve(outcome.result)
+        .then((result) => {
+          this.sendStatus(socket, {
+            type: "status",
+            name: "command_result",
+            message_id: command.message_id,
+            payload: { command_id: command.message_id, status: "completed", result },
+          });
+        })
+        .catch((error: unknown) => {
+          this.sendStatus(socket, {
+            type: "status",
+            name: "command_error",
+            message_id: command.message_id,
+            payload: {
+              command_id: command.message_id,
+              status: "failed",
+              error: error instanceof Error ? error.message : String(error),
+            },
+          });
+        });
+    });
+
+    const onClose = (): void => {
+      this.stopHeartbeat();
+      if (this.socket === socket) {
+        this.socket = undefined;
+      }
+      this.scheduleReconnect();
+    };
+    socket.addEventListener("close", onClose);
+    socket.addEventListener("error", () => {
+      // 'error' is followed by 'close' in the WS lifecycle; log and let
+      // onClose drive the reconnect so we don't schedule twice.
+      this.log("Preloop Agent Control websocket error");
+    });
+  }
+
+  presenceMessage(config: ControlConfig): Record<string, unknown> {
+    return {
+      type: "presence",
+      name: "capabilities",
+      message_id: randomUUID(),
+      payload: {
+        status: "online",
+        protocol: PROTOCOL,
+        runtime: this.runtime,
+        capabilities: {
+          new_session: true,
+          existing_session: true,
+          text: true,
+          voice: false,
+          interrupt: true,
+          tool_approval: this.toolApprovalEnabled(config),
+        },
+        runtime_principal_id: config.runtime_principal_id,
+        runtime_principal_name: config.runtime_principal_name,
+      },
+    };
+  }
+
+  private sendStatus(socket: WebSocket, frame: Record<string, unknown>): void {
+    try {
+      socket.send(JSON.stringify(frame));
+    } catch (error) {
+      this.log(
+        `Failed to send status frame: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer) {
+      return;
+    }
+    const delay = Math.min(
+      RECONNECT_MAX_DELAY_MS,
+      RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempts,
+    );
+    this.reconnectAttempts += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      this.connect();
+    }, delay);
+    // Don't keep the process alive solely for the reconnect timer.
+    (this.reconnectTimer as { unref?: () => void }).unref?.();
+  }
+
+  private startHeartbeat(config: ControlConfig): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      if (!this.socket || this.socket.readyState !== this.socket.OPEN) {
+        return;
+      }
+      this.socket.send(
+        JSON.stringify({
+          type: "status",
+          name: "heartbeat",
+          message_id: randomUUID(),
+          payload: {
+            status: "online",
+            runtime_principal_id: config.runtime_principal_id,
+          },
+        }),
+      );
+    }, HEARTBEAT_INTERVAL_MS);
+    (this.heartbeatTimer as { unref?: () => void }).unref?.();
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = undefined;
+    }
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+    this.stopHeartbeat();
+    this.socket?.close();
+    this.socket = undefined;
+  }
+
+  toolApprovalEnabled(config?: ControlConfig): boolean {
+    const resolved = config ?? this.controlConfig;
+    return resolved?.tool_approval_enabled !== false;
+  }
+
+  toolApprovalFailOpen(config?: ControlConfig): boolean {
+    const resolved = config ?? this.controlConfig;
+    return resolved?.tool_approval_fail_open === true;
+  }
+
+  approvalTimeoutMs(config?: ControlConfig): number {
+    const resolved = config ?? this.controlConfig;
+    const value = resolved?.approval_timeout_ms;
+    return typeof value === "number" && value > 0
+      ? value
+      : DEFAULT_APPROVAL_TIMEOUT_MS;
+  }
+
+  /**
+   * Derive the REST API base URL from the Agent Control WS URL, e.g.
+   * `wss://host/api/v1/agents/control/ws` -> `https://host`.
+   */
+  permissionCheckUrl(config: ControlConfig): string {
+    const cfg = config as ControlConfig & { permission_check_url?: string };
+    if (cfg.permission_check_url) {
+      return cfg.permission_check_url;
+    }
+    const wsUrl = new URL(config.control_ws_url!);
+    const httpProtocol = wsUrl.protocol === "wss:" ? "https:" : "http:";
+    return `${httpProtocol}//${wsUrl.host}/api/v1/agents/permission-check`;
+  }
+
+  /**
+   * Apply one inbound Agent Control command at most once.
+   *
+   * Returns `{ duplicate: true }` when `message_id` was already applied (the
+   * backend replays undelivered commands on reconnect), otherwise the result
+   * promise from {@link dispatch}.
+   */
+  handleCommand(command: OperatorCommand): {
+    duplicate: boolean;
+    result?: unknown;
+  } {
+    const messageId =
+      typeof command.message_id === "string" && command.message_id.trim() !== ""
+        ? command.message_id
+        : randomUUID();
+    if (this.seenCommandIds.has(messageId)) {
+      return { duplicate: true };
+    }
+    this.seenCommandIds.add(messageId);
+    while (this.seenCommandIds.size > DEDUPE_MAX_ENTRIES) {
+      const oldest = this.seenCommandIds.values().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.seenCommandIds.delete(oldest);
+    }
+    return { duplicate: false, result: this.dispatch(command) };
+  }
+
+  async dispatch(command: OperatorCommand): Promise<unknown> {
+    if (command.type !== "command" || command.name !== "send_message") {
+      return undefined;
+    }
+    const payload = command.payload ?? {};
+    const text = payload.text ?? payload.message ?? "";
+    if (payload.interrupt) {
+      throw new Error(
+        "OpenCode interrupt is not available over the SDK chat surface",
+      );
+    }
+    const sessionId = this.resolveSessionId(payload);
+    const chat = this.client?.session?.chat;
+    if (!chat) {
+      throw new Error("OpenCode SDK client.session.chat is not available");
+    }
+    return chat({
+      path: { id: sessionId },
+      body: { parts: [{ type: "text", text }] },
+    });
+  }
+
+  resolveSessionId(payload: NonNullable<OperatorCommand["payload"]>): string {
+    const configured = this.controlConfig?.session_reference;
+    for (const candidate of [
+      payload.target_session_id,
+      payload.session_reference,
+      payload.runtime_session_id,
+      configured,
+    ]) {
+      if (typeof candidate === "string" && candidate.trim() !== "") {
+        return candidate.trim();
+      }
+    }
+    throw new Error(
+      "no target session specified and no preloop.control.session_reference configured",
+    );
+  }
+
+  /**
+   * Bridge an OpenCode `permission.asked` event to Preloop's approval system.
+   *
+   * Repeated events for the same request id are collapsed into a single
+   * round trip (and a single reply). The decision is applied by replying
+   * `"once"` (approved) or `"reject"` (denied) through the SDK client —
+   * OpenCode holds tool execution open until a reply arrives, so awaiting
+   * the remote operator here genuinely blocks the tool call.
+   *
+   * Returns the reply that was sent, or why nothing was sent.
+   */
+  async handlePermissionAsked(request: PermissionRequest): Promise<{
+    replied: boolean;
+    response?: PermissionResponse;
+    skipped?: "disabled" | "duplicate" | "no-reply-channel";
+    reason?: string;
+  }> {
+    const config = this.controlConfig ?? this.loadConfig();
+    if (!this.toolApprovalEnabled(config)) {
+      return { replied: false, skipped: "disabled" };
+    }
+    if (!request.id || this.pendingApprovals.has(request.id)) {
+      return { replied: false, skipped: "duplicate" };
+    }
+    this.pendingApprovals.set(request.id, request);
+    while (this.pendingApprovals.size > DEDUPE_MAX_ENTRIES) {
+      const oldest = this.pendingApprovals.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.pendingApprovals.delete(oldest);
+    }
+
+    const decision = await this.requestOperatorDecision(request);
+    let response: PermissionResponse;
+    if (decision.decision === "deny") {
+      response = "reject";
+    } else {
+      response = "once";
+    }
+
+    const reply = this.client?.permission?.reply;
+    if (!reply) {
+      this.log(
+        `Preloop decision "${decision.decision}" for ${request.id} could not be applied: no SDK reply channel`,
+      );
+      return { replied: false, skipped: "no-reply-channel", response };
+    }
+    await reply({ path: { id: request.id }, body: { response } });
+    return { replied: true, response, reason: decision.reason };
+  }
+
+  /**
+   * Observe a locally-settled permission request (operator answered in the
+   * TUI or another client). Clears the dedupe entry so late plugin activity
+   * cannot double-reply, and forgets the request.
+   */
+  handlePermissionReplied(event: PermissionEvent): void {
+    const id = event.properties?.id;
+    if (id) {
+      this.pendingApprovals.delete(id);
+    }
+  }
+
+  buildPermissionRequestBody(
+    request: PermissionRequest,
+    cwd: string,
+  ): Record<string, unknown> {
+    const config = this.controlConfig ?? this.loadConfig();
+    const sessionId =
+      request.sessionID ??
+      config.session_reference ??
+      request.callID ??
+      undefined;
+    const body: Record<string, unknown> = {
+      source: this.runtime,
+      tool_name: request.permission ?? "tool",
+      tool_input: {
+        patterns: request.patterns ?? [],
+        title: request.title ?? null,
+        metadata: request.metadata ?? {},
+      },
+      session_id: sessionId,
+      cwd,
+    };
+    const reasoning = request.title ?? request.patterns?.join(", ");
+    if (reasoning) {
+      body.agent_reasoning = reasoning;
+    }
+    return body;
+  }
+
+  /**
+   * Blocking round trip to Preloop's permission-check endpoint. The backend
+   * parks the HTTP request until an operator decides (or its own ~300 s
+   * budget expires), so this promise resolves with the human's decision.
+   * On timeout or transport error the configured fallback applies: fail
+   * closed (deny, the default) or fail open (allow).
+   */
+  async requestOperatorDecision(
+    request: PermissionRequest,
+  ): Promise<PermissionDecision> {
+    const config = this.controlConfig ?? this.loadConfig();
+    const doFetch = this.fetchImpl ?? (fetch as unknown as FetchLike);
+    const timeoutMs = this.approvalTimeoutMs(config);
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      // Race the round trip against the configured budget instead of relying
+      // solely on AbortSignal: the backend parks the request until the
+      // operator decides, so the deadline must be enforced locally.
+      const decision = await Promise.race([
+        doFetch(this.permissionCheckUrl(config), {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${config.bearer_token}`,
+          },
+          body: JSON.stringify(
+            this.buildPermissionRequestBody(request, process.cwd()),
+          ),
+          signal: controller.signal,
+        }).then(async (response) => {
+          if (!response.ok) {
+            throw new Error(
+              `permission-check returned HTTP ${response.status}`,
+            );
+          }
+          return (await response.json()) as PermissionDecision;
+        }),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () =>
+              reject(
+                new Error(`operator decision timed out after ${timeoutMs}ms`),
+              ),
+            timeoutMs,
+          );
+        }),
+      ]);
+      if (decision.decision === "deny") {
+        return { ...decision, reason: decision.reason ?? "Denied in Preloop." };
+      }
+      return { ...decision, decision: "allow" };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (this.toolApprovalFailOpen(config)) {
+        return {
+          decision: "allow",
+          reason: `Preloop approval unavailable (failing open): ${message}`,
+        };
+      }
+      return {
+        decision: "deny",
+        reason: `Preloop approval unavailable (failing closed): ${message}`,
+      };
+    } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+      controller.abort();
+    }
+  }
+}
+
+export const plugin = new PreloopOpenCodePlugin();
+
+/**
+ * OpenCode plugin entry point.
+ *
+ * Register the package in `opencode.json`:
+ *
+ * ```json
+ * { "plugin": ["@preloop-ai/opencode-plugin"] }
+ * ```
+ *
+ * or drop a shim into `.opencode/plugins/preloop.ts`. OpenCode calls the
+ * exported function once per project with an SDK context; we keep the Agent
+ * Control websocket alive and bridge `permission.asked` events to Preloop.
+ */
+export const PreloopPlugin = async (ctx: {
+  client?: OpenCodeClient;
+  directory?: string;
+}): Promise<{
+  event: (input: { event: { type: string; properties?: unknown } }) => Promise<void>;
+}> => {
+  const instance = plugin;
+  if (ctx.client) {
+    instance.setOpenCodeClient(ctx.client);
+  }
+  instance.configure(loadControlConfig());
+  await instance.start(ctx.client);
+  return {
+    event: async ({ event }) => {
+      if (
+        event.type === "permission.asked" ||
+        event.type === "permission.replied"
+      ) {
+        const properties =
+          (event.properties as Partial<PermissionRequest> | undefined) ?? {};
+        if (event.type === "permission.asked") {
+          await instance.handlePermissionAsked({
+            ...properties,
+            id: properties.id ?? "",
+          });
+        } else {
+          instance.handlePermissionReplied({ type: event.type, properties });
+        }
+      }
+    },
+  };
+};
+
+export default PreloopPlugin;

--- a/runtime-plugins/opencode-preloop/test/plugin.test.mjs
+++ b/runtime-plugins/opencode-preloop/test/plugin.test.mjs
@@ -1,0 +1,400 @@
+// Unit tests for the Preloop OpenCode plugin: config parsing, permission-ask
+// bridging (approve/deny/timeout), dedupe, and Agent Control command
+// handling. Uses Node's built-in test runner against the built output:
+// `npm test` builds first, then runs `node --test`.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  PreloopOpenCodePlugin,
+} from "../dist/index.js";
+import {
+  extractControlConfig,
+  loadControlConfig,
+  verifyConfig,
+} from "../dist/config.js";
+
+const baseConfig = {
+  runtime: "opencode",
+  control_ws_url: "wss://example.preloop.ai/api/v1/agents/control/ws",
+  bearer_token: "secret-token",
+  runtime_principal_id: "principal-1",
+};
+
+function makePlugin(fetchImpl, overrides = {}) {
+  const plugin = new PreloopOpenCodePlugin(undefined, fetchImpl);
+  plugin.configure({ ...baseConfig, ...overrides });
+  return plugin;
+}
+
+const askRequest = (id) => ({
+  id,
+  sessionID: "ses_example",
+  permission: "bash",
+  patterns: ["rm -rf /"],
+});
+
+function makeClient(replyLog) {
+  return {
+    permission: {
+      reply: async (input) => {
+        replyLog?.push({ id: input.path.id, response: input.body.response });
+        return {};
+      },
+    },
+  };
+}
+
+function jsonResponse(status, body) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Config parsing
+
+test("extractControlConfig reads the nested preloop.control block", () => {
+  const raw = {
+    $schema: "https://opencode.ai/config.json",
+    plugin: ["@preloop-ai/opencode-plugin"],
+    preloop: { control: { ...baseConfig } },
+  };
+  const extracted = extractControlConfig(raw);
+  assert.equal(extracted.source, "control-block");
+  assert.equal(extracted.config.control_ws_url, baseConfig.control_ws_url);
+});
+
+test("extractControlConfig accepts a flat control file", () => {
+  const extracted = extractControlConfig({ ...baseConfig });
+  assert.equal(extracted.source, "flat");
+  assert.equal(extracted.config.bearer_token, "secret-token");
+});
+
+test("extractControlConfig classifies an unrelated opencode config as empty", () => {
+  const extracted = extractControlConfig({
+    theme: "dark",
+    plugin: ["something-else"],
+  });
+  assert.equal(extracted.source, "empty");
+  assert.deepEqual(extracted.config, {});
+});
+
+test("verifyConfig rejects a missing or wrong-runtime config", () => {
+  assert.throws(() => verifyConfig({}), /no preloop\.control settings/);
+  assert.throws(
+    () => verifyConfig({ ...baseConfig, runtime: "claude_code" }),
+    /Expected runtime "opencode"/,
+  );
+  assert.throws(
+    () =>
+      verifyConfig({
+        runtime: "opencode",
+        control_ws_url: baseConfig.control_ws_url,
+      }),
+    /bearer_token is required/,
+  );
+  assert.doesNotThrow(() => verifyConfig({ ...baseConfig }));
+});
+
+test("loadControlConfig honors the PRELOOP_OPENCODE_CONTROL_CONFIG override", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "preloop-opencode-"));
+  const filePath = path.join(dir, "control.json");
+  try {
+    fs.writeFileSync(filePath, JSON.stringify({ ...baseConfig }));
+    const previous = process.env.PRELOOP_OPENCODE_CONTROL_CONFIG;
+    process.env.PRELOOP_OPENCODE_CONTROL_CONFIG = filePath;
+    try {
+      assert.equal(loadControlConfig().runtime_principal_id, "principal-1");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.PRELOOP_OPENCODE_CONTROL_CONFIG;
+      } else {
+        process.env.PRELOOP_OPENCODE_CONTROL_CONFIG = previous;
+      }
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// URL derivation and approval policy knobs
+
+test("permissionCheckUrl derives https from the wss control URL", () => {
+  const plugin = makePlugin();
+  assert.equal(
+    plugin.permissionCheckUrl(baseConfig),
+    "https://example.preloop.ai/api/v1/agents/permission-check",
+  );
+});
+
+test("permissionCheckUrl derives http from a ws control URL", () => {
+  const plugin = makePlugin();
+  const wsConfig = {
+    ...baseConfig,
+    control_ws_url: "ws://localhost:8000/api/v1/agents/control/ws",
+  };
+  assert.equal(
+    plugin.permissionCheckUrl(wsConfig),
+    "http://localhost:8000/api/v1/agents/permission-check",
+  );
+});
+
+test("approval timeout falls back to the default when unset or invalid", () => {
+  assert.equal(makePlugin().approvalTimeoutMs(), 310000);
+  assert.equal(
+    makePlugin(undefined, { approval_timeout_ms: 1500 }).approvalTimeoutMs(),
+    1500,
+  );
+  assert.equal(
+    makePlugin(undefined, { approval_timeout_ms: -5 }).approvalTimeoutMs(),
+    310000,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Permission bridging: approve path
+
+test("allow decision replies once through the SDK client", async () => {
+  const replies = [];
+  let captured;
+  const plugin = makePlugin((url, init) => {
+    captured = { url, init };
+    return jsonResponse(200, { decision: "allow" });
+  });
+  plugin.setOpenCodeClient(makeClient(replies));
+
+  const outcome = await plugin.handlePermissionAsked(askRequest("perm-1"));
+
+  assert.equal(outcome.replied, true);
+  assert.equal(outcome.response, "once");
+  assert.deepEqual(replies, [{ id: "perm-1", response: "once" }]);
+  const body = JSON.parse(captured.init.body);
+  assert.equal(captured.init.method, "POST");
+  assert.equal(
+    captured.url,
+    "https://example.preloop.ai/api/v1/agents/permission-check",
+  );
+  assert.equal(captured.init.headers.authorization, "Bearer secret-token");
+  assert.equal(body.source, "opencode");
+  assert.equal(body.tool_name, "bash");
+  assert.deepEqual(body.tool_input.patterns, ["rm -rf /"]);
+  assert.equal(body.session_id, "ses_example");
+});
+
+// ---------------------------------------------------------------------------
+// Permission bridging: deny path
+
+test("deny decision rejects the tool with the operator's reason", async () => {
+  const replies = [];
+  const plugin = makePlugin(() =>
+    jsonResponse(200, {
+      decision: "deny",
+      reason: "Operator declined in Preloop",
+      request_id: "req-7",
+    }),
+  );
+  plugin.setOpenCodeClient(makeClient(replies));
+
+  const outcome = await plugin.handlePermissionAsked(askRequest("perm-2"));
+
+  assert.equal(outcome.replied, true);
+  assert.equal(outcome.response, "reject");
+  assert.equal(outcome.reason, "Operator declined in Preloop");
+  assert.deepEqual(replies, [{ id: "perm-2", response: "reject" }]);
+});
+
+// ---------------------------------------------------------------------------
+// Permission bridging: timeout fallback
+
+test("timeout applies the fail-closed fallback (reject) by default", async () => {
+  const replies = [];
+  const plugin = makePlugin(
+    () => new Promise(() => undefined),
+    { approval_timeout_ms: 25 },
+  );
+  plugin.setOpenCodeClient(makeClient(replies));
+
+  const outcome = await plugin.handlePermissionAsked(askRequest("perm-3"));
+
+  assert.equal(outcome.response, "reject");
+  assert.match(String(outcome.reason), /failing closed/);
+  assert.deepEqual(replies, [{ id: "perm-3", response: "reject" }]);
+});
+
+test("timeout applies the configured fail-open fallback (once)", async () => {
+  const replies = [];
+  const plugin = makePlugin(
+    () => new Promise(() => undefined),
+    { approval_timeout_ms: 25, tool_approval_fail_open: true },
+  );
+  plugin.setOpenCodeClient(makeClient(replies));
+
+  const outcome = await plugin.handlePermissionAsked(askRequest("perm-4"));
+
+  assert.equal(outcome.response, "once");
+  assert.match(String(outcome.reason), /failing open/);
+  assert.deepEqual(replies, [{ id: "perm-4", response: "once" }]);
+});
+
+test("transport error fails closed by default and open when configured", async () => {
+  const closed = makePlugin(() => Promise.reject(new Error("boom")));
+  closed.setOpenCodeClient(makeClient([]));
+  const closedOutcome = await closed.handlePermissionAsked(askRequest("perm-e1"));
+  assert.equal(closedOutcome.response, "reject");
+
+  const open = makePlugin(
+    () => Promise.reject(new Error("boom")),
+    { tool_approval_fail_open: true },
+  );
+  open.setOpenCodeClient(makeClient([]));
+  const openOutcome = await open.handlePermissionAsked(askRequest("perm-e2"));
+  assert.equal(openOutcome.response, "once");
+});
+
+// ---------------------------------------------------------------------------
+// Dedupe of repeated message/request ids
+
+test("repeated permission.asked events for one id produce one round trip", async () => {
+  let fetchCount = 0;
+  const replies = [];
+  const plugin = makePlugin(() => {
+    fetchCount += 1;
+    return jsonResponse(200, { decision: "allow" });
+  });
+  plugin.setOpenCodeClient(makeClient(replies));
+
+  await plugin.handlePermissionAsked(askRequest("perm-dup"));
+  const second = await plugin.handlePermissionAsked(askRequest("perm-dup"));
+
+  assert.equal(fetchCount, 1);
+  assert.deepEqual(second, { replied: false, skipped: "duplicate" });
+  assert.equal(replies.length, 1);
+});
+
+test("permission.replied clears the dedupe entry so later asks re-escalate", async () => {
+  let fetchCount = 0;
+  const plugin = makePlugin(() => {
+    fetchCount += 1;
+    return jsonResponse(200, { decision: "allow" });
+  });
+  plugin.setOpenCodeClient(makeClient([]));
+
+  await plugin.handlePermissionAsked(askRequest("perm-clear"));
+  plugin.handlePermissionReplied({
+    type: "permission.replied",
+    properties: { id: "perm-clear" },
+  });
+  await plugin.handlePermissionAsked(askRequest("perm-clear"));
+
+  assert.equal(fetchCount, 2);
+});
+
+test("disabled approvals short-circuit without contacting Preloop", async () => {
+  let called = false;
+  const plugin = makePlugin(
+    () => {
+      called = true;
+      return jsonResponse(200, { decision: "deny" });
+    },
+    { tool_approval_enabled: false },
+  );
+
+  const outcome = await plugin.handlePermissionAsked(askRequest("perm-off"));
+
+  assert.deepEqual(outcome, { replied: false, skipped: "disabled" });
+  assert.equal(called, false);
+});
+
+// ---------------------------------------------------------------------------
+// Agent Control commands: message_id dedupe + session targeting
+
+test("handleCommand executes each message_id once and flags replays", async () => {
+  const chats = [];
+  const plugin = new PreloopOpenCodePlugin();
+  plugin.configure(baseConfig);
+  plugin.setOpenCodeClient({
+    session: {
+      chat: async (input) => {
+        chats.push({ id: input.path.id, text: input.body.parts[0].text });
+        return {};
+      },
+    },
+  });
+
+  const command = {
+    message_id: "cmd-1",
+    type: "command",
+    name: "send_message",
+    payload: { text: "hello agent", target_session_id: "ses_target" },
+  };
+
+  const first = plugin.handleCommand(command);
+  assert.equal(first.duplicate, false);
+  await first.result;
+
+  const replay = plugin.handleCommand(command);
+  assert.equal(replay.duplicate, true);
+
+  const second = plugin.handleCommand({ ...command, message_id: "cmd-2" });
+  await second.result;
+
+  assert.deepEqual(chats, [
+    { id: "ses_target", text: "hello agent" },
+    { id: "ses_target", text: "hello agent" },
+  ]);
+});
+
+test("session targeting prefers explicit ids over the configured reference", () => {
+  const plugin = makePlugin(undefined, { session_reference: "ses_default" });
+
+  assert.equal(plugin.resolveSessionId({ target_session_id: "ses_a" }), "ses_a");
+  assert.equal(
+    plugin.resolveSessionId({ session_reference: "ses_b" }),
+    "ses_b",
+  );
+  assert.equal(plugin.resolveSessionId({ runtime_session_id: "ses_c" }), "ses_c");
+  assert.equal(plugin.resolveSessionId({}), "ses_default");
+  assert.throws(
+    () => makePlugin().resolveSessionId({}),
+    /no target session specified/,
+  );
+});
+
+test("dispatch ignores non send_message envelopes and reports missing client", async () => {
+  const plugin = makePlugin(undefined, { session_reference: "ses_default" });
+  assert.equal(
+    await plugin.dispatch({ message_id: "x", type: "status", name: "heartbeat" }),
+    undefined,
+  );
+  await assert.rejects(
+    plugin.dispatch({
+      message_id: "y",
+      type: "command",
+      name: "send_message",
+      payload: { text: "hi" },
+    }),
+    /client\.session\.chat is not available/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Presence envelope
+
+test("presence advertises the opencode runtime and tool_approval capability", () => {
+  const plugin = makePlugin();
+  const presence = plugin.presenceMessage(baseConfig);
+  assert.equal(presence.type, "presence");
+  assert.equal(presence.name, "capabilities");
+  const payload = presence.payload;
+  assert.equal(payload.runtime, "opencode");
+  assert.equal(payload.protocol, "preloop.agent_control.v1");
+  assert.equal(payload.capabilities.tool_approval, true);
+  assert.equal(payload.capabilities.voice, false);
+});

--- a/runtime-plugins/opencode-preloop/test/plugin.test.mjs
+++ b/runtime-plugins/opencode-preloop/test/plugin.test.mjs
@@ -367,21 +367,367 @@ test("session targeting prefers explicit ids over the configured reference", () 
   );
 });
 
-test("dispatch ignores non send_message envelopes and reports missing client", async () => {
+test("dispatch ignores non-command envelopes and reports a missing SDK surface", async () => {
   const plugin = makePlugin(undefined, { session_reference: "ses_default" });
   assert.equal(
     await plugin.dispatch({ message_id: "x", type: "status", name: "heartbeat" }),
     undefined,
   );
+  assert.equal(
+    await plugin.dispatch({
+      message_id: "z",
+      type: "command",
+      name: "request_takeover",
+      payload: { text: "hi" },
+    }),
+    undefined,
+  );
+  const noSession = makePlugin(undefined, { session_reference: "ses_default" });
+  noSession.setOpenCodeClient({ session: {} });
   await assert.rejects(
-    plugin.dispatch({
+    noSession.dispatch({
       message_id: "y",
       type: "command",
       name: "send_message",
       payload: { text: "hi" },
     }),
-    /client\.session\.chat is not available/,
+    /client\.session\.chat \/ client\.session\.prompt is not available/,
   );
+});
+
+// ---------------------------------------------------------------------------
+// Remote control: prompt fallback, timeout, stop/interrupt
+
+test("send_message falls back to blocking session.prompt with the same payload", async () => {
+  const prompts = [];
+  const plugin = makePlugin(undefined, { session_reference: "ses_default" });
+  plugin.setOpenCodeClient({
+    session: {
+      prompt: async (input) => {
+        prompts.push({ id: input.path.id, text: input.body.parts[0].text });
+        return { info: { role: "assistant" }, parts: [] };
+      },
+    },
+  });
+
+  const result = await plugin.dispatch({
+    message_id: "cmd-prompt",
+    type: "command",
+    name: "send_message",
+    payload: { text: "run the checks", target_session_id: "ses_live" },
+  });
+
+  assert.deepEqual(prompts, [{ id: "ses_live", text: "run the checks" }]);
+  assert.equal(result.info.role, "assistant");
+});
+
+test("a hanging session.prompt rejects after turn_timeout_ms", async () => {
+  const plugin = makePlugin(undefined, {
+    session_reference: "ses_default",
+    turn_timeout_ms: 25,
+  });
+  plugin.setOpenCodeClient({
+    session: {
+      prompt: () => new Promise(() => undefined),
+    },
+  });
+
+  await assert.rejects(
+    plugin.dispatch({
+      message_id: "cmd-hang",
+      type: "command",
+      name: "send_message",
+      payload: { text: "hello" },
+    }),
+    /timed out after 25ms/,
+  );
+});
+
+test("turnTimeoutMs falls back to the default when unset or invalid", () => {
+  assert.equal(makePlugin().turnTimeoutMs(), 300000);
+  assert.equal(
+    makePlugin(undefined, { turn_timeout_ms: 4000 }).turnTimeoutMs(),
+    4000,
+  );
+  assert.equal(
+    makePlugin(undefined, { turn_timeout_ms: 0 }).turnTimeoutMs(),
+    300000,
+  );
+});
+
+test("payload.interrupt maps to session.abort on the targeted session", async () => {
+  const aborts = [];
+  const plugin = makePlugin();
+  plugin.setOpenCodeClient({
+    session: {
+      abort: async (input) => {
+        aborts.push(input.path.id);
+        return true;
+      },
+    },
+  });
+
+  const result = await plugin.dispatch({
+    message_id: "cmd-stop",
+    type: "command",
+    name: "send_message",
+    payload: { text: "ignored", interrupt: true, target_session_id: "ses_run" },
+  });
+
+  assert.equal(result, "interrupted");
+  assert.deepEqual(aborts, ["ses_run"]);
+});
+
+test("stop and interrupt command names map to session.abort", async () => {
+  const aborts = [];
+  const plugin = makePlugin(undefined, { session_reference: "ses_default" });
+  plugin.setOpenCodeClient({
+    session: {
+      abort: async (input) => {
+        aborts.push(input.path.id);
+        return true;
+      },
+    },
+  });
+
+  for (const name of ["stop", "interrupt"]) {
+    const result = await plugin.dispatch({
+      message_id: `cmd-${name}`,
+      type: "command",
+      name,
+      payload: {},
+    });
+    assert.equal(result, "interrupted");
+  }
+  assert.deepEqual(aborts, ["ses_default", "ses_default"]);
+});
+
+test("a missing abort surface produces an actionable error", async () => {
+  const plugin = makePlugin(undefined, { session_reference: "ses_default" });
+  plugin.setOpenCodeClient({ session: {} });
+  await assert.rejects(
+    plugin.dispatch({
+      message_id: "cmd-noabort",
+      type: "command",
+      name: "stop",
+      payload: {},
+    }),
+    /client\.session\.abort is not available/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Remote control gating
+
+test("remote_control_enabled=false blocks steering and dims capabilities", async () => {
+  const chats = [];
+  const config = { ...baseConfig, remote_control_enabled: false };
+  const plugin = new PreloopOpenCodePlugin();
+  plugin.configure(config);
+  plugin.setOpenCodeClient({
+    session: {
+      chat: async (input) => {
+        chats.push(input);
+        return {};
+      },
+    },
+  });
+
+  await assert.rejects(
+    plugin.dispatch({
+      message_id: "cmd-gated",
+      type: "command",
+      name: "send_message",
+      payload: { text: "hi", target_session_id: "ses_x" },
+    }),
+    /remote control is disabled/,
+  );
+  assert.equal(chats.length, 0);
+
+  const presence = plugin.presenceMessage(config);
+  assert.equal(presence.payload.capabilities.text, false);
+  assert.equal(presence.payload.capabilities.interrupt, false);
+  // Approvals are independent of remote steering.
+  assert.equal(presence.payload.capabilities.tool_approval, true);
+});
+
+test("remoteControlEnabled defaults to on", () => {
+  assert.equal(makePlugin().remoteControlEnabled(), true);
+  assert.equal(
+    makePlugin(undefined, { remote_control_enabled: false }).remoteControlEnabled(),
+    false,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// WS frame handling: ack sequence ordering and replay dedupe
+
+function makeSocket() {
+  return {
+    frames: [],
+    send(data) {
+      this.frames.push(JSON.parse(data));
+    },
+  };
+}
+
+/** Yield so handleFrame's async result/ack chain can settle. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test("handleFrame emits one completed ack per command in order", async () => {
+  const socket = makeSocket();
+  let chatCount = 0;
+  const plugin = makePlugin(undefined, { session_reference: "ses_default" });
+  plugin.setOpenCodeClient({
+    session: {
+      chat: async (input) => {
+        chatCount += 1;
+        return { reply_text: `ack ${chatCount}` };
+      },
+    },
+  });
+
+  await plugin.handleFrame(
+    socket,
+    JSON.stringify({
+      message_id: "ws-1",
+      type: "command",
+      name: "send_message",
+      payload: { text: "first" },
+    }),
+  );
+  await flush();
+  await plugin.handleFrame(
+    socket,
+    JSON.stringify({
+      message_id: "ws-2",
+      type: "command",
+      name: "send_message",
+      payload: { message: "second" },
+    }),
+  );
+  await flush();
+
+  assert.equal(socket.frames.length, 2);
+  assert.deepEqual(
+    socket.frames.map((frame) => [frame.name, frame.message_id]),
+    [
+      ["command_result", "ws-1"],
+      ["command_result", "ws-2"],
+    ],
+  );
+  assert.deepEqual(socket.frames[0].payload, {
+    command_id: "ws-1",
+    status: "completed",
+    result: { reply_text: "ack 1" },
+    reply_text: "ack 1",
+  });
+  assert.equal(chatCount, 2);
+});
+
+test("handleFrame acknowledges a replayed message_id without re-executing", async () => {
+  const socket = makeSocket();
+  let chatCount = 0;
+  const plugin = makePlugin(undefined, { session_reference: "ses_default" });
+  plugin.setOpenCodeClient({
+    session: {
+      chat: async () => {
+        chatCount += 1;
+        return {};
+      },
+    },
+  });
+  const envelope = JSON.stringify({
+    message_id: "ws-dup",
+    type: "command",
+    name: "send_message",
+    payload: { text: "once only" },
+  });
+
+  await plugin.handleFrame(socket, envelope);
+  await flush();
+  await plugin.handleFrame(socket, envelope);
+  await flush();
+
+  assert.equal(chatCount, 1);
+  assert.equal(socket.frames.length, 2);
+  assert.deepEqual(socket.frames[1], {
+    type: "status",
+    name: "command_result",
+    message_id: "ws-dup",
+    payload: {
+      command_id: "ws-dup",
+      status: "completed",
+      duplicate: true,
+    },
+  });
+});
+
+test("handleFrame reports failures as command_error with the command id", async () => {
+  const socket = makeSocket();
+  const plugin = makePlugin(undefined, { session_reference: "ses_default" });
+  plugin.setOpenCodeClient({
+    session: {
+      chat: async () => {
+        throw new Error("session gone");
+      },
+    },
+  });
+
+  await plugin.handleFrame(
+    socket,
+    JSON.stringify({
+      message_id: "ws-fail",
+      type: "command",
+      name: "send_message",
+      payload: { text: "boom" },
+    }),
+  );
+  await flush();
+
+  assert.deepEqual(socket.frames, [
+    {
+      type: "status",
+      name: "command_error",
+      message_id: "ws-fail",
+      payload: {
+        command_id: "ws-fail",
+        status: "failed",
+        error: "session gone",
+      },
+    },
+  ]);
+});
+
+test("handleFrame rejects empty turns and malformed JSON", async () => {
+  const socket = makeSocket();
+  const plugin = makePlugin(undefined, { session_reference: "ses_default" });
+  plugin.setOpenCodeClient({
+    session: { chat: async () => ({}) },
+  });
+
+  await plugin.handleFrame(
+    socket,
+    JSON.stringify({
+      message_id: "ws-empty",
+      type: "command",
+      name: "send_message",
+      payload: {},
+    }),
+  );
+  await flush();
+  await plugin.handleFrame(socket, "{not json");
+  await flush();
+
+  assert.deepEqual(
+    socket.frames.map((frame) => [frame.name, frame.payload.status]),
+    [
+      ["command_error", "failed"],
+      ["command_error", "failed"],
+    ],
+  );
+  assert.match(socket.frames[0].payload.error, /requires non-empty text/);
+  assert.match(socket.frames[1].payload.error, /^invalid_json:/);
 });
 
 // ---------------------------------------------------------------------------

--- a/runtime-plugins/opencode-preloop/test/plugin.test.mjs
+++ b/runtime-plugins/opencode-preloop/test/plugin.test.mjs
@@ -134,6 +134,30 @@ test("permissionCheckUrl derives https from the wss control URL", () => {
   );
 });
 
+test("permissionCheckUrl honors the permission_check_url override", () => {
+  const plugin = makePlugin();
+  assert.equal(
+    plugin.permissionCheckUrl({
+      ...baseConfig,
+      permission_check_url: "https://gateway.internal/preloop/check",
+    }),
+    "https://gateway.internal/preloop/check",
+  );
+});
+
+test("extractControlConfig recognizes a config carrying only permission_check_url", () => {
+  const extracted = extractControlConfig({
+    preloop: {
+      control: { ...baseConfig, permission_check_url: "https://gw/check" },
+    },
+  });
+  assert.equal(extracted.source, "control-block");
+  assert.equal(
+    extracted.config.permission_check_url,
+    "https://gw/check",
+  );
+});
+
 test("permissionCheckUrl derives http from a ws control URL", () => {
   const plugin = makePlugin();
   const wsConfig = {
@@ -261,7 +285,7 @@ test("transport error fails closed by default and open when configured", async (
 // ---------------------------------------------------------------------------
 // Dedupe of repeated message/request ids
 
-test("repeated permission.asked events for one id produce one round trip", async () => {
+test("concurrent permission.asked events for one id produce one round trip", async () => {
   let fetchCount = 0;
   const replies = [];
   const plugin = makePlugin(() => {
@@ -270,12 +294,50 @@ test("repeated permission.asked events for one id produce one round trip", async
   });
   plugin.setOpenCodeClient(makeClient(replies));
 
-  await plugin.handlePermissionAsked(askRequest("perm-dup"));
-  const second = await plugin.handlePermissionAsked(askRequest("perm-dup"));
+  // Both events race while the first round trip is still parked at Preloop.
+  const [first, second] = await Promise.all([
+    plugin.handlePermissionAsked(askRequest("perm-dup")),
+    plugin.handlePermissionAsked(askRequest("perm-dup")),
+  ]);
 
-  assert.equal(fetchCount, 1);
+  assert.equal(first.replied, true);
   assert.deepEqual(second, { replied: false, skipped: "duplicate" });
+  assert.equal(fetchCount, 1);
   assert.equal(replies.length, 1);
+});
+
+test("pendingApprovals entry is cleared once the round trip settles", async () => {
+  const plugin = makePlugin(() => jsonResponse(200, { decision: "allow" }));
+  plugin.setOpenCodeClient(makeClient([]));
+
+  await plugin.handlePermissionAsked(askRequest("perm-settled"));
+  assert.equal(plugin.pendingApprovals.size, 0);
+
+  const noChannel = makePlugin(() => jsonResponse(200, { decision: "deny" }));
+  noChannel.setOpenCodeClient({}); // no permission.reply channel
+  await noChannel.handlePermissionAsked(askRequest("perm-nochan"));
+  assert.equal(noChannel.pendingApprovals.size, 0);
+});
+
+test("a permission.asked event without an id is skipped as missing-id", async () => {
+  let called = false;
+  const plugin = makePlugin(
+    () => {
+      called = true;
+      return jsonResponse(200, { decision: "allow" });
+    },
+    { session_reference: "ses_default" },
+  );
+  plugin.setOpenCodeClient(makeClient([]));
+
+  const outcome = await plugin.handlePermissionAsked({});
+
+  assert.equal(outcome.replied, false);
+  assert.equal(outcome.skipped, "missing-id");
+  assert.notEqual(outcome.skipped, "duplicate");
+  assert.match(String(outcome.reason), /no request id/);
+  assert.equal(called, false);
+  assert.equal(plugin.pendingApprovals.size, 0);
 });
 
 test("permission.replied clears the dedupe entry so later asks re-escalate", async () => {
@@ -349,6 +411,70 @@ test("handleCommand executes each message_id once and flags replays", async () =
     { id: "ses_target", text: "hello agent" },
     { id: "ses_target", text: "hello agent" },
   ]);
+});
+
+test("a failed dispatch forgets the message_id so a replay re-executes", async () => {
+  let attempts = 0;
+  const chats = [];
+  const plugin = new PreloopOpenCodePlugin();
+  plugin.configure(baseConfig);
+  plugin.setOpenCodeClient({
+    session: {
+      chat: async (input) => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error("session unavailable");
+        }
+        chats.push({ id: input.path.id, text: input.body.parts[0].text });
+        return {};
+      },
+    },
+  });
+
+  const command = {
+    message_id: "cmd-retry",
+    type: "command",
+    name: "send_message",
+    payload: { text: "deliver me", target_session_id: "ses_target" },
+  };
+
+  // First delivery fails (e.g. backend reconnects and replays afterwards).
+  const first = plugin.handleCommand(command);
+  assert.equal(first.duplicate, false);
+  await assert.rejects(first.result, /session unavailable/);
+
+  // The reconnect replay must re-execute, not be acked as a duplicate.
+  const replay = plugin.handleCommand(command);
+  assert.equal(replay.duplicate, false);
+  await replay.result;
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(chats, [{ id: "ses_target", text: "deliver me" }]);
+
+  // And once that retry succeeds, further replays stay completed-duplicates.
+  const settledReplay = plugin.handleCommand(command);
+  assert.equal(settledReplay.duplicate, true);
+});
+
+test("remote-control-gated failures also release the message_id for replay", async () => {
+  const plugin = makePlugin(undefined, { remote_control_enabled: false });
+  const command = {
+    message_id: "cmd-gated-retry",
+    type: "command",
+    name: "send_message",
+    payload: { text: "hi", target_session_id: "ses_x" },
+  };
+
+  const first = plugin.handleCommand(command);
+  await assert.rejects(first.result, /remote control is disabled/);
+
+  const enabledPlugin = makePlugin();
+  enabledPlugin.setOpenCodeClient({
+    session: { chat: async (input) => ({ text: input.body.parts[0].text }) },
+  });
+  const replay = enabledPlugin.handleCommand(command);
+  assert.equal(replay.duplicate, false);
+  await replay.result;
 });
 
 test("session targeting prefers explicit ids over the configured reference", () => {
@@ -743,4 +869,39 @@ test("presence advertises the opencode runtime and tool_approval capability", ()
   assert.equal(payload.protocol, "preloop.agent_control.v1");
   assert.equal(payload.capabilities.tool_approval, true);
   assert.equal(payload.capabilities.voice, false);
+});
+
+test("presence advertises steering capabilities the client actually supports", () => {
+  const full = makePlugin(undefined, { session_reference: "ses_default" });
+  full.setOpenCodeClient({
+    session: {
+      chat: async () => ({}),
+      prompt: async () => ({}),
+      abort: async () => true,
+    },
+  });
+  const fullPresence = full.presenceMessage(baseConfig);
+  assert.equal(fullPresence.payload.capabilities.text, true);
+  assert.equal(fullPresence.payload.capabilities.interrupt, true);
+
+  const chatOnly = makePlugin(undefined, { session_reference: "ses_default" });
+  chatOnly.setOpenCodeClient({ session: { chat: async () => ({}) } });
+  const chatOnlyPresence = chatOnly.presenceMessage(baseConfig);
+  assert.equal(chatOnlyPresence.payload.capabilities.text, true);
+  assert.equal(chatOnlyPresence.payload.capabilities.interrupt, false);
+
+  // No SDK client at all: nothing may be advertised.
+  const bare = makePlugin(undefined, { session_reference: "ses_default" });
+  const barePresence = bare.presenceMessage(baseConfig);
+  assert.equal(barePresence.payload.capabilities.text, false);
+  assert.equal(barePresence.payload.capabilities.interrupt, false);
+
+  // Prompt-only fallback still counts as text.
+  const promptOnly = makePlugin(undefined, { session_reference: "ses_default" });
+  promptOnly.setOpenCodeClient({
+    session: { prompt: async () => ({}), abort: async () => true },
+  });
+  const promptOnlyPresence = promptOnly.presenceMessage(baseConfig);
+  assert.equal(promptOnlyPresence.payload.capabilities.text, true);
+  assert.equal(promptOnlyPresence.payload.capabilities.interrupt, true);
 });

--- a/runtime-plugins/opencode-preloop/tsconfig.json
+++ b/runtime-plugins/opencode-preloop/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/runtime-plugins/tests/test_runtime_plugin_manifests.py
+++ b/runtime-plugins/tests/test_runtime_plugin_manifests.py
@@ -259,6 +259,23 @@ def test_hermes_package_metadata_matches_manifest() -> None:
     assert manifest["entrypoint"] == "preloop_hermes_plugin.plugin"
 
 
+def test_opencode_package_metadata_is_standalone() -> None:
+    package = json.loads((ROOT / "opencode-preloop" / "package.json").read_text())
+    opencode = package["opencode"]
+
+    assert package["name"] == "@preloop-ai/opencode-plugin"
+    assert opencode["capabilities"]["tool_approval"] is True
+    assert "event" in opencode["hooks"]
+    assert "network:wss" in opencode["permissions"]
+    assert opencode["configPath"] == "preloop.control"
+    assert opencode["verification"]["command"]
+    assert opencode["install"]["npmSpec"] == "@preloop-ai/opencode-plugin"
+    # OpenCode has no marketplace manifest; everything lives in package.json.
+    assert not list((ROOT / "opencode-preloop").glob("*.plugin.json"))
+    assert "opencode" not in package.get("dependencies", {})
+    assert "opencode" not in package.get("peerDependencies", {})
+
+
 def test_publishing_guide_covers_both_marketplaces() -> None:
     guide = (ROOT / "PUBLISHING.md").read_text()
 

--- a/runtime-plugins/tests/test_runtime_plugin_manifests.py
+++ b/runtime-plugins/tests/test_runtime_plugin_manifests.py
@@ -261,15 +261,11 @@ def test_hermes_package_metadata_matches_manifest() -> None:
 
 def test_opencode_package_metadata_is_standalone() -> None:
     package = json.loads((ROOT / "opencode-preloop" / "package.json").read_text())
-    opencode = package["opencode"]
 
     assert package["name"] == "@preloop-ai/opencode-plugin"
-    assert opencode["capabilities"]["tool_approval"] is True
-    assert "event" in opencode["hooks"]
-    assert "network:wss" in opencode["permissions"]
-    assert opencode["configPath"] == "preloop.control"
-    assert opencode["verification"]["command"]
-    assert opencode["install"]["npmSpec"] == "@preloop-ai/opencode-plugin"
+    # The plugin is distributed via npm only: no marketplace consumes the
+    # `opencode` manifest block, so it must not be present.
+    assert "opencode" not in package
     # OpenCode has no marketplace manifest; everything lives in package.json.
     assert not list((ROOT / "opencode-preloop").glob("*.plugin.json"))
     assert "opencode" not in package.get("dependencies", {})


### PR DESCRIPTION
## What it does

New standalone runtime plugin `runtime-plugins/opencode-preloop` (`@preloop-ai/opencode-plugin`, npm) that routes OpenCode's tool-permission approval prompts through Preloop Agent Control, mirroring the existing `openclaw-preloop` and `claude-preloop` integrations. The packages are intentionally standalone — no cross-package imports; patterns are copied.

## How approvals flow

1. The plugin reads the CLI-written `preloop.control` block from `~/.config/opencode/opencode.json` (nested block or flat file; `PRELOOP_OPENCODE_CONTROL_CONFIG` override supported), verifying `runtime: "opencode"` plus the required `control_ws_url` / `bearer_token` / `runtime_principal_id`.
2. It connects to the Agent Control WebSocket (bearer token as query param, same as openclaw), sends a `presence/capabilities` envelope (`runtime: "opencode"`, `tool_approval: true`), heartbeats every 30 s, and reconnects with exponential backoff.
3. On each OpenCode permission prompt it dedupes by request id, then POSTs `source: "opencode"`, tool name, proposed patterns, title/metadata, session id, and cwd to `/api/v1/agents/permission-check`. The backend parks that request until an operator decides (up to ~300 s).
4. The decision is applied by replying through the OpenCode SDK client: `"once"` for allow, `"reject"` for deny. Because OpenCode holds tool execution open until a reply arrives, awaiting the operator genuinely blocks the tool call.
5. Timeout fallback is configurable (`approval_timeout_ms`, default 310 s): fail closed (reject, default) or fail open (`tool_approval_fail_open: true`) — matching openclaw's policy knobs.
6. Inbound `send_message` commands over the control WS are deduped on `message_id` (the backend replays undelivered commands on reconnect), target sessions via explicit ids with fallback to `preloop.control.session_reference`, and are delivered via `client.session.chat`; results/errors are reported back as `command_result`/`command_error` status frames. `permission.replied` events clear dedupe entries so locally-settled prompts can't double-fire.

## OpenCode plugin API used

- **Registration**: npm package listed in the `plugin` array of `opencode.json` (or local shim in `.opencode/plugins/`). Docs: https://opencode.ai/docs/plugins
- **Permission interception**: the generic **`event`** hook with `permission.asked` / `permission.replied` events, plus an SDK reply (`client.permission.reply` with `once` / `always` / `reject`). Docs: https://opencode.ai/docs/plugins#events (permission events list) and https://opencode.ai/docs/permissions#what-ask-does (reply values).

**Honest caveat about the hook name:** OpenCode's plugin SDK types define a `permission.ask` hook, but the permission system never actually triggers it — `PermissionNext.ask()` publishes bus events instead (anomalyco/opencode issues [#7006](https://github.com/anomalyco/opencode/issues/7006) and [#9229](https://github.com/anomalyco/opencode/issues/9229)). We therefore implement against the working surface above, which is the same path OpenCode's own ACP bridge uses. Unlike a hypothetical sync-deny-only surface, this still blocks execution while awaiting the remote human decision, because opencode parks the tool call until any reply arrives.

## Limitations

- `permission.asked` event properties are matched structurally; if upstream renames fields (e.g. `sessionID`, `patterns`), the bridge degrades gracefully (tool name falls back to `"tool"`, patterns to empty) but should be re-checked against upstream releases.
- No `always` reply support: operator approvals map to `once` only; Preloop-side pattern persistence would be a follow-up.
- Operator message delivery uses `client.session.chat` into an existing session; creating brand-new sessions remotely falls back to errors rather than auto-provisioning.
- Voice capability advertised as `false` — OpenCode has no voice transcript surface in the plugin context.
- No ClawHub/marketplace manifest: OpenCode has no central marketplace; npm + config `plugin` array is the whole distribution story (documented in PUBLISHING.md).

## Test evidence

- New package: `npm test` → **20 passed, 0 failed** (`node --test`: approve path, deny path, timeout fail-closed/fail-open fallbacks, transport-error fallbacks, repeated-request-id dedupe, `permission.replied` clearing, disabled short-circuit, config parsing incl. env override, URL derivation, command `message_id` dedupe/replay, session-targeting precedence, presence envelope). Network/WS fully stubbed via injected fetch/client fakes, matching the openclaw test style.
- `npx tsc --noEmit` clean in the new package.
- Regression: `openclaw-preloop` npm test → 11 pass / 0 fail; `claude-preloop` npm test → 50 pass / 0 fail / 4 skipped (live e2e gated by env var); `pytest runtime-plugins/tests` → 12 passed (includes new `test_opencode_package_metadata_is_standalone`).

## Also updated

- `runtime-plugins/README.md` package list
- `runtime-plugins/PUBLISHING.md` release preconditions + npm-only "OpenCode Plugin" section

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> All previously raised issues — including the HIGH-severity command-dedupe flaw — are resolved and covered by regression tests.
>
> **Overview**
> Adds `@preloop-ai/opencode-plugin`, routing OpenCode tool-permission prompts through Preloop Agent Control and steering the agent remotely via the SDK `session.chat`/`session.prompt`/`session.abort` surfaces. The bearer token now travels on the `Authorization` header, and command dedupe releases failed `message_id`s so reconnect replays re-execute.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 33b103c. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->