### PR TITLE
feat(models): add AWS Bedrock as a model provider

### DIFF
--- a/backend/preloop/api/endpoints/ai_models.py
+++ b/backend/preloop/api/endpoints/ai_models.py
@@ -387,6 +387,7 @@ async def list_provider_available_models(
         api_key=request_in.api_key if request_in else None,
         model_kind=request_in.model_kind if request_in else "llm",
         api_endpoint=request_in.api_endpoint if request_in else None,
+        aws_auth=_aws_auth_from_request(request_in),
     )
 
 
@@ -439,17 +440,45 @@ async def get_provider_available_models(
     return result.models
 
 
+def _aws_auth_from_request(
+    request_in: Optional[AvailableModelsRequest],
+) -> Optional[dict]:
+    """Collect AWS credential fields into a service-layer mapping, or None.
+
+    Only present fields are forwarded, so boto3's default credential chain
+    stays in play for the bedrock provider when the user supplied nothing.
+    """
+    if request_in is None:
+        return None
+    auth = {
+        key: getattr(request_in, key)
+        for key in (
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_session_token",
+            "aws_region_name",
+        )
+        if getattr(request_in, key) is not None
+    }
+    return auth or None
+
+
 async def _fetch_provider_models(
     *,
     provider: str,
     api_key: Optional[str],
     model_kind: Literal["llm", "stt", "tts"],
     api_endpoint: Optional[str],
+    aws_auth: Optional[dict] = None,
 ) -> AvailableModelsResponse:
     """Shared body of the GET and POST available-models endpoints."""
     try:
         result = await get_available_models_for_provider(
-            provider, api_key, model_kind, api_endpoint
+            provider,
+            api_key,
+            model_kind,
+            api_endpoint,
+            aws_auth=aws_auth,
         )
         return AvailableModelsResponse(
             models=result.models,

--- a/backend/preloop/schemas/ai_model.py
+++ b/backend/preloop/schemas/ai_model.py
@@ -271,10 +271,43 @@ class AvailableModelsRequest(BaseModel):
     model_kind: Literal["llm", "stt", "tts"] = Field(
         "llm", description="Model service kind to fetch"
     )
+    aws_access_key_id: Optional[str] = Field(
+        None,
+        description=(
+            "AWS access key id for the bedrock provider. Never logged and "
+            "never persisted by this endpoint."
+        ),
+    )
+    aws_secret_access_key: Optional[str] = Field(
+        None,
+        description=(
+            "AWS secret access key for the bedrock provider. Never logged "
+            "and never persisted by this endpoint."
+        ),
+    )
+    aws_session_token: Optional[str] = Field(
+        None,
+        description=(
+            "Optional temporary-session token for the bedrock provider. "
+            "Never logged and never persisted by this endpoint."
+        ),
+    )
+    aws_region_name: Optional[str] = Field(
+        None,
+        description=(
+            "AWS region for the bedrock provider, e.g. us-east-1. Falls "
+            "back to boto3's default region chain when omitted."
+        ),
+    )
 
     @field_serializer("api_key")
     def _hide_api_key(self, value: Optional[str]) -> Optional[str]:
         """Keep the key out of any serialized copy of this model (logs, traces)."""
+        return "***" if value else value
+
+    @field_serializer("aws_access_key_id", "aws_secret_access_key", "aws_session_token")
+    def _hide_aws_secrets(self, value: Optional[str]) -> Optional[str]:
+        """Keep AWS credential material out of serialized copies (logs, traces)."""
         return "***" if value else value
 
 

--- a/backend/preloop/services/ai_model_provider.py
+++ b/backend/preloop/services/ai_model_provider.py
@@ -10,10 +10,11 @@ vocabulary and never contains raw exception text, which can carry endpoint
 URLs and key material (2026-08-04 key-leak incident).
 """
 
+import asyncio
 import ipaddress
 import logging
 from dataclasses import dataclass, field
-from typing import List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 from urllib.parse import urlsplit
 
 logger = logging.getLogger(__name__)
@@ -167,6 +168,7 @@ SUPPORTED_AUDIO_PROVIDER_KINDS: dict[str, set[ModelKind]] = {
     "moonshot": {"llm"},
     "zai": {"llm"},
     "mistral": {"llm"},
+    "bedrock": {"llm"},
 }
 
 
@@ -175,19 +177,26 @@ async def get_available_models_for_provider(
     api_key: Optional[str] = None,
     model_kind: ModelKind = "llm",
     api_endpoint: Optional[str] = None,
+    *,
+    aws_auth: Optional[Dict[str, Any]] = None,
 ) -> ModelDiscoveryResult:
     """
     Fetch available models from the specified AI provider, with provenance.
 
     Args:
         provider: The provider name (openai, anthropic, google, qwen,
-            deepseek, moonshot, zai, mistral, openai-compatible, custom,
-            openrouter)
+            deepseek, moonshot, zai, mistral, bedrock, openai-compatible,
+            custom, openrouter)
         api_key: Optional API key for authentication
         model_kind: Service kind to fetch (llm, stt, or tts)
         api_endpoint: Base URL of an OpenAI-compatible endpoint. Required for
             the openai-compatible/custom providers, which have no fixed
             catalog; defaulted for providers in DEFAULT_PROVIDER_ENDPOINTS.
+        aws_auth: Optional AWS credential mapping for the bedrock provider,
+            with any of the keys ``aws_access_key_id``,
+            ``aws_secret_access_key``, ``aws_session_token`` and
+            ``aws_region_name``. When omitted, boto3's default credential
+            chain (instance profile, env, ...) is used.
 
     Returns:
         ModelDiscoveryResult with the model identifiers, whether they came
@@ -231,6 +240,8 @@ async def get_available_models_for_provider(
         return await _get_zai_models(api_key)
     elif provider == "mistral":
         return await _get_mistral_models(api_key)
+    elif provider == "bedrock":
+        return await _get_bedrock_models(aws_auth)
     elif provider in OPENAI_COMPATIBLE_PROVIDERS:
         endpoint = (api_endpoint or "").strip() or DEFAULT_PROVIDER_ENDPOINTS.get(
             provider
@@ -987,3 +998,162 @@ async def _get_mistral_models(api_key: Optional[str] = None) -> ModelDiscoveryRe
         known_models=MISTRAL_KNOWN_MODELS,
         api_key=api_key,
     )
+
+
+# Fallback catalog used when the Bedrock listing call cannot be made.
+# Provenance: current on-demand chat model ids from AWS Bedrock documentation;
+# every id also resolves in litellm's price map under bedrock/<id>. Live
+# listing via the Bedrock control plane is always attempted first, so this
+# only surfaces when boto3 is missing or the control plane is unreachable.
+BEDROCK_FALLBACK_MODELS = [
+    "anthropic.claude-opus-4-5",
+    "anthropic.claude-sonnet-4-5",
+    "anthropic.claude-haiku-4-5",
+    "amazon.nova-pro-v1:0",
+    "amazon.nova-lite-v1:0",
+]
+
+# ClientError codes (and HTTP statuses) that mean the AWS credentials were
+# rejected or are missing permissions, mapped to ProviderAuthError so the
+# user learns their key is bad instead of seeing a stale catalog.
+_BEDROCK_AUTH_ERROR_CODES = frozenset(
+    {
+        "unrecognizedclientexception",
+        "invalidclienttokenid",
+        "invalidsignatureexception",
+        "expiredtoken",
+        "expiredtokenexception",
+        "accessdeniedexception",
+        "unauthorizedoperation",
+        "accessdenied",
+    }
+)
+
+
+def _is_bedrock_auth_error(exc: Exception) -> bool:
+    """Whether a botocore exception represents rejected AWS credentials."""
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        http_status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        if http_status in (401, 403):
+            return True
+        code = str(response.get("Error", {}).get("Code") or "").lower()
+        if code in _BEDROCK_AUTH_ERROR_CODES:
+            return True
+    # NoCredentialsError and friends carry no response payload at all.
+    name = type(exc).__name__.lower()
+    return "nocredentials" in name or "credential" in name
+
+
+def _is_bedrock_chat_model(summary: Any) -> bool:
+    """Keep ACTIVE foundation models that emit text; drop the rest.
+
+    ``list_foundation_models`` also returns embedding, image and video
+    generation models, which the LLM picker cannot use. A summary without an
+    ``outputModalities`` field predates modality reporting and is kept rather
+    than guessed away.
+    """
+    lifecycle = getattr(summary, "modelLifecycle", None)
+    if lifecycle is not None:
+        status = str(getattr(lifecycle, "status", "") or "").upper()
+        if status and status != "ACTIVE":
+            return False
+
+    modalities = getattr(summary, "outputModalities", None) or []
+    if not modalities:
+        return True
+    return any(str(m).upper() == "TEXT" for m in modalities)
+
+
+async def _get_bedrock_models(
+    aws_auth: Optional[Dict[str, Any]] = None,
+) -> ModelDiscoveryResult:
+    """List AWS Bedrock foundation models live via the Bedrock control plane.
+
+    Uses boto3's ``bedrock`` client ``list_foundation_models``, which answers
+    from IAM-authenticated credentials instead of a static key, so both
+    explicit access keys and ambient credentials (instance profile, env,
+    SSO) work. The listing validates the credentials for free — a bad key
+    fails the call with an auth error, which raises ProviderAuthError so the
+    user knows their credentials are wrong.
+
+    Args:
+        aws_auth: Optional mapping with ``aws_access_key_id``,
+            ``aws_secret_access_key``, ``aws_session_token`` and
+            ``aws_region_name``. Missing keys fall back to boto3's default
+            credential/region chain.
+
+    Returns:
+        ModelDiscoveryResult with sorted text-output foundation model ids.
+
+    Raises:
+        ProviderValidationError: When no region can be resolved.
+        ProviderAuthError: When AWS rejects the credentials.
+    """
+    try:
+        import boto3  # type: ignore[import-untyped]
+        from botocore.config import Config  # type: ignore[import-untyped]
+    except ImportError:
+        logger.warning("boto3 package not installed, cannot list Bedrock models")
+        return _fallback(BEDROCK_FALLBACK_MODELS, ERROR_SDK_MISSING)
+
+    auth = {key: str(value).strip() for key, value in (aws_auth or {}).items() if value}
+    session_kwargs = {
+        key: auth[key]
+        for key in ("aws_access_key_id", "aws_secret_access_key", "aws_session_token")
+        if auth.get(key)
+    }
+
+    try:
+        session = boto3.Session(**session_kwargs)
+        region = auth.get("aws_region_name") or session.region_name
+        if not region:
+            raise ProviderValidationError(
+                "AWS region is required. Enter a region (e.g. us-east-1) "
+                "or set AWS_DEFAULT_REGION."
+            )
+        client = session.client(
+            "bedrock",
+            region_name=region,
+            config=Config(
+                connect_timeout=MODEL_DISCOVERY_TIMEOUT_SECONDS,
+                read_timeout=MODEL_DISCOVERY_TIMEOUT_SECONDS,
+                retries={"max_attempts": 1},
+            ),
+        )
+        # list_foundation_models is synchronous; keep it off the event loop.
+        response = await asyncio.to_thread(client.list_foundation_models)
+    except ProviderValidationError:
+        raise
+    except Exception as e:
+        from botocore.exceptions import (  # type: ignore[import-untyped]
+            BotoCoreError,
+            ClientError,
+        )
+
+        if isinstance(e, (ClientError, BotoCoreError)) and _is_bedrock_auth_error(e):
+            logger.warning("Bedrock authentication failed: %s", type(e).__name__)
+            raise ProviderAuthError(
+                "Invalid AWS credentials. Check the access key, secret key "
+                "and region, then try again."
+            ) from e
+        logger.warning(
+            "Failed to list Bedrock models, using bundled fallback: %s",
+            type(e).__name__,
+        )
+        return _fallback(BEDROCK_FALLBACK_MODELS, _classify_fetch_error(e))
+
+    summaries = getattr(response, "modelSummaries", None) or []
+    model_ids = []
+    for summary in summaries:
+        model_id = str(getattr(summary, "modelId", "") or "").strip()
+        if model_id and _is_bedrock_chat_model(summary):
+            model_ids.append(model_id)
+
+    model_ids = sorted(set(model_ids))[:MAX_DISCOVERED_MODELS]
+    if not model_ids:
+        logger.info("Bedrock returned no chat models, using bundled fallback")
+        return _fallback(BEDROCK_FALLBACK_MODELS, ERROR_EMPTY_RESPONSE)
+
+    logger.info("Listed %d Bedrock models", len(model_ids))
+    return _live(model_ids)

--- a/backend/tests/endpoints/test_ai_models.py
+++ b/backend/tests/endpoints/test_ai_models.py
@@ -387,3 +387,59 @@ async def test_fetch_provider_models_bare_value_error_is_400(mocker: MockerFixtu
     http_exc = exc_info.value
     assert http_exc.status_code == 400
     assert "sk-SUPERSECRET-KEY" not in http_exc.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_provider_models_forwards_aws_credentials(
+    mocker: MockerFixture,
+):
+    """Bedrock discovery forwards AWS credential fields to the service layer."""
+    from fastapi import HTTPException
+
+    from preloop.schemas.ai_model import AvailableModelsRequest
+
+    mock = mocker.patch(
+        "preloop.api.endpoints.ai_models.get_available_models_for_provider",
+        side_effect=ValueError("stop here"),
+    )
+    request_in = AvailableModelsRequest(
+        model_kind="llm",
+        aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+        aws_secret_access_key="shhh",
+        aws_session_token="tok",
+        aws_region_name="eu-west-1",
+    )
+
+    with pytest.raises(HTTPException):
+        await ai_models._fetch_provider_models(
+            provider="bedrock",
+            api_key=None,
+            model_kind="llm",
+            api_endpoint=None,
+            aws_auth=ai_models._aws_auth_from_request(request_in),
+        )
+
+    assert mock.call_args.kwargs["aws_auth"] == {
+        "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+        "aws_secret_access_key": "shhh",
+        "aws_session_token": "tok",
+        "aws_region_name": "eu-west-1",
+    }
+
+
+def test_available_models_request_masks_aws_secrets():
+    """AWS credential material never survives serialization (logs, traces)."""
+    from preloop.schemas.ai_model import AvailableModelsRequest
+
+    request_in = AvailableModelsRequest(
+        api_key="sk-live-key",
+        aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+        aws_secret_access_key="shhh",
+        aws_session_token="tok",
+    )
+    dumped = request_in.model_dump()
+    assert dumped["api_key"] == "***"
+    serialized = request_in.model_dump_json()
+    assert "AKIAIOSFODNN7EXAMPLE" not in serialized
+    assert "shhh" not in serialized
+    assert '"***"' in serialized

--- a/backend/tests/endpoints/test_available_models_key_handling.py
+++ b/backend/tests/endpoints/test_available_models_key_handling.py
@@ -107,6 +107,7 @@ async def test_get_route_reads_the_key_from_the_header(mocker):
         "sk-or-v1-secret-value",
         "llm",
         "https://openrouter.ai/api/v1",
+        aws_auth=None,
     )
 
 
@@ -138,6 +139,7 @@ async def test_post_route_reads_the_key_from_the_body(mocker):
         "sk-or-v1-secret-value",
         "llm",
         "https://openrouter.ai/api/v1",
+        aws_auth=None,
     )
 
 
@@ -157,7 +159,7 @@ async def test_post_route_works_without_a_body(mocker):
 
     assert result.models == ["gpt-5.4"]
     assert result.source == "fallback"
-    fetch.assert_awaited_once_with("openai", None, "llm", None)
+    fetch.assert_awaited_once_with("openai", None, "llm", None, aws_auth=None)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_ai_model_provider.py
+++ b/backend/tests/services/test_ai_model_provider.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from preloop.services.ai_model_provider import (
     get_available_models_for_provider,
     ANTHROPIC_FALLBACK_MODELS,
+    BEDROCK_FALLBACK_MODELS,
     DEEPSEEK_KNOWN_MODELS,
     GOOGLE_FALLBACK_MODELS,
     MISTRAL_KNOWN_MODELS,
@@ -19,9 +20,13 @@ from preloop.services.ai_model_provider import (
     QWEN_US_BASE_URL,
     ZAI_KNOWN_MODELS,
     _is_qwen_chat_model,
+    ERROR_SDK_MISSING,
+    ERROR_UNKNOWN,
     FALLBACK_ERROR_REASONS,
     MODEL_DISCOVERY_TIMEOUT_SECONDS,
     ModelDiscoveryResult,
+    ProviderAuthError,
+    ProviderValidationError,
     _get_openai_models,
     _get_anthropic_models,
     _get_google_models,
@@ -1660,3 +1665,178 @@ class TestOpenAIAuthErrorDoesNotLeakSecrets:
         )
         # The type name IS logged (consistency with every other provider).
         assert "AuthenticationError" in full_log
+
+
+# ---------------------------------------------------------------------------
+# AWS Bedrock
+# ---------------------------------------------------------------------------
+
+
+def _foundation_summary(model_id, modalities=("TEXT",), status="ACTIVE"):
+    """Build a bedrock list_foundation_models summary entry."""
+    summary = MagicMock()
+    summary.modelId = model_id
+    summary.outputModalities = list(modalities)
+    summary.modelLifecycle.status = status
+    return summary
+
+
+def _bedrock_client(summaries):
+    client = MagicMock()
+    response = MagicMock()
+    response.modelSummaries = summaries
+    client.list_foundation_models.return_value = response
+    return client
+
+
+class TestBedrockModels:
+    """Bedrock discovery: live control-plane listing with a curated fallback."""
+
+    @pytest.mark.asyncio
+    async def test_routes_to_bedrock_handler(self):
+        with patch(
+            "preloop.services.ai_model_provider._get_bedrock_models"
+        ) as mock_get:
+            mock_get.return_value = ModelDiscoveryResult(
+                models=["anthropic.claude-sonnet-4-5"], source="live"
+            )
+            result = await get_available_models_for_provider("bedrock")
+            assert result.source == "live"
+            assert result.models == ["anthropic.claude-sonnet-4-5"]
+
+    @pytest.mark.asyncio
+    async def test_live_listing_keeps_text_chat_models_only(self):
+        client = _bedrock_client(
+            [
+                _foundation_summary("anthropic.claude-sonnet-4-5"),
+                # Embedding and image models cannot serve chat completions.
+                _foundation_summary(
+                    "amazon.titan-embed-text-v2:0", modalities=("EMBEDDING",)
+                ),
+                _foundation_summary("stability.sd3-large-v1:0", modalities=("IMAGE",)),
+                # Non-ACTIVE lifecycle entries are not usable on demand.
+                _foundation_summary("anthropic.claude-old", status="LEGACY"),
+                # Summaries without modality reporting predate the field;
+                # keep rather than guess.
+                _foundation_summary("legacy.model-v1", modalities=[]),
+            ]
+        )
+        session = MagicMock()
+        session.region_name = None
+        session.client.return_value = client
+
+        with patch("boto3.Session", return_value=session):
+            result = await get_available_models_for_provider(
+                "bedrock",
+                aws_auth={
+                    "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                    "aws_secret_access_key": "secret",
+                    "aws_region_name": "us-east-1",
+                },
+            )
+
+        assert result.source == "live"
+        assert result.error is None
+        assert set(result.models) == {
+            "anthropic.claude-sonnet-4-5",
+            "legacy.model-v1",
+        }
+        session.client.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rejected_credentials_raise_auth_error(self):
+        from botocore.exceptions import ClientError
+
+        client = MagicMock()
+        client.list_foundation_models.side_effect = ClientError(
+            {
+                "Error": {"Code": "UnrecognizedClientException"},
+                "ResponseMetadata": {"HTTPStatusCode": 403},
+            },
+            "ListFoundationModels",
+        )
+        session = MagicMock()
+        session.region_name = None
+        session.client.return_value = client
+
+        with (
+            patch("boto3.Session", return_value=session),
+            pytest.raises(ProviderAuthError, match="Invalid AWS credentials"),
+        ):
+            await get_available_models_for_provider(
+                "bedrock",
+                aws_auth={
+                    "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                    "aws_secret_access_key": "wrong",
+                    "aws_region_name": "us-east-1",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_credentials_raise_auth_error(self):
+        from botocore.exceptions import NoCredentialsError
+
+        client = MagicMock()
+        client.list_foundation_models.side_effect = NoCredentialsError()
+        session = MagicMock()
+        session.region_name = None
+        session.client.return_value = client
+
+        with (
+            patch("boto3.Session", return_value=session),
+            pytest.raises(ProviderAuthError),
+        ):
+            await get_available_models_for_provider(
+                "bedrock", aws_auth={"aws_region_name": "us-east-1"}
+            )
+
+    @pytest.mark.asyncio
+    async def test_control_plane_failure_returns_fallback_catalog(self):
+        client = MagicMock()
+        client.list_foundation_models.side_effect = Exception("boom")
+        session = MagicMock()
+        session.region_name = None
+        session.client.return_value = client
+
+        with patch("boto3.Session", return_value=session):
+            result = await get_available_models_for_provider(
+                "bedrock",
+                aws_auth={
+                    "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                    "aws_secret_access_key": "secret",
+                    "aws_region_name": "us-east-1",
+                },
+            )
+
+        assert result.source == "fallback"
+        assert result.error == ERROR_UNKNOWN
+        assert result.models == BEDROCK_FALLBACK_MODELS
+
+    @pytest.mark.asyncio
+    async def test_missing_region_is_a_validation_error(self):
+        session = MagicMock()
+        session.region_name = None
+
+        with (
+            patch("boto3.Session", return_value=session),
+            pytest.raises(ProviderValidationError, match="region"),
+        ):
+            await get_available_models_for_provider(
+                "bedrock",
+                aws_auth={
+                    "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                    "aws_secret_access_key": "secret",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_sdk_missing_returns_fallback_catalog(self):
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setitem(sys.modules, "boto3", None)
+        try:
+            result = await get_available_models_for_provider("bedrock")
+        finally:
+            monkeypatch.undo()
+        assert result.source == "fallback"
+        assert result.error == ERROR_SDK_MISSING
+        assert result.models == BEDROCK_FALLBACK_MODELS

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -4183,6 +4183,9 @@ func applyClaudeManagedGateway(
 	}
 	plan.ManagedModelAlias = modelAlias
 	plan.ManagedProviderName = "preloop"
+	// Shell-exported Bedrock variables survive the settings.json rewrite;
+	// warn instead of silently letting them override gateway routing.
+	plan.Notes = append(plan.Notes, claudeShellBedrockOverrideNotes()...)
 	plan.Notes = append(
 		plan.Notes,
 		fmt.Sprintf("Model traffic will route through Preloop using %s.", modelAlias),

--- a/cli/internal/cmd/agents_claude_fable_test.go
+++ b/cli/internal/cmd/agents_claude_fable_test.go
@@ -9,6 +9,7 @@ package cmd
 // default model instead of the managed alias.
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -197,5 +198,90 @@ func TestApplyClaudeManagedGatewayKeepsFamilySelectionBehavior(t *testing.T) {
 			"family aliases keep the selector form in settings.model, got %#v",
 			plan.ManagedDocument["model"],
 		)
+	}
+}
+
+func TestClaudeShellBedrockOverrideNotes(t *testing.T) {
+	// applyClaudeManagedGateway neutralizes Bedrock only inside settings.json.
+	// A shell-exported CLAUDE_CODE_USE_BEDROCK survives onboarding in the
+	// agent's process environment and can override the gateway config, so it
+	// must produce an actionable note.
+
+	cases := []struct {
+		name    string
+		flag    string
+		awsKey  string
+		want    bool
+		wantAWS bool
+	}{
+		{"flag exported triggers a warning", "1", "", true, false},
+		{"flag true triggers a warning", "true", "", true, false},
+		{"flag 0 is silent", "0", "", false, false},
+		{"flag unset is silent", "", "", false, false},
+		{"aws keys are listed alongside the flag", "1", "AKIAIOSFODNN7EXAMPLE", true, true},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("CLAUDE_CODE_USE_BEDROCK", testCase.flag)
+			t.Setenv("AWS_ACCESS_KEY_ID", testCase.awsKey)
+			t.Setenv("AWS_BEARER_TOKEN_BEDROCK", "")
+			t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+			t.Setenv("AWS_SESSION_TOKEN", "")
+			t.Setenv("AWS_REGION", "")
+			t.Setenv("AWS_DEFAULT_REGION", "")
+
+			notes := claudeShellBedrockOverrideNotes()
+			if !testCase.want {
+				if len(notes) != 0 {
+					t.Fatalf("expected no notes, got %#v", notes)
+				}
+				return
+			}
+			if len(notes) != 1 {
+				t.Fatalf("expected exactly one note, got %#v", notes)
+			}
+			if !strings.Contains(notes[0], "CLAUDE_CODE_USE_BEDROCK") {
+				t.Errorf("note must name the overriding variable: %q", notes[0])
+			}
+			hasAWSMention := strings.Contains(notes[0], "AWS_ACCESS_KEY_ID")
+			if testCase.wantAWS && !hasAWSMention {
+				t.Errorf("exported AWS key must be listed: %q", notes[0])
+			}
+			if !testCase.wantAWS && hasAWSMention {
+				t.Errorf("no AWS key exported; note must not list one: %q", notes[0])
+			}
+		})
+	}
+}
+
+func TestApplyClaudeManagedGatewayWarnsOnShellBedrockOverride(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	plan := managedMCPEnrollmentPlan{
+		ManagedDocument: map[string]interface{}{
+			"model": "claude-sonnet-4-5",
+		},
+	}
+	plan, err := applyClaudeManagedGateway(
+		plan,
+		"https://preloop.example",
+		"claude-durable-token",
+		"anthropic/claude-sonnet-4-5",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected gateway apply error: %v", err)
+	}
+
+	found := false
+	for _, note := range plan.Notes {
+		if strings.Contains(note, "CLAUDE_CODE_USE_BEDROCK") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a shell-override warning note, got %#v", plan.Notes)
 	}
 }

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -7185,6 +7185,41 @@ func claudeUsesBedrock(document map[string]interface{}) bool {
 	return value == "1" || value == "true" || value == "yes" || value == "on"
 }
 
+// claudeShellBedrockOverrideNotes warns when the CLI's own process
+// environment still carries CLAUDE_CODE_USE_BEDROCK. applyClaudeManagedGateway
+// neutralizes Bedrock routing inside settings.json's env block, but values
+// exported in the launching shell (or a shell rc file) survive onboarding and
+// can override what Preloop wrote, silently re-enabling direct-to-Bedrock
+// traffic that bypasses the gateway. AWS credential variables are inert
+// without the flag, so they are only listed alongside it.
+func claudeShellBedrockOverrideNotes() []string {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv("CLAUDE_CODE_USE_BEDROCK")))
+	if value != "1" && value != "true" && value != "yes" && value != "on" {
+		return nil
+	}
+	awsKeys := []string{}
+	for _, key := range []string{
+		"AWS_BEARER_TOKEN_BEDROCK",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_REGION",
+		"AWS_DEFAULT_REGION",
+	} {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			awsKeys = append(awsKeys, key)
+		}
+	}
+	note := "CLAUDE_CODE_USE_BEDROCK is exported in your current shell environment; it can override the gateway configuration Preloop just wrote and send Claude Code straight to Bedrock. Run `unset CLAUDE_CODE_USE_BEDROCK` and remove its export from your shell profile, then relaunch Claude Code."
+	if len(awsKeys) > 0 {
+		note += fmt.Sprintf(
+			" Also unset the exported %s so no direct Bedrock credentials remain.",
+			strings.Join(awsKeys, ", "),
+		)
+	}
+	return []string{note}
+}
+
 func augmentDocumentWithShellExports(
 	document map[string]interface{},
 	keys ...string,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2379,6 +2379,17 @@ export interface AvailableModelsResult {
 }
 
 /**
+ * AWS credential fields for the bedrock provider's model listing.
+ * Carried in the POST body for the same reason as `apiKey`.
+ */
+export interface AwsDiscoveryAuth {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  region?: string;
+}
+
+/**
  * List the models a provider offers, for the model picker.
  *
  * The API key goes in the POST body, never the query string: as a query
@@ -2388,6 +2399,9 @@ export interface AvailableModelsResult {
  * which have no fixed catalog and are listed from the endpoint's own
  * OpenAI-compatible GET /models.
  *
+ * `awsAuth` carries explicit AWS credentials for the bedrock provider; when
+ * omitted the backend falls back to its ambient credential chain.
+ *
  * Tolerates the old bare string[] response (pre-provenance servers) by
  * mapping it to { models, source: 'live' }.
  */
@@ -2395,7 +2409,8 @@ export async function getAvailableModelsForProvider(
   provider: string,
   apiKey?: string,
   modelKind: 'llm' | 'stt' | 'tts' = 'llm',
-  apiEndpoint?: string
+  apiEndpoint?: string,
+  awsAuth?: AwsDiscoveryAuth
 ): Promise<AvailableModelsResult> {
   const url = `/api/v1/ai-models/providers/${provider}/available-models`;
   const response = await fetchWithAuth(url, {
@@ -2405,6 +2420,16 @@ export async function getAvailableModelsForProvider(
       model_kind: modelKind,
       ...(apiKey ? { api_key: apiKey } : {}),
       ...(apiEndpoint ? { api_endpoint: apiEndpoint } : {}),
+      ...(awsAuth?.accessKeyId
+        ? { aws_access_key_id: awsAuth.accessKeyId }
+        : {}),
+      ...(awsAuth?.secretAccessKey
+        ? { aws_secret_access_key: awsAuth.secretAccessKey }
+        : {}),
+      ...(awsAuth?.sessionToken
+        ? { aws_session_token: awsAuth.sessionToken }
+        : {}),
+      ...(awsAuth?.region ? { aws_region_name: awsAuth.region } : {}),
     }),
   });
   if (!response.ok) {

--- a/frontend/src/components/add-ai-model-modal.test.ts
+++ b/frontend/src/components/add-ai-model-modal.test.ts
@@ -2,6 +2,7 @@ import { html, fixture, expect } from '@open-wc/testing';
 import sinon, { SinonSandbox, SinonStub } from 'sinon';
 import './add-ai-model-modal.ts';
 import { AddAIModelModal } from './add-ai-model-modal';
+import type { AIModel } from '../types';
 
 const SECRET_ID = '11111111-1111-1111-1111-111111111111';
 
@@ -864,5 +865,187 @@ describe('AddAIModelModal edit payload', () => {
     expect(payload).to.not.have.property('credentials_backend_type');
     expect(payload).to.not.have.property('credentials_external_ref');
     expect(payload).to.not.have.property('credentials_meta_data');
+  });
+});
+
+/**
+ * AWS Bedrock as a first-class provider: IAM credentials instead of an API
+ * key/endpoint pair, live model listing through the Bedrock control plane,
+ * and a stored credential JSON blob the gateway already understands.
+ */
+describe('AddAIModelModal Bedrock provider', () => {
+  let element: AddAIModelModal;
+  let sandbox: SinonSandbox;
+  let fetchStub: SinonStub;
+
+  const discoveryCalls = () =>
+    fetchStub
+      .getCalls()
+      .filter((call) => String(call.args[0]).includes('available-models'));
+
+  beforeEach(async () => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    sandbox = sinon.createSandbox();
+    fetchStub = sandbox.stub(window, 'fetch');
+    fetchStub.callsFake(async (url: any) => {
+      if (String(url).includes('available-models')) {
+        return new Response(
+          JSON.stringify({
+            models: ['anthropic.claude-sonnet-4-5', 'amazon.nova-lite-v1:0'],
+            source: 'live',
+          })
+        );
+      }
+      return new Response(JSON.stringify([]));
+    });
+    element = await fixture(html`<add-ai-model-modal></add-ai-model-modal>`);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    localStorage.clear();
+  });
+
+  it('offers Bedrock as an LLM provider', () => {
+    const values = (element as any)._availableProviders.map(
+      (p: { value: string }) => p.value
+    );
+    expect(values).to.contain('bedrock');
+  });
+
+  it('does not offer Bedrock for stt or tts', async () => {
+    (element as any)._currentModel = { model_kind: 'stt' };
+    const values = (element as any)._availableProviders.map(
+      (p: { value: string }) => p.value
+    );
+    expect(values).to.not.contain('bedrock');
+  });
+
+  it('resets AWS fields and clears endpoint/key when Bedrock is chosen', async () => {
+    await (element as any)._handleProviderChange({
+      target: { value: 'bedrock' },
+    } as unknown as Event);
+
+    expect((element as any)._bedrockRegion).to.equal('us-east-1');
+    expect((element as any)._currentModel.api_endpoint).to.equal('');
+    expect((element as any)._currentModel.api_key).to.be.undefined;
+  });
+
+  it('refuses to fetch before the AWS credentials are complete', async () => {
+    (element as any)._currentModel = { provider_name: 'bedrock' };
+    (element as any)._bedrockAccessKeyId = 'AKIAIOSFODNN7EXAMPLE';
+    // Secret key and region still missing.
+
+    await (element as any)._fetchModelsForCurrentProvider();
+
+    expect(discoveryCalls()).to.have.lengthOf(0);
+    expect((element as any)._modelsFetchError).to.contain('AWS');
+  });
+
+  it('sends AWS credential fields in the discovery POST body', async () => {
+    (element as any)._currentModel = { provider_name: 'bedrock' };
+    (element as any)._bedrockAccessKeyId = 'AKIAIOSFODNN7EXAMPLE';
+    (element as any)._bedrockSecretAccessKey = 'shhh';
+    (element as any)._bedrockSessionToken = 'tok';
+    (element as any)._bedrockRegion = 'eu-west-1';
+
+    await (element as any)._fetchModelsForCurrentProvider();
+
+    expect((element as any)._modelSuggestions).to.deep.equal([
+      'anthropic.claude-sonnet-4-5',
+      'amazon.nova-lite-v1:0',
+    ]);
+    const [, init] = discoveryCalls()[0].args;
+    const body = JSON.parse(String(init.body));
+    expect(body.aws_access_key_id).to.equal('AKIAIOSFODNN7EXAMPLE');
+    expect(body.aws_secret_access_key).to.equal('shhh');
+    expect(body.aws_session_token).to.equal('tok');
+    expect(body.aws_region_name).to.equal('eu-west-1');
+    expect(body.model_kind).to.equal('llm');
+  });
+
+  it('submits the gateway credential blob and routing region', async () => {
+    (element as any)._currentModel = {
+      name: 'Claude on Bedrock',
+      provider_name: 'bedrock',
+      model_identifier: 'anthropic.claude-sonnet-4-5',
+      model_kind: 'llm',
+    };
+    (element as any)._bedrockAccessKeyId = 'AKIAIOSFODNN7EXAMPLE';
+    (element as any)._bedrockSecretAccessKey = 'shhh';
+    (element as any)._bedrockSessionToken = 'tok';
+    (element as any)._bedrockRegion = 'eu-west-1';
+    (element as any)._syncBedrockApiKey();
+    (element as any)._modelSuggestions = ['anthropic.claude-sonnet-4-5'];
+    (element as any)._syncFormFromDom = () => {};
+    await element.updateComplete;
+
+    await (element as any)._handleFormSubmit(new Event('submit'));
+
+    const payloads = createdModelPayloads(fetchStub);
+    expect(payloads).to.have.lengthOf(1);
+    const payload = payloads[0];
+
+    // The stored secret IS this JSON blob; the gateway parses it back into
+    // litellm's aws_* kwargs.
+    const blob = JSON.parse(payload.api_key);
+    expect(blob).to.deep.equal({
+      aws_access_key_id: 'AKIAIOSFODNN7EXAMPLE',
+      aws_secret_access_key: 'shhh',
+      aws_session_token: 'tok',
+    });
+    // No HTTP endpoint exists for Bedrock; region travels in metadata.
+    expect(payload.api_endpoint).to.be.null;
+    expect(payload.meta_data.provider_runtime.region).to.equal('eu-west-1');
+    expect(payload.meta_data.gateway.model_alias).to.equal(
+      'bedrock/anthropic.claude-sonnet-4-5'
+    );
+  });
+
+  it('blocks submit until the AWS credentials are complete', async () => {
+    (element as any)._currentModel = {
+      name: 'Claude on Bedrock',
+      provider_name: 'bedrock',
+      model_identifier: 'anthropic.claude-sonnet-4-5',
+      model_kind: 'llm',
+    };
+    (element as any)._bedrockAccessKeyId = 'AKIAIOSFODNN7EXAMPLE';
+    // Secret key missing.
+    (element as any)._syncFormFromDom = () => {};
+
+    await (element as any)._handleFormSubmit(new Event('submit'));
+
+    expect((element as any)._formError).to.contain('AWS');
+    expect(createdModelPayloads(fetchStub)).to.have.lengthOf(0);
+  });
+
+  it('keeps the existing key when editing without retyping credentials', async () => {
+    element.model = {
+      id: 'existing-id',
+      name: 'Claude on Bedrock',
+      provider_name: 'bedrock',
+      model_identifier: 'anthropic.claude-sonnet-4-5',
+      model_kind: 'llm',
+      has_api_key: true,
+      meta_data: {},
+    } as unknown as AIModel;
+    element.open = true;
+    await element.updateComplete;
+    (element as any)._syncFormFromDom = () => {};
+
+    await (element as any)._handleFormSubmit(new Event('submit'));
+
+    expect((element as any)._formError).to.equal(null);
+    const putCalls = fetchStub
+      .getCalls()
+      .filter(
+        (call) =>
+          String(call.args[0]).includes('/api/v1/ai-models/existing-id') &&
+          call.args[1]?.method === 'PUT'
+      );
+    expect(putCalls).to.have.lengthOf(1);
+    const body = JSON.parse(String(putCalls[0].args[1].body));
+    expect(body.api_key).to.be.undefined;
   });
 });

--- a/frontend/src/components/add-ai-model-modal.ts
+++ b/frontend/src/components/add-ai-model-modal.ts
@@ -7,6 +7,7 @@ import {
   createAIModel,
   updateAIModel,
   type AvailableModelsResult,
+  type AwsDiscoveryAuth,
 } from '../api';
 import type { AIModel } from '../types';
 import type SlSelect from '@shoelace-style/shoelace/dist/components/select/select.js';
@@ -39,6 +40,7 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
   { value: 'deepseek', label: 'DeepSeek', serviceKinds: ['llm'] },
   { value: 'zai', label: 'Z.ai (GLM)', serviceKinds: ['llm'] },
   { value: 'mistral', label: 'Mistral', serviceKinds: ['llm'] },
+  { value: 'bedrock', label: 'AWS Bedrock', serviceKinds: ['llm'] },
   { value: 'openrouter', label: 'OpenRouter', serviceKinds: ['llm'] },
   {
     value: 'openai-compatible',
@@ -76,6 +78,35 @@ const PROVIDER_DEFAULT_ENDPOINTS: Record<string, string> = {
  * (OpenRouter) that is already satisfied without the user typing anything.
  */
 const ENDPOINT_LISTED_PROVIDERS = ['openai-compatible', 'custom', 'openrouter'];
+
+/**
+ * Default AWS region prefilled for the bedrock provider. Bedrock model
+ * availability is regional, so the region must be resolved before listing.
+ */
+const BEDROCK_DEFAULT_REGION = 'us-east-1';
+
+/**
+ * Assemble the credential blob stored for a bedrock model. The gateway
+ * (openai_gateway._bedrock_credential_kwargs) parses this JSON back into
+ * litellm's aws_* kwargs, so the shape here is load-bearing.
+ */
+function buildBedrockCredentialBlob(creds: {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+}): string | undefined {
+  if (!creds.accessKeyId?.trim() || !creds.secretAccessKey?.trim()) {
+    return undefined;
+  }
+  const payload: Record<string, string> = {
+    aws_access_key_id: creds.accessKeyId.trim(),
+    aws_secret_access_key: creds.secretAccessKey.trim(),
+  };
+  if (creds.sessionToken?.trim()) {
+    payload.aws_session_token = creds.sessionToken.trim();
+  }
+  return JSON.stringify(payload);
+}
 
 /**
  * Human wording for the server's fixed fallback-reason vocabulary.
@@ -154,9 +185,27 @@ export class AddAIModelModal extends LitElement {
   @state() private _additionalModelIds: string[] = [];
   /** When true, register this model for Preloop gateway routing (requires upstream API key). */
   @state() private _preloopGatewayEnabled = true;
+  /** AWS credential inputs for the bedrock provider. */
+  @state() private _bedrockAccessKeyId = '';
+  @state() private _bedrockSecretAccessKey = '';
+  @state() private _bedrockSessionToken = '';
+  @state() private _bedrockRegion = BEDROCK_DEFAULT_REGION;
 
   private get _isEditing(): boolean {
     return !!this.model;
+  }
+
+  private get _isBedrock(): boolean {
+    return this._currentModel.provider_name === 'bedrock';
+  }
+
+  /** True once enough AWS material is present to attempt a live listing. */
+  private get _bedrockCredsComplete(): boolean {
+    return Boolean(
+      this._bedrockAccessKeyId.trim() &&
+      this._bedrockSecretAccessKey.trim() &&
+      this._bedrockRegion.trim()
+    );
   }
 
   private get _canEnablePreloopGateway(): boolean {
@@ -216,6 +265,30 @@ export class AddAIModelModal extends LitElement {
     this._modelsFetchError = null;
     this._modelsSource = null;
     this._modelsFallbackReason = null;
+    this._resetBedrockFields();
+  }
+
+  /** Clear the AWS credential inputs; editing falls back to "keep stored key". */
+  private _resetBedrockFields() {
+    this._bedrockAccessKeyId = '';
+    this._bedrockSecretAccessKey = '';
+    this._bedrockSessionToken = '';
+    this._bedrockRegion = BEDROCK_DEFAULT_REGION;
+  }
+
+  /**
+   * Mirror the assembled AWS credential blob into `api_key` so submit,
+   * gateway gating, and extra-model creation all keep working unchanged:
+   * for bedrock the stored secret IS this JSON payload.
+   */
+  private _syncBedrockApiKey() {
+    if (!this._isBedrock) return;
+    this._currentModel.api_key =
+      buildBedrockCredentialBlob({
+        accessKeyId: this._bedrockAccessKeyId,
+        secretAccessKey: this._bedrockSecretAccessKey,
+        sessionToken: this._bedrockSessionToken,
+      }) || undefined;
   }
 
   /**
@@ -236,12 +309,20 @@ export class AddAIModelModal extends LitElement {
     const provider = this._currentModel.provider_name;
     const modelId = modelIdOverride ?? this._currentModel.model_identifier;
     const modelKind = this._currentModel.model_kind || 'llm';
-    const baseMeta = {
+    const baseMeta: Record<string, unknown> = {
       ...existing,
       service_kind: modelKind,
     };
     if (!provider || !modelId) {
       return baseMeta;
+    }
+    if (provider === 'bedrock') {
+      // The gateway reads the routing region from here
+      // (openai_gateway._bedrock_region) when litellm needs aws_region_name.
+      baseMeta.provider_runtime = {
+        ...(baseMeta.provider_runtime as Record<string, unknown> | undefined),
+        region: this._bedrockRegion.trim() || BEDROCK_DEFAULT_REGION,
+      };
     }
     const gatewayEnabled =
       modelKind === 'llm' &&
@@ -267,9 +348,18 @@ export class AddAIModelModal extends LitElement {
       else if (label === 'API URL' && val)
         this._currentModel.api_endpoint = val;
       else if (label === 'API Key' && val) this._currentModel.api_key = val;
-      else if (label === 'Custom Model Name / ID')
+      else if (label === 'AWS Access Key ID') {
+        this._bedrockAccessKeyId = val || '';
+      } else if (label === 'AWS Secret Access Key') {
+        this._bedrockSecretAccessKey = val || '';
+      } else if (label === 'AWS Session Token') {
+        this._bedrockSessionToken = val || '';
+      } else if (label === 'AWS Region') {
+        this._bedrockRegion = val || BEDROCK_DEFAULT_REGION;
+      } else if (label === 'Custom Model Name / ID')
         this._currentModel.model_identifier = val || undefined;
     }
+    if (this._isBedrock) this._syncBedrockApiKey();
     const serviceKindSelect = this.shadowRoot?.querySelector(
       'sl-select[label="Service Kind"]'
     ) as SlSelect | null;
@@ -303,6 +393,14 @@ export class AddAIModelModal extends LitElement {
       api_endpoint: PROVIDER_DEFAULT_ENDPOINTS[provider] || '',
       model_identifier: '',
     };
+
+    // Bedrock uses its own credential inputs; start from a clean slate with
+    // a usable default region so only key + secret are required.
+    this._resetBedrockFields();
+    if (provider === 'bedrock') {
+      this._currentModel.api_endpoint = '';
+      this._currentModel.api_key = undefined;
+    }
 
     this._modelSuggestions = [];
     this._isOtherModel = false;
@@ -376,13 +474,15 @@ export class AddAIModelModal extends LitElement {
   private async _fetchModelSuggestionsForProvider(
     provider: string,
     apiKey?: string,
-    apiEndpoint?: string
+    apiEndpoint?: string,
+    awsAuth?: AwsDiscoveryAuth
   ): Promise<AvailableModelsResult> {
     return await getAvailableModelsForProvider(
       provider,
       apiKey,
       this._selectedServiceKind,
-      apiEndpoint
+      apiEndpoint,
+      awsAuth
     );
   }
 
@@ -393,6 +493,21 @@ export class AddAIModelModal extends LitElement {
     }
 
     const provider = this._currentModel.provider_name;
+    // Bedrock authenticates with AWS credential fields, not a key/endpoint.
+    let awsAuth: AwsDiscoveryAuth | undefined;
+    if (provider === 'bedrock') {
+      if (!this._bedrockCredsComplete) {
+        this._modelsFetchError =
+          'Enter the AWS access key, secret key and region first, then fetch models';
+        return;
+      }
+      awsAuth = {
+        accessKeyId: this._bedrockAccessKeyId.trim(),
+        secretAccessKey: this._bedrockSecretAccessKey.trim(),
+        sessionToken: this._bedrockSessionToken.trim() || undefined,
+        region: this._bedrockRegion.trim(),
+      };
+    }
     // A provider with a known base URL can be listed even if the field was
     // cleared: the default stands in, matching the server-side default.
     const apiEndpoint =
@@ -416,7 +531,8 @@ export class AddAIModelModal extends LitElement {
       const result = await this._fetchModelSuggestionsForProvider(
         provider,
         this._currentModel.api_key,
-        apiEndpoint
+        apiEndpoint,
+        awsAuth
       );
       this._modelSuggestions = result.models;
       this._modelsSource = result.source;
@@ -523,7 +639,17 @@ export class AddAIModelModal extends LitElement {
     // Sync values from DOM in case event handlers missed a mutation
     this._syncFormFromDom();
 
-    if (
+    if (this._isBedrock) {
+      // Blank credential fields on an edited model mean "keep the stored key".
+      const hasStoredBedrockKey = Boolean(
+        this._isEditing && this.model?.has_api_key
+      );
+      if (!hasStoredBedrockKey && !this._bedrockCredsComplete) {
+        this._formError =
+          'Please fill in the AWS access key, secret key and region';
+        return;
+      }
+    } else if (
       !this._currentModel.name ||
       !this._currentModel.provider_name ||
       !this._currentModel.model_identifier ||
@@ -559,7 +685,8 @@ export class AddAIModelModal extends LitElement {
         provider_name: this._currentModel.provider_name,
         model_identifier: this._currentModel.model_identifier,
         model_kind: this._currentModel.model_kind,
-        api_endpoint: this._currentModel.api_endpoint,
+        // Bedrock has no HTTP endpoint; region travels in meta_data.
+        api_endpoint: this._isBedrock ? null : this._currentModel.api_endpoint,
         is_default: this._currentModel.is_default,
         meta_data: this._buildMetaDataForSubmit(),
         ...(typedApiKey ? { api_key: typedApiKey } : {}),
@@ -700,74 +827,151 @@ export class AddAIModelModal extends LitElement {
             )}
           </sl-select>
 
-          <sl-input
-            class="full-width"
-            label="API URL"
-            .value=${this._currentModel.api_endpoint || ''}
-            @sl-input=${(e: Event) => {
-              this._currentModel.api_endpoint = (
-                e.target as HTMLInputElement
-              ).value;
-              this.requestUpdate();
-            }}
-            ?disabled=${this._isSubmitting}
-          >
-            ${
-              this._currentModel.provider_name === 'qwen'
-                ? html`
+          ${
+            this._isBedrock
+              ? html`
+                  <sl-input
+                    label="AWS Access Key ID"
+                    .value=${this._bedrockAccessKeyId}
+                    @sl-input=${(e: Event) => {
+                      this._bedrockAccessKeyId = (
+                        e.target as HTMLInputElement
+                      ).value;
+                      this._syncBedrockApiKey();
+                      this.requestUpdate();
+                    }}
+                    placeholder=${
+                      this._isEditing ? 'Leave blank to keep existing key' : ''
+                    }
+                    ?disabled=${this._isSubmitting}
+                  >
                     <div slot="help-text">
-                      Default is China (Beijing):
-                      https://dashscope.aliyuncs.com/compatible-mode/v1.
-                      International (Singapore):
-                      https://dashscope-intl.aliyuncs.com/compatible-mode/v1.
-                      US: https://dashscope-us.aliyuncs.com/compatible-mode/v1.
-                      Keys are not interchangeable across regions.
+                      IAM credentials with Bedrock access. Find them in the AWS
+                      console under IAM &gt; Access keys.
                     </div>
-                  `
-                : ''
-            }
-          </sl-input>
-          <sl-input
-            class="full-width"
-            type="password"
-            label="API Key"
-            .value=${this._currentModel.api_key || ''}
-            @sl-input=${(e: Event) => {
-              this._currentModel.api_key = (e.target as HTMLInputElement).value;
-              this.requestUpdate();
-            }}
-            placeholder=${
-              this._isEditing ? 'Leave blank to keep existing key' : ''
-            }
-            ?disabled=${this._isSubmitting}
-          >
-            ${
-              !this._isEditing &&
-              this._getProviderKeyUrl(this._currentModel.provider_name)
-                ? html`
+                  </sl-input>
+                  <sl-input
+                    type="password"
+                    label="AWS Secret Access Key"
+                    .value=${this._bedrockSecretAccessKey}
+                    @sl-input=${(e: Event) => {
+                      this._bedrockSecretAccessKey = (
+                        e.target as HTMLInputElement
+                      ).value;
+                      this._syncBedrockApiKey();
+                      this.requestUpdate();
+                    }}
+                    placeholder=${
+                      this._isEditing ? 'Leave blank to keep existing key' : ''
+                    }
+                    ?disabled=${this._isSubmitting}
+                  ></sl-input>
+                  <sl-input
+                    type="password"
+                    label="AWS Session Token"
+                    .value=${this._bedrockSessionToken}
+                    @sl-input=${(e: Event) => {
+                      this._bedrockSessionToken = (
+                        e.target as HTMLInputElement
+                      ).value;
+                      this._syncBedrockApiKey();
+                      this.requestUpdate();
+                    }}
+                    placeholder="Optional, for temporary credentials"
+                    ?disabled=${this._isSubmitting}
+                  ></sl-input>
+                  <sl-input
+                    label="AWS Region"
+                    .value=${this._bedrockRegion}
+                    @sl-input=${(e: Event) => {
+                      this._bedrockRegion = (
+                        e.target as HTMLInputElement
+                      ).value;
+                      this.requestUpdate();
+                    }}
+                    placeholder=${BEDROCK_DEFAULT_REGION}
+                    ?disabled=${this._isSubmitting}
+                  >
                     <div slot="help-text">
-                      Enter your API key to fetch available models.
-                      <a
-                        href=${this._getProviderKeyUrl(
-                          this._currentModel.provider_name
-                        )}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        >Get your API key here.</a
-                      >
+                      Bedrock model availability is regional, e.g.
+                      ${BEDROCK_DEFAULT_REGION} or eu-west-1.
                     </div>
-                  `
-                : html`
-                    <div slot="help-text">
-                      ${
-                        this._isEditing
-                          ? ''
-                          : 'Enter your API key to fetch available models'
-                      }
-                    </div>
-                  `
-            }
-          </sl-input>
+                  </sl-input>
+                `
+              : html`
+                  <sl-input
+                    class="full-width"
+                    label="API URL"
+                    .value=${this._currentModel.api_endpoint || ''}
+                    @sl-input=${(e: Event) => {
+                      this._currentModel.api_endpoint = (
+                        e.target as HTMLInputElement
+                      ).value;
+                      this.requestUpdate();
+                    }}
+                    ?disabled=${this._isSubmitting}
+                  >
+                    ${
+                      this._currentModel.provider_name === 'qwen'
+                        ? html`
+                            <div slot="help-text">
+                              Default is China (Beijing):
+                              https://dashscope.aliyuncs.com/compatible-mode/v1.
+                              International (Singapore):
+                              https://dashscope-intl.aliyuncs.com/compatible-mode/v1.
+                              US:
+                              https://dashscope-us.aliyuncs.com/compatible-mode/v1.
+                              Keys are not interchangeable across regions.
+                            </div>
+                          `
+                        : ''
+                    }
+                  </sl-input>
+                  <sl-input
+                    class="full-width"
+                    type="password"
+                    label="API Key"
+                    .value=${this._currentModel.api_key || ''}
+                    @sl-input=${(e: Event) => {
+                      this._currentModel.api_key = (
+                        e.target as HTMLInputElement
+                      ).value;
+                      this.requestUpdate();
+                    }}
+                    placeholder=${
+                      this._isEditing ? 'Leave blank to keep existing key' : ''
+                    }
+                    ?disabled=${this._isSubmitting}
+                  >
+                    ${
+                      !this._isEditing &&
+                      this._getProviderKeyUrl(this._currentModel.provider_name)
+                        ? html`
+                            <div slot="help-text">
+                              Enter your API key to fetch available models.
+                              <a
+                                href=${this._getProviderKeyUrl(
+                                  this._currentModel.provider_name
+                                )}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                >Get your API key here.</a
+                              >
+                            </div>
+                          `
+                        : html`
+                            <div slot="help-text">
+                              ${
+                                this._isEditing
+                                  ? ''
+                                  : 'Enter your API key to fetch available models'
+                              }
+                            </div>
+                          `
+                    }
+                  </sl-input>
+                `
+          }
 
           <div class="full-width">
             <sl-checkbox

--- a/frontend/src/components/add-ai-model-modal.ts
+++ b/frontend/src/components/add-ai-model-modal.ts
@@ -1006,7 +1006,6 @@ export class AddAIModelModal extends LitElement {
                   </sl-input>
                 `
           }
-          }
 
           <div class="full-width">
             <sl-checkbox

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11160,6 +11160,34 @@ components:
           title: Model Kind
           description: Model service kind to fetch
           default: llm
+        aws_access_key_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Aws Access Key Id
+          description: AWS access key id for the bedrock provider. Never logged and
+            never persisted by this endpoint.
+        aws_secret_access_key:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Aws Secret Access Key
+          description: AWS secret access key for the bedrock provider. Never logged
+            and never persisted by this endpoint.
+        aws_session_token:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Aws Session Token
+          description: Optional temporary-session token for the bedrock provider.
+            Never logged and never persisted by this endpoint.
+        aws_region_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Aws Region Name
+          description: AWS region for the bedrock provider, e.g. us-east-1. Falls
+            back to boto3's default region chain when omitted.
       type: object
       title: AvailableModelsRequest
       description: 'Discovery request for a provider''s model catalog.


### PR DESCRIPTION
## Summary

Adds AWS Bedrock as a first-class model provider, selectable from the add-model dialog's provider dropdown.

**Backend**
- `get_available_models_for_provider("bedrock", ..., aws_auth=...)` lists foundation models **live** from the Bedrock control plane (`boto3` → `bedrock.list_foundation_models`), filtered to ACTIVE text-output chat models (embedding/image/video ids dropped). A small bundled catalog is used only when boto3 is missing or the control plane is unreachable, consistent with every other provider.
- Rejected/missing AWS credentials raise `ProviderAuthError` → HTTP 401 with fixed safe text; no raw botocore error text is surfaced.
- `AvailableModelsRequest` gains optional `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_region_name` fields; secret material is masked in serialized copies exactly like `api_key`.

**Frontend**
- The add-model dialog shows AWS credential inputs (access key, secret key, optional session token, region with `us-east-1` default) in place of the API URL/key pair when Bedrock is selected.
- "Fetch Available Models" sends the AWS fields in the POST body and populates the picker from the live Bedrock listing.
- On submit, the dialog stores the gateway credential JSON blob that the Bedrock completion path already parses (`openai_gateway._bedrock_credential_kwargs`) plus `meta_data.provider_runtime.region`. Editing a Bedrock model with blank credential fields keeps the stored key.

**Completion path**: no changes needed — provider `bedrock` already routes through litellm's bedrock adapter (`litellm_routing.PROVIDER_PREFIX`).

## Testing
- Backend: 7 new service tests (live listing/filtering, auth errors, control-plane failure fallback, missing region, SDK missing) + endpoint forwarding and schema-masking tests. All 127 tests in `test_ai_model_provider.py` pass; related endpoint suites green.
- Frontend: 8 new modal tests (provider availability, field reset, fetch gating/payload, submit payload incl. credential blob + gateway alias, edit-mode key retention). Full frontend suite: 737 passed.
- `ruff check` / `ruff format` / `mypy` clean on changed files; prettier clean.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Adds AWS Bedrock as a model provider (live model discovery + add-model dialog with IAM credentials). All findings from prior reviews are resolved; the code is ready to merge.
>
> **Overview**
> Backend discovery service, request schema, OpenAPI spec, and frontend add-model dialog now support AWS Bedrock end-to-end. Credential handling follows the existing provider patterns (auth errors → 401, secret masking). This update confirms the stray-brace cleanup, resolving the last remaining finding.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 152cd47a. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->