### PR TITLE
feat: Cursor usage rollup, hooks ingest CLI, and per-conversation cost view

### DIFF
--- a/backend/preloop/api/endpoints/cost.py
+++ b/backend/preloop/api/endpoints/cost.py
@@ -24,6 +24,7 @@ from preloop.models.models.user import User
 from preloop.schemas.cost_analytics import (
     CostAnalyticsSummaryResponse,
     CostHealthResponse,
+    ImportedUsageByConversation,
     ImportedUsageByModel,
     ImportedUsageSummary,
     LedgerBackfillBucket,
@@ -113,6 +114,20 @@ def get_cost_summary(
             usage_by_model=[
                 ImportedUsageByModel(**row)
                 for row in crud_api_usage.get_imported_usage_by_model(
+                    db,
+                    account_id=str(account.id),
+                    start_date=summary.period_start,
+                    end_date=summary.period_end,
+                    runtime_principal_id=runtime_principal_id,
+                )
+            ],
+            # Per-conversation rollup for the console: subagent workers
+            # (parent_conversation_id) nest under their parent thread, and
+            # estimated vs reconciled amounts stay separate fields — the UI
+            # must never add them together (design-partner honesty rail).
+            usage_by_conversation=[
+                ImportedUsageByConversation(**row)
+                for row in crud_api_usage.get_imported_usage_by_conversation(
                     db,
                     account_id=str(account.id),
                     start_date=summary.period_start,

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -2677,5 +2677,118 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             for row in query.all()
         ]
 
+    def get_imported_usage_by_conversation(
+        self,
+        db: Session,
+        *,
+        account_id: str,
+        start_date: datetime,
+        end_date: datetime,
+        runtime_principal_id: Optional[str] = None,
+        source: Optional[str] = None,
+        limit: Optional[int] = 200,
+    ) -> List[Dict[str, Any]]:
+        """Group imported usage by source-side conversation for thread rollup.
+
+        Powers the console's per-conversation rollup: rows sharing a
+        ``conversation_id`` collapse to one entry, and the caller nests
+        entries whose ``parent_conversation_id`` matches another entry
+        (subagent workers billed on separate conversations under their
+        parent thread).
+
+        Honesty contract (design-partner rail):
+          * ``estimated_cost`` sums ONLY ``cost_basis='estimated'`` rows and
+            ``reconciled_cost`` sums ONLY ``cost_basis='reconciled'`` rows.
+            The two bases are never combined into one number here; display
+            layers must keep them separate too. No supersession is applied:
+            both bases are surfaced side by side per conversation.
+          * A sum with no contributing rows is ``None`` ("not reported"),
+            never coerced to 0/0.0. Same for ``total_tokens``.
+          * Rows with a NULL ``cost_basis`` cannot occur with a
+            conversation_id today (only push-ingest writes conversation ids
+            and it always sets a basis); defensively, such cost would be
+            excluded from both sums rather than silently classified.
+
+        Rows without a ``conversation_id`` (CSV/JSON batch imports) are not
+        part of any conversation and are excluded.
+
+        Args:
+            db: Database session.
+            account_id: Account whose imported usage is aggregated.
+            start_date: Inclusive lower bound on event timestamp.
+            end_date: Exclusive upper bound on event timestamp.
+            runtime_principal_id: Restrict to one managed-agent principal.
+            source: Restrict to one import source label.
+            limit: Maximum grouped rows, newest activity first.
+
+        Returns:
+            One dict per (conversation_id, source) group, ordered by last
+            event descending. ``parent_conversation_id`` is the group's
+            maximum non-null value (records of one conversation are expected
+            to agree on their parent; MAX is a deterministic tie-break).
+        """
+        import_source = ApiUsage.meta_data["import_source"].astext
+        estimated_sum = func.sum(
+            case(
+                (ApiUsage.cost_basis == "estimated", ApiUsage.estimated_cost),
+                else_=None,
+            )
+        )
+        reconciled_sum = func.sum(
+            case(
+                (ApiUsage.cost_basis == "reconciled", ApiUsage.estimated_cost),
+                else_=None,
+            )
+        )
+        query = db.query(
+            ApiUsage.conversation_id,
+            func.max(ApiUsage.parent_conversation_id).label("parent_conversation_id"),
+            import_source.label("source"),
+            func.count(ApiUsage.id).label("event_count"),
+            # No COALESCE on purpose: NULL means "not reported", not zero.
+            func.sum(ApiUsage.total_tokens).label("total_tokens"),
+            estimated_sum.label("estimated_cost"),
+            reconciled_sum.label("reconciled_cost"),
+            func.max(ApiUsage.timestamp).label("last_event_at"),
+        ).filter(
+            ApiUsage.action_type == self.IMPORTED_USAGE_ACTION_TYPE,
+            ApiUsage.account_id == account_id,
+            ApiUsage.conversation_id.isnot(None),
+            ApiUsage.timestamp >= start_date,
+            ApiUsage.timestamp < end_date,
+        )
+        if runtime_principal_id:
+            query = query.filter(ApiUsage.runtime_principal_id == runtime_principal_id)
+        if source:
+            query = query.filter(import_source == source)
+        query = query.group_by(ApiUsage.conversation_id, import_source).order_by(
+            func.max(ApiUsage.timestamp).desc()
+        )
+        if limit is not None:
+            query = query.limit(limit)
+        return [
+            {
+                "conversation_id": row.conversation_id,
+                "parent_conversation_id": row.parent_conversation_id,
+                "source": row.source,
+                "event_count": int(row.event_count or 0),
+                "total_tokens": (
+                    int(row.total_tokens) if row.total_tokens is not None else None
+                ),
+                "estimated_cost": (
+                    float(row.estimated_cost)
+                    if row.estimated_cost is not None
+                    else None
+                ),
+                "reconciled_cost": (
+                    float(row.reconciled_cost)
+                    if row.reconciled_cost is not None
+                    else None
+                ),
+                "last_event_at": row.last_event_at,
+            }
+            for row in query.all()
+        ]
+
 
 crud_api_usage = CRUDApiUsage(ApiUsage)

--- a/backend/preloop/schemas/cost_analytics.py
+++ b/backend/preloop/schemas/cost_analytics.py
@@ -224,6 +224,27 @@ class ImportedUsageByModel(BaseModel):
     last_event_at: Optional[datetime] = None
 
 
+class ImportedUsageByConversation(BaseModel):
+    """Imported usage rolled up by source-side conversation.
+
+    ``estimated_cost`` (hook/transcript-derived) and ``reconciled_cost``
+    (billing export) are reported as SEPARATE fields and must never be
+    summed into one number by any consumer. ``None`` means the source
+    reported nothing for that quantity ("not reported") — it is not zero.
+    Entries whose ``parent_conversation_id`` matches another entry's
+    ``conversation_id`` are subagent workers of that parent thread.
+    """
+
+    conversation_id: str
+    parent_conversation_id: Optional[str] = None
+    source: Optional[str] = None
+    event_count: int = 0
+    total_tokens: Optional[int] = None
+    estimated_cost: Optional[float] = None
+    reconciled_cost: Optional[float] = None
+    last_event_at: Optional[datetime] = None
+
+
 class ImportedUsageSummary(BaseModel):
     """Spend ingested from outside the gateway (``usage_source='imported'``).
 
@@ -236,6 +257,9 @@ class ImportedUsageSummary(BaseModel):
     total_tokens: int = 0
     imported_cost: float = 0.0
     usage_by_model: List[ImportedUsageByModel] = Field(default_factory=list)
+    usage_by_conversation: List[ImportedUsageByConversation] = Field(
+        default_factory=list
+    )
 
 
 class CostAnalyticsSummaryResponse(BaseModel):

--- a/backend/tests/endpoints/test_usage_ingest.py
+++ b/backend/tests/endpoints/test_usage_ingest.py
@@ -509,3 +509,77 @@ class TestIngestRecords:
         # Event and token truth stays with all rows.
         assert imported["event_count"] == 4
         assert imported["total_tokens"] == 1750
+
+    def test_summary_rolls_up_conversations_with_split_bases(
+        self, client, db_session, test_user
+    ):
+        """The cost summary exposes a per-conversation rollup block.
+
+        The design-partner contract: subagent workers surface under their
+        parent thread via parent_conversation_id, and estimated vs
+        reconciled amounts arrive as separate fields with nulls preserved
+        (never fabricated zeros, never one summed number).
+        """
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+
+        records = [
+            _record(
+                external_id="turn-parent-1",
+                conversation_id="conv-parent",
+                charged_cost="2.00",
+                input_tokens=1000,
+                output_tokens=200,
+            ),
+            _record(
+                external_id="billing-parent",
+                conversation_id="conv-parent",
+                charged_cost="1.80",
+                cost_basis="reconciled",
+                input_tokens=None,
+                output_tokens=None,
+                cache_read_tokens=None,
+            ),
+            _record(
+                external_id="turn-worker-1",
+                conversation_id="conv-worker",
+                parent_conversation_id="conv-parent",
+                charged_cost="0.40",
+                input_tokens=300,
+                output_tokens=100,
+            ),
+            {
+                "external_id": "gen-worker-start",
+                "timestamp": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
+                "event_type": "subagent_start",
+                "conversation_id": "conv-lifecycle-only",
+                "parent_conversation_id": "conv-parent",
+            },
+        ]
+        assert client.post(INGEST_URL, json=_payload(records)).json()["accepted"] == 4
+
+        summary = client.get(COST_SUMMARY_URL).json()
+        conversations = summary["imported_usage"]["usage_by_conversation"]
+        by_id = {row["conversation_id"]: row for row in conversations}
+        assert set(by_id) == {"conv-parent", "conv-worker", "conv-lifecycle-only"}
+
+        parent = by_id["conv-parent"]
+        assert parent["parent_conversation_id"] is None
+        assert parent["event_count"] == 2
+        assert abs(parent["estimated_cost"] - 2.00) < 1e-9
+        assert abs(parent["reconciled_cost"] - 1.80) < 1e-9
+        assert parent["total_tokens"] == 1200
+        assert parent["source"] == "cursor"
+
+        worker = by_id["conv-worker"]
+        assert worker["parent_conversation_id"] == "conv-parent"
+        assert abs(worker["estimated_cost"] - 0.40) < 1e-9
+        # Never billed and never estimated: null, not 0.0.
+        assert worker["reconciled_cost"] is None
+
+        lifecycle = by_id["conv-lifecycle-only"]
+        assert lifecycle["parent_conversation_id"] == "conv-parent"
+        assert lifecycle["event_count"] == 1
+        assert lifecycle["total_tokens"] is None
+        assert lifecycle["estimated_cost"] is None
+        assert lifecycle["reconciled_cost"] is None

--- a/backend/tests/models/crud/test_imported_usage_crud.py
+++ b/backend/tests/models/crud/test_imported_usage_crud.py
@@ -350,3 +350,182 @@ def test_out_of_window_reconciled_does_not_zero_in_window_estimates(
 
     assert abs(in_window["imported_cost"] - 2.00) < 1e-9
     assert abs(later["imported_cost"] - 1.80) < 1e-9
+
+
+def test_by_conversation_groups_threads_and_splits_cost_bases(
+    db_session, create_account
+):
+    """Conversations roll up with estimated and reconciled kept apart.
+
+    The design-partner rail: billed (reconciled) amounts must stay visibly
+    separate from size-proxy (estimated) amounts — the aggregation exposes
+    them as two fields and never one combined number.
+    """
+    account = create_account()
+    now = _utcnow_naive()
+
+    # Parent thread: one estimated record, one reconciled record.
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        conversation_id="conv-parent",
+        cost_usd=2.00,
+        cost_basis="estimated",
+        total_tokens=1000,
+        import_fingerprint="fp-conv-p1",
+    )
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        conversation_id="conv-parent",
+        cost_usd=1.75,
+        cost_basis="reconciled",
+        prompt_tokens=None,
+        completion_tokens=None,
+        import_fingerprint="fp-conv-p2",
+    )
+    # Subagent worker billed on its own conversation, spawned from the parent.
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        conversation_id="conv-worker",
+        parent_conversation_id="conv-parent",
+        cost_usd=0.40,
+        cost_basis="estimated",
+        total_tokens=300,
+        import_fingerprint="fp-conv-w1",
+    )
+    # A CSV-style row without a conversation id never joins the rollup.
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        cost_usd=9.99,
+        import_fingerprint="fp-conv-none",
+    )
+
+    rows = crud_api_usage.get_imported_usage_by_conversation(
+        db_session,
+        account_id=str(account.id),
+        start_date=now - timedelta(hours=1),
+        end_date=now + timedelta(hours=1),
+    )
+
+    assert {row["conversation_id"] for row in rows} == {"conv-parent", "conv-worker"}
+    by_id = {row["conversation_id"]: row for row in rows}
+
+    parent = by_id["conv-parent"]
+    assert parent["parent_conversation_id"] is None
+    assert parent["event_count"] == 2
+    # The reconciled row was logged token-free, so only the estimated
+    # row's 1000 tokens count; token-free rows contribute NULL, not 0.
+    assert parent["total_tokens"] == 1000
+    assert abs(parent["estimated_cost"] - 2.00) < 1e-9
+    assert abs(parent["reconciled_cost"] - 1.75) < 1e-9
+    assert parent["last_event_at"] is not None
+    assert parent["source"] == "cursor"
+
+    worker = by_id["conv-worker"]
+    assert worker["parent_conversation_id"] == "conv-parent"
+    assert worker["event_count"] == 1
+    assert abs(worker["estimated_cost"] - 0.40) < 1e-9
+    # No reconciled record exists for the worker: null, never 0.0.
+    assert worker["reconciled_cost"] is None
+
+
+def test_by_conversation_nulls_stay_null(db_session, create_account):
+    """Lifecycle-only conversations report nulls, never fabricated zeros."""
+    account = create_account()
+    now = _utcnow_naive()
+
+    # A hook lifecycle event: no model, no tokens, no cost.
+    row = crud_api_usage.log_imported_usage_event(
+        db_session,
+        account_id=str(account.id),
+        timestamp=now,
+        model_alias=None,
+        source="cursor",
+        conversation_id="conv-lifecycle",
+        cost_basis="estimated",
+        import_fingerprint="fp-conv-lc1",
+    )
+    assert row is not None
+
+    rows = crud_api_usage.get_imported_usage_by_conversation(
+        db_session,
+        account_id=str(account.id),
+        start_date=now - timedelta(hours=1),
+        end_date=now + timedelta(hours=1),
+    )
+
+    assert len(rows) == 1
+    only = rows[0]
+    assert only["conversation_id"] == "conv-lifecycle"
+    assert only["event_count"] == 1
+    assert only["total_tokens"] is None
+    assert only["estimated_cost"] is None
+    assert only["reconciled_cost"] is None
+
+
+def test_by_conversation_is_account_scoped_windowed_and_filterable(
+    db_session, create_account
+):
+    """Rollup honors the account boundary, the window, and filters."""
+    account = create_account()
+    other = create_account()
+    now = _utcnow_naive()
+
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        conversation_id="conv-in",
+        cost_usd=0.10,
+        cost_basis="estimated",
+        runtime_principal_id="ws-A",
+        import_fingerprint="fp-scope-1",
+    )
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        conversation_id="conv-old",
+        cost_usd=0.20,
+        cost_basis="estimated",
+        timestamp=now - timedelta(days=40),
+        import_fingerprint="fp-scope-2",
+    )
+    _log_imported(
+        db_session,
+        account_id=account.id,
+        conversation_id="conv-windsurf",
+        source="windsurf",
+        cost_usd=0.30,
+        cost_basis="estimated",
+        runtime_principal_id="ws-B",
+        import_fingerprint="fp-scope-3",
+    )
+    _log_imported(
+        db_session,
+        account_id=other.id,
+        conversation_id="conv-other-account",
+        cost_usd=0.40,
+        cost_basis="estimated",
+        import_fingerprint="fp-scope-4",
+    )
+
+    window = dict(
+        account_id=str(account.id),
+        start_date=now - timedelta(days=30),
+        end_date=now + timedelta(hours=1),
+    )
+
+    rows = crud_api_usage.get_imported_usage_by_conversation(db_session, **window)
+    assert {row["conversation_id"] for row in rows} == {"conv-in", "conv-windsurf"}
+
+    by_source = crud_api_usage.get_imported_usage_by_conversation(
+        db_session, source="windsurf", **window
+    )
+    assert [row["conversation_id"] for row in by_source] == ["conv-windsurf"]
+
+    by_principal = crud_api_usage.get_imported_usage_by_conversation(
+        db_session, runtime_principal_id="ws-A", **window
+    )
+    assert [row["conversation_id"] for row in by_principal] == ["conv-in"]

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -178,6 +178,13 @@ func NewGatewayProbeClient(baseURL, token string) *Client {
 	return client
 }
 
+// SetTimeout overrides the HTTP client timeout. Callers on interactive
+// paths (e.g. editor hooks that block the UI until the process exits) use
+// this to bound a request well below DefaultTimeout.
+func (c *Client) SetTimeout(timeout time.Duration) {
+	c.httpClient.Timeout = timeout
+}
+
 // Get performs a GET request to the specified path.
 func (c *Client) Get(path string, result interface{}) error {
 	return c.do(http.MethodGet, path, nil, result)

--- a/cli/internal/cmd/usage_hook.go
+++ b/cli/internal/cmd/usage_hook.go
@@ -1,0 +1,290 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+const (
+	usageIngestPath = "/api/v1/usage/ingest"
+
+	// usageHookMaxStdinBytes bounds the hook payload read from stdin. Real
+	// Cursor hook payloads are small JSON objects; the cap only guards
+	// against a misconfigured pipe streaming unbounded data into us.
+	usageHookMaxStdinBytes = 1 << 20
+
+	// usageHookTimeout bounds the ingest POST. Cursor waits on hook
+	// processes before continuing the agent loop, so a slow or unreachable
+	// server must never stall the editor for the client's default 30s.
+	usageHookTimeout = 3 * time.Second
+)
+
+// cursorHookEventMap maps Cursor hook event names (cursor.com/docs/agent/
+// hooks) to the ingest API's lifecycle event types. The Cursor events map
+// one-to-one onto the ingest lifecycle vocabulary, except `stop`, which is
+// recorded as `response`: it fires when the agent loop finishes
+// responding, the closest observable "one response happened" marker.
+//
+// Events outside this map (permission/file/observation hooks such as
+// beforeShellExecution, beforeReadFile, afterFileEdit, beforeSubmitPrompt,
+// afterAgentResponse) are acknowledged without a POST: they would inflate
+// event counts without adding any cost signal.
+var cursorHookEventMap = map[string]string{
+	"sessionStart":  "session_start",
+	"sessionEnd":    "session_end",
+	"subagentStart": "subagent_start",
+	"subagentStop":  "subagent_stop",
+	"stop":          "response",
+	"preCompact":    "compaction",
+}
+
+// cursorHookInput mirrors the fields of a Cursor hook stdin payload this
+// command uses, per the hook schemas published at cursor.com/docs/agent/
+// hooks (verified 2026-08-27). Fields we do not use (prompt text, file
+// paths, transcripts, user email) are deliberately not decoded: they never
+// leave the machine through this command.
+type cursorHookInput struct {
+	// Common fields (all agent hooks).
+	ConversationID string `json:"conversation_id"`
+	GenerationID   string `json:"generation_id"`
+	HookEventName  string `json:"hook_event_name"`
+	Model          string `json:"model"`
+
+	// sessionStart / sessionEnd. The docs state session_id equals
+	// conversation_id; it is decoded as a fallback only.
+	SessionID string `json:"session_id"`
+	Reason    string `json:"reason"`
+
+	// stop ("completed" | "aborted" | "error") and subagentStop share the
+	// status field; stop also reports its auto-followup loop count.
+	Status    string `json:"status"`
+	LoopCount *int   `json:"loop_count"`
+
+	// subagentStart / subagentStop.
+	SubagentID           string `json:"subagent_id"`
+	SubagentType         string `json:"subagent_type"`
+	ParentConversationID string `json:"parent_conversation_id"`
+	IsParallelWorker     *bool  `json:"is_parallel_worker"`
+
+	// subagentStop and preCompact growth tripwires; ingest stores them as
+	// first-class columns.
+	MessageCount  *int `json:"message_count"`
+	ToolCallCount *int `json:"tool_call_count"`
+}
+
+// usageHookCmd ships one Cursor hook event to POST /api/v1/usage/ingest.
+var usageHookCmd = &cobra.Command{
+	Use:   "hook",
+	Short: "Ship a Cursor hook event to Preloop usage ingest",
+	Long: `Ship a Cursor hook event to Preloop usage ingest.
+
+Reads one Cursor hook payload (JSON) from stdin and records it as a
+lifecycle event via POST /api/v1/usage/ingest, so conversations and
+their subagent conversations appear in the Cost analytics conversation
+rollup as they happen.
+
+Cursor hook payloads carry no token counts and no billed amounts, so
+the shipped records are lifecycle markers on the 'estimated' basis with
+no cost attached. Billed spend arrives separately, e.g. via
+'preloop usage import' of a Cursor dashboard Usage export.
+
+The command is fail-open by design: any error (unreachable server,
+missing auth, malformed payload) is reported on stderr and the command
+still exits 0, so a broken shipper can never block the editor.
+
+Intended to be wired into hooks.json for the sessionStart, sessionEnd,
+subagentStart, subagentStop, stop and preCompact events; see the guide
+at docs/guide/cursor-usage-hooks.md.`,
+	RunE: runUsageHook,
+}
+
+func init() {
+	usageCmd.AddCommand(usageHookCmd)
+
+	usageHookCmd.Flags().String("agent-id", "", "managed agent to attribute the events to (default: the onboarded Cursor agent)")
+	usageHookCmd.Flags().String("source", "cursor", "origin label stored on each record")
+	usageHookCmd.Flags().String("parent-conversation-id", "", "conversation this chat was spawned from, when the payload reports none (also PRELOOP_PARENT_CONVERSATION_ID)")
+}
+
+func runUsageHook(cmd *cobra.Command, _ []string) error {
+	agentID, _ := cmd.Flags().GetString("agent-id")
+	source, _ := cmd.Flags().GetString("source")
+	parentFlag, _ := cmd.Flags().GetString("parent-conversation-id")
+
+	payload, err := io.ReadAll(io.LimitReader(cmd.InOrStdin(), usageHookMaxStdinBytes))
+	if err != nil {
+		return usageHookFailOpen(cmd, fmt.Errorf("read hook payload: %w", err))
+	}
+
+	var input cursorHookInput
+	if err := json.Unmarshal(payload, &input); err != nil {
+		return usageHookFailOpen(cmd, fmt.Errorf("parse hook payload: %w", err))
+	}
+
+	eventType, shipped := cursorHookEventMap[input.HookEventName]
+	if !shipped {
+		// Not a lifecycle event we track; acknowledge and do nothing.
+		return nil
+	}
+
+	record, err := buildUsageHookRecord(input, eventType, parentFlag, time.Now().UTC())
+	if err != nil {
+		return usageHookFailOpen(cmd, err)
+	}
+
+	request := map[string]interface{}{
+		"source":  source,
+		"records": []map[string]interface{}{record},
+	}
+	if agentID != "" {
+		request["agent_id"] = agentID
+	}
+
+	client, err := api.NewClient(FlagToken, FlagURL)
+	if err != nil {
+		return usageHookFailOpen(cmd, fmt.Errorf("create API client: %w", err))
+	}
+	client.SetTimeout(usageHookTimeout)
+
+	if err := client.Post(usageIngestPath, request, nil); err != nil {
+		return usageHookFailOpen(cmd, fmt.Errorf("usage ingest failed: %w", err))
+	}
+	// All shipped events are observational for Cursor (their hook output
+	// is either ignored or optional), so nothing is written to stdout.
+	return nil
+}
+
+// buildUsageHookRecord maps one Cursor hook payload to one ingest record.
+//
+// Only facts the hook actually reported are shipped: no token counts, no
+// costs, no fabricated values. The timestamp is the shipper's receive
+// time because Cursor hook payloads carry no event timestamp.
+func buildUsageHookRecord(
+	input cursorHookInput,
+	eventType, parentFlag string,
+	now time.Time,
+) (map[string]interface{}, error) {
+	// The docs define session_id as equal to conversation_id; prefer the
+	// common field and fall back to session_id for robustness.
+	conversationID := input.ConversationID
+	if conversationID == "" {
+		conversationID = input.SessionID
+	}
+	if conversationID == "" {
+		return nil, fmt.Errorf(
+			"hook payload has no conversation_id; nothing to attribute the event to",
+		)
+	}
+
+	// parent_conversation_id is documented on subagentStart ("Conversation
+	// ID of the parent agent session") and passed through verbatim from
+	// any event that carries it. The flag/env fallbacks cover
+	// orchestrations the operator drives (e.g. a wrapper launching worker
+	// sessions); the parent is never guessed.
+	parent := input.ParentConversationID
+	if parent == "" {
+		parent = parentFlag
+	}
+	if parent == "" {
+		parent = os.Getenv("PRELOOP_PARENT_CONVERSATION_ID")
+	}
+
+	metadata := map[string]interface{}{
+		"hook_event_name": input.HookEventName,
+	}
+	if input.Status != "" {
+		metadata["hook_status"] = input.Status
+	}
+	if input.Reason != "" {
+		metadata["session_end_reason"] = input.Reason
+	}
+	if input.SubagentID != "" {
+		metadata["subagent_id"] = input.SubagentID
+	}
+	if input.SubagentType != "" {
+		metadata["subagent_type"] = input.SubagentType
+	}
+	if input.IsParallelWorker != nil {
+		metadata["is_parallel_worker"] = *input.IsParallelWorker
+	}
+
+	record := map[string]interface{}{
+		"external_id":     usageHookExternalID(input, conversationID, now),
+		"conversation_id": conversationID,
+		"timestamp":       now.Format(time.RFC3339Nano),
+		"event_type":      eventType,
+		// Hook-derived records are estimates by definition; billed amounts
+		// only ever arrive via reconciled imports (billing exports).
+		"cost_basis": "estimated",
+		"metadata":   metadata,
+	}
+	if parent != "" {
+		record["parent_conversation_id"] = parent
+	}
+	if input.Model != "" {
+		record["model"] = input.Model
+	}
+	if input.MessageCount != nil {
+		record["message_count"] = *input.MessageCount
+	}
+	if input.ToolCallCount != nil {
+		record["tool_call_count"] = *input.ToolCallCount
+	}
+	return record, nil
+}
+
+// usageHookExternalID derives the server-side dedupe key for one event.
+// (source, external_id) is unique per account, so the key must be stable
+// for one logical event and distinct across different ones:
+//
+//   - sessionStart/sessionEnd fire once per conversation: keyed by it.
+//   - stop fires once per agent loop; generation_id plus the documented
+//     loop_count disambiguates auto-followup loops in one generation.
+//   - subagentStart carries a unique subagent_id.
+//   - subagentStop and preCompact carry no per-fire id in their
+//     documented payloads and can fire more than once per generation
+//     (parallel workers, repeated compaction), so a receive-time nanos
+//     suffix keeps parallel events distinct. The cost of that choice is
+//     no replay dedupe for them, and nothing else: the command makes a
+//     single delivery attempt, so duplicates cannot originate here.
+func usageHookExternalID(
+	input cursorHookInput, conversationID string, now time.Time,
+) string {
+	switch input.HookEventName {
+	case "sessionStart", "sessionEnd":
+		return input.HookEventName + ":" + conversationID
+	case "stop":
+		if input.GenerationID != "" && input.LoopCount != nil {
+			return fmt.Sprintf("stop:%s:%d", input.GenerationID, *input.LoopCount)
+		}
+	case "subagentStart":
+		if input.SubagentID != "" {
+			return "subagentStart:" + input.SubagentID
+		}
+	}
+	if input.GenerationID != "" {
+		return fmt.Sprintf(
+			"%s:%s:%d", input.HookEventName, input.GenerationID, now.UnixNano(),
+		)
+	}
+	return fmt.Sprintf(
+		"%s:%s:%d", input.HookEventName, conversationID, now.UnixNano(),
+	)
+}
+
+// usageHookFailOpen reports the problem on stderr and swallows the error:
+// a hook shipper must never block or fail the editor interaction it
+// observes, no matter what went wrong on our side. (Cursor itself treats
+// non-2 hook exit codes as fail-open; exiting 0 with no output keeps this
+// command inert even if it is ever wired to a permission-style event.)
+func usageHookFailOpen(cmd *cobra.Command, err error) error {
+	fmt.Fprintf(cmd.ErrOrStderr(), "preloop usage hook: %v (event not recorded)\n", err)
+	return nil
+}

--- a/cli/internal/cmd/usage_hook.go
+++ b/cli/internal/cmd/usage_hook.go
@@ -5,11 +5,17 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/preloop/preloop/cli/internal/api"
+)
+
+// uuidRe matches a canonical UUID (8-4-4-4-12 hex).
+var uuidRe = regexp.MustCompile(
+	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
 )
 
 const (
@@ -108,7 +114,7 @@ at docs/guide/cursor-usage-hooks.md.`,
 func init() {
 	usageCmd.AddCommand(usageHookCmd)
 
-	usageHookCmd.Flags().String("agent-id", "", "managed agent to attribute the events to (default: the onboarded Cursor agent)")
+	usageHookCmd.Flags().String("agent-id", "", "managed agent UUID to attribute the events to (default: the onboarded Cursor agent)")
 	usageHookCmd.Flags().String("source", "cursor", "origin label stored on each record")
 	usageHookCmd.Flags().String("parent-conversation-id", "", "conversation this chat was spawned from, when the payload reports none (also PRELOOP_PARENT_CONVERSATION_ID)")
 }
@@ -144,6 +150,9 @@ func runUsageHook(cmd *cobra.Command, _ []string) error {
 		"records": []map[string]interface{}{record},
 	}
 	if agentID != "" {
+		if !uuidRe.MatchString(agentID) {
+			return usageHookFailOpen(cmd, fmt.Errorf("--agent-id must be a UUID, got %q", agentID))
+		}
 		request["agent_id"] = agentID
 	}
 

--- a/cli/internal/cmd/usage_hook_test.go
+++ b/cli/internal/cmd/usage_hook_test.go
@@ -1,0 +1,466 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// newUsageHookTestCmd builds a fresh command wired like usageHookCmd so
+// flag state never leaks between tests.
+func newUsageHookTestCmd(stdin string) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	cmd := &cobra.Command{Use: "hook", RunE: runUsageHook}
+	cmd.Flags().String("agent-id", "", "")
+	cmd.Flags().String("source", "cursor", "")
+	cmd.Flags().String("parent-conversation-id", "", "")
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetIn(strings.NewReader(stdin))
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	return cmd, stdout, stderr
+}
+
+// withUsageHookServer points the global CLI connection flags at a test
+// server for the duration of one test.
+func withUsageHookServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	prevURL, prevToken := FlagURL, FlagToken
+	FlagURL, FlagToken = server.URL, "test-token"
+	t.Cleanup(func() {
+		FlagURL, FlagToken = prevURL, prevToken
+		server.Close()
+	})
+	return server
+}
+
+func usageHookOKHandler(t *testing.T, gotBody *map[string]interface{}) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"accepted": 1}`))
+	}
+}
+
+func decodeSingleIngestRecord(t *testing.T, body map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	records, ok := body["records"].([]interface{})
+	if !ok || len(records) != 1 {
+		t.Fatalf("expected exactly one record, got %#v", body["records"])
+	}
+	record, ok := records[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("record is not an object: %#v", records[0])
+	}
+	return record
+}
+
+func TestUsageHookShipsStopEventAsResponse(t *testing.T) {
+	var gotBody map[string]interface{}
+	var gotPath string
+	withUsageHookServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		usageHookOKHandler(t, &gotBody)(w, r)
+	})
+
+	cmd, stdout, stderr := newUsageHookTestCmd(
+		`{"conversation_id":"conv-1","generation_id":"gen-9",` +
+			`"hook_event_name":"stop","status":"completed","loop_count":0,` +
+			`"model":"composer","workspace_roots":["/repo"]}`,
+	)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if gotPath != usageIngestPath {
+		t.Fatalf("unexpected path %q", gotPath)
+	}
+	if gotBody["source"] != "cursor" {
+		t.Fatalf("unexpected source: %#v", gotBody["source"])
+	}
+	record := decodeSingleIngestRecord(t, gotBody)
+	if record["event_type"] != "response" {
+		t.Fatalf("stop must map to a response event, got %#v", record["event_type"])
+	}
+	if record["conversation_id"] != "conv-1" {
+		t.Fatalf("unexpected conversation_id: %#v", record["conversation_id"])
+	}
+	if record["external_id"] != "stop:gen-9:0" {
+		t.Fatalf("unexpected external_id: %#v", record["external_id"])
+	}
+	if record["cost_basis"] != "estimated" {
+		t.Fatalf("hook records must be estimated basis, got %#v", record["cost_basis"])
+	}
+	if record["model"] != "composer" {
+		t.Fatalf("reported model must pass through, got %#v", record["model"])
+	}
+	// Honesty rail: hook payloads carry no tokens or spend, so the record
+	// must not fabricate any.
+	for _, forbidden := range []string{
+		"charged_cost", "input_tokens", "output_tokens", "cache_read_tokens",
+	} {
+		if _, present := record[forbidden]; present {
+			t.Fatalf("record must not fabricate %q: %#v", forbidden, record)
+		}
+	}
+	metadata, _ := record["metadata"].(map[string]interface{})
+	if metadata["hook_event_name"] != "stop" || metadata["hook_status"] != "completed" {
+		t.Fatalf("unexpected metadata: %#v", record["metadata"])
+	}
+	if _, err := time.Parse(time.RFC3339Nano, record["timestamp"].(string)); err != nil {
+		t.Fatalf("timestamp not RFC3339: %v", err)
+	}
+	// Shipped hook events are observational for Cursor: no stdout output.
+	if stdout.String() != "" {
+		t.Fatalf("hook must not write to stdout, got %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestUsageHookEventTypeMapping(t *testing.T) {
+	testCases := []struct {
+		hookEvent string
+		eventType string
+	}{
+		{hookEvent: "sessionStart", eventType: "session_start"},
+		{hookEvent: "sessionEnd", eventType: "session_end"},
+		{hookEvent: "subagentStart", eventType: "subagent_start"},
+		{hookEvent: "subagentStop", eventType: "subagent_stop"},
+		{hookEvent: "stop", eventType: "response"},
+		{hookEvent: "preCompact", eventType: "compaction"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.hookEvent, func(t *testing.T) {
+			var gotBody map[string]interface{}
+			withUsageHookServer(t, usageHookOKHandler(t, &gotBody))
+
+			payload, _ := json.Marshal(map[string]interface{}{
+				"conversation_id": "conv-1",
+				"generation_id":   "gen-1",
+				"hook_event_name": tc.hookEvent,
+			})
+			cmd, _, _ := newUsageHookTestCmd(string(payload))
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			record := decodeSingleIngestRecord(t, gotBody)
+			if record["event_type"] != tc.eventType {
+				t.Fatalf("expected %q, got %#v", tc.eventType, record["event_type"])
+			}
+		})
+	}
+}
+
+func TestUsageHookSubagentStartCarriesDocumentedParent(t *testing.T) {
+	var gotBody map[string]interface{}
+	withUsageHookServer(t, usageHookOKHandler(t, &gotBody))
+
+	cmd, _, _ := newUsageHookTestCmd(
+		`{"conversation_id":"conv-worker","generation_id":"gen-1",` +
+			`"hook_event_name":"subagentStart","subagent_id":"sub-1",` +
+			`"subagent_type":"explore","parent_conversation_id":"conv-parent",` +
+			`"is_parallel_worker":true,"task":"Explore the auth flow"}`,
+	)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	record := decodeSingleIngestRecord(t, gotBody)
+	if record["parent_conversation_id"] != "conv-parent" {
+		t.Fatalf("documented parent must pass through, got %#v", record["parent_conversation_id"])
+	}
+	if record["external_id"] != "subagentStart:sub-1" {
+		t.Fatalf("subagent_id must key the record, got %#v", record["external_id"])
+	}
+	metadata, _ := record["metadata"].(map[string]interface{})
+	if metadata["subagent_type"] != "explore" || metadata["is_parallel_worker"] != true {
+		t.Fatalf("unexpected metadata: %#v", record["metadata"])
+	}
+	// Task descriptions are content, not cost signal; they must not ship.
+	if _, present := metadata["task"]; present {
+		t.Fatalf("task text must not leave the machine: %#v", metadata)
+	}
+}
+
+func TestUsageHookSubagentStopShipsGrowthTripwires(t *testing.T) {
+	var gotBody map[string]interface{}
+	withUsageHookServer(t, usageHookOKHandler(t, &gotBody))
+
+	cmd, _, _ := newUsageHookTestCmd(
+		`{"conversation_id":"conv-worker","generation_id":"gen-1",` +
+			`"hook_event_name":"subagentStop","subagent_type":"generalPurpose",` +
+			`"status":"completed","message_count":12,"tool_call_count":8,` +
+			`"summary":"secret summary text"}`,
+	)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	record := decodeSingleIngestRecord(t, gotBody)
+	if record["message_count"] != float64(12) || record["tool_call_count"] != float64(8) {
+		t.Fatalf("documented counters must pass through, got %#v", record)
+	}
+	metadata, _ := record["metadata"].(map[string]interface{})
+	if metadata["hook_status"] != "completed" {
+		t.Fatalf("unexpected metadata: %#v", metadata)
+	}
+	if _, present := metadata["summary"]; present {
+		t.Fatalf("summary text must not leave the machine: %#v", metadata)
+	}
+	// No per-fire id is documented for subagentStop, so the key must stay
+	// unique across parallel workers via the receive-time suffix.
+	externalID, _ := record["external_id"].(string)
+	if !strings.HasPrefix(externalID, "subagentStop:gen-1:") {
+		t.Fatalf("unexpected external_id: %q", externalID)
+	}
+}
+
+func TestUsageHookSessionEventsAreKeyedByConversation(t *testing.T) {
+	for hookEvent, wantPrefix := range map[string]string{
+		"sessionStart": "sessionStart:conv-1",
+		"sessionEnd":   "sessionEnd:conv-1",
+	} {
+		var gotBody map[string]interface{}
+		withUsageHookServer(t, usageHookOKHandler(t, &gotBody))
+
+		payload, _ := json.Marshal(map[string]interface{}{
+			"conversation_id": "conv-1",
+			"generation_id":   "gen-1",
+			"hook_event_name": hookEvent,
+			"session_id":      "conv-1",
+		})
+		cmd, _, _ := newUsageHookTestCmd(string(payload))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		record := decodeSingleIngestRecord(t, gotBody)
+		if record["external_id"] != wantPrefix {
+			t.Fatalf("unexpected external_id for %s: %#v", hookEvent, record["external_id"])
+		}
+	}
+}
+
+func TestUsageHookFallsBackToSessionID(t *testing.T) {
+	var gotBody map[string]interface{}
+	withUsageHookServer(t, usageHookOKHandler(t, &gotBody))
+
+	cmd, _, _ := newUsageHookTestCmd(
+		`{"session_id":"conv-sess","hook_event_name":"sessionEnd","reason":"completed"}`,
+	)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	record := decodeSingleIngestRecord(t, gotBody)
+	if record["conversation_id"] != "conv-sess" {
+		t.Fatalf("session_id must back-fill conversation_id, got %#v", record["conversation_id"])
+	}
+	metadata, _ := record["metadata"].(map[string]interface{})
+	if metadata["session_end_reason"] != "completed" {
+		t.Fatalf("unexpected metadata: %#v", metadata)
+	}
+}
+
+func TestUsageHookSkipsNonLifecycleEventsWithoutPosting(t *testing.T) {
+	for _, hookEvent := range []string{
+		"beforeShellExecution", "beforeMCPExecution", "beforeReadFile",
+		"afterFileEdit", "beforeSubmitPrompt", "afterAgentResponse",
+		"preToolUse", "postToolUse", "workspaceOpen",
+	} {
+		posted := false
+		withUsageHookServer(t, func(w http.ResponseWriter, r *http.Request) {
+			posted = true
+			w.WriteHeader(http.StatusOK)
+		})
+
+		payload, _ := json.Marshal(map[string]interface{}{
+			"conversation_id": "conv-1",
+			"hook_event_name": hookEvent,
+		})
+		cmd, stdout, stderr := newUsageHookTestCmd(string(payload))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute %s: %v", hookEvent, err)
+		}
+		if posted {
+			t.Fatalf("%s must not be shipped", hookEvent)
+		}
+		if stdout.String() != "" || stderr.String() != "" {
+			t.Fatalf("expected silence for %s, got stdout=%q stderr=%q",
+				hookEvent, stdout.String(), stderr.String())
+		}
+	}
+}
+
+func TestUsageHookParentConversationPrecedence(t *testing.T) {
+	testCases := []struct {
+		name           string
+		payloadParent  string
+		flagParent     string
+		envParent      string
+		expectedParent string // "" means the field must be absent
+	}{
+		{
+			name:           "documented payload field wins",
+			payloadParent:  "conv-from-payload",
+			flagParent:     "conv-from-flag",
+			envParent:      "conv-from-env",
+			expectedParent: "conv-from-payload",
+		},
+		{
+			name:           "flag beats env",
+			flagParent:     "conv-from-flag",
+			envParent:      "conv-from-env",
+			expectedParent: "conv-from-flag",
+		},
+		{
+			name:           "env is the last resort",
+			envParent:      "conv-from-env",
+			expectedParent: "conv-from-env",
+		},
+		{
+			name:           "absent stays absent - never fabricated",
+			expectedParent: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody map[string]interface{}
+			withUsageHookServer(t, usageHookOKHandler(t, &gotBody))
+			t.Setenv("PRELOOP_PARENT_CONVERSATION_ID", tc.envParent)
+
+			payload := map[string]interface{}{
+				"conversation_id": "conv-child",
+				"generation_id":   "gen-3",
+				"hook_event_name": "stop",
+				"loop_count":      0,
+			}
+			if tc.payloadParent != "" {
+				payload["parent_conversation_id"] = tc.payloadParent
+			}
+			encoded, _ := json.Marshal(payload)
+
+			cmd, _, _ := newUsageHookTestCmd(string(encoded))
+			if tc.flagParent != "" {
+				if err := cmd.Flags().Set("parent-conversation-id", tc.flagParent); err != nil {
+					t.Fatalf("set flag: %v", err)
+				}
+			}
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+
+			record := decodeSingleIngestRecord(t, gotBody)
+			parent, present := record["parent_conversation_id"]
+			if tc.expectedParent == "" {
+				if present {
+					t.Fatalf("parent must be absent, got %#v", parent)
+				}
+				return
+			}
+			if parent != tc.expectedParent {
+				t.Fatalf("expected parent %q, got %#v", tc.expectedParent, parent)
+			}
+		})
+	}
+}
+
+func TestUsageHookFailsOpenWithoutConversationID(t *testing.T) {
+	posted := false
+	withUsageHookServer(t, func(w http.ResponseWriter, r *http.Request) {
+		posted = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cmd, _, stderr := newUsageHookTestCmd(
+		`{"generation_id":"gen-1","hook_event_name":"stop"}`,
+	)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hook must fail open, got error: %v", err)
+	}
+
+	if posted {
+		t.Fatal("a record without a conversation_id must not be shipped")
+	}
+	if !strings.Contains(stderr.String(), "conversation_id") {
+		t.Fatalf("expected a conversation_id warning, got %q", stderr.String())
+	}
+}
+
+func TestUsageHookFailsOpenOnServerError(t *testing.T) {
+	withUsageHookServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"detail":"boom"}`, http.StatusInternalServerError)
+	})
+
+	cmd, stdout, stderr := newUsageHookTestCmd(
+		`{"conversation_id":"conv-1","generation_id":"gen-1",` +
+			`"hook_event_name":"stop","loop_count":0}`,
+	)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hook must fail open, got error: %v", err)
+	}
+
+	if !strings.Contains(stderr.String(), "not recorded") {
+		t.Fatalf("expected a shipment warning, got %q", stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Fatalf("no stdout output expected, got %q", stdout.String())
+	}
+}
+
+func TestUsageHookFailsOpenOnMalformedPayload(t *testing.T) {
+	posted := false
+	withUsageHookServer(t, func(w http.ResponseWriter, r *http.Request) {
+		posted = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cmd, _, stderr := newUsageHookTestCmd(`this is not json`)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hook must fail open, got error: %v", err)
+	}
+
+	if posted {
+		t.Fatal("malformed payloads must not be shipped")
+	}
+	if !strings.Contains(stderr.String(), "parse hook payload") {
+		t.Fatalf("expected a parse warning, got %q", stderr.String())
+	}
+}
+
+func TestUsageHookForwardsAgentIDAndSource(t *testing.T) {
+	var gotBody map[string]interface{}
+	withUsageHookServer(t, usageHookOKHandler(t, &gotBody))
+
+	cmd, _, _ := newUsageHookTestCmd(
+		`{"conversation_id":"conv-1","generation_id":"gen-1",` +
+			`"hook_event_name":"stop","loop_count":0}`,
+	)
+	if err := cmd.Flags().Set("agent-id", "agent-42"); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if gotBody["agent_id"] != "agent-42" {
+		t.Fatalf("unexpected agent_id: %#v", gotBody["agent_id"])
+	}
+	if gotBody["source"] != "cursor" {
+		t.Fatalf("unexpected source: %#v", gotBody["source"])
+	}
+}

--- a/cli/internal/cmd/usage_hook_test.go
+++ b/cli/internal/cmd/usage_hook_test.go
@@ -450,17 +450,43 @@ func TestUsageHookForwardsAgentIDAndSource(t *testing.T) {
 		`{"conversation_id":"conv-1","generation_id":"gen-1",` +
 			`"hook_event_name":"stop","loop_count":0}`,
 	)
-	if err := cmd.Flags().Set("agent-id", "agent-42"); err != nil {
+	if err := cmd.Flags().Set("agent-id", "a1b2c3d4-e5f6-7890-abcd-ef1234567890"); err != nil {
 		t.Fatalf("set flag: %v", err)
 	}
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 
-	if gotBody["agent_id"] != "agent-42" {
+	if gotBody["agent_id"] != "a1b2c3d4-e5f6-7890-abcd-ef1234567890" {
 		t.Fatalf("unexpected agent_id: %#v", gotBody["agent_id"])
 	}
 	if gotBody["source"] != "cursor" {
 		t.Fatalf("unexpected source: %#v", gotBody["source"])
+	}
+}
+
+func TestUsageHookRejectsNonUUIDAgentID(t *testing.T) {
+	posted := false
+	withUsageHookServer(t, func(w http.ResponseWriter, r *http.Request) {
+		posted = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cmd, _, stderr := newUsageHookTestCmd(
+		`{"conversation_id":"conv-1","generation_id":"gen-1",` +
+			`"hook_event_name":"stop","loop_count":0}`,
+	)
+	if err := cmd.Flags().Set("agent-id", "not-a-uuid"); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hook must fail open, got error: %v", err)
+	}
+
+	if posted {
+		t.Fatal("a non-UUID agent-id must not be shipped")
+	}
+	if !strings.Contains(stderr.String(), "must be a UUID") {
+		t.Fatalf("expected a UUID validation warning, got %q", stderr.String())
 	}
 }

--- a/docs/guide/cursor-usage-hooks.md
+++ b/docs/guide/cursor-usage-hooks.md
@@ -1,0 +1,149 @@
+# Cursor hooks: live conversation tracking in Cost analytics
+
+Cursor's bundled models never pass through the Preloop model gateway, so
+Preloop cannot meter that traffic itself. The `preloop usage hook` command
+closes part of that gap: wired into Cursor's hooks, it ships conversation
+lifecycle events to `POST /api/v1/usage/ingest` as they happen, so your
+chats and their subagent conversations appear in the Cost analytics
+conversation rollup in near real time.
+
+Hook payload fields referenced below come from Cursor's hooks reference
+(https://cursor.com/docs/agent/hooks, checked 2026-08-27).
+
+## What this does and does not record
+
+Cursor hook payloads carry no token counts and no billed amounts. This
+integration therefore records lifecycle facts only:
+
+- which conversations were active, and when
+- session, response, subagent, and compaction lifecycle events
+- parent and child conversation links (`parent_conversation_id` from
+  `subagentStart` payloads)
+- message and tool-call counters where Cursor reports them
+  (`subagentStop`), as growth tripwires
+
+Every shipped record is marked with the `estimated` cost basis and carries
+no cost figure. In the console, quantities the source never reported show
+as "not reported", never as 0 or $0.00. Billed amounts enter the system
+only through a reconciled import (for example a Cursor dashboard Usage
+export via `preloop usage import`, or a billing feed pushed to the ingest
+API with `cost_basis=reconciled`). Estimated and reconciled amounts are
+always displayed separately and are never summed together.
+
+Privacy: the shipper sends ids, event names, statuses, the reported model
+name, and counters. It never sends prompt text, task descriptions,
+subagent summaries, file paths, or shell commands, even though hook
+payloads contain them.
+
+## Prerequisites
+
+1. The Preloop CLI installed and logged in (`preloop login`), with a user
+   allowed to import usage.
+2. A managed Cursor agent to attribute events to. Either onboard one with
+   `preloop agents onboard cursor`, or pass `--agent-id` explicitly in the
+   hook command.
+
+## Configure Cursor
+
+Cursor reads hook configuration from `hooks.json`, either user wide at
+`~/.cursor/hooks.json` or per project at `<project>/.cursor/hooks.json`.
+Create or extend it:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [{ "command": "preloop usage hook" }],
+    "sessionEnd": [{ "command": "preloop usage hook" }],
+    "subagentStart": [{ "command": "preloop usage hook" }],
+    "subagentStop": [{ "command": "preloop usage hook" }],
+    "stop": [{ "command": "preloop usage hook" }],
+    "preCompact": [{ "command": "preloop usage hook" }]
+  }
+}
+```
+
+Cursor watches hook config files and reloads them automatically. The same
+command handles every event; it reads the hook payload from stdin and
+decides from `hook_event_name` what to do.
+
+## Event mapping
+
+| Cursor hook event | Shipped as | Notes |
+| ----------------- | ---------- | ----- |
+| `sessionStart` | `session_start` | Fires when a new conversation is created. |
+| `sessionEnd` | `session_end` | End reason recorded in metadata. |
+| `subagentStart` | `subagent_start` | Carries the documented `parent_conversation_id`, which powers thread nesting in the rollup. |
+| `subagentStop` | `subagent_stop` | Ships the documented `message_count` and `tool_call_count`. |
+| `stop` | `response` | Fires when the agent loop finishes responding. |
+| `preCompact` | `compaction` | Context compaction marker. |
+| any other event | not shipped | Permission, file, prompt, and thought hooks would inflate event counts without adding cost signal. The command acknowledges them and exits 0. |
+
+Deduplication: the server deduplicates on `(source, external_id)`.
+Records are keyed by conversation id (`sessionStart`/`sessionEnd`),
+`generation_id` plus `loop_count` (`stop`), or `subagent_id`
+(`subagentStart`). `subagentStop` and `preCompact` payloads document no
+per-fire id, so those records get a receive-time suffix; they stay unique
+across parallel workers but do not deduplicate on replay. The command
+makes a single delivery attempt, so duplicates cannot originate from it.
+
+## Subagent conversations
+
+When Cursor spawns a subagent (Task tool), the `subagentStart` payload
+reports `parent_conversation_id`, and the rollup nests the record under
+that parent thread automatically.
+
+One documented ambiguity: Cursor's reference does not state whether the
+common `conversation_id` field on subagent events refers to the worker's
+own conversation or the parent's. The command ships exactly what Cursor
+reports and never rewrites it; if both ids are equal, the record simply
+lands on the parent thread and per-thread totals stay correct.
+
+For orchestrations you drive yourself (a wrapper that launches worker
+sessions on behalf of a parent), you can set the parent id explicitly:
+`preloop usage hook --parent-conversation-id <id>` in that wrapper's hook
+configuration, or export `PRELOOP_PARENT_CONVERSATION_ID` in the worker's
+environment. Precedence: payload field, then flag, then environment
+variable. When none is present the field is omitted; it is never guessed.
+
+## Failure behavior
+
+The command is fail-open by design:
+
+- the ingest request is capped at 3 seconds
+- any error (server unreachable, expired login, malformed payload) is
+  printed to stderr and the command still exits 0
+- nothing is written to stdout; all shipped events are observational for
+  Cursor, and Cursor treats hook exit codes other than 2 as fail-open
+
+A failed shipment means one missing lifecycle event, nothing more.
+
+Timestamps are the shipper's receive time: Cursor hook payloads carry no
+event timestamp, and hooks fire at the moment of the event, so the skew
+is at most process startup plus queueing.
+
+## Verify the wiring
+
+Simulate a hook invocation from a shell:
+
+```bash
+echo '{"conversation_id":"test-conv","generation_id":"test-gen-1","hook_event_name":"stop","status":"completed","loop_count":0}' \
+  | preloop usage hook
+```
+
+Then open Cost analytics in the console. The "Imported usage" section
+shows a "Conversations" rollup listing `test-conv` with one event and its
+tokens and costs marked "not reported" (hooks report neither).
+
+## Reconciling billed amounts later
+
+When you have actual billed figures, import them separately:
+
+- `preloop usage import <cursor-usage-export>.csv` records the dashboard
+  export as imported spend (totals and per-model figures; the export
+  carries no conversation ids).
+- A billing source that does report per-conversation amounts can push
+  them to `POST /api/v1/usage/ingest` with `cost_basis=reconciled` and
+  the `conversation_id`; reconciled records then supersede hook-derived
+  estimates for that conversation in summary totals, and the conversation
+  rollup shows both figures side by side.

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -997,11 +997,30 @@ export interface ImportedUsageByModel {
   last_event_at: string | null;
 }
 
+// One source-side conversation (thread) of imported usage. `estimated_cost`
+// (hook/transcript-derived) and `reconciled_cost` (billing export) are kept
+// as SEPARATE fields and must never be summed into one number. `null` means
+// the source reported nothing ("not reported") — it is not zero. Entries
+// whose parent_conversation_id matches another entry's conversation_id are
+// subagent workers of that parent thread.
+export interface ImportedUsageByConversation {
+  conversation_id: string;
+  parent_conversation_id: string | null;
+  source: string | null;
+  event_count: number;
+  total_tokens: number | null;
+  estimated_cost: number | null;
+  reconciled_cost: number | null;
+  last_event_at: string | null;
+}
+
 export interface ImportedUsageSummary {
   event_count: number;
   total_tokens: number;
   imported_cost: number;
   usage_by_model: ImportedUsageByModel[];
+  // Absent on older servers; the console treats missing as "no rollup".
+  usage_by_conversation?: ImportedUsageByConversation[];
 }
 
 export interface CostAnalyticsSummaryResponse extends AccountGatewayUsageSummaryResponse {

--- a/frontend/src/views/authed/cost-view.test.ts
+++ b/frontend/src/views/authed/cost-view.test.ts
@@ -255,6 +255,143 @@ describe('CostView', () => {
       ).to.not.exist;
       expect(element.shadowRoot?.textContent).to.not.contain('Imported usage');
     });
+
+    describe('conversation rollup', () => {
+      // A parent thread with an estimated and a reconciled record, one
+      // subagent worker conversation, and one unrelated conversation whose
+      // costs were never reported.
+      const conversations = [
+        {
+          conversation_id: 'conv-parent',
+          parent_conversation_id: null,
+          source: 'cursor',
+          event_count: 2,
+          total_tokens: 1200,
+          estimated_cost: 2.0,
+          reconciled_cost: 1.8,
+          last_event_at: '2026-07-31T10:05:00Z',
+        },
+        {
+          conversation_id: 'conv-worker',
+          parent_conversation_id: 'conv-parent',
+          source: 'cursor',
+          event_count: 1,
+          total_tokens: 300,
+          estimated_cost: 0.4,
+          reconciled_cost: null,
+          last_event_at: '2026-07-31T10:04:00Z',
+        },
+        {
+          conversation_id: 'conv-lonely',
+          parent_conversation_id: null,
+          source: 'cursor',
+          event_count: 1,
+          total_tokens: null,
+          estimated_cost: null,
+          reconciled_cost: null,
+          last_event_at: '2026-07-31T09:00:00Z',
+        },
+      ];
+
+      function conversationTable(element: CostView) {
+        return element.shadowRoot?.querySelector(
+          'table[aria-label="Imported usage by conversation"]'
+        );
+      }
+
+      it('nests subagent conversations under their parent thread', async () => {
+        const element = await loadView({
+          ...importedUsage,
+          usage_by_conversation: conversations,
+        });
+
+        const table = conversationTable(element);
+        expect(table).to.exist;
+
+        const rows = [...(table?.querySelectorAll('tbody tr') ?? [])];
+        // parent, nested worker, thread total, lonely conversation.
+        expect(rows.length).to.equal(4);
+        expect(rows[0]?.textContent).to.contain('conv-parent');
+        expect(rows[1]?.textContent).to.contain('conv-worker');
+        expect(
+          rows[1]?.querySelector('.conversation-child-cell'),
+          'worker row must be visually nested under its parent'
+        ).to.exist;
+        expect(rows[3]?.textContent).to.contain('conv-lonely');
+      });
+
+      it('shows per-thread totals with estimated and reconciled kept apart', async () => {
+        const element = await loadView({
+          ...importedUsage,
+          usage_by_conversation: conversations,
+        });
+
+        const totalRow = conversationTable(element)?.querySelector(
+          'tr.conversation-thread-total'
+        );
+        expect(totalRow).to.exist;
+        const text = totalRow?.textContent ?? '';
+        expect(text).to.contain('Thread total');
+        expect(text).to.contain('1,500'); // 1200 + 300 tokens
+        expect(text).to.contain('$2.40'); // estimated: 2.00 + 0.40
+        expect(text).to.contain('$1.80'); // reconciled stays its own figure
+        // The two bases must never be summed into one number.
+        expect(text).to.not.contain('$4.20');
+      });
+
+      it('renders null quantities as "not reported", never as zero', async () => {
+        const element = await loadView({
+          ...importedUsage,
+          usage_by_conversation: conversations,
+        });
+
+        const rows = [
+          ...(conversationTable(element)?.querySelectorAll('tbody tr') ?? []),
+        ];
+        const lonely = rows.find((row) =>
+          row.textContent?.includes('conv-lonely')
+        );
+        expect(lonely).to.exist;
+        expect(lonely?.textContent).to.contain('not reported');
+        expect(lonely?.textContent).to.not.contain('$0.00');
+
+        // The worker's missing reconciled amount is also "not reported".
+        const worker = rows.find((row) =>
+          row.textContent?.includes('conv-worker')
+        );
+        expect(worker?.textContent).to.contain('not reported');
+      });
+
+      it('keeps the estimated and reconciled columns separate', async () => {
+        const element = await loadView({
+          ...importedUsage,
+          usage_by_conversation: conversations,
+        });
+
+        const headers = [
+          ...(conversationTable(element)?.querySelectorAll('th[scope="col"]') ??
+            []),
+        ].map((th) => th.textContent?.trim());
+        expect(headers).to.include('Estimated cost');
+        expect(headers).to.include('Reconciled cost');
+      });
+
+      it('hides the rollup when no conversations are reported', async () => {
+        const element = await loadView({
+          ...importedUsage,
+          usage_by_conversation: [],
+        });
+
+        expect(conversationTable(element)).to.not.exist;
+        expect(element.shadowRoot?.textContent).to.not.contain('Conversations');
+      });
+
+      it('hides the rollup when an older server omits the field', async () => {
+        const element = await loadView(importedUsage);
+
+        expect(conversationTable(element)).to.not.exist;
+      });
+    });
   });
 
   it('renders the page title and description in the view header', async () => {

--- a/frontend/src/views/authed/cost-view.ts
+++ b/frontend/src/views/authed/cost-view.ts
@@ -25,6 +25,7 @@ import type {
   CostReconciliationRow,
   GatewayUsageBySession,
   GatewayUsageByTool,
+  ImportedUsageByConversation,
   ImportedUsageByModel,
   ModelPriceOverride,
   ModelPriceOverrideCreate,
@@ -95,6 +96,13 @@ type UserGroupRow = {
   username: string;
   requests: number;
   cost: number;
+};
+
+// One imported-usage thread: a conversation plus the subagent conversations
+// spawned from it (rows whose parent_conversation_id points at it).
+type ImportedConversationThread = {
+  row: ImportedUsageByConversation;
+  children: ImportedUsageByConversation[];
 };
 
 const COST_DATE_RANGE_STORAGE_KEY = 'preloop.cost.dateRange';
@@ -402,6 +410,32 @@ export class CostView extends AuthedElement {
         font-size: 1.25rem;
         font-weight: 700;
         color: var(--sl-color-neutral-950);
+      }
+
+      .imported-conversations-title {
+        margin: var(--sl-spacing-large) 0 var(--sl-spacing-x-small);
+        font-size: var(--sl-font-size-medium);
+        font-weight: 600;
+        color: var(--sl-color-neutral-950);
+      }
+
+      .conversation-child-cell {
+        padding-left: var(--sl-spacing-x-large);
+      }
+
+      .conversation-child-marker {
+        color: var(--sl-color-neutral-500);
+        margin-right: var(--sl-spacing-2x-small);
+      }
+
+      .conversation-thread-total td {
+        font-weight: 600;
+        background: var(--sl-color-neutral-50);
+      }
+
+      .not-reported {
+        color: var(--sl-color-neutral-500);
+        font-style: italic;
       }
 
       .analytics-table-wrap {
@@ -1402,8 +1436,157 @@ export class CostView extends AuthedElement {
               </div>`
             : html`<div class="empty">No per-model imported usage yet.</div>`
         }
+        ${this.renderImportedConversations(imported.usage_by_conversation ?? [])}
       </sl-card>
     `;
+  }
+
+  // Per-conversation rollup of imported usage. Subagent conversations
+  // (parent_conversation_id) nest under the thread that spawned them.
+  // Honesty rails: estimated and reconciled amounts stay in separate
+  // columns — they are NEVER added into one number — and a null quantity
+  // renders as "not reported", never as 0 or $0.00.
+  private renderImportedConversations(rows: ImportedUsageByConversation[]) {
+    if (!rows.length) return nothing;
+    const threads = this.buildConversationThreads(rows);
+    return html`
+      <div class="imported-conversations-title">Conversations</div>
+      <div class="imported-usage-note">
+        Per-thread rollup of imported usage. Subagent conversations are nested
+        under the conversation that spawned them. Estimated amounts (derived
+        from hook or transcript data) and reconciled amounts (from a billing
+        export) are shown separately and are never summed together.
+      </div>
+      <div class="analytics-table-wrap">
+        <table class="styled-table" aria-label="Imported usage by conversation">
+          <thead>
+            <tr>
+              <th scope="col">Conversation</th>
+              <th scope="col">Events</th>
+              <th scope="col">Tokens</th>
+              <th scope="col">Estimated cost</th>
+              <th scope="col">Reconciled cost</th>
+              <th scope="col">Last event</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${threads.map((thread) => this.renderConversationThread(thread))}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  // Group conversations into threads. A row nests under its parent only
+  // when that parent is itself top-level (one nesting level); a deeper
+  // descendant is promoted to top-level instead so no conversation can
+  // ever disappear from the table.
+  private buildConversationThreads(
+    rows: ImportedUsageByConversation[]
+  ): ImportedConversationThread[] {
+    const byId = new Map(rows.map((row) => [row.conversation_id, row]));
+    const hasKnownParent = (row: ImportedUsageByConversation): boolean => {
+      const parent = row.parent_conversation_id;
+      return !!parent && parent !== row.conversation_id && byId.has(parent);
+    };
+    const isNested = (row: ImportedUsageByConversation): boolean => {
+      if (!hasKnownParent(row)) return false;
+      const parent = byId.get(row.parent_conversation_id as string);
+      return !!parent && !hasKnownParent(parent);
+    };
+    const childrenByParent = new Map<string, ImportedUsageByConversation[]>();
+    const roots: ImportedUsageByConversation[] = [];
+    for (const row of rows) {
+      if (isNested(row)) {
+        const parentId = row.parent_conversation_id as string;
+        const list = childrenByParent.get(parentId) ?? [];
+        list.push(row);
+        childrenByParent.set(parentId, list);
+      } else {
+        roots.push(row);
+      }
+    }
+    return roots.map((row) => ({
+      row,
+      children: childrenByParent.get(row.conversation_id) ?? [],
+    }));
+  }
+
+  private renderConversationThread(thread: ImportedConversationThread) {
+    const { row, children } = thread;
+    if (!children.length) return this.renderConversationRow(row, false);
+    const all = [row, ...children];
+    const totalEvents = all.reduce((sum, r) => sum + (r.event_count || 0), 0);
+    // Thread totals keep the two cost bases apart: an estimated total and a
+    // reconciled total, never one combined figure.
+    const totalTokens = this.sumReported(all.map((r) => r.total_tokens));
+    const totalEstimated = this.sumReported(all.map((r) => r.estimated_cost));
+    const totalReconciled = this.sumReported(all.map((r) => r.reconciled_cost));
+    return html`
+      ${this.renderConversationRow(row, false)}
+      ${children.map((child) => this.renderConversationRow(child, true))}
+      <tr class="conversation-thread-total">
+        <td>Thread total (${all.length} conversations)</td>
+        <td>${this.formatNumber(totalEvents)}</td>
+        <td>${this.renderReportedNumber(totalTokens)}</td>
+        <td>${this.renderReportedCurrency(totalEstimated)}</td>
+        <td>${this.renderReportedCurrency(totalReconciled)}</td>
+        <td></td>
+      </tr>
+    `;
+  }
+
+  private renderConversationRow(
+    row: ImportedUsageByConversation,
+    nested: boolean
+  ) {
+    return html`
+      <tr>
+        <td class=${nested ? 'conversation-child-cell' : ''}>
+          ${
+            nested
+              ? html`<span class="conversation-child-marker" aria-hidden="true"
+                  >&#8627;</span
+                >`
+              : nothing
+          }
+          ${row.conversation_id}
+        </td>
+        <td>${this.formatNumber(row.event_count)}</td>
+        <td>${this.renderReportedNumber(row.total_tokens)}</td>
+        <td>${this.renderReportedCurrency(row.estimated_cost)}</td>
+        <td>${this.renderReportedCurrency(row.reconciled_cost)}</td>
+        <td>
+          ${
+            row.last_event_at
+              ? new Date(row.last_event_at).toLocaleString()
+              : html`<span class="not-reported">not reported</span>`
+          }
+        </td>
+      </tr>
+    `;
+  }
+
+  // Null-preserving sum: null when every input is null ("not reported"),
+  // so a missing value can never be laundered into a fabricated zero.
+  private sumReported(values: Array<number | null | undefined>): number | null {
+    const reported = values.filter(
+      (value): value is number => value !== null && value !== undefined
+    );
+    if (!reported.length) return null;
+    return reported.reduce((sum, value) => sum + value, 0);
+  }
+
+  private renderReportedNumber(value?: number | null) {
+    return value === null || value === undefined
+      ? html`<span class="not-reported">not reported</span>`
+      : html`${this.formatNumber(value)}`;
+  }
+
+  private renderReportedCurrency(value?: number | null) {
+    return value === null || value === undefined
+      ? html`<span class="not-reported">not reported</span>`
+      : html`${this.formatCurrency(value)}`;
   }
 
   private renderBreakdown() {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13630,6 +13630,64 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
+    ImportedUsageByConversation:
+      properties:
+        conversation_id:
+          type: string
+          title: Conversation Id
+        parent_conversation_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Parent Conversation Id
+        source:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source
+        event_count:
+          type: integer
+          title: Event Count
+          default: 0
+        total_tokens:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Total Tokens
+        estimated_cost:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Estimated Cost
+        reconciled_cost:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Reconciled Cost
+        last_event_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Event At
+      type: object
+      required:
+      - conversation_id
+      title: ImportedUsageByConversation
+      description: 'Imported usage rolled up by source-side conversation.
+
+
+        ``estimated_cost`` (hook/transcript-derived) and ``reconciled_cost``
+
+        (billing export) are reported as SEPARATE fields and must never be
+
+        summed into one number by any consumer. ``None`` means the source
+
+        reported nothing for that quantity ("not reported") — it is not zero.
+
+        Entries whose ``parent_conversation_id`` matches another entry''s
+
+        ``conversation_id`` are subagent workers of that parent thread.'
     ImportedUsageByModel:
       properties:
         model_alias:
@@ -13682,6 +13740,11 @@ components:
             $ref: '#/components/schemas/ImportedUsageByModel'
           type: array
           title: Usage By Model
+        usage_by_conversation:
+          items:
+            $ref: '#/components/schemas/ImportedUsageByConversation'
+          type: array
+          title: Usage By Conversation
       type: object
       title: ImportedUsageSummary
       description: 'Spend ingested from outside the gateway (``usage_source=''imported''``).


### PR DESCRIPTION
## Summary

Adds per-conversation cost rollup for imported usage, a CLI command to ship Cursor hook events to the usage ingest API, and corresponding frontend and docs changes. 12 files changed, +1656/-3 across 4 commits.

### Per-conversation rollup (backend + frontend)

- New `get_imported_usage_by_conversation()` in `crud_api_usage.py`: groups imported rows by `(conversation_id, import_source)` within the queried time window. Extends the existing `/api/v1/cost/summary` imported-usage block with `usage_by_conversation` (no new endpoint, no migration; reuses `ix_api_usage_imported_conversation`).
- **Estimated vs. reconciled amounts stay separate fields and are never summed.** `estimated_cost` aggregates only `cost_basis='estimated'` rows; `reconciled_cost` only `cost_basis='reconciled'` rows. Quantities the source never reported stay `NULL` ("not reported" in the UI), never 0 or $0.00.
- Frontend "Conversations" table under Cost analytics > Imported usage. Child conversations (via `parent_conversation_id`) nest under their parent; thread totals preserve the estimated/reconciled separation. Deeper descendants are promoted to top level so no conversation can disappear.

### CLI: `preloop usage hook`

- Go subcommand (`cli/internal/cmd/usage_hook.go`) that reads one Cursor hook payload from stdin and POSTs a lifecycle record to `/api/v1/usage/ingest`. Reuses CLI auth/config (`api.NewClient`).
- Hook-event mapping (from Cursor's published hooks reference, https://cursor.com/docs/agent/hooks, fetched 2026-08-27): `sessionStart/sessionEnd` -> `session_start/session_end`, `subagentStart/subagentStop` -> `subagent_start/subagent_stop`, `stop` -> `response`, `preCompact` -> `compaction`. Other events are acknowledged without a POST.
- `subagentStart`'s documented `parent_conversation_id` passes through and powers rollup nesting. Precedence: payload field > `--parent-conversation-id` flag > `PRELOOP_PARENT_CONVERSATION_ID` env. Parent is never guessed.
- `message_count` and `tool_call_count` (from `subagentStop`) ship as growth-tripwire fields.
- Estimated basis only; no cost/token fields are ever fabricated.
- Privacy: prompt text, task descriptions, summaries, file paths are never decoded or sent.
- Fail-open: 3s HTTP timeout, warnings to stderr, always exits 0.

### Hook-payload assumptions documented

1. Cursor hook payloads carry no event timestamp; records use the shipper's receive time.
2. Cursor's reference does not state whether `conversation_id` on subagent events is the worker's own conversation or the parent's; we ship exactly what Cursor reports (frontend guards self-parent rows).
3. `subagentStop` and `preCompact` have no per-fire id; `external_id` gets a receive-time suffix (unique across parallel workers; no replay dedupe, but the command makes exactly one delivery attempt).
4. The reported `model` common field passes through on lifecycle records (real data, not "Unknown").

### Docs

- `docs/guide/cursor-usage-hooks.md`: setup, mapping table, dedupe semantics, failure behavior, verification, reconciliation path. No em dashes; no customer/partner names.

### Test evidence

- Backend: 41 passed (crud, ingest, cost endpoint tests).
- Frontend: 14 passed (8 pre-existing + 6 new rollup tests: nesting, thread totals with bases kept apart, "not reported" for nulls, separate columns, hidden when empty).
- CLI: `go test ./internal/cmd ./internal/api` green (11 new hook tests covering mapping, parent precedence, dedupe keys, privacy exclusions, fail-open paths).
- Ruff lint + format clean. `go vet` + `gofmt` clean. Prettier clean.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> No security issues; well-tested feature across backend, CLI, and frontend, with careful estimated-vs-reconciled cost separation and fail-open CLI behavior.
>
> **Overview**
> Adds per-conversation rollup for imported usage (backend + console), a `preloop usage hook` CLI subcommand that ships Cursor hook lifecycle events to the usage ingest API, and docs. 12 files, +1656/-3, with thorough tests across all three layers.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit b07e952c. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->