### PR TITLE
Make Vite HMR overridable and log approval context lookup failures

### DIFF
--- a/backend/preloop/services/approval_helper.py
+++ b/backend/preloop/services/approval_helper.py
@@ -80,7 +80,8 @@ def _session_context_for_in_band() -> _InBandSessionContext:
         from preloop.services.dynamic_fastmcp_http import get_current_user_context
 
         user_context = get_current_user_context()
-    except Exception:  # pragma: no cover - context lookup is optional
+    except Exception as e:  # pragma: no cover - context lookup is optional
+        logger.warning(f"Error getting current user context: {e}")
         return empty
     if not user_context:
         return empty

--- a/backend/preloop/services/approval_helper.py
+++ b/backend/preloop/services/approval_helper.py
@@ -80,8 +80,8 @@ def _session_context_for_in_band() -> _InBandSessionContext:
         from preloop.services.dynamic_fastmcp_http import get_current_user_context
 
         user_context = get_current_user_context()
-    except Exception as e:  # pragma: no cover - context lookup is optional
-        logger.warning(f"Error getting current user context: {e}")
+    except Exception as e:
+        logger.warning("Error getting current user context: %s", e, exc_info=True)
         return empty
     if not user_context:
         return empty

--- a/backend/tests/services/test_approval_helper.py
+++ b/backend/tests/services/test_approval_helper.py
@@ -1168,3 +1168,19 @@ class TestRequireApprovalProgressReporting:
         # Approval should still succeed
         assert approved is True
         assert error == ""
+
+
+async def test_in_band_context_lookup_failure_logs_traceback(caplog):
+    """Context lookup is best-effort; keep the exception traceback."""
+    from preloop.services.approval_helper import _session_context_for_in_band
+
+    with patch(
+        "preloop.services.dynamic_fastmcp_http.get_current_user_context",
+        side_effect=RuntimeError("no request context"),
+    ):
+        ctx = _session_context_for_in_band()
+    assert ctx.runtime_session_id is None
+    assert ctx.managed_agent_id is None
+    assert ctx.user_id is None
+    assert "Error getting current user context" in caplog.text
+    assert "no request context" in caplog.text

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,9 @@ const brand = process.env.VITE_BRAND || 'preloop';
 const apiProxyTarget = process.env.VITE_API_PROXY_TARGET || 'http://127.0.0.1:8000';
 const adminProxyTarget = process.env.VITE_ADMIN_PROXY_TARGET || 'http://127.0.0.1:5175';
 const gatewayProxyTarget = process.env.VITE_GATEWAY_PROXY_TARGET || apiProxyTarget;
+const hmrClientPort = Number(process.env.VITE_HMR_CLIENT_PORT || 5173);
+const hmrHost = process.env.VITE_HMR_HOST;
+const hmrProtocol = process.env.VITE_HMR_PROTOCOL;
 
 /**
  * Default Vite configuration for Preloop Open Source / Self-Hosted edition
@@ -63,7 +66,12 @@ export default defineConfig({
   },
   server: {
     hmr: {
-      clientPort: 5173,
+      clientPort:
+        Number.isFinite(hmrClientPort) && hmrClientPort > 0 ? hmrClientPort : 5173,
+      ...(hmrHost ? { host: hmrHost } : {}),
+      ...(hmrProtocol === 'ws' || hmrProtocol === 'wss'
+        ? { protocol: hmrProtocol }
+        : {}),
     },
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary
- Vite HMR client port, host, and protocol can be set with `VITE_HMR_CLIENT_PORT`, `VITE_HMR_HOST`, and `VITE_HMR_PROTOCOL` so proxied local frontend setups work.
- In-band approval user-context lookup failures are logged at warning instead of swallowed.

## Test plan
- [ ] Frontend `npm run dev` with default env still uses HMR on 5173
- [ ] With `VITE_HMR_CLIENT_PORT` / `VITE_HMR_HOST` / `VITE_HMR_PROTOCOL=wss` set, the client connects through the proxy
- [ ] Approval helper still returns empty session context when lookup fails; a warning appears in logs

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, well-guarded config change and a logging-only observability improvement; no security or functional risk.
>
> **Overview**
> Makes Vite HMR client port/host/protocol overridable via `VITE_HMR_CLIENT_PORT`, `VITE_HMR_HOST`, and `VITE_HMR_PROTOCOL`, and logs in-band approval context-lookup failures at warning level instead of swallowing them.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit ffe2f96. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->