### PR TITLE
Escape $ in OSS installer Compose .env so SMTP passwords are not interpolated

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -612,6 +612,7 @@ The system is designed to be containerized using Docker, enabling easy deploymen
 *   **Migrations:** `docker-compose.release.yaml` runs schema initialization in a dedicated one-shot `migrate` service that app services wait on (`service_completed_successfully`); Helm deployments run Alembic via their own lifecycle.
 *   **Health monitoring:** The Helm chart ships an optional in-cluster health-monitor deployment (`healthMonitor.*`, enabled by default) that polls `/api/v1/health` and logs alert lines after consecutive failures.
 *   **Release verification:** `scripts/release_smoke_test.sh` boots the release compose file with tagged images and verifies HTTP health, first-user sign-up/login, and restart-loop-free stability; the release workflow runs it as the `verify-oss-install` gate before publishing a GitHub release.
+*   **OSS installer `.env`:** `scripts/install-oss.sh` writes Compose `.env` values with `$` escaped as `$$` so secrets are not interpolated (and partial secrets are not leaked via compose WARNs). Hand-edits of `~/.preloop-oss/.env` need the same escaping.
 
 ## Security Considerations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **OSS installer Compose `.env` `$` escaping**: passwords and other
+  secrets that start with (or contain) `$` are written as `$$` so Docker
+  Compose does not interpolate them or leak the rest of the value via
+  `variable is not set` warnings. Re-runs unescape on read so values
+  round-trip.
+
 - **Private-cluster Helm tests after OTLP merge**: default `values.yaml`
   now includes the `otlp` block from main. The private-cluster suite no
   longer asserts that block is absent, and the README no longer claims

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ python3 scripts/measure_gateway_overhead.py --n 30 --json /tmp/gateway-overhead.
 
 The script is stdlib only. It prints p50/p95 time-to-first-SSE-byte and time-to-stream-close for the gateway path, and the delta when `DIRECT_*` is set.
 
-**Email is not optional in practice**: approval requests, invitations and password resets are delivered by email, so an instance without SMTP cannot notify approvers. Everything the installer writes lives in `~/.preloop-oss/.env` — edit it and run `docker compose up -d` to change any setting later.
+**Email is not optional in practice**: approval requests, invitations and password resets are delivered by email, so an instance without SMTP cannot notify approvers. Everything the installer writes lives in `~/.preloop-oss/.env` — edit it and run `docker compose up -d` to change any setting later. Compose interpolates `$` in that file, so a literal dollar (for example in `SMTP_PASSWORD`) must be written as `$$`; the installer escapes values this way automatically.
 
 **Passkeys (WebAuthn)**: passkey sign-in is enabled by default; set `PASSKEYS_ENABLED=false` to turn it off. Behind a proxy or on a non-standard domain setup, pin the relying party and origin explicitly with `WEBAUTHN_RP_ID` (the registrable domain, e.g. `preloop.example.com`) and `WEBAUTHN_ORIGIN` (e.g. `https://preloop.example.com`); by default both are derived from the request. `WEBAUTHN_CHALLENGE_RATE_LIMIT` (default `30`) caps challenge requests per IP per minute.
 

--- a/backend/tests/scripts/test_oss_install_env_escape.py
+++ b/backend/tests/scripts/test_oss_install_env_escape.py
@@ -155,7 +155,8 @@ def test_compose_env_assign_first_install_write_path(tmp_path: Path) -> None:
 
 def test_release_compose_interpolates_smtp_password_from_env() -> None:
     text = RELEASE_COMPOSE.read_text(encoding="utf-8")
-    assert text.count("SMTP_PASSWORD: ${SMTP_PASSWORD:-}") == 2
+    # Pin presence, not how many services interpolate the same env var.
+    assert text.count("SMTP_PASSWORD: ${SMTP_PASSWORD:-}") >= 1
 
 
 @pytest.mark.skipif(

--- a/backend/tests/scripts/test_oss_install_env_escape.py
+++ b/backend/tests/scripts/test_oss_install_env_escape.py
@@ -1,0 +1,214 @@
+"""Compose ``.env`` escaping for OSS installer secrets that contain ``$``.
+
+Docker Compose interpolates ``$VAR`` in ``.env`` files. The installer must
+write a literal dollar as ``$$`` and unescape on read so re-runs round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+INSTALL_OSS = REPO_ROOT / "scripts" / "install-oss.sh"
+RELEASE_COMPOSE = REPO_ROOT / "docker-compose.release.yaml"
+
+LEADING_DOLLAR_PASSWORD = "$UsErPassWoRd"
+COMPOSE_WARN_LEAK = 'The "UsErPassWoRd" variable is not set'
+
+
+def _installer_prelude() -> str:
+    """Return install-oss.sh without the trailing ``main`` invocation."""
+    text = INSTALL_OSS.read_text(encoding="utf-8")
+    marker = 'main "$@"'
+    if not text.rstrip().endswith(marker):
+        raise AssertionError('scripts/install-oss.sh must end with main "$@"')
+    return text.rsplit(marker, 1)[0]
+
+
+def _run_installer_sh(
+    snippet: str,
+    *args: str,
+    install_dir: Path | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a POSIX ``sh`` snippet after defining installer helpers (not main)."""
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    if install_dir is not None:
+        env["INSTALL_DIR"] = str(install_dir)
+    return subprocess.run(
+        ["sh", "-c", _installer_prelude() + snippet, "install-oss-test", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def compose_env_escape(value: str) -> str:
+    """Escape ``$`` the way ``scripts/install-oss.sh`` writes ``.env`` values."""
+    proc = _run_installer_sh('compose_env_escape "$1"', value)
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.rstrip("\n")
+
+
+def compose_env_unescape(value: str) -> str:
+    """Unescape ``$$`` the way ``env_value`` reads secrets back."""
+    proc = _run_installer_sh('compose_env_unescape "$1"', value)
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.rstrip("\n")
+
+
+def _docker_compose_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        subprocess.run(
+            ["docker", "compose", "version"],
+            check=True,
+            capture_output=True,
+            timeout=15,
+        )
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ):
+        return False
+    return True
+
+
+def test_escape_leading_dollar_password() -> None:
+    assert compose_env_escape(LEADING_DOLLAR_PASSWORD) == "$$UsErPassWoRd"
+
+
+def test_unescape_round_trip_leading_dollar() -> None:
+    escaped = compose_env_escape(LEADING_DOLLAR_PASSWORD)
+    assert compose_env_unescape(escaped) == LEADING_DOLLAR_PASSWORD
+
+
+@pytest.mark.parametrize(
+    ("secret", "escaped"),
+    [
+        ("a$b$c", "a$$b$$c"),
+        ("pw$$word", "pw$$$$word"),
+        ("$a$$b$", "$$a$$$$b$$"),
+        ("no-dollar", "no-dollar"),
+        ("", ""),
+    ],
+)
+def test_escape_unescape_round_trip_multiple_dollars(secret: str, escaped: str) -> None:
+    assert compose_env_escape(secret) == escaped
+    assert compose_env_unescape(escaped) == secret
+
+
+def test_set_env_value_writes_escaped_and_env_value_unescapes(
+    tmp_path: Path,
+) -> None:
+    proc = _run_installer_sh(
+        'set_env_value SMTP_PASSWORD "$1"\n'
+        'env_value SMTP_PASSWORD "${INSTALL_DIR}/.env"\n',
+        LEADING_DOLLAR_PASSWORD,
+        install_dir=tmp_path,
+    )
+    assert proc.returncode == 0, proc.stderr
+    on_disk = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert on_disk.split("=", 1)[1].strip() == "$$UsErPassWoRd"
+    assert proc.stdout.rstrip("\n") == LEADING_DOLLAR_PASSWORD
+
+
+def test_set_env_value_re_run_does_not_double_escape(tmp_path: Path) -> None:
+    first = _run_installer_sh(
+        'set_env_value SMTP_PASSWORD "$1"',
+        LEADING_DOLLAR_PASSWORD,
+        install_dir=tmp_path,
+    )
+    assert first.returncode == 0, first.stderr
+    second = _run_installer_sh(
+        'SMTP_PASSWORD="$(env_value SMTP_PASSWORD "${INSTALL_DIR}/.env")"\n'
+        'set_env_value SMTP_PASSWORD "$SMTP_PASSWORD"\n',
+        install_dir=tmp_path,
+    )
+    assert second.returncode == 0, second.stderr
+    on_disk = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "SMTP_PASSWORD=$$UsErPassWoRd\n" == on_disk
+
+
+def test_compose_env_assign_first_install_write_path(tmp_path: Path) -> None:
+    proc = _run_installer_sh(
+        'compose_env_assign SMTP_PASSWORD "$1" > "${INSTALL_DIR}/.env"\n',
+        LEADING_DOLLAR_PASSWORD,
+        install_dir=tmp_path,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert (tmp_path / ".env").read_text(encoding="utf-8") == (
+        "SMTP_PASSWORD=$$UsErPassWoRd\n"
+    )
+
+
+def test_release_compose_interpolates_smtp_password_from_env() -> None:
+    text = RELEASE_COMPOSE.read_text(encoding="utf-8")
+    assert text.count("SMTP_PASSWORD: ${SMTP_PASSWORD:-}") == 2
+
+
+@pytest.mark.skipif(
+    not _docker_compose_available(),
+    reason="docker compose is not available",
+)
+def test_compose_config_keeps_literal_leading_dollar_password(tmp_path: Path) -> None:
+    """Installer-escaped ``.env`` must not interpolate or leak via compose WARN."""
+    env_file = tmp_path / ".env"
+    write = _run_installer_sh(
+        'compose_env_assign SMTP_PASSWORD "$1" > "${INSTALL_DIR}/.env"\n',
+        LEADING_DOLLAR_PASSWORD,
+        install_dir=tmp_path,
+    )
+    assert write.returncode == 0, write.stderr
+    assert env_file.read_text(encoding="utf-8") == "SMTP_PASSWORD=$$UsErPassWoRd\n"
+
+    compose_file = tmp_path / "docker-compose.yaml"
+    compose_file.write_text(
+        "services:\n"
+        "  probe:\n"
+        "    image: alpine\n"
+        "    environment:\n"
+        "      SMTP_PASSWORD: ${SMTP_PASSWORD:-}\n",
+        encoding="utf-8",
+    )
+
+    env = {k: v for k, v in os.environ.items() if k != "SMTP_PASSWORD"}
+    env["COMPOSE_PROJECT_NAME"] = "preloop-oss-smtp-dollar-test"
+    proc = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            str(compose_file),
+            "--env-file",
+            str(env_file),
+            "config",
+            "--format",
+            "json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+        timeout=30,
+    )
+    combined = f"{proc.stdout}\n{proc.stderr}"
+    assert COMPOSE_WARN_LEAK not in combined
+    assert proc.returncode == 0, proc.stderr
+
+    data = json.loads(proc.stdout)
+    raw = data["services"]["probe"]["environment"]["SMTP_PASSWORD"]
+    assert raw, "SMTP_PASSWORD was interpolated to empty"
+    assert compose_env_unescape(raw) == LEADING_DOLLAR_PASSWORD

--- a/scripts/install-oss.sh
+++ b/scripts/install-oss.sh
@@ -71,6 +71,23 @@ PRELOOP_BOOTSTRAP_TOKEN="${PRELOOP_BOOTSTRAP_TOKEN:-}"
 
 DEFAULT_URL="http://localhost:3000"
 
+# Compose interpolates `$VAR` in `.env` files. A literal dollar must be written
+# as `$$` so a password like `$UsErPassWoRd` is not treated as a variable (and
+# the rest of the secret leaked in a WARN). Hand-edits of `.env` need the same
+# escaping. https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/
+compose_env_escape() {
+  printf '%s' "$1" | sed 's/[$]/$$/g'
+}
+
+compose_env_unescape() {
+  printf '%s' "$1" | sed 's/[$][$]/$/g'
+}
+
+# Print a KEY=value line with `$` escaped for Compose.
+compose_env_assign() {
+  printf '%s=%s\n' "$1" "$(compose_env_escape "$2")"
+}
+
 # Replace (or append) a single KEY=value line in the install's .env.
 set_env_value() {
   key="$1"
@@ -82,7 +99,7 @@ set_env_value() {
   else
     : > "$tmp_file"
   fi
-  echo "${key}=${value}" >> "$tmp_file"
+  compose_env_assign "$key" "$value" >> "$tmp_file"
   mv "$tmp_file" "$env_file"
 }
 
@@ -206,8 +223,9 @@ load_existing_env() {
 }
 
 env_value() {
-  # last assignment wins, value may contain '='
-  sed -n "s/^$1=//p" "$2" 2>/dev/null | tail -n 1
+  # last assignment wins, value may contain '='. Unescape `$$` so a re-run
+  # that reads secrets and writes them back does not double-escape.
+  compose_env_unescape "$(sed -n "s/^$1=//p" "$2" 2>/dev/null | tail -n 1)"
 }
 
 # True only when a real terminal is attached. `curl ... | sh` leaves stdin as
@@ -922,27 +940,28 @@ main() {
 
   if [ ! -f "${INSTALL_DIR}/.env" ]; then
     cat > "${INSTALL_DIR}/.env" <<EOF
-PRELOOP_VERSION=${VERSION}
-SECRET_KEY=$(generate_secret)
-POSTGRES_PASSWORD=$(generate_secret)
-PRELOOP_URL=${PRELOOP_URL}
-ALLOWED_ORIGINS=${PRELOOP_URL}
+$(compose_env_assign PRELOOP_VERSION "$VERSION")
+$(compose_env_assign SECRET_KEY "$(generate_secret)")
+$(compose_env_assign POSTGRES_PASSWORD "$(generate_secret)")
+$(compose_env_assign PRELOOP_URL "$PRELOOP_URL")
+$(compose_env_assign ALLOWED_ORIGINS "$PRELOOP_URL")
 # Public signup. Turned off after the first user is created; set to true to
 # reopen registration, then run 'docker compose up -d api'.
 REGISTRATION_ENABLED=true
 # First-user setup token: while the instance has zero users, signing up
 # requires the setup link printed at the end of the install (which carries
 # this token). Ignored once any user exists.
-PRELOOP_BOOTSTRAP_TOKEN=${PRELOOP_BOOTSTRAP_TOKEN}
+$(compose_env_assign PRELOOP_BOOTSTRAP_TOKEN "$PRELOOP_BOOTSTRAP_TOKEN")
 # Email (approval requests, invitations, password resets). Leave SMTP_HOST
 # empty to run without email; re-run the installer or edit these values, then
-# run 'docker compose up -d' to apply.
-SMTP_HOST=${SMTP_HOST}
-SMTP_PORT=${SMTP_PORT}
-SMTP_USERNAME=${SMTP_USERNAME}
-SMTP_PASSWORD=${SMTP_PASSWORD}
-SMTP_FROM=${SMTP_FROM}
-SMTP_FROM_NAME=${SMTP_FROM_NAME}
+# run 'docker compose up -d' to apply. Compose interpolates \$ in .env: a
+# literal \$ must be written as \$\$ (the installer does this automatically).
+$(compose_env_assign SMTP_HOST "$SMTP_HOST")
+$(compose_env_assign SMTP_PORT "$SMTP_PORT")
+$(compose_env_assign SMTP_USERNAME "$SMTP_USERNAME")
+$(compose_env_assign SMTP_PASSWORD "$SMTP_PASSWORD")
+$(compose_env_assign SMTP_FROM "$SMTP_FROM")
+$(compose_env_assign SMTP_FROM_NAME "$SMTP_FROM_NAME")
 EOF
   else
     # Keep an existing install's secrets, but refresh the public URL.
@@ -950,9 +969,9 @@ EOF
     grep -v -e '^PRELOOP_VERSION=' -e '^PRELOOP_URL=' -e '^ALLOWED_ORIGINS=' \
       "${INSTALL_DIR}/.env" > "$tmp_env" || true
     {
-      echo "PRELOOP_VERSION=${VERSION}"
-      echo "PRELOOP_URL=${PRELOOP_URL}"
-      echo "ALLOWED_ORIGINS=${PRELOOP_URL}"
+      compose_env_assign PRELOOP_VERSION "$VERSION"
+      compose_env_assign PRELOOP_URL "$PRELOOP_URL"
+      compose_env_assign ALLOWED_ORIGINS "$PRELOOP_URL"
     } >> "$tmp_env"
     # Only rewrite SMTP when this run supplied it, so an existing configuration
     # is never silently wiped.
@@ -960,12 +979,12 @@ EOF
       grep -v -e '^SMTP_' "$tmp_env" > "${tmp_env}.2" || true
       mv "${tmp_env}.2" "$tmp_env"
       {
-        echo "SMTP_HOST=${SMTP_HOST}"
-        echo "SMTP_PORT=${SMTP_PORT}"
-        echo "SMTP_USERNAME=${SMTP_USERNAME}"
-        echo "SMTP_PASSWORD=${SMTP_PASSWORD}"
-        echo "SMTP_FROM=${SMTP_FROM}"
-        echo "SMTP_FROM_NAME=${SMTP_FROM_NAME}"
+        compose_env_assign SMTP_HOST "$SMTP_HOST"
+        compose_env_assign SMTP_PORT "$SMTP_PORT"
+        compose_env_assign SMTP_USERNAME "$SMTP_USERNAME"
+        compose_env_assign SMTP_PASSWORD "$SMTP_PASSWORD"
+        compose_env_assign SMTP_FROM "$SMTP_FROM"
+        compose_env_assign SMTP_FROM_NAME "$SMTP_FROM_NAME"
       } >> "$tmp_env"
     fi
     mv "$tmp_env" "${INSTALL_DIR}/.env"
@@ -995,7 +1014,7 @@ EOF
   # Record what this install is, so the next run reproduces the same topology.
   if [ "$WANT_TLS" -eq 1 ] || [ "$HTTP_PROXY_ONLY" -eq 1 ] || [ -n "$PRELOOP_TLS_ENABLED" ]; then
     grep -v '^PRELOOP_TLS_ENABLED=' "${INSTALL_DIR}/.env" > "${INSTALL_DIR}/.env.tls" || true
-    echo "PRELOOP_TLS_ENABLED=1" >> "${INSTALL_DIR}/.env.tls"
+    compose_env_assign PRELOOP_TLS_ENABLED 1 >> "${INSTALL_DIR}/.env.tls"
     mv "${INSTALL_DIR}/.env.tls" "${INSTALL_DIR}/.env"
   fi
 


### PR DESCRIPTION
## Summary
- Docker Compose interpolates `$VAR` in `~/.preloop-oss/.env`. An SMTP password like `$UsErPassWoRd` was treated as a variable: compose printed `The \"UsErPassWoRd\" variable is not set` (leaking the rest of the secret) and blanked the password.
- The OSS installer now writes every `.env` value with `$` escaped as `$$` (first-install heredoc, SMTP rewrite, `set_env_value`, TLS flag) and unescapes on read (`env_value`) so re-runs round-trip instead of double-escaping.
- **Fixes #318**

## Test plan
- [x] `pytest backend/tests/scripts/test_oss_install_env_escape.py` (12 passed, including `docker compose config` with installer-written `.env`)
- [ ] Re-run `curl …/install/oss | sh` (or a local `INSTALL_DIR=…` first install) with `SMTP_PASSWORD='$UsErPassWoRd'` and confirm compose starts with no `variable is not set` WARN and the API sees the literal password
- [ ] Existing installs whose SMTP password starts with `$` should re-run the installer (or hand-edit `.env` to use `$$`) so the stored value is Compose-safe

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Security fix for Compose `.env` `$` interpolation; escape/unescape pair verified correct with no security or correctness issues.
>
> **Overview**
> Escapes `$` as `$$` when the OSS installer writes `.env` values (and unescapes on read) so SMTP passwords and other secrets containing `$` are not interpolated or partially leaked by Docker Compose. Includes comprehensive tests and doc updates.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 0a27a8a. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->