### PR TITLE
Fix model-io-rules RBAC 500 and keep Top Models nested usage on refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Model I/O policy API 500 under RBAC**: `/api/v1/policies/model-io-rules`
+  list/create/update/patch/delete used `@require_permission` without a
+  `current_user` FastAPI dependency. Nested `get_account_for_user` does
+  not put `current_user` in the handler kwargs, so the fail-closed
+  permission check returned 500
+  `Permission check requires current_user and db dependencies`.
 - **Dev compose no longer races postgres/NATS or schema init**:
   `docker-compose.yml` healthchecks postgres (`pg_isready`) and NATS
   (`/healthz`, with `-m 8222`) and runs `init_db.py --force` in a
@@ -33,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Compose does not interpolate them or leak the rest of the value via
   `variable is not set` warnings. Re-runs unescape on read so values
   round-trip.
+- **Overview Top Models card no longer flashes on live refresh**: websocket
+  reloads fetched a lightweight gateway summary that cleared
+  `usage_by_session`, then a second request filled the nested list back in.
+  The card now keeps the breakdown until the detailed summary arrives and
+  does not flip loading flags on background refresh.
 
 - **Private-cluster Helm tests after OTLP merge**: default `values.yaml`
   now includes the `otlp` block from main. The private-cluster suite no
@@ -99,6 +110,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   GitLab.
 
 ### Changed
+
+- **Overview Top Models shows a preview per model**: each model lists its
+  top four agents/flows/sessions by spend or usage, with a See N more
+  control when there are more. Expanded groups cap nested sessions the
+  same way so a busy model cannot dominate the card.
 
 - **GitHub CI backend tests run in parallel**: the backend unit suite is
   sharded across four GitHub Actions jobs with pytest-split, each with

--- a/backend/preloop/api/endpoints/policies.py
+++ b/backend/preloop/api/endpoints/policies.py
@@ -435,6 +435,7 @@ async def upload_policy(
 @require_permission("view_policies")
 def list_model_io_rules(
     account: Account = Depends(get_account_for_user),
+    current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db_session),
 ) -> ModelIORuleListResponse:
     """Return model.request and model.response rules for the console."""
@@ -450,6 +451,7 @@ def list_model_io_rules(
 def create_model_io_rule(
     rule: ModelIORule,
     account: Account = Depends(get_account_for_user),
+    current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db_session),
 ) -> Dict[str, Any]:
     """Save one model I/O rule from the Policies console form."""
@@ -467,6 +469,7 @@ def update_model_io_rule(
     rule_id: str,
     rule: ModelIORule,
     account: Account = Depends(get_account_for_user),
+    current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db_session),
 ) -> Dict[str, Any]:
     """Replace an existing model I/O rule. The path id wins."""
@@ -492,6 +495,7 @@ def patch_model_io_rule(
     rule_id: str,
     patch: ModelIORulePatchRequest,
     account: Account = Depends(get_account_for_user),
+    current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db_session),
 ) -> Dict[str, Any]:
     """Toggle enabled without rewriting the rest of the rule."""
@@ -526,6 +530,7 @@ def patch_model_io_rule(
 def remove_model_io_rule(
     rule_id: str,
     account: Account = Depends(get_account_for_user),
+    current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db_session),
 ) -> Response:
     """Delete one model I/O rule."""

--- a/backend/tests/endpoints/test_policies.py
+++ b/backend/tests/endpoints/test_policies.py
@@ -1,5 +1,6 @@
 """Tests for policies API endpoints."""
 
+import inspect
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
@@ -1219,3 +1220,48 @@ class TestPrunePolicyVersions:
             keep_tagged=True,  # default
             keep_count=10,  # default
         )
+
+
+_MODEL_IO_RULE_HANDLERS = (
+    policies.list_model_io_rules,
+    policies.create_model_io_rule,
+    policies.update_model_io_rule,
+    policies.patch_model_io_rule,
+    policies.remove_model_io_rule,
+)
+
+
+class TestModelIORulesPermissionDeps:
+    """RBAC fail-closed requires current_user and db on these handlers."""
+
+    def test_handlers_declare_current_user_and_db(self):
+        for handler in _MODEL_IO_RULE_HANDLERS:
+            params = inspect.signature(handler).parameters
+            assert "current_user" in params, handler.__name__
+            assert "db" in params, handler.__name__
+
+    async def test_list_without_current_user_fails_closed_when_rbac_on(
+        self, mock_db, mock_account, mocker
+    ):
+        mocker.patch(
+            "preloop.utils.permissions._rbac_checks_enabled",
+            return_value=True,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            policies.list_model_io_rules(account=mock_account, db=mock_db)
+        assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert "current_user and db" in exc_info.value.detail
+
+    async def test_list_returns_rules_when_current_user_present(
+        self, mock_db, mock_account, mock_user, mocker
+    ):
+        mocker.patch(
+            "preloop.api.endpoints.policies.load_model_io_rules",
+            return_value=[],
+        )
+        result = policies.list_model_io_rules(
+            account=mock_account,
+            current_user=mock_user,
+            db=mock_db,
+        )
+        assert result.rules == []

--- a/backend/tests/endpoints/test_policies.py
+++ b/backend/tests/endpoints/test_policies.py
@@ -1243,12 +1243,30 @@ class TestModelIORulesPermissionDeps:
     async def test_list_without_current_user_fails_closed_when_rbac_on(
         self, mock_db, mock_account, mocker
     ):
+        import preloop.utils.permissions as perms
+
+        def fake_plugin_require(permission_name: str):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        mocker.patch(
+            "preloop.utils.permissions._plugin_require_permission",
+            fake_plugin_require,
+        )
         mocker.patch(
             "preloop.utils.permissions._rbac_checks_enabled",
             return_value=True,
         )
+        # OSS has no RBAC plugin, so import-time require_permission is a
+        # no-op. Re-wrap after installing a fake plugin so the fail-closed
+        # kwargs gate actually runs (same pattern as test_permissions_fallback).
+        wrapped = perms.require_permission("view_policies")(
+            inspect.unwrap(policies.list_model_io_rules)
+        )
         with pytest.raises(HTTPException) as exc_info:
-            policies.list_model_io_rules(account=mock_account, db=mock_db)
+            wrapped(account=mock_account, db=mock_db)
         assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert "current_user and db" in exc_info.value.detail
 

--- a/frontend/src/utils/top-models-overview.test.ts
+++ b/frontend/src/utils/top-models-overview.test.ts
@@ -1,0 +1,164 @@
+import { expect } from '@open-wc/testing';
+
+import type { AccountGatewayUsageSummaryResponse } from '../types';
+import {
+  compareByUsageMetric,
+  mergeGatewaySummaryPreservingBreakdown,
+  previewWindow,
+  usageSortValue,
+} from './top-models-overview';
+
+function summary(
+  overrides: Partial<AccountGatewayUsageSummaryResponse> = {}
+): AccountGatewayUsageSummaryResponse {
+  return {
+    period_start: '2026-08-01T00:00:00Z',
+    period_end: '2026-08-31T00:00:00Z',
+    total_requests: 10,
+    successful_requests: 9,
+    failed_requests: 1,
+    token_usage: {
+      prompt_tokens: 1,
+      completion_tokens: 1,
+      total_tokens: 2,
+    },
+    estimated_cost: 1.25,
+    budget: {
+      monthly_limit_usd: null,
+      soft_limit_usd: null,
+      current_spend_usd: 1.25,
+      soft_limit_exceeded: false,
+      hard_limit_exceeded: false,
+    },
+    requests_by_day: [],
+    usage_by_model: [],
+    usage_by_flow: [],
+    usage_by_session: [],
+    ...overrides,
+  };
+}
+
+describe('mergeGatewaySummaryPreservingBreakdown', () => {
+  it('keeps previous session rows when the refresh has no breakdown', () => {
+    const previous = summary({
+      total_requests: 10,
+      usage_by_model: [
+        {
+          ai_model_id: 'm1',
+          model_alias: 'deepseek-v4-pro',
+          provider_name: 'deepseek',
+          request_count: 8,
+          token_usage: {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2,
+          },
+          estimated_cost: 4,
+        },
+      ],
+      usage_by_session: [
+        {
+          flow_execution_id: null,
+          flow_id: null,
+          flow_name: null,
+          session_reference: 's1',
+          runtime_session_id: 's1',
+          model_alias: 'deepseek-v4-pro',
+          provider_name: 'deepseek',
+          request_count: 8,
+          token_usage: {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2,
+          },
+          estimated_cost: 4,
+          last_request_at: '2026-08-29T17:00:00Z',
+        },
+      ],
+    });
+    const incoming = summary({
+      total_requests: 12,
+      estimated_cost: 1.5,
+    });
+
+    const merged = mergeGatewaySummaryPreservingBreakdown(previous, incoming);
+    expect(merged?.total_requests).to.equal(12);
+    expect(merged?.estimated_cost).to.equal(1.5);
+    expect(merged?.usage_by_session).to.equal(previous.usage_by_session);
+    expect(merged?.usage_by_model).to.equal(previous.usage_by_model);
+  });
+
+  it('replaces the previous summary when the incoming payload has a breakdown', () => {
+    const previous = summary({
+      usage_by_session: [
+        {
+          flow_execution_id: null,
+          flow_id: null,
+          flow_name: null,
+          session_reference: 'old',
+          runtime_session_id: 'old',
+          model_alias: 'm',
+          provider_name: 'p',
+          request_count: 1,
+          token_usage: {
+            prompt_tokens: 1,
+            completion_tokens: 0,
+            total_tokens: 1,
+          },
+          estimated_cost: 1,
+          last_request_at: null,
+        },
+      ],
+    });
+    const incoming = summary({
+      usage_by_model: [
+        {
+          ai_model_id: null,
+          model_alias: 'm',
+          provider_name: 'p',
+          request_count: 2,
+          token_usage: {
+            prompt_tokens: 2,
+            completion_tokens: 0,
+            total_tokens: 2,
+          },
+          estimated_cost: 2,
+        },
+      ],
+    });
+
+    const merged = mergeGatewaySummaryPreservingBreakdown(previous, incoming);
+    expect(merged).to.equal(incoming);
+  });
+});
+
+describe('previewWindow', () => {
+  it('returns the first N items and the overflow count when collapsed', () => {
+    const { visible, overflow } = previewWindow([1, 2, 3, 4, 5], 4, false);
+    expect(visible).to.deep.equal([1, 2, 3, 4]);
+    expect(overflow).to.equal(1);
+  });
+
+  it('returns every item when expanded', () => {
+    const { visible, overflow } = previewWindow([1, 2, 3, 4, 5], 4, true);
+    expect(visible).to.deep.equal([1, 2, 3, 4, 5]);
+    expect(overflow).to.equal(1);
+  });
+
+  it('has no overflow when the list fits the limit', () => {
+    const { visible, overflow } = previewWindow(['a', 'b'], 4, false);
+    expect(visible).to.deep.equal(['a', 'b']);
+    expect(overflow).to.equal(0);
+  });
+});
+
+describe('usageSortValue / compareByUsageMetric', () => {
+  it('sorts spend by estimated_cost and usage by request count', () => {
+    const cheap = { estimated_cost: 1, request_count: 50 };
+    const pricey = { estimated_cost: 9, request_count: 2 };
+    expect(usageSortValue(cheap, 'spend')).to.equal(1);
+    expect(usageSortValue(pricey, 'usage')).to.equal(2);
+    expect(compareByUsageMetric(cheap, pricey, 'spend')).to.be.greaterThan(0);
+    expect(compareByUsageMetric(cheap, pricey, 'usage')).to.be.lessThan(0);
+  });
+});

--- a/frontend/src/utils/top-models-overview.ts
+++ b/frontend/src/utils/top-models-overview.ts
@@ -1,0 +1,87 @@
+import type { AccountGatewayUsageSummaryResponse } from '../types';
+
+/** Collapsed rows shown per model (agents, flows, ungrouped sessions). */
+export const TOP_MODEL_GROUP_PREVIEW_LIMIT = 4;
+
+/** Nested sessions shown inside one expanded agent/flow group. */
+export const TOP_MODEL_SESSION_PREVIEW_LIMIT = 4;
+
+export type TopModelsSortMetric = 'spend' | 'usage';
+
+export type UsageSortable = {
+  estimated_cost?: number;
+  request_count?: number;
+  total_requests?: number;
+};
+
+/**
+ * Keep per-model/session breakdowns when a lightweight summary refresh
+ * would otherwise replace them with empty arrays (include_breakdown=false).
+ */
+export function mergeGatewaySummaryPreservingBreakdown(
+  previous: AccountGatewayUsageSummaryResponse | null,
+  incoming: AccountGatewayUsageSummaryResponse | null
+): AccountGatewayUsageSummaryResponse | null {
+  if (!incoming) {
+    return previous;
+  }
+  if (!previous) {
+    return incoming;
+  }
+  if (hasUsageBreakdown(incoming)) {
+    return incoming;
+  }
+  if (!hasUsageBreakdown(previous)) {
+    return incoming;
+  }
+  return {
+    ...incoming,
+    usage_by_model: previous.usage_by_model,
+    usage_by_flow: previous.usage_by_flow,
+    usage_by_session: previous.usage_by_session,
+    usage_by_tool: previous.usage_by_tool,
+    requests_by_day: previous.requests_by_day,
+  };
+}
+
+export function hasUsageBreakdown(
+  summary: AccountGatewayUsageSummaryResponse | null | undefined
+): boolean {
+  if (!summary) {
+    return false;
+  }
+  return (
+    (summary.usage_by_session?.length || 0) > 0 ||
+    (summary.usage_by_model?.length || 0) > 0
+  );
+}
+
+export function usageSortValue(
+  item: UsageSortable,
+  metric: TopModelsSortMetric
+): number {
+  if (metric === 'usage') {
+    return item.total_requests ?? item.request_count ?? 0;
+  }
+  return item.estimated_cost ?? 0;
+}
+
+export function compareByUsageMetric(
+  a: UsageSortable,
+  b: UsageSortable,
+  metric: TopModelsSortMetric
+): number {
+  return usageSortValue(b, metric) - usageSortValue(a, metric);
+}
+
+export function previewWindow<T>(
+  items: T[],
+  limit: number,
+  expanded: boolean
+): { visible: T[]; overflow: number } {
+  const overflow = Math.max(0, items.length - limit);
+  if (expanded || overflow === 0) {
+    return { visible: items, overflow };
+  }
+  return { visible: items.slice(0, limit), overflow };
+}

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -56,6 +56,13 @@ import type {
 } from '../../types';
 import { parseUTCDate } from '../../utils/date';
 import { executionDurationText } from '../../utils/execution';
+import {
+  TOP_MODEL_GROUP_PREVIEW_LIMIT,
+  TOP_MODEL_SESSION_PREVIEW_LIMIT,
+  compareByUsageMetric,
+  mergeGatewaySummaryPreservingBreakdown,
+  previewWindow,
+} from '../../utils/top-models-overview';
 import { getAgentControlState } from '../../utils/agent-control';
 import {
   pickDefaultModel,
@@ -121,6 +128,15 @@ interface UsageSessionSubject {
   kind: 'agent' | 'flow' | 'session';
   name: string;
   href: string;
+}
+
+interface TopModelSubjectGroup {
+  groupId: string;
+  kind: 'agent' | 'flow' | 'other';
+  subject: UsageSessionSubject;
+  sessions: GatewayUsageBySession[];
+  totalCost: number;
+  totalRequests: number;
 }
 
 interface DashboardMetric {
@@ -195,6 +211,7 @@ export class DashboardView extends AuthedElement {
   @state() private fetchingActiveAgents = false;
   @state() private topModelsSortMetric: 'spend' | 'usage' = 'spend';
   @state() private expandedOverviewGroups = new Set<string>();
+  @state() private expandedPreviewKeys = new Set<string>();
   @state() private showSetupDialog = false;
   @state() private showBudgetDialog = false;
   @state() private welcomeCardDismissed = false;
@@ -421,6 +438,10 @@ export class DashboardView extends AuthedElement {
         flex-direction: column;
         gap: var(--sl-spacing-2x-small);
         margin-top: var(--sl-spacing-2x-small);
+      }
+      .overview-see-more {
+        align-self: flex-start;
+        margin-top: 2px;
       }
       .expandable-subheader-metric {
         color: var(--sl-color-neutral-500);
@@ -1382,15 +1403,14 @@ export class DashboardView extends AuthedElement {
     }
     this.refreshInFlight = true;
 
-    this.fetchingGatewaySummary = true;
-    this.fetchingRecentExecutions = true;
-    this.fetchingApprovals = true;
-    this.fetchingActiveAgents = true;
-    this.fetchingBudget = true;
-    this.fetchingAudit = true;
-    this.fetchingMCPAndTools = true;
-
     if (!options.preserveLoadingState) {
+      this.fetchingGatewaySummary = true;
+      this.fetchingRecentExecutions = true;
+      this.fetchingApprovals = true;
+      this.fetchingActiveAgents = true;
+      this.fetchingBudget = true;
+      this.fetchingAudit = true;
+      this.fetchingMCPAndTools = true;
       this.loading = true;
     }
     this.error = null;
@@ -1457,7 +1477,10 @@ export class DashboardView extends AuthedElement {
       ]);
       await adminPromise;
 
-      this.gatewaySummary = gatewaySummary;
+      this.gatewaySummary = mergeGatewaySummaryPreservingBreakdown(
+        this.gatewaySummary,
+        gatewaySummary
+      );
       this.gatewayInteractions = gatewayInteractions.items || [];
       this.fetchingGatewaySummary = false;
 
@@ -1501,8 +1524,16 @@ export class DashboardView extends AuthedElement {
       this.loading = false;
       this.saveDashboardCache();
 
-      // Wave 2: audit / tools / trackers / models — does not block first paint
-      void this.fetchSecondaryDashboardData(startDateStr);
+      // Wave 2 is slow (full session breakdown + audit/tools). On a live
+      // websocket refresh only upgrade the top-models breakdown so the card
+      // does not flash empty while the rest of the dashboard stays put.
+      if (options.preserveLoadingState) {
+        void this.refreshTopModelsBreakdown(startDateStr).then(() =>
+          this.saveDashboardCache()
+        );
+      } else {
+        void this.fetchSecondaryDashboardData(startDateStr);
+      }
     } catch (error) {
       console.error(
         'Failed to complete background loading of overview dashboard',
@@ -1618,39 +1649,42 @@ export class DashboardView extends AuthedElement {
       }
     })();
 
-    // Top models need breakdown; upgrade the light summary once without
-    // blocking above-the-fold metrics/budget.
-    const pTopModels = (async () => {
-      try {
-        const detailed = await this.catchWith403Handling(
-          getAccountGatewayUsageSummary({
-            startDate: gatewayStartDate,
-            includeBreakdown: true,
-          }),
-          null
-        );
-        if (detailed) {
-          this.gatewaySummary = detailed;
-          if (
-            this.gatewayTimeRange === this.budgetTimeRange &&
-            this.budgetSummary
-          ) {
-            this.budgetSummary = {
-              ...this.budgetSummary,
-              usage_by_model: detailed.usage_by_model,
-              usage_by_flow: detailed.usage_by_flow,
-              usage_by_session: detailed.usage_by_session,
-              requests_by_day: detailed.requests_by_day,
-            };
-          }
-        }
-      } catch (error) {
-        console.error('Failed to load gateway breakdown for top models', error);
-      }
-    })();
-
-    await Promise.all([pAudit, pTools, pTopModels]);
+    await Promise.all([
+      pAudit,
+      pTools,
+      this.refreshTopModelsBreakdown(gatewayStartDate),
+    ]);
     this.saveDashboardCache();
+  }
+
+  private async refreshTopModelsBreakdown(gatewayStartDate: string) {
+    try {
+      const detailed = await this.catchWith403Handling(
+        getAccountGatewayUsageSummary({
+          startDate: gatewayStartDate,
+          includeBreakdown: true,
+        }),
+        null
+      );
+      if (!detailed) {
+        return;
+      }
+      this.gatewaySummary = detailed;
+      if (
+        this.gatewayTimeRange === this.budgetTimeRange &&
+        this.budgetSummary
+      ) {
+        this.budgetSummary = {
+          ...this.budgetSummary,
+          usage_by_model: detailed.usage_by_model,
+          usage_by_flow: detailed.usage_by_flow,
+          usage_by_session: detailed.usage_by_session,
+          requests_by_day: detailed.requests_by_day,
+        };
+      }
+    } catch (error) {
+      console.error('Failed to load gateway breakdown for top models', error);
+    }
   }
 
   private async fetchAuditExceptions(): Promise<GroupedAuditResponse> {
@@ -1898,6 +1932,91 @@ export class DashboardView extends AuthedElement {
     return this.expandedOverviewGroups.has(groupId);
   }
 
+  private togglePreviewKey(key: string) {
+    const next = new Set(this.expandedPreviewKeys);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    this.expandedPreviewKeys = next;
+  }
+
+  private isPreviewExpanded(key: string): boolean {
+    return this.expandedPreviewKeys.has(key);
+  }
+
+  private renderSeeMoreControl(key: string, overflow: number) {
+    if (overflow <= 0) {
+      return nothing;
+    }
+    const expanded = this.isPreviewExpanded(key);
+    return html`
+      <sl-button
+        class="overview-see-more"
+        size="small"
+        variant="text"
+        @click=${(event: Event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          this.togglePreviewKey(key);
+        }}
+      >
+        ${expanded ? 'Show less' : `See ${overflow} more`}
+        <sl-icon
+          slot="suffix"
+          name=${expanded ? 'chevron-up' : 'chevron-down'}
+        ></sl-icon>
+      </sl-button>
+    `;
+  }
+
+  private nestedSessionRepeatKey(
+    session: GatewayUsageBySession | RuntimeSessionSummary
+  ): string {
+    if ('total_requests' in session) {
+      return session.id;
+    }
+    return (
+      session.runtime_session_id ||
+      session.flow_execution_id ||
+      session.session_source_id ||
+      `${session.model_alias}-${session.last_request_at}`
+    );
+  }
+
+  private renderCappedNestedSessions(
+    sessions: Array<GatewayUsageBySession | RuntimeSessionSummary>,
+    previewKey: string
+  ) {
+    const sorted = [...sessions].sort((left, right) =>
+      compareByUsageMetric(left, right, this.topModelsSortMetric)
+    );
+    const { visible, overflow } = previewWindow(
+      sorted,
+      TOP_MODEL_SESSION_PREVIEW_LIMIT,
+      this.isPreviewExpanded(previewKey)
+    );
+    return html`
+      <div class="nested-session-list">
+        ${repeat(
+          visible,
+          (session) => this.nestedSessionRepeatKey(session),
+          (session) =>
+            this.renderNestedSessionRow(
+              session,
+              `${this.formatNumber(
+                'total_requests' in session
+                  ? session.total_requests
+                  : session.request_count
+              )} req`
+            )
+        )}
+        ${this.renderSeeMoreControl(previewKey, overflow)}
+      </div>
+    `;
+  }
+
   private renderExpandIcon(groupId: string) {
     return html`
       <sl-icon
@@ -1969,6 +2088,7 @@ export class DashboardView extends AuthedElement {
     options: {
       showTalkComposer?: boolean;
       onAgentControlSent?: () => void;
+      nestedPreviewKey?: string;
     } = {}
   ) {
     const expanded = this.isOverviewGroupExpanded(groupId);
@@ -2030,20 +2150,25 @@ export class DashboardView extends AuthedElement {
                 <div class="expandable-content">
                   ${
                     sessions.length > 0
-                      ? html`
-                          <div class="nested-session-list">
-                            ${sessions.map((session) =>
-                              this.renderNestedSessionRow(
-                                session,
-                                `${this.formatNumber(
-                                  'total_requests' in session
-                                    ? session.total_requests
-                                    : session.request_count
-                                )} req`
-                              )
-                            )}
-                          </div>
-                        `
+                      ? options.nestedPreviewKey
+                        ? this.renderCappedNestedSessions(
+                            sessions,
+                            options.nestedPreviewKey
+                          )
+                        : html`
+                            <div class="nested-session-list">
+                              ${sessions.map((session) =>
+                                this.renderNestedSessionRow(
+                                  session,
+                                  `${this.formatNumber(
+                                    'total_requests' in session
+                                      ? session.total_requests
+                                      : session.request_count
+                                  )} req`
+                                )
+                              )}
+                            </div>
+                          `
                       : html`<div class="nested-session-metric">
                           No recent sessions
                         </div>`
@@ -2945,6 +3070,138 @@ export class DashboardView extends AuthedElement {
     `;
   }
 
+  private collectTopModelSubjectGroups(
+    modelKey: string,
+    modelSessions: GatewayUsageBySession[]
+  ): TopModelSubjectGroup[] {
+    const agentGroups = new Map<
+      string,
+      { subject: UsageSessionSubject; sessions: GatewayUsageBySession[] }
+    >();
+    const flowGroups = new Map<
+      string,
+      { subject: UsageSessionSubject; sessions: GatewayUsageBySession[] }
+    >();
+    const otherSessions: GatewayUsageBySession[] = [];
+
+    modelSessions.forEach((session) => {
+      const subject = this.getUsageSessionSubject(session);
+      if (subject.kind === 'agent') {
+        const agent = this.getManagedAgentForUsageSession(session);
+        const key =
+          agent?.id ||
+          session.agent_id ||
+          session.runtime_session_id ||
+          session.session_source_id ||
+          session.runtime_principal_id ||
+          subject.href;
+        if (!agentGroups.has(key)) {
+          agentGroups.set(key, { subject, sessions: [] });
+        }
+        agentGroups.get(key)!.sessions.push(session);
+      } else if (subject.kind === 'flow') {
+        const key = session.flow_id || session.flow_name || subject.href;
+        if (!flowGroups.has(key)) {
+          flowGroups.set(key, { subject, sessions: [] });
+        }
+        flowGroups.get(key)!.sessions.push(session);
+      } else {
+        otherSessions.push(session);
+      }
+    });
+
+    const groups: TopModelSubjectGroup[] = [];
+    const pushGroup = (
+      kind: TopModelSubjectGroup['kind'],
+      groupId: string,
+      subject: UsageSessionSubject,
+      sessions: GatewayUsageBySession[]
+    ) => {
+      groups.push({
+        groupId,
+        kind,
+        subject,
+        sessions,
+        totalCost: sessions.reduce((acc, row) => acc + row.estimated_cost, 0),
+        totalRequests: sessions.reduce(
+          (acc, row) => acc + row.request_count,
+          0
+        ),
+      });
+    };
+
+    agentGroups.forEach(({ subject, sessions }, groupKey) => {
+      pushGroup(
+        'agent',
+        `top-model:${modelKey}:agent:${groupKey}`,
+        subject,
+        sessions
+      );
+    });
+    flowGroups.forEach(({ subject, sessions }, groupKey) => {
+      pushGroup(
+        'flow',
+        `top-model:${modelKey}:flow:${groupKey}`,
+        subject,
+        sessions
+      );
+    });
+    if (otherSessions.length > 0) {
+      pushGroup(
+        'other',
+        `top-model:${modelKey}:other`,
+        { kind: 'session', name: 'Other', href: '/console/runtime-sessions' },
+        otherSessions
+      );
+    }
+
+    groups.sort((left, right) =>
+      compareByUsageMetric(
+        {
+          estimated_cost: left.totalCost,
+          request_count: left.totalRequests,
+        },
+        {
+          estimated_cost: right.totalCost,
+          request_count: right.totalRequests,
+        },
+        this.topModelsSortMetric
+      )
+    );
+    return groups;
+  }
+
+  private renderTopModelSubjectGroup(group: TopModelSubjectGroup) {
+    const trailingMetric = `${this.formatCurrency(group.totalCost)} (${this.formatNumber(group.totalRequests)} req)`;
+    const nestedPreviewKey = `${group.groupId}:sessions`;
+    const nested = this.renderCappedNestedSessions(
+      group.sessions,
+      nestedPreviewKey
+    );
+
+    if (group.kind === 'agent') {
+      const agent = this.getManagedAgentForUsageSession(group.sessions[0]);
+      if (agent) {
+        return this.renderAgentExpandableGroup(
+          group.groupId,
+          agent,
+          group.sessions,
+          trailingMetric,
+          { nestedPreviewKey }
+        );
+      }
+    }
+
+    return this.renderCollapsibleGroup(
+      group.groupId,
+      group.subject.name,
+      group.kind === 'other' ? null : group.subject.href,
+      trailingMetric,
+      nested,
+      group.kind === 'flow' ? this.renderFlowIcon() : null
+    );
+  }
+
   private renderTopModelsCard() {
     const rawModels = this.gatewaySummary?.usage_by_model || [];
     if (rawModels.length === 0) {
@@ -2971,13 +3228,7 @@ export class DashboardView extends AuthedElement {
     });
 
     const models = Array.from(aggregatedModels.values());
-    models.sort((a, b) => {
-      if (this.topModelsSortMetric === 'usage') {
-        return b.request_count - a.request_count;
-      } else {
-        return b.estimated_cost - a.estimated_cost;
-      }
-    });
+    models.sort((a, b) => compareByUsageMetric(a, b, this.topModelsSortMetric));
 
     const allSessions = this.gatewaySummary?.usage_by_session || [];
 
@@ -3023,48 +3274,16 @@ export class DashboardView extends AuthedElement {
                       !item.provider_name ||
                       s.provider_name === item.provider_name))
               );
-
-              const agentGroups = new Map<
-                string,
-                {
-                  subject: UsageSessionSubject;
-                  sessions: typeof modelSessions;
-                }
-              >();
-              const flowGroups = new Map<
-                string,
-                {
-                  subject: UsageSessionSubject;
-                  sessions: typeof modelSessions;
-                }
-              >();
-              const otherSessions: typeof modelSessions = [];
-
-              modelSessions.forEach((s) => {
-                const subject = this.getUsageSessionSubject(s);
-                if (subject.kind === 'agent') {
-                  const agent = this.getManagedAgentForUsageSession(s);
-                  const key =
-                    agent?.id ||
-                    s.agent_id ||
-                    s.runtime_session_id ||
-                    s.session_source_id ||
-                    s.runtime_principal_id ||
-                    subject.href;
-                  if (!agentGroups.has(key)) {
-                    agentGroups.set(key, { subject, sessions: [] });
-                  }
-                  agentGroups.get(key)!.sessions.push(s);
-                } else if (subject.kind === 'flow') {
-                  const key = s.flow_id || s.flow_name || subject.href;
-                  if (!flowGroups.has(key)) {
-                    flowGroups.set(key, { subject, sessions: [] });
-                  }
-                  flowGroups.get(key)!.sessions.push(s);
-                } else {
-                  otherSessions.push(s);
-                }
-              });
+              const groups = this.collectTopModelSubjectGroups(
+                modelKey,
+                modelSessions
+              );
+              const groupsPreviewKey = `top-model-groups:${modelKey}`;
+              const { visible, overflow } = previewWindow(
+                groups,
+                TOP_MODEL_GROUP_PREVIEW_LIMIT,
+                this.isPreviewExpanded(groupsPreviewKey)
+              );
 
               return html`
                 <div
@@ -3120,112 +3339,18 @@ export class DashboardView extends AuthedElement {
                   </div>
 
                   ${
-                    agentGroups.size > 0 ||
-                    flowGroups.size > 0 ||
-                    otherSessions.length > 0
+                    groups.length > 0
                       ? html`
                           <div class="overview-nested-groups">
-                            ${Array.from(agentGroups.entries()).map(
-                              ([groupKey, { subject, sessions }]) => {
-                                const totalAgentCost = sessions.reduce(
-                                  (acc, s) => acc + s.estimated_cost,
-                                  0
-                                );
-                                const totalAgentReqs = sessions.reduce(
-                                  (acc, s) => acc + s.request_count,
-                                  0
-                                );
-                                const agent =
-                                  this.getManagedAgentForUsageSession(
-                                    sessions[0]
-                                  );
-                                const groupId = `top-model:${modelKey}:agent:${groupKey}`;
-                                const trailingMetric = `${this.formatCurrency(totalAgentCost)} (${this.formatNumber(totalAgentReqs)} req)`;
-                                if (agent) {
-                                  return this.renderAgentExpandableGroup(
-                                    groupId,
-                                    agent,
-                                    sessions,
-                                    trailingMetric
-                                  );
-                                }
-                                return this.renderCollapsibleGroup(
-                                  groupId,
-                                  subject.name,
-                                  subject.href,
-                                  trailingMetric,
-                                  html`
-                                    <div class="nested-session-list">
-                                      ${sessions.map((s) =>
-                                        this.renderNestedSessionRow(
-                                          s,
-                                          `${this.formatNumber(s.request_count)} req`
-                                        )
-                                      )}
-                                    </div>
-                                  `
-                                );
-                              }
+                            ${repeat(
+                              visible,
+                              (group) => group.groupId,
+                              (group) => this.renderTopModelSubjectGroup(group)
                             )}
-                            ${Array.from(flowGroups.entries()).map(
-                              ([groupKey, { subject, sessions }]) => {
-                                const totalFlowCost = sessions.reduce(
-                                  (acc, s) => acc + s.estimated_cost,
-                                  0
-                                );
-                                const totalFlowReqs = sessions.reduce(
-                                  (acc, s) => acc + s.request_count,
-                                  0
-                                );
-                                return this.renderCollapsibleGroup(
-                                  `top-model:${modelKey}:flow:${groupKey}`,
-                                  subject.name,
-                                  subject.href,
-                                  `${this.formatCurrency(totalFlowCost)} (${this.formatNumber(totalFlowReqs)} req)`,
-                                  html`
-                                    <div class="nested-session-list">
-                                      ${sessions.map((s) =>
-                                        this.renderNestedSessionRow(
-                                          s,
-                                          `${this.formatNumber(s.request_count)} req`
-                                        )
-                                      )}
-                                    </div>
-                                  `,
-                                  this.renderFlowIcon()
-                                );
-                              }
+                            ${this.renderSeeMoreControl(
+                              groupsPreviewKey,
+                              overflow
                             )}
-                            ${
-                              otherSessions.length > 0
-                                ? this.renderCollapsibleGroup(
-                                    `top-model:${modelKey}:other`,
-                                    'Other',
-                                    null,
-                                    `${this.formatCurrency(
-                                      otherSessions.reduce(
-                                        (acc, s) => acc + s.estimated_cost,
-                                        0
-                                      )
-                                    )} (${this.formatNumber(
-                                      otherSessions.reduce(
-                                        (acc, s) => acc + s.request_count,
-                                        0
-                                      )
-                                    )} req)`,
-                                    html`
-                                      <div class="nested-session-list">
-                                        ${otherSessions.map((s) =>
-                                          this.renderNestedSessionRow(
-                                            s,
-                                            `${this.formatNumber(s.request_count)} req`
-                                          )
-                                        )}
-                                      </div>
-                                    `
-                                  )
-                                : ''
-                            }
                           </div>
                         `
                       : ''


### PR DESCRIPTION
## Summary
- `/api/v1/policies/model-io-rules` list/create/update/patch/delete now declare `current_user` so `@require_permission` can run under RBAC instead of returning 500 `Permission check requires current_user and db dependencies`. Nested `get_account_for_user` does not put `current_user` in handler kwargs.
- Overview Top Models keeps `usage_by_session` across lightweight websocket refresh, shows a per-model preview (top four agents/flows/sessions), and caps expanded nested sessions.

## Test plan
- [ ] Open `/console/policies` (or call `GET /api/v1/policies/model-io-rules` with a logged-in user). Expect 200 or 403, not 500.
- [ ] Create/update/disable/delete a model I/O rule from the console.
- [ ] `pytest backend/tests/endpoints/test_policies.py::TestModelIORulesPermissionDeps`
- [ ] Overview Top Models: wait for a live refresh and confirm nested usage does not flash empty; expand a model with more than four groups and confirm See N more.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> No security concerns; a backend dependency fix plus a moderate frontend refactor, both now well-tested.
>
> **Overview**
> Fixes a 500 under RBAC on the model-io-rules policy endpoints and stops the Overview Top Models card from flashing empty on refresh while adding capped per-model previews. The previously flagged fail-closed test now patches the RBAC plugin so it passes in OSS CI.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 78967718. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->