### PR TITLE
docs: Editions table is users, teams, and RBAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   evaluation, AI Act pack, chargeback/forecasting as edition gates).
   CEL, AI-driven approvals, and quorum evaluation are OSS.
 
+- **CRA / AI Act evidence named as an OSS use case**: README intro and
+  What-you-get name the security-audit presets (`result.json`) as machine
+  evidence, not a conformity assessment. Editions table still lists only
+  users, teams, and RBAC.
+
 - **Overview Top Models shows a preview per model**: each model lists its
   top four agents/flows/sessions by spend or usage, with a See N more
   control when there are more. Expanded groups cap nested sessions the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   managed hosting; Cloud and Enterprise include support plans. Dropped
   Yes/Yes capability-tour rows and overclaims (CEL, AI-driven/quorum
   evaluation, AI Act pack, chargeback/forecasting as edition gates).
-  CEL, AI-driven approvals, and quorum evaluation are OSS.
+  CEL, AI-driven approvals, and quorum evaluation are OSS. Chargeback
+  and forecasting stay Cloud / Enterprise cost features; they were
+  dropped from the table because they are not users/teams/RBAC
+  edition gates, not because they went away.
 
 - **CRA / AI Act evidence named as an OSS use case**: README intro and
   What-you-get name the security-audit presets (`result.json`) as machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Frontend test/auth conventions that were only in
   `frontend/CLAUDE.md` now live in `frontend/README.md`; the stale
   file is not restored.
+- **Editions table lists differences only**: OSS is one operator per
+  account. Users, teams, and RBAC are Cloud / Enterprise. Cloud is
+  managed hosting; Cloud and Enterprise include support plans. Dropped
+  Yes/Yes capability-tour rows and overclaims (CEL, AI-driven/quorum
+  evaluation, AI Act pack, chargeback/forecasting as edition gates).
+  CEL, AI-driven approvals, and quorum evaluation are OSS.
 
 - **Overview Top Models shows a preview per model**: each model lists its
   top four agents/flows/sessions by spend or usage, with a See N more

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Preloop is a single self-hostable platform: an **MCP firewall** for tool access, an **AI model gateway** for cost, safety and attribution, **policy-as-code** with **human approvals**, and **runtime session observability**.
 
-Flow presets can collect machine evidence for CRA- and EU AI Act-style reviews (SBOM verify, exploit check, session traces). That is not a conformity assessment, certification, or legal advice. Presets: [security audit presets](docs/guide/flows/security-audit-presets.md).
+Flow presets can collect machine evidence for CRA- and EU AI Act-style reviews (SBOM verify, exploit check); Runtime Observability keeps the session timeline next to it. That is not a conformity assessment, certification, or legal advice. Presets: [security audit presets](docs/guide/flows/security-audit-presets.md).
 
 Onboard existing agents with one command. Talk to long-running ones from the console, phone, or watch. Deploy event-driven automations when GitHub, GitLab, Jira, or a webhook fires. Works with OpenClaw, Claude Code, Codex CLI, Cursor, Gemini CLI, Hermes, OpenCode, Windsurf, and any MCP-compatible agent.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The open-source AI agent control plane.** See them, govern them, cut their cost.
 
-Preloop is a single self-hostable platform: an **MCP firewall** for tool access, an **AI model gateway** for cost, safety and attribution, **policy-as-code** with **human approvals**, and **runtime session observability**. Durable **audit** packs (All events / AI Act evidence) ship on Preloop Cloud and Preloop Enterprise.
+Preloop is a single self-hostable platform: an **MCP firewall** for tool access, an **AI model gateway** for cost, safety and attribution, **policy-as-code** with **human approvals**, and **runtime session observability**.
 
 Onboard existing agents with one command. Talk to long-running ones from the console, phone, or watch. Deploy event-driven automations when GitHub, GitLab, Jira, or a webhook fires. Works with OpenClaw, Claude Code, Codex CLI, Cursor, Gemini CLI, Hermes, OpenCode, Windsurf, and any MCP-compatible agent.
 
@@ -59,7 +59,6 @@ Jobs teams otherwise buy from several vendors, in one Apache 2.0 stack:
 | **Cost & Budgets** | Spend by model, agent, session, API key, flow, and user, including usage you import when the model never hits the gateway. | FinOps dashboards, vendor billing exports |
 | **Human Approvals** | Mobile, watch, Slack, Mattermost, email, webhook, or `preloop approvals`. Native `Bash`/`Edit`. Agents can `ask_user`. | Custom Slack bots, Peta Desk |
 | **Runtime Observability** | One session timeline: tool calls, model calls, policy, approvals, spend, outcomes. | AgentOps, Langfuse, LangSmith |
-| **Audit & AI Act evidence** | Durable All-events log and AI Act pack. Preloop Cloud / Preloop Enterprise (`audit_logs`). Sessions timeline above is OSS. | Credo AI, IBM watsonx.governance |
 
 ```text
 AI Agent → Preloop → [Policy]  → Allow / Deny / Require Approval → Execute
@@ -162,17 +161,15 @@ Also compare: [LiteLLM](https://preloop.ai/vs/litellm), [Portkey](https://preloo
 
 ## Editions
 
-Same core. Unqualified **Preloop** is this repository (Apache 2.0, self-hosted). **Preloop Cloud** is the hosted service at [preloop.ai](https://preloop.ai). **Preloop Enterprise** is the commercial self-hosted edition.
+Unqualified **Preloop** is this repository (Apache 2.0, self-hosted). **Preloop Cloud** is the hosted service at [preloop.ai](https://preloop.ai). **Preloop Enterprise** is the commercial self-hosted edition.
+
+Cloud is managed hosting. Cloud and Enterprise include support plans.
 
 | Feature | Open Source | Cloud / Enterprise |
 |---|:---:|:---:|
-| Approvals, issue trackers, agentic flows | Yes | Yes |
-| Cost overview, usage drill-downs, budget-health | Yes | Yes |
-| Durable All-events audit / AI Act pack | No | Yes |
-| Budget policy configuration and enforcement | No | Yes |
-| RBAC, teams, admin dashboard | No | Yes |
-| CEL / AI-driven / quorum approvals | No | Yes |
-| Billing reconciliation, chargeback, forecasting | No | Yes |
+| Users, teams, and RBAC on one account | No | Yes |
+
+A self-hosted OSS instance is one operator per account. Public signup, if left on, creates a separate account, not a teammate. Invitations, users, teams, and permission roles ship with Cloud and Enterprise.
 
 Enterprise licensing: sales@preloop.ai.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Preloop is a single self-hostable platform: an **MCP firewall** for tool access, an **AI model gateway** for cost, safety and attribution, **policy-as-code** with **human approvals**, and **runtime session observability**.
 
+Flow presets can collect machine evidence for CRA- and EU AI Act-style reviews (SBOM verify, exploit check, session traces). That is not a conformity assessment, certification, or legal advice. Presets: [security audit presets](docs/guide/flows/security-audit-presets.md).
+
 Onboard existing agents with one command. Talk to long-running ones from the console, phone, or watch. Deploy event-driven automations when GitHub, GitLab, Jira, or a webhook fires. Works with OpenClaw, Claude Code, Codex CLI, Cursor, Gemini CLI, Hermes, OpenCode, Windsurf, and any MCP-compatible agent.
 
 ```bash
@@ -59,6 +61,7 @@ Jobs teams otherwise buy from several vendors, in one Apache 2.0 stack:
 | **Cost & Budgets** | Spend by model, agent, session, API key, flow, and user, including usage you import when the model never hits the gateway. | FinOps dashboards, vendor billing exports |
 | **Human Approvals** | Mobile, watch, Slack, Mattermost, email, webhook, or `preloop approvals`. Native `Bash`/`Edit`. Agents can `ask_user`. | Custom Slack bots, Peta Desk |
 | **Runtime Observability** | One session timeline: tool calls, model calls, policy, approvals, spend, outcomes. | AgentOps, Langfuse, LangSmith |
+| **Evidence packs** | Apache flow presets write `result.json` plus an evidence directory for CRA / AI Act-style work. Not a certification. | Custom GRC folders |
 
 ```text
 AI Agent → Preloop → [Policy]  → Allow / Deny / Require Approval → Execute


### PR DESCRIPTION
## Summary
- Editions table now lists the actual difference: same-account users, teams, and RBAC. OSS is one operator per account.
- Cloud is managed hosting. Cloud and Enterprise include support plans.
- Dropped Yes/Yes capability-tour rows and overclaims (CEL/AI-driven/quorum as EE-only, AI Act pack, chargeback/forecasting).
- Intro no longer says durable audit packs ship only on Cloud/Enterprise. Sessions timeline stays in What you get.

## Test plan
- [ ] README Editions section renders on GitHub
- [ ] Intro and What you get no longer contradict the table

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Docs-only change with no security or code impact; claims verified consistent with the codebase.
>
> **Overview**
> Corrects the Editions table to list the real differentiator (same-account users/teams/RBAC), removes overclaims and the intro claim that audit packs ship only on Cloud/Enterprise, names CRA/AI Act evidence as an OSS use case, and records the changes in CHANGELOG.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fec120ea. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->