### PR TITLE
fix: list provider models live; no bundled catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Edit-mode model refresh lists live models**: refreshing the picker
+  while editing a saved AI model (for example a Z.ai key that now serves
+  `glm-5.3-flash`) sends the model id so the server decrypts the stored
+  key and lists live. Create-with-a-typed-key already did this; edit
+  previously sent an empty key and fell back to a stale bundled catalog.
+  Stored secrets are never returned to the browser. Typed keys still win.
+
 - **Model I/O policy API 500 under RBAC**: `/api/v1/policies/model-io-rules`
   list/create/update/patch/delete used `@require_permission` without a
   `current_user` FastAPI dependency. Nested `get_account_for_user` does
@@ -110,6 +117,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   GitLab.
 
 ### Changed
+
+- **Provider model pickers are live-only**: bundled fallback catalogs
+  are gone. A failed or keyless listing returns an empty picker with a
+  safe `source`/`error` reason (timeout, network, empty_response,
+  missing_endpoint, sdk_missing, missing_key, auth) instead of a stale
+  guess. OpenAI STT/TTS ids are filtered from the same live
+  `GET /v1/models` list. The pricing table is unchanged.
 
 - **README is the product intro, not the operator manual**: ~390 lines
   down to ~200. Locked category line and lead, install + evidence first,

--- a/backend/preloop/api/endpoints/ai_models.py
+++ b/backend/preloop/api/endpoints/ai_models.py
@@ -390,6 +390,7 @@ async def list_provider_available_models(
     the body always wins. Stored secrets are never returned to the client.
     """
     api_key, api_endpoint, aws_auth, model_kind = _resolve_listing_inputs(
+        provider=provider,
         request_in=request_in,
         db=db,
         current_user=current_user,
@@ -491,6 +492,7 @@ def _aws_auth_from_stored_bedrock_secret(
 
 def _resolve_listing_inputs(
     *,
+    provider: str,
     request_in: Optional[AvailableModelsRequest],
     db: Optional[Session],
     current_user: Optional[User],
@@ -504,6 +506,13 @@ def _resolve_listing_inputs(
 
     The stored plaintext is used only for the live list call and is never
     copied into the response.
+
+    A stored secret is only ever used for the provider it was stored for. The
+    edit form leaves the provider dropdown enabled, so without that check a
+    caller could pair one model's ``ai_model_id`` with a different ``provider``
+    plus an attacker-chosen ``api_endpoint`` and have the server forward the
+    decrypted key there. ``validate_discovery_endpoint`` blocks private hosts
+    but not public ones, so the mismatch is rejected before decryption.
     """
     typed_key = (request_in.api_key or "").strip() if request_in else ""
     typed_endpoint = (request_in.api_endpoint or "").strip() if request_in else ""
@@ -533,9 +542,22 @@ def _resolve_listing_inputs(
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="AI Model not found"
             )
+        if (db_model.provider_name or "").strip().lower() != (
+            provider or ""
+        ).strip().lower():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Stored model provider does not match the requested provider",
+            )
         try:
             stored_key = crud_ai_model.resolve_listing_secret(db_model)
-        except Exception:
+        except ValueError:
+            # Every expected failure below resolve_listing_secret normalizes to
+            # ValueError: decrypt_value re-raises InvalidToken, the vault
+            # backend re-raises transport/lookup errors, credential payload
+            # parsing raises on bad JSON, and CredentialRefreshError subclasses
+            # ValueError. Anything else is a real bug and must stay loud rather
+            # than degrade to "missing_key".
             logger.warning(
                 "Failed to decrypt stored listing credentials for model %s",
                 model_id,

--- a/backend/preloop/api/endpoints/ai_models.py
+++ b/backend/preloop/api/endpoints/ai_models.py
@@ -1,7 +1,8 @@
+import json
 import logging
 import uuid
 from datetime import datetime
-from typing import List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Tuple
 
 from fastapi import (
     APIRouter,
@@ -369,25 +370,36 @@ def export_ai_model_credentials(
 async def list_provider_available_models(
     provider: str,
     request_in: Optional[AvailableModelsRequest] = None,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_active_user),
 ) -> AvailableModelsResponse:
     """
     Fetch available models from the specified AI provider, with provenance.
 
-    Every provider attempts a live listing when a key (and endpoint where
-    applicable) is present; the response reports ``source`` ("live" or
-    "fallback") and a short safe ``error`` reason when a live attempt failed.
-    The reason comes from a fixed vocabulary and never contains raw provider
-    error text, endpoint URLs, or key material.
+    Every provider lists live when a key (and endpoint where applicable) is
+    present; the response reports ``source`` ("live" or "fallback") and a
+    short safe ``error`` reason when a live attempt failed or credentials
+    were missing. The reason comes from a fixed vocabulary and never contains
+    raw provider error text, endpoint URLs, or key material.
 
     The provider API key travels in the request BODY, never the query string:
     as a query parameter it was written to access logs in plaintext.
+
+    Edit-mode refresh should send ``ai_model_id`` instead of the stored key.
+    The server decrypts the stored secret via CRUD. A typed ``api_key`` in
+    the body always wins. Stored secrets are never returned to the client.
     """
+    api_key, api_endpoint, aws_auth, model_kind = _resolve_listing_inputs(
+        request_in=request_in,
+        db=db,
+        current_user=current_user,
+    )
     return await _fetch_provider_models(
         provider=provider,
-        api_key=request_in.api_key if request_in else None,
-        model_kind=request_in.model_kind if request_in else "llm",
-        api_endpoint=request_in.api_endpoint if request_in else None,
-        aws_auth=_aws_auth_from_request(request_in),
+        api_key=api_key,
+        model_kind=model_kind,
+        api_endpoint=api_endpoint,
+        aws_auth=aws_auth,
     )
 
 
@@ -438,6 +450,106 @@ async def get_provider_available_models(
         api_endpoint=api_endpoint,
     )
     return result.models
+
+
+def _aws_auth_from_stored_bedrock_secret(
+    secret_value: str,
+    ai_model: AIModel,
+) -> Optional[Dict[str, str]]:
+    """Parse a stored Bedrock JSON blob plus routing region into aws_auth.
+
+    The stored secret is the same JSON shape the add-model modal writes
+    (``aws_access_key_id``, ``aws_secret_access_key``, optional session
+    token). Region lives on ``meta_data.provider_runtime.region``.
+    """
+    try:
+        payload = json.loads(secret_value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    auth: Dict[str, str] = {}
+    for key in (
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "aws_region_name",
+    ):
+        value = payload.get(key)
+        if value:
+            auth[key] = str(value).strip()
+    meta = ai_model.meta_data if isinstance(ai_model.meta_data, dict) else {}
+    runtime_raw = meta.get("provider_runtime")
+    runtime = runtime_raw if isinstance(runtime_raw, dict) else {}
+    region = runtime.get("region") if isinstance(runtime, dict) else None
+    if isinstance(region, str) and region.strip() and "aws_region_name" not in auth:
+        auth["aws_region_name"] = region.strip()
+    if not auth.get("aws_access_key_id") or not auth.get("aws_secret_access_key"):
+        return None
+    return auth
+
+
+def _resolve_listing_inputs(
+    *,
+    request_in: Optional[AvailableModelsRequest],
+    db: Optional[Session],
+    current_user: Optional[User],
+) -> Tuple[
+    Optional[str],
+    Optional[str],
+    Optional[dict],
+    Literal["llm", "stt", "tts"],
+]:
+    """Typed credentials win; otherwise decrypt the stored model secret.
+
+    The stored plaintext is used only for the live list call and is never
+    copied into the response.
+    """
+    typed_key = (request_in.api_key or "").strip() if request_in else ""
+    typed_endpoint = (request_in.api_endpoint or "").strip() if request_in else ""
+    typed_aws = _aws_auth_from_request(request_in)
+    model_kind: Literal["llm", "stt", "tts"] = (
+        request_in.model_kind if request_in else "llm"
+    )
+
+    stored_key: Optional[str] = None
+    stored_endpoint: Optional[str] = None
+    stored_aws: Optional[Dict[str, str]] = None
+    model_id = request_in.ai_model_id if request_in else None
+    if model_id is not None:
+        if (
+            db is None
+            or current_user is None
+            or not getattr(current_user, "account_id", None)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Authentication required to list with a stored model",
+            )
+        db_model = crud_ai_model.get_for_account(
+            db, id=model_id, account_id=current_user.account_id
+        )
+        if db_model is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="AI Model not found"
+            )
+        try:
+            stored_key = crud_ai_model.resolve_listing_secret(db_model)
+        except Exception:
+            logger.warning(
+                "Failed to decrypt stored listing credentials for model %s",
+                model_id,
+            )
+            stored_key = None
+        stored_endpoint = (db_model.api_endpoint or "").strip() or None
+        if (db_model.provider_name or "").lower() == "bedrock" and stored_key:
+            stored_aws = _aws_auth_from_stored_bedrock_secret(stored_key, db_model)
+            stored_key = None
+
+    api_key = typed_key or stored_key
+    api_endpoint = typed_endpoint or stored_endpoint
+    aws_auth = typed_aws or stored_aws
+    return api_key, api_endpoint, aws_auth, model_kind
 
 
 def _aws_auth_from_request(

--- a/backend/preloop/models/crud/ai_model.py
+++ b/backend/preloop/models/crud/ai_model.py
@@ -403,6 +403,45 @@ class CRUDAIModel(CRUDBase[AIModel]):
         """Get all AIModels for a specific account."""
         return db.query(self.model).filter(self.model.account_id == account_id).all()
 
+    def get_for_account(
+        self,
+        db: Session,
+        *,
+        id: uuid.UUID,
+        account_id: uuid.UUID,
+    ) -> Optional[AIModel]:
+        """Load one account-owned AI model with its credential secret eager-loaded.
+
+        Used by live model listing so stored keys can be decrypted without a
+        second query. Returns None when the id is missing or belongs to
+        another account.
+        """
+        return (
+            db.query(self.model)
+            .options(joinedload(self.model.credentials_secret))
+            .filter(self.model.id == id, self.model.account_id == account_id)
+            .first()
+        )
+
+    def resolve_listing_secret(self, ai_model: AIModel) -> Optional[str]:
+        """Decrypt stored provider credentials for server-side listing only.
+
+        The plaintext must never be returned to API clients. Callers use it
+        only to authenticate a live list-models request.
+
+        Args:
+            ai_model: Row previously loaded by :meth:`get_for_account`.
+
+        Returns:
+            The decrypted secret string, or None when the model has no
+            resolvable credential.
+        """
+        resolved = get_secret_service().resolve_ai_model_credentials(ai_model)
+        if resolved is None:
+            return None
+        value = (resolved.value or "").strip()
+        return value or None
+
     def get_for_managed_agent_enrichment(
         self,
         db: Session,

--- a/backend/preloop/schemas/ai_model.py
+++ b/backend/preloop/schemas/ai_model.py
@@ -256,7 +256,18 @@ class AvailableModelsRequest(BaseModel):
         None,
         description=(
             "Provider API key used to list models. Never logged and never "
-            "persisted by this endpoint."
+            "persisted by this endpoint. When omitted, pass ai_model_id so "
+            "the server can decrypt the stored key; the stored key is never "
+            "returned to the client. A typed key always wins over the stored "
+            "one."
+        ),
+    )
+    ai_model_id: Optional[uuid.UUID] = Field(
+        None,
+        description=(
+            "Existing AI model id. When no typed api_key is sent, the server "
+            "decrypts the stored credentials via CRUD and lists live. The "
+            "plaintext key is never returned in the response."
         ),
     )
     api_endpoint: Optional[str] = Field(
@@ -312,15 +323,15 @@ class AvailableModelsRequest(BaseModel):
 
 
 class AvailableModelsResponse(BaseModel):
-    """A provider's model catalog plus the provenance of the listing.
+    """A provider's model listing plus the provenance of the result.
 
     ``source`` reports whether the ids came from the provider's live listing
-    endpoint ("live") or from Preloop's bundled fallback catalog
-    ("fallback"). ``error`` is a short machine-readable reason drawn from a
+    endpoint ("live") or an empty fallback ("fallback"). There is no bundled
+    picker catalog. ``error`` is a short machine-readable reason drawn from a
     fixed vocabulary (e.g. "timeout", "network", "empty_response",
-    "unsupported", "missing_endpoint", "sdk_missing", "unknown") when a live
-    attempt failed; it never carries raw exception text, which can embed
-    endpoint URLs or key material.
+    "unsupported", "missing_endpoint", "sdk_missing", "missing_key", "auth",
+    "unknown") when a live attempt failed or was impossible; it never carries
+    raw exception text, which can embed endpoint URLs or key material.
     """
 
     models: List[str] = Field(
@@ -330,15 +341,15 @@ class AvailableModelsResponse(BaseModel):
         "fallback",
         description=(
             "'live' when the provider's listing endpoint answered; 'fallback' "
-            "when a bundled catalog (or empty list) was returned instead"
+            "when an empty list was returned instead of a live catalog"
         ),
     )
     error: Optional[str] = Field(
         None,
         description=(
-            "Short safe reason for a fallback after a failed live attempt "
-            "(fixed vocabulary, never raw provider error text). None for a "
-            "clean result."
+            "Short safe reason for a fallback after a failed or impossible "
+            "live attempt (fixed vocabulary, never raw provider error text). "
+            "None for a clean live result."
         ),
     )
 

--- a/backend/preloop/services/ai_model_provider.py
+++ b/backend/preloop/services/ai_model_provider.py
@@ -1,13 +1,12 @@
 """Service for fetching available models from AI providers.
 
-Every provider ATTEMPTS a live fetch when a key (and endpoint where
-applicable) is present. Hardcoded catalogs still exist, but only as named
-fallback constants, and every result carries provenance: ``source`` is
-``live`` when the provider's own listing endpoint answered, ``fallback``
-when a bundled catalog (or an empty list) was returned instead, with a
-short machine-readable ``error`` reason. The reason is drawn from a fixed
-vocabulary and never contains raw exception text, which can carry endpoint
-URLs and key material (2026-08-04 key-leak incident).
+Every provider lists live when credentials (and an endpoint where required)
+are present. There is no bundled picker catalog: a failed or impossible live
+attempt returns an empty list with provenance. ``source`` is ``live`` when
+the provider's own listing endpoint answered, ``fallback`` when the list is
+empty, with a short machine-readable ``error`` reason. The reason is drawn
+from a fixed vocabulary and never contains raw exception text, which can
+carry endpoint URLs and key material (2026-08-04 key-leak incident).
 """
 
 import asyncio
@@ -76,6 +75,8 @@ ERROR_EMPTY_RESPONSE = "empty_response"
 ERROR_UNSUPPORTED = "unsupported"
 ERROR_MISSING_ENDPOINT = "missing_endpoint"
 ERROR_SDK_MISSING = "sdk_missing"
+ERROR_MISSING_KEY = "missing_key"
+ERROR_AUTH = "auth"
 ERROR_UNKNOWN = "unknown"
 
 FALLBACK_ERROR_REASONS = frozenset(
@@ -86,6 +87,8 @@ FALLBACK_ERROR_REASONS = frozenset(
         ERROR_UNSUPPORTED,
         ERROR_MISSING_ENDPOINT,
         ERROR_SDK_MISSING,
+        ERROR_MISSING_KEY,
+        ERROR_AUTH,
         ERROR_UNKNOWN,
     }
 )
@@ -98,10 +101,10 @@ class ModelDiscoveryResult:
     Attributes:
         models: Model identifiers to offer in the picker.
         source: ``live`` when the provider's listing endpoint answered,
-            ``fallback`` when a bundled catalog (or empty list) was used.
+            ``fallback`` when the list is empty because live listing failed
+            or was impossible.
         error: Short safe reason from FALLBACK_ERROR_REASONS when a live
-            attempt failed or was impossible; None for a clean result (a
-            keyless bundled catalog is a clean fallback, not an error).
+            attempt failed or was impossible; None for a clean live result.
     """
 
     models: List[str] = field(default_factory=list)
@@ -135,29 +138,6 @@ def _classify_fetch_error(exc: Exception) -> str:
         return ERROR_NETWORK
     return ERROR_UNKNOWN
 
-
-# ---------------------------------------------------------------------------
-# Curated audio catalogs (no provider ships a discovery endpoint for these)
-# ---------------------------------------------------------------------------
-
-OPENAI_STT_MODELS = [
-    "gpt-4o-transcribe",
-    "gpt-4o-mini-transcribe",
-    "whisper-1",
-]
-
-OPENAI_TTS_MODELS = [
-    "gpt-4o-mini-tts",
-    "tts-1",
-    "tts-1-hd",
-]
-
-GOOGLE_STT_MODELS = [
-    "latest_short",
-    "latest_long",
-    "command_and_search",
-    "default",
-]
 
 SUPPORTED_AUDIO_PROVIDER_KINDS: dict[str, set[ModelKind]] = {
     "openai": {"llm", "stt", "tts"},
@@ -197,18 +177,18 @@ async def get_available_models_for_provider(
         aws_auth: Optional AWS credential mapping for the bedrock provider,
             with any of the keys ``aws_access_key_id``,
             ``aws_secret_access_key``, ``aws_session_token`` and
-            ``aws_region_name``. When omitted, boto3's default credential
-            chain (instance profile, env, ...) is used.
+            ``aws_region_name``. Typed or stored credentials are required;
+            ambient instance-profile listing is not used for the picker.
 
     Returns:
         ModelDiscoveryResult with the model identifiers, whether they came
-        from a live listing or a bundled fallback, and a short safe error
-        reason when a live attempt failed.
+        from a live listing, and a short safe error reason when a live
+        attempt failed or credentials were missing.
 
     Raises:
         ValueError: On an invalid model_kind, an invalid discovery endpoint,
             or when the provider rejected the API key (so the user learns the
-            key is bad instead of silently seeing a stale catalog).
+            key is bad instead of silently seeing an empty picker).
     """
     provider = provider.lower()
     normalized_model_kind = model_kind.lower()
@@ -219,18 +199,13 @@ async def get_available_models_for_provider(
     if normalized_model_kind not in supported_kinds:
         return _fallback([], ERROR_UNSUPPORTED)
 
-    # STT/TTS catalogs are curated: no provider exposes a listing endpoint
-    # for them, so they are honest fallbacks rather than live results.
-    if normalized_model_kind == "stt":
-        return _fallback(_get_stt_models(provider))
-    if normalized_model_kind == "tts":
-        return _fallback(_get_tts_models(provider))
-
     if provider == "openai":
-        return await _get_openai_models(api_key)
+        return await _get_openai_models(api_key, model_kind=normalized_model_kind)
     elif provider == "anthropic":
         return await _get_anthropic_models(api_key)
     elif provider == "google":
+        if normalized_model_kind == "stt":
+            return _get_google_stt_models(api_key)
         return await _get_google_models(api_key)
     elif provider == "qwen":
         return await _get_qwen_models(api_key, api_endpoint)
@@ -256,6 +231,8 @@ async def get_available_models_for_provider(
                 provider,
             )
             return _fallback([], ERROR_MISSING_ENDPOINT)
+        if provider == "openrouter" and not (api_key or "").strip():
+            return _fallback([], ERROR_MISSING_KEY)
         return await _get_openai_compatible_models(endpoint, api_key)
     else:
         # Unknown provider with no endpoint convention to follow.
@@ -445,31 +422,19 @@ def _extract_model_ids(response: object) -> List[str]:
     return sorted(set(model_ids))[:MAX_DISCOVERED_MODELS]
 
 
-def _get_stt_models(provider: str) -> List[str]:
-    """Return known speech-to-text model identifiers for supported providers."""
-    if provider in {"openai", "custom", "openai-compatible"}:
-        return OPENAI_STT_MODELS
-    if provider == "google":
-        return GOOGLE_STT_MODELS
-    return []
+def _get_google_stt_models(api_key: Optional[str] = None) -> ModelDiscoveryResult:
+    """Google Cloud Speech-to-Text has no API-key list-models resource.
 
+    Recognition uses POST https://speech.googleapis.com/v1/speech:recognize
+    (see ``audio_model.GOOGLE_SPEECH_RECOGNIZE_URL``). The v2 models list
+    (https://cloud.google.com/speech-to-text/docs/reference/rest/v2/projects.locations.models/list)
+    requires ``projects/{project}/locations/{location}``, which the API-key
+    flow does not have. Return empty rather than a stale guess.
+    """
+    if not (api_key or "").strip():
+        return _fallback([], ERROR_MISSING_KEY)
+    return _fallback([], ERROR_MISSING_ENDPOINT)
 
-def _get_tts_models(provider: str) -> List[str]:
-    """Return known text-to-speech model identifiers for supported providers."""
-    if provider in {"openai", "custom", "openai-compatible"}:
-        return OPENAI_TTS_MODELS
-    return []
-
-
-# Fallback catalog used when the OpenAI listing endpoint cannot be reached.
-# Provenance: hand-curated from OpenAI's model documentation; every id also
-# resolves in litellm's price map. Surfaced with source="fallback".
-OPENAI_FALLBACK_MODELS = [
-    "gpt-4.1",
-    "gpt-4.1-mini",
-    "gpt-4o",
-    "gpt-4o-mini",
-]
 
 # Model-id substrings that mark an OpenAI model as NOT a chat completion
 # model (embeddings, audio, image, moderation, legacy completions). This is
@@ -499,13 +464,43 @@ _OPENAI_NON_CHAT_MARKERS = (
 )
 
 
-async def _get_openai_models(api_key: Optional[str] = None) -> ModelDiscoveryResult:
-    """Fetch available models from the OpenAI API.
+_OPENAI_STT_MARKERS = ("transcribe", "whisper")
+_OPENAI_TTS_MARKERS = ("tts",)
 
-    Returns the full chat-capable listing (no arbitrary cap), excluding known
-    non-chat families rather than allow-listing "gpt-*" only, so o-series and
-    future chat model families stay visible.
+
+def _openai_ids_for_kind(model_ids: List[str], model_kind: ModelKind) -> List[str]:
+    """Keep OpenAI ids that match the requested service kind."""
+    if model_kind == "stt":
+        return [
+            model_id
+            for model_id in model_ids
+            if any(marker in model_id.lower() for marker in _OPENAI_STT_MARKERS)
+        ]
+    if model_kind == "tts":
+        return [
+            model_id
+            for model_id in model_ids
+            if any(marker in model_id.lower() for marker in _OPENAI_TTS_MARKERS)
+        ]
+    return [
+        model_id
+        for model_id in model_ids
+        if not any(marker in model_id for marker in _OPENAI_NON_CHAT_MARKERS)
+    ]
+
+
+async def _get_openai_models(
+    api_key: Optional[str] = None,
+    model_kind: ModelKind = "llm",
+) -> ModelDiscoveryResult:
+    """Fetch available models from OpenAI ``GET https://api.openai.com/v1/models``.
+
+    LLM ids exclude known non-chat families. STT/TTS ids are the same live
+    list filtered to transcribe/whisper and tts families.
     """
+    if not (api_key or "").strip():
+        return _fallback([], ERROR_MISSING_KEY)
+
     try:
         from openai import AsyncOpenAI, AuthenticationError
     except ImportError:
@@ -514,64 +509,37 @@ async def _get_openai_models(api_key: Optional[str] = None) -> ModelDiscoveryRes
         # ``except AuthenticationError`` against an unbound name and raise
         # NameError instead of returning a fallback.
         logger.warning("OpenAI package not installed, cannot list models")
-        return _fallback(OPENAI_FALLBACK_MODELS, ERROR_SDK_MISSING)
+        return _fallback([], ERROR_SDK_MISSING)
 
     try:
-        # Use provided API key or fall back to environment variable. Timeout
-        # and single retry match every other provider in this file: without
-        # them a hung connection blocks the listing request indefinitely.
-        client = (
-            AsyncOpenAI(
-                api_key=api_key,
-                max_retries=1,
-                timeout=MODEL_DISCOVERY_TIMEOUT_SECONDS,
-            )
-            if api_key
-            else AsyncOpenAI(
-                max_retries=1,
-                timeout=MODEL_DISCOVERY_TIMEOUT_SECONDS,
-            )
+        client = AsyncOpenAI(
+            api_key=api_key,
+            max_retries=1,
+            timeout=MODEL_DISCOVERY_TIMEOUT_SECONDS,
         )
         async with client:
             models_response = await client.models.list()
         models = models_response.data
 
-        chat_models = [
-            model.id
-            for model in models
-            if not any(marker in model.id for marker in _OPENAI_NON_CHAT_MARKERS)
-        ]
-
-        # Sort with newer models first
-        chat_models.sort(reverse=True)
-
-        return _live(chat_models)
-    except AuthenticationError as e:
-        logger.warning("OpenAI authentication failed: %s", type(e).__name__)
+        model_ids = [model.id for model in models if getattr(model, "id", None)]
+        filtered = _openai_ids_for_kind(model_ids, model_kind)
+        filtered.sort(reverse=True)
+        if not filtered:
+            return _fallback([], ERROR_EMPTY_RESPONSE)
+        return _live(filtered)
+    except AuthenticationError:
+        logger.warning("OpenAI authentication failed: %s", "AuthenticationError")
         # Re-raise authentication errors so the user knows their API key is invalid
         raise ProviderAuthError(
             "Invalid OpenAI API key. Please check your API key and try again."
         )
     except Exception as e:
         logger.warning("Failed to fetch OpenAI models: %s", type(e).__name__)
-        # Return fallback list for other errors (network issues, etc.)
-        return _fallback(OPENAI_FALLBACK_MODELS, _classify_fetch_error(e))
-
-
-# Fallback catalog used when the Anthropic listing endpoint cannot be
-# reached or no key is available. Provenance: hand-curated current ids;
-# every id must resolve in services/data/model_prices.json (pinned by
-# tests/services/test_ai_model_provider.py).
-ANTHROPIC_FALLBACK_MODELS = [
-    "claude-opus-4-8",
-    "claude-sonnet-5",
-    "claude-sonnet-4-6",
-    "claude-haiku-4-5",
-]
+        return _fallback([], _classify_fetch_error(e))
 
 
 async def _get_anthropic_models(api_key: Optional[str] = None) -> ModelDiscoveryResult:
-    """List Anthropic models live via ``GET /v1/models`` when a key is given.
+    """List Anthropic models live via ``GET https://api.anthropic.com/v1/models``.
 
     Replaces the previous paid ``messages.create`` validation ping: the
     models listing both validates the key (401 on a bad key) and returns the
@@ -580,13 +548,13 @@ async def _get_anthropic_models(api_key: Optional[str] = None) -> ModelDiscovery
     pagination is not followed.
     """
     if not api_key:
-        return _fallback(ANTHROPIC_FALLBACK_MODELS)
+        return _fallback([], ERROR_MISSING_KEY)
 
     try:
         from anthropic import AsyncAnthropic
     except ImportError:
         logger.warning("Anthropic package not installed, cannot list models")
-        return _fallback(ANTHROPIC_FALLBACK_MODELS, ERROR_SDK_MISSING)
+        return _fallback([], ERROR_SDK_MISSING)
 
     try:
         client = AsyncAnthropic(api_key=api_key)
@@ -616,15 +584,15 @@ async def _get_anthropic_models(api_key: Optional[str] = None) -> ModelDiscovery
                 "Invalid Anthropic API key. Please check your API key and try again."
             )
         logger.warning(
-            "Failed to list Anthropic models, using bundled fallback: %s",
+            "Failed to list Anthropic models: %s",
             type(e).__name__,
         )
-        return _fallback(ANTHROPIC_FALLBACK_MODELS, _classify_fetch_error(e))
+        return _fallback([], _classify_fetch_error(e))
 
     model_ids = _extract_model_ids(page)
     if not model_ids:
-        logger.info("Anthropic returned no models, using bundled fallback")
-        return _fallback(ANTHROPIC_FALLBACK_MODELS, ERROR_EMPTY_RESPONSE)
+        logger.info("Anthropic returned no models")
+        return _fallback([], ERROR_EMPTY_RESPONSE)
 
     logger.info("Listed %d Anthropic models", len(model_ids))
     return _live(model_ids)
@@ -664,37 +632,29 @@ def _build_scoped_google_client(api_key: str) -> Optional[object]:
         return None
 
 
-GOOGLE_FALLBACK_MODELS = [
-    "gemini-2.5-pro",
-    "gemini-2.5-flash",
-    "gemini-2.5-flash-lite",
-    "gemini-2.0-flash",
-]
-
-
 async def _get_google_models(api_key: Optional[str] = None) -> ModelDiscoveryResult:
-    """List Google Gemini models live via ``genai.list_models`` when keyed.
+    """List Google Gemini models live via ``genai.list_models``.
 
-    ``list_models`` itself fails on a bad key, so no separate paid
-    ``generate_content`` validation ping is made (it previously ran when the
-    listing produced nothing, burning tokens to validate a key the listing
-    had already exercised).
+    Listing API: Google AI Generative Language ``models.list``
+    (https://generativelanguage.googleapis.com/v1beta/models). ``list_models``
+    itself fails on a bad key, so no separate paid ``generate_content``
+    validation ping is made.
     """
     if not api_key:
-        return _fallback(GOOGLE_FALLBACK_MODELS)
+        return _fallback([], ERROR_MISSING_KEY)
 
     try:
         import google.generativeai as genai
     except ImportError:
         logger.warning("Google GenerativeAI package not installed, cannot list models")
-        return _fallback(GOOGLE_FALLBACK_MODELS, ERROR_SDK_MISSING)
+        return _fallback([], ERROR_SDK_MISSING)
 
     try:
         fetched_models = []
         list_models = getattr(genai, "list_models", None)
         if not callable(list_models):
-            logger.warning("genai.list_models unavailable, using bundled fallback")
-            return _fallback(GOOGLE_FALLBACK_MODELS, ERROR_SDK_MISSING)
+            logger.warning("genai.list_models unavailable")
+            return _fallback([], ERROR_SDK_MISSING)
 
         scoped_client = _build_scoped_google_client(api_key)
         if scoped_client is not None:
@@ -748,14 +708,14 @@ async def _get_google_models(api_key: Optional[str] = None) -> ModelDiscoveryRes
                 "Invalid Google API key. Please check your API key and try again."
             )
         logger.warning(
-            "Failed to list Google models, using bundled fallback: %s",
+            "Failed to list Google models: %s",
             type(e).__name__,
         )
-        return _fallback(GOOGLE_FALLBACK_MODELS, _classify_fetch_error(e))
+        return _fallback([], _classify_fetch_error(e))
 
     if not fetched_models:
-        logger.info("Google returned no models, using bundled fallback")
-        return _fallback(GOOGLE_FALLBACK_MODELS, ERROR_EMPTY_RESPONSE)
+        logger.info("Google returned no models")
+        return _fallback([], ERROR_EMPTY_RESPONSE)
 
     logger.info("Listed %d Google models", len(fetched_models))
     return _live(sorted(set(fetched_models), reverse=True))
@@ -765,23 +725,17 @@ async def _get_catalog_provider_models(
     *,
     provider_label: str,
     base_url: str,
-    known_models: List[str],
     api_key: Optional[str] = None,
 ) -> ModelDiscoveryResult:
-    """List models for a provider that ships an OpenAI-compatible ``/models``.
+    """List models from an OpenAI-compatible ``GET {base_url}/models``.
 
-    Without a key there is nothing to query, so the bundled catalog is
-    returned. With a key we return what the provider actually serves: these
-    catalogs go stale the moment the vendor ships a model (DeepSeek v4 was
-    hidden from the picker for exactly this reason) while litellm already
-    prices the new ids.
-
-    An authentication failure still raises, since the user needs to know the
-    key is bad. Any other failure (network, SDK, unexpected payload) falls
-    back to the bundled catalog rather than showing an empty picker.
+    Without a key there is nothing to query. With a key we return what the
+    provider actually serves. Authentication failures still raise so the
+    user knows the key is bad. Any other failure returns an empty list with
+    a safe reason rather than a stale guess.
     """
     if not api_key:
-        return _fallback(known_models)
+        return _fallback([], ERROR_MISSING_KEY)
 
     try:
         from openai import AsyncOpenAI, AuthenticationError
@@ -789,7 +743,7 @@ async def _get_catalog_provider_models(
         logger.warning(
             "OpenAI package not installed, cannot list %s models", provider_label
         )
-        return _fallback(known_models, ERROR_SDK_MISSING)
+        return _fallback([], ERROR_SDK_MISSING)
 
     try:
         client = AsyncOpenAI(
@@ -810,18 +764,16 @@ async def _get_catalog_provider_models(
         ) from e
     except Exception as e:
         logger.warning(
-            "Failed to list %s models, using bundled catalog: %s",
+            "Failed to list %s models: %s",
             provider_label,
             type(e).__name__,
         )
-        return _fallback(known_models, _classify_fetch_error(e))
+        return _fallback([], _classify_fetch_error(e))
 
     live_models = _extract_model_ids(response)
     if not live_models:
-        # A valid key that lists nothing is more likely a proxy quirk than an
-        # empty account; an empty picker is the worse outcome either way.
-        logger.info("%s returned no models, using bundled catalog", provider_label)
-        return _fallback(known_models, ERROR_EMPTY_RESPONSE)
+        logger.info("%s returned no models", provider_label)
+        return _fallback([], ERROR_EMPTY_RESPONSE)
 
     logger.info("Listed %d %s models", len(live_models), provider_label)
     return _live(live_models)
@@ -833,76 +785,6 @@ async def _get_catalog_provider_models(
 QWEN_DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 QWEN_INTL_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 QWEN_US_BASE_URL = "https://dashscope-us.aliyuncs.com/compatible-mode/v1"
-
-# Fallback catalog used when no Qwen / Model Studio key is available.
-# Provenance: Alibaba Cloud Model Studio text-generation list and the
-# qwen3.8-max product page (fetched 2026-08-17). Chat/completions only:
-# image, video, TTS, NSFW, Happy Horse, and Z-Image are excluded.
-# ORDER MATTERS: qwen3.8-max first (the headline model as of 2026-08-03).
-# Every id here is priced in services/data/model_prices.json under
-# dashscope/<id> (pinned by tests/services/test_model_pricing.py).
-QWEN_KNOWN_MODELS = [
-    "qwen3.8-max",
-    "qwen3.7-max",
-    "qwen3.7-plus",
-    "qwen3.6-flash",
-    "qwen3.5-plus",
-    "qwen3-max",
-    "qwen3-coder-plus",
-    "qwen-plus",
-    "qwen-flash",
-]
-
-# Fallback catalog used when no DeepSeek key is available to list the live set.
-# Keep in step with the deepseek entries in services/data/model_prices.json:
-# a model missing here is invisible in the picker even though it can be priced.
-DEEPSEEK_KNOWN_MODELS = [
-    "deepseek-chat",
-    "deepseek-reasoner",
-    "deepseek-v4-flash",
-    "deepseek-v4-pro",
-]
-
-# Fallback catalog used when no Moonshot key is available to list the live
-# set. Provenance: https://platform.kimi.ai/docs/models.md (fetched
-# 2026-08-05). ORDER MATTERS: kimi-k3 first (the headline model). The sunset
-# moonshot-v1 series and deprecated kimi-k2 previews are deliberately absent.
-# Every id here is priced in services/data/model_prices.json under
-# moonshot/<id> (pinned by tests/services/test_model_pricing.py).
-MOONSHOT_KNOWN_MODELS = [
-    "kimi-k3",
-    "kimi-k2.7-code",
-    "kimi-k2.7-code-highspeed",
-    "kimi-k2.6",
-]
-
-# Fallback catalog used when no Z.ai key is available to list the live set.
-# Provenance: live GET https://api.z.ai/api/paas/v4/models (2026-08-22)
-# plus the zai/* entries in the pinned litellm price map. glm-5.3 is on
-# the live list and on docs.z.ai/guides/overview/pricing; litellm's map
-# does not carry it yet. Priced under zai/<id> in model_prices.json
-# (pinned by tests/services/test_model_pricing.py).
-ZAI_KNOWN_MODELS = [
-    "glm-5.3",
-    "glm-5.1",
-    "glm-5",
-    "glm-4.7",
-    "glm-4.7-flash",
-]
-
-# Fallback catalog used when no Mistral key is available to list the live
-# set. Provenance: current chat models from the mistral/* entries in the
-# pinned litellm price map; embeddings (*-embed) and OCR (ocr-*) ids are
-# excluded on purpose. The *-latest aliases track Mistral's own rolling
-# pointers so this list ages more slowly than dated ids would.
-MISTRAL_KNOWN_MODELS = [
-    "mistral-large-latest",
-    "mistral-medium-latest",
-    "mistral-small-latest",
-    "codestral-latest",
-    "devstral-latest",
-    "ministral-8b-latest",
-]
 
 
 def _is_qwen_chat_model(model_id: str) -> bool:
@@ -955,7 +837,8 @@ async def _get_qwen_models(
     api_key: Optional[str] = None,
     api_endpoint: Optional[str] = None,
 ) -> ModelDiscoveryResult:
-    """Return Qwen / Model Studio models, live when a key is supplied.
+    """Return Qwen / Model Studio models via DashScope compatible-mode
+    ``GET {base}/models``.
 
     Default base URL is the China (Beijing) DashScope compatible-mode host so
     existing keys keep working. A caller-supplied endpoint (Singapore intl,
@@ -972,7 +855,6 @@ async def _get_qwen_models(
     result = await _get_catalog_provider_models(
         provider_label="Qwen",
         base_url=base_url,
-        known_models=QWEN_KNOWN_MODELS,
         api_key=api_key,
     )
     if result.source != "live":
@@ -980,66 +862,46 @@ async def _get_qwen_models(
 
     filtered = [model_id for model_id in result.models if _is_qwen_chat_model(model_id)]
     if not filtered:
-        logger.info(
-            "Qwen live list had no chat models after media/NSFW filter, "
-            "using bundled catalog"
-        )
-        return _fallback(QWEN_KNOWN_MODELS, ERROR_EMPTY_RESPONSE)
+        logger.info("Qwen live list had no chat models after media/NSFW filter")
+        return _fallback([], ERROR_EMPTY_RESPONSE)
     return _live(filtered)
 
 
 async def _get_deepseek_models(api_key: Optional[str] = None) -> ModelDiscoveryResult:
-    """Return DeepSeek models, live from the API when a key is supplied."""
+    """Return DeepSeek models via ``GET https://api.deepseek.com/v1/models``."""
     return await _get_catalog_provider_models(
         provider_label="DeepSeek",
         base_url="https://api.deepseek.com/v1",
-        known_models=DEEPSEEK_KNOWN_MODELS,
         api_key=api_key,
     )
 
 
 async def _get_moonshot_models(api_key: Optional[str] = None) -> ModelDiscoveryResult:
-    """Return Moonshot (Kimi) models, live from the API when a key is supplied."""
+    """Return Moonshot (Kimi) models via ``GET https://api.moonshot.ai/v1/models``."""
     return await _get_catalog_provider_models(
         provider_label="Moonshot (Kimi)",
         base_url="https://api.moonshot.ai/v1",
-        known_models=MOONSHOT_KNOWN_MODELS,
         api_key=api_key,
     )
 
 
 async def _get_zai_models(api_key: Optional[str] = None) -> ModelDiscoveryResult:
-    """Return Z.ai (GLM) models, live from the API when a key is supplied."""
+    """Return Z.ai (GLM) models via ``GET https://api.z.ai/api/paas/v4/models``."""
     return await _get_catalog_provider_models(
         provider_label="Z.ai (GLM)",
         base_url="https://api.z.ai/api/paas/v4",
-        known_models=ZAI_KNOWN_MODELS,
         api_key=api_key,
     )
 
 
 async def _get_mistral_models(api_key: Optional[str] = None) -> ModelDiscoveryResult:
-    """Return Mistral models, live from the API when a key is supplied."""
+    """Return Mistral models via ``GET https://api.mistral.ai/v1/models``."""
     return await _get_catalog_provider_models(
         provider_label="Mistral",
         base_url="https://api.mistral.ai/v1",
-        known_models=MISTRAL_KNOWN_MODELS,
         api_key=api_key,
     )
 
-
-# Fallback catalog used when the Bedrock listing call cannot be made.
-# Provenance: current on-demand chat model ids from AWS Bedrock documentation;
-# every id also resolves in litellm's price map under bedrock/<id>. Live
-# listing via the Bedrock control plane is always attempted first, so this
-# only surfaces when boto3 is missing or the control plane is unreachable.
-BEDROCK_FALLBACK_MODELS = [
-    "anthropic.claude-opus-4-5",
-    "anthropic.claude-sonnet-4-5",
-    "anthropic.claude-haiku-4-5",
-    "amazon.nova-pro-v1:0",
-    "amazon.nova-lite-v1:0",
-]
 
 # ClientError codes (and HTTP statuses) that mean the AWS credentials were
 # rejected or are missing permissions, mapped to ProviderAuthError so the
@@ -1096,20 +958,19 @@ def _is_bedrock_chat_model(summary: Any) -> bool:
 async def _get_bedrock_models(
     aws_auth: Optional[Dict[str, Any]] = None,
 ) -> ModelDiscoveryResult:
-    """List AWS Bedrock foundation models live via the Bedrock control plane.
+    """List AWS Bedrock foundation models via ``list_foundation_models``.
 
-    Uses boto3's ``bedrock`` client ``list_foundation_models``, which answers
-    from IAM-authenticated credentials instead of a static key, so both
-    explicit access keys and ambient credentials (instance profile, env,
-    SSO) work. The listing validates the credentials for free — a bad key
-    fails the call with an auth error, which raises ProviderAuthError so the
-    user knows their credentials are wrong.
+    Control-plane API:
+    https://docs.aws.amazon.com/bedrock/latest/APIReference/API_ListFoundationModels.html
+    Uses boto3's ``bedrock`` client. Explicit access keys (typed or stored)
+    are required for the picker; ambient instance-profile listing is not
+    used. A bad key fails the call with an auth error, which raises
+    ProviderAuthError.
 
     Args:
-        aws_auth: Optional mapping with ``aws_access_key_id``,
-            ``aws_secret_access_key``, ``aws_session_token`` and
-            ``aws_region_name``. Missing keys fall back to boto3's default
-            credential/region chain.
+        aws_auth: Mapping with ``aws_access_key_id``,
+            ``aws_secret_access_key``, optional ``aws_session_token`` and
+            ``aws_region_name``.
 
     Returns:
         ModelDiscoveryResult with sorted text-output foundation model ids.
@@ -1118,14 +979,17 @@ async def _get_bedrock_models(
         ProviderValidationError: When no region can be resolved.
         ProviderAuthError: When AWS rejects the credentials.
     """
+    auth = {key: str(value).strip() for key, value in (aws_auth or {}).items() if value}
+    if not auth.get("aws_access_key_id") or not auth.get("aws_secret_access_key"):
+        return _fallback([], ERROR_MISSING_KEY)
+
     try:
         import boto3  # type: ignore[import-untyped]
         from botocore.config import Config  # type: ignore[import-untyped]
     except ImportError:
         logger.warning("boto3 package not installed, cannot list Bedrock models")
-        return _fallback(BEDROCK_FALLBACK_MODELS, ERROR_SDK_MISSING)
+        return _fallback([], ERROR_SDK_MISSING)
 
-    auth = {key: str(value).strip() for key, value in (aws_auth or {}).items() if value}
     session_kwargs = {
         key: auth[key]
         for key in ("aws_access_key_id", "aws_secret_access_key", "aws_session_token")
@@ -1166,10 +1030,10 @@ async def _get_bedrock_models(
                 "and region, then try again."
             ) from e
         logger.warning(
-            "Failed to list Bedrock models, using bundled fallback: %s",
+            "Failed to list Bedrock models: %s",
             type(e).__name__,
         )
-        return _fallback(BEDROCK_FALLBACK_MODELS, _classify_fetch_error(e))
+        return _fallback([], _classify_fetch_error(e))
 
     summaries = getattr(response, "modelSummaries", None) or []
     model_ids = []
@@ -1180,8 +1044,8 @@ async def _get_bedrock_models(
 
     model_ids = sorted(set(model_ids))[:MAX_DISCOVERED_MODELS]
     if not model_ids:
-        logger.info("Bedrock returned no chat models, using bundled fallback")
-        return _fallback(BEDROCK_FALLBACK_MODELS, ERROR_EMPTY_RESPONSE)
+        logger.info("Bedrock returned no chat models")
+        return _fallback([], ERROR_EMPTY_RESPONSE)
 
     logger.info("Listed %d Bedrock models", len(model_ids))
     return _live(model_ids)

--- a/backend/preloop/services/ai_model_provider.py
+++ b/backend/preloop/services/ai_model_provider.py
@@ -233,7 +233,9 @@ async def get_available_models_for_provider(
             return _fallback([], ERROR_MISSING_ENDPOINT)
         if provider == "openrouter" and not (api_key or "").strip():
             return _fallback([], ERROR_MISSING_KEY)
-        return await _get_openai_compatible_models(endpoint, api_key)
+        return await _get_openai_compatible_models(
+            endpoint, api_key, model_kind=normalized_model_kind
+        )
     else:
         # Unknown provider with no endpoint convention to follow.
         return _fallback([], ERROR_UNSUPPORTED)
@@ -344,7 +346,9 @@ def validate_qwen_endpoint(api_endpoint: str) -> str:
 
 
 async def _get_openai_compatible_models(
-    api_endpoint: str, api_key: Optional[str] = None
+    api_endpoint: str,
+    api_key: Optional[str] = None,
+    model_kind: ModelKind = "llm",
 ) -> ModelDiscoveryResult:
     """List models from an OpenAI-compatible endpoint's ``GET /models``.
 
@@ -353,6 +357,12 @@ async def _get_openai_compatible_models(
     Some servers (OpenRouter included) return a bare list, which is accepted
     too. There is no bundled catalog for arbitrary endpoints, so a failed
     fetch yields an empty fallback with a reason rather than a stale guess.
+
+    ``stt``/``tts`` narrow the live ids by the same name markers OpenAI ids
+    use, which needs no catalog. The ``llm`` kind keeps the full live list:
+    the LLM filter is an exclusion list tuned to OpenAI's naming, and markers
+    like ``instruct`` are ordinary chat models on a self-hosted endpoint
+    (``Llama-3-8B-Instruct``), so applying it here would hide real models.
     """
     try:
         from openai import AsyncOpenAI, AuthenticationError
@@ -396,7 +406,12 @@ async def _get_openai_compatible_models(
         if http_client is not None:
             await http_client.aclose()
 
-    return _live(_extract_model_ids(response))
+    model_ids = _extract_model_ids(response)
+    if model_kind in ("stt", "tts"):
+        model_ids = _openai_ids_for_kind(model_ids, model_kind)
+        if not model_ids:
+            return _fallback([], ERROR_EMPTY_RESPONSE)
+    return _live(model_ids)
 
 
 def _extract_model_ids(response: object) -> List[str]:

--- a/backend/tests/endpoints/test_available_models_key_handling.py
+++ b/backend/tests/endpoints/test_available_models_key_handling.py
@@ -293,3 +293,152 @@ async def test_post_unknown_stored_model_is_404(mocker):
         )
 
     assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_post_provider_mismatch_never_decrypts_the_stored_key(mocker):
+    """A stored key is only usable for the provider it was stored for.
+
+    The edit form leaves the provider dropdown enabled, so a caller can pair
+    a Z.ai model id with ``provider=custom`` and an attacker-controlled
+    ``api_endpoint``. ``validate_discovery_endpoint`` blocks private hosts but
+    not public ones, so without this check the decrypted Z.ai key would be
+    forwarded to that URL.
+    """
+    user = MagicMock()
+    user.account_id = uuid.uuid4()
+    stored = MagicMock()
+    stored.provider_name = "zai"
+    stored.api_endpoint = None
+    stored.meta_data = {}
+    mocker.patch.object(ai_models.crud_ai_model, "get_for_account", return_value=stored)
+    resolve = mocker.patch.object(
+        ai_models.crud_ai_model,
+        "resolve_listing_secret",
+        return_value="stored-zai-key",
+    )
+    fetch = mocker.patch.object(
+        ai_models,
+        "get_available_models_for_provider",
+        new=AsyncMock(
+            return_value=ModelDiscoveryResult(models=["a-model"], source="live")
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await ai_models.list_provider_available_models(
+            provider="custom",
+            request_in=AvailableModelsRequest(
+                ai_model_id=uuid.uuid4(),
+                api_endpoint="https://attacker.example/v1",
+            ),
+            db=MagicMock(),
+            current_user=user,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == (
+        "Stored model provider does not match the requested provider"
+    )
+    resolve.assert_not_called()
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_provider_match_is_case_insensitive(mocker):
+    """Provider casing from the path must not break a legitimate refresh."""
+    user = MagicMock()
+    user.account_id = uuid.uuid4()
+    stored = MagicMock()
+    stored.provider_name = "ZAI"
+    stored.api_endpoint = None
+    stored.meta_data = {}
+    mocker.patch.object(ai_models.crud_ai_model, "get_for_account", return_value=stored)
+    mocker.patch.object(
+        ai_models.crud_ai_model,
+        "resolve_listing_secret",
+        return_value="stored-zai-key",
+    )
+    fetch = mocker.patch.object(
+        ai_models,
+        "get_available_models_for_provider",
+        new=AsyncMock(
+            return_value=ModelDiscoveryResult(models=["glm-5.3"], source="live")
+        ),
+    )
+
+    result = await ai_models.list_provider_available_models(
+        provider="zai",
+        request_in=AvailableModelsRequest(ai_model_id=uuid.uuid4()),
+        db=MagicMock(),
+        current_user=user,
+    )
+
+    assert result.models == ["glm-5.3"]
+    fetch.assert_awaited_once_with("zai", "stored-zai-key", "llm", None, aws_auth=None)
+
+
+@pytest.mark.asyncio
+async def test_post_unexpected_secret_error_is_not_swallowed(mocker):
+    """Only expected decryption failures degrade to an unauthenticated list.
+
+    Expected failures all normalize to ValueError. A programming bug (say an
+    AttributeError after a schema change) must surface instead of quietly
+    turning into a "missing_key" fallback.
+    """
+    user = MagicMock()
+    user.account_id = uuid.uuid4()
+    stored = MagicMock()
+    stored.provider_name = "zai"
+    stored.api_endpoint = None
+    stored.meta_data = {}
+    mocker.patch.object(ai_models.crud_ai_model, "get_for_account", return_value=stored)
+    mocker.patch.object(
+        ai_models.crud_ai_model,
+        "resolve_listing_secret",
+        side_effect=AttributeError("credentials_secret vanished"),
+    )
+
+    with pytest.raises(AttributeError):
+        await ai_models.list_provider_available_models(
+            provider="zai",
+            request_in=AvailableModelsRequest(ai_model_id=uuid.uuid4()),
+            db=MagicMock(),
+            current_user=user,
+        )
+
+
+@pytest.mark.asyncio
+async def test_post_undecryptable_secret_still_falls_back(mocker):
+    """An unreadable stored secret still degrades gracefully."""
+    user = MagicMock()
+    user.account_id = uuid.uuid4()
+    stored = MagicMock()
+    stored.provider_name = "zai"
+    stored.api_endpoint = None
+    stored.meta_data = {}
+    mocker.patch.object(ai_models.crud_ai_model, "get_for_account", return_value=stored)
+    mocker.patch.object(
+        ai_models.crud_ai_model,
+        "resolve_listing_secret",
+        side_effect=ValueError("Unable to decrypt value"),
+    )
+    fetch = mocker.patch.object(
+        ai_models,
+        "get_available_models_for_provider",
+        new=AsyncMock(
+            return_value=ModelDiscoveryResult(
+                models=[], source="fallback", error="missing_key"
+            )
+        ),
+    )
+
+    result = await ai_models.list_provider_available_models(
+        provider="zai",
+        request_in=AvailableModelsRequest(ai_model_id=uuid.uuid4()),
+        db=MagicMock(),
+        current_user=user,
+    )
+
+    assert result.error == "missing_key"
+    fetch.assert_awaited_once_with("zai", None, "llm", None, aws_auth=None)

--- a/backend/tests/endpoints/test_available_models_key_handling.py
+++ b/backend/tests/endpoints/test_available_models_key_handling.py
@@ -11,9 +11,12 @@ query parameter is gone rather than merely deprecated.
 """
 
 import pytest
+import uuid
 import yaml
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import HTTPException
 
 from preloop.api.endpoints import ai_models
 from preloop.schemas.ai_model import AvailableModelsRequest
@@ -192,3 +195,101 @@ async def test_post_response_never_carries_key_or_endpoint_material(mocker):
     assert "sk-or-v1-secret-value" not in dumped
     assert "secret-gateway.internal.example" not in dumped
     assert result.error == "network"
+
+
+def test_ai_model_id_is_a_body_field_on_the_post_route():
+    assert "ai_model_id" in AvailableModelsRequest.model_fields
+
+
+@pytest.mark.asyncio
+async def test_post_edit_refresh_decrypts_stored_key(mocker):
+    """Edit-mode refresh sends the model id; the server decrypts the key."""
+    model_id = uuid.uuid4()
+    user = MagicMock()
+    user.account_id = uuid.uuid4()
+    stored = MagicMock()
+    stored.provider_name = "zai"
+    stored.api_endpoint = None
+    stored.meta_data = {}
+    mocker.patch.object(ai_models.crud_ai_model, "get_for_account", return_value=stored)
+    mocker.patch.object(
+        ai_models.crud_ai_model,
+        "resolve_listing_secret",
+        return_value="stored-zai-key",
+    )
+    fetch = mocker.patch.object(
+        ai_models,
+        "get_available_models_for_provider",
+        new=AsyncMock(
+            return_value=ModelDiscoveryResult(
+                models=["glm-5.3", "glm-5.3-flash"], source="live"
+            )
+        ),
+    )
+
+    result = await ai_models.list_provider_available_models(
+        provider="zai",
+        request_in=AvailableModelsRequest(ai_model_id=model_id),
+        db=MagicMock(),
+        current_user=user,
+    )
+
+    assert result.models == ["glm-5.3", "glm-5.3-flash"]
+    assert result.source == "live"
+    assert "stored-zai-key" not in result.model_dump_json()
+    fetch.assert_awaited_once_with("zai", "stored-zai-key", "llm", None, aws_auth=None)
+
+
+@pytest.mark.asyncio
+async def test_post_typed_key_wins_over_stored_key(mocker):
+    model_id = uuid.uuid4()
+    user = MagicMock()
+    user.account_id = uuid.uuid4()
+    stored = MagicMock()
+    stored.provider_name = "zai"
+    stored.api_endpoint = None
+    stored.meta_data = {}
+    mocker.patch.object(ai_models.crud_ai_model, "get_for_account", return_value=stored)
+    mocker.patch.object(
+        ai_models.crud_ai_model,
+        "resolve_listing_secret",
+        return_value="stored-zai-key",
+    )
+    fetch = mocker.patch.object(
+        ai_models,
+        "get_available_models_for_provider",
+        new=AsyncMock(
+            return_value=ModelDiscoveryResult(models=["glm-5.3-flash"], source="live")
+        ),
+    )
+
+    result = await ai_models.list_provider_available_models(
+        provider="zai",
+        request_in=AvailableModelsRequest(
+            ai_model_id=model_id, api_key="typed-zai-key"
+        ),
+        db=MagicMock(),
+        current_user=user,
+    )
+
+    assert result.models == ["glm-5.3-flash"]
+    fetch.assert_awaited_once_with("zai", "typed-zai-key", "llm", None, aws_auth=None)
+    assert "stored-zai-key" not in result.model_dump_json()
+    assert "typed-zai-key" not in result.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_post_unknown_stored_model_is_404(mocker):
+    user = MagicMock()
+    user.account_id = uuid.uuid4()
+    mocker.patch.object(ai_models.crud_ai_model, "get_for_account", return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await ai_models.list_provider_available_models(
+            provider="zai",
+            request_in=AvailableModelsRequest(ai_model_id=uuid.uuid4()),
+            db=MagicMock(),
+            current_user=user,
+        )
+
+    assert exc_info.value.status_code == 404

--- a/backend/tests/services/test_ai_model_provider.py
+++ b/backend/tests/services/test_ai_model_provider.py
@@ -7,19 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from preloop.services.ai_model_provider import (
     get_available_models_for_provider,
-    ANTHROPIC_FALLBACK_MODELS,
-    BEDROCK_FALLBACK_MODELS,
-    DEEPSEEK_KNOWN_MODELS,
-    GOOGLE_FALLBACK_MODELS,
-    MISTRAL_KNOWN_MODELS,
-    MOONSHOT_KNOWN_MODELS,
-    OPENAI_FALLBACK_MODELS,
     QWEN_DEFAULT_BASE_URL,
     QWEN_INTL_BASE_URL,
-    QWEN_KNOWN_MODELS,
     QWEN_US_BASE_URL,
-    ZAI_KNOWN_MODELS,
     _is_qwen_chat_model,
+    ERROR_EMPTY_RESPONSE,
+    ERROR_MISSING_KEY,
     ERROR_SDK_MISSING,
     ERROR_UNKNOWN,
     FALLBACK_ERROR_REASONS,
@@ -79,49 +72,59 @@ class TestGetAvailableModelsForProvider:
             result = await get_available_models_for_provider("openai", "test_key")
             assert result.models == ["gpt-5.4", "gpt-5.4-mini"]
             assert result.source == "live"
-            mock_get.assert_called_once_with("test_key")
+            mock_get.assert_called_once_with("test_key", model_kind="llm")
 
     @pytest.mark.asyncio
     async def test_get_openai_stt_models(self):
-        """OpenAI speech-to-text catalog is curated, so provenance is fallback."""
-        result = await get_available_models_for_provider(
-            "openai", "test_key", model_kind="stt"
-        )
-        assert result.models == [
-            "gpt-4o-transcribe",
-            "gpt-4o-mini-transcribe",
-            "whisper-1",
-        ]
-        assert result.source == "fallback"
-        assert result.error is None
+        """OpenAI STT ids come from the live GET /v1/models list, filtered."""
+        with patch("preloop.services.ai_model_provider._get_openai_models") as mock_get:
+            mock_get.return_value = ModelDiscoveryResult(
+                models=["gpt-4o-transcribe", "whisper-1"], source="live"
+            )
+            result = await get_available_models_for_provider(
+                "openai", "test_key", model_kind="stt"
+            )
+            assert result.models == ["gpt-4o-transcribe", "whisper-1"]
+            assert result.source == "live"
+            mock_get.assert_called_once_with("test_key", model_kind="stt")
 
     @pytest.mark.asyncio
     async def test_get_openai_tts_models(self):
-        """Test OpenAI text-to-speech model catalog."""
-        result = await get_available_models_for_provider(
-            "openai", "test_key", model_kind="tts"
-        )
-        assert result.models == ["gpt-4o-mini-tts", "tts-1", "tts-1-hd"]
-        assert result.source == "fallback"
+        """OpenAI TTS ids come from the live GET /v1/models list, filtered."""
+        with patch("preloop.services.ai_model_provider._get_openai_models") as mock_get:
+            mock_get.return_value = ModelDiscoveryResult(
+                models=["gpt-4o-mini-tts", "tts-1"], source="live"
+            )
+            result = await get_available_models_for_provider(
+                "openai", "test_key", model_kind="tts"
+            )
+            assert result.models == ["gpt-4o-mini-tts", "tts-1"]
+            assert result.source == "live"
+            mock_get.assert_called_once_with("test_key", model_kind="tts")
 
     @pytest.mark.asyncio
     async def test_audio_models_only_for_supported_providers(self):
-        """Non-audio providers should not offer STT/TTS choices."""
+        """Unsupported audio kinds return empty with unsupported, not a catalog."""
         stt = await get_available_models_for_provider(
             "google", "test_key", model_kind="stt"
         )
-        assert stt.models == [
-            "latest_short",
-            "latest_long",
-            "command_and_search",
-            "default",
-        ]
+        assert stt.models == []
+        assert stt.source == "fallback"
+        assert stt.error == "missing_endpoint"
         tts = await get_available_models_for_provider(
             "google", "test_key", model_kind="tts"
         )
         assert tts.models == []
         assert tts.source == "fallback"
         assert tts.error == "unsupported"
+
+    @pytest.mark.asyncio
+    async def test_no_key_returns_empty_missing_key_not_a_catalog(self):
+        """Edit without id and without a typed key must not guess a catalog."""
+        result = await get_available_models_for_provider("zai")
+        assert result.models == []
+        assert result.source == "fallback"
+        assert result.error == ERROR_MISSING_KEY
 
     @pytest.mark.asyncio
     async def test_get_anthropic_models(self):
@@ -308,6 +311,41 @@ class TestGetOpenAIModels:
             assert "dall-e-3" not in result.models
 
     @pytest.mark.asyncio
+    async def test_get_openai_stt_models_lists_live_audio_ids(self):
+        """STT uses GET https://api.openai.com/v1/models, filtered to audio."""
+        mock_response = _models_response(
+            "gpt-5.4",
+            "whisper-1",
+            "gpt-4o-transcribe",
+            "tts-1",
+        )
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=mock_response)
+            mock_client.return_value = mock_instance
+
+            result = await _get_openai_models("test_key", model_kind="stt")
+
+        assert result.source == "live"
+        assert "whisper-1" in result.models
+        assert "gpt-4o-transcribe" in result.models
+        assert "gpt-5.4" not in result.models
+        assert "tts-1" not in result.models
+
+    @pytest.mark.asyncio
+    async def test_get_openai_tts_models_lists_live_audio_ids(self):
+        mock_response = _models_response("gpt-5.4", "whisper-1", "tts-1", "tts-1-hd")
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=mock_response)
+            mock_client.return_value = mock_instance
+
+            result = await _get_openai_models("test_key", model_kind="tts")
+
+        assert result.source == "live"
+        assert set(result.models) == {"tts-1", "tts-1-hd"}
+
+    @pytest.mark.asyncio
     async def test_get_openai_models_authentication_error(self):
         """Test handling of authentication errors."""
         from openai import AuthenticationError
@@ -338,7 +376,7 @@ class TestGetOpenAIModels:
 
             result = await _get_openai_models("test_key")
 
-            assert result.models == OPENAI_FALLBACK_MODELS
+            assert result.models == []
             assert result.source == "fallback"
             assert result.error in FALLBACK_ERROR_REASONS
 
@@ -354,15 +392,13 @@ class TestGetOpenAIModels:
 
             result = await _get_openai_models(None)
 
-            # Should call AsyncOpenAI without api_key parameter so the SDK
-            # picks the key up from the environment.
-            mock_client.assert_called_once()
-            assert "api_key" not in mock_client.call_args.kwargs
-            assert mock_client.call_args.args == ()
-            assert "gpt-5.4" in result.models
+            mock_client.assert_not_called()
+            assert result.models == []
+            assert result.source == "fallback"
+            assert result.error == ERROR_MISSING_KEY
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_key", ["test_key", None])
+    @pytest.mark.parametrize("api_key", ["test_key"])
     async def test_get_openai_models_client_is_bounded(self, api_key):
         """The client must carry the shared discovery timeout and one retry.
 
@@ -388,7 +424,7 @@ class TestGetOpenAIModels:
         with patch.dict(sys.modules, {"openai": None}):
             result = await _get_openai_models("test_key")
 
-        assert result.models == OPENAI_FALLBACK_MODELS
+        assert result.models == []
         assert result.source == "fallback"
         assert result.error == "sdk_missing"
 
@@ -398,11 +434,11 @@ class TestGetAnthropicModels:
 
     @pytest.mark.asyncio
     async def test_get_anthropic_models_without_key(self):
-        """No key: the named fallback with clean fallback provenance."""
+        """No key: empty list with missing_key, not a catalog."""
         result = await _get_anthropic_models(None)
-        assert result.models == ANTHROPIC_FALLBACK_MODELS
+        assert result.models == []
         assert result.source == "fallback"
-        assert result.error is None
+        assert result.error == ERROR_MISSING_KEY
 
     @pytest.mark.asyncio
     async def test_valid_key_lists_models_live(self):
@@ -486,7 +522,7 @@ class TestGetAnthropicModels:
 
             with patch("builtins.__import__", side_effect=mock_import):
                 result = await _get_anthropic_models("test_key")
-                assert result.models == ANTHROPIC_FALLBACK_MODELS
+                assert result.models == []
                 assert result.source == "fallback"
                 assert result.error == "sdk_missing"
         finally:
@@ -504,7 +540,7 @@ class TestGetAnthropicModels:
             mock_client.return_value = mock_instance
 
             result = await _get_anthropic_models("test_key")
-            assert result.models == ANTHROPIC_FALLBACK_MODELS
+            assert result.models == []
             assert result.source == "fallback"
             assert result.error in FALLBACK_ERROR_REASONS
 
@@ -517,17 +553,22 @@ class TestGetAnthropicModels:
             mock_client.return_value = mock_instance
 
             result = await _get_anthropic_models("valid_key")
-            assert result.models == ANTHROPIC_FALLBACK_MODELS
+            assert result.models == []
             assert result.error == "empty_response"
 
     def test_fallback_ids_are_priced_in_the_bundled_table(self):
-        """Every fallback id must resolve in the vendored price snapshot."""
+        """Pricing coverage lives in test_model_pricing, not a picker catalog."""
         import json
 
         from preloop.services.model_price_catalog import CATALOG_PATH
 
         prices = json.loads(CATALOG_PATH.read_text())
-        for model_id in ANTHROPIC_FALLBACK_MODELS:
+        for model_id in (
+            "claude-opus-4-8",
+            "claude-sonnet-5",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+        ):
             assert model_id in prices, f"{model_id} missing from model_prices.json"
 
 
@@ -536,11 +577,11 @@ class TestGetGoogleModels:
 
     @pytest.mark.asyncio
     async def test_get_google_models_without_key(self):
-        """No key: the named fallback with clean fallback provenance."""
+        """No key: empty list with missing_key, not a catalog."""
         result = await _get_google_models(None)
-        assert result.models == GOOGLE_FALLBACK_MODELS
+        assert result.models == []
         assert result.source == "fallback"
-        assert result.error is None
+        assert result.error == ERROR_MISSING_KEY
 
     @pytest.mark.asyncio
     async def test_get_google_models_with_valid_key_lists_live(self):
@@ -587,7 +628,7 @@ class TestGetGoogleModels:
         ):
             result = await _get_google_models("valid_key")
 
-            assert result.models == GOOGLE_FALLBACK_MODELS
+            assert result.models == []
             assert result.source == "fallback"
             assert result.error == "empty_response"
             # And no paid generate_content ping was fired to "validate".
@@ -648,7 +689,7 @@ class TestGetGoogleModels:
 
             with patch("builtins.__import__", side_effect=mock_import):
                 result = await _get_google_models("test_key")
-                assert result.models == GOOGLE_FALLBACK_MODELS
+                assert result.models == []
                 assert result.error == "sdk_missing"
         finally:
             if genai_module is not None:
@@ -662,7 +703,7 @@ class TestGetGoogleModels:
 
         with patch.dict(sys.modules, {"google.generativeai": mock_genai}):
             result = await _get_google_models("test_key")
-            assert result.models == GOOGLE_FALLBACK_MODELS
+            assert result.models == []
             assert result.source == "fallback"
             assert result.error in FALLBACK_ERROR_REASONS
 
@@ -792,11 +833,11 @@ class TestGetQwenModels:
 
     @pytest.mark.asyncio
     async def test_get_qwen_models_without_key(self):
-        """Test getting Qwen models without API key."""
+        """No key: empty list with missing_key, not a catalog."""
         result = await _get_qwen_models(None)
-        assert result.models == QWEN_KNOWN_MODELS
+        assert result.models == []
         assert result.source == "fallback"
-        assert result.error is None
+        assert result.error == ERROR_MISSING_KEY
 
     @pytest.mark.asyncio
     async def test_get_qwen_models_with_valid_key_returns_live_list(self):
@@ -829,7 +870,7 @@ class TestGetQwenModels:
 
             result = await _get_qwen_models("valid_key")
 
-            assert "qwen3.8-max" in result.models
+            assert result.models == []
             assert result.source == "fallback"
             assert result.error == "empty_response"
 
@@ -863,9 +904,9 @@ class TestGetQwenModels:
             mock_client.return_value = mock_instance
 
             result = await _get_qwen_models("test_key")
-            # Should return known models even on network error
-            assert "qwen3.8-max" in result.models
+            assert result.models == []
             assert result.source == "fallback"
+            assert result.error in FALLBACK_ERROR_REASONS
 
     @pytest.mark.asyncio
     async def test_get_qwen_models_uses_supplied_intl_endpoint(self):
@@ -937,12 +978,8 @@ class TestGetQwenModels:
                 "qwen3.8-max",
             ]
 
-    def test_qwen_fallback_catalog_is_current_chat_models(self):
-        """Keyless picker shows 2026-08 chat models, not the stale 2025 set."""
-        assert QWEN_KNOWN_MODELS[0] == "qwen3.8-max"
-        assert "qwen3.7-max" in QWEN_KNOWN_MODELS
-        assert "qwq-32b-preview" not in QWEN_KNOWN_MODELS
-        assert "qwen-turbo" not in QWEN_KNOWN_MODELS
+    def test_qwen_chat_filter_keeps_completions_and_drops_media(self):
+        """Live Qwen ids are filtered; there is no keyless catalog."""
         assert _is_qwen_chat_model("qwen3.8-max")
         assert _is_qwen_chat_model("deepseek-v4-pro")
         assert _is_qwen_chat_model("glm-5.2")
@@ -962,32 +999,11 @@ class TestGetDeepSeekModels:
 
     @pytest.mark.asyncio
     async def test_get_deepseek_models_without_key(self):
-        """Test getting DeepSeek models without API key."""
+        """No key: empty list with missing_key, not a catalog."""
         result = await _get_deepseek_models(None)
-        assert "deepseek-chat" in result.models
-        assert "deepseek-reasoner" in result.models
+        assert result.models == []
         assert result.source == "fallback"
-
-    @pytest.mark.asyncio
-    async def test_keyless_catalog_includes_v4_models(self):
-        """The bundled catalog must not hide models litellm already prices."""
-        result = await _get_deepseek_models(None)
-        assert "deepseek-v4-flash" in result.models
-        assert "deepseek-v4-pro" in result.models
-
-    @pytest.mark.asyncio
-    async def test_keyless_catalog_entries_are_priced(self):
-        """Every fallback id should resolve in the bundled price table.
-
-        This is what keeps the hardcoded list honest as DeepSeek ships models.
-        """
-        import json
-
-        from preloop.services.model_price_catalog import CATALOG_PATH
-
-        prices = json.loads(CATALOG_PATH.read_text())
-        for model_id in DEEPSEEK_KNOWN_MODELS:
-            assert model_id in prices, f"{model_id} missing from model_prices.json"
+        assert result.error == ERROR_MISSING_KEY
 
     @pytest.mark.asyncio
     async def test_get_deepseek_models_with_valid_key_returns_live_list(self):
@@ -1025,8 +1041,9 @@ class TestGetDeepSeekModels:
 
             result = await _get_deepseek_models("valid_key")
 
-            assert "deepseek-chat" in result.models
+            assert result.models == []
             assert result.source == "fallback"
+            assert result.error == ERROR_EMPTY_RESPONSE
 
     @pytest.mark.asyncio
     async def test_get_deepseek_models_authentication_error(self):
@@ -1058,30 +1075,21 @@ class TestGetDeepSeekModels:
             mock_client.return_value = mock_instance
 
             result = await _get_deepseek_models("test_key")
-            # Should return known models even on network error
-            assert "deepseek-chat" in result.models
+            assert result.models == []
+            assert result.source == "fallback"
+            assert result.error in FALLBACK_ERROR_REASONS
 
 
 class TestGetMoonshotModels:
     """Moonshot (Kimi): live discovery plus a kimi-k3-first fallback."""
 
     @pytest.mark.asyncio
-    async def test_without_key_returns_fallback_with_kimi_k3_first(self):
-        """kimi-k3 is the headline model and must lead the fallback list."""
+    async def test_without_key_returns_missing_key(self):
+        """No key: empty list with missing_key, not a catalog."""
         result = await _get_moonshot_models(None)
-        assert result.models == MOONSHOT_KNOWN_MODELS
-        assert result.models[0] == "kimi-k3"
+        assert result.models == []
         assert result.source == "fallback"
-        assert result.error is None
-
-    def test_fallback_excludes_sunset_and_deprecated_ids(self):
-        """No sunset moonshot-v1 series, no deprecated kimi-k2 previews."""
-        for model_id in MOONSHOT_KNOWN_MODELS:
-            assert not model_id.startswith("moonshot-v1")
-            assert "preview" not in model_id
-            assert "thinking" not in model_id
-            assert model_id != "kimi-latest"
-            assert model_id != "kimi-k2.5"  # sunset Aug 31
+        assert result.error == ERROR_MISSING_KEY
 
     @pytest.mark.asyncio
     async def test_with_valid_key_lists_live_from_moonshot_base_url(self):
@@ -1109,7 +1117,7 @@ class TestGetMoonshotModels:
 
             result = await _get_moonshot_models("valid_key")
 
-            assert result.models == MOONSHOT_KNOWN_MODELS
+            assert result.models == []
             assert result.source == "fallback"
             assert result.error == "empty_response"
 
@@ -1137,7 +1145,7 @@ class TestGetMoonshotModels:
             mock_client.return_value = mock_instance
 
             result = await _get_moonshot_models("test_key")
-            assert result.models == MOONSHOT_KNOWN_MODELS
+            assert result.models == []
             assert result.source == "fallback"
             assert result.error in FALLBACK_ERROR_REASONS
 
@@ -1146,27 +1154,25 @@ class TestGetZaiModels:
     """Z.ai (GLM): live discovery plus a litellm-priced fallback."""
 
     @pytest.mark.asyncio
-    async def test_without_key_returns_fallback(self):
+    async def test_without_key_returns_missing_key(self):
         result = await _get_zai_models(None)
-        assert result.models == ZAI_KNOWN_MODELS
-        assert "glm-5.3" in result.models
-        assert "glm-5" in result.models
-        assert "glm-4.7" in result.models
+        assert result.models == []
         assert result.source == "fallback"
+        assert result.error == ERROR_MISSING_KEY
 
     @pytest.mark.asyncio
     async def test_with_valid_key_lists_live_from_zai_base_url(self):
         with patch("openai.AsyncOpenAI") as mock_client:
             mock_instance = MagicMock()
             mock_instance.models.list = AsyncMock(
-                return_value=_models_response("glm-5.2", "glm-5")
+                return_value=_models_response("glm-5.2", "glm-5", "glm-5.3-flash")
             )
             mock_client.return_value = mock_instance
 
             result = await _get_zai_models("valid_key")
 
             assert result.source == "live"
-            assert result.models == ["glm-5", "glm-5.2"]
+            assert result.models == ["glm-5", "glm-5.2", "glm-5.3-flash"]
             call_kwargs = mock_client.call_args[1]
             assert call_kwargs["base_url"] == "https://api.z.ai/api/paas/v4"
 
@@ -1180,7 +1186,7 @@ class TestGetZaiModels:
 
             result = await _get_zai_models("valid_key")
 
-            assert result.models == ZAI_KNOWN_MODELS
+            assert result.models == []
             assert result.source == "fallback"
             assert result.error == "empty_response"
 
@@ -1208,7 +1214,7 @@ class TestGetZaiModels:
             mock_client.return_value = mock_instance
 
             result = await _get_zai_models("test_key")
-            assert result.models == ZAI_KNOWN_MODELS
+            assert result.models == []
             assert result.source == "fallback"
 
 
@@ -1216,15 +1222,11 @@ class TestGetMistralModels:
     """Mistral: live discovery plus a chat-only fallback."""
 
     @pytest.mark.asyncio
-    async def test_without_key_returns_fallback(self):
+    async def test_without_key_returns_missing_key(self):
         result = await _get_mistral_models(None)
-        assert result.models == MISTRAL_KNOWN_MODELS
+        assert result.models == []
         assert result.source == "fallback"
-
-    def test_fallback_excludes_embeddings_and_ocr(self):
-        for model_id in MISTRAL_KNOWN_MODELS:
-            assert "embed" not in model_id
-            assert "ocr" not in model_id
+        assert result.error == ERROR_MISSING_KEY
 
     @pytest.mark.asyncio
     async def test_with_valid_key_lists_live_from_mistral_base_url(self):
@@ -1252,7 +1254,7 @@ class TestGetMistralModels:
 
             result = await _get_mistral_models("valid_key")
 
-            assert result.models == MISTRAL_KNOWN_MODELS
+            assert result.models == []
             assert result.source == "fallback"
             assert result.error == "empty_response"
 
@@ -1280,7 +1282,7 @@ class TestGetMistralModels:
             mock_client.return_value = mock_instance
 
             result = await _get_mistral_models("test_key")
-            assert result.models == MISTRAL_KNOWN_MODELS
+            assert result.models == []
             assert result.source == "fallback"
 
 
@@ -1512,28 +1514,28 @@ class TestOpenAICompatibleModels:
 
 
 class TestCatalogProviderSdkMissing:
-    """The shared OpenAI-compatible catalog path (Qwen, DeepSeek, Moonshot...).
+    """The shared OpenAI-compatible listing path (Qwen, DeepSeek, Moonshot...).
 
     _get_catalog_provider_models imported the SDK outside a guard too, so a
-    missing package raised instead of falling back to the bundled catalog.
+    missing package raised instead of returning a named empty fallback.
     """
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "fetch,expected",
+        "fetch",
         [
-            (_get_qwen_models, QWEN_KNOWN_MODELS),
-            (_get_deepseek_models, DEEPSEEK_KNOWN_MODELS),
-            (_get_moonshot_models, MOONSHOT_KNOWN_MODELS),
-            (_get_zai_models, ZAI_KNOWN_MODELS),
-            (_get_mistral_models, MISTRAL_KNOWN_MODELS),
+            _get_qwen_models,
+            _get_deepseek_models,
+            _get_moonshot_models,
+            _get_zai_models,
+            _get_mistral_models,
         ],
     )
-    async def test_missing_sdk_returns_bundled_catalog(self, fetch, expected):
+    async def test_missing_sdk_returns_empty_with_sdk_missing(self, fetch):
         with patch.dict(sys.modules, {"openai": None}):
             result = await fetch("test_key")
 
-        assert result.models == expected
+        assert result.models == []
         assert result.source == "fallback"
         assert result.error == "sdk_missing"
 
@@ -1825,22 +1827,13 @@ class TestBedrockModels:
             )
 
     @pytest.mark.asyncio
-    async def test_missing_credentials_raise_auth_error(self):
-        from botocore.exceptions import NoCredentialsError
-
-        client = MagicMock()
-        client.list_foundation_models.side_effect = NoCredentialsError()
-        session = MagicMock()
-        session.region_name = None
-        session.client.return_value = client
-
-        with (
-            patch("boto3.Session", return_value=session),
-            pytest.raises(ProviderAuthError),
-        ):
-            await get_available_models_for_provider(
-                "bedrock", aws_auth={"aws_region_name": "us-east-1"}
-            )
+    async def test_missing_credentials_return_missing_key(self):
+        result = await get_available_models_for_provider(
+            "bedrock", aws_auth={"aws_region_name": "us-east-1"}
+        )
+        assert result.models == []
+        assert result.source == "fallback"
+        assert result.error == ERROR_MISSING_KEY
 
     @pytest.mark.asyncio
     async def test_control_plane_failure_returns_fallback_catalog(self):
@@ -1862,7 +1855,7 @@ class TestBedrockModels:
 
         assert result.source == "fallback"
         assert result.error == ERROR_UNKNOWN
-        assert result.models == BEDROCK_FALLBACK_MODELS
+        assert result.models == []
 
     @pytest.mark.asyncio
     async def test_missing_region_is_a_validation_error(self):
@@ -1882,13 +1875,20 @@ class TestBedrockModels:
             )
 
     @pytest.mark.asyncio
-    async def test_sdk_missing_returns_fallback_catalog(self):
+    async def test_sdk_missing_returns_empty_with_sdk_missing(self):
         monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setitem(sys.modules, "boto3", None)
         try:
-            result = await get_available_models_for_provider("bedrock")
+            result = await get_available_models_for_provider(
+                "bedrock",
+                aws_auth={
+                    "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                    "aws_secret_access_key": "secret",
+                    "aws_region_name": "us-east-1",
+                },
+            )
         finally:
             monkeypatch.undo()
         assert result.source == "fallback"
         assert result.error == ERROR_SDK_MISSING
-        assert result.models == BEDROCK_FALLBACK_MODELS
+        assert result.models == []

--- a/backend/tests/services/test_ai_model_provider.py
+++ b/backend/tests/services/test_ai_model_provider.py
@@ -1378,6 +1378,93 @@ class TestOpenAICompatibleModels:
         assert result.models == ["a-model", "b-model"]
 
     @pytest.mark.asyncio
+    async def test_stt_kind_narrows_the_live_list(self):
+        """Selecting "Speech to text" must not show the endpoint's chat ids."""
+        response = self._models_response(
+            "k3", "k3-turbo", "whisper-large-v3", "gpt-4o-transcribe"
+        )
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=response)
+            mock_client.return_value = mock_instance
+
+            result = await get_available_models_for_provider(
+                "custom",
+                "test_key",
+                model_kind="stt",
+                api_endpoint="https://api.kimi.example/v1",
+            )
+
+        assert result.models == ["gpt-4o-transcribe", "whisper-large-v3"]
+        assert result.source == "live"
+
+    @pytest.mark.asyncio
+    async def test_tts_kind_narrows_the_live_list(self):
+        response = self._models_response("k3", "tts-1", "tts-1-hd")
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=response)
+            mock_client.return_value = mock_instance
+
+            result = await get_available_models_for_provider(
+                "openai-compatible",
+                "test_key",
+                model_kind="tts",
+                api_endpoint="https://gateway.example.com/v1",
+            )
+
+        assert result.models == ["tts-1", "tts-1-hd"]
+        assert result.source == "live"
+
+    @pytest.mark.asyncio
+    async def test_audio_kind_with_no_matching_ids_is_an_empty_fallback(self):
+        """An endpoint serving only chat ids offers no stt suggestions."""
+        response = self._models_response("k3", "k3-turbo")
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=response)
+            mock_client.return_value = mock_instance
+
+            result = await get_available_models_for_provider(
+                "custom",
+                "test_key",
+                model_kind="stt",
+                api_endpoint="https://api.kimi.example/v1",
+            )
+
+        assert result.models == []
+        assert result.source == "fallback"
+        assert result.error == "empty_response"
+
+    @pytest.mark.asyncio
+    async def test_llm_kind_keeps_the_full_live_list(self):
+        """The OpenAI chat exclusion list must not run against a custom endpoint.
+
+        Markers like "instruct" name ordinary chat models on a self-hosted
+        server, so excluding them here would hide real models. Curation of
+        chat ids is an OpenAI-specific concern.
+        """
+        response = self._models_response(
+            "Llama-3-8B-Instruct", "k3", "text-embedding-ada-002"
+        )
+        with patch("openai.AsyncOpenAI") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.models.list = AsyncMock(return_value=response)
+            mock_client.return_value = mock_instance
+
+            result = await get_available_models_for_provider(
+                "custom",
+                "test_key",
+                api_endpoint="https://api.kimi.example/v1",
+            )
+
+        assert result.models == [
+            "Llama-3-8B-Instruct",
+            "k3",
+            "text-embedding-ada-002",
+        ]
+
+    @pytest.mark.asyncio
     async def test_openai_compatible_without_endpoint_returns_empty(self):
         # Nothing to query, but this must not raise: the picker just shows no
         # suggestions until an endpoint is entered.

--- a/backend/tests/services/test_model_pricing.py
+++ b/backend/tests/services/test_model_pricing.py
@@ -301,10 +301,13 @@ class TestNewProviderPricing:
         assert "mistral/mistral-large-latest" in candidates
 
     def test_bundled_table_prices_every_moonshot_fallback_id(self) -> None:
-        from preloop.services.ai_model_provider import MOONSHOT_KNOWN_MODELS
-
         prices = json.loads(CATALOG_PATH.read_text())
-        for model_id in MOONSHOT_KNOWN_MODELS:
+        for model_id in (
+            "kimi-k3",
+            "kimi-k2.7-code",
+            "kimi-k2.7-code-highspeed",
+            "kimi-k2.6",
+        ):
             key = f"moonshot/{model_id}"
             assert key in prices, f"{key} missing from model_prices.json"
             entry = prices[key]
@@ -353,11 +356,15 @@ class TestNewProviderPricing:
         assert estimate.cost is not None and estimate.cost > 0
 
     def test_zai_fallback_ids_resolve_via_litellm_map(self) -> None:
-        from preloop.services.ai_model_provider import ZAI_KNOWN_MODELS
-
         # glm-5.3 is in the vendored snapshot, not litellm's published map.
         load_catalog(force=True)
-        for model_id in ZAI_KNOWN_MODELS:
+        for model_id in (
+            "glm-5.3",
+            "glm-5.1",
+            "glm-5",
+            "glm-4.7",
+            "glm-4.7-flash",
+        ):
             ai_model = AIModel(provider_name="zai", model_identifier=model_id)
             estimate = estimate_ai_model_usage_cost_detailed(
                 ai_model,
@@ -371,9 +378,14 @@ class TestNewProviderPricing:
             assert estimate.cost is not None, f"{model_id} has no cost"
 
     def test_mistral_fallback_ids_resolve_via_litellm_map(self) -> None:
-        from preloop.services.ai_model_provider import MISTRAL_KNOWN_MODELS
-
-        for model_id in MISTRAL_KNOWN_MODELS:
+        for model_id in (
+            "mistral-large-latest",
+            "mistral-medium-latest",
+            "mistral-small-latest",
+            "codestral-latest",
+            "devstral-latest",
+            "ministral-8b-latest",
+        ):
             ai_model = AIModel(provider_name="mistral", model_identifier=model_id)
             estimate = estimate_ai_model_usage_cost_detailed(
                 ai_model,
@@ -417,10 +429,18 @@ class TestQwenProviderPricing:
         assert "dashscope/qwen3.8-max" in candidates
 
     def test_bundled_table_prices_every_qwen_fallback_id(self) -> None:
-        from preloop.services.ai_model_provider import QWEN_KNOWN_MODELS
-
         prices = json.loads(CATALOG_PATH.read_text())
-        for model_id in QWEN_KNOWN_MODELS:
+        for model_id in (
+            "qwen3.8-max",
+            "qwen3.7-max",
+            "qwen3.7-plus",
+            "qwen3.6-flash",
+            "qwen3.5-plus",
+            "qwen3-max",
+            "qwen3-coder-plus",
+            "qwen-plus",
+            "qwen-flash",
+        ):
             key = f"dashscope/{model_id}"
             assert key in prices, f"{key} missing from model_prices.json"
             entry = prices[key]

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2360,8 +2360,9 @@ export async function deleteAIModel(modelId: string) {
  * This vocabulary mirrors the server's fixed set (see
  * `preloop.services.ai_model_provider`). Raw exception text is deliberately
  * never sent, because it can embed endpoint URLs or key material. An
- * authentication failure is NOT in this list: bad keys raise a 401 instead of
- * returning a fallback list.
+ * authentication failure that the provider rejected as a bad key still
+ * raises a 401 instead of returning a fallback list; `auth` is reserved
+ * for provenance-only auth failures.
  */
 export type AvailableModelsFallbackReason =
   | 'timeout'
@@ -2370,6 +2371,8 @@ export type AvailableModelsFallbackReason =
   | 'unsupported'
   | 'missing_endpoint'
   | 'sdk_missing'
+  | 'missing_key'
+  | 'auth'
   | 'unknown';
 
 export interface AvailableModelsResult {
@@ -2399,8 +2402,11 @@ export interface AwsDiscoveryAuth {
  * which have no fixed catalog and are listed from the endpoint's own
  * OpenAI-compatible GET /models.
  *
- * `awsAuth` carries explicit AWS credentials for the bedrock provider; when
- * omitted the backend falls back to its ambient credential chain.
+ * `aiModelId` is the existing model row when editing. The server decrypts
+ * the stored key and lists live; the stored key is never returned. A typed
+ * `apiKey` still wins.
+ *
+ * `awsAuth` carries explicit AWS credentials for the bedrock provider.
  *
  * Tolerates the old bare string[] response (pre-provenance servers) by
  * mapping it to { models, source: 'live' }.
@@ -2410,7 +2416,8 @@ export async function getAvailableModelsForProvider(
   apiKey?: string,
   modelKind: 'llm' | 'stt' | 'tts' = 'llm',
   apiEndpoint?: string,
-  awsAuth?: AwsDiscoveryAuth
+  awsAuth?: AwsDiscoveryAuth,
+  aiModelId?: string
 ): Promise<AvailableModelsResult> {
   const url = `/api/v1/ai-models/providers/${provider}/available-models`;
   const response = await fetchWithAuth(url, {
@@ -2420,6 +2427,7 @@ export async function getAvailableModelsForProvider(
       model_kind: modelKind,
       ...(apiKey ? { api_key: apiKey } : {}),
       ...(apiEndpoint ? { api_endpoint: apiEndpoint } : {}),
+      ...(aiModelId ? { ai_model_id: aiModelId } : {}),
       ...(awsAuth?.accessKeyId
         ? { aws_access_key_id: awsAuth.accessKeyId }
         : {}),

--- a/frontend/src/components/add-ai-model-modal.test.ts
+++ b/frontend/src/components/add-ai-model-modal.test.ts
@@ -262,6 +262,51 @@ describe('AddAIModelModal model discovery', () => {
     expect(discoveryCalls()).to.have.lengthOf(1);
     expect(String(discoveryCalls()[0].args[0])).to.not.contain('sk-ant-secret');
   });
+
+  it('edit refresh sends the stored model id, not an empty api_key', async () => {
+    const model = {
+      id: 'b3af897d-3841-4d2a-8097-1e63d8367bc1',
+      name: 'Z.ai GLM',
+      provider_name: 'zai',
+      model_identifier: 'glm-5.3',
+      model_kind: 'llm',
+      has_api_key: true,
+    };
+    const el: AddAIModelModal = await fixture(
+      html`<add-ai-model-modal
+        .model=${model as any}
+        ?open=${true}
+      ></add-ai-model-modal>`
+    );
+    await el.updateComplete;
+
+    fetchStub.callsFake(async (url: any) => {
+      if (String(url).includes('available-models')) {
+        return new Response(
+          JSON.stringify({
+            models: ['glm-5.3', 'glm-5.3-flash'],
+            source: 'live',
+          })
+        );
+      }
+      return new Response(JSON.stringify([]));
+    });
+
+    await (el as any)._fetchModelsForCurrentProvider();
+
+    const [, init] = fetchStub
+      .getCalls()
+      .filter((call) =>
+        String(call.args[0]).includes('available-models')
+      )[0].args;
+    const body = JSON.parse(String(init.body));
+    expect(body.ai_model_id).to.equal(model.id);
+    expect(body.api_key).to.be.undefined;
+    expect((el as any)._modelSuggestions).to.deep.equal([
+      'glm-5.3',
+      'glm-5.3-flash',
+    ]);
+  });
 });
 
 /**
@@ -523,9 +568,9 @@ describe('AddAIModelModal model list provenance', () => {
       if (String(url).includes('available-models')) {
         return new Response(
           JSON.stringify({
-            models: ['kimi-k3', 'kimi-k2.6'],
+            models: [],
             source: 'fallback',
-            error: null,
+            error: 'missing_key',
           })
         );
       }
@@ -537,13 +582,9 @@ describe('AddAIModelModal model list provenance', () => {
     const text = noticeText();
     expect(text).to.not.contain('Could not fetch');
     expect(text).to.not.contain('provider unavailable');
-    expect(text).to.contain('Showing known models');
     expect(text).to.contain('API key');
-    // The list stays usable either way.
-    expect((element as any)._modelSuggestions).to.deep.equal([
-      'kimi-k3',
-      'kimi-k2.6',
-    ]);
+    expect(text).to.contain('stored key');
+    expect((element as any)._modelSuggestions).to.deep.equal([]);
   });
 
   it('shows no fallback notice for a live listing', async () => {

--- a/frontend/src/components/add-ai-model-modal.ts
+++ b/frontend/src/components/add-ai-model-modal.ts
@@ -123,6 +123,8 @@ const FALLBACK_REASON_LABELS: Record<string, string> = {
   unsupported: 'live listing not supported',
   missing_endpoint: 'no API endpoint configured',
   sdk_missing: 'provider SDK not installed',
+  missing_key: 'no API key',
+  auth: 'authentication failed',
   unknown: 'provider unavailable',
 };
 
@@ -494,14 +496,16 @@ export class AddAIModelModal extends LitElement {
     provider: string,
     apiKey?: string,
     apiEndpoint?: string,
-    awsAuth?: AwsDiscoveryAuth
+    awsAuth?: AwsDiscoveryAuth,
+    aiModelId?: string
   ): Promise<AvailableModelsResult> {
     return await getAvailableModelsForProvider(
       provider,
       apiKey,
       this._selectedServiceKind,
       apiEndpoint,
-      awsAuth
+      awsAuth,
+      aiModelId
     );
   }
 
@@ -512,20 +516,24 @@ export class AddAIModelModal extends LitElement {
     }
 
     const provider = this._currentModel.provider_name;
+    const storedModelId =
+      this._isEditing && this.model?.id ? String(this.model.id) : undefined;
+    const hasStoredKey = Boolean(this._isEditing && this.model?.has_api_key);
     // Bedrock authenticates with AWS credential fields, not a key/endpoint.
     let awsAuth: AwsDiscoveryAuth | undefined;
     if (provider === 'bedrock') {
-      if (!this._bedrockCredsComplete) {
+      if (this._bedrockCredsComplete) {
+        awsAuth = {
+          accessKeyId: this._bedrockAccessKeyId.trim(),
+          secretAccessKey: this._bedrockSecretAccessKey.trim(),
+          sessionToken: this._bedrockSessionToken.trim() || undefined,
+          region: this._bedrockRegion.trim(),
+        };
+      } else if (!hasStoredKey) {
         this._modelsFetchError =
           'Enter the AWS access key, secret key and region first, then fetch models';
         return;
       }
-      awsAuth = {
-        accessKeyId: this._bedrockAccessKeyId.trim(),
-        secretAccessKey: this._bedrockSecretAccessKey.trim(),
-        sessionToken: this._bedrockSessionToken.trim() || undefined,
-        region: this._bedrockRegion.trim(),
-      };
     }
     // A provider with a known base URL can be listed even if the field was
     // cleared: the default stands in, matching the server-side default.
@@ -547,20 +555,25 @@ export class AddAIModelModal extends LitElement {
     this._modelsFallbackReason = null;
 
     try {
+      const typedKey = (this._currentModel.api_key || '').trim();
       const result = await this._fetchModelSuggestionsForProvider(
         provider,
         // Bedrock credentials travel via the dedicated aws_* body fields;
         // sending the stored JSON blob as api_key would be redundant.
-        this._isBedrock ? undefined : this._currentModel.api_key,
+        this._isBedrock ? undefined : typedKey || undefined,
         apiEndpoint,
-        awsAuth
+        awsAuth,
+        storedModelId
       );
       this._modelSuggestions = result.models;
       this._modelsSource = result.source;
       this._modelsFallbackReason =
         result.source === 'fallback' ? result.error || null : null;
       if (this._modelSuggestions.length === 0) {
-        this._modelsFetchError = `No ${this._selectedServiceKind.toUpperCase()} models available for this provider`;
+        this._modelsFetchError =
+          result.error === 'missing_key'
+            ? null
+            : `No ${this._selectedServiceKind.toUpperCase()} models available for this provider`;
       }
     } catch (error) {
       console.error('Failed to fetch models:', error);
@@ -754,36 +767,33 @@ export class AddAIModelModal extends LitElement {
   /**
    * Non-blocking provenance notice for the model list. Fallback listings say
    * so, with a short safe reason; live listings get a subtle count. Never
-   * renders raw upstream text.
-   *
-   * A fallback WITHOUT a reason is not a failure: the server sends that when
-   * no live attempt was possible, which for these providers means no API key
-   * was entered yet. Saying "could not fetch" there would blame the provider
-   * for the user not having typed a key.
+   * renders raw upstream text. There is no bundled catalog, so a fallback
+   * means the picker is empty until the user retries or types an id.
    */
   private _renderModelsProvenanceNotice() {
     if (this._modelsSource === 'fallback') {
-      if (!this._modelsFallbackReason) {
+      if (this._modelsFallbackReason === 'missing_key') {
         return html`
           <div
             class="models-provenance-notice"
             style="color: var(--sl-color-neutral-600); font-size: 0.875rem; margin-top: 0.5rem;"
           >
-            Showing known models. Enter an API key and fetch again for this
-            provider's live list. You can also enter any model id via Other...
+            Enter an API key and fetch again for this provider's live list. When
+            editing, refresh uses the stored key. You can also enter any model
+            id via Other...
           </div>
         `;
       }
       const reason =
-        FALLBACK_REASON_LABELS[this._modelsFallbackReason] ||
+        FALLBACK_REASON_LABELS[this._modelsFallbackReason || ''] ||
         'provider unavailable';
       return html`
         <div
           class="models-provenance-notice"
           style="color: var(--sl-color-warning-700); font-size: 0.875rem; margin-top: 0.5rem;"
         >
-          Could not fetch the live model list (${reason}). Showing known models,
-          which may be incomplete. You can still enter any model id via Other...
+          Could not fetch the live model list (${reason}). You can still enter
+          any model id via Other...
         </div>
       `;
     }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5996,20 +5996,27 @@ paths:
       description: 'Fetch available models from the specified AI provider, with provenance.
 
 
-        Every provider attempts a live listing when a key (and endpoint where
+        Every provider lists live when a key (and endpoint where applicable) is
 
-        applicable) is present; the response reports ``source`` ("live" or
+        present; the response reports ``source`` ("live" or "fallback") and a
 
-        "fallback") and a short safe ``error`` reason when a live attempt failed.
+        short safe ``error`` reason when a live attempt failed or credentials
 
-        The reason comes from a fixed vocabulary and never contains raw provider
+        were missing. The reason comes from a fixed vocabulary and never contains
 
-        error text, endpoint URLs, or key material.
+        raw provider error text, endpoint URLs, or key material.
 
 
         The provider API key travels in the request BODY, never the query string:
 
-        as a query parameter it was written to access logs in plaintext.'
+        as a query parameter it was written to access logs in plaintext.
+
+
+        Edit-mode refresh should send ``ai_model_id`` instead of the stored key.
+
+        The server decrypts the stored secret via CRUD. A typed ``api_key`` in
+
+        the body always wins. Stored secrets are never returned to the client.'
       operationId: list_provider_available_models_api_v1_ai_models_providers__provider__available_models_post
       security:
       - bearerAuth: []
@@ -11289,7 +11296,18 @@ components:
           - type: 'null'
           title: Api Key
           description: Provider API key used to list models. Never logged and never
-            persisted by this endpoint.
+            persisted by this endpoint. When omitted, pass ai_model_id so the server
+            can decrypt the stored key; the stored key is never returned to the client.
+            A typed key always wins over the stored one.
+        ai_model_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Ai Model Id
+          description: Existing AI model id. When no typed api_key is sent, the server
+            decrypts the stored credentials via CRUD and lists live. The plaintext
+            key is never returned in the response.
         api_endpoint:
           anyOf:
           - type: string
@@ -11360,33 +11378,34 @@ components:
           - fallback
           title: Source
           description: '''live'' when the provider''s listing endpoint answered; ''fallback''
-            when a bundled catalog (or empty list) was returned instead'
+            when an empty list was returned instead of a live catalog'
           default: fallback
         error:
           anyOf:
           - type: string
           - type: 'null'
           title: Error
-          description: Short safe reason for a fallback after a failed live attempt
-            (fixed vocabulary, never raw provider error text). None for a clean result.
+          description: Short safe reason for a fallback after a failed or impossible
+            live attempt (fixed vocabulary, never raw provider error text). None for
+            a clean live result.
       type: object
       title: AvailableModelsResponse
-      description: 'A provider''s model catalog plus the provenance of the listing.
+      description: 'A provider''s model listing plus the provenance of the result.
 
 
         ``source`` reports whether the ids came from the provider''s live listing
 
-        endpoint ("live") or from Preloop''s bundled fallback catalog
+        endpoint ("live") or an empty fallback ("fallback"). There is no bundled
 
-        ("fallback"). ``error`` is a short machine-readable reason drawn from a
+        picker catalog. ``error`` is a short machine-readable reason drawn from a
 
         fixed vocabulary (e.g. "timeout", "network", "empty_response",
 
-        "unsupported", "missing_endpoint", "sdk_missing", "unknown") when a live
+        "unsupported", "missing_endpoint", "sdk_missing", "missing_key", "auth",
 
-        attempt failed; it never carries raw exception text, which can embed
+        "unknown") when a live attempt failed or was impossible; it never carries
 
-        endpoint URLs or key material.'
+        raw exception text, which can embed endpoint URLs or key material.'
     BatchExecutionListItem:
       properties:
         id:


### PR DESCRIPTION
## Summary
- Edit-mode Refresh models now sends the existing model id so the server decrypts the stored key via CRUD and lists live. Typed keys still win. Stored secrets are never returned to the browser.
- Bundled picker catalogs are gone (`ZAI_KNOWN_MODELS`, `QWEN_KNOWN_MODELS`, `DEEPSEEK_KNOWN_MODELS`, `MOONSHOT_KNOWN_MODELS`, `MISTRAL_KNOWN_MODELS`, `OPENAI_FALLBACK_MODELS`, `ANTHROPIC_FALLBACK_MODELS`, `GOOGLE_FALLBACK_MODELS`, `BEDROCK_FALLBACK_MODELS`, and STT/TTS picker lists). Live failures return an empty list with `source` plus a safe error (`timeout`, `network`, `empty_response`, `missing_endpoint`, `sdk_missing`, `missing_key`, `auth`).
- Every LLM provider lists live when credentials (and an endpoint where required) are present: openai, anthropic, google, qwen, deepseek, moonshot, zai, mistral, bedrock, openai-compatible, custom, openrouter. OpenAI STT/TTS ids are filtered from the same live `GET /v1/models` list. Google Cloud Speech-to-Text v1 has no API-key list-models resource, so STT returns `missing_endpoint` rather than a stale guess.

## Test plan
- [x] `PYTHONPATH=backend pytest backend/tests/services/test_ai_model_provider.py backend/tests/endpoints/test_available_models_key_handling.py` (141 passed)
- [x] `npx web-test-runner src/components/add-ai-model-modal.test.ts` (46 passed)
- [ ] On staging, edit the existing Z.ai model, click Refresh models, and confirm `glm-5.3-flash` appears without re-typing the key
- [ ] Create a new Z.ai model with the same key and confirm live listing still works
- [ ] Refresh with no key and no saved model: empty picker, `missing_key`, no catalog

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Live-only model listing removes stale bundled catalogs and safely decrypts stored keys server-side. The previously-flagged provider-mismatch gap is now closed (stored secrets are bound to their provider before decryption), and all review findings are resolved.
>
> **Overview**
> This PR drops all bundled picker catalogs in favor of live `GET /v1/models` listings and adds edit-mode refresh via `ai_model_id` (typed keys win; stored secrets never reach the browser). Failures return empty lists with a fixed safe-error vocabulary. All three prior findings (provider mismatch, model_kind filtering, broad exception handler) are fixed in `14b86f4d`.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 14b86f4d. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
