### PR TITLE
Restore expandable Event Filters section in Create/Edit Flow form

### DIFF
--- a/frontend/src/components/preloop-flow-form-event-filters.test.ts
+++ b/frontend/src/components/preloop-flow-form-event-filters.test.ts
@@ -1,0 +1,112 @@
+import { expect } from '@open-wc/testing';
+
+/**
+ * Tests for the restored Event Filters (Optional) section in the
+ * Create/Edit Flow form component (preloop-flow-form.ts).
+ *
+ * Uses the same source-fetch pattern as the tracker-unlock tests.
+ */
+
+let source: string;
+
+before(async () => {
+  const res = await fetch(
+    new URL('./preloop-flow-form.ts', import.meta.url).href
+  );
+  expect(res.ok).to.be.true;
+  source = await res.text();
+});
+
+describe('PreloopFlowForm event filters section', () => {
+  it('declares filtersExpanded state property', () => {
+    expect(source).to.include('filtersExpanded');
+  });
+
+  it('contains renderEventFilters method', () => {
+    expect(source).to.include('renderEventFilters()');
+  });
+
+  it('renders Add Filters button when collapsed', () => {
+    expect(source).to.include('Add Filters');
+  });
+
+  it('renders Hide Filters button when expanded', () => {
+    expect(source).to.include('Hide Filters');
+  });
+
+  it('renders Event Filters (Optional) heading', () => {
+    expect(source).to.include('Event Filters (Optional)');
+  });
+
+  it('renders author/Created By filter input', () => {
+    expect(source).to.include('Created By (username)');
+    expect(source).to.include('trigger_config.author');
+  });
+
+  it('renders assignee filter input', () => {
+    expect(source).to.include('Assigned To (username)');
+    expect(source).to.include('trigger_config.assignee');
+  });
+
+  it('renders reviewer filter gated on MR/PR events', () => {
+    expect(source).to.include('trigger_config.reviewer');
+    expect(source).to.include('Reviewer (username)');
+    expect(source).to.include('Requested Reviewer (username)');
+  });
+
+  it('renders labels filter as comma-separated input', () => {
+    expect(source).to.include('Labels (comma-separated)');
+    expect(source).to.include('trigger_config.labels');
+  });
+
+  it('renders milestone filter for non-Jira trackers', () => {
+    expect(source).to.include('trigger_config.milestone');
+  });
+
+  it('renders priority select for Jira trackers', () => {
+    expect(source).to.include('trigger_config.priority');
+    expect(source).to.include('Any Priority');
+  });
+
+  it('renders issue type filter for Jira trackers', () => {
+    expect(source).to.include('trigger_config.issue_type');
+  });
+
+  it('renders merged and draft checkbox filters for PR/MR events', () => {
+    expect(source).to.include('trigger_config.merged');
+    expect(source).to.include('trigger_config.draft');
+    expect(source).to.include('Only when marked as ready (not draft)');
+  });
+
+  it('renders GitLab-specific detailed_merge_status and state filters', () => {
+    expect(source).to.include('trigger_config.detailed_merge_status');
+    expect(source).to.include('Only when approved');
+    expect(source).to.include('Merge Status');
+  });
+
+  it('renders GitHub-specific state and mergeable_state filters', () => {
+    expect(source).to.include('Pull Request State');
+    expect(source).to.include('trigger_config.mergeable_state');
+    expect(source).to.include('Mergeable State');
+  });
+
+  it('renders filter semantics help alert', () => {
+    expect(source).to.include('How filters work:');
+    expect(source).to.include('ALL conditions must');
+  });
+
+  it('includes trigger_config in the submit payload via conditional spread', () => {
+    // The bundler may compile `!== undefined` to `!== void 0`
+    const hasTriggerConfigGuard =
+      source.includes('trigger_config !== undefined') ||
+      source.includes('trigger_config !== void 0');
+    expect(hasTriggerConfigGuard).to.be.true;
+    expect(source).to.include('trigger_config: this.flow.trigger_config');
+  });
+
+  it('calls renderEventFilters gated on trigger_event_source', () => {
+    expect(source).to.include(
+      'this.flow.trigger_event_source ? this.renderEventFilters()'
+    );
+  });
+});

--- a/frontend/src/components/preloop-flow-form-event-filters.test.ts
+++ b/frontend/src/components/preloop-flow-form-event-filters.test.ts
@@ -1,10 +1,22 @@
-import { expect } from '@open-wc/testing';
+import {
+  expect,
+  fixture,
+  fixtureCleanup,
+  html,
+  oneEvent,
+} from '@open-wc/testing';
+import sinon, { SinonSandbox } from 'sinon';
+import './preloop-flow-form.ts';
+import type { PreloopFlowForm } from './preloop-flow-form';
 
 /**
  * Tests for the restored Event Filters (Optional) section in the
  * Create/Edit Flow form component (preloop-flow-form.ts).
  *
- * Uses the same source-fetch pattern as the tracker-unlock tests.
+ * The source-substring block below is a coarse guard that every filter control
+ * is still wired to its trigger_config key. The behaviour block that follows it
+ * is what actually verifies the gating, the value bindings and the submitted
+ * payload.
  */
 
 let source: string;
@@ -108,5 +120,184 @@ describe('PreloopFlowForm event filters section', () => {
     expect(source).to.include(
       'this.flow.trigger_event_source ? this.renderEventFilters()'
     );
+  });
+});
+
+const GITHUB_TRACKER = {
+  id: 'tracker-github',
+  name: 'GitHub',
+  tracker_type: 'github',
+};
+const GITLAB_TRACKER = {
+  id: 'tracker-gitlab',
+  name: 'GitLab',
+  tracker_type: 'gitlab',
+};
+const ORGANIZATION = {
+  id: 'org-1',
+  name: 'Acme',
+  identifier: 'acme',
+  tracker_id: GITHUB_TRACKER.id,
+};
+const PROJECT = {
+  id: 'project-1',
+  name: 'api',
+  identifier: 'api',
+  organization_id: ORGANIZATION.id,
+};
+
+/** A saved tracker flow that already carries event filters. */
+function trackerFlow(trigger_config?: Record<string, unknown>) {
+  return {
+    id: 'flow-1',
+    name: 'PR Reviewer',
+    prompt_template: 'review',
+    agent_type: 'codex',
+    trigger_event_source: GITHUB_TRACKER.id,
+    trigger_event_types: ['pull_request_opened'],
+    trigger_organization_id: ORGANIZATION.id,
+    ...(trigger_config ? { trigger_config } : {}),
+  };
+}
+
+describe('PreloopFlowForm event filters behaviour', () => {
+  let sandbox: SinonSandbox;
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    sandbox = sinon.createSandbox();
+    sandbox.stub(window, 'fetch').callsFake(async (url: any) => {
+      const target = String(url);
+      if (target.includes('/api/v1/trackers')) {
+        return new Response(JSON.stringify([GITHUB_TRACKER, GITLAB_TRACKER]));
+      }
+      if (target.includes('/api/v1/organizations')) {
+        return new Response(JSON.stringify({ items: [ORGANIZATION] }));
+      }
+      if (target.includes('/api/v1/projects')) {
+        return new Response(JSON.stringify([PROJECT]));
+      }
+      if (target.includes('/api/v1/agents')) {
+        return new Response(JSON.stringify({ items: [] }));
+      }
+      return new Response(JSON.stringify([]));
+    });
+  });
+
+  afterEach(() => {
+    fixtureCleanup();
+    sandbox.restore();
+    localStorage.clear();
+  });
+
+  const mount = async (flow: Record<string, unknown>) => {
+    const element = await fixture<PreloopFlowForm>(
+      html`<preloop-flow-form .flow=${flow}></preloop-flow-form>`
+    );
+    // connectedCallback loads trackers/orgs/projects before the form renders.
+    while ((element as any)._loadingReferenceData) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    await element.updateComplete;
+    return element;
+  };
+
+  /** Submit the form and return the payload carried by flow-submit. */
+  const submit = async (element: PreloopFlowForm) => {
+    const submitted = oneEvent(element, 'flow-submit');
+    void (element as any).handleFormSubmit(new Event('submit'));
+    const event = await submitted;
+    return event.detail.flow;
+  };
+
+  const filterInput = (element: PreloopFlowForm, label: string) =>
+    element.shadowRoot!.querySelector(`sl-input[label="${label}"]`) as any;
+
+  it('renders saved filters and submits them unchanged', async () => {
+    const element = await mount(
+      trackerFlow({ author: 'octocat', labels: ['bug'] })
+    );
+
+    expect(filterInput(element, 'Created By (username)').value).to.equal(
+      'octocat'
+    );
+    expect(filterInput(element, 'Labels (comma-separated)').value).to.equal(
+      'bug'
+    );
+
+    const payload = await submit(element);
+    expect(payload.trigger_config).to.deep.equal({
+      author: 'octocat',
+      labels: ['bug'],
+    });
+  });
+
+  it('records typed filters on the flow', async () => {
+    const element = await mount(trackerFlow());
+    (element as any).filtersExpanded = true;
+    await element.updateComplete;
+
+    const author = filterInput(element, 'Created By (username)');
+    author.value = 'alice';
+    author.dispatchEvent(new CustomEvent('sl-input'));
+
+    const labels = filterInput(element, 'Labels (comma-separated)');
+    labels.value = ' bug, critical ';
+    labels.dispatchEvent(new CustomEvent('sl-input'));
+
+    const payload = await submit(element);
+    expect(payload.trigger_config).to.deep.equal({
+      author: 'alice',
+      labels: ['bug', 'critical'],
+    });
+  });
+
+  it('does not create trigger_config while rendering a flow without filters', async () => {
+    const element = await mount(trackerFlow());
+
+    expect(element.flow.trigger_config).to.equal(undefined);
+    const payload = await submit(element);
+    expect(payload).to.not.have.property('trigger_config');
+  });
+
+  it('clears filters when the trigger type moves away from a tracker', async () => {
+    const element = await mount(trackerFlow({ author: 'octocat' }));
+
+    (element as any).handleTriggerTypeChange('webhook');
+    await element.updateComplete;
+
+    // Explicit null so the backend clears the filters saved on the flow.
+    expect(element.flow.trigger_config).to.equal(null);
+    const payload = await submit(element);
+    expect(payload.trigger_event_source).to.equal('webhook');
+    expect(payload.trigger_config).to.equal(null);
+  });
+
+  it('clears filters when a different tracker is selected', async () => {
+    const element = await mount(
+      trackerFlow({ state: 'open', mergeable_state: 'clean' })
+    );
+
+    await (element as any).handleTrackerChange({
+      target: { value: GITLAB_TRACKER.id },
+    });
+    await element.updateComplete;
+
+    expect(element.flow.trigger_config).to.equal(null);
+    const payload = await submit(element);
+    expect(payload.trigger_event_source).to.equal(GITLAB_TRACKER.id);
+    expect(payload.trigger_config).to.equal(null);
+  });
+
+  it('keeps filters when the same tracker is re-selected', async () => {
+    const element = await mount(trackerFlow({ author: 'octocat' }));
+
+    await (element as any).handleTrackerChange({
+      target: { value: GITHUB_TRACKER.id },
+    });
+    await element.updateComplete;
+
+    expect(element.flow.trigger_config).to.deep.equal({ author: 'octocat' });
   });
 });

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -184,6 +184,9 @@ export class PreloopFlowForm extends LitElement {
   private isAddingTracker = false;
 
   @state()
+  private filtersExpanded = false;
+
+  @state()
   private isAddingAIModel = false;
 
   private orgPollingInterval?: number;
@@ -604,6 +607,9 @@ export class PreloopFlowForm extends LitElement {
         max_iterations: this.flow.max_iterations || undefined,
         max_budget: this.flow.max_budget || undefined,
         is_enabled: this.flow.is_enabled ?? true,
+        ...(this.flow.trigger_config !== undefined
+          ? { trigger_config: this.flow.trigger_config }
+          : {}),
       };
 
       if (!this.flow.id && this.sourcePresetId) {
@@ -852,6 +858,406 @@ export class PreloopFlowForm extends LitElement {
     `;
   }
 
+  private renderEventFilters() {
+    if (!this.flow.trigger_config) {
+      this.flow.trigger_config = {};
+    }
+
+    const tracker = this.trackers.find(
+      (t: any) => t.id === this.flow.trigger_event_source
+    );
+    if (!tracker) return nothing;
+
+    // Check if any filters are defined
+    const hasFilters =
+      this.flow.trigger_config &&
+      Object.keys(this.flow.trigger_config).length > 0;
+
+    // Show filters if expanded or if any filter is already defined
+    const showFilters = this.filtersExpanded || hasFilters;
+
+    // Determine if this is a PR/MR event
+    const eventTypes: string[] = this.flow.trigger_event_types || [];
+    const isMREvent = eventTypes.some(
+      (et: string) =>
+        et?.includes('merge_request') || et?.includes('pull_request')
+    );
+
+    return html`
+      <div style="margin-top: 1.5rem;">
+        <div
+          style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem;"
+        >
+          <label style="font-weight: 500;">
+            Event Filters (Optional)
+            <span style="font-weight: 400; color: var(--sl-color-neutral-600);">
+              - Only trigger when conditions match
+            </span>
+          </label>
+          ${
+            !showFilters
+              ? html`
+                  <sl-button
+                    size="small"
+                    @click=${() => (this.filtersExpanded = true)}
+                  >
+                    <sl-icon slot="prefix" name="plus-circle"></sl-icon>
+                    Add Filters
+                  </sl-button>
+                `
+              : html`
+                  <sl-button
+                    size="small"
+                    variant="text"
+                    @click=${() => (this.filtersExpanded = false)}
+                  >
+                    <sl-icon slot="prefix" name="dash-circle"></sl-icon>
+                    Hide Filters
+                  </sl-button>
+                `
+          }
+        </div>
+
+        ${
+          showFilters
+            ? html`
+                <div class="form-grid">
+                  <!-- Author/Creator filter -->
+                  <sl-input
+                    label="Created By (username)"
+                    placeholder="e.g., octocat, admin@example.com"
+                    .value=${this.flow.trigger_config?.author || ''}
+                    @sl-input=${(e: any) => {
+                      if (!this.flow.trigger_config)
+                        this.flow.trigger_config = {};
+                      const value = e.target.value.trim();
+                      if (value) {
+                        this.flow.trigger_config.author = value;
+                      } else {
+                        delete this.flow.trigger_config.author;
+                      }
+                      this.requestUpdate();
+                    }}
+                    help-text="Filter by who created the issue/PR"
+                  ></sl-input>
+
+                  <!-- Assignee filter -->
+                  <sl-input
+                    label="Assigned To (username)"
+                    placeholder="e.g., john_doe"
+                    .value=${this.flow.trigger_config?.assignee || ''}
+                    @sl-input=${(e: any) => {
+                      if (!this.flow.trigger_config)
+                        this.flow.trigger_config = {};
+                      const value = e.target.value.trim();
+                      if (value) {
+                        this.flow.trigger_config.assignee = value;
+                      } else {
+                        delete this.flow.trigger_config.assignee;
+                      }
+                      this.requestUpdate();
+                    }}
+                    help-text="Filter by assignee (matches if any assignee matches)"
+                  ></sl-input>
+
+                  <!-- Reviewer filter (PR/MR only) -->
+                  ${
+                    isMREvent
+                      ? html`
+                          <sl-input
+                            label="${
+                              tracker.tracker_type === 'gitlab'
+                                ? 'Reviewer (username)'
+                                : 'Requested Reviewer (username)'
+                            }"
+                            placeholder="e.g., jane_smith"
+                            .value=${this.flow.trigger_config?.reviewer || ''}
+                            @sl-input=${(e: any) => {
+                              if (!this.flow.trigger_config)
+                                this.flow.trigger_config = {};
+                              const value = e.target.value.trim();
+                              if (value) {
+                                this.flow.trigger_config.reviewer = value;
+                              } else {
+                                delete this.flow.trigger_config.reviewer;
+                              }
+                              this.requestUpdate();
+                            }}
+                            help-text="Filter by reviewer (matches if any reviewer matches)"
+                          ></sl-input>
+                        `
+                      : nothing
+                  }
+
+                  <!-- Labels filter -->
+                  <sl-input
+                    label="Labels (comma-separated)"
+                    placeholder="e.g., bug, critical, backend"
+                    .value=${(this.flow.trigger_config?.labels as string[])?.join(', ') || ''}
+                    @sl-input=${(e: any) => {
+                      if (!this.flow.trigger_config)
+                        this.flow.trigger_config = {};
+                      const value = e.target.value.trim();
+                      if (value) {
+                        this.flow.trigger_config.labels = value
+                          .split(',')
+                          .map((l: string) => l.trim())
+                          .filter((l: string) => l.length > 0);
+                      } else {
+                        delete this.flow.trigger_config.labels;
+                      }
+                      this.requestUpdate();
+                    }}
+                    help-text="Filter by labels (triggers if ANY label matches)"
+                  ></sl-input>
+
+                  <!-- Milestone filter (GitHub/GitLab only) -->
+                  ${
+                    tracker.tracker_type !== 'jira'
+                      ? html`
+                          <sl-input
+                            label="Milestone"
+                            placeholder="e.g., v1.0, Sprint 10"
+                            .value=${this.flow.trigger_config?.milestone || ''}
+                            @sl-input=${(e: any) => {
+                              if (!this.flow.trigger_config)
+                                this.flow.trigger_config = {};
+                              const value = e.target.value.trim();
+                              if (value) {
+                                this.flow.trigger_config.milestone = value;
+                              } else {
+                                delete this.flow.trigger_config.milestone;
+                              }
+                              this.requestUpdate();
+                            }}
+                            help-text="Filter by milestone name"
+                          ></sl-input>
+                        `
+                      : nothing
+                  }
+
+                  <!-- Priority filter (Jira only) -->
+                  ${
+                    tracker.tracker_type === 'jira'
+                      ? html`
+                          <sl-select
+                            label="Priority"
+                            .value=${this.flow.trigger_config?.priority || ''}
+                            @sl-change=${(e: any) => {
+                              if (!this.flow.trigger_config)
+                                this.flow.trigger_config = {};
+                              const value = e.target.value;
+                              if (value) {
+                                this.flow.trigger_config.priority = value;
+                              } else {
+                                delete this.flow.trigger_config.priority;
+                              }
+                              this.requestUpdate();
+                            }}
+                            clearable
+                          >
+                            <sl-option value="">Any Priority</sl-option>
+                            <sl-option value="Highest">Highest</sl-option>
+                            <sl-option value="High">High</sl-option>
+                            <sl-option value="Medium">Medium</sl-option>
+                            <sl-option value="Low">Low</sl-option>
+                            <sl-option value="Lowest">Lowest</sl-option>
+                          </sl-select>
+
+                          <sl-input
+                            label="Issue Type"
+                            placeholder="e.g., Task, Bug, Story"
+                            .value=${this.flow.trigger_config?.issue_type || ''}
+                            @sl-input=${(e: any) => {
+                              if (!this.flow.trigger_config)
+                                this.flow.trigger_config = {};
+                              const value = e.target.value.trim();
+                              if (value) {
+                                this.flow.trigger_config.issue_type = value;
+                              } else {
+                                delete this.flow.trigger_config.issue_type;
+                              }
+                              this.requestUpdate();
+                            }}
+                            help-text="Filter by Jira issue type"
+                          ></sl-input>
+                        `
+                      : nothing
+                  }
+
+                  <!-- Merge Request / Pull Request State Filters -->
+                  ${
+                    isMREvent && tracker.tracker_type !== 'jira'
+                      ? html`
+                          <sl-checkbox
+                            ?checked=${this.flow.trigger_config?.merged === true}
+                            @sl-change=${(e: any) => {
+                              if (!this.flow.trigger_config)
+                                this.flow.trigger_config = {};
+                              if (e.target.checked) {
+                                this.flow.trigger_config.merged = true;
+                              } else {
+                                delete this.flow.trigger_config.merged;
+                              }
+                              this.requestUpdate();
+                            }}
+                          >
+                            Only when
+                            ${
+                              tracker.tracker_type === 'gitlab'
+                                ? 'Merge Request'
+                                : 'Pull Request'
+                            }
+                            is merged
+                          </sl-checkbox>
+
+                          <sl-checkbox
+                            ?checked=${this.flow.trigger_config?.draft === false}
+                            @sl-change=${(e: any) => {
+                              if (!this.flow.trigger_config)
+                                this.flow.trigger_config = {};
+                              if (e.target.checked) {
+                                this.flow.trigger_config.draft = false;
+                              } else {
+                                delete this.flow.trigger_config.draft;
+                              }
+                              this.requestUpdate();
+                            }}
+                          >
+                            Only when marked as ready (not draft)
+                          </sl-checkbox>
+
+                          ${
+                            tracker.tracker_type === 'gitlab'
+                              ? html`
+                                  <sl-checkbox
+                                    ?checked=${
+                                      this.flow.trigger_config
+                                        ?.detailed_merge_status === 'approved'
+                                    }
+                                    @sl-change=${(e: any) => {
+                                      if (!this.flow.trigger_config)
+                                        this.flow.trigger_config = {};
+                                      if (e.target.checked) {
+                                        this.flow.trigger_config.detailed_merge_status =
+                                          'approved';
+                                      } else {
+                                        delete this.flow.trigger_config
+                                          .detailed_merge_status;
+                                      }
+                                      this.requestUpdate();
+                                    }}
+                                  >
+                                    Only when approved
+                                  </sl-checkbox>
+
+                                  <sl-select
+                                    label="Merge Status"
+                                    .value=${this.flow.trigger_config?.state || ''}
+                                    @sl-change=${(e: any) => {
+                                      if (!this.flow.trigger_config)
+                                        this.flow.trigger_config = {};
+                                      const value = e.target.value;
+                                      if (value) {
+                                        this.flow.trigger_config.state = value;
+                                      } else {
+                                        delete this.flow.trigger_config.state;
+                                      }
+                                      this.requestUpdate();
+                                    }}
+                                    clearable
+                                    help-text="Filter by merge request state"
+                                  >
+                                    <sl-option value="">Any State</sl-option>
+                                    <sl-option value="opened">Opened</sl-option>
+                                    <sl-option value="closed">Closed</sl-option>
+                                    <sl-option value="merged">Merged</sl-option>
+                                  </sl-select>
+                                `
+                              : tracker.tracker_type === 'github'
+                                ? html`
+                                    <sl-select
+                                      label="Pull Request State"
+                                      .value=${this.flow.trigger_config?.state || ''}
+                                      @sl-change=${(e: any) => {
+                                        if (!this.flow.trigger_config)
+                                          this.flow.trigger_config = {};
+                                        const value = e.target.value;
+                                        if (value) {
+                                          this.flow.trigger_config.state =
+                                            value;
+                                        } else {
+                                          delete this.flow.trigger_config.state;
+                                        }
+                                        this.requestUpdate();
+                                      }}
+                                      clearable
+                                      help-text="Filter by pull request state"
+                                    >
+                                      <sl-option value="">Any State</sl-option>
+                                      <sl-option value="open">Open</sl-option>
+                                      <sl-option value="closed"
+                                        >Closed</sl-option
+                                      >
+                                    </sl-select>
+
+                                    <sl-select
+                                      label="Mergeable State"
+                                      .value=${
+                                        this.flow.trigger_config
+                                          ?.mergeable_state || ''
+                                      }
+                                      @sl-change=${(e: any) => {
+                                        if (!this.flow.trigger_config)
+                                          this.flow.trigger_config = {};
+                                        const value = e.target.value;
+                                        if (value) {
+                                          this.flow.trigger_config.mergeable_state =
+                                            value;
+                                        } else {
+                                          delete this.flow.trigger_config
+                                            .mergeable_state;
+                                        }
+                                        this.requestUpdate();
+                                      }}
+                                      clearable
+                                      help-text="Filter by whether PR can be merged"
+                                    >
+                                      <sl-option value="">Any</sl-option>
+                                      <sl-option value="clean"
+                                        >Clean (can merge)</sl-option
+                                      >
+                                      <sl-option value="unstable"
+                                        >Unstable (tests failing)</sl-option
+                                      >
+                                      <sl-option value="dirty"
+                                        >Dirty (merge conflict)</sl-option
+                                      >
+                                      <sl-option value="blocked"
+                                        >Blocked</sl-option
+                                      >
+                                    </sl-select>
+                                  `
+                                : nothing
+                          }
+                        `
+                      : nothing
+                  }
+                </div>
+
+                <sl-alert variant="primary" open style="margin-top: 1rem;">
+                  <sl-icon slot="icon" name="info-circle"></sl-icon>
+                  <strong>How filters work:</strong> Leave empty to match all
+                  events. When multiple filters are set, ALL conditions must
+                  match for the flow to trigger.
+                </sl-alert>
+              `
+            : nothing
+        }
+      </div>
+    `;
+  }
+
   render() {
     if (this._loadingReferenceData) {
       return html`
@@ -1070,6 +1476,7 @@ export class PreloopFlowForm extends LitElement {
                         )}
                       </sl-select>
                     </div>
+                    ${this.flow.trigger_event_source ? this.renderEventFilters() : nothing}
                   `
           }
         </sl-card>

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -433,7 +433,25 @@ export class PreloopFlowForm extends LitElement {
     this.requestUpdate();
   }
 
+  /**
+   * Drop event filters that no longer apply to the selected trigger.
+   *
+   * Filter keys are tracker- and event-type specific and the filters UI only
+   * renders for tracker triggers, so a key left behind by a trigger or tracker
+   * change would keep being enforced (webhook submits fail with 422, tracker
+   * events are skipped) with no way for the user to see or clear it. Explicit
+   * null rather than undefined so the backend's exclude_unset update path
+   * clears a previously-saved trigger_config instead of keeping it.
+   */
+  private clearEventFilters() {
+    this.flow.trigger_config = null;
+    this.filtersExpanded = false;
+  }
+
   private handleTriggerTypeChange(newType: 'webhook' | 'tracker' | 'schedule') {
+    if (newType !== this.triggerType) {
+      this.clearEventFilters();
+    }
     this.triggerType = newType;
     if (newType === 'webhook') {
       this.flow.trigger_event_source = 'webhook';
@@ -457,6 +475,9 @@ export class PreloopFlowForm extends LitElement {
 
   private async handleTrackerChange(e: any) {
     const trackerId = e.target.value;
+    if (trackerId !== this.flow.trigger_event_source) {
+      this.clearEventFilters();
+    }
     this.flow.trigger_event_source = trackerId;
     this.flow.trigger_event_types = undefined;
     this.flow.trigger_organization_id = undefined;
@@ -607,6 +628,8 @@ export class PreloopFlowForm extends LitElement {
         max_iterations: this.flow.max_iterations || undefined,
         max_budget: this.flow.max_budget || undefined,
         is_enabled: this.flow.is_enabled ?? true,
+        // Sent only once filters exist on the form. An explicit null (set by
+        // clearEventFilters) is forwarded so the backend clears saved filters.
         ...(this.flow.trigger_config !== undefined
           ? { trigger_config: this.flow.trigger_config }
           : {}),
@@ -859,19 +882,15 @@ export class PreloopFlowForm extends LitElement {
   }
 
   private renderEventFilters() {
-    if (!this.flow.trigger_config) {
-      this.flow.trigger_config = {};
-    }
-
     const tracker = this.trackers.find(
       (t: any) => t.id === this.flow.trigger_event_source
     );
     if (!tracker) return nothing;
 
-    // Check if any filters are defined
-    const hasFilters =
-      this.flow.trigger_config &&
-      Object.keys(this.flow.trigger_config).length > 0;
+    // Check if any filters are defined. trigger_config stays absent until a
+    // filter is actually set: the input handlers below create it lazily, so
+    // render never mutates it.
+    const hasFilters = Object.keys(this.flow.trigger_config ?? {}).length > 0;
 
     // Show filters if expanded or if any filter is already defined
     const showFilters = this.filtersExpanded || hasFilters;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,3 +1,27 @@
+export interface Flow {
+  id?: string;
+  name?: string;
+  description?: string;
+  prompt_template?: string;
+  agent_type?: string;
+  agent_config?: Record<string, unknown>;
+  ai_model_id?: string;
+  trigger_event_source?: string;
+  trigger_event_types?: string[];
+  trigger_organization_id?: string;
+  trigger_project_ids?: string[];
+  trigger_config?: Record<string, unknown>;
+  schedule_config?: Record<string, unknown> | null;
+  webhook_config?: Record<string, unknown>;
+  allowed_mcp_servers?: string[];
+  allowed_mcp_tools?: Array<{ server_name: string; tool_name: string }>;
+  git_clone_config?: Record<string, unknown>;
+  max_iterations?: number | null;
+  max_budget?: number | null;
+  is_enabled?: boolean;
+  [key: string]: unknown;
+}
+
 export interface AIModel {
   id: string;
   name: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,7 +1,61 @@
+export interface GitCloneRepository {
+  tracker_id: string;
+  repository_url?: string;
+  clone_path: string;
+  branch?: string;
+}
+
+export interface GitCloneConfig {
+  enabled: boolean;
+  repositories?: GitCloneRepository[];
+  git_user_name?: string;
+  git_user_email?: string;
+  source_branch?: string;
+  target_branch?: string;
+  create_pull_request?: boolean;
+  pull_request_title?: string;
+  pull_request_description?: string;
+}
+
+export interface FlowCustomCommands {
+  enabled: boolean;
+  commands?: string[];
+}
+
+export interface FlowWebhookConfig {
+  webhook_secret: string;
+}
+
+/** Server-computed schedule state; read-only for the console. */
+export interface FlowScheduleState {
+  active: boolean;
+  type: string;
+  description: string;
+  timezone: string;
+  next_run_at: string | null;
+  cron?: string;
+}
+
+export interface FlowExecutionStats {
+  total_execs?: number;
+  running_execs?: number;
+  last_seen_at?: string | null;
+  estimated_cost?: number;
+}
+
+/**
+ * Canonical console-side shape of a flow. Views must import this rather than
+ * redeclaring a local copy, so filter and trigger fields cannot drift.
+ *
+ * `trigger_config` holds the tracker event filters. `null` means "clear the
+ * saved filters" on update; absent means "leave them untouched".
+ */
 export interface Flow {
   id?: string;
   name?: string;
   description?: string;
+  icon?: string;
+  account_id?: string;
   prompt_template?: string;
   agent_type?: string;
   agent_config?: Record<string, unknown>;
@@ -10,15 +64,19 @@ export interface Flow {
   trigger_event_types?: string[];
   trigger_organization_id?: string;
   trigger_project_ids?: string[];
-  trigger_config?: Record<string, unknown>;
+  trigger_config?: Record<string, unknown> | null;
   schedule_config?: Record<string, unknown> | null;
-  webhook_config?: Record<string, unknown>;
+  schedule_state?: FlowScheduleState | null;
+  webhook_config?: FlowWebhookConfig;
   allowed_mcp_servers?: string[];
   allowed_mcp_tools?: Array<{ server_name: string; tool_name: string }>;
-  git_clone_config?: Record<string, unknown>;
+  git_clone_config?: GitCloneConfig;
+  custom_commands?: FlowCustomCommands;
   max_iterations?: number | null;
   max_budget?: number | null;
+  is_preset?: boolean;
   is_enabled?: boolean;
+  execution_stats?: FlowExecutionStats;
   [key: string]: unknown;
 }
 

--- a/frontend/src/views/authed/flow-view.ts
+++ b/frontend/src/views/authed/flow-view.ts
@@ -38,72 +38,7 @@ import '../../components/resource-actions.ts';
 import type { ResourceAction } from '../../components/resource-actions.ts';
 import consoleStyles from '../../styles/console-styles.css?inline';
 import { getTrackerEventOptions } from '../../constants/tracker-event-types';
-
-interface GitCloneRepository {
-  tracker_id: string;
-  repository_url?: string;
-  clone_path: string;
-  branch?: string;
-}
-
-interface GitCloneConfig {
-  enabled: boolean;
-  repositories?: GitCloneRepository[];
-  git_user_name?: string;
-  git_user_email?: string;
-  source_branch?: string;
-  target_branch?: string;
-  create_pull_request?: boolean;
-  pull_request_title?: string;
-  pull_request_description?: string;
-}
-
-interface CustomCommands {
-  enabled: boolean;
-  commands?: string[];
-}
-
-interface WebhookConfig {
-  webhook_secret: string;
-}
-
-interface ScheduleState {
-  active: boolean;
-  type: string;
-  description: string;
-  timezone: string;
-  next_run_at: string | null;
-  cron?: string;
-}
-
-interface Flow {
-  id?: string;
-  name: string;
-  description?: string;
-  icon?: string;
-  trigger_event_source?: string;
-  // Event types that trigger this flow (e.g., ['pull_request_created', 'pull_request_updated'])
-  trigger_event_types?: string[];
-  trigger_organization_id?: string;
-  // Project IDs that can trigger this flow (empty = all projects in org)
-  trigger_project_ids?: string[];
-  trigger_config?: any;
-  webhook_config?: WebhookConfig;
-  schedule_config?: any;
-  schedule_state?: ScheduleState | null;
-  ai_model_id?: string;
-  prompt_template?: string;
-  allowed_mcp_servers?: string[];
-  allowed_mcp_tools?: { server_name: string; tool_name: string }[];
-  git_clone_config?: GitCloneConfig;
-  custom_commands?: CustomCommands;
-  max_iterations?: number;
-  max_budget?: number;
-  is_preset?: boolean;
-  is_enabled?: boolean;
-  agent_type?: string;
-  agent_config?: any;
-}
+import type { Flow } from '../../types';
 
 @customElement('flow-view')
 export class FlowView extends LitElement {
@@ -2184,7 +2119,11 @@ ${(this.flow.custom_commands.commands || []).join('\n')}</pre>
                   <sl-input
                     label="Labels (comma-separated)"
                     placeholder="e.g., bug, critical, backend"
-                    .value=${this.flow.trigger_config?.labels?.join(', ') || ''}
+                    .value=${
+                      (
+                        this.flow.trigger_config?.labels as string[] | undefined
+                      )?.join(', ') || ''
+                    }
                     @sl-input=${(e: any) => {
                       if (!this.flow.trigger_config)
                         this.flow.trigger_config = {};

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -18,32 +18,10 @@ import {
 import { formatLocalDateTime } from '../../utils/date';
 import { executionDurationText } from '../../utils/execution';
 import consoleStyles from '../../styles/console-styles.css?inline';
+import type { Flow } from '../../types';
 
-interface ScheduleState {
-  active: boolean;
-  type: string;
-  description: string;
-  timezone: string;
-  next_run_at: string | null;
-  cron?: string;
-}
-
-interface Flow {
-  id: string;
-  name: string;
-  description?: string;
-  icon?: string;
-  account_id?: string;
-  trigger_event_source?: string;
-  is_enabled?: boolean;
-  schedule_state?: ScheduleState | null;
-  execution_stats?: {
-    total_execs?: number;
-    running_execs?: number;
-    last_seen_at?: string | null;
-    estimated_cost?: number;
-  };
-}
+/** A flow row from the list endpoints, where id and name are always present. */
+type FlowListItem = Flow & { id: string; name: string };
 
 interface FlowExecution {
   id: string;
@@ -289,10 +267,10 @@ export class FlowsView extends LitElement {
   ];
 
   @state()
-  private flows: Flow[] = [];
+  private flows: FlowListItem[] = [];
 
   @state()
-  private presets: Flow[] = [];
+  private presets: FlowListItem[] = [];
 
   @state()
   private presetsLoading = false;
@@ -594,7 +572,7 @@ export class FlowsView extends LitElement {
     `;
   }
 
-  renderFlowCard(flow: Flow) {
+  renderFlowCard(flow: FlowListItem) {
     const activeCount = flow.execution_stats?.running_execs || 0;
     const totalCount = flow.execution_stats?.total_execs || 0;
 
@@ -664,7 +642,7 @@ export class FlowsView extends LitElement {
     `;
   }
 
-  renderPresetCard(preset: Flow) {
+  renderPresetCard(preset: FlowListItem) {
     return html`
       <sl-card class="flow-card">
         <div slot="header" class="flow-header">
@@ -734,7 +712,7 @@ export class FlowsView extends LitElement {
    * Paused flows (schedule suspended) get a warning badge; active
    * schedules show the next run time in local time.
    */
-  renderScheduleStat(flow: Flow) {
+  renderScheduleStat(flow: FlowListItem) {
     const schedule = flow.schedule_state;
     if (flow.trigger_event_source !== 'schedule' || !schedule) {
       return '';
@@ -845,7 +823,7 @@ export class FlowsView extends LitElement {
     return `${preview}...`;
   }
 
-  private renderFlowDescription(flow: Flow) {
+  private renderFlowDescription(flow: FlowListItem) {
     const description = flow.description?.trim();
     const shouldShowFull = (description?.length ?? 0) > 140;
     const preview = description ? this.truncateDescription(description) : '';
@@ -885,7 +863,7 @@ export class FlowsView extends LitElement {
     `;
   }
 
-  private sortPresets(presets: Flow[]): Flow[] {
+  private sortPresets(presets: FlowListItem[]): FlowListItem[] {
     return [...presets].sort((a, b) => {
       const aIsPR = a.name?.toLowerCase().includes('pull request reviewer')
         ? 0


### PR DESCRIPTION
## What

Restores the expandable **Event Filters (Optional)** section in the Trigger Configuration card of the Create/Edit Flow form.

## Why

The Event Filters UI was accidentally removed in commit `3f1553ae` (2026-06-09, "Add Agent Control, cost analytics, and runtime session observer") when the form was extracted from `flow-view.ts` into the `preloop-flow-form` component. The extraction dropped:

1. The entire `renderEventFilters()` section
2. `trigger_config` from the submit payload

The backend (`flow_trigger_service.py::_matches_trigger_config`) never lost support for these filters, so this was purely a frontend regression.

## What is restored

- `filtersExpanded` state and `renderEventFilters()` method, ported from the dead copy still present in `flow-view.ts`
- All filter fields: Created By, Assigned To, Reviewer (PR/MR events only), Labels (comma-separated), Milestone (non-Jira), Priority select and Issue Type (Jira only), merged/draft/approved checkboxes, and state/mergeable_state selects for GitHub and GitLab PR/MR events
- Explanatory alert describing filter semantics
- `trigger_config` in the submit payload via conditional spread: an empty object `{}` clears saved filters on edit; `undefined` omits the key for new flows that never set filters
- `Flow` interface added to `types.ts` including `trigger_config`
- Source-level tests covering all restored filter fields and payload inclusion

## Follow-up

The dead copy of `renderEventFilters()` in `flow-view.ts` remains in place for a separate cleanup.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Frontend restoration of a previously-removed feature with no security implications or breaking changes; one medium correctness edge case (stale `trigger_config` across trigger-type switches) and minor maintainability notes.
>
> **Overview**
> Restores the expandable Event Filters section and `trigger_config` submission in the Create/Edit Flow form, ported from the dead copy in `flow-view.ts`. Includes all filter fields, the submit-payload conditional spread, a `Flow` interface, and source-level tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 950be961. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->