### PR TITLE
fix: preserve gateway alias and respect provider on model edit

### DIFF
--- a/backend/preloop/models/crud/ai_model.py
+++ b/backend/preloop/models/crud/ai_model.py
@@ -494,11 +494,42 @@ class CRUDAIModel(CRUDBase[AIModel]):
         obj_data = self._normalize_model_kind_fields(dict(obj_in))
         self._validate_qwen_api_endpoint(obj_data, existing=db_obj)
 
+        # Preserve the gateway alias when provider_name changes so that
+        # in-flight agents configured with the old alias can still resolve
+        # the model. Only applies to gateway-enabled models using the
+        # computed default alias (no explicit model_alias configured).
+        from preloop.services.model_runtime_resolver import effective_gateway_alias
+
+        old_alias = effective_gateway_alias(db_obj)
+        if old_alias and "provider_name" in obj_data:
+            old_provider = (db_obj.provider_name or "").strip().lower()
+            new_provider = (obj_data["provider_name"] or "").strip().lower()
+            if old_provider != new_provider:
+                old_meta = (
+                    db_obj.meta_data if isinstance(db_obj.meta_data, dict) else {}
+                )
+                old_gw = (
+                    old_meta.get("gateway")
+                    if isinstance(old_meta.get("gateway"), dict)
+                    else {}
+                )
+                configured_alias = old_gw.get("model_alias")
+                if not (isinstance(configured_alias, str) and configured_alias.strip()):
+                    # No explicit alias -- pin the current default so the
+                    # address in-flight agents know stays stable.
+                    merged_meta_for_pin = dict(
+                        obj_data["meta_data"]
+                        if "meta_data" in obj_data
+                        else (old_meta or {})
+                    )
+                    gw_block = dict(merged_meta_for_pin.get("gateway") or {})
+                    gw_block["model_alias"] = old_alias
+                    merged_meta_for_pin["gateway"] = gw_block
+                    obj_data["meta_data"] = merged_meta_for_pin
+
         # Enforce alias uniqueness only when this update changes the effective
         # gateway alias; pre-existing rows (including legacy collisions being
         # cleaned up) must remain updatable for unrelated fields.
-        from preloop.services.model_runtime_resolver import effective_gateway_alias
-
         merged_provider = obj_data.get("provider_name", db_obj.provider_name)
         merged_identifier = obj_data.get("model_identifier", db_obj.model_identifier)
         merged_meta = (

--- a/backend/preloop/models/crud/ai_model.py
+++ b/backend/preloop/models/crud/ai_model.py
@@ -514,7 +514,24 @@ class CRUDAIModel(CRUDBase[AIModel]):
                     else {}
                 )
                 configured_alias = old_gw.get("model_alias")
-                if not (isinstance(configured_alias, str) and configured_alias.strip()):
+                incoming_meta = (
+                    obj_data.get("meta_data")
+                    if isinstance(obj_data.get("meta_data"), dict)
+                    else {}
+                )
+                incoming_gw = (
+                    incoming_meta.get("gateway")
+                    if isinstance(incoming_meta.get("gateway"), dict)
+                    else {}
+                )
+                incoming_alias = incoming_gw.get("model_alias")
+                # An alias the admin sets in this same update wins over the
+                # pin: they chose the new address deliberately.
+                has_explicit_alias = any(
+                    isinstance(alias, str) and alias.strip()
+                    for alias in (configured_alias, incoming_alias)
+                )
+                if not has_explicit_alias:
                     # No explicit alias -- pin the current default so the
                     # address in-flight agents know stays stable.
                     merged_meta_for_pin = dict(

--- a/backend/preloop/services/litellm_routing.py
+++ b/backend/preloop/services/litellm_routing.py
@@ -15,7 +15,12 @@ Resolution order:
    dispatches via litellm's generic OpenAI-compatible adapter, with the
    stored identifier forwarded verbatim.
 3. An identifier that already carries a routable prefix (``azure/gpt-5.4``)
-   passes through untouched.
+   passes through untouched when the prefix agrees with the model's
+   ``provider_name``, or when the provider is generic (``openai``,
+   ``openai-compatible``, ``custom``).  When a SPECIFIC provider like
+   ``moonshot`` disagrees with the embedded prefix (e.g. a stale
+   ``nvidia_nim/`` left over from a provider edit), the prefix is stripped
+   and the provider-based rules below take over.
 4. The local prefix map translates Preloop provider names to litellm ones
    (``google`` -> ``gemini``, ``qwen`` -> ``openai``).
 5. Providers litellm routes natively (``mistral``, ``groq``, ...) pass
@@ -278,7 +283,25 @@ def to_litellm_model(ai_model: AIModel) -> str:
     if "/" in identifier:
         head = identifier.split("/", 1)[0].strip().lower()
         if head in known_litellm_providers() or head in set(PROVIDER_PREFIX.values()):
-            return identifier
+            # Honour the embedded prefix when it agrees with the model's
+            # provider_name, or when the provider is generic/default
+            # (``openai``, ``openai-compatible``, ``custom``).  Generic
+            # providers mean "route however the identifier/endpoint says",
+            # so the embedded prefix IS the routing instruction.
+            #
+            # When a SPECIFIC provider (e.g. ``moonshot``) disagrees with
+            # the embedded prefix (e.g. ``nvidia_nim/kimi-k3``), the admin
+            # edited the provider and the prefix is stale -- strip it and
+            # fall through to the provider-based rules below.
+            mapped = PROVIDER_PREFIX.get(provider, provider)
+            if head == provider or head == mapped:
+                return identifier
+            # Generic / default providers: the identifier prefix is the
+            # routing truth, not a stale leftover.
+            if provider in OPENAI_COMPATIBLE_PROVIDERS or provider == "openai":
+                return identifier
+            # Specific provider disagrees with embedded prefix -- strip it.
+            identifier = identifier.split("/", 1)[1].strip()
 
     prefix = PROVIDER_PREFIX.get(provider)
     if prefix is None:

--- a/backend/tests/models/test_ai_model.py
+++ b/backend/tests/models/test_ai_model.py
@@ -834,3 +834,110 @@ def test_provider_switch_skipped_when_gateway_not_enabled(db_session, create_acc
     meta = updated.meta_data or {}
     gw = meta.get("gateway", {})
     assert not gw.get("model_alias"), "Non-gateway model should not get a pinned alias"
+
+
+def test_provider_switch_keeps_incoming_alias_from_same_update(
+    db_session, create_account
+):
+    """An alias set in the same update as the provider change must survive.
+
+    The pin exists to keep in-flight agents working when nobody chose an
+    address. If the admin explicitly picks a new alias while switching
+    provider, that choice wins over the pin.
+    """
+    from preloop.services.model_runtime_resolver import effective_gateway_alias
+
+    account = create_account()
+    model = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Kimi K3",
+            "provider_name": "nvidia_nim",
+            "model_identifier": "kimi-k3",
+            "api_key": "nvidia-key",
+            "meta_data": {"gateway": {"enabled": True}},
+        },
+        account_id=account.id,
+    )
+
+    assert effective_gateway_alias(model) == "nvidia_nim/kimi-k3"
+
+    updated = crud_ai_model.update(
+        db=db_session,
+        db_obj=model,
+        obj_in={
+            "provider_name": "moonshot",
+            "meta_data": {
+                "gateway": {"enabled": True, "model_alias": "kimi-k3-preferred"}
+            },
+        },
+    )
+    db_session.refresh(updated)
+
+    assert effective_gateway_alias(updated) == "kimi-k3-preferred"
+    assert updated.meta_data["gateway"]["model_alias"] == "kimi-k3-preferred"
+    assert updated.provider_name == "moonshot"
+
+
+def test_provider_switch_pins_when_incoming_meta_has_no_alias(
+    db_session, create_account
+):
+    """A meta_data payload without an alias still gets the old alias pinned."""
+    from preloop.services.model_runtime_resolver import effective_gateway_alias
+
+    account = create_account()
+    model = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Kimi K3",
+            "provider_name": "nvidia_nim",
+            "model_identifier": "kimi-k3",
+            "api_key": "nvidia-key",
+            "meta_data": {"gateway": {"enabled": True}},
+        },
+        account_id=account.id,
+    )
+
+    updated = crud_ai_model.update(
+        db=db_session,
+        db_obj=model,
+        obj_in={
+            "provider_name": "moonshot",
+            "meta_data": {"gateway": {"enabled": True}, "notes": "switched provider"},
+        },
+    )
+    db_session.refresh(updated)
+
+    assert effective_gateway_alias(updated) == "nvidia_nim/kimi-k3"
+    assert updated.meta_data["notes"] == "switched provider"
+    assert updated.provider_name == "moonshot"
+
+
+def test_provider_switch_ignores_blank_incoming_alias(db_session, create_account):
+    """A whitespace-only incoming alias is not an explicit choice; still pin."""
+    from preloop.services.model_runtime_resolver import effective_gateway_alias
+
+    account = create_account()
+    model = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Kimi K3",
+            "provider_name": "nvidia_nim",
+            "model_identifier": "kimi-k3",
+            "api_key": "nvidia-key",
+            "meta_data": {"gateway": {"enabled": True}},
+        },
+        account_id=account.id,
+    )
+
+    updated = crud_ai_model.update(
+        db=db_session,
+        db_obj=model,
+        obj_in={
+            "provider_name": "moonshot",
+            "meta_data": {"gateway": {"enabled": True, "model_alias": "   "}},
+        },
+    )
+    db_session.refresh(updated)
+
+    assert effective_gateway_alias(updated) == "nvidia_nim/kimi-k3"

--- a/backend/tests/models/test_ai_model.py
+++ b/backend/tests/models/test_ai_model.py
@@ -720,3 +720,117 @@ def test_get_all_for_account_is_deterministically_ordered(
     # Repeated calls must agree — this is what pricing stability depends on.
     for _ in range(3):
         assert ordering() == observed
+
+
+def test_provider_switch_preserves_gateway_alias(db_session, create_account):
+    """Changing provider_name must pin the old default gateway alias.
+
+    In-flight agents talk to the gateway using the alias they were configured
+    with. If the alias changes because the admin edits provider_name, the
+    agent gets a 404 and the provider switch is invisible to running sessions.
+    The CRUD update should auto-set meta_data.gateway.model_alias to the old
+    default alias so the model stays addressable under the old name while
+    routing with the new provider.
+    """
+    from preloop.services.model_runtime_resolver import effective_gateway_alias
+
+    account = create_account()
+    model = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Kimi K3",
+            "provider_name": "nvidia_nim",
+            "model_identifier": "kimi-k3",
+            "api_key": "nvidia-key",
+            "meta_data": {"gateway": {"enabled": True}},
+        },
+        account_id=account.id,
+    )
+
+    old_alias = effective_gateway_alias(model)
+    assert old_alias == "nvidia_nim/kimi-k3"
+
+    # Edit: switch provider to moonshot
+    updated = crud_ai_model.update(
+        db=db_session,
+        db_obj=model,
+        obj_in={"provider_name": "moonshot"},
+    )
+    db_session.refresh(updated)
+
+    # The alias must still resolve to the OLD spelling so in-flight agents
+    # keep working.
+    new_alias = effective_gateway_alias(updated)
+    assert new_alias == old_alias, (
+        f"Gateway alias changed from {old_alias!r} to {new_alias!r} on "
+        "provider edit; in-flight agents would 404"
+    )
+
+    # The provider_name itself must have changed.
+    assert updated.provider_name == "moonshot"
+
+    # The alias is pinned via meta_data, not by blocking the provider change.
+    gw = updated.meta_data.get("gateway", {})
+    assert gw.get("model_alias") == "nvidia_nim/kimi-k3"
+
+
+def test_provider_switch_no_op_when_alias_already_configured(
+    db_session, create_account
+):
+    """If the admin already set a custom gateway alias, do not overwrite it."""
+    from preloop.services.model_runtime_resolver import effective_gateway_alias
+
+    account = create_account()
+    model = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Custom Alias Model",
+            "provider_name": "nvidia_nim",
+            "model_identifier": "kimi-k3",
+            "api_key": "nvidia-key",
+            "meta_data": {
+                "gateway": {"enabled": True, "model_alias": "my-custom-alias"}
+            },
+        },
+        account_id=account.id,
+    )
+
+    assert effective_gateway_alias(model) == "my-custom-alias"
+
+    updated = crud_ai_model.update(
+        db=db_session,
+        db_obj=model,
+        obj_in={"provider_name": "moonshot"},
+    )
+    db_session.refresh(updated)
+
+    # Custom alias must be untouched.
+    assert effective_gateway_alias(updated) == "my-custom-alias"
+    assert updated.provider_name == "moonshot"
+
+
+def test_provider_switch_skipped_when_gateway_not_enabled(db_session, create_account):
+    """Non-gateway models should not get an alias pinned on provider change."""
+    account = create_account()
+    model = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Direct Model",
+            "provider_name": "nvidia_nim",
+            "model_identifier": "kimi-k3",
+            "api_key": "nvidia-key",
+        },
+        account_id=account.id,
+    )
+
+    updated = crud_ai_model.update(
+        db=db_session,
+        db_obj=model,
+        obj_in={"provider_name": "moonshot"},
+    )
+    db_session.refresh(updated)
+
+    # No gateway block should have been created.
+    meta = updated.meta_data or {}
+    gw = meta.get("gateway", {})
+    assert not gw.get("model_alias"), "Non-gateway model should not get a pinned alias"

--- a/backend/tests/services/test_litellm_routing.py
+++ b/backend/tests/services/test_litellm_routing.py
@@ -330,3 +330,38 @@ class TestProviderSwitchStalePrefix:
         # Bare identifier (no /) is unaffected by this fix.
         model = _model("moonshot", "kimi-k3")
         assert to_litellm_model(model) == "moonshot/kimi-k3"
+
+
+class TestRuleThreePrefixOverride:
+    """Rule 3: an embedded prefix is a routing instruction only when it agrees
+    with provider_name, or when the provider is generic.
+
+    A deliberate prefix override therefore lives on a generic provider
+    (``openai-compatible``, ``custom``, ``openai``). On a specific provider a
+    disagreeing prefix is treated as stale and stripped, because that is what
+    a provider edit leaves behind.
+    """
+
+    def test_generic_openai_compatible_keeps_deliberate_override(self):
+        model = _model("openai-compatible", "azure/gpt-5.4")
+        assert to_litellm_model(model) == "azure/gpt-5.4"
+
+    def test_generic_custom_keeps_deliberate_override(self):
+        model = _model("custom", "bedrock/anthropic.claude-3")
+        assert to_litellm_model(model) == "bedrock/anthropic.claude-3"
+
+    def test_generic_openai_keeps_deliberate_override(self):
+        model = _model("openai", "azure/gpt-5.4")
+        assert to_litellm_model(model) == "azure/gpt-5.4"
+
+    def test_specific_provider_disagreeing_prefix_is_stripped(self):
+        # The stale-provider bug: a specific provider_name must win over a
+        # prefix left behind by an earlier provider.
+        model = _model("anthropic", "bedrock/anthropic.claude-3")
+        assert to_litellm_model(model) == "anthropic/anthropic.claude-3"
+
+    def test_unknown_prefix_is_not_treated_as_routing_instruction(self):
+        # Heads that are not routable prefixes never entered rule 3, before
+        # or after this change (issue #172).
+        model = _model("moonshot", "some-org/kimi-k3")
+        assert to_litellm_model(model) == "moonshot/some-org/kimi-k3"

--- a/backend/tests/services/test_litellm_routing.py
+++ b/backend/tests/services/test_litellm_routing.py
@@ -285,3 +285,48 @@ class TestSslVerifyOnCompletions:
             ),
         )
         assert "ssl_verify" not in kwargs
+
+
+class TestProviderSwitchStalePrefix:
+    """Editing a model's provider must change litellm routing even when the
+    model_identifier carries a stale vendor prefix from the old provider."""
+
+    def test_stale_nvidia_nim_prefix_uses_new_provider(self):
+        # Admin switched from nvidia_nim to moonshot but model_identifier
+        # still carries the nvidia_nim/ prefix from the import.
+        model = _model("moonshot", "nvidia_nim/kimi-k3")
+        result = to_litellm_model(model)
+        assert result == "moonshot/kimi-k3", (
+            "Stale nvidia_nim prefix in identifier must not override "
+            "the admin-set moonshot provider"
+        )
+
+    def test_stale_deepseek_prefix_uses_new_provider(self):
+        model = _model("moonshot", "deepseek/deepseek-coder")
+        result = to_litellm_model(model)
+        assert result == "moonshot/deepseek-coder"
+
+    def test_matching_prefix_still_passes_through(self):
+        # When the identifier prefix matches the provider, passthrough is fine.
+        model = _model("moonshot", "moonshot/kimi-k3")
+        assert to_litellm_model(model) == "moonshot/kimi-k3"
+
+    def test_matching_mapped_prefix_still_passes_through(self):
+        # google maps to gemini in PROVIDER_PREFIX.
+        model = _model("google", "gemini/gemini-2.0-flash")
+        assert to_litellm_model(model) == "gemini/gemini-2.0-flash"
+
+    def test_stale_prefix_with_endpoint_routes_via_openai(self):
+        # Unknown new provider with endpoint falls back to openai/ adapter.
+        model = _model(
+            "custom-provider",
+            "nvidia_nim/kimi-k3",
+            endpoint="https://custom.example.com/v1",
+        )
+        result = to_litellm_model(model)
+        assert result == "openai/kimi-k3"
+
+    def test_no_prefix_provider_switch_still_works(self):
+        # Bare identifier (no /) is unaffected by this fix.
+        model = _model("moonshot", "kimi-k3")
+        assert to_litellm_model(model) == "moonshot/kimi-k3"


### PR DESCRIPTION
## Problem

When an admin edits a model's `provider_name` (e.g. switching from `nvidia_nim` to `moonshot`), two things broke for in-flight gateway agents:

1. **Gateway alias changed** - The default alias (`provider_name/model_identifier`) changed, so agents configured with the old alias could no longer resolve the model. Their requests got 404s instead of routing through the new provider.

2. **Stale identifier prefix** - If the `model_identifier` carried a routable vendor prefix from the old provider (e.g. `nvidia_nim/kimi-k3`), `to_litellm_model` passed it through unchanged, silently routing to the old provider.

## Fix

**CRUD alias preservation**: When `provider_name` changes on a gateway-enabled model that uses the computed default alias (no explicit `model_alias` configured), the update now auto-pins the old alias as `meta_data.gateway.model_alias`. The model stays addressable under the old name while routing with the new provider.

**litellm routing**: `to_litellm_model` now strips a stale identifier prefix when a specific provider (e.g. `moonshot`) disagrees with the embedded prefix (e.g. `nvidia_nim/`). Generic providers (`openai`, `openai-compatible`, `custom`) still honour the identifier prefix as before, preserving backward compatibility.

## Tests

- 6 new routing tests in `test_litellm_routing.py` (stale prefix stripping, agreement passthrough, mapped prefix, endpoint fallback)
- 3 new CRUD tests in `test_ai_model.py` (alias preservation on provider switch, no-op when alias already configured, skipped when gateway not enabled)
- All 52 existing routing tests pass
- All 99 existing service tests pass

## Files changed

- `backend/preloop/services/litellm_routing.py` - rule 3 now checks provider agreement
- `backend/preloop/models/crud/ai_model.py` - `update()` preserves gateway alias on provider change
- `backend/tests/services/test_litellm_routing.py` - regression tests
- `backend/tests/models/test_ai_model.py` - CRUD regression tests

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Risk Level] Medium**
> The HIGH-severity config-write bug (explicit alias overwritten on provider change) is fixed. The remaining consideration is that the litellm routing change intentionally re-routes pre-existing rows whose specific-provider prefix disagrees with `provider_name`, now documented as intended behaviour.
>
> **Overview**
> Fixes gateway alias preservation and litellm provider routing when an admin switches a model's `provider_name`, preventing in-flight agents from 404ing or silently routing to the old provider. The explicit-alias overwrite bug is fixed in a follow-up commit; the routing-rule change is intentional and covered by `TestRuleThreePrefixOverride`.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 29b75d3d. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->