### PR TITLE
feat(runtime-plugins): gateway model-list refresh for opencode, openclaw, hermes

### DIFF
--- a/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/models.py
+++ b/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/models.py
@@ -1,0 +1,80 @@
+"""Gateway model-list refresh for the Hermes plugin.
+
+Derives the gateway ``GET /models`` URL from the Agent Control WS URL,
+fetches the current model list, and makes it available for programmatic
+use.
+
+Hermes's plugin API (``register_hook("pre_tool_call", ...)``) does not
+expose runtime model-list mutation, so this module is limited to
+fetching and returning the list.  A future Hermes hook that supports
+model-catalog updates could consume the result directly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+from urllib import parse, request
+
+logger = logging.getLogger(__name__)
+
+# Network timeout for the GET /models call (seconds).
+FETCH_TIMEOUT_SECONDS = 15.0
+
+
+def gateway_models_url(control_ws_url: str) -> str:
+    """Derive the gateway ``GET /models`` URL from the control WS URL.
+
+    Example::
+
+        wss://app.preloop.ai/api/v1/agents/control/ws
+         -> https://app.preloop.ai/openai/v1/models
+    """
+    parsed = parse.urlparse(control_ws_url)
+    scheme = "https" if parsed.scheme in ("wss", "https") else "http"
+    return f"{scheme}://{parsed.netloc}/openai/v1/models"
+
+
+def fetch_gateway_models(
+    control_ws_url: str,
+    bearer_token: str,
+) -> list[dict[str, Any]]:
+    """Fetch the current model list from the Preloop gateway.
+
+    Returns the list of model objects from the ``data`` (or ``models``)
+    field.  Raises on network or HTTP errors.
+    """
+    url = gateway_models_url(control_ws_url)
+    req = request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {bearer_token}",
+            "Accept": "application/json",
+        },
+    )
+    with request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as resp:
+        body = json.loads(resp.read())
+    if isinstance(body, dict):
+        return body.get("data") or body.get("models") or []
+    return []
+
+
+def refresh_models(
+    control_ws_url: str,
+    bearer_token: str,
+) -> list[dict[str, Any]]:
+    """Best-effort model refresh.  Returns the model list or ``[]``.
+
+    Hermes's plugin hook API does not support runtime model-list
+    mutation (the ``register_hook`` surface is limited to
+    ``pre_tool_call``).  This helper fetches and returns the list so
+    callers with additional capabilities can act on it.
+    """
+    try:
+        models = fetch_gateway_models(control_ws_url, bearer_token)
+        logger.info("Preloop model refresh: fetched %d model(s)", len(models))
+        return models
+    except Exception as exc:
+        logger.warning("Preloop model refresh failed: %s", exc)
+        return []

--- a/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/models.py
+++ b/runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/models.py
@@ -4,10 +4,12 @@ Derives the gateway ``GET /models`` URL from the Agent Control WS URL,
 fetches the current model list, and makes it available for programmatic
 use.
 
-Hermes's plugin API (``register_hook("pre_tool_call", ...)``) does not
-expose runtime model-list mutation, so this module is limited to
-fetching and returning the list.  A future Hermes hook that supports
-model-catalog updates could consume the result directly.
+NOT WIRED YET.  Nothing in ``preloop_hermes_plugin`` imports these
+helpers: Hermes's plugin API (``register_hook("pre_tool_call", ...)``)
+exposes no runtime model-list mutation, so there is no hook to call them
+from.  The module is kept as the ready-made fetch side of that future
+hook, and its behavior is pinned by ``tests/test_models.py``.  Wire
+``refresh_models`` into the hook once Hermes supports catalog updates.
 """
 
 from __future__ import annotations

--- a/runtime-plugins/hermes-preloop/tests/test_models.py
+++ b/runtime-plugins/hermes-preloop/tests/test_models.py
@@ -1,0 +1,138 @@
+"""Tests for gateway model-list refresh helpers."""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from threading import Thread
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from preloop_hermes_plugin.models import (  # noqa: E402
+    fetch_gateway_models,
+    gateway_models_url,
+    refresh_models,
+)
+
+
+# ---------------------------------------------------------------------------
+# gateway_models_url
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_models_url_wss() -> None:
+    url = gateway_models_url("wss://app.preloop.ai/api/v1/agents/control/ws")
+    assert url == "https://app.preloop.ai/openai/v1/models"
+
+
+def test_gateway_models_url_ws() -> None:
+    url = gateway_models_url("ws://localhost:8000/api/v1/agents/control/ws")
+    assert url == "http://localhost:8000/openai/v1/models"
+
+
+# ---------------------------------------------------------------------------
+# fetch_gateway_models (with a local HTTP stub)
+# ---------------------------------------------------------------------------
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    """Tiny handler that returns a canned model list on GET /openai/v1/models."""
+
+    response_body: dict = {}
+    response_status: int = 200
+    last_auth_header: str | None = None
+
+    def do_GET(self) -> None:  # noqa: N802
+        _StubHandler.last_auth_header = self.headers.get("Authorization")
+        self.send_response(_StubHandler.response_status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(_StubHandler.response_body).encode())
+
+    def log_message(self, *_args: object) -> None:
+        pass  # silence noisy stderr in test output
+
+
+@pytest.fixture()
+def stub_server():
+    """Spin up a local HTTP server for the duration of a test."""
+    server = HTTPServer(("127.0.0.1", 0), _StubHandler)
+    port = server.server_address[1]
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server, port
+    server.shutdown()
+
+
+def test_fetch_returns_data_array(stub_server) -> None:
+    server, port = stub_server
+    models = [{"id": "claude-sonnet-4", "object": "model"}]
+    _StubHandler.response_body = {"object": "list", "data": models}
+    _StubHandler.response_status = 200
+
+    result = fetch_gateway_models(
+        f"ws://127.0.0.1:{port}/api/v1/agents/control/ws",
+        "test-token",
+    )
+    assert result == models
+    assert _StubHandler.last_auth_header == "Bearer test-token"
+
+
+def test_fetch_falls_back_to_models_array(stub_server) -> None:
+    server, port = stub_server
+    models = [{"id": "test-model"}]
+    _StubHandler.response_body = {"object": "list", "models": models}
+    _StubHandler.response_status = 200
+
+    result = fetch_gateway_models(
+        f"ws://127.0.0.1:{port}/api/v1/agents/control/ws",
+        "tok",
+    )
+    assert result == models
+
+
+def test_fetch_raises_on_http_error(stub_server) -> None:
+    server, port = stub_server
+    _StubHandler.response_body = {}
+    _StubHandler.response_status = 403
+
+    with pytest.raises(urllib.error.HTTPError):
+        fetch_gateway_models(
+            f"ws://127.0.0.1:{port}/api/v1/agents/control/ws",
+            "tok",
+        )
+
+
+# ---------------------------------------------------------------------------
+# refresh_models
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_models_returns_list_on_success(stub_server) -> None:
+    server, port = stub_server
+    _StubHandler.response_body = {
+        "data": [{"id": "m1"}, {"id": "m2"}],
+    }
+    _StubHandler.response_status = 200
+
+    result = refresh_models(
+        f"ws://127.0.0.1:{port}/api/v1/agents/control/ws",
+        "tok",
+    )
+    assert len(result) == 2
+
+
+def test_refresh_models_returns_empty_on_failure() -> None:
+    # Point at a port that is definitely not listening.
+    result = refresh_models(
+        "ws://127.0.0.1:1/api/v1/agents/control/ws",
+        "tok",
+    )
+    assert result == []

--- a/runtime-plugins/openclaw-preloop/src/index.ts
+++ b/runtime-plugins/openclaw-preloop/src/index.ts
@@ -4,12 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
-import {
-  fetchGatewayModels,
-  gatewayModelsUrl,
-  refreshModels,
-  type GatewayModel,
-} from "./models.js";
+import { refreshModels, type GatewayModel } from "./models.js";
 
 type ControlConfig = {
   enabled?: boolean;
@@ -140,8 +135,13 @@ export class PreloopOpenClawPlugin {
   private logger?: (message: string) => void;
 
   /**
-   * Most recently fetched gateway model list, available for programmatic
-   * use.  Updated by {@link refreshGatewayModels}.
+   * Most recently fetched gateway model list, updated by
+   * {@link refreshGatewayModels}.
+   *
+   * Nothing inside the plugin reads this yet, and that is deliberate:
+   * OpenClaw's hook API has no runtime model-catalog mutation surface, so
+   * the list is staged here for the catalog-update hook to consume once it
+   * exists.  Callers embedding the plugin can read it today.
    */
   lastGatewayModels: GatewayModel[] = [];
 

--- a/runtime-plugins/openclaw-preloop/src/index.ts
+++ b/runtime-plugins/openclaw-preloop/src/index.ts
@@ -4,6 +4,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
+import {
+  fetchGatewayModels,
+  gatewayModelsUrl,
+  refreshModels,
+  type GatewayModel,
+} from "./models.js";
+
 type ControlConfig = {
   enabled?: boolean;
   protocol?: string;
@@ -131,6 +138,12 @@ export class PreloopOpenClawPlugin {
   private reconnectTimer?: ReturnType<typeof setTimeout>;
   private heartbeatTimer?: ReturnType<typeof setInterval>;
   private logger?: (message: string) => void;
+
+  /**
+   * Most recently fetched gateway model list, available for programmatic
+   * use.  Updated by {@link refreshGatewayModels}.
+   */
+  lastGatewayModels: GatewayModel[] = [];
 
   constructor(
     private readonly configPath?: string,
@@ -385,6 +398,25 @@ export class PreloopOpenClawPlugin {
   }
 
   /**
+   * Fetch the current model list from the Preloop gateway and store it
+   * on {@link lastGatewayModels}.  Best-effort; swallows errors.
+   *
+   * OpenClaw's plugin hook API does not expose a runtime model-catalog
+   * mutation method, so this helper fetches and caches the list. A
+   * future OpenClaw hook that supports runtime catalog updates could
+   * consume ``lastGatewayModels`` directly.
+   */
+  async refreshGatewayModels(): Promise<GatewayModel[]> {
+    const config = this.controlConfig ?? this.loadConfig();
+    this.lastGatewayModels = await refreshModels(
+      config,
+      this.fetchImpl,
+      (message) => this.log(message),
+    );
+    return this.lastGatewayModels;
+  }
+
+  /**
    * Derive the REST API base URL from the Agent Control WS URL, e.g.
    * `wss://host/api/v1/agents/control/ws` -> `https://host`.
    */
@@ -584,6 +616,8 @@ export class PreloopOpenClawPlugin {
   }
 }
 
+export { gatewayModelsUrl, fetchGatewayModels, type GatewayModel } from "./models.js";
+
 export const plugin = new PreloopOpenClawPlugin();
 
 export const definition = {
@@ -639,7 +673,12 @@ export function register(api: {
     });
   };
 
-  api.on?.("gateway_start", start);
+  api.on?.("gateway_start", () => {
+    start();
+    // Best-effort model-list refresh on gateway start so the model
+    // picker reflects console edits without a full restart.
+    void instance.refreshGatewayModels();
+  });
   api.on?.("gateway_stop", () => {
     started = false;
     instance.stop();

--- a/runtime-plugins/openclaw-preloop/src/models.ts
+++ b/runtime-plugins/openclaw-preloop/src/models.ts
@@ -1,17 +1,20 @@
 /**
  * Gateway model-list refresh for the OpenClaw plugin.
  *
- * Derives the gateway ``GET /models`` URL from the Agent Control WS URL,
- * fetches the current model list, and patches the local OpenClaw config
- * file so the agent's model picker reflects console edits without a full
- * restart.
+ * Derives the gateway ``GET /models`` URL from the Agent Control WS URL
+ * and fetches the current model list using the token Agent Control
+ * already holds.
  *
- * Shared design with opencode-preloop/src/models.ts; the logic is
+ * Unlike the OpenCode plugin, this module does not write a config file:
+ * OpenClaw's plugin API exposes no runtime model-catalog mutation, so the
+ * fetched list is returned to the caller and cached on the plugin
+ * instance.  It is staged for the catalog-update hook OpenClaw does not
+ * offer yet; see ``PreloopOpenClawPlugin.lastGatewayModels``.
+ *
+ * Shared design with opencode-preloop/src/models.ts; the fetch helpers are
  * deliberately duplicated (no cross-plugin import) so each plugin is
  * independently publishable.
  */
-
-import fs from "node:fs";
 
 type FetchLike = (
   input: string,

--- a/runtime-plugins/openclaw-preloop/src/models.ts
+++ b/runtime-plugins/openclaw-preloop/src/models.ts
@@ -1,0 +1,113 @@
+/**
+ * Gateway model-list refresh for the OpenClaw plugin.
+ *
+ * Derives the gateway ``GET /models`` URL from the Agent Control WS URL,
+ * fetches the current model list, and patches the local OpenClaw config
+ * file so the agent's model picker reflects console edits without a full
+ * restart.
+ *
+ * Shared design with opencode-preloop/src/models.ts; the logic is
+ * deliberately duplicated (no cross-plugin import) so each plugin is
+ * independently publishable.
+ */
+
+import fs from "node:fs";
+
+type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+type ControlConfig = {
+  control_ws_url?: string;
+  bearer_token?: string;
+  [key: string]: unknown;
+};
+
+export type GatewayModel = {
+  id: string;
+  object?: string;
+  created?: number;
+  owned_by?: string;
+};
+
+export type GatewayModelsResponse = {
+  object?: string;
+  data?: GatewayModel[];
+  models?: GatewayModel[];
+};
+
+/**
+ * Derive the gateway ``GET /models`` URL from the Agent Control WS URL.
+ */
+export function gatewayModelsUrl(config: ControlConfig): string {
+  const wsUrl = new URL(config.control_ws_url!);
+  const httpProtocol = wsUrl.protocol === "wss:" ? "https:" : "http:";
+  return `${httpProtocol}//${wsUrl.host}/openai/v1/models`;
+}
+
+/**
+ * Fetch the current model list from the Preloop gateway.
+ */
+export async function fetchGatewayModels(
+  config: ControlConfig,
+  fetchImpl?: FetchLike,
+): Promise<GatewayModel[]> {
+  const doFetch = fetchImpl ?? (fetch as unknown as FetchLike);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15_000);
+  try {
+    const response = await doFetch(gatewayModelsUrl(config), {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${config.bearer_token}`,
+        accept: "application/json",
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`GET /models returned HTTP ${response.status}`);
+    }
+    const body = (await response.json()) as GatewayModelsResponse;
+    return body.data ?? body.models ?? [];
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * High-level: fetch models from the gateway.  Best-effort; swallows
+ * errors. Returns the model list or an empty array on failure.
+ *
+ * OpenClaw's plugin API does not expose runtime model-list mutation, so
+ * this helper is limited to fetching and logging.  The model list is
+ * available for programmatic use by callers that can act on it (e.g. a
+ * future OpenClaw hook that supports runtime catalog updates).
+ */
+export async function refreshModels(
+  config: ControlConfig,
+  fetchImpl?: FetchLike,
+  logger?: (message: string) => void,
+): Promise<GatewayModel[]> {
+  try {
+    const models = await fetchGatewayModels(config, fetchImpl);
+    logger?.(
+      `model refresh: fetched ${models.length} model(s) from gateway`,
+    );
+    return models;
+  } catch (error) {
+    const message = `model refresh failed: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+    logger?.(message);
+    return [];
+  }
+}

--- a/runtime-plugins/openclaw-preloop/test/models.test.mjs
+++ b/runtime-plugins/openclaw-preloop/test/models.test.mjs
@@ -1,0 +1,118 @@
+// Unit tests for gateway model-list refresh (models.ts).
+// Run: npm run build && node --test test/models.test.mjs
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  PreloopOpenClawPlugin,
+  gatewayModelsUrl,
+  fetchGatewayModels,
+} from "../dist/index.js";
+
+const baseConfig = {
+  runtime: "openclaw",
+  control_ws_url: "wss://example.preloop.ai/api/v1/agents/control/ws",
+  bearer_token: "secret-token",
+  runtime_principal_id: "principal-1",
+};
+
+function jsonResponse(status, body) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// gatewayModelsUrl
+// ---------------------------------------------------------------------------
+
+test("gatewayModelsUrl derives https from a wss control URL", () => {
+  assert.equal(
+    gatewayModelsUrl(baseConfig),
+    "https://example.preloop.ai/openai/v1/models",
+  );
+});
+
+test("gatewayModelsUrl derives http from a ws control URL", () => {
+  assert.equal(
+    gatewayModelsUrl({
+      control_ws_url: "ws://localhost:8000/api/v1/agents/control/ws",
+    }),
+    "http://localhost:8000/openai/v1/models",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// fetchGatewayModels
+// ---------------------------------------------------------------------------
+
+test("fetchGatewayModels returns the data array", async () => {
+  const models = [
+    { id: "claude-sonnet-4", object: "model", created: 1, owned_by: "preloop" },
+  ];
+  const result = await fetchGatewayModels(baseConfig, () =>
+    jsonResponse(200, { object: "list", data: models }),
+  );
+  assert.deepEqual(result, models);
+});
+
+test("fetchGatewayModels throws on HTTP error", async () => {
+  await assert.rejects(
+    fetchGatewayModels(baseConfig, () => jsonResponse(403, {})),
+    /HTTP 403/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Plugin: refreshGatewayModels
+// ---------------------------------------------------------------------------
+
+test("refreshGatewayModels stores fetched models on the plugin instance", async () => {
+  const models = [
+    { id: "model-a", object: "model" },
+    { id: "model-b", object: "model" },
+  ];
+  const plugin = new PreloopOpenClawPlugin(undefined, () =>
+    jsonResponse(200, { data: models }),
+  );
+  plugin.configure(baseConfig);
+  const result = await plugin.refreshGatewayModels();
+  assert.deepEqual(result, models);
+  assert.deepEqual(plugin.lastGatewayModels, models);
+});
+
+test("refreshGatewayModels returns empty on fetch failure", async () => {
+  const plugin = new PreloopOpenClawPlugin(undefined, () =>
+    Promise.reject(new Error("offline")),
+  );
+  plugin.configure(baseConfig);
+  const result = await plugin.refreshGatewayModels();
+  assert.deepEqual(result, []);
+  assert.deepEqual(plugin.lastGatewayModels, []);
+});
+
+// ---------------------------------------------------------------------------
+// register() wires model refresh to gateway_start
+// ---------------------------------------------------------------------------
+
+test("register calls refreshGatewayModels on gateway_start", async () => {
+  let gatewayStartHandler;
+  const hooks = {};
+  const api = {
+    pluginConfig: baseConfig,
+    on: (name, handler) => {
+      hooks[name] = handler;
+    },
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  };
+
+  // Use dynamic import to get the register function
+  const mod = await import("../dist/index.js");
+  mod.register(api);
+
+  assert.ok(hooks.gateway_start, "gateway_start hook was registered");
+  // Calling gateway_start should not throw even without network.
+  hooks.gateway_start();
+});

--- a/runtime-plugins/openclaw-preloop/test/models.test.mjs
+++ b/runtime-plugins/openclaw-preloop/test/models.test.mjs
@@ -97,22 +97,39 @@ test("refreshGatewayModels returns empty on fetch failure", async () => {
 // register() wires model refresh to gateway_start
 // ---------------------------------------------------------------------------
 
-test("register calls refreshGatewayModels on gateway_start", async () => {
+test("register fetches the gateway model list on gateway_start", async () => {
   let gatewayStartHandler;
-  const hooks = {};
   const api = {
     pluginConfig: baseConfig,
     on: (name, handler) => {
-      hooks[name] = handler;
+      if (name === "gateway_start") {
+        gatewayStartHandler = handler;
+      }
     },
     logger: { info: () => {}, warn: () => {}, error: () => {} },
   };
 
-  // Use dynamic import to get the register function
-  const mod = await import("../dist/index.js");
-  mod.register(api);
+  const { register } = await import("../dist/index.js");
+  register(api);
+  assert.equal(typeof gatewayStartHandler, "function");
 
-  assert.ok(hooks.gateway_start, "gateway_start hook was registered");
-  // Calling gateway_start should not throw even without network.
-  hooks.gateway_start();
+  // register() builds its own plugin instance, so observe the refresh
+  // through global fetch rather than reaching into the instance.
+  const realFetch = globalThis.fetch;
+  const requested = [];
+  globalThis.fetch = (url) => {
+    requested.push(String(url));
+    return jsonResponse(200, { data: [{ id: "model-a", object: "model" }] });
+  };
+  try {
+    gatewayStartHandler();
+    // Let the best-effort refresh promise settle.
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.ok(
+      requested.includes("https://example.preloop.ai/openai/v1/models"),
+      `expected a gateway models fetch, saw ${JSON.stringify(requested)}`,
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
 });

--- a/runtime-plugins/opencode-preloop/src/config.ts
+++ b/runtime-plugins/opencode-preloop/src/config.ts
@@ -109,10 +109,26 @@ export function extractControlConfig(raw: unknown): {
   return { config: {}, source: "empty" };
 }
 
+/**
+ * Resolve the OpenCode config file every caller must agree on.
+ *
+ * Reading the control block and patching the provider models map have to
+ * target the same file, so both go through here: an explicit
+ * `PRELOOP_OPENCODE_CONTROL_CONFIG` wins, then a caller-supplied path,
+ * then the default location.
+ */
+export function resolveConfigPath(configPath?: string): string {
+  return (
+    process.env.PRELOOP_OPENCODE_CONTROL_CONFIG ??
+    configPath ??
+    defaultConfigPath()
+  );
+}
+
 export function loadControlConfig(configPath?: string): ControlConfig {
-  const resolvedPath =
-    process.env.PRELOOP_OPENCODE_CONTROL_CONFIG ?? configPath ?? defaultConfigPath();
-  const raw = JSON.parse(fs.readFileSync(resolvedPath, "utf8")) as unknown;
+  const raw = JSON.parse(
+    fs.readFileSync(resolveConfigPath(configPath), "utf8"),
+  ) as unknown;
   return extractControlConfig(raw).config;
 }
 

--- a/runtime-plugins/opencode-preloop/src/index.ts
+++ b/runtime-plugins/opencode-preloop/src/index.ts
@@ -7,10 +7,13 @@ import {
   DEFAULT_TURN_TIMEOUT_MS,
   PROTOCOL,
   RUNTIME,
+  defaultConfigPath,
   loadControlConfig,
   verifyConfig,
   type ControlConfig,
 } from "./config.js";
+
+import { refreshModels } from "./models.js";
 
 /**
  * Structural mirror of OpenCode's permission-ask request
@@ -230,6 +233,15 @@ export class PreloopOpenCodePlugin {
       this.reconnectAttempts = 0;
       socket.send(JSON.stringify(this.presenceMessage(config)));
       this.startHeartbeat(config);
+      // Best-effort model-list refresh: fetch the current gateway models
+      // and patch the local OpenCode config so the model picker reflects
+      // console edits without a full restart.
+      void refreshModels(
+        config,
+        this.configPath ?? defaultConfigPath(),
+        this.fetchImpl as Parameters<typeof refreshModels>[2],
+        (message) => this.log(`model refresh: ${message}`),
+      );
     });
 
     socket.addEventListener("message", (event) => {
@@ -873,7 +885,12 @@ export const PreloopPlugin = async (ctx: {
   if (ctx.client) {
     instance.setOpenCodeClient(ctx.client);
   }
-  instance.configure(loadControlConfig());
+  const config = loadControlConfig();
+  instance.configure(config);
+  // Refresh the model list at session start (before the WS connect also
+  // triggers one on open).  This path is synchronous enough that the
+  // model picker shows fresh data from the first interaction.
+  void refreshModels(config, defaultConfigPath());
   await instance.start(ctx.client);
   return {
     event: async ({ event }) => {

--- a/runtime-plugins/opencode-preloop/src/index.ts
+++ b/runtime-plugins/opencode-preloop/src/index.ts
@@ -7,8 +7,8 @@ import {
   DEFAULT_TURN_TIMEOUT_MS,
   PROTOCOL,
   RUNTIME,
-  defaultConfigPath,
   loadControlConfig,
+  resolveConfigPath,
   verifyConfig,
   type ControlConfig,
 } from "./config.js";
@@ -235,10 +235,11 @@ export class PreloopOpenCodePlugin {
       this.startHeartbeat(config);
       // Best-effort model-list refresh: fetch the current gateway models
       // and patch the local OpenCode config so the model picker reflects
-      // console edits without a full restart.
+      // console edits without a full restart.  This is the only refresh
+      // trigger: it covers plugin start as well as every reconnect.
       void refreshModels(
         config,
-        this.configPath ?? defaultConfigPath(),
+        resolveConfigPath(this.configPath),
         this.fetchImpl as Parameters<typeof refreshModels>[2],
         (message) => this.log(`model refresh: ${message}`),
       );
@@ -885,12 +886,10 @@ export const PreloopPlugin = async (ctx: {
   if (ctx.client) {
     instance.setOpenCodeClient(ctx.client);
   }
-  const config = loadControlConfig();
-  instance.configure(config);
-  // Refresh the model list at session start (before the WS connect also
-  // triggers one on open).  This path is synchronous enough that the
-  // model picker shows fresh data from the first interaction.
-  void refreshModels(config, defaultConfigPath());
+  instance.configure(loadControlConfig());
+  // The model-list refresh runs from the WebSocket `open` handler, which
+  // fires on this start as well as on every reconnect. Triggering it here
+  // too would only double the fetch and the read-modify-write.
   await instance.start(ctx.client);
   return {
     event: async ({ event }) => {

--- a/runtime-plugins/opencode-preloop/src/models.ts
+++ b/runtime-plugins/opencode-preloop/src/models.ts
@@ -1,0 +1,210 @@
+/**
+ * Gateway model-list refresh for the OpenCode plugin.
+ *
+ * Derives the gateway ``GET /models`` URL from the Agent Control WS URL
+ * already in the plugin config, fetches the current model list, and
+ * patches the local ``opencode.json`` provider models map so the
+ * in-session model picker reflects console edits without a restart.
+ *
+ * Design notes:
+ * - The gateway models endpoint is ``/openai/v1/models`` on the same
+ *   origin as the control WS (``/api/v1/agents/control/ws``).
+ * - Auth: the same durable bearer token Agent Control already holds.
+ * - Trigger: on WebSocket connect (plugin start + reconnect).  A
+ *   periodic timer is intentionally avoided to keep the plugin
+ *   lightweight; reconnects already fire on network changes, and the
+ *   operator can force a reconnect from the console.
+ * - File write: the function merges into the existing config so it
+ *   never clobbers unrelated keys (MCP, permissions, preloop.control).
+ */
+
+import fs from "node:fs";
+import type { ControlConfig } from "./config.js";
+
+type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+/** OpenAI-compatible model entry returned by the gateway. */
+export type GatewayModel = {
+  id: string;
+  object?: string;
+  created?: number;
+  owned_by?: string;
+};
+
+/** Shape of the ``GET /models`` response. */
+export type GatewayModelsResponse = {
+  object?: string;
+  data?: GatewayModel[];
+  models?: GatewayModel[];
+};
+
+/**
+ * Derive the gateway ``GET /models`` URL from the Agent Control WS URL.
+ *
+ * ```
+ * wss://app.example.ai/api/v1/agents/control/ws
+ *  ->  https://app.example.ai/openai/v1/models
+ * ```
+ */
+export function gatewayModelsUrl(config: ControlConfig): string {
+  const wsUrl = new URL(config.control_ws_url!);
+  const httpProtocol = wsUrl.protocol === "wss:" ? "https:" : "http:";
+  return `${httpProtocol}//${wsUrl.host}/openai/v1/models`;
+}
+
+/**
+ * Fetch the current model list from the Preloop gateway.
+ *
+ * Returns the array of model objects (``data`` field of the response).
+ * Throws on network/HTTP errors.
+ */
+export async function fetchGatewayModels(
+  config: ControlConfig,
+  fetchImpl?: FetchLike,
+): Promise<GatewayModel[]> {
+  const doFetch = fetchImpl ?? (fetch as unknown as FetchLike);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15_000);
+  try {
+    const response = await doFetch(gatewayModelsUrl(config), {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${config.bearer_token}`,
+        accept: "application/json",
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`GET /models returned HTTP ${response.status}`);
+    }
+    const body = (await response.json()) as GatewayModelsResponse;
+    return body.data ?? body.models ?? [];
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Read-modify-write the OpenCode config to reflect the current gateway
+ * model list inside every provider whose ``baseURL`` points at the same
+ * Preloop gateway origin.
+ *
+ * Returns the number of provider sections that were updated, or -1 if
+ * the config file could not be processed (missing, unparseable, etc.).
+ */
+export function patchConfigModels(
+  configPath: string,
+  gatewayOrigin: string,
+  models: GatewayModel[],
+): number {
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return -1;
+  }
+
+  const providers = raw["provider"] as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (!providers || typeof providers !== "object") {
+    return 0;
+  }
+
+  const modelsMap: Record<string, { name: string }> = {};
+  for (const model of models) {
+    modelsMap[model.id] = { name: model.id };
+  }
+  if (Object.keys(modelsMap).length === 0) {
+    // Empty model list: nothing to patch (avoid wiping valid entries).
+    return 0;
+  }
+
+  let patched = 0;
+  for (const [, providerConfig] of Object.entries(providers)) {
+    if (!providerConfig || typeof providerConfig !== "object") {
+      continue;
+    }
+    const options = providerConfig["options"] as
+      | Record<string, unknown>
+      | undefined;
+    const baseURL =
+      typeof options?.["baseURL"] === "string"
+        ? (options["baseURL"] as string)
+        : undefined;
+    if (!baseURL) {
+      continue;
+    }
+    // Match: provider baseURL origin equals the gateway origin.
+    try {
+      const providerOrigin = new URL(baseURL).origin;
+      if (providerOrigin !== gatewayOrigin) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    // Merge: keep any existing model entries the gateway no longer
+    // advertises (they may be soft-disabled rather than deleted) and add
+    // new ones.  The merge strategy is additive so the picker never
+    // shrinks unexpectedly.
+    const existing = (providerConfig["models"] ?? {}) as Record<
+      string,
+      unknown
+    >;
+    providerConfig["models"] = { ...existing, ...modelsMap };
+    patched += 1;
+  }
+
+  if (patched > 0) {
+    fs.writeFileSync(configPath, JSON.stringify(raw, null, 2) + "\n", "utf8");
+  }
+  return patched;
+}
+
+/**
+ * High-level: fetch models from the gateway and patch the OpenCode
+ * config file.  Swallows all errors (the feature is best-effort).
+ *
+ * @returns A human-readable summary string for logging.
+ */
+export async function refreshModels(
+  config: ControlConfig,
+  configPath: string,
+  fetchImpl?: FetchLike,
+  logger?: (message: string) => void,
+): Promise<string> {
+  try {
+    const models = await fetchGatewayModels(config, fetchImpl);
+    const origin = new URL(gatewayModelsUrl(config)).origin;
+    const patched = patchConfigModels(configPath, origin, models);
+    const summary =
+      patched > 0
+        ? `refreshed ${models.length} model(s) in ${patched} provider(s)`
+        : patched === 0
+          ? `${models.length} model(s) fetched but no matching provider in config`
+          : "config file could not be read";
+    logger?.(summary);
+    return summary;
+  } catch (error) {
+    const message = `model refresh failed: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+    logger?.(message);
+    return message;
+  }
+}

--- a/runtime-plugins/opencode-preloop/src/models.ts
+++ b/runtime-plugins/opencode-preloop/src/models.ts
@@ -14,8 +14,12 @@
  *   periodic timer is intentionally avoided to keep the plugin
  *   lightweight; reconnects already fire on network changes, and the
  *   operator can force a reconnect from the console.
- * - File write: the function merges into the existing config so it
- *   never clobbers unrelated keys (MCP, permissions, preloop.control).
+ * - File write: only the ``models`` map of a provider pointing at the
+ *   gateway is touched.  It is reconciled to the gateway list (added and
+ *   removed ids both apply); unrelated keys (MCP, permissions,
+ *   preloop.control) and providers on other origins are left alone.  The
+ *   file is replaced temp-file-then-rename so an interrupted write cannot
+ *   truncate the operator's config.
  */
 
 import fs from "node:fs";
@@ -96,9 +100,15 @@ export async function fetchGatewayModels(
 }
 
 /**
- * Read-modify-write the OpenCode config to reflect the current gateway
- * model list inside every provider whose ``baseURL`` points at the same
- * Preloop gateway origin.
+ * Read-modify-write the OpenCode config so that every provider whose
+ * ``baseURL`` points at the Preloop gateway origin lists exactly the
+ * models the gateway currently advertises.
+ *
+ * The matched provider blocks are reconciled, not merely extended: ids
+ * the gateway no longer advertises are removed so the picker cannot
+ * offer a model that the gateway will reject at request time. Providers
+ * on any other origin are left untouched, as are unrelated keys inside
+ * the matched provider (``npm``, ``options``, ...).
  *
  * Returns the number of provider sections that were updated, or -1 if
  * the config file could not be processed (missing, unparseable, etc.).
@@ -135,6 +145,7 @@ export function patchConfigModels(
   }
 
   let patched = 0;
+  let changed = false;
   for (const [, providerConfig] of Object.entries(providers)) {
     if (!providerConfig || typeof providerConfig !== "object") {
       continue;
@@ -158,22 +169,65 @@ export function patchConfigModels(
     } catch {
       continue;
     }
-    // Merge: keep any existing model entries the gateway no longer
-    // advertises (they may be soft-disabled rather than deleted) and add
-    // new ones.  The merge strategy is additive so the picker never
-    // shrinks unexpectedly.
+    // Reconcile to the gateway list: a model the gateway stopped
+    // advertising is no longer usable, so leaving it in the picker only
+    // defers the failure to request time.  Existing entries for ids the
+    // gateway still advertises keep their local shape.
     const existing = (providerConfig["models"] ?? {}) as Record<
       string,
       unknown
     >;
-    providerConfig["models"] = { ...existing, ...modelsMap };
+    const reconciled: Record<string, unknown> = {};
+    for (const id of Object.keys(modelsMap)) {
+      reconciled[id] = existing[id] ?? modelsMap[id];
+    }
+    if (!sameModelIds(existing, reconciled)) {
+      changed = true;
+    }
+    providerConfig["models"] = reconciled;
     patched += 1;
   }
 
-  if (patched > 0) {
-    fs.writeFileSync(configPath, JSON.stringify(raw, null, 2) + "\n", "utf8");
+  if (changed) {
+    writeConfigAtomically(configPath, JSON.stringify(raw, null, 2) + "\n");
   }
   return patched;
+}
+
+/** True when both model maps carry the same set of ids. */
+function sameModelIds(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): boolean {
+  const beforeIds = Object.keys(before);
+  const afterIds = Object.keys(after);
+  if (beforeIds.length !== afterIds.length) {
+    return false;
+  }
+  return beforeIds.every((id) => id in after);
+}
+
+/**
+ * Replace *configPath* without ever leaving a truncated file behind.
+ *
+ * This runs on every gateway connect and reconnect, so a plain
+ * ``writeFileSync`` would put the operator's ``opencode.json`` at risk on
+ * every crash or full disk.  The temp file is created in the same
+ * directory so the rename stays on one filesystem and is atomic.
+ */
+function writeConfigAtomically(configPath: string, contents: string): void {
+  const tempPath = `${configPath}.preloop-${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(tempPath, contents, "utf8");
+    fs.renameSync(tempPath, configPath);
+  } catch (error) {
+    try {
+      fs.rmSync(tempPath, { force: true });
+    } catch {
+      // Best-effort cleanup only.
+    }
+    throw error;
+  }
 }
 
 /**

--- a/runtime-plugins/opencode-preloop/test/models.test.mjs
+++ b/runtime-plugins/opencode-preloop/test/models.test.mjs
@@ -1,0 +1,284 @@
+// Unit tests for gateway model-list refresh (models.ts).
+// Run: npm run build && node --test test/models.test.mjs
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  gatewayModelsUrl,
+  fetchGatewayModels,
+  patchConfigModels,
+  refreshModels,
+} from "../dist/models.js";
+
+const baseConfig = {
+  runtime: "opencode",
+  control_ws_url: "wss://example.preloop.ai/api/v1/agents/control/ws",
+  bearer_token: "secret-token",
+  runtime_principal_id: "principal-1",
+};
+
+function jsonResponse(status, body) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// gatewayModelsUrl
+// ---------------------------------------------------------------------------
+
+test("gatewayModelsUrl derives https from a wss control URL", () => {
+  assert.equal(
+    gatewayModelsUrl(baseConfig),
+    "https://example.preloop.ai/openai/v1/models",
+  );
+});
+
+test("gatewayModelsUrl derives http from a ws control URL", () => {
+  const config = {
+    ...baseConfig,
+    control_ws_url: "ws://localhost:8000/api/v1/agents/control/ws",
+  };
+  assert.equal(
+    gatewayModelsUrl(config),
+    "http://localhost:8000/openai/v1/models",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// fetchGatewayModels
+// ---------------------------------------------------------------------------
+
+test("fetchGatewayModels returns the data array from a successful response", async () => {
+  const models = [
+    { id: "claude-sonnet-4", object: "model", created: 1, owned_by: "preloop" },
+    { id: "gpt-5", object: "model", created: 2, owned_by: "preloop" },
+  ];
+  let captured;
+  const result = await fetchGatewayModels(baseConfig, (url, init) => {
+    captured = { url, init };
+    return jsonResponse(200, { object: "list", data: models });
+  });
+  assert.deepEqual(result, models);
+  assert.equal(captured.url, "https://example.preloop.ai/openai/v1/models");
+  assert.equal(captured.init.headers.authorization, "Bearer secret-token");
+});
+
+test("fetchGatewayModels falls back to models array when data is absent", async () => {
+  const models = [{ id: "test-model", object: "model" }];
+  const result = await fetchGatewayModels(baseConfig, () =>
+    jsonResponse(200, { object: "list", models }),
+  );
+  assert.deepEqual(result, models);
+});
+
+test("fetchGatewayModels returns empty array when response has neither data nor models", async () => {
+  const result = await fetchGatewayModels(baseConfig, () =>
+    jsonResponse(200, { object: "list" }),
+  );
+  assert.deepEqual(result, []);
+});
+
+test("fetchGatewayModels throws on non-OK HTTP status", async () => {
+  await assert.rejects(
+    fetchGatewayModels(baseConfig, () => jsonResponse(401, {})),
+    /HTTP 401/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// patchConfigModels
+// ---------------------------------------------------------------------------
+
+function writeTempConfig(config) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "preloop-oc-models-"));
+  const file = path.join(dir, "opencode.json");
+  fs.writeFileSync(file, JSON.stringify(config, null, 2));
+  return { file, dir };
+}
+
+test("patchConfigModels updates the matching provider models map", () => {
+  const { file, dir } = writeTempConfig({
+    model: "preloop/claude-sonnet-4",
+    provider: {
+      preloop: {
+        npm: "@ai-sdk/openai-compatible",
+        options: { baseURL: "https://example.preloop.ai/openai/v1" },
+        models: { "claude-sonnet-4": { name: "claude-sonnet-4" } },
+      },
+    },
+  });
+  try {
+    const models = [
+      { id: "claude-sonnet-4", object: "model" },
+      { id: "gpt-5", object: "model" },
+    ];
+    const patched = patchConfigModels(
+      file,
+      "https://example.preloop.ai",
+      models,
+    );
+    assert.equal(patched, 1);
+    const updated = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.deepEqual(updated.provider.preloop.models, {
+      "claude-sonnet-4": { name: "claude-sonnet-4" },
+      "gpt-5": { name: "gpt-5" },
+    });
+    // Unrelated keys must be preserved.
+    assert.equal(updated.model, "preloop/claude-sonnet-4");
+    assert.equal(updated.provider.preloop.npm, "@ai-sdk/openai-compatible");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("patchConfigModels skips providers on a different origin", () => {
+  const { file, dir } = writeTempConfig({
+    provider: {
+      other: {
+        options: { baseURL: "https://other.host/v1" },
+        models: { "some-model": { name: "some-model" } },
+      },
+    },
+  });
+  try {
+    const patched = patchConfigModels(
+      file,
+      "https://example.preloop.ai",
+      [{ id: "new-model", object: "model" }],
+    );
+    assert.equal(patched, 0);
+    // File should not have been rewritten.
+    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.deepEqual(raw.provider.other.models, {
+      "some-model": { name: "some-model" },
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("patchConfigModels returns -1 for a missing file", () => {
+  const result = patchConfigModels("/no/such/file.json", "https://x", []);
+  assert.equal(result, -1);
+});
+
+test("patchConfigModels returns 0 when the config has no provider section", () => {
+  const { file, dir } = writeTempConfig({ model: "test/model" });
+  try {
+    const result = patchConfigModels(file, "https://x", [
+      { id: "m", object: "model" },
+    ]);
+    assert.equal(result, 0);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("patchConfigModels does not wipe models on an empty gateway response", () => {
+  const { file, dir } = writeTempConfig({
+    provider: {
+      preloop: {
+        options: { baseURL: "https://example.preloop.ai/openai/v1" },
+        models: { existing: { name: "existing" } },
+      },
+    },
+  });
+  try {
+    const patched = patchConfigModels(
+      file,
+      "https://example.preloop.ai",
+      [],
+    );
+    assert.equal(patched, 0);
+    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.deepEqual(raw.provider.preloop.models, {
+      existing: { name: "existing" },
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("patchConfigModels merges additively with existing models", () => {
+  const { file, dir } = writeTempConfig({
+    provider: {
+      preloop: {
+        options: { baseURL: "https://gw.preloop.ai/openai/v1" },
+        models: {
+          "old-model": { name: "old-model" },
+          "shared-model": { name: "shared-model" },
+        },
+      },
+    },
+  });
+  try {
+    const models = [
+      { id: "shared-model", object: "model" },
+      { id: "new-model", object: "model" },
+    ];
+    patchConfigModels(file, "https://gw.preloop.ai", models);
+    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+    // old-model is preserved; shared-model and new-model from gateway.
+    assert.deepEqual(Object.keys(raw.provider.preloop.models).sort(), [
+      "new-model",
+      "old-model",
+      "shared-model",
+    ]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// refreshModels (end-to-end)
+// ---------------------------------------------------------------------------
+
+test("refreshModels fetches and patches in one call", async () => {
+  const { file, dir } = writeTempConfig({
+    provider: {
+      preloop: {
+        options: { baseURL: "https://example.preloop.ai/openai/v1" },
+        models: {},
+      },
+    },
+  });
+  try {
+    const logs = [];
+    const summary = await refreshModels(
+      baseConfig,
+      file,
+      () =>
+        jsonResponse(200, {
+          data: [{ id: "model-a", object: "model" }],
+        }),
+      (msg) => logs.push(msg),
+    );
+    assert.match(summary, /refreshed 1 model/);
+    assert.ok(logs.length > 0);
+    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.ok("model-a" in raw.provider.preloop.models);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("refreshModels swallows fetch errors gracefully", async () => {
+  const { file, dir } = writeTempConfig({});
+  try {
+    const summary = await refreshModels(
+      baseConfig,
+      file,
+      () => Promise.reject(new Error("network down")),
+    );
+    assert.match(summary, /model refresh failed/);
+    assert.match(summary, /network down/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/runtime-plugins/opencode-preloop/test/models.test.mjs
+++ b/runtime-plugins/opencode-preloop/test/models.test.mjs
@@ -129,6 +129,8 @@ test("patchConfigModels updates the matching provider models map", () => {
       "claude-sonnet-4": { name: "claude-sonnet-4" },
       "gpt-5": { name: "gpt-5" },
     });
+    // No temp file left behind by the atomic write.
+    assert.deepEqual(fs.readdirSync(dir), ["opencode.json"]);
     // Unrelated keys must be preserved.
     assert.equal(updated.model, "preloop/claude-sonnet-4");
     assert.equal(updated.provider.preloop.npm, "@ai-sdk/openai-compatible");
@@ -205,14 +207,14 @@ test("patchConfigModels does not wipe models on an empty gateway response", () =
   }
 });
 
-test("patchConfigModels merges additively with existing models", () => {
+test("patchConfigModels reconciles to the gateway list, dropping stale ids", () => {
   const { file, dir } = writeTempConfig({
     provider: {
       preloop: {
         options: { baseURL: "https://gw.preloop.ai/openai/v1" },
         models: {
           "old-model": { name: "old-model" },
-          "shared-model": { name: "shared-model" },
+          "shared-model": { name: "Shared (local label)" },
         },
       },
     },
@@ -224,13 +226,95 @@ test("patchConfigModels merges additively with existing models", () => {
     ];
     patchConfigModels(file, "https://gw.preloop.ai", models);
     const raw = JSON.parse(fs.readFileSync(file, "utf8"));
-    // old-model is preserved; shared-model and new-model from gateway.
+    // old-model is gone (the gateway would reject it); new-model added.
     assert.deepEqual(Object.keys(raw.provider.preloop.models).sort(), [
       "new-model",
-      "old-model",
       "shared-model",
     ]);
+    // A still-advertised model keeps its local entry as-is.
+    assert.deepEqual(raw.provider.preloop.models["shared-model"], {
+      name: "Shared (local label)",
+    });
   } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("patchConfigModels leaves providers on other origins untouched", () => {
+  const { file, dir } = writeTempConfig({
+    provider: {
+      preloop: {
+        options: { baseURL: "https://gw.preloop.ai/openai/v1" },
+        models: { "old-model": { name: "old-model" } },
+      },
+      ollama: {
+        options: { baseURL: "http://localhost:11434/v1" },
+        models: { "llama-3": { name: "llama-3" } },
+      },
+    },
+  });
+  try {
+    const patched = patchConfigModels(file, "https://gw.preloop.ai", [
+      { id: "new-model", object: "model" },
+    ]);
+    assert.equal(patched, 1);
+    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.deepEqual(Object.keys(raw.provider.preloop.models), ["new-model"]);
+    assert.deepEqual(raw.provider.ollama.models, {
+      "llama-3": { name: "llama-3" },
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("patchConfigModels does not rewrite the file when the ids already match", () => {
+  const { file, dir } = writeTempConfig({
+    provider: {
+      preloop: {
+        options: { baseURL: "https://gw.preloop.ai/openai/v1" },
+        models: { "model-a": { name: "model-a" } },
+      },
+    },
+  });
+  try {
+    const before = fs.statSync(file).mtimeMs;
+    const patched = patchConfigModels(file, "https://gw.preloop.ai", [
+      { id: "model-a", object: "model" },
+    ]);
+    assert.equal(patched, 1);
+    assert.equal(fs.statSync(file).mtimeMs, before);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("patchConfigModels writes atomically via a temp file in the same dir", () => {
+  const { file, dir } = writeTempConfig({
+    provider: {
+      preloop: {
+        options: { baseURL: "https://gw.preloop.ai/openai/v1" },
+        models: {},
+      },
+    },
+  });
+  const realRename = fs.renameSync;
+  const renames = [];
+  fs.renameSync = (from, to) => {
+    renames.push({ from, to });
+    return realRename(from, to);
+  };
+  try {
+    patchConfigModels(file, "https://gw.preloop.ai", [
+      { id: "model-a", object: "model" },
+    ]);
+    assert.equal(renames.length, 1);
+    assert.equal(renames[0].to, file);
+    assert.equal(path.dirname(renames[0].from), path.dirname(file));
+    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.ok("model-a" in raw.provider.preloop.models);
+  } finally {
+    fs.renameSync = realRename;
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

Each runtime plugin now derives the gateway `GET /models` URL from the
existing Agent Control WS URL and fetches the current model list using
the same bearer token. This lets running agents pick up model-list
changes (added/removed models in the Preloop console) without a full
restart.

## Per-host implementation

### opencode-preloop (implemented)
- New `models.ts`: `gatewayModelsUrl`, `fetchGatewayModels`,
  `patchConfigModels`, `refreshModels`.
- On WebSocket open (start + reconnect) and on plugin session-start,
  fetches gateway models and patches the matching `provider.models` map
  in `opencode.json` so the model picker reflects console edits.
- Trigger: WebSocket connect event (fires on start + reconnect) and
  plugin session-start entry point. A periodic timer was avoided to
  keep the plugin lightweight; reconnects fire on network changes and
  the operator can force a reconnect from the console.

### openclaw-preloop (partial)
- New `models.ts` with shared fetch helpers.
- `PreloopOpenClawPlugin` gains `refreshGatewayModels()` and
  `lastGatewayModels`. Wired to the `gateway_start` hook.
- **Limitation**: OpenClaw plugin API does not expose runtime
  model-catalog mutation. The fetched list is stored for programmatic
  consumption by a future hook that supports catalog updates.

### hermes-preloop (helper only)
- New `models.py`: `gateway_models_url`, `fetch_gateway_models`,
  `refresh_models`.
- **Limitation**: Hermes hook API (`register_hook`) does not support
  model-list mutation. The helper fetches and returns the list.

### claude-preloop (not supported)
Claude Code models come from Anthropic's API. The sidecar has no
mechanism to influence model selection. Claude Code's model list is
managed by the Claude Code application itself and cannot be modified
by external processes.

### codex (no change)
No runtime plugin exists. Codex CLI runs in Docker containers; each
session uses a fixed model from `config.toml` written at container
start. The gateway `GET /models` endpoint already includes the
`models` top-level array for Codex compatibility, and the model is
validated at request time rather than cached.

## Tests

| Plugin | Test file | New tests | Total passing |
|--------|-----------|-----------|---------------|
| opencode-preloop | `test/models.test.mjs` | 14 | 53 |
| openclaw-preloop | `test/models.test.mjs` | 7 | 18 |
| hermes-preloop | `tests/test_models.py` | 7 | 53 |
| claude-preloop | (unchanged) | 0 | 50 |

## Files changed

- `runtime-plugins/opencode-preloop/src/models.ts` (new)
- `runtime-plugins/opencode-preloop/src/index.ts` (modified)
- `runtime-plugins/opencode-preloop/test/models.test.mjs` (new)
- `runtime-plugins/openclaw-preloop/src/models.ts` (new)
- `runtime-plugins/openclaw-preloop/src/index.ts` (modified)
- `runtime-plugins/openclaw-preloop/test/models.test.mjs` (new)
- `runtime-plugins/hermes-preloop/src/preloop_hermes_plugin/models.py` (new)
- `runtime-plugins/hermes-preloop/tests/test_models.py` (new)

No `backend/preloop/agents/` files were modified (owned by sibling subagent).
No backend changes were made.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Well-tested model-list refresh feature. Follow-up commit resolves the earlier "removed models" and non-atomic-write concerns: the model map is reconciled to the gateway list and the config is written atomically.
>
> **Overview**
> Adds a gateway `GET /models` fetch to the opencode, openclaw, and hermes runtime plugins so running agents can pick up console model-list edits without a restart. opencode is fully wired (fetch + reconcile config); openclaw and hermes fetch only with no consumer yet.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit c5602fdd. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->