### PR TITLE
feat: agent configs list all authorized models at session start

### DIFF
--- a/backend/preloop/agents/opencode.py
+++ b/backend/preloop/agents/opencode.py
@@ -577,6 +577,45 @@ exit $OPENCODE_EXIT_CODE
 """
         return script
 
+    def _build_provider_models_map(
+        self,
+        primary_local_id: str,
+        primary_model: str,
+        effective_provider: str,
+        execution_context: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Build the provider ``models`` map for opencode.json.
+
+        When the execution context carries ``authorized_gateway_models``
+        (populated by the flow orchestrator from the account's full
+        gateway-enabled inventory), every authorized model is registered so
+        OpenCode's ``/models`` picker shows them all.  The primary model is
+        always included even if the list is absent or empty.
+
+        Args:
+            primary_local_id: Provider-local id of the primary model.
+            primary_model: Original (possibly qualified) primary model name.
+            effective_provider: The provider id used in the config.
+            execution_context: Execution context (may carry
+                ``authorized_gateway_models``).
+
+        Returns:
+            ``{local_id: {"name": display_name}, ...}`` dict.
+        """
+        models: Dict[str, Any] = {primary_local_id: {"name": primary_model}}
+
+        authorized: list[dict] = execution_context.get("authorized_gateway_models", [])
+        for entry in authorized:
+            alias = entry.get("alias", "")
+            if not alias:
+                continue
+            local_id = _opencode_provider_local_model_id(alias, effective_provider)
+            if not local_id or local_id in models:
+                continue
+            models[local_id] = {"name": entry.get("display_name") or alias}
+
+        return models
+
     def _build_opencode_config(
         self,
         model: str,
@@ -662,11 +701,19 @@ exit $OPENCODE_EXIT_CODE
             "mcp": mcp,
         }
 
+        # Build the full provider models map.  When authorized_gateway_models
+        # is present in the execution context all authorized models are
+        # registered so OpenCode's model picker shows them.  The primary
+        # model is always included regardless.
+        provider_models = self._build_provider_models_map(
+            model_local_id, model, effective_model_provider, execution_context
+        )
+
         # Add provider configuration for custom/non-builtin endpoints.
         # OpenCode schema requires:
-        #   npm   – AI SDK adapter package (e.g. "@ai-sdk/openai-compatible")
-        #   options.baseURL – API endpoint
-        #   models – map of model-id → {name}
+        #   npm   -- AI SDK adapter package (e.g. "@ai-sdk/openai-compatible")
+        #   options.baseURL -- API endpoint
+        #   models -- map of model-id -> {name}
         # ``timeout`` is OpenCode's whole-request LLM abort (see
         # _opencode_llm_timeout_ms); ``chunkTimeout`` is the SSE inter-chunk
         # inactivity abort in opencode >= 1.18 (ignored by older builds) and
@@ -684,9 +731,7 @@ exit $OPENCODE_EXIT_CODE
                             "timeout": llm_timeout_ms,
                             "chunkTimeout": llm_timeout_ms,
                         },
-                        "models": {
-                            model_local_id: {"name": model},
-                        },
+                        "models": provider_models,
                     }
                 }
             elif not gateway_enabled and model_provider in ("google", "gemini"):
@@ -699,9 +744,7 @@ exit $OPENCODE_EXIT_CODE
                             "timeout": llm_timeout_ms,
                             "chunkTimeout": llm_timeout_ms,
                         },
-                        "models": {
-                            model_local_id: {"name": model},
-                        },
+                        "models": provider_models,
                     }
                 }
             else:
@@ -714,9 +757,7 @@ exit $OPENCODE_EXIT_CODE
                             "timeout": llm_timeout_ms,
                             "chunkTimeout": llm_timeout_ms,
                         },
-                        "models": {
-                            model_local_id: {"name": model},
-                        },
+                        "models": provider_models,
                     }
                 }
 

--- a/backend/preloop/services/agent_model_list.py
+++ b/backend/preloop/services/agent_model_list.py
@@ -1,0 +1,91 @@
+"""Shared helper to list authorized gateway models for agent configs.
+
+Agent config generators (OpenCode, Codex, etc.) need the full set of models
+the agent principal is authorized for so the generated config includes ALL
+models, not just the primary one.  This module provides a single function
+that reuses the gateway's authorization predicate
+(``compute_authorized_model_ids``) and runtime resolver
+(``resolve_ai_model_runtime``) to return the list.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+from sqlalchemy.orm import Session
+
+from preloop.models.models.ai_model import AIModel
+from preloop.services.model_gateway_auth import (
+    ModelGatewayAuthContext,
+    compute_authorized_model_ids,
+)
+from preloop.services.model_runtime_resolver import resolve_ai_model_runtime
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AuthorizedGatewayModel:
+    """Lightweight descriptor for one gateway-enabled model."""
+
+    alias: str
+    display_name: str
+
+
+def list_authorized_gateway_models(
+    db: Session,
+    account_id: str,
+    auth_context: Optional[ModelGatewayAuthContext] = None,
+) -> List[AuthorizedGatewayModel]:
+    """Return every gateway-enabled model the principal is authorized for.
+
+    When *auth_context* is ``None`` (e.g. during flow-execution context
+    building where no gateway request is in-flight) the function skips the
+    per-principal authorization filter and returns all gateway-enabled models
+    in the account.  This matches the behavior for user-token callers whose
+    ``compute_authorized_model_ids`` returns the full inventory.
+
+    Args:
+        db: Active database session.
+        account_id: Account whose model inventory to scan.
+        auth_context: Gateway auth context for per-principal filtering.
+            Pass ``None`` when running outside an authenticated gateway
+            request to return the full account inventory.
+
+    Returns:
+        Deduplicated list of authorized, gateway-enabled models sorted by
+        alias for deterministic config output.
+    """
+    from preloop.models.crud.ai_model import ai_model as crud_ai_model
+
+    account_models: Sequence[AIModel] = crud_ai_model.get_all_for_account(
+        db, account_id=account_id
+    )
+    if not account_models:
+        return []
+
+    if auth_context is not None:
+        authorized_ids = compute_authorized_model_ids(db, auth_context, account_models)
+    else:
+        authorized_ids = frozenset(str(m.id) for m in account_models)
+
+    result: list[AuthorizedGatewayModel] = []
+    seen_aliases: set[str] = set()
+
+    for ai_model in account_models:
+        if str(ai_model.id) not in authorized_ids:
+            continue
+        runtime = resolve_ai_model_runtime(ai_model)
+        if not runtime.model_gateway_enabled:
+            continue
+        alias = runtime.model_gateway_model_alias
+        if not alias or alias in seen_aliases:
+            continue
+        seen_aliases.add(alias)
+        display_name = ai_model.display_name or ai_model.model_identifier or alias
+        result.append(AuthorizedGatewayModel(alias=alias, display_name=display_name))
+
+    result.sort(key=lambda m: m.alias)
+    return result

--- a/backend/preloop/services/agent_model_list.py
+++ b/backend/preloop/services/agent_model_list.py
@@ -41,18 +41,18 @@ def list_authorized_gateway_models(
 ) -> List[AuthorizedGatewayModel]:
     """Return every gateway-enabled model the principal is authorized for.
 
-    When *auth_context* is ``None`` (e.g. during flow-execution context
-    building where no gateway request is in-flight) the function skips the
-    per-principal authorization filter and returns all gateway-enabled models
-    in the account.  This matches the behavior for user-token callers whose
-    ``compute_authorized_model_ids`` returns the full inventory.
+    When *auth_context* is ``None`` the per-principal predicate cannot run,
+    so this function fails closed and drops subscription-OAuth models
+    (``is_principal_bound_oauth``): only the managed agent holding an active
+    binding may use those, and the gateway rejects every other credential
+    with a 400.  Callers that hold a credential should always build a
+    context so managed-agent bindings are honored.
 
     Args:
         db: Active database session.
         account_id: Account whose model inventory to scan.
         auth_context: Gateway auth context for per-principal filtering.
-            Pass ``None`` when running outside an authenticated gateway
-            request to return the full account inventory.
+            ``None`` selects the fail-closed subset described above.
 
     Returns:
         Deduplicated list of authorized, gateway-enabled models sorted by
@@ -69,7 +69,16 @@ def list_authorized_gateway_models(
     if auth_context is not None:
         authorized_ids = compute_authorized_model_ids(db, auth_context, account_models)
     else:
-        authorized_ids = frozenset(str(m.id) for m in account_models)
+        authorized_ids = frozenset(
+            str(m.id)
+            for m in account_models
+            if not bool(getattr(m, "is_principal_bound_oauth", False))
+        )
+        logger.debug(
+            "Listing gateway models for account %s without an auth context; "
+            "principal-bound OAuth models are excluded",
+            account_id,
+        )
 
     result: list[AuthorizedGatewayModel] = []
     seen_aliases: set[str] = set()
@@ -84,7 +93,7 @@ def list_authorized_gateway_models(
         if not alias or alias in seen_aliases:
             continue
         seen_aliases.add(alias)
-        display_name = ai_model.display_name or ai_model.model_identifier or alias
+        display_name = ai_model.name or ai_model.model_identifier or alias
         result.append(AuthorizedGatewayModel(alias=alias, display_name=display_name))
 
     result.sort(key=lambda m: m.alias)

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -1812,6 +1812,28 @@ class FlowExecutionOrchestrator:
                     else None
                 )
             )
+
+            # Populate the full authorized gateway model list so agent
+            # config generators (e.g. OpenCode) can include every model the
+            # principal is allowed to use, not just the primary one.
+            if resolved_model_runtime.model_gateway_enabled:
+                try:
+                    from preloop.services.agent_model_list import (
+                        list_authorized_gateway_models,
+                    )
+
+                    authorized = list_authorized_gateway_models(
+                        self.db, str(self.flow.account_id)
+                    )
+                    execution_context["authorized_gateway_models"] = [
+                        {"alias": m.alias, "display_name": m.display_name}
+                        for m in authorized
+                    ]
+                except Exception:
+                    logger.debug(
+                        "Could not resolve authorized gateway models",
+                        exc_info=True,
+                    )
         else:
             logger.warning(
                 f"No AI model configured for flow {self.flow.id}, "

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -1813,25 +1813,46 @@ class FlowExecutionOrchestrator:
                 )
             )
 
-            # Populate the full authorized gateway model list so agent
-            # config generators (e.g. OpenCode) can include every model the
-            # principal is allowed to use, not just the primary one.
+            # Populate the authorized gateway model list so agent config
+            # generators (e.g. OpenCode) can include every model the
+            # principal is allowed to use, not just the primary one.  The
+            # list must be scoped to the execution credential: this flow
+            # principal is not authorized for subscription-OAuth models
+            # bound to a managed agent, and offering them would only
+            # produce a 400 at the gateway.
             if resolved_model_runtime.model_gateway_enabled:
                 try:
                     from preloop.services.agent_model_list import (
                         list_authorized_gateway_models,
                     )
+                    from preloop.services.model_gateway_auth import (
+                        build_runtime_key_auth_context,
+                    )
 
+                    auth_context = (
+                        build_runtime_key_auth_context(
+                            self.db,
+                            token=account_api_token,
+                            api_key_id=str(self.temporary_api_key_id),
+                        )
+                        if account_api_token and self.temporary_api_key_id
+                        else None
+                    )
                     authorized = list_authorized_gateway_models(
-                        self.db, str(self.flow.account_id)
+                        self.db,
+                        str(self.flow.account_id),
+                        auth_context=auth_context,
                     )
                     execution_context["authorized_gateway_models"] = [
                         {"alias": m.alias, "display_name": m.display_name}
                         for m in authorized
                     ]
                 except Exception:
-                    logger.debug(
-                        "Could not resolve authorized gateway models",
+                    logger.warning(
+                        "Could not resolve authorized gateway models for flow "
+                        "%s; the agent config falls back to the primary model "
+                        "only",
+                        self.flow.id,
                         exc_info=True,
                     )
         else:

--- a/backend/preloop/services/model_gateway_auth.py
+++ b/backend/preloop/services/model_gateway_auth.py
@@ -118,6 +118,41 @@ async def authenticate_bearer_token(
     )
 
 
+def build_runtime_key_auth_context(
+    db: Session, *, token: str, api_key_id: str
+) -> Optional[ModelGatewayAuthContext]:
+    """Build a gateway auth context for an already-minted runtime API key.
+
+    Non-request callers (e.g. the flow orchestrator building an execution
+    context) mint a short-lived runtime credential and then need to answer
+    "which models may this principal use?" with the same rules the gateway
+    applies to a live request.  Resolving the key row and its owning user
+    here avoids re-authenticating the plaintext token.
+
+    Args:
+        db: Active database session.
+        token: Plaintext runtime token minted for the principal.
+        api_key_id: Id of the ``ApiKey`` row backing *token*.
+
+    Returns:
+        Context carrying the key and its owning user, or ``None`` when the
+        key or user cannot be resolved or is not usable.  Callers must treat
+        ``None`` as "no principal" and fail closed.
+    """
+    if not token or not api_key_id:
+        return None
+
+    api_key = crud_api_key.get(db, id=api_key_id)
+    if api_key is None or not api_key.is_active or api_key.is_expired:
+        return None
+
+    user = crud_user.get(db, id=str(api_key.user_id))
+    if user is None or not user.is_active:
+        return None
+
+    return ModelGatewayAuthContext(token=token, user=user, api_key=api_key)
+
+
 def resolve_managed_agent_id_for_context(
     db: Session, auth_context: ModelGatewayAuthContext
 ) -> Optional[str]:

--- a/backend/tests/agents/test_agent_codex.py
+++ b/backend/tests/agents/test_agent_codex.py
@@ -393,3 +393,39 @@ class TestCodexPrepareEnvironment:
         env = await agent._prepare_environment(context)
         assert env["MCP_TOOL_TIMEOUT"] == "600"
         assert context["_mcp_tool_timeout"] == 600
+
+
+class TestCodexDynamicModelListing:
+    """Codex CLI populates its model picker from GET /models.
+
+    The Preloop gateway already includes a top-level ``models`` array in
+    the GET /models response (see openai_gateway.py list_models) which
+    Codex CLI's model-manager deserializes.  This means Codex is already
+    dynamic: enabling a new model on the account makes it appear in
+    ``GET /models`` immediately without config regeneration.
+
+    These tests assert the contract so regressions are caught.
+    """
+
+    def test_codex_config_has_no_static_model_list(self):
+        """Codex auth config does not embed a models list.
+
+        Unlike OpenCode (which writes a ``models`` map in opencode.json),
+        Codex's config.toml and auth.json contain only the primary model
+        and provider setup.  The model picker is populated at runtime via
+        ``GET /models``.
+        """
+        agent = CodexAgent({})
+        auth_block = agent._build_codex_auth_config("gpt-5", "openai", "")
+        # config.toml has model = "..." but no [models] section
+        assert 'model = "gpt-5"' in auth_block
+        assert "[models]" not in auth_block
+
+    def test_codex_custom_provider_has_no_static_model_list(self):
+        """Custom-provider config.toml also has no embedded model list."""
+        agent = CodexAgent({})
+        auth_block = agent._build_codex_auth_config(
+            "claude-sonnet-4", "preloop", "https://gw.example/openai/v1"
+        )
+        assert 'model = "claude-sonnet-4"' in auth_block
+        assert "[models]" not in auth_block

--- a/backend/tests/agents/test_agent_opencode.py
+++ b/backend/tests/agents/test_agent_opencode.py
@@ -589,3 +589,116 @@ class TestOpenCodeStderrCapture:
         agent = OpenCodeAgent({})
         script = agent._build_opencode_script(self._context())
         assert "2>&1 | node /tmp/opencode-json-log-filter.js" in script
+
+
+class TestOpenCodeMultiModelConfig:
+    """Test that OpenCode config includes all authorized models."""
+
+    def test_single_model_when_no_authorized_list(self):
+        """Without authorized_gateway_models the config has only the primary."""
+        agent = OpenCodeAgent({})
+        context = {"model_endpoint": "https://gw.example/v1"}
+        config = agent._build_opencode_config("model-a", "custom", context, 600000)
+        models = config["provider"]["custom"]["models"]
+        assert models == {"model-a": {"name": "model-a"}}
+
+    def test_multi_model_from_authorized_list(self):
+        """authorized_gateway_models populates the full models map."""
+        agent = OpenCodeAgent({})
+        context = {
+            "model_endpoint": "https://gw.example/v1",
+            "model_gateway_enabled": True,
+            "model_gateway_provider": "preloop",
+            "model_gateway_url": "https://gw.example/openai/v1",
+            "authorized_gateway_models": [
+                {
+                    "alias": "anthropic/claude-sonnet-4",
+                    "display_name": "Claude Sonnet 4",
+                },
+                {"alias": "openai/gpt-5", "display_name": "GPT 5"},
+                {"alias": "deepseek/deepseek-v4", "display_name": "DeepSeek V4"},
+            ],
+        }
+        config = agent._build_opencode_config(
+            "anthropic/claude-sonnet-4", "anthropic", context, 600000
+        )
+        models = config["provider"]["preloop"]["models"]
+        # Primary model is always present
+        assert "anthropic/claude-sonnet-4" in models
+        # All authorized models are present
+        assert "openai/gpt-5" in models
+        assert "deepseek/deepseek-v4" in models
+        assert len(models) == 3
+
+    def test_primary_model_always_present(self):
+        """Primary model is in the map even if not in the authorized list."""
+        agent = OpenCodeAgent({})
+        context = {
+            "model_endpoint": "https://gw.example/v1",
+            "model_gateway_enabled": True,
+            "model_gateway_provider": "preloop",
+            "model_gateway_url": "https://gw.example/openai/v1",
+            "authorized_gateway_models": [
+                {"alias": "openai/gpt-5", "display_name": "GPT 5"},
+            ],
+        }
+        config = agent._build_opencode_config(
+            "anthropic/claude-sonnet-4", "anthropic", context, 600000
+        )
+        models = config["provider"]["preloop"]["models"]
+        assert "anthropic/claude-sonnet-4" in models
+        assert "openai/gpt-5" in models
+
+    def test_primary_remains_default_model(self):
+        """model and small_model stay set to the primary, not an authorized one."""
+        agent = OpenCodeAgent({})
+        context = {
+            "model_endpoint": "https://gw.example/v1",
+            "model_gateway_enabled": True,
+            "model_gateway_provider": "preloop",
+            "model_gateway_url": "https://gw.example/openai/v1",
+            "authorized_gateway_models": [
+                {"alias": "openai/gpt-5", "display_name": "GPT 5"},
+            ],
+        }
+        config = agent._build_opencode_config(
+            "anthropic/claude-sonnet-4", "anthropic", context, 600000
+        )
+        assert config["model"] == "preloop/anthropic/claude-sonnet-4"
+        assert config["small_model"] == "preloop/anthropic/claude-sonnet-4"
+
+    def test_duplicate_alias_not_duplicated(self):
+        """If the primary alias appears in authorized_gateway_models it is not doubled."""
+        agent = OpenCodeAgent({})
+        context = {
+            "model_endpoint": "https://gw.example/v1",
+            "model_gateway_enabled": True,
+            "model_gateway_provider": "preloop",
+            "model_gateway_url": "https://gw.example/openai/v1",
+            "authorized_gateway_models": [
+                {
+                    "alias": "anthropic/claude-sonnet-4",
+                    "display_name": "Claude Sonnet 4",
+                },
+                {"alias": "openai/gpt-5", "display_name": "GPT 5"},
+            ],
+        }
+        config = agent._build_opencode_config(
+            "anthropic/claude-sonnet-4", "anthropic", context, 600000
+        )
+        models = config["provider"]["preloop"]["models"]
+        assert len(models) == 2
+        # Primary is keyed by local id which strips provider prefix
+        assert "anthropic/claude-sonnet-4" in models
+        assert "openai/gpt-5" in models
+
+    def test_empty_authorized_list_keeps_primary(self):
+        """An empty authorized_gateway_models list still keeps the primary."""
+        agent = OpenCodeAgent({})
+        context = {
+            "model_endpoint": "https://gw.example/v1",
+            "authorized_gateway_models": [],
+        }
+        config = agent._build_opencode_config("model-a", "custom", context, 600000)
+        models = config["provider"]["custom"]["models"]
+        assert models == {"model-a": {"name": "model-a"}}

--- a/backend/tests/services/test_agent_model_list.py
+++ b/backend/tests/services/test_agent_model_list.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
+from preloop.models.crud import crud_ai_model
 from preloop.services.agent_model_list import (
     list_authorized_gateway_models,
+)
+from preloop.services.flow_runtime_token import create_flow_runtime_token
+from preloop.services.model_gateway_auth import build_runtime_key_auth_context
+from preloop.services.secret_service import (
+    ANTHROPIC_CLAUDE_CODE_OAUTH_CREDENTIAL_TYPE,
 )
 
 _CRUD_PATCH = "preloop.models.crud.ai_model.ai_model"
@@ -15,7 +23,7 @@ def _make_ai_model(
     id_: str,
     identifier: str,
     provider: str = "openai",
-    display_name: str | None = None,
+    name: str | None = None,
     gateway_enabled: bool = True,
     gateway_alias: str | None = None,
 ) -> MagicMock:
@@ -24,7 +32,7 @@ def _make_ai_model(
     m.id = id_
     m.model_identifier = identifier
     m.provider_name = provider
-    m.display_name = display_name
+    m.name = name
     m.is_principal_bound_oauth = False
     m.meta_data = {
         "gateway": {
@@ -43,7 +51,7 @@ class TestListAuthorizedGatewayModels:
     """Test list_authorized_gateway_models."""
 
     def test_returns_all_gateway_enabled_models(self):
-        """All gateway-enabled models are returned when no auth context."""
+        """Gateway-enabled BYOK models are returned when no auth context."""
         models = [
             _make_ai_model("1", "claude-sonnet-4", "anthropic", gateway_enabled=True),
             _make_ai_model("2", "gpt-5", "openai", gateway_enabled=True),
@@ -141,10 +149,10 @@ class TestListAuthorizedGatewayModels:
         assert aliases == sorted(aliases)
 
     def test_display_name_fallback_chain(self):
-        """display_name falls back to model_identifier then alias."""
+        """The model's name falls back to model_identifier then alias."""
         models = [
-            _make_ai_model("1", "gpt-5", "openai", display_name="GPT 5"),
-            _make_ai_model("2", "claude-opus-4", "anthropic", display_name=None),
+            _make_ai_model("1", "gpt-5", "openai", name="GPT 5"),
+            _make_ai_model("2", "claude-opus-4", "anthropic", name=None),
         ]
         db = MagicMock()
         with patch(_CRUD_PATCH) as mock_crud:
@@ -154,3 +162,113 @@ class TestListAuthorizedGatewayModels:
         by_alias = {m.alias: m for m in result}
         assert by_alias["openai/gpt-5"].display_name == "GPT 5"
         assert by_alias["anthropic/claude-opus-4"].display_name == "claude-opus-4"
+
+    def test_principal_bound_models_excluded_without_auth_context(self):
+        """No context means fail closed: subscription-OAuth models drop out.
+
+        Only the managed agent holding an active binding may use a
+        principal-bound OAuth model, so a caller that cannot name its
+        principal must never see one advertised.
+        """
+        byok = _make_ai_model("1", "gpt-5", "openai")
+        bound = _make_ai_model("2", "claude-sonnet-4-5", "anthropic")
+        bound.is_principal_bound_oauth = True
+        db = MagicMock()
+
+        with patch(_CRUD_PATCH) as mock_crud:
+            mock_crud.get_all_for_account.return_value = [byok, bound]
+            result = list_authorized_gateway_models(db, "acct-1")
+
+        assert [m.alias for m in result] == ["openai/gpt-5"]
+
+
+BYOK_ALIAS = "openai/gpt-5-flow"
+BOUND_ALIAS = "anthropic/claude-sonnet-4-5-flow"
+
+
+def _create_byok_model(db_session, test_user):
+    return crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": f"BYOK {uuid4()}",
+            "provider_name": "openai",
+            "model_identifier": "gpt-5",
+            "api_key": "sk-byok-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": BYOK_ALIAS,
+                    "provider_adapter": "preloop",
+                }
+            },
+        },
+        account_id=test_user.account_id,
+    )
+
+
+def _create_principal_bound_model(db_session, test_user):
+    return crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": f"Subscription {uuid4()}",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "credential_type": ANTHROPIC_CLAUDE_CODE_OAUTH_CREDENTIAL_TYPE,
+            "credential_payload": {"access": "oauth-access-token"},
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": BOUND_ALIAS,
+                    "provider_adapter": "preloop",
+                }
+            },
+        },
+        account_id=test_user.account_id,
+    )
+
+
+class TestFlowExecutionPrincipal:
+    """The flow-execution credential must not be offered bound models.
+
+    A flow execution mints a runtime key whose ``runtime_principal.type`` is
+    ``flow_execution`` and which carries no ``managed_agent_id``, so it
+    resolves to no managed agent and is never authorized for
+    ``is_principal_bound_oauth`` models.  Advertising them in the generated
+    agent config would only produce a 400 at the gateway.
+    """
+
+    def test_bound_models_excluded_for_flow_execution_credential(
+        self, db_session, test_user
+    ):
+        _create_byok_model(db_session, test_user)
+        _create_principal_bound_model(db_session, test_user)
+
+        flow = SimpleNamespace(
+            id=uuid4(),
+            account_id=test_user.account_id,
+            name="Nightly triage",
+            allowed_mcp_tools=[],
+            allowed_mcp_servers=[],
+        )
+        token, api_key_id = create_flow_runtime_token(
+            db_session, flow=flow, execution_id=uuid4()
+        )
+        assert token and api_key_id
+
+        auth_context = build_runtime_key_auth_context(
+            db_session, token=token, api_key_id=str(api_key_id)
+        )
+        assert auth_context is not None
+        assert auth_context.api_key is not None
+
+        aliases = [
+            m.alias
+            for m in list_authorized_gateway_models(
+                db_session,
+                str(test_user.account_id),
+                auth_context=auth_context,
+            )
+        ]
+
+        assert BYOK_ALIAS in aliases
+        assert BOUND_ALIAS not in aliases

--- a/backend/tests/services/test_agent_model_list.py
+++ b/backend/tests/services/test_agent_model_list.py
@@ -1,0 +1,156 @@
+"""Tests for the agent_model_list shared helper."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from preloop.services.agent_model_list import (
+    list_authorized_gateway_models,
+)
+
+_CRUD_PATCH = "preloop.models.crud.ai_model.ai_model"
+
+
+def _make_ai_model(
+    id_: str,
+    identifier: str,
+    provider: str = "openai",
+    display_name: str | None = None,
+    gateway_enabled: bool = True,
+    gateway_alias: str | None = None,
+) -> MagicMock:
+    """Create a minimal AIModel mock."""
+    m = MagicMock()
+    m.id = id_
+    m.model_identifier = identifier
+    m.provider_name = provider
+    m.display_name = display_name
+    m.is_principal_bound_oauth = False
+    m.meta_data = {
+        "gateway": {
+            "enabled": gateway_enabled,
+            **({"model_alias": gateway_alias} if gateway_alias else {}),
+        }
+    }
+    m.api_endpoint = None
+    m.model_parameters = None
+    m.is_default = False
+    m.credentials_secret = None
+    return m
+
+
+class TestListAuthorizedGatewayModels:
+    """Test list_authorized_gateway_models."""
+
+    def test_returns_all_gateway_enabled_models(self):
+        """All gateway-enabled models are returned when no auth context."""
+        models = [
+            _make_ai_model("1", "claude-sonnet-4", "anthropic", gateway_enabled=True),
+            _make_ai_model("2", "gpt-5", "openai", gateway_enabled=True),
+            _make_ai_model("3", "local-only", "custom", gateway_enabled=False),
+        ]
+        db = MagicMock()
+        with patch(_CRUD_PATCH) as mock_crud:
+            mock_crud.get_all_for_account.return_value = models
+            result = list_authorized_gateway_models(db, "acct-1")
+
+        assert len(result) == 2
+        aliases = {m.alias for m in result}
+        assert "anthropic/claude-sonnet-4" in aliases
+        assert "openai/gpt-5" in aliases
+
+    def test_excludes_unauthorized_models(self):
+        """Models not in the authorized set are excluded."""
+        models = [
+            _make_ai_model("1", "claude-sonnet-4", "anthropic"),
+            _make_ai_model("2", "gpt-5", "openai"),
+        ]
+        db = MagicMock()
+        auth_ctx = MagicMock()
+
+        with patch(_CRUD_PATCH) as mock_crud:
+            mock_crud.get_all_for_account.return_value = models
+            with patch(
+                "preloop.services.agent_model_list.compute_authorized_model_ids",
+                return_value=frozenset({"1"}),
+            ):
+                result = list_authorized_gateway_models(
+                    db, "acct-1", auth_context=auth_ctx
+                )
+
+        assert len(result) == 1
+        assert result[0].alias == "anthropic/claude-sonnet-4"
+
+    def test_empty_account_returns_empty_list(self):
+        """An account with no models returns an empty list."""
+        db = MagicMock()
+        with patch(_CRUD_PATCH) as mock_crud:
+            mock_crud.get_all_for_account.return_value = []
+            result = list_authorized_gateway_models(db, "acct-1")
+        assert result == []
+
+    def test_custom_alias_used_over_default(self):
+        """A configured gateway alias takes precedence over the default."""
+        models = [
+            _make_ai_model(
+                "1",
+                "claude-sonnet-4-20250514",
+                "anthropic",
+                gateway_enabled=True,
+                gateway_alias="sonnet-4",
+            ),
+        ]
+        db = MagicMock()
+        with patch(_CRUD_PATCH) as mock_crud:
+            mock_crud.get_all_for_account.return_value = models
+            result = list_authorized_gateway_models(db, "acct-1")
+
+        assert len(result) == 1
+        assert result[0].alias == "sonnet-4"
+
+    def test_deduplicates_aliases(self):
+        """Two models resolving to the same alias produce one entry."""
+        models = [
+            _make_ai_model(
+                "1", "gpt-5", "openai", gateway_enabled=True, gateway_alias="gpt-5"
+            ),
+            _make_ai_model(
+                "2", "gpt-5", "openai", gateway_enabled=True, gateway_alias="gpt-5"
+            ),
+        ]
+        db = MagicMock()
+        with patch(_CRUD_PATCH) as mock_crud:
+            mock_crud.get_all_for_account.return_value = models
+            result = list_authorized_gateway_models(db, "acct-1")
+
+        assert len(result) == 1
+
+    def test_sorted_by_alias(self):
+        """Results are sorted by alias for deterministic output."""
+        models = [
+            _make_ai_model("1", "zmodel", "openai"),
+            _make_ai_model("2", "amodel", "openai"),
+            _make_ai_model("3", "mmodel", "openai"),
+        ]
+        db = MagicMock()
+        with patch(_CRUD_PATCH) as mock_crud:
+            mock_crud.get_all_for_account.return_value = models
+            result = list_authorized_gateway_models(db, "acct-1")
+
+        aliases = [m.alias for m in result]
+        assert aliases == sorted(aliases)
+
+    def test_display_name_fallback_chain(self):
+        """display_name falls back to model_identifier then alias."""
+        models = [
+            _make_ai_model("1", "gpt-5", "openai", display_name="GPT 5"),
+            _make_ai_model("2", "claude-opus-4", "anthropic", display_name=None),
+        ]
+        db = MagicMock()
+        with patch(_CRUD_PATCH) as mock_crud:
+            mock_crud.get_all_for_account.return_value = models
+            result = list_authorized_gateway_models(db, "acct-1")
+
+        by_alias = {m.alias: m for m in result}
+        assert by_alias["openai/gpt-5"].display_name == "GPT 5"
+        assert by_alias["anthropic/claude-opus-4"].display_name == "claude-opus-4"

--- a/backend/tests/services/test_flow_orchestrator_model_list.py
+++ b/backend/tests/services/test_flow_orchestrator_model_list.py
@@ -1,0 +1,112 @@
+"""The flow orchestrator must scope its model list to the flow credential.
+
+``list_authorized_gateway_models`` without an auth context returns only the
+fail-closed subset, so the orchestrator has to build a real
+``ModelGatewayAuthContext`` from the runtime key it just minted. Otherwise the
+generated agent config advertises models the flow principal cannot use and the
+gateway rejects them with a 400 mid-session.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from preloop.services.flow_orchestrator import FlowExecutionOrchestrator
+
+pytestmark = pytest.mark.asyncio
+
+TOKEN = "preloop-runtime-token"
+
+
+@pytest.fixture
+def orchestrator():
+    orch = FlowExecutionOrchestrator(
+        db=MagicMock(),
+        flow_id="test-flow-id",
+        trigger_event_data={},
+        nats_client=AsyncMock(),
+    )
+    orch.flow = MagicMock()
+    orch.flow.id = "test-flow-id"
+    orch.flow.account_id = "test-account-id"
+    orch.flow.git_clone_config = None
+    orch.flow.trigger_project_ids = None
+    orch.flow.agent_type = "opencode"
+    orch.execution_log = MagicMock()
+    orch.execution_log.id = "test-execution-id"
+    orch.ai_model = MagicMock()
+    return orch
+
+
+def _gateway_runtime() -> MagicMock:
+    runtime = MagicMock()
+    runtime.model_gateway_enabled = True
+    runtime.to_execution_context.return_value = {}
+    return runtime
+
+
+async def _prepare(orchestrator, *, list_models):
+    """Run _prepare_execution_context with the model-list seam patched."""
+    api_key_id = uuid4()
+    with (
+        patch.object(orchestrator, "_resolve_prompt", AsyncMock(return_value="do it")),
+        patch.object(
+            orchestrator,
+            "_create_temporary_api_token",
+            return_value=(TOKEN, api_key_id),
+        ),
+        patch.object(
+            orchestrator,
+            "_resolve_execution_model_runtime",
+            return_value=_gateway_runtime(),
+        ),
+        patch(
+            "preloop.services.agent_model_list.list_authorized_gateway_models",
+            side_effect=list_models,
+        ),
+        patch(
+            "preloop.services.model_gateway_auth.build_runtime_key_auth_context",
+        ) as build_context,
+    ):
+        build_context.return_value = MagicMock()
+        context = await orchestrator._prepare_execution_context()
+    return context, build_context, api_key_id
+
+
+class TestAuthorizedGatewayModelList:
+    async def test_passes_the_flow_credential_auth_context(self, orchestrator):
+        """The helper is called with the context built from the minted key."""
+        captured = {}
+
+        def list_models(db, account_id, auth_context=None):
+            captured["auth_context"] = auth_context
+            return [MagicMock(alias="openai/gpt-5", display_name="GPT 5")]
+
+        context, build_context, api_key_id = await _prepare(
+            orchestrator, list_models=list_models
+        )
+
+        build_context.assert_called_once()
+        assert build_context.call_args.kwargs["token"] == TOKEN
+        assert build_context.call_args.kwargs["api_key_id"] == str(api_key_id)
+        assert captured["auth_context"] is build_context.return_value
+        assert context["authorized_gateway_models"] == [
+            {"alias": "openai/gpt-5", "display_name": "GPT 5"}
+        ]
+
+    async def test_resolution_failure_is_logged_at_warning(self, orchestrator, caplog):
+        """A silent degradation to primary-only must be visible in prod logs."""
+
+        def list_models(db, account_id, auth_context=None):
+            raise RuntimeError("inventory unavailable")
+
+        with caplog.at_level("WARNING", logger="preloop.services.flow_orchestrator"):
+            context, _, _ = await _prepare(orchestrator, list_models=list_models)
+
+        assert "authorized_gateway_models" not in context
+        assert any(
+            record.levelname == "WARNING"
+            and "Could not resolve authorized gateway models" in record.getMessage()
+            for record in caplog.records
+        )

--- a/backend/tests/services/test_model_gateway_auth.py
+++ b/backend/tests/services/test_model_gateway_auth.py
@@ -5,7 +5,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from preloop.models.crud import crud_api_key
-from preloop.services.model_gateway_auth import authenticate_bearer_token
+from preloop.services.model_gateway_auth import (
+    authenticate_bearer_token,
+    build_runtime_key_auth_context,
+)
 
 
 from datetime import datetime
@@ -53,3 +56,61 @@ async def test_authenticate_bearer_token_preserves_api_key_context(
     assert auth_context.api_key.id == api_key.id
     assert auth_context.api_key.context_data["flow_execution_id"] == "flow-123"
     assert auth_context.api_key.context_data["runtime_session_id"] == session_id
+
+
+def test_build_runtime_key_auth_context_resolves_key_and_user(db_session, test_user):
+    """A minted runtime key resolves to a context without re-authenticating."""
+    api_key, presented_token = crud_api_key.create_runtime_key(
+        db_session,
+        name="Flow Execution Token",
+        account_id=test_user.account_id,
+        user_id=test_user.id,
+        context_data={
+            "runtime_principal": {"type": "flow_execution", "id": "flow-777"},
+        },
+    )
+
+    auth_context = build_runtime_key_auth_context(
+        db_session, token=presented_token, api_key_id=str(api_key.id)
+    )
+
+    assert auth_context is not None
+    assert auth_context.token == presented_token
+    assert auth_context.user.id == test_user.id
+    assert auth_context.api_key is not None
+    assert auth_context.api_key.id == api_key.id
+
+
+def test_build_runtime_key_auth_context_rejects_deactivated_key(db_session, test_user):
+    """A deactivated key yields no principal so callers fail closed."""
+    api_key, presented_token = crud_api_key.create_runtime_key(
+        db_session,
+        name="Flow Execution Token",
+        account_id=test_user.account_id,
+        user_id=test_user.id,
+        context_data={},
+    )
+    crud_api_key.deactivate(db_session, key_id=api_key.id)
+
+    assert (
+        build_runtime_key_auth_context(
+            db_session, token=presented_token, api_key_id=str(api_key.id)
+        )
+        is None
+    )
+
+
+def test_build_runtime_key_auth_context_requires_a_token(db_session, test_user):
+    """No token means no context, even when the key row exists."""
+    api_key, _ = crud_api_key.create_runtime_key(
+        db_session,
+        name="Flow Execution Token",
+        account_id=test_user.account_id,
+        user_id=test_user.id,
+        context_data={},
+    )
+
+    assert (
+        build_runtime_key_auth_context(db_session, token="", api_key_id=str(api_key.id))
+        is None
+    )


### PR DESCRIPTION
## Summary

OpenCode generated configs included only the primary model in the provider
models map.  Agents authorized for multiple gateway models never saw them
in the model picker (founder repro: enabling another model on an agent did
not appear in /models within OpenCode).

## Changes

### Shared helper: `agent_model_list.py`
New service-level helper that returns every authorized, gateway-enabled model
for a given account.  Reuses `compute_authorized_model_ids` and
`resolve_ai_model_runtime` so the predicate stays in one place.

### Flow orchestrator
When building the execution context for a gateway-enabled flow, the
orchestrator now populates `authorized_gateway_models` with the full
authorized model list (id/alias + display name).

### OpenCode
`_build_opencode_config` reads `authorized_gateway_models` from the
execution context and populates the provider `models` map with every
authorized model.  The primary model stays the default/selected one.

### Codex
Already dynamic: Codex CLI populates its model picker from
`GET /models` at runtime (the gateway response includes a top-level
`models` array for Codex's model-manager).  Added contract tests.

### Gemini, Aider, OpenHands
Model selection is CLI-flag or env-var based with no static model
registry.  No changes needed.

### Agents not present in codebase
Claude Code, Hermes, and OpenClaw do not have agent modules in the
current `backend/preloop/agents/` registry.

## Tests

- 7 tests for `agent_model_list` helper (authorization, dedup, sorting)
- 6 tests for OpenCode multi-model config generation
- 2 tests for Codex dynamic model listing contract
- All 340 existing agent tests pass (zero regressions)

## Test command

```bash
PYTHONPATH=backend python -m pytest backend/tests/agents/ backend/tests/services/test_agent_model_list.py -v
```

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> The follow-up commit `edaef934` scopes the model list to the flow-execution credential, so the authorization predicate runs correctly and principal-bound OAuth models are excluded. No active issues remain.
>
> **Overview**
> Adds a shared `list_authorized_gateway_models` helper wired into the flow orchestrator so OpenCode configs register every authorized model. The list is scoped to the flow credential via `build_runtime_key_auth_context`, and the helper fails closed (excluding principal-bound OAuth models) when no context is available. Both prior findings are resolved.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit edaef934. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->