### PR TITLE
Registry-based upstream-repo resolution for vendored SBOM components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`resolve_sbom_upstreams` builtin (default-disabled)**: maps vendored
+  Arduino/PlatformIO SBOM components (name + version) to an upstream
+  repository URL and version-shaped tag candidates via the public library
+  registries. A resolution requires a registry-confirmed name AND version
+  match with a usable repository URL; everything else is unresolved with a
+  reason. Default-off so regular sessions do not pay the tools/list context
+  tax; security-audit presets 005 (SBOM Exploit Check) and 006 (Release
+  Security Audit) allow-list it.
 - **CRA result.json contract**: the four security-audit presets pin
   `/workspace/result.json` as a versioned contract (`preloop.cra.sbomaudit/v1`,
   `vulnscan/v1`, `releaseaudit/v1`, `duediligence/v1`). Tests parse each YAML

--- a/backend/preloop/api/endpoints/tools.py
+++ b/backend/preloop/api/endpoints/tools.py
@@ -49,7 +49,11 @@ from preloop.schemas.gateway_usage import GatewayUsageByTool
 from preloop.utils.audit import log_config_change
 from preloop.utils.permissions import require_permission
 
-from preloop.tools.builtin_defs import ASK_USER_TOOL, PERMISSION_PROMPT_TOOL
+from preloop.tools.builtin_defs import (
+    ASK_USER_TOOL,
+    PERMISSION_PROMPT_TOOL,
+    RESOLVE_SBOM_UPSTREAMS_TOOL,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -92,6 +96,7 @@ BUILTIN_TOOLS = [
     },
     ASK_USER_TOOL,
     PERMISSION_PROMPT_TOOL,
+    RESOLVE_SBOM_UPSTREAMS_TOOL,
     {
         "name": "get_issue",
         "description": "Get detailed information about an issue by its identifier (URL, key, or ID)",

--- a/backend/preloop/services/initialize_mcp.py
+++ b/backend/preloop/services/initialize_mcp.py
@@ -18,7 +18,11 @@ from preloop.services.dynamic_fastmcp import (
     _justification_var,
     create_dynamic_mcp_server,
 )
-from preloop.tools.builtin_defs import ASK_USER_TOOL, PERMISSION_PROMPT_TOOL
+from preloop.tools.builtin_defs import (
+    ASK_USER_TOOL,
+    PERMISSION_PROMPT_TOOL,
+    RESOLVE_SBOM_UPSTREAMS_TOOL,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -659,6 +663,55 @@ def initialize_mcp_with_tools() -> DynamicFastMCP:
                 "as a safety measure. Retry the tool call.",
             }
         return _dump(behavior)
+
+    # Register Tool 7d: resolve_sbom_upstreams (shared metadata:
+    # tools.builtin_defs.RESOLVE_SBOM_UPSTREAMS_TOOL). Read-only registry
+    # lookup used by the SBOM security presets (005/006) to enrich vendored
+    # Arduino/PlatformIO components for osv_git screening. Resolution logic
+    # lives in preloop.services.sbom_upstream_resolver; it performs no DB
+    # access and degrades gracefully when the registries are unreachable.
+    @mcp.tool(description=RESOLVE_SBOM_UPSTREAMS_TOOL["description"])
+    async def resolve_sbom_upstreams(
+        components: list[dict],
+        ctx: Optional[Context] = None,
+    ) -> str:
+        """Resolve vendored SBOM components to upstream repositories.
+
+        Args:
+            components: Component mappings carrying ``name`` and
+                ``version`` (strings) plus optionally ``purl``.
+            ctx: MCP context (injected by FastMCP).
+
+        Returns:
+            The JSON resolution report, or an error string.
+        """
+        import json
+
+        from preloop.services.dynamic_fastmcp_http import get_current_user_context
+        from preloop.services.sbom_upstream_resolver import resolve_components
+
+        user_context = get_current_user_context()
+        if not user_context:
+            return "Error: No user context available"
+
+        approved, error = await require_approval(
+            tool_name=RESOLVE_SBOM_UPSTREAMS_TOOL["name"],
+            tool_source="builtin",
+            account_id=user_context.account_id,
+            arguments={"components": components},
+            ctx=ctx,
+            workflow_id=_rule_workflow_id_var.get(None),
+            correlation_id=_correlation_id_var.get(None),
+            justification=_justification_var.get(None),
+        )
+        if not approved:
+            return error
+
+        try:
+            report = await resolve_components(components)
+        except ValueError as exc:
+            return f"Error: {exc}"
+        return json.dumps(report)
 
     # Register Tool 8: add_comment
     @mcp.tool()

--- a/backend/preloop/services/sbom_upstream_resolver.py
+++ b/backend/preloop/services/sbom_upstream_resolver.py
@@ -667,8 +667,11 @@ class SbomUpstreamResolver:
         Returns:
             A pair of (payload, error). ``payload`` is the parsed JSON
             object on success. ``error`` describes the terminal failure
-            when the endpoint was unreachable; a 404 returns
-            ``(None, None)`` — an honest miss, not an outage.
+            when the endpoint was unreachable. Non-retryable 4xx client
+            errors (400/401/403/404) return ``(None, None)`` — an honest
+            miss, not an outage — so they do not trip the PlatformIO
+            circuit breaker. Transport failures and exhausted 5xx/429
+            retries return ``(None, error)``.
         """
         last_error = "unknown error"
         for attempt in range(self._retries + 1):
@@ -677,8 +680,6 @@ class SbomUpstreamResolver:
             except httpx.HTTPError as exc:
                 last_error = f"{type(exc).__name__}: {exc}"
             else:
-                if response.status_code == 404:
-                    return None, None
                 if response.status_code == 200:
                     try:
                         payload = response.json()
@@ -688,6 +689,12 @@ class SbomUpstreamResolver:
                         return payload, None
                     return None, "unexpected JSON shape in registry response"
                 last_error = f"HTTP {response.status_code}"
+                if (
+                    400 <= response.status_code < 500
+                    and response.status_code not in _RETRYABLE_STATUS
+                ):
+                    # Client error: honest miss, not a registry outage.
+                    return None, None
                 if response.status_code not in _RETRYABLE_STATUS:
                     return None, last_error
             if attempt < self._retries and self._retry_delay > 0:

--- a/backend/preloop/services/sbom_upstream_resolver.py
+++ b/backend/preloop/services/sbom_upstream_resolver.py
@@ -1,0 +1,751 @@
+"""Registry-based upstream-repository resolution for vendored components.
+
+Real embedded-firmware SBOMs are full of vendored Arduino/PlatformIO
+libraries carried as generic purls with no VCS metadata. The osv_git
+screening source (presets 005/006) can only evaluate a component when
+its purl carries a ``vcs_url`` qualifier or a resolvable tag, so those
+components stay blind to the one source that catches CVEs in vendored C
+code.
+
+This service resolves such components to their upstream repository URL
+plus version-shaped tag candidates via the public library registries:
+
+- the Arduino library index (one JSON document, one entry per library
+  version, carrying a ``repository`` URL) — primary source, cached
+  in-memory with a TTL;
+- the PlatformIO registry API (name search + package detail carrying
+  ``repository_url`` and a versions list) — fallback. The detail
+  endpoint may truncate its versions list to recent releases, so a
+  version it does not carry stays unresolved rather than being guessed.
+
+Honesty contract: a resolution requires a repository URL AND a registry
+entry whose version matches the SBOM version. Anything else is reported
+as unresolved with a reason — unresolved is a first-class outcome, and
+a resolution is never fabricated. Unreachable registries degrade
+gracefully: affected components stay unresolved, the registry status is
+reported, and nothing raises.
+
+The service performs no DB access; caching is in-memory only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+from urllib.parse import quote
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+ARDUINO_INDEX_URL = "https://downloads.arduino.cc/libraries/library_index.json"
+PLATFORMIO_API_BASE = "https://api.registry.platformio.org"
+
+DEFAULT_TIMEOUT_SECONDS = 15.0
+DEFAULT_RETRIES = 2
+DEFAULT_RETRY_DELAY_SECONDS = 0.5
+ARDUINO_INDEX_TTL_SECONDS = 24 * 60 * 60
+# Consecutive hard PlatformIO failures after which remaining lookups are
+# skipped for the run (bounded degradation instead of N timeouts).
+PLATFORMIO_FAILURE_THRESHOLD = 3
+# Candidate package pages inspected per PlatformIO name search.
+PLATFORMIO_MAX_CANDIDATES = 3
+MAX_COMPONENTS = 500
+
+_RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
+
+@dataclass(frozen=True)
+class ComponentRef:
+    """One SBOM component to resolve.
+
+    Attributes:
+        name: Component name as carried by the SBOM/purl.
+        version: Component version string from the SBOM.
+        purl: Optional original purl; when present, the resolution
+            carries an enriched purl with a ``vcs_url`` qualifier.
+    """
+
+    name: str
+    version: str
+    purl: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class UpstreamResolution:
+    """A conservative, registry-confirmed upstream resolution.
+
+    Attributes:
+        name: Component name as requested.
+        version: Component version as requested.
+        source: Registry that confirmed the resolution (``arduino`` or
+            ``platformio``).
+        repository_url: Upstream repository URL from the registry.
+        registry_version: The registry's own version string that matched
+            the SBOM version.
+        ref_candidates: Version-shaped tag names to resolve with
+            ``git ls-remote`` (the resolver never guesses a commit).
+        enriched_purl: Original purl with a ``vcs_url`` qualifier
+            appended, or ``None`` when no purl was supplied.
+    """
+
+    name: str
+    version: str
+    source: str
+    repository_url: str
+    registry_version: str
+    ref_candidates: Tuple[str, ...]
+    enriched_purl: Optional[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-safe representation of this resolution."""
+        return {
+            "name": self.name,
+            "version": self.version,
+            "source": self.source,
+            "repository_url": self.repository_url,
+            "registry_version": self.registry_version,
+            "ref_candidates": list(self.ref_candidates),
+            "enriched_purl": self.enriched_purl,
+        }
+
+
+@dataclass(frozen=True)
+class UnresolvedComponent:
+    """A component no registry could conservatively resolve.
+
+    Attributes:
+        name: Component name as requested.
+        version: Component version as requested.
+        reason: Why the component stayed unresolved.
+    """
+
+    name: str
+    version: str
+    reason: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-safe representation of this outcome."""
+        return {"name": self.name, "version": self.version, "reason": self.reason}
+
+
+@dataclass(frozen=True)
+class UpstreamResolutionReport:
+    """Outcome of one resolution run.
+
+    Attributes:
+        resolved: Registry-confirmed resolutions, in request order.
+        unresolved: Components that stayed unresolved, in request order.
+        registry_status: Per-registry health for the run (``ok``,
+            ``not queried``, or ``unreachable: <detail>``).
+    """
+
+    resolved: Tuple[UpstreamResolution, ...]
+    unresolved: Tuple[UnresolvedComponent, ...]
+    registry_status: Mapping[str, str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the JSON-safe report shape used as MCP tool output."""
+        by_source: Dict[str, int] = {}
+        for res in self.resolved:
+            by_source[res.source] = by_source.get(res.source, 0) + 1
+        return {
+            "resolved": [r.to_dict() for r in self.resolved],
+            "unresolved": [u.to_dict() for u in self.unresolved],
+            "stats": {
+                "requested": len(self.resolved) + len(self.unresolved),
+                "resolved": len(self.resolved),
+                "unresolved": len(self.unresolved),
+                "by_source": by_source,
+            },
+            "registry_status": dict(self.registry_status),
+        }
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize a library name for conservative matching.
+
+    Lowercases and removes space/dash/underscore separators so purl
+    names such as ``adafruit-gfx-library`` match index names such as
+    ``Adafruit GFX Library`` without admitting fuzzy matches.
+
+    Args:
+        name: Raw component or registry library name.
+
+    Returns:
+        The normalized matching key.
+    """
+    return "".join(ch for ch in name.lower() if ch not in " -_")
+
+
+def _normalize_version(version: str) -> str:
+    """Normalize a version string for exact comparison.
+
+    Strips surrounding whitespace and a single leading ``v``/``V``
+    prefix when followed by a digit; no other transformation is applied.
+
+    Args:
+        version: Raw version string.
+
+    Returns:
+        The normalized version string.
+    """
+    cleaned = version.strip()
+    if len(cleaned) > 1 and cleaned[0] in "vV" and cleaned[1].isdigit():
+        return cleaned[1:]
+    return cleaned
+
+
+def _usable_repository_url(url: Optional[str]) -> Optional[str]:
+    """Validate a registry-carried repository URL.
+
+    Args:
+        url: Repository URL as published by the registry.
+
+    Returns:
+        The URL when it is a plausible public http(s) repository URL,
+        otherwise ``None``.
+    """
+    if not url:
+        return None
+    candidate = url.strip()
+    if not candidate.lower().startswith(("http://", "https://")):
+        return None
+    # Reject embedded credentials outright rather than trying to launder
+    # them: registries publish anonymous clone URLs.
+    if "@" in candidate.split("://", 1)[1].split("/", 1)[0]:
+        return None
+    return candidate
+
+
+def _ref_candidates(registry_version: str, sbom_version: str) -> Tuple[str, ...]:
+    """Build version-shaped tag candidates for ``git ls-remote``.
+
+    Args:
+        registry_version: The registry's version string that matched.
+        sbom_version: The version string carried by the SBOM.
+
+    Returns:
+        Ordered, de-duplicated tag candidates.
+    """
+    candidates = [
+        registry_version,
+        f"v{registry_version}",
+        sbom_version.strip(),
+        f"v{_normalize_version(sbom_version)}",
+    ]
+    seen: List[str] = []
+    for cand in candidates:
+        if cand and cand not in seen:
+            seen.append(cand)
+    return tuple(seen)
+
+
+def _enrich_purl(purl: Optional[str], repository_url: str) -> Optional[str]:
+    """Append a ``vcs_url`` qualifier to a purl.
+
+    Args:
+        purl: Original component purl, if any.
+        repository_url: Registry-confirmed upstream repository URL.
+
+    Returns:
+        The enriched purl, the unchanged purl when it already carries a
+        ``vcs_url`` qualifier, or ``None`` when no purl was supplied.
+    """
+    if not purl:
+        return None
+    if "vcs_url=" in purl:
+        return purl
+    qualifier = "vcs_url=" + quote(f"git+{repository_url}", safe="")
+    separator = "&" if "?" in purl else "?"
+    return f"{purl}{separator}{qualifier}"
+
+
+@dataclass
+class _ArduinoIndexCache:
+    """In-memory cache of the parsed Arduino library index."""
+
+    fetched_at: float = 0.0
+    # (normalized name, normalized version) -> (repository URL, version)
+    entries: Dict[Tuple[str, str], Tuple[Optional[str], str]] = field(
+        default_factory=dict
+    )
+    known_names: Dict[str, bool] = field(default_factory=dict)
+    loaded: bool = False
+
+
+class SbomUpstreamResolver:
+    """Resolve vendored components to upstream repositories via registries.
+
+    The resolver is safe to reuse across runs: the Arduino index is
+    cached in-memory with a TTL, and per-run PlatformIO lookups are
+    memoized by normalized name. All network failures degrade to
+    unresolved outcomes; ``resolve`` never raises for registry errors.
+    """
+
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        retries: int = DEFAULT_RETRIES,
+        retry_delay_seconds: float = DEFAULT_RETRY_DELAY_SECONDS,
+        arduino_index_ttl_seconds: float = ARDUINO_INDEX_TTL_SECONDS,
+        transport: Optional[httpx.AsyncBaseTransport] = None,
+    ) -> None:
+        """Initialize the resolver.
+
+        Args:
+            timeout_seconds: Per-request timeout.
+            retries: Bounded retry count for retryable failures.
+            retry_delay_seconds: Base delay between retries.
+            arduino_index_ttl_seconds: How long the parsed Arduino index
+                stays cached.
+            transport: Optional httpx transport (tests inject a
+                ``httpx.MockTransport``).
+        """
+        self._timeout = timeout_seconds
+        self._retries = max(0, retries)
+        self._retry_delay = max(0.0, retry_delay_seconds)
+        self._arduino_ttl = arduino_index_ttl_seconds
+        self._transport = transport
+        self._arduino_cache = _ArduinoIndexCache()
+        self._arduino_lock = asyncio.Lock()
+
+    async def resolve(
+        self, components: Sequence[ComponentRef]
+    ) -> UpstreamResolutionReport:
+        """Resolve components to upstream repository URLs and tag refs.
+
+        Args:
+            components: SBOM components to resolve.
+
+        Returns:
+            A report with registry-confirmed resolutions, unresolved
+            components (with reasons), and per-registry status.
+        """
+        resolved: List[UpstreamResolution] = []
+        unresolved: List[UnresolvedComponent] = []
+        status: Dict[str, str] = {
+            "arduino_index": "not queried",
+            "platformio": "not queried",
+        }
+        pio_cache: Dict[str, Optional[Tuple[str, List[str]]]] = {}
+        pio_failures = 0
+
+        async with httpx.AsyncClient(
+            transport=self._transport,
+            timeout=self._timeout,
+            follow_redirects=True,
+            headers={"User-Agent": "preloop-sbom-upstream-resolver"},
+        ) as client:
+            arduino_ok = await self._ensure_arduino_index(client, status)
+
+            for comp in components:
+                nname = _normalize_name(comp.name)
+                nversion = _normalize_version(comp.version)
+
+                if arduino_ok:
+                    outcome = self._resolve_from_arduino(comp, nname, nversion)
+                    if isinstance(outcome, UpstreamResolution):
+                        resolved.append(outcome)
+                        continue
+                    if isinstance(outcome, UnresolvedComponent):
+                        unresolved.append(outcome)
+                        continue
+
+                if pio_failures >= PLATFORMIO_FAILURE_THRESHOLD:
+                    unresolved.append(
+                        UnresolvedComponent(
+                            name=comp.name,
+                            version=comp.version,
+                            reason=(
+                                "PlatformIO registry unreachable "
+                                "(lookups suspended for this run); "
+                                "no other registry matched"
+                            ),
+                        )
+                    )
+                    continue
+
+                pio_outcome, hard_failure = await self._resolve_from_platformio(
+                    client, comp, nname, nversion, pio_cache, status
+                )
+                if hard_failure:
+                    pio_failures += 1
+                else:
+                    pio_failures = 0
+                if isinstance(pio_outcome, UpstreamResolution):
+                    resolved.append(pio_outcome)
+                else:
+                    unresolved.append(pio_outcome)
+
+        return UpstreamResolutionReport(
+            resolved=tuple(resolved),
+            unresolved=tuple(unresolved),
+            registry_status=status,
+        )
+
+    # -- Arduino library index ------------------------------------------
+
+    async def _ensure_arduino_index(
+        self, client: httpx.AsyncClient, status: Dict[str, str]
+    ) -> bool:
+        """Load (or reuse) the parsed Arduino library index.
+
+        Args:
+            client: HTTP client for the run.
+            status: Mutable per-registry status map to update.
+
+        Returns:
+            True when an index (fresh or cached) is available.
+        """
+        async with self._arduino_lock:
+            cache = self._arduino_cache
+            fresh = (
+                cache.loaded
+                and (time.monotonic() - cache.fetched_at) < self._arduino_ttl
+            )
+            if fresh:
+                status["arduino_index"] = "ok"
+                return True
+
+            payload, error = await self._get_json(client, ARDUINO_INDEX_URL)
+            if payload is None:
+                if cache.loaded:
+                    # Keep serving the stale index rather than going blind.
+                    status["arduino_index"] = f"stale cache ({error})"
+                    return True
+                status["arduino_index"] = f"unreachable: {error}"
+                return False
+
+            entries: Dict[Tuple[str, str], Tuple[Optional[str], str]] = {}
+            known: Dict[str, bool] = {}
+            libraries = payload.get("libraries")
+            if not isinstance(libraries, list):
+                status["arduino_index"] = "unreachable: malformed index document"
+                return cache.loaded
+            for lib in libraries:
+                if not isinstance(lib, dict):
+                    continue
+                name = lib.get("name")
+                version = lib.get("version")
+                if not isinstance(name, str) or not isinstance(version, str):
+                    continue
+                repo = _usable_repository_url(lib.get("repository"))
+                key = (_normalize_name(name), _normalize_version(version))
+                entries[key] = (repo, version)
+                known[_normalize_name(name)] = True
+
+            cache.entries = entries
+            cache.known_names = known
+            cache.fetched_at = time.monotonic()
+            cache.loaded = True
+            status["arduino_index"] = "ok"
+            return True
+
+    def _resolve_from_arduino(
+        self, comp: ComponentRef, nname: str, nversion: str
+    ) -> Optional[UpstreamResolution | UnresolvedComponent]:
+        """Match one component against the cached Arduino index.
+
+        Args:
+            comp: The component to resolve.
+            nname: Normalized component name.
+            nversion: Normalized component version.
+
+        Returns:
+            A resolution, a terminal unresolved outcome (name+version
+            matched but the entry is unusable), or ``None`` when the
+            index has no match and the PlatformIO fallback should run.
+        """
+        entry = self._arduino_cache.entries.get((nname, nversion))
+        if entry is None:
+            return None
+        repo, registry_version = entry
+        if repo is None:
+            return UnresolvedComponent(
+                name=comp.name,
+                version=comp.version,
+                reason=(
+                    "Arduino index entry matches name and version but "
+                    "carries no usable repository URL"
+                ),
+            )
+        return UpstreamResolution(
+            name=comp.name,
+            version=comp.version,
+            source="arduino",
+            repository_url=repo,
+            registry_version=registry_version,
+            ref_candidates=_ref_candidates(registry_version, comp.version),
+            enriched_purl=_enrich_purl(comp.purl, repo),
+        )
+
+    # -- PlatformIO registry --------------------------------------------
+
+    async def _resolve_from_platformio(
+        self,
+        client: httpx.AsyncClient,
+        comp: ComponentRef,
+        nname: str,
+        nversion: str,
+        cache: Dict[str, Optional[Tuple[str, List[str]]]],
+        status: Dict[str, str],
+    ) -> Tuple[UpstreamResolution | UnresolvedComponent, bool]:
+        """Resolve one component via the PlatformIO registry.
+
+        Args:
+            client: HTTP client for the run.
+            comp: The component to resolve.
+            nname: Normalized component name.
+            nversion: Normalized component version.
+            cache: Per-run memo of normalized name -> (repository URL,
+                listed version names), or ``None`` for a confirmed miss.
+            status: Mutable per-registry status map to update.
+
+        Returns:
+            A pair of (outcome, hard_failure). ``hard_failure`` is True
+            when the registry itself was unreachable (feeds the
+            circuit breaker), False for honest misses.
+        """
+        arduino_known = nname in self._arduino_cache.known_names
+
+        if nname in cache:
+            hit = cache[nname]
+        else:
+            hit, error = await self._platformio_lookup(client, comp.name, nname)
+            if error is not None:
+                status["platformio"] = f"unreachable: {error}"
+                return (
+                    UnresolvedComponent(
+                        name=comp.name,
+                        version=comp.version,
+                        reason=f"PlatformIO registry unreachable ({error}); "
+                        "no other registry matched",
+                    ),
+                    True,
+                )
+            cache[nname] = hit
+            status["platformio"] = "ok"
+
+        if hit is None:
+            if arduino_known:
+                reason = (
+                    f"registries know the library but no entry matches "
+                    f"version {comp.version!r}"
+                )
+            else:
+                reason = (
+                    "not found in the Arduino library index or the PlatformIO registry"
+                )
+            return (
+                UnresolvedComponent(
+                    name=comp.name, version=comp.version, reason=reason
+                ),
+                False,
+            )
+
+        repo, version_names = hit
+        registry_version = next(
+            (v for v in version_names if _normalize_version(v) == nversion),
+            None,
+        )
+        if registry_version is None:
+            return (
+                UnresolvedComponent(
+                    name=comp.name,
+                    version=comp.version,
+                    reason=(
+                        f"PlatformIO registry knows the library but no "
+                        f"listed version matches {comp.version!r}"
+                    ),
+                ),
+                False,
+            )
+        return (
+            UpstreamResolution(
+                name=comp.name,
+                version=comp.version,
+                source="platformio",
+                repository_url=repo,
+                registry_version=registry_version,
+                ref_candidates=_ref_candidates(registry_version, comp.version),
+                enriched_purl=_enrich_purl(comp.purl, repo),
+            ),
+            False,
+        )
+
+    async def _platformio_lookup(
+        self, client: httpx.AsyncClient, raw_name: str, nname: str
+    ) -> Tuple[Optional[Tuple[str, List[str]]], Optional[str]]:
+        """Search PlatformIO for a library and read its repository detail.
+
+        Args:
+            client: HTTP client for the run.
+            raw_name: Library name as carried by the SBOM.
+            nname: Normalized name used for exact matching.
+
+        Returns:
+            A pair of (match, error). ``match`` is (repository URL,
+            listed version names) for the first exactly-named library
+            package whose detail page carries a usable repository URL;
+            ``None`` when nothing matched. ``error`` is set only for
+            registry-unreachable failures. The caller matches the SBOM
+            version against the listed versions — a version the registry
+            does not list never resolves.
+        """
+        search_url = f"{PLATFORMIO_API_BASE}/v3/search"
+        payload, error = await self._get_json(
+            client, search_url, params={"query": raw_name}
+        )
+        if payload is None:
+            return None, error
+
+        items = payload.get("items")
+        if not isinstance(items, list):
+            return None, None
+        candidates = [
+            item
+            for item in items
+            if isinstance(item, dict)
+            and item.get("type") == "library"
+            and isinstance(item.get("name"), str)
+            and _normalize_name(item["name"]) == nname
+            and isinstance(item.get("owner"), dict)
+            and isinstance(item["owner"].get("username"), str)
+        ][:PLATFORMIO_MAX_CANDIDATES]
+
+        for item in candidates:
+            owner = item["owner"]["username"]
+            pkg_name = item["name"]
+            detail_url = (
+                f"{PLATFORMIO_API_BASE}/v3/packages/"
+                f"{quote(owner, safe='')}/library/{quote(pkg_name, safe='')}"
+            )
+            detail, error = await self._get_json(client, detail_url)
+            if detail is None:
+                if error is not None:
+                    return None, error
+                continue
+            repo = _usable_repository_url(detail.get("repository_url"))
+            if repo is None:
+                continue
+            version_names: List[str] = []
+            versions = detail.get("versions")
+            if isinstance(versions, list):
+                version_names.extend(
+                    v["name"]
+                    for v in versions
+                    if isinstance(v, dict) and isinstance(v.get("name"), str)
+                )
+            latest = detail.get("version")
+            if isinstance(latest, dict) and isinstance(latest.get("name"), str):
+                version_names.append(latest["name"])
+            if version_names:
+                return (repo, version_names), None
+
+        return None, None
+
+    # -- HTTP helpers -----------------------------------------------------
+
+    async def _get_json(
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        params: Optional[Dict[str, str]] = None,
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        """GET a JSON document with bounded retries.
+
+        Args:
+            client: HTTP client for the run.
+            url: Absolute request URL.
+            params: Optional query parameters.
+
+        Returns:
+            A pair of (payload, error). ``payload`` is the parsed JSON
+            object on success. ``error`` describes the terminal failure
+            when the endpoint was unreachable; a 404 returns
+            ``(None, None)`` — an honest miss, not an outage.
+        """
+        last_error = "unknown error"
+        for attempt in range(self._retries + 1):
+            try:
+                response = await client.get(url, params=params)
+            except httpx.HTTPError as exc:
+                last_error = f"{type(exc).__name__}: {exc}"
+            else:
+                if response.status_code == 404:
+                    return None, None
+                if response.status_code == 200:
+                    try:
+                        payload = response.json()
+                    except ValueError:
+                        return None, "invalid JSON in registry response"
+                    if isinstance(payload, dict):
+                        return payload, None
+                    return None, "unexpected JSON shape in registry response"
+                last_error = f"HTTP {response.status_code}"
+                if response.status_code not in _RETRYABLE_STATUS:
+                    return None, last_error
+            if attempt < self._retries and self._retry_delay > 0:
+                await asyncio.sleep(self._retry_delay * (attempt + 1))
+        logger.warning("Registry request failed for %s: %s", url, last_error)
+        return None, last_error
+
+
+_default_resolver: Optional[SbomUpstreamResolver] = None
+
+
+def _get_default_resolver() -> SbomUpstreamResolver:
+    """Return the shared resolver (keeps the Arduino index cache warm)."""
+    global _default_resolver
+    if _default_resolver is None:
+        _default_resolver = SbomUpstreamResolver()
+    return _default_resolver
+
+
+async def resolve_components(
+    raw_components: Sequence[Mapping[str, Any]],
+    resolver: Optional[SbomUpstreamResolver] = None,
+) -> Dict[str, Any]:
+    """Validate raw tool input and run one resolution pass.
+
+    Args:
+        raw_components: Sequence of mappings each carrying ``name`` and
+            ``version`` (strings) and optionally ``purl``.
+        resolver: Optional resolver override (tests inject one wired to
+            a mock transport).
+
+    Returns:
+        The JSON-safe report dict (see
+        ``UpstreamResolutionReport.to_dict``).
+
+    Raises:
+        ValueError: When the input is not a list of well-formed
+            component mappings or exceeds ``MAX_COMPONENTS`` entries.
+    """
+    if len(raw_components) > MAX_COMPONENTS:
+        raise ValueError(
+            f"Too many components: {len(raw_components)} > {MAX_COMPONENTS}"
+        )
+    components: List[ComponentRef] = []
+    for idx, raw in enumerate(raw_components):
+        if not isinstance(raw, Mapping):
+            raise ValueError(f"Component #{idx} is not an object")
+        name = raw.get("name")
+        version = raw.get("version")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"Component #{idx} is missing a 'name' string")
+        if not isinstance(version, str) or not version.strip():
+            raise ValueError(f"Component #{idx} is missing a 'version' string")
+        purl = raw.get("purl")
+        if purl is not None and not isinstance(purl, str):
+            raise ValueError(f"Component #{idx} has a non-string 'purl'")
+        components.append(ComponentRef(name=name, version=version, purl=purl))
+
+    active = resolver if resolver is not None else _get_default_resolver()
+    report = await active.resolve(components)
+    return report.to_dict()

--- a/backend/preloop/tools/builtin_defs.py
+++ b/backend/preloop/tools/builtin_defs.py
@@ -93,6 +93,63 @@ PERMISSION_PROMPT_TOOL: Dict[str, Any] = {
 }
 
 
+RESOLVE_SBOM_UPSTREAMS_TOOL: Dict[str, Any] = {
+    "name": "resolve_sbom_upstreams",
+    "description": (
+        "Resolve vendored Arduino/PlatformIO SBOM components (name + "
+        "version) to their upstream git repository URL and version-shaped "
+        "tag candidates via the public library registries (Arduino library "
+        "index, PlatformIO registry). Read-only lookup: a component "
+        "resolves only when a registry entry matches its name AND version "
+        "and carries a repository URL; everything else comes back "
+        "unresolved with a reason — a resolution is never fabricated. "
+        "Returns JSON with resolved[] (repository_url, ref_candidates, "
+        "enriched_purl), unresolved[] (reason), stats, and per-registry "
+        "status."
+    ),
+    "source": "builtin",
+    # Default-off: only SBOM security flows need this lookup, so regular
+    # sessions should not pay its tools/list context tax (cf. issue #128).
+    # Flow executions opt in via their allowed_mcp_tools allow-list, which
+    # bypasses the default-enable filter.
+    "default_enabled": False,
+    "requires_tracker": False,
+    "required_tracker_types": [],
+    "schema": {
+        "type": "object",
+        "properties": {
+            "components": {
+                "type": "array",
+                "description": (
+                    "Components to resolve. Each entry carries the SBOM's "
+                    "name and version, plus optionally its purl (echoed "
+                    "back enriched with a vcs_url qualifier on success)."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Component name from the SBOM",
+                        },
+                        "version": {
+                            "type": "string",
+                            "description": "Component version from the SBOM",
+                        },
+                        "purl": {
+                            "type": "string",
+                            "description": "Optional original purl",
+                        },
+                    },
+                    "required": ["name", "version"],
+                },
+            },
+        },
+        "required": ["components"],
+    },
+}
+
+
 def builtin_tools_with_ask_user(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Return ``tools`` with ``ASK_USER_TOOL`` inserted after request_approval."""
     result: List[Dict[str, Any]] = []

--- a/backend/presets/005-sbom-exploit-check.yaml
+++ b/backend/presets/005-sbom-exploit-check.yaml
@@ -119,7 +119,29 @@ prompt_template: |
     component version with git ls-remote <vcs_url> '<tag>^{}'
     (read-only, no clone), then POST {"commit": "<40 hex sha>"} to OSV
     /v1/query so OSV evaluates its GIT ranges against that commit.
-    This screens vendored C code that purl queries are blind to. A
+    This screens vendored C code that purl queries are blind to.
+    UPSTREAM RESOLUTION (registry enrichment). Most vendored
+    Arduino/PlatformIO components carry neither a vcs_url nor a
+    resolvable tag. Before declaring such a component blind for this
+    source, call the platform's built-in resolve_sbom_upstreams tool
+    (the only tool on this flow's allowlist; a read-only lookup
+    against the public Arduino library index and PlatformIO registry)
+    ONCE, batched with every {name, version, purl} entry that lacks a
+    vcs_url. It returns, per component, the upstream repository_url
+    plus version-shaped ref_candidates when — and only when — a
+    registry entry matches both name AND version; everything else
+    comes back unresolved with a reason. Treat a resolved
+    repository_url exactly like an enriched vcs_url: resolve one of
+    the ref_candidates to a 40-hex commit with git ls-remote
+    '<tag>^{}' and query OSV with that commit. A component that
+    stays unresolved — or whose ref candidates resolve to no commit —
+    stays blind for this source. If the tool is missing, errors, or
+    reports its registries unreachable, the affected components stay
+    blind and the failure is recorded in checks; NEVER fabricate a
+    resolution. Count resolution provenance for the report
+    (inventory.upstream_resolution): components screenable here via
+    an already-present vcs_url, via registry resolution, and
+    unresolved — unresolved is a first-class outcome. A
     component with no vcs_url and no resolvable tag stays blind for
     this source — record it, never guess a commit. Negative control:
     {"commit": "6fa1d817e5b1a00d7d0c8168091877476b499317"} (a curl
@@ -166,7 +188,10 @@ prompt_template: |
     with the per-source negative controls.
   - vuln-report.md — human-readable report: inventory size, PER-SOURCE
     match coverage derived from the screening matrix (one line per
-    source: screened N of total, control passed or BLIND), sources
+    source: screened N of total, control passed or BLIND), an UPSTREAM
+    RESOLUTION line (osv_git enrichment: resolved via registry / via
+    already-present vcs_url / unresolved, from
+    inventory.upstream_resolution), sources
     queried with snapshot dates/timestamps, findings by severity with
     heuristic hits labeled, KEV hits called out, VEX suppressions echoed
     with their justification, gate outcome.
@@ -202,6 +227,13 @@ prompt_template: |
     },
     "inventory": {
       "components": <int>, "matchable": <int>, "unmatchable": <int>,
+      "upstream_resolution": null | {
+        "attempted": <int>,
+        "vcs_url_present": <int>,
+        "registry_resolved": <int>,
+        "unresolved": <int>,
+        "registry_status": { "arduino_index": "...", "platformio": "..." }
+      },
       "source_matrix": {
         "osv_purl": { "kind": "database", "screenable": <int>, "blind": <int>, "negative_control": { "query": "<verbatim>", "result": "<what came back>", "method_blind": true|false } },
         "osv_git": { "kind": "database", "screenable": <int>, "blind": <int>, "negative_control": { ... } },
@@ -257,13 +289,27 @@ prompt_template: |
   - "new_since_last_run" is ALWAYS null in this standalone preset: it is
     reserved for drift-capable runs (the Release Security Audit preset
     computes drift). Do not attempt to populate it here.
+  - "inventory.upstream_resolution" is an additive nullable field: fill
+    it whenever the osv_git registry enrichment ran; set it to null only
+    when no component was eligible (nothing lacked a vcs_url) or the
+    resolve_sbom_upstreams tool was unavailable — and record the tool
+    failure in checks in that case. The counts are honest provenance:
+    unresolved components are reported, never padded into coverage.
   - Set unknown envelope fields to null rather than inventing values.
 agent_type: codex
 agent_config:
   sandbox_type: exec
   enable_auto_lint: false
 allowed_mcp_servers: []
-allowed_mcp_tools: []
+# The ONLY tool on this allowlist is the built-in resolve_sbom_upstreams
+# registry lookup (PHASE 2, osv_git source): a read-only Arduino/
+# PlatformIO registry query that maps vendored components to their
+# upstream repository URL and tag candidates. It writes nothing and a
+# resolution requires a registry-confirmed name+version match — never
+# fabricated. Everything else stays off the allowlist — the scan itself
+# runs in the sandbox.
+allowed_mcp_tools:
+  - name: resolve_sbom_upstreams
 git_clone_config: null
 trigger_config: null
 is_preset: true

--- a/backend/presets/006-release-security-audit.yaml
+++ b/backend/presets/006-release-security-audit.yaml
@@ -224,7 +224,31 @@ prompt_template: |
       the upstream release tag matching the component version with
       git ls-remote <vcs_url> '<tag>^{}' (read-only, no clone), then
       POST {"commit": "<40 hex sha>"} to OSV /v1/query so OSV
-      evaluates its GIT ranges against that commit. A component with
+      evaluates its GIT ranges against that commit.
+      UPSTREAM RESOLUTION (registry enrichment). Most vendored
+      Arduino/PlatformIO components carry neither a vcs_url nor a
+      resolvable tag. Before declaring such a component blind for
+      this source, call the platform's built-in
+      resolve_sbom_upstreams tool (on this flow's allowlist; a
+      read-only lookup against the public Arduino library index and
+      PlatformIO registry) ONCE, batched with every {name, version,
+      purl} entry that lacks a vcs_url. It returns, per component,
+      the upstream repository_url plus version-shaped ref_candidates
+      when — and only when — a registry entry matches both name AND
+      version; everything else comes back unresolved with a reason.
+      Treat a resolved repository_url exactly like an enriched
+      vcs_url: resolve one of the ref_candidates to a 40-hex commit
+      with git ls-remote '<tag>^{}' and query OSV with that commit.
+      A component that stays unresolved — or whose ref candidates
+      resolve to no commit — stays blind for this source. If the
+      tool is missing, errors, or reports its registries
+      unreachable, the affected components stay blind and the
+      failure is recorded in checks; NEVER fabricate a resolution.
+      Count resolution provenance for the report
+      (vuln_scan.inventory.upstream_resolution): components
+      screenable here via an already-present vcs_url, via registry
+      resolution, and unresolved — unresolved is a first-class
+      outcome. A component with
       no vcs_url and no resolvable tag stays blind for this source —
       record it, never guess a commit. Negative control:
       {"commit": "6fa1d817e5b1a00d7d0c8168091877476b499317"} (a curl
@@ -314,11 +338,13 @@ prompt_template: |
 
   WAIVER COLLECTION (only when the payload says
   waiver_collection: "interactive"). This flow's allowed_mcp_tools
-  contains exactly one tool — the platform's built-in ask_user — as
-  the SOLE exception to the otherwise-empty allowlist: it is a
-  question channel routed through the platform approval workflow
-  (which captures the approver's identity), not a write tool, and it
-  exists here only so a human can put waivers on the record mid-run.
+  carries exactly two read-only platform tools: the
+  resolve_sbom_upstreams registry lookup (PHASE 2, osv_git source)
+  and the platform's built-in ask_user. ask_user is the SOLE
+  question channel on the allowlist: it is routed through the
+  platform approval workflow (which captures the approver's
+  identity), not a write tool, and it exists here only so a human
+  can put waivers on the record mid-run.
   Rules:
   - Non-interactive runs (the default) NEVER call ask_user, not even
     to report progress. Interactive runs call it ONLY for waiver
@@ -593,7 +619,10 @@ prompt_template: |
       matrix order — "<source>: screened <screenable> of <total>
       components (database match|labeled heuristic; control passed|
       control BLIND)" — no aggregate coverage claim that the matrix
-      does not support. It must contain the sentence: this
+      does not support — plus one UPSTREAM RESOLUTION line (osv_git
+      enrichment: resolved via registry / via already-present
+      vcs_url / unresolved, from
+      vuln_scan.inventory.upstream_resolution). It must contain the sentence: this
       run demonstrates the pipeline; it is not yet a complete CRA gap
       review unless the gap-register phase ran AND private product
       repositories were in scope. Say which of those two held.
@@ -765,6 +794,13 @@ prompt_template: |
         "db_resolvable": <int>,
         "not_db_resolvable": <int>,
         "by_ecosystem": { "<ecosystem or 'generic'>": <int> },
+        "upstream_resolution": null | {
+          "attempted": <int>,
+          "vcs_url_present": <int>,
+          "registry_resolved": <int>,
+          "unresolved": <int>,
+          "registry_status": { "arduino_index": "...", "platformio": "..." }
+        },
         "negative_control": { "query": "<the control query as sent>", "result": "<what came back>", "method_blind": true|false },
         "source_matrix": {
           "osv_purl": { "kind": "database", "screenable": <int>, "blind": <int>, "negative_control": { "query": "<verbatim>", "result": "<what came back>", "method_blind": true|false } },
@@ -879,14 +915,20 @@ agent_config:
   sandbox_type: exec
   enable_auto_lint: false
 allowed_mcp_servers: []
-# The ONLY tool on this allowlist is the built-in ask_user question
-# channel, and only for interactive waiver collection (see the WAIVER
-# COLLECTION rules in the prompt). It is not a write tool: it routes a
-# question through the platform approval workflow, which captures the
-# approver's identity. Non-interactive runs never call it. Everything
-# else stays off the allowlist — scanners run in the sandbox.
+# The ONLY tools on this allowlist are two read-only platform builtins:
+# - ask_user: the question channel for interactive waiver collection
+#   (see the WAIVER COLLECTION rules in the prompt). Not a write tool:
+#   it routes a question through the platform approval workflow, which
+#   captures the approver's identity. Non-interactive runs never call
+#   it.
+# - resolve_sbom_upstreams: the Arduino/PlatformIO registry lookup the
+#   osv_git source uses to enrich vendored components (PHASE 2). It
+#   writes nothing and a resolution requires a registry-confirmed
+#   name+version match — never fabricated.
+# Everything else stays off the allowlist — scanners run in the sandbox.
 allowed_mcp_tools:
   - name: ask_user
+  - name: resolve_sbom_upstreams
 git_clone_config: null
 trigger_config: null
 is_preset: true

--- a/backend/tests/endpoints/test_tools.py
+++ b/backend/tests/endpoints/test_tools.py
@@ -86,6 +86,7 @@ class TestListAllTools:
             "estimate_compliance",
             "improve_compliance",
             "permission_prompt",
+            "resolve_sbom_upstreams",
         }
         for tool in result:
             expected = tool["name"] not in default_disabled

--- a/backend/tests/services/test_initialize_mcp.py
+++ b/backend/tests/services/test_initialize_mcp.py
@@ -99,6 +99,7 @@ EXPECTED_TOOLS = {
     "update_pull_request",
     "create_pull_request",
     "get_approval_status",
+    "resolve_sbom_upstreams",
 }
 
 
@@ -183,6 +184,71 @@ class TestRegisteredToolBehaviour:
             result = await fn(issue="ABC-1")
         assert result == '{"issue": "ok"}'
         mock_router.assert_awaited_once_with("ABC-1")
+
+    async def test_resolve_sbom_upstreams_no_user_context(self, mcp_server):
+        fn = await self._fn(mcp_server, "resolve_sbom_upstreams")
+        with patch(
+            "preloop.services.dynamic_fastmcp_http.get_current_user_context",
+            return_value=None,
+        ):
+            result = await fn(components=[{"name": "JPEGDEC", "version": "1.2.8"}])
+        assert result == "Error: No user context available"
+
+    async def test_resolve_sbom_upstreams_calls_service(self, mcp_server):
+        fn = await self._fn(mcp_server, "resolve_sbom_upstreams")
+        user_ctx = SimpleNamespace(account_id=str(uuid4()), username="u")
+        report = {
+            "resolved": [],
+            "unresolved": [],
+            "stats": {
+                "requested": 0,
+                "resolved": 0,
+                "unresolved": 0,
+                "by_source": {},
+            },
+            "registry_status": {
+                "arduino_index": "not queried",
+                "platformio": "not queried",
+            },
+        }
+        with (
+            patch(
+                "preloop.services.dynamic_fastmcp_http.get_current_user_context",
+                return_value=user_ctx,
+            ),
+            patch(
+                "preloop.services.initialize_mcp.require_approval",
+                new=AsyncMock(return_value=(True, None)),
+            ),
+            patch(
+                "preloop.services.sbom_upstream_resolver.resolve_components",
+                new=AsyncMock(return_value=report),
+            ) as mock_resolve,
+        ):
+            result = await fn(components=[{"name": "JPEGDEC", "version": "1.2.8"}])
+        import json
+
+        assert json.loads(result) == report
+        mock_resolve.assert_awaited_once_with([{"name": "JPEGDEC", "version": "1.2.8"}])
+
+    async def test_resolve_sbom_upstreams_invalid_input_returns_error(self, mcp_server):
+        """Malformed component entries surface as an error string, never
+        an exception (the tool is called from unattended flow runs)."""
+        fn = await self._fn(mcp_server, "resolve_sbom_upstreams")
+        user_ctx = SimpleNamespace(account_id=str(uuid4()), username="u")
+        with (
+            patch(
+                "preloop.services.dynamic_fastmcp_http.get_current_user_context",
+                return_value=user_ctx,
+            ),
+            patch(
+                "preloop.services.initialize_mcp.require_approval",
+                new=AsyncMock(return_value=(True, None)),
+            ),
+        ):
+            result = await fn(components=[{"name": "JPEGDEC"}])
+        assert result.startswith("Error:")
+        assert "version" in result
 
     async def test_removed_test_progress_tool_not_registered(self, mcp_server):
         """The old test_progress debug tool must no longer ship to users."""

--- a/backend/tests/services/test_sbom_upstream_resolver.py
+++ b/backend/tests/services/test_sbom_upstream_resolver.py
@@ -249,6 +249,26 @@ class TestArduinoResolution:
         assert len(report.unresolved) == 1
 
     @pytest.mark.asyncio
+    async def test_credentialed_repository_url_is_unresolved(self):
+        """Embedded credentials are rejected, not laundered into a resolution."""
+        index = {
+            "libraries": [
+                {
+                    "name": "SecretLib",
+                    "version": "1.0.0",
+                    "repository": "https://user:pass@host/repo.git",
+                }
+            ]
+        }
+        resolver = make_resolver(_routes(arduino_body=index))
+        report = await resolver.resolve(
+            [ComponentRef(name="SecretLib", version="1.0.0")]
+        )
+        assert not report.resolved
+        assert len(report.unresolved) == 1
+        assert "no usable repository URL" in report.unresolved[0].reason
+
+    @pytest.mark.asyncio
     async def test_index_downloaded_once_across_resolve_calls(self):
         counters: dict = {}
         resolver = make_resolver(_routes(counters=counters))
@@ -347,6 +367,66 @@ class TestGracefulDegradation:
         # Each search retries a bounded number of times; the circuit
         # breaker must stop far before one search per component.
         assert search_requests < 10
+
+    @pytest.mark.asyncio
+    async def test_stale_arduino_cache_served_when_refresh_fails(self):
+        """A warm index stays in service when the TTL refresh fails."""
+        calls = {"arduino": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if url.startswith(ARDUINO_INDEX_URL):
+                calls["arduino"] += 1
+                if calls["arduino"] == 1:
+                    return httpx.Response(200, json=ARDUINO_INDEX)
+                return httpx.Response(503, text="registry down")
+            return httpx.Response(404, json={"message": "Not Found"})
+
+        resolver = SbomUpstreamResolver(
+            transport=httpx.MockTransport(handler),
+            retry_delay_seconds=0.0,
+            arduino_index_ttl_seconds=0.0,
+        )
+        first = await resolver.resolve([ComponentRef(name="JPEGDEC", version="1.2.8")])
+        assert len(first.resolved) == 1
+        assert first.registry_status["arduino_index"] == "ok"
+
+        second = await resolver.resolve([ComponentRef(name="JPEGDEC", version="1.2.8")])
+        assert len(second.resolved) == 1
+        assert second.resolved[0].repository_url == (
+            "https://github.com/bitbank2/JPEGDEC.git"
+        )
+        assert second.registry_status["arduino_index"].startswith("stale cache (")
+
+    @pytest.mark.asyncio
+    async def test_malformed_arduino_index_does_not_raise(self):
+        resolver = make_resolver(_routes(arduino_body={"libraries": "not-a-list"}))
+        report = await resolver.resolve([ComponentRef(name="JPEGDEC", version="1.2.8")])
+        assert not report.resolved
+        assert report.registry_status["arduino_index"] == (
+            "unreachable: malformed index document"
+        )
+
+    @pytest.mark.asyncio
+    async def test_platformio_http_400_does_not_open_circuit_breaker(self):
+        """A 4xx client error is an honest miss, not a registry outage."""
+        counters: dict = {}
+        resolver = make_resolver(
+            _routes(arduino_status=503, pio_status=400, counters=counters)
+        )
+        components = [ComponentRef(name=f"lib-{i}", version="1.0.0") for i in range(10)]
+        report = await resolver.resolve(components)
+        assert len(report.unresolved) == 10
+        search_requests = sum(
+            count
+            for url, count in counters.items()
+            if url.startswith(f"{PLATFORMIO_API_BASE}/v3/search")
+        )
+        # One search per unique name: 400 is not retried and must not
+        # increment the hard-failure counter / open the breaker.
+        assert search_requests == 10
+        assert all("lookups suspended" not in u.reason for u in report.unresolved)
+        assert report.registry_status["platformio"] == "ok"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_sbom_upstream_resolver.py
+++ b/backend/tests/services/test_sbom_upstream_resolver.py
@@ -1,0 +1,403 @@
+"""Tests for the SBOM upstream-repository resolver service.
+
+The resolver maps vendored Arduino/PlatformIO components (generic purls
+with no VCS metadata) to their upstream repository URL plus
+version-shaped tag candidates, using the public library registries.
+All registry traffic is mocked with realistic fixtures (shapes captured
+from the live Arduino library index and PlatformIO registry API).
+
+Core honesty invariants under test:
+- a resolution requires a repository URL AND a registry entry whose
+  version matches the SBOM version — otherwise the component is
+  unresolved (never fabricated);
+- unreachable registries degrade gracefully: components stay
+  unresolved, the registry status is reported, nothing raises.
+"""
+
+import json
+from typing import Callable
+
+import httpx
+import pytest
+
+from preloop.services.sbom_upstream_resolver import (
+    ARDUINO_INDEX_URL,
+    MAX_COMPONENTS,
+    PLATFORMIO_API_BASE,
+    ComponentRef,
+    SbomUpstreamResolver,
+    resolve_components,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic registry payload shapes (public registry data).
+# ---------------------------------------------------------------------------
+
+ARDUINO_INDEX = {
+    "libraries": [
+        {
+            "name": "JPEGDEC",
+            "version": "1.2.8",
+            "author": "Larry Bank",
+            "website": "https://github.com/bitbank2/JPEGDEC",
+            "category": "Display",
+            "architectures": ["*"],
+            "types": ["Contributed"],
+            "repository": "https://github.com/bitbank2/JPEGDEC.git",
+            "url": (
+                "https://downloads.arduino.cc/libraries/github.com/"
+                "bitbank2/JPEGDEC-1.2.8.zip"
+            ),
+            "archiveFileName": "JPEGDEC-1.2.8.zip",
+        },
+        {
+            "name": "JPEGDEC",
+            "version": "1.8.4",
+            "author": "Larry Bank",
+            "website": "https://github.com/bitbank2/JPEGDEC",
+            "repository": "https://github.com/bitbank2/JPEGDEC.git",
+        },
+        {
+            "name": "Adafruit GFX Library",
+            "version": "1.11.9",
+            "author": "Adafruit",
+            "website": "https://github.com/adafruit/Adafruit-GFX-Library",
+            "repository": "https://github.com/adafruit/Adafruit-GFX-Library.git",
+        },
+        {
+            # Entry with no repository URL: must never resolve.
+            "name": "OrphanLib",
+            "version": "2.0.0",
+            "repository": "",
+        },
+    ]
+}
+
+PIO_SEARCH_PUBSUBCLIENT = {
+    "page": 1,
+    "limit": 10,
+    "total": 1,
+    "items": [
+        {
+            "id": 89,
+            "type": "library",
+            "tier": "community",
+            "owner": {"username": "knolleary"},
+            "name": "PubSubClient",
+            "description": "A client library for MQTT messaging.",
+        }
+    ],
+}
+
+PIO_DETAIL_PUBSUBCLIENT = {
+    "id": 89,
+    "type": "library",
+    "owner": {"username": "knolleary"},
+    "name": "PubSubClient",
+    "repository_url": "https://github.com/knolleary/pubsubclient.git",
+    "version": {"name": "2.8.0", "released_at": "2020-05-20T00:00:00Z"},
+    "versions": [
+        {"name": "2.8.0", "released_at": "2020-05-20T00:00:00Z"},
+        {"name": "2.7.0", "released_at": "2018-12-01T00:00:00Z"},
+    ],
+}
+
+
+def _routes(
+    *,
+    arduino_status: int = 200,
+    arduino_body: dict | None = None,
+    pio_status: int = 200,
+    counters: dict | None = None,
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Build a MockTransport handler for both registries.
+
+    Args:
+        arduino_status: HTTP status for the Arduino index download.
+        arduino_body: Arduino index payload (defaults to ARDUINO_INDEX).
+        pio_status: HTTP status for all PlatformIO endpoints.
+        counters: Optional dict collecting per-URL request counts.
+
+    Returns:
+        A handler suitable for ``httpx.MockTransport``.
+    """
+    index = arduino_body if arduino_body is not None else ARDUINO_INDEX
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if counters is not None:
+            counters[url] = counters.get(url, 0) + 1
+        if url.startswith(ARDUINO_INDEX_URL):
+            if arduino_status != 200:
+                return httpx.Response(arduino_status, text="registry down")
+            return httpx.Response(200, json=index)
+        if url.startswith(f"{PLATFORMIO_API_BASE}/v3/search"):
+            if pio_status != 200:
+                return httpx.Response(pio_status, text="registry down")
+            query = request.url.params.get("query", "")
+            if "pubsubclient" in query.lower():
+                return httpx.Response(200, json=PIO_SEARCH_PUBSUBCLIENT)
+            return httpx.Response(
+                200, json={"page": 1, "limit": 10, "total": 0, "items": []}
+            )
+        if url.startswith(
+            f"{PLATFORMIO_API_BASE}/v3/packages/knolleary/library/PubSubClient"
+        ):
+            if pio_status != 200:
+                return httpx.Response(pio_status, text="registry down")
+            return httpx.Response(200, json=PIO_DETAIL_PUBSUBCLIENT)
+        return httpx.Response(404, json={"message": "Not Found"})
+
+    return handler
+
+
+def make_resolver(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> SbomUpstreamResolver:
+    """Create a resolver wired to a mock transport with no retry delay."""
+    return SbomUpstreamResolver(
+        transport=httpx.MockTransport(handler), retry_delay_seconds=0.0
+    )
+
+
+# ---------------------------------------------------------------------------
+# Arduino library index resolution
+# ---------------------------------------------------------------------------
+
+
+class TestArduinoResolution:
+    @pytest.mark.asyncio
+    async def test_jpegdec_resolves_with_repo_and_ref_candidates(self):
+        resolver = make_resolver(_routes())
+        report = await resolver.resolve(
+            [
+                ComponentRef(
+                    name="JPEGDEC",
+                    version="1.2.8",
+                    purl="pkg:generic/JPEGDEC@1.2.8",
+                )
+            ]
+        )
+        assert len(report.resolved) == 1
+        assert not report.unresolved
+        res = report.resolved[0]
+        assert res.source == "arduino"
+        assert res.repository_url == "https://github.com/bitbank2/JPEGDEC.git"
+        assert res.registry_version == "1.2.8"
+        assert "1.2.8" in res.ref_candidates
+        assert "v1.2.8" in res.ref_candidates
+        assert report.registry_status["arduino_index"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_enriched_purl_carries_vcs_url_qualifier(self):
+        resolver = make_resolver(_routes())
+        report = await resolver.resolve(
+            [
+                ComponentRef(
+                    name="JPEGDEC",
+                    version="1.2.8",
+                    purl="pkg:generic/JPEGDEC@1.2.8",
+                )
+            ]
+        )
+        enriched = report.resolved[0].enriched_purl
+        assert enriched is not None
+        assert enriched.startswith("pkg:generic/JPEGDEC@1.2.8?vcs_url=")
+        # The qualifier is percent-encoded and carries the git+https URL.
+        assert "git%2Bhttps" in enriched
+
+    @pytest.mark.asyncio
+    async def test_v_prefixed_sbom_version_matches_registry_version(self):
+        resolver = make_resolver(_routes())
+        report = await resolver.resolve(
+            [ComponentRef(name="JPEGDEC", version="v1.2.8")]
+        )
+        assert len(report.resolved) == 1
+        res = report.resolved[0]
+        assert res.registry_version == "1.2.8"
+        assert "v1.2.8" in res.ref_candidates
+
+    @pytest.mark.asyncio
+    async def test_separator_insensitive_name_match(self):
+        """purl names use dashes/underscores; the index uses spaces."""
+        resolver = make_resolver(_routes())
+        report = await resolver.resolve(
+            [ComponentRef(name="adafruit-gfx-library", version="1.11.9")]
+        )
+        assert len(report.resolved) == 1
+        assert report.resolved[0].repository_url == (
+            "https://github.com/adafruit/Adafruit-GFX-Library.git"
+        )
+
+    @pytest.mark.asyncio
+    async def test_version_not_in_any_registry_is_unresolved(self):
+        """Never fabricate: a repo-known name with an unknown version
+        stays unresolved."""
+        resolver = make_resolver(_routes())
+        report = await resolver.resolve([ComponentRef(name="JPEGDEC", version="9.9.9")])
+        assert not report.resolved
+        assert len(report.unresolved) == 1
+        assert "9.9.9" in report.unresolved[0].reason
+
+    @pytest.mark.asyncio
+    async def test_entry_without_repository_url_is_unresolved(self):
+        resolver = make_resolver(_routes())
+        report = await resolver.resolve(
+            [ComponentRef(name="OrphanLib", version="2.0.0")]
+        )
+        assert not report.resolved
+        assert len(report.unresolved) == 1
+
+    @pytest.mark.asyncio
+    async def test_index_downloaded_once_across_resolve_calls(self):
+        counters: dict = {}
+        resolver = make_resolver(_routes(counters=counters))
+        await resolver.resolve([ComponentRef(name="JPEGDEC", version="1.2.8")])
+        await resolver.resolve([ComponentRef(name="JPEGDEC", version="1.8.4")])
+        assert counters[ARDUINO_INDEX_URL] == 1
+
+
+# ---------------------------------------------------------------------------
+# PlatformIO registry fallback
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformIOResolution:
+    @pytest.mark.asyncio
+    async def test_resolves_via_platformio_when_not_in_arduino_index(self):
+        resolver = make_resolver(_routes())
+        report = await resolver.resolve(
+            [ComponentRef(name="PubSubClient", version="2.8.0")]
+        )
+        assert len(report.resolved) == 1
+        res = report.resolved[0]
+        assert res.source == "platformio"
+        assert res.repository_url == ("https://github.com/knolleary/pubsubclient.git")
+        assert "2.8.0" in res.ref_candidates
+        assert "v2.8.0" in res.ref_candidates
+        assert report.registry_status["platformio"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_platformio_version_mismatch_is_unresolved(self):
+        """The PIO detail versions list is authoritative and may be
+        truncated upstream: a version it does not carry never resolves."""
+        resolver = make_resolver(_routes())
+        report = await resolver.resolve(
+            [ComponentRef(name="PubSubClient", version="1.0.0")]
+        )
+        assert not report.resolved
+        assert len(report.unresolved) == 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_component_is_unresolved(self):
+        resolver = make_resolver(_routes())
+        report = await resolver.resolve(
+            [ComponentRef(name="totally-private-lib", version="0.0.1")]
+        )
+        assert not report.resolved
+        assert len(report.unresolved) == 1
+
+
+# ---------------------------------------------------------------------------
+# Degradation: unreachable registries never crash, never fabricate
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulDegradation:
+    @pytest.mark.asyncio
+    async def test_both_registries_down_all_unresolved(self):
+        resolver = make_resolver(_routes(arduino_status=503, pio_status=503))
+        report = await resolver.resolve(
+            [
+                ComponentRef(name="JPEGDEC", version="1.2.8"),
+                ComponentRef(name="PubSubClient", version="2.8.0"),
+            ]
+        )
+        assert not report.resolved
+        assert len(report.unresolved) == 2
+        assert report.registry_status["arduino_index"].startswith("unreachable")
+        assert report.registry_status["platformio"].startswith("unreachable")
+
+    @pytest.mark.asyncio
+    async def test_network_errors_do_not_raise(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom", request=request)
+
+        resolver = make_resolver(handler)
+        report = await resolver.resolve([ComponentRef(name="JPEGDEC", version="1.2.8")])
+        assert not report.resolved
+        assert len(report.unresolved) == 1
+
+    @pytest.mark.asyncio
+    async def test_platformio_lookups_stop_after_repeated_failures(self):
+        """Bounded degradation: after the failure threshold, remaining
+        components are marked unresolved without further requests."""
+        counters: dict = {}
+        resolver = make_resolver(
+            _routes(arduino_status=503, pio_status=503, counters=counters)
+        )
+        components = [ComponentRef(name=f"lib-{i}", version="1.0.0") for i in range(10)]
+        report = await resolver.resolve(components)
+        assert len(report.unresolved) == 10
+        search_requests = sum(
+            count
+            for url, count in counters.items()
+            if url.startswith(f"{PLATFORMIO_API_BASE}/v3/search")
+        )
+        # Each search retries a bounded number of times; the circuit
+        # breaker must stop far before one search per component.
+        assert search_requests < 10
+
+
+# ---------------------------------------------------------------------------
+# Report shape and the resolve_components() tool entry point
+# ---------------------------------------------------------------------------
+
+
+class TestReportContract:
+    @pytest.mark.asyncio
+    async def test_report_dict_shape_and_stats(self):
+        resolver = make_resolver(_routes())
+        report = await resolver.resolve(
+            [
+                ComponentRef(name="JPEGDEC", version="1.2.8"),
+                ComponentRef(name="PubSubClient", version="2.8.0"),
+                ComponentRef(name="mystery", version="0.1.0"),
+            ]
+        )
+        data = report.to_dict()
+        assert data["stats"] == {
+            "requested": 3,
+            "resolved": 2,
+            "unresolved": 1,
+            "by_source": {"arduino": 1, "platformio": 1},
+        }
+        assert {r["name"] for r in data["resolved"]} == {
+            "JPEGDEC",
+            "PubSubClient",
+        }
+        assert data["unresolved"][0]["name"] == "mystery"
+        assert data["unresolved"][0]["reason"]
+        assert set(data["registry_status"]) == {"arduino_index", "platformio"}
+        # The whole report must be JSON-serializable (MCP tool output).
+        json.dumps(data)
+
+    @pytest.mark.asyncio
+    async def test_resolve_components_validates_input(self):
+        with pytest.raises(ValueError):
+            await resolve_components([{"name": "JPEGDEC"}])  # missing version
+        with pytest.raises(ValueError):
+            await resolve_components([{"version": "1.0.0"}])  # missing name
+        with pytest.raises(ValueError):
+            await resolve_components(
+                [{"name": "x", "version": "1"}] * (MAX_COMPONENTS + 1)
+            )
+
+    @pytest.mark.asyncio
+    async def test_resolve_components_uses_injected_resolver(self):
+        resolver = make_resolver(_routes())
+        data = await resolve_components(
+            [{"name": "JPEGDEC", "version": "1.2.8"}], resolver=resolver
+        )
+        assert data["stats"]["resolved"] == 1
+        assert data["resolved"][0]["source"] == "arduino"

--- a/backend/tests/test_security_audit_presets.py
+++ b/backend/tests/test_security_audit_presets.py
@@ -59,17 +59,27 @@ class TestSecurityAuditPresetInvariants:
     def test_read_only_toolset(self, preset):
         """Write tools stay off. Scanners run in the sandbox, not via MCP.
 
-        SOLE exception: the Release Security Audit carries the built-in
-        ask_user question channel — and nothing else — so a human can put
-        gate waivers on the record when the payload asks for interactive
-        waiver collection. ask_user is not a write tool: it routes a
-        question through the platform approval workflow, which captures
-        the approver identity the waiver register records.
+        Exceptions, all read-only: the exploit-check and release-audit
+        presets carry the built-in resolve_sbom_upstreams registry
+        lookup (osv_git enrichment for vendored Arduino/PlatformIO
+        components; a resolution requires a registry-confirmed
+        name+version match, never fabricated), and the Release Security
+        Audit additionally carries the built-in ask_user question
+        channel so a human can put gate waivers on the record when the
+        payload asks for interactive waiver collection. ask_user is not
+        a write tool: it routes a question through the platform
+        approval workflow, which captures the approver identity the
+        waiver register records.
         """
         name, data = preset
         assert data["allowed_mcp_servers"] == []
         if name == "Release Security Audit":
-            assert data["allowed_mcp_tools"] == [{"name": "ask_user"}]
+            assert data["allowed_mcp_tools"] == [
+                {"name": "ask_user"},
+                {"name": "resolve_sbom_upstreams"},
+            ]
+        elif name == "SBOM Exploit Check":
+            assert data["allowed_mcp_tools"] == [{"name": "resolve_sbom_upstreams"}]
         else:
             assert data["allowed_mcp_tools"] == []
         assert "repo-audit" not in json.dumps(data)
@@ -487,6 +497,60 @@ class TestPerSourceScreeningMatrix:
         assert 'never "zero vulnerabilities"' in norm
 
 
+class TestUpstreamResolutionEnrichment:
+    """The osv_git source resolves vendored Arduino/PlatformIO components
+    through the resolve_sbom_upstreams builtin: registry-confirmed
+    name+version matches only, honest provenance counts, unresolved as a
+    first-class outcome, graceful degradation when registries are down."""
+
+    @pytest.fixture(params=["SBOM Exploit Check", "Release Security Audit"])
+    def prompt(self, request):
+        return _load_preset(PRESET_FILES[request.param])["prompt_template"]
+
+    def test_enrichment_step_present(self, prompt):
+        norm = _norm(prompt)
+        assert "UPSTREAM RESOLUTION (registry enrichment)" in norm
+        assert "resolve_sbom_upstreams" in prompt
+        # One batched call, not one call per component.
+        assert "ONCE, batched" in norm
+
+    def test_resolution_is_conservative(self, prompt):
+        norm = _norm(prompt)
+        assert (
+            "when — and only when — a registry entry matches both name "
+            "AND version" in norm
+        )
+        assert "NEVER fabricate a resolution" in norm
+
+    def test_resolved_repo_feeds_osv_git_not_a_new_source(self, prompt):
+        """Enrichment feeds the existing osv_git source: tag candidates
+        are still resolved to a commit with git ls-remote before OSV."""
+        norm = _norm(prompt)
+        assert (
+            "Treat a resolved repository_url exactly like an enriched vcs_url" in norm
+        )
+        assert "ref_candidates" in prompt
+
+    def test_provenance_counts_in_contract(self, prompt):
+        assert "upstream_resolution" in prompt
+        for fld in (
+            '"attempted"',
+            '"vcs_url_present"',
+            '"registry_resolved"',
+            '"unresolved"',
+            '"registry_status"',
+        ):
+            assert fld in prompt, f"missing upstream_resolution field {fld}"
+
+    def test_unresolved_is_first_class_and_degradation_honest(self, prompt):
+        norm = _norm(prompt)
+        assert "unresolved is a first-class outcome" in norm
+        assert (
+            "the affected components stay blind and the failure is "
+            "recorded in checks" in norm
+        )
+
+
 class TestReleaseAuditWaivers:
     """Waivers: the governed alternative to verdict upgrades. Human-authored
     inputs, deterministic application, verbatim echo, fail-closed defaults."""
@@ -578,9 +642,12 @@ class TestReleaseAuditWaivers:
             "waives nothing" in norm
         )
 
-    def test_ask_user_is_the_sole_allowlist_exception(self, prompt):
+    def test_ask_user_is_the_sole_question_channel(self, prompt):
+        """The allowlist carries exactly two read-only builtins; ask_user
+        remains the only question/approval channel among them."""
         norm = _norm(prompt)
-        assert "SOLE exception to the otherwise-empty allowlist" in norm
+        assert "carries exactly two read-only platform tools" in norm
+        assert "SOLE question channel on the allowlist" in norm
         assert "not a write tool" in norm
         assert "captures the approver's identity" in norm
         assert "Non-interactive runs (the default) NEVER call ask_user" in norm

--- a/docs/guide/flows/security-audit-presets.md
+++ b/docs/guide/flows/security-audit-presets.md
@@ -41,7 +41,10 @@ Every `result.json` and every markdown evidence file carries this line:
 
 The audit presets follow the Observe / Eval pattern: no write tools
 (except `ask_user` on the release audit for optional interactive waivers,
-and `request_approval` on due diligence); deterministic checks separated
+and `request_approval` on due diligence; the exploit check and release
+audit additionally carry the read-only `resolve_sbom_upstreams` registry
+lookup that enriches vendored Arduino/PlatformIO components for `osv_git`
+screening); deterministic checks separated
 from agent judgment (`checks[]` vs `assessments[]`); and the disclaimer
 above on every artifact.
 
@@ -478,6 +481,14 @@ uses the built-in `ask_user` channel once, batched; timeout fails closed.
 Heuristic sources stay labeled and never enter the severity gate.
 `pkg:generic` and `pkg:github` are not db-resolvable by purl; they may
 still be screenable on `osv_git` when a `vcs_url` qualifier is present.
+Vendored Arduino/PlatformIO components without a `vcs_url` are first
+resolved through the built-in `resolve_sbom_upstreams` tool (public
+Arduino library index + PlatformIO registry, read-only): a resolution
+requires a registry-confirmed name+version match and is never
+fabricated. Resolution provenance is reported per SBOM in the additive
+nullable `inventory.upstream_resolution` block (`registry_resolved` /
+`vcs_url_present` / `unresolved`); unreachable registries leave the
+affected components blind and recorded, never guessed.
 
 When a repository is attached, the gap-register phase installs and
 runs **gitleaks** (recommended pin 8.24.3, git mode, full history,


### PR DESCRIPTION
## Summary
- New `sbom_upstream_resolver` service: resolves vendored Arduino/PlatformIO components (generic purls without `vcs_url`) to upstream repository URLs and tag candidates via the Arduino library index (primary, full version history, 24h in-memory cache) and the PlatformIO registry (fallback, truncated version list honored, never guessed past).
- Exposed as `resolve_sbom_upstreams`: a read-only, default-disabled, approval-gated builtin MCP tool, allowlisted on presets 005/006 only.
- Presets 005/006 gain an upstream-resolution step feeding the existing `osv_git` screening; the "never guess a commit" contract is unchanged (the tool emits tag candidates, the preset still pins commits via `git ls-remote`).
- Additive nullable `inventory.upstream_resolution` result block (attempted / vcs_url_present / registry_resolved / unresolved / registry_status) so every run reports its real resolution rate. Unresolved and unreachable-registry outcomes are first-class, never fabricated.

## Why
Embedded-firmware SBOMs are dominated by vendored libraries no CVE database indexes by package name. In a real run, upstream-repo screening reached 18 of 139 components; this closes that gap for registry-published libraries.

## Test plan
- [x] 262 tests pass across touched areas (resolver unit tests with mocked registries, MCP registration, tools endpoint, preset invariants, result contract)
- [x] ruff / mypy / pre-commit clean on touched files
- [x] Live smoke: JPEGDEC@1.2.8 resolves Arduino index -> repo URL -> tag -> pinned commit (full osv_git chain); unknown lib and impossible version stay honestly unresolved
- [ ] Staging: verify egress to downloads.arduino.cc and api.registry.platformio.org, then one run of preset 005 against a real SBOM to read the measured resolution rate

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Additive, default-disabled, approval-gated, read-only change with no CRITICAL/HIGH findings; only minor test-coverage, robustness, performance, and changelog suggestions.
>
> **Overview**
> Adds a `sbom_upstream_resolver` service and a default-disabled `resolve_sbom_upstreams` builtin MCP tool that enriches vendored Arduino/PlatformIO SBOM components for the existing `osv_git` screening in presets 005/006, honoring a strict "never fabricate / never guess a commit" honesty contract.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit ee5c1bbe. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->