### PR TITLE
One-minute verdict cover on all audit and review presets

### DIFF
--- a/backend/presets/004-sbom-verify.yaml
+++ b/backend/presets/004-sbom-verify.yaml
@@ -86,9 +86,34 @@ prompt_template: |
   PHASE 2: EVIDENCE PACK
   ═══════════════════════════════════════════════════════════
   Write to /workspace/evidence/:
-  - audit-report.md — human-readable audit: what SBOM was verified,
-    against which build evidence, with which tools/versions, every check
-    with its outcome, and the findings register.
+  - audit-report.md — human-readable audit. It MUST OPEN with a
+    one-page cover for a non-AI reader, at the TOP of the report,
+    before any table or finding list. Verdict sentence first: one
+    sentence stating the run's verdict (the same value written to
+    result.json) and the blocking reason if the verdict is fail. Then
+    three clearly labelled boxes, in this order:
+      BOX 1 — "What we checked". List the SBOM actually delivered and
+      the deterministic checks that ran (format validity, minimum
+      elements, coverage quality, build cross-check, license flags).
+      Derive this from inputs_declared and checks[]. No aggregate
+      claim the checks do not support.
+      BOX 2 — "What we did NOT check". Mandatory. May not be empty if
+      anything was out of scope, skipped, or not delivered. List
+      skipped build cross-check when no manifests were delivered,
+      license policy not applied when no policy file was delivered,
+      and vulnerability matching (belongs to SBOM Exploit Check /
+      Release Security Audit).
+      BOX 3 — "What you should do next week". A short, concrete,
+      ordered list of the highest-value SBOM completeness, identifier,
+      and license fixes implied by the findings. No legal advice, no
+      certification.
+    HONESTY RAIL. The cover may only summarize findings, checks,
+    coverage, and out-of-scope items already present in the body of
+    this report or the other evidence files. No new claims. Strictly
+    one page.
+    After the cover: what SBOM was verified, against which build
+    evidence, with which tools/versions, every check with its
+    outcome, and the findings register.
   - findings.json — the full machine-readable findings list (no size
     limit here; result.json stays small and references this file).
   Every evidence file must end with the line:

--- a/backend/presets/005-sbom-exploit-check.yaml
+++ b/backend/presets/005-sbom-exploit-check.yaml
@@ -164,12 +164,38 @@ prompt_template: |
   - findings.json — full machine-readable findings (all of them).
   - source-matrix.json — the full component x source screening matrix
     with the per-source negative controls.
-  - vuln-report.md — human-readable report: inventory size, PER-SOURCE
-    match coverage derived from the screening matrix (one line per
-    source: screened N of total, control passed or BLIND), sources
-    queried with snapshot dates/timestamps, findings by severity with
-    heuristic hits labeled, KEV hits called out, VEX suppressions echoed
-    with their justification, gate outcome.
+  - vuln-report.md — human-readable report. It MUST OPEN with a
+    one-page cover for a non-AI reader, at the TOP of the report,
+    before any table or finding list. Verdict sentence first: one
+    sentence stating the run's verdict (the same status and
+    gate.passed written to result.json) and the blocking reason if
+    the gate failed. Then three clearly labelled boxes, in this
+    order:
+      BOX 1 — "What we checked". List the SBOM actually delivered,
+      sources queried with snapshot dates, and per-source screening
+      from the matrix (one line per source: screened N of total,
+      control passed or BLIND). No aggregate coverage claim the
+      matrix does not support.
+      BOX 2 — "What we did NOT check". Mandatory. May not be empty if
+      anything was out of scope, not screened, or skipped. Include
+      unscreened components by count
+      (source_matrix.screened_by_no_source), unmatchable components
+      by count, and every source whose negative control came back
+      blind. Skipped NVD or EPSS when unused or unreachable.
+      BOX 3 — "What you should do next week". A short, concrete,
+      ordered list of the highest-value fixes implied by KEV and
+      high/critical database-match findings. No legal advice, no
+      Article 14 filing, no certification.
+    HONESTY RAIL. The cover may only summarize findings, the source
+    matrix, gate outcome, and out-of-scope items already present in
+    the body of this report or the other evidence files. No new
+    claims. Strictly one page.
+    After the cover: inventory size, PER-SOURCE match coverage
+    derived from the screening matrix (one line per source: screened
+    N of total, control passed or BLIND), sources queried with
+    snapshot dates/timestamps, findings by severity with heuristic
+    hits labeled, KEV hits called out, VEX suppressions echoed with
+    their justification, gate outcome.
   Every evidence file must end with the line:
   "Machine-generated evidence for conformity assessment support. Not a
   conformity assessment, certification, or legal advice."

--- a/backend/presets/006-release-security-audit.yaml
+++ b/backend/presets/006-release-security-audit.yaml
@@ -585,8 +585,11 @@ prompt_template: |
   ═══════════════════════════════════════════════════════════
   Write a compliance-folder-ready pack to /workspace/evidence/:
   - audit-report.md — the combined human-readable audit. It MUST OPEN
-    with a one-page cover for a non-AI reader: three clearly labelled
-    boxes, in this order, before any table or finding list.
+    with a one-page cover for a non-AI reader. Verdict sentence first:
+    one sentence stating the run's verdict (the same value written to
+    result.json) and the blocking reason if the verdict is fail. Then
+    three clearly labelled boxes, in this order, before any table or
+    finding list.
       BOX 1 — "What we checked". List the inputs actually delivered and
       the classes actually screened. The screening coverage statement
       DERIVES FROM THE PER-SOURCE MATRIX: one line per source, in

--- a/backend/presets/007-component-due-diligence.yaml
+++ b/backend/presets/007-component-due-diligence.yaml
@@ -93,11 +93,32 @@ prompt_template: |
   PHASE 2: DOSSIER
   ═══════════════════════════════════════════════════════════
   Write the evidence pack to /workspace/evidence/:
-  - dossier.md — human-readable due-diligence dossier: component
-    identity and usage context; documents examined; CVE history with
-    KEV callouts; maintenance signals; CE declaration presence; license;
-    and an explicit OPEN UNKNOWNS section listing what could not be
-    determined and why.
+  - dossier.md — human-readable due-diligence dossier. It MUST OPEN
+    with a one-page cover for a non-AI reader, at the TOP of the
+    report, before any table or finding list. Verdict sentence first:
+    one sentence stating the run's verdict (the same value written to
+    result.json) and the blocking reason if the verdict is error.
+    Then three clearly labelled boxes, in this order:
+      BOX 1 — "What we checked". List the component identity, documents
+      actually examined, CVE/KEV query that ran, maintenance signals
+      retrieved, CE declaration presence check, and license facts.
+      Derive this from inputs_declared and evidence.docs_examined.
+      BOX 2 — "What we did NOT check". Mandatory. May not be empty if
+      anything was out of scope or not determined. List the OPEN
+      UNKNOWNS (what could not be determined and why), documents not
+      retrieved, and CVE history that was unmatchable. CE authenticity
+      is never verified.
+      BOX 3 — "What you should do next week". A short, concrete,
+      ordered list of the highest-value unknowns a human should close.
+      Present facts; do NOT recommend accept or reject. No legal
+      advice, no certification.
+    HONESTY RAIL. The cover may only summarize facts, open unknowns,
+    and out-of-scope items already present in the body of this
+    dossier or facts.json. No new claims. Strictly one page.
+    After the cover: component identity and usage context; documents
+    examined; CVE history with KEV callouts; maintenance signals; CE
+    declaration presence; license; and an explicit OPEN UNKNOWNS
+    section listing what could not be determined and why.
   - facts.json — the same facts machine-readable.
   Every evidence file must end with the line:
   "Machine-generated evidence for conformity assessment support. Not a

--- a/backend/presets/008-architecture-strategy-review.yaml
+++ b/backend/presets/008-architecture-strategy-review.yaml
@@ -189,10 +189,36 @@ prompt_template: |
   PHASE 5: EVIDENCE PACK
   ═══════════════════════════════════════════════════════════
   Write to /workspace/evidence/:
-  - architecture-review.md: the human-readable review. What was
-    declared and where; the observed architecture (from the inventory
-    and opened files); the conformance register; drift findings by
-    severity; coverage statement; drift vs baseline when present.
+  - architecture-review.md: the human-readable review. It MUST OPEN
+    with a one-page cover for a non-AI reader, at the TOP of the
+    report, before any table or finding list. Verdict sentence first:
+    one sentence stating the run's verdict (the same value written to
+    result.json) and the blocking reason if the verdict is fail. Then
+    three clearly labelled boxes, in this order:
+      BOX 1 — "What we checked". List the intent sources actually read,
+      the declarations extracted, the sampling plan, and the modules
+      and files opened. Derive this from inputs_declared,
+      intent.sources, and coverage. No aggregate claim the coverage
+      block does not support.
+      BOX 2 — "What we did NOT check". Mandatory. May not be empty if
+      anything was out of scope, not reviewed, not_checkable, deferred,
+      or skipped. List modules and paths in coverage.not_reviewed,
+      register not_checkable rows, skipped drift when no baseline was
+      delivered, and intent sources that were not found. Security is
+      out of scope on this preset, so this box always names the
+      Release Security Audit family at minimum.
+      BOX 3 — "What you should do next week". A short, concrete,
+      ordered list of the highest-value conformance fixes implied by
+      open drift findings and gap/partial register rows. No legal
+      advice, no certification.
+    HONESTY RAIL. The cover may only summarize findings, register rows,
+    coverage, and out-of-scope items already present in the body of
+    this report or the other evidence files. No new claims. Strictly
+    one page.
+    After the cover: what was declared and where; the observed
+    architecture (from the inventory and opened files); the
+    conformance register; drift findings by severity; coverage
+    statement; drift vs baseline when present.
   - conformance-register.md: every declaration with status, both
     pointers, and the required not_checkable list.
   - findings.json: the machine-readable drift findings ledger.

--- a/backend/presets/009-repo-code-health-review.yaml
+++ b/backend/presets/009-repo-code-health-review.yaml
@@ -178,9 +178,36 @@ prompt_template: |
   PHASE 6: EVIDENCE PACK AND REPORT (MANDATORY)
   ═══════════════════════════════════════════════════════════
   Write to /workspace/evidence/:
-  - code-health-report.md: human-readable review; module map; findings
-    by severity with pointers and snippets; the health register; the
-    coverage statement; drift when a baseline exists.
+  - code-health-report.md: human-readable review. It MUST OPEN with a
+    one-page cover for a non-AI reader, at the TOP of the report,
+    before any table or finding list. Verdict sentence first: one
+    sentence stating the run's verdict (the same value written to
+    result.json) and the blocking reason if the verdict is fail. Then
+    three clearly labelled boxes, in this order:
+      BOX 1 — "What we checked". List the five lenses applied, the
+      sampling plan, modules and files opened, and any project tests
+      actually run. Derive this from inputs_declared, the health
+      register, and coverage. No aggregate claim the coverage block
+      does not support. Never present test shape as a measured
+      coverage percentage.
+      BOX 2 — "What we did NOT check". Mandatory. May not be empty if
+      anything was out of scope, not reviewed, not_checkable, deferred,
+      or skipped. List modules and paths in coverage.not_reviewed,
+      register not_checkable rows, skipped drift when no baseline was
+      delivered, excluded paths, and lenses not applied to a module
+      because of budget. Security is out of scope on this preset, so
+      this box always names the Release Security Audit family at
+      minimum.
+      BOX 3 — "What you should do next week". A short, concrete,
+      ordered list of the highest-value health fixes implied by open
+      findings, correctness first. No legal advice, no certification.
+    HONESTY RAIL. The cover may only summarize findings, register rows,
+    coverage, and out-of-scope items already present in the body of
+    this report or the other evidence files. No new claims. Strictly
+    one page.
+    After the cover: module map; findings by severity with pointers
+    and snippets; the health register; the coverage statement; drift
+    when a baseline exists.
   - health-register.md: the PHASE 4 register plus not_checkable list.
   - findings.json: the machine-readable findings ledger.
   - drift-report.md: only when a baseline was delivered.

--- a/backend/presets/010-standards-compliance-walk.yaml
+++ b/backend/presets/010-standards-compliance-walk.yaml
@@ -156,9 +156,34 @@ prompt_template: |
   PHASE 5: EVIDENCE PACK AND REPORT (MANDATORY)
   ═══════════════════════════════════════════════════════════
   Write to /workspace/evidence/:
-  - standards-report.md: human-readable walk; which standards were
-    delivered and how; the requirement register grouped by standard;
-    gaps first; the coverage statement; drift when a baseline exists.
+  - standards-report.md: human-readable walk. It MUST OPEN with a
+    one-page cover for a non-AI reader, at the TOP of the report,
+    before any table or finding list. Verdict sentence first: one
+    sentence stating the run's verdict (the same value written to
+    result.json) and the blocking reason if the verdict is fail. Then
+    three clearly labelled boxes, in this order:
+      BOX 1 — "What we checked". List the standards actually delivered
+      and walked, requirement counts by obligation, and the full-repo
+      searches recorded. Derive this from inputs_declared, standards[],
+      and coverage. No aggregate claim the coverage block does not
+      support.
+      BOX 2 — "What we did NOT check". Mandatory. May not be empty if
+      anything was out of scope, not reviewed, not_checkable, deferred,
+      or skipped. List undelivered standards, not_checkable
+      requirements, covered_elsewhere security rows, sampling-budget
+      items, and skipped drift when no baseline was delivered.
+      Security is out of scope on this preset, so this box always
+      names the Release Security Audit family at minimum.
+      BOX 3 — "What you should do next week". A short, concrete,
+      ordered list of the highest-value fixes implied by the register,
+      mandatory gaps first. No legal advice, no certification.
+    HONESTY RAIL. The cover may only summarize findings, register rows,
+    coverage, and out-of-scope items already present in the body of
+    this report or the other evidence files. No new claims. Strictly
+    one page.
+    After the cover: which standards were delivered and how; the
+    requirement register grouped by standard; gaps first; the coverage
+    statement; drift when a baseline exists.
   - requirements-register.md: every requirement row with status,
     obligation, evidence basis, and the required not_checkable list.
   - findings.json: machine-readable rows (the register in JSON).

--- a/backend/tests/test_component_due_diligence_preset.py
+++ b/backend/tests/test_component_due_diligence_preset.py
@@ -128,6 +128,27 @@ class TestHonestLegwork:
         assert "OPEN UNKNOWNS" in norm
         assert 'an honest "not determined" is evidence' in norm
 
+    def test_one_page_verdict_cover(self, preset):
+        """dossier.md opens with the same three-box cover as 004-006."""
+        prompt = preset["prompt_template"]
+        norm = _norm(prompt)
+        assert "dossier.md" in prompt
+        assert "MUST OPEN" in prompt
+        assert "one-page cover" in prompt
+        assert "Verdict sentence first" in prompt
+        assert "the same value written to result.json" in norm
+        for box in (
+            'BOX 1 — "What we checked"',
+            'BOX 2 — "What we did NOT check"',
+            'BOX 3 — "What you should do next week"',
+        ):
+            assert box in prompt, f"missing cover box: {box}"
+        assert "OPEN UNKNOWNS" in prompt
+        assert "do NOT recommend accept or reject" in norm
+        assert "HONESTY RAIL" in prompt
+        assert "may only summarize" in norm
+        assert "Strictly one page" in norm
+
 
 class TestRecordStorage:
     def test_record_lands_in_compliance_repo(self, preset):

--- a/backend/tests/test_repo_review_presets.py
+++ b/backend/tests/test_repo_review_presets.py
@@ -247,6 +247,39 @@ class TestRepoReviewPresetInvariants:
         assert "under 200 KB" in norm
         assert "null rather than inventing values" in norm
 
+    def test_one_page_verdict_cover(self, preset):
+        """Human report opens with the same three-box cover 006 uses.
+
+        Additive: the machine result.json contract is unchanged. The
+        cover may only summarize the body; BOX 2 is mandatory whenever
+        anything was out of scope (security always is).
+        """
+        name, data = preset
+        prompt = data["prompt_template"]
+        norm = _norm(prompt)
+        report_file = {
+            "Architecture and Strategy Conformance Review": ("architecture-review.md"),
+            "Full Repo Code Health Review": "code-health-report.md",
+            "Standards Compliance Walk": "standards-report.md",
+        }[name]
+        assert report_file in prompt
+        assert "MUST OPEN" in prompt
+        assert "one-page cover" in prompt
+        assert "at the TOP of the report" in norm
+        assert "Verdict sentence first" in prompt
+        for box in (
+            'BOX 1 — "What we checked"',
+            'BOX 2 — "What we did NOT check"',
+            'BOX 3 — "What you should do next week"',
+        ):
+            assert box in prompt, f"missing cover box: {box}"
+        assert "HONESTY RAIL" in prompt
+        assert "may only summarize" in norm
+        assert "No new claims" in prompt
+        assert "May not be empty if anything was out of scope" in norm
+        assert "Strictly one page" in norm
+        assert "Release Security Audit family at minimum" in norm
+
 
 class TestArchitectureStrategyReviewPreset:
     @pytest.fixture()
@@ -304,6 +337,12 @@ class TestArchitectureStrategyReviewPreset:
         norm = _norm(prompt)
         assert "goes ONLY in assessments" in norm
 
+    def test_cover_box1_is_intent_and_sampling(self, prompt):
+        """BOX 1 is adapted to declared intent vs observed structure."""
+        norm = _norm(prompt)
+        assert "intent sources actually read" in norm
+        assert "declarations extracted" in norm
+
 
 class TestRepoCodeHealthReviewPreset:
     @pytest.fixture()
@@ -355,6 +394,12 @@ class TestRepoCodeHealthReviewPreset:
             'fail" if any open high-severity correctness finding exists OR '
             "freeze_floor_passed is false" in norm
         )
+
+    def test_cover_box1_is_lenses_and_sampling(self, prompt):
+        """BOX 1 is adapted to the five health lenses."""
+        norm = _norm(prompt)
+        assert "five lenses applied" in norm
+        assert "correctness first" in norm
 
 
 class TestStandardsComplianceWalkPreset:
@@ -410,6 +455,12 @@ class TestStandardsComplianceWalkPreset:
     def test_mandatory_gap_blocks_the_verdict(self, prompt):
         norm = _norm(prompt)
         assert 'fail" if any MANDATORY requirement is gap' in norm
+
+    def test_cover_box1_is_standards_delivered(self, prompt):
+        """BOX 1 is adapted to the named-standards walk."""
+        norm = _norm(prompt)
+        assert "standards actually delivered" in norm
+        assert "mandatory gaps first" in norm
 
 
 class TestPresetsLoadThroughLoader:

--- a/backend/tests/test_security_audit_presets.py
+++ b/backend/tests/test_security_audit_presets.py
@@ -122,6 +122,25 @@ class TestSecurityAuditPresetInvariants:
         if name != "SBOM Exploit Check":
             assert "GENERATE" in prompt
 
+    def test_one_page_verdict_cover(self, preset):
+        """Every 004-006 human report opens with the three-box cover."""
+        name, data = preset
+        prompt = data["prompt_template"]
+        report_file = {
+            "SBOM Verify": "audit-report.md",
+            "SBOM Exploit Check": "vuln-report.md",
+            "Release Security Audit": "audit-report.md",
+        }[name]
+        assert report_file in prompt
+        assert "one-page cover" in prompt
+        assert "Verdict sentence first" in prompt
+        for box in (
+            'BOX 1 — "What we checked"',
+            'BOX 2 — "What we did NOT check"',
+            'BOX 3 — "What you should do next week"',
+        ):
+            assert box in prompt, f"missing cover box: {box}"
+
 
 class TestSbomVerifyPreset:
     def test_deterministic_check_catalogue(self):
@@ -136,6 +155,18 @@ class TestSbomVerifyPreset:
             assert marker in prompt
         # Missing build evidence must be reported as skipped, not guessed.
         assert "skipped: no build evidence delivered" in prompt
+
+    def test_cover_adapted_to_sbom_checks(self):
+        """BOX 1 lists the five deterministic checks; honesty rail holds."""
+        prompt = _load_preset(PRESET_FILES["SBOM Verify"])["prompt_template"]
+        norm = _norm(prompt)
+        assert "MUST OPEN" in prompt
+        assert "the same value written to result.json" in norm
+        assert "format validity, minimum elements, coverage quality" in norm
+        assert "vulnerability matching" in norm
+        assert "HONESTY RAIL" in prompt
+        assert "may only summarize" in norm
+        assert "Strictly one page" in norm
 
 
 class TestSbomExploitCheckPreset:
@@ -161,6 +192,19 @@ class TestSbomExploitCheckPreset:
         assert '"status" is REQUIRED — it is the flow completion signal' in norm
         # Completion is about the scan finishing, not the gate outcome.
         assert "regardless of the gate outcome or findings" in norm
+
+    def test_cover_box2_includes_unscreened_count(self):
+        """BOX 2 must name unscreened components by count from the matrix."""
+        prompt = _load_preset(PRESET_FILES["SBOM Exploit Check"])["prompt_template"]
+        norm = _norm(prompt)
+        assert "MUST OPEN" in prompt
+        assert "gate.passed written to result.json" in norm
+        assert "unscreened components by count" in norm
+        assert "source_matrix.screened_by_no_source" in prompt
+        assert "unmatchable components" in norm
+        assert "HONESTY RAIL" in prompt
+        assert "may only summarize" in norm
+        assert "Strictly one page" in norm
 
 
 class TestReleaseSecurityAuditPreset:
@@ -336,6 +380,8 @@ class TestReleaseAuditEvidenceStorage:
             'BOX 3 — "What you should do next week"',
         ):
             assert box in prompt, f"missing cover box: {box}"
+        assert "Verdict sentence first" in prompt
+        assert "the same value written to result.json" in _norm(prompt)
         assert "DRIFT LINE" in prompt
         assert "NTIA RECONCILIATION LINE" in prompt
 

--- a/docs/guide/flows/repo-review-presets.md
+++ b/docs/guide/flows/repo-review-presets.md
@@ -32,8 +32,9 @@ Compliance Walk marks security rows of a named standard
 `covered_elsewhere: release-security-audit` instead of re-checking them.
 
 **One-minute verdict cover.** Every review report leads with the same
-one-page cover the [Release Security Audit](security-audit-presets.md)
-already requires, so nobody has to write a verdict summary by hand. The
+one-page cover every [audit preset](security-audit-presets.md) requires
+on its human-readable report (`audit-report.md`, `vuln-report.md`,
+`dossier.md`), so nobody has to write a verdict summary by hand. The
 cover sits at the top of `architecture-review.md`,
 `code-health-report.md`, or `standards-report.md`: a verdict sentence
 first, then three labelled boxes (What we checked / What we did not

--- a/docs/guide/flows/repo-review-presets.md
+++ b/docs/guide/flows/repo-review-presets.md
@@ -31,6 +31,19 @@ pointer only, never a secret value — and moves on. The Standards
 Compliance Walk marks security rows of a named standard
 `covered_elsewhere: release-security-audit` instead of re-checking them.
 
+**One-minute verdict cover.** Every review report leads with the same
+one-page cover the [Release Security Audit](security-audit-presets.md)
+already requires, so nobody has to write a verdict summary by hand. The
+cover sits at the top of `architecture-review.md`,
+`code-health-report.md`, or `standards-report.md`: a verdict sentence
+first, then three labelled boxes (What we checked / What we did not
+check / What you should do next week). Strictly one page. The cover may
+only summarize findings already present in the body; the "What we did
+not check" box is mandatory and may not be empty when anything was out
+of scope (security always is, so that box always names the Release
+Security Audit family at minimum). The machine `result.json` contract is
+unchanged.
+
 ## The shared skeleton
 
 All three presets follow the same guarantees:
@@ -75,6 +88,10 @@ All three presets follow the same guarantees:
   rows, `declared` rows, resolved items, and positive prose never raise
   it, and `declared` (a stated commitment the files cannot verify) is
   not a pass. `not_checkable` is required, never empty by assumption.
+- **One-minute verdict cover.** The human-readable report artifact
+  opens with a verdict sentence and the three-box cover described
+  above, before any table or finding list. Additive on top of the
+  existing report body; `result.json` is unchanged.
 - **Evidence envelope.** Same `checks[]` (deterministic facts) vs
   `assessments[]` (marked judgment) split as the Observe/Eval and
   security presets; every artifact carries the line:
@@ -158,11 +175,11 @@ gap fails the run.
   inventory.json               # phase-1 command-only inventory (all three)
   findings.json                # machine-readable findings/register ledger (all three)
   drift-report.md              # only when a baseline was delivered (all three)
-  architecture-review.md       # human-readable review (architecture-strategy)
+  architecture-review.md       # human-readable review; opens with the one-minute cover
   conformance-register.md      # declaration register (architecture-strategy)
-  code-health-report.md        # human-readable review (code health)
+  code-health-report.md        # human-readable review; opens with the one-minute cover
   health-register.md           # per-module register (code health)
-  standards-report.md          # human-readable walk (standards walk)
+  standards-report.md          # human-readable walk; opens with the one-minute cover
   requirements-register.md     # requirement register (standards walk)
 ```
 

--- a/docs/guide/flows/security-audit-presets.md
+++ b/docs/guide/flows/security-audit-presets.md
@@ -45,17 +45,22 @@ and `request_approval` on due diligence); deterministic checks separated
 from agent judgment (`checks[]` vs `assessments[]`); and the disclaimer
 above on every artifact.
 
-**One-minute verdict cover.** Human-readable audit and review reports
-lead with a one-page cover so nobody has to write a verdict summary by
-hand. The Release Security Audit requires this at the top of
-`audit-report.md`. The [full-repo review presets](repo-review-presets.md)
+**One-minute verdict cover.** Every audit and review preset that writes
+a human-readable report leads with a one-page cover so nobody has to
+write a verdict summary by hand. On the audit family that is
+`audit-report.md` (SBOM Verify and Release Security Audit),
+`vuln-report.md` (SBOM Exploit Check), and `dossier.md` (Component Due
+Diligence). The [full-repo review presets](repo-review-presets.md)
 require the same cover on their report artifacts. The cover is a verdict
-sentence first, then three labelled boxes in this order: What we checked /
+sentence first (matching `result.json`; on SBOM Exploit Check that is
+`status` and `gate.passed`, because that schema has no top-level
+`verdict`), then three labelled boxes in this order: What we checked /
 What we did not check / What you should do next week. It is strictly one
 page. The cover may only summarize findings already present in the body;
 the "What we did not check" box is mandatory and may not be empty when
-anything was out of scope. The machine `result.json` contract is
-unchanged.
+anything was out of scope. On SBOM Exploit Check that box includes
+unscreened components by count from the source matrix. The machine
+`result.json` contract is unchanged.
 
 Retrieve the structured result with
 `GET /api/v1/flows/executions/{execution_id}/result`. Download the
@@ -886,15 +891,15 @@ trail is the auditable record.
 
 ```
 /workspace/evidence/
-  audit-report.md      # human-readable audit (all presets); Release Security Audit opens with the one-minute cover
+  audit-report.md      # human-readable audit (004 / 006); opens with the one-minute cover
   findings.json        # full vulnerability findings (exploit check / release audit)
   source-matrix.json   # component x source screening matrix (exploit check / release audit)
   waivers.json          # waiver entries seen (release audit, when any existed)
   sbom-findings.json   # full SBOM verification findings (release audit)
-  vuln-report.md       # human-readable vuln report (exploit check)
+  vuln-report.md       # human-readable vuln report (005); opens with the one-minute cover
   drift-report.md      # delta vs previous run (release audit, when baseline given)
   gap-register.md      # file-presence / hygiene register (release audit, when a repo is attached)
-  dossier.md           # due-diligence dossier (component due diligence)
+  dossier.md           # due-diligence dossier (007); opens with the one-minute cover
   facts.json           # machine-readable due-diligence facts (component due diligence)
 ```
 

--- a/docs/guide/flows/security-audit-presets.md
+++ b/docs/guide/flows/security-audit-presets.md
@@ -45,6 +45,18 @@ and `request_approval` on due diligence); deterministic checks separated
 from agent judgment (`checks[]` vs `assessments[]`); and the disclaimer
 above on every artifact.
 
+**One-minute verdict cover.** Human-readable audit and review reports
+lead with a one-page cover so nobody has to write a verdict summary by
+hand. The Release Security Audit requires this at the top of
+`audit-report.md`. The [full-repo review presets](repo-review-presets.md)
+require the same cover on their report artifacts. The cover is a verdict
+sentence first, then three labelled boxes in this order: What we checked /
+What we did not check / What you should do next week. It is strictly one
+page. The cover may only summarize findings already present in the body;
+the "What we did not check" box is mandatory and may not be empty when
+anything was out of scope. The machine `result.json` contract is
+unchanged.
+
 Retrieve the structured result with
 `GET /api/v1/flows/executions/{execution_id}/result`. Download the
 captured evidence tarball with
@@ -874,7 +886,7 @@ trail is the auditable record.
 
 ```
 /workspace/evidence/
-  audit-report.md      # human-readable audit (all presets)
+  audit-report.md      # human-readable audit (all presets); Release Security Audit opens with the one-minute cover
   findings.json        # full vulnerability findings (exploit check / release audit)
   source-matrix.json   # component x source screening matrix (exploit check / release audit)
   waivers.json          # waiver entries seen (release audit, when any existed)


### PR DESCRIPTION
## Summary
- Every human-readable report from presets 004-010 now opens with a one-page cover for a non-AI reader: a verdict sentence first (matching result.json), then three boxes: What we checked / What we did NOT check / What you should do next week.
- The "not checked" box is mandatory and may not be empty when anything was out of scope; on 005 it must include unscreened component counts from the source matrix; on 007 the next-steps box may not recommend accept/reject.
- Honesty rail in the preset text: the cover may only summarize findings already present in the report body, no new claims, strictly one page.
- Machine result.json contracts unchanged everywhere; docs updated to match.

## Why
Audit packs were readable only by whoever wrote them a verdict summary by hand. Now the deliverable leads with one.

## Test plan
- [x] 294 tests pass (security-audit, due-diligence, repo-review, flow-presets, result-contract suites), covers pinned by new invariants
- [x] pre-commit clean on every commit

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Text-only prompt-template change with matching tests and docs; no machine contract changes, no security surface.
>
> **Overview**
> Adds a one-page verdict cover (verdict sentence + three boxes) to every human-readable report from presets 004-010, with an honesty rail restricting the cover to summarizing existing findings. All cover field references were verified against their result.json schemas.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit fc5d2ab. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->