### PR TITLE
Fix approval waits pinning DB connections for the whole human decision

### DIFF
--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -336,6 +336,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     else:
         logger.info("Skipping execution monitor for %s role.", service_role)
 
+    # Start the DB pool monitor (skip in testing mode): pool gauges plus a
+    # WARNING log when either engine's checked-out connections near the
+    # ceiling, so pool saturation is visible before requests start timing
+    # out. Runs on every role; gated by DB_MONITORING_ENABLED.
+    db_pool_monitor = None
+    if not is_testing:
+        from preloop.services.db_pool_monitor import (
+            db_monitoring_enabled,
+            get_db_pool_monitor,
+        )
+
+        if db_monitoring_enabled():
+            db_pool_monitor = get_db_pool_monitor()
+            await db_pool_monitor.start()
+            logger.info("DB pool monitor started.")
+        else:
+            logger.info("DB pool monitor disabled via DB_MONITORING_ENABLED.")
+
     # Start the optimization-job recovery sweeper (skip in testing mode). It
     # runs one sweep immediately, recovering jobs abandoned by the previous
     # process, then every couple of minutes.
@@ -565,6 +583,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.error(f"Error stopping execution monitor: {e}", exc_info=True)
     else:
         logger.info("Skipping execution monitor shutdown for %s role.", service_role)
+
+    # Stop the DB pool monitor
+    if db_pool_monitor:
+        try:
+            await db_pool_monitor.stop()
+            logger.info("DB pool monitor stopped.")
+        except Exception as e:
+            logger.error(f"Error stopping DB pool monitor: {e}", exc_info=True)
 
     # Cancel the NATS consumer task (skip in testing mode)
     if not is_testing and getattr(app.state, "nats_connected", False):

--- a/backend/preloop/models/db/session.py
+++ b/backend/preloop/models/db/session.py
@@ -131,6 +131,20 @@ def get_engine(database_url: Optional[str] = None):
         raise Exception(f"Database connection failed: {e}")
 
 
+def get_engine_if_initialized() -> Optional[Engine]:
+    """Return the sync engine if one exists, without creating it.
+
+    Used by pool observability, which must never trigger engine creation
+    (a worker role may legitimately never build one of the engines).
+    """
+    return _engine
+
+
+def get_async_engine_if_initialized() -> Optional[AsyncEngine]:
+    """Return the async engine if one exists, without creating it."""
+    return _async_engine
+
+
 def get_session_factory(engine=None):
     """Get or create session factory for database."""
     global _session_factory, _engine

--- a/backend/preloop/services/approval_helper.py
+++ b/backend/preloop/services/approval_helper.py
@@ -123,13 +123,16 @@ async def _deliver_question_in_band(
     tool_name: str,
     arguments: dict,
     account_id: str,
-    approval_request: "models.ApprovalRequest",
+    approval_request_id,
+    expires_at,
     base_url: str,
 ) -> bool:
     """Best-effort in-session delivery of a pending question (issue #130).
 
     Never raises and never blocks the approval flow; remote channels have
-    already been notified when this runs.
+    already been notified when this runs. Takes plain values rather than the
+    ApprovalRequest instance so callers can release their DB session before
+    invoking it.
     """
     try:
         from preloop.services.ask_user_inband import (
@@ -143,20 +146,20 @@ async def _deliver_question_in_band(
             return False
         return await deliver_question_to_session(
             account_id=str(account_id),
-            approval_request_id=approval_request.id,
+            approval_request_id=approval_request_id,
             tool_name=tool_name,
             arguments=arguments,
-            console_url=approval_console_url(base_url, approval_request.id),
-            mobile_link=approval_mobile_deep_link(approval_request.id),
+            console_url=approval_console_url(base_url, approval_request_id),
+            mobile_link=approval_mobile_deep_link(approval_request_id),
             runtime_session_id=session_ctx.runtime_session_id,
             managed_agent_id=session_ctx.managed_agent_id,
             user_id=session_ctx.user_id,
-            expires_at=getattr(approval_request, "expires_at", None),
+            expires_at=expires_at,
         )
     except Exception:
         logger.warning(
             "In-band question delivery failed for approval %s",
-            getattr(approval_request, "id", None),
+            approval_request_id,
             exc_info=True,
         )
         return False
@@ -479,9 +482,34 @@ async def require_approval(
                     rule_context=rule_context,
                 )
 
+                # Extract every value needed past this point into plain
+                # locals, then release this session BEFORE any waiting
+                # starts. A session held across the approval wait pins one
+                # pooled connection per pending approval for up to the
+                # workflow timeout; a handful of concurrent pending
+                # approvals then exhaust the async engine's pool. Keeping
+                # ORM instances alive across the wait is not safe either:
+                # attribute access after a commit can silently re-begin a
+                # transaction on this session.
+                approval_request_id = approval_request.id
+                approval_request_expires_at = approval_request.expires_at
+                resolved_workflow_id = workflow.id
+                workflow_name = workflow.name
+                workflow_approval_type = workflow.approval_type
+                workflow_timeout_seconds = workflow.timeout_seconds or 300
+                workflow_async_enabled = bool(
+                    getattr(workflow, "async_approval_enabled", False)
+                )
+                workflow_approver_user_ids = list(workflow.approver_user_ids or [])
+                workflow_escalation_user_ids = workflow.escalation_user_ids
+                workflow_escalation_team_ids = workflow.escalation_team_ids
+                # The remainder of this function (event logging, in-band
+                # delivery, polling) uses fresh short-lived sessions only.
+                await db.close()
+
                 # Derive notification channel from approval_type
                 notification_channels = (
-                    [workflow.approval_type] if workflow.approval_type else ["manual"]
+                    [workflow_approval_type] if workflow_approval_type else ["manual"]
                 )
                 channels_display = ", ".join(notification_channels)
 
@@ -493,10 +521,10 @@ async def require_approval(
                     f"{'=' * 60}\n"
                     f"Tool: {tool_name}\n"
                     f"Arguments: {redact_for_log(arguments)}\n"
-                    f"Request ID: {approval_request.id}\n"
+                    f"Request ID: {approval_request_id}\n"
                     f"Notification sent via: {channels_display}\n"
-                    f"Approval type: {workflow.approval_type}\n"
-                    f"Timeout: {workflow.timeout_seconds or 300}s\n"
+                    f"Approval type: {workflow_approval_type}\n"
+                    f"Timeout: {workflow_timeout_seconds}s\n"
                     f"Approval URL: [sent via notification]\n"
                     f"{'=' * 60}\n"
                     f"⏳ Waiting for approval (polling every 2s)..."
@@ -511,7 +539,7 @@ async def require_approval(
                     # Record approval request creation
                     event_db.add(
                         ApprovalEventModel(
-                            approval_request_id=approval_request.id,
+                            approval_request_id=approval_request_id,
                             account_id=account_id,
                             event_type="approval_requested",
                             detail=f"Approval request created for tool '{tool_name}'",
@@ -521,7 +549,7 @@ async def require_approval(
                     for channel in notification_channels:
                         event_db.add(
                             ApprovalEventModel(
-                                approval_request_id=approval_request.id,
+                                approval_request_id=approval_request_id,
                                 account_id=account_id,
                                 event_type="notification_sent",
                                 detail=f"Notification sent via {channel}",
@@ -541,14 +569,15 @@ async def require_approval(
                         tool_name=tool_name,
                         arguments=arguments,
                         account_id=account_id,
-                        approval_request=approval_request,
+                        approval_request_id=approval_request_id,
+                        expires_at=approval_request_expires_at,
                         base_url=base_url,
                     )
                     if delivered_in_band:
                         async with get_async_db_session() as event_db:
                             event_db.add(
                                 ApprovalEventModel(
-                                    approval_request_id=approval_request.id,
+                                    approval_request_id=approval_request_id,
                                     account_id=account_id,
                                     event_type="notification_sent",
                                     detail=(
@@ -560,17 +589,17 @@ async def require_approval(
                             await event_db.commit()
 
                 # Check if async approval mode is enabled
-                if getattr(workflow, "async_approval_enabled", False):
+                if workflow_async_enabled:
                     import json
 
                     logger.info(
-                        f"Async approval enabled for workflow '{workflow.name}' - "
+                        f"Async approval enabled for workflow '{workflow_name}' - "
                         f"returning immediately with polling instructions"
                     )
 
                     # Build approver display names
                     approver_display = []
-                    if workflow.approver_user_ids:
+                    if workflow_approver_user_ids:
                         # Try to resolve user emails
                         try:
                             from sqlalchemy import select
@@ -579,17 +608,17 @@ async def require_approval(
                             async with get_async_db_session() as user_db:
                                 users_result = await user_db.execute(
                                     select(User).where(
-                                        User.id.in_(workflow.approver_user_ids)
+                                        User.id.in_(workflow_approver_user_ids)
                                     )
                                 )
                                 for u in users_result.scalars():
                                     approver_display.append(u.email or u.username)
                         except Exception:
                             approver_display = [
-                                str(uid) for uid in workflow.approver_user_ids
+                                str(uid) for uid in workflow_approver_user_ids
                             ]
 
-                    poll_interval = min(15, (workflow.timeout_seconds or 300) // 20)
+                    poll_interval = min(15, workflow_timeout_seconds // 20)
                     poll_interval = max(5, poll_interval)  # At least 5 seconds
 
                     from preloop.services.ask_user_inband import (
@@ -602,27 +631,27 @@ async def require_approval(
                     # authenticated console/mobile session, so they cannot be
                     # used to self-approve (unlike the tokenized approval_url,
                     # which stays notification-only — see NOTE below).
-                    console_url = approval_console_url(base_url, approval_request.id)
-                    mobile_link = approval_mobile_deep_link(approval_request.id)
+                    console_url = approval_console_url(base_url, approval_request_id)
+                    mobile_link = approval_mobile_deep_link(approval_request_id)
 
                     async_response = {
                         "status": "pending_approval",
-                        "request_id": str(approval_request.id),
+                        "request_id": str(approval_request_id),
                         "message": (
-                            f"This tool call triggered approval workflow '{workflow.name}'. "
+                            f"This tool call triggered approval workflow '{workflow_name}'. "
                             f"Approval request has been sent to {', '.join(approver_display) if approver_display else 'configured approvers'} "
                             f"via {channels_display}. "
                             f"If the user is present, show them this link to answer directly: "
                             f"{console_url} (mobile: {mobile_link}). "
-                            f"Poll the approval status by calling get_approval_status(request_id='{approval_request.id}') "
-                            f"every {poll_interval} seconds for up to {workflow.timeout_seconds or 300} seconds. "
+                            f"Poll the approval status by calling get_approval_status(request_id='{approval_request_id}') "
+                            f"every {poll_interval} seconds for up to {workflow_timeout_seconds} seconds. "
                             f"When the status is 'approved', the response will include the tool execution result. "
                             f"When the status is 'declined' or 'expired', stop polling and inform the user."
                         ),
                         "approval_console_url": console_url,
                         "approval_mobile_link": mobile_link,
                         "poll_interval_seconds": poll_interval,
-                        "timeout_seconds": workflow.timeout_seconds or 300,
+                        "timeout_seconds": workflow_timeout_seconds,
                         "channels": notification_channels,
                         # NOTE: the tokenized approval_url stays intentionally
                         # excluded from the agent-visible response. That URL
@@ -654,7 +683,7 @@ async def require_approval(
                         status_message = (
                             f"Approval request sent via {channels_display} — "
                             f"answer at "
-                            f"{approval_console_url(base_url, approval_request.id)}"
+                            f"{approval_console_url(base_url, approval_request_id)}"
                         )
                         # Check if progressToken is available (do not log - sensitive)
                         progress_token = None
@@ -705,20 +734,21 @@ async def require_approval(
                         "❌ No Context available - cannot send progress notifications!"
                     )
 
-                # Polling loop with progress updates
+                # Polling loop with progress updates. Every poll uses a fresh
+                # short-lived session; no session is held across the sleep.
                 poll_interval = 2.0
-                timeout_seconds = workflow.timeout_seconds or 300
+                timeout_seconds = workflow_timeout_seconds
                 elapsed = 0
                 escalation_triggered = False
 
                 # Check if escalation is configured
                 has_escalation = bool(
-                    workflow.escalation_user_ids or workflow.escalation_team_ids
+                    workflow_escalation_user_ids or workflow_escalation_team_ids
                 )
                 logger.info(
                     f"[Polling] Escalation configured: {has_escalation}, "
-                    f"escalation_user_ids={workflow.escalation_user_ids}, "
-                    f"escalation_team_ids={workflow.escalation_team_ids}"
+                    f"escalation_user_ids={workflow_escalation_user_ids}, "
+                    f"escalation_team_ids={workflow_escalation_team_ids}"
                 )
 
                 while True:
@@ -729,7 +759,7 @@ async def require_approval(
 
                     async with get_async_db_session() as poll_db:
                         current_request = await get_approval_request_async(
-                            poll_db, request_id=approval_request.id
+                            poll_db, request_id=approval_request_id
                         )
                         # Extract needed fields before session closes to avoid DetachedInstanceError
                         current_status = (
@@ -779,7 +809,7 @@ async def require_approval(
                     if not current_request:
                         return (
                             False,
-                            f"Error: Approval request {approval_request.id} not found",
+                            f"Error: Approval request {approval_request_id} not found",
                         )
 
                     # Check if resolved
@@ -790,7 +820,7 @@ async def require_approval(
                         final_status = current_status
                         final_comment = current_comment
                         _set_last_approval_meta(
-                            approval_request.id,
+                            approval_request_id,
                             current_status,
                             resolved_at=current_resolved_at,
                             responded_by=current_responded_by,
@@ -812,13 +842,13 @@ async def require_approval(
                                 # Lock the row and check if already escalated
                                 fresh_request = (
                                     await get_approval_request_for_update_async(
-                                        escalation_db, request_id=approval_request.id
+                                        escalation_db, request_id=approval_request_id
                                     )
                                 )
 
                                 if not fresh_request:
                                     logger.warning(
-                                        f"[Polling] Request {approval_request.id} not found during escalation"
+                                        f"[Polling] Request {approval_request_id} not found during escalation"
                                     )
                                     escalation_triggered = True
                                     continue
@@ -835,7 +865,7 @@ async def require_approval(
                                     continue
 
                                 logger.info(
-                                    f"[Polling] Initial timeout reached, triggering escalation for request {approval_request.id}"
+                                    f"[Polling] Initial timeout reached, triggering escalation for request {approval_request_id}"
                                 )
                                 escalation_triggered = True
 
@@ -853,9 +883,17 @@ async def require_approval(
                                     escalation_db, base_url
                                 )
 
+                                # Re-fetch the workflow in this session rather
+                                # than reusing an instance loaded before the
+                                # wait started.
+                                escalation_workflow = await get_approval_workflow_async(
+                                    escalation_db,
+                                    workflow_id=resolved_workflow_id,
+                                )
+
                                 # Send escalation notifications
                                 await escalation_service._send_escalation_notifications(
-                                    fresh_request, workflow
+                                    fresh_request, escalation_workflow
                                 )
 
                                 # Broadcast escalation event
@@ -913,10 +951,10 @@ async def require_approval(
                             async with get_async_db_session() as update_db:
                                 update_service = ApprovalService(update_db, base_url)
                                 await update_service.update_approval_request(
-                                    approval_request.id,
+                                    approval_request_id,
                                     ApprovalRequestUpdate(status="expired"),
                                 )
-                            _set_last_approval_meta(approval_request.id, "expired")
+                            _set_last_approval_meta(approval_request_id, "expired")
                             return (
                                 False,
                                 f"Approval timeout: request expired after {timeout_seconds}s",
@@ -944,10 +982,10 @@ async def require_approval(
                         async with get_async_db_session() as update_db:
                             update_service = ApprovalService(update_db, base_url)
                             await update_service.update_approval_request(
-                                approval_request.id,
+                                approval_request_id,
                                 ApprovalRequestUpdate(status="expired"),
                             )
-                        _set_last_approval_meta(approval_request.id, "expired")
+                        _set_last_approval_meta(approval_request_id, "expired")
                         return (
                             False,
                             f"Approval timeout: request expired after {total_timeout}s (including escalation)",

--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -2975,7 +2975,10 @@ class ApprovalService:
             poll_interval: How often to poll (seconds)
 
         Returns:
-            Final approval request
+            Final approval request. The instance is detached from the
+            per-poll session that loaded it; callers may read preloaded
+            scalar columns only. Accessing lazy relationships raises
+            DetachedInstanceError.
 
         Raises:
             TimeoutError: If request expires before being resolved (after escalation if configured)

--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -2963,6 +2963,13 @@ class ApprovalService:
         expired, or cancelled. If escalation is configured and the request
         expires, escalation will be triggered and the timeout extended.
 
+        Every poll runs in its own short-lived session; ``self.db`` is never
+        touched while waiting. A session held across the human decision (up
+        to the workflow timeout) pins one pooled connection per pending
+        approval and exhausts the async pool under concurrent approvals, so
+        callers may release the session this service was constructed with
+        before awaiting this method.
+
         Args:
             request_id: Approval request ID
             poll_interval: How often to poll (seconds)
@@ -2973,106 +2980,111 @@ class ApprovalService:
         Raises:
             TimeoutError: If request expires before being resolved (after escalation if configured)
         """
+        from preloop.models.db.session import get_async_db_session
+
         while True:
-            approval_request = await self.get_approval_request(request_id)
-            if not approval_request:
-                raise ValueError(f"Approval request {request_id} not found")
+            async with get_async_db_session() as poll_db:
+                poll_service = ApprovalService(poll_db, self.base_url)
+                approval_request = await poll_service.get_approval_request(request_id)
+                if not approval_request:
+                    raise ValueError(f"Approval request {request_id} not found")
 
-            # Check if resolved
-            if approval_request.status in ["approved", "declined", "cancelled"]:
-                return approval_request
+                # Check if resolved
+                if approval_request.status in ["approved", "declined", "cancelled"]:
+                    return approval_request
 
-            # Check if expired
-            if (
-                approval_request.expires_at
-                and datetime.utcnow() > approval_request.expires_at
-            ):
-                # Get the approval workflow to check for escalation configuration
-                approval_workflow = approval_request.approval_workflow
+                # Check if expired
+                if (
+                    approval_request.expires_at
+                    and datetime.utcnow() > approval_request.expires_at
+                ):
+                    # Get the approval workflow to check for escalation configuration
+                    approval_workflow = approval_request.approval_workflow
 
-                # Debug logging for escalation check
-                logger.info(
-                    f"Checking escalation for request {request_id}: "
-                    f"approval_workflow={approval_workflow}, "
-                    f"approval_workflow_id={approval_request.approval_workflow_id}, "
-                    f"escalation_user_ids={getattr(approval_workflow, 'escalation_user_ids', None) if approval_workflow else None}, "
-                    f"escalation_team_ids={getattr(approval_workflow, 'escalation_team_ids', None) if approval_workflow else None}, "
-                    f"escalation_triggered_at={approval_request.escalation_triggered_at}"
-                )
-
-                # Check if escalation is configured and hasn't been triggered yet
-                has_escalation = approval_workflow and (
-                    approval_workflow.escalation_user_ids
-                    or approval_workflow.escalation_team_ids
-                )
-                escalation_already_triggered = (
-                    approval_request.escalation_triggered_at is not None
-                )
-
-                logger.info(
-                    f"Escalation decision for request {request_id}: "
-                    f"has_escalation={has_escalation}, "
-                    f"escalation_already_triggered={escalation_already_triggered}"
-                )
-
-                if has_escalation and not escalation_already_triggered:
-                    # Trigger escalation
+                    # Debug logging for escalation check
                     logger.info(
-                        f"Triggering escalation for approval request {request_id}"
+                        f"Checking escalation for request {request_id}: "
+                        f"approval_workflow={approval_workflow}, "
+                        f"approval_workflow_id={approval_request.approval_workflow_id}, "
+                        f"escalation_user_ids={getattr(approval_workflow, 'escalation_user_ids', None) if approval_workflow else None}, "
+                        f"escalation_team_ids={getattr(approval_workflow, 'escalation_team_ids', None) if approval_workflow else None}, "
+                        f"escalation_triggered_at={approval_request.escalation_triggered_at}"
                     )
 
-                    # Mark escalation as triggered
-                    approval_request.escalation_triggered_at = datetime.utcnow()
-
-                    # Extend the timeout - give escalation recipients the same amount of time
-                    original_timeout = approval_workflow.timeout_seconds or 300
-                    new_expires_at = datetime.utcnow() + timedelta(
-                        seconds=original_timeout
+                    # Check if escalation is configured and hasn't been triggered yet
+                    has_escalation = approval_workflow and (
+                        approval_workflow.escalation_user_ids
+                        or approval_workflow.escalation_team_ids
                     )
-                    approval_request.expires_at = new_expires_at
-
-                    await self.db.commit()
-                    await self.db.refresh(approval_request)
-
-                    # Send escalation notifications
-                    await self._send_escalation_notifications(
-                        approval_request, approval_workflow
+                    escalation_already_triggered = (
+                        approval_request.escalation_triggered_at is not None
                     )
 
-                    # Broadcast escalation event
-                    await self._broadcast_approval_update(
-                        approval_request,
-                        "escalated",
-                        extra_data={"new_expires_at": new_expires_at.isoformat()},
+                    logger.info(
+                        f"Escalation decision for request {request_id}: "
+                        f"has_escalation={has_escalation}, "
+                        f"escalation_already_triggered={escalation_already_triggered}"
                     )
 
-                    # Continue polling - don't expire yet
-                    await asyncio.sleep(poll_interval)
-                    continue
+                    if has_escalation and not escalation_already_triggered:
+                        # Trigger escalation
+                        logger.info(
+                            f"Triggering escalation for approval request {request_id}"
+                        )
 
-                # No escalation configured or already escalated - expire the request
-                expired_request = await self.update_approval_request(
-                    request_id, ApprovalRequestUpdate(status="expired")
-                )
-                # Broadcast expiration event
-                if expired_request:
-                    await self._broadcast_approval_update(expired_request, "expired")
+                        # Mark escalation as triggered
+                        approval_request.escalation_triggered_at = datetime.utcnow()
 
-                    # Log to audit trail (fire-and-forget)
-                    _log_approval_lifecycle_async(
-                        account_id=str(expired_request.account_id),
-                        approval_id=expired_request.id,
-                        event="expired",
-                        tool_name=expired_request.tool_name,
-                        reason="Request timed out without response",
-                        execution_id=expired_request.execution_id,
-                    )
+                        # Extend the timeout - give escalation recipients the same amount of time
+                        original_timeout = approval_workflow.timeout_seconds or 300
+                        new_expires_at = datetime.utcnow() + timedelta(
+                            seconds=original_timeout
+                        )
+                        approval_request.expires_at = new_expires_at
 
-                raise TimeoutError(
-                    f"Approval request {request_id} expired without response"
-                )
+                        await poll_db.commit()
+                        await poll_db.refresh(approval_request)
 
-            # Wait before polling again
+                        # Send escalation notifications
+                        await poll_service._send_escalation_notifications(
+                            approval_request, approval_workflow
+                        )
+
+                        # Broadcast escalation event
+                        await poll_service._broadcast_approval_update(
+                            approval_request,
+                            "escalated",
+                            extra_data={"new_expires_at": new_expires_at.isoformat()},
+                        )
+
+                        # Continue polling - don't expire yet (the shared
+                        # sleep below runs with the session already closed)
+                    else:
+                        # No escalation configured or already escalated - expire the request
+                        expired_request = await poll_service.update_approval_request(
+                            request_id, ApprovalRequestUpdate(status="expired")
+                        )
+                        # Broadcast expiration event
+                        if expired_request:
+                            await poll_service._broadcast_approval_update(
+                                expired_request, "expired"
+                            )
+
+                            # Log to audit trail (fire-and-forget)
+                            _log_approval_lifecycle_async(
+                                account_id=str(expired_request.account_id),
+                                approval_id=expired_request.id,
+                                event="expired",
+                                tool_name=expired_request.tool_name,
+                                reason="Request timed out without response",
+                                execution_id=expired_request.execution_id,
+                            )
+
+                        raise TimeoutError(
+                            f"Approval request {request_id} expired without response"
+                        )
+
+            # Wait before polling again with no session checked out
             await asyncio.sleep(poll_interval)
 
     async def _send_escalation_notifications(

--- a/backend/preloop/services/approval_wrapper.py
+++ b/backend/preloop/services/approval_wrapper.py
@@ -28,6 +28,14 @@ def with_approval(tool_func: Callable) -> Callable:
     The key difference from the previous approach is that this runs at the tool
     function level where FastMCP's Context provides proper streaming support.
 
+    Connection-pool contract: no database session may be held across the
+    approval wait. A pending approval can take up to the workflow timeout
+    (default 300s) to resolve; a session held open for that long pins one
+    pooled connection per pending approval, and a handful of concurrent
+    approvals exhaust the async engine's pool. The policy check and approval
+    creation therefore run in one short-lived session that closes before the
+    polling loop starts, and every poll opens (and closes) its own session.
+
     Args:
         tool_func: The tool function to wrap
 
@@ -60,12 +68,31 @@ def with_approval(tool_func: Callable) -> Callable:
                 get_approval_workflow_async,
             )
             from preloop.services.policy_evaluator import evaluate_policy_async
+            from preloop.services.approval_service import ApprovalService
+            from preloop.models.schemas.approval_request import (
+                ApprovalRequestUpdate,
+            )
 
             logger.info(
                 f"Checking approval requirement for tool '{tool_name}' "
                 f"(account_id={user_context.account_id})"
             )
 
+            base_url = os.getenv("PRELOOP_URL", "http://localhost:8000")
+
+            # Everything needed after the session closes is extracted into
+            # plain locals. ORM instances must not outlive the session block:
+            # attribute access after a commit can silently re-begin a
+            # transaction and re-pin a pooled connection for the whole wait.
+            action = None
+            rule_description = None
+            approval_request_id = None
+            timeout_seconds = 300
+            approval_type = None
+            notification_channel = None
+
+            # Session 1 (short-lived): tool config lookup, policy evaluation,
+            # workflow fetch, and approval creation. Closes before any wait.
             async with get_async_db_session() as db:
                 # Check for tool configuration using CRUD
                 config = await get_tool_config_by_name_and_source_async(
@@ -101,69 +128,65 @@ def with_approval(tool_func: Callable) -> Callable:
                     )
                     return f"Tool execution denied: {rule_description}"
 
-                # Handle allow action - execute directly
-                if action == "allow":
+                if action != "allow":
+                    # Handle require_approval action
+                    # Get approval workflow (from rule evaluation or tool config fallback)
+                    workflow_id = approval_workflow_id or (
+                        config.approval_workflow_id if config else None
+                    )
+
+                    if not workflow_id:
+                        # No approval workflow configured - fail closed (require approval by default)
+                        logger.warning(
+                            f"Tool {tool_name} requires approval but no workflow configured - failing closed"
+                        )
+                        return "Tool requires approval but no approval workflow is configured"
+
+                    # Get approval workflow using CRUD
+                    workflow = await get_approval_workflow_async(
+                        db, workflow_id=workflow_id
+                    )
+
+                    if not workflow:
+                        logger.error(
+                            f"Approval workflow {workflow_id} not found for tool {tool_name}"
+                        )
+                        return (
+                            f"Error: Approval workflow not found for tool '{tool_name}'"
+                        )
+
+                    # Tool requires approval - handle it with streaming
                     logger.info(
-                        f"Tool {tool_name} allowed by policy rule: {rule_description}"
-                    )
-                    return await tool_func(*args, **kwargs)
-
-                # Handle require_approval action
-                # Get approval workflow (from rule evaluation or tool config fallback)
-                workflow_id = approval_workflow_id or (
-                    config.approval_workflow_id if config else None
-                )
-
-                if not workflow_id:
-                    # No approval workflow configured - fail closed (require approval by default)
-                    logger.warning(
-                        f"Tool {tool_name} requires approval but no workflow configured - failing closed"
-                    )
-                    return (
-                        "Tool requires approval but no approval workflow is configured"
+                        f"Tool {tool_name} requires approval - initiating approval flow with streaming"
                     )
 
-                # Get approval workflow using CRUD
-                workflow = await get_approval_workflow_async(
-                    db, workflow_id=workflow_id
-                )
-
-                if not workflow:
-                    logger.error(
-                        f"Approval workflow {workflow_id} not found for tool {tool_name}"
-                    )
-                    return f"Error: Approval workflow not found for tool '{tool_name}'"
-
-                # Tool requires approval - handle it with streaming
-                logger.info(
-                    f"Tool {tool_name} requires approval - initiating approval flow with streaming"
-                )
-
-                # Create approval request
-                from preloop.services.approval_service import ApprovalService
-                from preloop.models.schemas.approval_request import (
-                    ApprovalRequestUpdate,
-                )
-
-                base_url = os.getenv("PRELOOP_URL", "http://localhost:8000")
-                approval_service = ApprovalService(db, base_url)
-
-                try:
                     # Create approval request and send notification
-                    approval_request = await approval_service.create_and_notify(
-                        account_id=user_context.account_id,
-                        tool_configuration_id=config.id,
-                        approval_workflow=workflow,
-                        tool_name=tool_name,
-                        tool_args=kwargs,  # Use kwargs as tool arguments
-                        agent_reasoning=None,
-                        execution_id=None,
-                        # getattr: a patched evaluator may return a plain
-                        # tuple, and a missing snapshot must read as
-                        # "not recorded" rather than raise here.
-                        rule_context=getattr(policy_decision, "rule_context", None),
-                    )
+                    approval_service = ApprovalService(db, base_url)
 
+                    try:
+                        approval_request = await approval_service.create_and_notify(
+                            account_id=user_context.account_id,
+                            tool_configuration_id=config.id,
+                            approval_workflow=workflow,
+                            tool_name=tool_name,
+                            tool_args=kwargs,  # Use kwargs as tool arguments
+                            agent_reasoning=None,
+                            execution_id=None,
+                            # getattr: a patched evaluator may return a plain
+                            # tuple, and a missing snapshot must read as
+                            # "not recorded" rather than raise here.
+                            rule_context=getattr(policy_decision, "rule_context", None),
+                        )
+                    except Exception as e:
+                        logger.error(
+                            f"Approval flow error for tool {tool_name}: {e}",
+                            exc_info=True,
+                        )
+                        return f"Approval error: {str(e)}"
+
+                    approval_request_id = approval_request.id
+                    timeout_seconds = workflow.timeout_seconds or 300
+                    approval_type = workflow.approval_type
                     notification_channel = (
                         f"#{workflow.channel}"
                         if workflow.channel
@@ -171,155 +194,170 @@ def with_approval(tool_func: Callable) -> Callable:
                         if workflow.user
                         else "webhook"
                     )
+            # Session 1 is closed here; nothing below may hold a DB session
+            # across a wait.
 
-                    from preloop.utils.redaction import redact_for_log
+            # Handle allow action - execute directly (outside the session so a
+            # long-running tool does not pin a pooled connection either)
+            if action == "allow":
+                logger.info(
+                    f"Tool {tool_name} allowed by policy rule: {rule_description}"
+                )
+                return await tool_func(*args, **kwargs)
 
-                    logger.warning(
-                        f"\n{'=' * 60}\n"
-                        f"🚨 APPROVAL REQUIRED 🚨\n"
-                        f"{'=' * 60}\n"
-                        f"Tool: {tool_name}\n"
-                        f"Arguments: {redact_for_log(kwargs)}\n"
-                        f"Request ID: {approval_request.id}\n"
-                        f"Notification sent to: {workflow.approval_type} ({notification_channel})\n"
-                        f"Timeout: {workflow.timeout_seconds or 300}s\n"
-                        f"Approval URL: [sent via notification]\n"
-                        f"{'=' * 60}\n"
-                        f"⏳ Waiting for approval (polling every 2s)..."
+            from preloop.utils.redaction import redact_for_log
+
+            logger.warning(
+                f"\n{'=' * 60}\n"
+                f"🚨 APPROVAL REQUIRED 🚨\n"
+                f"{'=' * 60}\n"
+                f"Tool: {tool_name}\n"
+                f"Arguments: {redact_for_log(kwargs)}\n"
+                f"Request ID: {approval_request_id}\n"
+                f"Notification sent to: {approval_type} ({notification_channel})\n"
+                f"Timeout: {timeout_seconds}s\n"
+                f"Approval URL: [sent via notification]\n"
+                f"{'=' * 60}\n"
+                f"⏳ Waiting for approval (polling every 2s)..."
+            )
+
+            # Send initial notification via Context (FastMCP streaming)
+            if ctx:
+                try:
+                    # Report progress at 0%
+                    await ctx.report_progress(progress=0, total=100)
+                    logger.info("✅ Sent initial progress via Context (0%)")
+                except Exception as e:
+                    logger.warning(f"Could not send progress via Context: {e}")
+
+            try:
+                # Polling loop with progress updates. Each poll opens a fresh,
+                # short-lived session; no session is held during the sleep.
+                poll_interval = 2.0
+                elapsed = 0
+
+                while True:
+                    # Check approval status with fresh database session
+                    from preloop.models.crud.approval_request import (
+                        get_approval_request_async,
                     )
 
-                    # Send initial notification via Context (FastMCP streaming)
-                    if ctx:
-                        try:
-                            # Report progress at 0%
-                            await ctx.report_progress(progress=0, total=100)
-                            logger.info("✅ Sent initial progress via Context (0%)")
-                        except Exception as e:
-                            logger.warning(f"Could not send progress via Context: {e}")
-
-                    # Polling loop with progress updates
-                    poll_interval = 2.0
-                    timeout_seconds = workflow.timeout_seconds or 300
-                    elapsed = 0
-
-                    while True:
-                        # Check approval status with fresh database session
-                        from preloop.models.crud.approval_request import (
-                            get_approval_request_async,
+                    async with get_async_db_session() as poll_db:
+                        current_request = await get_approval_request_async(
+                            poll_db, request_id=approval_request_id
+                        )
+                        # Extract needed fields before session closes to avoid DetachedInstanceError
+                        current_status = (
+                            current_request.status if current_request else None
+                        )
+                        current_comment = (
+                            current_request.approver_comment
+                            if current_request
+                            else None
                         )
 
-                        async with get_async_db_session() as poll_db:
-                            current_request = await get_approval_request_async(
-                                poll_db, request_id=approval_request.id
-                            )
-                            # Extract needed fields before session closes to avoid DetachedInstanceError
-                            current_status = (
-                                current_request.status if current_request else None
-                            )
-                            current_comment = (
-                                current_request.approver_comment
-                                if current_request
-                                else None
-                            )
+                    logger.info(
+                        f"[Polling] Checked approval status: {current_status if current_status else 'NOT_FOUND'} "
+                        f"(elapsed: {elapsed}s)"
+                    )
 
+                    if not current_request:
+                        raise ValueError(
+                            f"Approval request {approval_request_id} not found"
+                        )
+
+                    # Check if resolved
+                    if current_status in [
+                        "approved",
+                        "declined",
+                        "cancelled",
+                    ]:
                         logger.info(
-                            f"[Polling] Checked approval status: {current_status if current_status else 'NOT_FOUND'} "
-                            f"(elapsed: {elapsed}s)"
+                            f"[Polling] ✅ Approval resolved with status: {current_status}"
+                        )
+                        final_status = current_status
+                        final_comment = current_comment
+                        break
+
+                    # Check if expired
+                    if elapsed >= timeout_seconds:
+                        async with get_async_db_session() as update_db:
+                            update_service = ApprovalService(update_db, base_url)
+                            await update_service.update_approval_request(
+                                approval_request_id,
+                                ApprovalRequestUpdate(status="expired"),
+                            )
+                        raise TimeoutError(
+                            f"Approval request {approval_request_id} expired without response"
                         )
 
-                        if not current_request:
-                            raise ValueError(
-                                f"Approval request {approval_request.id} not found"
-                            )
-
-                        # Check if resolved
-                        if current_status in [
-                            "approved",
-                            "declined",
-                            "cancelled",
-                        ]:
-                            logger.info(
-                                f"[Polling] ✅ Approval resolved with status: {current_status}"
-                            )
-                            final_status = current_status
-                            final_comment = current_comment
-                            break
-
-                        # Check if expired
-                        if elapsed >= timeout_seconds:
-                            async with get_async_db_session() as update_db:
-                                update_service = ApprovalService(update_db, base_url)
-                                await update_service.update_approval_request(
-                                    approval_request.id,
-                                    ApprovalRequestUpdate(status="expired"),
-                                )
-                            raise TimeoutError(
-                                f"Approval request {approval_request.id} expired without response"
-                            )
-
-                        # Send progress update every 10 seconds via Context
-                        if ctx and int(elapsed) % 10 == 0 and elapsed > 0:
-                            try:
-                                progress_pct = int((elapsed / timeout_seconds) * 100)
-                                remaining = timeout_seconds - elapsed
-
-                                # Use Context.report_progress for streaming
-                                await ctx.report_progress(
-                                    progress=progress_pct, total=100
-                                )
-                                logger.info(
-                                    f"[Polling] Sent progress via Context ({progress_pct}%, {int(remaining)}s remaining)"
-                                )
-                            except Exception as e:
-                                logger.error(
-                                    f"Failed to send progress update: {e}",
-                                    exc_info=True,
-                                )
-
-                        # Wait before next poll
-                        await asyncio.sleep(poll_interval)
-                        elapsed += poll_interval
-
-                    # Send completion notification
-                    if ctx:
+                    # Send progress update every 10 seconds via Context
+                    if ctx and int(elapsed) % 10 == 0 and elapsed > 0:
                         try:
-                            await ctx.report_progress(progress=100, total=100)
+                            progress_pct = int((elapsed / timeout_seconds) * 100)
+                            remaining = timeout_seconds - elapsed
+
+                            # Use Context.report_progress for streaming
+                            await ctx.report_progress(progress=progress_pct, total=100)
                             logger.info(
-                                "[Polling] Sent completion progress via Context (100%)"
+                                f"[Polling] Sent progress via Context ({progress_pct}%, {int(remaining)}s remaining)"
                             )
                         except Exception as e:
                             logger.error(
-                                f"Failed to send completion notification: {e}",
+                                f"Failed to send progress update: {e}",
                                 exc_info=True,
                             )
 
-                    # Check final status
-                    if final_status == "declined":
-                        logger.warning(f"Tool {tool_name} execution declined")
-                        comment = f": {final_comment}" if final_comment else ""
-                        return f"Tool execution declined{comment}"
-                    elif final_status == "cancelled":
-                        logger.warning(f"Tool {tool_name} execution cancelled")
-                        return "Tool execution cancelled"
-                    elif final_status != "approved":
-                        logger.error(
-                            f"Unexpected approval status for tool {tool_name}: {final_status}"
+                    # Wait before next poll
+                    await asyncio.sleep(poll_interval)
+                    elapsed += poll_interval
+
+                # Send completion notification
+                if ctx:
+                    try:
+                        await ctx.report_progress(progress=100, total=100)
+                        logger.info(
+                            "[Polling] Sent completion progress via Context (100%)"
                         )
-                        return f"Unexpected approval status: {final_status}"
+                    except Exception as e:
+                        logger.error(
+                            f"Failed to send completion notification: {e}",
+                            exc_info=True,
+                        )
 
-                    # Approved! Continue with execution
-                    logger.warning(
-                        f"✅ Tool {tool_name} APPROVED - proceeding with execution"
-                    )
-
-                except TimeoutError as e:
-                    logger.error(f"⏱️ Approval timeout for tool {tool_name}: {e}")
-                    return f"Approval timeout: {str(e)}"
-                except Exception as e:
+                # Check final status
+                if final_status == "declined":
+                    logger.warning(f"Tool {tool_name} execution declined")
+                    comment = f": {final_comment}" if final_comment else ""
+                    return f"Tool execution declined{comment}"
+                elif final_status == "cancelled":
+                    logger.warning(f"Tool {tool_name} execution cancelled")
+                    return "Tool execution cancelled"
+                elif final_status != "approved":
                     logger.error(
-                        f"Approval flow error for tool {tool_name}: {e}", exc_info=True
+                        f"Unexpected approval status for tool {tool_name}: {final_status}"
                     )
-                    return f"Approval error: {str(e)}"
+                    return f"Unexpected approval status: {final_status}"
+
+                # Approved! Continue with execution
+                logger.warning(
+                    f"✅ Tool {tool_name} APPROVED - proceeding with execution"
+                )
+
+            except TimeoutError as e:
+                logger.error(f"⏱️ Approval timeout for tool {tool_name}: {e}")
+                return f"Approval timeout: {str(e)}"
+            except Exception as e:
+                logger.error(
+                    f"Approval flow error for tool {tool_name}: {e}", exc_info=True
+                )
+                return f"Approval error: {str(e)}"
+
+            # Approved: execute the tool. (This previously fell through to the
+            # unexpected-code-path guard below and blocked the tool even after
+            # an approval; executing it is the documented contract of this
+            # decorator.)
+            return await tool_func(*args, **kwargs)
 
         except Exception as e:
             # SECURITY: Fail closed on errors - do not execute tool
@@ -331,9 +369,5 @@ def with_approval(tool_func: Callable) -> Callable:
             return (
                 f"Tool execution blocked: Error evaluating access workflow - {str(e)}"
             )
-
-        # This should not be reached - all paths above either return or raise
-        logger.error(f"Unexpected code path reached for tool {tool_name}")
-        return "Tool execution blocked: Unexpected error in approval flow"
 
     return wrapper

--- a/backend/preloop/services/db_pool_monitor.py
+++ b/backend/preloop/services/db_pool_monitor.py
@@ -29,6 +29,18 @@ DEFAULT_WARN_RATIO = 0.8
 _FALSE_VALUES = {"0", "false", "no", "off"}
 
 
+def _env_float(name: str, default: float) -> float:
+    """Read a float environment variable with a safe fallback."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %s", name, value, default)
+        return default
+
+
 def db_monitoring_enabled() -> bool:
     """Return whether pool monitoring is enabled (DB_MONITORING_ENABLED)."""
     return os.getenv("DB_MONITORING_ENABLED", "true").strip().lower() not in (
@@ -143,12 +155,16 @@ class DbPoolMonitor:
             warn_ratio: Fraction of the ceiling that triggers a WARNING
                 (DB_POOL_WARN_RATIO).
         """
-        self.interval_seconds = interval_seconds or int(
-            os.getenv("DB_MONITORING_INTERVAL", str(DEFAULT_INTERVAL_SECONDS))
-        )
-        self.warn_ratio = warn_ratio or float(
-            os.getenv("DB_POOL_WARN_RATIO", str(DEFAULT_WARN_RATIO))
-        )
+        if interval_seconds is None:
+            from preloop.models.db.session import _env_int
+
+            interval_seconds = _env_int(
+                "DB_MONITORING_INTERVAL", DEFAULT_INTERVAL_SECONDS
+            )
+        self.interval_seconds = interval_seconds
+        if warn_ratio is None:
+            warn_ratio = _env_float("DB_POOL_WARN_RATIO", DEFAULT_WARN_RATIO)
+        self.warn_ratio = warn_ratio
         self._running = False
         self._task: Optional[asyncio.Task] = None
 

--- a/backend/preloop/services/db_pool_monitor.py
+++ b/backend/preloop/services/db_pool_monitor.py
@@ -1,0 +1,229 @@
+"""SQLAlchemy connection pool observability.
+
+Makes pool saturation visible before it turns into ``QueuePool limit
+reached`` errors (a deployment observed exactly that under concurrent
+pending approvals). Two integrations, both intentionally small:
+
+* OpenTelemetry observable gauges on the meter configured by
+  ``services/otel_export.py``. When OTLP export is disabled the global
+  meter provider is a no-op, so registration is free.
+* A periodic WARNING log whenever an engine's checked-out connections
+  reach ``DB_POOL_WARN_RATIO`` (default 80%) of its ceiling
+  (``pool_size + max_overflow``).
+
+Gated by the ``DB_MONITORING_ENABLED`` env var (default enabled). The
+monitor never creates engines: roles that never build one of the two
+engines simply report nothing for it.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INTERVAL_SECONDS = 30
+DEFAULT_WARN_RATIO = 0.8
+
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def db_monitoring_enabled() -> bool:
+    """Return whether pool monitoring is enabled (DB_MONITORING_ENABLED)."""
+    return os.getenv("DB_MONITORING_ENABLED", "true").strip().lower() not in (
+        _FALSE_VALUES
+    )
+
+
+def _snapshot(pool: Any, engine_name: str, max_overflow: int) -> Dict[str, Any]:
+    """Read one pool's counters. Never raises; pools expose these methods."""
+    size = int(pool.size())
+    checked_out = int(pool.checkedout())
+    # QueuePool.overflow() can be negative while the base pool is not full.
+    overflow_in_use = max(int(pool.overflow()), 0)
+    ceiling = size + max_overflow
+    return {
+        "engine": engine_name,
+        "size": size,
+        "checked_out": checked_out,
+        "checked_in": int(pool.checkedin()),
+        "overflow_in_use": overflow_in_use,
+        "ceiling": ceiling,
+        "status": pool.status(),
+    }
+
+
+def collect_pool_stats() -> List[Dict[str, Any]]:
+    """Snapshot both engines' pools; engines not yet created are skipped."""
+    from preloop.models.db.session import (
+        _env_int,
+        get_async_engine_if_initialized,
+        get_engine_if_initialized,
+    )
+
+    max_overflow = _env_int("DATABASE_MAX_OVERFLOW", 40)
+    stats: List[Dict[str, Any]] = []
+    sync_engine = get_engine_if_initialized()
+    if sync_engine is not None:
+        stats.append(_snapshot(sync_engine.pool, "sync", max_overflow))
+    async_engine = get_async_engine_if_initialized()
+    if async_engine is not None:
+        stats.append(_snapshot(async_engine.sync_engine.pool, "async", max_overflow))
+    return stats
+
+
+def register_otel_pool_gauges() -> bool:
+    """Register observable pool gauges on the process meter provider.
+
+    Uses the same OpenTelemetry metrics stack that services/otel_export.py
+    configures; when OTLP export is off the default no-op meter absorbs
+    the registration. Returns True when registration succeeded.
+    """
+    try:
+        from opentelemetry import metrics
+        from opentelemetry.metrics import Observation
+
+        meter = metrics.get_meter("preloop.db_pool")
+
+        def _used(_options) -> List[Observation]:
+            return [
+                Observation(s["checked_out"], {"preloop.db.engine": s["engine"]})
+                for s in collect_pool_stats()
+            ]
+
+        def _overflow(_options) -> List[Observation]:
+            return [
+                Observation(s["overflow_in_use"], {"preloop.db.engine": s["engine"]})
+                for s in collect_pool_stats()
+            ]
+
+        def _ceiling(_options) -> List[Observation]:
+            return [
+                Observation(s["ceiling"], {"preloop.db.engine": s["engine"]})
+                for s in collect_pool_stats()
+            ]
+
+        meter.create_observable_gauge(
+            "db.client.connections.usage",
+            callbacks=[_used],
+            unit="{connection}",
+            description="Checked-out SQLAlchemy connections per engine",
+        )
+        meter.create_observable_gauge(
+            "db.client.connections.overflow",
+            callbacks=[_overflow],
+            unit="{connection}",
+            description="Overflow SQLAlchemy connections currently in use",
+        )
+        meter.create_observable_gauge(
+            "db.client.connections.max",
+            callbacks=[_ceiling],
+            unit="{connection}",
+            description="Connection ceiling per engine (pool_size + max_overflow)",
+        )
+        return True
+    except Exception:
+        logger.debug("Could not register OTLP pool gauges", exc_info=True)
+        return False
+
+
+class DbPoolMonitor:
+    """Background task that periodically checks pool saturation."""
+
+    def __init__(
+        self,
+        interval_seconds: Optional[int] = None,
+        warn_ratio: Optional[float] = None,
+    ) -> None:
+        """Initialize the monitor.
+
+        Args:
+            interval_seconds: Seconds between checks (DB_MONITORING_INTERVAL).
+            warn_ratio: Fraction of the ceiling that triggers a WARNING
+                (DB_POOL_WARN_RATIO).
+        """
+        self.interval_seconds = interval_seconds or int(
+            os.getenv("DB_MONITORING_INTERVAL", str(DEFAULT_INTERVAL_SECONDS))
+        )
+        self.warn_ratio = warn_ratio or float(
+            os.getenv("DB_POOL_WARN_RATIO", str(DEFAULT_WARN_RATIO))
+        )
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+    def check_once(self) -> List[Dict[str, Any]]:
+        """Check both pools once; log a WARNING for any near-saturated pool.
+
+        Returns:
+            The collected pool snapshots (also used by tests).
+        """
+        stats = collect_pool_stats()
+        for snapshot in stats:
+            ceiling = snapshot["ceiling"]
+            if ceiling <= 0:
+                continue
+            if snapshot["checked_out"] >= self.warn_ratio * ceiling:
+                logger.warning(
+                    "DB connection pool nearing exhaustion: engine=%s "
+                    "checked_out=%d/%d (%.0f%%), overflow_in_use=%d, "
+                    "checked_in=%d. Requests beyond the ceiling wait up to "
+                    "pool_timeout and then fail; look for code holding a "
+                    "session across a wait. Pool status: %s",
+                    snapshot["engine"],
+                    snapshot["checked_out"],
+                    ceiling,
+                    100.0 * snapshot["checked_out"] / ceiling,
+                    snapshot["overflow_in_use"],
+                    snapshot["checked_in"],
+                    snapshot["status"],
+                )
+        return stats
+
+    async def start(self) -> None:
+        """Start the periodic check task and register OTLP gauges."""
+        if self._running:
+            return
+        self._running = True
+        register_otel_pool_gauges()
+        self._task = asyncio.create_task(self._loop())
+        logger.info(
+            "DB pool monitor started (interval=%ss, warn_ratio=%s)",
+            self.interval_seconds,
+            self.warn_ratio,
+        )
+
+    async def stop(self) -> None:
+        """Stop the periodic check task."""
+        if not self._running:
+            return
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                # Expected when stop() cancels the monitor loop task.
+                pass
+
+    async def _loop(self) -> None:
+        while self._running:
+            try:
+                self.check_once()
+            except Exception:
+                logger.error("Error in DB pool monitor check", exc_info=True)
+            try:
+                await asyncio.sleep(self.interval_seconds)
+            except asyncio.CancelledError:
+                break
+
+
+_monitor_instance: Optional[DbPoolMonitor] = None
+
+
+def get_db_pool_monitor() -> DbPoolMonitor:
+    """Get or create the global DB pool monitor instance."""
+    global _monitor_instance
+    if _monitor_instance is None:
+        _monitor_instance = DbPoolMonitor()
+    return _monitor_instance

--- a/backend/preloop/services/dynamic_mcp_server.py
+++ b/backend/preloop/services/dynamic_mcp_server.py
@@ -711,35 +711,38 @@ class DynamicMCPServer:
                     execution_id=None,  # Could be extracted from context if available
                     rule_context=rule_context,
                 )
+                approval_request_id = approval_request.id
+            # The session closes HERE, before the wait: holding it across the
+            # human decision (up to the workflow timeout) pins one pooled
+            # connection per pending approval and exhausts the async pool
+            # under concurrent approvals. wait_for_approval polls with fresh
+            # short-lived sessions and does not use the session this service
+            # was constructed with.
 
-                logger.info(
-                    f"Approval request created: {approval_request.id}, waiting for response..."
+            logger.info(
+                f"Approval request created: {approval_request_id}, waiting for response..."
+            )
+
+            # Wait for approval with polling
+            final_request = await approval_service.wait_for_approval(
+                approval_request_id, poll_interval=2.0
+            )
+            final_status = final_request.status
+            final_comment = final_request.approver_comment
+
+            # Check final status
+            if final_status == "declined":
+                raise PermissionError(
+                    "Tool execution declined"
+                    + (f": {final_comment}" if final_comment else "")
                 )
+            elif final_status == "cancelled":
+                raise PermissionError("Tool execution cancelled")
+            elif final_status != "approved":
+                raise Exception(f"Unexpected approval status: {final_status}")
 
-                # Wait for approval with polling
-                final_request = await approval_service.wait_for_approval(
-                    approval_request.id, poll_interval=2.0
-                )
-
-                # Check final status
-                if final_request.status == "declined":
-                    raise PermissionError(
-                        "Tool execution declined"
-                        + (
-                            f": {final_request.approver_comment}"
-                            if final_request.approver_comment
-                            else ""
-                        )
-                    )
-                elif final_request.status == "cancelled":
-                    raise PermissionError("Tool execution cancelled")
-                elif final_request.status != "approved":
-                    raise Exception(
-                        f"Unexpected approval status: {final_request.status}"
-                    )
-
-                # Approval granted!
-                logger.info(f"Tool {tool_name} approved by user")
+            # Approval granted!
+            logger.info(f"Tool {tool_name} approved by user")
 
         except Exception as e:
             logger.error(f"Error in approval flow: {e}", exc_info=True)

--- a/backend/tests/services/test_approval_service.py
+++ b/backend/tests/services/test_approval_service.py
@@ -2,6 +2,7 @@
 
 import json
 import uuid
+from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,6 +13,26 @@ from preloop.models.schemas.approval_request import ApprovalRequestUpdate
 from preloop.services.approval_service import ApprovalService
 
 pytestmark = pytest.mark.asyncio
+
+
+@contextmanager
+def fresh_poll_sessions():
+    """Stub the fresh per-poll sessions opened by wait_for_approval.
+
+    wait_for_approval must not reuse the session the service was constructed
+    with (that would pin a pooled connection for the whole human wait), so it
+    opens a short-lived session per poll; tests provide those here.
+    """
+
+    @asynccontextmanager
+    async def _fake_session():
+        yield AsyncMock()
+
+    with patch(
+        "preloop.models.db.session.get_async_db_session",
+        new=_fake_session,
+    ):
+        yield
 
 
 @pytest.fixture
@@ -1760,7 +1781,12 @@ class TestCreateAndNotify:
 
 
 class TestWaitForApproval:
-    """Test wait_for_approval method."""
+    """Test wait_for_approval method.
+
+    wait_for_approval polls with a fresh service on a fresh session per
+    iteration, so the tests patch methods at the class level rather than on
+    the instance under test.
+    """
 
     async def test_wait_for_approval_already_approved(
         self, approval_service, sample_approval_request
@@ -1768,10 +1794,13 @@ class TestWaitForApproval:
         """Test waiting for an already approved request."""
         sample_approval_request.status = "approved"
 
-        with patch.object(
-            approval_service,
-            "get_approval_request",
-            return_value=sample_approval_request,
+        with (
+            fresh_poll_sessions(),
+            patch.object(
+                ApprovalService,
+                "get_approval_request",
+                return_value=sample_approval_request,
+            ),
         ):
             result = await approval_service.wait_for_approval(
                 sample_approval_request.id
@@ -1785,10 +1814,13 @@ class TestWaitForApproval:
         """Test waiting for an already declined request."""
         sample_approval_request.status = "declined"
 
-        with patch.object(
-            approval_service,
-            "get_approval_request",
-            return_value=sample_approval_request,
+        with (
+            fresh_poll_sessions(),
+            patch.object(
+                ApprovalService,
+                "get_approval_request",
+                return_value=sample_approval_request,
+            ),
         ):
             result = await approval_service.wait_for_approval(
                 sample_approval_request.id
@@ -1802,10 +1834,13 @@ class TestWaitForApproval:
         """Test waiting for a cancelled request."""
         sample_approval_request.status = "cancelled"
 
-        with patch.object(
-            approval_service,
-            "get_approval_request",
-            return_value=sample_approval_request,
+        with (
+            fresh_poll_sessions(),
+            patch.object(
+                ApprovalService,
+                "get_approval_request",
+                return_value=sample_approval_request,
+            ),
         ):
             result = await approval_service.wait_for_approval(
                 sample_approval_request.id
@@ -1817,7 +1852,10 @@ class TestWaitForApproval:
         """Test waiting for a non-existent request."""
         request_id = uuid.uuid4()
 
-        with patch.object(approval_service, "get_approval_request", return_value=None):
+        with (
+            fresh_poll_sessions(),
+            patch.object(ApprovalService, "get_approval_request", return_value=None),
+        ):
             with pytest.raises(ValueError) as exc_info:
                 await approval_service.wait_for_approval(request_id)
 
@@ -1830,14 +1868,19 @@ class TestWaitForApproval:
         # Set expiration in the past
         sample_approval_request.status = "pending"
         sample_approval_request.expires_at = datetime.utcnow() - timedelta(seconds=1)
+        sample_approval_request.escalation_triggered_at = None
+        sample_approval_request.approval_workflow = None
 
-        with patch.object(
-            approval_service,
-            "get_approval_request",
-            return_value=sample_approval_request,
+        with (
+            fresh_poll_sessions(),
+            patch.object(
+                ApprovalService,
+                "get_approval_request",
+                return_value=sample_approval_request,
+            ),
         ):
             with patch.object(
-                approval_service, "update_approval_request"
+                ApprovalService, "update_approval_request"
             ) as mock_update:
                 with pytest.raises(TimeoutError) as exc_info:
                     await approval_service.wait_for_approval(sample_approval_request.id)
@@ -1853,6 +1896,7 @@ class TestWaitForApproval:
         """Test polling behavior when waiting for approval."""
         # First call: pending, second call: approved
         sample_approval_request.status = "pending"
+        sample_approval_request.expires_at = None
         approved_request = MagicMock(spec=ApprovalRequest)
         approved_request.status = "approved"
 
@@ -1866,10 +1910,13 @@ class TestWaitForApproval:
             else:
                 return approved_request
 
-        with patch.object(
-            approval_service,
-            "get_approval_request",
-            side_effect=mock_get_approval_request,
+        with (
+            fresh_poll_sessions(),
+            patch.object(
+                ApprovalService,
+                "get_approval_request",
+                side_effect=mock_get_approval_request,
+            ),
         ):
             result = await approval_service.wait_for_approval(
                 sample_approval_request.id, poll_interval=0.5
@@ -1885,10 +1932,13 @@ class TestWaitForApproval:
         """Test waiting with custom poll interval."""
         sample_approval_request.status = "approved"
 
-        with patch.object(
-            approval_service,
-            "get_approval_request",
-            return_value=sample_approval_request,
+        with (
+            fresh_poll_sessions(),
+            patch.object(
+                ApprovalService,
+                "get_approval_request",
+                return_value=sample_approval_request,
+            ),
         ):
             result = await approval_service.wait_for_approval(
                 sample_approval_request.id, poll_interval=2.0
@@ -2150,19 +2200,22 @@ class TestEscalationBehavior:
                 approved.status = "approved"
                 return approved
 
-        with patch.object(
-            approval_service,
-            "get_approval_request",
-            side_effect=mock_get_request,
+        with (
+            fresh_poll_sessions(),
+            patch.object(
+                ApprovalService,
+                "get_approval_request",
+                side_effect=mock_get_request,
+            ),
         ):
             with patch.object(
-                approval_service,
+                ApprovalService,
                 "_send_escalation_notifications",
                 new_callable=AsyncMock,
                 return_value={"success": True},
             ) as mock_escalation:
                 with patch.object(
-                    approval_service,
+                    ApprovalService,
                     "_broadcast_approval_update",
                     new_callable=AsyncMock,
                 ):
@@ -2187,25 +2240,28 @@ class TestEscalationBehavior:
         sample_approval_workflow.escalation_user_ids = [uuid.uuid4()]
         sample_approval_request.approval_workflow = sample_approval_workflow
 
-        with patch.object(
-            approval_service,
-            "get_approval_request",
-            new_callable=AsyncMock,
-            return_value=sample_approval_request,
+        with (
+            fresh_poll_sessions(),
+            patch.object(
+                ApprovalService,
+                "get_approval_request",
+                new_callable=AsyncMock,
+                return_value=sample_approval_request,
+            ),
         ):
             with patch.object(
-                approval_service,
+                ApprovalService,
                 "update_approval_request",
                 new_callable=AsyncMock,
                 return_value=sample_approval_request,
             ):
                 with patch.object(
-                    approval_service,
+                    ApprovalService,
                     "_send_escalation_notifications",
                     new_callable=AsyncMock,
                 ) as mock_escalation:
                     with patch.object(
-                        approval_service,
+                        ApprovalService,
                         "_broadcast_approval_update",
                         new_callable=AsyncMock,
                     ):
@@ -2228,20 +2284,23 @@ class TestEscalationBehavior:
         sample_approval_workflow.escalation_team_ids = None
         sample_approval_request.approval_workflow = sample_approval_workflow
 
-        with patch.object(
-            approval_service,
-            "get_approval_request",
-            new_callable=AsyncMock,
-            return_value=sample_approval_request,
+        with (
+            fresh_poll_sessions(),
+            patch.object(
+                ApprovalService,
+                "get_approval_request",
+                new_callable=AsyncMock,
+                return_value=sample_approval_request,
+            ),
         ):
             with patch.object(
-                approval_service,
+                ApprovalService,
                 "update_approval_request",
                 new_callable=AsyncMock,
                 return_value=sample_approval_request,
             ):
                 with patch.object(
-                    approval_service,
+                    ApprovalService,
                     "_broadcast_approval_update",
                     new_callable=AsyncMock,
                 ):
@@ -2269,20 +2328,23 @@ class TestEscalationBehavior:
         expired_request.tool_name = sample_approval_request.tool_name
         expired_request.execution_id = None
 
-        with patch.object(
-            approval_service,
-            "get_approval_request",
-            new_callable=AsyncMock,
-            return_value=sample_approval_request,
+        with (
+            fresh_poll_sessions(),
+            patch.object(
+                ApprovalService,
+                "get_approval_request",
+                new_callable=AsyncMock,
+                return_value=sample_approval_request,
+            ),
         ):
             with patch.object(
-                approval_service,
+                ApprovalService,
                 "update_approval_request",
                 new_callable=AsyncMock,
                 return_value=expired_request,
             ):
                 with patch.object(
-                    approval_service,
+                    ApprovalService,
                     "_broadcast_approval_update",
                     new_callable=AsyncMock,
                 ) as mock_broadcast:

--- a/backend/tests/services/test_approval_session_hold.py
+++ b/backend/tests/services/test_approval_session_hold.py
@@ -1,0 +1,496 @@
+"""Regression tests: approval waits must not hold a DB session.
+
+A deployment observed SQLAlchemy QueuePool exhaustion under concurrent
+pending approvals: the approval paths opened a session before creating the
+approval request and kept it checked out across the whole human-decision
+polling loop (up to the workflow timeout). These tests instrument
+``get_async_db_session`` and assert that no session is held at any point
+where the code sleeps waiting for a decision.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from preloop.services.approval_wrapper import with_approval
+
+pytestmark = pytest.mark.asyncio
+
+REAL_SLEEP = asyncio.sleep
+
+
+class SessionLedger:
+    """Track how many instrumented DB sessions are currently held.
+
+    A session counts as held from context-manager entry until it is
+    released, either by exiting the context manager or by an explicit
+    ``close()`` (both return the pooled connection in production).
+    """
+
+    def __init__(self) -> None:
+        self.held = 0
+        self.opened = 0
+        self.at_sleep: list[int] = []
+
+    def make_session_factory(self):
+        ledger = self
+
+        @asynccontextmanager
+        async def _fake_session():
+            ledger.opened += 1
+            ledger.held += 1
+            released = False
+
+            def _release() -> None:
+                nonlocal released
+                if not released:
+                    ledger.held -= 1
+                    released = True
+
+            session = MagicMock()
+            session.execute = AsyncMock()
+            session.commit = AsyncMock()
+            session.rollback = AsyncMock()
+            session.refresh = AsyncMock()
+            session.add = MagicMock()
+
+            async def _close() -> None:
+                _release()
+
+            session.close = _close
+            try:
+                yield session
+            finally:
+                _release()
+
+        return _fake_session
+
+    def make_sleep(self, on_sleep=None):
+        """Fake asyncio.sleep that records held sessions and yields control."""
+        ledger = self
+
+        async def _fake_sleep(_seconds) -> None:
+            ledger.at_sleep.append(ledger.held)
+            if on_sleep is not None:
+                on_sleep()
+            await REAL_SLEEP(0)
+
+        return _fake_sleep
+
+
+def make_request(status: str, comment=None):
+    request = MagicMock()
+    request.id = uuid4()
+    request.status = status
+    request.approver_comment = comment
+    request.resolved_at = None
+    request.responses = []
+    request.expires_at = None
+    return request
+
+
+def make_workflow(timeout_seconds: int = 300):
+    workflow = MagicMock()
+    workflow.id = uuid4()
+    workflow.approval_type = "slack"
+    workflow.channel = "approvals"
+    workflow.user = None
+    workflow.name = "test-workflow"
+    workflow.timeout_seconds = timeout_seconds
+    workflow.escalation_user_ids = None
+    workflow.escalation_team_ids = None
+    workflow.async_approval_enabled = False
+    workflow.approvals_required = 1
+    workflow.approver_user_ids = None
+    return workflow
+
+
+@pytest.fixture
+def mock_user_context():
+    ctx = MagicMock()
+    ctx.account_id = uuid4()
+    ctx.user_id = uuid4()
+    ctx.execution_id = None
+    return ctx
+
+
+def wrapper_patches(ledger, poll_state, workflow, mock_user_context, fake_sleep):
+    """Common patch set for driving with_approval into its polling loop."""
+    config = MagicMock()
+    config.id = uuid4()
+    config.approval_workflow_id = workflow.id
+
+    approval_service = AsyncMock()
+    approval_service.create_and_notify = AsyncMock(return_value=poll_state["pending"])
+    approval_service.update_approval_request = AsyncMock()
+
+    async def _get_request(_db, request_id=None):
+        return poll_state["current"]
+
+    return (
+        patch(
+            "preloop.services.dynamic_fastmcp_http.get_current_user_context",
+            return_value=mock_user_context,
+        ),
+        patch(
+            "preloop.models.db.session.get_async_db_session",
+            new=ledger.make_session_factory(),
+        ),
+        patch(
+            "preloop.models.crud.tool_configuration."
+            "get_tool_config_by_name_and_source_async",
+            new_callable=AsyncMock,
+            return_value=config,
+        ),
+        patch(
+            "preloop.services.policy_evaluator.evaluate_policy_async",
+            new_callable=AsyncMock,
+            return_value=("require_approval", workflow.id, "gated by test rule"),
+        ),
+        patch(
+            "preloop.models.crud.approval_workflow.get_approval_workflow_async",
+            new_callable=AsyncMock,
+            return_value=workflow,
+        ),
+        patch(
+            "preloop.services.approval_service.ApprovalService",
+            return_value=approval_service,
+        ),
+        patch(
+            "preloop.models.crud.approval_request.get_approval_request_async",
+            new=AsyncMock(side_effect=_get_request),
+        ),
+        patch("preloop.services.approval_wrapper.asyncio.sleep", new=fake_sleep),
+    )
+
+
+async def run_with_approval(
+    ledger, poll_state, workflow, user_context, fake_sleep, concurrency=1
+):
+    """Run one or more wrapped calls under a single shared patch stack."""
+
+    async def tool_func(**kwargs):
+        return "tool_result"
+
+    wrapped = with_approval(tool_func)
+    patches = wrapper_patches(ledger, poll_state, workflow, user_context, fake_sleep)
+    from contextlib import ExitStack
+
+    with ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        results = await asyncio.gather(
+            *(wrapped(arg1="value") for _ in range(concurrency))
+        )
+    return results if concurrency > 1 else results[0]
+
+
+class TestWithApprovalSessionRelease:
+    """The outer session must be returned before any approval-wait sleep."""
+
+    async def test_outer_session_released_before_first_poll_sleep(
+        self, mock_user_context
+    ):
+        ledger = SessionLedger()
+        pending = make_request("pending")
+        approved = make_request("approved")
+        approved.id = pending.id
+        poll_state = {"pending": pending, "current": pending}
+
+        def resolve():
+            poll_state["current"] = approved
+
+        fake_sleep = ledger.make_sleep(on_sleep=resolve)
+        result = await run_with_approval(
+            ledger, poll_state, make_workflow(), mock_user_context, fake_sleep
+        )
+
+        assert ledger.at_sleep, "polling loop never slept"
+        assert ledger.at_sleep[0] == 0, (
+            "a DB session was still checked out when the approval wait began; "
+            f"held sessions at first poll sleep: {ledger.at_sleep[0]}"
+        )
+        # Approved requests must execute the wrapped tool.
+        assert result == "tool_result"
+
+    async def test_concurrent_pending_approvals_hold_no_sessions(
+        self, mock_user_context
+    ):
+        n_tasks = 5
+        ledger = SessionLedger()
+        pending = make_request("pending")
+        approved = make_request("approved")
+        approved.id = pending.id
+        poll_state = {"pending": pending, "current": pending}
+
+        def resolve_after_all_waiting():
+            # Let every concurrent call reach its polling wait at least once
+            # before the approval resolves.
+            if len(ledger.at_sleep) >= n_tasks:
+                poll_state["current"] = approved
+
+        fake_sleep = ledger.make_sleep(on_sleep=resolve_after_all_waiting)
+        results = await run_with_approval(
+            ledger,
+            poll_state,
+            make_workflow(),
+            mock_user_context,
+            fake_sleep,
+            concurrency=n_tasks,
+        )
+
+        assert len(ledger.at_sleep) >= n_tasks
+        assert max(ledger.at_sleep) == 0, (
+            "concurrent pending approvals accumulated checked-out sessions "
+            f"during their waits: peak {max(ledger.at_sleep)}"
+        )
+        assert all(result == "tool_result" for result in results)
+
+
+class TestWithApprovalDecisionPaths:
+    """Approved, declined, and expired paths keep their caller behavior."""
+
+    async def test_declined_returns_decline_message(self, mock_user_context):
+        ledger = SessionLedger()
+        pending = make_request("pending")
+        declined = make_request("declined", comment="not allowed")
+        declined.id = pending.id
+        poll_state = {"pending": pending, "current": pending}
+
+        def resolve():
+            poll_state["current"] = declined
+
+        fake_sleep = ledger.make_sleep(on_sleep=resolve)
+        result = await run_with_approval(
+            ledger, poll_state, make_workflow(), mock_user_context, fake_sleep
+        )
+
+        assert result == "Tool execution declined: not allowed"
+        assert max(ledger.at_sleep) == 0
+
+    async def test_cancelled_returns_cancel_message(self, mock_user_context):
+        ledger = SessionLedger()
+        pending = make_request("pending")
+        cancelled = make_request("cancelled")
+        cancelled.id = pending.id
+        poll_state = {"pending": pending, "current": pending}
+
+        def resolve():
+            poll_state["current"] = cancelled
+
+        fake_sleep = ledger.make_sleep(on_sleep=resolve)
+        result = await run_with_approval(
+            ledger, poll_state, make_workflow(), mock_user_context, fake_sleep
+        )
+
+        assert result == "Tool execution cancelled"
+
+    async def test_expired_returns_timeout_message(self, mock_user_context):
+        ledger = SessionLedger()
+        pending = make_request("pending")
+        poll_state = {"pending": pending, "current": pending}
+
+        fake_sleep = ledger.make_sleep()
+        result = await run_with_approval(
+            ledger,
+            poll_state,
+            make_workflow(timeout_seconds=4),
+            mock_user_context,
+            fake_sleep,
+        )
+
+        assert result.startswith("Approval timeout:")
+        assert "expired" in result
+        assert max(ledger.at_sleep) == 0
+
+
+class TestRequireApprovalSessionRelease:
+    """approval_helper.require_approval must not hold a session while polling."""
+
+    async def test_session_released_before_first_poll_sleep(self):
+        from preloop.services.approval_helper import require_approval
+
+        ledger = SessionLedger()
+        workflow = make_workflow()
+        pending = make_request("pending")
+        approved = make_request("approved")
+        approved.id = pending.id
+        poll_state = {"current": pending}
+
+        def resolve():
+            poll_state["current"] = approved
+
+        async def _get_request(_db, request_id=None):
+            return poll_state["current"]
+
+        config = MagicMock()
+        config.id = uuid4()
+        config.approval_workflow_id = workflow.id
+
+        approval_service = AsyncMock()
+        approval_service.create_and_notify = AsyncMock(return_value=pending)
+
+        with (
+            patch(
+                "preloop.models.db.session.get_async_db_session",
+                new=ledger.make_session_factory(),
+            ),
+            patch(
+                "preloop.models.crud.tool_configuration."
+                "get_tool_config_by_name_and_source_async",
+                new_callable=AsyncMock,
+                return_value=config,
+            ),
+            patch(
+                "preloop.models.crud.approval_workflow.get_approval_workflow_async",
+                new_callable=AsyncMock,
+                return_value=workflow,
+            ),
+            patch(
+                "preloop.services.approval_service.ApprovalService",
+                return_value=approval_service,
+            ),
+            patch(
+                "preloop.models.crud.approval_request.get_approval_request_async",
+                new=AsyncMock(side_effect=_get_request),
+            ),
+            patch(
+                "preloop.services.approval_helper.asyncio.sleep",
+                new=ledger.make_sleep(on_sleep=resolve),
+            ),
+        ):
+            approved_result, error = await require_approval(
+                tool_name="test_tool",
+                tool_source="mcp",
+                account_id=str(uuid4()),
+                arguments={"arg": "value"},
+                ctx=None,
+                workflow_id=str(workflow.id),
+            )
+
+        assert approved_result is True
+        assert error == ""
+        assert ledger.at_sleep, "polling loop never slept"
+        assert max(ledger.at_sleep) == 0, (
+            "require_approval held a DB session during the approval wait: "
+            f"{max(ledger.at_sleep)} session(s) checked out at sleep"
+        )
+
+
+class TestWaitForApprovalSessionRelease:
+    """ApprovalService.wait_for_approval must poll with fresh sessions."""
+
+    async def test_polls_with_fresh_sessions_and_none_held_at_sleep(self):
+        from preloop.services.approval_service import ApprovalService
+
+        ledger = SessionLedger()
+        pending = make_request("pending")
+        approved = make_request("approved")
+        approved.id = pending.id
+        poll_state = {"current": pending}
+
+        def resolve():
+            poll_state["current"] = approved
+
+        async def _get_request(_db, request_id=None):
+            return poll_state["current"]
+
+        # The service is constructed with a session that is closed before the
+        # wait begins; polling must not rely on it.
+        service = ApprovalService(MagicMock(), "http://test")
+
+        with (
+            patch(
+                "preloop.models.db.session.get_async_db_session",
+                new=ledger.make_session_factory(),
+            ),
+            # approval_service binds the CRUD function at module import time,
+            # so patch that binding rather than the crud module.
+            patch(
+                "preloop.services.approval_service.get_approval_request_async",
+                new=AsyncMock(side_effect=_get_request),
+            ),
+            patch(
+                "preloop.services.approval_service.asyncio.sleep",
+                new=ledger.make_sleep(on_sleep=resolve),
+            ),
+        ):
+            final_request = await service.wait_for_approval(
+                pending.id, poll_interval=2.0
+            )
+
+        assert final_request.status == "approved"
+        assert ledger.opened >= 1, (
+            "wait_for_approval never opened a fresh polling session; it is "
+            "still polling on the caller's long-lived session"
+        )
+        assert ledger.at_sleep, "polling loop never slept"
+        assert max(ledger.at_sleep) == 0, (
+            "wait_for_approval held a DB session during the approval wait"
+        )
+
+
+class TestDynamicMcpServerSessionRelease:
+    """_request_and_wait_for_approval must close its session before waiting."""
+
+    async def test_no_session_held_while_waiting(self):
+        from preloop.services.dynamic_mcp_server import DynamicMCPServer
+
+        ledger = SessionLedger()
+        workflow = make_workflow()
+        pending = make_request("pending")
+        approved = make_request("approved")
+        approved.id = pending.id
+
+        config = MagicMock()
+        config.id = uuid4()
+        config.approval_workflow_id = workflow.id
+
+        held_during_wait: list[int] = []
+
+        async def _wait(request_id, poll_interval=1.0):
+            held_during_wait.append(ledger.held)
+            return approved
+
+        approval_service = AsyncMock()
+        approval_service.create_and_notify = AsyncMock(return_value=pending)
+        approval_service.wait_for_approval = AsyncMock(side_effect=_wait)
+
+        user_context = MagicMock()
+        user_context.account_id = uuid4()
+
+        with (
+            patch(
+                "preloop.models.db.session.get_async_db_session",
+                new=ledger.make_session_factory(),
+            ),
+            patch(
+                "preloop.models.crud.tool_configuration."
+                "get_tool_config_by_name_and_source_async",
+                new_callable=AsyncMock,
+                return_value=config,
+            ),
+            patch(
+                "preloop.models.crud.approval_workflow.get_approval_workflow_async",
+                new_callable=AsyncMock,
+                return_value=workflow,
+            ),
+            patch(
+                "preloop.services.approval_service.ApprovalService",
+                return_value=approval_service,
+            ),
+        ):
+            await DynamicMCPServer._request_and_wait_for_approval(
+                MagicMock(),
+                user_context,
+                "test_tool",
+                {"arg": "value"},
+            )
+
+        assert held_during_wait == [0], (
+            "a DB session was still checked out while waiting for the "
+            f"approval decision: {held_during_wait}"
+        )

--- a/backend/tests/services/test_db_pool_monitor.py
+++ b/backend/tests/services/test_db_pool_monitor.py
@@ -1,0 +1,132 @@
+"""Tests for the SQLAlchemy connection pool monitor."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from preloop.services.db_pool_monitor import (
+    DbPoolMonitor,
+    collect_pool_stats,
+    db_monitoring_enabled,
+    register_otel_pool_gauges,
+)
+
+
+def make_pool(size=8, checked_out=0, checked_in=None, overflow=0):
+    pool = MagicMock()
+    pool.size.return_value = size
+    pool.checkedout.return_value = checked_out
+    pool.checkedin.return_value = (
+        checked_in if checked_in is not None else max(size - checked_out, 0)
+    )
+    pool.overflow.return_value = overflow
+    pool.status.return_value = (
+        f"Pool size: {size} Connections in pool: {max(size - checked_out, 0)}"
+    )
+    return pool
+
+
+def make_engine(pool):
+    engine = MagicMock()
+    engine.pool = pool
+    engine.sync_engine.pool = pool
+    return engine
+
+
+def patch_engines(sync_engine=None, async_engine=None):
+    return (
+        patch(
+            "preloop.models.db.session.get_engine_if_initialized",
+            return_value=sync_engine,
+        ),
+        patch(
+            "preloop.models.db.session.get_async_engine_if_initialized",
+            return_value=async_engine,
+        ),
+        patch(
+            "preloop.models.db.session._env_int",
+            side_effect=lambda name, default: 12
+            if name == "DATABASE_MAX_OVERFLOW"
+            else default,
+        ),
+    )
+
+
+class TestCollectPoolStats:
+    def test_skips_uninitialized_engines(self):
+        p1, p2, p3 = patch_engines(sync_engine=None, async_engine=None)
+        with p1, p2, p3:
+            assert collect_pool_stats() == []
+
+    def test_reports_both_engines(self):
+        sync_engine = make_engine(make_pool(size=8, checked_out=2))
+        async_engine = make_engine(make_pool(size=8, checked_out=5, overflow=1))
+        p1, p2, p3 = patch_engines(sync_engine, async_engine)
+        with p1, p2, p3:
+            stats = collect_pool_stats()
+
+        assert [s["engine"] for s in stats] == ["sync", "async"]
+        async_stats = stats[1]
+        assert async_stats["checked_out"] == 5
+        assert async_stats["overflow_in_use"] == 1
+        # Ceiling is pool_size + max_overflow (12 from the patched env).
+        assert async_stats["ceiling"] == 20
+
+    def test_negative_overflow_clamped_to_zero(self):
+        engine = make_engine(make_pool(size=8, checked_out=1, overflow=-7))
+        p1, p2, p3 = patch_engines(sync_engine=engine)
+        with p1, p2, p3:
+            stats = collect_pool_stats()
+        assert stats[0]["overflow_in_use"] == 0
+
+
+class TestWarnThreshold:
+    def test_warns_at_80_percent_of_ceiling(self, caplog):
+        # Ceiling is 8 + 12 = 20; 16 checked out is exactly 80%.
+        engine = make_engine(make_pool(size=8, checked_out=16, overflow=8))
+        monitor = DbPoolMonitor(interval_seconds=30, warn_ratio=0.8)
+        p1, p2, p3 = patch_engines(async_engine=engine)
+        with p1, p2, p3, caplog.at_level(logging.WARNING):
+            monitor.check_once()
+
+        warnings = [
+            r for r in caplog.records if "pool nearing exhaustion" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "engine=async" in message
+        assert "16/20" in message
+
+    def test_quiet_below_threshold(self, caplog):
+        engine = make_engine(make_pool(size=8, checked_out=10, overflow=2))
+        monitor = DbPoolMonitor(interval_seconds=30, warn_ratio=0.8)
+        p1, p2, p3 = patch_engines(async_engine=engine)
+        with p1, p2, p3, caplog.at_level(logging.WARNING):
+            monitor.check_once()
+
+        assert not [
+            r for r in caplog.records if "pool nearing exhaustion" in r.getMessage()
+        ]
+
+
+class TestEnableFlag:
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("DB_MONITORING_ENABLED", raising=False)
+        assert db_monitoring_enabled() is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "OFF"])
+    def test_disabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("DB_MONITORING_ENABLED", value)
+        assert db_monitoring_enabled() is False
+
+    def test_enabled_values(self, monkeypatch):
+        monkeypatch.setenv("DB_MONITORING_ENABLED", "true")
+        assert db_monitoring_enabled() is True
+
+
+class TestOtelGauges:
+    def test_registers_against_noop_meter(self):
+        # With no meter provider configured the default no-op meter must
+        # absorb the registration without errors.
+        assert register_otel_pool_gauges() is True

--- a/backend/tests/services/test_db_pool_monitor.py
+++ b/backend/tests/services/test_db_pool_monitor.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from preloop.services.db_pool_monitor import (
+    DEFAULT_INTERVAL_SECONDS,
+    DEFAULT_WARN_RATIO,
     DbPoolMonitor,
     collect_pool_stats,
     db_monitoring_enabled,
@@ -108,6 +110,15 @@ class TestWarnThreshold:
         assert not [
             r for r in caplog.records if "pool nearing exhaustion" in r.getMessage()
         ]
+
+
+class TestEnvParsing:
+    def test_invalid_env_falls_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("DB_MONITORING_INTERVAL", "30s")
+        monkeypatch.setenv("DB_POOL_WARN_RATIO", "not-a-float")
+        monitor = DbPoolMonitor()
+        assert monitor.interval_seconds == DEFAULT_INTERVAL_SECONDS
+        assert monitor.warn_ratio == DEFAULT_WARN_RATIO
 
 
 class TestEnableFlag:

--- a/helm/preloop/values.yaml
+++ b/helm/preloop/values.yaml
@@ -345,6 +345,15 @@ database:
   # whole was 65/200. Raising the gateway ceiling from 10 to 20 per pod is
   # what fixes it.
   #
+  # Approval waits no longer hold connections: the approval paths used to
+  # keep one async-pool connection checked out per pending approval for the
+  # whole human wait (up to the workflow timeout), so ~15-20 concurrent
+  # pending approvals could exhaust a pod's async ceiling. They now release
+  # the session before waiting and poll with short-lived sessions, so this
+  # budget does not need headroom for pending approvals. The DB pool monitor
+  # (DB_MONITORING_ENABLED, default on) logs a WARNING when a pod's
+  # checked-out connections reach 80% of its ceiling.
+  #
   # If you increase gateway maxReplicas or add components, re-check the
   # steady total against max_connections (see cnpg.parameters below).
   pool:


### PR DESCRIPTION
## Summary

A deployment observed SQLAlchemy QueuePool exhaustion (pool timeout errors) under concurrent pending approvals. Root cause: the approval paths open a DB session before creating the approval request and keep it checked out across the entire polling loop that waits for a human decision, up to the workflow timeout (default 300s). Every pending approval therefore pins one async-pool connection for minutes; with a per-pod ceiling of pool_size + max_overflow, a modest number of concurrent pending approvals exhausts the pool and every other request on that pod hits the 30s pool timeout.

The subtle part: the creation path commits and then refreshes the new row on the caller's session. The refresh re-begins a transaction after the commit, so the connection stays checked out for the whole wait even though the loop itself polls with fresh sessions.

## Changes

- `approval_wrapper.with_approval`: policy check, workflow fetch, and approval creation now run in one short-lived session that closes before any waiting. Values needed later are extracted into plain locals, so no ORM instance survives the session. Each poll opens and closes its own session. This also fixes a latent fall-through bug where an approved request never executed the wrapped tool (the code logged "proceeding with execution" and then hit the unexpected-code-path guard).
- `approval_helper.require_approval`: same restructure. The session is released right after `create_and_notify`, workflow and request values are extracted into locals, and the escalation path re-fetches the workflow in its own session. `_deliver_question_in_band` now takes plain values instead of the ORM instance.
- `ApprovalService.wait_for_approval`: polls with a fresh session per iteration instead of reusing `self.db` across sleeps; escalation and expiry updates run in the per-poll session. Callers may release the session the service was constructed with before awaiting it.
- `dynamic_mcp_server._request_and_wait_for_approval`: closes its session before awaiting the decision.
- Observability (`services/db_pool_monitor.py`, wired in the app lifespan and gated by `DB_MONITORING_ENABLED`, default on): OpenTelemetry observable gauges for checked-out, overflow-in-use, and ceiling per engine, registered on the same metrics stack `otel_export.py` configures (no-op when OTLP is off), plus a periodic WARNING log when an engine's checked-out connections reach 80% of its ceiling (tunable via `DB_POOL_WARN_RATIO`, interval via `DB_MONITORING_INTERVAL`). The monitor never creates engines.
- `models/db/session.py`: adds `get_engine_if_initialized` / `get_async_engine_if_initialized` accessors for the monitor.
- `helm/preloop/values.yaml`: pool-budget comment updated to note approval waits no longer hold connections; no pool numbers changed.

## Tests

- New `test_approval_session_hold.py` instruments `get_async_db_session` and asserts the outer session is returned before the first poll sleep and that concurrent pending approvals accumulate zero checked-out sessions, across all four fixed paths. All of these fail on main (the concurrent test observes 5 held sessions for 5 pending approvals) and pass with the fix. Approved, declined, cancelled, and expired behavior is covered.
- New `test_db_pool_monitor.py` covers the snapshot logic, the 80% warning threshold, the enable flag, and gauge registration against the no-op meter.
- `test_approval_service.py` wait_for_approval tests updated to the fresh-session-per-poll contract (class-level patches).
- `backend/tests/services`: 2429 passed on this branch vs 2409 on main (20 new tests), with an identical set of pre-existing environment-dependent errors in both runs.

## Notes for reviewers

- `with_approval` previously never executed the tool after an approval (fall-through to the unexpected-code-path guard). This PR makes the approved path execute the tool, which matches the decorator's documented contract; the decorator currently has no production call sites in this repository.
- Behavior is otherwise unchanged from the caller's perspective: streaming progress via ctx, fail-closed error handling, and decline/cancel/expiry messages are preserved.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium risk**
> Refactors session lifetimes across four approval paths and adds a new DB pool monitor; well-tested and fail-closed behavior is preserved, but the changes touch core human-in-the-loop approval flows.
>
> **Overview**
> Fixes async-pool exhaustion by ensuring approval waits no longer hold a DB session: policy check, workflow fetch, and approval creation run in a short-lived session that closes before polling, and each poll opens its own session. Also fixes a fall-through bug where `with_approval` never executed the tool after an approval, and adds OTel pool gauges plus a saturation WARNING log.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 1b6c243e. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->