### PR TITLE
Console UX wave 1: Overview, Attention page, Usage card, Limits dialog, Agents list

### DIFF
--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -60,6 +60,10 @@ The Tracker Detail page is the entry point for issue analytics. Clicking a track
 
 Issue analytics features are no longer accessible from the main sidebar — they are scoped to individual trackers via this detail page.
 
+### Overview and Attention (`src/views/authed/dashboard-control-plane-view.ts`, `attention-view.ts`)
+
+The Overview (`/console`) leads with five current-state counts (agents, flows, models, tools, need attention), the two gateway endpoints (model gateway and tool firewall), a Usage card (tokens or estimated dollars over one page-wide time range, with global budget rows and the limits dialog), and activity cards. "Need attention" links to `/console/attention`, which lists pending approvals, agents with setup or live-check problems, flows with failed runs, models with gateway failures, budgets over their soft or hard limit, and a stale price catalog. Both views derive their items with `utils/attention.ts` (`deriveAttentionItems`, pure) from the same inputs fetched by `utils/attention-data.ts` (`loadAttentionInputs`), so the hero count and the page agree.
+
 ### Tools Page (`src/views/authed/tools-view.ts`)
 
 The Tools page has been redesigned from a card-based layout to a tree-style list view:

--- a/frontend/src/components/budget-health-card.ts
+++ b/frontend/src/components/budget-health-card.ts
@@ -5,6 +5,7 @@ import type {
   AccountGatewayUsageSummaryResponse,
   ManagedAgentSummary,
 } from '../types';
+import { budgetTrackStyles } from '../styles/budget-track';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
@@ -30,159 +31,117 @@ export class BudgetHealthCard extends LitElement {
   @property({ type: String }) timeRange = 'month';
   @property({ type: Boolean }) showRangeSelector = false;
 
-  static styles = css`
-    :host {
-      display: block;
-      width: 100%;
-    }
+  static styles = [
+    budgetTrackStyles,
+    css`
+      :host {
+        display: block;
+        width: 100%;
+      }
 
-    .content-card {
-      width: 100%;
-    }
+      .content-card {
+        width: 100%;
+      }
 
-    .content-card::part(base) {
-      width: 100%;
-    }
+      .content-card::part(base) {
+        width: 100%;
+      }
 
-    .header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: var(--sl-spacing-small);
-    }
+      .header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: var(--sl-spacing-small);
+      }
 
-    .title {
-      display: flex;
-      align-items: center;
-      gap: var(--sl-spacing-2x-small);
-      font-weight: 600;
-    }
+      .title {
+        display: flex;
+        align-items: center;
+        gap: var(--sl-spacing-2x-small);
+        font-weight: 600;
+      }
 
-    select {
-      background: transparent;
-      border: none;
-      color: var(--sl-color-neutral-600);
-      cursor: pointer;
-      font-size: var(--sl-font-size-small);
-      outline: none;
-    }
+      select {
+        background: transparent;
+        border: none;
+        color: var(--sl-color-neutral-600);
+        cursor: pointer;
+        font-size: var(--sl-font-size-small);
+        outline: none;
+      }
 
-    .content {
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-medium);
-    }
+      .content {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-medium);
+      }
 
-    .rows {
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-small);
-    }
+      .rows {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-small);
+      }
 
-    .budget-row {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
+      .budget-row {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
 
-    .row-header,
-    .row-footer {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: var(--sl-spacing-small);
-    }
+      .row-header,
+      .row-footer {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: var(--sl-spacing-small);
+      }
 
-    .row-header {
-      font-size: var(--sl-font-size-small);
-    }
+      .row-header {
+        font-size: var(--sl-font-size-small);
+      }
 
-    .row-label {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      min-width: 0;
-      color: var(--sl-color-neutral-800);
-    }
+      .row-label {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        min-width: 0;
+        color: var(--sl-color-neutral-800);
+      }
 
-    .row-value {
-      font-weight: 500;
-      text-align: right;
-      white-space: nowrap;
-    }
+      .row-value {
+        font-weight: 500;
+        text-align: right;
+        white-space: nowrap;
+      }
 
-    .row-footer {
-      color: var(--sl-color-neutral-500);
-      font-size: var(--sl-font-size-x-small);
-    }
+      .row-footer {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-x-small);
+      }
 
-    .budget-track {
-      position: relative;
-      height: 6px;
-      border-radius: 999px;
-      background: var(--sl-color-neutral-200);
-      overflow: hidden;
-    }
+      .title.exceeded {
+        color: var(--sl-color-danger-700);
+      }
 
-    .budget-track-fill {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: var(--budget-fill-left, 0%);
-      width: var(--budget-fill-width, 0%);
-      background: var(--sl-color-success-600);
-    }
+      .row-value.exceeded {
+        color: var(--sl-color-danger-700);
+      }
 
-    .title.exceeded {
-      color: var(--sl-color-danger-700);
-    }
+      .row-footer .limit-status {
+        color: var(--sl-color-danger-700);
+        font-weight: var(--sl-font-weight-semibold);
+      }
 
-    .row-value.exceeded {
-      color: var(--sl-color-danger-700);
-    }
+      .empty {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+      }
 
-    .row-footer .limit-status {
-      color: var(--sl-color-danger-700);
-      font-weight: var(--sl-font-weight-semibold);
-    }
-
-    .budget-track-fill.warning {
-      background: var(--sl-color-warning-600);
-    }
-
-    .budget-track-fill.danger {
-      background: var(--sl-color-danger-600);
-    }
-
-    .budget-soft-marker {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: var(--budget-soft-position, 0%);
-      width: 2px;
-      background: var(--sl-color-warning-600);
-      box-shadow: 0 0 0 1px var(--sl-color-neutral-0);
-    }
-
-    .budget-hard-marker {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      width: 2px;
-      background: var(--sl-color-danger-600);
-      box-shadow: 0 0 0 1px var(--sl-color-neutral-0);
-    }
-
-    .empty {
-      color: var(--sl-color-neutral-600);
-      font-size: var(--sl-font-size-small);
-    }
-
-    sl-button {
-      width: 100%;
-    }
-  `;
+      sl-button {
+        width: 100%;
+      }
+    `,
+  ];
 
   private formatCurrency(value?: number | null): string {
     const amount = Number(value || 0);

--- a/frontend/src/components/budget-limits-dialog.test.ts
+++ b/frontend/src/components/budget-limits-dialog.test.ts
@@ -1,0 +1,52 @@
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import './budget-limits-dialog.ts';
+import type { BudgetLimitsDialog } from './budget-limits-dialog';
+
+describe('budget-limits-dialog', () => {
+  it('hosts the limits editor with the shared explanation', async () => {
+    const element = await fixture<BudgetLimitsDialog>(
+      html`<budget-limits-dialog></budget-limits-dialog>`
+    );
+    await element.updateComplete;
+
+    const dialog = element.shadowRoot!.querySelector('sl-dialog')!;
+    expect(dialog.getAttribute('label')).to.equal('Spending limits');
+    expect(
+      element.shadowRoot!.querySelector('.description')!.textContent!.trim()
+    ).to.equal(
+      'Soft limits notify. Hard limits stop model calls through the gateway.'
+    );
+    expect(element.shadowRoot!.querySelector('budget-policy-editor')).to.exist;
+  });
+
+  it('forwards budget-policies-changed from the editor', async () => {
+    const element = await fixture<BudgetLimitsDialog>(
+      html`<budget-limits-dialog open></budget-limits-dialog>`
+    );
+    await element.updateComplete;
+    const editor = element.shadowRoot!.querySelector('budget-policy-editor')!;
+
+    setTimeout(() =>
+      editor.dispatchEvent(
+        new CustomEvent('budget-policies-changed', {
+          bubbles: true,
+          composed: true,
+        })
+      )
+    );
+    await oneEvent(element, 'budget-policies-changed');
+  });
+
+  it('clears open when the dialog is dismissed', async () => {
+    const element = await fixture<BudgetLimitsDialog>(
+      html`<budget-limits-dialog open></budget-limits-dialog>`
+    );
+    await element.updateComplete;
+    const dialog = element.shadowRoot!.querySelector('sl-dialog')!;
+
+    dialog.dispatchEvent(new CustomEvent('sl-hide', { bubbles: true }));
+    await element.updateComplete;
+
+    expect(element.open).to.be.false;
+  });
+});

--- a/frontend/src/components/budget-limits-dialog.test.ts
+++ b/frontend/src/components/budget-limits-dialog.test.ts
@@ -5,7 +5,7 @@ import type { BudgetLimitsDialog } from './budget-limits-dialog';
 describe('budget-limits-dialog', () => {
   it('hosts the limits editor with the shared explanation', async () => {
     const element = await fixture<BudgetLimitsDialog>(
-      html`<budget-limits-dialog></budget-limits-dialog>`
+      html`<budget-limits-dialog open></budget-limits-dialog>`
     );
     await element.updateComplete;
 
@@ -17,6 +17,16 @@ describe('budget-limits-dialog', () => {
       'Soft limits notify. Hard limits stop model calls through the gateway.'
     );
     expect(element.shadowRoot!.querySelector('budget-policy-editor')).to.exist;
+  });
+
+  it('keeps the editor out of the tree until it is opened', async () => {
+    const element = await fixture<BudgetLimitsDialog>(
+      html`<budget-limits-dialog></budget-limits-dialog>`
+    );
+    await element.updateComplete;
+
+    expect(element.shadowRoot!.querySelector('budget-policy-editor')).to.not
+      .exist;
   });
 
   it('forwards budget-policies-changed from the editor', async () => {
@@ -31,6 +41,7 @@ describe('budget-limits-dialog', () => {
         new CustomEvent('budget-policies-changed', {
           bubbles: true,
           composed: true,
+          detail: { policies: [] },
         })
       )
     );

--- a/frontend/src/components/budget-limits-dialog.ts
+++ b/frontend/src/components/budget-limits-dialog.ts
@@ -1,4 +1,4 @@
-import { LitElement, css, html } from 'lit';
+import { LitElement, css, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
@@ -36,12 +36,13 @@ export class BudgetLimitsDialog extends LitElement {
     );
   }
 
-  private handlePoliciesChanged(event: Event) {
+  private handlePoliciesChanged(event: CustomEvent) {
     event.stopPropagation();
     this.dispatchEvent(
       new CustomEvent('budget-policies-changed', {
         bubbles: true,
         composed: true,
+        detail: event.detail,
       })
     );
   }
@@ -57,12 +58,18 @@ export class BudgetLimitsDialog extends LitElement {
         <div class="description">
           Soft limits notify. Hard limits stop model calls through the gateway.
         </div>
-        <budget-policy-editor
-          .billingEnabled=${this.billingEnabled}
-          .subjectType=${this.subjectType}
-          .subjectId=${this.subjectId}
-          @budget-policies-changed=${this.handlePoliciesChanged}
-        ></budget-policy-editor>
+        ${
+          // The editor loads policies and subject lists on connect; keep it out
+          // of the tree until the operator actually opens the dialog.
+          this.open
+            ? html`<budget-policy-editor
+                .billingEnabled=${this.billingEnabled}
+                .subjectType=${this.subjectType}
+                .subjectId=${this.subjectId}
+                @budget-policies-changed=${this.handlePoliciesChanged}
+              ></budget-policy-editor>`
+            : nothing
+        }
       </sl-dialog>
     `;
   }

--- a/frontend/src/components/budget-limits-dialog.ts
+++ b/frontend/src/components/budget-limits-dialog.ts
@@ -1,0 +1,75 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
+import './budget-policy-editor.ts';
+
+/**
+ * One dialog for spending limits, shared by the Overview usage card and the
+ * attention page, so the limits editor is never re-wrapped per view.
+ */
+@customElement('budget-limits-dialog')
+export class BudgetLimitsDialog extends LitElement {
+  @property({ type: Boolean, reflect: true }) open = false;
+  @property({ type: Boolean }) billingEnabled = false;
+  /** Optional scoping, forwarded to the editor (agent/model embeds). */
+  @property({ type: String }) subjectType?: string;
+  @property({ type: String }) subjectId?: string;
+
+  static styles = css`
+    sl-dialog::part(body) {
+      padding-top: var(--sl-spacing-small);
+    }
+
+    .description {
+      color: var(--sl-color-neutral-600);
+      font-size: var(--sl-font-size-small);
+      margin-bottom: var(--sl-spacing-medium);
+    }
+  `;
+
+  private handleHide(event: Event) {
+    if (event.target !== event.currentTarget) return;
+    this.open = false;
+    this.dispatchEvent(
+      new CustomEvent('sl-hide', { bubbles: true, composed: true })
+    );
+  }
+
+  private handlePoliciesChanged(event: Event) {
+    event.stopPropagation();
+    this.dispatchEvent(
+      new CustomEvent('budget-policies-changed', {
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  render() {
+    return html`
+      <sl-dialog
+        label="Spending limits"
+        style="--width: 720px;"
+        ?open=${this.open}
+        @sl-hide=${this.handleHide}
+      >
+        <div class="description">
+          Soft limits notify. Hard limits stop model calls through the gateway.
+        </div>
+        <budget-policy-editor
+          .billingEnabled=${this.billingEnabled}
+          .subjectType=${this.subjectType}
+          .subjectId=${this.subjectId}
+          @budget-policies-changed=${this.handlePoliciesChanged}
+        ></budget-policy-editor>
+      </sl-dialog>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'budget-limits-dialog': BudgetLimitsDialog;
+  }
+}

--- a/frontend/src/components/budget-policy-editor.test.ts
+++ b/frontend/src/components/budget-policy-editor.test.ts
@@ -17,7 +17,10 @@ describe('BudgetPolicyEditor', () => {
     localStorage.clear();
   });
 
-  const stubBillingFetch = (opts?: { failModels?: boolean }) => {
+  const stubBillingFetch = (opts?: {
+    failModels?: boolean;
+    policies?: unknown[];
+  }) => {
     fetchStub.callsFake(
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input.toString();
@@ -72,7 +75,7 @@ describe('BudgetPolicyEditor', () => {
           });
         }
         if (url.includes('/api/v1/budget/policies') && method === 'GET') {
-          return new Response(JSON.stringify([]), {
+          return new Response(JSON.stringify(opts?.policies || []), {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
           });
@@ -81,6 +84,202 @@ describe('BudgetPolicyEditor', () => {
       }
     );
   };
+
+  const mountEditor = async () => {
+    const element = (await fixture(
+      html`<budget-policy-editor billingEnabled></budget-policy-editor>`
+    )) as BudgetPolicyEditor;
+    await waitUntil(
+      () => !element.shadowRoot?.textContent?.includes('Loading limits'),
+      'editor finished loading its policies'
+    );
+    await element.updateComplete;
+    return element;
+  };
+
+  it('lists the limits grouped by scope with periods and amounts', async () => {
+    stubBillingFetch({
+      policies: [
+        {
+          id: 'policy-1',
+          subject_type: 'global',
+          subject_id: null,
+          model_alias: null,
+          period: 'monthly',
+          hard_limit_usd: 300,
+          soft_limit_usd: 200,
+          current_spend_usd: 220,
+          notify_on_soft: true,
+          notify_on_hard: false,
+          notification_user_ids: ['user-1'],
+          notification_team_ids: [],
+          notification_emails: [],
+        },
+        {
+          id: 'policy-2',
+          subject_type: 'managed_agent',
+          subject_id: 'agent-1',
+          model_alias: null,
+          period: 'daily',
+          hard_limit_usd: null,
+          soft_limit_usd: 25,
+          current_spend_usd: 5,
+          notify_on_soft: false,
+          notify_on_hard: false,
+          notification_user_ids: [],
+          notification_team_ids: [],
+          notification_emails: [],
+        },
+      ],
+    });
+
+    const element = await mountEditor();
+    await waitUntil(() =>
+      Boolean(element.shadowRoot?.querySelector('.limit-row'))
+    );
+
+    const title = element.shadowRoot?.querySelector(
+      '#budget-policy-editor-title'
+    );
+    expect(title?.textContent?.trim()).to.equal('Limits');
+
+    const groups = Array.from(
+      element.shadowRoot!.querySelectorAll('.group-label')
+    ).map((label) => label.textContent!.trim());
+    expect(groups).to.eql(['Global', 'Agents']);
+
+    const rows = element.shadowRoot!.querySelectorAll('.limit-row');
+    expect(rows.length).to.equal(2);
+    expect(rows[0].textContent).to.contain('Global');
+    expect(rows[0].textContent).to.contain('Monthly');
+    expect(rows[0].textContent).to.contain('Soft $200.00 · Hard $300.00');
+    expect(rows[0].querySelector('.budget-track')).to.exist;
+    expect(rows[0].querySelector('sl-icon[name="bell"]')).to.exist;
+    expect(rows[1].textContent).to.contain('Soft $25.00');
+    expect(rows[1].textContent).to.not.contain('Hard $');
+    expect(rows[1].querySelector('sl-icon[name="bell"]')).to.not.exist;
+  });
+
+  it('invites a first limit when none exist', async () => {
+    stubBillingFetch();
+    const element = await mountEditor();
+
+    expect(element.shadowRoot?.textContent).to.contain(
+      'No limits yet. Start with a global monthly hard limit.'
+    );
+    expect(element.shadowRoot?.querySelector('.limit-row')).to.not.exist;
+  });
+
+  it('replaces the list with the form and comes back', async () => {
+    stubBillingFetch();
+    const element = await mountEditor();
+
+    (
+      element.shadowRoot!.querySelector(
+        'sl-button[variant="primary"]'
+      ) as HTMLElement
+    ).click();
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.textContent).to.contain('New limit');
+    expect(element.shadowRoot?.textContent).to.not.contain('No limits yet');
+    expect(element.shadowRoot?.querySelector('sl-radio-group')).to.exist;
+    expect(
+      element.shadowRoot?.querySelector('sl-input[label="Soft limit (USD)"]')
+    ).to.exist;
+
+    (element.shadowRoot!.querySelector('.back-button') as HTMLElement).click();
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.textContent).to.contain('No limits yet');
+  });
+
+  it('refuses to save without a limit and with soft above hard', async () => {
+    stubBillingFetch();
+    const element = await mountEditor();
+    (element as any).startAdd();
+    await element.updateComplete;
+
+    const save = () =>
+      (
+        element.shadowRoot!.querySelectorAll(
+          'sl-button[variant="primary"]'
+        )[0] as HTMLElement
+      ).click();
+
+    save();
+    await element.updateComplete;
+    expect(
+      element.shadowRoot?.querySelector('.field-error')?.textContent
+    ).to.contain('Set a soft limit, a hard limit, or both.');
+
+    (element as any).newSoftLimit = '300';
+    (element as any).newHardLimit = '100';
+    await element.updateComplete;
+    save();
+    await element.updateComplete;
+    expect(
+      element.shadowRoot?.querySelector('.field-error')?.textContent
+    ).to.contain('The soft limit must be at or below the hard limit.');
+
+    expect(
+      fetchStub
+        .getCalls()
+        .some((call) => (call.args[1] as any)?.method === 'POST')
+    ).to.be.false;
+  });
+
+  it('confirms in a dialog before deleting a limit', async () => {
+    stubBillingFetch({
+      policies: [
+        {
+          id: 'policy-1',
+          subject_type: 'global',
+          subject_id: null,
+          model_alias: null,
+          period: 'monthly',
+          hard_limit_usd: 300,
+          soft_limit_usd: null,
+          current_spend_usd: 10,
+          notify_on_soft: false,
+          notify_on_hard: false,
+          notification_user_ids: [],
+          notification_team_ids: [],
+          notification_emails: [],
+        },
+      ],
+    });
+    const element = await mountEditor();
+    await waitUntil(() =>
+      Boolean(element.shadowRoot?.querySelector('.limit-row'))
+    );
+
+    const dialog = element.shadowRoot!.querySelector('sl-dialog')!;
+    expect(dialog.hasAttribute('open')).to.be.false;
+
+    (
+      element.shadowRoot!.querySelectorAll('sl-menu-item')[1] as HTMLElement
+    ).click();
+    await element.updateComplete;
+    expect(dialog.hasAttribute('open')).to.be.true;
+
+    (
+      dialog.querySelector('sl-button[variant="danger"]') as HTMLElement
+    ).click();
+    await waitUntil(() =>
+      fetchStub
+        .getCalls()
+        .some(
+          (call) =>
+            String(call.args[0]).includes('/api/v1/budget/policies/policy-1') &&
+            (call.args[1] as any)?.method === 'DELETE'
+        )
+    );
+    await waitUntil(
+      () => !element.shadowRoot?.querySelector('.limit-row'),
+      'row disappears after the delete'
+    );
+  });
 
   it('renders budget policy region when billing is enabled', async () => {
     stubBillingFetch();
@@ -94,7 +293,7 @@ describe('BudgetPolicyEditor', () => {
     const title = element.shadowRoot?.querySelector(
       '#budget-policy-editor-title'
     );
-    expect(title?.textContent?.trim()).to.equal('Budget Policies');
+    expect(title?.textContent?.trim()).to.equal('Limits');
     expect(element.shadowRoot?.querySelector('[role="region"]')).to.exist;
   });
 
@@ -206,21 +405,19 @@ describe('BudgetPolicyEditor', () => {
       html`<budget-policy-editor billingEnabled></budget-policy-editor>`
     )) as BudgetPolicyEditor;
     await waitUntil(() =>
-      Boolean(
-        element.shadowRoot?.querySelector('sl-icon-button[name="pencil"]')
-      )
+      Boolean(element.shadowRoot?.querySelector('sl-menu-item'))
     );
 
-    element.shadowRoot
-      ?.querySelector('sl-icon-button[name="pencil"]')
-      ?.dispatchEvent(new Event('click', { bubbles: true, composed: true }));
+    (
+      element.shadowRoot!.querySelectorAll('sl-menu-item')[0] as HTMLElement
+    ).click();
     await element.updateComplete;
 
-    expect(element.shadowRoot?.textContent).to.include('Update Policy');
-    expect(element.shadowRoot?.textContent).to.include('Global (Account-wide)');
+    expect(element.shadowRoot?.textContent).to.include('Edit limit');
+    expect(element.shadowRoot?.textContent).to.include('Save limit');
 
     const hardLimitInput = element.shadowRoot?.querySelector(
-      'sl-input[label="Hard Limit (USD)"]'
+      'sl-input[label="Hard limit (USD)"]'
     ) as HTMLInputElement | null;
     expect(hardLimitInput?.value).to.equal('100');
 
@@ -261,8 +458,8 @@ describe('BudgetPolicyEditor', () => {
     });
 
     await waitUntil(() =>
-      element.shadowRoot?.textContent?.includes('Hard: $150.00')
+      element.shadowRoot?.textContent?.includes('Hard $150.00')
     );
-    expect(element.shadowRoot?.textContent).to.include('Hard: $150.00');
+    expect(element.shadowRoot?.textContent).to.include('Hard $150.00');
   });
 });

--- a/frontend/src/components/budget-policy-editor.ts
+++ b/frontend/src/components/budget-policy-editor.ts
@@ -15,20 +15,67 @@ import {
   fetchWithAuth,
 } from '../api.js';
 import type { User, UserListResponse, Team } from '../types.js';
+import { budgetTrackStyles, renderBudgetTrack } from '../styles/budget-track';
 import './notify-recipients-field.ts';
 import type { NotifyRecipientsValue } from './notify-recipients-field.ts';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
-
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
-import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
+import '@shoelace-style/shoelace/dist/components/switch/switch.js';
+import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
+import '@shoelace-style/shoelace/dist/components/radio-button/radio-button.js';
+import '@shoelace-style/shoelace/dist/components/dropdown/dropdown.js';
+import '@shoelace-style/shoelace/dist/components/menu/menu.js';
+import '@shoelace-style/shoelace/dist/components/menu-item/menu-item.js';
+import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
+import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
 import '@shoelace-style/shoelace/dist/components/icon-button/icon-button.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 
+/** List groups, in display order. Rendered only when they hold a limit. */
+const SUBJECT_GROUPS: {
+  types: string[];
+  label: string;
+  icon: string;
+}[] = [
+  { types: ['global', 'account'], label: 'Global', icon: 'globe' },
+  { types: ['managed_agent'], label: 'Agents', icon: 'robot' },
+  { types: ['ai_model'], label: 'Models', icon: 'cpu' },
+  { types: ['user'], label: 'Users', icon: 'person' },
+  { types: ['team'], label: 'Teams', icon: 'people' },
+  { types: ['api_key'], label: 'API keys', icon: 'key' },
+];
+
+const PERIOD_LABELS: Record<string, string> = {
+  hourly: 'Hourly',
+  daily: 'Daily',
+  weekly: 'Weekly',
+  monthly: 'Monthly',
+  yearly: 'Yearly',
+  all_time: 'All time',
+};
+
+const SCOPE_CHOICES: { value: string; label: string }[] = [
+  { value: 'global', label: 'Global' },
+  { value: 'managed_agent', label: 'Agent' },
+  { value: 'ai_model', label: 'Model' },
+  { value: 'user', label: 'User' },
+];
+
+/** Above this many options the subject picker grows a search box. */
+const SUBJECT_SEARCH_THRESHOLD = 8;
+
+/**
+ * Two steps in one component: a grouped list of the limits that exist, and a
+ * form that replaces the list while an operator writes one. Embedded scoped
+ * (agent, model, API key detail pages) it shows a flat list for that subject
+ * only, which is why the public API stays `subjectType` / `subjectId` /
+ * `billingEnabled` plus the `budget-policies-changed` event.
+ */
 @customElement('budget-policy-editor')
 export class BudgetPolicyEditor extends LitElement {
   @property({ type: String }) subjectType?: string;
@@ -37,9 +84,11 @@ export class BudgetPolicyEditor extends LitElement {
   @property({ type: Boolean }) billingEnabled = false;
 
   @state() private policies: BudgetPolicy[] = [];
-  @state() private showAddForm = false;
+  @state() private step: 'list' | 'form' = 'list';
   @state() private editingPolicyId: string | null = null;
   @state() private error = '';
+  @state() private formError = '';
+  @state() private pendingDeleteId: string | null = null;
 
   @state() private models: AIModel[] = [];
   @state() private agents: ManagedAgentSummary[] = [];
@@ -51,8 +100,9 @@ export class BudgetPolicyEditor extends LitElement {
   @state() private subjectsLoaded = false;
   @state() private features: Record<string, boolean> = {};
   @state() private availableUsers: User[] = [];
+  @state() private subjectFilter = '';
 
-  // New Policy Form State
+  // Form state
   @state() private newSubjectType = 'global';
   @state() private newSubjectId = 'global';
   @state() private newPeriod = 'monthly';
@@ -64,90 +114,128 @@ export class BudgetPolicyEditor extends LitElement {
   @state() private newNotifyTeamIds: string[] = [];
   @state() private newCustomEmails: string[] = [];
 
-  static styles = css`
-    :host {
-      display: block;
-      font-family: var(--sl-font-sans);
-    }
-    .policy-list {
-      margin-top: var(--sl-spacing-medium);
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-small);
-    }
-    .policy-item {
-      padding: var(--sl-spacing-small) var(--sl-spacing-medium);
-      border: 1px solid var(--sl-color-neutral-200);
-      border-radius: var(--sl-border-radius-medium);
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      background: var(--sl-panel-background-color);
-      color: var(--sl-color-neutral-900);
-    }
-    .form-container {
-      margin-top: var(--sl-spacing-medium);
-      padding: var(--sl-spacing-medium);
-      border: 1px solid var(--sl-color-neutral-200);
-      border-radius: var(--sl-border-radius-medium);
-      background: var(--sl-panel-background-color);
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-medium);
-    }
-    .form-row {
-      display: flex;
-      gap: var(--sl-spacing-medium);
-    }
-    .form-row > * {
-      flex: 1;
-    }
-    .form-actions {
-      display: flex;
-      justify-content: flex-end;
-      gap: var(--sl-spacing-small);
-      margin-top: var(--sl-spacing-small);
-    }
-    .checkbox-group {
-      display: flex;
-      gap: var(--sl-spacing-medium);
-      align-items: center;
-    }
-    .policy-actions {
-      display: flex;
-      align-items: center;
-      gap: var(--sl-spacing-2x-small);
-    }
-    .readonly-field {
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-3x-small);
-      flex: 1;
-    }
-    .readonly-label {
-      font-size: var(--sl-font-size-small);
-      font-weight: var(--sl-font-weight-semibold);
-      color: var(--sl-color-neutral-700);
-    }
-    .readonly-value {
-      font-size: var(--sl-font-size-small);
-      color: var(--sl-color-neutral-900);
-    }
-    .meta-text {
-      font-size: var(--sl-font-size-small);
-      color: var(--sl-color-neutral-500);
-      margin-top: var(--sl-spacing-3x-small);
-    }
-    .loading-state {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: var(--sl-spacing-small);
-      padding: var(--sl-spacing-large);
-      color: var(--sl-color-neutral-600);
-      font-size: var(--sl-font-size-small);
-    }
-  `;
+  static styles = [
+    budgetTrackStyles,
+    css`
+      :host {
+        display: block;
+        font-family: var(--sl-font-sans);
+        color: var(--sl-color-neutral-900);
+      }
+      .header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: var(--sl-spacing-small);
+      }
+      h4 {
+        margin: 0;
+        font-size: var(--sl-font-size-large);
+        font-weight: var(--sl-font-weight-semibold);
+      }
+      .group {
+        margin-top: var(--sl-spacing-medium);
+      }
+      .group-label {
+        display: flex;
+        align-items: center;
+        gap: var(--sl-spacing-2x-small);
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-x-small);
+        font-weight: var(--sl-font-weight-semibold);
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        margin-bottom: var(--sl-spacing-2x-small);
+      }
+      .limit-row {
+        display: flex;
+        align-items: center;
+        gap: var(--sl-spacing-small);
+        padding: var(--sl-spacing-x-small) 0;
+      }
+      .limit-row + .limit-row {
+        border-top: 1px solid var(--sl-color-neutral-100);
+      }
+      .row-main {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: var(--sl-spacing-2x-small);
+        min-width: 0;
+      }
+      .row-name {
+        font-weight: var(--sl-font-weight-semibold);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .row-limits {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        font-variant-numeric: tabular-nums;
+      }
+      .row-meter {
+        margin-left: auto;
+        width: 96px;
+        flex-shrink: 0;
+      }
+      .row-notify {
+        color: var(--sl-color-neutral-500);
+        flex-shrink: 0;
+      }
+      .empty {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        margin: var(--sl-spacing-medium) 0;
+      }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-medium);
+      }
+      .form-top {
+        display: flex;
+        align-items: center;
+        gap: var(--sl-spacing-small);
+      }
+      .back-button::part(base) {
+        padding-left: 0;
+      }
+      .form-row {
+        display: flex;
+        gap: var(--sl-spacing-medium);
+      }
+      .form-row > * {
+        flex: 1;
+      }
+      .switch-row {
+        display: flex;
+        gap: var(--sl-spacing-large);
+        align-items: center;
+      }
+      .field-error {
+        color: var(--sl-color-danger-700);
+        font-size: var(--sl-font-size-small);
+      }
+      .form-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--sl-spacing-small);
+      }
+      .form-actions .spacer {
+        margin-left: auto;
+      }
+      .loading-state {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--sl-spacing-small);
+        padding: var(--sl-spacing-large);
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+      }
+    `,
+  ];
 
   async connectedCallback() {
     super.connectedCallback();
@@ -179,7 +267,7 @@ export class BudgetPolicyEditor extends LitElement {
     if (this.subjectType) {
       return false;
     }
-    if (this.showAddForm) {
+    if (this.step === 'form') {
       return true;
     }
     return this.policies.some(
@@ -216,6 +304,10 @@ export class BudgetPolicyEditor extends LitElement {
     if (type === 'user') {
       const user = this.availableUsers.find((u) => u.id === id);
       return user ? user.username || user.email || user.id : id;
+    }
+    if (type === 'team') {
+      const team = this.teams.find((t) => t.id === id);
+      return team ? team.name || team.id : id;
     }
     return id;
   }
@@ -293,21 +385,31 @@ export class BudgetPolicyEditor extends LitElement {
     try {
       await deleteBudgetPolicy(id);
       if (this.editingPolicyId === id) {
-        this.cancelForm();
+        this.showList();
       }
       this.policies = this.policies.filter((policy) => policy.id !== id);
       this.dispatchPoliciesChanged();
     } catch (e: any) {
-      this.error = 'Failed to delete policy.';
+      this.error = 'Failed to delete limit.';
     } finally {
+      this.pendingDeleteId = null;
       this.saving = false;
     }
   }
 
+  private startAdd() {
+    this.resetForm();
+    this.editingPolicyId = null;
+    this.error = '';
+    this.formError = '';
+    this.step = 'form';
+    void this.ensureSubjectsLoaded();
+  }
+
   private startEdit(policy: BudgetPolicy) {
-    this.showAddForm = false;
     this.editingPolicyId = policy.id;
     this.error = '';
+    this.formError = '';
     this.newSubjectType = policy.subject_type;
     this.newSubjectId = policy.subject_id || 'global';
     this.newPeriod = policy.period;
@@ -320,13 +422,16 @@ export class BudgetPolicyEditor extends LitElement {
     this.newNotifyUserIds = [...(policy.notification_user_ids || [])];
     this.newNotifyTeamIds = [...(policy.notification_team_ids || [])];
     this.newCustomEmails = [...(policy.notification_emails || [])];
+    this.step = 'form';
+    void this.ensureSubjectsLoaded();
   }
 
-  private cancelForm() {
-    this.showAddForm = false;
+  private showList() {
+    this.step = 'list';
     this.editingPolicyId = null;
+    this.formError = '';
+    this.subjectFilter = '';
     this.resetForm();
-    this.error = '';
   }
 
   private buildNotifyPayload() {
@@ -348,12 +453,43 @@ export class BudgetPolicyEditor extends LitElement {
     this.newCustomEmails = event.detail.customEmails;
   }
 
+  /** Inline validation, so a typo never reaches the server as a 422. */
+  private validate(soft: number | null, hard: number | null): string {
+    if (soft === null && hard === null) {
+      return 'Set a soft limit, a hard limit, or both.';
+    }
+    if (soft !== null && soft <= 0) {
+      return 'The soft limit must be greater than zero.';
+    }
+    if (hard !== null && hard <= 0) {
+      return 'The hard limit must be greater than zero.';
+    }
+    if (soft !== null && hard !== null && soft > hard) {
+      return 'The soft limit must be at or below the hard limit.';
+    }
+    if (
+      !this.subjectType &&
+      this.newSubjectType !== 'global' &&
+      !this.newSubjectId
+    ) {
+      return 'Choose what this limit applies to.';
+    }
+    return '';
+  }
+
   private async handleSave() {
-    this.error = '';
-    this.saving = true;
-    const notifyPayload = this.buildNotifyPayload();
     const hardLimit = this.newHardLimit ? parseFloat(this.newHardLimit) : null;
     const softLimit = this.newSoftLimit ? parseFloat(this.newSoftLimit) : null;
+    const validationError = this.validate(softLimit, hardLimit);
+    if (validationError) {
+      this.formError = validationError;
+      return;
+    }
+
+    this.error = '';
+    this.formError = '';
+    this.saving = true;
+    const notifyPayload = this.buildNotifyPayload();
 
     try {
       if (this.editingPolicyId) {
@@ -367,7 +503,7 @@ export class BudgetPolicyEditor extends LitElement {
         this.policies = this.policies.map((policy) =>
           policy.id === updated.id ? updated : policy
         );
-        this.cancelForm();
+        this.showList();
         this.dispatchPoliciesChanged();
         return;
       }
@@ -388,55 +524,14 @@ export class BudgetPolicyEditor extends LitElement {
 
       const created = await createBudgetPolicy(payload);
       this.policies = [...this.policies, created];
-      this.cancelForm();
+      this.showList();
       this.dispatchPoliciesChanged();
     } catch (err: any) {
-      this.error =
-        'Failed to save policy. ' + (err instanceof Error ? err.message : '');
+      this.formError =
+        'Failed to save limit. ' + (err instanceof Error ? err.message : '');
     } finally {
       this.saving = false;
     }
-  }
-
-  private get isFormOpen(): boolean {
-    return this.showAddForm || this.editingPolicyId !== null;
-  }
-
-  private get editingPolicy(): BudgetPolicy | undefined {
-    return this.policies.find((policy) => policy.id === this.editingPolicyId);
-  }
-
-  private renderScopeSummary(policy?: BudgetPolicy) {
-    const subjectType = policy?.subject_type || this.newSubjectType;
-    const subjectId = policy?.subject_id || this.newSubjectId;
-    const scopeLabel =
-      subjectType === 'global'
-        ? 'Global (Account-wide)'
-        : subjectType === 'ai_model'
-          ? 'AI Model'
-          : subjectType === 'managed_agent'
-            ? 'Agent'
-            : subjectType === 'user'
-              ? 'User'
-              : subjectType;
-    return html`
-      <div class="form-row">
-        <div class="readonly-field">
-          <span class="readonly-label">Target Scope</span>
-          <span class="readonly-value">${scopeLabel}</span>
-        </div>
-        ${
-          subjectType !== 'global' && subjectId
-            ? html`<div class="readonly-field">
-                <span class="readonly-label">Subject</span>
-                <span class="readonly-value"
-                  >${this.getSubjectName(subjectType, subjectId)}</span
-                >
-              </div>`
-            : html`<div style="flex: 1"></div>`
-        }
-      </div>
-    `;
   }
 
   private resetForm() {
@@ -452,21 +547,421 @@ export class BudgetPolicyEditor extends LitElement {
     this.newCustomEmails = [];
   }
 
-  private formatNotifySummary(policy: BudgetPolicy): string {
-    const parts: string[] = [];
-    const userCount = policy.notification_user_ids?.length || 0;
-    const teamCount = policy.notification_team_ids?.length || 0;
-    const emailCount = policy.notification_emails?.length || 0;
-    if (userCount > 0) {
-      parts.push(`${userCount} user${userCount === 1 ? '' : 's'}`);
+  private formatCurrency(value: number): string {
+    const amount = Number(value || 0);
+    if (amount > 0 && amount < 0.01) return `$${amount.toFixed(4)}`;
+    return `$${amount.toFixed(2)}`;
+  }
+
+  private recipientCount(policy: BudgetPolicy): number {
+    return (
+      (policy.notification_user_ids?.length || 0) +
+      (policy.notification_team_ids?.length || 0) +
+      (policy.notification_emails?.length || 0)
+    );
+  }
+
+  private policyRowName(policy: BudgetPolicy): string {
+    if (policy.subject_type === 'global' || policy.subject_type === 'account') {
+      return 'Global';
     }
-    if (teamCount > 0) {
-      parts.push(`${teamCount} team${teamCount === 1 ? '' : 's'}`);
+    if (!policy.subject_id) {
+      return policy.subject_type.replace(/_/g, ' ');
     }
-    if (emailCount > 0) {
-      parts.push(`${emailCount} email${emailCount === 1 ? '' : 's'}`);
+    return this.getSubjectName(policy.subject_type, policy.subject_id);
+  }
+
+  private renderPolicyRow(policy: BudgetPolicy) {
+    const soft = policy.soft_limit_usd || 0;
+    const hard = policy.hard_limit_usd || 0;
+    const spend = policy.current_spend_usd || 0;
+    const limits = [
+      soft > 0 ? `Soft ${this.formatCurrency(soft)}` : null,
+      hard > 0 ? `Hard ${this.formatCurrency(hard)}` : null,
+    ].filter(Boolean);
+    const notifies = policy.notify_on_soft || policy.notify_on_hard;
+    const recipients = this.recipientCount(policy);
+
+    return html`
+      <div class="limit-row">
+        <div class="row-main">
+          <span class="row-name">${this.policyRowName(policy)}</span>
+          <sl-badge variant="neutral" pill
+            >${PERIOD_LABELS[policy.period] || policy.period}</sl-badge
+          >
+          <span class="row-limits"
+            >${limits.length ? limits.join(' · ') : 'No limit set'}</span
+          >
+        </div>
+        <div class="row-meter">
+          ${renderBudgetTrack({
+            spend,
+            softLimit: soft,
+            hardLimit: hard,
+            label: `${this.policyRowName(policy)} limit`,
+          })}
+        </div>
+        ${
+          notifies
+            ? html`<sl-tooltip
+                content=${
+                  recipients > 0
+                    ? `Notifies ${recipients} recipient${recipients === 1 ? '' : 's'}`
+                    : 'Notifications on, no recipients yet'
+                }
+              >
+                <sl-icon class="row-notify" name="bell"></sl-icon>
+              </sl-tooltip>`
+            : nothing
+        }
+        <sl-dropdown hoist>
+          <sl-icon-button
+            slot="trigger"
+            name="three-dots-vertical"
+            label="Limit actions"
+            ?disabled=${this.saving}
+          ></sl-icon-button>
+          <sl-menu>
+            <sl-menu-item @click=${() => this.startEdit(policy)}>
+              <sl-icon slot="prefix" name="pencil"></sl-icon>
+              Edit
+            </sl-menu-item>
+            <sl-menu-item @click=${() => (this.pendingDeleteId = policy.id)}>
+              <sl-icon slot="prefix" name="trash"></sl-icon>
+              Delete
+            </sl-menu-item>
+          </sl-menu>
+        </sl-dropdown>
+      </div>
+    `;
+  }
+
+  private renderList() {
+    if (this.loadingPolicies) {
+      return html`
+        <div class="loading-state" role="status" aria-live="polite">
+          <sl-spinner></sl-spinner>
+          Loading limits…
+        </div>
+      `;
     }
-    return parts.length > 0 ? parts.join(', ') : 'None';
+
+    if (this.policies.length === 0) {
+      return html`
+        <div class="empty">
+          No limits yet. Start with a global monthly hard limit.
+        </div>
+      `;
+    }
+
+    // Scoped embeds already filter to one subject, so grouping would print a
+    // single header over a single list.
+    if (this.subjectType) {
+      return html`<div class="group">
+        ${this.policies.map((policy) => this.renderPolicyRow(policy))}
+      </div>`;
+    }
+
+    const seen = new Set<string>();
+    const groups = SUBJECT_GROUPS.map((group) => {
+      const policies = this.policies.filter((policy) =>
+        group.types.includes(policy.subject_type)
+      );
+      policies.forEach((policy) => seen.add(policy.id));
+      return { ...group, policies };
+    }).filter((group) => group.policies.length > 0);
+
+    const other = this.policies.filter((policy) => !seen.has(policy.id));
+    if (other.length > 0) {
+      groups.push({
+        types: [],
+        label: 'Other',
+        icon: 'sliders',
+        policies: other,
+      });
+    }
+
+    return html`
+      ${groups.map(
+        (group) => html`
+          <div class="group">
+            <div class="group-label">
+              <sl-icon name=${group.icon}></sl-icon>
+              ${group.label}
+            </div>
+            ${group.policies.map((policy) => this.renderPolicyRow(policy))}
+          </div>
+        `
+      )}
+    `;
+  }
+
+  private subjectOptions(): { value: string; label: string }[] {
+    if (this.newSubjectType === 'ai_model') {
+      return this.models.map((m) => ({ value: m.id, label: m.alias || m.id }));
+    }
+    if (this.newSubjectType === 'managed_agent') {
+      return this.agents.map((a) => ({
+        value: a.id,
+        label: a.display_name || a.id,
+      }));
+    }
+    if (this.newSubjectType === 'user') {
+      return this.availableUsers.map((u) => ({
+        value: u.id,
+        label: u.username || u.email || u.id,
+      }));
+    }
+    return [];
+  }
+
+  private renderSubjectField() {
+    const options = this.subjectOptions();
+    const filter = this.subjectFilter.trim().toLowerCase();
+    const visible = filter
+      ? options.filter((option) => option.label.toLowerCase().includes(filter))
+      : options;
+    const searchable = options.length > SUBJECT_SEARCH_THRESHOLD;
+    const label =
+      this.newSubjectType === 'ai_model'
+        ? 'Model'
+        : this.newSubjectType === 'managed_agent'
+          ? 'Agent'
+          : 'User';
+
+    return html`
+      <div>
+        ${
+          searchable
+            ? html`<sl-input
+                size="small"
+                clearable
+                placeholder=${`Search ${label.toLowerCase()}s`}
+                aria-label=${`Search ${label.toLowerCase()}s`}
+                .value=${this.subjectFilter}
+                @sl-input=${(e: any) => (this.subjectFilter = e.target.value)}
+                style="margin-bottom: var(--sl-spacing-2x-small);"
+              >
+                <sl-icon slot="prefix" name="search"></sl-icon>
+              </sl-input>`
+            : nothing
+        }
+        <sl-select
+          label=${label}
+          value=${this.newSubjectId}
+          hoist
+          ?disabled=${this.loadingSubjects || this.editingPolicyId !== null}
+          help-text=${
+            this.newSubjectType === 'user'
+              ? 'Enforces across all agents owned by this user'
+              : ''
+          }
+          @sl-change=${(e: any) => (this.newSubjectId = e.target.value)}
+        >
+          ${visible.map(
+            (option) =>
+              html`<sl-option value=${option.value}>${option.label}</sl-option>`
+          )}
+        </sl-select>
+      </div>
+    `;
+  }
+
+  private renderForm() {
+    const editing = this.editingPolicyId !== null;
+
+    return html`
+      <div class="form">
+        <div class="form-top">
+          <sl-button
+            class="back-button"
+            variant="text"
+            size="small"
+            @click=${this.showList}
+          >
+            ← Limits
+          </sl-button>
+          <h4 id="budget-policy-editor-title">
+            ${editing ? 'Edit limit' : 'New limit'}
+          </h4>
+        </div>
+
+        ${
+          this.subjectType
+            ? nothing
+            : html`
+                <sl-radio-group
+                  label="Scope"
+                  value=${this.newSubjectType}
+                  @sl-change=${(e: any) => {
+                    this.newSubjectType = e.target.value;
+                    this.newSubjectId =
+                      this.newSubjectType === 'global' ? 'global' : '';
+                    this.subjectFilter = '';
+                  }}
+                >
+                  ${SCOPE_CHOICES.map(
+                    (choice) => html`
+                      <sl-radio-button
+                        size="small"
+                        value=${choice.value}
+                        ?disabled=${editing}
+                        >${choice.label}</sl-radio-button
+                      >
+                    `
+                  )}
+                </sl-radio-group>
+                ${
+                  this.newSubjectType === 'global'
+                    ? nothing
+                    : this.renderSubjectField()
+                }
+              `
+        }
+
+        <sl-select
+          label="Period"
+          value=${this.newPeriod}
+          hoist
+          ?disabled=${editing}
+          @sl-change=${(e: any) => (this.newPeriod = e.target.value)}
+        >
+          ${Object.entries(PERIOD_LABELS).map(
+            ([value, label]) =>
+              html`<sl-option value=${value}>${label}</sl-option>`
+          )}
+        </sl-select>
+
+        <div class="form-row">
+          <sl-input
+            label="Soft limit (USD)"
+            type="number"
+            step="0.0001"
+            inputmode="decimal"
+            help-text="Notifies recipients"
+            .value=${this.newSoftLimit}
+            @sl-input=${(e: any) => (this.newSoftLimit = e.target.value)}
+          ></sl-input>
+          <sl-input
+            label="Hard limit (USD)"
+            type="number"
+            step="0.0001"
+            inputmode="decimal"
+            help-text="Blocks further model calls"
+            .value=${this.newHardLimit}
+            @sl-input=${(e: any) => (this.newHardLimit = e.target.value)}
+          ></sl-input>
+        </div>
+
+        ${
+          this.formError
+            ? html`<div class="field-error" role="alert">
+                ${this.formError}
+              </div>`
+            : nothing
+        }
+
+        <div class="switch-row">
+          <sl-switch
+            ?checked=${this.newNotifySoft}
+            @sl-change=${(e: any) => (this.newNotifySoft = e.target.checked)}
+          >
+            Notify on soft
+          </sl-switch>
+          <sl-switch
+            ?checked=${this.newNotifyHard}
+            @sl-change=${(e: any) => (this.newNotifyHard = e.target.checked)}
+          >
+            Notify on hard
+          </sl-switch>
+        </div>
+
+        ${
+          this.newNotifySoft || this.newNotifyHard
+            ? html`
+                <notify-recipients-field
+                  .users=${this.availableUsers}
+                  .teams=${this.teams}
+                  .userIds=${this.newNotifyUserIds}
+                  .teamIds=${this.newNotifyTeamIds}
+                  .customEmails=${this.newCustomEmails}
+                  help-text="Recipients are notified via their email and mobile app preferences. Add custom emails when needed."
+                  @notify-recipients-change=${this.handleNotifyRecipientsChange}
+                ></notify-recipients-field>
+              `
+            : nothing
+        }
+
+        <div class="form-actions">
+          ${
+            editing
+              ? html`<sl-button
+                  variant="danger"
+                  outline
+                  size="small"
+                  ?disabled=${this.saving}
+                  @click=${() => (this.pendingDeleteId = this.editingPolicyId)}
+                >
+                  Delete
+                </sl-button>`
+              : nothing
+          }
+          <span class="spacer"></span>
+          <sl-button
+            size="small"
+            ?disabled=${this.saving}
+            @click=${this.showList}
+            >Cancel</sl-button
+          >
+          <sl-button
+            variant="primary"
+            size="small"
+            ?loading=${this.saving}
+            ?disabled=${this.saving}
+            @click=${this.handleSave}
+          >
+            Save limit
+          </sl-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderDeleteConfirm() {
+    const policy = this.policies.find(
+      (candidate) => candidate.id === this.pendingDeleteId
+    );
+    return html`
+      <sl-dialog
+        label="Delete limit"
+        ?open=${this.pendingDeleteId !== null}
+        @sl-hide=${() => (this.pendingDeleteId = null)}
+      >
+        Delete the ${policy ? this.policyRowName(policy) : ''}
+        ${
+          policy
+            ? (PERIOD_LABELS[policy.period] || policy.period).toLowerCase()
+            : ''
+        }
+        limit? Spending will no longer be capped for that scope.
+        <div slot="footer">
+          <sl-button
+            size="small"
+            @click=${() => (this.pendingDeleteId = null)}
+            ?disabled=${this.saving}
+            >Cancel</sl-button
+          >
+          <sl-button
+            variant="danger"
+            size="small"
+            ?loading=${this.saving}
+            @click=${() =>
+              this.pendingDeleteId && this.handleDelete(this.pendingDeleteId)}
+            >Delete limit</sl-button
+          >
+        </div>
+      </sl-dialog>
+    `;
   }
 
   render() {
@@ -485,35 +980,23 @@ export class BudgetPolicyEditor extends LitElement {
 
     return html`
       <div role="region" aria-labelledby="budget-policy-editor-title">
-        <div
-          style="display: flex; justify-content: space-between; align-items: center;"
-        >
-          <h4
-            id="budget-policy-editor-title"
-            style="margin: 0; font-size: var(--sl-font-size-large); font-weight: var(--sl-font-weight-semibold); color: var(--sl-color-neutral-900);"
-          >
-            Budget Policies
-          </h4>
-          ${
-            !this.isFormOpen
-              ? html`
+        ${
+          this.step === 'list'
+            ? html`
+                <div class="header">
+                  <h4 id="budget-policy-editor-title">Limits</h4>
                   <sl-button
                     size="small"
                     variant="primary"
-                    @click=${() => {
-                      this.cancelForm();
-                      this.showAddForm = true;
-                      void this.ensureSubjectsLoaded();
-                    }}
+                    @click=${this.startAdd}
                   >
                     <sl-icon slot="prefix" name="plus"></sl-icon>
-                    Add Policy
+                    Add limit
                   </sl-button>
-                `
-              : ''
-          }
-        </div>
-
+                </div>
+              `
+            : nothing
+        }
         ${
           this.error
             ? html`
@@ -528,334 +1011,10 @@ export class BudgetPolicyEditor extends LitElement {
                   ${this.error}
                 </sl-alert>
               `
-            : ''
+            : nothing
         }
-
-        <div class="policy-list">
-          ${
-            this.loadingPolicies
-              ? html`
-                  <div class="loading-state" role="status" aria-live="polite">
-                    <sl-spinner></sl-spinner>
-                    Loading policies…
-                  </div>
-                `
-              : this.policies.length === 0 && !this.isFormOpen
-                ? html`<div
-                    style="color: var(--sl-color-neutral-500); font-size: var(--sl-font-size-small);"
-                  >
-                    No budget policies configured.
-                  </div>`
-                : this.policies.map(
-                    (p) => html`
-                      <div class="policy-item">
-                        <div>
-                          <strong style="color: var(--sl-color-neutral-900);"
-                            >${
-                              p.period.charAt(0).toUpperCase() +
-                              p.period.slice(1)
-                            }</strong
-                          >
-                          ${
-                            !this.subjectType
-                              ? html`
-                                  <sl-badge
-                                    variant="neutral"
-                                    style="margin-left: 8px;"
-                                  >
-                                    ${
-                                      p.subject_type === 'global'
-                                        ? 'Global'
-                                        : p.subject_type === 'ai_model'
-                                          ? 'Model'
-                                          : p.subject_type === 'managed_agent'
-                                            ? 'Agent'
-                                            : p.subject_type === 'user'
-                                              ? 'User'
-                                              : p.subject_type
-                                    }
-                                  </sl-badge>
-                                  <span
-                                    style="font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-600); margin-left: 4px;"
-                                  >
-                                    ${
-                                      p.subject_type !== 'global' &&
-                                      p.subject_id
-                                        ? this.getSubjectName(
-                                            p.subject_type,
-                                            p.subject_id
-                                          )
-                                        : ''
-                                    }
-                                  </span>
-                                `
-                              : ''
-                          }
-                          <br />
-                          <span
-                            style="font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-700);"
-                            >Limit:</span
-                          >
-                          ${
-                            p.hard_limit_usd
-                              ? html`<span
-                                  style="font-size: var(--sl-font-size-small);"
-                                  >Hard: $${p.hard_limit_usd.toFixed(2)}</span
-                                >`
-                              : html`<span
-                                  style="font-size: var(--sl-font-size-small);"
-                                  >No Hard Limit</span
-                                >`
-                          }
-                          ${
-                            p.soft_limit_usd
-                              ? html`<span
-                                  style="font-size: var(--sl-font-size-small);"
-                                  >| Soft: $${p.soft_limit_usd.toFixed(2)}</span
-                                >`
-                              : ''
-                          }
-                          ${
-                            this.features?.['billing']
-                              ? html`
-                                  <div class="meta-text">
-                                    Notify: ${this.formatNotifySummary(p)}
-                                  </div>
-                                `
-                              : ''
-                          }
-                        </div>
-                        <div class="policy-actions">
-                          <sl-icon-button
-                            name="pencil"
-                            label="Edit policy"
-                            ?disabled=${this.saving}
-                            @click=${() => this.startEdit(p)}
-                          ></sl-icon-button>
-                          <sl-icon-button
-                            name="trash"
-                            label="Delete policy"
-                            style="color: var(--sl-color-danger-600);"
-                            ?disabled=${this.saving}
-                            @click=${() => this.handleDelete(p.id)}
-                          ></sl-icon-button>
-                        </div>
-                      </div>
-                    `
-                  )
-          }
-        </div>
-
-        ${
-          this.isFormOpen
-            ? html`
-                <div class="form-container">
-                  ${
-                    this.editingPolicyId
-                      ? html`
-                          ${this.renderScopeSummary(this.editingPolicy)}
-                          <div class="readonly-field">
-                            <span class="readonly-label">Period</span>
-                            <span class="readonly-value"
-                              >${
-                                this.editingPolicy?.period
-                                  ? this.editingPolicy.period
-                                      .charAt(0)
-                                      .toUpperCase() +
-                                    this.editingPolicy.period.slice(1)
-                                  : this.newPeriod
-                              }</span
-                            >
-                          </div>
-                        `
-                      : !this.subjectType
-                        ? html`
-                            <div class="form-row">
-                              <sl-select
-                                label="Target Scope"
-                                value=${this.newSubjectType}
-                                @sl-change=${(e: any) => {
-                                  this.newSubjectType = e.target.value;
-                                  this.newSubjectId =
-                                    this.newSubjectType === 'global'
-                                      ? 'global'
-                                      : '';
-                                }}
-                              >
-                                <sl-option value="global"
-                                  >Global (Account-wide)</sl-option
-                                >
-                                <sl-option value="ai_model">AI Model</sl-option>
-                                <sl-option value="managed_agent"
-                                  >Agent</sl-option
-                                >
-                                <sl-option value="user">User</sl-option>
-                              </sl-select>
-
-                              ${
-                                this.newSubjectType === 'ai_model'
-                                  ? html`
-                                      <sl-select
-                                        label="Select Model"
-                                        value=${this.newSubjectId}
-                                        @sl-change=${(e: any) =>
-                                          (this.newSubjectId = e.target.value)}
-                                        ?disabled=${this.loadingSubjects}
-                                      >
-                                        ${this.models.map(
-                                          (m) =>
-                                            html`<sl-option value=${m.id}
-                                              >${m.alias || m.id}</sl-option
-                                            >`
-                                        )}
-                                      </sl-select>
-                                    `
-                                  : this.newSubjectType === 'managed_agent'
-                                    ? html`
-                                        <sl-select
-                                          label="Select Agent"
-                                          value=${this.newSubjectId}
-                                          @sl-change=${(e: any) =>
-                                            (this.newSubjectId =
-                                              e.target.value)}
-                                          ?disabled=${this.loadingSubjects}
-                                        >
-                                          ${this.agents.map(
-                                            (a) =>
-                                              html`<sl-option value=${a.id}
-                                                >${a.display_name || a.id}</sl-option
-                                              >`
-                                          )}
-                                        </sl-select>
-                                      `
-                                    : this.newSubjectType === 'user'
-                                      ? html`
-                                          <sl-select
-                                            label="Select User"
-                                            value=${this.newSubjectId}
-                                            @sl-change=${(e: any) =>
-                                              (this.newSubjectId =
-                                                e.target.value)}
-                                            ?disabled=${this.loadingSubjects}
-                                            help-text="Enforces across all agents owned by this user"
-                                          >
-                                            ${this.availableUsers.map(
-                                              (u) =>
-                                                html`<sl-option value=${u.id}
-                                                  >${
-                                                    u.username ||
-                                                    u.email ||
-                                                    u.id
-                                                  }</sl-option
-                                                >`
-                                            )}
-                                          </sl-select>
-                                        `
-                                      : html`<div style="flex: 1"></div>`
-                              }
-                            </div>
-                            <sl-select
-                              label="Period"
-                              value=${this.newPeriod}
-                              @sl-change=${(e: any) =>
-                                (this.newPeriod = e.target.value)}
-                            >
-                              <sl-option value="hourly">Hourly</sl-option>
-                              <sl-option value="daily">Daily</sl-option>
-                              <sl-option value="weekly">Weekly</sl-option>
-                              <sl-option value="monthly">Monthly</sl-option>
-                              <sl-option value="yearly">Yearly</sl-option>
-                              <sl-option value="all_time">All Time</sl-option>
-                            </sl-select>
-                          `
-                        : html`
-                            <sl-select
-                              label="Period"
-                              value=${this.newPeriod}
-                              @sl-change=${(e: any) =>
-                                (this.newPeriod = e.target.value)}
-                            >
-                              <sl-option value="hourly">Hourly</sl-option>
-                              <sl-option value="daily">Daily</sl-option>
-                              <sl-option value="weekly">Weekly</sl-option>
-                              <sl-option value="monthly">Monthly</sl-option>
-                              <sl-option value="yearly">Yearly</sl-option>
-                              <sl-option value="all_time">All Time</sl-option>
-                            </sl-select>
-                          `
-                  }
-
-                  <div class="form-row">
-                    <sl-input
-                      label="Hard Limit (USD)"
-                      type="number"
-                      step="0.0001"
-                      .value=${this.newHardLimit}
-                      @sl-input=${(e: any) =>
-                        (this.newHardLimit = e.target.value)}
-                    ></sl-input>
-                    <sl-input
-                      label="Soft Limit (USD)"
-                      type="number"
-                      step="0.0001"
-                      .value=${this.newSoftLimit}
-                      @sl-input=${(e: any) =>
-                        (this.newSoftLimit = e.target.value)}
-                    ></sl-input>
-                  </div>
-
-                  ${
-                    this.features?.['billing']
-                      ? html`
-                          <notify-recipients-field
-                            .users=${this.availableUsers}
-                            .teams=${this.teams}
-                            .userIds=${this.newNotifyUserIds}
-                            .teamIds=${this.newNotifyTeamIds}
-                            .customEmails=${this.newCustomEmails}
-                            help-text="Recipients are notified via their email and mobile app preferences. Add custom emails when needed."
-                            @notify-recipients-change=${this.handleNotifyRecipientsChange}
-                          ></notify-recipients-field>
-
-                          <div class="checkbox-group">
-                            <sl-checkbox
-                              ?checked=${this.newNotifySoft}
-                              @sl-change=${(e: any) =>
-                                (this.newNotifySoft = e.target.checked)}
-                            >
-                              Send email on Soft Limit
-                            </sl-checkbox>
-                            <sl-checkbox
-                              ?checked=${this.newNotifyHard}
-                              @sl-change=${(e: any) =>
-                                (this.newNotifyHard = e.target.checked)}
-                            >
-                              Send email on Hard Limit
-                            </sl-checkbox>
-                          </div>
-                        `
-                      : ''
-                  }
-
-                  <div class="form-actions">
-                    <sl-button
-                      @click=${this.cancelForm}
-                      ?disabled=${this.saving}
-                      >Cancel</sl-button
-                    >
-                    <sl-button
-                      variant="primary"
-                      @click=${this.handleSave}
-                      ?loading=${this.saving}
-                      ?disabled=${this.saving}
-                    >
-                      ${this.editingPolicyId ? 'Update Policy' : 'Save Policy'}
-                    </sl-button>
-                  </div>
-                </div>
-              `
-            : ''
-        }
+        ${this.step === 'list' ? this.renderList() : this.renderForm()}
+        ${this.renderDeleteConfirm()}
       </div>
     `;
   }

--- a/frontend/src/components/confirm-dialog.test.ts
+++ b/frontend/src/components/confirm-dialog.test.ts
@@ -1,0 +1,129 @@
+import { expect, aTimeout } from '@open-wc/testing';
+
+import {
+  confirmDialog,
+  resetConfirmDialogForTests,
+  showToast,
+} from './confirm-dialog';
+import type { ConfirmDialog } from './confirm-dialog';
+
+function dialogElement(): ConfirmDialog {
+  const element = document.body.querySelector(
+    'confirm-dialog'
+  ) as ConfirmDialog | null;
+  expect(element, 'confirm-dialog singleton is mounted').to.exist;
+  return element as ConfirmDialog;
+}
+
+async function clickFooterButton(label: string) {
+  const element = dialogElement();
+  await element.updateComplete;
+  const button = [
+    ...(element.shadowRoot?.querySelectorAll('sl-button') || []),
+  ].find((candidate) => candidate.textContent?.trim() === label);
+  expect(button, `footer button "${label}" exists`).to.exist;
+  (button as HTMLElement).click();
+}
+
+describe('confirmDialog', () => {
+  afterEach(() => {
+    resetConfirmDialogForTests();
+    document.body
+      .querySelectorAll('sl-alert')
+      .forEach((alert) => alert.remove());
+  });
+
+  it('mounts a single shared dialog no matter how often it is called', async () => {
+    const first = confirmDialog({ title: 'One', message: 'First question' });
+    await aTimeout(0);
+    const second = confirmDialog({ title: 'Two', message: 'Second question' });
+    await aTimeout(0);
+
+    expect(document.body.querySelectorAll('confirm-dialog')).to.have.length(1);
+    // The superseded question resolves false instead of hanging forever.
+    expect(await first).to.equal(false);
+
+    await clickFooterButton('Confirm');
+    expect(await second).to.equal(true);
+  });
+
+  it('resolves true only when the confirm button is pressed', async () => {
+    const answer = confirmDialog({
+      title: 'Remove agent',
+      message: 'Remove Hermes from the managed agents list?',
+      confirmLabel: 'Remove',
+      variant: 'danger',
+    });
+    await aTimeout(0);
+
+    const element = dialogElement();
+    await element.updateComplete;
+    expect(element.shadowRoot?.textContent).to.contain(
+      'Remove Hermes from the managed agents list?'
+    );
+    const dialog = element.shadowRoot?.querySelector('sl-dialog');
+    expect(dialog?.getAttribute('label')).to.equal('Remove agent');
+
+    await clickFooterButton('Remove');
+    expect(await answer).to.equal(true);
+  });
+
+  it('resolves false when cancelled', async () => {
+    const answer = confirmDialog({ title: 'Pause', message: 'Pause Hermes?' });
+    await aTimeout(0);
+
+    await clickFooterButton('Cancel');
+    expect(await answer).to.equal(false);
+  });
+
+  it('resolves false when dismissed without answering', async () => {
+    const answer = confirmDialog({ title: 'Pause', message: 'Pause Hermes?' });
+    await aTimeout(0);
+
+    const element = dialogElement();
+    await element.updateComplete;
+    element.shadowRoot
+      ?.querySelector('sl-dialog')
+      ?.dispatchEvent(new CustomEvent('sl-after-hide', { bubbles: false }));
+
+    expect(await answer).to.equal(false);
+  });
+
+  it('renders the optional detail line under the message', async () => {
+    const answer = confirmDialog({
+      title: 'Remove agent',
+      message: 'Remove Hermes?',
+      detail: 'This also revokes its credentials.',
+    });
+    await aTimeout(0);
+
+    const element = dialogElement();
+    await element.updateComplete;
+    expect(
+      element.shadowRoot?.querySelector('.detail')?.textContent
+    ).to.contain('This also revokes its credentials.');
+
+    await clickFooterButton('Cancel');
+    await answer;
+  });
+});
+
+describe('showToast', () => {
+  afterEach(() => {
+    document.body
+      .querySelectorAll('sl-alert')
+      .forEach((alert) => alert.remove());
+  });
+
+  it('appends a Shoelace alert instead of blocking the tab', async () => {
+    showToast('No user matched that username or email.', 'warning');
+    await aTimeout(0);
+
+    const alert = document.body.querySelector('sl-alert');
+    expect(alert).to.exist;
+    expect(alert?.getAttribute('variant')).to.equal('warning');
+    expect(alert?.textContent).to.contain(
+      'No user matched that username or email.'
+    );
+  });
+});

--- a/frontend/src/components/confirm-dialog.ts
+++ b/frontend/src/components/confirm-dialog.ts
@@ -1,0 +1,176 @@
+import { LitElement, css, html, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import '@shoelace-style/shoelace/dist/components/alert/alert.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+
+export interface ConfirmDialogOptions {
+  title: string;
+  message: string;
+  /** Extra muted line under the message, for consequences worth spelling out. */
+  detail?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'danger' | 'primary';
+}
+
+/**
+ * The console's replacement for `window.confirm`.
+ *
+ * A native confirm cannot be styled, cannot be themed for dark mode, blocks the
+ * whole tab and reads as a browser warning rather than as part of the product.
+ * One singleton `sl-dialog` lives at the end of `document.body` and every call
+ * site awaits a promise instead.
+ */
+@customElement('confirm-dialog')
+export class ConfirmDialog extends LitElement {
+  @state() private options: ConfirmDialogOptions | null = null;
+  @state() private isOpen = false;
+
+  private resolver: ((confirmed: boolean) => void) | null = null;
+  /**
+   * Set while the confirm button settles the promise, so the `sl-after-hide`
+   * that Shoelace fires on the way out is not read as a cancel.
+   */
+  private settled = false;
+
+  static styles = css`
+    :host {
+      display: contents;
+    }
+    .message {
+      color: var(--sl-color-neutral-800);
+      white-space: pre-line;
+    }
+    .detail {
+      margin-top: var(--sl-spacing-small);
+      color: var(--sl-color-neutral-600);
+      font-size: var(--sl-font-size-small);
+      white-space: pre-line;
+    }
+  `;
+
+  /** Opens the dialog and resolves once the operator answers. */
+  ask(options: ConfirmDialogOptions): Promise<boolean> {
+    // A second ask while one is pending cancels the first rather than
+    // stranding its caller in a promise that never settles.
+    this.settle(false);
+    this.options = options;
+    this.settled = false;
+    this.isOpen = true;
+    return new Promise<boolean>((resolve) => {
+      this.resolver = resolve;
+    });
+  }
+
+  private settle(confirmed: boolean): void {
+    const resolver = this.resolver;
+    this.resolver = null;
+    resolver?.(confirmed);
+  }
+
+  private confirm(): void {
+    this.settled = true;
+    this.isOpen = false;
+    this.settle(true);
+  }
+
+  private cancel(): void {
+    this.settled = true;
+    this.isOpen = false;
+    this.settle(false);
+  }
+
+  render() {
+    const options = this.options;
+    if (!options) return nothing;
+    const variant = options.variant || 'primary';
+    return html`
+      <sl-dialog
+        label=${options.title}
+        ?open=${this.isOpen}
+        @sl-after-hide=${(event: Event) => {
+          if (event.target !== event.currentTarget) return;
+          this.isOpen = false;
+          // Dismissed with Escape, the overlay or the close button.
+          if (!this.settled) this.settle(false);
+        }}
+      >
+        <div class="message">${options.message}</div>
+        ${
+          options.detail
+            ? html`<div class="detail">${options.detail}</div>`
+            : nothing
+        }
+        <sl-button slot="footer" @click=${() => this.cancel()}>
+          ${options.cancelLabel || 'Cancel'}
+        </sl-button>
+        <sl-button
+          slot="footer"
+          variant=${variant}
+          ?outline=${variant === 'danger'}
+          data-testid="confirm-dialog-confirm"
+          @click=${() => this.confirm()}
+        >
+          ${options.confirmLabel || 'Confirm'}
+        </sl-button>
+      </sl-dialog>
+    `;
+  }
+}
+
+let singleton: ConfirmDialog | null = null;
+
+function getConfirmDialog(): ConfirmDialog {
+  if (singleton?.isConnected) return singleton;
+  singleton = document.createElement('confirm-dialog') as ConfirmDialog;
+  document.body.append(singleton);
+  return singleton;
+}
+
+/**
+ * Asks the operator to confirm an action. Resolves `true` only when they press
+ * the confirm button; dismissing the dialog any other way resolves `false`.
+ */
+export function confirmDialog(options: ConfirmDialogOptions): Promise<boolean> {
+  return getConfirmDialog().ask(options);
+}
+
+/** Test seam: drops the singleton so each case starts from a clean dialog. */
+export function resetConfirmDialogForTests(): void {
+  singleton?.remove();
+  singleton = null;
+}
+
+/**
+ * The console's replacement for `window.alert`: a Shoelace toast, so a
+ * non-blocking message never freezes the tab.
+ */
+export function showToast(
+  message: string,
+  variant: 'primary' | 'success' | 'neutral' | 'warning' | 'danger' = 'primary'
+): void {
+  const icon =
+    variant === 'danger' || variant === 'warning'
+      ? 'exclamation-triangle'
+      : variant === 'success'
+        ? 'check2-circle'
+        : 'info-circle';
+  const alert = Object.assign(document.createElement('sl-alert'), {
+    variant,
+    duration: 4000,
+    closable: true,
+  });
+  alert.innerHTML = `<sl-icon slot="icon" name="${icon}"></sl-icon>`;
+  alert.append(document.createTextNode(message));
+  document.body.append(alert);
+  void (alert as unknown as { toast: () => Promise<void> }).toast();
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'confirm-dialog': ConfirmDialog;
+  }
+}

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -176,6 +176,21 @@ export class ConsoleHeader extends LitElement {
     .notification-section {
       border-bottom: 1px solid var(--sl-color-neutral-100);
     }
+    .dropdown-footer {
+      border-top: 1px solid var(--sl-color-neutral-100);
+      padding: var(--sl-spacing-x-small) var(--sl-spacing-medium);
+      position: sticky;
+      bottom: 0;
+      background: var(--sl-color-neutral-0);
+    }
+    .dropdown-footer a {
+      color: var(--sl-color-primary-600);
+      font-size: var(--sl-font-size-small);
+      text-decoration: none;
+    }
+    .dropdown-footer a:hover {
+      text-decoration: underline;
+    }
     .notification-section:last-child {
       border-bottom: none;
     }
@@ -1037,6 +1052,9 @@ export class ConsoleHeader extends LitElement {
                     `
                   : this.renderEmptyState()
               }
+              <div class="dropdown-footer">
+                <a href="/console/attention">Everything needing attention →</a>
+              </div>
             </div>
           </sl-dropdown>
 

--- a/frontend/src/components/lit-app.ts
+++ b/frontend/src/components/lit-app.ts
@@ -20,6 +20,7 @@ import '../views/public/delete-account-view';
 import '../views/public/whatis-mcp-view';
 import '../views/public/pricing-view';
 import '../views/public/welcome-view';
+import '../views/public/not-found-view';
 import '../views/public/static-view';
 import '../views/authed/console-shell';
 import '../views/authed/oauth-consent-view';
@@ -60,6 +61,7 @@ import '../views/authed/policies-view';
 import '../views/authed/audit-view';
 import '../views/authed/agents-view';
 import '../views/authed/agent-detail-view';
+import '../views/authed/attention-view';
 import './app-header';
 import './app-footer';
 import './update-banner';
@@ -430,8 +432,12 @@ export class LitApp extends LitElement {
             },
           },
           { path: 'audit', component: 'audit-view' },
+          { path: 'attention', component: 'attention-view' },
         ],
       },
+      // Must stay last: Vaadin Router matches in order, so a catch-all above
+      // any real route would swallow it.
+      { path: '(.*)', component: 'not-found-view' },
     ]);
   }
 

--- a/frontend/src/components/preloop-session-observer.test.ts
+++ b/frontend/src/components/preloop-session-observer.test.ts
@@ -807,7 +807,7 @@ describe('PreloopSessionObserver', () => {
       const text = (hint?.textContent || '').replace(/\s+/g, ' ');
       expect(text).to.contain('This session used 1,300 tokens ($0.42).');
       expect(text).to.contain(
-        'Optimize finds where they went and suggests cuts — you verify each one by replaying the session, without touching your agent.'
+        'Optimize finds where they went and suggests cuts. You verify each one by replaying the session, without touching your agent.'
       );
       expect(text).to.contain('Try Optimize');
     });

--- a/frontend/src/components/preloop-session-observer.test.ts
+++ b/frontend/src/components/preloop-session-observer.test.ts
@@ -549,10 +549,48 @@ describe('PreloopSessionObserver', () => {
     await (panel as any).updateComplete;
 
     expect(deepText(el.shadowRoot)).to.include(
-      'No sessions yet for this agent. Its first gateway call will appear here live.'
+      'The first gateway call from this agent will appear here.'
     );
     expect(panel!.shadowRoot?.querySelector('.loading sl-spinner')).to.not
       .exist;
+  });
+
+  it('replaces the dead toolbar with a slim waiting pill when there are no sessions', async () => {
+    const el = (await fixture(
+      html`<preloop-session-observer
+        scope="managed_agent"
+        .scopeId=${'agent-1'}
+        .sessions=${[]}
+      ></preloop-session-observer>`
+    )) as PreloopSessionObserver;
+    await el.updateComplete;
+
+    const toolbar = el.shadowRoot?.querySelector('.toolbar');
+    expect(toolbar).to.exist;
+    expect(toolbar?.classList.contains('toolbar-waiting')).to.equal(true);
+    expect(toolbar?.textContent?.replace(/\s+/g, ' ').trim()).to.equal(
+      'Live \u00b7 waiting for first session'
+    );
+    // None of the follow/replay/refresh controls are offered yet.
+    expect(toolbar?.querySelector('sl-button')).to.not.exist;
+  });
+
+  it('reveals the full toolbar once the first session arrives', async () => {
+    const el = (await fixture(
+      html`<preloop-session-observer
+        scope="managed_agent"
+        .scopeId=${'agent-1'}
+        .sessions=${[]}
+      ></preloop-session-observer>`
+    )) as PreloopSessionObserver;
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector('.toolbar-waiting')).to.exist;
+
+    el.sessions = [session];
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('.toolbar-waiting')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.toolbar sl-button')).to.exist;
   });
 
   describe('Collapsing session list', () => {

--- a/frontend/src/components/preloop-session-observer.ts
+++ b/frontend/src/components/preloop-session-observer.ts
@@ -2045,7 +2045,7 @@ export class PreloopSessionObserver extends LitElement {
                             ?selected=${session.id === this.activeSessionId}
                           >
                             ${session.title}${
-                              session.subtitle ? ` — ${session.subtitle}` : ''
+                              session.subtitle ? ` · ${session.subtitle}` : ''
                             }
                           </option>
                         `

--- a/frontend/src/components/preloop-session-observer.ts
+++ b/frontend/src/components/preloop-session-observer.ts
@@ -478,6 +478,14 @@ export class PreloopSessionObserver extends LitElement {
         width: 7px;
       }
 
+      /* Zero sessions: a slim pill instead of a toolbar of dead controls. */
+      .toolbar-waiting {
+        background: transparent;
+        border: none;
+        justify-content: flex-start;
+        padding: 0;
+      }
+
       .live-indicator.pulsing {
         background: var(--sl-color-success-100);
         color: var(--sl-color-success-700);
@@ -1610,7 +1618,7 @@ export class PreloopSessionObserver extends LitElement {
    */
   private get replayEmptyText(): string {
     if (this.scope === 'managed_agent' && this.observedSessions.length === 0) {
-      return 'No sessions yet for this agent. Its first gateway call will appear here live.';
+      return 'The first gateway call from this agent will appear here.';
     }
     return 'Select a session to follow it live or replay it.';
   }
@@ -1649,6 +1657,22 @@ export class PreloopSessionObserver extends LitElement {
 
   private renderToolbar() {
     const session = this.activeSession;
+
+    // With no sessions there is nothing to follow, pause, replay, filter or
+    // refresh, so the full toolbar is six controls that all do nothing. Show
+    // only that we are listening, and reveal the toolbar when the first
+    // session arrives.
+    if (this.observedSessions.length === 0) {
+      return html`
+        <div class="toolbar toolbar-waiting">
+          <span class="live-indicator pulsing" title="Realtime session updates">
+            <span class="live-dot"></span>
+            Live · waiting for first session
+          </span>
+        </div>
+      `;
+    }
+
     return html`
       <div class="toolbar">
         <div>

--- a/frontend/src/components/preloop-session-observer.ts
+++ b/frontend/src/components/preloop-session-observer.ts
@@ -1589,7 +1589,7 @@ export class PreloopSessionObserver extends LitElement {
       <div class="optimize-hint" role="note">
         <div class="optimize-hint-body">
           <strong>${ledger}</strong> Optimize finds where they went and suggests
-          cuts — you verify each one by replaying the session, without touching
+          cuts. You verify each one by replaying the session, without touching
           your agent. →
           <a
             class="optimize-hint-link"

--- a/frontend/src/components/resource-actions.ts
+++ b/frontend/src/components/resource-actions.ts
@@ -20,6 +20,17 @@ export interface ResourceAction {
     | 'warning'
     | 'danger'
     | 'text';
+  /**
+   * Render the button outlined rather than solid. Used for destructive
+   * actions that should stay legible as "danger" without a solid red block
+   * competing with the primary action on the page.
+   */
+  outline?: boolean;
+  /**
+   * Push this action away from the ones before it. Separates a destructive
+   * action from the everyday ones so it is not clicked by muscle memory.
+   */
+  separated?: boolean;
   disabled?: boolean;
   loading?: boolean;
   tooltip?: string;
@@ -85,6 +96,9 @@ export class ResourceActions extends LitElement {
         font-size: 1rem;
         margin-right: var(--sl-spacing-2x-small);
       }
+      .separated {
+        margin-left: var(--sl-spacing-large);
+      }
     `,
   ];
 
@@ -134,7 +148,9 @@ export class ResourceActions extends LitElement {
 
     const button = html`
       <sl-button
+        class=${action.separated ? 'separated' : ''}
         variant=${action.variant || 'default'}
+        ?outline=${action.outline}
         ?disabled=${action.disabled}
         ?loading=${action.loading}
         href=${action.href || ''}

--- a/frontend/src/components/time-range-select.test.ts
+++ b/frontend/src/components/time-range-select.test.ts
@@ -1,0 +1,78 @@
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import './time-range-select.ts';
+import type { TimeRangeSelect } from './time-range-select';
+
+const OPTIONS = [
+  { value: 'day', label: '24h' },
+  { value: 'week', label: '7d' },
+  { value: 'month', label: '30d' },
+];
+
+describe('time-range-select', () => {
+  async function render(value = 'month'): Promise<TimeRangeSelect> {
+    const element = await fixture<TimeRangeSelect>(html`
+      <time-range-select
+        ariaLabel="Usage time range"
+        .value=${value}
+        .options=${OPTIONS}
+      ></time-range-select>
+    `);
+    await element.updateComplete;
+    return element;
+  }
+
+  it('renders one option per configured range', async () => {
+    const element = await render();
+    const options = element.shadowRoot!.querySelectorAll('sl-option');
+    expect(options.length).to.equal(3);
+    expect(
+      Array.from(options).map((option) => option.textContent?.trim())
+    ).to.deep.equal(['24h', '7d', '30d']);
+  });
+
+  it('labels the control for assistive technology', async () => {
+    const element = await render();
+    const select = element.shadowRoot!.querySelector('sl-select')!;
+    expect(select.getAttribute('aria-label')).to.equal('Usage time range');
+  });
+
+  it('reflects the current value on the select', async () => {
+    const element = await render('week');
+    const select = element.shadowRoot!.querySelector(
+      'sl-select'
+    )! as unknown as {
+      value: string;
+    };
+    expect(select.value).to.equal('week');
+  });
+
+  it('emits range-change with the new value', async () => {
+    const element = await render('month');
+    const select = element.shadowRoot!.querySelector('sl-select')!;
+    (select as unknown as { value: string }).value = 'day';
+
+    setTimeout(() =>
+      select.dispatchEvent(new CustomEvent('sl-change', { bubbles: true }))
+    );
+    const event = (await oneEvent(element, 'range-change')) as CustomEvent<{
+      value: string;
+    }>;
+
+    expect(event.detail.value).to.equal('day');
+    expect(element.value).to.equal('day');
+  });
+
+  it('does not emit when the value is unchanged', async () => {
+    const element = await render('month');
+    let emitted = 0;
+    element.addEventListener('range-change', () => {
+      emitted += 1;
+    });
+    const select = element.shadowRoot!.querySelector('sl-select')!;
+    (select as unknown as { value: string }).value = 'month';
+    select.dispatchEvent(new CustomEvent('sl-change', { bubbles: true }));
+    await element.updateComplete;
+
+    expect(emitted).to.equal(0);
+  });
+});

--- a/frontend/src/components/time-range-select.ts
+++ b/frontend/src/components/time-range-select.ts
@@ -1,0 +1,94 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import '@shoelace-style/shoelace/dist/components/select/select.js';
+import '@shoelace-style/shoelace/dist/components/option/option.js';
+
+export interface TimeRangeOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * The one time range control the console uses on cards.
+ *
+ * Every card used to roll its own bare `<select>`, which read as a different
+ * control on every card. This is a compact Shoelace select so the Usage card,
+ * the Active agents card and (later) the Cost and API usage views all look and
+ * behave the same.
+ */
+@customElement('time-range-select')
+export class TimeRangeSelect extends LitElement {
+  @property({ type: String }) value = '';
+  @property({ type: Array }) options: TimeRangeOption[] = [];
+  @property({ type: String }) ariaLabel = 'Time range';
+
+  static styles = css`
+    :host {
+      display: inline-block;
+    }
+
+    sl-select {
+      width: var(--time-range-select-width, 96px);
+    }
+
+    sl-select::part(combobox) {
+      font-variant-numeric: tabular-nums;
+      padding-inline: var(--sl-spacing-small);
+    }
+
+    /* The label names the control for screen readers without taking room
+       inside a card header. */
+    sl-select::part(form-control-label) {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
+    }
+  `;
+
+  private handleChange(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    if (value === this.value) {
+      return;
+    }
+    this.value = value;
+    this.dispatchEvent(
+      new CustomEvent('range-change', {
+        detail: { value },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  render() {
+    return html`
+      <sl-select
+        size="small"
+        pill
+        hoist
+        label=${this.ariaLabel}
+        aria-label=${this.ariaLabel}
+        .value=${this.value}
+        @sl-change=${this.handleChange}
+      >
+        ${this.options.map(
+          (option) =>
+            html`<sl-option value=${option.value}>${option.label}</sl-option>`
+        )}
+      </sl-select>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'time-range-select': TimeRangeSelect;
+  }
+}

--- a/frontend/src/components/time-range-select.ts
+++ b/frontend/src/components/time-range-select.ts
@@ -52,6 +52,11 @@ export class TimeRangeSelect extends LitElement {
     }
   `;
 
+  /**
+   * `value` is bound as an attribute on purpose: Shoelace resets its selection
+   * to `defaultValue` (the attribute) when the option slot changes, so a
+   * property-only binding silently clears the control on first render.
+   */
   private handleChange(event: Event) {
     const value = (event.target as HTMLInputElement).value;
     if (value === this.value) {
@@ -75,7 +80,7 @@ export class TimeRangeSelect extends LitElement {
         hoist
         label=${this.ariaLabel}
         aria-label=${this.ariaLabel}
-        .value=${this.value}
+        value=${this.value}
         @sl-change=${this.handleChange}
       >
         ${this.options.map(

--- a/frontend/src/components/usage-card.test.ts
+++ b/frontend/src/components/usage-card.test.ts
@@ -158,8 +158,11 @@ describe('usage-card', () => {
     });
     const rows = element.shadowRoot!.querySelectorAll('.budget-row');
     expect(rows.length).to.equal(2);
-    expect(rows[0].textContent).to.contain('Daily budget');
-    expect(rows[1].textContent).to.contain('Monthly budget');
+    // Each row says which window it resets in, so the number is not read as
+    // a running total.
+    expect(rows[0].textContent).to.contain('Daily budget · today');
+    const month = new Date().toLocaleDateString(undefined, { month: 'short' });
+    expect(rows[1].textContent).to.contain(`Monthly budget · ${month}`);
     expect(rows[1].textContent!.replace(/\s+/g, ' ')).to.contain(
       '$33.57 / $300.00'
     );
@@ -185,6 +188,28 @@ describe('usage-card', () => {
     expect(row.textContent!.replace(/\s+/g, ' ')).to.contain(
       '$33.57 / $500.00'
     );
+  });
+
+  it('puts the unit toggle in the header, left of the range select', async () => {
+    const element = await renderCard({});
+    const header = element.shadowRoot!.querySelector('.header')!;
+    const controls = header.querySelector('.header-controls')!;
+    const children = Array.from(controls.children).map((child) =>
+      child.tagName.toLowerCase()
+    );
+    expect(children[0]).to.equal('div');
+    expect(controls.querySelector('.unit-toggle')).to.exist;
+    expect(children[children.length - 1]).to.equal('time-range-select');
+
+    // The label stays for screen readers but takes no room on screen.
+    const group = controls.querySelector('sl-radio-group')!;
+    expect(group.getAttribute('label')).to.equal('Usage unit');
+    const label = group.shadowRoot?.querySelector(
+      '[part~="form-control-label"]'
+    ) as HTMLElement | null;
+    if (label) {
+      expect(label.getBoundingClientRect().height).to.be.at.most(1);
+    }
   });
 
   it('summarises non global policies on one line', async () => {

--- a/frontend/src/components/usage-card.test.ts
+++ b/frontend/src/components/usage-card.test.ts
@@ -1,0 +1,256 @@
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import './usage-card.ts';
+import { USAGE_UNIT_STORAGE_KEY } from './usage-card';
+import type { UsageCard } from './usage-card';
+import type { BudgetPolicy } from '../api';
+import type { AccountGatewayUsageSummaryResponse } from '../types';
+
+function summaryFixture(
+  overrides: Partial<AccountGatewayUsageSummaryResponse> = {}
+): AccountGatewayUsageSummaryResponse {
+  return {
+    period_start: '2026-08-03T00:00:00Z',
+    period_end: '2026-09-02T00:00:00Z',
+    total_requests: 19500000,
+    successful_requests: 19400000,
+    failed_requests: 100000,
+    token_usage: {
+      prompt_tokens: 412100000,
+      completion_tokens: 172200000,
+      total_tokens: 584300000,
+    },
+    estimated_cost: 33.57,
+    budget: {
+      monthly_limit_usd: null,
+      soft_limit_usd: null,
+      current_spend_usd: 33.57,
+      soft_limit_exceeded: false,
+      hard_limit_exceeded: false,
+    },
+    requests_by_day: [],
+    usage_by_model: [],
+    usage_by_flow: [],
+    usage_by_session: [],
+    ...overrides,
+  } as AccountGatewayUsageSummaryResponse;
+}
+
+function policyFixture(overrides: Partial<BudgetPolicy> = {}): BudgetPolicy {
+  return {
+    id: 'policy-1',
+    subject_type: 'global',
+    subject_id: null,
+    model_alias: null,
+    period: 'monthly',
+    hard_limit_usd: 300,
+    soft_limit_usd: 200,
+    notify_on_soft: true,
+    notify_on_hard: true,
+    notification_user_ids: null,
+    notification_team_ids: null,
+    notification_emails: null,
+    current_spend_usd: 33.57,
+    ...overrides,
+  };
+}
+
+function daysFixture(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    date: `2026-08-${String(index + 1).padStart(2, '0')}`,
+    request_count: 100 + index,
+    estimated_cost: 1 + index,
+    total_tokens: 1000 + index * 10,
+  }));
+}
+
+async function renderCard(props: Partial<UsageCard> = {}): Promise<UsageCard> {
+  const element = await fixture<UsageCard>(html`
+    <usage-card
+      .summary=${'summary' in props ? props.summary : summaryFixture()}
+      .policies=${props.policies ?? []}
+      .timeRange=${props.timeRange ?? 'month'}
+      .toolCallsCount=${props.toolCallsCount ?? 0}
+      .loading=${props.loading ?? false}
+      .error=${props.error ?? null}
+    ></usage-card>
+  `);
+  await element.updateComplete;
+  return element;
+}
+
+function text(element: UsageCard, selector: string): string {
+  return (
+    element
+      .shadowRoot!.querySelector(selector)
+      ?.textContent?.replace(/\s+/g, ' ') || ''
+  ).trim();
+}
+
+describe('usage-card', () => {
+  beforeEach(() => {
+    localStorage.removeItem(USAGE_UNIT_STORAGE_KEY);
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(USAGE_UNIT_STORAGE_KEY);
+  });
+
+  it('leads with tokens for the selected range', async () => {
+    const element = await renderCard();
+    expect(text(element, '.primary-value')).to.equal('584.3M');
+    expect(text(element, '.primary-label')).to.contain('tokens · 30d');
+    expect(text(element, '.secondary-line')).to.equal(
+      '412.1M prompt · 172.2M completion · 19.5M requests'
+    );
+  });
+
+  it('appends tool calls to the secondary line when present', async () => {
+    const element = await renderCard({ toolCallsCount: 4200 });
+    expect(text(element, '.secondary-line')).to.contain('4.2K tool calls');
+  });
+
+  it('switches to estimated dollars and persists the choice', async () => {
+    const element = await renderCard();
+    const group = element.shadowRoot!.querySelector('sl-radio-group')!;
+    (group as unknown as { value: string }).value = 'dollars';
+    group.dispatchEvent(new CustomEvent('sl-change', { bubbles: true }));
+    await element.updateComplete;
+
+    expect(text(element, '.primary-value')).to.equal('$33.57');
+    expect(text(element, '.primary-label')).to.contain('est. spend · 30d');
+    expect(text(element, '.secondary-line')).to.equal(
+      '584.3M tokens · 19.5M requests'
+    );
+    expect(localStorage.getItem(USAGE_UNIT_STORAGE_KEY)).to.equal('dollars');
+
+    const restored = await renderCard();
+    expect(text(restored, '.primary-value')).to.equal('$33.57');
+  });
+
+  it('hides the sparkline under three points and shows it above', async () => {
+    const sparse = await renderCard({
+      summary: summaryFixture({ requests_by_day: daysFixture(2) }),
+    });
+    expect(sparse.shadowRoot!.querySelector('.sparkline')).to.be.null;
+
+    const dense = await renderCard({
+      summary: summaryFixture({ requests_by_day: daysFixture(7) }),
+    });
+    const sparkline = dense.shadowRoot!.querySelector('.sparkline');
+    expect(sparkline).to.exist;
+    expect(
+      sparkline!.querySelector('polyline')!.getAttribute('points')!.split(' ')
+    ).to.have.lengthOf(7);
+  });
+
+  it('shows a budget row per global policy with the spend meter', async () => {
+    const element = await renderCard({
+      policies: [
+        policyFixture({ id: 'p-month', period: 'monthly' }),
+        policyFixture({
+          id: 'p-day',
+          period: 'daily',
+          hard_limit_usd: 20,
+          soft_limit_usd: 10,
+          current_spend_usd: 12,
+        }),
+      ],
+    });
+    const rows = element.shadowRoot!.querySelectorAll('.budget-row');
+    expect(rows.length).to.equal(2);
+    expect(rows[0].textContent).to.contain('Daily budget');
+    expect(rows[1].textContent).to.contain('Monthly budget');
+    expect(rows[1].textContent!.replace(/\s+/g, ' ')).to.contain(
+      '$33.57 / $300.00'
+    );
+    expect(
+      element.shadowRoot!.querySelectorAll('.budget-track').length
+    ).to.equal(2);
+  });
+
+  it('renders the legacy account budget as a monthly row', async () => {
+    const element = await renderCard({
+      summary: summaryFixture({
+        budget: {
+          monthly_limit_usd: 500,
+          soft_limit_usd: 400,
+          current_spend_usd: 33.57,
+          soft_limit_exceeded: false,
+          hard_limit_exceeded: false,
+        },
+      }),
+    });
+    const row = element.shadowRoot!.querySelector('.budget-row')!;
+    expect(row.textContent).to.contain('Monthly budget');
+    expect(row.textContent!.replace(/\s+/g, ' ')).to.contain(
+      '$33.57 / $500.00'
+    );
+  });
+
+  it('summarises non global policies on one line', async () => {
+    const element = await renderCard({
+      policies: [
+        policyFixture(),
+        policyFixture({
+          id: 'p-agent',
+          subject_type: 'managed_agent',
+          subject_id: 'agent-1',
+        }),
+        policyFixture({
+          id: 'p-model',
+          subject_type: 'ai_model',
+          subject_id: 'model-1',
+        }),
+      ],
+    });
+    const more = element.shadowRoot!.querySelector('.more-limits')!;
+    expect(more.textContent!.replace(/\s+/g, ' ')).to.contain(
+      '+ 2 more limits (agents, models)'
+    );
+  });
+
+  it('tells the operator when there is no budget at all', async () => {
+    const element = await renderCard();
+    expect(text(element, '.muted')).to.equal('No budget set.');
+    expect(element.shadowRoot!.querySelector('.budget-row')).to.be.null;
+  });
+
+  it('emits configure-limits from the footer button', async () => {
+    const element = await renderCard();
+    const button = element.shadowRoot!.querySelector(
+      '.footer sl-button'
+    ) as HTMLElement;
+    setTimeout(() => button.click());
+    await oneEvent(element, 'configure-limits');
+  });
+
+  it('forwards the range change from the header select', async () => {
+    const element = await renderCard();
+    const select = element.shadowRoot!.querySelector('time-range-select')!;
+    setTimeout(() =>
+      select.dispatchEvent(
+        new CustomEvent('range-change', {
+          detail: { value: 'week' },
+          bubbles: true,
+          composed: true,
+        })
+      )
+    );
+    const event = (await oneEvent(element, 'range-change')) as CustomEvent<{
+      value: string;
+    }>;
+    expect(event.detail.value).to.equal('week');
+  });
+
+  it('shows skeletons while loading and an inline alert on error', async () => {
+    const loading = await renderCard({ loading: true, summary: null });
+    expect(
+      loading.shadowRoot!.querySelectorAll('sl-skeleton').length
+    ).to.be.at.least(2);
+
+    const failed = await renderCard({ error: 'Failed to load usage' });
+    const alert = failed.shadowRoot!.querySelector('sl-alert')!;
+    expect(alert.getAttribute('variant')).to.equal('danger');
+    expect(alert.textContent).to.contain('Failed to load usage');
+  });
+});

--- a/frontend/src/components/usage-card.ts
+++ b/frontend/src/components/usage-card.ts
@@ -1,0 +1,574 @@
+import { LitElement, css, html, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+import '@shoelace-style/shoelace/dist/components/alert/alert.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/card/card.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/radio-button/radio-button.js';
+import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
+import '@shoelace-style/shoelace/dist/components/skeleton/skeleton.js';
+import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
+import './time-range-select.ts';
+
+import type { BudgetPolicy } from '../api';
+import type { AccountGatewayUsageSummaryResponse } from '../types';
+import { budgetTrackStyles, renderBudgetTrack } from '../styles/budget-track';
+
+export type UsageUnit = 'tokens' | 'dollars';
+
+export const USAGE_UNIT_STORAGE_KEY = 'overview_usage_unit';
+
+const PERIOD_ORDER = [
+  'hourly',
+  'daily',
+  'weekly',
+  'monthly',
+  'yearly',
+  'all_time',
+];
+
+const SUBJECT_TYPE_LABELS: Record<string, string> = {
+  managed_agent: 'agents',
+  ai_model: 'models',
+  user: 'users',
+  team: 'teams',
+  flow: 'flows',
+  api_key: 'API keys',
+};
+
+/**
+ * Usage first, budgets second: tokens are the primary currency of the
+ * gateway, dollars are always an estimate. Replaces Budget health on the
+ * Overview (cost-view still uses `<budget-health-card>`).
+ */
+@customElement('usage-card')
+export class UsageCard extends LitElement {
+  @property({ type: Object })
+  summary: AccountGatewayUsageSummaryResponse | null = null;
+  @property({ type: Array }) policies: BudgetPolicy[] = [];
+  @property({ type: Boolean }) loading = false;
+  @property({ type: String }) error: string | null = null;
+  /** 'day' | 'week' | 'month' | 'year', shared with the rest of the page. */
+  @property({ type: String }) timeRange = 'month';
+  @property({ type: Number }) toolCallsCount = 0;
+
+  @state() private unit: UsageUnit = 'tokens';
+
+  static styles = [
+    budgetTrackStyles,
+    css`
+      :host {
+        display: block;
+        width: 100%;
+      }
+
+      .content-card,
+      .content-card::part(base) {
+        width: 100%;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--sl-spacing-small);
+      }
+
+      .title {
+        font-weight: 600;
+        color: var(--sl-color-neutral-900);
+      }
+
+      .body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-medium);
+      }
+
+      .unit-toggle {
+        display: flex;
+        justify-content: flex-end;
+      }
+
+      .primary-value {
+        font-size: 2rem;
+        font-weight: 700;
+        line-height: 1.1;
+        color: var(--sl-color-neutral-900);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .primary-label {
+        display: flex;
+        align-items: center;
+        gap: var(--sl-spacing-2x-small);
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        margin-top: var(--sl-spacing-2x-small);
+      }
+
+      .secondary-line {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .sparkline {
+        display: block;
+        width: 100%;
+        height: 40px;
+      }
+
+      .budgets {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-small);
+      }
+
+      .budget-row {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .budget-row-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--sl-spacing-small);
+        font-size: var(--sl-font-size-small);
+      }
+
+      .budget-row-label {
+        color: var(--sl-color-neutral-800);
+      }
+
+      .budget-row-value {
+        font-weight: 500;
+        white-space: nowrap;
+        font-variant-numeric: tabular-nums;
+      }
+
+      .muted {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-small);
+      }
+
+      .more-limits {
+        align-self: flex-start;
+      }
+
+      .footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--sl-spacing-small);
+      }
+
+      .footer a {
+        color: var(--sl-color-primary-600);
+        font-size: var(--sl-font-size-small);
+        text-decoration: none;
+      }
+
+      .footer a:hover {
+        text-decoration: underline;
+      }
+
+      sl-radio-button::part(button) {
+        font-size: var(--sl-font-size-x-small);
+      }
+    `,
+  ];
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    try {
+      const stored = localStorage.getItem(USAGE_UNIT_STORAGE_KEY);
+      if (stored === 'tokens' || stored === 'dollars') {
+        this.unit = stored;
+      }
+    } catch {
+      // Private mode or a blocked storage partition: keep the default.
+    }
+  }
+
+  private get rangeLabel(): string {
+    if (this.timeRange === 'day') return '24h';
+    if (this.timeRange === 'week') return '7d';
+    if (this.timeRange === 'year') return '1y';
+    return '30d';
+  }
+
+  private setUnit(unit: UsageUnit): void {
+    if (unit === this.unit) return;
+    this.unit = unit;
+    try {
+      localStorage.setItem(USAGE_UNIT_STORAGE_KEY, unit);
+    } catch {
+      // Non-fatal: the toggle still works for this session.
+    }
+  }
+
+  private formatCompactNumber(value: number | null | undefined): string {
+    const amount = Number(value || 0);
+    if (amount < 1000) {
+      return String(Math.round(amount));
+    }
+    return new Intl.NumberFormat(undefined, {
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(amount);
+  }
+
+  private formatCurrency(value: number | null | undefined): string {
+    const amount = Number(value || 0);
+    if (amount > 0 && amount < 0.01) {
+      return `$${amount.toFixed(4)}`;
+    }
+    return `$${amount.toFixed(2)}`;
+  }
+
+  private handleRangeChange(event: CustomEvent<{ value: string }>) {
+    event.stopPropagation();
+    this.dispatchEvent(
+      new CustomEvent('range-change', {
+        detail: { value: event.detail.value },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private emit(name: string) {
+    this.dispatchEvent(
+      new CustomEvent(name, { bubbles: true, composed: true })
+    );
+  }
+
+  private renderUnitToggle() {
+    return html`
+      <div class="unit-toggle">
+        <sl-radio-group
+          size="small"
+          label="Usage unit"
+          value=${this.unit}
+          @sl-change=${(event: Event) =>
+            this.setUnit((event.target as HTMLInputElement).value as UsageUnit)}
+        >
+          <sl-radio-button value="tokens">Tokens</sl-radio-button>
+          <sl-radio-button value="dollars">$ est.</sl-radio-button>
+        </sl-radio-group>
+      </div>
+    `;
+  }
+
+  private renderPrimary() {
+    if (this.loading && !this.summary) {
+      return html`
+        <div>
+          <sl-skeleton
+            effect="sheen"
+            style="width: 55%; height: 2rem;"
+          ></sl-skeleton>
+          <sl-skeleton
+            effect="sheen"
+            style="width: 80%; height: 1rem; margin-top: var(--sl-spacing-small);"
+          ></sl-skeleton>
+        </div>
+      `;
+    }
+
+    const tokens = this.summary?.token_usage?.total_tokens || 0;
+    const cost = this.summary?.estimated_cost || 0;
+
+    if (this.unit === 'dollars') {
+      return html`
+        <div>
+          <div class="primary-value">${this.formatCurrency(cost)}</div>
+          <div class="primary-label">
+            <span>est. spend · ${this.rangeLabel}</span>
+            <sl-tooltip
+              content="Estimated from provider list prices and your plan. See Cost for reconciliation."
+            >
+              <sl-icon
+                name="info-circle"
+                label="About estimated spend"
+              ></sl-icon>
+            </sl-tooltip>
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div>
+        <div class="primary-value">${this.formatCompactNumber(tokens)}</div>
+        <div class="primary-label">
+          <span>tokens · ${this.rangeLabel}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderSecondaryLine() {
+    if (this.loading && !this.summary) {
+      return html`<sl-skeleton
+        effect="sheen"
+        style="width: 90%; height: 0.85rem;"
+      ></sl-skeleton>`;
+    }
+
+    const usage = this.summary?.token_usage;
+    const requests = this.summary?.total_requests || 0;
+    const parts =
+      this.unit === 'dollars'
+        ? [
+            `${this.formatCompactNumber(usage?.total_tokens || 0)} tokens`,
+            `${this.formatCompactNumber(requests)} requests`,
+          ]
+        : [
+            `${this.formatCompactNumber(usage?.prompt_tokens || 0)} prompt`,
+            `${this.formatCompactNumber(usage?.completion_tokens || 0)} completion`,
+            `${this.formatCompactNumber(requests)} requests`,
+          ];
+    if (this.toolCallsCount > 0) {
+      parts.push(`${this.formatCompactNumber(this.toolCallsCount)} tool calls`);
+    }
+    return html`<div class="secondary-line">${parts.join(' · ')}</div>`;
+  }
+
+  /** Inline SVG: a trend line is worth more here than a charting library. */
+  private renderSparkline() {
+    const days = this.summary?.requests_by_day || [];
+    if (days.length < 3) {
+      return nothing;
+    }
+    const values = days.map((day) =>
+      this.unit === 'dollars'
+        ? Number(day.estimated_cost || 0)
+        : Number(day.total_tokens || 0)
+    );
+    const max = Math.max(...values);
+    const min = Math.min(...values);
+    const span = max - min || 1;
+    const width = 100;
+    const height = 40;
+    const step = values.length > 1 ? width / (values.length - 1) : width;
+    const points = values.map((value, index) => {
+      const x = index * step;
+      const y = height - ((value - min) / span) * (height - 4) - 2;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    });
+    const areaPoints = `0,${height} ${points.join(' ')} ${width},${height}`;
+
+    return html`
+      <svg
+        class="sparkline"
+        viewBox="0 0 ${width} ${height}"
+        preserveAspectRatio="none"
+        role="img"
+        aria-label=${
+          this.unit === 'dollars'
+            ? `Estimated spend per day over the last ${this.rangeLabel}`
+            : `Tokens per day over the last ${this.rangeLabel}`
+        }
+      >
+        <polygon
+          points=${areaPoints}
+          fill="var(--sl-color-primary-500)"
+          opacity="0.12"
+        ></polygon>
+        <polyline
+          points=${points.join(' ')}
+          fill="none"
+          stroke="var(--sl-color-primary-500)"
+          stroke-width="1.5"
+          vector-effect="non-scaling-stroke"
+        ></polyline>
+      </svg>
+    `;
+  }
+
+  private get globalPolicies(): BudgetPolicy[] {
+    return this.policies
+      .filter(
+        (policy) =>
+          policy.subject_type === 'global' || policy.subject_type === 'account'
+      )
+      .sort(
+        (left, right) =>
+          PERIOD_ORDER.indexOf(left.period) - PERIOD_ORDER.indexOf(right.period)
+      );
+  }
+
+  private get scopedPolicies(): BudgetPolicy[] {
+    return this.policies.filter(
+      (policy) =>
+        policy.subject_type !== 'global' && policy.subject_type !== 'account'
+    );
+  }
+
+  private get legacyMonthlyLimit(): number {
+    return this.summary?.budget?.monthly_limit_usd || 0;
+  }
+
+  private periodLabel(period: string): string {
+    if (period === 'all_time') return 'All time budget';
+    return `${period.charAt(0).toUpperCase()}${period.slice(1)} budget`;
+  }
+
+  private renderBudgetRow(
+    label: string,
+    spend: number,
+    softLimit: number,
+    hardLimit: number
+  ) {
+    const denominator = hardLimit || softLimit;
+    return html`
+      <div class="budget-row">
+        <div class="budget-row-header">
+          <span class="budget-row-label">${label}</span>
+          <span class="budget-row-value">
+            ${this.formatCurrency(spend)}
+            ${
+              denominator > 0
+                ? html`/ ${this.formatCurrency(denominator)}`
+                : html`<span class="muted">spent</span>`
+            }
+          </span>
+        </div>
+        ${
+          denominator > 0
+            ? renderBudgetTrack({
+                spend,
+                softLimit,
+                hardLimit,
+                label,
+              })
+            : nothing
+        }
+      </div>
+    `;
+  }
+
+  private renderBudgets() {
+    const globals = this.globalPolicies;
+    const scoped = this.scopedPolicies;
+    const legacyLimit = this.legacyMonthlyLimit;
+    const hasGlobalMonthly = globals.some(
+      (policy) => policy.period === 'monthly'
+    );
+
+    if (globals.length === 0 && legacyLimit <= 0 && scoped.length === 0) {
+      return html`<div class="muted">No budget set.</div>`;
+    }
+
+    const rows = globals.map((policy) =>
+      this.renderBudgetRow(
+        this.periodLabel(policy.period),
+        policy.current_spend_usd || 0,
+        policy.soft_limit_usd || 0,
+        policy.hard_limit_usd || 0
+      )
+    );
+
+    if (!hasGlobalMonthly && legacyLimit > 0) {
+      rows.unshift(
+        this.renderBudgetRow(
+          'Monthly budget',
+          this.summary?.budget?.current_spend_usd || 0,
+          this.summary?.budget?.soft_limit_usd || 0,
+          legacyLimit
+        )
+      );
+    }
+
+    return html`
+      <div class="budgets">
+        ${rows}
+        ${
+          scoped.length > 0
+            ? html`
+                <sl-button
+                  class="more-limits"
+                  size="small"
+                  variant="text"
+                  @click=${() => this.emit('configure-limits')}
+                >
+                  + ${scoped.length} more limit${scoped.length === 1 ? '' : 's'}
+                  (${this.scopedSubjectSummary(scoped)})
+                </sl-button>
+              `
+            : nothing
+        }
+      </div>
+    `;
+  }
+
+  private scopedSubjectSummary(policies: BudgetPolicy[]): string {
+    const seen: string[] = [];
+    for (const policy of policies) {
+      const label =
+        SUBJECT_TYPE_LABELS[policy.subject_type] ||
+        policy.subject_type.replace(/_/g, ' ');
+      if (!seen.includes(label)) {
+        seen.push(label);
+      }
+    }
+    return seen.join(', ');
+  }
+
+  render() {
+    return html`
+      <sl-card class="content-card">
+        <div slot="header" class="header">
+          <div class="title">Usage</div>
+          <time-range-select
+            ariaLabel="Usage time range"
+            .value=${this.timeRange}
+            .options=${[
+              { value: 'day', label: '24h' },
+              { value: 'week', label: '7d' },
+              { value: 'month', label: '30d' },
+              { value: 'year', label: '1y' },
+            ]}
+            @range-change=${this.handleRangeChange}
+          ></time-range-select>
+        </div>
+
+        <div class="body">
+          ${
+            this.error
+              ? html`<sl-alert variant="danger" open>
+                  <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
+                  ${this.error}
+                </sl-alert>`
+              : nothing
+          }
+          ${this.renderUnitToggle()} ${this.renderPrimary()}
+          ${this.renderSecondaryLine()} ${this.renderSparkline()}
+          ${this.renderBudgets()}
+          <div class="footer">
+            <sl-button
+              size="small"
+              variant="text"
+              @click=${() => this.emit('configure-limits')}
+            >
+              <sl-icon slot="prefix" name="gear"></sl-icon>
+              Configure limits
+            </sl-button>
+            <a href="/console/cost">Cost details</a>
+          </div>
+        </div>
+      </sl-card>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'usage-card': UsageCard;
+  }
+}

--- a/frontend/src/components/usage-card.ts
+++ b/frontend/src/components/usage-card.ts
@@ -87,6 +87,14 @@ export class UsageCard extends LitElement {
         gap: var(--sl-spacing-small);
       }
 
+      /* Unit toggle and range live together in the header: they are the two
+         controls that change what every number below them means. */
+      .header-controls {
+        align-items: center;
+        display: flex;
+        gap: var(--sl-spacing-small);
+      }
+
       .title {
         font-weight: 600;
         color: var(--sl-color-neutral-900);
@@ -100,7 +108,17 @@ export class UsageCard extends LitElement {
 
       .unit-toggle {
         display: flex;
-        justify-content: flex-end;
+      }
+
+      /* The control is self-explanatory next to the numbers it switches, so
+         the label is for screen readers only. */
+      .unit-toggle sl-radio-group::part(form-control-label) {
+        clip: rect(0 0 0 0);
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
       }
 
       .primary-value {
@@ -426,9 +444,28 @@ export class UsageCard extends LitElement {
     return this.summary?.budget?.monthly_limit_usd || 0;
   }
 
-  private periodLabel(period: string): string {
-    if (period === 'all_time') return 'All time budget';
-    return `${period.charAt(0).toUpperCase()}${period.slice(1)} budget`;
+  /**
+   * Which window a budget row is about. "Monthly budget: $12 / $50" was read
+   * as a running total; "Monthly budget - Sep" says the number resets.
+   */
+  private periodWindow(period: string, now: Date): string {
+    if (period === 'hourly') return 'this hour';
+    if (period === 'daily') return 'today';
+    if (period === 'weekly') return 'this week';
+    if (period === 'monthly') {
+      return now.toLocaleDateString(undefined, { month: 'short' });
+    }
+    if (period === 'yearly') return String(now.getFullYear());
+    return '';
+  }
+
+  private periodLabel(period: string, now: Date = new Date()): string {
+    const base =
+      period === 'all_time'
+        ? 'All time budget'
+        : `${period.charAt(0).toUpperCase()}${period.slice(1)} budget`;
+    const window = this.periodWindow(period, now);
+    return window ? `${base} · ${window}` : base;
   }
 
   private renderBudgetRow(
@@ -489,7 +526,7 @@ export class UsageCard extends LitElement {
     if (!hasGlobalMonthly && legacyLimit > 0) {
       rows.unshift(
         this.renderBudgetRow(
-          'Monthly budget',
+          this.periodLabel('monthly'),
           this.summary?.budget?.current_spend_usd || 0,
           this.summary?.budget?.soft_limit_usd || 0,
           legacyLimit
@@ -538,17 +575,20 @@ export class UsageCard extends LitElement {
       <sl-card class="content-card">
         <div slot="header" class="header">
           <div class="title">Usage</div>
-          <time-range-select
-            ariaLabel="Usage time range"
-            .value=${this.timeRange}
-            .options=${[
-              { value: 'day', label: '24h' },
-              { value: 'week', label: '7d' },
-              { value: 'month', label: '30d' },
-              { value: 'year', label: '1y' },
-            ]}
-            @range-change=${this.handleRangeChange}
-          ></time-range-select>
+          <div class="header-controls">
+            ${this.renderUnitToggle()}
+            <time-range-select
+              ariaLabel="Usage time range"
+              .value=${this.timeRange}
+              .options=${[
+                { value: 'day', label: '24h' },
+                { value: 'week', label: '7d' },
+                { value: 'month', label: '30d' },
+                { value: 'year', label: '1y' },
+              ]}
+              @range-change=${this.handleRangeChange}
+            ></time-range-select>
+          </div>
         </div>
 
         <div class="body">
@@ -560,9 +600,8 @@ export class UsageCard extends LitElement {
                 </sl-alert>`
               : nothing
           }
-          ${this.renderUnitToggle()} ${this.renderPrimary()}
-          ${this.renderSecondaryLine()} ${this.renderSparkline()}
-          ${this.renderBudgets()}
+          ${this.renderPrimary()} ${this.renderSecondaryLine()}
+          ${this.renderSparkline()} ${this.renderBudgets()}
           <div class="footer">
             <sl-button
               size="small"

--- a/frontend/src/components/usage-card.ts
+++ b/frontend/src/components/usage-card.ts
@@ -68,6 +68,18 @@ export class UsageCard extends LitElement {
         width: 100%;
       }
 
+      .content-card::part(base) {
+        border: 1px solid var(--sl-color-neutral-200);
+        border-radius: var(--sl-border-radius-medium);
+        box-shadow: var(--sl-shadow-x-small);
+      }
+
+      .content-card::part(header) {
+        background-color: transparent;
+        border-bottom: 1px solid var(--sl-color-neutral-200);
+        padding: var(--sl-spacing-medium);
+      }
+
       .header {
         display: flex;
         align-items: center;
@@ -497,8 +509,9 @@ export class UsageCard extends LitElement {
                   variant="text"
                   @click=${() => this.emit('configure-limits')}
                 >
-                  + ${scoped.length} more limit${scoped.length === 1 ? '' : 's'}
-                  (${this.scopedSubjectSummary(scoped)})
+                  ${`+ ${scoped.length} more limit${
+                    scoped.length === 1 ? '' : 's'
+                  } (${this.scopedSubjectSummary(scoped)})`}
                 </sl-button>
               `
             : nothing

--- a/frontend/src/styles/budget-track.ts
+++ b/frontend/src/styles/budget-track.ts
@@ -1,0 +1,190 @@
+import { css, html, nothing, type TemplateResult } from 'lit';
+
+/**
+ * The spend meter shared by `budget-health-card` (Cost) and `usage-card`
+ * (Overview): a track that fills green up to the soft limit, amber between
+ * soft and hard, red once a limit is reached, with a marker at the soft limit
+ * and one at the hard end.
+ */
+export const budgetTrackStyles = css`
+  .budget-track {
+    position: relative;
+    height: 6px;
+    border-radius: 999px;
+    background: var(--sl-color-neutral-200);
+    overflow: hidden;
+  }
+
+  .budget-track-fill {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--budget-fill-left, 0%);
+    width: var(--budget-fill-width, 0%);
+    background: var(--sl-color-success-600);
+  }
+
+  .budget-track-fill.warning {
+    background: var(--sl-color-warning-600);
+  }
+
+  .budget-track-fill.danger {
+    background: var(--sl-color-danger-600);
+  }
+
+  .budget-soft-marker {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--budget-soft-position, 0%);
+    width: 2px;
+    background: var(--sl-color-warning-600);
+    box-shadow: 0 0 0 1px var(--sl-color-neutral-0);
+  }
+
+  .budget-hard-marker {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--sl-color-danger-600);
+    box-shadow: 0 0 0 1px var(--sl-color-neutral-0);
+  }
+`;
+
+export function isHardLimitExceeded(spend: number, hardLimit: number): boolean {
+  return hardLimit > 0 && spend >= hardLimit;
+}
+
+export function isSoftOnlyLimitExceeded(
+  spend: number,
+  softLimit: number,
+  hardLimit: number
+): boolean {
+  return softLimit > 0 && hardLimit <= 0 && spend >= softLimit;
+}
+
+export function isLimitExceeded(
+  spend: number,
+  softLimit: number,
+  hardLimit: number
+): boolean {
+  return (
+    isHardLimitExceeded(spend, hardLimit) ||
+    isSoftOnlyLimitExceeded(spend, softLimit, hardLimit)
+  );
+}
+
+export function isSoftLimitWarning(
+  spend: number,
+  softLimit: number,
+  hardLimit: number
+): boolean {
+  return (
+    softLimit > 0 && hardLimit > 0 && spend >= softLimit && spend < hardLimit
+  );
+}
+
+export type BudgetTone = 'success' | 'warning' | 'danger';
+
+export function budgetTone(
+  spend: number,
+  softLimit: number,
+  hardLimit: number
+): BudgetTone {
+  if (isLimitExceeded(spend, softLimit, hardLimit)) return 'danger';
+  if (isSoftLimitWarning(spend, softLimit, hardLimit)) return 'warning';
+  return 'success';
+}
+
+function formatCurrency(value: number): string {
+  const amount = Number(value || 0);
+  if (amount > 0 && amount < 0.01) return `$${amount.toFixed(4)}`;
+  return `$${amount.toFixed(2)}`;
+}
+
+export interface BudgetTrackOptions {
+  spend: number;
+  softLimit: number;
+  hardLimit: number;
+  label: string;
+}
+
+/** Renders the meter itself; callers own the surrounding label row. */
+export function renderBudgetTrack({
+  spend,
+  softLimit,
+  hardLimit,
+  label,
+}: BudgetTrackOptions): TemplateResult | typeof nothing {
+  const maxLimit = hardLimit || softLimit;
+  if (maxLimit <= 0) return nothing;
+
+  const fillPercent = Math.min(100, (spend / maxLimit) * 100);
+  const softPercent =
+    softLimit > 0 ? Math.min(100, (softLimit / maxLimit) * 100) : 0;
+  const limitExceeded = isLimitExceeded(spend, softLimit, hardLimit);
+  const softLimitWarning = isSoftLimitWarning(spend, softLimit, hardLimit);
+  const successFillPercent = limitExceeded
+    ? 0
+    : softLimit > 0
+      ? Math.min(fillPercent, softPercent)
+      : fillPercent;
+  const warningFillPercent =
+    !limitExceeded && softLimitWarning ? fillPercent - softPercent : 0;
+  const dangerFillPercent = limitExceeded ? fillPercent : 0;
+
+  return html`
+    <div
+      class="budget-track"
+      role="progressbar"
+      aria-label=${`${label} usage`}
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-valuenow=${Math.round(fillPercent)}
+    >
+      ${
+        successFillPercent > 0
+          ? html`<div
+              class="budget-track-fill"
+              style="--budget-fill-width: ${successFillPercent}%;"
+            ></div>`
+          : nothing
+      }
+      ${
+        warningFillPercent > 0
+          ? html`<div
+              class="budget-track-fill warning"
+              style="--budget-fill-left: ${softPercent}%; --budget-fill-width: ${warningFillPercent}%;"
+            ></div>`
+          : nothing
+      }
+      ${
+        dangerFillPercent > 0
+          ? html`<div
+              class="budget-track-fill danger"
+              style="--budget-fill-width: ${dangerFillPercent}%;"
+            ></div>`
+          : nothing
+      }
+      ${
+        softLimit > 0 && hardLimit > 0 && softLimit < hardLimit
+          ? html`<div
+              class="budget-soft-marker"
+              title=${`Soft limit ${formatCurrency(softLimit)}`}
+              style="--budget-soft-position: ${softPercent}%;"
+            ></div>`
+          : nothing
+      }
+      ${
+        hardLimit > 0
+          ? html`<div
+              class="budget-hard-marker"
+              title=${`Hard limit ${formatCurrency(hardLimit)}`}
+            ></div>`
+          : nothing
+      }
+    </div>
+  `;
+}

--- a/frontend/src/styles/console-styles.css
+++ b/frontend/src/styles/console-styles.css
@@ -286,16 +286,23 @@ sl-dialog.large::part(panel) {
 }
 
 /* Empty state */
+/* One centered line in a 72px box: an empty list should say what is missing
+   in the space of a row, not in the space of a full card. */
 .empty-state {
-    text-align: center;
-    padding: var(--sl-spacing-large);
+    align-items: center;
     color: var(--sl-color-neutral-600);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-height: 72px;
+    padding: var(--sl-spacing-medium);
+    text-align: center;
 }
 
 .empty-state sl-icon {
-    font-size: 3rem;
+    font-size: 1.5rem;
     color: var(--sl-color-neutral-400);
-    margin-bottom: var(--sl-spacing-small);
+    margin-bottom: var(--sl-spacing-2x-small);
 }
 
 /* Chart/Card header */

--- a/frontend/src/styles/console-styles.css
+++ b/frontend/src/styles/console-styles.css
@@ -120,8 +120,27 @@ a:hover {
     padding: 0;
 }
 
+/* Cards read as one quiet surface: no gray header band, a hairline border and
+   the smallest shadow, so content (not chrome) carries the hierarchy. */
 sl-card::part(header) {
-    background-color: var(--sl-color-neutral-100);
+    background-color: transparent;
+    border-bottom: 1px solid var(--sl-color-neutral-200);
+    padding: var(--sl-spacing-medium);
+    font-weight: 600;
+}
+
+.content-card::part(base) {
+    border: 1px solid var(--sl-color-neutral-200);
+    border-radius: var(--sl-border-radius-medium);
+    box-shadow: var(--sl-shadow-x-small);
+}
+
+/* Numbers line up column-wise wherever they appear. */
+.row-value,
+.tool-count-value,
+.metric-value,
+.summary-value {
+    font-variant-numeric: tabular-nums;
 }
 
 .styled-table {

--- a/frontend/src/utils/agent-display.test.ts
+++ b/frontend/src/utils/agent-display.test.ts
@@ -7,6 +7,7 @@ import {
   getSystemAgentTags,
   getVisibleAgentTags,
   isSystemAgentTag,
+  sessionBelongsToAgent,
 } from './agent-display';
 
 const baseAgent = {
@@ -89,5 +90,57 @@ describe('agent tag visibility', () => {
   it('tolerates agents without tags', () => {
     expect(getVisibleAgentTags(null)).to.deep.equal([]);
     expect(getSystemAgentTags(undefined)).to.deep.equal({});
+  });
+});
+
+describe('sessionBelongsToAgent', () => {
+  const agent = { id: 'agent-1', session_source_id: 'openclaw-1' };
+
+  it('matches the agent source id on either session identifier', () => {
+    expect(
+      sessionBelongsToAgent(
+        { runtime_principal_id: 'openclaw-1', session_source_id: null },
+        agent
+      )
+    ).to.equal(true);
+    expect(
+      sessionBelongsToAgent(
+        { runtime_principal_id: null, session_source_id: 'openclaw-1' },
+        agent
+      )
+    ).to.equal(true);
+  });
+
+  it('matches the agent id itself', () => {
+    expect(
+      sessionBelongsToAgent(
+        { runtime_principal_id: 'agent-1', session_source_id: null },
+        agent
+      )
+    ).to.equal(true);
+  });
+
+  it('matches per-run suffixes of the source id', () => {
+    expect(
+      sessionBelongsToAgent(
+        { runtime_principal_id: 'openclaw-1:2', session_source_id: null },
+        agent
+      )
+    ).to.equal(true);
+    expect(
+      sessionBelongsToAgent(
+        { runtime_principal_id: 'openclaw-1-cli', session_source_id: null },
+        agent
+      )
+    ).to.equal(true);
+  });
+
+  it('rejects an unrelated session', () => {
+    expect(
+      sessionBelongsToAgent(
+        { runtime_principal_id: 'other-agent', session_source_id: 'other' },
+        agent
+      )
+    ).to.equal(false);
   });
 });

--- a/frontend/src/utils/agent-display.test.ts
+++ b/frontend/src/utils/agent-display.test.ts
@@ -4,6 +4,7 @@ import type { ManagedAgentSummary } from '../types';
 import {
   getAgentLifecycleLabel,
   getAgentLifecycleVariant,
+  getAgentStatusChip,
   getSystemAgentTags,
   getVisibleAgentTags,
   isSystemAgentTag,
@@ -62,6 +63,85 @@ describe('agent lifecycle presentation', () => {
         lifecycle_state: 'decommissioned',
       })
     ).to.equal('danger');
+  });
+});
+
+describe('getAgentStatusChip', () => {
+  const onboarded = {
+    ...baseAgent,
+    onboarding_state: 'fully_onboarded',
+  } satisfies ManagedAgentSummary;
+
+  it('puts lifecycle ahead of everything else', () => {
+    expect(
+      getAgentStatusChip({
+        ...onboarded,
+        lifecycle_state: 'decommissioned',
+        is_active_now: true,
+      })
+    ).to.deep.equal({ label: 'Decommissioned', variant: 'neutral' });
+    expect(
+      getAgentStatusChip({
+        ...onboarded,
+        lifecycle_state: 'suspended',
+        live_validation_status: 'failed',
+      })
+    ).to.deep.equal({ label: 'Paused', variant: 'neutral' });
+  });
+
+  it('reports a failed live check ahead of onboarding and activity', () => {
+    expect(
+      getAgentStatusChip({
+        ...baseAgent,
+        live_validation_status: 'failed',
+        is_active_now: true,
+      })
+    ).to.deep.equal({ label: 'Live check failed', variant: 'warning' });
+  });
+
+  it('flags every partially onboarded state as Setup incomplete', () => {
+    for (const state of ['incomplete', 'gateway_only', 'mcp_proxy_only']) {
+      expect(
+        getAgentStatusChip({
+          ...baseAgent,
+          onboarding_state: state,
+          is_active_now: true,
+        }),
+        state
+      ).to.deep.equal({ label: 'Setup incomplete', variant: 'warning' });
+    }
+  });
+
+  it('shows Active now for a live agent and an outlined chip for a recent one', () => {
+    expect(
+      getAgentStatusChip({ ...onboarded, is_active_now: true })
+    ).to.deep.equal({ label: 'Active now', variant: 'success' });
+    expect(
+      getAgentStatusChip({ ...onboarded, activity_status: 'recently_active' })
+    ).to.deep.equal({
+      label: 'Recently active',
+      variant: 'success',
+      outline: true,
+    });
+  });
+
+  it('falls back to Idle', () => {
+    expect(getAgentStatusChip(onboarded)).to.deep.equal({
+      label: 'Idle',
+      variant: 'neutral',
+    });
+  });
+
+  it('does not treat an unsupported or passing live check as a failure', () => {
+    expect(getAgentStatusChip({ ...onboarded }).label).to.equal('Idle');
+    expect(
+      getAgentStatusChip({ ...onboarded, live_validation_status: 'passed' })
+        .label
+    ).to.equal('Idle');
+    expect(
+      getAgentStatusChip({ ...onboarded, live_validation_status: 'not_run' })
+        .label
+    ).to.equal('Idle');
   });
 });
 

--- a/frontend/src/utils/agent-display.ts
+++ b/frontend/src/utils/agent-display.ts
@@ -26,6 +26,53 @@ export function getAgentLifecycleLabel(agent: ManagedAgentSummary): string {
   return 'Idle';
 }
 
+export interface AgentStatusChip {
+  label: string;
+  variant: 'success' | 'neutral' | 'warning' | 'danger';
+  /** Render as an outlined chip rather than a solid one. */
+  outline?: boolean;
+}
+
+/** Onboarding states that still leave part of the agent ungoverned. */
+const INCOMPLETE_ONBOARDING_STATES = [
+  'incomplete',
+  'gateway_only',
+  'mcp_proxy_only',
+];
+
+/**
+ * The single status taxonomy for an agent, shared by the agents list rows,
+ * the agent cards, the canvas nodes and the agent detail header so the same
+ * agent never reads as two different things in two places.
+ *
+ * Conditions are evaluated in order and the first match wins: lifecycle beats
+ * health, health beats activity. Amber means "you have something to fix",
+ * green means "working right now", neutral means "nothing to do".
+ */
+export function getAgentStatusChip(
+  agent: ManagedAgentSummary
+): AgentStatusChip {
+  if (agent.lifecycle_state === 'decommissioned') {
+    return { label: 'Decommissioned', variant: 'neutral' };
+  }
+  if (agent.lifecycle_state === 'suspended') {
+    return { label: 'Paused', variant: 'neutral' };
+  }
+  if (agent.live_validation_status === 'failed') {
+    return { label: 'Live check failed', variant: 'warning' };
+  }
+  if (INCOMPLETE_ONBOARDING_STATES.includes(agent.onboarding_state)) {
+    return { label: 'Setup incomplete', variant: 'warning' };
+  }
+  if (agent.is_active_now) {
+    return { label: 'Active now', variant: 'success' };
+  }
+  if (agent.activity_status === 'recently_active') {
+    return { label: 'Recently active', variant: 'success', outline: true };
+  }
+  return { label: 'Idle', variant: 'neutral' };
+}
+
 /**
  * Tags in the reserved `identity.*` namespace are written by the server
  * (re-keying records `identity.previous_ids=...`). They are bookkeeping, not

--- a/frontend/src/utils/agent-display.ts
+++ b/frontend/src/utils/agent-display.ts
@@ -26,6 +26,14 @@ export function getAgentLifecycleLabel(agent: ManagedAgentSummary): string {
   return 'Idle';
 }
 
+/**
+ * Spelled out on every Remove confirmation, on the list and on the detail
+ * page: removing an agent revokes its credentials, which is not obvious from
+ * the word "remove" alone.
+ */
+export const REMOVE_AGENT_CONSEQUENCE =
+  "This also revokes the agent's Preloop credentials. If the agent is still onboarded on a machine, its gateway and MCP access stop working until you run `preloop agents onboard` again. To disconnect cleanly, run `preloop agents offboard` on that machine instead.";
+
 export interface AgentStatusChip {
   label: string;
   variant: 'success' | 'neutral' | 'warning' | 'danger';

--- a/frontend/src/utils/agent-display.ts
+++ b/frontend/src/utils/agent-display.ts
@@ -1,6 +1,35 @@
 import { html, type TemplateResult } from 'lit';
-import type { ManagedAgentSummary } from '../types';
+import type { ManagedAgentSummary, RuntimeSessionSummary } from '../types';
 import { getAgentKindPresentation } from './agent-kinds';
+
+/**
+ * Does a runtime session belong to this managed agent?
+ *
+ * Sessions reference an agent through the runtime principal or the session
+ * source, and long-lived agents suffix those ids per run (`<base>:2`,
+ * `<base>-cli`), so prefix matches count too. Shared by the Overview's active
+ * agents card and the attention rules.
+ */
+export function sessionBelongsToAgent(
+  session: Pick<
+    RuntimeSessionSummary,
+    'runtime_principal_id' | 'session_source_id'
+  >,
+  agent: Pick<ManagedAgentSummary, 'id' | 'session_source_id'>
+): boolean {
+  const base = agent.session_source_id;
+  const candidates = [
+    session.runtime_principal_id,
+    session.session_source_id,
+  ].filter((value): value is string => Boolean(value));
+  return candidates.some(
+    (id) =>
+      id === base ||
+      id === agent.id ||
+      (Boolean(base) &&
+        (id.startsWith(`${base}:`) || id.startsWith(`${base}-`)))
+  );
+}
 
 export function getAgentSourceLabel(
   sourceType: string | null | undefined

--- a/frontend/src/utils/attention-data.test.ts
+++ b/frontend/src/utils/attention-data.test.ts
@@ -27,7 +27,14 @@ describe('loadAttentionInputs', () => {
           return new Response('{"detail":"forbidden"}', { status: 403 });
         }
         if (url.startsWith('/api/v1/approval-requests')) {
-          return json([{ id: 'approval-1', status: 'pending' }]);
+          return json([
+            { id: 'approval-1', status: 'pending' },
+            {
+              id: 'approval-expired',
+              status: 'pending',
+              expires_at: new Date(Date.now() - 3600_000).toISOString(),
+            },
+          ]);
         }
         if (url.startsWith('/api/v1/agents')) {
           return json({ items: [{ id: 'agent-1' }], total: 1 });
@@ -131,6 +138,16 @@ describe('loadAttentionInputs', () => {
     expect(inputs.gatewayFailures?.[0].id).to.equal('bad');
     expect(inputs.budgetPolicies).to.have.length(1);
     expect(inputs.usageSummary?.total_requests).to.equal(3);
+  });
+
+  it('hides approvals whose expiry has passed, whatever the API calls them', async () => {
+    const inputs = await loadAttentionInputs();
+
+    // The API keeps reporting expired requests as pending (backend issue
+    // #335). Nobody can act on one, so neither view may count it.
+    expect(inputs.approvals?.map((approval) => approval.id)).to.eql([
+      'approval-1',
+    ]);
   });
 
   it('drops only the input whose request fails', async () => {

--- a/frontend/src/utils/attention-data.test.ts
+++ b/frontend/src/utils/attention-data.test.ts
@@ -1,0 +1,151 @@
+import { expect } from '@open-wc/testing';
+import sinon from 'sinon';
+
+import { ATTENTION_QUERY, loadAttentionInputs } from './attention-data';
+
+describe('loadAttentionInputs', () => {
+  let fetchStub: sinon.SinonStub;
+  let failing: string[] = [];
+
+  const json = (data: unknown) =>
+    new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  const requestedUrls = () =>
+    fetchStub.getCalls().map((call) => String(call.args[0]));
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    failing = [];
+    fetchStub = sinon
+      .stub(window, 'fetch')
+      .callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (failing.some((fragment) => url.includes(fragment))) {
+          return new Response('{"detail":"forbidden"}', { status: 403 });
+        }
+        if (url.startsWith('/api/v1/approval-requests')) {
+          return json([{ id: 'approval-1', status: 'pending' }]);
+        }
+        if (url.startsWith('/api/v1/agents')) {
+          return json({ items: [{ id: 'agent-1' }], total: 1 });
+        }
+        if (url.startsWith('/api/v1/runtime-sessions')) {
+          return json({ items: [{ id: 'session-1' }], total: 1 });
+        }
+        if (url.startsWith('/api/v1/flows/executions')) {
+          return json([{ id: 'execution-1', status: 'FAILED' }]);
+        }
+        if (url.startsWith('/api/v1/account/gateway-usage/search')) {
+          return json({
+            items: [
+              { id: 'ok', outcome: 'success' },
+              { id: 'bad', outcome: 'error' },
+            ],
+          });
+        }
+        if (url.startsWith('/api/v1/budget/policies')) {
+          return json([{ id: 'policy-1' }]);
+        }
+        if (url.startsWith('/api/v1/account/gateway-usage/summary')) {
+          return json({ total_requests: 3 });
+        }
+        return json({ detail: `Unhandled ${url}` });
+      });
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  it('requests every input with the parameters both views share', async () => {
+    await loadAttentionInputs();
+    const urls = requestedUrls();
+
+    expect(
+      urls.some((url) =>
+        url.includes(
+          `/api/v1/approval-requests?status=pending&limit=${ATTENTION_QUERY.approvalsLimit}`
+        )
+      ),
+      'pending approvals'
+    ).to.be.true;
+    // 100 is the maximum the agents endpoint accepts; 200 is a 422 that used
+    // to empty the Agents section of the Attention page.
+    expect(
+      urls.some(
+        (url) =>
+          url.startsWith('/api/v1/agents') &&
+          url.includes(`limit=${ATTENTION_QUERY.agentsLimit}`)
+      ),
+      'agents limit'
+    ).to.be.true;
+    expect(ATTENTION_QUERY.agentsLimit).to.be.at.most(100);
+    expect(
+      urls.some(
+        (url) =>
+          url.startsWith('/api/v1/flows/executions') &&
+          url.includes('status=FAILED') &&
+          url.includes(`limit=${ATTENTION_QUERY.executionsLimit}`)
+      ),
+      'failed executions'
+    ).to.be.true;
+    expect(
+      urls.some(
+        (url) =>
+          url.startsWith('/api/v1/runtime-sessions') &&
+          url.includes(`limit=${ATTENTION_QUERY.sessionsLimit}`) &&
+          url.includes('start_date')
+      ),
+      'runtime sessions'
+    ).to.be.true;
+    expect(
+      urls.some((url) =>
+        url.startsWith('/api/v1/account/gateway-usage/search')
+      ),
+      'gateway failures'
+    ).to.be.true;
+    expect(
+      urls.some((url) => url.startsWith('/api/v1/budget/policies')),
+      'budget policies'
+    ).to.be.true;
+    expect(
+      urls.some((url) =>
+        url.startsWith('/api/v1/account/gateway-usage/summary')
+      ),
+      'usage summary'
+    ).to.be.true;
+  });
+
+  it('returns every input and keeps only failed gateway interactions', async () => {
+    const inputs = await loadAttentionInputs();
+
+    expect(inputs.approvals).to.have.length(1);
+    expect(inputs.agents).to.have.length(1);
+    expect(inputs.sessions).to.have.length(1);
+    expect(inputs.executions).to.have.length(1);
+    expect(inputs.gatewayFailures).to.have.length(1);
+    expect(inputs.gatewayFailures?.[0].id).to.equal('bad');
+    expect(inputs.budgetPolicies).to.have.length(1);
+    expect(inputs.usageSummary?.total_requests).to.equal(3);
+  });
+
+  it('drops only the input whose request fails', async () => {
+    failing = ['/api/v1/budget/policies'];
+    const inputs = await loadAttentionInputs();
+
+    expect(inputs.budgetPolicies).to.eql([]);
+    expect(inputs.approvals).to.have.length(1);
+    expect(inputs.agents).to.have.length(1);
+  });
+
+  it('skips the budget call when billing is off', async () => {
+    await loadAttentionInputs({ includeBudgetPolicies: false });
+    expect(
+      requestedUrls().some((url) => url.startsWith('/api/v1/budget/policies'))
+    ).to.be.false;
+  });
+});

--- a/frontend/src/utils/attention-data.ts
+++ b/frontend/src/utils/attention-data.ts
@@ -1,0 +1,134 @@
+import {
+  getAccountAgents,
+  getAccountGatewayUsageSearch,
+  getAccountGatewayUsageSummary,
+  getAccountRuntimeSessions,
+  getBudgetPolicies,
+  getFlowExecutions,
+  listApprovalRequests,
+  type BudgetPolicy,
+} from '../api';
+import type {
+  AccountGatewayUsageSummaryResponse,
+  GatewayUsageSearchResultItem,
+  ManagedAgentSummary,
+  RuntimeSessionSummary,
+} from '../types';
+import type {
+  AttentionApproval,
+  AttentionFlowExecution,
+  AttentionInputs,
+} from './attention';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * One place that decides which requests feed `deriveAttentionItems`.
+ *
+ * The Overview hero count and the Attention page used to fetch their own
+ * inputs with different parameters (approvals filtered by expiry on one side,
+ * `limit: 200` agents that the API rejects with a 422 on the other, ten mixed
+ * flow executions versus the twenty-five most recent failures), so the same
+ * account showed "3 need attention" next to a page listing nine items. Both
+ * call this loader now, so a disagreement means a bug in the derivation, not
+ * in the fetch parameters.
+ *
+ * The agents limit is 100 because that is the maximum the `/api/v1/agents`
+ * endpoint accepts (`limit: int = Query(20, ge=1, le=100)`); anything larger
+ * is a 422 that silently empties the Agents section.
+ */
+export const ATTENTION_QUERY = {
+  approvalsLimit: 100,
+  agentsLimit: 100,
+  sessionsLimit: 100,
+  sessionsWindowDays: 7,
+  executionsLimit: 25,
+  gatewayFailuresLimit: 12,
+  usageWindowDays: 30,
+} as const;
+
+export interface LoadAttentionInputsOptions {
+  /** Injected in tests and by callers that already know "now". */
+  now?: Date;
+  /** Skip the budget policies call when billing is off (it 403s). */
+  includeBudgetPolicies?: boolean;
+}
+
+/**
+ * Fetches every input of the attention rules. Individual failures (a 403 for a
+ * permission this operator lacks, a 422, a flaky endpoint) drop that one input
+ * instead of failing the whole page, exactly like the page-level
+ * `Promise.allSettled` it replaces.
+ */
+export async function loadAttentionInputs(
+  options: LoadAttentionInputsOptions = {}
+): Promise<AttentionInputs> {
+  const now = options.now || new Date();
+  const sessionsStart = new Date(
+    now.getTime() - ATTENTION_QUERY.sessionsWindowDays * DAY_MS
+  ).toISOString();
+  const usageStart = new Date(
+    now.getTime() - ATTENTION_QUERY.usageWindowDays * DAY_MS
+  ).toISOString();
+
+  const [approvals, agents, sessions, executions, failures, policies, summary] =
+    await Promise.allSettled([
+      listApprovalRequests({
+        status: 'pending',
+        limit: ATTENTION_QUERY.approvalsLimit,
+      }),
+      getAccountAgents({ status: 'all', limit: ATTENTION_QUERY.agentsLimit }),
+      getAccountRuntimeSessions({
+        status: 'all',
+        limit: ATTENTION_QUERY.sessionsLimit,
+        startDate: sessionsStart,
+      }),
+      getFlowExecutions({
+        status: 'FAILED',
+        limit: ATTENTION_QUERY.executionsLimit,
+      }),
+      getAccountGatewayUsageSearch({
+        limit: ATTENTION_QUERY.gatewayFailuresLimit,
+      }),
+      options.includeBudgetPolicies === false
+        ? Promise.resolve([] as BudgetPolicy[])
+        : getBudgetPolicies(),
+      getAccountGatewayUsageSummary({
+        startDate: usageStart,
+        includeBreakdown: false,
+      }),
+    ]);
+
+  return {
+    approvals:
+      approvals.status === 'fulfilled' && Array.isArray(approvals.value)
+        ? (approvals.value as AttentionApproval[])
+        : [],
+    agents:
+      agents.status === 'fulfilled'
+        ? ((agents.value.items || []) as ManagedAgentSummary[])
+        : [],
+    sessions:
+      sessions.status === 'fulfilled'
+        ? ((sessions.value.items || []) as RuntimeSessionSummary[])
+        : [],
+    executions:
+      executions.status === 'fulfilled' && Array.isArray(executions.value)
+        ? (executions.value as AttentionFlowExecution[])
+        : [],
+    gatewayFailures:
+      failures.status === 'fulfilled'
+        ? (
+            (failures.value.items || []) as GatewayUsageSearchResultItem[]
+          ).filter((item) => item.outcome !== 'success')
+        : [],
+    budgetPolicies:
+      policies.status === 'fulfilled' && Array.isArray(policies.value)
+        ? (policies.value as BudgetPolicy[])
+        : [],
+    usageSummary:
+      summary.status === 'fulfilled'
+        ? (summary.value as AccountGatewayUsageSummaryResponse)
+        : null,
+  };
+}

--- a/frontend/src/utils/attention-data.ts
+++ b/frontend/src/utils/attention-data.ts
@@ -19,6 +19,7 @@ import type {
   AttentionFlowExecution,
   AttentionInputs,
 } from './attention';
+import { parseUTCDate } from './date';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -46,6 +47,27 @@ export const ATTENTION_QUERY = {
   gatewayFailuresLimit: 12,
   usageWindowDays: 30,
 } as const;
+
+/**
+ * The API still reports a request as `pending` after its expiry passes
+ * (backend issue #335), and nobody can act on one of those. The Overview
+ * filtered them out and the Attention page did not, which is how the same
+ * account showed two different approval counts. The filter lives here so
+ * there is one answer for both views; the backend should flip those rows to
+ * `expired` separately.
+ */
+function isUnexpiredPendingApproval(
+  approval: AttentionApproval,
+  now: Date
+): boolean {
+  if (approval.status && approval.status !== 'pending') {
+    return false;
+  }
+  if (!approval.expires_at) {
+    return true;
+  }
+  return parseUTCDate(approval.expires_at).getTime() > now.getTime();
+}
 
 export interface LoadAttentionInputsOptions {
   /** Injected in tests and by callers that already know "now". */
@@ -102,7 +124,9 @@ export async function loadAttentionInputs(
   return {
     approvals:
       approvals.status === 'fulfilled' && Array.isArray(approvals.value)
-        ? (approvals.value as AttentionApproval[])
+        ? (approvals.value as AttentionApproval[]).filter((approval) =>
+            isUnexpiredPendingApproval(approval, now)
+          )
         : [],
     agents:
       agents.status === 'fulfilled'

--- a/frontend/src/utils/attention.test.ts
+++ b/frontend/src/utils/attention.test.ts
@@ -83,7 +83,7 @@ describe('deriveAttentionItems', () => {
       expect(items[0].kind).to.equal('approval');
       expect(items[0].severity).to.equal('critical');
       expect(items[0].title).to.equal('Deploy to production');
-      expect(items[0].detail).to.equal('Hermes · 5m ago');
+      expect(items[0].detail).to.equal('Hermes · pending 5m');
       expect(items[0].href).to.equal('/console/approval/approval-1');
     });
 
@@ -222,7 +222,7 @@ describe('deriveAttentionItems', () => {
   });
 
   describe('flows', () => {
-    it('emits one item per failed execution inside the 7 day window', () => {
+    it('emits one item for a single failed execution inside the 7 day window', () => {
       const items = derive({
         executions: [
           {
@@ -240,6 +240,52 @@ describe('deriveAttentionItems', () => {
       expect(items[0].title).to.equal('Pull Request Reviewer');
       expect(items[0].detail).to.equal('Failed · 1h ago · 2m 0s');
       expect(items[0].href).to.equal('/console/flows/executions/exec-1');
+    });
+
+    it('groups repeated failures of one flow into a single counted row', () => {
+      const items = derive({
+        executions: [
+          {
+            id: 'exec-1',
+            flow_id: 'flow-1',
+            flow_name: 'Pull Request Reviewer',
+            status: 'FAILED',
+            start_time: daysAgo(2),
+            end_time: minutesAgo(2 * 24 * 60 - 1),
+          },
+          {
+            id: 'exec-2',
+            flow_id: 'flow-1',
+            flow_name: 'Pull Request Reviewer',
+            status: 'FAILED',
+            start_time: daysAgo(3),
+          },
+          {
+            id: 'exec-3',
+            flow_id: 'flow-2',
+            flow_name: 'Merge Request Reviewer',
+            status: 'FAILED',
+            start_time: daysAgo(1),
+          },
+        ],
+      });
+
+      expect(items).to.have.length(2);
+      const reviewer = items.find(
+        (item) => item.title === 'Pull Request Reviewer'
+      )!;
+      expect(reviewer.id).to.equal('flow:flow-1');
+      expect(reviewer.detail).to.equal(
+        '2 failed runs in 3d · latest 2d ago · 1m 0s'
+      );
+      expect(reviewer.href).to.equal(
+        '/console/flows/executions?flow_id=flow-1&status=FAILED'
+      );
+
+      const merge = items.find(
+        (item) => item.title === 'Merge Request Reviewer'
+      )!;
+      expect(merge.href).to.equal('/console/flows/executions/exec-3');
     });
 
     it('ignores succeeded runs and anything older than 7 days', () => {

--- a/frontend/src/utils/attention.test.ts
+++ b/frontend/src/utils/attention.test.ts
@@ -1,0 +1,527 @@
+import { expect } from '@open-wc/testing';
+
+import {
+  ATTENTION_KIND_META,
+  ATTENTION_KIND_ORDER,
+  attentionKindChipLabel,
+  deriveAttentionItems,
+  groupAttentionItems,
+  type AttentionInputs,
+} from './attention';
+
+const NOW = new Date('2026-09-02T12:00:00Z');
+
+function minutesAgo(minutes: number): string {
+  return new Date(NOW.getTime() - minutes * 60000).toISOString();
+}
+
+function daysAgo(days: number): string {
+  return new Date(NOW.getTime() - days * 86400000).toISOString();
+}
+
+function agentFixture(overrides: Record<string, unknown> = {}): any {
+  return {
+    id: 'agent-1',
+    display_name: 'Hermes',
+    session_source_id: 'hermes-principal',
+    lifecycle_state: 'active',
+    activity_status: 'idle',
+    onboarding_state: 'fully_onboarded',
+    live_validation_status: 'passed',
+    last_seen_at: minutesAgo(30),
+    ...overrides,
+  };
+}
+
+function sessionFixture(overrides: Record<string, unknown> = {}): any {
+  return {
+    id: 'session-1',
+    runtime_principal_id: 'hermes-principal',
+    session_source_id: 'hermes-principal',
+    started_at: minutesAgo(60),
+    last_activity_at: minutesAgo(10),
+    failed_requests: 0,
+    ...overrides,
+  };
+}
+
+function failureFixture(overrides: Record<string, unknown> = {}): any {
+  return {
+    api_usage_id: 'usage-1',
+    timestamp: minutesAgo(5),
+    status_code: 500,
+    outcome: 'error',
+    endpoint: '/openai/v1/chat/completions',
+    model_alias: 'deepseek/deepseek-v4-pro',
+    provider_name: 'deepseek',
+    ...overrides,
+  };
+}
+
+function derive(inputs: AttentionInputs) {
+  return deriveAttentionItems({ now: NOW, ...inputs });
+}
+
+describe('deriveAttentionItems', () => {
+  describe('approvals', () => {
+    it('emits a critical item per pending request with agent and relative time', () => {
+      const items = derive({
+        approvals: [
+          {
+            id: 'approval-1',
+            tool_name: 'shell.run',
+            summary: 'Deploy to production',
+            status: 'pending',
+            requested_at: minutesAgo(5),
+            managed_agent_name: 'Hermes',
+          },
+        ],
+      });
+
+      expect(items).to.have.length(1);
+      expect(items[0].id).to.equal('approval:approval-1');
+      expect(items[0].kind).to.equal('approval');
+      expect(items[0].severity).to.equal('critical');
+      expect(items[0].title).to.equal('Deploy to production');
+      expect(items[0].detail).to.equal('Hermes · 5m ago');
+      expect(items[0].href).to.equal('/console/approval/approval-1');
+    });
+
+    it('falls back to the tool name and prefixes questions', () => {
+      const items = derive({
+        approvals: [
+          {
+            id: 'approval-2',
+            tool_name: 'github.merge',
+            requested_at: minutesAgo(1),
+          },
+          {
+            id: 'approval-3',
+            tool_name: 'ask.user',
+            summary: 'Which branch?',
+            is_question: true,
+            requested_at: minutesAgo(1),
+          },
+        ],
+      });
+
+      const titles = items.map((item) => item.title);
+      expect(titles).to.include('github.merge');
+      expect(titles).to.include('Question: Which branch?');
+    });
+
+    it('ignores requests that are no longer pending', () => {
+      const items = derive({
+        approvals: [
+          {
+            id: 'approval-4',
+            tool_name: 'shell.run',
+            status: 'approved',
+            requested_at: minutesAgo(5),
+          },
+        ],
+      });
+
+      expect(items).to.have.length(0);
+    });
+  });
+
+  describe('agents', () => {
+    it('reports a failed live check', () => {
+      const items = derive({
+        agents: [agentFixture({ live_validation_status: 'failed' })],
+      });
+
+      expect(items).to.have.length(1);
+      expect(items[0].kind).to.equal('agent');
+      expect(items[0].severity).to.equal('warning');
+      expect(items[0].title).to.equal('Hermes');
+      expect(items[0].detail).to.equal('Live check failed');
+      expect(items[0].href).to.equal('/console/agents/agent-1');
+    });
+
+    it('joins every reason for one agent with a middle dot', () => {
+      const items = derive({
+        agents: [
+          agentFixture({
+            live_validation_status: 'failed',
+            onboarding_state: 'incomplete',
+          }),
+        ],
+        sessions: [sessionFixture({ failed_requests: 2 })],
+      });
+
+      expect(items).to.have.length(1);
+      expect(items[0].detail).to.equal(
+        'Live check failed · Setup incomplete · 2 failed requests in last session'
+      );
+    });
+
+    it('counts failures from the latest session only', () => {
+      const items = derive({
+        agents: [agentFixture()],
+        sessions: [
+          sessionFixture({
+            id: 'older',
+            last_activity_at: minutesAgo(600),
+            failed_requests: 9,
+          }),
+          sessionFixture({
+            id: 'newest',
+            last_activity_at: minutesAgo(2),
+            failed_requests: 1,
+          }),
+        ],
+      });
+
+      expect(items[0].detail).to.equal('1 failed request in last session');
+    });
+
+    it('matches sessions whose principal id is suffixed from the agent source id', () => {
+      const items = derive({
+        agents: [agentFixture()],
+        sessions: [
+          sessionFixture({
+            runtime_principal_id: 'hermes-principal:2',
+            session_source_id: 'hermes-principal:2',
+            failed_requests: 3,
+          }),
+        ],
+      });
+
+      expect(items[0].detail).to.contain('3 failed requests in last session');
+    });
+
+    it('skips suspended and decommissioned agents', () => {
+      const items = derive({
+        agents: [
+          agentFixture({
+            id: 'agent-suspended',
+            lifecycle_state: 'suspended',
+            live_validation_status: 'failed',
+          }),
+          agentFixture({
+            id: 'agent-gone',
+            lifecycle_state: 'decommissioned',
+            onboarding_state: 'incomplete',
+          }),
+        ],
+      });
+
+      expect(items).to.have.length(0);
+    });
+
+    it('stays quiet for a healthy agent', () => {
+      const items = derive({
+        agents: [agentFixture()],
+        sessions: [sessionFixture()],
+      });
+
+      expect(items).to.have.length(0);
+    });
+  });
+
+  describe('flows', () => {
+    it('emits one item per failed execution inside the 7 day window', () => {
+      const items = derive({
+        executions: [
+          {
+            id: 'exec-1',
+            flow_name: 'Pull Request Reviewer',
+            status: 'FAILED',
+            start_time: minutesAgo(90),
+            end_time: minutesAgo(88),
+          },
+        ],
+      });
+
+      expect(items).to.have.length(1);
+      expect(items[0].kind).to.equal('flow');
+      expect(items[0].title).to.equal('Pull Request Reviewer');
+      expect(items[0].detail).to.equal('Failed · 1h ago · 2m 0s');
+      expect(items[0].href).to.equal('/console/flows/executions/exec-1');
+    });
+
+    it('ignores succeeded runs and anything older than 7 days', () => {
+      const items = derive({
+        executions: [
+          {
+            id: 'exec-ok',
+            flow_name: 'Nightly',
+            status: 'SUCCEEDED',
+            start_time: minutesAgo(30),
+          },
+          {
+            id: 'exec-old',
+            flow_name: 'Nightly',
+            status: 'FAILED',
+            start_time: daysAgo(8),
+          },
+        ],
+      });
+
+      expect(items).to.have.length(0);
+    });
+  });
+
+  describe('models', () => {
+    it('groups gateway failures by model alias', () => {
+      const items = derive({
+        gatewayFailures: [
+          failureFixture({ api_usage_id: 'u1', timestamp: minutesAgo(30) }),
+          failureFixture({ api_usage_id: 'u2', timestamp: minutesAgo(5) }),
+        ],
+      });
+
+      expect(items).to.have.length(1);
+      expect(items[0].id).to.equal('model:deepseek/deepseek-v4-pro');
+      expect(items[0].detail).to.equal('2 failed requests · last 5m ago');
+      expect(items[0].href).to.equal('/console/ai-models');
+      expect(items[0].at).to.equal(minutesAgo(5));
+    });
+
+    it('deep links to the model when the id is known and falls back to the provider name', () => {
+      const items = derive({
+        gatewayFailures: [
+          failureFixture({ ai_model_id: 'model-9' }),
+          failureFixture({
+            api_usage_id: 'u3',
+            model_alias: null,
+            provider_name: 'openai',
+          }),
+        ],
+      });
+
+      const byId = new Map(items.map((item) => [item.id, item]));
+      expect(byId.get('model:deepseek/deepseek-v4-pro')?.href).to.equal(
+        '/console/ai-models/model-9'
+      );
+      expect(byId.get('model:openai')).to.exist;
+    });
+
+    it('ignores successful interactions', () => {
+      const items = derive({
+        gatewayFailures: [failureFixture({ outcome: 'success' })],
+      });
+
+      expect(items).to.have.length(0);
+    });
+  });
+
+  describe('budgets', () => {
+    const policy = (overrides: Record<string, unknown> = {}): any => ({
+      id: 'policy-1',
+      subject_type: 'global',
+      subject_id: null,
+      model_alias: null,
+      period: 'monthly',
+      hard_limit_usd: 300,
+      soft_limit_usd: 200,
+      notify_on_soft: true,
+      notify_on_hard: true,
+      notification_user_ids: null,
+      notification_team_ids: null,
+      notification_emails: null,
+      ...overrides,
+    });
+
+    it('is critical at or over the hard limit', () => {
+      const items = derive({
+        budgetPolicies: [policy({ current_spend_usd: 300 })],
+      });
+
+      expect(items).to.have.length(1);
+      expect(items[0].severity).to.equal('critical');
+      expect(items[0].title).to.equal('Global · monthly');
+      expect(items[0].detail).to.equal(
+        'Hard limit reached ($300.00 / $300.00)'
+      );
+      expect(items[0].href).to.equal('/console/attention#budgets');
+      expect(items[0].action).to.deep.equal({
+        label: 'Configure limits',
+        event: 'configure-limits',
+      });
+    });
+
+    it('is a warning between soft and hard', () => {
+      const items = derive({
+        budgetPolicies: [policy({ current_spend_usd: 220 })],
+      });
+
+      expect(items[0].severity).to.equal('warning');
+      expect(items[0].detail).to.equal(
+        'Soft limit exceeded ($220.00 / $200.00)'
+      );
+    });
+
+    it('stays quiet under the soft limit and without a spend figure', () => {
+      const items = derive({
+        budgetPolicies: [
+          policy({ current_spend_usd: 12 }),
+          policy({ id: 'policy-2', current_spend_usd: null }),
+        ],
+      });
+
+      expect(items).to.have.length(0);
+    });
+
+    it('names the model scope for model policies', () => {
+      const items = derive({
+        budgetPolicies: [
+          policy({
+            subject_type: 'ai_model',
+            subject_id: 'model-1',
+            model_alias: 'gpt-5.4',
+            period: 'daily',
+            current_spend_usd: 400,
+          }),
+        ],
+      });
+
+      expect(items[0].title).to.equal('gpt-5.4 · daily');
+    });
+  });
+
+  describe('pricing', () => {
+    const summary = (overrides: Record<string, unknown> = {}): any => ({
+      period_start: daysAgo(30),
+      period_end: NOW.toISOString(),
+      total_requests: 10,
+      successful_requests: 10,
+      failed_requests: 0,
+      token_usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      estimated_cost: 1,
+      budget: {
+        monthly_limit_usd: null,
+        soft_limit_usd: null,
+        current_spend_usd: 0,
+        soft_limit_exceeded: false,
+        hard_limit_exceeded: false,
+      },
+      requests_by_day: [],
+      usage_by_model: [],
+      usage_by_flow: [],
+      usage_by_session: [],
+      ...overrides,
+    });
+
+    it('flags a catalog older than 14 days', () => {
+      const items = derive({
+        usageSummary: summary({
+          price_catalog: { fetched_at: daysAgo(30), model_count: 120 },
+        }),
+      });
+
+      expect(items).to.have.length(1);
+      expect(items[0].kind).to.equal('pricing');
+      expect(items[0].title).to.equal('Price catalog');
+      expect(items[0].detail).to.contain('Price catalog stale since');
+      expect(items[0].action).to.deep.equal({
+        label: 'Update prices',
+        href: '/console/cost',
+      });
+    });
+
+    it('flags an empty catalog and unpriced requests in one item', () => {
+      const items = derive({
+        usageSummary: summary({
+          price_catalog: { fetched_at: null, model_count: 0 },
+          unpriced_requests: 4,
+        }),
+      });
+
+      expect(items).to.have.length(1);
+      expect(items[0].detail).to.equal(
+        'Price catalog has no models · 4 requests unpriced'
+      );
+    });
+
+    it('stays quiet for a fresh catalog with everything priced', () => {
+      const items = derive({
+        usageSummary: summary({
+          price_catalog: { fetched_at: daysAgo(1), model_count: 120 },
+          unpriced_requests: 0,
+        }),
+      });
+
+      expect(items).to.have.length(0);
+    });
+  });
+
+  it('sorts critical items first, then most recent, nulls last', () => {
+    const items = derive({
+      approvals: [
+        { id: 'a-old', tool_name: 'old', requested_at: minutesAgo(120) },
+        { id: 'a-new', tool_name: 'new', requested_at: minutesAgo(2) },
+      ],
+      gatewayFailures: [failureFixture({ timestamp: minutesAgo(1) })],
+      budgetPolicies: [
+        {
+          id: 'policy-soft',
+          subject_type: 'global',
+          subject_id: null,
+          model_alias: null,
+          period: 'weekly',
+          hard_limit_usd: null,
+          soft_limit_usd: 10,
+          current_spend_usd: 20,
+          notify_on_soft: false,
+          notify_on_hard: false,
+          notification_user_ids: null,
+          notification_team_ids: null,
+          notification_emails: null,
+        } as any,
+      ],
+    });
+
+    expect(items.map((item) => item.id)).to.deep.equal([
+      'approval:a-new',
+      'approval:a-old',
+      'model:deepseek/deepseek-v4-pro',
+      'budget:policy-soft',
+    ]);
+  });
+
+  it('returns an empty list when nothing is wrong', () => {
+    expect(derive({})).to.deep.equal([]);
+  });
+});
+
+describe('groupAttentionItems', () => {
+  it('groups by kind in section order and omits empty kinds', () => {
+    const items = derive({
+      approvals: [
+        { id: 'a1', tool_name: 'shell.run', requested_at: minutesAgo(3) },
+      ],
+      agents: [agentFixture({ onboarding_state: 'incomplete' })],
+      gatewayFailures: [failureFixture()],
+    });
+
+    const grouped = groupAttentionItems(items);
+    expect(Array.from(grouped.keys())).to.deep.equal([
+      'approval',
+      'agent',
+      'model',
+    ]);
+    expect(grouped.get('approval')).to.have.length(1);
+    expect(grouped.get('flow')).to.equal(undefined);
+  });
+});
+
+describe('ATTENTION_KIND_META', () => {
+  it('describes every kind in the section order', () => {
+    for (const kind of ATTENTION_KIND_ORDER) {
+      const meta = ATTENTION_KIND_META[kind];
+      expect(meta.label, kind).to.be.a('string');
+      expect(meta.plural, kind).to.be.a('string');
+      expect(meta.icon, kind).to.be.a('string');
+      expect(meta.sectionHref, kind).to.contain('/console');
+    }
+  });
+
+  it('builds singular and plural chip labels', () => {
+    expect(attentionKindChipLabel('approval', 2)).to.equal('2 approvals');
+    expect(attentionKindChipLabel('agent', 1)).to.equal('1 agent');
+    expect(attentionKindChipLabel('flow', 0)).to.equal('0 flows');
+  });
+});

--- a/frontend/src/utils/attention.ts
+++ b/frontend/src/utils/attention.ts
@@ -1,0 +1,466 @@
+import type { BudgetPolicy } from '../api';
+import type {
+  AccountGatewayUsageSummaryResponse,
+  GatewayUsageSearchResultItem,
+  ManagedAgentSummary,
+  RuntimeSessionSummary,
+} from '../types';
+import {
+  formatDurationBetween,
+  formatRelativeTime,
+  parseUTCDate,
+} from './date';
+import { sessionBelongsToAgent } from './agent-display';
+
+/**
+ * Everything the console considers "needs attention", derived from data the
+ * Overview already fetches. Pure so both the Overview side card and the
+ * Attention page can render the same list without a second source of truth.
+ */
+export type AttentionKind =
+  'approval' | 'agent' | 'flow' | 'model' | 'budget' | 'pricing';
+
+export type AttentionSeverity = 'critical' | 'warning';
+
+export interface AttentionItemAction {
+  label: string;
+  href?: string;
+  event?: 'configure-limits';
+}
+
+export interface AttentionItem {
+  /** Stable across refetches: `${kind}:${entityId}`. */
+  id: string;
+  kind: AttentionKind;
+  severity: AttentionSeverity;
+  title: string;
+  detail: string;
+  href: string;
+  /** ISO timestamp used for ordering and relative time; null when unknown. */
+  at: string | null;
+  action?: AttentionItemAction;
+}
+
+/**
+ * Structural shapes rather than the full API types: the attention rules only
+ * read a handful of fields, and tests stay readable when a fixture is five
+ * lines instead of forty. The real API types are assignable to these.
+ */
+export interface AttentionApproval {
+  id: string;
+  tool_name?: string | null;
+  summary?: string | null;
+  status?: string;
+  requested_at: string;
+  managed_agent_name?: string | null;
+  flow_name?: string | null;
+  is_question?: boolean;
+  question?: string | null;
+}
+
+export interface AttentionFlowExecution {
+  id: string;
+  flow_id?: string | null;
+  flow_name?: string | null;
+  status: string;
+  /** The executions API returns `start_time`; `started_at` is accepted too. */
+  start_time?: string | null;
+  started_at?: string | null;
+  end_time?: string | null;
+}
+
+export interface AttentionInputs {
+  approvals?: AttentionApproval[];
+  agents?: ManagedAgentSummary[];
+  sessions?: RuntimeSessionSummary[];
+  executions?: AttentionFlowExecution[];
+  gatewayFailures?: GatewayUsageSearchResultItem[];
+  budgetPolicies?: BudgetPolicy[];
+  usageSummary?: AccountGatewayUsageSummaryResponse | null;
+  now?: Date;
+}
+
+export const ATTENTION_KIND_META: Record<
+  AttentionKind,
+  { label: string; plural: string; icon: string; sectionHref: string }
+> = {
+  approval: {
+    label: 'Approval',
+    plural: 'Approvals',
+    icon: 'shield-check',
+    sectionHref: '/console/approvals',
+  },
+  agent: {
+    label: 'Agent',
+    plural: 'Agents',
+    icon: 'robot',
+    sectionHref: '/console/agents',
+  },
+  flow: {
+    label: 'Flow',
+    plural: 'Flows',
+    icon: 'diagram-3',
+    sectionHref: '/console/flows/executions',
+  },
+  model: {
+    label: 'Model',
+    plural: 'Models',
+    icon: 'cpu',
+    sectionHref: '/console/ai-models',
+  },
+  budget: {
+    label: 'Budget',
+    plural: 'Budgets',
+    icon: 'wallet2',
+    sectionHref: '/console/cost',
+  },
+  pricing: {
+    label: 'Pricing',
+    plural: 'Pricing',
+    icon: 'tags',
+    sectionHref: '/console/cost',
+  },
+};
+
+/** Section order on the Attention page and in the grouped map. */
+export const ATTENTION_KIND_ORDER: AttentionKind[] = [
+  'approval',
+  'agent',
+  'flow',
+  'model',
+  'budget',
+  'pricing',
+];
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
+
+function formatUsd(value: number | null | undefined): string {
+  return `$${Number(value || 0).toFixed(2)}`;
+}
+
+function timestampOf(value: string | null | undefined): number {
+  if (!value) return 0;
+  const parsed = parseUTCDate(value).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function joinReasons(reasons: string[]): string {
+  return reasons.filter(Boolean).join(' · ');
+}
+
+function approvalItems(
+  approvals: AttentionApproval[],
+  now: Date
+): AttentionItem[] {
+  return approvals
+    .filter((approval) => !approval.status || approval.status === 'pending')
+    .map((approval) => {
+      const subject =
+        approval.summary || approval.tool_name || 'Approval request';
+      const title = approval.is_question ? `Question: ${subject}` : subject;
+      const requester = approval.managed_agent_name || approval.flow_name || '';
+      const detail = joinReasons([
+        requester,
+        approval.requested_at
+          ? formatRelativeTime(approval.requested_at, now)
+          : '',
+      ]);
+      return {
+        id: `approval:${approval.id}`,
+        kind: 'approval' as const,
+        severity: 'critical' as const,
+        title,
+        detail,
+        href: `/console/approval/${approval.id}`,
+        at: approval.requested_at || null,
+      };
+    });
+}
+
+function latestSessionForAgent(
+  agent: ManagedAgentSummary,
+  sessions: RuntimeSessionSummary[]
+): RuntimeSessionSummary | undefined {
+  return sessions
+    .filter((session) => sessionBelongsToAgent(session, agent))
+    .sort(
+      (left, right) =>
+        timestampOf(right.last_activity_at || right.started_at) -
+        timestampOf(left.last_activity_at || left.started_at)
+    )[0];
+}
+
+function agentItems(
+  agents: ManagedAgentSummary[],
+  sessions: RuntimeSessionSummary[]
+): AttentionItem[] {
+  const items: AttentionItem[] = [];
+  for (const agent of agents) {
+    if (
+      agent.lifecycle_state === 'suspended' ||
+      agent.lifecycle_state === 'decommissioned'
+    ) {
+      continue;
+    }
+    const reasons: string[] = [];
+    if (agent.live_validation_status === 'failed') {
+      reasons.push('Live check failed');
+    }
+    if (agent.onboarding_state === 'incomplete') {
+      reasons.push('Setup incomplete');
+    }
+    const latestSession = latestSessionForAgent(agent, sessions);
+    const failedRequests = latestSession?.failed_requests || 0;
+    if (failedRequests > 0) {
+      reasons.push(
+        `${failedRequests} failed request${
+          failedRequests === 1 ? '' : 's'
+        } in last session`
+      );
+    }
+    if (reasons.length === 0) {
+      continue;
+    }
+    items.push({
+      id: `agent:${agent.id}`,
+      kind: 'agent',
+      severity: 'warning',
+      title: agent.display_name || agent.id,
+      detail: joinReasons(reasons),
+      href: `/console/agents/${agent.id}`,
+      at:
+        latestSession?.last_activity_at ||
+        latestSession?.started_at ||
+        agent.last_seen_at ||
+        null,
+    });
+  }
+  return items;
+}
+
+function flowItems(
+  executions: AttentionFlowExecution[],
+  now: Date
+): AttentionItem[] {
+  const cutoff = now.getTime() - SEVEN_DAYS_MS;
+  return executions
+    .filter((execution) => execution.status === 'FAILED')
+    .filter((execution) => {
+      const startedAt = execution.start_time || execution.started_at;
+      return Boolean(startedAt) && timestampOf(startedAt) >= cutoff;
+    })
+    .map((execution) => {
+      const startedAt = (execution.start_time ||
+        execution.started_at) as string;
+      const duration = formatDurationBetween(
+        startedAt,
+        execution.end_time,
+        now
+      );
+      return {
+        id: `flow:${execution.id}`,
+        kind: 'flow' as const,
+        severity: 'warning' as const,
+        title: execution.flow_name || 'Unnamed flow',
+        detail: joinReasons([
+          'Failed',
+          formatRelativeTime(startedAt, now),
+          duration,
+        ]),
+        href: `/console/flows/executions/${execution.id}`,
+        at: startedAt,
+      };
+    });
+}
+
+function modelItems(
+  failures: GatewayUsageSearchResultItem[],
+  now: Date
+): AttentionItem[] {
+  const groups = new Map<
+    string,
+    { count: number; lastAt: string | null; modelId: string | null }
+  >();
+  for (const failure of failures) {
+    if (failure.outcome === 'success') {
+      continue;
+    }
+    const key = failure.model_alias || failure.provider_name || 'Unknown model';
+    const existing = groups.get(key) || {
+      count: 0,
+      lastAt: null as string | null,
+      modelId: null as string | null,
+    };
+    existing.count += 1;
+    if (timestampOf(failure.timestamp) > timestampOf(existing.lastAt)) {
+      existing.lastAt = failure.timestamp;
+    }
+    const modelId = (failure as { ai_model_id?: string | null }).ai_model_id;
+    if (!existing.modelId && modelId) {
+      existing.modelId = modelId;
+    }
+    groups.set(key, existing);
+  }
+
+  return Array.from(groups.entries()).map(([key, group]) => ({
+    id: `model:${key}`,
+    kind: 'model' as const,
+    severity: 'warning' as const,
+    title: key,
+    detail: joinReasons([
+      `${group.count} failed request${group.count === 1 ? '' : 's'}`,
+      group.lastAt ? `last ${formatRelativeTime(group.lastAt, now)}` : '',
+    ]),
+    href: group.modelId
+      ? `/console/ai-models/${group.modelId}`
+      : '/console/ai-models',
+    at: group.lastAt,
+  }));
+}
+
+function budgetScopeName(policy: BudgetPolicy): string {
+  if (policy.subject_type === 'global' || policy.subject_type === 'account') {
+    return 'Global';
+  }
+  if (policy.subject_type === 'ai_model') {
+    return policy.model_alias || 'Model';
+  }
+  if (policy.subject_type === 'managed_agent') {
+    return 'Agent';
+  }
+  return policy.subject_type.replace(/_/g, ' ');
+}
+
+function budgetItems(policies: BudgetPolicy[]): AttentionItem[] {
+  const items: AttentionItem[] = [];
+  for (const policy of policies) {
+    const spend = policy.current_spend_usd;
+    if (typeof spend !== 'number') {
+      continue;
+    }
+    const hardLimit = policy.hard_limit_usd || 0;
+    const softLimit = policy.soft_limit_usd || 0;
+    let severity: AttentionSeverity | null = null;
+    let detail = '';
+    if (hardLimit > 0 && spend >= hardLimit) {
+      severity = 'critical';
+      detail = `Hard limit reached (${formatUsd(spend)} / ${formatUsd(
+        hardLimit
+      )})`;
+    } else if (softLimit > 0 && spend >= softLimit) {
+      severity = 'warning';
+      detail = `Soft limit exceeded (${formatUsd(spend)} / ${formatUsd(
+        softLimit
+      )})`;
+    }
+    if (!severity) {
+      continue;
+    }
+    items.push({
+      id: `budget:${policy.id}`,
+      kind: 'budget',
+      severity,
+      title: `${budgetScopeName(policy)} · ${policy.period}`,
+      detail,
+      href: '/console/attention#budgets',
+      at: policy.period_end || null,
+      action: { label: 'Configure limits', event: 'configure-limits' },
+    });
+  }
+  return items;
+}
+
+function pricingItems(
+  usageSummary: AccountGatewayUsageSummaryResponse | null | undefined,
+  now: Date
+): AttentionItem[] {
+  if (!usageSummary) {
+    return [];
+  }
+  const catalog = usageSummary.price_catalog;
+  const reasons: string[] = [];
+  const fetchedAt = catalog?.fetched_at || null;
+  const modelCount = catalog?.model_count ?? null;
+  const stale =
+    Boolean(fetchedAt) &&
+    now.getTime() - timestampOf(fetchedAt) > FOURTEEN_DAYS_MS;
+  if (catalog && (stale || modelCount === 0)) {
+    reasons.push(
+      fetchedAt
+        ? `Price catalog stale since ${formatRelativeTime(fetchedAt, now)}`
+        : 'Price catalog has no models'
+    );
+  }
+  const unpriced = usageSummary.unpriced_requests || 0;
+  if (unpriced > 0) {
+    reasons.push(`${unpriced} request${unpriced === 1 ? '' : 's'} unpriced`);
+  }
+  if (reasons.length === 0) {
+    return [];
+  }
+  return [
+    {
+      id: 'pricing:catalog',
+      kind: 'pricing',
+      severity: 'warning',
+      title: 'Price catalog',
+      detail: joinReasons(reasons),
+      href: '/console/cost',
+      at: fetchedAt,
+      action: { label: 'Update prices', href: '/console/cost' },
+    },
+  ];
+}
+
+/** Critical first, then most recent first; items without a timestamp last. */
+export function sortAttentionItems(items: AttentionItem[]): AttentionItem[] {
+  return [...items].sort((left, right) => {
+    if (left.severity !== right.severity) {
+      return left.severity === 'critical' ? -1 : 1;
+    }
+    const leftAt = left.at ? timestampOf(left.at) : null;
+    const rightAt = right.at ? timestampOf(right.at) : null;
+    if (leftAt === null && rightAt === null) return 0;
+    if (leftAt === null) return 1;
+    if (rightAt === null) return -1;
+    return rightAt - leftAt;
+  });
+}
+
+export function deriveAttentionItems(inputs: AttentionInputs): AttentionItem[] {
+  const now = inputs.now || new Date();
+  const items: AttentionItem[] = [
+    ...approvalItems(inputs.approvals || [], now),
+    ...agentItems(inputs.agents || [], inputs.sessions || []),
+    ...flowItems(inputs.executions || [], now),
+    ...modelItems(inputs.gatewayFailures || [], now),
+    ...budgetItems(inputs.budgetPolicies || []),
+    ...pricingItems(inputs.usageSummary, now),
+  ];
+  return sortAttentionItems(items);
+}
+
+/** Non-empty kinds only, in the canonical section order. */
+export function groupAttentionItems(
+  items: AttentionItem[]
+): Map<AttentionKind, AttentionItem[]> {
+  const grouped = new Map<AttentionKind, AttentionItem[]>();
+  for (const kind of ATTENTION_KIND_ORDER) {
+    const forKind = items.filter((item) => item.kind === kind);
+    if (forKind.length > 0) {
+      grouped.set(kind, forKind);
+    }
+  }
+  return grouped;
+}
+
+/** "2 approvals", "1 agent" - the chip label used by the Attention page. */
+export function attentionKindChipLabel(
+  kind: AttentionKind,
+  count: number
+): string {
+  const meta = ATTENTION_KIND_META[kind];
+  const noun = count === 1 ? meta.label : meta.plural;
+  return `${count} ${noun.toLowerCase()}`;
+}

--- a/frontend/src/utils/attention.ts
+++ b/frontend/src/utils/attention.ts
@@ -52,6 +52,7 @@ export interface AttentionApproval {
   summary?: string | null;
   status?: string;
   requested_at: string;
+  expires_at?: string | null;
   managed_agent_name?: string | null;
   flow_name?: string | null;
   is_question?: boolean;

--- a/frontend/src/utils/attention.ts
+++ b/frontend/src/utils/attention.ts
@@ -160,12 +160,20 @@ function approvalItems(
         approval.summary || approval.tool_name || 'Approval request';
       const title = approval.is_question ? `Question: ${subject}` : subject;
       const requester = approval.managed_agent_name || approval.flow_name || '';
-      const detail = joinReasons([
-        requester,
-        approval.requested_at
-          ? formatRelativeTime(approval.requested_at, now)
-          : '',
-      ]);
+      // "pending 7w", never a bare date: an approval that has been waiting
+      // seven weeks reads as urgent, "7/13/2026" reads as a log line.
+      const elapsed = approval.requested_at
+        ? formatRelativeTime(approval.requested_at, now, {
+            maxRelativeDays: Infinity,
+            withSuffix: false,
+          })
+        : '';
+      const waiting = !elapsed
+        ? ''
+        : elapsed === 'just now'
+          ? 'just requested'
+          : `pending ${elapsed}`;
+      const detail = joinReasons([requester, waiting]);
       return {
         id: `approval:${approval.id}`,
         kind: 'approval' as const,
@@ -239,39 +247,89 @@ function agentItems(
   return items;
 }
 
+/**
+ * One item per flow, not per run: a flow that fails on every trigger produced
+ * seven identical rows and pushed everything else off the page. The count and
+ * the age of the oldest failure carry the same information in one row.
+ */
 function flowItems(
   executions: AttentionFlowExecution[],
   now: Date
 ): AttentionItem[] {
   const cutoff = now.getTime() - SEVEN_DAYS_MS;
-  return executions
+  const recentFailures = executions
     .filter((execution) => execution.status === 'FAILED')
     .filter((execution) => {
       const startedAt = execution.start_time || execution.started_at;
       return Boolean(startedAt) && timestampOf(startedAt) >= cutoff;
-    })
-    .map((execution) => {
-      const startedAt = (execution.start_time ||
-        execution.started_at) as string;
-      const duration = formatDurationBetween(
-        startedAt,
-        execution.end_time,
-        now
-      );
-      return {
-        id: `flow:${execution.id}`,
-        kind: 'flow' as const,
-        severity: 'warning' as const,
-        title: execution.flow_name || 'Unnamed flow',
-        detail: joinReasons([
-          'Failed',
-          formatRelativeTime(startedAt, now),
-          duration,
-        ]),
-        href: `/console/flows/executions/${execution.id}`,
-        at: startedAt,
-      };
     });
+
+  const groups = new Map<
+    string,
+    { flowId: string | null; name: string; runs: AttentionFlowExecution[] }
+  >();
+  for (const execution of recentFailures) {
+    const name = execution.flow_name || 'Unnamed flow';
+    const key = execution.flow_id || `name:${name}`;
+    const group = groups.get(key) || {
+      flowId: execution.flow_id || null,
+      name,
+      runs: [] as AttentionFlowExecution[],
+    };
+    group.runs.push(execution);
+    groups.set(key, group);
+  }
+
+  return Array.from(groups.entries()).map(([key, group]) => {
+    const runs = [...group.runs].sort(
+      (left, right) =>
+        timestampOf(right.start_time || right.started_at) -
+        timestampOf(left.start_time || left.started_at)
+    );
+    const latest = runs[0];
+    const oldest = runs[runs.length - 1];
+    const latestStart = (latest.start_time || latest.started_at) as string;
+    const oldestStart = (oldest.start_time || oldest.started_at) as string;
+    const duration = formatDurationBetween(latestStart, latest.end_time, now);
+
+    const span = formatRelativeTime(oldestStart, now, {
+      maxRelativeDays: Infinity,
+      withSuffix: false,
+    });
+    const detail =
+      runs.length === 1
+        ? joinReasons([
+            'Failed',
+            formatRelativeTime(latestStart, now),
+            duration,
+          ])
+        : joinReasons([
+            `${runs.length} failed runs in ${
+              span === 'just now' ? '1m' : span
+            }`,
+            `latest ${formatRelativeTime(latestStart, now)}`,
+            duration,
+          ]);
+
+    // A single failure opens the run itself; a group opens the failed runs of
+    // that flow, which is what the count is about.
+    const href =
+      runs.length === 1 || !group.flowId
+        ? `/console/flows/executions/${latest.id}`
+        : `/console/flows/executions?flow_id=${encodeURIComponent(
+            group.flowId
+          )}&status=FAILED`;
+
+    return {
+      id: `flow:${key}`,
+      kind: 'flow' as const,
+      severity: 'warning' as const,
+      title: group.name,
+      detail,
+      href,
+      at: latestStart,
+    };
+  });
 }
 
 function modelItems(

--- a/frontend/src/utils/date.test.ts
+++ b/frontend/src/utils/date.test.ts
@@ -20,6 +20,42 @@ describe('date utilities', () => {
     expect(formatRelativeTime('2026-07-12T20:00:00', now)).to.equal('3h ago');
   });
 
+  it('keeps the 7 day relative window by default', () => {
+    const now = new Date('2026-07-12T20:00:00Z');
+
+    expect(formatRelativeTime('2026-07-06T20:00:00', now)).to.equal('6d ago');
+    expect(formatRelativeTime('2026-07-05T20:00:00', now)).to.equal(
+      new Date('2026-07-05T20:00:00Z').toLocaleDateString()
+    );
+  });
+
+  it('stays relative up to the caller window and then shows the date', () => {
+    const now = new Date('2026-07-12T20:00:00Z');
+    const options = { maxRelativeDays: 30 };
+
+    expect(formatRelativeTime('2026-07-04T20:00:00', now, options)).to.equal(
+      '8d ago'
+    );
+    expect(formatRelativeTime('2026-06-20T20:00:00', now, options)).to.equal(
+      '22d ago'
+    );
+    expect(formatRelativeTime('2026-06-01T20:00:00', now, options)).to.equal(
+      new Date('2026-06-01T20:00:00Z').toLocaleDateString()
+    );
+  });
+
+  it('counts weeks and years for pages that stay relative', () => {
+    const now = new Date('2026-09-02T20:00:00Z');
+    const options = { maxRelativeDays: Infinity, withSuffix: false };
+
+    expect(formatRelativeTime('2026-07-13T20:00:00', now, options)).to.equal(
+      '7w'
+    );
+    expect(formatRelativeTime('2024-09-02T20:00:00', now, options)).to.equal(
+      '2y'
+    );
+  });
+
   it('formats future expiry times as time remaining', () => {
     const now = new Date('2026-07-12T20:00:00Z');
 

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -73,16 +73,34 @@ export function formatUTCDateTime(dateTimeString: string): string {
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds} UTC`;
 }
 
+export interface RelativeTimeOptions {
+  /**
+   * How long a timestamp stays relative. Past this many days the absolute
+   * date is shown instead, because "just now" next to "213d ago" reads worse
+   * than "just now" next to a date. Lists that mix fresh and stale rows
+   * (agents "Last seen") use 30; pages that are entirely relative, like
+   * /console/attention, pass Infinity.
+   */
+  maxRelativeDays?: number;
+  /** Append " ago". Off for phrasings that supply their own word ("pending 7w"). */
+  withSuffix?: boolean;
+}
+
 /**
- * Calculates relative time from now (e.g., "2m ago", "3h ago", "5d ago").
+ * Calculates relative time from now (e.g., "2m ago", "3h ago", "5d ago",
+ * "7w ago").
  *
  * @param dateTimeString - Datetime string from backend
- * @returns Relative time string
+ * @param now - Instant to measure against
+ * @param options - Relative window and suffix, see RelativeTimeOptions
+ * @returns Relative time string, or the local date past the relative window
  */
 export function formatRelativeTime(
   dateTimeString: string,
-  now: Date = new Date()
+  now: Date = new Date(),
+  options: RelativeTimeOptions = {}
 ): string {
+  const { maxRelativeDays = 7, withSuffix = true } = options;
   const date = parseUTCDate(dateTimeString);
   const diffMs = now.getTime() - date.getTime();
   const diffMins = Math.floor(diffMs / 60000);
@@ -90,10 +108,16 @@ export function formatRelativeTime(
   const diffDays = Math.floor(diffMs / 86400000);
 
   if (diffMins < 1) return 'just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
+  if (diffDays >= maxRelativeDays) return date.toLocaleDateString();
+
+  const suffix = withSuffix ? ' ago' : '';
+  if (diffMins < 60) return `${diffMins}m${suffix}`;
+  if (diffHours < 24) return `${diffHours}h${suffix}`;
+  if (diffDays < 30) return `${diffDays}d${suffix}`;
+
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffWeeks < 52) return `${diffWeeks}w${suffix}`;
+  return `${Math.floor(diffDays / 365)}y${suffix}`;
 }
 
 /**

--- a/frontend/src/views/authed/agent-detail-view.test.ts
+++ b/frontend/src/views/authed/agent-detail-view.test.ts
@@ -544,6 +544,7 @@ describe('AgentDetailView', () => {
 
     const actions = (element as any).agentActions as Array<{
       id: string;
+      icon?: string;
       variant?: string;
       outline?: boolean;
       separated?: boolean;
@@ -552,6 +553,11 @@ describe('AgentDetailView', () => {
     expect(ids.indexOf('rename')).to.be.lessThan(ids.indexOf('edit-tags'));
     expect(ids.indexOf('edit-tags')).to.be.lessThan(ids.indexOf('pause'));
     expect(ids[ids.length - 1], 'Remove is last').to.equal('remove');
+
+    // Pause is an everyday control, not a warning: amber competed with Talk.
+    const pause = actions.find((action) => action.id === 'pause');
+    expect(pause?.variant, 'Pause is neutral').to.equal('default');
+    expect((pause as { icon?: string }).icon).to.equal('pause-fill');
 
     const remove = actions[actions.length - 1];
     expect(remove.variant).to.equal('danger');

--- a/frontend/src/views/authed/agent-detail-view.test.ts
+++ b/frontend/src/views/authed/agent-detail-view.test.ts
@@ -461,11 +461,18 @@ describe('AgentDetailView', () => {
     );
 
     const content = getDeepText(element).replace(/\s+/g, ' ');
-    expect(content).to.contain('Live validated');
     expect(content).to.contain('openai/gpt-5');
-    expect(
-      element.shadowRoot?.querySelector('sl-tooltip')?.getAttribute('content')
-    ).to.contain('Tool calls and model traffic both flow through Preloop.');
+
+    // A fully onboarded agent whose live check passed has nothing to warn
+    // about, so the header carries the status chip and nothing else.
+    const chips = Array.from(
+      element.shadowRoot?.querySelectorAll('.badge-row sl-badge') || []
+    ).map((chip) => chip.textContent?.replace(/\s+/g, ' ').trim());
+    expect(chips).to.deep.equal(['Active now']);
+    expect(content).to.not.contain('Live check: off');
+    expect(content).to.not.contain('Live validated');
+    // Enrolment method is plumbing, not a feature: no blue chip for it.
+    expect(content).to.not.contain('runtime_session_token');
 
     (element as any).activeTab = 'models';
     await element.updateComplete;
@@ -491,8 +498,9 @@ describe('AgentDetailView', () => {
     );
 
     // The CLI persisted an upstream-refused probe: the gateway plumbing is
-    // proven but model traffic is unverified. The badge must say so — the
-    // old fallthrough rendered an eternal "Live check pending".
+    // proven but model traffic is unverified. The header chip says "Live
+    // check: off" and the detail is on its tooltip; the old fallthrough
+    // rendered an eternal "Live check pending".
     (element as any).agent = {
       ...(element as any).agent,
       live_validation_passed: false,
@@ -500,9 +508,15 @@ describe('AgentDetailView', () => {
     };
     await element.updateComplete;
 
-    const content = getDeepText(element).replace(/\s+/g, ' ');
-    expect(content).to.contain('Live check throttled — unverified');
-    expect(content).to.not.contain('Live check pending');
+    const chip = element.shadowRoot?.querySelector(
+      '.badge-row sl-badge.capability-chip'
+    );
+    expect(chip?.textContent?.trim()).to.equal('Live check: off');
+    expect(chip?.getAttribute('variant')).to.equal('warning');
+    expect(chip?.closest('sl-tooltip')?.getAttribute('content')).to.equal(
+      'Live check throttled, unverified'
+    );
+    expect(getDeepText(element)).to.not.contain('Live check pending');
     expect((element as any).getLiveValidationVariant()).to.equal('warning');
 
     (element as any).agent = {
@@ -510,7 +524,84 @@ describe('AgentDetailView', () => {
       live_validation_status: 'upstream_unavailable',
     };
     await element.updateComplete;
-    expect(getDeepText(element)).to.contain('Upstream refused — unverified');
+    expect(
+      element.shadowRoot
+        ?.querySelector('.badge-row sl-badge.capability-chip')
+        ?.closest('sl-tooltip')
+        ?.getAttribute('content')
+    ).to.equal('Upstream refused, unverified');
+  });
+
+  it('orders the action bar and keeps Remove last, outlined and set apart', async () => {
+    const element = await fixture<AgentDetailView>(
+      html`<agent-detail-view agentId="agent-1"></agent-detail-view>`
+    );
+
+    await waitUntil(
+      () => !(element as any).loading && (element as any).agent !== null,
+      'Agent detail view did not finish loading'
+    );
+
+    const actions = (element as any).agentActions as Array<{
+      id: string;
+      variant?: string;
+      outline?: boolean;
+      separated?: boolean;
+    }>;
+    const ids = actions.map((action) => action.id);
+    expect(ids.indexOf('rename')).to.be.lessThan(ids.indexOf('edit-tags'));
+    expect(ids.indexOf('edit-tags')).to.be.lessThan(ids.indexOf('pause'));
+    expect(ids[ids.length - 1], 'Remove is last').to.equal('remove');
+
+    const remove = actions[actions.length - 1];
+    expect(remove.variant).to.equal('danger');
+    expect(remove.outline, 'Remove is outlined, never solid red').to.equal(
+      true
+    );
+    expect(remove.separated, 'Remove is set apart').to.equal(true);
+  });
+
+  it('shows operator tags as outlined chips prefixed with a hash', async () => {
+    const element = await fixture<AgentDetailView>(
+      html`<agent-detail-view agentId="agent-1"></agent-detail-view>`
+    );
+
+    await waitUntil(
+      () => !(element as any).loading && (element as any).agent !== null,
+      'Agent detail view did not finish loading'
+    );
+
+    (element as any).agent = {
+      ...(element as any).agent,
+      tags: { team: 'platform', pilot: 'true' },
+    };
+    await element.updateComplete;
+
+    const tagChips = Array.from(
+      element.shadowRoot?.querySelectorAll('.badge-row sl-badge.tag-chip') || []
+    );
+    expect(tagChips.map((chip) => chip.getAttribute('variant'))).to.deep.equal([
+      'neutral',
+      'neutral',
+    ]);
+    expect(
+      tagChips.map((chip) => chip.textContent?.replace(/\s+/g, '').trim())
+    ).to.deep.equal(['#team=platform', '#pilot']);
+  });
+
+  it('calls the session history panel Session History', async () => {
+    const element = await fixture<AgentDetailView>(
+      html`<agent-detail-view agentId="agent-1"></agent-detail-view>`
+    );
+
+    await waitUntil(
+      () => !(element as any).loading && (element as any).agent !== null,
+      'Agent detail view did not finish loading'
+    );
+
+    const text = getDeepText(element).replace(/\s+/g, ' ');
+    expect(text).to.not.contain('Sessions History');
+    expect(text).to.contain('Session History');
   });
 
   it('lets the user pick the approval workflow for native tool approvals', async () => {

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -358,7 +358,46 @@ export class AgentDetailView extends LitElement {
       .badge-row {
         display: flex;
         flex-wrap: wrap;
+        align-items: center;
         gap: var(--sl-spacing-small);
+      }
+
+      /* "Recently active" is real but not live: outline it so only a genuinely
+         active agent gets a solid green chip. */
+      .status-chip.outline::part(base) {
+        background-color: transparent;
+        color: var(--sl-color-success-700);
+        border: 1px solid var(--sl-color-success-400);
+      }
+
+      .capability-chip::part(base) {
+        text-transform: none;
+      }
+
+      /* Tags are the operator's own labels, so they stay quiet: outlined
+         neutral, never a solid feature-flag blue. */
+      .tag-chip::part(base) {
+        background-color: transparent;
+        color: var(--sl-color-neutral-700);
+        border: 1px solid var(--sl-color-neutral-300);
+        text-transform: none;
+        font-weight: var(--sl-font-weight-normal);
+      }
+
+      .tag-chip-value {
+        opacity: 0.7;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .status-chip.outline::part(base) {
+          color: var(--sl-color-success-400);
+          border-color: var(--sl-color-success-600);
+        }
+
+        .tag-chip::part(base) {
+          color: var(--sl-color-neutral-400);
+          border-color: var(--sl-color-neutral-600);
+        }
       }
 
       .server-badges {
@@ -929,14 +968,91 @@ export class AgentDetailView extends LitElement {
     // gateway plumbing is proven but model traffic is UNVERIFIED. Never
     // present this as a check that is still in flight.
     if (this.agent.live_validation_status === 'throttled')
-      return 'Live check throttled — unverified';
+      return 'Live check throttled, unverified';
     if (this.agent.live_validation_status === 'upstream_unavailable')
-      return 'Upstream refused — unverified';
+      return 'Upstream refused, unverified';
     // ``not_run`` means the CLI was never invoked with ``--live-validate`` —
     // it's an opt-in step, not a check that's currently in flight.
     if (this.agent.live_validation_status === 'not_run')
       return 'Live check not run';
     return 'Live check pending';
+  }
+
+  /**
+   * The chips under the agent name, in one deliberate order: what the agent is
+   * doing right now, then anything that is switched off and costing you
+   * governance, then the operator's own labels.
+   *
+   * Everything here used to be a chip of its own -- onboarding state,
+   * lifecycle, live check, Agent Control, enrolment method -- which produced a
+   * row of five or six badges in four colours where nothing stood out. The
+   * status chip now carries lifecycle and onboarding (see getAgentStatusChip),
+   * capability gaps are amber and only appear when there is a gap, and tags
+   * are outlined neutral so they read as labels rather than as state.
+   */
+  private renderHeaderChips(): TemplateResult | typeof nothing {
+    if (!this.agent) return nothing;
+
+    const status = getAgentStatusChip(this.agent);
+    const control = getAgentControlState(this.agent);
+    const liveCount =
+      this.liveActivity.modelCalls + this.liveActivity.toolCalls;
+
+    // "Off" here means the check exists for this kind of agent but has not
+    // proven anything yet: never run, throttled, refused upstream or failed.
+    const liveCheckOff =
+      this.agent.live_validation_supported &&
+      this.agent.live_validation_status !== 'passed';
+    const controlOff = control.visible && !control.enabled;
+
+    return html`
+      <sl-tooltip
+        content=${`Last seen: ${this.formatDateTime(
+          this.liveActivity.lastActivityAt || this.agent.last_seen_at
+        )}`}
+      >
+        <sl-badge
+          class="status-chip ${status.outline ? 'outline' : ''}"
+          variant=${status.variant}
+          pill
+          >${status.label}</sl-badge
+        >
+      </sl-tooltip>
+      ${
+        liveCount > 0
+          ? html`<sl-badge variant="primary" pill>Live ${liveCount}</sl-badge>`
+          : nothing
+      }
+      ${
+        liveCheckOff
+          ? html`<sl-tooltip content=${this.getLiveValidationLabel()}>
+              <sl-badge class="capability-chip" variant="warning" pill
+                >Live check: off</sl-badge
+              >
+            </sl-tooltip>`
+          : nothing
+      }
+      ${
+        controlOff
+          ? html`<sl-tooltip content=${control.detail}>
+              <sl-badge class="capability-chip" variant="warning" pill
+                >Agent Control: off</sl-badge
+              >
+            </sl-tooltip>`
+          : nothing
+      }
+      ${getVisibleAgentTags(this.agent.tags).map(
+        ([key, value]) => html`
+          <sl-badge class="tag-chip" variant="neutral" pill>
+            #${key}${
+              value && value !== 'true'
+                ? html`<span class="tag-chip-value">=${value}</span>`
+                : nothing
+            }
+          </sl-badge>
+        `
+      )}
+    `;
   }
 
   private handleGatewayActivity(message: any): void {
@@ -1551,13 +1667,6 @@ export class AgentDetailView extends LitElement {
         onClick: () => this.promptRename(),
       },
       {
-        id: 'remove',
-        label: 'Remove',
-        variant: 'danger',
-        loading: this.actionLoading,
-        onClick: () => this.removeAgent(),
-      },
-      {
         id: 'edit-tags',
         label: 'Edit Tags',
         icon: 'tag',
@@ -1619,6 +1728,20 @@ export class AgentDetailView extends LitElement {
         `,
       });
     }
+
+    // Remove goes last, set apart from the everyday actions and outlined
+    // rather than solid: it is the one action on this page you cannot undo,
+    // and a solid red block next to Rename invites a mis-click.
+    actions.push({
+      id: 'remove',
+      label: 'Remove',
+      icon: 'trash',
+      variant: 'danger',
+      outline: true,
+      separated: true,
+      loading: this.actionLoading,
+      onClick: () => this.removeAgent(),
+    });
 
     return actions;
   }
@@ -2524,93 +2647,8 @@ export class AgentDetailView extends LitElement {
             <div
               style="display: flex; flex-direction: column; align-items: flex-start; gap: var(--sl-spacing-small); margin-top: var(--sl-spacing-small);"
             >
-              <div class="badge-row">
-                <sl-tooltip content=${this.getOnboardingDescription()}>
-                  <sl-badge variant=${this.getOnboardingVariant()}>
-                    ${this.getOnboardingLabel()}
-                  </sl-badge>
-                </sl-tooltip>
-                <sl-tooltip
-                  content=${`Last seen: ${this.formatDateTime(this.liveActivity.lastActivityAt || this.agent.last_seen_at)}`}
-                >
-                  <sl-badge variant=${this.getLifecycleVariant()}>
-                    ${this.getLifecycleLabel()}
-                  </sl-badge>
-                </sl-tooltip>
-                <sl-badge variant=${this.getLiveValidationVariant()}>
-                  ${this.getLiveValidationLabel()}
-                </sl-badge>
-                ${
-                  getAgentControlState(this.agent).visible
-                    ? html`
-                        <sl-tooltip
-                          content=${getAgentControlState(this.agent).detail}
-                        >
-                          <sl-badge
-                            variant=${
-                              getAgentControlState(this.agent).badgeVariant
-                            }
-                          >
-                            ${getAgentControlState(this.agent).label}
-                          </sl-badge>
-                        </sl-tooltip>
-                      `
-                    : html`<sl-badge variant="neutral"
-                        >No Agent Control</sl-badge
-                      >`
-                }
-                <sl-badge variant="primary"
-                  >${this.agent.enrolled_via}</sl-badge
-                >
-                ${
-                  this.liveActivity.modelCalls || this.liveActivity.toolCalls
-                    ? html`
-                        <sl-badge variant="primary">
-                          Live
-                          ${
-                            this.liveActivity.modelCalls +
-                            this.liveActivity.toolCalls
-                          }
-                        </sl-badge>
-                      `
-                    : null
-                }
-              </div>
+              <div class="badge-row">${this.renderHeaderChips()}</div>
 
-              ${
-                getVisibleAgentTags(this.agent.tags).length > 0
-                  ? html`
-                      <div
-                        style="display: flex; gap: var(--sl-spacing-small); align-items: center; margin-top: var(--sl-spacing-x-small);"
-                      >
-                        <div
-                          style="font-size: var(--sl-font-size-small); font-weight: 500; color: var(--sl-color-neutral-700);"
-                        >
-                          Tags:
-                        </div>
-                        <div style="display: flex; flex-wrap: wrap; gap: 4px;">
-                          ${getVisibleAgentTags(this.agent.tags).map(
-                            ([k, v]) => html`
-                              <sl-badge
-                                variant="neutral"
-                                style="text-transform: none;"
-                              >
-                                <span style="opacity: 0.7">${k}</span>${
-                                  v && v !== 'true'
-                                    ? html`<span
-                                          style="opacity: 0.4; margin: 0 4px;"
-                                          >=</span
-                                        >${v}`
-                                    : ''
-                                }
-                              </sl-badge>
-                            `
-                          )}
-                        </div>
-                      </div>
-                    `
-                  : nothing
-              }
               ${this.renderIdentityHistory()}
             </div>
           </div>
@@ -2759,7 +2797,7 @@ export class AgentDetailView extends LitElement {
                                 class="hero-title"
                                 style="display: flex; align-items: center; gap: 8px;"
                               >
-                                Sessions History
+                                Session History
                                 <sl-icon-button
                                   name="arrow-clockwise"
                                   style="font-size: 1.1rem; color: var(--sl-color-neutral-500);"
@@ -2872,10 +2910,10 @@ export class AgentDetailView extends LitElement {
                                   })
                                 </sl-option>
                                 <sl-option value="enforce">
-                                  Enforce — always require approval
+                                  Enforce: always require approval
                                 </sl-option>
                                 <sl-option value="off">
-                                  Off — auto-approve (recorded)
+                                  Off: auto-approve (recorded)
                                 </sl-option>
                               </sl-select>
                               <sl-select

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -1687,8 +1687,9 @@ export class AgentDetailView extends LitElement {
       this.agent.lifecycle_state === 'suspended' ||
       this.agent.lifecycle_state === 'decommissioned';
 
-    // Play/pause toggle in warning (amber) tones: pausing is reversible, so
-    // danger red stays reserved for offboard/remove.
+    // Resume is a green "start it again"; Pause is an everyday, reversible
+    // control, so it stays neutral. Amber read as a warning next to Talk and
+    // pulled the eye away from the action people actually came for.
     if (isSuspendedOrDecommissioned) {
       actions.push({
         id: 'resume',
@@ -1704,7 +1705,7 @@ export class AgentDetailView extends LitElement {
       actions.push({
         id: 'pause',
         label: 'Pause',
-        variant: 'warning',
+        variant: 'default',
         icon: 'pause-fill',
         loading: this.actionLoading,
         onClick: () => this.updateAgentLifecycle('suspend'),

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -22,6 +22,8 @@ import '../../components/preloop-session-observer.ts';
 import '../../components/view-header.ts';
 import '../../components/resource-actions.ts';
 import '../../components/agent-talk-composer.ts';
+import '../../components/confirm-dialog.ts';
+import { confirmDialog } from '../../components/confirm-dialog';
 import type { ResourceAction } from '../../components/resource-actions.ts';
 import {
   fetchWithAuth,
@@ -63,7 +65,9 @@ import {
 import { getAgentControlState } from '../../utils/agent-control';
 import { renderAgentIcon } from '../../utils/agent-icons';
 import {
+  REMOVE_AGENT_CONSEQUENCE,
   getAgentSourceLabel,
+  getAgentStatusChip,
   getSystemAgentTags,
   getVisibleAgentTags,
 } from '../../utils/agent-display';
@@ -1442,11 +1446,14 @@ export class AgentDetailView extends LitElement {
     if (!this.agentId || !this.agent) {
       return;
     }
-    if (
-      !window.confirm(
-        `Remove ${this.agent.display_name} from the managed agents list?\n\nThis also revokes the agent's Preloop credentials: if this agent is still onboarded on a machine, its gateway and MCP access will stop working until you run \`preloop agents onboard\` again. To disconnect cleanly, run \`preloop agents offboard\` on that machine instead.`
-      )
-    ) {
+    const confirmed = await confirmDialog({
+      title: 'Remove agent',
+      message: `Remove ${this.agent.display_name} from the managed agents list?`,
+      detail: REMOVE_AGENT_CONSEQUENCE,
+      confirmLabel: 'Remove agent',
+      variant: 'danger',
+    });
+    if (!confirmed) {
       return;
     }
     this.actionLoading = true;
@@ -1470,12 +1477,18 @@ export class AgentDetailView extends LitElement {
     if (!this.agentId || !this.agent) {
       return;
     }
-    const actionLabel = lifecycleAction === 'suspend' ? 'pause' : 'resume';
-    if (
-      !window.confirm(
-        `Are you sure you want to ${actionLabel} ${this.agent.display_name}?`
-      )
-    ) {
+    const isSuspend = lifecycleAction === 'suspend';
+    const confirmed = await confirmDialog({
+      title: isSuspend ? 'Pause agent' : 'Resume agent',
+      message: isSuspend
+        ? `Pause ${this.agent.display_name}?`
+        : `Resume ${this.agent.display_name}?`,
+      detail: isSuspend
+        ? 'Requests are blocked while paused. Resume restores the agent without re-onboarding it.'
+        : 'The existing credentials start working again immediately.',
+      confirmLabel: isSuspend ? 'Pause' : 'Resume',
+    });
+    if (!confirmed) {
       return;
     }
     this.actionLoading = true;

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -74,6 +74,7 @@ function makeRow(overrides: Partial<AgentListRow>): AgentListRow {
     statusOutline: false,
     owner: '',
     modelLabel: 'direct (not gated)',
+    modelTitle: 'direct (not gated)',
     modelId: null,
     modelGated: false,
     requests: 0,
@@ -544,6 +545,130 @@ describe('AgentsView', () => {
     await waitForAgents(el);
 
     expect(el.shadowRoot?.querySelector('.model-traffic-failing')).to.not.exist;
+  });
+
+  it('gives every column a fixed width so the kebab stays inside the card', async () => {
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const table = el.shadowRoot?.querySelector('table.agents-table');
+    const cols = Array.from(table?.querySelectorAll('colgroup col') || []);
+    expect(cols.map((col) => col.className)).to.deep.equal([
+      'col-agent',
+      'col-status',
+      'col-owner',
+      'col-model',
+      'col-requests',
+      'col-spend',
+      'col-last-seen',
+      'col-actions',
+    ]);
+
+    const actionsCell = table?.querySelector('tbody td.actions-cell');
+    expect(actionsCell, 'the actions cell renders').to.exist;
+    const tableRight = table!.getBoundingClientRect().right;
+    const cellRight = actionsCell!.getBoundingClientRect().right;
+    expect(cellRight, 'kebab column is not clipped').to.be.at.most(
+      tableRight + 1
+    );
+
+    const name = table?.querySelector('tbody .agent-cell a.row-link');
+    expect(getComputedStyle(name!).whiteSpace).to.equal('nowrap');
+  });
+
+  it('shows only the model alias, with the full model text in the title', async () => {
+    agentItems = [
+      {
+        ...makeAgent('agent-1', 'Claude Code Workspace', 'claude_code'),
+        ai_model_id: 'model-1',
+        configured_model_alias: 'preloop/deepseek/deepseek-chat',
+      },
+    ];
+    fetchStub.withArgs(sinon.match(/\/api\/v1\/ai-models/)).resolves(
+      new Response(
+        JSON.stringify([
+          {
+            id: 'model-1',
+            name: 'OpenClaw preloop/deepseek/deepseek-chat',
+            provider_name: 'deepseek',
+            model_identifier: 'deepseek-chat',
+            created_at: '2026-03-01T00:00:00Z',
+          },
+        ]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const cell = el.shadowRoot?.querySelector('tbody td.model-cell');
+    expect(cell?.textContent?.trim()).to.equal(
+      'preloop/deepseek/deepseek-chat'
+    );
+    expect(cell?.getAttribute('title')).to.contain(
+      'OpenClaw preloop/deepseek/deepseek-chat'
+    );
+  });
+
+  it('keeps last seen relative for a month and absolute after it', async () => {
+    const now = Date.now();
+    const tenDaysAgo = new Date(now - 10 * 86400000).toISOString();
+    const twoHundredDaysAgo = new Date(now - 200 * 86400000).toISOString();
+    agentItems = [
+      {
+        ...makeAgent('agent-1', 'Recent agent', 'claude_code'),
+        last_seen_at: tenDaysAgo,
+        last_activity_at: tenDaysAgo,
+        is_active_now: false,
+        activity_status: 'idle',
+      },
+      {
+        ...makeAgent('agent-2', 'Stale agent', 'claude_code'),
+        last_seen_at: twoHundredDaysAgo,
+        last_activity_at: twoHundredDaysAgo,
+        is_active_now: false,
+        activity_status: 'idle',
+      },
+    ];
+
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const lastSeen = Array.from(
+      el.shadowRoot?.querySelectorAll('tbody tr') || []
+    ).map((row) => row.children[6].textContent?.trim());
+    expect(lastSeen).to.contain('10d ago');
+    expect(lastSeen).to.contain(
+      new Date(twoHundredDaysAgo).toLocaleDateString()
+    );
+  });
+
+  it('counts the rows the filters matched next to the view switcher', async () => {
+    agentItems = [
+      makeAgent('agent-1', 'One', 'claude_code'),
+      makeAgent('agent-2', 'Two', 'claude_code'),
+    ];
+
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    expect(
+      el.shadowRoot?.querySelector('.results-count')?.textContent?.trim()
+    ).to.equal('2 agents');
+  });
+
+  it('labels the header actions by what they do', async () => {
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const labels = Array.from(
+      el.shadowRoot?.querySelectorAll('view-header sl-button') || []
+    ).map((button) => button.textContent?.trim());
+    expect(labels).to.deep.equal([
+      'Deploy new agent',
+      'Onboard existing agent',
+    ]);
   });
 
   it('explains the dashed unmanaged nodes in the canvas legend', async () => {

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -2,7 +2,8 @@ import { expect, fixture, html, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon';
 
 import './agents-view.ts';
-import type { AgentsView } from './agents-view';
+import type { AgentListRow, AgentsView } from './agents-view';
+import { sortAgentListRows } from './agents-view';
 
 function makeAgent(
   id: string,
@@ -43,6 +44,43 @@ function makeAgent(
     live_validation_passed: true,
     live_validation_status: 'passed',
     last_validated_at: '2026-03-10T10:01:00Z',
+  };
+}
+
+/** The list view has no spinner, so wait for the loading placeholder to go. */
+async function waitForAgents(el: AgentsView): Promise<void> {
+  await waitUntil(
+    () =>
+      !el.shadowRoot?.querySelector('sl-spinner') &&
+      !(el.shadowRoot?.textContent || '').includes('Loading agents...') &&
+      !!el.shadowRoot?.querySelector(
+        'table.agents-table tbody tr, sl-card.agent-card, .agent-node, .empty-state'
+      ),
+    'agents finished loading'
+  );
+  await el.updateComplete;
+}
+
+function makeRow(overrides: Partial<AgentListRow>): AgentListRow {
+  return {
+    id: 'row',
+    isFlow: false,
+    name: 'Agent',
+    kindLabel: 'Claude Code',
+    kind: 'claude_code',
+    detailUrl: '/console/agents/row',
+    statusLabel: 'Idle',
+    statusVariant: 'neutral',
+    statusOutline: false,
+    owner: '',
+    modelLabel: 'direct (not gated)',
+    modelId: null,
+    modelGated: false,
+    requests: 0,
+    spend: 0,
+    lastSeen: null,
+    source: {} as AgentListRow['source'],
+    ...overrides,
   };
 }
 
@@ -130,10 +168,10 @@ describe('AgentsView', () => {
     localStorage.clear();
   });
 
-  it('renders enrolled agents and links to agent detail', async () => {
+  it('renders enrolled agents in the list and links to agent detail', async () => {
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
 
-    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+    await waitForAgents(el);
 
     const text = el.shadowRoot?.textContent || '';
     expect(text).to.contain('Claude Code Workspace');
@@ -144,11 +182,153 @@ describe('AgentsView', () => {
       'Onboard agents you already run with the CLI, or deploy new ones.'
     );
 
-    const agentNode = el.shadowRoot?.querySelector('.agent-node');
-    expect(agentNode).to.exist;
+    // Nothing persisted means the table, not the canvas.
+    const table = el.shadowRoot?.querySelector('table.agents-table');
+    expect(table, 'list view is the default').to.exist;
+
+    const nameLink = table?.querySelector<HTMLAnchorElement>(
+      'tbody .agent-cell a.row-link'
+    );
+    expect(nameLink?.textContent?.trim()).to.equal('Claude Code Workspace');
+    expect(nameLink?.getAttribute('href')).to.equal('/console/agents/agent-1');
+    expect(
+      table?.querySelector('tbody .row-subtitle')?.textContent?.trim()
+    ).to.equal('Claude Code');
+  });
+
+  it('renders the three view options and remembers the chosen one', async () => {
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const buttons = Array.from(
+      el.shadowRoot?.querySelectorAll('sl-button-group sl-button[data-view]') ||
+        []
+    );
+    expect(buttons.map((b) => b.getAttribute('data-view'))).to.deep.equal([
+      'list',
+      'cards',
+      'canvas',
+    ]);
+    expect(buttons.map((b) => b.textContent?.trim())).to.deep.equal([
+      'List',
+      'Cards',
+      'Canvas',
+    ]);
+    expect(buttons[0].getAttribute('variant')).to.equal('primary');
+    expect(buttons[0].getAttribute('aria-pressed')).to.equal('true');
+
+    (buttons[2] as HTMLElement).click();
+    await el.updateComplete;
+
+    expect(localStorage.getItem('preloop.agents.view_mode')).to.equal('canvas');
+    expect(el.shadowRoot?.querySelector('table.agents-table')).to.not.exist;
+  });
+
+  it('honours a persisted cards preference over the list default', async () => {
+    localStorage.setItem('preloop.agents.view_mode', 'cards');
+
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    expect(el.shadowRoot?.querySelector('table.agents-table')).to.not.exist;
+    const cardLink = el.shadowRoot?.querySelector<HTMLAnchorElement>(
+      '.cards a.agent-name'
+    );
+    expect(cardLink?.getAttribute('href')).to.equal('/console/agents/agent-1');
+  });
+
+  it('gives every column a sortable header with aria-sort', async () => {
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const headers = Array.from(
+      el.shadowRoot?.querySelectorAll('table.agents-table thead th') || []
+    );
+    expect(headers.map((th) => th.textContent?.trim())).to.deep.equal([
+      'Agent',
+      'Status',
+      'Owner',
+      'Model',
+      'Requests',
+      'Spend (est.)',
+      'Last seen',
+      'Actions',
+    ]);
+
+    const lastSeen = headers[6];
+    expect(lastSeen.getAttribute('aria-sort'), 'default sort').to.equal(
+      'descending'
+    );
+    expect(headers[0].getAttribute('aria-sort')).to.equal('none');
+
+    lastSeen.querySelector<HTMLButtonElement>('.sort-button')?.click();
+    await el.updateComplete;
+    expect(
+      el.shadowRoot
+        ?.querySelectorAll('table.agents-table thead th')[6]
+        .getAttribute('aria-sort')
+    ).to.equal('ascending');
+
+    headers[0].querySelector<HTMLButtonElement>('.sort-button')?.click();
+    await el.updateComplete;
+    const after = el.shadowRoot?.querySelectorAll(
+      'table.agents-table thead th'
+    );
+    expect(after?.[0].getAttribute('aria-sort')).to.equal('ascending');
+    expect(after?.[6].getAttribute('aria-sort')).to.equal('none');
+  });
+
+  it('shows the status chip taxonomy and a right-aligned request count', async () => {
+    agentItems = [
+      {
+        ...makeAgent('agent-1', 'Claude Code Workspace', 'claude_code'),
+        total_requests: 1234,
+      },
+    ];
+
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const chip = el.shadowRoot?.querySelector('tbody sl-badge.status-chip');
+    expect(chip?.textContent?.trim()).to.equal('Active now');
+    expect(chip?.getAttribute('variant')).to.equal('success');
+
+    const numeric = el.shadowRoot?.querySelectorAll('tbody td.numeric');
+    expect(numeric?.[0].textContent?.trim()).to.equal((1234).toLocaleString());
+  });
+
+  it('shows a relative last seen with the absolute time on hover', async () => {
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const cell = el.shadowRoot?.querySelectorAll('tbody td')[6];
+    expect(cell?.textContent?.trim()).to.not.contain('2026-03-10T10:00:00Z');
+    expect(cell?.getAttribute('title'))
+      .to.be.a('string')
+      .and.to.have.length.greaterThan(0);
+  });
+
+  it('falls back to cards on a narrow viewport without losing the preference', async () => {
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+    expect(el.shadowRoot?.querySelector('table.agents-table')).to.exist;
+
+    // Simulate the matchMedia listener firing for a phone-width viewport.
+    (el as unknown as { narrowViewport: boolean }).narrowViewport = true;
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('table.agents-table')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.cards')).to.exist;
+    // The switcher still reports List as the chosen view.
+    expect(
+      el.shadowRoot
+        ?.querySelector('sl-button[data-view="list"]')
+        ?.getAttribute('aria-pressed')
+    ).to.equal('true');
   });
 
   it('renders claude_desktop agents and agents of unknown kinds', async () => {
+    localStorage.setItem('preloop.agents.view_mode', 'canvas');
     agentItems = [
       makeAgent('agent-desktop', 'My Claude Desktop', 'claude_desktop'),
       makeAgent('agent-unknown', 'Mystery Agent', 'some_future_kind'),
@@ -156,7 +336,7 @@ describe('AgentsView', () => {
 
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
 
-    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+    await waitForAgents(el);
 
     const text = el.shadowRoot?.textContent || '';
     expect(text).to.contain('My Claude Desktop');
@@ -169,7 +349,7 @@ describe('AgentsView', () => {
   it('omits the agent kind allowlist by default so unknown kinds are fetched', async () => {
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
 
-    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+    await waitForAgents(el);
 
     const agentUrls = fetchStub
       .getCalls()
@@ -243,7 +423,7 @@ describe('AgentsView', () => {
 
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
 
-    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+    await waitForAgents(el);
 
     const agentUrls = fetchStub
       .getCalls()
@@ -263,6 +443,7 @@ describe('AgentsView', () => {
   });
 
   it('surfaces the unverified badge on the list when validation was throttled', async () => {
+    localStorage.setItem('preloop.agents.view_mode', 'cards');
     agentItems = [
       {
         ...makeAgent('agent-1', 'Claude Code Workspace', 'claude_code'),
@@ -272,15 +453,16 @@ describe('AgentsView', () => {
     ];
 
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
-    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+    await waitForAgents(el);
 
     const text = (el.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
-    expect(text).to.contain('Live check throttled — unverified');
+    expect(text).to.contain('Live check throttled, unverified');
     const badge = el.shadowRoot?.querySelector('sl-badge.validation-badge');
     expect(badge?.getAttribute('variant')).to.equal('warning');
   });
 
   it('surfaces a red badge on the list when validation failed', async () => {
+    localStorage.setItem('preloop.agents.view_mode', 'cards');
     agentItems = [
       {
         ...makeAgent('agent-1', 'Claude Code Workspace', 'claude_code'),
@@ -290,7 +472,7 @@ describe('AgentsView', () => {
     ];
 
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
-    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+    await waitForAgents(el);
 
     const text = (el.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
     expect(text).to.contain('Live check failed');
@@ -299,9 +481,10 @@ describe('AgentsView', () => {
   });
 
   it('suppresses the validation badge when the live check passed', async () => {
+    localStorage.setItem('preloop.agents.view_mode', 'cards');
     // Default makeAgent fixture has live_validation_status: 'passed'.
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
-    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+    await waitForAgents(el);
 
     expect(el.shadowRoot?.querySelector('sl-badge.validation-badge')).to.not
       .exist;
@@ -309,6 +492,7 @@ describe('AgentsView', () => {
   });
 
   it('shows the red model-traffic-failing strip when every request failed', async () => {
+    localStorage.setItem('preloop.agents.view_mode', 'cards');
     agentItems = [
       {
         ...makeAgent('agent-1', 'Broken Claude', 'claude_code'),
@@ -319,12 +503,12 @@ describe('AgentsView', () => {
     ];
 
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
-    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+    await waitForAgents(el);
 
     const strip = el.shadowRoot?.querySelector('.model-traffic-failing');
     expect(strip, 'failing strip renders').to.exist;
     expect(strip?.textContent?.replace(/\s+/g, ' ')).to.contain(
-      'Model traffic failing — see latest session'
+      'Model traffic failing: see latest session'
     );
     const link = strip?.querySelector('a');
     expect(link?.getAttribute('href')).to.contain(
@@ -333,6 +517,7 @@ describe('AgentsView', () => {
   });
 
   it('keeps the strip off below the 5-request threshold and on mixed outcomes', async () => {
+    localStorage.setItem('preloop.agents.view_mode', 'cards');
     agentItems = [
       {
         ...makeAgent('agent-few', 'New Agent', 'claude_code'),
@@ -349,8 +534,81 @@ describe('AgentsView', () => {
     ];
 
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
-    await waitUntil(() => !el.shadowRoot?.querySelector('sl-spinner'));
+    await waitForAgents(el);
 
     expect(el.shadowRoot?.querySelector('.model-traffic-failing')).to.not.exist;
+  });
+
+  it('explains the dashed unmanaged nodes in the canvas legend', async () => {
+    localStorage.setItem('preloop.agents.view_mode', 'canvas');
+
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const legend = el.shadowRoot?.querySelector('.canvas-legend');
+    expect(legend, 'canvas legend renders').to.exist;
+    const items = Array.from(
+      legend?.querySelectorAll('.legend-item') || []
+    ).map((item) => item.textContent?.replace(/\s+/g, ' ').trim());
+    expect(items).to.have.length(3);
+    expect(items[2]).to.contain('Unmanaged (dashed gray)');
+  });
+});
+
+describe('sortAgentListRows', () => {
+  const rows = [
+    makeRow({
+      id: 'b',
+      name: 'Beta',
+      requests: 10,
+      spend: 1,
+      lastSeen: '2026-03-10T09:00:00Z',
+      owner: 'zoe',
+    }),
+    makeRow({
+      id: 'a',
+      name: 'Alpha',
+      requests: 2,
+      spend: 30,
+      lastSeen: '2026-03-10T11:00:00Z',
+      owner: 'adam',
+    }),
+    makeRow({
+      id: 'c',
+      name: 'Gamma',
+      requests: 40,
+      spend: 2,
+      lastSeen: null,
+      owner: '',
+    }),
+  ];
+
+  const ids = (
+    key: Parameters<typeof sortAgentListRows>[1],
+    dir: 'asc' | 'desc'
+  ) => sortAgentListRows(rows, key, dir).map((row) => row.id);
+
+  it('does not mutate the rows it is given', () => {
+    const before = rows.map((row) => row.id);
+    sortAgentListRows(rows, 'agent', 'asc');
+    expect(rows.map((row) => row.id)).to.deep.equal(before);
+  });
+
+  it('sorts by name in both directions', () => {
+    expect(ids('agent', 'asc')).to.deep.equal(['a', 'b', 'c']);
+    expect(ids('agent', 'desc')).to.deep.equal(['c', 'b', 'a']);
+  });
+
+  it('sorts numeric columns by value, not by their formatted text', () => {
+    expect(ids('requests', 'desc')).to.deep.equal(['c', 'b', 'a']);
+    expect(ids('spend', 'desc')).to.deep.equal(['a', 'c', 'b']);
+  });
+
+  it('sorts last seen newest first and keeps never-seen agents last', () => {
+    expect(ids('last_seen', 'desc')).to.deep.equal(['a', 'b', 'c']);
+  });
+
+  it('sorts owners alphabetically with unassigned agents last', () => {
+    expect(ids('owner', 'asc')).to.deep.equal(['a', 'b', 'c']);
   });
 });

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -474,10 +474,17 @@ describe('AgentsView', () => {
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
     await waitForAgents(el);
 
+    // A failed live check IS the status, so it shows once as the status chip
+    // rather than twice (status plus a second red badge saying the same).
     const text = (el.shadowRoot?.textContent || '').replace(/\s+/g, ' ');
     expect(text).to.contain('Live check failed');
-    const badge = el.shadowRoot?.querySelector('sl-badge.validation-badge');
-    expect(badge?.getAttribute('variant')).to.equal('danger');
+    expect(el.shadowRoot?.querySelector('sl-badge.validation-badge')).to.not
+      .exist;
+    const chip = el.shadowRoot?.querySelector(
+      '.identity-badges sl-badge.status-chip'
+    );
+    expect(chip?.textContent?.trim()).to.equal('Live check failed');
+    expect(chip?.getAttribute('variant')).to.equal('warning');
   });
 
   it('suppresses the validation badge when the live check passed', async () => {

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -24,6 +24,8 @@ import '../../components/preloop-agent-deployer.ts';
 import '../../components/preloop-deploy-wizard.ts';
 import '../../components/resource-actions.ts';
 import '../../components/agent-talk-composer.ts';
+import '../../components/confirm-dialog.ts';
+import { confirmDialog, showToast } from '../../components/confirm-dialog';
 import type { ResourceAction } from '../../components/resource-actions.ts';
 import {
   fetchWithAuth,
@@ -49,6 +51,7 @@ import { unifiedWebSocketManager } from '../../services/unified-websocket-manage
 import { getAgentControlState } from '../../utils/agent-control';
 import { renderAgentIcon } from '../../utils/agent-icons';
 import {
+  REMOVE_AGENT_CONSEQUENCE,
   getAgentSourceLabel,
   getSystemAgentTags,
   getVisibleAgentTags,
@@ -2144,12 +2147,14 @@ export class AgentsView extends LitElement {
   }
 
   private async removeAgent(agent: ManagedAgentSummary): Promise<void> {
-    if (
-      !window.confirm(
-        `Remove ${agent.display_name} from the managed agents list?\n\nThis also revokes the agent's Preloop credentials: if this agent is still onboarded on a machine, its gateway and MCP access will stop working until you run \`preloop agents onboard\` again. To disconnect cleanly, run \`preloop agents offboard\` on that machine instead.`
-      )
-    )
-      return;
+    const confirmed = await confirmDialog({
+      title: 'Remove agent',
+      message: `Remove ${agent.display_name} from the managed agents list?`,
+      detail: REMOVE_AGENT_CONSEQUENCE,
+      confirmLabel: 'Remove agent',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
     this.actionAgentId = agent.id;
     try {
       await removeAccountAgent(agent.id);
@@ -2235,7 +2240,7 @@ export class AgentsView extends LitElement {
       (user) => user.username === trimmed || user.email === trimmed
     );
     if (!selected) {
-      window.alert('No user matched that username or email.');
+      showToast('No user matched that username or email.', 'warning');
       return;
     }
     void this.updateAgent(agent, { owner_user_id: selected.id });
@@ -2245,14 +2250,18 @@ export class AgentsView extends LitElement {
     agent: ManagedAgentSummary,
     lifecycleAction: 'suspend' | 'resume'
   ): Promise<void> {
-    const label = lifecycleAction === 'suspend' ? 'pause' : 'resume';
-    if (
-      !window.confirm(
-        `Are you sure you want to ${label} ${agent.display_name}?`
-      )
-    ) {
-      return;
-    }
+    const isSuspend = lifecycleAction === 'suspend';
+    const confirmed = await confirmDialog({
+      title: isSuspend ? 'Pause agent' : 'Resume agent',
+      message: isSuspend
+        ? `Pause ${agent.display_name}?`
+        : `Resume ${agent.display_name}?`,
+      detail: isSuspend
+        ? 'Requests are blocked while paused. Resume restores the agent without re-onboarding it.'
+        : 'The existing credentials start working again immediately.',
+      confirmLabel: isSuspend ? 'Pause' : 'Resume',
+    });
+    if (!confirmed) return;
     await this.updateAgent(agent, {
       lifecycle_action: lifecycleAction,
       reason:

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -6,6 +6,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/button-group/button-group.js';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
@@ -53,9 +54,11 @@ import { renderAgentIcon } from '../../utils/agent-icons';
 import {
   REMOVE_AGENT_CONSEQUENCE,
   getAgentSourceLabel,
+  getAgentStatusChip,
   getSystemAgentTags,
   getVisibleAgentTags,
 } from '../../utils/agent-display';
+import { formatRelativeTime } from '../../utils/date';
 
 const AVAILABLE_AGENT_KINDS = [
   { value: 'openclaw', label: 'OpenClaw' },
@@ -109,6 +112,118 @@ function persistAgentKinds(selected: string[]): void {
     localStorage.setItem(HIDDEN_AGENT_KINDS_KEY, JSON.stringify(hidden));
     localStorage.removeItem(LEGACY_AGENT_KINDS_KEY);
   } catch (e) {}
+}
+
+export type AgentsViewMode = 'list' | 'cards' | 'canvas';
+
+const VIEW_MODE_KEY = 'preloop.agents.view_mode';
+const AGENTS_VIEW_MODES: AgentsViewMode[] = ['list', 'cards', 'canvas'];
+
+/**
+ * The list is the default: a table answers "which agents do I have and are
+ * they healthy" at a glance, where cards and canvas answer "show me one" and
+ * "show me the topology". A previously persisted choice still wins.
+ */
+const DEFAULT_AGENTS_VIEW: AgentsViewMode = 'list';
+
+function loadInitialViewMode(): AgentsViewMode {
+  try {
+    const saved = localStorage.getItem(VIEW_MODE_KEY);
+    if (saved && (AGENTS_VIEW_MODES as string[]).includes(saved)) {
+      return saved as AgentsViewMode;
+    }
+  } catch (e) {}
+  return DEFAULT_AGENTS_VIEW;
+}
+
+/** Below this width the table cannot show its columns, so cards take over. */
+const LIST_TO_CARDS_BREAKPOINT = '(max-width: 640px)';
+
+export type AgentListSortKey =
+  'agent' | 'status' | 'owner' | 'model' | 'requests' | 'spend' | 'last_seen';
+
+export type SortDirection = 'asc' | 'desc';
+
+/** One normalized table row, covering both managed agents and flow nodes. */
+export interface AgentListRow {
+  id: string;
+  isFlow: boolean;
+  name: string;
+  kindLabel: string;
+  kind: string | null;
+  detailUrl: string;
+  statusLabel: string;
+  statusVariant: 'success' | 'neutral' | 'warning' | 'danger';
+  statusOutline: boolean;
+  owner: string;
+  modelLabel: string;
+  modelId: string | null;
+  modelGated: boolean;
+  requests: number;
+  spend: number;
+  lastSeen: string | null;
+  /** The original API item, so row actions keep working on the real object. */
+  source: any;
+}
+
+function timestampValue(value: string | null): number {
+  if (!value) return Number.NEGATIVE_INFINITY;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
+}
+
+/** Sorts blank owners to the end of an ascending sort. */
+function ownerSortValue(row: AgentListRow): string {
+  return row.owner || '￿';
+}
+
+function compareRowsByKey(
+  a: AgentListRow,
+  b: AgentListRow,
+  key: AgentListSortKey
+): number {
+  switch (key) {
+    case 'agent':
+      return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+    case 'status':
+      return a.statusLabel.localeCompare(b.statusLabel, undefined, {
+        sensitivity: 'base',
+      });
+    case 'owner':
+      // Unassigned agents have no owner to alphabetise, so they sort after
+      // every named owner rather than landing at the top of an A-Z sort.
+      return ownerSortValue(a).localeCompare(ownerSortValue(b), undefined, {
+        sensitivity: 'base',
+      });
+    case 'model':
+      return a.modelLabel.localeCompare(b.modelLabel, undefined, {
+        sensitivity: 'base',
+      });
+    case 'requests':
+      return a.requests - b.requests;
+    case 'spend':
+      return a.spend - b.spend;
+    case 'last_seen':
+      return timestampValue(a.lastSeen) - timestampValue(b.lastSeen);
+  }
+}
+
+/**
+ * Sorts table rows without mutating the input. Ties fall back to the agent
+ * name so a re-sort on a column full of equal values (every Idle agent, every
+ * zero-spend agent) still produces a stable, readable order.
+ */
+export function sortAgentListRows(
+  rows: AgentListRow[],
+  key: AgentListSortKey,
+  direction: SortDirection
+): AgentListRow[] {
+  const factor = direction === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const primary = compareRowsByKey(a, b, key);
+    if (primary !== 0) return primary * factor;
+    return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  });
 }
 
 const CANVAS_LAYOUT_VERSION = 'polygon-rings-v1';
@@ -220,7 +335,15 @@ export class AgentsView extends LitElement {
   private hasAutoOpenedOnboarding = false;
 
   // Switcher state
-  @state() private currentView: 'cards' | 'canvas' = 'canvas';
+  @state() private currentView: AgentsViewMode = loadInitialViewMode();
+  @state() private sortKey: AgentListSortKey = 'last_seen';
+  @state() private sortDirection: SortDirection = 'desc';
+  /** True on phone-width viewports, where the table falls back to cards. */
+  @state() private narrowViewport = false;
+  private narrowViewportQuery: MediaQueryList | null = null;
+  private handleNarrowViewportChange = (event: MediaQueryListEvent) => {
+    this.narrowViewport = event.matches;
+  };
 
   // VM Provisioning state variables
   @state() private computeFeatureEnabled = false;
@@ -353,6 +476,147 @@ export class AgentsView extends LitElement {
         gap: var(--sl-spacing-large);
         padding: 1rem 1rem 0 2rem;
       }
+      /* --- List view --- */
+      .list-bounds {
+        width: 100%;
+        max-width: 80rem;
+        margin: 0 auto;
+        padding: 0 1rem 2rem 2rem;
+        box-sizing: border-box;
+      }
+      .agents-table {
+        table-layout: auto;
+      }
+      .agents-table th,
+      .agents-table td {
+        padding: var(--sl-spacing-small) var(--sl-spacing-medium);
+        vertical-align: middle;
+      }
+      .agents-table th {
+        padding: 0;
+      }
+      .agents-table th.actions-cell,
+      .agents-table td.actions-cell {
+        width: 48px;
+        text-align: right;
+        padding-right: var(--sl-spacing-small);
+      }
+      .sort-button {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        width: 100%;
+        background: none;
+        border: none;
+        cursor: pointer;
+        font: inherit;
+        font-weight: var(--sl-font-weight-semibold);
+        font-size: var(--sl-font-size-x-small);
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--sl-color-neutral-600);
+        padding: var(--sl-spacing-small) var(--sl-spacing-medium);
+      }
+      th.numeric .sort-button {
+        justify-content: flex-end;
+      }
+      .sort-button:hover,
+      .sort-button:focus-visible {
+        color: var(--sl-color-neutral-900);
+      }
+      th.active .sort-button {
+        color: var(--sl-color-neutral-900);
+      }
+      .sort-caret {
+        font-size: 0.75em;
+        opacity: 0.55;
+      }
+      th.active .sort-caret {
+        opacity: 1;
+      }
+      .agent-row {
+        cursor: pointer;
+      }
+      .agent-row:hover td {
+        background: var(--sl-color-neutral-100);
+      }
+      .agent-identity {
+        display: flex;
+        align-items: center;
+        gap: var(--sl-spacing-small);
+        min-width: 0;
+      }
+      .agent-identity-text {
+        min-width: 0;
+      }
+      .row-icon {
+        width: 20px;
+        height: 20px;
+        flex-shrink: 0;
+      }
+      .row-link {
+        color: var(--sl-color-primary-700);
+        font-weight: var(--sl-font-weight-semibold);
+        text-decoration: none;
+      }
+      .row-link:hover,
+      .row-link:focus-visible {
+        text-decoration: underline;
+      }
+      .row-subtitle {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-small);
+      }
+      .muted-cell {
+        color: var(--sl-color-neutral-500);
+      }
+      .agents-table td.numeric,
+      .agents-table th.numeric {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+      }
+      .model-cell {
+        max-width: 260px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .row-actions {
+        display: flex;
+        justify-content: flex-end;
+      }
+      /* Shoelace badges are solid by default; the outline variant marks a
+         softer state (recently active) without stealing attention from a
+         live one. */
+      .status-chip.outline::part(base) {
+        background-color: transparent;
+        color: var(--sl-color-success-700);
+        border-color: var(--sl-color-success-500);
+      }
+      .canvas-last-seen {
+        font-weight: 600;
+      }
+      .metric-row .value.numeric {
+        font-variant-numeric: tabular-nums;
+      }
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+      }
+      @media (prefers-color-scheme: dark) {
+        .agent-row:hover td {
+          background: var(--sl-color-neutral-100);
+        }
+        .status-chip.outline::part(base) {
+          color: var(--sl-color-success-400);
+          border-color: var(--sl-color-success-600);
+        }
+      }
       .deploy-grid {
         display: grid;
         grid-template-columns: 1fr 1fr;
@@ -415,6 +679,16 @@ export class AgentsView extends LitElement {
         font-weight: 700;
         font-size: 1.15rem;
         letter-spacing: -0.01em;
+      }
+      /* The card is clickable, but the title is a real anchor so cmd-click
+         and middle-click open the agent in a new tab (AG-B). */
+      a.agent-name {
+        color: inherit;
+        text-decoration: none;
+      }
+      a.agent-name:hover,
+      a.agent-name:focus-visible {
+        text-decoration: underline;
       }
       .agent-meta {
         opacity: 0.7;
@@ -744,13 +1018,46 @@ export class AgentsView extends LitElement {
         transform: translateY(-4px);
         box-shadow: var(--sl-shadow-large);
       }
+      .canvas-legend {
+        position: absolute;
+        left: 20px;
+        bottom: 20px;
+        z-index: 20;
+        background: color-mix(
+          in srgb,
+          var(--sl-panel-background-color) 92%,
+          transparent
+        );
+        border: 1px solid var(--sl-color-neutral-200);
+        border-radius: var(--sl-border-radius-medium);
+        padding: 10px 12px;
+        font-size: 0.8rem;
+        color: var(--sl-color-neutral-700);
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        max-width: calc(100% - 40px);
+      }
+      .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .legend-swatch {
+        display: inline-block;
+        width: 20px;
+        height: 0;
+        flex-shrink: 0;
+      }
+      /* Top-right, not bottom-right: at the bottom the zoom stack sat on top
+         of the nearest agent card and swallowed its clicks. */
       .controls-overlay {
         position: absolute;
-        bottom: 24px;
-        right: 24px;
+        top: 16px;
+        right: 16px;
         z-index: 20;
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
         gap: 8px;
         background: var(--sl-panel-background-color, var(--sl-color-neutral-0));
         padding: 8px;
@@ -793,11 +1100,16 @@ export class AgentsView extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
 
-    // Restore saved view preference
-    const savedView = localStorage.getItem('preloop.agents.view_mode');
-    if (savedView === 'cards' || savedView === 'canvas') {
-      this.currentView = savedView;
-    }
+    // Restore saved view preference (the default is applied at field init so
+    // the very first render already knows which view to paint).
+    this.currentView = loadInitialViewMode();
+
+    this.narrowViewportQuery = window.matchMedia(LIST_TO_CARDS_BREAKPOINT);
+    this.narrowViewport = this.narrowViewportQuery.matches;
+    this.narrowViewportQuery.addEventListener(
+      'change',
+      this.handleNarrowViewportChange
+    );
 
     // Restore saved node positions
     try {
@@ -857,10 +1169,13 @@ export class AgentsView extends LitElement {
 
   updated(changedProperties: Map<string, unknown>) {
     super.updated?.(changedProperties);
-    if (changedProperties.has('currentView')) {
+    if (
+      changedProperties.has('currentView') ||
+      changedProperties.has('narrowViewport')
+    ) {
       this.dispatchEvent(
         new CustomEvent('request-full-bleed', {
-          detail: this.currentView === 'canvas',
+          detail: this.effectiveView === 'canvas',
           bubbles: true,
           composed: true,
         })
@@ -868,9 +1183,25 @@ export class AgentsView extends LitElement {
     }
   }
 
+  /**
+   * The view actually painted. On phone widths a seven-column table would
+   * either scroll sideways or crush every cell, so `list` renders as cards.
+   */
+  private get effectiveView(): AgentsViewMode {
+    if (this.currentView === 'list' && this.narrowViewport) {
+      return 'cards';
+    }
+    return this.currentView;
+  }
+
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.unsubscribeRealtime?.();
+    this.narrowViewportQuery?.removeEventListener(
+      'change',
+      this.handleNarrowViewportChange
+    );
+    this.narrowViewportQuery = null;
     this.resizeObserver.disconnect();
     if (this.refreshTimer !== null) {
       window.clearTimeout(this.refreshTimer);
@@ -1611,9 +1942,13 @@ export class AgentsView extends LitElement {
 
       const cardHalfW = CANVAS_CARD_HALF_WIDTH;
       const cardHalfH = CANVAS_CARD_HALF_HEIGHT;
-      const sideMargin = 56;
-      const topMargin = 44;
-      const bottomMargin = 44;
+      // Margins keep the outermost cards clear of the viewport edges and of
+      // the two overlays: the zoom controls at the top right and the legend
+      // at the bottom left. Without them the rightmost card was clipped by
+      // the container's `overflow: hidden`.
+      const sideMargin = 96;
+      const topMargin = 88;
+      const bottomMargin = 88;
 
       const paddedMinX = minX - (cardHalfW + sideMargin);
       const paddedMaxX = maxX + (cardHalfW + sideMargin);
@@ -1745,6 +2080,23 @@ export class AgentsView extends LitElement {
     return parsed.toLocaleString();
   }
 
+  /**
+   * Timestamps on this page read as "4d ago", with the exact instant on hover.
+   * A wall of absolute datetimes tells you nothing at a glance about which
+   * agent went quiet yesterday and which one went quiet in March.
+   */
+  private renderRelativeTimestamp(
+    value: string | null | undefined,
+    className = ''
+  ) {
+    if (!value) {
+      return html`<span class=${className} title="Never seen">Never</span>`;
+    }
+    return html`<span class=${className} title=${this.formatDateTime(value)}
+      >${formatRelativeTime(value)}</span
+    >`;
+  }
+
   private getLifecycleVariant(agent: ManagedAgentSummary): string {
     if (agent.lifecycle_state === 'decommissioned') return 'danger';
     if (agent.lifecycle_state === 'suspended') return 'warning';
@@ -1813,9 +2165,9 @@ export class AgentsView extends LitElement {
     if (agent.live_validation_status === 'passed') return 'Live validated';
     if (agent.live_validation_status === 'failed') return 'Live check failed';
     if (agent.live_validation_status === 'throttled')
-      return 'Live check throttled — unverified';
+      return 'Live check throttled, unverified';
     if (agent.live_validation_status === 'upstream_unavailable')
-      return 'Upstream refused — unverified';
+      return 'Upstream refused, unverified';
     // ``not_run`` means the CLI was never invoked with ``--live-validate`` —
     // it's an opt-in step, not a check that's currently in flight.
     if (agent.live_validation_status === 'not_run') return 'Live check not run';
@@ -2273,7 +2625,7 @@ export class AgentsView extends LitElement {
 
   // --- CANVAS VIEWPORT LOGIC ---
   private handleWheel(e: WheelEvent) {
-    if (this.currentView !== 'canvas') return;
+    if (this.effectiveView !== 'canvas') return;
     e.preventDefault();
     const zoomSensitivity = 0.001;
     const delta = -e.deltaY * zoomSensitivity;
@@ -2476,9 +2828,29 @@ export class AgentsView extends LitElement {
     }
   }
 
-  private setCurrentView(view: 'cards' | 'canvas') {
+  private setCurrentView(view: AgentsViewMode) {
     this.currentView = view;
-    localStorage.setItem('preloop.agents.view_mode', view);
+    try {
+      localStorage.setItem(VIEW_MODE_KEY, view);
+    } catch (e) {}
+  }
+
+  /**
+   * Clicking a header sorts by that column; clicking the active one flips the
+   * direction. Text columns start ascending (A first), numeric and time
+   * columns start descending (biggest and newest first), which is what an
+   * operator scanning for the busiest or most recent agent expects.
+   */
+  private toggleSort(key: AgentListSortKey) {
+    if (this.sortKey === key) {
+      this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+      return;
+    }
+    this.sortKey = key;
+    this.sortDirection =
+      key === 'requests' || key === 'spend' || key === 'last_seen'
+        ? 'desc'
+        : 'asc';
   }
 
   // --- RENDERING ---
@@ -2664,6 +3036,294 @@ export class AgentsView extends LitElement {
     `;
   }
 
+  /** Model label + link target for one agent, shared by the list and cards. */
+  private getAgentModelPresentation(agent: ManagedAgentSummary): {
+    label: string;
+    modelId: string | null;
+    gated: boolean;
+  } {
+    const modelId =
+      (agent as any).ai_model_id || agent.configured_model_id || null;
+    const alias =
+      agent.configured_model_alias ||
+      (agent as any).ai_model_name ||
+      agent.latest_model_alias ||
+      null;
+    if (modelId) {
+      const known = this.aiModels.find((model) => model.id === modelId);
+      return {
+        label: known?.name || alias || modelId,
+        modelId,
+        gated: true,
+      };
+    }
+    if (alias) {
+      return { label: alias, modelId: null, gated: true };
+    }
+    return { label: 'direct (not gated)', modelId: null, gated: false };
+  }
+
+  /** Flattens agents and flow nodes into the rows the table renders. */
+  private getListRows(): AgentListRow[] {
+    return this.getCanvasItems({ includeExiting: false }).map((item: any) => {
+      const isFlow =
+        'flow_status' in item || ('name' in item && !('display_name' in item));
+      if (isFlow) {
+        const stats = item.execution_stats || {};
+        return {
+          id: item.id,
+          isFlow: true,
+          name: item.name || 'Unnamed flow',
+          kindLabel: 'Flow',
+          kind: 'flow',
+          detailUrl: `/console/flows/${encodeURIComponent(item.id)}`,
+          statusLabel: item.flow_status === 'active' ? 'Active' : 'Inactive',
+          statusVariant:
+            item.flow_status === 'active'
+              ? ('success' as const)
+              : ('neutral' as const),
+          statusOutline: false,
+          owner: item.owner_username || '',
+          modelLabel: item.ai_model_id ? item.ai_model_id : '',
+          modelId: item.ai_model_id || null,
+          modelGated: Boolean(item.ai_model_id),
+          requests: stats.total_execs || 0,
+          spend: stats.estimated_cost || 0,
+          lastSeen: stats.last_seen_at || null,
+          source: item,
+        };
+      }
+
+      const agent = item as ManagedAgentSummary;
+      const chip = getAgentStatusChip(agent);
+      const model = this.getAgentModelPresentation(agent);
+      const live = this.liveActivity[agent.id];
+      return {
+        id: agent.id,
+        isFlow: false,
+        name: agent.display_name,
+        kindLabel: this.getSourceLabel(
+          agent.agent_kind || agent.session_source_type
+        ),
+        kind: agent.agent_kind || agent.session_source_type,
+        detailUrl: `/console/agents/${encodeURIComponent(agent.id)}`,
+        statusLabel: chip.label,
+        statusVariant: chip.variant,
+        statusOutline: Boolean(chip.outline),
+        owner: agent.owner_username || agent.owner_email || '',
+        modelLabel: model.label,
+        modelId: model.modelId,
+        modelGated: model.gated,
+        requests: agent.total_requests || 0,
+        spend: agent.estimated_cost || 0,
+        lastSeen: live?.lastActivityAt || agent.last_seen_at || null,
+        source: agent,
+      };
+    });
+  }
+
+  private renderSortableHeader(
+    key: AgentListSortKey,
+    label: string,
+    numeric = false
+  ) {
+    const active = this.sortKey === key;
+    const ariaSort = active
+      ? this.sortDirection === 'asc'
+        ? 'ascending'
+        : 'descending'
+      : 'none';
+    return html`
+      <th
+        class="sortable ${numeric ? 'numeric' : ''} ${active ? 'active' : ''}"
+        aria-sort=${ariaSort}
+        scope="col"
+      >
+        <button
+          type="button"
+          class="sort-button"
+          data-sort-key=${key}
+          @click=${() => this.toggleSort(key)}
+        >
+          <span>${label}</span>
+          <sl-icon
+            class="sort-caret"
+            name=${
+              active
+                ? this.sortDirection === 'asc'
+                  ? 'caret-up-fill'
+                  : 'caret-down-fill'
+                : 'chevron-expand'
+            }
+          ></sl-icon>
+        </button>
+      </th>
+    `;
+  }
+
+  private renderStatusChip(row: AgentListRow) {
+    return html`
+      <sl-badge
+        class="status-chip ${row.statusOutline ? 'outline' : ''}"
+        variant=${row.statusVariant}
+        pill
+        >${row.statusLabel}</sl-badge
+      >
+    `;
+  }
+
+  private renderListRow(row: AgentListRow) {
+    const actions = this.getCardActions(row.source);
+    return html`
+      <tr
+        class="agent-row"
+        @click=${(event: MouseEvent) => this.handleRowClick(event, row)}
+      >
+        <td class="agent-cell">
+          <div class="agent-identity">
+            ${
+              row.isFlow
+                ? html`<img
+                    src="/images/flow.svg"
+                    class="row-icon"
+                    alt=""
+                    aria-hidden="true"
+                  />`
+                : renderAgentIcon(
+                    row.kind,
+                    'font-size: 20px; color: var(--sl-color-neutral-700); flex-shrink: 0;'
+                  )
+            }
+            <div class="agent-identity-text">
+              <a class="row-link" href=${row.detailUrl}>${row.name}</a>
+              <div class="row-subtitle">${row.kindLabel}</div>
+            </div>
+          </div>
+        </td>
+        <td>${this.renderStatusChip(row)}</td>
+        <td class="muted-cell">${row.owner || 'Unassigned'}</td>
+        <td class="model-cell">
+          ${
+            row.modelId
+              ? html`<a
+                  class="row-link"
+                  href="/console/ai-models/${encodeURIComponent(row.modelId)}"
+                  >${row.modelLabel}</a
+                >`
+              : row.modelGated
+                ? html`<span>${row.modelLabel}</span>`
+                : html`<span class="muted-cell">${row.modelLabel}</span>`
+          }
+        </td>
+        <td class="numeric">${(row.requests || 0).toLocaleString()}</td>
+        <td class="numeric">${this.formatMoney(row.spend)}</td>
+        <td
+          class="muted-cell"
+          title=${row.lastSeen ? this.formatDateTime(row.lastSeen) : 'Never'}
+        >
+          ${row.lastSeen ? formatRelativeTime(row.lastSeen) : 'Never'}
+        </td>
+        <td class="actions-cell">
+          ${
+            actions.length
+              ? html`<div
+                  class="row-actions"
+                  @click=${(event: Event) => event.stopPropagation()}
+                  @keydown=${(event: Event) => event.stopPropagation()}
+                >
+                  <resource-actions
+                    .actions=${actions}
+                    menu-only
+                  ></resource-actions>
+                </div>`
+              : null
+          }
+        </td>
+      </tr>
+    `;
+  }
+
+  /**
+   * The whole row is clickable for convenience, but the name is a real anchor
+   * so cmd-click and middle-click open a tab. Let the browser handle those and
+   * any click that started inside a link, a button or the kebab menu.
+   */
+  private handleRowClick(event: MouseEvent, row: AgentListRow) {
+    if (event.defaultPrevented) return;
+    if (
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.button !== 0
+    ) {
+      return;
+    }
+    const path = event.composedPath();
+    for (const node of path) {
+      if (!(node instanceof HTMLElement)) continue;
+      if (node.tagName === 'TR') break;
+      const tag = node.tagName.toLowerCase();
+      if (
+        tag === 'a' ||
+        tag === 'button' ||
+        tag === 'sl-button' ||
+        tag === 'sl-menu-item' ||
+        tag === 'resource-actions'
+      ) {
+        return;
+      }
+    }
+    this.navigateToCardTarget(row.detailUrl);
+  }
+
+  private renderListView() {
+    const rows = sortAgentListRows(
+      this.getListRows(),
+      this.sortKey,
+      this.sortDirection
+    );
+
+    if (rows.length === 0) {
+      return html`
+        <div class="list-bounds">
+          <div class="empty-state">
+            ${
+              this.loading
+                ? 'Loading agents...'
+                : 'No agents or flows found matching your query.'
+            }
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="list-bounds">
+        <sl-card class="table-card">
+          <table class="styled-table agents-table">
+            <thead>
+              <tr>
+                ${this.renderSortableHeader('agent', 'Agent')}
+                ${this.renderSortableHeader('status', 'Status')}
+                ${this.renderSortableHeader('owner', 'Owner')}
+                ${this.renderSortableHeader('model', 'Model')}
+                ${this.renderSortableHeader('requests', 'Requests', true)}
+                ${this.renderSortableHeader('spend', 'Spend (est.)', true)}
+                ${this.renderSortableHeader('last_seen', 'Last seen')}
+                <th class="actions-cell">
+                  <span class="visually-hidden">Actions</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              ${rows.map((row) => this.renderListRow(row))}
+            </tbody>
+          </table>
+        </sl-card>
+      </div>
+    `;
+  }
+
   private renderAgentCard(item: any) {
     const isFlow =
       'flow_status' in item || ('name' in item && !('display_name' in item));
@@ -2742,7 +3402,13 @@ export class AgentsView extends LitElement {
                     )
               }
               <div class="identity-stack">
-                <div class="agent-name">${displayName}</div>
+                <a
+                  class="agent-name"
+                  href=${detailUrl}
+                  @click=${(event: Event) => event.stopPropagation()}
+                  @pointerdown=${(event: Event) => event.stopPropagation()}
+                  >${displayName}</a
+                >
                 <div
                   class="agent-meta"
                   title="${sessionSourceId ? sessionSourceId : ''}"
@@ -2861,7 +3527,7 @@ export class AgentsView extends LitElement {
             !isFlow && agent && this.isModelTrafficFailing(agent)
               ? html`
                   <div class="model-traffic-failing">
-                    Model traffic failing —
+                    Model traffic failing:
                     <a
                       href=${
                         agent.runtime_session_id
@@ -2925,21 +3591,24 @@ export class AgentsView extends LitElement {
 
           <div class="metric-row">
             <span class="label">Estimated Cost</span>
-            <span class="value">${this.formatMoney(estimatedCost!)}</span>
+            <span class="value numeric"
+              >${this.formatMoney(estimatedCost!)}</span
+            >
           </div>
 
           <div class="metric-row">
             <span class="label">${isFlow ? 'Executions' : 'Requests'}</span>
-            <span class="value">${totalRequests}</span>
+            <span class="value numeric"
+              >${(totalRequests || 0).toLocaleString()}</span
+            >
           </div>
 
           <div class="metric-row">
             <span class="label">Last Seen</span>
-            <span class="value"
-              >${this.formatDateTime(
-                liveActivity?.lastActivityAt || lastSeen
-              )}</span
-            >
+            ${this.renderRelativeTimestamp(
+              liveActivity?.lastActivityAt || lastSeen,
+              'value'
+            )}
           </div>
         </div>
       </sl-card>
@@ -3005,20 +3674,27 @@ export class AgentsView extends LitElement {
             </sl-tooltip>
           </div>
 
-          <div
-            style="position: absolute; left: 20px; bottom: 20px; z-index: 20; background: color-mix(in srgb, var(--sl-panel-background-color) 92%, transparent); border: 1px solid var(--sl-color-neutral-200); border-radius: var(--sl-border-radius-medium); padding: 10px 12px; font-size: 0.8rem; color: var(--sl-color-neutral-700); display: flex; gap: 16px;"
-          >
-            <div style="display: flex; align-items: center; gap: 8px;">
+          <div class="canvas-legend">
+            <div class="legend-item">
               <span
-                style="display: inline-block; width: 20px; height: 0; border-top: 2px solid var(--sl-color-primary-500);"
+                class="legend-swatch"
+                style="border-top: 2px solid var(--sl-color-primary-500);"
               ></span>
               <span>Model traffic</span>
             </div>
-            <div style="display: flex; align-items: center; gap: 8px;">
+            <div class="legend-item">
               <span
-                style="display: inline-block; width: 20px; height: 0; border-top: 2px dashed var(--sl-color-warning-500);"
+                class="legend-swatch"
+                style="border-top: 2px dashed var(--sl-color-warning-500);"
               ></span>
               <span>Tool traffic</span>
+            </div>
+            <div class="legend-item">
+              <span
+                class="legend-swatch"
+                style="border-top: 2px dashed var(--sl-color-neutral-400); opacity: 0.7;"
+              ></span>
+              <span>Unmanaged (dashed gray)</span>
             </div>
           </div>
 
@@ -3272,7 +3948,7 @@ export class AgentsView extends LitElement {
                             this.isModelTrafficFailing(agent)
                               ? html`
                                   <div class="model-traffic-failing">
-                                    Model traffic failing —
+                                    Model traffic failing:
                                     <a
                                       href=${
                                         agent.runtime_session_id
@@ -3430,18 +4106,11 @@ export class AgentsView extends LitElement {
                                 style="opacity: 0.7; font-size: 0.75rem; text-transform: uppercase;"
                                 >Last Seen</span
                               >
-                              <span style="font-weight: 600;"
-                                >${new Date(
-                                  liveActivity?.lastActivityAt ||
-                                    (isFlow
-                                      ? lastSeenFlow
-                                      : agent?.last_seen_at) ||
-                                    0
-                                ).toLocaleTimeString([], {
-                                  hour: '2-digit',
-                                  minute: '2-digit',
-                                })}</span
-                              >
+                              ${this.renderRelativeTimestamp(
+                                liveActivity?.lastActivityAt ||
+                                  (isFlow ? lastSeenFlow : agent?.last_seen_at),
+                                'canvas-last-seen'
+                              )}
                             </div>
                           </div>
                         </sl-card>
@@ -3573,7 +4242,7 @@ export class AgentsView extends LitElement {
     return html`
       <div
         class="page ${
-          this.currentView === 'canvas' ? 'page-canvas-wrapper' : ''
+          this.effectiveView === 'canvas' ? 'page-canvas-wrapper' : ''
         }"
       >
         ${this.renderOnboardingDialog()}
@@ -3607,7 +4276,7 @@ export class AgentsView extends LitElement {
         <div class="content-bounds">
           <view-header
             headerText="Agents"
-            description="Agents connected to Preloop — their gateway credentials, MCP access, and live status. Onboard agents you already run with the CLI, or deploy new ones."
+            description="Agents connected to Preloop: their gateway credentials, MCP access, and live status. Onboard agents you already run with the CLI, or deploy new ones."
             width="extra-wide"
           >
             <div
@@ -3703,18 +4372,38 @@ export class AgentsView extends LitElement {
 
             <div class="view-switcher-group">
               <span class="toolbar-divider" aria-hidden="true"></span>
-              <sl-radio-group
-                value=${this.currentView}
-                @sl-change=${(e: any) => this.setCurrentView(e.target.value)}
-                size="small"
-              >
-                <sl-radio-button value="cards" title="Cards View">
-                  <sl-icon name="grid"></sl-icon>
-                </sl-radio-button>
-                <sl-radio-button value="canvas" title="Canvas View">
-                  <sl-icon name="share"></sl-icon>
-                </sl-radio-button>
-              </sl-radio-group>
+              <sl-button-group label="Agents view">
+                ${[
+                  { value: 'list' as const, label: 'List', icon: 'list-ul' },
+                  {
+                    value: 'cards' as const,
+                    label: 'Cards',
+                    icon: 'grid-3x3-gap',
+                  },
+                  {
+                    value: 'canvas' as const,
+                    label: 'Canvas',
+                    icon: 'diagram-3',
+                  },
+                ].map(
+                  (option) => html`
+                    <sl-button
+                      size="small"
+                      data-view=${option.value}
+                      variant=${
+                        this.currentView === option.value
+                          ? 'primary'
+                          : 'default'
+                      }
+                      aria-pressed=${this.currentView === option.value}
+                      @click=${() => this.setCurrentView(option.value)}
+                    >
+                      <sl-icon slot="prefix" name=${option.icon}></sl-icon>
+                      ${option.label}
+                    </sl-button>
+                  `
+                )}
+              </sl-button-group>
             </div>
           </div>
           ${
@@ -3727,26 +4416,28 @@ export class AgentsView extends LitElement {
         </div>
 
         ${
-          this.currentView === 'canvas'
+          this.effectiveView === 'canvas'
             ? this.renderCanvas()
-            : html`
-                <div class="cards">
-                  ${
-                    (!this.agents ||
-                      (this.agents.items.length === 0 &&
-                        this.flows.length === 0)) &&
-                    !this.loading
-                      ? html`
-                          <div class="empty-state">
-                            No agents or flows found matching your query.
-                          </div>
-                        `
-                      : [...(this.agents?.items || []), ...this.flows].map(
-                          (item) => this.renderAgentCard(item)
-                        )
-                  }
-                </div>
-              `
+            : this.effectiveView === 'list'
+              ? this.renderListView()
+              : html`
+                  <div class="cards">
+                    ${
+                      (!this.agents ||
+                        (this.agents.items.length === 0 &&
+                          this.flows.length === 0)) &&
+                      !this.loading
+                        ? html`
+                            <div class="empty-state">
+                              No agents or flows found matching your query.
+                            </div>
+                          `
+                        : [...(this.agents?.items || []), ...this.flows].map(
+                            (item) => this.renderAgentCard(item)
+                          )
+                    }
+                  </div>
+                `
         }
       </div>
     `;

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -157,6 +157,8 @@ export interface AgentListRow {
   statusOutline: boolean;
   owner: string;
   modelLabel: string;
+  /** Full model text for the `title` attribute, since the cell truncates. */
+  modelTitle: string;
   modelId: string | null;
   modelGated: boolean;
   requests: number;
@@ -455,6 +457,14 @@ export class AgentsView extends LitElement {
       .view-switcher-group sl-radio-group {
         white-space: nowrap;
       }
+      /* Says how many rows the filters matched, right where the eye already
+         goes to switch views. */
+      .results-count {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+      }
       .toolbar-divider {
         width: 1px;
         height: 32px;
@@ -472,7 +482,9 @@ export class AgentsView extends LitElement {
       }
       .cards {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        /* auto-fill, not auto-fit: two agents should stay two 320px cards, not
+           stretch into two half-screen banners. */
+        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
         gap: var(--sl-spacing-large);
         padding: 1rem 1rem 0 2rem;
       }
@@ -484,13 +496,29 @@ export class AgentsView extends LitElement {
         padding: 0 1rem 2rem 2rem;
         box-sizing: border-box;
       }
+      /* The table sizes itself from the colgroup, not from its content: an
+         agent named after a container hash used to push the kebab column past
+         the right edge of the card, where it was clipped and unclickable. */
       .agents-table {
-        table-layout: auto;
+        table-layout: fixed;
+        width: 100%;
+        /* Below this the eight columns cannot hold their content, so the card
+           scrolls sideways instead of hiding the actions. Agent keeps at least
+           180px at this width; the list falls back to cards under 640px. */
+        min-width: 880px;
+      }
+      .table-scroll {
+        overflow-x: auto;
+        width: 100%;
       }
       .agents-table th,
       .agents-table td {
         padding: var(--sl-spacing-small) var(--sl-spacing-medium);
         vertical-align: middle;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .agents-table th {
         padding: 0;
@@ -500,6 +528,30 @@ export class AgentsView extends LitElement {
         width: 48px;
         text-align: right;
         padding-right: var(--sl-spacing-small);
+      }
+      /* Percentages for the text columns so wide screens give them the space,
+         pixels for the ones whose content has a known width. Agent takes what
+         is left. */
+      .col-status {
+        width: 96px;
+      }
+      .col-owner {
+        width: 13%;
+      }
+      .col-model {
+        width: 18%;
+      }
+      .col-requests {
+        width: 80px;
+      }
+      .col-spend {
+        width: 88px;
+      }
+      .col-last-seen {
+        width: 104px;
+      }
+      .col-actions {
+        width: 48px;
       }
       .sort-button {
         display: flex;
@@ -544,20 +596,27 @@ export class AgentsView extends LitElement {
         display: flex;
         align-items: center;
         gap: var(--sl-spacing-small);
-        min-width: 0;
+        min-width: 180px;
       }
       .agent-identity-text {
         min-width: 0;
+        overflow: hidden;
       }
       .row-icon {
         width: 20px;
         height: 20px;
         flex-shrink: 0;
       }
+      /* Names never wrap: a two-line name in one row and a one-line name in
+         the next made the whole table look ragged. */
       .row-link {
         color: var(--sl-color-primary-700);
+        display: block;
         font-weight: var(--sl-font-weight-semibold);
+        overflow: hidden;
         text-decoration: none;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .row-link:hover,
       .row-link:focus-visible {
@@ -566,6 +625,9 @@ export class AgentsView extends LitElement {
       .row-subtitle {
         color: var(--sl-color-neutral-500);
         font-size: var(--sl-font-size-small);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .muted-cell {
         color: var(--sl-color-neutral-500);
@@ -577,7 +639,6 @@ export class AgentsView extends LitElement {
         white-space: nowrap;
       }
       .model-cell {
-        max-width: 260px;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -3031,6 +3092,7 @@ export class AgentsView extends LitElement {
   /** Model label + link target for one agent, shared by the list and cards. */
   private getAgentModelPresentation(agent: ManagedAgentSummary): {
     label: string;
+    title: string;
     modelId: string | null;
     gated: boolean;
   } {
@@ -3043,16 +3105,47 @@ export class AgentsView extends LitElement {
       null;
     if (modelId) {
       const known = this.aiModels.find((model) => model.id === modelId);
-      return {
-        label: known?.name || alias || modelId,
-        modelId,
-        gated: true,
-      };
+      // The column shows the alias alone. The catalog display name repeats the
+      // provider ("OpenClaw preloop/deepseek/deepseek-chat"), which truncated
+      // to the part every row has in common; the full name lives in `title`.
+      const label = alias || known?.model_identifier || known?.name || modelId;
+      const title = [label, known?.name, known?.model_identifier]
+        .filter((part): part is string => Boolean(part))
+        .filter((part, index, parts) => parts.indexOf(part) === index)
+        .join(' · ');
+      return { label, title, modelId, gated: true };
     }
     if (alias) {
-      return { label: alias, modelId: null, gated: true };
+      return { label: alias, title: alias, modelId: null, gated: true };
     }
-    return { label: 'direct (not gated)', modelId: null, gated: false };
+    return {
+      label: 'direct (not gated)',
+      title: 'Calls a provider directly, without a gateway credential',
+      modelId: null,
+      gated: false,
+    };
+  }
+
+  /**
+   * "11 agents", or "9 agents · 2 flows" when the query also matched flows.
+   * A count next to the view switcher answers "did my filter do anything"
+   * without counting rows by hand.
+   */
+  private get resultsLabel(): string {
+    if (this.loading && !this.agents) {
+      return '';
+    }
+    const items = this.getCanvasItems({ includeExiting: false });
+    const flows = items.filter(
+      (item: any) =>
+        'flow_status' in item || ('name' in item && !('display_name' in item))
+    ).length;
+    const agents = items.length - flows;
+    const parts = [`${agents} ${agents === 1 ? 'agent' : 'agents'}`];
+    if (flows > 0) {
+      parts.push(`${flows} ${flows === 1 ? 'flow' : 'flows'}`);
+    }
+    return parts.join(' · ');
   }
 
   /** Flattens agents and flow nodes into the rows the table renders. */
@@ -3077,6 +3170,7 @@ export class AgentsView extends LitElement {
           statusOutline: false,
           owner: item.owner_username || '',
           modelLabel: item.ai_model_id ? item.ai_model_id : '',
+          modelTitle: item.ai_model_id ? item.ai_model_id : '',
           modelId: item.ai_model_id || null,
           modelGated: Boolean(item.ai_model_id),
           requests: stats.total_execs || 0,
@@ -3104,6 +3198,7 @@ export class AgentsView extends LitElement {
         statusOutline: Boolean(chip.outline),
         owner: agent.owner_username || agent.owner_email || '',
         modelLabel: model.label,
+        modelTitle: model.title,
         modelId: model.modelId,
         modelGated: model.gated,
         requests: agent.total_requests || 0,
@@ -3171,7 +3266,7 @@ export class AgentsView extends LitElement {
         class="agent-row"
         @click=${(event: MouseEvent) => this.handleRowClick(event, row)}
       >
-        <td class="agent-cell">
+        <td class="agent-cell" title=${row.name}>
           <div class="agent-identity">
             ${
               row.isFlow
@@ -3194,7 +3289,7 @@ export class AgentsView extends LitElement {
         </td>
         <td>${this.renderStatusChip(row)}</td>
         <td class="muted-cell">${row.owner || 'Unassigned'}</td>
-        <td class="model-cell">
+        <td class="model-cell" title=${row.modelTitle || row.modelLabel}>
           ${
             row.modelId
               ? html`<a
@@ -3213,7 +3308,15 @@ export class AgentsView extends LitElement {
           class="muted-cell"
           title=${row.lastSeen ? this.formatDateTime(row.lastSeen) : 'Never'}
         >
-          ${row.lastSeen ? formatRelativeTime(row.lastSeen) : 'Never'}
+          ${
+            row.lastSeen
+              ? // A month of relative time: "23d ago" still reads as recent
+                // activity, "213d ago" is arithmetic, so that becomes a date.
+                formatRelativeTime(row.lastSeen, undefined, {
+                  maxRelativeDays: 30,
+                })
+              : 'Never'
+          }
         </td>
         <td class="actions-cell">
           ${
@@ -3292,25 +3395,37 @@ export class AgentsView extends LitElement {
     return html`
       <div class="list-bounds">
         <sl-card class="table-card">
-          <table class="styled-table agents-table">
-            <thead>
-              <tr>
-                ${this.renderSortableHeader('agent', 'Agent')}
-                ${this.renderSortableHeader('status', 'Status')}
-                ${this.renderSortableHeader('owner', 'Owner')}
-                ${this.renderSortableHeader('model', 'Model')}
-                ${this.renderSortableHeader('requests', 'Requests', true)}
-                ${this.renderSortableHeader('spend', 'Spend (est.)', true)}
-                ${this.renderSortableHeader('last_seen', 'Last seen')}
-                <th class="actions-cell">
-                  <span class="visually-hidden">Actions</span>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              ${rows.map((row) => this.renderListRow(row))}
-            </tbody>
-          </table>
+          <div class="table-scroll">
+            <table class="styled-table agents-table">
+              <colgroup>
+                <col class="col-agent" />
+                <col class="col-status" />
+                <col class="col-owner" />
+                <col class="col-model" />
+                <col class="col-requests" />
+                <col class="col-spend" />
+                <col class="col-last-seen" />
+                <col class="col-actions" />
+              </colgroup>
+              <thead>
+                <tr>
+                  ${this.renderSortableHeader('agent', 'Agent')}
+                  ${this.renderSortableHeader('status', 'Status')}
+                  ${this.renderSortableHeader('owner', 'Owner')}
+                  ${this.renderSortableHeader('model', 'Model')}
+                  ${this.renderSortableHeader('requests', 'Requests', true)}
+                  ${this.renderSortableHeader('spend', 'Spend (est.)', true)}
+                  ${this.renderSortableHeader('last_seen', 'Last seen')}
+                  <th class="actions-cell">
+                    <span class="visually-hidden">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                ${rows.map((row) => this.renderListRow(row))}
+              </tbody>
+            </table>
+          </div>
         </sl-card>
       </div>
     `;
@@ -4282,14 +4397,14 @@ export class AgentsView extends LitElement {
                 }}
               >
                 <sl-icon slot="prefix" name="cloud-arrow-up"></sl-icon>
-                Deploy Agent
+                Deploy new agent
               </sl-button>
               <sl-button
                 variant="primary"
                 @click=${() => (this.showOnboardingDialog = true)}
               >
                 <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                Onboard Agents
+                Onboard existing agent
               </sl-button>
             </div>
           </view-header>
@@ -4363,6 +4478,9 @@ export class AgentsView extends LitElement {
             </form>
 
             <div class="view-switcher-group">
+              <span class="results-count" aria-live="polite"
+                >${this.resultsLabel}</span
+              >
               <span class="toolbar-divider" aria-hidden="true"></span>
               <sl-button-group label="Agents view">
                 ${[

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -505,7 +505,7 @@ export class AgentsView extends LitElement {
         /* Below this the eight columns cannot hold their content, so the card
            scrolls sideways instead of hiding the actions. Agent keeps at least
            180px at this width; the list falls back to cards under 640px. */
-        min-width: 880px;
+        min-width: 1040px;
       }
       .table-scroll {
         overflow-x: auto;
@@ -525,15 +525,16 @@ export class AgentsView extends LitElement {
       }
       .agents-table th.actions-cell,
       .agents-table td.actions-cell {
-        width: 48px;
+        width: 56px;
         text-align: right;
         padding-right: var(--sl-spacing-small);
+        overflow: visible;
       }
       /* Percentages for the text columns so wide screens give them the space,
          pixels for the ones whose content has a known width. Agent takes what
          is left. */
       .col-status {
-        width: 96px;
+        width: 150px;
       }
       .col-owner {
         width: 13%;
@@ -542,16 +543,16 @@ export class AgentsView extends LitElement {
         width: 18%;
       }
       .col-requests {
-        width: 80px;
+        width: 110px;
       }
       .col-spend {
-        width: 88px;
+        width: 110px;
       }
       .col-last-seen {
-        width: 104px;
+        width: 128px;
       }
       .col-actions {
-        width: 48px;
+        width: 56px;
       }
       .sort-button {
         display: flex;

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -609,9 +609,6 @@ export class AgentsView extends LitElement {
         white-space: nowrap;
       }
       @media (prefers-color-scheme: dark) {
-        .agent-row:hover td {
-          background: var(--sl-color-neutral-100);
-        }
         .status-chip.outline::part(base) {
           color: var(--sl-color-success-400);
           border-color: var(--sl-color-success-600);
@@ -2097,24 +2094,6 @@ export class AgentsView extends LitElement {
     >`;
   }
 
-  private getLifecycleVariant(agent: ManagedAgentSummary): string {
-    if (agent.lifecycle_state === 'decommissioned') return 'danger';
-    if (agent.lifecycle_state === 'suspended') return 'warning';
-    if (agent.activity_status === 'active_now') return 'success';
-    if (agent.activity_status === 'recently_active') return 'primary';
-    if (agent.ended_at) return 'neutral';
-    return 'primary';
-  }
-
-  private getLifecycleLabel(agent: ManagedAgentSummary): string {
-    if (agent.lifecycle_state === 'decommissioned') return 'Decommissioned';
-    if (agent.lifecycle_state === 'suspended') return 'Paused';
-    if (agent.activity_status === 'active_now') return 'Active now';
-    if (agent.activity_status === 'recently_active') return 'Recently active';
-    if (agent.ended_at) return 'Ended';
-    return 'Idle';
-  }
-
   private getOnboardingVariant(agent: ManagedAgentSummary): string {
     if (agent.onboarding_state === 'fully_onboarded') return 'success';
     if (agent.onboarding_state === 'mcp_proxy_only') return 'warning';
@@ -2967,13 +2946,26 @@ export class AgentsView extends LitElement {
 
   private renderAgentIdentityBadges(agent: ManagedAgentSummary) {
     const tags = getVisibleAgentTags(agent.tags);
+    // Same taxonomy as the list rows and the detail header, so an agent never
+    // reads as two different things depending on which view you opened.
+    const status = getAgentStatusChip(agent);
+    // A failed live check is already the status; repeating it as a second
+    // badge just doubles the noise. Throttled and upstream-refused are not
+    // status (the agent may be perfectly healthy), so they still get a badge.
+    const showValidationBadge =
+      this.shouldShowValidationBadge(agent) &&
+      status.label !== 'Live check failed';
     return html`
       <div class="identity-badges">
-        <sl-badge variant="${this.getLifecycleVariant(agent)}" pill>
-          ${this.getLifecycleLabel(agent)}
+        <sl-badge
+          class="status-chip ${status.outline ? 'outline' : ''}"
+          variant="${status.variant}"
+          pill
+        >
+          ${status.label}
         </sl-badge>
         ${
-          this.shouldShowValidationBadge(agent)
+          showValidationBadge
             ? html`<sl-badge
                 class="validation-badge"
                 variant="${this.getLiveValidationVariant(agent)}"

--- a/frontend/src/views/authed/attention-parity.test.ts
+++ b/frontend/src/views/authed/attention-parity.test.ts
@@ -225,8 +225,8 @@ describe('attention count parity', () => {
 
     const pageRows = page.shadowRoot!.querySelectorAll('.attention-row').length;
 
-    // 1 approval + 1 agent + 3 failed flow runs.
-    expect(pageRows).to.equal(5);
+    // 1 approval + 1 agent + 2 flows (three failed runs of two flows).
+    expect(pageRows).to.equal(4);
     expect(heroValue).to.equal(String(pageRows));
     expect(dashboard['attentionItems'].map((item) => item.id)).to.eql(
       page['items'].map((item) => item.id)

--- a/frontend/src/views/authed/attention-parity.test.ts
+++ b/frontend/src/views/authed/attention-parity.test.ts
@@ -29,14 +29,23 @@ describe('attention count parity', () => {
       headers: { 'Content-Type': 'application/json' },
     });
 
-  // Pending for seven weeks and past its expiry: the Overview used to hide it.
+  // The API reports both of these as pending. The first one's expiry has
+  // passed, so nobody can act on it: both views must hide it, and neither may
+  // count it (backend issue #335 tracks flipping those rows to `expired`).
   const pendingApprovals = [
     {
-      id: 'approval-1',
+      id: 'approval-expired',
       tool_name: 'Bash',
       status: 'pending',
       requested_at: ago(49 * 24 * 3600_000),
       expires_at: ago(48 * 24 * 3600_000),
+      managed_agent_name: 'Claude Code',
+    },
+    {
+      id: 'approval-1',
+      tool_name: 'Write',
+      status: 'pending',
+      requested_at: ago(49 * 24 * 3600_000),
       managed_agent_name: 'Claude Code',
     },
   ];
@@ -225,9 +234,13 @@ describe('attention count parity', () => {
 
     const pageRows = page.shadowRoot!.querySelectorAll('.attention-row').length;
 
-    // 1 approval + 1 agent + 2 flows (three failed runs of two flows).
+    // 1 live approval + 1 agent + 2 flows (three failed runs of two flows).
+    // The expired-but-still-pending request is on neither side.
     expect(pageRows).to.equal(4);
     expect(heroValue).to.equal(String(pageRows));
+    expect(page['items'].map((item) => item.id)).to.not.contain(
+      'approval:approval-expired'
+    );
     expect(dashboard['attentionItems'].map((item) => item.id)).to.eql(
       page['items'].map((item) => item.id)
     );

--- a/frontend/src/views/authed/attention-parity.test.ts
+++ b/frontend/src/views/authed/attention-parity.test.ts
@@ -1,0 +1,255 @@
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
+
+import '../../components/view-header.ts';
+import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
+import './attention-view';
+import './dashboard-control-plane-view';
+import type { AttentionView } from './attention-view';
+import type { DashboardView } from './dashboard-control-plane-view';
+
+/**
+ * The Overview hero used to say "3 need attention" while /console/attention
+ * listed nine items, because the two fetched their inputs differently: the
+ * Overview dropped expired approvals and derived flows from its five most
+ * recent executions, and the page asked for 200 agents, which the API rejects
+ * with a 422. The fixture below reproduces all three traps.
+ */
+describe('attention count parity', () => {
+  let fetchStub: sinon.SinonStub;
+  let connectStub: sinon.SinonStub;
+  let subscribeStub: sinon.SinonStub;
+  let agentsRequests: string[] = [];
+
+  const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
+
+  const json = (data: unknown) =>
+    new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  // Pending for seven weeks and past its expiry: the Overview used to hide it.
+  const pendingApprovals = [
+    {
+      id: 'approval-1',
+      tool_name: 'Bash',
+      status: 'pending',
+      requested_at: ago(49 * 24 * 3600_000),
+      expires_at: ago(48 * 24 * 3600_000),
+      managed_agent_name: 'Claude Code',
+    },
+  ];
+
+  const agents = [
+    {
+      id: 'agent-1',
+      display_name: 'Analyst',
+      onboarding_state: 'incomplete',
+      lifecycle_state: 'active',
+      last_seen_at: ago(3600_000),
+    },
+  ];
+
+  const failedExecutions = [
+    {
+      id: 'execution-1',
+      flow_id: 'flow-1',
+      flow_name: 'Pull Request Reviewer',
+      status: 'FAILED',
+      start_time: ago(2 * 24 * 3600_000),
+      end_time: ago(2 * 24 * 3600_000 - 31_000),
+    },
+    {
+      id: 'execution-2',
+      flow_id: 'flow-1',
+      flow_name: 'Pull Request Reviewer',
+      status: 'FAILED',
+      start_time: ago(3 * 24 * 3600_000),
+      end_time: ago(3 * 24 * 3600_000 - 12_000),
+    },
+    {
+      id: 'execution-3',
+      flow_id: 'flow-2',
+      flow_name: 'Merge Request Reviewer',
+      status: 'FAILED',
+      start_time: ago(24 * 3600_000),
+      end_time: ago(24 * 3600_000 - 5_000),
+    },
+  ];
+
+  // What the Overview's own "Recent Flow Executions" card asks for: the ten
+  // most recent runs of any status, which here contain no failures at all.
+  const recentExecutions = [
+    {
+      id: 'execution-9',
+      flow_id: 'flow-1',
+      flow_name: 'Pull Request Reviewer',
+      status: 'SUCCEEDED',
+      start_time: ago(1800_000),
+      end_time: ago(1700_000),
+    },
+  ];
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    agentsRequests = [];
+
+    fetchStub = sinon
+      .stub(window, 'fetch')
+      .callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+
+        if (url.startsWith('/api/v1/agents')) {
+          agentsRequests.push(url);
+          const limit = Number(
+            new URLSearchParams(url.split('?')[1] || '').get('limit') || '20'
+          );
+          // Mirrors the backend: limit is Query(20, ge=1, le=100).
+          if (limit > 100) {
+            return new Response('{"detail":"too large"}', { status: 422 });
+          }
+          return json({ items: agents, total: agents.length });
+        }
+        if (url.startsWith('/api/v1/approval-requests')) {
+          return json(url.includes('status=pending') ? pendingApprovals : []);
+        }
+        if (url.startsWith('/api/v1/flows/executions')) {
+          return json(
+            url.includes('status=FAILED') ? failedExecutions : recentExecutions
+          );
+        }
+        if (url.startsWith('/api/v1/flows')) {
+          return json([]);
+        }
+        if (url.startsWith('/api/v1/runtime-sessions')) {
+          return json({ items: [], total: 0 });
+        }
+        if (url.startsWith('/api/v1/account/gateway-usage/search')) {
+          return json({ items: [] });
+        }
+        if (url.startsWith('/api/v1/account/gateway-usage/summary')) {
+          return json({
+            total_requests: 0,
+            successful_requests: 0,
+            failed_requests: 0,
+            token_usage: {
+              prompt_tokens: 0,
+              completion_tokens: 0,
+              total_tokens: 0,
+            },
+            estimated_cost: 0,
+            requests_by_day: [],
+            usage_by_model: [],
+            usage_by_flow: [],
+            usage_by_session: [],
+          });
+        }
+        if (url.startsWith('/api/v1/budget/policies')) {
+          return json([]);
+        }
+        if (url === '/api/v1/features') {
+          return json({ features: { billing: true } });
+        }
+        if (url.startsWith('/api/v1/audit-logs/grouped')) {
+          return json({ groups: [], total: 0 });
+        }
+        if (url === '/api/v1/auth/users/me') {
+          return json({
+            username: 'tester',
+            email: 'tester@example.com',
+            email_verified: true,
+            is_superuser: false,
+            permissions: null,
+          });
+        }
+        if (url === '/api/v1/issue-count') {
+          return json({ count: 0 });
+        }
+        if (url.startsWith('/api/v1/trackers')) {
+          return json([]);
+        }
+        if (url.startsWith('/api/v1/mcp-servers')) {
+          return json([]);
+        }
+        if (url.startsWith('/api/v1/tools')) {
+          return json([]);
+        }
+        if (url === '/api/v1/auth/api-keys') {
+          return json([]);
+        }
+        if (url === '/api/v1/ai-models') {
+          return json([]);
+        }
+        return json({});
+      });
+
+    connectStub = sinon.stub(unifiedWebSocketManager, 'connect').resolves();
+    subscribeStub = sinon
+      .stub(unifiedWebSocketManager, 'subscribe')
+      .callsFake(() => () => undefined);
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    connectStub.restore();
+    subscribeStub.restore();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('shows the same count on the Overview hero and the Attention page', async () => {
+    const dashboard = (await fixture(
+      html`<dashboard-view></dashboard-view>`
+    )) as DashboardView;
+    await waitUntil(
+      () => !dashboard['loading'] && dashboard['attentionInputs'] !== null,
+      'dashboard did not finish loading'
+    );
+    await dashboard.updateComplete;
+
+    const heroValue = dashboard
+      .shadowRoot!.querySelector('a.tool-count[href="/console/attention"]')!
+      .querySelector('.tool-count-value')!
+      .textContent!.trim();
+
+    const page = (await fixture(
+      html`<attention-view></attention-view>`
+    )) as AttentionView;
+    await waitUntil(
+      () => !page.shadowRoot!.querySelector('sl-spinner'),
+      'attention page did not finish loading'
+    );
+    await page.updateComplete;
+
+    const pageRows = page.shadowRoot!.querySelectorAll('.attention-row').length;
+
+    // 1 approval + 1 agent + 3 failed flow runs.
+    expect(pageRows).to.equal(5);
+    expect(heroValue).to.equal(String(pageRows));
+    expect(dashboard['attentionItems'].map((item) => item.id)).to.eql(
+      page['items'].map((item) => item.id)
+    );
+  });
+
+  it('never asks the agents endpoint for more than it accepts', async () => {
+    const page = (await fixture(
+      html`<attention-view></attention-view>`
+    )) as AttentionView;
+    await waitUntil(
+      () => !page.shadowRoot!.querySelector('sl-spinner'),
+      'attention page did not finish loading'
+    );
+
+    expect(agentsRequests).to.have.length.greaterThan(0);
+    for (const url of agentsRequests) {
+      const limit = Number(
+        new URLSearchParams(url.split('?')[1] || '').get('limit') || '20'
+      );
+      expect(limit, url).to.be.at.most(100);
+    }
+    expect(page.shadowRoot!.querySelector('#agents'), 'agents section').to
+      .exist;
+  });
+});

--- a/frontend/src/views/authed/attention-view.test.ts
+++ b/frontend/src/views/authed/attention-view.test.ts
@@ -1,0 +1,214 @@
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
+
+import '../../components/view-header.ts';
+import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
+import './attention-view';
+import type { AttentionView } from './attention-view';
+
+describe('AttentionView', () => {
+  let fetchStub: sinon.SinonStub;
+  let connectStub: sinon.SinonStub;
+  let subscribeStub: sinon.SinonStub;
+  let approvalsResponse: any[];
+  let executionsResponse: any[];
+  let policiesResponse: any[];
+  let rejectPolicies = false;
+
+  const json = (data: unknown) =>
+    new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    rejectPolicies = false;
+
+    approvalsResponse = [
+      {
+        id: 'approval-1',
+        tool_name: 'refund_order',
+        status: 'pending',
+        requested_at: new Date(Date.now() - 60_000).toISOString(),
+      },
+    ];
+    executionsResponse = [
+      {
+        id: 'execution-1',
+        flow_id: 'flow-1',
+        flow_name: 'Refund Assistant',
+        status: 'FAILED',
+        start_time: new Date(Date.now() - 3_600_000).toISOString(),
+        end_time: new Date(Date.now() - 3_500_000).toISOString(),
+      },
+    ];
+    policiesResponse = [
+      {
+        id: 'budget-global',
+        subject_type: 'global',
+        subject_id: null,
+        model_alias: null,
+        period: 'monthly',
+        hard_limit_usd: 50,
+        soft_limit_usd: 40,
+        current_spend_usd: 55,
+      },
+    ];
+
+    fetchStub = sinon
+      .stub(window, 'fetch')
+      .callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+
+        if (url.startsWith('/api/v1/approval-requests')) {
+          return json(approvalsResponse);
+        }
+        if (url.startsWith('/api/v1/flows/executions')) {
+          return json(executionsResponse);
+        }
+        if (url.startsWith('/api/v1/budget/policies')) {
+          return rejectPolicies
+            ? new Response('{"detail":"forbidden"}', { status: 403 })
+            : json(policiesResponse);
+        }
+        if (url.startsWith('/api/v1/agents')) {
+          return json({ items: [], total: 0 });
+        }
+        if (url.startsWith('/api/v1/runtime-sessions')) {
+          return json({ items: [], total: 0 });
+        }
+        if (url.startsWith('/api/v1/account/gateway-usage/search')) {
+          return json({ items: [] });
+        }
+        if (url.startsWith('/api/v1/account/gateway-usage/summary')) {
+          return json({
+            total_requests: 0,
+            successful_requests: 0,
+            failed_requests: 0,
+            token_usage: {
+              prompt_tokens: 0,
+              completion_tokens: 0,
+              total_tokens: 0,
+            },
+            estimated_cost: 0,
+            requests_by_day: [],
+            usage_by_model: [],
+            usage_by_flow: [],
+            usage_by_session: [],
+          });
+        }
+        if (url === '/api/v1/features') {
+          return json({ features: { billing: true } });
+        }
+        return json({ detail: `Unhandled ${url}` });
+      });
+
+    connectStub = sinon.stub(unifiedWebSocketManager, 'connect').resolves();
+    subscribeStub = sinon
+      .stub(unifiedWebSocketManager, 'subscribe')
+      .callsFake(() => () => undefined);
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    connectStub.restore();
+    subscribeStub.restore();
+    localStorage.clear();
+  });
+
+  const mount = async (): Promise<AttentionView> => {
+    const el = (await fixture(
+      html`<attention-view></attention-view>`
+    )) as AttentionView;
+    await waitUntil(
+      () => !el.shadowRoot!.querySelector('sl-spinner'),
+      'attention view finished loading'
+    );
+    await el.updateComplete;
+    return el;
+  };
+
+  const text = (el: AttentionView) =>
+    el.shadowRoot!.textContent!.replace(/\s+/g, ' ');
+
+  it('groups items into sections with counts and actions', async () => {
+    const el = await mount();
+
+    expect(
+      el.shadowRoot!.querySelector('view-header')!.getAttribute('headerText')
+    ).to.equal('Needs attention');
+    const sections = Array.from(
+      el.shadowRoot!.querySelectorAll('sl-card[id]')
+    ).map((card) => card.id);
+    expect(sections).to.eql(['approvals', 'flows', 'budgets']);
+
+    const approvals = el.shadowRoot!.querySelector('#approvals')!;
+    expect(approvals.textContent).to.contain('refund_order');
+    expect(approvals.querySelector('sl-badge')!.textContent!.trim()).to.equal(
+      '1'
+    );
+    expect(approvals.querySelector('sl-button')!.getAttribute('href')).to.equal(
+      '/console/approval/approval-1'
+    );
+
+    const flows = el.shadowRoot!.querySelector('#flows')!;
+    expect(flows.textContent).to.contain('Refund Assistant');
+
+    const budgets = el.shadowRoot!.querySelector('#budgets')!;
+    expect(budgets.textContent).to.contain('Hard limit reached');
+    expect(
+      budgets.querySelector('.severity-dot')!.classList.contains('critical')
+    ).to.be.true;
+  });
+
+  it('shows a chip per kind, muted when the kind is empty', async () => {
+    const el = await mount();
+    const chips = Array.from(el.shadowRoot!.querySelectorAll('.chip')).map(
+      (chip) => chip.textContent!.trim()
+    );
+    expect(chips).to.eql([
+      '1 approval',
+      '0 agents',
+      '1 flow',
+      '0 models',
+      '1 budget',
+      '0 pricing',
+    ]);
+    const agentsChip = el.shadowRoot!.querySelectorAll('.chip')[1];
+    expect(agentsChip.classList.contains('empty')).to.be.true;
+  });
+
+  it('opens the limits dialog from a budget row', async () => {
+    const el = await mount();
+    const configure = Array.from(
+      el.shadowRoot!.querySelectorAll('#budgets sl-button')
+    ).find((button) => button.textContent!.includes('Configure limits'))!;
+    expect(configure).to.exist;
+
+    (configure as HTMLElement).click();
+    await el.updateComplete;
+
+    expect(
+      el.shadowRoot!.querySelector('budget-limits-dialog')!.hasAttribute('open')
+    ).to.be.true;
+  });
+
+  it('drops a section when its request fails and keeps the rest', async () => {
+    rejectPolicies = true;
+    const el = await mount();
+
+    expect(el.shadowRoot!.querySelector('#budgets')).to.not.exist;
+    expect(el.shadowRoot!.querySelector('#approvals')).to.exist;
+  });
+
+  it('shows an all-clear card when nothing needs attention', async () => {
+    approvalsResponse = [];
+    executionsResponse = [];
+    policiesResponse = [];
+
+    const el = await mount();
+    expect(text(el)).to.contain('Nothing needs you right now.');
+    expect(el.shadowRoot!.querySelector('sl-card[id]')).to.not.exist;
+  });
+});

--- a/frontend/src/views/authed/attention-view.test.ts
+++ b/frontend/src/views/authed/attention-view.test.ts
@@ -162,6 +162,59 @@ describe('AttentionView', () => {
     ).to.be.true;
   });
 
+  it('states how long an approval has been waiting, with the date on hover', async () => {
+    approvalsResponse = [
+      {
+        id: 'approval-1',
+        tool_name: 'Bash',
+        status: 'pending',
+        requested_at: new Date(Date.now() - 49 * 24 * 3600_000).toISOString(),
+        managed_agent_name: 'Claude Code',
+      },
+    ];
+    const el = await mount();
+
+    const detail = el.shadowRoot!.querySelector('#approvals .row-detail')!;
+    expect(detail.textContent!.trim()).to.equal('Claude Code · pending 7w');
+    expect(detail.getAttribute('title')).to.not.be.null;
+  });
+
+  it('shows one row per flow with the failure count', async () => {
+    const start = (daysAgo: number) =>
+      new Date(Date.now() - daysAgo * 24 * 3600_000).toISOString();
+    executionsResponse = [
+      {
+        id: 'execution-1',
+        flow_id: 'flow-1',
+        flow_name: 'Pull Request Reviewer',
+        status: 'FAILED',
+        start_time: start(2),
+        end_time: new Date(
+          Date.now() - 2 * 24 * 3600_000 + 31_000
+        ).toISOString(),
+      },
+      {
+        id: 'execution-2',
+        flow_id: 'flow-1',
+        flow_name: 'Pull Request Reviewer',
+        status: 'FAILED',
+        start_time: start(3),
+      },
+    ];
+    const el = await mount();
+
+    const rows = el.shadowRoot!.querySelectorAll('#flows .attention-row');
+    expect(rows).to.have.length(1);
+    expect(rows[0].textContent).to.contain('2 failed runs in 3d');
+    expect(
+      el.shadowRoot!.querySelector('#flows sl-button')!.getAttribute('href')
+    ).to.equal('/console/flows/executions?flow_id=flow-1&status=FAILED');
+    const flowsChip = Array.from(el.shadowRoot!.querySelectorAll('.chip')).find(
+      (chip) => chip.textContent!.includes('flow')
+    )!;
+    expect(flowsChip.textContent!.trim()).to.equal('1 flow');
+  });
+
   it('shows a chip per kind, muted when the kind is empty', async () => {
     const el = await mount();
     const chips = Array.from(el.shadowRoot!.querySelectorAll('.chip')).map(

--- a/frontend/src/views/authed/attention-view.ts
+++ b/frontend/src/views/authed/attention-view.ts
@@ -1,0 +1,477 @@
+import { css, html, nothing, unsafeCSS } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+import '@shoelace-style/shoelace/dist/components/badge/badge.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/card/card.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
+import '../../components/budget-limits-dialog.ts';
+import '../../components/view-header.ts';
+
+import {
+  AuthedElement,
+  getAccountAgents,
+  getAccountGatewayUsageSearch,
+  getAccountGatewayUsageSummary,
+  getAccountRuntimeSessions,
+  getBudgetPolicies,
+  getFeatures,
+  getFlowExecutions,
+  listApprovalRequests,
+  type BudgetPolicy,
+} from '../../api';
+import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
+import consoleStyles from '../../styles/console-styles.css?inline';
+import type {
+  AccountGatewayUsageSummaryResponse,
+  GatewayUsageSearchResultItem,
+  ManagedAgentSummary,
+  RuntimeSessionSummary,
+} from '../../types';
+import {
+  ATTENTION_KIND_META,
+  ATTENTION_KIND_ORDER,
+  attentionKindChipLabel,
+  deriveAttentionItems,
+  groupAttentionItems,
+  type AttentionApproval,
+  type AttentionFlowExecution,
+  type AttentionItem,
+  type AttentionKind,
+} from '../../utils/attention';
+import { formatRelativeTime } from '../../utils/date';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * One page for everything waiting on a human or degraded right now. The
+ * Overview shows the first five of exactly this list; this view is where the
+ * count in the hero metric leads.
+ */
+@customElement('attention-view')
+export class AttentionView extends AuthedElement {
+  @state() private loading = true;
+  @state() private approvals: AttentionApproval[] = [];
+  @state() private agents: ManagedAgentSummary[] = [];
+  @state() private sessions: RuntimeSessionSummary[] = [];
+  @state() private executions: AttentionFlowExecution[] = [];
+  @state() private gatewayFailures: GatewayUsageSearchResultItem[] = [];
+  @state() private budgetPolicies: BudgetPolicy[] = [];
+  @state() private usageSummary: AccountGatewayUsageSummaryResponse | null =
+    null;
+  @state() private lastUpdatedAt: string | null = null;
+  @state() private billingEnabled = false;
+  @state() private showLimitsDialog = false;
+
+  private unsubscribeRealtime?: () => void;
+  private refreshTimer: number | null = null;
+
+  static styles = [
+    unsafeCSS(consoleStyles),
+    css`
+      :host {
+        display: block;
+      }
+
+      .chip-strip {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sl-spacing-x-small);
+        margin-bottom: var(--sl-spacing-large);
+      }
+
+      .chip {
+        align-items: center;
+        background: var(--sl-color-neutral-0);
+        border: 1px solid var(--sl-color-neutral-200);
+        border-radius: var(--sl-border-radius-pill);
+        color: var(--sl-color-neutral-800);
+        cursor: pointer;
+        display: inline-flex;
+        font-size: var(--sl-font-size-small);
+        font-variant-numeric: tabular-nums;
+        gap: var(--sl-spacing-2x-small);
+        padding: var(--sl-spacing-2x-small) var(--sl-spacing-small);
+      }
+
+      .chip.empty {
+        color: var(--sl-color-neutral-500);
+        cursor: default;
+      }
+
+      .chip sl-icon {
+        color: var(--sl-color-neutral-500);
+      }
+
+      .sections {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-large);
+      }
+
+      .section-title {
+        align-items: center;
+        display: flex;
+        font-weight: 600;
+        gap: var(--sl-spacing-2x-small);
+      }
+
+      .attention-row {
+        align-items: center;
+        display: flex;
+        gap: var(--sl-spacing-small);
+        padding: var(--sl-spacing-x-small) 0;
+      }
+
+      .attention-row + .attention-row {
+        border-top: 1px solid var(--sl-color-neutral-100);
+      }
+
+      .severity-dot {
+        background: var(--sl-color-warning-600);
+        border-radius: 50%;
+        flex-shrink: 0;
+        height: 8px;
+        width: 8px;
+      }
+
+      .severity-dot.critical {
+        background: var(--sl-color-danger-600);
+      }
+
+      .row-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+
+      .row-title {
+        color: var(--sl-color-neutral-900);
+        text-decoration: none;
+      }
+
+      .row-title:hover {
+        text-decoration: underline;
+      }
+
+      .row-detail {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-small);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .row-action {
+        margin-left: auto;
+      }
+
+      .all-clear {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-small);
+        padding: var(--sl-spacing-2x-large);
+        text-align: center;
+      }
+
+      .all-clear sl-icon {
+        color: var(--sl-color-success-600);
+        font-size: 2.5rem;
+      }
+
+      .updated-at {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-small);
+      }
+
+      .loading-container {
+        display: flex;
+        justify-content: center;
+        padding: var(--sl-spacing-2x-large);
+      }
+    `,
+  ];
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    void this.fetchAll();
+    this.connectRealtime();
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.unsubscribeRealtime?.();
+    if (this.refreshTimer !== null) {
+      window.clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  private connectRealtime(): void {
+    const scheduleRefresh = () => this.scheduleRefresh();
+    const unsubscribers = [
+      unifiedWebSocketManager.subscribe('approvals', scheduleRefresh),
+      unifiedWebSocketManager.subscribe('managed_agents', scheduleRefresh),
+      unifiedWebSocketManager.subscribe('flow_executions', scheduleRefresh),
+      unifiedWebSocketManager.subscribe('gateway_activity', scheduleRefresh),
+      unifiedWebSocketManager.subscribe('budget_health', scheduleRefresh),
+    ];
+    this.unsubscribeRealtime = () => {
+      for (const unsubscribe of unsubscribers) {
+        unsubscribe();
+      }
+    };
+    void unifiedWebSocketManager.connect();
+  }
+
+  /** Bursts of websocket events collapse into one refetch. */
+  private scheduleRefresh(): void {
+    if (this.refreshTimer !== null) {
+      window.clearTimeout(this.refreshTimer);
+    }
+    this.refreshTimer = window.setTimeout(() => {
+      this.refreshTimer = null;
+      void this.fetchAll();
+    }, 1500);
+  }
+
+  private async fetchAll(): Promise<void> {
+    const sessionsStart = new Date(Date.now() - 7 * DAY_MS).toISOString();
+    const usageStart = new Date(Date.now() - 30 * DAY_MS).toISOString();
+
+    const [
+      approvals,
+      agents,
+      sessions,
+      executions,
+      failures,
+      policies,
+      summary,
+      features,
+    ] = await Promise.allSettled([
+      listApprovalRequests({ status: 'pending', limit: 100 }),
+      getAccountAgents({ status: 'all', limit: 200 }),
+      getAccountRuntimeSessions({
+        status: 'all',
+        limit: 100,
+        startDate: sessionsStart,
+      }),
+      getFlowExecutions({ status: 'FAILED', limit: 25 }),
+      getAccountGatewayUsageSearch({ limit: 12 }),
+      getBudgetPolicies(),
+      getAccountGatewayUsageSummary({
+        startDate: usageStart,
+        includeBreakdown: false,
+      }),
+      getFeatures(),
+    ]);
+
+    // A rejected call (usually a 403 for a permission this operator lacks)
+    // simply drops its section rather than failing the page.
+    if (approvals.status === 'fulfilled') {
+      this.approvals = (approvals.value || []) as AttentionApproval[];
+    }
+    if (agents.status === 'fulfilled') {
+      this.agents = agents.value.items || [];
+    }
+    if (sessions.status === 'fulfilled') {
+      this.sessions = sessions.value.items || [];
+    }
+    if (executions.status === 'fulfilled') {
+      this.executions = (executions.value || []) as AttentionFlowExecution[];
+    }
+    if (failures.status === 'fulfilled') {
+      this.gatewayFailures = (failures.value.items || []).filter(
+        (item) => item.outcome !== 'success'
+      );
+    }
+    if (policies.status === 'fulfilled') {
+      this.budgetPolicies = policies.value || [];
+    }
+    if (summary.status === 'fulfilled') {
+      this.usageSummary = summary.value;
+    }
+    if (features.status === 'fulfilled') {
+      this.billingEnabled = features.value?.features?.billing === true;
+    }
+
+    this.lastUpdatedAt = new Date().toISOString();
+    this.loading = false;
+  }
+
+  private get items(): AttentionItem[] {
+    return deriveAttentionItems({
+      approvals: this.approvals,
+      agents: this.agents,
+      sessions: this.sessions,
+      executions: this.executions,
+      gatewayFailures: this.gatewayFailures,
+      budgetPolicies: this.budgetPolicies,
+      usageSummary: this.usageSummary,
+    });
+  }
+
+  /** `approval` -> `approvals`, `pricing` -> `pricing`. */
+  private sectionId(kind: AttentionKind): string {
+    return ATTENTION_KIND_META[kind].plural.toLowerCase();
+  }
+
+  private scrollToSection(kind: AttentionKind): void {
+    const section = this.renderRoot.querySelector(`#${this.sectionId(kind)}`);
+    section?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  private renderChipStrip(grouped: Map<AttentionKind, AttentionItem[]>) {
+    return html`
+      <div class="chip-strip">
+        ${ATTENTION_KIND_ORDER.map((kind) => {
+          const count = grouped.get(kind)?.length || 0;
+          return html`
+            <button
+              class="chip ${count === 0 ? 'empty' : ''}"
+              ?disabled=${count === 0}
+              @click=${() => this.scrollToSection(kind)}
+            >
+              <sl-icon name=${ATTENTION_KIND_META[kind].icon}></sl-icon>
+              ${attentionKindChipLabel(kind, count)}
+            </button>
+          `;
+        })}
+      </div>
+    `;
+  }
+
+  private renderAction(item: AttentionItem) {
+    if (item.action?.event === 'configure-limits') {
+      return html`
+        <sl-button
+          class="row-action"
+          size="small"
+          @click=${() => (this.showLimitsDialog = true)}
+        >
+          ${item.action.label}
+        </sl-button>
+      `;
+    }
+    if (item.action?.href) {
+      return html`
+        <sl-button class="row-action" size="small" href=${item.action.href}>
+          ${item.action.label}
+        </sl-button>
+      `;
+    }
+    return html`
+      <sl-button class="row-action" size="small" href=${item.href}>
+        ${item.kind === 'approval' ? 'Review' : 'Open'}
+      </sl-button>
+    `;
+  }
+
+  private renderSection(kind: AttentionKind, items: AttentionItem[]) {
+    if (items.length === 0) {
+      return nothing;
+    }
+    const meta = ATTENTION_KIND_META[kind];
+    return html`
+      <sl-card class="content-card" id=${this.sectionId(kind)}>
+        <div slot="header" class="card-header-with-action">
+          <div class="section-title">
+            <sl-icon name=${meta.icon}></sl-icon>
+            ${meta.plural}
+            <sl-badge variant="neutral" pill>${items.length}</sl-badge>
+          </div>
+        </div>
+        <div class="list">
+          ${repeat(
+            items,
+            (item) => item.id,
+            (item) => html`
+              <div class="attention-row">
+                <span
+                  class="severity-dot ${item.severity}"
+                  aria-hidden="true"
+                ></span>
+                <div class="row-body">
+                  <a class="row-title" href=${item.href}>${item.title}</a>
+                  <span class="row-detail">${item.detail}</span>
+                </div>
+                ${this.renderAction(item)}
+              </div>
+            `
+          )}
+        </div>
+      </sl-card>
+    `;
+  }
+
+  private renderAllClear() {
+    return html`
+      <sl-card class="content-card">
+        <div class="all-clear">
+          <sl-icon name="check-circle"></sl-icon>
+          <div>Nothing needs you right now.</div>
+          <a href="/console">Back to Overview</a>
+        </div>
+      </sl-card>
+    `;
+  }
+
+  render() {
+    const items = this.items;
+    const grouped = groupAttentionItems(items);
+
+    return html`
+      <view-header headerText="Needs attention" width="wide">
+        <div slot="description">
+          Everything waiting on you or degraded right now: approvals, agents,
+          flows, models, and budgets.
+          ${
+            this.lastUpdatedAt
+              ? html`<span class="updated-at"
+                  >Updated ${formatRelativeTime(this.lastUpdatedAt)}</span
+                >`
+              : nothing
+          }
+        </div>
+      </view-header>
+
+      <div class="column-layout wide">
+        <div class="main-column">
+          ${
+            this.loading
+              ? html`<div class="loading-container">
+                  <sl-spinner style="font-size: 2rem;"></sl-spinner>
+                </div>`
+              : html`
+                  ${this.renderChipStrip(grouped)}
+                  <div class="sections">
+                    ${
+                      items.length === 0
+                        ? this.renderAllClear()
+                        : ATTENTION_KIND_ORDER.map((kind) =>
+                            this.renderSection(kind, grouped.get(kind) || [])
+                          )
+                    }
+                  </div>
+                `
+          }
+        </div>
+      </div>
+
+      <budget-limits-dialog
+        ?open=${this.showLimitsDialog}
+        .billingEnabled=${this.billingEnabled}
+        @sl-hide=${() => (this.showLimitsDialog = false)}
+        @budget-policies-changed=${() => void this.fetchAll()}
+      ></budget-limits-dialog>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'attention-view': AttentionView;
+  }
+}

--- a/frontend/src/views/authed/attention-view.ts
+++ b/frontend/src/views/authed/attention-view.ts
@@ -10,18 +10,7 @@ import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '../../components/budget-limits-dialog.ts';
 import '../../components/view-header.ts';
 
-import {
-  AuthedElement,
-  getAccountAgents,
-  getAccountGatewayUsageSearch,
-  getAccountGatewayUsageSummary,
-  getAccountRuntimeSessions,
-  getBudgetPolicies,
-  getFeatures,
-  getFlowExecutions,
-  listApprovalRequests,
-  type BudgetPolicy,
-} from '../../api';
+import { AuthedElement, getFeatures, type BudgetPolicy } from '../../api';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import consoleStyles from '../../styles/console-styles.css?inline';
 import type {
@@ -41,9 +30,8 @@ import {
   type AttentionItem,
   type AttentionKind,
 } from '../../utils/attention';
+import { loadAttentionInputs } from '../../utils/attention-data';
 import { formatRelativeTime } from '../../utils/date';
-
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
  * One page for everything waiting on a human or degraded right now. The
@@ -238,64 +226,21 @@ export class AttentionView extends AuthedElement {
   }
 
   private async fetchAll(): Promise<void> {
-    const sessionsStart = new Date(Date.now() - 7 * DAY_MS).toISOString();
-    const usageStart = new Date(Date.now() - 30 * DAY_MS).toISOString();
-
-    const [
-      approvals,
-      agents,
-      sessions,
-      executions,
-      failures,
-      policies,
-      summary,
-      features,
-    ] = await Promise.allSettled([
-      listApprovalRequests({ status: 'pending', limit: 100 }),
-      getAccountAgents({ status: 'all', limit: 200 }),
-      getAccountRuntimeSessions({
-        status: 'all',
-        limit: 100,
-        startDate: sessionsStart,
-      }),
-      getFlowExecutions({ status: 'FAILED', limit: 25 }),
-      getAccountGatewayUsageSearch({ limit: 12 }),
-      getBudgetPolicies(),
-      getAccountGatewayUsageSummary({
-        startDate: usageStart,
-        includeBreakdown: false,
-      }),
-      getFeatures(),
+    // Exactly the same loader the Overview uses, so the hero count and this
+    // page can never be computed from differently shaped data.
+    const [inputs, features] = await Promise.all([
+      loadAttentionInputs(),
+      getFeatures().catch(() => null),
     ]);
 
-    // A rejected call (usually a 403 for a permission this operator lacks)
-    // simply drops its section rather than failing the page.
-    if (approvals.status === 'fulfilled') {
-      this.approvals = (approvals.value || []) as AttentionApproval[];
-    }
-    if (agents.status === 'fulfilled') {
-      this.agents = agents.value.items || [];
-    }
-    if (sessions.status === 'fulfilled') {
-      this.sessions = sessions.value.items || [];
-    }
-    if (executions.status === 'fulfilled') {
-      this.executions = (executions.value || []) as AttentionFlowExecution[];
-    }
-    if (failures.status === 'fulfilled') {
-      this.gatewayFailures = (failures.value.items || []).filter(
-        (item) => item.outcome !== 'success'
-      );
-    }
-    if (policies.status === 'fulfilled') {
-      this.budgetPolicies = policies.value || [];
-    }
-    if (summary.status === 'fulfilled') {
-      this.usageSummary = summary.value;
-    }
-    if (features.status === 'fulfilled') {
-      this.billingEnabled = features.value?.features?.billing === true;
-    }
+    this.approvals = (inputs.approvals || []) as AttentionApproval[];
+    this.agents = inputs.agents || [];
+    this.sessions = inputs.sessions || [];
+    this.executions = (inputs.executions || []) as AttentionFlowExecution[];
+    this.gatewayFailures = inputs.gatewayFailures || [];
+    this.budgetPolicies = inputs.budgetPolicies || [];
+    this.usageSummary = inputs.usageSummary || null;
+    this.billingEnabled = features?.features?.billing === true;
 
     this.lastUpdatedAt = new Date().toISOString();
     this.loading = false;

--- a/frontend/src/views/authed/attention-view.ts
+++ b/frontend/src/views/authed/attention-view.ts
@@ -31,7 +31,7 @@ import {
   type AttentionKind,
 } from '../../utils/attention';
 import { loadAttentionInputs } from '../../utils/attention-data';
-import { formatRelativeTime } from '../../utils/date';
+import { formatLocalDateTime, formatRelativeTime } from '../../utils/date';
 
 /**
  * One page for everything waiting on a human or degraded right now. The
@@ -340,7 +340,11 @@ export class AttentionView extends AuthedElement {
                 ></span>
                 <div class="row-body">
                   <a class="row-title" href=${item.href}>${item.title}</a>
-                  <span class="row-detail">${item.detail}</span>
+                  <span
+                    class="row-detail"
+                    title=${item.at ? formatLocalDateTime(item.at) : nothing}
+                    >${item.detail}</span
+                  >
                 </div>
                 ${this.renderAction(item)}
               </div>

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -51,8 +51,10 @@ import {
 import {
   ATTENTION_KIND_META,
   deriveAttentionItems,
+  type AttentionInputs,
   type AttentionItem,
 } from '../../utils/attention';
+import { loadAttentionInputs } from '../../utils/attention-data';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import type {
   AccountGatewayUsageSummaryResponse,
@@ -215,6 +217,14 @@ export class DashboardView extends AuthedElement {
   @state() private isAdmin = false;
 
   @state() private budgetPolicies: BudgetPolicy[] = [];
+  /**
+   * Inputs for the hero "need attention" count and the side card, fetched
+   * through the shared loader rather than reusing the cards' own data: the
+   * cards are scoped to what they display (five recent executions, approvals
+   * minus the expired ones), and reusing them made the Overview disagree with
+   * /console/attention.
+   */
+  @state() private attentionInputs: AttentionInputs | null = null;
   @state()
   private approvalStats = {
     total: 0,
@@ -1123,6 +1133,7 @@ export class DashboardView extends AuthedElement {
       this.hasAIModels = data.hasAIModels || false;
       if (data.lastUpdatedAt) this.lastUpdatedAt = data.lastUpdatedAt;
       this.approvalStats = data.approvalStats || this.approvalStats;
+      this.attentionInputs = data.attentionInputs || null;
       this.budgetPolicies = data.budgetPolicies || [];
       this.budgetAgents = data.budgetAgents || [];
 
@@ -1163,6 +1174,7 @@ export class DashboardView extends AuthedElement {
         hasAIModels: this.hasAIModels,
         lastUpdatedAt: this.lastUpdatedAt,
         approvalStats: this.approvalStats,
+        attentionInputs: this.attentionInputs,
         budgetPolicies: this.budgetPolicies,
         budgetAgents: this.budgetAgents,
       };
@@ -1421,6 +1433,7 @@ export class DashboardView extends AuthedElement {
     this.error = null;
 
     const startDateStr = this.getGatewayStartDate();
+    const attentionPromise = this.refreshAttentionInputs();
 
     try {
       // Wave 1 (above-the-fold): gateway metrics, budget, recent executions,
@@ -1526,6 +1539,8 @@ export class DashboardView extends AuthedElement {
         sharedAgents: managedAgents,
         features: featuresRes,
       });
+
+      await attentionPromise;
 
       this.lastUpdatedAt = new Date().toISOString();
       this.loading = false;
@@ -2217,15 +2232,24 @@ export class DashboardView extends AuthedElement {
    * disagree.
    */
   private get attentionItems(): AttentionItem[] {
-    return deriveAttentionItems({
-      approvals: this.pendingApprovals,
-      agents: this.managedAgents,
-      sessions: this.runtimeSessions,
-      executions: this.recentFlowExecutions,
-      gatewayFailures: this.gatewayFailures,
-      budgetPolicies: this.budgetPolicies,
-      usageSummary: this.gatewaySummary,
-    });
+    if (!this.attentionInputs) {
+      return [];
+    }
+    return deriveAttentionItems(this.attentionInputs);
+  }
+
+  /**
+   * Same loader, same parameters as the Attention page. Runs alongside the
+   * dashboard fetch rather than inside it so a slow attention input never
+   * holds up the cards above the fold.
+   */
+  private async refreshAttentionInputs(): Promise<void> {
+    try {
+      this.attentionInputs = await loadAttentionInputs();
+      this.saveDashboardCache();
+    } catch (error) {
+      console.error('Failed to load attention inputs', error);
+    }
   }
 
   private get gatewayRangeLabel(): string {

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -9,10 +9,12 @@ import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/progress-bar/progress-bar.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
+import '@shoelace-style/shoelace/dist/components/skeleton/skeleton.js';
 import '../../components/agent-talk-composer.ts';
 import '../../components/mcp-setup-dialog.ts';
-import '../../components/budget-policy-editor.ts';
-import '../../components/budget-health-card.ts';
+import '../../components/budget-limits-dialog.ts';
+import '../../components/time-range-select.ts';
+import '../../components/usage-card.ts';
 import '../../components/view-header.ts';
 import {
   AuthedElement,
@@ -44,7 +46,13 @@ import { renderAgentIcon } from '../../utils/agent-icons';
 import {
   getAgentSourceLabel,
   renderAgentIdentityBadges,
+  sessionBelongsToAgent,
 } from '../../utils/agent-display';
+import {
+  ATTENTION_KIND_META,
+  deriveAttentionItems,
+  type AttentionItem,
+} from '../../utils/attention';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import type {
   AccountGatewayUsageSummaryResponse,
@@ -122,6 +130,10 @@ interface ApprovalRequest {
   requested_at: string;
   resolved_at?: string | null;
   expires_at?: string | null;
+  summary?: string | null;
+  managed_agent_name?: string | null;
+  flow_name?: string | null;
+  is_question?: boolean;
 }
 
 interface UsageSessionSubject {
@@ -146,15 +158,6 @@ interface DashboardMetric {
   href?: string;
   tone?: 'primary' | 'neutral' | 'success' | 'warning' | 'danger';
 }
-
-type BudgetPolicyUsage = {
-  policy: BudgetPolicy;
-  spend: number;
-  hardLimit: number;
-  softLimit: number;
-  maxLimit: number;
-  percent: number;
-};
 
 @customElement('dashboard-view')
 export class DashboardView extends AuthedElement {
@@ -194,18 +197,7 @@ export class DashboardView extends AuthedElement {
   @state() private totalRuntimeSessionsCount = 0;
   @state() private gatewayTimeRange: 'day' | 'week' | 'month' | 'year' =
     'month';
-  @state() private budgetTimeRange: 'day' | 'week' | 'month' | 'year' = 'month';
-  @state() private budgetSummary: AccountGatewayUsageSummaryResponse | null =
-    null;
   @state() private fetchingBudget = false;
-  @state() private budgetSummariesByPeriod = new Map<
-    string,
-    AccountGatewayUsageSummaryResponse
-  >();
-  @state() private budgetPolicySummaries = new Map<
-    string,
-    AccountGatewayUsageSummaryResponse
-  >();
   @state() private activeAgentsTimeRange: '5m' | '1h' | '1d' | '1w' | '1mo' =
     '1d';
   @state() private fetchingActiveAgents = false;
@@ -215,7 +207,6 @@ export class DashboardView extends AuthedElement {
   @state() private showSetupDialog = false;
   @state() private showBudgetDialog = false;
   @state() private welcomeCardDismissed = false;
-  @state() private gatewayMetricsExpanded = false;
 
   @state() private aiModels: AIModel[] = [];
   @state() private isInviteDialogOpen = false;
@@ -224,7 +215,6 @@ export class DashboardView extends AuthedElement {
   @state() private isAdmin = false;
 
   @state() private budgetPolicies: BudgetPolicy[] = [];
-  @state() private dismissedExecutions: string[] = [];
   @state()
   private approvalStats = {
     total: 0,
@@ -237,16 +227,6 @@ export class DashboardView extends AuthedElement {
   private unsubscribeRealtime?: () => void;
   private refreshTimer: number | null = null;
   private refreshInFlight = false;
-
-  private dismissExecution(id: string) {
-    if (!this.dismissedExecutions.includes(id)) {
-      this.dismissedExecutions = [...this.dismissedExecutions, id];
-      localStorage.setItem(
-        'dashboard_dismissed_executions',
-        JSON.stringify(this.dismissedExecutions)
-      );
-    }
-  }
 
   /** Start time plus, when known, how long the run took or has been going. */
   private executionSecondaryText(exec: FlowExecution): string {
@@ -309,6 +289,79 @@ export class DashboardView extends AuthedElement {
         row-gap: var(--sl-spacing-2x-large);
         align-items: start;
         margin-bottom: var(--sl-spacing-2x-large);
+      }
+      .tool-count-value {
+        font-variant-numeric: tabular-nums;
+      }
+      .updated-at {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-small);
+        font-weight: var(--sl-font-weight-normal);
+      }
+      .capsule-eyebrow {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-x-small);
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .range-note {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-small);
+        font-weight: var(--sl-font-weight-normal);
+        font-variant-numeric: tabular-nums;
+      }
+      .attention-title {
+        align-items: center;
+        display: flex;
+        gap: var(--sl-spacing-2x-small);
+      }
+      .attention-title sl-icon {
+        color: var(--sl-color-warning-600);
+      }
+      .attention-row {
+        align-items: flex-start;
+        display: flex;
+        gap: var(--sl-spacing-x-small);
+      }
+      .severity-dot {
+        border-radius: 50%;
+        flex-shrink: 0;
+        height: 8px;
+        margin-top: 6px;
+        width: 8px;
+        background: var(--sl-color-warning-600);
+      }
+      .severity-dot.critical {
+        background: var(--sl-color-danger-600);
+      }
+      .attention-kind-icon {
+        color: var(--sl-color-neutral-500);
+        flex-shrink: 0;
+        margin-top: 3px;
+      }
+      .attention-main {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .attention-detail {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-x-small);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .attention-more {
+        color: var(--sl-color-primary-600);
+        display: inline-block;
+        font-size: var(--sl-font-size-small);
+        margin-top: var(--sl-spacing-small);
+        text-decoration: none;
+      }
+      .attention-more:hover {
+        text-decoration: underline;
       }
       .budget-track {
         position: relative;
@@ -951,7 +1004,7 @@ export class DashboardView extends AuthedElement {
         }
 
         .metrics-grid {
-          grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+          grid-template-columns: repeat(3, minmax(0, 1fr));
           gap: var(--sl-spacing-medium);
           row-gap: var(--sl-spacing-large);
         }
@@ -1070,16 +1123,8 @@ export class DashboardView extends AuthedElement {
       this.hasAIModels = data.hasAIModels || false;
       if (data.lastUpdatedAt) this.lastUpdatedAt = data.lastUpdatedAt;
       this.approvalStats = data.approvalStats || this.approvalStats;
-      if (data.budgetSummary) this.budgetSummary = data.budgetSummary;
       this.budgetPolicies = data.budgetPolicies || [];
       this.budgetAgents = data.budgetAgents || [];
-
-      if (data.budgetSummariesByPeriod) {
-        this.budgetSummariesByPeriod = new Map(data.budgetSummariesByPeriod);
-      }
-      if (data.budgetPolicySummaries) {
-        this.budgetPolicySummaries = new Map(data.budgetPolicySummaries);
-      }
 
       this.loading = false;
     } catch (e) {
@@ -1118,13 +1163,8 @@ export class DashboardView extends AuthedElement {
         hasAIModels: this.hasAIModels,
         lastUpdatedAt: this.lastUpdatedAt,
         approvalStats: this.approvalStats,
-        budgetSummary: this.budgetSummary,
         budgetPolicies: this.budgetPolicies,
         budgetAgents: this.budgetAgents,
-        budgetSummariesByPeriod: Array.from(
-          this.budgetSummariesByPeriod.entries()
-        ),
-        budgetPolicySummaries: Array.from(this.budgetPolicySummaries.entries()),
       };
       sessionStorage.setItem(key, JSON.stringify(cacheObj));
     } catch (e) {
@@ -1135,22 +1175,6 @@ export class DashboardView extends AuthedElement {
   private loadDismissedState(): void {
     this.welcomeCardDismissed =
       localStorage.getItem('dashboard_welcome_dismissed') === 'true';
-    this.gatewayMetricsExpanded =
-      localStorage.getItem('preloop_dashboard_metrics_expanded') === 'true';
-
-    try {
-      const dismissedExecsRaw = localStorage.getItem(
-        'dashboard_dismissed_executions'
-      );
-      if (dismissedExecsRaw) {
-        const parsed = JSON.parse(dismissedExecsRaw);
-        if (Array.isArray(parsed)) {
-          this.dismissedExecutions = parsed as string[];
-        }
-      }
-    } catch (e) {
-      console.warn('Failed to parse dismissed executions from localStorage', e);
-    }
   }
 
   private dismissWelcomeCard(): void {
@@ -1161,14 +1185,6 @@ export class DashboardView extends AuthedElement {
     if (this.managedAgents.length > 0) {
       localStorage.setItem('dashboard_welcome_dismissed', 'true');
     }
-  }
-
-  private toggleGatewayMetrics(): void {
-    this.gatewayMetricsExpanded = !this.gatewayMetricsExpanded;
-    localStorage.setItem(
-      'preloop_dashboard_metrics_expanded',
-      String(this.gatewayMetricsExpanded)
-    );
   }
 
   private connectRealtime(): void {
@@ -1324,27 +1340,21 @@ export class DashboardView extends AuthedElement {
     this.budgetPolicies = event.detail.policies;
   }
 
+  /**
+   * Budget policies and the agents that name their subjects. The spend the
+   * Usage card shows comes from the one gateway summary the page already
+   * fetches for `gatewayTimeRange`, plus each policy's period-aligned
+   * `current_spend_usd`, so there is no second summary request.
+   */
   private async fetchBudgetSummary(
     options: {
-      sharedGatewaySummary?: AccountGatewayUsageSummaryResponse | null;
       sharedAgents?: Awaited<ReturnType<typeof getAccountAgents>> | null;
       features?: Awaited<ReturnType<typeof getFeatures>> | null;
     } = {}
   ) {
     this.fetchingBudget = true;
     try {
-      const budgetStartDate = this.getBudgetStartDate(this.budgetTimeRange);
-      const canReuseGatewaySummary =
-        options.sharedGatewaySummary != null &&
-        this.gatewayTimeRange === this.budgetTimeRange;
-
-      const [budgetSummary, budgetAgents, featuresRes] = await Promise.all([
-        canReuseGatewaySummary
-          ? Promise.resolve(options.sharedGatewaySummary!)
-          : getAccountGatewayUsageSummary({
-              startDate: budgetStartDate,
-              includeBreakdown: false,
-            }).catch(() => null),
+      const [budgetAgents, featuresRes] = await Promise.all([
         options.sharedAgents
           ? Promise.resolve(options.sharedAgents)
           : this.managedAgents.length > 0
@@ -1366,13 +1376,8 @@ export class DashboardView extends AuthedElement {
         ? await getBudgetPolicies().catch(() => [] as BudgetPolicy[])
         : [];
 
-      this.budgetSummary = budgetSummary;
       this.budgetPolicies = Array.isArray(policies) ? policies : [];
       this.budgetAgents = budgetAgents.items || [];
-      // Prefer a single selected-window summary; policy.current_spend_usd
-      // (from getBudgetPolicies) drives per-policy spend in the card.
-      this.budgetSummariesByPeriod = new Map();
-      this.budgetPolicySummaries = new Map();
       this.saveDashboardCache();
     } finally {
       this.fetchingBudget = false;
@@ -1457,7 +1462,10 @@ export class DashboardView extends AuthedElement {
           getFlowExecutions({ limit: 10 }),
           [] as FlowExecution[]
         ),
-        this.catchWith403Handling(this.fetchApprovalRequests('pending', 3), []),
+        this.catchWith403Handling(
+          this.fetchApprovalRequests('pending', 100),
+          []
+        ),
         this.catchWith403Handling(
           this.fetchApprovalRequests(undefined, 100),
           []
@@ -1515,7 +1523,6 @@ export class DashboardView extends AuthedElement {
       this.fetchingActiveAgents = false;
 
       await this.fetchBudgetSummary({
-        sharedGatewaySummary: gatewaySummary,
         sharedAgents: managedAgents,
         features: featuresRes,
       });
@@ -1670,18 +1677,6 @@ export class DashboardView extends AuthedElement {
         return;
       }
       this.gatewaySummary = detailed;
-      if (
-        this.gatewayTimeRange === this.budgetTimeRange &&
-        this.budgetSummary
-      ) {
-        this.budgetSummary = {
-          ...this.budgetSummary,
-          usage_by_model: detailed.usage_by_model,
-          usage_by_flow: detailed.usage_by_flow,
-          usage_by_session: detailed.usage_by_session,
-          requests_by_day: detailed.requests_by_day,
-        };
-      }
     } catch (error) {
       console.error('Failed to load gateway breakdown for top models', error);
     }
@@ -1794,49 +1789,6 @@ export class DashboardView extends AuthedElement {
       });
   }
 
-  private getBudgetStartDate(range: 'day' | 'week' | 'month' | 'year'): string {
-    const now = new Date();
-    const start = new Date(now);
-    if (range === 'day') {
-      start.setDate(start.getDate() - 1);
-    } else if (range === 'week') {
-      start.setDate(start.getDate() - 7);
-    } else if (range === 'month') {
-      start.setMonth(start.getMonth() - 1);
-    } else if (range === 'year') {
-      start.setFullYear(start.getFullYear() - 1);
-    }
-    return start.toISOString();
-  }
-
-  private getBudgetPolicyStartDate(period: string): string | undefined {
-    const now = new Date();
-    const start = new Date(now);
-    if (period === 'hourly') {
-      start.setHours(start.getHours() - 1);
-    } else if (period === 'daily') {
-      start.setDate(start.getDate() - 1);
-    } else if (period === 'weekly') {
-      start.setDate(start.getDate() - 7);
-    } else if (period === 'monthly') {
-      start.setMonth(start.getMonth() - 1);
-    } else if (period === 'yearly') {
-      start.setFullYear(start.getFullYear() - 1);
-    } else {
-      return undefined;
-    }
-    return start.toISOString();
-  }
-
-  private timeRangeToBudgetPeriod(
-    range: 'day' | 'week' | 'month' | 'year'
-  ): string {
-    if (range === 'day') return 'daily';
-    if (range === 'week') return 'weekly';
-    if (range === 'year') return 'yearly';
-    return 'monthly';
-  }
-
   private get gatewayFailures(): GatewayUsageSearchResultItem[] {
     return this.gatewayInteractions.filter(
       (item) => item.outcome !== 'success'
@@ -1845,9 +1797,7 @@ export class DashboardView extends AuthedElement {
 
   private get failedFlowExecutions(): FlowExecution[] {
     return this.recentFlowExecutions.filter(
-      (execution) =>
-        execution.status === 'FAILED' &&
-        !this.dismissedExecutions.includes(execution.id)
+      (execution) => execution.status === 'FAILED'
     );
   }
 
@@ -1857,13 +1807,6 @@ export class DashboardView extends AuthedElement {
 
   private formatNumber(value: number | null | undefined): string {
     return Intl.NumberFormat().format(value || 0);
-  }
-
-  private formatPercent(numerator: number, denominator: number): string {
-    if (denominator <= 0) {
-      return '0%';
-    }
-    return `${((numerator / denominator) * 100).toFixed(1)}%`;
   }
 
   private formatDateTime(value: string | null | undefined): string {
@@ -2268,6 +2211,30 @@ export class DashboardView extends AuthedElement {
     }
   }
 
+  /**
+   * The same derivation the Attention page uses, over data this view already
+   * fetches, so the hero count, the side card and /console/attention can never
+   * disagree.
+   */
+  private get attentionItems(): AttentionItem[] {
+    return deriveAttentionItems({
+      approvals: this.pendingApprovals,
+      agents: this.managedAgents,
+      sessions: this.runtimeSessions,
+      executions: this.recentFlowExecutions,
+      gatewayFailures: this.gatewayFailures,
+      budgetPolicies: this.budgetPolicies,
+      usageSummary: this.gatewaySummary,
+    });
+  }
+
+  private get gatewayRangeLabel(): string {
+    if (this.gatewayTimeRange === 'day') return '24h';
+    if (this.gatewayTimeRange === 'week') return '7d';
+    if (this.gatewayTimeRange === 'year') return '1y';
+    return '30d';
+  }
+
   private get enabledToolsCount(): number {
     return this.tools.filter((tool) => tool.is_enabled).length;
   }
@@ -2279,315 +2246,6 @@ export class DashboardView extends AuthedElement {
         agent.activity_status === 'active_now' ||
         agent.activity_status === 'recently_active'
     ).length;
-  }
-
-  private get inactiveAgentsCount(): number {
-    return Math.max(0, this.totalAgentsCount - this.activeAgentsCount);
-  }
-
-  private get flowExecutionSuccessRate(): string {
-    return this.formatPercent(
-      this.succeededFlowExecutionsCount,
-      this.flowExecutionsCount
-    );
-  }
-
-  private get modelRequestSuccessRate(): string {
-    return this.formatPercent(
-      this.gatewaySummary?.successful_requests || 0,
-      this.gatewaySummary?.total_requests || 0
-    );
-  }
-
-  private get toolCallSuccessRate(): string {
-    return this.formatPercent(
-      this.toolCallsCount - this.failedToolCallsCount,
-      this.toolCallsCount
-    );
-  }
-
-  private get approvalRate(): string {
-    const decidedApprovals =
-      this.approvalStats.approved +
-      this.approvalStats.declined +
-      this.approvalStats.expired;
-    return this.formatPercent(this.approvalStats.approved, decidedApprovals);
-  }
-
-  private getGlobalPolicyUsage() {
-    return this.calculatePolicyUsages().find(
-      (u) =>
-        u.policy.subject_type === 'global' ||
-        u.policy.subject_type === 'account'
-    );
-  }
-
-  private getSelectedGlobalPolicyUsage(): BudgetPolicyUsage | undefined {
-    const selectedPeriod = this.timeRangeToBudgetPeriod(this.budgetTimeRange);
-    return this.calculatePolicyUsages().find(
-      (u) =>
-        (u.policy.subject_type === 'global' ||
-          u.policy.subject_type === 'account') &&
-        u.policy.period === selectedPeriod
-    );
-  }
-
-  private budgetVariant() {
-    const globalUsage =
-      this.getSelectedGlobalPolicyUsage() || this.getGlobalPolicyUsage();
-    if (globalUsage && globalUsage.maxLimit > 0) {
-      if (globalUsage.percent >= 100) return 'danger';
-      if (globalUsage.percent >= 80) return 'warning';
-      return 'success';
-    }
-
-    const budget = this.budgetSummary?.budget;
-    if (!budget) {
-      return 'neutral';
-    }
-    if (budget.hard_limit_exceeded) {
-      return 'danger';
-    }
-    if (budget.soft_limit_exceeded) {
-      return 'warning';
-    }
-    return 'success';
-  }
-
-  private budgetPercent(): number {
-    const globalUsage =
-      this.getSelectedGlobalPolicyUsage() || this.getGlobalPolicyUsage();
-    if (globalUsage && globalUsage.maxLimit > 0) {
-      return globalUsage.percent;
-    }
-
-    const budget = this.budgetSummary?.budget;
-    const limit = budget?.monthly_limit_usd || budget?.soft_limit_usd || 0;
-    if (!limit) {
-      return 0;
-    }
-    return Math.min(
-      100,
-      Math.round(((budget?.current_spend_usd || 0) / limit) * 100)
-    );
-  }
-
-  private calculatePolicyUsages(): BudgetPolicyUsage[] {
-    if (!this.budgetPolicies) return [];
-
-    return this.budgetPolicies
-      .map((policy) => {
-        const summary =
-          this.budgetPolicySummaries.get(policy.id) ||
-          this.budgetSummariesByPeriod.get(policy.period) ||
-          this.budgetSummary;
-        let spend = 0;
-        if (!summary) {
-          spend = 0;
-        } else if (
-          policy.subject_type === 'global' ||
-          policy.subject_type === 'account'
-        ) {
-          spend =
-            summary.budget?.current_spend_usd || summary.estimated_cost || 0;
-        } else if (policy.subject_type === 'ai_model') {
-          spend = summary.usage_by_model
-            .filter((m) => m.ai_model_id === policy.subject_id)
-            .reduce((acc, m) => acc + m.estimated_cost, 0);
-        } else if (policy.subject_type === 'managed_agent') {
-          const agent = this.getManagedAgentBySourceId(policy.subject_id);
-          const agentIds = new Set(
-            [policy.subject_id, agent?.id, agent?.session_source_id].filter(
-              Boolean
-            ) as string[]
-          );
-          if (this.budgetPolicySummaries.has(policy.id)) {
-            spend =
-              summary.estimated_cost || summary.budget?.current_spend_usd || 0;
-          } else {
-            spend = summary.usage_by_session
-              .filter(
-                (s) =>
-                  agentIds.has(s.session_source_id || '') ||
-                  agentIds.has(s.runtime_principal_id || '')
-              )
-              .reduce((acc, s) => acc + s.estimated_cost, 0);
-          }
-        } else if (policy.subject_type === 'flow') {
-          spend = summary.usage_by_flow
-            .filter((flow) => flow.flow_id === policy.subject_id)
-            .reduce((acc, flow) => acc + flow.estimated_cost, 0);
-        } else if (policy.subject_type === 'api_key') {
-          spend = summary.usage_by_session
-            .filter(
-              (session) =>
-                session.session_source_id === policy.subject_id ||
-                session.runtime_principal_id === policy.subject_id
-            )
-            .reduce((acc, session) => acc + session.estimated_cost, 0);
-        }
-
-        const hardLimit = policy.hard_limit_usd || 0;
-        const softLimit = policy.soft_limit_usd || 0;
-        const maxLimit = hardLimit || softLimit;
-        const percent =
-          maxLimit > 0
-            ? Math.min(100, Math.round((spend / maxLimit) * 100))
-            : 0;
-
-        return { policy, spend, hardLimit, softLimit, maxLimit, percent };
-      })
-      .sort((a, b) => {
-        const aGlobal =
-          a.policy.subject_type === 'global' ||
-          a.policy.subject_type === 'account';
-        const bGlobal =
-          b.policy.subject_type === 'global' ||
-          b.policy.subject_type === 'account';
-        if (aGlobal !== bGlobal) return aGlobal ? -1 : 1;
-        return b.percent - a.percent;
-      });
-  }
-
-  private getBudgetPolicyDisplayName(policy: BudgetPolicy): string {
-    const period = this.formatBudgetPeriod(policy.period);
-    if (policy.subject_type === 'global' || policy.subject_type === 'account') {
-      return `Global · ${period}`;
-    }
-    if (policy.subject_type === 'managed_agent') {
-      const agentName =
-        this.getManagedAgentBySourceId(policy.subject_id)?.display_name ||
-        'Managed agent';
-      return `${agentName} · ${period}`;
-    }
-    if (policy.subject_type === 'ai_model') {
-      return `${policy.model_alias || 'Model'} · ${period}`;
-    }
-    return `${policy.subject_type.replace(/_/g, ' ')} · ${period}`;
-  }
-
-  private formatBudgetPeriod(period: string): string {
-    if (period === 'hourly') return '1h';
-    if (period === 'daily') return '24h';
-    if (period === 'weekly') return '7d';
-    if (period === 'monthly') return '30d';
-    if (period === 'yearly') return '1y';
-    if (period === 'all_time') return 'all time';
-    return period;
-  }
-
-  private getBudgetPolicyIcon(policy: BudgetPolicy): string {
-    if (policy.subject_type === 'global' || policy.subject_type === 'account') {
-      return 'globe';
-    }
-    if (policy.subject_type === 'managed_agent') {
-      return 'robot';
-    }
-    if (policy.subject_type === 'ai_model') {
-      return 'cpu';
-    }
-    return 'sliders';
-  }
-
-  private renderBudgetLimitRow(
-    label: string,
-    icon: string,
-    spend: number,
-    softLimit: number,
-    hardLimit: number
-  ) {
-    const maxLimit = hardLimit || softLimit;
-    const fillPercent =
-      maxLimit > 0 ? Math.min(100, (spend / maxLimit) * 100) : 0;
-    const softPercent =
-      softLimit > 0 && maxLimit > 0
-        ? Math.min(100, (softLimit / maxLimit) * 100)
-        : 0;
-    const successFillPercent =
-      softLimit > 0 ? Math.min(fillPercent, softPercent) : fillPercent;
-    const warningFillPercent =
-      softLimit > 0 && fillPercent > softPercent
-        ? fillPercent - softPercent
-        : 0;
-    return html`
-      <div style="display: flex; flex-direction: column; gap: 4px;">
-        <div
-          style="display: flex; justify-content: space-between; font-size: var(--sl-font-size-small); align-items: center; gap: var(--sl-spacing-small);"
-        >
-          <span style="display: flex; align-items: center; gap: 4px;">
-            <sl-icon name=${icon}></sl-icon>
-            ${label}
-          </span>
-          <span style="font-weight: 500; text-align: right;">
-            ${this.formatCurrency(spend)}
-            ${
-              maxLimit > 0
-                ? html` / ${this.formatCurrency(maxLimit)}`
-                : html`<span
-                    style="color: var(--sl-color-neutral-500); font-weight: 400;"
-                  >
-                    spent</span
-                  >`
-            }
-          </span>
-        </div>
-        ${
-          maxLimit > 0
-            ? html`
-                <div class="budget-track">
-                  <div
-                    class="budget-track-fill success"
-                    style="--budget-fill-width: ${successFillPercent}%;"
-                  ></div>
-                  ${
-                    warningFillPercent > 0
-                      ? html`<div
-                          class="budget-track-fill warning"
-                          style="--budget-fill-left: ${softPercent}%; --budget-fill-width: ${warningFillPercent}%;"
-                        ></div>`
-                      : nothing
-                  }
-                  ${
-                    softLimit > 0 && hardLimit > 0 && softLimit < hardLimit
-                      ? html`<div
-                          class="budget-soft-marker"
-                          title=${`Soft limit ${this.formatCurrency(softLimit)}`}
-                          style="--budget-soft-position: ${softPercent}%;"
-                        ></div>`
-                      : nothing
-                  }
-                  ${
-                    hardLimit > 0
-                      ? html`<div
-                          class="budget-hard-marker"
-                          title=${`Hard limit ${this.formatCurrency(hardLimit)}`}
-                        ></div>`
-                      : nothing
-                  }
-                </div>
-                <div
-                  style="display: flex; justify-content: space-between; gap: var(--sl-spacing-small); color: var(--sl-color-neutral-500); font-size: var(--sl-font-size-x-small);"
-                >
-                  <span>
-                    ${
-                      softLimit > 0
-                        ? html`Soft ${this.formatCurrency(softLimit)}`
-                        : nothing
-                    }
-                  </span>
-                  <span>
-                    ${
-                      hardLimit > 0
-                        ? html`Hard ${this.formatCurrency(hardLimit)}`
-                        : nothing
-                    }
-                  </span>
-                </div>
-              `
-            : nothing
-        }
-      </div>
-    `;
   }
 
   private getManagedAgentBySourceId(
@@ -2817,63 +2475,47 @@ export class DashboardView extends AuthedElement {
               `
             : html`
                 <div class="item-list">
-                  ${this.recentFlowExecutions
-                    .filter(
-                      (exec) => !this.dismissedExecutions.includes(exec.id)
-                    )
-                    .slice(0, 5)
-                    .map(
-                      (exec) => html`
-                        <div
-                          class="item-card ${
-                            exec.status === 'FAILED' ? 'failed-execution' : ''
-                          }"
-                        >
-                          <div class="item-info">
-                            <span class="item-name"
-                              >${exec.flow_name || 'Unnamed Flow'}</span
-                            >
-                            ${
-                              exec.error_message
-                                ? html`<span
-                                    class="item-error"
-                                    title=${exec.error_message}
-                                    >${exec.error_message}</span
-                                  >`
-                                : ''
-                            }
-                            <span class="item-secondary"
-                              >${this.executionSecondaryText(exec)}</span
-                            >
-                          </div>
-                          <div class="item-actions">
-                            <sl-tag
-                              size="small"
-                              variant="${this.getStatusColor(exec.status)}"
-                            >
-                              ${exec.status}
-                            </sl-tag>
-                            <sl-button
-                              size="small"
-                              href="/console/flows/executions/${exec.id}"
-                            >
-                              View
-                            </sl-button>
-                            <sl-icon-button
-                              class="item-dismiss"
-                              name="x-lg"
-                              label="Dismiss execution ${
-                                exec.flow_name || 'Unnamed Flow'
-                              }"
-                              @click=${(e: Event) => {
-                                e.preventDefault();
-                                this.dismissExecution(exec.id);
-                              }}
-                            ></sl-icon-button>
-                          </div>
+                  ${this.recentFlowExecutions.slice(0, 5).map(
+                    (exec) => html`
+                      <div
+                        class="item-card ${
+                          exec.status === 'FAILED' ? 'failed-execution' : ''
+                        }"
+                      >
+                        <div class="item-info">
+                          <span class="item-name"
+                            >${exec.flow_name || 'Unnamed Flow'}</span
+                          >
+                          ${
+                            exec.error_message
+                              ? html`<span
+                                  class="item-error"
+                                  title=${exec.error_message}
+                                  >${exec.error_message}</span
+                                >`
+                              : ''
+                          }
+                          <span class="item-secondary"
+                            >${this.executionSecondaryText(exec)}</span
+                          >
                         </div>
-                      `
-                    )}
+                        <div class="item-actions">
+                          <sl-tag
+                            size="small"
+                            variant="${this.getStatusColor(exec.status)}"
+                          >
+                            ${exec.status}
+                          </sl-tag>
+                          <sl-button
+                            size="small"
+                            href="/console/flows/executions/${exec.id}"
+                          >
+                            View
+                          </sl-button>
+                        </div>
+                      </div>
+                    `
+                  )}
                 </div>
 
                 <div class="quick-actions">
@@ -2891,81 +2533,23 @@ export class DashboardView extends AuthedElement {
       </sl-card>
     `;
   }
-  private renderBudgetHealthCard() {
+  private renderUsageCard() {
     return html`
-      <budget-health-card
-        .summary=${this.budgetSummary}
+      <usage-card
+        .summary=${this.gatewaySummary}
         .policies=${this.budgetPolicies}
-        .agents=${this.managedAgents.length > 0 ? this.managedAgents : this.budgetAgents}
-        .loading=${this.fetchingBudget}
-        .timeRange=${this.budgetTimeRange}
-        .showRangeSelector=${true}
-        configurable
+        .loading=${this.fetchingGatewaySummary || this.fetchingBudget}
+        .error=${this.error}
+        .timeRange=${this.gatewayTimeRange}
+        .toolCallsCount=${this.toolCallsCount}
         @range-change=${(event: CustomEvent<{ value: string }>) => {
-          this.budgetTimeRange = event.detail.value as any;
-          this.fetchBudgetSummary();
+          event.stopPropagation();
+          this.gatewayTimeRange = event.detail.value as
+            'day' | 'week' | 'month' | 'year';
+          void this.fetchDashboardData({ preserveLoadingState: true });
         }}
-        @configure=${() => (this.showBudgetDialog = true)}
-      ></budget-health-card>
-    `;
-  }
-
-  private renderBudgetHealthContent() {
-    const policyUsages = this.calculatePolicyUsages();
-    const selectedPeriod = this.timeRangeToBudgetPeriod(this.budgetTimeRange);
-    const selectedGlobalUsage = policyUsages.find(
-      (usage) =>
-        (usage.policy.subject_type === 'global' ||
-          usage.policy.subject_type === 'account') &&
-        usage.policy.period === selectedPeriod
-    );
-    const additionalUsages = selectedGlobalUsage
-      ? policyUsages.filter(
-          (usage) => usage.policy.id !== selectedGlobalUsage.policy.id
-        )
-      : policyUsages;
-    const globalSpend = this.budgetSummary?.budget?.current_spend_usd || 0;
-
-    return html`
-      <div
-        style="display: flex; flex-direction: column; gap: var(--sl-spacing-medium);"
-      >
-        <div
-          style="display: flex; flex-direction: column; gap: var(--sl-spacing-small);"
-        >
-          ${this.renderBudgetLimitRow(
-            `Global spend · ${this.formatBudgetPeriod(selectedPeriod)}`,
-            'globe',
-            globalSpend,
-            selectedGlobalUsage?.softLimit ||
-              this.budgetSummary?.budget?.soft_limit_usd ||
-              0,
-            selectedGlobalUsage?.hardLimit ||
-              this.budgetSummary?.budget?.monthly_limit_usd ||
-              0
-          )}
-          ${additionalUsages.map((usage) =>
-            this.renderBudgetLimitRow(
-              this.getBudgetPolicyDisplayName(usage.policy),
-              this.getBudgetPolicyIcon(usage.policy),
-              usage.spend,
-              usage.softLimit,
-              usage.hardLimit
-            )
-          )}
-        </div>
-        <div style="margin-top: var(--sl-spacing-small);">
-          <sl-button
-            size="small"
-            variant="default"
-            @click=${() => (this.showBudgetDialog = true)}
-            style="width: 100%;"
-          >
-            <sl-icon slot="prefix" name="gear"></sl-icon>
-            Configure Limits
-          </sl-button>
-        </div>
-      </div>
+        @configure-limits=${() => (this.showBudgetDialog = true)}
+      ></usage-card>
     `;
   }
 
@@ -3202,10 +2786,38 @@ export class DashboardView extends AuthedElement {
     );
   }
 
+  private renderTopModelsSkeleton() {
+    return html`
+      <sl-card class="content-card">
+        <div slot="header" class="card-header-with-action">
+          <div class="card-title">Top Models</div>
+        </div>
+        <div class="list">
+          ${[0, 1, 2, 3].map(
+            () => html`
+              <div class="row">
+                <sl-skeleton
+                  effect="sheen"
+                  style="width: 60%; height: 0.9rem;"
+                ></sl-skeleton>
+                <sl-skeleton
+                  effect="sheen"
+                  style="width: 35%; height: 0.75rem; margin-top: var(--sl-spacing-2x-small);"
+                ></sl-skeleton>
+              </div>
+            `
+          )}
+        </div>
+      </sl-card>
+    `;
+  }
+
   private renderTopModelsCard() {
     const rawModels = this.gatewaySummary?.usage_by_model || [];
     if (rawModels.length === 0) {
-      return nothing;
+      return this.fetchingGatewaySummary
+        ? this.renderTopModelsSkeleton()
+        : nothing;
     }
 
     const aggregatedModels = new Map<string, any>();
@@ -3248,6 +2860,7 @@ export class DashboardView extends AuthedElement {
               <option value="spend">by Spend</option>
               <option value="usage">by Usage</option>
             </select>
+            <span class="range-note">· ${this.gatewayRangeLabel}</span>
           </div>
           <div
             style="display: flex; gap: var(--sl-spacing-small); align-items: center;"
@@ -3559,21 +3172,24 @@ export class DashboardView extends AuthedElement {
                 : ''
             }
           </div>
-          <select
-            style="background: transparent; border: none; font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-600); cursor: pointer; outline: none; margin-left: auto; margin-right: var(--sl-spacing-small);"
+          <time-range-select
+            style="margin-left: auto; margin-right: var(--sl-spacing-small);"
+            ariaLabel="Active agents time range"
             .value=${this.activeAgentsTimeRange}
-            @change=${(e: Event) => {
-              this.activeAgentsTimeRange = (e.target as HTMLSelectElement)
-                .value as any;
+            .options=${[
+              { value: '5m', label: '5m' },
+              { value: '1h', label: '1h' },
+              { value: '1d', label: '1d' },
+              { value: '1w', label: '1w' },
+              { value: '1mo', label: '1mo' },
+            ]}
+            @range-change=${(event: CustomEvent<{ value: string }>) => {
+              event.stopPropagation();
+              this.activeAgentsTimeRange = event.detail.value as
+                '5m' | '1h' | '1d' | '1w' | '1mo';
               this.fetchActiveAgentsData();
             }}
-          >
-            <option value="5m">5m</option>
-            <option value="1h">1h</option>
-            <option value="1d">1d</option>
-            <option value="1w">1w</option>
-            <option value="1mo">1mo</option>
-          </select>
+          ></time-range-select>
           <div
             style="display: flex; gap: var(--sl-spacing-small); align-items: center;"
           >
@@ -3680,40 +3296,56 @@ export class DashboardView extends AuthedElement {
     `;
   }
 
-  private renderPendingApprovalsCard() {
-    if (this.pendingApprovals.length === 0) {
+  private renderAttentionCard() {
+    const items = this.attentionItems;
+    if (items.length === 0) {
       return nothing;
     }
+    const visible = items.slice(0, 5);
+    const overflow = items.length - visible.length;
 
     return html`
       <sl-card class="content-card">
         <div slot="header" class="card-header-with-action">
-          Pending approvals
-          <sl-badge variant="warning">${this.pendingApprovals.length}</sl-badge>
+          <div class="card-title attention-title">
+            <sl-icon name="exclamation-triangle"></sl-icon>
+            Needs attention
+            <sl-badge variant="warning" pill>${items.length}</sl-badge>
+          </div>
+          <a href="/console/attention" class="header-action-link">View all</a>
         </div>
         <div class="list">
           ${repeat(
-            this.pendingApprovals,
-            (approval) => approval.id,
-            (approval) => html`
-              <div class="row">
-                <div class="row-main">
-                  <span class="row-primary">${approval.tool_name}</span>
-                  <sl-button
-                    size="small"
-                    href=${`/console/approval/${approval.id}`}
+            visible,
+            (item) => item.id,
+            (item) => html`
+              <div class="row attention-row">
+                <span
+                  class="severity-dot ${item.severity}"
+                  aria-hidden="true"
+                ></span>
+                <sl-icon
+                  class="attention-kind-icon"
+                  name=${ATTENTION_KIND_META[item.kind].icon}
+                  aria-hidden="true"
+                ></sl-icon>
+                <div class="attention-main">
+                  <a class="row-link row-primary" href=${item.href}
+                    >${item.title}</a
                   >
-                    Review
-                  </sl-button>
-                </div>
-                <div class="row-meta">
-                  <span>${approval.status}</span>
-                  <span>${this.formatRelativeTime(approval.requested_at)}</span>
+                  <span class="attention-detail">${item.detail}</span>
                 </div>
               </div>
             `
           )}
         </div>
+        ${
+          overflow > 0
+            ? html`<a class="attention-more" href="/console/attention"
+                >and ${overflow} more</a
+              >`
+            : nothing
+        }
       </sl-card>
     `;
   }
@@ -3762,6 +3394,7 @@ export class DashboardView extends AuthedElement {
   }
 
   private get gatewayMetrics(): DashboardMetric[] {
+    const attentionCount = this.attentionItems.length;
     return [
       {
         label: 'agents',
@@ -3792,127 +3425,16 @@ export class DashboardView extends AuthedElement {
         tone: 'primary',
       },
       {
-        label: 'approved requests',
-        value: this.formatNumber(this.approvalStats.approved),
-        icon: 'check-circle',
-        href: '/console/approvals?status=approved',
-        tone: 'success',
-      },
-      {
-        label: 'inactive agents',
-        value: this.formatNumber(this.inactiveAgentsCount),
-        icon: 'pause-circle',
-        href: '/console/agents',
-        tone: this.inactiveAgentsCount > 0 ? 'warning' : 'neutral',
-      },
-      {
-        label: 'flow executions',
-        value: this.formatNumber(this.flowExecutionsCount),
-        icon: 'play-circle',
-        href: '/console/flows/executions',
-        tone: 'primary',
-      },
-      {
-        label: 'model requests',
-        value: this.formatNumber(this.gatewaySummary?.total_requests || 0),
-        icon: 'activity',
-        href: '/console/audit?event_type=model_gateway_request',
-        tone: 'primary',
-      },
-      {
-        label: 'tool calls',
-        value: this.formatNumber(this.toolCallsCount),
-        icon: 'terminal',
-        href: '/console/audit?event_type=tool_call',
-        tone: 'primary',
-      },
-      {
-        label: 'declined requests',
-        value: this.formatNumber(this.approvalStats.declined),
-        icon: 'x-circle',
-        href: '/console/approvals?status=declined',
-        tone: this.approvalStats.declined > 0 ? 'danger' : 'neutral',
-      },
-      {
-        label: 'total runtime sessions',
-        value: this.formatNumber(this.totalRuntimeSessionsCount),
-        icon: 'collection',
-        href: '/console/runtime-sessions',
-        tone: 'primary',
-      },
-      {
-        label: 'failed executions',
-        value: this.formatNumber(this.failedExecutionsCount),
-        icon: 'exclamation-triangle',
-        href: '/console/flows/executions',
-        tone: this.failedExecutionsCount > 0 ? 'danger' : 'neutral',
-      },
-      {
-        label: 'failed requests',
-        value: this.formatNumber(this.gatewaySummary?.failed_requests || 0),
-        icon: 'exclamation-triangle',
-        href: '/console/audit?event_type=model_gateway_request&outcome=failed',
-        tone: this.gatewaySummary?.failed_requests ? 'danger' : 'neutral',
-      },
-      {
-        label: 'failed tool calls',
-        value: this.formatNumber(this.failedToolCallsCount),
-        icon: 'exclamation-octagon',
-        href: '/console/audit?event_type=tool_call&outcome=failed',
-        tone: this.failedToolCallsCount > 0 ? 'danger' : 'neutral',
-      },
-      {
-        label: 'timed out approval requests',
-        value: this.formatNumber(this.approvalStats.expired),
-        icon: 'clock',
-        href: '/console/approvals?status=expired',
-        tone: this.approvalStats.expired > 0 ? 'warning' : 'neutral',
-      },
-      {
-        label: 'total tokens',
-        value: this.formatNumber(
-          this.gatewaySummary?.token_usage.total_tokens || 0
-        ),
-        icon: 'braces',
-        href: '/console/api-usage',
-        tone: 'primary',
-      },
-      {
-        label: 'flow execution success rate',
-        value: this.flowExecutionSuccessRate,
-        icon: 'check-circle',
-        href: '/console/flows/executions',
-        tone: 'success',
-      },
-      {
-        label: 'model request success rate',
-        value: this.modelRequestSuccessRate,
-        icon: 'check-circle',
-        href: '/console/audit?event_type=model_gateway_request',
-        tone: 'success',
-      },
-      {
-        label: 'tool call success rate',
-        value: this.toolCallSuccessRate,
-        icon: 'check-circle',
-        href: '/console/audit?event_type=tool_call',
-        tone: 'success',
-      },
-      {
-        label: 'approval rate',
-        value: this.approvalRate,
-        icon: 'shield-check',
-        href: '/console/approvals',
-        tone: 'success',
+        label: 'need attention',
+        value: this.formatNumber(attentionCount),
+        icon: attentionCount > 0 ? 'exclamation-triangle' : 'check-circle',
+        href: '/console/attention',
+        tone: attentionCount > 0 ? 'warning' : 'success',
       },
     ];
   }
 
   private renderPreloopGatewayCard() {
-    const visibleMetrics = this.gatewayMetricsExpanded
-      ? this.gatewayMetrics
-      : this.gatewayMetrics.slice(0, 5);
-
     return html`
       <!-- Preloop Gateway Status -->
       <sl-card class="content-card">
@@ -3930,6 +3452,9 @@ export class DashboardView extends AuthedElement {
             >
               <sl-icon name="question-circle"></sl-icon>
             </sl-tooltip>
+            <span class="updated-at"
+              >Updated ${this.formatLastUpdatedLabel()}</span
+            >
           </div>
           <div
             style="display: flex; gap: var(--sl-spacing-small); align-items: center;"
@@ -3952,41 +3477,20 @@ export class DashboardView extends AuthedElement {
                 `
               : html`
                   <div style="display: contents;">
-                    ${visibleMetrics.map((metric) =>
+                    ${this.gatewayMetrics.map((metric) =>
                       this.renderMetricItem(metric)
                     )}
                   </div>
                 `
           }
         </div>
-        <div
-          style="display: flex; justify-content: center; margin-top: calc(-1 * var(--sl-spacing-medium)); margin-bottom: var(--sl-spacing-medium);"
-        >
-          <sl-button
-            size="small"
-            variant="text"
-            @click=${this.toggleGatewayMetrics}
-          >
-            ${
-              this.gatewayMetricsExpanded
-                ? 'Show less metrics'
-                : 'Show more metrics'
-            }
-            <sl-icon
-              slot="suffix"
-              name=${
-                this.gatewayMetricsExpanded ? 'chevron-up' : 'chevron-down'
-              }
-            ></sl-icon>
-          </sl-button>
-        </div>
-
         <!-- AI Model Gateway Endpoint -->
         <div
           class="mcp-server-capsule"
           style="margin-top: 0; margin-bottom: var(--sl-spacing-small);"
         >
           <div class="status-indicator"></div>
+          <span class="capsule-eyebrow">Model gateway</span>
           <sl-badge variant="primary" size="small" style="margin-right: -4px;"
             >AI models</sl-badge
           >
@@ -4053,6 +3557,7 @@ export class DashboardView extends AuthedElement {
         <!-- Built-in MCP Server Endpoint -->
         <div class="mcp-server-capsule" style="margin-top: 0;">
           <div class="status-indicator"></div>
+          <span class="capsule-eyebrow">Tool firewall</span>
           <sl-badge variant="neutral" size="small" style="margin-right: -4px;"
             >MCP tools</sl-badge
           >
@@ -4106,11 +3611,7 @@ export class DashboardView extends AuthedElement {
     }
 
     return html`
-      <view-header headerText="Overview" width="extra-wide">
-        <div class="updated-at" slot="description">
-          Last updated ${this.formatLastUpdatedLabel()}
-        </div>
-      </view-header>
+      <view-header headerText="Overview" width="extra-wide"></view-header>
       <div class="extra-wide" style="margin-bottom: var(--sl-spacing-large);">
         ${
           this.error
@@ -4137,41 +3638,19 @@ export class DashboardView extends AuthedElement {
         </div>
 
         <div class="side-column">
-          ${this.renderPendingApprovalsCard()} ${this.renderBudgetHealthCard()}
+          ${this.renderAttentionCard()} ${this.renderUsageCard()}
           ${this.renderTopModelsCard()}
         </div>
         <mcp-setup-dialog
           ?open=${this.showSetupDialog}
           @close=${() => (this.showSetupDialog = false)}
         ></mcp-setup-dialog>
-        <sl-dialog
-          label="Configure Budget Limits"
+        <budget-limits-dialog
           ?open=${this.showBudgetDialog}
-          @sl-after-hide=${(e: Event) => {
-            if (e.target === e.currentTarget) {
-              this.showBudgetDialog = false;
-            }
-          }}
-          style="--width: 600px;"
-        >
-          ${
-            this.showBudgetDialog
-              ? html`
-                  <p
-                    style="margin: 0 0 var(--sl-spacing-medium); color: var(--sl-color-neutral-500); font-size: 0.9rem;"
-                  >
-                    Spending limits for the account or individual agents. Soft
-                    limits notify you; hard limits stop further model calls
-                    through the gateway.
-                  </p>
-                  <budget-policy-editor
-                    billingEnabled
-                    @budget-policies-changed=${this.handleBudgetPoliciesChanged}
-                  ></budget-policy-editor>
-                `
-              : nothing
-          }
-        </sl-dialog>
+          billingEnabled
+          @sl-hide=${() => (this.showBudgetDialog = false)}
+          @budget-policies-changed=${this.handleBudgetPoliciesChanged}
+        ></budget-limits-dialog>
         <preloop-invite-dialog
           ?open=${this.isInviteDialogOpen}
           @close=${() => {

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -292,13 +292,16 @@ export class DashboardView extends AuthedElement {
       .hover-underline:hover {
         text-decoration: underline;
       }
+      /* The hero metrics sat in their own screenful of whitespace: a
+         two-x-large row gap and the same margin under them pushed the first
+         card below the fold at 1440x900. */
       .metrics-grid {
         display: grid;
         grid-template-columns: repeat(5, minmax(0, 1fr));
         gap: var(--sl-spacing-large);
-        row-gap: var(--sl-spacing-2x-large);
+        row-gap: var(--sl-spacing-large);
         align-items: start;
-        margin-bottom: var(--sl-spacing-2x-large);
+        margin-bottom: var(--sl-spacing-large);
       }
       .tool-count-value {
         font-variant-numeric: tabular-nums;
@@ -329,16 +332,22 @@ export class DashboardView extends AuthedElement {
       .attention-title sl-icon {
         color: var(--sl-color-warning-600);
       }
-      .attention-row {
-        align-items: flex-start;
+      /* One line per item, about 44px tall, so five items and the Usage card
+         fit above the fold. The shared .row rule below stacks its children,
+         which turned every attention item into three lines: dot, icon, text.
+         The double class beats it without touching the other lists. */
+      .row.attention-row {
+        align-items: center;
         display: flex;
+        flex-direction: row;
         gap: var(--sl-spacing-x-small);
+        min-height: 44px;
+        padding: var(--sl-spacing-x-small) 0;
       }
       .severity-dot {
         border-radius: 50%;
         flex-shrink: 0;
         height: 8px;
-        margin-top: 6px;
         width: 8px;
         background: var(--sl-color-warning-600);
       }
@@ -348,17 +357,27 @@ export class DashboardView extends AuthedElement {
       .attention-kind-icon {
         color: var(--sl-color-neutral-500);
         flex-shrink: 0;
-        margin-top: 3px;
       }
       .attention-main {
+        align-items: baseline;
         display: flex;
-        flex-direction: column;
-        gap: 2px;
+        flex-direction: row;
+        gap: var(--sl-spacing-x-small);
         min-width: 0;
+      }
+      /* The title keeps what it needs, the detail gives way first. */
+      .attention-row .row-primary {
+        flex: 0 1 auto;
+        overflow: hidden;
+        overflow-wrap: normal;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .attention-detail {
         color: var(--sl-color-neutral-500);
+        flex: 1 1 auto;
         font-size: var(--sl-font-size-x-small);
+        min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -582,6 +601,7 @@ export class DashboardView extends AuthedElement {
         min-width: 0;
       }
       .server-endpoint {
+        min-width: 0;
         font-family: monospace;
         font-size: var(--sl-font-size-small);
         color: var(--sl-color-neutral-900);
@@ -610,6 +630,40 @@ export class DashboardView extends AuthedElement {
       }
       .capsule-link:hover {
         text-decoration: underline;
+      }
+      /* "Updated 2m ago" and "Manage Keys" read as one muted line about the
+         card, wherever the header has room for them. */
+      .gateway-header-meta {
+        align-items: center;
+        display: flex;
+        gap: var(--sl-spacing-small);
+        min-width: 0;
+      }
+      /* Phone width: the capsule is a two-row block, not a pill. Row one
+         names the endpoint, row two is the thing you came to copy. Without
+         this the select and the URL pushed the copy button outside the card. */
+      @media (max-width: 640px) {
+        .card-header-with-action {
+          align-items: flex-start;
+          flex-direction: column;
+          gap: var(--sl-spacing-2x-small);
+        }
+        .mcp-server-capsule {
+          border-radius: var(--sl-border-radius-medium);
+          column-gap: var(--sl-spacing-x-small);
+          flex-wrap: wrap;
+          row-gap: var(--sl-spacing-x-small);
+        }
+        .mcp-server-capsule > * {
+          min-width: 0;
+        }
+        /* Leaves room on the same row for the copy button that follows. */
+        .server-details {
+          flex: 1 1 calc(100% - 3rem);
+        }
+        .server-details select {
+          max-width: 8rem;
+        }
       }
       @media (min-width: 1024px) {
         .overview-layout {
@@ -735,10 +789,17 @@ export class DashboardView extends AuthedElement {
         padding: var(--sl-spacing-2x-large);
       }
 
+      /* Overview only: the cards are dense, so a large gap between them read
+         as "unrelated sections" and cost a scroll. */
       .dashboard-stack {
         display: flex;
         flex-direction: column;
-        gap: var(--sl-spacing-large);
+        gap: var(--sl-spacing-medium);
+      }
+
+      .main-column,
+      .side-column {
+        gap: var(--sl-spacing-medium);
       }
 
       .summary-grid,
@@ -969,12 +1030,30 @@ export class DashboardView extends AuthedElement {
         align-items: center;
       }
 
+      /* One centered line in a 72px box. An empty card used to take as much
+         vertical space as a full one, so a quiet account looked like a broken
+         one. */
       .empty-state {
+        align-items: center;
+        background: var(--sl-color-neutral-0);
         border: 1px dashed var(--sl-color-neutral-300);
         border-radius: var(--sl-border-radius-medium);
-        padding: var(--sl-spacing-large);
+        display: flex;
+        gap: var(--sl-spacing-small);
+        justify-content: center;
+        min-height: 72px;
+        padding: var(--sl-spacing-medium);
         text-align: center;
-        background: var(--sl-color-neutral-0);
+      }
+
+      .empty-state sl-icon {
+        color: var(--sl-color-neutral-400);
+        flex-shrink: 0;
+        font-size: 1.25rem;
+      }
+
+      .empty-state p {
+        margin: 0;
       }
 
       /* Failed flows: visible but calm — accent border only, no red wash */
@@ -3476,13 +3555,11 @@ export class DashboardView extends AuthedElement {
             >
               <sl-icon name="question-circle"></sl-icon>
             </sl-tooltip>
+          </div>
+          <div class="gateway-header-meta">
             <span class="updated-at"
               >Updated ${this.formatLastUpdatedLabel()}</span
             >
-          </div>
-          <div
-            style="display: flex; gap: var(--sl-spacing-small); align-items: center;"
-          >
             <a href="/console/settings/api-keys" class="header-action-link"
               >Manage Keys</a
             >
@@ -3653,7 +3730,7 @@ export class DashboardView extends AuthedElement {
             ${this.renderRecentFlowExecutionsCard()}
 
             <div
-              style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--sl-spacing-large); margin-top: var(--sl-spacing-large);"
+              style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--sl-spacing-medium);"
             >
               ${this.renderGatewayFailuresCard()}
               ${this.renderAuditExceptionsCard()}

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -430,7 +430,7 @@ describe('DashboardView', () => {
           return json(flowsResponse);
         }
 
-        if (url === '/api/v1/approval-requests?limit=3&status=pending') {
+        if (url === '/api/v1/approval-requests?limit=100&status=pending') {
           return json(pendingApprovalRequestsResponse);
         }
 
@@ -491,7 +491,7 @@ describe('DashboardView', () => {
       'Recent Flow Executions'
     );
     expect(element.shadowRoot?.textContent).to.contain('Audit exceptions');
-    expect(element.shadowRoot?.textContent).to.contain('Pending approvals');
+    expect(element.shadowRoot?.textContent).to.contain('Needs attention');
   });
 
   it('subscribes to realtime topics and fetches dashboard data', async () => {
@@ -537,7 +537,7 @@ describe('DashboardView', () => {
       .be.true;
 
     const updatedAt = element.shadowRoot?.querySelector('.updated-at');
-    expect(updatedAt?.textContent || '').to.match(/Last updated (just now|\d)/);
+    expect(updatedAt?.textContent || '').to.match(/Updated (just now|\d)/);
     expect(updatedAt?.textContent || '').to.not.contain('Never');
     expect(updatedAt?.textContent || '').to.not.contain('Loading');
 
@@ -548,7 +548,7 @@ describe('DashboardView', () => {
     expect(element.shadowRoot?.querySelector('.item-card.danger')).to.not.exist;
   });
 
-  describe('Recent Flow Executions dismiss control (#174)', () => {
+  describe('Recent Flow Executions failed row (#174)', () => {
     // A real failing run: a git clone error long enough to overflow the row.
     // The URL has no break opportunity, which is what actually broke the
     // layout: it set the min-content width of the flex column.
@@ -582,47 +582,6 @@ describe('DashboardView', () => {
       return element;
     }
 
-    function dismissButtonOf(element: DashboardView) {
-      const row = element.shadowRoot?.querySelector(
-        '.item-card.failed-execution'
-      ) as HTMLElement | null;
-      const button = row?.querySelector(
-        'sl-icon-button.item-dismiss'
-      ) as HTMLElement | null;
-      return { row, button };
-    }
-
-    // The bug: a long error message pushed the action group past the row's
-    // right edge, so the dismiss control could not be clicked.
-    ['520px', '640px', '900px'].forEach((width) => {
-      it(`keeps the dismiss control inside the row at ${width}`, async () => {
-        const element = await mountWithFailedExecution(width);
-        const { row, button } = dismissButtonOf(element);
-
-        expect(row, 'failed execution row').to.exist;
-        expect(button, 'dismiss button').to.exist;
-
-        const rowBox = row!.getBoundingClientRect();
-        const buttonBox = button!.getBoundingClientRect();
-
-        expect(buttonBox.width, 'dismiss button has width').to.be.greaterThan(
-          0
-        );
-        expect(buttonBox.height, 'dismiss button has height').to.be.greaterThan(
-          0
-        );
-        // Allow a 1px rounding tolerance on the border-box edge.
-        expect(
-          buttonBox.right,
-          'dismiss button overflows the row on the right'
-        ).to.be.at.most(rowBox.right + 1);
-        expect(
-          buttonBox.left,
-          'dismiss button starts beyond the row'
-        ).to.be.at.least(rowBox.left - 1);
-      });
-    });
-
     it('does not let the error text overflow the row horizontally', async () => {
       const element = await mountWithFailedExecution('520px');
       const row = element.shadowRoot?.querySelector(
@@ -638,32 +597,16 @@ describe('DashboardView', () => {
       ).to.be.at.most(error.clientWidth + 1);
     });
 
-    it('dismisses the failed execution when the control is clicked', async () => {
+    it('keeps the row after a reload, with no dismiss control', async () => {
       const element = await mountWithFailedExecution('520px');
-      const { button } = dismissButtonOf(element);
 
-      (button as HTMLElement).click();
-      await element.updateComplete;
-
+      expect(element.shadowRoot?.querySelector('sl-icon-button.item-dismiss'))
+        .to.not.exist;
       expect(
         element.shadowRoot?.querySelector('.item-card.failed-execution'),
-        'row remains after dismiss'
-      ).to.not.exist;
-      expect(
-        JSON.parse(
-          localStorage.getItem('dashboard_dismissed_executions') || '[]'
-        )
-      ).to.include('execution-failed');
-    });
-
-    it('exposes an accessible name on the dismiss control', async () => {
-      const element = await mountWithFailedExecution('520px');
-      const { button } = dismissButtonOf(element);
-
-      expect(button?.getAttribute('label')).to.contain('Dismiss');
-      expect(button?.getAttribute('label')).to.contain(
-        'Security Vulnerability Scanner'
-      );
+        'failed execution row'
+      ).to.exist;
+      expect(localStorage.getItem('dashboard_dismissed_executions')).to.be.null;
     });
   });
 
@@ -692,7 +635,7 @@ describe('DashboardView', () => {
     expect(content).to.not.contain('Audit exceptions');
   });
 
-  it('shows all configured budget policies with matching spend and thresholds', async () => {
+  it('shows usage first with the global budgets under it', async () => {
     const element = await mountDashboard();
     await waitUntil(
       () =>
@@ -705,39 +648,29 @@ describe('DashboardView', () => {
     );
     await element.updateComplete;
 
-    const budgetCard = element.shadowRoot?.querySelector('budget-health-card');
-    await budgetCard?.updateComplete;
-    const budgetContent = budgetCard?.shadowRoot?.textContent || '';
-    expect(budgetContent).to.contain('Global spend · 30d');
-    expect(budgetContent).to.contain('Global · 24h');
-    expect(budgetContent).to.contain('$12.34');
-    expect(budgetContent).to.contain('$50.00');
-    expect(budgetContent).to.not.contain('Configured limits');
-    expect(budgetContent).to.contain('Ops Agent');
-    expect(budgetContent).to.contain('$4.20');
-    expect(budgetContent).to.contain('$25.00');
-    expect(budgetContent).to.contain('Soft $20.00');
-    expect(budgetContent).to.contain('Hard $25.00');
+    expect(element.shadowRoot?.querySelector('budget-health-card')).to.not
+      .exist;
 
-    const softMarkers = budgetCard?.shadowRoot?.querySelectorAll(
-      '.budget-soft-marker'
-    );
-    const hardMarkers = budgetCard?.shadowRoot?.querySelectorAll(
-      '.budget-hard-marker'
-    );
-    const warningSegments = budgetCard?.shadowRoot?.querySelectorAll(
-      '.budget-track-fill.warning'
-    );
-    const dangerSegments = budgetCard?.shadowRoot?.querySelectorAll(
-      '.budget-track-fill.danger'
-    );
-    expect(softMarkers?.length).to.be.greaterThan(0);
-    expect(hardMarkers?.length).to.be.greaterThan(0);
-    expect(dangerSegments?.length).to.be.greaterThan(0);
-    expect(warningSegments?.length || 0).to.equal(0);
+    const usageCard = element.shadowRoot?.querySelector('usage-card');
+    expect(usageCard).to.exist;
+    await usageCard?.updateComplete;
+    const usageContent = usageCard?.shadowRoot?.textContent || '';
+
+    // Tokens lead, dollars are one toggle away.
+    expect(usageContent).to.contain('1.5K');
+    expect(usageContent).to.contain('tokens · 30d');
+    expect(usageContent).to.contain('1K prompt');
+
+    // Global policies only, ordered daily then monthly; the agent policy is
+    // summarised on one line.
+    expect(usageContent).to.contain('Daily budget');
+    expect(usageContent).to.contain('Monthly budget');
+    expect(usageContent).to.contain('$50.00');
+    expect(usageContent).to.contain('+ 1 more limit (agents)');
+    expect(usageContent).to.contain('Configure limits');
   });
 
-  it('renders budget health when there is no gateway usage or configured limit', async () => {
+  it('offers to set a budget when none is configured', async () => {
     gatewaySummaryResponse = {
       ...gatewaySummaryResponse,
       total_requests: 0,
@@ -773,16 +706,15 @@ describe('DashboardView', () => {
     );
     await element.updateComplete;
 
-    const budgetCard = element.shadowRoot?.querySelector('budget-health-card');
-    await budgetCard?.updateComplete;
-    const budgetContent = budgetCard?.shadowRoot?.textContent || '';
-    expect(budgetContent).to.contain('Budget health');
-    expect(budgetContent).to.contain('Global spend · 30d');
-    expect(budgetContent).to.contain('$0.00');
-    expect(budgetContent).to.contain('Configure Limits');
+    const usageCard = element.shadowRoot?.querySelector('usage-card');
+    await usageCard?.updateComplete;
+    const usageContent = usageCard?.shadowRoot?.textContent || '';
+    expect(usageContent).to.contain('No budget set.');
+    expect(usageContent).to.contain('Configure limits');
+    expect(usageContent).to.contain('Cost details');
   });
 
-  it('renders the requested responsive control-plane metrics behind the expand toggle', async () => {
+  it('renders exactly the five hero metrics with no expand toggle', async () => {
     const element = await mountDashboard();
     await waitUntil(
       () =>
@@ -797,12 +729,17 @@ describe('DashboardView', () => {
 
     const metricsGrid = element.shadowRoot?.querySelector('.metrics-grid');
     expect(metricsGrid).to.exist;
-    let metricText = metricsGrid?.textContent || '';
-    ['agents', 'flows', 'models', 'tools', 'approved requests'].forEach(
-      (label) => expect(metricText).to.contain(label)
+    const metricText = metricsGrid?.textContent || '';
+    ['agents', 'flows', 'models', 'tools', 'need attention'].forEach((label) =>
+      expect(metricText).to.contain(label)
     );
 
+    const metricLinks = metricsGrid?.querySelectorAll('a.tool-count') || [];
+    expect(metricLinks.length).to.equal(5);
+    expect(metricLinks[4].getAttribute('href')).to.equal('/console/attention');
+
     [
+      'approved requests',
       'inactive agents',
       'flow executions',
       'model requests',
@@ -823,35 +760,33 @@ describe('DashboardView', () => {
     const toggle = Array.from(
       element.shadowRoot?.querySelectorAll('sl-button') || []
     ).find((button) => button.textContent?.includes('Show more metrics'));
-    expect(toggle).to.exist;
-    (toggle as HTMLElement).click();
+    expect(toggle).to.not.exist;
+    expect(localStorage.getItem('preloop_dashboard_metrics_expanded')).to.be
+      .null;
+  });
+
+  it('surfaces pending approvals in the attention card', async () => {
+    const element = await mountDashboard();
+    await waitUntil(
+      () =>
+        !element['loading'] &&
+        !element['fetchingApprovals'] &&
+        !element['fetchingAudit'] &&
+        !element['fetchingMCPAndTools'],
+      'dashboard did not finish loading'
+    );
     await element.updateComplete;
 
-    metricText =
-      element.shadowRoot?.querySelector('.metrics-grid')?.textContent || '';
-    [
-      'inactive agents',
-      'flow executions',
-      'model requests',
-      'tool calls',
-      'declined requests',
-      'total runtime sessions',
-      'failed executions',
-      'failed requests',
-      'failed tool calls',
-      'timed out approval requests',
-      'total tokens',
-      'flow execution success rate',
-      'model request success rate',
-      'tool call success rate',
-      'approval rate',
-    ].forEach((label) => expect(metricText).to.contain(label));
-    expect(element.shadowRoot?.textContent || '').to.contain(
-      'Show less metrics'
+    const attentionLink = element.shadowRoot?.querySelector(
+      'a.header-action-link[href="/console/attention"]'
     );
+    expect(attentionLink, 'View all link').to.exist;
 
-    expect(metricText).to.not.contain('used tools');
-    expect(metricText).to.not.contain('total tools');
+    const rows = element.shadowRoot?.querySelectorAll('.attention-row') || [];
+    expect(rows.length).to.be.greaterThan(0);
+    expect(element.shadowRoot?.textContent || '').to.not.contain(
+      'Pending approvals'
+    );
   });
 
   it('skips zero-request runtime sessions and displays ids instead of config paths', async () => {

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -430,12 +430,12 @@ describe('DashboardView', () => {
           return json(flowsResponse);
         }
 
-        if (url === '/api/v1/approval-requests?limit=100&status=pending') {
-          return json(pendingApprovalRequestsResponse);
-        }
-
-        if (url === '/api/v1/approval-requests?limit=100') {
-          return json(allApprovalRequestsResponse);
+        if (url.startsWith('/api/v1/approval-requests')) {
+          return json(
+            url.includes('status=pending')
+              ? pendingApprovalRequestsResponse
+              : allApprovalRequestsResponse
+          );
         }
 
         if (url === '/api/v1/ai-models') {
@@ -515,16 +515,20 @@ describe('DashboardView', () => {
         url.startsWith('/api/v1/account/gateway-usage/summary')
       )
     ).to.be.true;
+    // Two for the cards (summary + breakdown upgrade) plus the fixed 30d one
+    // the shared attention loader uses, and one agents call per source: the
+    // cards' own list and the attention loader's, which must stay on the
+    // parameters the Attention page uses.
     expect(
       urls.filter((url) =>
         url.startsWith('/api/v1/account/gateway-usage/summary')
       ).length
-    ).to.be.at.most(2);
+    ).to.be.at.most(3);
     expect(urls.some((url) => url.includes('include_breakdown=false'))).to.be
       .true;
     expect(
       urls.filter((url) => url.startsWith('/api/v1/agents')).length
-    ).to.equal(1);
+    ).to.equal(2);
     expect(urls.some((url) => url === '/api/v1/auth/api-usage')).to.be.false;
     expect(urls.some((url) => url.startsWith('/api/v1/audit-logs/grouped'))).to
       .be.true;

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -793,6 +793,54 @@ describe('DashboardView', () => {
     );
   });
 
+  it('keeps each attention row on one line about 44px tall', async () => {
+    const element = await mountDashboard();
+    await waitUntil(
+      () =>
+        !element['loading'] &&
+        !element['fetchingApprovals'] &&
+        !element['fetchingAudit'] &&
+        !element['fetchingMCPAndTools'],
+      'dashboard did not finish loading'
+    );
+    await element.updateComplete;
+
+    const row = element.shadowRoot?.querySelector(
+      '.attention-row'
+    ) as HTMLElement | null;
+    expect(row, 'an attention row renders').to.exist;
+    // Three stacked lines (dot, icon, text) used to make these ~70px each, so
+    // five items pushed the Usage card below the fold.
+    expect(row!.offsetHeight, 'row height').to.be.at.most(52);
+
+    const title = row!.querySelector('.row-primary') as HTMLElement;
+    const detail = row!.querySelector('.attention-detail') as HTMLElement;
+    expect(title.getBoundingClientRect().top).to.be.closeTo(
+      detail.getBoundingClientRect().top,
+      8
+    );
+    expect(getComputedStyle(title).whiteSpace).to.equal('nowrap');
+    expect(
+      title.getBoundingClientRect().right,
+      'nothing escapes the row'
+    ).to.be.at.most(row!.getBoundingClientRect().right + 1);
+  });
+
+  it('shows Updated and Manage Keys as one muted line in the gateway header', async () => {
+    const element = await mountDashboard();
+    await waitUntil(() => !element['loading'], 'dashboard did not load');
+    await element.updateComplete;
+
+    const meta = element.shadowRoot?.querySelector('.gateway-header-meta');
+    expect(meta, 'the gateway header meta line renders').to.exist;
+    expect(meta?.querySelector('.updated-at')?.textContent).to.contain(
+      'Updated'
+    );
+    expect(
+      meta?.querySelector('a.header-action-link')?.textContent?.trim()
+    ).to.equal('Manage Keys');
+  });
+
   it('skips zero-request runtime sessions and displays ids instead of config paths', async () => {
     runtimeSessionsResponse = {
       ...runtimeSessionsResponse,

--- a/frontend/src/views/authed/flow-executions-view.test.ts
+++ b/frontend/src/views/authed/flow-executions-view.test.ts
@@ -71,6 +71,39 @@ describe('FlowExecutionsView', () => {
     expect(el.shadowRoot?.textContent).to.contain('Triage');
   });
 
+  it('preselects the status and flow filters from the query string', async () => {
+    const requested: string[] = [];
+    fetchStub = sinon.stub(window, 'fetch').callsFake(async (input) => {
+      requested.push(String(input));
+      return new Response(JSON.stringify(EXECUTIONS), { status: 200 });
+    });
+    const original = window.location.href;
+    window.history.replaceState(
+      {},
+      '',
+      '/console/flows/executions?status=FAILED&flow_id=flow-1'
+    );
+
+    try {
+      const el = (await fixture(
+        html`<flow-executions-view></flow-executions-view>`
+      )) as FlowExecutionsView;
+      await tick();
+      await el.updateComplete;
+
+      expect(requested.some((url) => url.includes('status=FAILED'))).to.be.true;
+      expect(requested.some((url) => url.includes('flow_id=flow-1'))).to.be
+        .true;
+      const failedButton = el.shadowRoot?.querySelector(
+        'sl-button[data-status="FAILED"]'
+      );
+      expect(failedButton?.getAttribute('variant')).to.equal('danger');
+      expect(el.shadowRoot?.textContent).to.contain('Flow: Nightly Sync');
+    } finally {
+      window.history.replaceState({}, '', original);
+    }
+  });
+
   it('renders filter buttons for all execution statuses', async () => {
     fetchStub = stub(EXECUTIONS);
     const el = (await fixture(

--- a/frontend/src/views/authed/flow-executions-view.ts
+++ b/frontend/src/views/authed/flow-executions-view.ts
@@ -144,6 +144,16 @@ export class FlowExecutionsView extends AuthedElement {
   @state()
   private statusFilter = 'all';
 
+  /**
+   * Set from `?flow_id=` so links can point at the failed runs of one flow
+   * (the Attention page groups failures per flow and links here).
+   */
+  @state()
+  private flowIdFilter: string | null = null;
+
+  @state()
+  private flowNameFilter: string | null = null;
+
   @state()
   private currentPage = 1;
 
@@ -157,8 +167,31 @@ export class FlowExecutionsView extends AuthedElement {
 
   async connectedCallback() {
     super.connectedCallback();
+    this.applyQueryParams();
     await this.loadExecutions();
     this.connectWebSocket();
+  }
+
+  /** `?status=FAILED&flow_id=<id>` preselects the filters on entry. */
+  private applyQueryParams(): void {
+    const params = new URLSearchParams(window.location.search);
+    const status = params.get('status');
+    if (status) {
+      const known = [
+        'all',
+        'RUNNING',
+        'PENDING',
+        'SUCCEEDED',
+        'FAILED',
+        'CANCELLED',
+      ];
+      const normalized =
+        status.toLowerCase() === 'all' ? 'all' : status.toUpperCase();
+      if (known.includes(normalized)) {
+        this.statusFilter = normalized;
+      }
+    }
+    this.flowIdFilter = params.get('flow_id');
   }
 
   async loadExecutions() {
@@ -166,9 +199,24 @@ export class FlowExecutionsView extends AuthedElement {
       limit: this.pageSize + 1,
       skip: (this.currentPage - 1) * this.pageSize,
       status: this.statusFilter === 'all' ? undefined : this.statusFilter,
+      flowId: this.flowIdFilter || undefined,
     });
     this.hasNextPage = rows.length > this.pageSize;
     this.executions = rows.slice(0, this.pageSize);
+    this.flowNameFilter = this.flowIdFilter
+      ? this.executions.find((execution) => execution.flow_name)?.flow_name ||
+        this.flowNameFilter
+      : null;
+  }
+
+  private clearFlowFilter(): void {
+    this.flowIdFilter = null;
+    this.flowNameFilter = null;
+    this.currentPage = 1;
+    const url = new URL(window.location.href);
+    url.searchParams.delete('flow_id');
+    window.history.replaceState({}, '', url.toString());
+    void this.loadExecutions();
   }
 
   get filteredExecutions(): FlowExecution[] {
@@ -319,6 +367,19 @@ export class FlowExecutionsView extends AuthedElement {
                 <sl-icon name="arrow-clockwise"></sl-icon>
                 Refresh
               </sl-button>
+              ${
+                this.flowIdFilter
+                  ? html`<sl-button
+                      size="small"
+                      pill
+                      class="flow-filter-chip"
+                      @click=${this.clearFlowFilter}
+                    >
+                      Flow: ${this.flowNameFilter || this.flowIdFilter}
+                      <sl-icon slot="suffix" name="x"></sl-icon>
+                    </sl-button>`
+                  : ''
+              }
             </div>
             <div class="connection-status">
               <div

--- a/frontend/src/views/public/not-found-view.test.ts
+++ b/frontend/src/views/public/not-found-view.test.ts
@@ -1,0 +1,17 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import './not-found-view';
+import type { NotFoundView } from './not-found-view';
+
+describe('NotFoundView', () => {
+  it('explains the miss and links back to the console', async () => {
+    const el = (await fixture(
+      html`<not-found-view></not-found-view>`
+    )) as NotFoundView;
+
+    expect(el.shadowRoot!.textContent).to.contain('Page not found');
+    expect(
+      el.shadowRoot!.querySelector('sl-button')!.getAttribute('href')
+    ).to.equal('/console');
+  });
+});

--- a/frontend/src/views/public/not-found-view.ts
+++ b/frontend/src/views/public/not-found-view.ts
@@ -1,0 +1,66 @@
+import { LitElement, css, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+
+/**
+ * Catch-all page. Without it an unknown path (`/agents` instead of
+ * `/console/agents`, a stale bookmark, a typo) rendered a blank document.
+ */
+@customElement('not-found-view')
+export class NotFoundView extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .wrapper {
+      align-items: center;
+      display: flex;
+      flex-direction: column;
+      gap: var(--sl-spacing-medium);
+      margin: 0 auto;
+      max-width: 480px;
+      padding: var(--sl-spacing-3x-large) var(--sl-spacing-large);
+      text-align: center;
+    }
+
+    sl-icon {
+      color: var(--sl-color-neutral-400);
+      font-size: 3rem;
+    }
+
+    h1 {
+      font-size: var(--sl-font-size-2x-large);
+      margin: 0;
+    }
+
+    p {
+      color: var(--sl-color-neutral-600);
+      margin: 0;
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="wrapper">
+        <sl-icon name="compass"></sl-icon>
+        <h1>Page not found</h1>
+        <p>
+          The page you asked for does not exist. It may have moved, or the link
+          may be out of date.
+        </p>
+        <sl-button variant="primary" href="/console">
+          Go to the console
+        </sl-button>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'not-found-view': NotFoundView;
+  }
+}


### PR DESCRIPTION
Console UX wave 1 from the 2026-08-30 review, after founder revisions. Frontend only, no backend changes, no new dependencies. Spec: `product/ux-review/2026-09-02/CONSOLE-WAVE-1-SPEC.md` (private repo).

## Overview (`/console`)
- Hero row is five current-state metrics: agents, flows, models, tools, **need attention** (amber with a count, green check at 0; links to the new page). "Approved requests" and the "Show more metrics" toggle are gone.
- New **Usage** card replaces Budget health: one time range (24h/7d/30d/1y) drives the whole page, Tokens ⇄ $ est. toggle (persisted), inline sparkline, global budget rows with soft/hard track directly under the value, "+ N more limits" opener, Configure limits + Cost details.
- New **Needs attention** side card (top 5 items, replaces the Pending approvals card).
- Endpoint pills keep both capsules, labeled MODEL GATEWAY / TOOL FIREWALL.
- Styling pass: card elevation, transparent card headers with hairline, tabular numerals, "Updated just now" in the gateway header, Top Models skeleton, per-row X dismiss removed from Recent Flow Executions.

## Attention page (`/console/attention`)
- Pure `utils/attention.ts` derives items from data the console already fetches: pending approvals (critical), agents (live check failed, setup incomplete, failed requests in last session), FAILED executions (7d), models with gateway failures, budgets at soft/hard, stale price catalog / unpriced requests. 26 unit tests.
- Page with a kind chip strip, per-kind sections with deep links and actions, embedded limits dialog, all-clear state, per-section 403 tolerance, realtime refetch.
- Entry points: hero metric, Overview card, bell dropdown footer link.
- Catch-all `not-found-view` so `/agents`, `/foo` no longer render a blank page.

## Limits dialog
- `budget-limits-dialog` + redesigned `budget-policy-editor` (public API unchanged for the scoped embeds): grouped list with period chip, limits, inline spend meter, notify bell, kebab; two-step form (scope → subject → period → soft | hard → notify) with inline validation; Delete outline-danger far from Save; sl-dialog confirm instead of `window.confirm`.

## Agents
- List / Cards / Canvas switcher, **List** default; sortable columns (Agent, Status, Owner, Model, Requests, Spend est., Last seen), kebab, real anchors for cmd/middle-click, cards under 640px.
- One status chip taxonomy (`getAgentStatusChip`) used by list, cards, canvas, and detail.
- Canvas legend gains "Unmanaged (dashed gray)"; rightmost clipping and zoom-control overlap fixed.
- Relative timestamps with absolute on hover.

## Agent detail
- Action bar: Rename · Edit Tags · Change Owner · Pause/Resume · (gap) · Remove as outline danger.
- Header chips: status, amber `Live check: off` / `Agent Control: off`, outlined `#tags`.
- "Session History" heading unified; single empty state (slim live pill + one sentence, toolbar reveals on first session).
- Shared `confirm-dialog` replaces every `window.confirm` / `window.alert` on the agent pages.

## Verification
- `npm run build` clean; `npm test` 106 files, 944 passed, 0 failed on the merged tree.
- pre-commit clean on every commit.

## Review by eye (staging)
1. `/console`: hero, side column order (attention → usage → top models), Usage card in both units, `No budget set.` state.
2. `/console/attention` with items, with a 403 on one call, and empty.
3. Configure limits from Overview and from an attention budget row; add, edit, delete.
4. `/console/agents` List default, sort each column, switcher persistence, < 640px fallback, Canvas rightmost ring.
5. `/console/agents/:id` chip row on healthy / paused / failed-live-check / no-plugin / tagged agents; Remove confirm; zero-session empty state.
6. `/foo` and `/agents` render not-found; signed-out `/console` still redirects to login.
7. Dark mode on the new surfaces; Cost/Tools/Agents cards inherit the shared header/elevation change.

## Known limits / follow-ups
- Team-scoped budgets are listed but not offered in the form (gateway does not resolve team scope yet).
- Pending approvals fetched with `limit: 100`; a `total` on the endpoint would make the count exact.
- `GatewayUsageSearchResultItem` lacks `ai_model_id` in `types.ts`; model attention items fall back to `/console/ai-models`.
- Synthesis groups A-D (flows/sessions, governance, cost/infra, work items/settings) are later waves.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Large, well-tested frontend-only console UX wave with no security issues. The prior correctness concern (Overview "need attention" count disagreeing with the Attention page) is now resolved via a shared `loadAttentionInputs` loader.
>
> **Overview**
> Reworks the console Overview (hero metrics, Usage card, Needs-attention card), adds a `/console/attention` page and a catch-all not-found view, and redesigns the limits dialog and agents list/detail with a shared status-chip taxonomy and a shared confirm dialog. Both views now derive attention items from one shared loader, so the hero count and page agree.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 92778d1f. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->