### PR TITLE
Split GitHub backend tests into eight shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,12 @@ jobs:
       - name: Helm render checks (chart lint + CNPG backup wiring)
         run: sh scripts/helm-render-check.sh
 
-  # Four shards, each with its own Postgres. GitLab splits this suite into
+  # Eight shards, each with its own Postgres. GitLab splits this suite into
   # dozens of per-file jobs; that is a poor fit here because each GitHub
   # runner spends ~1.5m on checkout/pip/migrations before pytest starts.
+  # Four shards left group 1 (the first duration_based_chunks slice) as the
+  # wall-clock pole: ~7-9m vs ~3-4.5m for the others. Eight shards cut that
+  # first slice in half without going back to per-file jobs.
   # pytest-split keeps new tests in the partition automatically. Use
   # duration_based_chunks (not least_duration): without a timings file,
   # least_duration round-robins individual tests across shards and breaks
@@ -86,12 +89,12 @@ jobs:
   # coverage floor is applied after shards are combined -- a single shard
   # only sees part of the tree.
   test-backend:
-    name: Backend Tests (${{ matrix.group }}/4)
+    name: Backend Tests (${{ matrix.group }}/8)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4]
+        group: [1, 2, 3, 4, 5, 6, 7, 8]
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -144,7 +147,7 @@ jobs:
         run: |
           pytest -v \
             -m "not integration" \
-            --splits 4 \
+            --splits 8 \
             --group ${{ matrix.group }} \
             --splitting-algorithm=duration_based_chunks \
             --cov=preloop \
@@ -203,8 +206,8 @@ jobs:
       - name: Combine coverage and enforce floor
         run: |
           mapfile -t coverage_files < <(find coverage-shards -name 'coverage-data.*' -type f | sort)
-          if [ ${#coverage_files[@]} -ne 4 ]; then
-            echo "Expected 4 shard coverage files, found ${#coverage_files[@]}"
+          if [ ${#coverage_files[@]} -ne 8 ]; then
+            echo "Expected 8 shard coverage files, found ${#coverage_files[@]}"
             find coverage-shards -type f -print
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **GitHub backend CI uses 8 pytest-split shards**: group 1 of 4 was the
+  wall-clock pole (~7-9m vs ~3-4.5m). Eight `duration_based_chunks` slices
+  split that first quarter in half. Coverage still combines before the 60%
+  floor.
+
 - **Blog posts can show a hero image**: `og_image` in frontmatter is
   rendered as a figure under the tags on the post, as a linked thumbnail
   on `/blog`, and a missing `og_image` logs a build warning.

--- a/backend/tests/test_github_ci_backend_shards.py
+++ b/backend/tests/test_github_ci_backend_shards.py
@@ -17,7 +17,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 
-BACKEND_TEST_SPLITS = 4
+BACKEND_TEST_SPLITS = 8
 
 
 def _load_ci_jobs() -> dict[str, Any]:

--- a/backend/tests/test_github_ci_backend_shards.py
+++ b/backend/tests/test_github_ci_backend_shards.py
@@ -52,6 +52,9 @@ def test_backend_shards_partition_with_pytest_split() -> None:
     backend = _load_ci_jobs()["test-backend"]
     groups = backend["strategy"]["matrix"]["group"]
     assert groups == list(range(1, BACKEND_TEST_SPLITS + 1))
+    assert backend["name"] == (
+        f"Backend Tests (${{{{ matrix.group }}}}/{BACKEND_TEST_SPLITS})"
+    )
     assert backend["strategy"]["fail-fast"] is False
 
     script = _step_script(backend, "Run tests")


### PR DESCRIPTION
## Summary
- Backend Tests (1/4) was the CI wall-clock pole (~7-9m vs ~3-4.5m for the other groups). pytest-split uses `duration_based_chunks` without a timings file, so group 1 is the first 25% of collected tests (the slow prefix).
- Matrix and `--splits` go from 4 to 8 so that first slice is cut in half. Setup cost stays ~1.5m per runner; still far fewer jobs than GitLab's per-file split.
- Coverage combine still waits for every shard and applies the 60% floor only on the combined data. The existing shard-lockstep test now asserts 8.

## Test plan
- [x] `pytest backend/tests/test_github_ci_backend_shards.py` (5 passed)
- [ ] Confirm CI shows Backend Tests (1/8)..(8/8) and the slowest shard is closer to the others
- [ ] Confirm Backend Coverage still combines 8 files

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change with no security or runtime impact; the shard-count increase is internally consistent and guarded by an updated lockstep test.
>
> **Overview**
> Splits the GitHub backend test matrix from 4 to 8 `duration_based_chunks` shards to halve the slow group-1 slice, keeping the coverage combine/floor logic intact. The display-name lockstep note from the previous pass is now addressed by commit `6ba3348`.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 6ba3348. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
