### PR TITLE
Console UX wave 2: surface tokens, attention strip, compact hero, connect disclosure, usage delta, next steps

### DIFF
--- a/frontend/src/components/agent-talk-composer.ts
+++ b/frontend/src/components/agent-talk-composer.ts
@@ -1157,6 +1157,13 @@ export class AgentTalkComposer extends LitElement {
     );
   }
 
+  /**
+   * Compact means "in a row of a list", where one primary button per agent
+   * would put five blue buttons on the Overview. There the button is default
+   * and the tooltip carries the state; the full-size one on the agent detail
+   * page is that page's main action and keeps primary when the agent is
+   * online.
+   */
   render() {
     const controlState = getAgentControlState(this.agent);
     if (!controlState.visible) {
@@ -1167,7 +1174,7 @@ export class AgentTalkComposer extends LitElement {
       <sl-tooltip content=${controlState.detail}>
         <sl-button
           size=${this.compact ? 'small' : 'medium'}
-          variant=${controlState.online ? 'primary' : 'default'}
+          variant=${!this.compact && controlState.online ? 'primary' : 'default'}
           ?disabled=${!controlState.enabled || this.disabled}
           @click=${() => this.openDialog()}
         >

--- a/frontend/src/components/usage-card.test.ts
+++ b/frontend/src/components/usage-card.test.ts
@@ -72,6 +72,7 @@ async function renderCard(props: Partial<UsageCard> = {}): Promise<UsageCard> {
       .toolCallsCount=${props.toolCallsCount ?? 0}
       .loading=${props.loading ?? false}
       .error=${props.error ?? null}
+      .priorSummary=${props.priorSummary ?? null}
     ></usage-card>
   `);
   await element.updateComplete;
@@ -277,5 +278,74 @@ describe('usage-card', () => {
     const alert = failed.shadowRoot!.querySelector('sl-alert')!;
     expect(alert.getAttribute('variant')).to.equal('danger');
     expect(alert.textContent).to.contain('Failed to load usage');
+  });
+  describe('prior-period delta', () => {
+    it('states the change against the previous window of the same length', async () => {
+      const element = await renderCard({
+        priorSummary: summaryFixture({
+          token_usage: {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 500000000,
+          },
+        }),
+      });
+
+      // 584.3M against 500M is up 17%.
+      expect(text(element, '.delta')).to.equal('▲ 17% vs prior 30d');
+    });
+
+    it('points down when usage falls, and stays colour-free either way', async () => {
+      const element = await renderCard({
+        priorSummary: summaryFixture({
+          token_usage: {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 1000000000,
+          },
+        }),
+      });
+
+      expect(text(element, '.delta')).to.contain('▼');
+
+      // Colour-free: the delta is meta text, not a verdict. The sentinel
+      // stands in for the theme sheet, which the test page does not load.
+      document.documentElement.style.setProperty(
+        '--sl-color-neutral-500',
+        'rgb(7, 8, 9)'
+      );
+      try {
+        const delta = element.shadowRoot!.querySelector(
+          '.delta'
+        ) as HTMLElement;
+        expect(getComputedStyle(delta).color).to.equal('rgb(7, 8, 9)');
+      } finally {
+        document.documentElement.style.removeProperty('--sl-color-neutral-500');
+      }
+
+      // The unit toggle switches what the delta compares.
+      const dollars = await renderCard({
+        priorSummary: summaryFixture({ estimated_cost: 16.78 }),
+      });
+      dollars['unit'] = 'dollars';
+      await dollars.updateComplete;
+      expect(text(dollars, '.delta')).to.equal('▲ 100% vs prior 30d');
+    });
+
+    it('says nothing when there is no prior period to compare against', async () => {
+      const none = await renderCard();
+      expect(none.shadowRoot!.querySelector('.delta')).to.not.exist;
+
+      const zero = await renderCard({
+        priorSummary: summaryFixture({
+          token_usage: {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+          },
+        }),
+      });
+      expect(zero.shadowRoot!.querySelector('.delta')).to.not.exist;
+    });
   });
 });

--- a/frontend/src/components/usage-card.ts
+++ b/frontend/src/components/usage-card.ts
@@ -46,6 +46,13 @@ const SUBJECT_TYPE_LABELS: Record<string, string> = {
 export class UsageCard extends LitElement {
   @property({ type: Object })
   summary: AccountGatewayUsageSummaryResponse | null = null;
+  /**
+   * Same window, shifted back one period. A number on its own says nothing
+   * about direction, so the card states the change against the window the
+   * user is already looking at.
+   */
+  @property({ type: Object })
+  priorSummary: AccountGatewayUsageSummaryResponse | null = null;
   @property({ type: Array }) policies: BudgetPolicy[] = [];
   @property({ type: Boolean }) loading = false;
   @property({ type: String }) error: string | null = null;
@@ -136,6 +143,15 @@ export class UsageCard extends LitElement {
         gap: var(--sl-spacing-2x-small);
         color: var(--sl-color-neutral-500);
         font-size: 0.8125rem; /* console meta */
+        margin-top: var(--sl-spacing-2x-small);
+      }
+
+      /* The delta is information, not an alarm: no red, no green, no arrow
+         colouring. Spend going up is not by itself a problem. */
+      .delta {
+        color: var(--sl-color-neutral-500);
+        font-size: 0.8125rem;
+        font-variant-numeric: tabular-nums;
         margin-top: var(--sl-spacing-2x-small);
       }
 
@@ -357,6 +373,7 @@ export class UsageCard extends LitElement {
               ></sl-icon>
             </sl-tooltip>
           </div>
+          ${this.renderDelta()}
         </div>
       `;
     }
@@ -367,8 +384,44 @@ export class UsageCard extends LitElement {
         <div class="primary-label">
           <span>tokens · ${this.rangeLabel}</span>
         </div>
+        ${this.renderDelta()}
       </div>
     `;
+  }
+
+  /** The value the delta compares, in whichever unit is showing. */
+  private valueFor(summary: AccountGatewayUsageSummaryResponse | null): number {
+    if (!summary) return 0;
+    return this.unit === 'dollars'
+      ? Number(summary.estimated_cost || 0)
+      : Number(summary.token_usage?.total_tokens || 0);
+  }
+
+  /**
+   * Percent change against the previous window of equal length. Returns null
+   * when there is no prior period to compare against: "up 100% from nothing"
+   * is noise, not news.
+   */
+  private renderDelta() {
+    if (this.loading && !this.summary) {
+      return nothing;
+    }
+    const prior = this.valueFor(this.priorSummary);
+    if (prior <= 0) {
+      return nothing;
+    }
+    const current = this.valueFor(this.summary);
+    const change = ((current - prior) / prior) * 100;
+    const rounded = Math.round(change);
+    if (rounded === 0) {
+      return html`<div class="delta">
+        No change vs prior ${this.rangeLabel}
+      </div>`;
+    }
+    const arrow = rounded > 0 ? '▲' : '▼';
+    return html`<div class="delta">
+      ${arrow} ${Math.abs(rounded)}% vs prior ${this.rangeLabel}
+    </div>`;
   }
 
   private renderSecondaryLine() {

--- a/frontend/src/components/usage-card.ts
+++ b/frontend/src/components/usage-card.ts
@@ -96,6 +96,7 @@ export class UsageCard extends LitElement {
       }
 
       .title {
+        font-size: 0.9375rem; /* console card title */
         font-weight: 600;
         color: var(--sl-color-neutral-900);
       }
@@ -133,14 +134,14 @@ export class UsageCard extends LitElement {
         display: flex;
         align-items: center;
         gap: var(--sl-spacing-2x-small);
-        color: var(--sl-color-neutral-600);
-        font-size: var(--sl-font-size-small);
+        color: var(--sl-color-neutral-500);
+        font-size: 0.8125rem; /* console meta */
         margin-top: var(--sl-spacing-2x-small);
       }
 
       .secondary-line {
-        color: var(--sl-color-neutral-600);
-        font-size: var(--sl-font-size-small);
+        color: var(--sl-color-neutral-500);
+        font-size: 0.8125rem;
         font-variant-numeric: tabular-nums;
       }
 
@@ -148,6 +149,34 @@ export class UsageCard extends LitElement {
         display: block;
         width: 100%;
         height: 40px;
+      }
+
+      /* One deliberate motion on the Overview: the trend line draws itself
+         once, on the paint that first has data. Nothing loops, nothing
+         pulses. Under prefers-reduced-motion the line is simply there. */
+      @media (prefers-reduced-motion: no-preference) {
+        .sparkline-line {
+          animation: sparkline-draw 300ms ease-out forwards;
+          stroke-dasharray: 1;
+          stroke-dashoffset: 1;
+        }
+
+        .sparkline-area {
+          animation: sparkline-fade 300ms ease-out forwards;
+          opacity: 0;
+        }
+      }
+
+      @keyframes sparkline-draw {
+        to {
+          stroke-dashoffset: 0;
+        }
+      }
+
+      @keyframes sparkline-fade {
+        to {
+          opacity: 0.12;
+        }
       }
 
       .budgets {
@@ -182,7 +211,7 @@ export class UsageCard extends LitElement {
 
       .muted {
         color: var(--sl-color-neutral-500);
-        font-size: var(--sl-font-size-small);
+        font-size: 0.8125rem;
       }
 
       .more-limits {
@@ -406,12 +435,15 @@ export class UsageCard extends LitElement {
         }
       >
         <polygon
+          class="sparkline-area"
           points=${areaPoints}
           fill="var(--sl-color-primary-500)"
           opacity="0.12"
         ></polygon>
         <polyline
+          class="sparkline-line"
           points=${points.join(' ')}
+          pathLength="1"
           fill="none"
           stroke="var(--sl-color-primary-500)"
           stroke-width="1.5"

--- a/frontend/src/components/view-header.test.ts
+++ b/frontend/src/components/view-header.test.ts
@@ -29,6 +29,35 @@ describe('ViewHeader', () => {
     );
   });
 
+  it('renders the title at the console H1 scale, not the marketing one', async () => {
+    const el = (await fixture(
+      html`<view-header headerText="Overview"></view-header>`
+    )) as ViewHeader;
+
+    const h1 = el.shadowRoot?.querySelector('h1') as HTMLElement;
+    const styles = getComputedStyle(h1);
+    // 26px/600: the title introduces the page, it does not compete with the
+    // numbers on it (1.75rem/700 did).
+    expect(styles.fontSize).to.equal('26px');
+    expect(styles.fontWeight).to.equal('600');
+  });
+
+  it('offers a meta slot beside the title for "Updated ..." lines', async () => {
+    const el = (await fixture(
+      html`<view-header headerText="Overview"
+        ><span slot="meta">Updated just now</span></view-header
+      >`
+    )) as ViewHeader;
+
+    const slot = el.shadowRoot?.querySelector(
+      'slot[name="meta"]'
+    ) as HTMLSlotElement;
+    expect(slot, 'meta slot').to.exist;
+    expect(slot.assignedElements()[0]?.textContent).to.equal(
+      'Updated just now'
+    );
+  });
+
   it('renders no description element when description is not set', async () => {
     const el = (await fixture(
       html`<view-header headerText="Tools"></view-header>`

--- a/frontend/src/components/view-header.ts
+++ b/frontend/src/components/view-header.ts
@@ -30,12 +30,22 @@ export class ViewHeader extends LitElement {
       }
       h1 {
         margin: 0;
+        font-size: var(--console-text-h1);
+        font-weight: 600;
+        letter-spacing: -0.01em;
       }
       .description,
       ::slotted([slot='description']) {
         margin: var(--sl-spacing-2x-small) 0 0;
         color: var(--sl-color-neutral-500);
-        font-size: 0.9rem;
+        font-size: var(--console-text-meta);
+      }
+      /* Page-level meta ("Updated just now") sits opposite the title, in the
+         meta register: it says when, not what. */
+      ::slotted([slot='meta']) {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--console-text-meta);
+        font-variant-numeric: tabular-nums;
       }
     `,
   ];
@@ -50,6 +60,7 @@ export class ViewHeader extends LitElement {
               <slot name="title-prefix"></slot>${this.headerText}
             </h1>
             <slot name="main-column"></slot>
+            <slot name="meta"></slot>
           </div>
           ${
             this.description

--- a/frontend/src/styles/console-styles.css
+++ b/frontend/src/styles/console-styles.css
@@ -1,9 +1,41 @@
+/* =====================================================================
+   Console surface tokens (wave 2).
+
+   One place decides the console's compact scale so a new view matches its
+   neighbours by importing this file instead of inventing sizes. Colour is
+   never spelled out here: every value is a Shoelace token, so the dark theme
+   derives from the same declarations.
+   ===================================================================== */
+:host {
+    --console-text-h1: 1.625rem; /* 26px */
+    --console-text-card-title: 0.9375rem; /* 15px */
+    --console-text-body: 0.875rem; /* 14px */
+    --console-text-meta: 0.8125rem; /* 13px */
+    --console-text-eyebrow: 0.6875rem; /* 11px */
+    --console-stat-value: 1.375rem; /* 22px */
+}
+
 a {
     color: var(--sl-color-primary-600);
     text-decoration: none;
 }
 a:hover {
     text-decoration: underline;
+}
+
+/* Every interactive thing in the console answers the keyboard the same way. */
+a:focus-visible,
+button:focus-visible,
+summary:focus-visible,
+[tabindex]:focus-visible,
+sl-button:focus-visible,
+sl-icon-button:focus-visible,
+sl-badge:focus-visible,
+.row:focus-visible,
+.item-card:focus-visible {
+    outline: 2px solid var(--sl-color-primary-500);
+    outline-offset: 2px;
+    border-radius: var(--sl-border-radius-small);
 }
 .column-layout {
     display: grid;
@@ -89,10 +121,13 @@ a:hover {
     padding: var(--sl-spacing-x-large);
 }
 
+/* The page title is the quietest thing that can still read as a title: at
+   1.75rem/700 it was louder than any number on the page it introduces. */
 .header h1 {
     text-align: left;
-    font-size: 1.75rem;
+    font-size: var(--console-text-h1);
     font-weight: 600;
+    letter-spacing: -0.01em;
     color: var(--sl-color-neutral-900);
     margin: 0;
 }
@@ -126,6 +161,7 @@ sl-card::part(header) {
     background-color: transparent;
     border-bottom: 1px solid var(--sl-color-neutral-200);
     padding: var(--sl-spacing-medium);
+    font-size: var(--console-text-card-title);
     font-weight: 600;
 }
 
@@ -135,12 +171,61 @@ sl-card::part(header) {
     box-shadow: var(--sl-shadow-x-small);
 }
 
+/* Cards keep the page's card surface even where a component sets its own. */
+sl-card::part(base) {
+    background-color: var(--sl-color-neutral-0);
+}
+
+/* Card title, section eyebrow, meta: the three sizes below body text. */
+.card-title,
+.section-title {
+    font-size: var(--console-text-card-title);
+    font-weight: 600;
+}
+
+.eyebrow {
+    color: var(--sl-color-neutral-500);
+    font-size: var(--console-text-eyebrow);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.meta {
+    color: var(--sl-color-neutral-500);
+    font-size: var(--console-text-meta);
+}
+
 /* Numbers line up column-wise wherever they appear. */
 .row-value,
 .tool-count-value,
 .metric-value,
-.summary-value {
+.summary-value,
+.stat-value,
+.meta {
     font-variant-numeric: tabular-nums;
+}
+
+/* =====================================================================
+   Chips. One recipe for every status pill in the console (agents list,
+   agent detail, attention, overview cards, executions), so "RUNNING" on
+   one page and "Active now" on another are the same object.
+   ===================================================================== */
+sl-badge[pill]::part(base),
+sl-badge.chip::part(base) {
+    border-width: 0;
+    font-size: 0.75rem; /* 12px */
+    font-weight: 500;
+    line-height: 1.4;
+    padding: 2px 8px;
+}
+
+/* Tags are labels, not states: outline instead of fill. */
+sl-badge.chip-tag::part(base),
+sl-badge.tag-chip::part(base) {
+    background-color: transparent;
+    border: 1px solid var(--sl-color-neutral-300);
+    color: var(--sl-color-neutral-700);
 }
 
 .styled-table {
@@ -167,6 +252,11 @@ sl-card::part(header) {
 
 .styled-table tr:last-child td {
     border-bottom: none;
+}
+
+/* Rows react to the pointer everywhere, at one weight. */
+.styled-table tbody tr:hover {
+    background-color: var(--sl-color-neutral-100);
 }
 
 .styled-table th:last-child:not(:only-child), .styled-table td:last-child:not(:only-child) {
@@ -240,6 +330,10 @@ sl-dialog.large::part(panel) {
     margin-left: auto;
 }
 
+.item-card:hover {
+    background: var(--sl-color-neutral-100);
+}
+
 .item-card.warning {
     background: var(--sl-color-warning-50);
     border-left-color: var(--sl-color-warning-600);
@@ -268,8 +362,9 @@ sl-dialog.large::part(panel) {
 }
 
 .item-secondary {
-    font-size: var(--sl-font-size-small);
-    color: var(--sl-color-neutral-600);
+    font-size: var(--console-text-meta);
+    color: var(--sl-color-neutral-500);
+    font-variant-numeric: tabular-nums;
 }
 
 .item-error {
@@ -385,13 +480,13 @@ sl-dialog.large::part(panel) {
 }
 
 .stat-label {
-    font-size: var(--sl-font-size-small);
-    color: var(--sl-color-neutral-600);
+    font-size: var(--console-text-meta);
+    color: var(--sl-color-neutral-500);
     margin-top: var(--sl-spacing-x-small);
 }
 
 .stat-subtext {
-    font-size: var(--sl-font-size-x-small);
+    font-size: var(--console-text-meta);
     color: var(--sl-color-neutral-500);
     margin-top: var(--sl-spacing-2x-small);
 }

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -1020,7 +1020,7 @@ export class AgentDetailView extends LitElement {
       </sl-tooltip>
       ${
         liveCount > 0
-          ? html`<sl-badge variant="primary" pill>Live ${liveCount}</sl-badge>`
+          ? html`<sl-badge variant="success" pill>Live ${liveCount}</sl-badge>`
           : nothing
       }
       ${

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -3537,6 +3537,7 @@ export class AgentsView extends LitElement {
                   ? this.renderAgentTalkButton(agent, 'agents-card')
                   : html`
                       <sl-badge
+                        pill
                         variant=${
                           !isFlow
                             ? ''
@@ -3556,7 +3557,7 @@ export class AgentsView extends LitElement {
               }
               ${
                 liveTotal
-                  ? html`<sl-badge variant="primary"
+                  ? html`<sl-badge variant="success" pill
                       >Live ${liveTotal}</sl-badge
                     >`
                   : null
@@ -4021,11 +4022,11 @@ export class AgentsView extends LitElement {
                                     'agents-canvas'
                                   )
                                 : liveTotal > 0
-                                  ? html`<sl-badge variant="success" pulse
+                                  ? html`<sl-badge variant="success" pill pulse
                                       >Live</sl-badge
                                     >`
                                   : isFlow
-                                    ? html`<sl-badge variant="success"
+                                    ? html`<sl-badge variant="success" pill
                                         >Active</sl-badge
                                       >`
                                     : ''

--- a/frontend/src/views/authed/attention-parity.test.ts
+++ b/frontend/src/views/authed/attention-parity.test.ts
@@ -219,8 +219,8 @@ describe('attention count parity', () => {
     await dashboard.updateComplete;
 
     const heroValue = dashboard
-      .shadowRoot!.querySelector('a.tool-count[href="/console/attention"]')!
-      .querySelector('.tool-count-value')!
+      .shadowRoot!.querySelector('a.hero-stat[href="/console/attention"]')!
+      .querySelector('.hero-stat-value')!
       .textContent!.trim();
 
     const page = (await fixture(

--- a/frontend/src/views/authed/console-shell.test.ts
+++ b/frontend/src/views/authed/console-shell.test.ts
@@ -165,6 +165,79 @@ describe('ConsoleShell', () => {
     expect(mainContent).to.exist;
   });
 
+  it('tints the page behind the cards and sets the compact type scale', async () => {
+    // The Shoelace theme sheet is not loaded in the test page, so pin the two
+    // tokens to sentinel colours: if the rule stops reading them the computed
+    // colour stops matching.
+    document.documentElement.style.setProperty(
+      '--sl-color-neutral-50',
+      'rgb(1, 2, 3)'
+    );
+
+    try {
+      const el = (await fixture(
+        html`<console-shell></console-shell>`
+      )) as ConsoleShell;
+
+      await waitUntil(
+        () => el.shadowRoot?.querySelector('.main-content') !== null,
+        'Main content did not render'
+      );
+
+      const mainContent = el.shadowRoot?.querySelector(
+        '.main-content'
+      ) as HTMLElement;
+      const styles = getComputedStyle(mainContent);
+
+      // Page is neutral-50, cards stay neutral-0: depth without decoration.
+      expect(styles.backgroundColor).to.equal('rgb(1, 2, 3)');
+      expect(styles.fontSize).to.equal('14px');
+      expect(styles.fontVariantNumeric).to.contain('tabular-nums');
+    } finally {
+      document.documentElement.style.removeProperty('--sl-color-neutral-50');
+    }
+  });
+
+  it('marks the active nav item with a rule and colour, not bold', async () => {
+    const originalPath = window.location.pathname;
+    window.history.replaceState({}, '', '/console/tools');
+    document.documentElement.style.setProperty(
+      '--sl-color-primary-600',
+      'rgb(4, 5, 6)'
+    );
+
+    try {
+      const el = (await fixture(
+        html`<console-shell></console-shell>`
+      )) as ConsoleShell;
+
+      await waitUntil(
+        () =>
+          el.shadowRoot?.querySelector(
+            'a.sidebar-link.active[href="/console/tools"]'
+          ) !== null,
+        'Active tools link did not render'
+      );
+
+      const link = el.shadowRoot?.querySelector(
+        'a.sidebar-link.active[href="/console/tools"]'
+      ) as HTMLElement;
+      const styles = getComputedStyle(link);
+      // A 3px primary rule and a primary label carry "you are here"; weight
+      // stays at 600 so the nav does not shout.
+      expect(styles.borderLeftWidth).to.equal('3px');
+      expect(styles.borderLeftColor).to.equal('rgb(4, 5, 6)');
+
+      const label = link.querySelector('.sidebar-label') as HTMLElement;
+      const labelStyles = getComputedStyle(label);
+      expect(labelStyles.fontWeight).to.equal('600');
+      expect(labelStyles.fontSize).to.equal('14px');
+    } finally {
+      document.documentElement.style.removeProperty('--sl-color-primary-600');
+      window.history.replaceState({}, '', originalPath);
+    }
+  });
+
   it('highlights the active sidebar section for the current route', async () => {
     const originalPath = window.location.pathname;
     window.history.replaceState({}, '', '/console/tools');

--- a/frontend/src/views/authed/console-shell.ts
+++ b/frontend/src/views/authed/console-shell.ts
@@ -203,15 +203,22 @@ export class ConsoleShell extends LitElement {
         display: grid;
         grid-template-rows: auto auto 1fr; /* Header, bypass banner, content */
         overflow-y: hidden;
-        background-color: var(--sl-color-neutral-0);
+        background-color: var(--sl-color-neutral-50);
       }
 
+      /* Page is tinted, cards are not: the one change that gives the console
+         depth without a single shadow, glow or gradient. Slotted views inherit
+         the console's compact type scale and tabular figures from here, so a
+         new page matches its neighbours without opting in. */
       .main-content {
         overflow-y: auto;
         padding: 1rem 2rem 2rem 2rem;
         display: flex;
         flex-direction: column;
         align-items: center;
+        background-color: var(--sl-color-neutral-50);
+        font-size: var(--console-text-body);
+        font-variant-numeric: tabular-nums;
       }
 
       .main-content.full-bleed {
@@ -278,16 +285,48 @@ export class ConsoleShell extends LitElement {
         color: inherit;
         text-decoration: none;
         border-radius: var(--sl-border-radius-medium);
+        /* Reserved so the active rule appears without shifting the label. */
+        border-left: 3px solid transparent;
+      }
+
+      .sidebar-link:hover {
+        background-color: var(--sl-color-neutral-200);
       }
 
       /* Style the anchor, not ::part — Shoelace shadow styles override ::part rules */
       .sidebar-link.active {
-        background-color: var(--sl-color-neutral-200);
+        background-color: var(--sl-color-primary-50);
+        border-left-color: var(--sl-color-primary-600);
       }
 
+      /* The active item is stated once, in colour and weight; bold on top of
+         a tinted rule was three signals for one fact. */
       .sidebar-link.active .sidebar-label,
-      .sidebar-link.active sl-menu-item::part(label) {
-        font-weight: var(--sl-font-weight-bold);
+      .sidebar-link.active sl-menu-item::part(label),
+      .sidebar-link.active sl-icon {
+        color: var(--sl-color-primary-700);
+        font-weight: 600;
+      }
+
+      :host-context(.sl-theme-dark) .sidebar-link.active {
+        background-color: var(--sl-color-primary-950);
+      }
+
+      :host-context(.sl-theme-dark) .sidebar-link.active .sidebar-label,
+      :host-context(.sl-theme-dark)
+        .sidebar-link.active
+        sl-menu-item::part(label),
+      :host-context(.sl-theme-dark) .sidebar-link.active sl-icon {
+        color: var(--sl-color-primary-300);
+      }
+
+      .sidebar-link sl-icon,
+      sl-details.nav-section sl-icon {
+        font-size: 18px;
+      }
+
+      .sidebar-label {
+        font-size: var(--console-text-body);
       }
 
       sl-menu-item::part(base) {
@@ -590,7 +629,7 @@ export class ConsoleShell extends LitElement {
                 ><logo-component></logo-component
               ></a>
             </div>
-            <sl-menu style="font-size: 16px;">
+            <sl-menu style="font-size: var(--console-text-body);">
               ${this._renderNavLink(
                 '/console',
                 html`

--- a/frontend/src/views/authed/console-shell.ts
+++ b/frontend/src/views/authed/console-shell.ts
@@ -308,17 +308,10 @@ export class ConsoleShell extends LitElement {
         font-weight: 600;
       }
 
-      :host-context(.sl-theme-dark) .sidebar-link.active {
-        background-color: var(--sl-color-primary-950);
-      }
-
-      :host-context(.sl-theme-dark) .sidebar-link.active .sidebar-label,
-      :host-context(.sl-theme-dark)
-        .sidebar-link.active
-        sl-menu-item::part(label),
-      :host-context(.sl-theme-dark) .sidebar-link.active sl-icon {
-        color: var(--sl-color-primary-300);
-      }
+      /* No dark-mode override here on purpose: Shoelace's dark theme inverts
+         the palette scale, so primary-50 is already the dark tint and
+         primary-700 already the light ink. Hard-coding primary-950/300 for
+         dark inverted it twice and painted the active item near-white. */
 
       .sidebar-link sl-icon,
       sl-details.nav-section sl-icon {

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -153,6 +153,17 @@ interface TopModelSubjectGroup {
   totalRequests: number;
 }
 
+export const NEXT_STEPS_DISMISSED_KEY = 'dashboard_next_steps_dismissed';
+export const ENDPOINTS_EXPANDED_KEY = 'dashboard_endpoints_expanded';
+
+interface NextStep {
+  id: string;
+  label: string;
+  done: boolean;
+  href?: string;
+  onClick?: () => void;
+}
+
 interface DashboardMetric {
   label: string;
   value: string | number;
@@ -173,6 +184,9 @@ export class DashboardView extends AuthedElement {
   @state() private error: string | null = null;
   @state() private gatewaySummary: AccountGatewayUsageSummaryResponse | null =
     null;
+  /** The window before `gatewayTimeRange`, for the Usage card's delta. */
+  @state()
+  private priorGatewaySummary: AccountGatewayUsageSummaryResponse | null = null;
   @state() private runtimeSessions: RuntimeSessionSummary[] = [];
   @state() private managedAgents: ManagedAgentSummary[] = [];
   @state() private budgetAgents: ManagedAgentSummary[] = [];
@@ -209,6 +223,14 @@ export class DashboardView extends AuthedElement {
   @state() private showSetupDialog = false;
   @state() private showBudgetDialog = false;
   @state() private welcomeCardDismissed = false;
+  @state() private nextStepsDismissed = false;
+  /**
+   * null means "the user has not said": the disclosure then follows the
+   * account. An instance with a fully onboarded agent has already copied
+   * these URLs; a fresh one still needs them.
+   */
+  @state() private endpointsExpandedPreference: boolean | null = null;
+  @state() private userManagementEnabled = false;
 
   @state() private aiModels: AIModel[] = [];
   @state() private isInviteDialogOpen = false;
@@ -263,48 +285,159 @@ export class DashboardView extends AuthedElement {
   static styles = [
     reducedMotionStyles,
     css`
-      .tool-counts {
+      /* Five stats, left aligned, on one 64px row. They are counts, so they
+         are read across, not admired: icon and number on one line, the noun
+         under it in the meta register. */
+      .hero-stats {
+        align-items: flex-start;
         display: flex;
         flex-wrap: wrap;
         gap: var(--sl-spacing-2x-large);
-        margin-top: var(--sl-spacing-small);
-        justify-content: center;
+        margin-bottom: var(--sl-spacing-medium);
+        min-height: 64px;
       }
-      .tool-count {
+      .hero-stat {
+        color: inherit;
         display: flex;
         flex-direction: column;
+        gap: 2px;
+        text-decoration: none;
+      }
+      .hero-stat-top {
         align-items: center;
-        gap: var(--sl-spacing-small);
-        font-size: var(--sl-font-size-small);
+        display: flex;
+        gap: var(--sl-spacing-2x-small);
       }
-      .tool-count sl-icon {
-        font-size: 2.5rem;
+      .hero-stat-icon {
+        color: var(--sl-color-neutral-400);
+        font-size: 18px;
       }
-      .tool-count-value {
-        font-size: 1.5rem;
-        font-weight: 700;
+      .hero-stat-value {
+        font-size: var(--console-stat-value);
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        line-height: 1.2;
       }
-      .tool-count-label {
-        font-size: var(--sl-font-size-small);
-        color: var(--sl-color-neutral-600);
-        text-align: center;
+      .hero-stat-label {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--console-text-meta);
       }
-      .hover-underline:hover {
+      .hero-stat:hover .hero-stat-label {
         text-decoration: underline;
       }
-      /* The hero metrics sat in their own screenful of whitespace: a
-         two-x-large row gap and the same margin under them pushed the first
-         card below the fold at 1440x900. */
-      .metrics-grid {
-        display: grid;
-        grid-template-columns: repeat(5, minmax(0, 1fr));
-        gap: var(--sl-spacing-large);
-        row-gap: var(--sl-spacing-large);
-        align-items: start;
-        margin-bottom: var(--sl-spacing-large);
+      /* The only stat allowed a colour is the one that asks for something. */
+      .hero-stat.tone-warning .hero-stat-icon,
+      .hero-stat.tone-warning .hero-stat-value {
+        color: var(--sl-color-warning-600);
       }
-      .tool-count-value {
+      .hero-stat.tone-success .hero-stat-icon {
+        color: var(--sl-color-success-600);
+      }
+      /* Connect row: state first, endpoints on request. */
+      .connect-row {
+        align-items: center;
+        border-top: 1px solid var(--sl-color-neutral-200);
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sl-spacing-large);
+        padding-top: var(--sl-spacing-small);
+      }
+      .connect-status {
+        align-items: center;
+        color: var(--sl-color-neutral-700);
+        display: flex;
+        gap: var(--sl-spacing-2x-small);
+        font-size: var(--console-text-body);
+      }
+      .connect-toggle {
+        margin-left: auto;
+      }
+      /* One amber line above the page, or nothing. */
+      .attention-strip {
+        align-items: center;
+        background: var(--sl-color-warning-50);
+        border: 1px solid var(--sl-color-warning-200);
+        border-radius: var(--sl-border-radius-medium);
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sl-spacing-small);
+        padding: var(--sl-spacing-x-small) var(--sl-spacing-medium);
+      }
+      .attention-strip-icon {
+        color: var(--sl-color-warning-600);
+        flex-shrink: 0;
+        font-size: 18px;
+      }
+      .attention-strip-count {
+        color: var(--sl-color-warning-800);
+        font-weight: 600;
         font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+      }
+      .attention-strip-items {
+        display: flex;
+        flex: 1 1 auto;
+        flex-wrap: wrap;
+        gap: var(--sl-spacing-x-small);
+        min-width: 0;
+      }
+      .attention-chip-link {
+        max-width: 100%;
+        text-decoration: none;
+      }
+      .attention-chip-link sl-badge::part(base) {
+        align-items: center;
+        display: flex;
+        gap: var(--sl-spacing-3x-small);
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .attention-strip-all {
+        color: var(--sl-color-primary-700);
+        font-size: var(--console-text-meta);
+        margin-left: auto;
+        text-decoration: none;
+        white-space: nowrap;
+      }
+      .attention-strip-all:hover {
+        text-decoration: underline;
+      }
+      /* Next steps: a checklist, not a wizard. */
+      .next-steps-list {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-2x-small);
+      }
+      .next-step-link {
+        align-items: center;
+        background: none;
+        border: none;
+        color: var(--sl-color-neutral-900);
+        cursor: pointer;
+        display: flex;
+        font: inherit;
+        gap: var(--sl-spacing-x-small);
+        padding: var(--sl-spacing-2x-small) 0;
+        text-align: left;
+        text-decoration: none;
+        width: 100%;
+      }
+      .next-step-link:hover .next-step-label {
+        text-decoration: underline;
+      }
+      .next-step-mark {
+        color: var(--sl-color-neutral-400);
+        flex-shrink: 0;
+        font-size: 16px;
+      }
+      .next-step-mark.done {
+        color: var(--sl-color-success-600);
+      }
+      .next-step.done .next-step-label {
+        color: var(--sl-color-neutral-500);
+        text-decoration: line-through;
       }
       .updated-at {
         color: var(--sl-color-neutral-500);
@@ -323,74 +456,6 @@ export class DashboardView extends AuthedElement {
         font-size: var(--sl-font-size-small);
         font-weight: var(--sl-font-weight-normal);
         font-variant-numeric: tabular-nums;
-      }
-      .attention-title {
-        align-items: center;
-        display: flex;
-        gap: var(--sl-spacing-2x-small);
-      }
-      .attention-title sl-icon {
-        color: var(--sl-color-warning-600);
-      }
-      /* One line per item, about 44px tall, so five items and the Usage card
-         fit above the fold. The shared .row rule below stacks its children,
-         which turned every attention item into three lines: dot, icon, text.
-         The double class beats it without touching the other lists. */
-      .row.attention-row {
-        align-items: center;
-        display: flex;
-        flex-direction: row;
-        gap: var(--sl-spacing-x-small);
-        min-height: 44px;
-        padding: var(--sl-spacing-x-small) 0;
-      }
-      .severity-dot {
-        border-radius: 50%;
-        flex-shrink: 0;
-        height: 8px;
-        width: 8px;
-        background: var(--sl-color-warning-600);
-      }
-      .severity-dot.critical {
-        background: var(--sl-color-danger-600);
-      }
-      .attention-kind-icon {
-        color: var(--sl-color-neutral-500);
-        flex-shrink: 0;
-      }
-      .attention-main {
-        align-items: baseline;
-        display: flex;
-        flex-direction: row;
-        gap: var(--sl-spacing-x-small);
-        min-width: 0;
-      }
-      /* The title keeps what it needs, the detail gives way first. */
-      .attention-row .row-primary {
-        flex: 0 1 auto;
-        overflow: hidden;
-        overflow-wrap: normal;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-      .attention-detail {
-        color: var(--sl-color-neutral-500);
-        flex: 1 1 auto;
-        font-size: var(--sl-font-size-x-small);
-        min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-      .attention-more {
-        color: var(--sl-color-primary-600);
-        display: inline-block;
-        font-size: var(--sl-font-size-small);
-        margin-top: var(--sl-spacing-small);
-        text-decoration: none;
-      }
-      .attention-more:hover {
-        text-decoration: underline;
       }
       .budget-track {
         position: relative;
@@ -1092,24 +1157,21 @@ export class DashboardView extends AuthedElement {
           grid-template-columns: 1fr;
         }
 
-        .metrics-grid {
+        /* Phone: the five stats wrap into a grid rather than scrolling off
+           the card, and the strip becomes two rows. */
+        .hero-stats {
+          column-gap: var(--sl-spacing-large);
+          display: grid;
           grid-template-columns: repeat(3, minmax(0, 1fr));
-          gap: var(--sl-spacing-medium);
-          row-gap: var(--sl-spacing-large);
+          row-gap: var(--sl-spacing-medium);
         }
 
-        .tool-count {
-          min-width: 0;
+        .attention-strip-all {
+          margin-left: 0;
         }
 
-        .tool-count-value {
-          font-size: clamp(1rem, 7vw, 1.5rem);
-          overflow-wrap: anywhere;
-        }
-
-        .tool-count-label {
-          font-size: var(--sl-font-size-x-small);
-          line-height: 1.25;
+        .connect-toggle {
+          margin-left: 0;
         }
       }
     `,
@@ -1138,11 +1200,13 @@ export class DashboardView extends AuthedElement {
     try {
       const res = await getFeatures();
       this.computeFeatureEnabled = !!res.features?.['compute'];
+      this.userManagementEnabled = !!res.features?.['user_management'];
       this.isEnterprise = Array.isArray(res.plugins) && res.plugins.length > 0;
       return res;
     } catch {
       this.computeFeatureEnabled = false;
       this.isEnterprise = false;
+      this.userManagementEnabled = false;
       return null;
     }
   }
@@ -1266,6 +1330,30 @@ export class DashboardView extends AuthedElement {
   private loadDismissedState(): void {
     this.welcomeCardDismissed =
       localStorage.getItem('dashboard_welcome_dismissed') === 'true';
+    this.nextStepsDismissed =
+      localStorage.getItem(NEXT_STEPS_DISMISSED_KEY) === 'true';
+    const endpoints = localStorage.getItem(ENDPOINTS_EXPANDED_KEY);
+    this.endpointsExpandedPreference =
+      endpoints === 'true' ? true : endpoints === 'false' ? false : null;
+  }
+
+  private dismissNextSteps(): void {
+    this.nextStepsDismissed = true;
+    try {
+      localStorage.setItem(NEXT_STEPS_DISMISSED_KEY, 'true');
+    } catch {
+      // Private mode: the card stays hidden for this session only.
+    }
+  }
+
+  private toggleEndpoints(): void {
+    const next = !this.endpointsExpanded;
+    this.endpointsExpandedPreference = next;
+    try {
+      localStorage.setItem(ENDPOINTS_EXPANDED_KEY, String(next));
+    } catch {
+      // Non-fatal: the disclosure still works for this session.
+    }
   }
 
   private dismissWelcomeCard(): void {
@@ -1344,6 +1432,23 @@ export class DashboardView extends AuthedElement {
     const d = new Date(now);
     d.setMonth(d.getMonth() - 1);
     return d.toISOString();
+  }
+
+  /**
+   * The window immediately before the one on screen, same length. Computed
+   * from the current start date so the two summaries always cover equal spans
+   * (a month is not always 30 days).
+   */
+  private getPriorGatewayWindow(startDateStr: string): {
+    startDate: string;
+    endDate: string;
+  } {
+    const start = new Date(startDateStr).getTime();
+    const span = Date.now() - start;
+    return {
+      startDate: new Date(start - span).toISOString(),
+      endDate: new Date(start).toISOString(),
+    };
   }
 
   private getActiveAgentsStartDate(): string | undefined {
@@ -1531,6 +1636,15 @@ export class DashboardView extends AuthedElement {
         }),
         null
       );
+      const priorWindow = this.getPriorGatewayWindow(startDateStr);
+      const priorSummaryPromise = this.catchWith403Handling(
+        getAccountGatewayUsageSummary({
+          startDate: priorWindow.startDate,
+          endDate: priorWindow.endDate,
+          includeBreakdown: false,
+        }),
+        null
+      );
       const featuresPromise = this.fetchFeatures();
       const adminPromise = this.fetchAdminStatus();
 
@@ -1544,6 +1658,7 @@ export class DashboardView extends AuthedElement {
         runtimeSessions,
         managedAgents,
         featuresRes,
+        priorGatewaySummary,
       ] = await Promise.all([
         gatewaySummaryPromise,
         this.catchWith403Handling(getAccountGatewayUsageSearch({ limit: 12 }), {
@@ -1574,6 +1689,7 @@ export class DashboardView extends AuthedElement {
         ),
         agentsPromise,
         featuresPromise,
+        priorSummaryPromise,
       ]);
       await adminPromise;
 
@@ -1581,6 +1697,7 @@ export class DashboardView extends AuthedElement {
         this.gatewaySummary,
         gatewaySummary
       );
+      this.priorGatewaySummary = priorGatewaySummary;
       this.gatewayInteractions = gatewayInteractions.items || [];
       this.fetchingGatewaySummary = false;
 
@@ -2287,19 +2404,22 @@ export class DashboardView extends AuthedElement {
     return 'Never';
   }
 
+  /**
+   * Chip colour is a taxonomy, not decoration: success means finished or
+   * live, danger means failed. A run that is still going is a state, so it
+   * is neutral; amber is reserved for things asking for a human.
+   */
   private getStatusColor(status: string): string {
     switch (status.toLowerCase()) {
       case 'active':
       case 'succeeded':
+      case 'completed':
       case 'approved':
         return 'success';
       case 'failed':
       case 'error':
       case 'declined':
         return 'danger';
-      case 'running':
-      case 'pending':
-        return 'warning';
       default:
         return 'neutral';
     }
@@ -2336,6 +2456,63 @@ export class DashboardView extends AuthedElement {
     if (this.gatewayTimeRange === 'week') return '7d';
     if (this.gatewayTimeRange === 'year') return '1y';
     return '30d';
+  }
+
+  /** True once an agent talks to both the model gateway and the tool firewall. */
+  private get hasFullyOnboardedAgent(): boolean {
+    return this.managedAgents.some(
+      (agent) => agent.onboarding_state === 'fully_onboarded'
+    );
+  }
+
+  private get endpointsExpanded(): boolean {
+    if (this.endpointsExpandedPreference !== null) {
+      return this.endpointsExpandedPreference;
+    }
+    return !this.hasFullyOnboardedAgent;
+  }
+
+  /**
+   * The Policies page derives tool access rules from the tools themselves: a
+   * tool that is disabled or needs approval is a policy. Anything else is the
+   * default allow, which is not a decision anyone made.
+   */
+  private get hasToolPolicy(): boolean {
+    return this.tools.some(
+      (tool) => !tool.is_enabled || Boolean(tool.approval_workflow_id)
+    );
+  }
+
+  private get nextSteps(): NextStep[] {
+    const steps: NextStep[] = [
+      {
+        id: 'agent',
+        label: 'Onboard an agent',
+        done: this.managedAgents.length > 0 || this.totalAgentsCount > 0,
+        href: '/console/agents',
+      },
+      {
+        id: 'budget',
+        label: 'Set a spending limit',
+        done: this.budgetPolicies.length > 0,
+        onClick: () => (this.showBudgetDialog = true),
+      },
+      {
+        id: 'policy',
+        label: 'Add a tool policy',
+        done: this.hasToolPolicy,
+        href: '/console/policies',
+      },
+    ];
+    if (this.userManagementEnabled) {
+      steps.push({
+        id: 'invite',
+        label: 'Invite a teammate',
+        done: this.enabledUsersCount > 1,
+        href: '/console/settings/invitations',
+      });
+    }
+    return steps;
   }
 
   private get enabledToolsCount(): number {
@@ -2542,6 +2719,63 @@ export class DashboardView extends AuthedElement {
     `;
   }
 
+  /**
+   * The four things a new account has to do, with their real state read from
+   * the same data the rest of the page uses. It disappears on its own when
+   * they are done, so nobody has to dismiss it to be rid of it.
+   */
+  private renderNextStepsCard() {
+    if (this.nextStepsDismissed) {
+      return nothing;
+    }
+    const steps = this.nextSteps;
+    if (steps.every((step) => step.done)) {
+      return nothing;
+    }
+
+    return html`
+      <sl-card class="content-card next-steps-card">
+        <div slot="header" class="card-header-with-action">
+          <div class="card-title">Next steps</div>
+          <sl-icon-button
+            name="x-lg"
+            label="Dismiss next steps"
+            @click=${this.dismissNextSteps}
+          ></sl-icon-button>
+        </div>
+        <div class="next-steps-list">
+          ${steps.map((step) => {
+            const label = html`
+              <sl-icon
+                class="next-step-mark ${step.done ? 'done' : ''}"
+                name=${step.done ? 'check-circle-fill' : 'circle'}
+                aria-hidden="true"
+              ></sl-icon>
+              <span class="next-step-label">${step.label}</span>
+            `;
+            return html`
+              <div class="next-step ${step.done ? 'done' : ''}">
+                ${
+                  step.href
+                    ? html`<a class="next-step-link" href=${step.href}
+                        >${label}</a
+                      >`
+                    : html`<button
+                        class="next-step-link"
+                        type="button"
+                        @click=${step.onClick}
+                      >
+                        ${label}
+                      </button>`
+                }
+              </div>
+            `;
+          })}
+        </div>
+      </sl-card>
+    `;
+  }
+
   private renderRecentFlowExecutionsCard() {
     if (
       this.fetchingRecentExecutions &&
@@ -2558,7 +2792,7 @@ export class DashboardView extends AuthedElement {
           Recent Flow Executions
           ${
             this.failedFlowExecutions.length > 0
-              ? html`<sl-badge variant="danger"
+              ? html`<sl-badge class="chip" variant="danger" pill
                   >${this.failedFlowExecutions.length} failed</sl-badge
                 >`
               : ''
@@ -2603,12 +2837,12 @@ export class DashboardView extends AuthedElement {
                           >
                         </div>
                         <div class="item-actions">
-                          <sl-tag
-                            size="small"
-                            variant="${this.getStatusColor(exec.status)}"
+                          <sl-badge
+                            class="chip"
+                            pill
+                            variant=${this.getStatusColor(exec.status)}
+                            >${exec.status}</sl-badge
                           >
-                            ${exec.status}
-                          </sl-tag>
                           <sl-button
                             size="small"
                             href="/console/flows/executions/${exec.id}"
@@ -2640,6 +2874,7 @@ export class DashboardView extends AuthedElement {
     return html`
       <usage-card
         .summary=${this.gatewaySummary}
+        .priorSummary=${this.priorGatewaySummary}
         .policies=${this.budgetPolicies}
         .loading=${this.fetchingGatewaySummary || this.fetchingBudget}
         .error=${this.error}
@@ -3399,133 +3634,119 @@ export class DashboardView extends AuthedElement {
     `;
   }
 
-  private renderAttentionCard() {
+  /**
+   * One amber line across the top of the page, above everything else, or
+   * nothing at all. The side card it replaces competed with Usage for the
+   * same column and was read after it; a strip is read first because it is
+   * first, and it costs one line instead of a card.
+   */
+  private renderAttentionStrip() {
     const items = this.attentionItems;
     if (items.length === 0) {
       return nothing;
     }
-    const visible = items.slice(0, 5);
-    const overflow = items.length - visible.length;
+    const visible = items.slice(0, 3);
 
     return html`
-      <sl-card class="content-card">
-        <div slot="header" class="card-header-with-action">
-          <div class="card-title attention-title">
-            <sl-icon name="exclamation-triangle"></sl-icon>
-            Needs attention
-            <sl-badge variant="warning" pill>${items.length}</sl-badge>
-          </div>
-          <a href="/console/attention" class="header-action-link">View all</a>
-        </div>
-        <div class="list">
+      <div class="attention-strip">
+        <sl-icon
+          class="attention-strip-icon"
+          name="exclamation-triangle"
+          aria-hidden="true"
+        ></sl-icon>
+        <span class="attention-strip-count"
+          >${this.formatNumber(items.length)} need attention</span
+        >
+        <div class="attention-strip-items">
           ${repeat(
             visible,
             (item) => item.id,
             (item) => html`
-              <div class="row attention-row">
-                <span
-                  class="severity-dot ${item.severity}"
-                  aria-hidden="true"
-                ></span>
-                <sl-icon
-                  class="attention-kind-icon"
-                  name=${ATTENTION_KIND_META[item.kind].icon}
-                  aria-hidden="true"
-                ></sl-icon>
-                <div class="attention-main">
-                  <a class="row-link row-primary" href=${item.href}
-                    >${item.title}</a
-                  >
-                  <span class="attention-detail">${item.detail}</span>
-                </div>
-              </div>
+              <a class="attention-chip-link" href=${item.href}>
+                <sl-badge class="chip" variant="warning" pill>
+                  <sl-icon
+                    name=${ATTENTION_KIND_META[item.kind].icon}
+                    aria-hidden="true"
+                  ></sl-icon>
+                  ${item.title} · ${item.detail}
+                </sl-badge>
+              </a>
             `
           )}
         </div>
-        ${
-          overflow > 0
-            ? html`<a class="attention-more" href="/console/attention"
-                >and ${overflow} more</a
-              >`
-            : nothing
-        }
-      </sl-card>
+        <a class="attention-strip-all" href="/console/attention"
+          >View all <span aria-hidden="true">→</span></a
+        >
+      </div>
     `;
   }
 
+  /**
+   * A stat is an icon, a number and a word, on two lines, about 64px tall.
+   * The old block spent a fifth of a 900px screen on the same five numbers.
+   */
   private renderMetricItem(metric: DashboardMetric) {
-    const iconColor =
-      metric.tone === 'danger'
-        ? 'var(--sl-color-danger-600)'
-        : metric.tone === 'warning'
-          ? 'var(--sl-color-warning-600)'
-          : metric.tone === 'success'
-            ? 'var(--sl-color-success-600)'
-            : metric.tone === 'primary'
-              ? 'var(--sl-color-primary-600)'
-              : 'var(--sl-color-neutral-400)';
     const content = html`
-      ${
-        metric.icon.includes('/')
-          ? html`<sl-icon
-              src=${metric.icon}
-              style="color: ${iconColor};"
-            ></sl-icon>`
-          : html`<sl-icon
-              name=${metric.icon}
-              style="color: ${iconColor};"
-            ></sl-icon>`
-      }
-      <div class="tool-count-value">${metric.value}</div>
-      <div class="tool-count-label ${metric.href ? 'hover-underline' : ''}">
-        ${metric.label}
-      </div>
+      <span class="hero-stat-top">
+        ${
+          metric.icon.includes('/')
+            ? html`<sl-icon
+                class="hero-stat-icon"
+                src=${metric.icon}
+              ></sl-icon>`
+            : html`<sl-icon
+                class="hero-stat-icon"
+                name=${metric.icon}
+              ></sl-icon>`
+        }
+        <span class="hero-stat-value">${metric.value}</span>
+      </span>
+      <span class="hero-stat-label">${metric.label}</span>
     `;
+
+    const toneClass = metric.tone ? `tone-${metric.tone}` : '';
 
     if (metric.href) {
       return html`
-        <a
-          class="tool-count"
-          href=${metric.href}
-          style="color: inherit; text-decoration: none;"
-          >${content}</a
-        >
+        <a class="hero-stat ${toneClass}" href=${metric.href}>${content}</a>
       `;
     }
 
-    return html`<div class="tool-count">${content}</div>`;
+    return html`<div class="hero-stat ${toneClass}">${content}</div>`;
   }
 
   private get gatewayMetrics(): DashboardMetric[] {
     const attentionCount = this.attentionItems.length;
+    // Four counts are just counts: their icons stay neutral so the only
+    // coloured stat in the row is the one that means something.
     return [
       {
         label: 'agents',
         value: this.formatNumber(this.totalAgentsCount),
         icon: 'robot',
         href: '/console/agents',
-        tone: 'primary',
+        tone: 'neutral',
       },
       {
         label: 'flows',
         value: this.formatNumber(this.totalFlowsCount),
         icon: '/images/flow.svg',
         href: '/console/flows',
-        tone: 'primary',
+        tone: 'neutral',
       },
       {
         label: 'models',
         value: this.formatNumber(this.aiModelsCount),
         icon: 'cpu',
         href: '/console/ai-models',
-        tone: 'primary',
+        tone: 'neutral',
       },
       {
         label: 'tools',
         value: this.formatNumber(this.enabledToolsCount),
         icon: 'tools',
         href: '/console/tools',
-        tone: 'primary',
+        tone: 'neutral',
       },
       {
         label: 'need attention',
@@ -3556,24 +3777,19 @@ export class DashboardView extends AuthedElement {
               <sl-icon name="question-circle"></sl-icon>
             </sl-tooltip>
           </div>
-          <div class="gateway-header-meta">
-            <span class="updated-at"
-              >Updated ${this.formatLastUpdatedLabel()}</span
-            >
-            <a href="/console/settings/api-keys" class="header-action-link"
-              >Manage Keys</a
-            >
-          </div>
+          <a href="/console/settings/api-keys" class="header-action-link"
+            >Manage Keys</a
+          >
         </div>
 
-        <div class="metrics-grid">
+        <div class="hero-stats">
           ${
             this.fetchingGatewaySummary && !this.gatewaySummary
               ? html`
                   <div
-                    style="grid-column: 1 / -1; display: flex; justify-content: center; align-items: center; padding: var(--sl-spacing-2x-large);"
+                    style="display: flex; align-items: center; min-height: 64px;"
                   >
-                    <sl-spinner style="font-size: 2rem;"></sl-spinner>
+                    <sl-spinner style="font-size: 1.5rem;"></sl-spinner>
                   </div>
                 `
               : html`
@@ -3585,111 +3801,155 @@ export class DashboardView extends AuthedElement {
                 `
           }
         </div>
-        <!-- AI Model Gateway Endpoint -->
-        <div
-          class="mcp-server-capsule"
-          style="margin-top: 0; margin-bottom: var(--sl-spacing-small);"
-        >
-          <div class="status-indicator"></div>
-          <span class="capsule-eyebrow">Model gateway</span>
-          <sl-badge variant="primary" size="small" style="margin-right: -4px;"
-            >AI models</sl-badge
+
+        <!-- Connect: two green dots and a disclosure. The endpoints matter
+             once, when an agent is wired up; after that they are reference. -->
+        <div class="connect-row">
+          <span class="connect-status">
+            <span class="status-indicator" aria-hidden="true"></span>
+            Model gateway
+          </span>
+          <span class="connect-status">
+            <span class="status-indicator" aria-hidden="true"></span>
+            Tool firewall
+          </span>
+          <sl-button
+            class="connect-toggle"
+            size="small"
+            variant="text"
+            aria-expanded=${this.endpointsExpanded ? 'true' : 'false'}
+            @click=${this.toggleEndpoints}
           >
-          <div
-            class="server-details"
-            style="display: flex; gap: var(--sl-spacing-small); align-items: center;"
-          >
-            <span
-              style="font-size: var(--sl-font-size-x-small); font-weight: 600; color: var(--sl-color-neutral-500); text-transform: uppercase;"
-              >Format:</span
-            >
-            <select
-              aria-label="Gateway API Format"
-              style="background: transparent; border: 1px solid var(--sl-color-neutral-300); border-radius: var(--sl-border-radius-small); padding: 1px 6px; font-size: inherit; font-family: inherit; color: var(--sl-color-primary-600); cursor: pointer; outline: none; margin-right: var(--sl-spacing-2x-small);"
-              @change=${(e: Event) => {
-                const target = e.target as HTMLSelectElement;
-                const endpointSpan = target.parentElement?.querySelector(
-                  '.server-endpoint'
-                ) as HTMLElement;
-                if (endpointSpan) {
-                  endpointSpan.innerText = `${window.location.origin}${target.value}`;
-                }
-              }}
-            >
-              <option value="/openai/v1">OpenAI</option>
-              <option value="/anthropic/v1">Anthropic</option>
-              <option value="/google/v1">Gemini</option>
-            </select>
-            <span class="server-endpoint"
-              >${window.location.origin}/openai/v1</span
-            >
-            <a
-              href="https://docs.preloop.ai/guide/ai-proxy"
-              target="_blank"
-              style="display: flex; color: var(--sl-color-neutral-500); margin-left: auto;"
-            >
-              <sl-icon name="info-circle"></sl-icon>
-            </a>
-          </div>
-          <sl-tooltip content="Copy URL">
-            <sl-icon-button
-              name="clipboard"
-              style="font-size: 1rem;"
-              @click=${(e: Event) => {
-                const capsule = (e.target as HTMLElement).closest(
-                  '.mcp-server-capsule'
-                );
-                const url =
-                  capsule?.querySelector('.server-endpoint')?.textContent ||
-                  `${window.location.origin}/openai/v1`;
-                navigator.clipboard.writeText(url);
-                this.dispatchEvent(
-                  new CustomEvent('show-toast', {
-                    bubbles: true,
-                    composed: true,
-                    detail: { message: 'AI Gateway URL copied!' },
-                  })
-                );
-              }}
-            ></sl-icon-button>
-          </sl-tooltip>
+            ${this.endpointsExpanded ? 'Hide endpoints' : 'Show endpoints'}
+            <sl-icon
+              slot="suffix"
+              name=${this.endpointsExpanded ? 'chevron-up' : 'chevron-down'}
+            ></sl-icon>
+          </sl-button>
         </div>
 
-        <!-- Built-in MCP Server Endpoint -->
-        <div class="mcp-server-capsule" style="margin-top: 0;">
-          <div class="status-indicator"></div>
-          <span class="capsule-eyebrow">Tool firewall</span>
-          <sl-badge variant="neutral" size="small" style="margin-right: -4px;"
-            >MCP tools</sl-badge
-          >
-          <div class="server-details">
-            <span class="server-endpoint">${window.location.origin}/mcp</span>
-            <a
-              href="https://docs.preloop.ai/guide/mcp-server"
-              target="_blank"
-              style="display: flex; color: var(--sl-color-neutral-500); margin-left: auto;"
-            >
-              <sl-icon name="info-circle"></sl-icon>
-            </a>
-          </div>
-          <sl-tooltip content="Copy URL">
-            <sl-icon-button
-              name="clipboard"
-              style="font-size: 1rem;"
-              @click=${() => {
-                navigator.clipboard.writeText(`${window.location.origin}/mcp`);
-                this.dispatchEvent(
-                  new CustomEvent('show-toast', {
-                    bubbles: true,
-                    composed: true,
-                    detail: { message: 'MCP URL copied!' },
-                  })
-                );
-              }}
-            ></sl-icon-button>
-          </sl-tooltip>
-        </div>
+        ${this.endpointsExpanded ? this.renderGatewayEndpoints() : nothing}
       </sl-card>
+    `;
+  }
+
+  /** The two capsules, unchanged: eyebrow, format select, URL, copy. */
+  private renderGatewayEndpoints() {
+    return html`
+      <!-- AI Model Gateway Endpoint -->
+      <div
+        class="mcp-server-capsule"
+        style="margin-top: 0; margin-bottom: var(--sl-spacing-small);"
+      >
+        <div class="status-indicator"></div>
+        <span class="capsule-eyebrow">Model gateway</span>
+        <sl-badge
+          class="chip"
+          variant="neutral"
+          pill
+          size="small"
+          style="margin-right: -4px;"
+          >AI models</sl-badge
+        >
+        <div
+          class="server-details"
+          style="display: flex; gap: var(--sl-spacing-small); align-items: center;"
+        >
+          <span
+            style="font-size: var(--sl-font-size-x-small); font-weight: 600; color: var(--sl-color-neutral-500); text-transform: uppercase;"
+            >Format:</span
+          >
+          <select
+            aria-label="Gateway API Format"
+            style="background: transparent; border: 1px solid var(--sl-color-neutral-300); border-radius: var(--sl-border-radius-small); padding: 1px 6px; font-size: inherit; font-family: inherit; color: var(--sl-color-primary-600); cursor: pointer; outline: none; margin-right: var(--sl-spacing-2x-small);"
+            @change=${(e: Event) => {
+              const target = e.target as HTMLSelectElement;
+              const endpointSpan = target.parentElement?.querySelector(
+                '.server-endpoint'
+              ) as HTMLElement;
+              if (endpointSpan) {
+                endpointSpan.innerText = `${window.location.origin}${target.value}`;
+              }
+            }}
+          >
+            <option value="/openai/v1">OpenAI</option>
+            <option value="/anthropic/v1">Anthropic</option>
+            <option value="/google/v1">Gemini</option>
+          </select>
+          <span class="server-endpoint"
+            >${window.location.origin}/openai/v1</span
+          >
+          <a
+            href="https://docs.preloop.ai/guide/ai-proxy"
+            target="_blank"
+            style="display: flex; color: var(--sl-color-neutral-500); margin-left: auto;"
+          >
+            <sl-icon name="info-circle"></sl-icon>
+          </a>
+        </div>
+        <sl-tooltip content="Copy URL">
+          <sl-icon-button
+            name="clipboard"
+            style="font-size: 1rem;"
+            @click=${(e: Event) => {
+              const capsule = (e.target as HTMLElement).closest(
+                '.mcp-server-capsule'
+              );
+              const url =
+                capsule?.querySelector('.server-endpoint')?.textContent ||
+                `${window.location.origin}/openai/v1`;
+              navigator.clipboard.writeText(url);
+              this.dispatchEvent(
+                new CustomEvent('show-toast', {
+                  bubbles: true,
+                  composed: true,
+                  detail: { message: 'AI Gateway URL copied!' },
+                })
+              );
+            }}
+          ></sl-icon-button>
+        </sl-tooltip>
+      </div>
+
+      <!-- Built-in MCP Server Endpoint -->
+      <div class="mcp-server-capsule" style="margin-top: 0;">
+        <div class="status-indicator"></div>
+        <span class="capsule-eyebrow">Tool firewall</span>
+        <sl-badge
+          class="chip"
+          variant="neutral"
+          pill
+          size="small"
+          style="margin-right: -4px;"
+          >MCP tools</sl-badge
+        >
+        <div class="server-details">
+          <span class="server-endpoint">${window.location.origin}/mcp</span>
+          <a
+            href="https://docs.preloop.ai/guide/mcp-server"
+            target="_blank"
+            style="display: flex; color: var(--sl-color-neutral-500); margin-left: auto;"
+          >
+            <sl-icon name="info-circle"></sl-icon>
+          </a>
+        </div>
+        <sl-tooltip content="Copy URL">
+          <sl-icon-button
+            name="clipboard"
+            style="font-size: 1rem;"
+            @click=${() => {
+              navigator.clipboard.writeText(`${window.location.origin}/mcp`);
+              this.dispatchEvent(
+                new CustomEvent('show-toast', {
+                  bubbles: true,
+                  composed: true,
+                  detail: { message: 'MCP URL copied!' },
+                })
+              );
+            }}
+          ></sl-icon-button>
+        </sl-tooltip>
+      </div>
     `;
   }
 
@@ -3712,20 +3972,24 @@ export class DashboardView extends AuthedElement {
     }
 
     return html`
-      <view-header headerText="Overview" width="extra-wide"></view-header>
+      <view-header headerText="Overview" width="extra-wide">
+        <span slot="meta" class="updated-at"
+          >Updated ${this.formatLastUpdatedLabel()}</span
+        >
+      </view-header>
       <div class="extra-wide" style="margin-bottom: var(--sl-spacing-large);">
         ${
           this.error
             ? html`<sl-alert variant="danger" open>${this.error}</sl-alert>`
             : nothing
         }
-        ${this.renderWelcomeCard()}
+        ${this.renderAttentionStrip()} ${this.renderWelcomeCard()}
       </div>
 
       <div class="column-layout dashboard extra-wide">
         <div class="main-column">
           <div class="dashboard-stack">
-            ${this.renderPreloopGatewayCard()}
+            ${this.renderPreloopGatewayCard()} ${this.renderNextStepsCard()}
             ${this.renderActiveExecutionsCard()}
             ${this.renderRecentFlowExecutionsCard()}
 
@@ -3739,8 +4003,7 @@ export class DashboardView extends AuthedElement {
         </div>
 
         <div class="side-column">
-          ${this.renderAttentionCard()} ${this.renderUsageCard()}
-          ${this.renderTopModelsCard()}
+          ${this.renderUsageCard()} ${this.renderTopModelsCard()}
         </div>
         <mcp-setup-dialog
           ?open=${this.showSetupDialog}

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -352,14 +352,16 @@ export class DashboardView extends AuthedElement {
       .connect-toggle {
         margin-left: auto;
       }
-      /* One amber line above the page, or nothing. */
+      /* One amber line above the page, or nothing. It stays one line: the
+         chips truncate before the strip is allowed to wrap, so "View all"
+         never falls to a second row. */
       .attention-strip {
         align-items: center;
         background: var(--sl-color-warning-50);
         border: 1px solid var(--sl-color-warning-200);
         border-radius: var(--sl-border-radius-medium);
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         gap: var(--sl-spacing-small);
         padding: var(--sl-spacing-x-small) var(--sl-spacing-medium);
       }
@@ -376,20 +378,41 @@ export class DashboardView extends AuthedElement {
       }
       .attention-strip-items {
         display: flex;
-        flex: 1 1 auto;
-        flex-wrap: wrap;
+        flex: 0 1 auto;
+        flex-wrap: nowrap;
         gap: var(--sl-spacing-x-small);
         min-width: 0;
+        overflow: hidden;
       }
       .attention-chip-link {
-        max-width: 100%;
+        display: flex;
+        max-width: 26ch;
+        min-width: 0;
         text-decoration: none;
       }
+      .attention-chip-link sl-badge {
+        max-width: 100%;
+        min-width: 0;
+      }
+      /* Quiet amber: the strip behind them is already the alarm, so the
+         chips read as labels rather than as five more warnings. */
       .attention-chip-link sl-badge::part(base) {
         align-items: center;
+        background-color: var(--sl-color-warning-100);
+        border-color: var(--sl-color-warning-200);
+        color: var(--sl-color-warning-900);
         display: flex;
         gap: var(--sl-spacing-3x-small);
         max-width: 100%;
+        min-width: 0;
+      }
+      .attention-chip-link:hover sl-badge::part(base) {
+        background-color: var(--sl-color-warning-200);
+      }
+      /* min-width lets the label shrink inside the badge, so a long one ends
+         in an ellipsis instead of being cut mid-word by the strip. */
+      .attention-chip-text {
+        min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -1166,12 +1189,35 @@ export class DashboardView extends AuthedElement {
           row-gap: var(--sl-spacing-medium);
         }
 
+        /* Phone: the strip is allowed the second row it needs, and the chips
+           stop competing for one line of 390px. */
+        .attention-strip {
+          flex-wrap: wrap;
+        }
+
+        .attention-strip-items {
+          flex-wrap: wrap;
+          overflow: visible;
+        }
+
+        .attention-chip-link {
+          max-width: 100%;
+        }
+
         .attention-strip-all {
           margin-left: 0;
         }
 
         .connect-toggle {
           margin-left: 0;
+        }
+
+        /* A title and a dismiss button are a row at any width; stacking them
+           put the x on a line of its own. */
+        .next-steps-card .card-header-with-action {
+          align-items: center;
+          flex-direction: row;
+          justify-content: space-between;
         }
       }
     `,
@@ -3668,7 +3714,9 @@ export class DashboardView extends AuthedElement {
                     name=${ATTENTION_KIND_META[item.kind].icon}
                     aria-hidden="true"
                   ></sl-icon>
-                  ${item.title} · ${item.detail}
+                  <span class="attention-chip-text"
+                    >${item.title} · ${item.detail}</span
+                  >
                 </sl-badge>
               </a>
             `

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -728,14 +728,6 @@ export class DashboardView extends AuthedElement {
       .capsule-link:hover {
         text-decoration: underline;
       }
-      /* "Updated 2m ago" and "Manage Keys" read as one muted line about the
-         card, wherever the header has room for them. */
-      .gateway-header-meta {
-        align-items: center;
-        display: flex;
-        gap: var(--sl-spacing-small);
-        min-width: 0;
-      }
       /* Phone width: the capsule is a two-row block, not a pill. Row one
          names the endpoint, row two is the thing you came to copy. Without
          this the select and the URL pushed the copy button outside the card. */
@@ -2528,9 +2520,9 @@ export class DashboardView extends AuthedElement {
   }
 
   /**
-   * The Policies page derives tool access rules from the tools themselves: a
-   * tool that is disabled or needs approval is a policy. Anything else is the
-   * default allow, which is not a decision anyone made.
+   * True when at least one tool is disabled or approval-gated. The next-step
+   * label ("Restrict a tool") matches this signal. Subject-scoped model lists
+   * and other Policies-page rules are not visible here.
    */
   private get hasToolPolicy(): boolean {
     return this.tools.some(
@@ -2554,7 +2546,7 @@ export class DashboardView extends AuthedElement {
       },
       {
         id: 'policy',
-        label: 'Add a tool policy',
+        label: 'Restrict a tool',
         done: this.hasToolPolicy,
         href: '/console/policies',
       },

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -157,6 +157,8 @@ export const NEXT_STEPS_DISMISSED_KEY = 'dashboard_next_steps_dismissed';
 export const ENDPOINTS_EXPANDED_KEY = 'dashboard_endpoints_expanded';
 
 interface NextStep {
+  /** Nice to have: never keeps the card alive on its own. */
+  optional?: boolean;
   id: string;
   label: string;
   done: boolean;
@@ -357,8 +359,15 @@ export class DashboardView extends AuthedElement {
          never falls to a second row. */
       .attention-strip {
         align-items: center;
-        background: var(--sl-color-warning-50);
-        border: 1px solid var(--sl-color-warning-200);
+        /* A translucent mix of one warning token reads as a pale tint in light
+           and a dim tint in dark, instead of the inverted-scale solid band. */
+        background: color-mix(
+          in srgb,
+          var(--sl-color-warning-500) 12%,
+          var(--sl-color-neutral-0)
+        );
+        border: 1px solid
+          color-mix(in srgb, var(--sl-color-warning-500) 40%, transparent);
         border-radius: var(--sl-border-radius-medium);
         display: flex;
         flex-wrap: nowrap;
@@ -2553,6 +2562,7 @@ export class DashboardView extends AuthedElement {
     if (this.userManagementEnabled) {
       steps.push({
         id: 'invite',
+        optional: true,
         label: 'Invite a teammate',
         done: this.enabledUsersCount > 1,
         href: '/console/settings/invitations',
@@ -2775,7 +2785,7 @@ export class DashboardView extends AuthedElement {
       return nothing;
     }
     const steps = this.nextSteps;
-    if (steps.every((step) => step.done)) {
+    if (steps.every((step) => step.done || step.optional)) {
       return nothing;
     }
 
@@ -3723,7 +3733,12 @@ export class DashboardView extends AuthedElement {
           )}
         </div>
         <a class="attention-strip-all" href="/console/attention"
-          >View all <span aria-hidden="true">→</span></a
+          >${
+            items.length > visible.length
+              ? html`+${this.formatNumber(items.length - visible.length)} more · `
+              : nothing
+          }View
+          all <span aria-hidden="true">→</span></a
         >
       </div>
     `;

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -1146,7 +1146,7 @@ describe('DashboardView', () => {
       expect(steps.length).to.equal(3);
       expect(card?.textContent).to.contain('Onboard an agent');
       expect(card?.textContent).to.contain('Set a spending limit');
-      expect(card?.textContent).to.contain('Add a tool policy');
+      expect(card?.textContent).to.contain('Restrict a tool');
       // The agent exists, so that step is ticked and the other two are not.
       expect(steps[0].classList.contains('done'), 'agent step done').to.be.true;
       expect(steps[1].classList.contains('done'), 'budget step done').to.be

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -491,7 +491,7 @@ describe('DashboardView', () => {
       'Recent Flow Executions'
     );
     expect(element.shadowRoot?.textContent).to.contain('Audit exceptions');
-    expect(element.shadowRoot?.textContent).to.contain('Needs attention');
+    expect(element.shadowRoot?.textContent).to.contain('need attention');
   });
 
   it('subscribes to realtime topics and fetches dashboard data', async () => {
@@ -515,15 +515,16 @@ describe('DashboardView', () => {
         url.startsWith('/api/v1/account/gateway-usage/summary')
       )
     ).to.be.true;
-    // Two for the cards (summary + breakdown upgrade) plus the fixed 30d one
-    // the shared attention loader uses, and one agents call per source: the
-    // cards' own list and the attention loader's, which must stay on the
-    // parameters the Attention page uses.
+    // Two for the cards (summary + breakdown upgrade), one for the prior
+    // window behind the Usage delta, plus the fixed 30d one the shared
+    // attention loader uses; and one agents call per source: the cards' own
+    // list and the attention loader's, which must stay on the parameters the
+    // Attention page uses.
     expect(
       urls.filter((url) =>
         url.startsWith('/api/v1/account/gateway-usage/summary')
       ).length
-    ).to.be.at.most(3);
+    ).to.be.at.most(4);
     expect(urls.some((url) => url.includes('include_breakdown=false'))).to.be
       .true;
     expect(
@@ -731,14 +732,14 @@ describe('DashboardView', () => {
     );
     await element.updateComplete;
 
-    const metricsGrid = element.shadowRoot?.querySelector('.metrics-grid');
-    expect(metricsGrid).to.exist;
-    const metricText = metricsGrid?.textContent || '';
+    const heroStats = element.shadowRoot?.querySelector('.hero-stats');
+    expect(heroStats).to.exist;
+    const metricText = heroStats?.textContent || '';
     ['agents', 'flows', 'models', 'tools', 'need attention'].forEach((label) =>
       expect(metricText).to.contain(label)
     );
 
-    const metricLinks = metricsGrid?.querySelectorAll('a.tool-count') || [];
+    const metricLinks = heroStats?.querySelectorAll('a.hero-stat') || [];
     expect(metricLinks.length).to.equal(5);
     expect(metricLinks[4].getAttribute('href')).to.equal('/console/attention');
 
@@ -769,7 +770,7 @@ describe('DashboardView', () => {
       .null;
   });
 
-  it('surfaces pending approvals in the attention card', async () => {
+  it('surfaces pending approvals in the attention strip', async () => {
     const element = await mountDashboard();
     await waitUntil(
       () =>
@@ -781,19 +782,18 @@ describe('DashboardView', () => {
     );
     await element.updateComplete;
 
-    const attentionLink = element.shadowRoot?.querySelector(
-      'a.header-action-link[href="/console/attention"]'
-    );
-    expect(attentionLink, 'View all link').to.exist;
-
-    const rows = element.shadowRoot?.querySelectorAll('.attention-row') || [];
-    expect(rows.length).to.be.greaterThan(0);
+    const strip = element.shadowRoot?.querySelector('.attention-strip');
+    expect(strip, 'the attention strip').to.exist;
+    expect(strip?.textContent).to.contain('need attention');
+    expect(
+      strip?.querySelector('a.attention-strip-all')?.getAttribute('href')
+    ).to.equal('/console/attention');
     expect(element.shadowRoot?.textContent || '').to.not.contain(
       'Pending approvals'
     );
   });
 
-  it('keeps each attention row on one line about 44px tall', async () => {
+  it('keeps the attention strip on one line at 1440 and shows at most three items', async () => {
     const element = await mountDashboard();
     await waitUntil(
       () =>
@@ -805,40 +805,63 @@ describe('DashboardView', () => {
     );
     await element.updateComplete;
 
-    const row = element.shadowRoot?.querySelector(
-      '.attention-row'
-    ) as HTMLElement | null;
-    expect(row, 'an attention row renders').to.exist;
-    // Three stacked lines (dot, icon, text) used to make these ~70px each, so
-    // five items pushed the Usage card below the fold.
-    expect(row!.offsetHeight, 'row height').to.be.at.most(52);
-
-    const title = row!.querySelector('.row-primary') as HTMLElement;
-    const detail = row!.querySelector('.attention-detail') as HTMLElement;
-    expect(title.getBoundingClientRect().top).to.be.closeTo(
-      detail.getBoundingClientRect().top,
-      8
-    );
-    expect(getComputedStyle(title).whiteSpace).to.equal('nowrap');
-    expect(
-      title.getBoundingClientRect().right,
-      'nothing escapes the row'
-    ).to.be.at.most(row!.getBoundingClientRect().right + 1);
+    const strip = element.shadowRoot?.querySelector(
+      '.attention-strip'
+    ) as HTMLElement;
+    expect(strip, 'the attention strip').to.exist;
+    const chips = strip.querySelectorAll('a.attention-chip-link');
+    expect(chips.length, 'chips shown inline').to.be.at.most(3);
+    // The whole thing is a line, not a card: a side card cost 5 rows plus a
+    // header for the same facts.
+    expect(strip.offsetHeight, 'strip height').to.be.at.most(56);
   });
 
-  it('shows Updated and Manage Keys as one muted line in the gateway header', async () => {
+  it('hides the attention strip when nothing needs attention', async () => {
+    const element = await mountDashboard();
+    await waitUntil(
+      () =>
+        !element['loading'] &&
+        !element['fetchingApprovals'] &&
+        !element['fetchingAudit'] &&
+        !element['fetchingMCPAndTools'],
+      'dashboard did not finish loading'
+    );
+    // A quiet account: the same shape the loader returns, with nothing in it.
+    element['attentionInputs'] = {};
+    await element.updateComplete;
+
+    expect(
+      element['attentionItems'].length,
+      'nothing needs attention'
+    ).to.equal(0);
+    expect(element.shadowRoot?.querySelector('.attention-strip')).to.not.exist;
+
+    // The hero stat still states the fact, in green.
+    const attentionStat = element.shadowRoot?.querySelector(
+      'a.hero-stat[href="/console/attention"]'
+    );
+    expect(attentionStat?.classList.contains('tone-success')).to.be.true;
+    expect(
+      attentionStat?.querySelector('.hero-stat-value')?.textContent?.trim()
+    ).to.equal('0');
+  });
+
+  it('shows Updated beside the page title, and Manage Keys in the gateway header', async () => {
     const element = await mountDashboard();
     await waitUntil(() => !element['loading'], 'dashboard did not load');
     await element.updateComplete;
 
-    const meta = element.shadowRoot?.querySelector('.gateway-header-meta');
-    expect(meta, 'the gateway header meta line renders').to.exist;
-    expect(meta?.querySelector('.updated-at')?.textContent).to.contain(
-      'Updated'
+    const updated = element.shadowRoot?.querySelector(
+      'view-header .updated-at'
     );
-    expect(
-      meta?.querySelector('a.header-action-link')?.textContent?.trim()
-    ).to.equal('Manage Keys');
+    expect(updated, 'the page-level updated line renders').to.exist;
+    expect(updated?.getAttribute('slot')).to.equal('meta');
+    expect(updated?.textContent).to.contain('Updated');
+
+    const manageKeys = element.shadowRoot?.querySelector(
+      'a.header-action-link[href="/console/settings/api-keys"]'
+    );
+    expect(manageKeys?.textContent?.trim()).to.equal('Manage Keys');
   });
 
   it('skips zero-request runtime sessions and displays ids instead of config paths', async () => {
@@ -982,5 +1005,209 @@ describe('DashboardView', () => {
       'Pull Request Reviewer'
     );
     expect(element.shadowRoot?.textContent || '').to.contain('PR #42 review');
+  });
+  describe('wave 2 Overview', () => {
+    async function mountLoaded(): Promise<DashboardView> {
+      const element = await mountDashboard();
+      await waitUntil(
+        () =>
+          !element['loading'] &&
+          !element['fetchingActiveAgents'] &&
+          !element['fetchingBudget'] &&
+          !element['fetchingAudit'] &&
+          !element['fetchingMCPAndTools'],
+        'dashboard did not finish loading'
+      );
+      await element.updateComplete;
+      return element;
+    }
+
+    it('states the five counts in a single 64px row', async () => {
+      const element = await mountLoaded();
+
+      const row = element.shadowRoot?.querySelector(
+        '.hero-stats'
+      ) as HTMLElement;
+      expect(row, 'the hero row').to.exist;
+      // It used to be about 200px: a fifth of the window for five numbers.
+      expect(row.offsetHeight, 'hero row height').to.be.at.most(96);
+
+      expect(getComputedStyle(row).flexDirection, 'stats read across').to.equal(
+        'row'
+      );
+
+      const stats = row.querySelectorAll('a.hero-stat');
+      expect(stats.length).to.equal(5);
+      const stat = stats[0] as HTMLElement;
+      expect(stat.offsetHeight, 'one stat').to.be.at.most(64);
+
+      const value = stat.querySelector('.hero-stat-value') as HTMLElement;
+      const valueStyles = getComputedStyle(value);
+      expect(valueStyles.fontSize).to.equal('22px');
+      expect(valueStyles.fontWeight).to.equal('600');
+      expect(valueStyles.fontVariantNumeric).to.contain('tabular-nums');
+
+      // Label under the number, in the meta register.
+      const label = stat.querySelector('.hero-stat-label') as HTMLElement;
+      expect(getComputedStyle(label).fontSize).to.equal('13px');
+      expect(label.getBoundingClientRect().top).to.be.greaterThan(
+        value.getBoundingClientRect().top
+      );
+
+      const icon = stat.querySelector('sl-icon') as HTMLElement;
+      expect(getComputedStyle(icon).fontSize).to.equal('18px');
+    });
+
+    it('colours the attention stat amber and marks it with a triangle when items exist', async () => {
+      const element = await mountLoaded();
+
+      const stat = element.shadowRoot?.querySelector(
+        'a.hero-stat[href="/console/attention"]'
+      ) as HTMLElement;
+      expect(stat.classList.contains('tone-warning')).to.be.true;
+      expect(stat.querySelector('sl-icon')?.getAttribute('name')).to.equal(
+        'exclamation-triangle'
+      );
+    });
+
+    it('expands the endpoints for an account with no fully onboarded agent', async () => {
+      const element = await mountLoaded();
+
+      expect(element['endpointsExpanded']).to.be.true;
+      const capsules =
+        element.shadowRoot?.querySelectorAll('.mcp-server-capsule') || [];
+      expect(capsules.length, 'both capsules').to.equal(2);
+      const toggle = element.shadowRoot?.querySelector('.connect-toggle');
+      expect(toggle?.textContent).to.contain('Hide endpoints');
+    });
+
+    it('collapses the endpoints once an agent is fully onboarded', async () => {
+      agentsResponse = {
+        ...agentsResponse,
+        items: [
+          { ...agentsResponse.items[0], onboarding_state: 'fully_onboarded' },
+        ],
+      };
+
+      const element = await mountLoaded();
+
+      expect(element['endpointsExpanded']).to.be.false;
+      expect(element.shadowRoot?.querySelector('.mcp-server-capsule')).to.not
+        .exist;
+      // The state is still stated, just without the URLs.
+      const row = element.shadowRoot?.querySelector('.connect-row');
+      expect(row?.textContent).to.contain('Model gateway');
+      expect(row?.textContent).to.contain('Tool firewall');
+      expect(row?.textContent).to.contain('Show endpoints');
+    });
+
+    it('remembers the endpoints disclosure across visits', async () => {
+      const element = await mountLoaded();
+
+      const toggle = element.shadowRoot?.querySelector(
+        '.connect-toggle'
+      ) as HTMLElement;
+      toggle.click();
+      await element.updateComplete;
+
+      expect(element['endpointsExpanded']).to.be.false;
+      expect(localStorage.getItem('dashboard_endpoints_expanded')).to.equal(
+        'false'
+      );
+
+      const second = await mountLoaded();
+      expect(second['endpointsExpanded']).to.be.false;
+      expect(second.shadowRoot?.querySelector('.mcp-server-capsule')).to.not
+        .exist;
+    });
+
+    it('hides next steps when every step is already done', async () => {
+      const element = await mountLoaded();
+
+      // The fixture has an agent, budget policies and a tool under approval.
+      expect(element['nextSteps'].every((step: any) => step.done)).to.be.true;
+      expect(element.shadowRoot?.querySelector('.next-steps-card')).to.not
+        .exist;
+    });
+
+    it('lists the open steps for a new account, with the done ones ticked', async () => {
+      budgetPoliciesResponse = [];
+      toolsResponse = toolsResponse.map((tool: any) => ({
+        ...tool,
+        is_enabled: true,
+        approval_workflow_id: null,
+      }));
+
+      const element = await mountLoaded();
+
+      const card = element.shadowRoot?.querySelector('.next-steps-card');
+      expect(card, 'the next steps card').to.exist;
+      const steps = card?.querySelectorAll('.next-step') || [];
+      expect(steps.length).to.equal(3);
+      expect(card?.textContent).to.contain('Onboard an agent');
+      expect(card?.textContent).to.contain('Set a spending limit');
+      expect(card?.textContent).to.contain('Add a tool policy');
+      // The agent exists, so that step is ticked and the other two are not.
+      expect(steps[0].classList.contains('done'), 'agent step done').to.be.true;
+      expect(steps[1].classList.contains('done'), 'budget step done').to.be
+        .false;
+      expect(
+        (steps[1].querySelector('.next-step-link') as HTMLElement).tagName
+      ).to.equal('BUTTON');
+      expect(
+        steps[2].querySelector('a.next-step-link')?.getAttribute('href')
+      ).to.equal('/console/policies');
+    });
+
+    it('adds the invite step only when user management is on', async () => {
+      budgetPoliciesResponse = [];
+      const element = await mountLoaded();
+      expect(element['nextSteps'].map((step: any) => step.id)).to.not.include(
+        'invite'
+      );
+
+      element['userManagementEnabled'] = true;
+      await element.updateComplete;
+      const invite = element['nextSteps'].find(
+        (step: any) => step.id === 'invite'
+      );
+      expect(invite?.href).to.equal('/console/settings/invitations');
+    });
+
+    it('dismisses next steps and remembers it', async () => {
+      budgetPoliciesResponse = [];
+      const element = await mountLoaded();
+
+      const dismiss = element.shadowRoot?.querySelector(
+        '.next-steps-card sl-icon-button[label="Dismiss next steps"]'
+      ) as HTMLElement;
+      expect(dismiss, 'the dismiss control').to.exist;
+      dismiss.click();
+      await element.updateComplete;
+
+      expect(element.shadowRoot?.querySelector('.next-steps-card')).to.not
+        .exist;
+      expect(localStorage.getItem('dashboard_next_steps_dismissed')).to.equal(
+        'true'
+      );
+    });
+
+    it('asks the gateway for the previous window and hands it to the Usage card', async () => {
+      const element = await mountLoaded();
+
+      const summaryCalls = fetchStub
+        .getCalls()
+        .map((call: any) => String(call.args[0]))
+        .filter((url: string) =>
+          url.startsWith('/api/v1/account/gateway-usage/summary')
+        );
+      const priorCall = summaryCalls.find((url: string) =>
+        url.includes('end_date=')
+      );
+      expect(priorCall, 'a bounded prior-window request').to.exist;
+
+      const usageCard = element.shadowRoot?.querySelector('usage-card') as any;
+      expect(usageCard.priorSummary, 'prior summary reaches the card').to.exist;
+    });
   });
 });

--- a/frontend/src/views/authed/flow-executions-view.ts
+++ b/frontend/src/views/authed/flow-executions-view.ts
@@ -445,6 +445,7 @@ export class FlowExecutionsView extends AuthedElement {
                                       : ''
                                   }
                                   <sl-badge
+                                    pill
                                     variant=${this.getStatusVariant(exec.status)}
                                     >${exec.status}</sl-badge
                                   >

--- a/frontend/src/views/authed/flow-executions-view.ts
+++ b/frontend/src/views/authed/flow-executions-view.ts
@@ -537,14 +537,14 @@ export class FlowExecutionsView extends AuthedElement {
     return html`<span title=${subject}>${subject}</span>`;
   }
 
+  /** Same taxonomy as the Overview: success finished, danger failed, the
+   * rest is state. The pulsing dot beside the chip says "still running". */
   getStatusVariant(status: string) {
     switch (status) {
       case 'SUCCEEDED':
         return 'success';
       case 'FAILED':
         return 'danger';
-      case 'RUNNING':
-        return 'primary';
       default:
         return 'neutral';
     }


### PR DESCRIPTION
Console UX wave 2, stacked on #348 (merge #348 first; this PR targets `ux/console-wave-1`). Frontend only, no new dependencies. Spec: `product/ux-review/2026-09-02/CONSOLE-WAVE-2-SPEC.md`; style guide: EE `DESIGN.md` gains a `## Console` section (D25).

## Console surface (every authed page)
- Page `neutral-50`, cards `neutral-0` with hairline + x-small shadow; sidebar active item as a tinted row with a 3px primary rule (token-only, correct in dark).
- One type scale (26/22/15/14/13/11), tabular numerals pushed from the shell, one chip recipe for every status pill (RUNNING/PENDING are neutral; warning means a person must act; danger means failed).
- Visible focus rings, row hover, one primary button per page (compact Talk buttons are default now).
- Motion: sparkline draws once under `prefers-reduced-motion: no-preference`; nothing pulses except the existing running dot.

## Overview
- **Attention strip** above the page (replaces the side card): amber only when something needs attention, up to three quiet chips, "+N more · View all". Zero items: no strip, green stat.
- **Compact hero**: five left-aligned stats in a 64px row (was ~200px).
- **Connect disclosure**: `● Model gateway ● Tool firewall [Show endpoints]`, collapsed by default once an agent is fully onboarded, both capsules unchanged when open, choice persisted.
- **Usage delta**: `▲ 91% vs prior 30d` from a second summary call for the prior window (grey, direction by arrow).
- **Next steps** card for week one: onboard an agent, set a spending limit, add a tool policy (+ invite a teammate when user management is on, optional). Dismissable; auto-hides when the core steps are done.

## Verification
- `npm run build` clean; `npm test` 108 files, 984 passed, 0 failed.
- Screenshots light + dark at 1440 and 390 in `product/ux-review/2026-09-02/shots-wave2/` (private repo), reviewed and corrected before push (dark sidebar, chip weight, mobile header, stray primary).

## Review by eye
`/console` light and dark: strip on one line, stat row, disclosure closed/open, usage delta, Next steps hidden on this account. `/console/agents`, an agent detail, `/console/attention`: page tint, chips, focus rings. Cost and Tools inherit the surface change; glance at them.

## Open questions
- Prior-window delta on a partial period flatters the current window; clip to elapsed fraction?
- "Add a tool policy" is derived from tool rows (disabled or approval-gated); governance rules that never touch a tool row would leave it unticked.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Frontend-only, token-driven console UX refinement with no security surface, no new dependencies, and thorough component tests; all review findings resolved.
>
> **Overview**
> Wave 2 of the console UX: compact type scale and unified chip recipe, an attention strip replacing the side card, a 64px hero row, a collapsible connect disclosure, a prior-period usage delta, and a dismissable Next-steps checklist. Reviewed at `57e3aaed`; the single LOW finding (dead `.gateway-header-meta` CSS) is resolved and both open questions are answered in-thread.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 57e3aaed. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->