### PR TITLE
Retry transient aux-model 429s and authenticate flow git push

### DIFF
--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -2532,7 +2532,16 @@ echo "========================================="
                         execution_context, idx, token
                     )
 
-                username = credential_username(None, tracker_type)
+                trigger_data = execution_context.get("trigger_event_data", {})
+                repo_url = self._resolve_repository_clone_url(
+                    repo_config, idx, execution_context, trigger_data
+                )
+                host_kind = (
+                    tracker_host_kind(strip_url_credentials(repo_url))
+                    if repo_url
+                    else None
+                )
+                username = credential_username(host_kind, tracker_type)
                 push_auth = build_push_auth_setup_shell(
                     token_ref=token_ref, username=username
                 )

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -20,6 +20,7 @@ from preloop.utils.git_credentials import (
     GitCredential,
     build_credential_env,
     build_credential_setup_shell,
+    build_push_auth_setup_shell,
     credential_username,
     git_token_env_var,
     needs_http_path_scoping,
@@ -2481,8 +2482,11 @@ echo "========================================="
                 self.logger.debug("No git_clone_config in execution context")
                 return ""
 
-            # Check for repositories - if they exist, we should have cloned them
-            repositories = git_config.get("repositories", [])
+            # Match clone: empty repositories still falls back to the trigger
+            # project, otherwise post-exec would skip a repo that was cloned.
+            repositories = self._resolve_git_clone_repositories(
+                execution_context, git_config
+            )
             if not repositories:
                 self.logger.debug("No repositories in git_clone_config")
                 return ""
@@ -2512,16 +2516,11 @@ echo "========================================="
                     # Relative path - prepend /workspace/
                     full_path = f"/workspace/{clone_path}"
 
-                # Get tracker info for PR/MR creation
-                tracker_id = repo_config.get("tracker_id")
-                git_credentials_map = execution_context.get("git_credentials_map", {})
-                tracker_creds = git_credentials_map.get(tracker_id)
-
-                if not tracker_creds:
-                    continue
-
-                tracker_type = tracker_creds.get("tracker_type")
-                token = tracker_creds.get("token")
+                # Resolve the tracker token the same way clone does, so a
+                # missing tracker_id still finds the trigger-project token.
+                token, tracker_type = self._resolve_repository_token(
+                    repo_config, execution_context
+                )
 
                 # The REST API token is passed through the environment rather
                 # than interpolated into the script, so it cannot leak via the
@@ -2533,7 +2532,14 @@ echo "========================================="
                         execution_context, idx, token
                     )
 
-                # Commands to check for commits and push
+                username = credential_username(None, tracker_type)
+                push_auth = build_push_auth_setup_shell(
+                    token_ref=token_ref, username=username
+                )
+
+                # Commands to check for commits and push. Persist a bundle
+                # under /workspace/evidence *before* push so a failed push
+                # still leaves a recoverable artifact in the log stream.
                 # Note: Directory is guaranteed to exist because git clone validation would have failed earlier
                 repo_post_commands = [
                     f"cd {full_path}",
@@ -2541,6 +2547,18 @@ echo "========================================="
                     f'COMMIT_COUNT=$(git rev-list --count {source_branch}..{target_branch} 2>/dev/null || echo "0")',
                     'if [ "$COMMIT_COUNT" -gt "0" ]; then',
                     f'  echo "Found $COMMIT_COUNT commits on {target_branch}, pushing..."',
+                    f"  mkdir -p {EVIDENCE_DIR_PATH}",
+                    f"  git rev-parse HEAD > {EVIDENCE_DIR_PATH}/HEAD.txt 2>/dev/null || true",
+                    f"  git log -1 --format='%H %s' >> {EVIDENCE_DIR_PATH}/HEAD.txt 2>/dev/null || true",
+                    f"  git format-patch --stdout {source_branch}..HEAD > {EVIDENCE_DIR_PATH}/branch.patch 2>/dev/null || true",
+                    (
+                        f"  git bundle create {EVIDENCE_DIR_PATH}/branch.bundle "
+                        f"{source_branch}..HEAD 2>/dev/null "
+                        f"|| git bundle create {EVIDENCE_DIR_PATH}/branch.bundle HEAD "
+                        f"2>/dev/null || true"
+                    ),
+                    f'  echo "Wrote git recovery artifacts under {EVIDENCE_DIR_PATH}"',
+                    push_auth,
                     f"  git push origin {target_branch}",
                 ]
 

--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -98,6 +98,7 @@ from preloop.services.cache_accounting import (
     build_request_cache_accounting,
     summarize_session_cache,
 )
+from preloop.services.aux_model_retry import call_with_aux_retry
 from preloop.services.managed_agent_identity import (
     ManagedAgentIdentityError,
     PrincipalIdentity,
@@ -1325,9 +1326,12 @@ async def extract_agent_name(
     )
 
     def _call():
-        response = litellm.completion(**kwargs)
-        check_reasoning_model_empty_content(response)
-        return response.choices[0].message.content.strip()
+        def _complete():
+            response = litellm.completion(**kwargs)
+            check_reasoning_model_empty_content(response)
+            return response.choices[0].message.content.strip()
+
+        return call_with_aux_retry(_complete, operation_name="extract_agent_name")
 
     try:
         name = await asyncio.to_thread(_call)

--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -1331,7 +1331,11 @@ async def extract_agent_name(
             check_reasoning_model_empty_content(response)
             return response.choices[0].message.content.strip()
 
-        return call_with_aux_retry(_complete, operation_name="extract_agent_name")
+        return call_with_aux_retry(
+            _complete,
+            operation_name="extract_agent_name",
+            provider=getattr(default_model, "provider_name", None),
+        )
 
     try:
         name = await asyncio.to_thread(_call)

--- a/backend/preloop/services/aux_model_retry.py
+++ b/backend/preloop/services/aux_model_retry.py
@@ -16,7 +16,10 @@ import logging
 import time
 from typing import Callable, Optional, TypeVar
 
-from preloop.services.model_gateway_errors import ModelGatewayAPIError
+from preloop.services.model_gateway_errors import (
+    GatewayProvider,
+    ModelGatewayAPIError,
+)
 from preloop.services.upstream_errors import (
     ERROR_CLASS_UPSTREAM_RATE_LIMITED,
     UpstreamErrorClass,
@@ -35,6 +38,19 @@ AUX_RETRY_COUNT = 1
 AUX_BASE_BACKOFF_SECONDS = 0.5
 AUX_RETRY_AFTER_CAP_SECONDS = 4.0
 
+# ModelGatewayAPIError.provider is a closed literal used for the error
+# envelope shape. Unknown/custom aux providers fall back to openai.
+_GATEWAY_PROVIDERS: frozenset[str] = frozenset({"openai", "anthropic", "gemini"})
+
+
+def _as_gateway_provider(provider: Optional[str]) -> GatewayProvider:
+    """Map an AIModel.provider_name onto the gateway envelope literal."""
+
+    name = (provider or "").strip().lower()
+    if name in _GATEWAY_PROVIDERS:
+        return name  # type: ignore[return-value]
+    return "openai"
+
 
 def _backoff_seconds(classified: Optional[UpstreamErrorClass], attempt: int) -> float:
     """Exponential backoff, raised to the provider Retry-After, capped at 4s."""
@@ -45,7 +61,9 @@ def _backoff_seconds(classified: Optional[UpstreamErrorClass], attempt: int) -> 
     return min(delay, AUX_RETRY_AFTER_CAP_SECONDS)
 
 
-def _to_gateway_error(exc: Exception) -> ModelGatewayAPIError:
+def _to_gateway_error(
+    exc: Exception, *, provider: Optional[str] = None
+) -> ModelGatewayAPIError:
     """Surface an exhausted transient as a classified gateway error.
 
     The raw provider exception is chained as ``__cause__`` so GlitchTip
@@ -63,7 +81,7 @@ def _to_gateway_error(exc: Exception) -> ModelGatewayAPIError:
     retry_after = classified.retry_after_seconds if classified is not None else None
     terminal = classified.terminal if classified is not None else False
     return ModelGatewayAPIError(
-        provider="openai",
+        provider=_as_gateway_provider(provider),
         status_code=status_code,
         message=str(exc),
         error_class=error_class,
@@ -76,6 +94,7 @@ def call_with_aux_retry(
     fn: Callable[[], T],
     *,
     operation_name: str = "aux_model",
+    provider: Optional[str] = None,
     sleep: Optional[Callable[[float], None]] = None,
 ) -> T:
     """Call ``fn``, retrying once on a transient upstream fault.
@@ -83,6 +102,10 @@ def call_with_aux_retry(
     Terminal quota / auth failures fail fast. Exhausted transients are
     re-raised as :class:`ModelGatewayAPIError` with the raw exception
     chained as ``__cause__``.
+
+    ``provider`` is the model's ``provider_name`` so the classified error
+    envelope matches Anthropic/Gemini aux calls instead of always looking
+    like OpenAI.
 
     ``sleep`` is resolved at call time so tests can patch
     ``preloop.services.aux_model_retry.time.sleep``.
@@ -113,4 +136,4 @@ def call_with_aux_retry(
             sleeper(delay)
 
     assert last_exc is not None
-    raise _to_gateway_error(last_exc) from last_exc
+    raise _to_gateway_error(last_exc, provider=provider) from last_exc

--- a/backend/preloop/services/aux_model_retry.py
+++ b/backend/preloop/services/aux_model_retry.py
@@ -1,0 +1,116 @@
+"""Bounded Retry-After-aware retry for aux (non-gateway) model calls.
+
+The model gateway already retries transient 429 / overload / network faults.
+Auxiliary call sites (approval summaries, session summaries, policy
+generation, agent-name extraction) talk to providers through litellm
+directly and historically let a single transient 429 propagate raw — or
+burn the capped one-shot system-default fallback.
+
+This helper reuses ``classify_upstream_error`` / ``is_retryable_upstream_failure``
+so aux paths share the gateway taxonomy instead of growing a parallel one.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Callable, Optional, TypeVar
+
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
+from preloop.services.upstream_errors import (
+    ERROR_CLASS_UPSTREAM_RATE_LIMITED,
+    UpstreamErrorClass,
+    classify_upstream_error,
+    is_retryable_upstream_failure,
+)
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# One retry = two total attempts. Aux paths sit on short request deadlines
+# (approval summaries, name extraction), so this stays tighter than the
+# gateway's retry budget.
+AUX_RETRY_COUNT = 1
+AUX_BASE_BACKOFF_SECONDS = 0.5
+AUX_RETRY_AFTER_CAP_SECONDS = 4.0
+
+
+def _backoff_seconds(classified: Optional[UpstreamErrorClass], attempt: int) -> float:
+    """Exponential backoff, raised to the provider Retry-After, capped at 4s."""
+
+    delay = AUX_BASE_BACKOFF_SECONDS * float(1 << attempt)
+    if classified is not None and classified.retry_after_seconds is not None:
+        delay = max(delay, float(classified.retry_after_seconds))
+    return min(delay, AUX_RETRY_AFTER_CAP_SECONDS)
+
+
+def _to_gateway_error(exc: Exception) -> ModelGatewayAPIError:
+    """Surface an exhausted transient as a classified gateway error.
+
+    The raw provider exception is chained as ``__cause__`` so GlitchTip
+    still has the original body, but callers see a stable error_class
+    instead of ``RateLimitError: Error code: 429 - ...``.
+    """
+
+    classified = classify_upstream_error(exc)
+    error_class = (
+        classified.error_class
+        if classified is not None
+        else ERROR_CLASS_UPSTREAM_RATE_LIMITED
+    )
+    status_code = classified.status_code if classified is not None else 429
+    retry_after = classified.retry_after_seconds if classified is not None else None
+    terminal = classified.terminal if classified is not None else False
+    return ModelGatewayAPIError(
+        provider="openai",
+        status_code=status_code,
+        message=str(exc),
+        error_class=error_class,
+        retry_after_seconds=retry_after,
+        terminal=terminal,
+    )
+
+
+def call_with_aux_retry(
+    fn: Callable[[], T],
+    *,
+    operation_name: str = "aux_model",
+    sleep: Optional[Callable[[float], None]] = None,
+) -> T:
+    """Call ``fn``, retrying once on a transient upstream fault.
+
+    Terminal quota / auth failures fail fast. Exhausted transients are
+    re-raised as :class:`ModelGatewayAPIError` with the raw exception
+    chained as ``__cause__``.
+
+    ``sleep`` is resolved at call time so tests can patch
+    ``preloop.services.aux_model_retry.time.sleep``.
+    """
+
+    sleeper = time.sleep if sleep is None else sleep
+    last_exc: Optional[Exception] = None
+
+    for attempt in range(AUX_RETRY_COUNT + 1):
+        try:
+            return fn()
+        except Exception as exc:
+            last_exc = exc
+            classified = classify_upstream_error(exc)
+            if classified is not None and classified.terminal:
+                raise
+            if not is_retryable_upstream_failure(exc):
+                raise
+            if attempt >= AUX_RETRY_COUNT:
+                break
+            delay = _backoff_seconds(classified, attempt)
+            logger.info(
+                "Retrying %s after %.2fs (%s)",
+                operation_name,
+                delay,
+                type(exc).__name__,
+            )
+            sleeper(delay)
+
+    assert last_exc is not None
+    raise _to_gateway_error(last_exc) from last_exc

--- a/backend/preloop/services/model_credentials.py
+++ b/backend/preloop/services/model_credentials.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 
 from preloop.models.crud.ai_model import ai_model as crud_ai_model
 from preloop.models.models.ai_model import AIModel
+from preloop.services.aux_model_retry import call_with_aux_retry
 from preloop.services.litellm_routing import apply_preloop_client_headers
 from preloop.services.secret_service import get_secret_service
 
@@ -415,8 +416,12 @@ async def call_with_default_model_fallback(
 
     def _resolve_and_call(model: AIModel) -> Any:
         # Resolve inside the worker thread: a secret backend lookup can do
-        # network I/O and must never run on the event loop.
-        return caller(model, resolve_model_call_credentials(model, db=db))
+        # network I/O and must never run on the event loop. Retry transient
+        # provider 429s here so a blip does not burn the one-shot fallback.
+        return call_with_aux_retry(
+            lambda: caller(model, resolve_model_call_credentials(model, db=db)),
+            operation_name=operation_name,
+        )
 
     async def _attempt(model: AIModel) -> Any:
         coro = asyncio.to_thread(_resolve_and_call, model)

--- a/backend/preloop/services/model_credentials.py
+++ b/backend/preloop/services/model_credentials.py
@@ -421,6 +421,7 @@ async def call_with_default_model_fallback(
         return call_with_aux_retry(
             lambda: caller(model, resolve_model_call_credentials(model, db=db)),
             operation_name=operation_name,
+            provider=getattr(model, "provider_name", None),
         )
 
     async def _attempt(model: AIModel) -> Any:

--- a/backend/preloop/services/policy_generation.py
+++ b/backend/preloop/services/policy_generation.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 from preloop.models.crud.ai_model import ai_model as crud_ai_model
 from preloop.models.crud.audit_log import crud_audit_log
 from preloop.models.models.ai_model import AIModel
+from preloop.services.aux_model_retry import call_with_aux_retry
 from preloop.services.litellm_routing import to_litellm_model
 from preloop.services.model_credentials import (
     build_aux_kwargs,
@@ -448,7 +449,10 @@ If a "CURRENT ACCOUNT CONFIGURATION" block is provided below:
 
         for attempt in range(2):
             try:
-                response = litellm.completion(**kwargs)
+                response = call_with_aux_retry(
+                    lambda: litellm.completion(**kwargs),
+                    operation_name="policy_generation",
+                )
                 check_reasoning_model_empty_content(response)
                 raw = response.choices[0].message.content or ""
                 yaml_text = self._extract_yaml(raw)

--- a/backend/preloop/services/policy_generation.py
+++ b/backend/preloop/services/policy_generation.py
@@ -452,6 +452,7 @@ If a "CURRENT ACCOUNT CONFIGURATION" block is provided below:
                 response = call_with_aux_retry(
                     lambda: litellm.completion(**kwargs),
                     operation_name="policy_generation",
+                    provider=getattr(model, "provider_name", None),
                 )
                 check_reasoning_model_empty_content(response)
                 raw = response.choices[0].message.content or ""

--- a/backend/preloop/utils/git_credentials.py
+++ b/backend/preloop/utils/git_credentials.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shlex
 import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -196,6 +197,53 @@ if [ -n "${{{GIT_CREDENTIALS_ENV_VAR}:-}}" ]; then
     git config --global credential.helper 'store --file={GIT_CREDENTIALS_FILE}'
 {http_path_line}    unset {GIT_CREDENTIALS_ENV_VAR}
     echo "Configured git credential helper (credentials are not stored in remotes)"
+fi
+""".strip()
+
+
+def build_push_auth_setup_shell(*, token_ref: str, username: str) -> str:
+    """Reinstall the credential helper immediately before ``git push``.
+
+    Clone of a public repository succeeds with no helper, so
+    ``PRELOOP_GIT_CREDENTIALS`` may never be set even when a tracker token is
+    available for the post-execution REST calls. The clone snippet also
+    unsets that variable after writing the store file, and agents often
+    overwrite ``~/.gitconfig``. Either way, ``git push`` with
+    ``GIT_TERMINAL_PROMPT=0`` fails with "could not read Username for
+    'https://github.com'".
+
+    ``token_ref`` must be a shell expansion such as ``${PRELOOP_GIT_TOKEN_1}``,
+    never the raw secret. The token is written only into the mode-0600 store
+    file, matching the clone helper.
+    """
+
+    # token_ref is empty when this repository has no tracker token; the
+    # PRELOOP_GIT_CREDENTIALS / existing-file branches still apply.
+    token_quoted = f'"{token_ref}"' if token_ref else '""'
+    user_quoted = shlex.quote(username)
+    return f"""
+export GIT_TERMINAL_PROMPT=0
+if [ -n "${{{GIT_CREDENTIALS_ENV_VAR}:-}}" ]; then
+    (umask 077 && printf '%s\\n' "${GIT_CREDENTIALS_ENV_VAR}" > {GIT_CREDENTIALS_FILE})
+    chmod 600 {GIT_CREDENTIALS_FILE}
+    git config --global credential.helper 'store --file={GIT_CREDENTIALS_FILE}'
+    echo "Reinstalled git credential helper from {GIT_CREDENTIALS_ENV_VAR}"
+elif [ -f {GIT_CREDENTIALS_FILE} ]; then
+    git config --global credential.helper 'store --file={GIT_CREDENTIALS_FILE}'
+    echo "Reinstalled git credential helper from existing store file"
+elif [ -n {token_quoted} ]; then
+    git config --global credential.helper 'store --file={GIT_CREDENTIALS_FILE}'
+    (umask 077 && : > {GIT_CREDENTIALS_FILE})
+    chmod 600 {GIT_CREDENTIALS_FILE}
+    ORIGIN_URL=$(git remote get-url origin 2>/dev/null || true)
+    HOST=$(printf '%s\\n' "$ORIGIN_URL" | sed -E 's#^git@([^:]+):.*#\\1#; t; s#^https?://##; s#^[^/@]*@##; s#[/:].*##')
+    if [ -z "$HOST" ]; then
+        HOST=github.com
+    fi
+    printf 'protocol=https\\nhost=%s\\nusername=%s\\npassword=%s\\n\\n' "$HOST" {user_quoted} {token_quoted} | git credential approve
+    echo "Installed git credential helper from tracker token for push"
+else
+    echo "WARNING: no git credentials available for push"
 fi
 """.strip()
 

--- a/backend/preloop/utils/git_credentials.py
+++ b/backend/preloop/utils/git_credentials.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import logging
 import os
-import shlex
 import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -220,7 +219,8 @@ def build_push_auth_setup_shell(*, token_ref: str, username: str) -> str:
     # token_ref is empty when this repository has no tracker token; the
     # PRELOOP_GIT_CREDENTIALS / existing-file branches still apply.
     token_quoted = f'"{token_ref}"' if token_ref else '""'
-    user_quoted = shlex.quote(username)
+    # Username is interpolated into a heredoc, not argv; keep it a single token.
+    safe_username = "".join(username.split())
     return f"""
 export GIT_TERMINAL_PROMPT=0
 if [ -n "${{{GIT_CREDENTIALS_ENV_VAR}:-}}" ]; then
@@ -240,7 +240,12 @@ elif [ -n {token_quoted} ]; then
     if [ -z "$HOST" ]; then
         HOST=github.com
     fi
-    printf 'protocol=https\\nhost=%s\\nusername=%s\\npassword=%s\\n\\n' "$HOST" {user_quoted} {token_quoted} | git credential approve
+    git credential approve <<PRELOOP_GIT_CRED_EOF
+protocol=https
+host=$HOST
+username={safe_username}
+password={token_ref}
+PRELOOP_GIT_CRED_EOF
     echo "Installed git credential helper from tracker token for push"
 else
     echo "WARNING: no git credentials available for push"

--- a/backend/tests/agents/test_container.py
+++ b/backend/tests/agents/test_container.py
@@ -1337,6 +1337,14 @@ class TestGitApiTokensNotInScript:
         assert "/workspace/evidence/branch.patch" in commands
         assert commands.index("branch.bundle") < commands.index("git push origin")
 
+    def test_post_execution_username_follows_host_kind(self, container_executor):
+        """Clone uses host_kind when tracker_type is missing; push must match."""
+        context = self._context()
+        context["git_credentials_map"]["tracker-1"]["tracker_type"] = None
+        commands = container_executor._prepare_git_post_execution_commands(context)
+        assert "username=x-access-token" in commands
+        assert "username=oauth2" not in commands
+
 
 class TestLogScrubbing:
     """Logs are scrubbed on read as well, so a token already present in a

--- a/backend/tests/agents/test_container.py
+++ b/backend/tests/agents/test_container.py
@@ -1319,6 +1319,24 @@ class TestGitApiTokensNotInScript:
         env = container_executor._apply_git_credential_env({}, context)
         assert env["PRELOOP_GIT_TOKEN_1"] == self.PAT
 
+    def test_post_execution_reinstalls_credential_helper(self, container_executor):
+        context = self._context()
+        commands = container_executor._prepare_git_post_execution_commands(context)
+        assert "credential.helper" in commands
+        assert "git credential approve" in commands
+        helper_at = commands.index("credential.helper")
+        push_at = commands.index("git push origin")
+        assert helper_at < push_at
+
+    def test_post_execution_writes_recovery_artifacts_before_push(
+        self, container_executor
+    ):
+        context = self._context()
+        commands = container_executor._prepare_git_post_execution_commands(context)
+        assert "/workspace/evidence/branch.bundle" in commands
+        assert "/workspace/evidence/branch.patch" in commands
+        assert commands.index("branch.bundle") < commands.index("git push origin")
+
 
 class TestLogScrubbing:
     """Logs are scrubbed on read as well, so a token already present in a

--- a/backend/tests/services/test_aux_model_retry.py
+++ b/backend/tests/services/test_aux_model_retry.py
@@ -160,9 +160,10 @@ def test_exhausted_transient_surfaces_classified_gateway_error():
     exc = _RateLimitError("Error code: 429 - Too Many Requests")
     fn = MagicMock(side_effect=exc)
     with pytest.raises(ModelGatewayAPIError) as caught:
-        call_with_aux_retry(fn, sleep=lambda _: None)
+        call_with_aux_retry(fn, sleep=lambda _: None, provider="anthropic")
     err = caught.value
     assert err.error_class == ERROR_CLASS_UPSTREAM_RATE_LIMITED
+    assert err.provider == "anthropic"
     assert err.__cause__ is exc
     assert fn.call_count == 2
 
@@ -292,10 +293,62 @@ def test_policy_generation_retries_litellm_completion():
     assert completion.call_count == 2
 
 
-def test_extract_agent_name_uses_aux_retry():
-    from preloop.services.aux_model_retry import call_with_aux_retry as retry_fn
+@pytest.mark.asyncio
+async def test_extract_agent_name_retries_transient_429():
+    from preloop.api.endpoints.account import (
+        AgentNameExtractionRequest,
+        extract_agent_name,
+    )
 
-    assert retry_fn.__module__ == "preloop.services.aux_model_retry"
-    import preloop.api.endpoints.account as account_mod
+    account = SimpleNamespace(id="acct-1")
+    user = SimpleNamespace(id="user-1", username="tester")
+    db = MagicMock()
+    model = SimpleNamespace(
+        id="model-1",
+        model_identifier="claude-sonnet-4-5",
+        provider_name="anthropic",
+        api_endpoint=None,
+        kind="llm",
+        created_at=None,
+    )
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Loopbot"))]
+    )
+    completion = MagicMock(
+        side_effect=[
+            _RateLimitError("Error code: 429 - Too Many Requests"),
+            response,
+        ]
+    )
 
-    assert account_mod.call_with_aux_retry is retry_fn
+    with (
+        patch("preloop.api.auth.permissions.has_permission", return_value=True),
+        patch(
+            "preloop.api.endpoints.account.crud_ai_model.get_default_active_model",
+            return_value=model,
+        ),
+        patch(
+            "preloop.api.endpoints.account.resolve_model_call_credentials",
+            return_value={"api_key": "sk-test"},
+        ),
+        patch(
+            "preloop.api.endpoints.account.build_aux_kwargs",
+            side_effect=lambda model, creds, call_site_kwargs: call_site_kwargs,
+        ),
+        patch("preloop.api.endpoints.account.check_reasoning_model_empty_content"),
+        patch(
+            "preloop.services.litellm_routing.to_litellm_model",
+            return_value="anthropic/claude-sonnet-4-5",
+        ),
+        patch("litellm.completion", completion),
+        patch("preloop.services.aux_model_retry.time.sleep", lambda _: None),
+    ):
+        result = await extract_agent_name(
+            request=AgentNameExtractionRequest(identity_content="# IDENTITY\nLoopbot"),
+            account=account,
+            current_user=user,
+            db=db,
+        )
+
+    assert result.name == "Loopbot"
+    assert completion.call_count == 2

--- a/backend/tests/services/test_aux_model_retry.py
+++ b/backend/tests/services/test_aux_model_retry.py
@@ -1,0 +1,301 @@
+"""Tests for bounded retry of aux (non-gateway) model calls."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from preloop.services.aux_model_retry import (
+    AUX_RETRY_AFTER_CAP_SECONDS,
+    call_with_aux_retry,
+)
+from preloop.services.model_credentials import (
+    _fallback_counters,
+    call_with_default_model_fallback,
+)
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
+from preloop.services.upstream_errors import ERROR_CLASS_UPSTREAM_RATE_LIMITED
+
+
+class _RateLimitError(Exception):
+    """Name-matched stand-in for litellm RateLimitError."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int = 429,
+        retry_after: Optional[int] = None,
+        code: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.code = code
+        if retry_after is not None:
+            self.response = SimpleNamespace(headers={"retry-after": str(retry_after)})
+
+
+class _APIConnectionError(Exception):
+    """Name-matched stand-in for litellm.exceptions.APIConnectionError."""
+
+
+class _AuthError(Exception):
+    def __init__(self, message: str, *, status_code: int = 401) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+class _OverloadError(Exception):
+    def __init__(self, message: str, *, status_code: int = 529) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+class _ClientError(Exception):
+    def __init__(self, message: str, *, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def test_transient_429_is_retried_once_then_succeeds():
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _RateLimitError("Error code: 429 - Too Many Requests")
+        return "ok"
+
+    slept = []
+    assert call_with_aux_retry(fn, sleep=slept.append) == "ok"
+    assert calls["n"] == 2
+    assert slept == [0.5]
+
+
+def test_retry_after_hint_raises_backoff():
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _RateLimitError("Error code: 429 - Too Many Requests", retry_after=2)
+        return "ok"
+
+    slept = []
+    assert call_with_aux_retry(fn, sleep=slept.append) == "ok"
+    assert slept == [2.0]
+
+
+def test_retry_after_is_capped_for_aux_deadlines():
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _RateLimitError("Error code: 429 - Too Many Requests", retry_after=30)
+        return "ok"
+
+    slept = []
+    call_with_aux_retry(fn, sleep=slept.append)
+    assert slept == [AUX_RETRY_AFTER_CAP_SECONDS]
+
+
+def test_quota_exhausted_fails_fast():
+    fn = MagicMock(
+        side_effect=_RateLimitError(
+            "You exceeded your current quota",
+            code="insufficient_quota",
+        )
+    )
+    slept = []
+    with pytest.raises(_RateLimitError):
+        call_with_aux_retry(fn, sleep=slept.append)
+    fn.assert_called_once()
+    assert slept == []
+
+
+def test_auth_failure_fails_fast():
+    fn = MagicMock(side_effect=_AuthError("Invalid API key"))
+    slept = []
+    with pytest.raises(_AuthError):
+        call_with_aux_retry(fn, sleep=slept.append)
+    fn.assert_called_once()
+    assert slept == []
+
+
+def test_network_fault_is_retried():
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _APIConnectionError("Connection refused")
+        return "ok"
+
+    assert call_with_aux_retry(fn, sleep=lambda _: None) == "ok"
+    assert calls["n"] == 2
+
+
+def test_overload_is_retried():
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _OverloadError("overloaded_error: engine is overloaded")
+        return "ok"
+
+    assert call_with_aux_retry(fn, sleep=lambda _: None) == "ok"
+    assert calls["n"] == 2
+
+
+def test_exhausted_transient_surfaces_classified_gateway_error():
+    exc = _RateLimitError("Error code: 429 - Too Many Requests")
+    fn = MagicMock(side_effect=exc)
+    with pytest.raises(ModelGatewayAPIError) as caught:
+        call_with_aux_retry(fn, sleep=lambda _: None)
+    err = caught.value
+    assert err.error_class == ERROR_CLASS_UPSTREAM_RATE_LIMITED
+    assert err.__cause__ is exc
+    assert fn.call_count == 2
+
+
+def test_client_shaped_errors_are_not_retried():
+    fn = MagicMock(side_effect=_ClientError("invalid_request: bad param"))
+    slept = []
+    with pytest.raises(_ClientError):
+        call_with_aux_retry(fn, sleep=slept.append)
+    fn.assert_called_once()
+    assert slept == []
+
+
+@pytest.fixture
+def mock_model():
+    return SimpleNamespace(
+        id="model-1",
+        model_identifier="gpt-4o-mini",
+        provider_name="openai",
+        api_endpoint=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_fallback_counters():
+    _fallback_counters.clear()
+    yield
+    _fallback_counters.clear()
+
+
+@pytest.mark.asyncio
+async def test_transient_429_does_not_burn_aux_fallback(mock_model):
+    """A retried primary 429 must not consume the one-shot fallback budget."""
+    calls = {"n": 0}
+
+    def caller(model, creds):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _RateLimitError("Error code: 429 - Too Many Requests")
+        return "ok"
+
+    result = await call_with_default_model_fallback(
+        db=MagicMock(),
+        account_id="acct-1",
+        primary_model=mock_model,
+        caller=caller,
+        operation_name="approval_summary",
+    )
+    assert result == "ok"
+    assert calls["n"] == 2
+    assert _fallback_counters == {}
+
+
+@pytest.mark.asyncio
+async def test_exhausted_429_still_attempts_fallback(mock_model):
+    system_default = SimpleNamespace(
+        id="system-model",
+        model_identifier="gpt-3.5-turbo",
+        provider_name="openai",
+        api_endpoint=None,
+    )
+
+    def caller(model, creds):
+        if model.id == "model-1":
+            raise _RateLimitError("Error code: 429 - Too Many Requests")
+        return "fallback_ok"
+
+    with patch(
+        "preloop.services.model_credentials.crud_ai_model.get_default_active_model",
+        return_value=system_default,
+    ):
+        result = await call_with_default_model_fallback(
+            db=MagicMock(),
+            account_id="acct-1",
+            primary_model=mock_model,
+            caller=caller,
+            operation_name="approval_summary",
+        )
+
+    assert result == "fallback_ok"
+    assert any(
+        key[0] == "acct-1" and count >= 1 for key, count in _fallback_counters.items()
+    )
+
+
+def test_policy_generation_retries_litellm_completion():
+    from preloop.services.policy_generation import PolicyGenerationService
+
+    service = PolicyGenerationService(db=MagicMock(), account_id="acct-1")
+    model = SimpleNamespace(
+        id="model-1",
+        model_identifier="gpt-4o-mini",
+        provider_name="openai",
+        api_endpoint=None,
+        kind="llm",
+    )
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="key: value\n"))]
+    )
+    completion = MagicMock(
+        side_effect=[
+            _RateLimitError("Error code: 429 - Too Many Requests"),
+            response,
+        ]
+    )
+
+    with (
+        patch(
+            "preloop.services.policy_generation.resolve_model_call_credentials",
+            return_value={"api_key": "sk-test"},
+        ),
+        patch(
+            "preloop.services.policy_generation.build_aux_kwargs",
+            side_effect=lambda model, creds, call_site_kwargs: call_site_kwargs,
+        ),
+        patch(
+            "preloop.services.policy_generation.to_litellm_model",
+            return_value="openai/gpt-4o-mini",
+        ),
+        patch("preloop.services.policy_generation.check_reasoning_model_empty_content"),
+        patch("preloop.services.policy_generation.litellm.completion", completion),
+        patch.object(service, "_validate_output"),
+        patch.object(service, "_extract_yaml", return_value="key: value\n"),
+    ):
+        assert service._call_llm(model, "sys", "user") == "key: value\n"
+
+    assert completion.call_count == 2
+
+
+def test_extract_agent_name_uses_aux_retry():
+    from preloop.services.aux_model_retry import call_with_aux_retry as retry_fn
+
+    assert retry_fn.__module__ == "preloop.services.aux_model_retry"
+    import preloop.api.endpoints.account as account_mod
+
+    assert account_mod.call_with_aux_retry is retry_fn

--- a/backend/tests/utils/test_git_credentials.py
+++ b/backend/tests/utils/test_git_credentials.py
@@ -18,6 +18,7 @@ from preloop.utils.git_credentials import (
     build_credential_env,
     build_credential_setup_shell,
     build_credentials_file_content,
+    build_push_auth_setup_shell,
     credential_username,
     git_token_env_var,
     needs_http_path_scoping,
@@ -192,6 +193,29 @@ class TestCredentialSetupShell:
         assert "credential.useHttpPath true" in build_credential_setup_shell(
             use_http_path=True
         )
+
+
+class TestPushAuthSetupShell:
+    def test_shell_never_contains_a_secret(self) -> None:
+        shell = build_push_auth_setup_shell(
+            token_ref="${PRELOOP_GIT_TOKEN_1}", username="x-access-token"
+        )
+        assert LEAKED_PAT not in shell
+        assert "${PRELOOP_GIT_TOKEN_1}" in shell
+
+    def test_falls_back_to_tracker_token_when_clone_had_no_helper(self) -> None:
+        """Public clones skip PRELOOP_GIT_CREDENTIALS; push still needs a token."""
+        shell = build_push_auth_setup_shell(
+            token_ref="${PRELOOP_GIT_TOKEN_1}", username="x-access-token"
+        )
+        assert "git credential approve" in shell
+        assert "credential.helper" in shell
+        assert "GIT_TERMINAL_PROMPT=0" in shell
+
+    def test_empty_token_ref_does_not_invent_an_expansion(self) -> None:
+        shell = build_push_auth_setup_shell(token_ref="", username="oauth2")
+        assert "${PRELOOP_GIT_TOKEN" not in shell
+        assert "WARNING: no git credentials available for push" in shell
 
 
 class TestGitTokenEnvVar:

--- a/backend/tests/utils/test_git_credentials.py
+++ b/backend/tests/utils/test_git_credentials.py
@@ -208,9 +208,16 @@ class TestPushAuthSetupShell:
         shell = build_push_auth_setup_shell(
             token_ref="${PRELOOP_GIT_TOKEN_1}", username="x-access-token"
         )
-        assert "git credential approve" in shell
+        assert "git credential approve <<" in shell
         assert "credential.helper" in shell
         assert "GIT_TERMINAL_PROMPT=0" in shell
+
+    def test_token_is_expanded_in_heredoc_not_printf_argv(self) -> None:
+        shell = build_push_auth_setup_shell(
+            token_ref="${PRELOOP_GIT_TOKEN_1}", username="x-access-token"
+        )
+        assert "password=${PRELOOP_GIT_TOKEN_1}" in shell
+        assert "printf 'protocol=https" not in shell
 
     def test_empty_token_ref_does_not_invent_an_expansion(self) -> None:
         shell = build_push_auth_setup_shell(token_ref="", username="oauth2")


### PR DESCRIPTION
## Summary
- Recreates the lost #269 implementation: bounded Retry-After-aware retry for aux (non-gateway) litellm calls so a transient 429 no longer burns the one-shot system-default fallback. Wired into `call_with_default_model_fallback`, policy generation, and agent-name extraction.
- Fixes the post-execution `git push` failure that dropped the original branch (`could not read Username for 'https://github.com': terminal prompts disabled`). Public clones never install the credential helper; push now reinstalls it from `${PRELOOP_GIT_TOKEN_N}` and writes a git bundle/patch under `/workspace/evidence` before pushing.

Closes #269

## Test plan
- [ ] `PYTHONPATH=backend pytest backend/tests/services/test_aux_model_retry.py backend/tests/services/test_model_credentials.py backend/tests/services/test_policy_generation.py backend/tests/utils/test_git_credentials.py backend/tests/agents/test_container.py::TestGitApiTokensNotInScript`
- [ ] Confirm a public-repo Automated Issue Implementation flow can push its branch and open the PR
- [ ] Confirm a private-repo flow still clones/pushes without putting the token in the remote URL or the generated script
- [ ] If push still fails, confirm `/workspace/evidence/branch.bundle` (or `branch.patch`) appears in the execution evidence artifact

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> All previously raised suggestions (provider labeling, token-in-argv, host-kind detection, and one weak test) have been addressed. No security vulnerabilities or correctness issues.
>
> **Overview**
> Recreates the lost #269 implementation (bounded Retry-After-aware retry for aux litellm calls wired into fallback, policy generation, and agent-name extraction) and fixes post-execution git push auth on public clones by reinstalling the credential helper and writing a git bundle/patch under `/workspace/evidence` before pushing.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 89c75a7. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->