### PR TITLE
Restart issue-implementation flows from comments on the PR they opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Issue-implementation pickup and PR-comment resume**: `update_issue` can add a GitHub reaction (eyes on pickup) with no other fields. Flow prompts can use `{{execution.url}}`. Opening a PR records its URL on the execution, so a human comment on that PR restarts the same flow on the same branch. Unmatched comments do not start a run. Native CLI `--resume` is a follow-up (#356).
 - **`preloop agents refresh` (alias `sync`), `preloop models sync`, and `POST /api/v1/ai-models/sync`**: refresh rewrites managed model sections of onboarded agent configs from the account catalog; models sync (and the endpoint) pull newly released provider models into that catalog using stored credentials.
 - **Opt-in scheduled model-catalog sync**: `MODEL_CATALOG_SYNC_SCHEDULED_ENABLED` (default false; helm `config.modelCatalogSync.*`) runs the same discovery as `preloop models sync` for every account, attributing audit events to the `model-catalog-sync` system actor.
 - **`preloop usage hook` accepts harness-agnostic events**: stdin is
@@ -19,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a stub).
 
 ### Changed
+
+- **GitHub merged PRs emit `pull_request_merged`**: a closed-and-merged pull request is no longer normalized as `pull_request_closed`. GitLab Job Hooks expose `build_name` / `build_status`, and GitHub issue close exposes `state_reason`, so flows can filter `deploy:staging` success and merge-completed closes. The event pickers list Job Event and Deployment.
 
 - **GitHub backend CI uses 8 pytest-split shards**: group 1 of 4 was the
   wall-clock pole (~7-9m vs ~3-4.5m). Eight `duration_based_chunks` slices

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -37,19 +37,28 @@ from preloop.utils.workspace_seed import (
 logger = logging.getLogger(__name__)
 
 # Git ref names interpolated into generated shell (origin/<branch>..HEAD).
-# Reject anything that would need quoting so we never splice shlex.quote
-# into the middle of a token (origin/'feat/x').
-_SAFE_GIT_REF = re.compile(r"^[A-Za-z0-9._/\-]+$")
+# Charset is unquoted-shell-safe so we never splice shlex.quote into the
+# middle of a token (origin/'feat/x'). Extra checks below match git's
+# own refname rules: no ``..``, leading ``-``, trailing ``.``, or
+# ``~``/``^``/``:`` (the last three are already outside the charset).
+_SAFE_GIT_REF_CHARS = re.compile(r"^[A-Za-z0-9._/\-]+$")
 
 
 def _validated_git_ref(name: Optional[str]) -> Optional[str]:
-    """Return ``name`` when it is a safe git ref, otherwise None."""
+    """Return ``name`` when it is a safe git branch/ref, otherwise None."""
 
     if not name or not isinstance(name, str):
         return None
-    if _SAFE_GIT_REF.fullmatch(name):
-        return name
-    return None
+    if not _SAFE_GIT_REF_CHARS.fullmatch(name):
+        return None
+    if name.startswith("-") or name.startswith("/") or name.endswith("."):
+        return None
+    if name.endswith("/") or ".." in name or "//" in name:
+        return None
+    for part in name.split("/"):
+        if not part or part.startswith(".") or part.endswith(".lock"):
+            return None
+    return name
 
 
 # Path inside the agent container where eval/observe flows write their
@@ -2536,13 +2545,21 @@ echo "========================================="
                 return ""
 
             safe_target = _validated_git_ref(target_branch)
-            safe_source = _validated_git_ref(source_branch) or "main"
             if not safe_target:
                 self.logger.warning(
                     "Skipping post-execution git: unsafe target branch %r",
                     target_branch,
                 )
                 return ""
+            safe_source = _validated_git_ref(source_branch)
+            if source_branch and safe_source is None:
+                self.logger.warning(
+                    "Skipping post-execution git: unsafe source branch %r",
+                    source_branch,
+                )
+                return ""
+            if safe_source is None:
+                safe_source = "main"
 
             post_commands = []
 

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -1977,17 +1977,31 @@ class ContainerAgentExecutor(AgentExecutor):
         source_branch = git_config.get("source_branch") or None
         target_branch = git_config.get("target_branch") or None
         trigger_data = execution_context.get("trigger_event_data", {})
+        resume = trigger_data.get("_resume") if isinstance(trigger_data, dict) else None
+        resume_branch = None
+        if isinstance(resume, dict):
+            resume_branch = resume.get("source_branch") or None
 
-        if not source_branch:
-            source_branch = self._extract_source_branch_from_trigger(trigger_data)
-        if not source_branch:
-            source_branch = "main"
+        if resume_branch:
+            # Clone and push the same PR branch so a comment restart continues
+            # the existing review, not a new branch off main.
+            source_branch = resume_branch
+            target_branch = resume_branch
+            self.logger.info(
+                "Resume clone: using existing PR branch %s as source and target",
+                resume_branch,
+            )
+        else:
+            if not source_branch:
+                source_branch = self._extract_source_branch_from_trigger(trigger_data)
+            if not source_branch:
+                source_branch = "main"
 
-        if not target_branch:
-            flow_name = execution_context.get("flow_name", "flow")
-            execution_id = execution_context.get("execution_id", "exec")
-            safe_flow_name = flow_name.lower().replace(" ", "-")[:30]
-            target_branch = f"preloop/{safe_flow_name}-{execution_id[:8]}"
+            if not target_branch:
+                flow_name = execution_context.get("flow_name", "flow")
+                execution_id = execution_context.get("execution_id", "exec")
+                safe_flow_name = flow_name.lower().replace(" ", "-")[:30]
+                target_branch = f"preloop/{safe_flow_name}-{execution_id[:8]}"
 
         commit_sha = self._extract_commit_sha_from_trigger(trigger_data)
         if commit_sha:
@@ -2550,10 +2564,12 @@ echo "========================================="
                 # under /workspace/evidence *before* push so a failed push
                 # still leaves a recoverable artifact in the log stream.
                 # Note: Directory is guaranteed to exist because git clone validation would have failed earlier
+                quoted_source = shlex.quote(source_branch)
+                quoted_target = shlex.quote(target_branch)
                 repo_post_commands = [
                     f"cd {full_path}",
                     # Check if there are any commits on target branch vs source
-                    f'COMMIT_COUNT=$(git rev-list --count {source_branch}..{target_branch} 2>/dev/null || echo "0")',
+                    f'COMMIT_COUNT=$(git rev-list --count origin/{quoted_target}..HEAD 2>/dev/null || git rev-list --count {quoted_source}..{quoted_target} 2>/dev/null || echo "0")',
                     'if [ "$COMMIT_COUNT" -gt "0" ]; then',
                     f'  echo "Found $COMMIT_COUNT commits on {target_branch}, pushing..."',
                     f"  mkdir -p {EVIDENCE_DIR_PATH}",
@@ -3001,6 +3017,22 @@ MREOF
                 self.logger.info(f"Extracted GitHub PR fetch ref: {ref}")
                 return ref
 
+            issue = payload.get("issue")
+            if (
+                isinstance(issue, dict)
+                and isinstance(issue.get("pull_request"), dict)
+                and issue.get("number") is not None
+            ):
+                ref = f"pull/{issue['number']}/head"
+                self.logger.info(f"Extracted GitHub PR comment fetch ref: {ref}")
+                return ref
+
+            mr = payload.get("merge_request")
+            if isinstance(mr, dict) and mr.get("iid") is not None:
+                ref = f"refs/merge-requests/{mr['iid']}/head"
+                self.logger.info(f"Extracted GitLab MR note fetch ref: {ref}")
+                return ref
+
             return None
         except Exception as e:
             self.logger.debug(f"Error extracting merge request ref from trigger: {e}")
@@ -3075,6 +3107,15 @@ MREOF
             if isinstance(obj_attrs, dict) and obj_attrs.get("source_branch"):
                 branch = obj_attrs["source_branch"]
                 self.logger.info(f"Extracted source branch from GitLab MR: {branch}")
+                return branch
+
+            # GitLab note on an MR
+            mr = payload.get("merge_request")
+            if isinstance(mr, dict) and mr.get("source_branch"):
+                branch = mr["source_branch"]
+                self.logger.info(
+                    f"Extracted source branch from GitLab MR note: {branch}"
+                )
                 return branch
 
             return None

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -6,6 +6,7 @@ import io
 import json
 import logging
 import os
+import re
 import shlex
 import tarfile
 from typing import Any, Dict, Optional
@@ -34,6 +35,22 @@ from preloop.utils.workspace_seed import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Git ref names interpolated into generated shell (origin/<branch>..HEAD).
+# Reject anything that would need quoting so we never splice shlex.quote
+# into the middle of a token (origin/'feat/x').
+_SAFE_GIT_REF = re.compile(r"^[A-Za-z0-9._/\-]+$")
+
+
+def _validated_git_ref(name: Optional[str]) -> Optional[str]:
+    """Return ``name`` when it is a safe git ref, otherwise None."""
+
+    if not name or not isinstance(name, str):
+        return None
+    if _SAFE_GIT_REF.fullmatch(name):
+        return name
+    return None
+
 
 # Path inside the agent container where eval/observe flows write their
 # structured result report (see backend/presets/003-observe-eval.yaml).
@@ -2518,6 +2535,15 @@ echo "========================================="
             if not target_branch:
                 return ""
 
+            safe_target = _validated_git_ref(target_branch)
+            safe_source = _validated_git_ref(source_branch) or "main"
+            if not safe_target:
+                self.logger.warning(
+                    "Skipping post-execution git: unsafe target branch %r",
+                    target_branch,
+                )
+                return ""
+
             post_commands = []
 
             for idx, repo_config in enumerate(repositories):
@@ -2564,27 +2590,28 @@ echo "========================================="
                 # under /workspace/evidence *before* push so a failed push
                 # still leaves a recoverable artifact in the log stream.
                 # Note: Directory is guaranteed to exist because git clone validation would have failed earlier
-                quoted_source = shlex.quote(source_branch)
-                quoted_target = shlex.quote(target_branch)
                 repo_post_commands = [
                     f"cd {full_path}",
-                    # Check if there are any commits on target branch vs source
-                    f'COMMIT_COUNT=$(git rev-list --count origin/{quoted_target}..HEAD 2>/dev/null || git rev-list --count {quoted_source}..{quoted_target} 2>/dev/null || echo "0")',
+                    # Resume clones source==target, so origin/<branch>..HEAD
+                    # still counts local commits the branch-vs-branch range
+                    # would miss. Branch names are validated above; do not
+                    # shlex.quote mid-token (that yields origin/'feat/x').
+                    f'COMMIT_COUNT=$(git rev-list --count origin/{safe_target}..HEAD 2>/dev/null || git rev-list --count {safe_source}..{safe_target} 2>/dev/null || echo "0")',
                     'if [ "$COMMIT_COUNT" -gt "0" ]; then',
-                    f'  echo "Found $COMMIT_COUNT commits on {target_branch}, pushing..."',
+                    f'  echo "Found $COMMIT_COUNT commits on {safe_target}, pushing..."',
                     f"  mkdir -p {EVIDENCE_DIR_PATH}",
                     f"  git rev-parse HEAD > {EVIDENCE_DIR_PATH}/HEAD.txt 2>/dev/null || true",
                     f"  git log -1 --format='%H %s' >> {EVIDENCE_DIR_PATH}/HEAD.txt 2>/dev/null || true",
-                    f"  git format-patch --stdout {source_branch}..HEAD > {EVIDENCE_DIR_PATH}/branch.patch 2>/dev/null || true",
+                    f"  git format-patch --stdout {safe_source}..HEAD > {EVIDENCE_DIR_PATH}/branch.patch 2>/dev/null || true",
                     (
                         f"  git bundle create {EVIDENCE_DIR_PATH}/branch.bundle "
-                        f"{source_branch}..HEAD 2>/dev/null "
+                        f"{safe_source}..HEAD 2>/dev/null "
                         f"|| git bundle create {EVIDENCE_DIR_PATH}/branch.bundle HEAD "
                         f"2>/dev/null || true"
                     ),
                     f'  echo "Wrote git recovery artifacts under {EVIDENCE_DIR_PATH}"',
                     push_auth,
-                    f"  git push origin {target_branch}",
+                    f"  git push origin {safe_target}",
                 ]
 
                 # Add PR/MR creation if enabled

--- a/backend/preloop/api/endpoints/mcp.py
+++ b/backend/preloop/api/endpoints/mcp.py
@@ -626,6 +626,8 @@ async def update_issue(
     priority: Optional[str] = None,
     assignee: Optional[str] = None,
     labels: Optional[List[str]] = None,
+    add_reaction: Optional[str] = None,
+    remove_reaction: Optional[str] = None,
 ) -> UpdateIssueResponse:
     """
     Handles the 'update_issue' tool call.
@@ -661,7 +663,8 @@ async def update_issue(
     # Filter out None values, as tracker clients might interpret None as "clear this field"
     update_data_for_tracker = issue_update.model_dump(exclude_unset=True)
 
-    if not update_data_for_tracker:
+    has_reactions = bool(add_reaction or remove_reaction)
+    if not update_data_for_tracker and not has_reactions:
         logger.info(
             f"No fields provided to update for issue {issue_obj.id}. Skipping tracker update."
         )
@@ -680,37 +683,73 @@ async def update_issue(
                 detail="Cannot update issue in tracker: Missing external identifier.",
             )
 
-        try:
-            # Determine the correct identifier for the tracker API call
-            # Prefer using the key (e.g., "owner/repo#1" for GitHub) over external_id
-            # since external_id might be the internal tracker ID (e.g., GitHub's numeric ID)
-            issue_repo_id = issue_obj.key if issue_obj.key else issue_obj.external_id
+        issue_repo_id = issue_obj.key if issue_obj.key else issue_obj.external_id
+        issue_number = (
+            issue_obj.key.split("#")[-1]
+            if issue_obj.key and "#" in str(issue_obj.key)
+            else issue_obj.external_id
+        )
 
-            logger.info(
-                f"Calling tracker client to update issue {issue_repo_id} with data: {update_data_for_tracker}"
-            )
-            await tracker_client.update_issue(
-                issue_repo_id, IssueUpdate(**update_data_for_tracker)
-            )
-            logger.info(
-                f"Successfully updated issue {issue_obj.external_id} via tracker client."
-            )
-        except NotImplementedError:
-            logger.warning(
-                f"Tracker type {tracker_client.tracker_type} does not support updating issues."
-            )
-            # Decide if this should be an error or just a warning
-            # raise HTTPException(status_code=501, detail="Issue updates not supported by this tracker type.")
-        except Exception as e:
-            logger.error(
-                f"Error updating issue {issue_obj.external_id} via tracker client: {e}",
-                exc_info=True,
-            )
-            # Depending on requirements, you might still update the local DB or raise an error
-            raise HTTPException(
-                status_code=502,
-                detail=f"Failed to update issue in the external tracker: {str(e)}",
-            )
+        if has_reactions:
+            try:
+                platform = (tracker_client.tracker_type or "").lower()
+                if platform == "github":
+                    if add_reaction:
+                        await tracker_client.add_issue_reaction(
+                            issue_number=str(issue_number),
+                            reaction=add_reaction,
+                        )
+                    if remove_reaction:
+                        await tracker_client.remove_issue_reaction(
+                            issue_number=str(issue_number),
+                            reaction=remove_reaction,
+                        )
+                elif platform == "gitlab":
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Issue reactions are not supported on GitLab. Use update_pull_request on the merge request instead.",
+                    )
+                else:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Issue reactions are not supported on {platform}.",
+                    )
+            except HTTPException:
+                raise
+            except Exception as e:
+                logger.error(
+                    f"Error updating issue reaction on {issue_obj.external_id}: {e}",
+                    exc_info=True,
+                )
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"Failed to update issue reaction: {str(e)}",
+                )
+
+        if update_data_for_tracker:
+            try:
+                logger.info(
+                    f"Calling tracker client to update issue {issue_repo_id} with data: {update_data_for_tracker}"
+                )
+                await tracker_client.update_issue(
+                    issue_repo_id, IssueUpdate(**update_data_for_tracker)
+                )
+                logger.info(
+                    f"Successfully updated issue {issue_obj.external_id} via tracker client."
+                )
+            except NotImplementedError:
+                logger.warning(
+                    f"Tracker type {tracker_client.tracker_type} does not support updating issues."
+                )
+            except Exception as e:
+                logger.error(
+                    f"Error updating issue {issue_obj.external_id} via tracker client: {e}",
+                    exc_info=True,
+                )
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"Failed to update issue in the external tracker: {str(e)}",
+                )
 
         # --- Update Local DB ---
         # Prepare data for local DB update using the IssueUpdate model
@@ -2255,6 +2294,33 @@ async def update_pull_request(
         )
 
 
+def _record_opened_pr_on_execution(
+    db, *, url: Optional[str], source_branch: Optional[str]
+) -> None:
+    """Persist the opened PR on the in-flight execution for later resume."""
+
+    if not url:
+        return
+    try:
+        from preloop.services.dynamic_fastmcp_http import get_current_user_context
+        from preloop.services.flow_pr_binding import record_opened_pr
+
+        user_context = get_current_user_context()
+        if not user_context or not user_context.flow_execution_id:
+            return
+        record_opened_pr(
+            db,
+            user_context.flow_execution_id,
+            url,
+            source_branch,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to record opened PR URL on the current flow execution",
+            exc_info=True,
+        )
+
+
 async def create_pull_request(
     project: str,
     title: str,
@@ -2364,7 +2430,7 @@ async def create_pull_request(
                 milestone=milestone,
             )
 
-            return CreatePullRequestResponse(
+            response = CreatePullRequestResponse(
                 pull_request_id=str(result["id"]),
                 number=result["number"],
                 status="created",
@@ -2374,6 +2440,10 @@ async def create_pull_request(
                 target_branch=target_branch,
                 is_draft=result.get("is_draft", False),
             )
+            _record_opened_pr_on_execution(
+                db, url=result["url"], source_branch=source_branch
+            )
+            return response
 
         else:  # GitLab
             logger.info(
@@ -2469,7 +2539,7 @@ async def create_pull_request(
             if warnings:
                 message += f". Note: {' '.join(warnings)}"
 
-            return CreatePullRequestResponse(
+            response = CreatePullRequestResponse(
                 pull_request_id=str(result["id"]),
                 number=result["iid"],
                 status="created",
@@ -2479,6 +2549,10 @@ async def create_pull_request(
                 target_branch=target_branch,
                 is_draft=result.get("work_in_progress", False),
             )
+            _record_opened_pr_on_execution(
+                db, url=result["url"], source_branch=source_branch
+            )
+            return response
 
     except HTTPException:
         raise

--- a/backend/preloop/api/endpoints/tools.py
+++ b/backend/preloop/api/endpoints/tools.py
@@ -140,7 +140,7 @@ BUILTIN_TOOLS = [
     },
     {
         "name": "update_issue",
-        "description": "Update an existing issue",
+        "description": "Update an existing issue's metadata and/or manage GitHub issue reactions. To add or remove a reaction only, pass add_reaction or remove_reaction without other fields.",
         "source": "builtin",
         "requires_tracker": True,
         "required_tracker_types": [],
@@ -154,6 +154,14 @@ BUILTIN_TOOLS = [
                 "priority": {"type": "string", "description": "New priority"},
                 "assignee": {"type": "string", "description": "New assignee"},
                 "labels": {"type": "array", "items": {"type": "string"}},
+                "add_reaction": {
+                    "type": "string",
+                    "description": "Reaction to add (GitHub: eyes, +1, heart, hooray, rocket, laugh, confused, -1). GitLab issues do not support reactions.",
+                },
+                "remove_reaction": {
+                    "type": "string",
+                    "description": "Reaction to remove (same names as add_reaction)",
+                },
             },
             "required": ["issue"],
         },

--- a/backend/preloop/models/crud/flow_execution.py
+++ b/backend/preloop/models/crud/flow_execution.py
@@ -216,6 +216,29 @@ class CRUDFlowExecution(CRUDBase[FlowExecution]):
             query = query.join(Flow).filter(Flow.account_id == account_id)
         return query.offset(skip).limit(limit).all()
 
+    def get_by_result_pr_url(
+        self,
+        db: Session,
+        flow_id: Any,
+        pr_url: str,
+    ) -> Optional[FlowExecution]:
+        """Return the newest execution of this flow that recorded ``pr_url``.
+
+        Matches ``FlowExecution.result['pr_url']`` exactly so resume does not
+        depend on a recency window. Callers should pass a normalized URL.
+        """
+        if not pr_url:
+            return None
+        return (
+            db.query(FlowExecution)
+            .filter(
+                FlowExecution.flow_id == flow_id,
+                FlowExecution.result["pr_url"].astext == pr_url,
+            )
+            .order_by(FlowExecution.start_time.desc())
+            .first()
+        )
+
     def get_by_batch(
         self,
         db: Session,

--- a/backend/preloop/services/dynamic_mcp_server.py
+++ b/backend/preloop/services/dynamic_mcp_server.py
@@ -961,7 +961,7 @@ def register_default_tools(server: DynamicMCPServer):
     # Tool 3: update_issue
     server.register_default_tool(
         name="update_issue",
-        description="Update an existing issue",
+        description="Update an existing issue. Pass add_reaction (e.g. eyes) to ack pickup on GitHub without changing other fields.",
         input_schema={
             "type": "object",
             "properties": {
@@ -993,6 +993,14 @@ def register_default_tools(server: DynamicMCPServer):
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "New labels list",
+                },
+                "add_reaction": {
+                    "type": "string",
+                    "description": "GitHub issue reaction to add (eyes, +1, heart, ...)",
+                },
+                "remove_reaction": {
+                    "type": "string",
+                    "description": "GitHub issue reaction to remove",
                 },
             },
             "required": ["issue"],

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -34,12 +34,14 @@ from preloop.agents import (
 )
 from preloop.agents.failure_analysis import analyze_agent_failure
 from preloop.config import settings
+from preloop.services.flow_pr_binding import merge_result_preserving_pr_binding
 from preloop.services.prompt_resolvers import (
     resolver_registry,
     ResolverContext,
     TriggerEventResolver,
     ProjectResolver,
     AccountResolver,
+    ExecutionResolver,
 )
 from preloop.services.flow_execution_logger import FlowExecutionLogger
 from preloop.services.flow_runtime_token import create_flow_runtime_token
@@ -1047,6 +1049,8 @@ class FlowExecutionOrchestrator:
             resolver_registry.register(ProjectResolver())
         if not resolver_registry.get("account"):
             resolver_registry.register(AccountResolver())
+        if not resolver_registry.get("execution"):
+            resolver_registry.register(ExecutionResolver())
 
     def _sync_runtime_session(
         self,
@@ -3481,13 +3485,27 @@ class FlowExecutionOrchestrator:
                     # (expire + rebind the execution row) instead.
                     self.db.rollback()
 
+            # MCP create_pull_request writes pr_url onto result in another
+            # session. Refresh so a None agent result cannot wipe the binding.
+            try:
+                self.db.refresh(self.execution_log)
+            except Exception:
+                logger.debug(
+                    "Could not refresh execution log before merging result",
+                    exc_info=True,
+                )
+            merged_result = merge_result_preserving_pr_binding(
+                getattr(self.execution_log, "result", None),
+                agent_result.get("result"),
+            )
+
             await self._update_execution_log(
                 status=final_status,
                 model_output_summary=output_summary,
                 error_message=agent_result.get("error_message"),
                 actions_taken_summary=agent_result.get("actions_taken"),
                 mcp_usage_logs=agent_result.get("mcp_usage_logs"),
-                result=agent_result.get("result"),
+                result=merged_result,
                 end_time=datetime.now(timezone.utc),
                 tool_calls_count=self.tool_calls_count,
                 total_tokens=self.total_tokens,

--- a/backend/preloop/services/flow_pr_binding.py
+++ b/backend/preloop/services/flow_pr_binding.py
@@ -21,6 +21,24 @@ from preloop.models.models.flow_execution import FlowExecution
 logger = logging.getLogger(__name__)
 
 _RESUME_LOOKBACK = 50
+_GITHUB_HOSTS = frozenset({"github.com", "www.github.com"})
+
+
+def _is_github_host(host: str) -> bool:
+    return host in _GITHUB_HOSTS
+
+
+def _is_tracker_api_url(url: str) -> bool:
+    """True for GitLab/GitHub REST URLs that must not be compared to HTML URLs."""
+
+    parsed = urlparse(url.strip())
+    host = (parsed.hostname or "").lower()
+    path = parsed.path or ""
+    if "/api/v4/" in path:
+        return True
+    if host == "api.github.com":
+        return True
+    return False
 
 
 def normalize_pr_url(url: Optional[str]) -> str:
@@ -28,12 +46,15 @@ def normalize_pr_url(url: Optional[str]) -> str:
 
     if not url or not isinstance(url, str):
         return ""
-    parsed = urlparse(url.strip())
+    raw = url.strip()
+    if _is_tracker_api_url(raw):
+        return ""
+    parsed = urlparse(raw)
     if not parsed.netloc or not parsed.path:
         return ""
     path = parsed.path.rstrip("/")
-    host = parsed.netloc.lower()
-    if host.endswith("github.com"):
+    host = (parsed.hostname or "").lower()
+    if _is_github_host(host):
         parts = path.split("/")
         # GitHub issue comments on PRs often use /issues/N in html_url.
         if len(parts) >= 5 and parts[3] == "issues":
@@ -41,6 +62,14 @@ def normalize_pr_url(url: Optional[str]) -> str:
             path = "/".join(parts)
     scheme = parsed.scheme or "https"
     return f"{scheme}://{host}{path}"
+
+
+def _first_html_pr_url(*candidates: Optional[str]) -> Optional[str]:
+    for raw in candidates:
+        normalized = normalize_pr_url(raw)
+        if normalized:
+            return normalized
+    return None
 
 
 def extract_pr_url_from_comment_event(event_data: Dict[str, Any]) -> Optional[str]:
@@ -54,21 +83,25 @@ def extract_pr_url_from_comment_event(event_data: Dict[str, Any]) -> Optional[st
     if isinstance(issue, dict):
         pr_stub = issue.get("pull_request")
         if isinstance(pr_stub, dict):
-            url = pr_stub.get("html_url") or issue.get("html_url") or pr_stub.get("url")
-            normalized = normalize_pr_url(url)
-            return normalized or None
+            return _first_html_pr_url(
+                pr_stub.get("html_url"),
+                issue.get("html_url"),
+                pr_stub.get("url"),
+            )
 
     pr = payload.get("pull_request")
     if isinstance(pr, dict):
-        normalized = normalize_pr_url(pr.get("html_url") or pr.get("url"))
-        if normalized:
-            return normalized
+        found = _first_html_pr_url(pr.get("html_url"), pr.get("url"))
+        if found:
+            return found
 
     mr = payload.get("merge_request")
     if isinstance(mr, dict):
-        normalized = normalize_pr_url(mr.get("url") or mr.get("web_url"))
-        if normalized:
-            return normalized
+        # create_merge_request persists mr.web_url. Webhook notes expose both
+        # an API ``url`` and a browser ``web_url``; prefer the HTML form.
+        found = _first_html_pr_url(mr.get("web_url"), mr.get("url"))
+        if found:
+            return found
 
     return None
 
@@ -114,7 +147,8 @@ def record_opened_pr(
             current = dict(execution.result)
         else:
             current = {}
-        current["pr_url"] = pr_url
+        stored_url = normalize_pr_url(pr_url) or pr_url
+        current["pr_url"] = stored_url
         if source_branch:
             current["pr_source_branch"] = source_branch
         execution.result = current
@@ -122,7 +156,7 @@ def record_opened_pr(
         db.commit()
         logger.info(
             "Recorded opened PR %s (branch=%s) on execution %s",
-            pr_url,
+            stored_url,
             source_branch,
             execution_id,
         )
@@ -135,7 +169,11 @@ def record_opened_pr(
         try:
             db.rollback()
         except Exception:
-            pass
+            # Best-effort: the outer warning already recorded the write failure.
+            logger.debug(
+                "Could not roll back after a failed PR-binding write",
+                exc_info=True,
+            )
 
 
 def find_bound_execution(
@@ -146,6 +184,9 @@ def find_bound_execution(
     needle = normalize_pr_url(pr_url)
     if not needle:
         return None
+    direct = crud_flow_execution.get_by_result_pr_url(db, flow_id, needle)
+    if direct is not None:
+        return direct
     executions = crud_flow_execution.get_by_flow(
         db, flow_id=flow_id, skip=0, limit=_RESUME_LOOKBACK
     )
@@ -154,6 +195,12 @@ def find_bound_execution(
         stored = normalize_pr_url(result.get("pr_url"))
         if stored and stored == needle:
             return execution
+    logger.info(
+        "No execution of flow %s recorded PR %s (jsonb miss, lookback=%s)",
+        flow_id,
+        needle,
+        _RESUME_LOOKBACK,
+    )
     return None
 
 

--- a/backend/preloop/services/flow_pr_binding.py
+++ b/backend/preloop/services/flow_pr_binding.py
@@ -1,0 +1,197 @@
+"""Bind a flow execution to the pull request it opened.
+
+Issue-implementation flows persist the opened PR URL on
+``FlowExecution.result`` so a later ``comment_created`` on that PR can start
+a new execution of the same flow with ``_resume`` metadata. Native CLI
+session resume (``--resume``) is a separate follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from preloop.models.crud import crud_flow_execution
+from preloop.models.models.flow_execution import FlowExecution
+
+logger = logging.getLogger(__name__)
+
+_RESUME_LOOKBACK = 50
+
+
+def normalize_pr_url(url: Optional[str]) -> str:
+    """Canonicalize a GitHub PR or GitLab MR HTML URL for matching."""
+
+    if not url or not isinstance(url, str):
+        return ""
+    parsed = urlparse(url.strip())
+    if not parsed.netloc or not parsed.path:
+        return ""
+    path = parsed.path.rstrip("/")
+    host = parsed.netloc.lower()
+    if host.endswith("github.com"):
+        parts = path.split("/")
+        # GitHub issue comments on PRs often use /issues/N in html_url.
+        if len(parts) >= 5 and parts[3] == "issues":
+            parts[3] = "pull"
+            path = "/".join(parts)
+    scheme = parsed.scheme or "https"
+    return f"{scheme}://{host}{path}"
+
+
+def extract_pr_url_from_comment_event(event_data: Dict[str, Any]) -> Optional[str]:
+    """Return the PR/MR HTML URL for a comment event, or None for issue comments."""
+
+    payload = event_data.get("payload") or event_data
+    if not isinstance(payload, dict):
+        return None
+
+    issue = payload.get("issue")
+    if isinstance(issue, dict):
+        pr_stub = issue.get("pull_request")
+        if isinstance(pr_stub, dict):
+            url = pr_stub.get("html_url") or issue.get("html_url") or pr_stub.get("url")
+            normalized = normalize_pr_url(url)
+            return normalized or None
+
+    pr = payload.get("pull_request")
+    if isinstance(pr, dict):
+        normalized = normalize_pr_url(pr.get("html_url") or pr.get("url"))
+        if normalized:
+            return normalized
+
+    mr = payload.get("merge_request")
+    if isinstance(mr, dict):
+        normalized = normalize_pr_url(mr.get("url") or mr.get("web_url"))
+        if normalized:
+            return normalized
+
+    return None
+
+
+def merge_result_preserving_pr_binding(
+    existing: Optional[Any], incoming: Optional[Any]
+) -> Optional[Any]:
+    """Keep ``pr_url`` / ``pr_source_branch`` when the agent result overwrites."""
+
+    if incoming is None:
+        return existing
+    if not isinstance(incoming, dict):
+        return incoming
+    if not isinstance(existing, dict):
+        return incoming
+    merged = dict(existing)
+    merged.update(incoming)
+    for key in ("pr_url", "pr_source_branch"):
+        if not merged.get(key) and existing.get(key):
+            merged[key] = existing[key]
+    return merged
+
+
+def record_opened_pr(
+    db: Session,
+    execution_id: Any,
+    pr_url: str,
+    source_branch: Optional[str] = None,
+) -> None:
+    """Merge the opened PR URL onto the execution result. Never raises."""
+
+    try:
+        if not execution_id or not pr_url:
+            return
+        execution = crud_flow_execution.get(db, id=execution_id)
+        if execution is None:
+            logger.warning(
+                "Cannot record opened PR: execution %s not found", execution_id
+            )
+            return
+        current: Dict[str, Any]
+        if isinstance(execution.result, dict):
+            current = dict(execution.result)
+        else:
+            current = {}
+        current["pr_url"] = pr_url
+        if source_branch:
+            current["pr_source_branch"] = source_branch
+        execution.result = current
+        flag_modified(execution, "result")
+        db.commit()
+        logger.info(
+            "Recorded opened PR %s (branch=%s) on execution %s",
+            pr_url,
+            source_branch,
+            execution_id,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to record opened PR on execution %s",
+            execution_id,
+            exc_info=True,
+        )
+        try:
+            db.rollback()
+        except Exception:
+            pass
+
+
+def find_bound_execution(
+    db: Session, flow_id: Any, pr_url: str
+) -> Optional[FlowExecution]:
+    """Return the most recent execution of this flow that opened ``pr_url``."""
+
+    needle = normalize_pr_url(pr_url)
+    if not needle:
+        return None
+    executions = crud_flow_execution.get_by_flow(
+        db, flow_id=flow_id, skip=0, limit=_RESUME_LOOKBACK
+    )
+    for execution in executions:
+        result = execution.result if isinstance(execution.result, dict) else {}
+        stored = normalize_pr_url(result.get("pr_url"))
+        if stored and stored == needle:
+            return execution
+    return None
+
+
+def flow_requires_pr_comment_resume(flow: Any) -> bool:
+    """True when comment_created on this flow must correlate to an opened PR.
+
+    Flows that listen to both issue labeling and comments would otherwise start
+    a cold agent on every issue comment. Comment-only flows are unchanged.
+    """
+
+    types = getattr(flow, "trigger_event_types", None)
+    if not isinstance(types, (list, tuple, set)):
+        return False
+    type_set = set(types)
+    if "comment_created" not in type_set:
+        return False
+    return bool(type_set & {"issue_labeled", "issue_opened"})
+
+
+def bind_resume_or_skip(
+    db: Session, flow: Any, event_data: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Attach ``_resume`` when this comment belongs to a PR this flow opened.
+
+    Returns the resume dict, or None when the event should not start a run.
+    """
+
+    pr_url = extract_pr_url_from_comment_event(event_data)
+    if not pr_url:
+        return None
+    execution = find_bound_execution(db, flow.id, pr_url)
+    if execution is None:
+        return None
+    result = execution.result if isinstance(execution.result, dict) else {}
+    resume = {
+        "execution_id": str(execution.id),
+        "pr_url": result.get("pr_url") or pr_url,
+        "source_branch": result.get("pr_source_branch"),
+    }
+    event_data["_resume"] = resume
+    return resume

--- a/backend/preloop/services/flow_trigger_service.py
+++ b/backend/preloop/services/flow_trigger_service.py
@@ -1020,6 +1020,28 @@ class FlowTriggerService:
                         f"Triggering flow '{flow.name}' ({flow.id}) for event {event_type}"
                     )
                     event_copy = dict(event_data)
+                    if event_type == "comment_created":
+                        from preloop.services.flow_pr_binding import (
+                            bind_resume_or_skip,
+                            flow_requires_pr_comment_resume,
+                        )
+
+                        if flow_requires_pr_comment_resume(flow):
+                            resume = bind_resume_or_skip(self.db, flow, event_copy)
+                            if resume is None:
+                                logger.info(
+                                    "Skipping comment_created on flow '%s' (%s): "
+                                    "no matching opened PR for this comment",
+                                    flow.name,
+                                    flow.id,
+                                )
+                                continue
+                            logger.info(
+                                "Resuming flow '%s' from execution %s on %s",
+                                flow.name,
+                                resume.get("execution_id"),
+                                resume.get("pr_url"),
+                            )
                     await self._start_flow_execution(
                         flow=flow,
                         event_data=event_copy,

--- a/backend/preloop/services/initialize_mcp.py
+++ b/backend/preloop/services/initialize_mcp.py
@@ -186,9 +186,11 @@ def initialize_mcp_with_tools() -> DynamicFastMCP:
         priority: str | None = None,
         assignee: str | None = None,
         labels: list[str] | None = None,
+        add_reaction: str | None = None,
+        remove_reaction: str | None = None,
         ctx: Optional[Context] = None,
     ) -> str:
-        """Update an existing issue."""
+        """Update an existing issue. To add a GitHub eyes reaction on pickup, pass add_reaction=\"eyes\" with no other fields."""
         # Get user context for approval checking
         from preloop.services.dynamic_fastmcp_http import get_current_user_context
 
@@ -210,6 +212,8 @@ def initialize_mcp_with_tools() -> DynamicFastMCP:
                 "priority": priority,
                 "assignee": assignee,
                 "labels": labels,
+                "add_reaction": add_reaction,
+                "remove_reaction": remove_reaction,
             },
             ctx=ctx,
             workflow_id=_rule_workflow_id_var.get(None),
@@ -228,6 +232,8 @@ def initialize_mcp_with_tools() -> DynamicFastMCP:
             priority=priority,
             assignee=assignee,
             labels=labels,
+            add_reaction=add_reaction,
+            remove_reaction=remove_reaction,
         )
         return result.model_dump_json()
 

--- a/backend/preloop/services/prompt_resolvers/__init__.py
+++ b/backend/preloop/services/prompt_resolvers/__init__.py
@@ -5,6 +5,7 @@ from .registry import resolver_registry
 from .trigger_event import TriggerEventResolver
 from .project import ProjectResolver
 from .account import AccountResolver
+from .execution import ExecutionResolver
 
 __all__ = [
     "PromptResolver",
@@ -13,4 +14,5 @@ __all__ = [
     "TriggerEventResolver",
     "ProjectResolver",
     "AccountResolver",
+    "ExecutionResolver",
 ]

--- a/backend/preloop/services/prompt_resolvers/execution.py
+++ b/backend/preloop/services/prompt_resolvers/execution.py
@@ -1,0 +1,45 @@
+"""Resolver for the current flow execution."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from .base import PromptResolver, ResolverContext
+
+DEFAULT_PRELOOP_URL = "http://localhost:8000"
+
+
+def execution_console_url(execution_id: str) -> str:
+    """Return the console URL for a flow execution."""
+
+    base = os.getenv("PRELOOP_URL", DEFAULT_PRELOOP_URL).rstrip("/")
+    return f"{base}/console/flows/executions/{execution_id}"
+
+
+class ExecutionResolver(PromptResolver):
+    """Placeholders for the in-flight execution.
+
+    - ``{{execution.id}}``
+    - ``{{execution.url}}`` — console URL
+    - ``{{execution.resume_from}}`` — prior execution id when this run
+      was started from a PR comment on a PR this flow opened
+    """
+
+    @property
+    def prefix(self) -> str:
+        return "execution"
+
+    async def resolve(self, path: str, context: ResolverContext) -> Optional[str]:
+        if path == "id":
+            return context.execution_id
+        if path == "url":
+            if not context.execution_id:
+                return None
+            return execution_console_url(context.execution_id)
+        if path == "resume_from":
+            resume = context.trigger_event_data.get("_resume") or {}
+            prior = resume.get("execution_id")
+            return str(prior) if prior else None
+        self.logger.warning("Unknown execution field: %s", path)
+        return None

--- a/backend/preloop/sync/event_normalizer.py
+++ b/backend/preloop/sync/event_normalizer.py
@@ -246,7 +246,10 @@ def normalize_event_type(
                         # This matches user expectation that "PR Updated" includes new commits
                         normalized = "pull_request_updated"
                     elif action == "closed":
-                        normalized = "pull_request_closed"
+                        if payload.get("pull_request", {}).get("merged"):
+                            normalized = "pull_request_merged"
+                        else:
+                            normalized = "pull_request_closed"
                     elif action == "reopened":
                         normalized = "pull_request_reopened"
                     elif action == "review_requested":
@@ -588,6 +591,16 @@ def extract_filter_fields(
                 "detailed_merge_status"
             )
 
+        if payload.get("object_kind") == "build" or payload.get("build_name"):
+            if payload.get("build_name"):
+                filter_fields["build_name"] = payload.get("build_name")
+            if payload.get("build_status"):
+                filter_fields["build_status"] = payload.get("build_status")
+            if payload.get("build_stage"):
+                filter_fields["build_stage"] = payload.get("build_stage")
+            if payload.get("ref"):
+                filter_fields["ref"] = payload.get("ref")
+
     elif tracker_type_lower == "github":
         # GitHub structure varies by event type
         action = payload.get("action")
@@ -630,6 +643,8 @@ def extract_filter_fields(
 
             # State
             filter_fields["state"] = issue.get("state")
+            if issue.get("state_reason"):
+                filter_fields["state_reason"] = issue.get("state_reason")
 
         # Extract from pull_request object
         elif "pull_request" in payload:
@@ -693,6 +708,18 @@ def extract_filter_fields(
         # Sender (who triggered the event)
         sender = payload.get("sender", {})
         filter_fields["sender"] = sender.get("login")
+
+        deployment = payload.get("deployment") or {}
+        deployment_status = payload.get("deployment_status") or {}
+        if deployment or deployment_status:
+            environment = deployment_status.get("environment") or deployment.get(
+                "environment"
+            )
+            if environment:
+                filter_fields["environment"] = environment
+            dep_state = deployment_status.get("state")
+            if dep_state:
+                filter_fields["state"] = dep_state
 
     elif tracker_type_lower == "jira":
         # Jira webhook structure

--- a/backend/tests/agents/test_container.py
+++ b/backend/tests/agents/test_container.py
@@ -1388,3 +1388,65 @@ class TestLogScrubbing:
         assert streamed == [
             "origin\thttps://[REDACTED]@github.com/acme/private.git (push)"
         ]
+
+
+class TestResolveGitBranchPlan:
+    def test_resume_overrides_config_source_branch(self, container_executor):
+        source, target, _, _, _ = container_executor._resolve_git_branch_plan(
+            {
+                "flow_name": "Automated Issue Implementation",
+                "execution_id": "83021dcc-4658-45a3-814c-0e67d07642f6",
+                "trigger_event_data": {
+                    "_resume": {
+                        "execution_id": "prior",
+                        "source_branch": "preloop/issue-353",
+                    }
+                },
+            },
+            {"source_branch": "main", "target_branch": None},
+        )
+        assert source == "preloop/issue-353"
+        assert target == "preloop/issue-353"
+
+    def test_default_target_when_not_resuming(self, container_executor):
+        source, target, _, _, _ = container_executor._resolve_git_branch_plan(
+            {
+                "flow_name": "Automated Issue Implementation",
+                "execution_id": "83021dcc-4658-45a3-814c-0e67d07642f6",
+                "trigger_event_data": {},
+            },
+            {"source_branch": None, "target_branch": None},
+        )
+        assert source == "main"
+        assert target == "preloop/automated-issue-implementation-83021dcc"
+
+
+class TestExtractMergeRequestRef:
+    def test_github_pr_comment_issue_stub(self, container_executor):
+        ref = container_executor._extract_merge_request_ref_from_trigger(
+            {
+                "payload": {
+                    "issue": {
+                        "number": 353,
+                        "pull_request": {
+                            "html_url": "https://github.com/preloop/preloop/pull/353"
+                        },
+                    }
+                }
+            }
+        )
+        assert ref == "pull/353/head"
+
+    def test_gitlab_mr_note(self, container_executor):
+        ref = container_executor._extract_merge_request_ref_from_trigger(
+            {"payload": {"merge_request": {"iid": 10}}}
+        )
+        assert ref == "refs/merge-requests/10/head"
+
+
+class TestExtractSourceBranch:
+    def test_gitlab_mr_note_source_branch(self, container_executor):
+        branch = container_executor._extract_source_branch_from_trigger(
+            {"payload": {"merge_request": {"source_branch": "feat/x"}}}
+        )
+        assert branch == "feat/x"

--- a/backend/tests/agents/test_container.py
+++ b/backend/tests/agents/test_container.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from preloop.agents.base import AgentExecutionResult, AgentStatus
-from preloop.agents.container import ContainerAgentExecutor
+from preloop.agents.container import ContainerAgentExecutor, _validated_git_ref
 
 pytestmark = pytest.mark.asyncio
 
@@ -1270,6 +1270,37 @@ class TestGitCloneCredentialsNotInUrl:
         assert command.index("credential.helper") < command.index("git clone")
 
 
+class TestValidatedGitRef:
+    """Branch names interpolated into origin/<ref>..HEAD must match git rules."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["main", "preloop/fix", "preloop/issue-353", "feat/foo-bar_1.2"],
+    )
+    def test_accepts_normal_names(self, name):
+        assert _validated_git_ref(name) == name
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "foo..bar",
+            "-d",
+            "preloop/fix.",
+            "foo~1",
+            "foo^2",
+            "foo:bar",
+            ".hidden",
+            "feat/.dot",
+            "heads/foo.lock",
+            "/abs",
+            "trailing/",
+            "a//b",
+        ],
+    )
+    def test_rejects_git_forbidden_names(self, name):
+        assert _validated_git_ref(name) is None
+
+
 class TestGitApiTokensNotInScript:
     """The PR/MR creation curls used to interpolate the raw token into the
     generated shell script (issue #173).
@@ -1365,6 +1396,26 @@ class TestGitApiTokensNotInScript:
         context["_git_target_branch"] = "feat/x; rm -rf /"
         commands = container_executor._prepare_git_post_execution_commands(context)
         assert commands == ""
+
+    @pytest.mark.parametrize(
+        "unsafe",
+        ["foo..bar", "-d", "preloop/fix.", "foo~1", "foo^2", "foo:bar"],
+    )
+    def test_git_forbidden_target_ref_skips_post_execution(
+        self, container_executor, unsafe
+    ):
+        context = self._context()
+        context["_git_target_branch"] = unsafe
+        commands = container_executor._prepare_git_post_execution_commands(context)
+        assert commands == ""
+        assert f"origin/{unsafe}" not in commands
+
+    def test_unsafe_source_branch_skips_post_execution(self, container_executor):
+        context = self._context()
+        context["_git_source_branch"] = "foo..bar"
+        commands = container_executor._prepare_git_post_execution_commands(context)
+        assert commands == ""
+        assert "origin/preloop/fix" not in commands
 
 
 class TestLogScrubbing:

--- a/backend/tests/agents/test_container.py
+++ b/backend/tests/agents/test_container.py
@@ -1345,6 +1345,27 @@ class TestGitApiTokensNotInScript:
         assert "username=x-access-token" in commands
         assert "username=oauth2" not in commands
 
+    def test_resume_commit_count_uses_origin_target_head(self, container_executor):
+        context = self._context()
+        context["_git_source_branch"] = "preloop/issue-353"
+        context["_git_target_branch"] = "preloop/issue-353"
+        commands = container_executor._prepare_git_post_execution_commands(context)
+        assert "origin/preloop/issue-353..HEAD" in commands
+        assert "origin/'preloop" not in commands
+
+    def test_normal_commit_count_falls_back_to_source_target(self, container_executor):
+        context = self._context()
+        commands = container_executor._prepare_git_post_execution_commands(context)
+        assert "origin/preloop/fix..HEAD" in commands
+        assert "main..preloop/fix" in commands
+        assert "origin/'preloop" not in commands
+
+    def test_unsafe_target_branch_skips_post_execution(self, container_executor):
+        context = self._context()
+        context["_git_target_branch"] = "feat/x; rm -rf /"
+        commands = container_executor._prepare_git_post_execution_commands(context)
+        assert commands == ""
+
 
 class TestLogScrubbing:
     """Logs are scrubbed on read as well, so a token already present in a

--- a/backend/tests/endpoints/test_mcp.py
+++ b/backend/tests/endpoints/test_mcp.py
@@ -238,6 +238,147 @@ async def test_mcp_update_issue_success(db_session: Session, test_user: User):
 
 
 @pytest.mark.asyncio
+async def test_mcp_update_issue_add_reaction_only(db_session: Session, test_user: User):
+    """Reaction-only update_issue should not require other fields."""
+    tracker = Tracker(
+        name="test-tracker-react",
+        account_id=test_user.account_id,
+        tracker_type="github",
+        api_key="test_key",
+        url="https://github.com",
+    )
+    db_session.add(tracker)
+    db_session.commit()
+
+    organization = Organization(
+        name="test-org-react",
+        identifier="test-org-react",
+        tracker_id=tracker.id,
+    )
+    db_session.add(organization)
+    db_session.commit()
+
+    project = Project(
+        name="test-proj-react",
+        identifier="test-proj-react",
+        slug="test-proj-react",
+        organization_id=organization.id,
+    )
+    db_session.add(project)
+    db_session.commit()
+
+    issue = Issue(
+        title="Original Title",
+        description="Original description.",
+        project_id=project.id,
+        tracker_id=tracker.id,
+        external_id="456",
+        key="owner/repo#456",
+        status="open",
+    )
+    db_session.add(issue)
+    db_session.commit()
+
+    with (
+        patch("preloop.api.endpoints.mcp.get_http_request") as mock_get_request,
+        patch(
+            "preloop.api.endpoints.mcp.get_user_from_token_if_valid",
+            new_callable=AsyncMock,
+        ) as mock_get_user,
+        patch(
+            "preloop.api.endpoints.mcp.get_tracker_client", new_callable=AsyncMock
+        ) as mock_get_tracker,
+        patch("preloop.api.endpoints.mcp.get_db") as mock_get_db,
+    ):
+        mock_get_request.return_value.headers = {"authorization": "Bearer testtoken"}
+        mock_get_user.return_value = test_user
+        mock_get_db.return_value = iter([db_session])
+        mock_tracker_client = AsyncMock()
+        mock_tracker_client.tracker_type = "github"
+        mock_get_tracker.return_value = mock_tracker_client
+
+        response = await mcp.update_issue(issue=str(issue.id), add_reaction="eyes")
+
+    assert isinstance(response, GetIssueResponse)
+    mock_tracker_client.add_issue_reaction.assert_called_once_with(
+        issue_number="456",
+        reaction="eyes",
+    )
+    mock_tracker_client.update_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mcp_update_issue_reaction_rejected_on_gitlab(
+    db_session: Session, test_user: User
+):
+    """GitLab issues have no reaction API."""
+    tracker = Tracker(
+        name="test-tracker-gl",
+        account_id=test_user.account_id,
+        tracker_type="gitlab",
+        api_key="test_key",
+        url="https://gitlab.com",
+    )
+    db_session.add(tracker)
+    db_session.commit()
+
+    organization = Organization(
+        name="test-org-gl",
+        identifier="test-org-gl",
+        tracker_id=tracker.id,
+    )
+    db_session.add(organization)
+    db_session.commit()
+
+    project = Project(
+        name="test-proj-gl",
+        identifier="test-proj-gl",
+        slug="test-proj-gl",
+        organization_id=organization.id,
+    )
+    db_session.add(project)
+    db_session.commit()
+
+    issue = Issue(
+        title="Original Title",
+        description="Original description.",
+        project_id=project.id,
+        tracker_id=tracker.id,
+        external_id="99",
+        key="99",
+        status="open",
+    )
+    db_session.add(issue)
+    db_session.commit()
+
+    from fastapi import HTTPException
+
+    with (
+        patch("preloop.api.endpoints.mcp.get_http_request") as mock_get_request,
+        patch(
+            "preloop.api.endpoints.mcp.get_user_from_token_if_valid",
+            new_callable=AsyncMock,
+        ) as mock_get_user,
+        patch(
+            "preloop.api.endpoints.mcp.get_tracker_client", new_callable=AsyncMock
+        ) as mock_get_tracker,
+        patch("preloop.api.endpoints.mcp.get_db") as mock_get_db,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        mock_get_request.return_value.headers = {"authorization": "Bearer testtoken"}
+        mock_get_user.return_value = test_user
+        mock_get_db.return_value = iter([db_session])
+        mock_tracker_client = AsyncMock()
+        mock_tracker_client.tracker_type = "gitlab"
+        mock_get_tracker.return_value = mock_tracker_client
+
+        await mcp.update_issue(issue=str(issue.id), add_reaction="eyes")
+
+    assert exc_info.value.status_code == 400
+    assert "GitLab" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
 async def test_mcp_search_success(db_session: Session, test_user: User):
     """
     Tests the MCP search tool.

--- a/backend/tests/services/prompt_resolvers/test_execution.py
+++ b/backend/tests/services/prompt_resolvers/test_execution.py
@@ -1,0 +1,54 @@
+"""Tests for the execution prompt resolver."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from preloop.services.prompt_resolvers.base import ResolverContext
+from preloop.services.prompt_resolvers.execution import ExecutionResolver
+
+
+def _context(**event):
+    return ResolverContext(
+        db=MagicMock(),
+        trigger_event_data=event,
+        flow_id="flow-1",
+        execution_id="83021dcc-4658-45a3-814c-0e67d07642f6",
+    )
+
+
+class TestExecutionResolver:
+    def test_prefix(self):
+        assert ExecutionResolver().prefix == "execution"
+
+    @pytest.mark.asyncio
+    async def test_id(self):
+        result = await ExecutionResolver().resolve("id", _context())
+        assert result == "83021dcc-4658-45a3-814c-0e67d07642f6"
+
+    @pytest.mark.asyncio
+    async def test_url_uses_preloop_url(self, monkeypatch):
+        monkeypatch.setenv("PRELOOP_URL", "https://preloop.ai")
+        result = await ExecutionResolver().resolve("url", _context())
+        assert result == (
+            "https://preloop.ai/console/flows/executions/"
+            "83021dcc-4658-45a3-814c-0e67d07642f6"
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_from(self):
+        result = await ExecutionResolver().resolve(
+            "resume_from",
+            _context(_resume={"execution_id": "prior-exec"}),
+        )
+        assert result == "prior-exec"
+
+    @pytest.mark.asyncio
+    async def test_resume_from_absent(self):
+        result = await ExecutionResolver().resolve("resume_from", _context())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_unknown_field(self):
+        result = await ExecutionResolver().resolve("nope", _context())
+        assert result is None

--- a/backend/tests/services/test_flow_pr_binding.py
+++ b/backend/tests/services/test_flow_pr_binding.py
@@ -31,6 +31,29 @@ class TestNormalizePrUrl:
         assert normalize_pr_url("") == ""
         assert normalize_pr_url(None) == ""
 
+    def test_non_github_host_does_not_rewrite_issues_path(self):
+        assert (
+            normalize_pr_url("https://notgithub.com/org/repo/issues/12")
+            == "https://notgithub.com/org/repo/issues/12"
+        )
+        assert (
+            normalize_pr_url("https://github.com.evil.example/org/repo/issues/12")
+            == "https://github.com.evil.example/org/repo/issues/12"
+        )
+
+    def test_www_github_issues_url_becomes_pull(self):
+        assert (
+            normalize_pr_url("https://www.github.com/preloop/preloop/issues/353")
+            == "https://www.github.com/preloop/preloop/pull/353"
+        )
+
+    def test_tracker_api_url_is_rejected(self):
+        assert (
+            normalize_pr_url("https://gitlab.com/api/v4/projects/1/merge_requests/10")
+            == ""
+        )
+        assert normalize_pr_url("https://api.github.com/repos/a/b/pulls/1") == ""
+
 
 class TestExtractPrUrlFromCommentEvent:
     def test_github_pr_comment(self):
@@ -76,6 +99,21 @@ class TestExtractPrUrlFromCommentEvent:
             == "https://gitlab.com/acme/backend/-/merge_requests/10"
         )
 
+    def test_gitlab_prefers_web_url_over_api_url(self):
+        event = {
+            "payload": {
+                "merge_request": {
+                    "iid": 10,
+                    "url": "https://gitlab.com/api/v4/projects/1/merge_requests/10",
+                    "web_url": "https://gitlab.com/acme/backend/-/merge_requests/10",
+                }
+            }
+        }
+        assert (
+            extract_pr_url_from_comment_event(event)
+            == "https://gitlab.com/acme/backend/-/merge_requests/10"
+        )
+
 
 class TestMergeResultPreservingPrBinding:
     def test_none_incoming_keeps_existing(self):
@@ -111,6 +149,27 @@ class TestFlowRequiresPrCommentResume:
 
 
 class TestFindAndBind:
+    def test_find_bound_execution_jsonb_hit(self):
+        execution = MagicMock()
+        db = MagicMock()
+        from preloop.services import flow_pr_binding as mod
+
+        original_jsonb = mod.crud_flow_execution.get_by_result_pr_url
+        original_flow = mod.crud_flow_execution.get_by_flow
+        mod.crud_flow_execution.get_by_result_pr_url = MagicMock(return_value=execution)
+        mod.crud_flow_execution.get_by_flow = MagicMock()
+        try:
+            found = find_bound_execution(
+                db,
+                flow_id="flow-1",
+                pr_url="https://github.com/preloop/preloop/pull/353",
+            )
+            assert found is execution
+            mod.crud_flow_execution.get_by_flow.assert_not_called()
+        finally:
+            mod.crud_flow_execution.get_by_result_pr_url = original_jsonb
+            mod.crud_flow_execution.get_by_flow = original_flow
+
     def test_find_bound_execution_matches_normalized_url(self):
         execution = MagicMock()
         execution.result = {
@@ -120,7 +179,9 @@ class TestFindAndBind:
         db = MagicMock()
         from preloop.services import flow_pr_binding as mod
 
-        original = mod.crud_flow_execution.get_by_flow
+        original_jsonb = mod.crud_flow_execution.get_by_result_pr_url
+        original_flow = mod.crud_flow_execution.get_by_flow
+        mod.crud_flow_execution.get_by_result_pr_url = MagicMock(return_value=None)
         mod.crud_flow_execution.get_by_flow = MagicMock(return_value=[execution])
         try:
             found = find_bound_execution(
@@ -130,7 +191,29 @@ class TestFindAndBind:
             )
             assert found is execution
         finally:
-            mod.crud_flow_execution.get_by_flow = original
+            mod.crud_flow_execution.get_by_result_pr_url = original_jsonb
+            mod.crud_flow_execution.get_by_flow = original_flow
+
+    def test_find_bound_execution_logs_when_missing(self, caplog):
+        db = MagicMock()
+        from preloop.services import flow_pr_binding as mod
+
+        original_jsonb = mod.crud_flow_execution.get_by_result_pr_url
+        original_flow = mod.crud_flow_execution.get_by_flow
+        mod.crud_flow_execution.get_by_result_pr_url = MagicMock(return_value=None)
+        mod.crud_flow_execution.get_by_flow = MagicMock(return_value=[])
+        try:
+            with caplog.at_level("INFO"):
+                found = find_bound_execution(
+                    db,
+                    flow_id="flow-1",
+                    pr_url="https://github.com/preloop/preloop/pull/999",
+                )
+            assert found is None
+            assert "lookback=" in caplog.text
+        finally:
+            mod.crud_flow_execution.get_by_result_pr_url = original_jsonb
+            mod.crud_flow_execution.get_by_flow = original_flow
 
     def test_bind_resume_or_skip_attaches_resume(self):
         execution = MagicMock()

--- a/backend/tests/services/test_flow_pr_binding.py
+++ b/backend/tests/services/test_flow_pr_binding.py
@@ -1,0 +1,185 @@
+"""Tests for flow PR binding used by issue-implementation resume."""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from preloop.services.flow_pr_binding import (
+    bind_resume_or_skip,
+    extract_pr_url_from_comment_event,
+    find_bound_execution,
+    flow_requires_pr_comment_resume,
+    merge_result_preserving_pr_binding,
+    normalize_pr_url,
+    record_opened_pr,
+)
+
+
+class TestNormalizePrUrl:
+    def test_github_pull_url(self):
+        assert (
+            normalize_pr_url("https://github.com/preloop/preloop/pull/353")
+            == "https://github.com/preloop/preloop/pull/353"
+        )
+
+    def test_github_issues_url_becomes_pull(self):
+        assert (
+            normalize_pr_url("https://github.com/preloop/preloop/issues/353/")
+            == "https://github.com/preloop/preloop/pull/353"
+        )
+
+    def test_empty(self):
+        assert normalize_pr_url("") == ""
+        assert normalize_pr_url(None) == ""
+
+
+class TestExtractPrUrlFromCommentEvent:
+    def test_github_pr_comment(self):
+        event = {
+            "payload": {
+                "issue": {
+                    "number": 353,
+                    "html_url": "https://github.com/preloop/preloop/issues/353",
+                    "pull_request": {
+                        "html_url": "https://github.com/preloop/preloop/pull/353",
+                    },
+                }
+            }
+        }
+        assert (
+            extract_pr_url_from_comment_event(event)
+            == "https://github.com/preloop/preloop/pull/353"
+        )
+
+    def test_github_issue_comment_is_none(self):
+        event = {
+            "payload": {
+                "issue": {
+                    "number": 12,
+                    "html_url": "https://github.com/preloop/preloop/issues/12",
+                }
+            }
+        }
+        assert extract_pr_url_from_comment_event(event) is None
+
+    def test_gitlab_mr_note(self):
+        event = {
+            "payload": {
+                "merge_request": {
+                    "iid": 10,
+                    "url": "https://gitlab.com/acme/backend/-/merge_requests/10",
+                    "source_branch": "feat/x",
+                }
+            }
+        }
+        assert (
+            extract_pr_url_from_comment_event(event)
+            == "https://gitlab.com/acme/backend/-/merge_requests/10"
+        )
+
+
+class TestMergeResultPreservingPrBinding:
+    def test_none_incoming_keeps_existing(self):
+        existing = {"pr_url": "https://github.com/a/b/pull/1"}
+        assert merge_result_preserving_pr_binding(existing, None) == existing
+
+    def test_incoming_dict_keeps_pr_url(self):
+        existing = {
+            "pr_url": "https://github.com/a/b/pull/1",
+            "pr_source_branch": "feat/x",
+        }
+        incoming = {"verdict": "ship"}
+        merged = merge_result_preserving_pr_binding(existing, incoming)
+        assert merged["verdict"] == "ship"
+        assert merged["pr_url"] == "https://github.com/a/b/pull/1"
+        assert merged["pr_source_branch"] == "feat/x"
+
+
+class TestFlowRequiresPrCommentResume:
+    def test_issue_impl_flow(self):
+        flow = MagicMock()
+        flow.trigger_event_types = ["issue_labeled", "comment_created"]
+        assert flow_requires_pr_comment_resume(flow) is True
+
+    def test_comment_only_flow(self):
+        flow = MagicMock()
+        flow.trigger_event_types = ["comment_created"]
+        assert flow_requires_pr_comment_resume(flow) is False
+
+    def test_mock_types_are_ignored(self):
+        flow = MagicMock()
+        assert flow_requires_pr_comment_resume(flow) is False
+
+
+class TestFindAndBind:
+    def test_find_bound_execution_matches_normalized_url(self):
+        execution = MagicMock()
+        execution.result = {
+            "pr_url": "https://github.com/preloop/preloop/pull/353/",
+            "pr_source_branch": "feat/x",
+        }
+        db = MagicMock()
+        from preloop.services import flow_pr_binding as mod
+
+        original = mod.crud_flow_execution.get_by_flow
+        mod.crud_flow_execution.get_by_flow = MagicMock(return_value=[execution])
+        try:
+            found = find_bound_execution(
+                db,
+                flow_id="flow-1",
+                pr_url="https://github.com/preloop/preloop/issues/353",
+            )
+            assert found is execution
+        finally:
+            mod.crud_flow_execution.get_by_flow = original
+
+    def test_bind_resume_or_skip_attaches_resume(self):
+        execution = MagicMock()
+        execution.id = uuid4()
+        execution.result = {
+            "pr_url": "https://github.com/preloop/preloop/pull/353",
+            "pr_source_branch": "feat/x",
+        }
+        flow = MagicMock()
+        flow.id = uuid4()
+        db = MagicMock()
+        event = {
+            "payload": {
+                "issue": {
+                    "pull_request": {
+                        "html_url": "https://github.com/preloop/preloop/pull/353",
+                    }
+                }
+            }
+        }
+        from preloop.services import flow_pr_binding as mod
+
+        original = mod.find_bound_execution
+        mod.find_bound_execution = MagicMock(return_value=execution)
+        try:
+            resume = bind_resume_or_skip(db, flow, event)
+            assert resume["source_branch"] == "feat/x"
+            assert event["_resume"]["execution_id"] == str(execution.id)
+        finally:
+            mod.find_bound_execution = original
+
+    def test_bind_skips_issue_comment(self):
+        flow = MagicMock()
+        event = {"payload": {"issue": {"number": 1}}}
+        assert bind_resume_or_skip(MagicMock(), flow, event) is None
+
+    def test_record_opened_pr_merges_result(self):
+        execution = MagicMock()
+        execution.result = {"other": 1}
+        db = MagicMock()
+        from preloop.services import flow_pr_binding as mod
+
+        original = mod.crud_flow_execution.get
+        mod.crud_flow_execution.get = MagicMock(return_value=execution)
+        try:
+            record_opened_pr(db, "exec-1", "https://github.com/a/b/pull/1", "feat/x")
+            assert execution.result["pr_url"] == "https://github.com/a/b/pull/1"
+            assert execution.result["pr_source_branch"] == "feat/x"
+            assert execution.result["other"] == 1
+            db.commit.assert_called_once()
+        finally:
+            mod.crud_flow_execution.get = original

--- a/backend/tests/services/test_flow_trigger_service.py
+++ b/backend/tests/services/test_flow_trigger_service.py
@@ -524,6 +524,75 @@ class TestProcessEvent:
 
         mock_create_task.assert_not_called()
 
+    @patch("preloop.services.flow_trigger_service.asyncio.create_task")
+    @patch("preloop.services.flow_trigger_service.get_nats_client")
+    @patch("preloop.services.flow_trigger_service.crud_flow")
+    @patch("preloop.services.flow_pr_binding.bind_resume_or_skip")
+    async def test_comment_on_opened_pr_resumes(
+        self,
+        mock_bind,
+        mock_crud,
+        mock_nats,
+        mock_create_task,
+        flow_trigger_service,
+        sample_flow,
+    ):
+        sample_flow.trigger_event_types = ["issue_labeled", "comment_created"]
+        mock_bind.return_value = {
+            "execution_id": "prior",
+            "pr_url": "https://github.com/preloop/preloop/pull/353",
+            "source_branch": "feat/x",
+        }
+        mock_nats.return_value = AsyncMock()
+        mock_crud.get_by_trigger.return_value = [sample_flow]
+        event = {
+            "source": "github",
+            "type": "comment_created",
+            "account_id": str(uuid.uuid4()),
+            "payload": {
+                "issue": {
+                    "pull_request": {
+                        "html_url": "https://github.com/preloop/preloop/pull/353"
+                    }
+                }
+            },
+        }
+
+        await flow_trigger_service.process_event(event)
+
+        mock_bind.assert_called_once()
+        mock_create_task.assert_called_once()
+
+    @patch("preloop.services.flow_trigger_service.asyncio.create_task")
+    @patch("preloop.services.flow_trigger_service.get_nats_client")
+    @patch("preloop.services.flow_trigger_service.crud_flow")
+    async def test_unmatched_pr_comment_does_not_start_run(
+        self,
+        mock_crud,
+        mock_nats,
+        mock_create_task,
+        flow_trigger_service,
+        sample_flow,
+    ):
+        sample_flow.trigger_event_types = ["issue_labeled", "comment_created"]
+        mock_nats.return_value = AsyncMock()
+        mock_crud.get_by_trigger.return_value = [sample_flow]
+        event = {
+            "source": "github",
+            "type": "comment_created",
+            "account_id": str(uuid.uuid4()),
+            "payload": {
+                "issue": {
+                    "number": 1,
+                    "html_url": "https://github.com/preloop/preloop/issues/1",
+                }
+            },
+        }
+
+        await flow_trigger_service.process_event(event)
+
+        mock_create_task.assert_not_called()
+
 
 class TestProcessEventReleaseDedupe:
     """process_event must coalesce duplicate release events (issue #241).

--- a/backend/tests/sync/test_event_normalizer.py
+++ b/backend/tests/sync/test_event_normalizer.py
@@ -189,6 +189,27 @@ class TestEventNormalization:
         }
         assert normalize_event_type("github", "issues", payload) == "issue_labeled"
 
+    def test_github_pr_merged_on_close(self):
+        """GitHub PR closed+merged is pull_request_merged, not closed."""
+        payload = {"action": "closed", "pull_request": {"merged": True, "number": 1}}
+        assert (
+            normalize_event_type("github", "pull_request", payload)
+            == "pull_request_merged"
+        )
+
+    def test_github_pr_closed_without_merge(self):
+        payload = {"action": "closed", "pull_request": {"merged": False, "number": 1}}
+        assert (
+            normalize_event_type("github", "pull_request", payload)
+            == "pull_request_closed"
+        )
+
+    def test_gitlab_job_hook(self):
+        assert normalize_event_type("gitlab", "Job Hook", {}) == "job"
+
+    def test_github_deployment_status(self):
+        assert normalize_event_type("github", "deployment_status", {}) == "deployment"
+
 
 class TestFilterFieldExtraction:
     """Test extraction of filter fields from webhook payloads."""
@@ -308,6 +329,44 @@ class TestFilterFieldExtraction:
 
         # Should be a single string, not a list
         assert fields["assignee"] == "single_assignee"
+
+    def test_github_issue_closed_exposes_state_reason(self):
+        payload = {
+            "action": "closed",
+            "issue": {
+                "state": "closed",
+                "state_reason": "completed",
+                "user": {"login": "octocat"},
+            },
+            "sender": {"login": "octocat"},
+        }
+        fields = extract_filter_fields("github", "issues", payload)
+        assert fields["state_reason"] == "completed"
+        assert fields["state"] == "closed"
+
+    def test_gitlab_job_hook_exposes_build_fields(self):
+        payload = {
+            "object_kind": "build",
+            "build_name": "deploy:staging",
+            "build_status": "success",
+            "build_stage": "deploy",
+            "ref": "main",
+        }
+        fields = extract_filter_fields("gitlab", "Job Hook", payload)
+        assert fields["build_name"] == "deploy:staging"
+        assert fields["build_status"] == "success"
+        assert fields["build_stage"] == "deploy"
+        assert fields["ref"] == "main"
+
+    def test_github_deployment_exposes_environment(self):
+        payload = {
+            "deployment": {"environment": "staging"},
+            "deployment_status": {"state": "success", "environment": "staging"},
+            "sender": {"login": "octocat"},
+        }
+        fields = extract_filter_fields("github", "deployment_status", payload)
+        assert fields["environment"] == "staging"
+        assert fields["state"] == "success"
 
 
 class TestFilterMatching:
@@ -492,6 +551,9 @@ class TestHumanizeEventType:
         assert humanize_event_type("pull_request_updated") == "Pull Request Updated"
         assert humanize_event_type("merge_request_merged") == "Merge Request Merged"
         assert humanize_event_type("push") == "Push to Repository"
+        assert humanize_event_type("job") == "Job Event"
+        assert humanize_event_type("deployment") == "Deployment"
+        assert humanize_event_type("pull_request_merged") == "Pull Request Merged"
 
     def test_unknown_event_type_falls_back_to_title_case(self):
         """Unknown/future event types still render readably, not as slugs."""

--- a/docs/architecture/flows.md
+++ b/docs/architecture/flows.md
@@ -4,6 +4,18 @@ This chapter covers the Flow subsystem: the Trigger Service, Flow Orchestrator, 
 
 Flows with a `runner_pool` use `RemoteRunnerExecutor` to lease work to a matching self-hosted runner instead of starting a hosted container. Runners maintain an outbound WebSocket control plane for leases, heartbeats, status, logs, completion, and halt requests; durable lease metadata stays in PostgreSQL so temporary disconnects can recover without persisting short-lived API tokens.
 
+## Prompt placeholders
+
+Flow `prompt_template` strings are resolved before the agent starts. Besides `{{project.*}}`, `{{account.*}}`, and `{{trigger_event.*}}`, an execution resolver provides:
+
+*   `{{execution.id}}` — this run's id.
+*   `{{execution.url}}` — console URL `{PRELOOP_URL}/console/flows/executions/{id}`.
+*   `{{execution.resume_from}}` — prior execution id when this run was started from a human comment on a PR this flow opened. Empty otherwise.
+
+## PR-comment resume
+
+`create_pull_request` (and GitLab merge-request creation) records the opened HTML URL and source branch on `flow_execution.result` (`flow_pr_binding`). When a flow listens to both issue events (`issue_labeled` or `issue_opened`) and `comment_created`, a later human comment on that PR starts a new execution of the same flow with `_resume` in the trigger payload. The container clones and pushes the existing PR branch. Unmatched comments do not start a run. Native CLI `--resume` is a separate follow-up.
+
 ## Matrix / Batch Fan-Out
 
 One flow definition can drive an agent-harness × model evaluation grid without cloning the flow per combination:

--- a/frontend/src/constants/tracker-event-types.test.ts
+++ b/frontend/src/constants/tracker-event-types.test.ts
@@ -12,5 +12,6 @@ describe('getTrackerEventOptions', () => {
     expect(events.some((event) => event.value === 'merge_request_updated')).to
       .be.true;
     expect(events.some((event) => event.value === 'issue_updated')).to.be.true;
+    expect(events.some((event) => event.value === 'deployment')).to.be.true;
   });
 });

--- a/frontend/src/constants/tracker-event-types.ts
+++ b/frontend/src/constants/tracker-event-types.ts
@@ -19,6 +19,7 @@ export const GITHUB_TRACKER_EVENTS: TrackerEventOption[] = [
   { name: 'Comment Updated', value: 'comment_updated' },
   { name: 'Push to Repository', value: 'push' },
   { name: 'Release Published', value: 'release' },
+  { name: 'Deployment', value: 'deployment' },
 ];
 
 export const GITLAB_TRACKER_EVENTS: TrackerEventOption[] = [
@@ -39,6 +40,7 @@ export const GITLAB_TRACKER_EVENTS: TrackerEventOption[] = [
   { name: 'Push to Repository', value: 'push' },
   { name: 'Tag Push', value: 'tag_push' },
   { name: 'Pipeline Event', value: 'pipeline' },
+  { name: 'Job Event', value: 'job' },
   { name: 'Release Published', value: 'release' },
 ];
 

--- a/frontend/src/constants/tracker-event-types.ts
+++ b/frontend/src/constants/tracker-event-types.ts
@@ -41,6 +41,7 @@ export const GITLAB_TRACKER_EVENTS: TrackerEventOption[] = [
   { name: 'Tag Push', value: 'tag_push' },
   { name: 'Pipeline Event', value: 'pipeline' },
   { name: 'Job Event', value: 'job' },
+  { name: 'Deployment', value: 'deployment' },
   { name: 'Release Published', value: 'release' },
 ];
 


### PR DESCRIPTION
## Summary
- Issue-implementation pickup can add a GitHub `eyes` reaction via `update_issue` and comment with `{{execution.url}}`. GitLab issues skip reactions (no API).
- Opening a PR records its URL and source branch on the execution. A later human comment on that PR starts a new run of the same flow on the same branch. Comments on unrelated PRs or on the issue itself do not start a run. Bot comments still hit the existing loop guard.
- GitHub PRs that close as merged now emit `pull_request_merged`. Job and deployment filter fields (`build_name`, `build_status`, `state_reason`, `environment`) are available for close-audit and staging-QA flows. Event pickers list Job Event and Deployment.

Native CLI `--resume` (OpenCode/Codex session files) is not in this PR. Follow-up: #356.

EE presets 003/009/010 (ack prompt, close-audit, `deploy:staging` QA) live in the parent repo and will ship separately.

## Test plan
- [ ] `PYTHONPATH=backend pytest backend/tests/services/test_flow_pr_binding.py backend/tests/services/prompt_resolvers/test_execution.py backend/tests/sync/test_event_normalizer.py backend/tests/agents/test_container.py::TestResolveGitBranchPlan backend/tests/agents/test_container.py::TestExtractMergeRequestRef backend/tests/agents/test_container.py::TestExtractSourceBranch backend/tests/services/test_flow_trigger_service.py::TestProcessEvent`
- [ ] Label an issue `agent-ready`, confirm eyes + pickup comment with an execution link
- [ ] Let the agent open a PR, then comment on that PR as a human; confirm a new execution clones the same branch
- [ ] Comment on an unrelated issue and confirm no new execution
- [ ] Close a GitHub PR by merging and confirm the event type is `pull_request_merged`

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> All seven previously raised issues are resolved, including the `_validated_git_ref` hardening from the last pass. No new findings.
>
> **Overview**
> Binds issue-implementation flows to the PR they open, records the PR URL/branch on the execution, and resumes the flow on a human PR comment. Adds `pull_request_merged` and job/deployment filter fields plus event-picker entries.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit a4efedc4. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
