### PR TITLE
Keep a flow execution's gateway token alive across a worker handoff

### DIFF
--- a/backend/preloop/services/execution_recovery.py
+++ b/backend/preloop/services/execution_recovery.py
@@ -19,6 +19,39 @@ def _exception_message(exc: BaseException) -> str:
     return str(exc) or exc.__class__.__name__
 
 
+def _retire_runtime_credentials(db: Session, execution) -> None:
+    """Close the runtime session and revoke the runtime tokens of an execution.
+
+    Recovery decides an execution is over without ever running its
+    orchestrator's teardown, so it has to retire the credentials itself.
+    Otherwise the gateway token of a run that recovery just marked FAILED keeps
+    authenticating until its two-hour expiry.
+    """
+    if execution is None:
+        return
+    account_id = getattr(getattr(execution, "flow", None), "account_id", None)
+    if account_id is None:
+        return
+    from datetime import datetime, timezone
+
+    from preloop.services.flow_runtime_token import (
+        end_flow_execution_runtime_session,
+        revoke_flow_runtime_tokens,
+    )
+
+    end_flow_execution_runtime_session(
+        db,
+        account_id=account_id,
+        execution_id=execution.id,
+        ended_at=datetime.now(timezone.utc),
+    )
+    revoke_flow_runtime_tokens(
+        db,
+        account_id=account_id,
+        execution_id=execution.id,
+    )
+
+
 class ExecutionRecoveryService:
     """Recovers and resumes monitoring for orphaned flow executions."""
 
@@ -189,6 +222,7 @@ class ExecutionRecoveryService:
             )
             crud_flow_execution.update(db, db_obj=execution, obj_in=update_data)
             db.commit()
+            _retire_runtime_credentials(db, execution)
             return
 
         # Check if the container/job still exists before trying to monitor
@@ -240,6 +274,7 @@ class ExecutionRecoveryService:
                             db, db_obj=execution, obj_in=update_data
                         )
                         db.commit()
+                        _retire_runtime_credentials(db, execution)
                         return
                     elif status == AgentStatus.SUCCEEDED:
                         logger.info(
@@ -253,6 +288,7 @@ class ExecutionRecoveryService:
                             db, db_obj=execution, obj_in=update_data
                         )
                         db.commit()
+                        _retire_runtime_credentials(db, execution)
                         return
                     # Container is RUNNING/STARTING - proceed with monitoring below
                 finally:
@@ -273,6 +309,7 @@ class ExecutionRecoveryService:
             )
             crud_flow_execution.update(db, db_obj=execution, obj_in=update_data)
             db.commit()
+            _retire_runtime_credentials(db, execution)
             return
 
         # Container is still running - create orchestrator and resume monitoring
@@ -357,6 +394,7 @@ class ExecutionRecoveryService:
                     obj_in=update_data,
                 )
                 failure_db.commit()
+                _retire_runtime_credentials(failure_db, execution_log)
             except Exception as update_error:
                 logger.error(f"Failed to mark execution as failed: {update_error}")
             finally:

--- a/backend/preloop/services/execution_recovery.py
+++ b/backend/preloop/services/execution_recovery.py
@@ -19,7 +19,7 @@ def _exception_message(exc: BaseException) -> str:
     return str(exc) or exc.__class__.__name__
 
 
-def _retire_runtime_credentials(db: Session, execution) -> None:
+def _retire_runtime_credentials(db: Session, execution: models.FlowExecution) -> None:
     """Close the runtime session and revoke the runtime tokens of an execution.
 
     Recovery decides an execution is over without ever running its
@@ -309,7 +309,9 @@ class ExecutionRecoveryService:
             )
             crud_flow_execution.update(db, db_obj=execution, obj_in=update_data)
             db.commit()
-            _retire_runtime_credentials(db, execution)
+            # Status check failed: agent liveness is unknown. Leave the
+            # runtime token alone (it lapses on expiry) rather than revoking
+            # a credential an agent may still be using.
             return
 
         # Container is still running - create orchestrator and resume monitoring

--- a/backend/preloop/services/flow_execution_runner.py
+++ b/backend/preloop/services/flow_execution_runner.py
@@ -84,6 +84,12 @@ async def resume_existing_execution(
             result=agent_result.get("result"),
             end_time=datetime.now(timezone.utc),
         )
+        # The worker that finishes a run owns its teardown, even though it did
+        # not mint the credential: close the runtime session and revoke every
+        # runtime token of this execution. The worker that started the run left
+        # both alive on purpose, because the agent was still using them.
+        orchestrator._sync_runtime_session(ended_at=datetime.now(timezone.utc))
+        orchestrator._revoke_execution_runtime_tokens()
         logger.info(
             "Resumed execution %s completed with status %s",
             orchestrator.execution_log.id,

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -42,7 +42,10 @@ from preloop.services.prompt_resolvers import (
     AccountResolver,
 )
 from preloop.services.flow_execution_logger import FlowExecutionLogger
-from preloop.services.flow_runtime_token import create_flow_runtime_token
+from preloop.services.flow_runtime_token import (
+    create_flow_runtime_token,
+    revoke_flow_runtime_tokens,
+)
 from preloop.sync.event_normalizer import attach_trigger_subject
 from preloop.services.model_runtime_resolver import resolve_ai_model_runtime
 from preloop.utils.git_credentials import (
@@ -65,6 +68,12 @@ from preloop.services.account_realtime import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Statuses after which no agent of this execution can still be running, so its
+# runtime credentials can be retired. Anything else means the agent may still
+# be live (an interrupted run is resumed by a peer worker), and its gateway
+# token must keep working.
+TERMINAL_EXECUTION_STATUSES = frozenset({"SUCCEEDED", "FAILED", "STOPPED", "CANCELLED"})
 
 # Sentinel string that agents print when completing successfully.
 FLOW_SUCCESS_SENTINEL = "FLOW_EXECUTION_SUCCESS"
@@ -1193,27 +1202,82 @@ class FlowExecutionOrchestrator:
             self.db.rollback()
             return None, None
 
+    def _execution_reached_terminal_state(self) -> bool:
+        """Read this execution's committed status back from the database.
+
+        The in-memory row can be stale (another worker may have finished the
+        execution), so the status is re-read rather than trusted.
+        """
+        if self.execution_log is None:
+            return False
+        try:
+            row = crud_flow_execution.get(self.db, id=self.execution_log.id)
+            if row is not None:
+                # Another worker may have finished this execution; without an
+                # explicit refresh the identity map hands back this session's
+                # own, possibly stale, copy of the row.
+                self.db.refresh(row)
+        except Exception as exc:
+            logger.warning(
+                "Could not read execution status for %s: %s",
+                self.execution_log.id,
+                type(exc).__name__,
+            )
+            return False
+        if row is None:
+            return False
+        return str(row.status).upper() in TERMINAL_EXECUTION_STATUSES
+
+    def _revoke_execution_runtime_tokens(self) -> int:
+        """Revoke every runtime token minted for this execution."""
+        account_id = getattr(self.flow, "account_id", None)
+        execution_id = self.execution_log.id if self.execution_log else None
+        revoked = revoke_flow_runtime_tokens(
+            self.db,
+            account_id=account_id,
+            execution_id=execution_id,
+        )
+        if revoked == 0 and self.temporary_api_key_id:
+            # Fall back to the key this orchestrator minted (account or
+            # execution unknown, e.g. a flow row that never loaded).
+            try:
+                if crud_api_key.deactivate(self.db, key_id=self.temporary_api_key_id):
+                    revoked = 1
+            except Exception as exc:
+                logger.error(
+                    "Failed to cleanup temporary API key record: %s",
+                    type(exc).__name__,
+                    exc_info=True,
+                )
+                self.db.rollback()
+        return revoked
+
     def _cleanup_temporary_api_token(self):
-        """Deactivate the temporary API token created for this flow execution."""
-        if not self.temporary_api_key_id:
+        """Retire this execution's runtime token once the execution is terminal.
+
+        The agent outlives its orchestrator. A deploy drain cancels the
+        in-flight handler, releases the claim and re-dispatches the execution
+        so a peer worker resumes monitoring the *same* agent Job (see
+        ``flow_execution_runner.claim_and_run_execution``). Revoking the token
+        on the way out of an interrupted run leaves that still-running agent
+        holding a credential the gateway rejects, and the run dies mid-stream
+        with "Invalid authentication credentials".
+
+        So the token is retired only when the execution itself has reached a
+        terminal state; whichever worker finishes the run revokes it.
+        """
+        if not self.temporary_api_key_id and self.execution_log is None:
             return
 
-        try:
-            api_key = crud_api_key.deactivate(self.db, key_id=self.temporary_api_key_id)
-
-            if api_key:
-                # Log outcome only — key ids are treated as sensitive by CodeQL.
-                logger.info("Deactivated temporary API key record")
-            else:
-                logger.warning("Temporary API key record not found for cleanup")
-
-        except Exception as e:
-            logger.error(
-                "Failed to cleanup temporary API key record: %s",
-                type(e).__name__,
-                exc_info=True,
+        if not self._execution_reached_terminal_state():
+            logger.info(
+                "Leaving runtime token active for execution %s: not terminal "
+                "(handed off to another worker)",
+                self.execution_log.id if self.execution_log else "unknown",
             )
-            self.db.rollback()
+            return
+
+        self._revoke_execution_runtime_tokens()
 
     def _simple_resolve(self, placeholder: str, data: Dict[str, Any]) -> Optional[str]:
         """
@@ -3513,6 +3577,18 @@ class FlowExecutionOrchestrator:
                 f"Flow execution completed with status {final_status}: {self.execution_log.id}"
             )
 
+        except asyncio.CancelledError:
+            # Deploy drain: the worker cancels in-flight handlers, releases the
+            # claim and re-dispatches so a peer resumes monitoring the agent,
+            # which keeps running. Nothing is finalized here (the execution is
+            # not over) and, critically, the runtime token is left active for
+            # the agent that is still streaming.
+            logger.info(
+                "Flow execution %s interrupted; leaving it to the worker that "
+                "resumes it (agent and runtime token untouched)",
+                self.execution_log.id if self.execution_log else "unknown",
+            )
+            raise
         except Exception as e:
             logger.error(
                 f"Flow execution {self.execution_log.id if self.execution_log else 'unknown'} failed: {e}",
@@ -3568,5 +3644,5 @@ class FlowExecutionOrchestrator:
             else:
                 logger.error("Cannot update execution log - not created yet")
         finally:
-            # Always cleanup the temporary API token
+            # Retire the runtime token, but only if this execution is over.
             self._cleanup_temporary_api_token()

--- a/backend/preloop/services/flow_runtime_token.py
+++ b/backend/preloop/services/flow_runtime_token.py
@@ -9,9 +9,114 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from preloop.models.crud import crud_account, crud_api_key, crud_user
+from preloop.models.crud import (
+    crud_account,
+    crud_api_key,
+    crud_runtime_session,
+    crud_user,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def revoke_flow_runtime_tokens(
+    db: Session,
+    *,
+    account_id: Any,
+    execution_id: Any,
+    commit: bool = True,
+) -> int:
+    """Revoke every runtime token minted for one flow execution.
+
+    Revoking by execution rather than by key id is deliberate: an execution
+    that was interrupted and handed to another worker can own more than one
+    minted key, and the worker that finishes the run is not always the worker
+    that minted the key it is holding.
+
+    Args:
+        db: Active database session.
+        account_id: Account owning the execution.
+        execution_id: Flow execution whose credentials are being retired.
+        commit: Whether to commit the revocation.
+
+    Returns:
+        Number of keys deactivated.
+    """
+    if account_id is None or execution_id is None:
+        return 0
+    try:
+        revoked = crud_api_key.deactivate_runtime_keys_for_flow_execution(
+            db,
+            account_id=account_id,
+            execution_id=execution_id,
+            commit=commit,
+        )
+    except Exception as exc:
+        logger.error(
+            "Failed to revoke runtime tokens for flow execution %s: %s",
+            execution_id,
+            type(exc).__name__,
+            exc_info=True,
+        )
+        db.rollback()
+        return 0
+    if revoked:
+        # Outcome only: key ids are treated as sensitive by CodeQL.
+        logger.info(
+            "Revoked %d runtime token(s) for flow execution %s",
+            len(revoked),
+            execution_id,
+        )
+    return len(revoked)
+
+
+def end_flow_execution_runtime_session(
+    db: Session,
+    *,
+    account_id: Any,
+    execution_id: Any,
+    ended_at: Optional[datetime] = None,
+) -> bool:
+    """Close the runtime session of a flow execution if one is still open.
+
+    Only closes an existing session; it never creates one, because a code path
+    that is retiring an execution has no business opening a session that was
+    never started.
+
+    Args:
+        db: Active database session.
+        account_id: Account owning the execution.
+        execution_id: Flow execution whose session is being closed.
+        ended_at: End timestamp; defaults to now.
+
+    Returns:
+        True if a session was closed by this call.
+    """
+    if account_id is None or execution_id is None:
+        return False
+    try:
+        session = crud_runtime_session.get_by_source(
+            db,
+            account_id=account_id,
+            session_source_type="flow_execution",
+            session_source_id=str(execution_id),
+        )
+        if session is None or session.ended_at is not None:
+            return False
+        session.ended_at = ended_at or datetime.now(timezone.utc)
+        session.last_activity_at = session.ended_at
+        db.add(session)
+        db.commit()
+        return True
+    except Exception as exc:
+        logger.error(
+            "Failed to end runtime session for flow execution %s: %s",
+            execution_id,
+            type(exc).__name__,
+            exc_info=True,
+        )
+        db.rollback()
+        return False
 
 
 def create_flow_runtime_token(

--- a/backend/tests/services/test_execution_recovery.py
+++ b/backend/tests/services/test_execution_recovery.py
@@ -173,11 +173,13 @@ async def test_resume_marks_failed_when_no_agent_session():
     db = MagicMock()
     execution = _make_execution(agent_session_reference=None)
     with patch.object(execution_recovery.crud_flow_execution, "update") as update_mock:
-        await svc._resume_execution_monitoring(db, execution, None)
+        with patch.object(execution_recovery, "_retire_runtime_credentials") as retire:
+            await svc._resume_execution_monitoring(db, execution, None)
     update_mock.assert_called_once()
     update_data = update_mock.call_args.kwargs["obj_in"]
     assert update_data.status == "FAILED"
     db.commit.assert_called_once()
+    retire.assert_called_once_with(db, execution)
 
 
 @pytest.mark.asyncio
@@ -195,11 +197,13 @@ async def test_resume_marks_failed_when_container_failed():
             "preloop.agents.create_executor_for_execution", return_value=agent_executor
         ),
         patch.object(execution_recovery.crud_flow_execution, "update") as update_mock,
+        patch.object(execution_recovery, "_retire_runtime_credentials") as retire,
     ):
         await svc._resume_execution_monitoring(db, execution, None)
     update_mock.assert_called_once()
     assert update_mock.call_args.kwargs["obj_in"].status == "FAILED"
     agent_executor.aclose.assert_awaited_once()
+    retire.assert_called_once_with(db, execution)
 
 
 @pytest.mark.asyncio
@@ -217,9 +221,11 @@ async def test_resume_marks_succeeded_when_container_succeeded():
             "preloop.agents.create_executor_for_execution", return_value=agent_executor
         ),
         patch.object(execution_recovery.crud_flow_execution, "update") as update_mock,
+        patch.object(execution_recovery, "_retire_runtime_credentials") as retire,
     ):
         await svc._resume_execution_monitoring(db, execution, None)
     assert update_mock.call_args.kwargs["obj_in"].status == "SUCCEEDED"
+    retire.assert_called_once_with(db, execution)
 
 
 @pytest.mark.asyncio
@@ -234,12 +240,14 @@ async def test_resume_marks_failed_when_status_check_raises():
             side_effect=RuntimeError("docker down"),
         ),
         patch.object(execution_recovery.crud_flow_execution, "update") as update_mock,
+        patch.object(execution_recovery, "_retire_runtime_credentials") as retire,
     ):
         await svc._resume_execution_monitoring(db, execution, None)
     update_mock.assert_called_once()
     update_data = update_mock.call_args.kwargs["obj_in"]
     assert update_data.status == "FAILED"
     assert "docker down" in update_data.error_message
+    retire.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_flow_runtime_token_lifetime.py
+++ b/backend/tests/services/test_flow_runtime_token_lifetime.py
@@ -1,0 +1,377 @@
+"""Lifetime of a flow execution's runtime (gateway) token across a worker handoff.
+
+A deploy drains the flow-execution worker: in-flight handlers are cancelled so
+the claim can be released and the execution re-dispatched, while the agent Job
+keeps running in Kubernetes and a peer worker resumes monitoring it. The
+interrupted worker must therefore leave the runtime token alone (the live agent
+is still authenticating with it against the model gateway), and the worker that
+actually finishes the execution must retire it.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from preloop.models.crud import (
+    crud_account,
+    crud_api_key,
+    crud_flow,
+    crud_runtime_session,
+    crud_user,
+)
+from preloop.models.models import Account, Flow
+from preloop.models.models.flow_execution import FlowExecution
+from preloop.models.models.user import User
+from preloop.models.schemas.flow import FlowCreate
+from preloop.services.flow_orchestrator import FlowExecutionOrchestrator
+from preloop.services.model_gateway_auth import authenticate_bearer_token
+
+
+@pytest.fixture
+def token_account(db_session: Session) -> Account:
+    return crud_account.create(
+        db_session,
+        obj_in={
+            "organization_name": f"Token Org {uuid4().hex[:8]}",
+            "is_active": True,
+        },
+    )
+
+
+@pytest.fixture
+def token_user(db_session: Session, token_account: Account) -> User:
+    user = crud_user.create(
+        db_session,
+        obj_in={
+            "account_id": token_account.id,
+            "email": f"token_{uuid4().hex[:8]}@example.com",
+            "username": f"token_user_{uuid4().hex[:8]}",
+            "full_name": "Runtime Token User",
+            "is_active": True,
+            "email_verified": True,
+            "hashed_password": "test_password",
+            "user_source": "local",
+        },
+    )
+    db_session.flush()
+    db_session.refresh(user)
+    token_account.primary_user_id = user.id
+    db_session.add(token_account)
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
+def token_flow(db_session: Session, token_account: Account, token_user: User) -> Flow:
+    flow_in = FlowCreate(
+        name="Runtime Token Flow",
+        description="Flow used to exercise runtime token lifetime",
+        trigger_event_source="github",
+        trigger_event_types=["issue_created"],
+        prompt_template="Fix issue: {{payload.issue.title}}",
+        agent_type="openhands",
+        agent_config={"max_iterations": 10},
+        account_id=token_account.id,
+    )
+    return crud_flow.create(db=db_session, flow_in=flow_in, account_id=token_account.id)
+
+
+@pytest.fixture
+def trigger_data():
+    return {
+        "source": "github",
+        "type": "issue_created",
+        "event_id": "evt_runtime_token",
+        "payload": {"issue": {"title": "Broken login", "number": 7}},
+    }
+
+
+def _new_orchestrator(db_session, flow, trigger_data):
+    nats_client = AsyncMock()
+    nats_client.is_connected = True
+    return FlowExecutionOrchestrator(
+        db=db_session,
+        flow_id=flow.id,
+        trigger_event_data=trigger_data,
+        nats_client=nats_client,
+    )
+
+
+def _succeeding_executor():
+    from preloop.agents.base import AgentExecutionResult, AgentStatus
+
+    executor = AsyncMock()
+    executor.start = AsyncMock(return_value="agent-session-ref")
+    executor.get_status = AsyncMock(return_value=AgentStatus.SUCCEEDED)
+    executor.get_result = AsyncMock(
+        return_value=AgentExecutionResult(
+            status=AgentStatus.SUCCEEDED,
+            session_reference="agent-session-ref",
+            output_summary="done",
+            actions_taken=None,
+            exit_code=0,
+        )
+    )
+    executor.stop = AsyncMock()
+    return executor
+
+
+async def _run_until_drained(orchestrator) -> str:
+    """Run an execution until a deploy drain cancels its monitoring task.
+
+    Returns the plaintext runtime token minted for the execution.
+    """
+    minted = {}
+    original = FlowExecutionOrchestrator._create_temporary_api_token
+
+    def spy(self):
+        token, key_id = original(self)
+        minted["token"] = token
+        return token, key_id
+
+    with (
+        patch(
+            "preloop.services.flow_orchestrator.create_executor_for_execution",
+            return_value=_succeeding_executor(),
+        ),
+        patch.object(FlowExecutionOrchestrator, "_create_temporary_api_token", spy),
+        patch.object(
+            orchestrator,
+            "_monitor_agent_execution",
+            new_callable=AsyncMock,
+            side_effect=asyncio.CancelledError(),
+        ),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await orchestrator.run()
+
+    assert minted.get("token"), "no runtime token was minted"
+    return minted["token"]
+
+
+class TestRuntimeTokenSurvivesWorkerHandoff:
+    """The interrupted worker must not disarm a still-running agent."""
+
+    @pytest.mark.asyncio
+    async def test_drained_worker_leaves_token_and_session_alive(
+        self, db_session: Session, token_flow: Flow, token_user: User, trigger_data
+    ):
+        orchestrator = _new_orchestrator(db_session, token_flow, trigger_data)
+
+        token = await _run_until_drained(orchestrator)
+
+        key = crud_api_key.get(db_session, id=orchestrator.temporary_api_key_id)
+        assert key is not None
+        assert key.is_active is True, (
+            "the drained worker revoked the token of an agent that is still running"
+        )
+
+        # The credential still authenticates: this is exactly the call the live
+        # agent makes against the model gateway after the handoff.
+        auth = await authenticate_bearer_token(token, db_session)
+        assert auth is not None
+        assert auth.user.id == token_user.id
+
+        session = crud_runtime_session.get_by_source(
+            db_session,
+            account_id=token_flow.account_id,
+            session_source_type="flow_execution",
+            session_source_id=str(orchestrator.execution_log.id),
+        )
+        assert session is not None
+        assert session.ended_at is None
+        assert orchestrator.execution_log.status not in (
+            "SUCCEEDED",
+            "FAILED",
+            "STOPPED",
+            "CANCELLED",
+        )
+
+    @pytest.mark.asyncio
+    async def test_resuming_worker_retires_token_and_session(
+        self, db_session: Session, token_flow: Flow, trigger_data
+    ):
+        from preloop.services.flow_execution_runner import resume_existing_execution
+
+        drained = _new_orchestrator(db_session, token_flow, trigger_data)
+        token = await _run_until_drained(drained)
+        execution_id = drained.execution_log.id
+        key_id = drained.temporary_api_key_id
+
+        # A peer worker picks the execution up: fresh orchestrator, no
+        # temporary_api_key_id of its own, adopting the running agent.
+        resuming = _new_orchestrator(db_session, token_flow, trigger_data)
+        resuming.execution_log = drained.execution_log
+        assert resuming.temporary_api_key_id is None
+
+        with (
+            patch("preloop.agents.create_agent_executor", return_value=AsyncMock()),
+            patch.object(
+                resuming,
+                "_monitor_agent_execution",
+                new_callable=AsyncMock,
+                return_value={"status": "SUCCEEDED", "output_summary": "done"},
+            ),
+        ):
+            await resume_existing_execution(resuming, "agent-session-ref")
+
+        key = crud_api_key.get(db_session, id=key_id)
+        assert key is not None
+        assert key.is_active is False
+        assert await authenticate_bearer_token(token, db_session) is None
+
+        session = crud_runtime_session.get_by_source(
+            db_session,
+            account_id=token_flow.account_id,
+            session_source_type="flow_execution",
+            session_source_id=str(execution_id),
+        )
+        assert session is not None
+        assert session.ended_at is not None
+
+    @pytest.mark.asyncio
+    async def test_completed_run_still_revokes_its_token(
+        self, db_session: Session, token_flow: Flow, trigger_data
+    ):
+        orchestrator = _new_orchestrator(db_session, token_flow, trigger_data)
+        minted = {}
+        original = FlowExecutionOrchestrator._create_temporary_api_token
+
+        def spy(self):
+            token, key_id = original(self)
+            minted["token"] = token
+            return token, key_id
+
+        with (
+            patch(
+                "preloop.services.flow_orchestrator.create_executor_for_execution",
+                return_value=_succeeding_executor(),
+            ),
+            patch.object(FlowExecutionOrchestrator, "_create_temporary_api_token", spy),
+        ):
+            await orchestrator.run()
+
+        assert orchestrator.execution_log.status in ("SUCCEEDED", "FAILED")
+        key = crud_api_key.get(db_session, id=orchestrator.temporary_api_key_id)
+        assert key is not None
+        assert key.is_active is False
+        assert await authenticate_bearer_token(minted["token"], db_session) is None
+
+    def test_cleanup_is_a_no_op_while_the_execution_runs(
+        self, db_session: Session, token_flow: Flow, trigger_data
+    ):
+        orchestrator = _new_orchestrator(db_session, token_flow, trigger_data)
+        orchestrator.flow = token_flow
+        execution = FlowExecution(flow_id=token_flow.id, status="RUNNING")
+        db_session.add(execution)
+        db_session.commit()
+        db_session.refresh(execution)
+        orchestrator.execution_log = execution
+
+        token, key_id = orchestrator._create_temporary_api_token()
+        assert token is not None
+
+        orchestrator._cleanup_temporary_api_token()
+
+        key = crud_api_key.get(db_session, id=key_id)
+        assert key.is_active is True
+
+        # Same call once the execution is terminal does revoke it.
+        execution.status = "SUCCEEDED"
+        db_session.add(execution)
+        db_session.commit()
+
+        orchestrator._cleanup_temporary_api_token()
+
+        db_session.refresh(key)
+        assert key.is_active is False
+
+    def test_revocation_covers_every_key_of_the_execution(
+        self, db_session: Session, token_flow: Flow, trigger_data
+    ):
+        """Two workers, two minted keys, one execution: both must be retired."""
+        orchestrator = _new_orchestrator(db_session, token_flow, trigger_data)
+        orchestrator.flow = token_flow
+        execution = FlowExecution(flow_id=token_flow.id, status="RUNNING")
+        db_session.add(execution)
+        db_session.commit()
+        db_session.refresh(execution)
+        orchestrator.execution_log = execution
+
+        _, first_key_id = orchestrator._create_temporary_api_token()
+        _, second_key_id = orchestrator._create_temporary_api_token()
+        assert first_key_id != second_key_id
+
+        revoked = orchestrator._revoke_execution_runtime_tokens()
+
+        assert revoked == 2
+        for key_id in (first_key_id, second_key_id):
+            assert crud_api_key.get(db_session, id=key_id).is_active is False
+
+    def test_a_sibling_executions_token_is_untouched(
+        self, db_session: Session, token_flow: Flow, trigger_data
+    ):
+        """Revocation is scoped to one execution, never to the flow."""
+        sibling = _new_orchestrator(db_session, token_flow, trigger_data)
+        sibling.flow = token_flow
+        sibling_execution = FlowExecution(flow_id=token_flow.id, status="RUNNING")
+        db_session.add(sibling_execution)
+        db_session.commit()
+        db_session.refresh(sibling_execution)
+        sibling.execution_log = sibling_execution
+        sibling_token, sibling_key_id = sibling._create_temporary_api_token()
+
+        finishing = _new_orchestrator(db_session, token_flow, trigger_data)
+        finishing.flow = token_flow
+        finished_execution = FlowExecution(flow_id=token_flow.id, status="SUCCEEDED")
+        db_session.add(finished_execution)
+        db_session.commit()
+        db_session.refresh(finished_execution)
+        finishing.execution_log = finished_execution
+        finishing._create_temporary_api_token()
+
+        finishing._cleanup_temporary_api_token()
+
+        assert crud_api_key.get(db_session, id=sibling_key_id).is_active is True
+
+
+class TestRecoveryRetiresCredentials:
+    """Recovery decides a run is over without running its orchestrator teardown."""
+
+    @pytest.mark.asyncio
+    async def test_startup_failure_recovery_revokes_token_and_ends_session(
+        self, db_session: Session, token_flow: Flow, trigger_data
+    ):
+        from preloop.services.execution_recovery import ExecutionRecoveryService
+
+        orchestrator = _new_orchestrator(db_session, token_flow, trigger_data)
+        orchestrator.flow = token_flow
+        execution = FlowExecution(flow_id=token_flow.id, status="RUNNING")
+        db_session.add(execution)
+        db_session.commit()
+        db_session.refresh(execution)
+        orchestrator.execution_log = execution
+
+        token, key_id = orchestrator._create_temporary_api_token()
+        assert execution.agent_session_reference is None
+
+        await ExecutionRecoveryService()._resume_execution_monitoring(
+            db_session, execution, AsyncMock()
+        )
+
+        db_session.refresh(execution)
+        assert execution.status == "FAILED"
+        assert crud_api_key.get(db_session, id=key_id).is_active is False
+        assert await authenticate_bearer_token(token, db_session) is None
+
+        session = crud_runtime_session.get_by_source(
+            db_session,
+            account_id=token_flow.account_id,
+            session_source_type="flow_execution",
+            session_source_id=str(execution.id),
+        )
+        assert session is not None
+        assert session.ended_at is not None


### PR DESCRIPTION
## What broke

Ten staging flow executions between 2026-08-11 23:26 and 2026-09-02 23:51 died mid-run with

```
message=\"stream error\" providerID=preloop ... error.error=\"AI_APICallError: Invalid authentication credentials\"
```

That message is ours: `preloop/api/auth/jwt.py` rejecting the run's own runtime token, 1.5 to 30 minutes into runs whose token is minted with a 2 hour expiry.

## Root cause

A deploy drains `preloop-sync-worker-flow-execution`. `NatsWorker.begin_drain()` cancels the in-flight handler so `claim_and_run_execution` can release the claim and re-dispatch the execution; a peer worker then adopts the **same** agent Job through `resume_existing_execution`. The agent never stopped.

`asyncio.CancelledError` is a `BaseException`, so it skips every `except Exception` block in `FlowExecutionOrchestrator.run()` but still runs the `finally`, which called `_cleanup_temporary_api_token()` and deactivated the runtime API key the still-running agent was authenticating with. Its next model call got a 401 from our gateway, OpenCode exited 1 within ~0.2 s, and the resuming monitor recorded FAILED a few seconds later.

Evidence from staging (read-only):

- Every failing key is `is_active=false` and none had expired; `updated_at` lands 47 to 160 s before the run's `end_time`, while healthy runs update the key exactly at `end_time`.
- All recorded `model_gateway_call` events for these runs are successes; the failing call produces no event at all, because auth fails in the dependency before the gateway handler runs.
- Only 14 terminal executions in 40 days have `runtime_session.ended_at IS NULL`, the fingerprint of a run that exited through a `BaseException` rather than a normal terminal path. All 10 gateway_auth failures are in that set.
- Worker ReplicaSet creation times line up with the failures that are still within retention: 2026-09-02T23:52:01Z (401 at 23:52:48) and 2026-09-02T16:16:04Z (401 at 16:18:51), matching helm revisions 231 and 226.
- Duplicate FAILED `status_update` events with different `elapsed` values on the same run confirm the re-dispatch and resume handoff.

Ruled out: expiry, clock skew, an ended runtime session, a sibling execution of the same flow sharing or revoking the key, operator revocation (no audit events), managed-agent lifecycle, an api-key cache (there is none), and gateway pool exhaustion.

## The fix

The runtime token now belongs to the execution, not to the worker that happens to be holding it, and is retired only once the execution is terminal.

- `flow_orchestrator.py`: `_cleanup_temporary_api_token()` re-reads the committed execution status and no-ops unless it is `SUCCEEDED`, `FAILED`, `STOPPED` or `CANCELLED`, logging the handoff instead. Revocation goes through the new `_revoke_execution_runtime_tokens()`, which revokes by execution id (an interrupted execution can own more than one minted key) and falls back to the key this orchestrator minted. `run()` handles `CancelledError` explicitly and finalizes nothing.
- `flow_execution_runner.py`: the worker that resumes an execution now ends the runtime session and revokes the execution's tokens after writing the terminal status. Previously it did neither, which is why staging accumulated permanently open runtime sessions.
- `execution_recovery.py`: the three terminal short-circuits (no agent session, container already terminal, container status check failed) retire the credentials as well, instead of leaving a usable token behind for up to 2 hours.
- `flow_runtime_token.py`: `revoke_flow_runtime_tokens()` and `end_flow_execution_runtime_session()` as the shared, execution-scoped primitives. Revocation is never widened to the flow, so a concurrent run of the same flow is untouched.

## Tests

`backend/tests/services/test_flow_runtime_token_lifetime.py` reproduces the handoff: a drained worker leaves the key active and still authenticating through `authenticate_bearer_token`, the resuming worker revokes it and ends the session, a normal terminal run still revokes, cleanup is a no-op while the execution runs, all keys of one execution are covered, and a sibling execution's key is untouched. Five of the seven fail on `main`.

```
tests/services/test_flow_runtime_token_lifetime.py ....... [7 passed]
tests/services tests/models tests/agents: 3750 passed
tests/test_flow_orchestrator.py, tests/test_flow_matrix_batch.py, tests/services/test_execution_recovery.py,
tests/services/test_flow_execution_worker_orchestration.py, tests/models/test_api_key.py: 167 passed, 5 skipped
```

`openapi.yaml` is unchanged (no API surface change).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium risk**
> Token-lifetime logic moves from worker-scoped to execution-scoped teardown across the orchestrator, resume, and recovery paths; correct and well-tested, with two medium-priority refinements recommended (indeterminate-status revocation in recovery, and an untyped parameter).
>
> **Overview**
> Fixes flow executions dying mid-run with gateway 401s during worker handoff by keeping the runtime token alive until the execution is terminal, revoking it execution-scoped rather than when the interrupted worker tears down. Includes new shared revocation/session primitives and comprehensive handoff tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 688310ec. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->