### PR TITLE
Blog index: render the thumbnail under the post title

### DIFF
--- a/frontend/src/blog-seo.test.ts
+++ b/frontend/src/blog-seo.test.ts
@@ -328,6 +328,20 @@ describe('blog-seo', () => {
       expect(html).to.contain('href="/blog/a-post"');
     });
 
+    it('puts the index thumbnail under the title, not above it', () => {
+      const html = render_blog_index_html(
+        config,
+        [makePost({ og_image: '/assets/blog/ship.png' })],
+        ''
+      );
+      const title_at = html.indexOf('<h2>');
+      const hero_at = html.indexOf('class="blog-index-hero"');
+      const description_at = html.indexOf('<p>A description.</p>');
+      expect(title_at).to.be.greaterThan(-1);
+      expect(hero_at).to.be.greaterThan(title_at);
+      expect(description_at).to.be.greaterThan(hero_at);
+    });
+
     it('renders an empty state rather than failing with no posts', () => {
       const html = render_blog_index_html(config, [], '');
       expect(html).to.contain('No posts yet.');

--- a/frontend/src/blog-seo.ts
+++ b/frontend/src/blog-seo.ts
@@ -721,8 +721,8 @@ export function render_blog_index_html(
         <p class="blog-index-dateline"><time datetime="${escape_html(
           post.date
         )}">${escape_html(format_display_date(post.date))}</time>${reading}</p>
-        ${hero}
         <h2><a href="${escape_html(route)}">${escape_html(post.title)}</a></h2>
+        ${hero}
         <p>${escape_html(post.description)}</p>
       </li>`;
           })


### PR DESCRIPTION
## What

On `/blog` each entry rendered dateline, thumbnail, title, description. The picture came before the words it belonged to, and since only some posts carry an `og_image`, the list read unevenly. The thumbnail now renders after the `<h2>` title and before the description. Post pages are unchanged (hero already sits under the title and meta there).

## Files

- `frontend/src/blog-seo.ts`: move `${hero}` below the title in `render_blog_index_html`.
- `frontend/src/blog-seo.test.ts`: new test asserting title, then thumbnail, then description.

## Tests

`web-test-runner src/blog-seo.test.ts`: 47 passed, 0 failed. Prettier clean. Pre-commit run on both files.

## Context

Founder review of the live blog index, 2026-09-03: "the blog shows the images before the post titles, this doesn't feel right".

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> No security issues; a minor, well-tested rendering-order change to the blog index markup.
>
> **Overview**
> Moves the blog index thumbnail from above the post title to below it (title → thumbnail → description), keeping post pages unchanged. Adds a regression test asserting the new ordering.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 766cf90a. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->