### PR TITLE
fix: Windows CLI runner interrupt test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI runner interrupt test no longer races `exec.Cmd`**: GitLab
   `test:unit:cli` (`-race`) failed because the test read `Process` /
   `ProcessState` while the runner called `Start`/`Wait`. It now watches a
-  pid file from the child.
+  pid file from a helper process. Windows GitHub CLI CI does not implement
+  `Signal(0)`, so liveness uses `tasklist` there.
 - **Unused dashboard test helper and redundant asyncio import**: drop
   `isReddish` from `dashboard-view.test.ts` and the second `import asyncio`
   in the Kubernetes log streamer (`container.py` already imports it at

--- a/cli/internal/cmd/runner_test.go
+++ b/cli/internal/cmd/runner_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -720,11 +721,49 @@ func TestStopForegroundOnInterruptKillsJobAndUnregisters(t *testing.T) {
 	t.Fatal("interrupt must send unregister")
 }
 
+func TestHelperSleepJob(t *testing.T) {
+	if os.Getenv("PRELOOP_HELPER_SLEEP_JOB") != "1" {
+		t.Skip("spawned by TestRunnerFgInterruptDuringBackoffKillsJob")
+	}
+	path := os.Getenv("PRELOOP_HELPER_PID_PATH")
+	if path == "" {
+		t.Fatal("PRELOOP_HELPER_PID_PATH is required")
+	}
+	if err := os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(30 * time.Second)
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		// Signal(0) is not implemented on Windows (the GitHub CLI job
+		// failed with "leased job did not start" for that reason).
+		out, err := exec.Command(
+			"tasklist",
+			"/FI",
+			"PID eq "+strconv.Itoa(pid),
+			"/FO",
+			"CSV",
+			"/NH",
+		).CombinedOutput()
+		if err != nil {
+			return false
+		}
+		return strings.Contains(string(out), `"`+strconv.Itoa(pid)+`"`)
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
 func TestRunnerFgInterruptDuringBackoffKillsJob(t *testing.T) {
 	testenv.SetTempHome(t)
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("needs sh to start a job the test can observe without racing exec.Cmd")
-	}
 	oldMin, oldMax := runnerReconnectMin, runnerReconnectMax
 	runnerReconnectMin = 2 * time.Second
 	runnerReconnectMax = 2 * time.Second
@@ -738,8 +777,13 @@ func TestRunnerFgInterruptDuringBackoffKillsJob(t *testing.T) {
 		// Pid file instead of sharing *exec.Cmd: the runner calls Start/Wait
 		// on that Cmd, and -race flags unsynchronized reads of Process /
 		// ProcessState from the test goroutine (GitLab test:unit:cli).
-		quoted := strconv.Quote(pidPath)
-		return exec.Command("sh", "-c", "echo $$ >"+quoted+"; exec sleep 30")
+		cmd := exec.Command(os.Args[0], "-test.run=^TestHelperSleepJob$", "--")
+		cmd.Env = append(
+			os.Environ(),
+			"PRELOOP_HELPER_SLEEP_JOB=1",
+			"PRELOOP_HELPER_PID_PATH="+pidPath,
+		)
+		return cmd
 	}
 	readJobPID := func() int {
 		raw, err := os.ReadFile(pidPath)
@@ -752,19 +796,9 @@ func TestRunnerFgInterruptDuringBackoffKillsJob(t *testing.T) {
 		}
 		return pid
 	}
-	jobAlive := func(pid int) bool {
-		if pid <= 0 {
-			return false
-		}
-		proc, err := os.FindProcess(pid)
-		if err != nil {
-			return false
-		}
-		return proc.Signal(syscall.Signal(0)) == nil
-	}
 	t.Cleanup(func() {
 		runnerHasDocker, newRunnerJobCmd = oldDocker, oldCmd
-		if pid := readJobPID(); jobAlive(pid) {
+		if pid := readJobPID(); processAlive(pid) {
 			proc, err := os.FindProcess(pid)
 			if err == nil {
 				_ = proc.Kill()
@@ -843,12 +877,12 @@ func TestRunnerFgInterruptDuringBackoffKillsJob(t *testing.T) {
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		jobPID = readJobPID()
-		if jobAlive(jobPID) {
+		if processAlive(jobPID) {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if !jobAlive(jobPID) {
+	if !processAlive(jobPID) {
 		interrupt <- os.Interrupt
 		t.Fatal("leased job did not start")
 	}
@@ -872,7 +906,7 @@ func TestRunnerFgInterruptDuringBackoffKillsJob(t *testing.T) {
 	}
 	deadline = time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if unregistered.Load() && !jobAlive(jobPID) {
+		if unregistered.Load() && !processAlive(jobPID) {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
@@ -880,7 +914,7 @@ func TestRunnerFgInterruptDuringBackoffKillsJob(t *testing.T) {
 	if !unregistered.Load() {
 		t.Fatal("interrupt during backoff must unregister")
 	}
-	if jobAlive(jobPID) {
+	if processAlive(jobPID) {
 		t.Fatal("interrupt during backoff must kill the in-flight job")
 	}
 }


### PR DESCRIPTION
## Summary
- GitHub [CLI Tests (Windows)](https://github.com/preloop/preloop/actions/runs/33795532495/job/100782191577) failed in `TestRunnerFgInterruptDuringBackoffKillsJob` with `leased job did not start`.
- Cause: the pid-file helper used `sh` plus `Signal(0)`. Windows GitHub runners have `sh`, so the test did not skip, but `os.Process.Signal(0)` is not implemented, so the job never looked alive.
- The child is now the test binary (`TestHelperSleepJob`); Windows liveness uses `tasklist`. Unix still uses `Signal(0)` so GitLab `-race` stays clean.

## Test plan
- [ ] `go test -race -count=1 ./internal/cmd -run TestRunnerFgInterruptDuringBackoffKillsJob` (local)
- [ ] GitHub CLI Tests (Windows) green on this PR

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change with no production code or security surface; well-scoped Windows CI fix.
>
> **Overview**
> Fixes the Windows CLI runner interrupt test by replacing the `sh`+`Signal(0)` pid-file helper with a self-spawned test-binary helper and a `tasklist`-based liveness check, preserving the Unix `Signal(0)` path.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 949d625. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->