### PR TITLE
fix: spending-limit save 422 and accidental dialog dismiss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Spending-limit save no longer posts a null notify user**: `/auth/users/me`
+  has no `id`, so the limits editor used to send `notification_user_ids: [null]`
+  and the API rejected the create. Recipients now come from the users list
+  (matched by email) or are omitted. Overlay clicks no longer close the
+  limits dialog, so opening the notify dropdowns does not dismiss it.
 - **CLI runner interrupt test no longer races `exec.Cmd`**: GitLab
   `test:unit:cli` (`-race`) failed because the test read `Process` /
   `ProcessState` while the runner called `Start`/`Wait`. It now watches a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,8 +84,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Spending-limit save no longer posts a null notify user**: `/auth/users/me`
   has no `id`, so the limits editor used to send `notification_user_ids: [null]`
   and the API rejected the create. Recipients now come from the users list
-  (matched by email) or are omitted. Overlay clicks no longer close the
-  limits dialog, so opening the notify dropdowns does not dismiss it.
+  (matched by email, case-insensitive) or are omitted. Overlay clicks no
+  longer close the limits dialog, so opening the notify dropdowns does not
+  dismiss it.
 - **CLI runner interrupt test no longer races `exec.Cmd`**: GitLab
   `test:unit:cli` (`-race`) failed because the test read `Process` /
   `ProcessState` while the runner called `Start`/`Wait`. It now watches a

--- a/frontend/src/components/budget-limits-dialog.test.ts
+++ b/frontend/src/components/budget-limits-dialog.test.ts
@@ -60,4 +60,24 @@ describe('budget-limits-dialog', () => {
 
     expect(element.open).to.be.false;
   });
+
+  it('does not dismiss when the overlay is clicked', async () => {
+    const element = await fixture<BudgetLimitsDialog>(
+      html`<budget-limits-dialog open></budget-limits-dialog>`
+    );
+    await element.updateComplete;
+    const dialog = element.shadowRoot!.querySelector('sl-dialog')!;
+    const event = new CustomEvent('sl-request-close', {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      detail: { source: 'overlay' },
+    });
+
+    dialog.dispatchEvent(event);
+    await element.updateComplete;
+
+    expect(event.defaultPrevented).to.be.true;
+    expect(element.open).to.be.true;
+  });
 });

--- a/frontend/src/components/budget-limits-dialog.ts
+++ b/frontend/src/components/budget-limits-dialog.ts
@@ -32,6 +32,18 @@ export class BudgetLimitsDialog extends LitElement {
     `,
   ];
 
+  /**
+   * Overlay clicks are too easy to hit while filling the form. Hoisted
+   * selects (notify recipients, period, scope) portal outside the panel, so
+   * a click on an option looks like an overlay click and used to close the
+   * dialog. Only the close button and Escape dismiss it.
+   */
+  private handleRequestClose = (event: CustomEvent<{ source?: string }>) => {
+    if (event.detail?.source === 'overlay') {
+      event.preventDefault();
+    }
+  };
+
   private handleHide(event: Event) {
     if (event.target !== event.currentTarget) return;
     this.open = false;
@@ -57,6 +69,7 @@ export class BudgetLimitsDialog extends LitElement {
         label="Spending limits"
         style="--width: 720px;"
         ?open=${this.open}
+        @sl-request-close=${this.handleRequestClose}
         @sl-hide=${this.handleHide}
       >
         <div class="description">

--- a/frontend/src/components/budget-policy-editor.test.ts
+++ b/frontend/src/components/budget-policy-editor.test.ts
@@ -20,6 +20,7 @@ describe('BudgetPolicyEditor', () => {
   const stubBillingFetch = (opts?: {
     failModels?: boolean;
     policies?: unknown[];
+    users?: Array<{ id: string; email: string; username?: string }>;
   }) => {
     fetchStub.callsFake(
       async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -40,7 +41,12 @@ describe('BudgetPolicyEditor', () => {
         }
         if (url.includes('/api/v1/users?')) {
           return new Response(
-            JSON.stringify({ users: [], total: 0, skip: 0, limit: 100 }),
+            JSON.stringify({
+              users: opts?.users || [],
+              total: opts?.users?.length || 0,
+              skip: 0,
+              limit: 100,
+            }),
             { status: 200, headers: { 'Content-Type': 'application/json' } }
           );
         }
@@ -73,6 +79,26 @@ describe('BudgetPolicyEditor', () => {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
           });
+        }
+        if (url.includes('/api/v1/budget/policies') && method === 'POST') {
+          const body = JSON.parse(String(init?.body || '{}'));
+          return new Response(
+            JSON.stringify({
+              id: 'policy-new',
+              subject_type: body.subject_type || 'global',
+              subject_id: body.subject_id || null,
+              model_alias: null,
+              period: body.period || 'monthly',
+              hard_limit_usd: body.hard_limit_usd,
+              soft_limit_usd: body.soft_limit_usd,
+              notify_on_soft: body.notify_on_soft,
+              notify_on_hard: body.notify_on_hard,
+              notification_user_ids: body.notification_user_ids,
+              notification_team_ids: body.notification_team_ids,
+              notification_emails: body.notification_emails,
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          );
         }
         if (url.includes('/api/v1/budget/policies') && method === 'GET') {
           return new Response(JSON.stringify(opts?.policies || []), {
@@ -461,5 +487,79 @@ describe('BudgetPolicyEditor', () => {
       element.shadowRoot?.textContent?.includes('Hard $150.00')
     );
     expect(element.shadowRoot?.textContent).to.include('Hard $150.00');
+  });
+
+  async function fillHardLimitAndSave(element: BudgetPolicyEditor) {
+    await waitUntil(
+      () => Boolean(element.shadowRoot?.textContent?.includes('Save limit')),
+      'add-limit form did not open'
+    );
+    const hardLimitInput = element.shadowRoot?.querySelector(
+      'sl-input[label="Hard limit (USD)"]'
+    ) as HTMLInputElement | null;
+    expect(hardLimitInput).to.exist;
+    hardLimitInput!.value = '10';
+    hardLimitInput!.dispatchEvent(new Event('sl-input', { bubbles: true }));
+    await element.updateComplete;
+    await waitUntil(
+      () =>
+        Boolean(
+          (element as unknown as { subjectsLoaded: boolean }).subjectsLoaded
+        ),
+      'subject lists did not finish loading'
+    );
+    element.shadowRoot
+      ?.querySelector('sl-button[variant="primary"]')
+      ?.dispatchEvent(new Event('click', { bubbles: true, composed: true }));
+    await waitUntil(() =>
+      fetchStub
+        .getCalls()
+        .some(
+          (call) =>
+            String(call.args[0]).includes('/api/v1/budget/policies') &&
+            call.args[1]?.method === 'POST'
+        )
+    );
+    const createCall = fetchStub
+      .getCalls()
+      .find(
+        (call) =>
+          String(call.args[0]).includes('/api/v1/budget/policies') &&
+          call.args[1]?.method === 'POST'
+      );
+    return JSON.parse(String(createCall?.args[1]?.body));
+  }
+
+  it('does not POST a null notification user id when /me has no id', async () => {
+    stubBillingFetch();
+    const element = await mountEditor();
+    (
+      element.shadowRoot!.querySelector(
+        'sl-button[variant="primary"]'
+      ) as HTMLElement
+    ).click();
+    const body = await fillHardLimitAndSave(element);
+    expect(body.notification_user_ids).to.equal(null);
+    expect(body.hard_limit_usd).to.equal(10);
+  });
+
+  it('defaults notify recipients to the current user from the users list', async () => {
+    stubBillingFetch({
+      users: [
+        {
+          id: 'owner-user-id',
+          email: 'owner@example.com',
+          username: 'owner',
+        },
+      ],
+    });
+    const element = await mountEditor();
+    (
+      element.shadowRoot!.querySelector(
+        'sl-button[variant="primary"]'
+      ) as HTMLElement
+    ).click();
+    const body = await fillHardLimitAndSave(element);
+    expect(body.notification_user_ids).to.deep.equal(['owner-user-id']);
   });
 });

--- a/frontend/src/components/budget-policy-editor.test.ts
+++ b/frontend/src/components/budget-policy-editor.test.ts
@@ -562,4 +562,24 @@ describe('BudgetPolicyEditor', () => {
     const body = await fillHardLimitAndSave(element);
     expect(body.notification_user_ids).to.deep.equal(['owner-user-id']);
   });
+
+  it('matches the current user by email case-insensitively', async () => {
+    stubBillingFetch({
+      users: [
+        {
+          id: 'owner-user-id',
+          email: 'Owner@Example.com',
+          username: 'owner',
+        },
+      ],
+    });
+    const element = await mountEditor();
+    (
+      element.shadowRoot!.querySelector(
+        'sl-button[variant="primary"]'
+      ) as HTMLElement
+    ).click();
+    const body = await fillHardLimitAndSave(element);
+    expect(body.notification_user_ids).to.deep.equal(['owner-user-id']);
+  });
 });

--- a/frontend/src/components/budget-policy-editor.ts
+++ b/frontend/src/components/budget-policy-editor.ts
@@ -457,7 +457,8 @@ export class BudgetPolicyEditor extends LitElement {
 
   /**
    * `/auth/users/me` does not include `id`. Prefer a real string, then the
-   * account user list matched by email, otherwise leave recipients empty.
+   * account user list matched by email (case-insensitive), otherwise leave
+   * recipients empty rather than posting `[null]`.
    */
   private currentUserNotifyId(
     userProfile: { id?: unknown; email?: string } | null
@@ -469,7 +470,10 @@ export class BudgetPolicyEditor extends LitElement {
     if (!email) {
       return undefined;
     }
-    return this.availableUsers.find((user) => user.email === email)?.id;
+    const needle = email.toLowerCase();
+    return this.availableUsers.find(
+      (user) => user.email?.toLowerCase() === needle
+    )?.id;
   }
 
   private compactIds(ids: Array<string | null | undefined>): string[] {

--- a/frontend/src/components/budget-policy-editor.ts
+++ b/frontend/src/components/budget-policy-editor.ts
@@ -357,13 +357,16 @@ export class BudgetPolicyEditor extends LitElement {
       this.agents = agentsResponse.items || [];
       this.availableUsers = (usersRes as UserListResponse).users || [];
       this.teams = teamsResponse.teams || [];
+      // /auth/users/me has no `id` (AuthUserResponse). Using userProfile.id
+      // anyway posted `[null]` and the API 422'd on UUID validation.
+      const selfId = this.currentUserNotifyId(userProfile);
       if (
-        userProfile &&
+        selfId &&
         this.newNotifyUserIds.length === 0 &&
         this.newNotifyTeamIds.length === 0 &&
         this.newCustomEmails.length === 0
       ) {
-        this.newNotifyUserIds = [userProfile.id];
+        this.newNotifyUserIds = [selfId];
       }
       this.subjectsLoaded = true;
     } catch (e) {
@@ -437,9 +440,9 @@ export class BudgetPolicyEditor extends LitElement {
       policy.soft_limit_usd != null ? String(policy.soft_limit_usd) : '';
     this.newNotifySoft = policy.notify_on_soft;
     this.newNotifyHard = policy.notify_on_hard;
-    this.newNotifyUserIds = [...(policy.notification_user_ids || [])];
-    this.newNotifyTeamIds = [...(policy.notification_team_ids || [])];
-    this.newCustomEmails = [...(policy.notification_emails || [])];
+    this.newNotifyUserIds = this.compactIds(policy.notification_user_ids || []);
+    this.newNotifyTeamIds = this.compactIds(policy.notification_team_ids || []);
+    this.newCustomEmails = this.compactIds(policy.notification_emails || []);
     this.step = 'form';
     void this.ensureSubjectsLoaded();
   }
@@ -452,23 +455,46 @@ export class BudgetPolicyEditor extends LitElement {
     this.resetForm();
   }
 
+  /**
+   * `/auth/users/me` does not include `id`. Prefer a real string, then the
+   * account user list matched by email, otherwise leave recipients empty.
+   */
+  private currentUserNotifyId(
+    userProfile: { id?: unknown; email?: string } | null
+  ): string | undefined {
+    if (typeof userProfile?.id === 'string' && userProfile.id.length > 0) {
+      return userProfile.id;
+    }
+    const email = userProfile?.email;
+    if (!email) {
+      return undefined;
+    }
+    return this.availableUsers.find((user) => user.email === email)?.id;
+  }
+
+  private compactIds(ids: Array<string | null | undefined>): string[] {
+    return ids.filter(
+      (id): id is string => typeof id === 'string' && id.length > 0
+    );
+  }
+
   private buildNotifyPayload() {
+    const userIds = this.compactIds(this.newNotifyUserIds);
+    const teamIds = this.compactIds(this.newNotifyTeamIds);
+    const emails = this.compactIds(this.newCustomEmails);
     return {
-      notification_user_ids:
-        this.newNotifyUserIds.length > 0 ? this.newNotifyUserIds : null,
-      notification_team_ids:
-        this.newNotifyTeamIds.length > 0 ? this.newNotifyTeamIds : null,
-      notification_emails:
-        this.newCustomEmails.length > 0 ? this.newCustomEmails : null,
+      notification_user_ids: userIds.length > 0 ? userIds : null,
+      notification_team_ids: teamIds.length > 0 ? teamIds : null,
+      notification_emails: emails.length > 0 ? emails : null,
     };
   }
 
   private handleNotifyRecipientsChange(
     event: CustomEvent<NotifyRecipientsValue>
   ) {
-    this.newNotifyUserIds = event.detail.userIds;
-    this.newNotifyTeamIds = event.detail.teamIds;
-    this.newCustomEmails = event.detail.customEmails;
+    this.newNotifyUserIds = this.compactIds(event.detail.userIds);
+    this.newNotifyTeamIds = this.compactIds(event.detail.teamIds);
+    this.newCustomEmails = this.compactIds(event.detail.customEmails);
   }
 
   /** Inline validation, so a typo never reaches the server as a 422. */

--- a/frontend/src/components/notify-recipients-field.test.ts
+++ b/frontend/src/components/notify-recipients-field.test.ts
@@ -39,4 +39,17 @@ describe('NotifyRecipientsField', () => {
 
     expect(element.shadowRoot?.textContent).to.contain('alerts@example.com');
   });
+
+  it('drops empty user slots from a select change', async () => {
+    const element = (await fixture(
+      html`<notify-recipients-field></notify-recipients-field>`
+    )) as NotifyRecipientsField;
+    const select = element.shadowRoot?.querySelector('sl-select') as
+      (HTMLElement & { value: unknown }) | null;
+    expect(select).to.exist;
+    select!.value = ['user:', 'user:abc', '', null];
+    select!.dispatchEvent(new CustomEvent('sl-change', { bubbles: true }));
+    await element.updateComplete;
+    expect(element.userIds).to.deep.equal(['abc']);
+  });
 });

--- a/frontend/src/components/notify-recipients-field.ts
+++ b/frontend/src/components/notify-recipients-field.ts
@@ -89,14 +89,25 @@ export class NotifyRecipientsField extends LitElement {
   }
 
   private handleRecipientChange(event: Event) {
-    const select = event.target as HTMLSelectElement & { value: string[] };
-    const values = select.value || [];
+    const select = event.target as HTMLSelectElement & {
+      value: string | string[] | null;
+    };
+    const raw = select.value;
+    const values = Array.isArray(raw) ? raw : raw ? [raw] : [];
     this.userIds = values
-      .filter((value) => value.startsWith('user:'))
-      .map((value) => value.replace('user:', ''));
+      .filter(
+        (value): value is string =>
+          typeof value === 'string' && value.startsWith('user:')
+      )
+      .map((value) => value.slice('user:'.length))
+      .filter((id) => id.length > 0);
     this.teamIds = values
-      .filter((value) => value.startsWith('team:'))
-      .map((value) => value.replace('team:', ''));
+      .filter(
+        (value): value is string =>
+          typeof value === 'string' && value.startsWith('team:')
+      )
+      .map((value) => value.slice('team:'.length))
+      .filter((id) => id.length > 0);
     this.dispatchChange();
   }
 


### PR DESCRIPTION
## Summary
- Next steps "Set a spending limit" posted `notification_user_ids: [null]` because `/api/v1/auth/users/me` has no `id`. The editor now matches the current user from `/users` by email, or omits recipients. Empty/null ids are stripped before POST.
- Overlay clicks no longer close the spending-limits dialog. Hoisted notify/period dropdowns portal outside the panel, so a click on an option was treated as an overlay dismiss.

## Test plan
- [ ] Overview Next steps → Set a spending limit → Add limit → save a monthly hard cap (notify off). Expect 201, not 422.
- [ ] Enable Notify on soft, open the recipients dropdown, click a user. Dialog stays open. Save succeeds.
- [ ] Escape and the X still close the dialog.
- [ ] `budget-policy-editor`, `budget-limits-dialog`, `notify-recipients-field` tests (18 passed locally).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Well-tested frontend-only bug fix with no security implications; only a minor edge-case observation.
>
> **Overview**
> Fixes a spending-limit save 422 (was posting `notification_user_ids: [null]`) by resolving the current user from `/users` by email and stripping empty ids, and stops overlay clicks from dismissing the limits dialog so hoisted dropdowns don't close it.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 752c8d43. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->