### PR TITLE
fix: picking period or subject no longer closes spending limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Picking a period or subject no longer closes spending limits**:
   `sl-select` / `sl-dropdown` fire composed `sl-hide` when their popup
   closes. Overview and Attention treated that as the dialog hiding.
-  Nested hides are contained; parents listen for `budget-limits-hide`.
+  The outer dialog ignores nested hides; parents listen for
+  `budget-limits-hide`. The inner "Delete limit" confirm still receives
+  its own `sl-hide` so dismissals clear `pendingDeleteId`.
 - **Overview first paint no longer waits on the attention usage breakdown**:
   the shared attention loader used to fetch ``include_breakdown=true`` in
   parallel with wave 1, and the page waited for it before drawing. Attention

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (matched by email, case-insensitive) or are omitted. Overlay clicks no
   longer close the limits dialog, so opening the notify dropdowns does not
   dismiss it.
+- **Picking a period or subject no longer closes spending limits**:
+  `sl-select` / `sl-dropdown` fire composed `sl-hide` when their popup
+  closes. Overview and Attention treated that as the dialog hiding.
+  Nested hides are contained; parents listen for `budget-limits-hide`.
 - **Overview first paint no longer waits on the attention usage breakdown**:
   the shared attention loader used to fetch ``include_breakdown=true`` in
   parallel with wave 1, and the page waited for it before drawing. Attention

--- a/frontend/src/components/budget-limits-dialog.test.ts
+++ b/frontend/src/components/budget-limits-dialog.test.ts
@@ -55,7 +55,9 @@ describe('budget-limits-dialog', () => {
     await element.updateComplete;
     const dialog = element.shadowRoot!.querySelector('sl-dialog')!;
 
+    const hidden = oneEvent(element, 'budget-limits-hide');
     dialog.dispatchEvent(new CustomEvent('sl-hide', { bubbles: true }));
+    await hidden;
     await element.updateComplete;
 
     expect(element.open).to.be.false;
@@ -79,5 +81,44 @@ describe('budget-limits-dialog', () => {
 
     expect(event.defaultPrevented).to.be.true;
     expect(element.open).to.be.true;
+  });
+
+  it('does not close when a nested select or dropdown hides', async () => {
+    const element = await fixture<BudgetLimitsDialog>(
+      html`<budget-limits-dialog open></budget-limits-dialog>`
+    );
+    await element.updateComplete;
+    const editor = element.shadowRoot!.querySelector('budget-policy-editor')!;
+
+    editor.dispatchEvent(
+      new CustomEvent('sl-hide', { bubbles: true, composed: true })
+    );
+    await element.updateComplete;
+
+    expect(element.open).to.be.true;
+  });
+
+  it('does not let nested sl-hide reach parent listeners', async () => {
+    let parentSawHide = false;
+    const wrap = await fixture(
+      html`<div
+        @sl-hide=${() => {
+          parentSawHide = true;
+        }}
+      >
+        <budget-limits-dialog open></budget-limits-dialog>
+      </div>`
+    );
+    const element = wrap.querySelector('budget-limits-dialog')!;
+    await element.updateComplete;
+    const editor = element.shadowRoot!.querySelector('budget-policy-editor')!;
+
+    editor.dispatchEvent(
+      new CustomEvent('sl-hide', { bubbles: true, composed: true })
+    );
+    await element.updateComplete;
+
+    expect(element.open).to.be.true;
+    expect(parentSawHide).to.be.false;
   });
 });

--- a/frontend/src/components/budget-limits-dialog.test.ts
+++ b/frontend/src/components/budget-limits-dialog.test.ts
@@ -1,4 +1,5 @@
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 import './budget-limits-dialog.ts';
 import type { BudgetLimitsDialog } from './budget-limits-dialog';
 
@@ -120,5 +121,32 @@ describe('budget-limits-dialog', () => {
 
     expect(element.open).to.be.true;
     expect(parentSawHide).to.be.false;
+  });
+
+  it('lets a nested dialog sl-hide handler run', async () => {
+    const element = await fixture<BudgetLimitsDialog>(
+      html`<budget-limits-dialog open></budget-limits-dialog>`
+    );
+    await element.updateComplete;
+    const editor = element.shadowRoot!.querySelector('budget-policy-editor')!;
+    const nested = document.createElement('sl-dialog');
+    let nestedHideRan = false;
+    nested.addEventListener('sl-hide', () => {
+      nestedHideRan = true;
+    });
+    editor.appendChild(nested);
+
+    let outerHide = false;
+    element.addEventListener('budget-limits-hide', () => {
+      outerHide = true;
+    });
+    nested.dispatchEvent(
+      new CustomEvent('sl-hide', { bubbles: true, composed: true })
+    );
+    await element.updateComplete;
+
+    expect(nestedHideRan).to.be.true;
+    expect(element.open).to.be.true;
+    expect(outerHide).to.be.false;
   });
 });

--- a/frontend/src/components/budget-limits-dialog.ts
+++ b/frontend/src/components/budget-limits-dialog.ts
@@ -32,18 +32,6 @@ export class BudgetLimitsDialog extends LitElement {
     `,
   ];
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.addEventListener('sl-hide', this.containNestedHide, true);
-    this.addEventListener('sl-after-hide', this.containNestedHide, true);
-  }
-
-  disconnectedCallback() {
-    this.removeEventListener('sl-hide', this.containNestedHide, true);
-    this.removeEventListener('sl-after-hide', this.containNestedHide, true);
-    super.disconnectedCallback();
-  }
-
   /**
    * Overlay clicks are too easy to hit while filling the form. Hoisted
    * selects (notify recipients, period, scope) portal outside the panel, so
@@ -57,23 +45,12 @@ export class BudgetLimitsDialog extends LitElement {
   };
 
   /**
-   * `sl-select` / `sl-dropdown` fire `sl-hide` when their popup closes.
-   * That event is composed and used to bubble out to Overview / Attention,
-   * which listen for `sl-hide` on this host and set `open` false. Picking
-   * Daily or an agent then closed the whole dialog. Stop those here; the
-   * real dialog hide still reaches `handleHide`.
+   * Nested `sl-select` / `sl-dropdown` popups (and the inner "Delete limit"
+   * dialog) also fire `sl-hide`. Stop those from looking like this dialog
+   * closed. Do not capture-stop on the host: that runs before the event
+   * reaches a nested dialog's own `@sl-hide`, so Escape on "Delete limit"
+   * would never clear `pendingDeleteId`.
    */
-  private containNestedHide = (event: Event) => {
-    if (event.target === this) {
-      return;
-    }
-    const dialog = this.renderRoot.querySelector('sl-dialog');
-    if (event.composedPath()[0] === dialog) {
-      return;
-    }
-    event.stopPropagation();
-  };
-
   private handleHide(event: Event) {
     if (event.target !== event.currentTarget) {
       event.stopPropagation();

--- a/frontend/src/components/budget-limits-dialog.ts
+++ b/frontend/src/components/budget-limits-dialog.ts
@@ -32,6 +32,18 @@ export class BudgetLimitsDialog extends LitElement {
     `,
   ];
 
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('sl-hide', this.containNestedHide, true);
+    this.addEventListener('sl-after-hide', this.containNestedHide, true);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('sl-hide', this.containNestedHide, true);
+    this.removeEventListener('sl-after-hide', this.containNestedHide, true);
+    super.disconnectedCallback();
+  }
+
   /**
    * Overlay clicks are too easy to hit while filling the form. Hoisted
    * selects (notify recipients, period, scope) portal outside the panel, so
@@ -44,11 +56,32 @@ export class BudgetLimitsDialog extends LitElement {
     }
   };
 
+  /**
+   * `sl-select` / `sl-dropdown` fire `sl-hide` when their popup closes.
+   * That event is composed and used to bubble out to Overview / Attention,
+   * which listen for `sl-hide` on this host and set `open` false. Picking
+   * Daily or an agent then closed the whole dialog. Stop those here; the
+   * real dialog hide still reaches `handleHide`.
+   */
+  private containNestedHide = (event: Event) => {
+    if (event.target === this) {
+      return;
+    }
+    const dialog = this.renderRoot.querySelector('sl-dialog');
+    if (event.composedPath()[0] === dialog) {
+      return;
+    }
+    event.stopPropagation();
+  };
+
   private handleHide(event: Event) {
-    if (event.target !== event.currentTarget) return;
+    if (event.target !== event.currentTarget) {
+      event.stopPropagation();
+      return;
+    }
     this.open = false;
     this.dispatchEvent(
-      new CustomEvent('sl-hide', { bubbles: true, composed: true })
+      new CustomEvent('budget-limits-hide', { bubbles: true, composed: true })
     );
   }
 

--- a/frontend/src/views/authed/attention-view.ts
+++ b/frontend/src/views/authed/attention-view.ts
@@ -1440,7 +1440,7 @@ export class AttentionView extends AuthedElement {
       <budget-limits-dialog
         ?open=${this.showLimitsDialog}
         .billingEnabled=${this.billingEnabled}
-        @sl-hide=${() => (this.showLimitsDialog = false)}
+        @budget-limits-hide=${() => (this.showLimitsDialog = false)}
         @budget-policies-changed=${() => void this.fetchAll()}
       ></budget-limits-dialog>
     `;

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -3362,7 +3362,7 @@ export class DashboardView extends AuthedElement {
         <budget-limits-dialog
           ?open=${this.showBudgetDialog}
           billingEnabled
-          @sl-hide=${() => (this.showBudgetDialog = false)}
+          @budget-limits-hide=${() => (this.showBudgetDialog = false)}
           @budget-policies-changed=${this.handleBudgetPoliciesChanged}
         ></budget-limits-dialog>
         <preloop-invite-dialog


### PR DESCRIPTION
## Summary
- Overlay-click cancel in #375 was not enough: `sl-select` / `sl-dropdown` fire composed `sl-hide` when their popup closes (Daily, agent, model, kebab).
- Overview and Attention listened for `sl-hide` on the limits dialog host, so that nested hide set `open` false and tore the form down.
- Nested hides are now stopped at the host; parents listen for `budget-limits-hide` from the real dialog.

## Test plan
- [ ] Open spending limits from Overview, start a global monthly limit, switch Period to Daily — dialog stays open and the value sticks
- [ ] Switch Scope to Agent (or Model), pick one from the list — dialog stays open
- [ ] Notify recipient dropdown still does not dismiss the dialog
- [ ] Escape and the close button still dismiss it
- [ ] Same flow from `/console/attention`

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> The capture-phase guard that regressed "Delete limit" dismissal has been dropped; nested `sl-hide` now reaches the inner dialog while `handleHide` still contains popup hides. A regression test covers the nested-dialog case.
>
> **Overview**
> Renames the limits-dialog hide event to `budget-limits-hide` and stops nested `sl-hide` in the bubble phase so popup selects no longer close the spending-limits dialog, without breaking the inner delete-confirm dialog.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 782010e3. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->