### PR TITLE
fix: do not page admins for customer-owned unpriced endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Unpriced-model admin mail skips customer-owned endpoints**:
+  ``openai-compatible`` / ``custom`` models on a host we do not catalog
+  (home LiteLLM, OpenCode Zen, a private proxy) stay unpriced on the
+  Attention page, but no longer page an admin to add a global price.
+  OpenRouter- and DashScope-fronted configs still alert.
 - **Spending-limit save no longer posts a null notify user**: `/auth/users/me`
   has no `id`, so the limits editor used to send `notification_user_ids: [null]`
   and the API rejected the create. Recipients now come from the users list

--- a/backend/preloop/services/litellm_routing.py
+++ b/backend/preloop/services/litellm_routing.py
@@ -218,7 +218,7 @@ def known_litellm_providers() -> frozenset:
         return frozenset()
 
 
-def _endpoint_host(endpoint: Optional[str]) -> str:
+def endpoint_host(endpoint: Optional[str]) -> str:
     """Return the lowercase hostname of an endpoint URL, or "" if unparseable."""
     if not isinstance(endpoint, str):
         return ""
@@ -236,7 +236,7 @@ def _endpoint_host(endpoint: Optional[str]) -> str:
 
 def is_openrouter_endpoint(endpoint: Optional[str]) -> bool:
     """Whether an api_endpoint points at OpenRouter."""
-    host = _endpoint_host(endpoint)
+    host = endpoint_host(endpoint)
     if not host:
         return False
     return any(

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -7739,6 +7739,7 @@ class OpenAIGatewayService:
                 usage_accounting_requested=usage_accounting_requested,
                 usage_details=usage_details,
                 completion_tokens=int(completion_tokens or 0),
+                ai_model=ai_model,
             ):
                 try:
                     notify_unpriced_model(

--- a/backend/preloop/services/unpriced_model_alert.py
+++ b/backend/preloop/services/unpriced_model_alert.py
@@ -29,14 +29,13 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
-from urllib.parse import urlsplit
-
 from sqlalchemy.orm import Session
 
 from preloop.models.crud import crud_audit_log
 from preloop.models.models.ai_model import AIModel
 from preloop.services.litellm_routing import (
     OPENAI_COMPATIBLE_PROVIDERS,
+    endpoint_host,
     is_openrouter_endpoint,
 )
 from preloop.services.model_runtime_resolver import gateway_model_alias_candidates
@@ -126,26 +125,11 @@ def _dedupe_key(
     return f"{(provider_name or 'unknown').strip().lower()}|{model_alias.strip()}"
 
 
-def _endpoint_host(endpoint: Optional[str]) -> str:
-    """Return the lowercase hostname of an endpoint URL, or "" if unparseable."""
-    if not isinstance(endpoint, str):
-        return ""
-    raw = endpoint.strip()
-    if not raw:
-        return ""
-    if "//" not in raw:
-        raw = f"//{raw}"
-    try:
-        return (urlsplit(raw).hostname or "").lower()
-    except ValueError:  # pragma: no cover - malformed URLs
-        return ""
-
-
 def _is_cataloged_marketplace_endpoint(endpoint: Optional[str]) -> bool:
     """True when this endpoint is a host whose prices we maintain."""
     if is_openrouter_endpoint(endpoint):
         return True
-    host = _endpoint_host(endpoint)
+    host = endpoint_host(endpoint)
     if not host:
         return False
     return any(
@@ -162,6 +146,10 @@ def should_page_unpriced_model(ai_model: Optional[AIModel]) -> bool:
     so the account can set an override. OpenRouter- and DashScope-fronted
     configs still page, because those hosts are ones we catalog.
 
+    A missing or unparseable ``api_endpoint`` still pages: the identifier
+    prefix can still route to a cataloged marketplace
+    (``to_litellm_model``), so "unknown host" is not "customer-owned".
+
     Args:
         ai_model: The resolved model. ``None`` keeps the previous contract
             (page), used by callers that only have the alias.
@@ -173,6 +161,9 @@ def should_page_unpriced_model(ai_model: Optional[AIModel]) -> bool:
         return True
     provider = (ai_model.provider_name or "").strip().lower()
     if provider not in OPENAI_COMPATIBLE_PROVIDERS:
+        return True
+    host = endpoint_host(ai_model.api_endpoint)
+    if not host:
         return True
     return _is_cataloged_marketplace_endpoint(ai_model.api_endpoint)
 

--- a/backend/preloop/services/unpriced_model_alert.py
+++ b/backend/preloop/services/unpriced_model_alert.py
@@ -29,11 +29,16 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
+from urllib.parse import urlsplit
+
 from sqlalchemy.orm import Session
 
 from preloop.models.crud import crud_audit_log
 from preloop.models.models.ai_model import AIModel
-from preloop.services.litellm_routing import is_openrouter_endpoint
+from preloop.services.litellm_routing import (
+    OPENAI_COMPATIBLE_PROVIDERS,
+    is_openrouter_endpoint,
+)
 from preloop.services.model_runtime_resolver import gateway_model_alias_candidates
 from preloop.sync.tasks import notify_admins
 
@@ -44,6 +49,17 @@ UNPRICED_ALERT_ACTION = "unpriced_model_alert"
 
 #: Quiet period per (model_alias, provider) after an alert is sent.
 ALERT_COOLDOWN_HOURS = int(os.getenv("UNPRICED_MODEL_ALERT_COOLDOWN_HOURS", "24"))
+
+#: DashScope hosts we catalog. openai-compatible configs pointed here are
+#: still a shared-catalog hole and should page; home LiteLLM / OpenCode Zen
+#: / other customer endpoints should not.
+_DASHSCOPE_HOSTS = frozenset(
+    {
+        "dashscope.aliyuncs.com",
+        "dashscope-intl.aliyuncs.com",
+        "dashscope-us.aliyuncs.com",
+    }
+)
 
 # Fast path only; the audit-log marker remains authoritative across replicas.
 _local_lock = threading.Lock()
@@ -110,11 +126,63 @@ def _dedupe_key(
     return f"{(provider_name or 'unknown').strip().lower()}|{model_alias.strip()}"
 
 
+def _endpoint_host(endpoint: Optional[str]) -> str:
+    """Return the lowercase hostname of an endpoint URL, or "" if unparseable."""
+    if not isinstance(endpoint, str):
+        return ""
+    raw = endpoint.strip()
+    if not raw:
+        return ""
+    if "//" not in raw:
+        raw = f"//{raw}"
+    try:
+        return (urlsplit(raw).hostname or "").lower()
+    except ValueError:  # pragma: no cover - malformed URLs
+        return ""
+
+
+def _is_cataloged_marketplace_endpoint(endpoint: Optional[str]) -> bool:
+    """True when this endpoint is a host whose prices we maintain."""
+    if is_openrouter_endpoint(endpoint):
+        return True
+    host = _endpoint_host(endpoint)
+    if not host:
+        return False
+    return any(
+        host == known or host.endswith(f".{known}") for known in _DASHSCOPE_HOSTS
+    )
+
+
+def should_page_unpriced_model(ai_model: Optional[AIModel]) -> bool:
+    """Return False when paging an admin cannot fix the catalog.
+
+    ``openai-compatible`` / ``custom`` models on a customer-owned endpoint
+    (home LiteLLM, OpenCode Zen, a private proxy) will never appear in the
+    shared price snapshot. The Attention page still lists them as unpriced
+    so the account can set an override. OpenRouter- and DashScope-fronted
+    configs still page, because those hosts are ones we catalog.
+
+    Args:
+        ai_model: The resolved model. ``None`` keeps the previous contract
+            (page), used by callers that only have the alias.
+
+    Returns:
+        True when ``notify_unpriced_model`` should still run.
+    """
+    if ai_model is None:
+        return True
+    provider = (ai_model.provider_name or "").strip().lower()
+    if provider not in OPENAI_COMPATIBLE_PROVIDERS:
+        return True
+    return _is_cataloged_marketplace_endpoint(ai_model.api_endpoint)
+
+
 def should_notify_unpriced_model(
     *,
     usage_accounting_requested: bool,
     usage_details: Optional[Dict[str, Any]],
     completion_tokens: int,
+    ai_model: Optional[AIModel] = None,
 ) -> bool:
     """Return False when an unpriced row should not page admins.
 
@@ -124,15 +192,21 @@ def should_notify_unpriced_model(
     not ask an admin to add catalog pricing. Prompt plus completion
     with no cost and no catalog still alerts.
 
+    Customer-owned OpenAI-compatible endpoints are also skipped: see
+    :func:`should_page_unpriced_model`.
+
     Args:
         usage_accounting_requested: True when this request asked
             OpenRouter for usage accounting.
         usage_details: Raw provider usage dict from the response.
         completion_tokens: Completion tokens on the recorded row.
+        ai_model: The resolved model, when the caller has it.
 
     Returns:
         True when ``notify_unpriced_model`` should still run.
     """
+    if not should_page_unpriced_model(ai_model):
+        return False
     if not usage_accounting_requested:
         return True
     if int(completion_tokens or 0) != 0:

--- a/backend/tests/services/test_unpriced_model_alert.py
+++ b/backend/tests/services/test_unpriced_model_alert.py
@@ -463,3 +463,21 @@ def test_openai_compatible_openrouter_and_dashscope_still_page():
 def test_missing_ai_model_keeps_previous_page_contract():
     """Callers that only have the alias still page (dedup is on the alias)."""
     assert should_notify_unpriced_model(**_notify_kwargs()) is True
+
+
+def test_openai_compatible_without_endpoint_still_pages():
+    """Empty or unparseable endpoint is unknown, not customer-owned."""
+    from preloop.models.models.ai_model import AIModel
+
+    missing = AIModel(
+        provider_name="openai-compatible",
+        model_identifier="openrouter/auto-beta",
+        api_endpoint=None,
+    )
+    blank = AIModel(
+        provider_name="openai-compatible",
+        model_identifier="openrouter/auto-beta",
+        api_endpoint="   ",
+    )
+    assert should_notify_unpriced_model(ai_model=missing, **_notify_kwargs()) is True
+    assert should_notify_unpriced_model(ai_model=blank, **_notify_kwargs()) is True

--- a/backend/tests/services/test_unpriced_model_alert.py
+++ b/backend/tests/services/test_unpriced_model_alert.py
@@ -394,3 +394,72 @@ def test_endpoint_containing_openrouter_string_is_not_classified_openrouter(
     assert first is True
     assert second is True
     assert mock_notify.call_count == 2
+
+
+def _notify_kwargs(**usage_overrides):
+    """Defaults for should_notify that would page if the endpoint is cataloged."""
+    kwargs = {
+        "usage_accounting_requested": False,
+        "usage_details": {"prompt_tokens": 10, "completion_tokens": 20},
+        "completion_tokens": 20,
+    }
+    kwargs.update(usage_overrides)
+    return kwargs
+
+
+def test_customer_owned_openai_compatible_endpoint_does_not_page():
+    """Home LiteLLM / OpenCode Zen are not a shared-catalog hole."""
+    from preloop.models.models.ai_model import AIModel
+
+    zen = AIModel(
+        provider_name="openai-compatible",
+        model_identifier="muse-spark-1.3-contributor-free",
+        api_endpoint="https://opencode.ai/zen/v1",
+    )
+    home = AIModel(
+        provider_name="openai-compatible",
+        model_identifier="qwen2.5-coder",
+        api_endpoint="https://llm.dynamicdevices.co.uk",
+    )
+    custom = AIModel(
+        provider_name="custom",
+        model_identifier="alien-fast",
+        api_endpoint="https://llm.example.invalid/v1",
+    )
+    assert should_notify_unpriced_model(ai_model=zen, **_notify_kwargs()) is False
+    assert should_notify_unpriced_model(ai_model=home, **_notify_kwargs()) is False
+    assert should_notify_unpriced_model(ai_model=custom, **_notify_kwargs()) is False
+
+
+def test_openai_compatible_openrouter_and_dashscope_still_page():
+    """Marketplace hosts we catalog still notify so a price can be added."""
+    from preloop.models.models.ai_model import AIModel
+
+    via_openrouter = AIModel(
+        provider_name="openai-compatible",
+        model_identifier="openrouter/auto-beta",
+        api_endpoint="https://openrouter.ai/api/v1",
+    )
+    via_dashscope = AIModel(
+        provider_name="openai-compatible",
+        model_identifier="qwen-coder",
+        api_endpoint="https://dashscope.aliyuncs.com/compatible-mode/v1",
+    )
+    native = AIModel(
+        provider_name="openrouter",
+        model_identifier="openrouter/auto-beta",
+        api_endpoint="https://openrouter.ai/api/v1",
+    )
+    assert (
+        should_notify_unpriced_model(ai_model=via_openrouter, **_notify_kwargs())
+        is True
+    )
+    assert (
+        should_notify_unpriced_model(ai_model=via_dashscope, **_notify_kwargs()) is True
+    )
+    assert should_notify_unpriced_model(ai_model=native, **_notify_kwargs()) is True
+
+
+def test_missing_ai_model_keeps_previous_page_contract():
+    """Callers that only have the alias still page (dedup is on the alias)."""
+    assert should_notify_unpriced_model(**_notify_kwargs()) is True


### PR DESCRIPTION
## Summary
- Admin mail for unpriced gateway usage was firing for customer-owned OpenAI-compatible endpoints (Alex's OpenCode Zen `muse-spark-1.3-contributor-free`, previously home LiteLLM). Those hosts are not in the shared catalog, so paging to "add a global price" is the wrong action.
- Skip the alert when provider is `openai-compatible` / `custom` unless the endpoint is OpenRouter or DashScope. Rows stay `unpriced`; the Attention page can still take an account override.

## Test plan
- [ ] `pytest backend/tests/services/test_unpriced_model_alert.py`
- [ ] After deploy, a completion through `https://opencode.ai/zen/v1` does not send `Preloop: no pricing for model ...`
- [ ] An unpriced OpenRouter-fronted `openai-compatible` model still pages

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Targeted bug fix to alerting logic; both prior review items (code duplication and empty-endpoint coverage) are now addressed. No security concerns.
>
> **Overview**
> Stops paging admins for unpriced usage on customer-owned OpenAI-compatible endpoints (home LiteLLM, OpenCode Zen, private proxies) while keeping OpenRouter- and DashScope-fronted configs alerting. Rows remain unpriced and the Attention page can still take an account override.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit d6a7dcb. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->