### PR TITLE
Retry transient provider 429s on direct-SDK aux call paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Similarity search embeddings no longer block the event loop**: comment,
+  issue, and generic search query embeddings run in a worker thread so a
+  slow OpenAI embedding call cannot serialize concurrent requests. Gemini
+  aux 429s (`google.api_core.exceptions.ResourceExhausted`) classify as
+  retryable rate limits, matching the OpenAI SDK path.
 - **Spending-limit save no longer posts a null notify user**: `/auth/users/me`
   has no `id`, so the limits editor used to send `notification_user_ids: [null]`
   and the API rejected the create. Recipients now come from the users list

--- a/backend/preloop/api/endpoints/comments.py
+++ b/backend/preloop/api/endpoints/comments.py
@@ -27,7 +27,7 @@ from preloop.models.models.issue import Issue
 from preloop.models.models.organization import Organization
 from preloop.models.models.project import Project
 from preloop.models.models.tracker import Tracker
-from preloop.services.aux_model_retry import call_with_aux_retry
+from preloop.services.aux_model_retry import call_with_aux_retry_async
 from preloop.services.model_gateway_errors import ModelGatewayAPIError
 from preloop.utils.permissions import require_permission
 
@@ -213,10 +213,12 @@ async def search_comments(
                 )
             model = active_models[0]
             try:
-                query_vector = call_with_aux_retry(
-                    lambda: crud_issue_embedding._generate_embedding_vector(
-                        query, model
-                    ),
+
+                async def _embed_query() -> list:
+                    return crud_issue_embedding._generate_embedding_vector(query, model)
+
+                query_vector = await call_with_aux_retry_async(
+                    _embed_query,
                     operation_name="comment_similarity_query_embedding",
                     provider=getattr(model, "provider", None),
                 )

--- a/backend/preloop/api/endpoints/comments.py
+++ b/backend/preloop/api/endpoints/comments.py
@@ -1,5 +1,6 @@
 """Endpoints for managing issue comments."""
 
+import asyncio
 import logging
 
 from typing import Optional, List
@@ -215,7 +216,11 @@ async def search_comments(
             try:
 
                 async def _embed_query() -> list:
-                    return crud_issue_embedding._generate_embedding_vector(query, model)
+                    return await asyncio.to_thread(
+                        crud_issue_embedding._generate_embedding_vector,
+                        query,
+                        model,
+                    )
 
                 query_vector = await call_with_aux_retry_async(
                     _embed_query,

--- a/backend/preloop/api/endpoints/comments.py
+++ b/backend/preloop/api/endpoints/comments.py
@@ -27,6 +27,8 @@ from preloop.models.models.issue import Issue
 from preloop.models.models.organization import Organization
 from preloop.models.models.project import Project
 from preloop.models.models.tracker import Tracker
+from preloop.services.aux_model_retry import call_with_aux_retry
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
 from preloop.utils.permissions import require_permission
 
 logger = logging.getLogger(__name__)
@@ -211,8 +213,21 @@ async def search_comments(
                 )
             model = active_models[0]
             try:
-                query_vector = crud_issue_embedding._generate_embedding_vector(
-                    query, model
+                query_vector = call_with_aux_retry(
+                    lambda: crud_issue_embedding._generate_embedding_vector(
+                        query, model
+                    ),
+                    operation_name="comment_similarity_query_embedding",
+                    provider=getattr(model, "provider", None),
+                )
+            except ModelGatewayAPIError as exc:
+                logger.warning(
+                    "Comment similarity query embedding did not recover: %s", exc
+                )
+                raise HTTPException(
+                    status_code=exc.status_code,
+                    detail="Embedding provider is rate limited; retry later.",
+                    headers=exc.response_headers(),
                 )
             except Exception as e:
                 logger.error(

--- a/backend/preloop/api/endpoints/issue_compliance.py
+++ b/backend/preloop/api/endpoints/issue_compliance.py
@@ -12,10 +12,12 @@ from sqlalchemy.orm import Session
 from preloop.api.auth import get_current_active_user
 from preloop.config import get_settings, Settings
 from preloop.schemas.issue import IssueResponse, IssueUpdate
+from preloop.services.aux_model_retry import call_with_aux_retry
 from preloop.services.model_credentials import (
     get_aux_openai_sdk_extra_kwargs,
     resolve_model_call_credentials,
 )
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
 from preloop.schemas.issue_compliance import (
     ComplianceSuggestionResponse,
     CompliancePromptMetadata,
@@ -144,11 +146,15 @@ def _calculate_issue_compliance(
             },
         )
 
-        response = client.chat.completions.create(
-            model=default_model.model_identifier,
-            messages=messages,
-            response_format={"type": "json_object"},
-            **aux_extras,
+        response = call_with_aux_retry(
+            lambda: client.chat.completions.create(
+                model=default_model.model_identifier,
+                messages=messages,
+                response_format={"type": "json_object"},
+                **aux_extras,
+            ),
+            operation_name="issue_compliance_check",
+            provider=getattr(default_model, "provider_name", None),
         )
         llm_response_text = response.choices[0].message.content.strip()
 
@@ -161,6 +167,13 @@ def _calculate_issue_compliance(
 
     except openai.APIError as e:
         raise HTTPException(status_code=500, detail=f"AI model API error: {e}")
+    except ModelGatewayAPIError as exc:
+        logger.warning("AI compliance check did not recover: %s", exc)
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail="AI model is rate limited; retry later.",
+            headers=exc.response_headers(),
+        )
     except (ValueError, IndexError) as e:
         raise HTTPException(
             status_code=500, detail=f"Error parsing AI model response: {e}"
@@ -303,11 +316,15 @@ def get_compliance_improvement_suggestion(
         },
     )
     try:
-        llm_response = client.chat.completions.create(
-            model=default_model.model_identifier,
-            messages=compliance_messages,
-            response_format={"type": "json_object"},
-            **aux_extras,
+        llm_response = call_with_aux_retry(
+            lambda: client.chat.completions.create(
+                model=default_model.model_identifier,
+                messages=compliance_messages,
+                response_format={"type": "json_object"},
+                **aux_extras,
+            ),
+            operation_name="issue_compliance_suggestion",
+            provider=getattr(default_model, "provider_name", None),
         )
         suggestion_data = json.loads(llm_response.choices[0].message.content)
         return ComplianceSuggestionResponse(**suggestion_data)
@@ -316,6 +333,13 @@ def get_compliance_improvement_suggestion(
         logger.error(f"OpenAI API call failed: {e}")
         raise HTTPException(
             status_code=500, detail="Failed to get compliance suggestion from AI model."
+        )
+    except ModelGatewayAPIError as exc:
+        logger.warning("AI compliance suggestion did not recover: %s", exc)
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail="AI model is rate limited; retry later.",
+            headers=exc.response_headers(),
         )
 
 

--- a/backend/preloop/api/endpoints/issue_dependencies.py
+++ b/backend/preloop/api/endpoints/issue_dependencies.py
@@ -16,10 +16,12 @@ from preloop.models.crud import (
     crud_issue_set,
     crud_issue_relationship,
 )
+from preloop.services.aux_model_retry import call_with_aux_retry
 from preloop.services.model_credentials import (
     get_aux_openai_sdk_extra_kwargs,
     resolve_model_call_credentials,
 )
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
 from preloop.models.db.session import get_db_session as get_db
 from preloop.models.models.issue import Issue
 from preloop.api.auth import get_current_active_user
@@ -184,11 +186,15 @@ def detect_issue_dependencies(
             },
         )
 
-        response = client.chat.completions.create(
-            model=ai_model.model_identifier,
-            messages=dep_messages,
-            response_format={"type": "json_object"},
-            **aux_extras,
+        response = call_with_aux_retry(
+            lambda: client.chat.completions.create(
+                model=ai_model.model_identifier,
+                messages=dep_messages,
+                response_format={"type": "json_object"},
+                **aux_extras,
+            ),
+            operation_name="issue_dependency_detection",
+            provider=getattr(ai_model, "provider_name", None),
         )
 
         response_content = response.choices[0].message.content
@@ -247,6 +253,13 @@ def detect_issue_dependencies(
         logger.error(f"OpenAI API call failed: {e}")
         raise HTTPException(
             status_code=502, detail="Failed to get dependency analysis from AI model."
+        )
+    except ModelGatewayAPIError as exc:
+        logger.warning("AI dependency analysis did not recover: %s", exc)
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail="AI model is rate limited; retry later.",
+            headers=exc.response_headers(),
         )
     except (json.JSONDecodeError, KeyError, TypeError) as e:
         logger.error(f"Error parsing AI model response: {e}")
@@ -485,11 +498,15 @@ def extend_dependency_scan(
                 "response_format": {"type": "json_object"},
             },
         )
-        response = client.chat.completions.create(
-            model=ai_model.model_identifier,
-            messages=dep_messages2,
-            response_format={"type": "json_object"},
-            **aux_extras,
+        response = call_with_aux_retry(
+            lambda: client.chat.completions.create(
+                model=ai_model.model_identifier,
+                messages=dep_messages2,
+                response_format={"type": "json_object"},
+                **aux_extras,
+            ),
+            operation_name="issue_dependency_extend_scan",
+            provider=getattr(ai_model, "provider_name", None),
         )
         response_content = response.choices[0].message.content
         dependencies_from_ai = json.loads(response_content).get("dependencies", [])
@@ -552,6 +569,13 @@ def extend_dependency_scan(
         logger.error(f"OpenAI API call failed: {e}")
         raise HTTPException(
             status_code=502, detail="Failed to get dependency analysis from AI model."
+        )
+    except ModelGatewayAPIError as exc:
+        logger.warning("AI dependency analysis did not recover: %s", exc)
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail="AI model is rate limited; retry later.",
+            headers=exc.response_headers(),
         )
     except (json.JSONDecodeError, KeyError, TypeError) as e:
         logger.error(f"Error parsing AI model response: {e}")

--- a/backend/preloop/api/endpoints/issue_duplicates.py
+++ b/backend/preloop/api/endpoints/issue_duplicates.py
@@ -8,10 +8,12 @@ import os
 import json
 from datetime import datetime, UTC
 
+from preloop.services.aux_model_retry import call_with_aux_retry
 from preloop.services.model_credentials import (
     get_aux_openai_sdk_extra_kwargs,
     resolve_model_call_credentials,
 )
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
 from preloop.schemas.issue_duplicate import (
     IssueDuplicate as IssueDuplicateSchema,
     IssueDuplicateSuggestionRequest,
@@ -190,11 +192,15 @@ def check_or_create_issue_duplicate(
             },
         )
 
-        response = client.chat.completions.create(
-            model=default_model.model_identifier,
-            messages=messages,
-            response_format={"type": "json_object"},
-            **aux_extras,
+        response = call_with_aux_retry(
+            lambda: client.chat.completions.create(
+                model=default_model.model_identifier,
+                messages=messages,
+                response_format={"type": "json_object"},
+                **aux_extras,
+            ),
+            operation_name="issue_duplicate_check",
+            provider=getattr(default_model, "provider_name", None),
         )
         llm_response_text = response.choices[0].message.content.strip()
         logger.info(
@@ -243,6 +249,15 @@ def check_or_create_issue_duplicate(
             f"OpenAI API call for model '{default_model.model_identifier}' failed: {e}"
         )
         raise HTTPException(status_code=500, detail="AI model API error")
+    except ModelGatewayAPIError as exc:
+        logger.warning(
+            "AI model call for issue duplicate check did not recover: %s", exc
+        )
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail="AI model is rate limited; retry later.",
+            headers=exc.response_headers(),
+        )
     except Exception as e:
         logger.exception(
             f"An unexpected error occurred during AI model invocation for model '{default_model.model_identifier}': {e}"
@@ -933,11 +948,15 @@ def get_resolution_suggestion(
     )
 
     try:
-        llm_response = client.chat.completions.create(
-            model=default_model.model_identifier,
-            messages=dup_messages,
-            response_format={"type": "json_object"},
-            **aux_extras,
+        llm_response = call_with_aux_retry(
+            lambda: client.chat.completions.create(
+                model=default_model.model_identifier,
+                messages=dup_messages,
+                response_format={"type": "json_object"},
+                **aux_extras,
+            ),
+            operation_name="issue_duplicate_resolution_suggestion",
+            provider=getattr(default_model, "provider_name", None),
         )
         suggestion_data = json.loads(llm_response.choices[0].message.content)
 
@@ -953,4 +972,11 @@ def get_resolution_suggestion(
         logger.error(f"OpenAI API call failed: {e}")
         raise HTTPException(
             status_code=500, detail="Failed to get suggestion from AI model."
+        )
+    except ModelGatewayAPIError as exc:
+        logger.warning("AI suggestion call did not recover: %s", exc)
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail="AI model is rate limited; retry later.",
+            headers=exc.response_headers(),
         )

--- a/backend/preloop/api/endpoints/issues.py
+++ b/backend/preloop/api/endpoints/issues.py
@@ -35,6 +35,8 @@ from preloop.models.models.organization import Organization
 from preloop.models.models.project import Project
 from preloop.models.models.tracker import Tracker
 from preloop.api.auth import get_current_active_user
+from preloop.services.aux_model_retry import call_with_aux_retry
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
 from preloop.utils.permissions import require_permission
 from preloop.config import settings
 
@@ -343,8 +345,12 @@ async def search_issues(
                 model = active_models[0]
                 model_id = model.id
                 # Generate query vector
-                query_vector = crud_issue_embedding._generate_embedding_vector(
-                    query, model
+                query_vector = call_with_aux_retry(
+                    lambda: crud_issue_embedding._generate_embedding_vector(
+                        query, model
+                    ),
+                    operation_name="issue_similarity_query_embedding",
+                    provider=getattr(model, "provider", None),
                 )
                 # Find similar issues using similarity search
                 similar_issues = crud_issue_embedding.similarity_search(
@@ -432,6 +438,15 @@ async def search_issues(
                         )
                     )
 
+            except ModelGatewayAPIError as exc:
+                logger.warning(
+                    "Similarity search query embedding did not recover: %s", exc
+                )
+                raise HTTPException(
+                    status_code=exc.status_code,
+                    detail="Embedding provider is rate limited; retry later.",
+                    headers=exc.response_headers(),
+                )
             except Exception as e:
                 logger.error(f"Error during similarity search: {e}", exc_info=True)
                 raise HTTPException(

--- a/backend/preloop/api/endpoints/issues.py
+++ b/backend/preloop/api/endpoints/issues.py
@@ -35,7 +35,7 @@ from preloop.models.models.organization import Organization
 from preloop.models.models.project import Project
 from preloop.models.models.tracker import Tracker
 from preloop.api.auth import get_current_active_user
-from preloop.services.aux_model_retry import call_with_aux_retry
+from preloop.services.aux_model_retry import call_with_aux_retry_async
 from preloop.services.model_gateway_errors import ModelGatewayAPIError
 from preloop.utils.permissions import require_permission
 from preloop.config import settings
@@ -344,11 +344,12 @@ async def search_issues(
                     )
                 model = active_models[0]
                 model_id = model.id
-                # Generate query vector
-                query_vector = call_with_aux_retry(
-                    lambda: crud_issue_embedding._generate_embedding_vector(
-                        query, model
-                    ),
+
+                async def _embed_query() -> list:
+                    return crud_issue_embedding._generate_embedding_vector(query, model)
+
+                query_vector = await call_with_aux_retry_async(
+                    _embed_query,
                     operation_name="issue_similarity_query_embedding",
                     provider=getattr(model, "provider", None),
                 )

--- a/backend/preloop/api/endpoints/issues.py
+++ b/backend/preloop/api/endpoints/issues.py
@@ -1,5 +1,6 @@
 """Endpoints for managing issues across trackers."""
 
+import asyncio
 import logging
 from typing import Optional, List, Dict
 
@@ -346,7 +347,11 @@ async def search_issues(
                 model_id = model.id
 
                 async def _embed_query() -> list:
-                    return crud_issue_embedding._generate_embedding_vector(query, model)
+                    return await asyncio.to_thread(
+                        crud_issue_embedding._generate_embedding_vector,
+                        query,
+                        model,
+                    )
 
                 query_vector = await call_with_aux_retry_async(
                     _embed_query,

--- a/backend/preloop/api/endpoints/search.py
+++ b/backend/preloop/api/endpoints/search.py
@@ -1,5 +1,6 @@
-from typing import List, Optional, Union
+import asyncio
 import logging
+from typing import List, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
@@ -191,7 +192,11 @@ async def perform_search(
         try:
 
             async def _embed_query() -> list:
-                return crud_issue_embedding._generate_embedding_vector(query, model)
+                return await asyncio.to_thread(
+                    crud_issue_embedding._generate_embedding_vector,
+                    query,
+                    model,
+                )
 
             query_vector = await call_with_aux_retry_async(
                 _embed_query,

--- a/backend/preloop/api/endpoints/search.py
+++ b/backend/preloop/api/endpoints/search.py
@@ -27,6 +27,8 @@ from preloop.models.models.organization import Organization
 from preloop.models.models.project import Project
 from preloop.models.models.tracker import Tracker
 from preloop.config import get_settings
+from preloop.services.aux_model_retry import call_with_aux_retry_async
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
 
 settings = get_settings()
 # Initialize CRUD operations
@@ -187,7 +189,22 @@ async def perform_search(
             )
         model = active_models[0]
         try:
-            query_vector = crud_issue_embedding._generate_embedding_vector(query, model)
+
+            async def _embed_query() -> list:
+                return crud_issue_embedding._generate_embedding_vector(query, model)
+
+            query_vector = await call_with_aux_retry_async(
+                _embed_query,
+                operation_name="search_query_embedding",
+                provider=getattr(model, "provider", None),
+            )
+        except ModelGatewayAPIError as exc:
+            logger.warning("Search query embedding did not recover: %s", exc)
+            raise HTTPException(
+                status_code=exc.status_code,
+                detail="Embedding provider is rate limited; retry later.",
+                headers=exc.response_headers(),
+            )
         except Exception as e:
             logger.error(
                 f"Error generating query vector for '{query}': {e}", exc_info=True

--- a/backend/preloop/services/ai_approval_service.py
+++ b/backend/preloop/services/ai_approval_service.py
@@ -12,6 +12,8 @@ import re
 from dataclasses import dataclass
 from typing import Any, Dict, Literal, Optional, TYPE_CHECKING
 
+from preloop.services.aux_model_retry import call_with_aux_retry_async
+
 if TYPE_CHECKING:
     from preloop.models.models import ApprovalWorkflow
 
@@ -375,17 +377,21 @@ class AIApprovalService:
 
         client = AsyncOpenAI(**client_kwargs)
 
-        response = await client.chat.completions.create(
-            model=model,
-            messages=[
-                {
-                    "role": "system",
-                    "content": "You are an AI approval system. Respond only with valid JSON.",
-                },
-                {"role": "user", "content": prompt},
-            ],
-            temperature=0.1,  # Low temperature for consistent output
-            max_tokens=500,  # Limit response length
+        response = await call_with_aux_retry_async(
+            lambda: client.chat.completions.create(
+                model=model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "You are an AI approval system. Respond only with valid JSON.",
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0.1,  # Low temperature for consistent output
+                max_tokens=500,  # Limit response length
+            ),
+            operation_name="ai_approval_evaluation",
+            provider=provider,
         )
 
         return response.choices[0].message.content or ""
@@ -414,11 +420,15 @@ class AIApprovalService:
 
         client = AsyncAnthropic(**client_kwargs)
 
-        response = await client.messages.create(
-            model=model,
-            max_tokens=500,
-            messages=[{"role": "user", "content": prompt}],
-            system="You are an AI approval system. Respond only with valid JSON.",
+        response = await call_with_aux_retry_async(
+            lambda: client.messages.create(
+                model=model,
+                max_tokens=500,
+                messages=[{"role": "user", "content": prompt}],
+                system="You are an AI approval system. Respond only with valid JSON.",
+            ),
+            operation_name="ai_approval_evaluation",
+            provider="anthropic",
         )
 
         # Extract text from response

--- a/backend/preloop/services/ai_approval_service.py
+++ b/backend/preloop/services/ai_approval_service.py
@@ -462,13 +462,22 @@ class AIApprovalService:
             system_instruction="You are an AI approval system. Respond only with valid JSON.",
         )
 
-        response = await asyncio.to_thread(
-            gemini_model.generate_content,
-            prompt,
-            generation_config=genai.GenerationConfig(
-                temperature=0.1,
-                max_output_tokens=500,
-            ),
+        generation_config = genai.GenerationConfig(
+            temperature=0.1,
+            max_output_tokens=500,
+        )
+
+        async def _generate() -> Any:
+            return await asyncio.to_thread(
+                gemini_model.generate_content,
+                prompt,
+                generation_config=generation_config,
+            )
+
+        response = await call_with_aux_retry_async(
+            _generate,
+            operation_name="ai_approval_evaluation",
+            provider="gemini",
         )
 
         return response.text if response.text else ""

--- a/backend/preloop/services/aux_model_retry.py
+++ b/backend/preloop/services/aux_model_retry.py
@@ -12,9 +12,10 @@ so aux paths share the gateway taxonomy instead of growing a parallel one.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
-from typing import Callable, Optional, TypeVar
+from typing import Awaitable, Callable, Optional, TypeVar
 
 from preloop.services.model_gateway_errors import (
     GatewayProvider,
@@ -79,6 +80,13 @@ def _to_gateway_error(
     )
     status_code = classified.status_code if classified is not None else 429
     retry_after = classified.retry_after_seconds if classified is not None else None
+    if retry_after is None:
+        # An already-classified gateway error carries its own Retry-After as
+        # a structured attribute; re-classification cannot see it because
+        # there is no httpx response attached to read headers from.
+        fallback = getattr(exc, "retry_after_seconds", None)
+        if isinstance(fallback, int) and fallback >= 0:
+            retry_after = fallback
     terminal = classified.terminal if classified is not None else False
     return ModelGatewayAPIError(
         provider=_as_gateway_provider(provider),
@@ -134,6 +142,53 @@ def call_with_aux_retry(
                 type(exc).__name__,
             )
             sleeper(delay)
+
+    assert last_exc is not None
+    raise _to_gateway_error(last_exc, provider=provider) from last_exc
+
+
+async def call_with_aux_retry_async(
+    fn: Callable[[], Awaitable[T]],
+    *,
+    operation_name: str = "aux_model",
+    provider: Optional[str] = None,
+    sleep: Optional[Callable[[float], Awaitable[None]]] = None,
+) -> T:
+    """Async twin of :func:`call_with_aux_retry` for awaited provider calls.
+
+    Same bounded, Retry-After-aware behaviour as the sync helper: one retry
+    on a transient upstream fault, terminal quota / auth failures fail fast,
+    and an exhausted transient is re-raised as :class:`ModelGatewayAPIError`
+    with the raw exception chained as ``__cause__``. Designed for call sites
+    that use async provider SDKs directly (AsyncOpenAI, AsyncAnthropic).
+
+    ``sleep`` is resolved at call time so tests can inject an awaitable fake
+    instead of patching ``asyncio.sleep``.
+    """
+
+    sleeper = asyncio.sleep if sleep is None else sleep
+    last_exc: Optional[Exception] = None
+
+    for attempt in range(AUX_RETRY_COUNT + 1):
+        try:
+            return await fn()
+        except Exception as exc:
+            last_exc = exc
+            classified = classify_upstream_error(exc)
+            if classified is not None and classified.terminal:
+                raise
+            if not is_retryable_upstream_failure(exc):
+                raise
+            if attempt >= AUX_RETRY_COUNT:
+                break
+            delay = _backoff_seconds(classified, attempt)
+            logger.info(
+                "Retrying %s after %.2fs (%s)",
+                operation_name,
+                delay,
+                type(exc).__name__,
+            )
+            await sleeper(delay)
 
     assert last_exc is not None
     raise _to_gateway_error(last_exc, provider=provider) from last_exc

--- a/backend/preloop/services/upstream_errors.py
+++ b/backend/preloop/services/upstream_errors.py
@@ -110,6 +110,10 @@ def _exception_text(exc: Exception) -> str:
 
 def _status_code(exc: Exception) -> Optional[int]:
     raw = getattr(exc, "status_code", None) or getattr(exc, "status", None)
+    if raw is None:
+        # google.api_core.exceptions.ResourceExhausted stores HTTP 429 on
+        # ``code``, not ``status_code``.
+        raw = getattr(exc, "code", None)
     try:
         status = int(raw)  # type: ignore[arg-type]
     except (TypeError, ValueError):
@@ -205,7 +209,12 @@ def classify_upstream_error(exc: Exception) -> Optional[UpstreamErrorClass]:
             retry_after_seconds=retry_after,
         )
 
-    if status == 429 or _mro_contains(exc, "RateLimitError"):
+    if (
+        status == 429
+        or _mro_contains(exc, "RateLimitError")
+        or _mro_contains(exc, "ResourceExhausted")
+        or _mro_contains(exc, "TooManyRequests")
+    ):
         if _contains(text, _QUOTA_MARKERS):
             return UpstreamErrorClass(
                 error_class=ERROR_CLASS_UPSTREAM_QUOTA_EXHAUSTED,

--- a/backend/tests/endpoints/test_comments.py
+++ b/backend/tests/endpoints/test_comments.py
@@ -581,7 +581,8 @@ async def test_search_comments_similarity_embedding_429_is_retried(
                     return_value=[],
                 ):
                     with patch(
-                        "preloop.services.aux_model_retry.time.sleep", lambda _: None
+                        "preloop.services.aux_model_retry.asyncio.sleep",
+                        new=AsyncMock(return_value=None),
                     ):
                         result = await comments.search_comments(
                             db=db_session,
@@ -618,7 +619,8 @@ async def test_search_comments_similarity_embedding_429_surfaces_retry_after(
                 side_effect=_openai_rate_limit_error(retry_after="3"),
             ) as mock_vector:
                 with patch(
-                    "preloop.services.aux_model_retry.time.sleep", lambda _: None
+                    "preloop.services.aux_model_retry.asyncio.sleep",
+                    new=AsyncMock(return_value=None),
                 ):
                     with pytest.raises(HTTPException) as exc_info:
                         await comments.search_comments(
@@ -700,7 +702,8 @@ async def test_search_comments_similarity_gateway_rate_limit_surfaces_429(
                 side_effect=gateway_error,
             ):
                 with patch(
-                    "preloop.services.aux_model_retry.time.sleep", lambda _: None
+                    "preloop.services.aux_model_retry.asyncio.sleep",
+                    new=AsyncMock(return_value=None),
                 ):
                     with pytest.raises(HTTPException) as exc_info:
                         await comments.search_comments(

--- a/backend/tests/endpoints/test_comments.py
+++ b/backend/tests/endpoints/test_comments.py
@@ -1,12 +1,26 @@
 import uuid
 from datetime import datetime, UTC
 
+import httpx
+import openai
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 from fastapi import HTTPException
 
 from preloop.api.endpoints import comments
 from preloop.schemas.comment import CommentCreate
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
+from preloop.services.upstream_errors import ERROR_CLASS_UPSTREAM_RATE_LIMITED
+
+
+def _openai_rate_limit_error(retry_after: str = "3") -> openai.RateLimitError:
+    request = httpx.Request("POST", "https://example.com/v1/embeddings")
+    response = httpx.Response(
+        429, headers={"retry-after": retry_after}, request=request
+    )
+    return openai.RateLimitError(
+        "Error code: 429 - Too Many Requests", response=response, body=None
+    )
 
 
 @pytest.fixture
@@ -534,3 +548,168 @@ async def test_search_comments_fulltext_with_results(
 
             assert result.total == 1
             assert len(result.items) == 1
+
+
+# --- Transient 429 handling on the similarity-search query embedding (#269) --
+
+
+@pytest.mark.asyncio
+async def test_search_comments_similarity_embedding_429_is_retried(
+    mock_user: MagicMock,
+    mock_tracker: MagicMock,
+) -> None:
+    """One provider 429 during query embedding must not fail the search."""
+    db_session = MagicMock()
+    mock_model = MagicMock()
+    mock_model.id = str(uuid.uuid4())
+    mock_model.provider = "openai"
+
+    with patch(
+        "preloop.api.endpoints.comments.crud_tracker.get_for_account",
+        return_value=[mock_tracker],
+    ):
+        with patch(
+            "preloop.api.endpoints.comments.crud_embedding_model.get_active",
+            return_value=[mock_model],
+        ):
+            with patch(
+                "preloop.api.endpoints.comments.crud_issue_embedding._generate_embedding_vector",
+                side_effect=[_openai_rate_limit_error(), [0.1] * 1536],
+            ) as mock_vector:
+                with patch(
+                    "preloop.api.endpoints.comments.crud_issue_embedding.similarity_search",
+                    return_value=[],
+                ):
+                    with patch(
+                        "preloop.services.aux_model_retry.time.sleep", lambda _: None
+                    ):
+                        result = await comments.search_comments(
+                            db=db_session,
+                            current_user=mock_user,
+                            query="test query",
+                            search_type="similarity",
+                        )
+
+    assert result.total == 0
+    assert mock_vector.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_search_comments_similarity_embedding_429_surfaces_retry_after(
+    mock_user: MagicMock,
+    mock_tracker: MagicMock,
+) -> None:
+    """An exhausted transient 429 surfaces as 429 with a Retry-After header."""
+    db_session = MagicMock()
+    mock_model = MagicMock()
+    mock_model.id = str(uuid.uuid4())
+    mock_model.provider = "openai"
+
+    with patch(
+        "preloop.api.endpoints.comments.crud_tracker.get_for_account",
+        return_value=[mock_tracker],
+    ):
+        with patch(
+            "preloop.api.endpoints.comments.crud_embedding_model.get_active",
+            return_value=[mock_model],
+        ):
+            with patch(
+                "preloop.api.endpoints.comments.crud_issue_embedding._generate_embedding_vector",
+                side_effect=_openai_rate_limit_error(retry_after="3"),
+            ) as mock_vector:
+                with patch(
+                    "preloop.services.aux_model_retry.time.sleep", lambda _: None
+                ):
+                    with pytest.raises(HTTPException) as exc_info:
+                        await comments.search_comments(
+                            db=db_session,
+                            current_user=mock_user,
+                            query="test query",
+                            search_type="similarity",
+                        )
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers is not None
+    assert exc_info.value.headers.get("Retry-After") == "3"
+    assert mock_vector.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_search_comments_similarity_embedding_non_retryable_fails_fast(
+    mock_user: MagicMock,
+    mock_tracker: MagicMock,
+) -> None:
+    """A non-transient embedding failure is not retried and stays a 500."""
+    db_session = MagicMock()
+    mock_model = MagicMock()
+    mock_model.id = str(uuid.uuid4())
+    mock_model.provider = "openai"
+
+    with patch(
+        "preloop.api.endpoints.comments.crud_tracker.get_for_account",
+        return_value=[mock_tracker],
+    ):
+        with patch(
+            "preloop.api.endpoints.comments.crud_embedding_model.get_active",
+            return_value=[mock_model],
+        ):
+            with patch(
+                "preloop.api.endpoints.comments.crud_issue_embedding._generate_embedding_vector",
+                side_effect=ValueError("Unsupported provider: fake"),
+            ) as mock_vector:
+                with pytest.raises(HTTPException) as exc_info:
+                    await comments.search_comments(
+                        db=db_session,
+                        current_user=mock_user,
+                        query="test query",
+                        search_type="similarity",
+                    )
+
+    assert exc_info.value.status_code == 500
+    assert mock_vector.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_search_comments_similarity_gateway_rate_limit_surfaces_429(
+    mock_user: MagicMock,
+    mock_tracker: MagicMock,
+) -> None:
+    """A classified ModelGatewayAPIError maps to its own status + headers."""
+    db_session = MagicMock()
+    mock_model = MagicMock()
+    mock_model.id = str(uuid.uuid4())
+    mock_model.provider = "openai"
+    gateway_error = ModelGatewayAPIError(
+        provider="openai",
+        status_code=429,
+        message="rate limited",
+        error_class=ERROR_CLASS_UPSTREAM_RATE_LIMITED,
+        retry_after_seconds=2,
+    )
+
+    with patch(
+        "preloop.api.endpoints.comments.crud_tracker.get_for_account",
+        return_value=[mock_tracker],
+    ):
+        with patch(
+            "preloop.api.endpoints.comments.crud_embedding_model.get_active",
+            return_value=[mock_model],
+        ):
+            with patch(
+                "preloop.api.endpoints.comments.crud_issue_embedding._generate_embedding_vector",
+                side_effect=gateway_error,
+            ):
+                with patch(
+                    "preloop.services.aux_model_retry.time.sleep", lambda _: None
+                ):
+                    with pytest.raises(HTTPException) as exc_info:
+                        await comments.search_comments(
+                            db=db_session,
+                            current_user=mock_user,
+                            query="test query",
+                            search_type="similarity",
+                        )
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers is not None
+    assert exc_info.value.headers.get("Retry-After") == "2"

--- a/backend/tests/endpoints/test_issue_dependencies.py
+++ b/backend/tests/endpoints/test_issue_dependencies.py
@@ -185,3 +185,72 @@ def test_detect_issue_dependencies_uses_secret_service_credentials(
         api_key="resolved-external-key",
         base_url="https://custom.example.com/v1",
     )
+
+
+def test_detect_issue_dependencies_retries_transient_429(
+    mock_issues: list[MagicMock], mocker: MockerFixture
+) -> None:
+    """A single provider 429 must not fail dependency detection (#269)."""
+    import httpx
+    import openai
+
+    request = httpx.Request("POST", "https://example.com/v1/chat/completions")
+    response = httpx.Response(429, headers={"retry-after": "2"}, request=request)
+    rate_limit_error = openai.RateLimitError(
+        "Error code: 429 - Too Many Requests", response=response, body=None
+    )
+
+    issue_ids = [issue.id for issue in mock_issues]
+    request = DependencyRequest(issue_ids=issue_ids)
+    mock_user = MagicMock(spec=Account)
+    mock_user.id = "user-123"
+    mock_user.account_id = "account-123"
+
+    mock_crud_issue = mocker.patch(
+        "preloop.api.endpoints.issue_dependencies.crud_issue"
+    )
+    mock_crud_issue.get.side_effect = mock_issues
+
+    mock_crud_ai_model = mocker.patch(
+        "preloop.api.endpoints.issue_dependencies.crud_ai_model"
+    )
+    mock_ai_model = MagicMock(spec=AIModel)
+    mock_ai_model.model_identifier = "gpt-5.4"
+    mock_ai_model.id = "model-1"
+    mock_ai_model.provider_name = "openai"
+    mock_ai_model.api_key = "fake-key"
+    mock_ai_model.credentials_secret = None
+    mock_crud_ai_model.get_default_active_model.return_value = mock_ai_model
+
+    mock_crud_issue_set = mocker.patch(
+        "preloop.api.endpoints.issue_dependencies.crud_issue_set"
+    )
+    mock_crud_issue_set.get_supersets_by_issues.return_value = []
+
+    mock_openai_client = mocker.patch(
+        "preloop.api.endpoints.issue_dependencies.openai.OpenAI"
+    )
+    mock_completion = MagicMock()
+    mock_completion.choices = [
+        MagicMock(message=MagicMock(content=json.dumps({"dependencies": []})))
+    ]
+    mock_openai_client.return_value.chat.completions.create.side_effect = [
+        rate_limit_error,
+        mock_completion,
+    ]
+    mocker.patch("preloop.services.aux_model_retry.time.sleep", lambda _: None)
+
+    mock_settings = MagicMock()
+    mock_settings.PROMPTS_FILE = "/path/to/prompts.yml"
+    mocker.patch(
+        "preloop.api.endpoints.issue_dependencies.load_dependencies_prompts_config",
+        return_value={"dependency_detection_v1": {"system": "Test prompt"}},
+    )
+
+    result = detect_issue_dependencies(
+        request=request, db=MagicMock(), current_user=mock_user, settings=mock_settings
+    )
+
+    assert isinstance(result, DependencyResponse)
+    assert result.dependencies == []
+    assert mock_openai_client.return_value.chat.completions.create.call_count == 2

--- a/backend/tests/endpoints/test_issue_duplicates.py
+++ b/backend/tests/endpoints/test_issue_duplicates.py
@@ -1,10 +1,14 @@
 import pytest
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Tuple
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from uuid import uuid4
 from fastapi import HTTPException
 from pytest_mock import MockerFixture
+
+import httpx
+import openai
 
 from preloop.api.endpoints.issue_duplicates import (
     _find_issue_duplicates_logic,
@@ -1548,3 +1552,156 @@ def test_get_resolution_suggestion_no_credentials_raises_500(
 
     assert excinfo.value.status_code == 500
     mock_openai_class.assert_not_called()
+
+
+# --- Transient 429 handling on the direct-SDK aux calls (#269) ---------------
+
+
+def _openai_rate_limit_error(retry_after: str = "3") -> openai.RateLimitError:
+    request = httpx.Request("POST", "https://example.com/v1/chat/completions")
+    response = httpx.Response(
+        429, headers={"retry-after": retry_after}, request=request
+    )
+    return openai.RateLimitError(
+        "Error code: 429 - Too Many Requests", response=response, body=None
+    )
+
+
+def _setup_check_or_create_duplicate(
+    mocker: MockerFixture,
+    mock_openai_class: MagicMock,
+    create_side_effect,
+) -> MagicMock:
+    """Common wiring for check_or_create_issue_duplicate model-call tests."""
+    issue_a = MagicMock()
+    issue_a.id = uuid4()
+    issue_a.key = "PROJ-1"
+    issue_a.title = "Title A"
+    issue_a.description = "Description A"
+
+    issue_b = MagicMock()
+    issue_b.id = uuid4()
+    issue_b.key = "PROJ-2"
+    issue_b.title = "Title B"
+    issue_b.description = "Description B"
+
+    model = MagicMock(model_identifier="gpt-5.4", provider_name="openai")
+    model.id = uuid4()
+
+    mocker.patch(
+        "preloop.api.endpoints.issue_duplicates.crud_issue_duplicate",
+        new_callable=MagicMock,
+    )
+    mocker.patch(
+        "preloop.api.endpoints.issue_duplicates.crud_issue_duplicate.get_by_issue_ids",
+        return_value=None,
+    )
+    mocker.patch(
+        "preloop.api.endpoints.issue_duplicates.crud_issue.get",
+        side_effect=[issue_a, issue_b],
+    )
+    mocker.patch(
+        "preloop.api.endpoints.issue_duplicates.crud_ai_model.get_default_active_model",
+        return_value=model,
+    )
+    mocker.patch(
+        "preloop.api.endpoints.issue_duplicates.load_duplicates_prompts_config",
+        return_value={
+            "duplicate_classification_v1": {
+                "system": "You classify duplicate issues.",
+                "user": "Compare {issue1_title} with {issue2_title}.",
+            }
+        },
+    )
+    mocker.patch(
+        "preloop.api.endpoints.issue_duplicates.resolve_model_call_credentials",
+        return_value={"api_key": "sk-test", "api_base": None},
+    )
+    mocker.patch(
+        "preloop.api.endpoints.issue_duplicates.get_aux_openai_sdk_extra_kwargs",
+        return_value={},
+    )
+    mocker.patch("preloop.services.aux_model_retry.time.sleep", lambda _: None)
+
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.chat.completions.create.side_effect = create_side_effect
+    return mock_client
+
+
+@patch("preloop.api.endpoints.issue_duplicates.openai.OpenAI")
+def test_check_or_create_duplicate_retries_transient_429(
+    mock_openai_class: MagicMock, mocker: MockerFixture
+) -> None:
+    """A single provider 429 must not fail the check; the retry succeeds."""
+    completion = MagicMock(
+        choices=[
+            MagicMock(
+                message=MagicMock(
+                    content=(
+                        '{"classification": "DUPLICATE", "reason": "same root cause",'
+                        ' "suggestion": "merge"}'
+                    )
+                )
+            )
+        ]
+    )
+    created = SimpleNamespace(
+        id=uuid4(),
+        issue1_id=uuid4(),
+        issue2_id=uuid4(),
+        decision="duplicate",
+        reason="same root cause",
+        suggestion="merge",
+    )
+
+    _setup_check_or_create_duplicate(
+        mocker,
+        mock_openai_class,
+        create_side_effect=[
+            _openai_rate_limit_error(),
+            completion,
+        ],
+    )
+    mocker.patch(
+        "preloop.api.endpoints.issue_duplicates.crud_issue_duplicate.create",
+        return_value=created,
+    )
+
+    result = check_or_create_issue_duplicate(
+        db=MagicMock(),
+        issue1_id=str(uuid4()),
+        issue2_id=str(uuid4()),
+        current_user=MagicMock(),
+        settings=MagicMock(PROMPTS_FILE="prompts.yaml"),
+    )
+
+    assert result.decision == "duplicate"
+    assert mock_openai_class.return_value.chat.completions.create.call_count == 2
+
+
+@patch("preloop.api.endpoints.issue_duplicates.openai.OpenAI")
+def test_check_or_create_duplicate_persistent_429_surfaces_retry_after(
+    mock_openai_class: MagicMock, mocker: MockerFixture
+) -> None:
+    """An exhausted transient 429 surfaces as a clean 429 with Retry-After."""
+    _setup_check_or_create_duplicate(
+        mocker,
+        mock_openai_class,
+        create_side_effect=_openai_rate_limit_error(retry_after="3"),
+    )
+    mocker.patch("preloop.api.endpoints.issue_duplicates.crud_issue_duplicate.create")
+
+    with pytest.raises(HTTPException) as excinfo:
+        check_or_create_issue_duplicate(
+            db=MagicMock(),
+            issue1_id=str(uuid4()),
+            issue2_id=str(uuid4()),
+            current_user=MagicMock(),
+            settings=MagicMock(PROMPTS_FILE="prompts.yaml"),
+        )
+
+    assert excinfo.value.status_code == 429
+    assert excinfo.value.headers is not None
+    assert excinfo.value.headers.get("Retry-After") == "3"
+    assert mock_openai_class.return_value.chat.completions.create.call_count == 2

--- a/backend/tests/endpoints/test_issues.py
+++ b/backend/tests/endpoints/test_issues.py
@@ -1,10 +1,12 @@
 """Unit tests for issues API endpoints."""
 
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -757,3 +759,105 @@ class TestGetIssueCount:
         assert response.status_code == 200
         data = response.json()
         assert data["total_issues"] == 0
+
+
+class TestSearchIssuesRateLimit:
+    """Transient 429 handling for the similarity-search query embedding (#269)."""
+
+    @staticmethod
+    def _openai_rate_limit_error(retry_after: str = "3") -> Exception:
+        import httpx
+        import openai
+
+        request = httpx.Request("POST", "https://example.com/v1/embeddings")
+        response = httpx.Response(
+            429, headers={"retry-after": retry_after}, request=request
+        )
+        return openai.RateLimitError(
+            "Error code: 429 - Too Many Requests", response=response, body=None
+        )
+
+    @staticmethod
+    def _similarity_patches(
+        vector_side_effect: object,
+    ) -> tuple[Any, ...]:
+        return (
+            patch(
+                "preloop.api.endpoints.issues.crud_tracker.get_for_account",
+                return_value=[MagicMock()],
+            ),
+            patch(
+                "preloop.api.endpoints.issues.crud_issue.get_for_trackers",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "preloop.api.endpoints.issues.crud_embedding_model.get_active",
+                return_value=[MagicMock(id="model-1", provider="openai")],
+            ),
+            patch(
+                "preloop.api.endpoints.issues.crud_issue_embedding._generate_embedding_vector",
+                side_effect=vector_side_effect,
+            ),
+            patch(
+                "preloop.api.endpoints.issues.crud_issue_embedding.similarity_search",
+                return_value=[],
+            ),
+            patch("preloop.services.aux_model_retry.time.sleep", lambda _: None),
+        )
+
+    @staticmethod
+    async def _search_similarity() -> Any:
+        from preloop.api.endpoints import issues as issues_endpoint
+
+        return await issues_endpoint.search_issues(
+            db=MagicMock(),
+            current_user=MagicMock(),
+            organization_id=None,
+            organization=None,
+            project_id=None,
+            project=None,
+            query="test query",
+            limit=10,
+            search_type="similarity",
+            status=None,
+            labels=None,
+            assignee=None,
+            priority=None,
+            last_updated_before=None,
+            last_updated_after=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_search_issues_similarity_embedding_429_is_retried(self) -> None:
+        """One provider 429 during query embedding must not fail the search."""
+        patches = self._similarity_patches(
+            [self._openai_rate_limit_error(), [0.1] * 1536]
+        )
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3] as mock_vector,
+            patches[4],
+            patches[5],
+        ):
+            result = await self._search_similarity()
+
+        assert result == []
+        assert mock_vector.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_search_issues_similarity_embedding_429_surfaces_retry_after(
+        self,
+    ) -> None:
+        """An exhausted transient 429 surfaces as 429 with a Retry-After header."""
+        patches = self._similarity_patches(
+            self._openai_rate_limit_error(retry_after="3")
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            with pytest.raises(HTTPException) as exc_info:
+                await self._search_similarity()
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.headers is not None
+        assert exc_info.value.headers.get("Retry-After") == "3"

--- a/backend/tests/endpoints/test_issues.py
+++ b/backend/tests/endpoints/test_issues.py
@@ -802,7 +802,10 @@ class TestSearchIssuesRateLimit:
                 "preloop.api.endpoints.issues.crud_issue_embedding.similarity_search",
                 return_value=[],
             ),
-            patch("preloop.services.aux_model_retry.time.sleep", lambda _: None),
+            patch(
+                "preloop.services.aux_model_retry.asyncio.sleep",
+                new=AsyncMock(return_value=None),
+            ),
         )
 
     @staticmethod

--- a/backend/tests/endpoints/test_search.py
+++ b/backend/tests/endpoints/test_search.py
@@ -1,8 +1,10 @@
 """Tests for search endpoint."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import httpx
+import openai
 import pytest
 from fastapi import HTTPException
 from preloop.models.models.user import User
@@ -494,3 +496,91 @@ class TestPerformSearch:
         # Verify similarity_search was called with status parameter
         call_args = mock_crud_issue_embed.similarity_search.call_args
         assert call_args[1]["status"] == "open"
+
+
+def _openai_rate_limit_error(retry_after: str = "3") -> openai.RateLimitError:
+    request = httpx.Request("POST", "https://example.com/v1/embeddings")
+    response = httpx.Response(
+        429, headers={"retry-after": retry_after}, request=request
+    )
+    return openai.RateLimitError(
+        "Error code: 429 - Too Many Requests", response=response, body=None
+    )
+
+
+class TestPerformSearchRateLimit:
+    """Transient 429 handling for generic similarity search (#269)."""
+
+    @pytest.mark.asyncio
+    @patch("preloop.api.endpoints.search.get_accessible_projects", return_value=[])
+    @patch("preloop.api.endpoints.search.crud_issue_embedding")
+    @patch("preloop.api.endpoints.search.crud_embedding_model")
+    async def test_similarity_search_embedding_429_is_retried(
+        self, mock_crud_embed_model, mock_crud_issue_embed, mock_get_accessible
+    ) -> None:
+        from preloop.api.endpoints.search import perform_search
+
+        mock_user = MagicMock(spec=User)
+        mock_user.account_id = uuid4()
+        mock_model = MagicMock()
+        mock_model.id = uuid4()
+        mock_model.provider = "openai"
+        mock_crud_embed_model.get_active.return_value = [mock_model]
+        mock_crud_issue_embed._generate_embedding_vector.side_effect = [
+            _openai_rate_limit_error(),
+            [0.1, 0.2, 0.3],
+        ]
+        mock_crud_issue_embed.similarity_search.return_value = []
+
+        with patch(
+            "preloop.services.aux_model_retry.asyncio.sleep",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await perform_search(
+                query="test query",
+                db=MagicMock(),
+                current_user=mock_user,
+                search_type="similarity",
+                limit=10,
+                skip=0,
+            )
+
+        assert result.results == []
+        assert mock_crud_issue_embed._generate_embedding_vector.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("preloop.api.endpoints.search.get_accessible_projects", return_value=[])
+    @patch("preloop.api.endpoints.search.crud_issue_embedding")
+    @patch("preloop.api.endpoints.search.crud_embedding_model")
+    async def test_similarity_search_embedding_429_surfaces_retry_after(
+        self, mock_crud_embed_model, mock_crud_issue_embed, mock_get_accessible
+    ) -> None:
+        from preloop.api.endpoints.search import perform_search
+
+        mock_user = MagicMock(spec=User)
+        mock_user.account_id = uuid4()
+        mock_model = MagicMock()
+        mock_model.id = uuid4()
+        mock_model.provider = "openai"
+        mock_crud_embed_model.get_active.return_value = [mock_model]
+        mock_crud_issue_embed._generate_embedding_vector.side_effect = (
+            _openai_rate_limit_error(retry_after="3")
+        )
+
+        with patch(
+            "preloop.services.aux_model_retry.asyncio.sleep",
+            new=AsyncMock(return_value=None),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await perform_search(
+                    query="test query",
+                    db=MagicMock(),
+                    current_user=mock_user,
+                    search_type="similarity",
+                    limit=10,
+                    skip=0,
+                )
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.headers is not None
+        assert exc_info.value.headers.get("Retry-After") == "3"

--- a/backend/tests/services/test_ai_approval_service.py
+++ b/backend/tests/services/test_ai_approval_service.py
@@ -4,7 +4,7 @@ All LLM/provider calls are mocked so the tests are hermetic.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -350,3 +350,76 @@ class TestOpenaiSdkRetry:
                 )
 
         assert caught.value.status_code == 429
+
+
+class TestGoogleSdkRetry:
+    """Gemini approval path must share the same bounded 429 retry (#269)."""
+
+    @staticmethod
+    def _rate_limit_error() -> Exception:
+        return TestOpenaiSdkRetry._rate_limit_error()
+
+    @pytest.mark.asyncio
+    async def test_transient_429_is_retried(self, service: AIApprovalService) -> None:
+        error = self._rate_limit_error()
+        calls = {"n": 0}
+
+        def generate_content(*args: object, **kwargs: object) -> SimpleNamespace:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise error
+            return SimpleNamespace(text="ok")
+
+        mock_google = MagicMock()
+        mock_genai = MagicMock()
+        mock_genai.GenerativeModel.return_value.generate_content = generate_content
+        mock_google.generativeai = mock_genai
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"google": mock_google, "google.generativeai": mock_genai},
+                clear=False,
+            ),
+            patch(
+                "preloop.services.aux_model_retry.asyncio.sleep",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = await service._call_google(
+                "prompt", "gemini-1.5-pro", api_key="test-key"
+            )
+
+        assert result == "ok"
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_exhausted_429_surfaces_classified_gateway_error(
+        self, service: AIApprovalService
+    ) -> None:
+        error = self._rate_limit_error()
+        mock_google = MagicMock()
+        mock_genai = MagicMock()
+        mock_genai.GenerativeModel.return_value.generate_content = MagicMock(
+            side_effect=error
+        )
+        mock_google.generativeai = mock_genai
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"google": mock_google, "google.generativeai": mock_genai},
+                clear=False,
+            ),
+            patch(
+                "preloop.services.aux_model_retry.asyncio.sleep",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(ModelGatewayAPIError) as caught:
+                await service._call_google(
+                    "prompt", "gemini-1.5-pro", api_key="test-key"
+                )
+
+        assert caught.value.status_code == 429
+        assert caught.value.provider == "gemini"

--- a/backend/tests/services/test_ai_approval_service.py
+++ b/backend/tests/services/test_ai_approval_service.py
@@ -15,6 +15,7 @@ from preloop.services.ai_approval_service import (
     DEFAULT_MODEL,
     get_ai_approval_service,
 )
+from preloop.services.model_gateway_errors import ModelGatewayAPIError
 
 
 def make_workflow(**overrides):
@@ -275,3 +276,77 @@ class TestSingletonAndTemplate:
             model_used="m",
         )
         assert r.raw_response is None
+
+
+class TestOpenaiSdkRetry:
+    """Direct-SDK aux calls must survive a transient provider 429 (#269)."""
+
+    @staticmethod
+    def _rate_limit_error() -> Exception:
+        import httpx
+        import openai
+
+        request = httpx.Request("POST", "https://example.com/v1/chat/completions")
+        response = httpx.Response(429, headers={}, request=request)
+        return openai.RateLimitError(
+            "Error code: 429 - Too Many Requests", response=response, body=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_transient_429_is_retried(self, service: AIApprovalService) -> None:
+        error = self._rate_limit_error()
+        ok = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+        calls = {"n": 0}
+
+        class _FakeCompletions:
+            async def create(self, **kwargs: object) -> SimpleNamespace:
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise error
+                return ok
+
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=_FakeCompletions())
+        )
+        with (
+            patch("openai.AsyncOpenAI", return_value=fake_client),
+            patch(
+                "preloop.services.aux_model_retry.asyncio.sleep",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = await service._call_openai(
+                "prompt", "gpt-5.4-mini", api_key="sk-test", provider="openai"
+            )
+
+        assert result == "ok"
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_exhausted_429_surfaces_classified_gateway_error(
+        self, service: AIApprovalService
+    ) -> None:
+        error = self._rate_limit_error()
+
+        class _AlwaysThrottled:
+            async def create(self, **kwargs: object) -> SimpleNamespace:
+                raise error
+
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=_AlwaysThrottled())
+        )
+        with (
+            patch("openai.AsyncOpenAI", return_value=fake_client),
+            patch(
+                "preloop.services.aux_model_retry.asyncio.sleep",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(ModelGatewayAPIError) as caught:
+                await service._call_openai(
+                    "prompt", "gpt-5.4-mini", api_key="sk-test", provider="openai"
+                )
+
+        assert caught.value.status_code == 429

--- a/backend/tests/services/test_ai_approval_service.py
+++ b/backend/tests/services/test_ai_approval_service.py
@@ -357,7 +357,9 @@ class TestGoogleSdkRetry:
 
     @staticmethod
     def _rate_limit_error() -> Exception:
-        return TestOpenaiSdkRetry._rate_limit_error()
+        from google.api_core.exceptions import ResourceExhausted
+
+        return ResourceExhausted("429 Resource exhausted")
 
     @pytest.mark.asyncio
     async def test_transient_429_is_retried(self, service: AIApprovalService) -> None:

--- a/backend/tests/services/test_aux_model_retry.py
+++ b/backend/tests/services/test_aux_model_retry.py
@@ -6,11 +6,14 @@ from types import SimpleNamespace
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
+import httpx
+import openai
 import pytest
 
 from preloop.services.aux_model_retry import (
     AUX_RETRY_AFTER_CAP_SECONDS,
     call_with_aux_retry,
+    call_with_aux_retry_async,
 )
 from preloop.services.model_credentials import (
     _fallback_counters,
@@ -352,3 +355,136 @@ async def test_extract_agent_name_retries_transient_429():
 
     assert result.name == "Loopbot"
     assert completion.call_count == 2
+
+
+class _AsyncSleeper:
+    """Collects requested delays instead of sleeping."""
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def __call__(self, delay: float) -> None:
+        self.calls.append(delay)
+
+
+def _openai_rate_limit_error(
+    retry_after: Optional[str] = None,
+) -> openai.RateLimitError:
+    """A real OpenAI SDK RateLimitError, the shape aux SDK call sites raise."""
+    request = httpx.Request("POST", "https://example.com/v1/chat/completions")
+    headers = {"retry-after": retry_after} if retry_after is not None else {}
+    response = httpx.Response(429, headers=headers, request=request)
+    return openai.RateLimitError(
+        "Error code: 429 - Too Many Requests", response=response, body=None
+    )
+
+
+# --- async twin (direct SDK call sites) -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_transient_429_is_retried_once_then_succeeds() -> None:
+    calls = {"n": 0}
+
+    async def fn() -> str:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _RateLimitError("Error code: 429 - Too Many Requests")
+        return "ok"
+
+    sleeper = _AsyncSleeper()
+    assert await call_with_aux_retry_async(fn, sleep=sleeper) == "ok"
+    assert calls["n"] == 2
+    assert sleeper.calls == [0.5]
+
+
+@pytest.mark.asyncio
+async def test_async_retry_after_is_honored_and_capped() -> None:
+    async def always_rate_limited() -> None:
+        raise _RateLimitError("Error code: 429 - Too Many Requests", retry_after=30)
+
+    sleeper = _AsyncSleeper()
+    with pytest.raises(ModelGatewayAPIError):
+        await call_with_aux_retry_async(always_rate_limited, sleep=sleeper)
+    assert sleeper.calls == [AUX_RETRY_AFTER_CAP_SECONDS]
+
+
+@pytest.mark.asyncio
+async def test_async_terminal_quota_fails_fast() -> None:
+    calls = {"n": 0}
+
+    async def fn() -> None:
+        calls["n"] += 1
+        raise _RateLimitError(
+            "Error code: 429 - you exceeded your current quota", retry_after=600
+        )
+
+    sleeper = _AsyncSleeper()
+    with pytest.raises(_RateLimitError):
+        await call_with_aux_retry_async(fn, sleep=sleeper)
+    assert calls["n"] == 1
+    assert sleeper.calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_auth_error_is_not_retried() -> None:
+    calls = {"n": 0}
+
+    async def fn() -> None:
+        calls["n"] += 1
+        raise _AuthError("Error code: 401 - invalid api key")
+
+    sleeper = _AsyncSleeper()
+    with pytest.raises(_AuthError):
+        await call_with_aux_retry_async(fn, sleep=sleeper)
+    assert calls["n"] == 1
+    assert sleeper.calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_exhausted_transient_surfaces_classified_gateway_error() -> None:
+    exc = _RateLimitError("Error code: 429 - Too Many Requests", retry_after=2)
+
+    async def fn() -> None:
+        raise exc
+
+    with pytest.raises(ModelGatewayAPIError) as caught:
+        await call_with_aux_retry_async(fn, sleep=_AsyncSleeper(), provider="anthropic")
+    err = caught.value
+    assert err.error_class == ERROR_CLASS_UPSTREAM_RATE_LIMITED
+    assert err.provider == "anthropic"
+    assert err.__cause__ is exc
+    assert err.response_headers()["Retry-After"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_async_openai_sdk_rate_limit_error_is_retried_with_retry_after() -> None:
+    """The real OpenAI SDK 429 shape (status_code + httpx response) classifies."""
+    calls = {"n": 0}
+
+    async def fn() -> str:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _openai_rate_limit_error(retry_after="2")
+        return "ok"
+
+    sleeper = _AsyncSleeper()
+    assert await call_with_aux_retry_async(fn, sleep=sleeper) == "ok"
+    assert calls["n"] == 2
+    assert sleeper.calls == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_async_exhausted_openai_429_carries_retry_after_header() -> None:
+    async def fn() -> None:
+        raise _openai_rate_limit_error(retry_after="3")
+
+    with pytest.raises(ModelGatewayAPIError) as caught:
+        await call_with_aux_retry_async(fn, sleep=_AsyncSleeper())
+    err = caught.value
+    assert err.status_code == 429
+    assert err.retry_after_seconds == 3
+    assert err.response_headers()["Retry-After"] == "3"
+    assert err.response_headers()["X-Preloop-Error-Class"] == (
+        ERROR_CLASS_UPSTREAM_RATE_LIMITED
+    )

--- a/backend/tests/services/test_upstream_errors.py
+++ b/backend/tests/services/test_upstream_errors.py
@@ -107,6 +107,18 @@ def test_transient_429_maps_to_rate_limited():
     assert result.terminal is False
 
 
+def test_google_resource_exhausted_maps_to_rate_limited():
+    """Gemini SDK 429s are ResourceExhausted, not openai.RateLimitError."""
+    from google.api_core.exceptions import ResourceExhausted
+
+    result = classify_upstream_error(ResourceExhausted("429 Resource exhausted"))
+    assert result is not None
+    assert result.error_class == ERROR_CLASS_UPSTREAM_RATE_LIMITED
+    assert result.status_code == 429
+    assert result.terminal is False
+    assert is_retryable_upstream_failure(ResourceExhausted("429 Resource exhausted"))
+
+
 def test_quota_exhausted_429_is_terminal():
     """#114: daily TPD / rate_limit_reached_error must fail fast."""
     exc = _FakeHTTPError(


### PR DESCRIPTION
Closes #269

Recovered from flow execution 85b67a24 (Automated Issue Implementation): the agent committed this fix in the container but the post-execution push failed for lack of git credentials. The commit was restored from the execution evidence bundle (branch.bundle) unchanged.

Agent-reported tests: ruff clean; 212 passed across the targeted services/endpoints suites.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> All previously raised concerns are resolved: embedding calls now run off the event loop via `asyncio.to_thread`, and Gemini 429s are exercised with a genuine `google.api_core.exceptions.ResourceExhausted`.
>
> **Overview**
> Wraps direct-SDK aux model call paths in a bounded retry helper so transient provider 429s are retried once and exhausted transients surface as clean 429s with Retry-After. Reuses the existing gateway error taxonomy and adds comprehensive endpoint/service tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 7a4f2c97. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->