### PR TITLE
Policies page: fix rule dialog errors, tool rules, generate dialog; remove dead tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,7 +154,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upload-read path.
 - **Describe a change no longer opens against a stale policy**: the button
   refetches the current export first and reports an error instead of
-  silently opening an empty dialog when the export fails.
+  silently opening an empty dialog when the export fails. Closing the dialog
+  (including a programmatic hide after Save) resets the prompt and YAML so
+  the next open is a fresh form; nested `sl-details` toggles do not reset it.
+- **Tool-rule CEL detection matches the backend**: the Policies editor and
+  the access-rule create/update endpoints classify `!`, ` in `, ternaries,
+  and CEL functions as `cel`, so a deny rule cannot be stored as `simple`
+  and silently fail closed to an approval prompt.
 - **Add rule dialog no longer closes on every choice**: the dialog listened
   for `sl-hide`, which every inner `sl-select` emits when its dropdown
   closes, so picking a target or action dismissed the form. It now listens

--- a/backend/preloop/api/endpoints/tools.py
+++ b/backend/preloop/api/endpoints/tools.py
@@ -42,6 +42,7 @@ from preloop.schemas.tool_approval_condition import (
     ConditionTestRequest,
     ConditionTestResponse,
 )
+from preloop.services.policy.loader import _detect_condition_type
 from preloop.services.policy_evaluator import evaluate_cel_expression
 from preloop.services.tool_schema_tokens import estimate_tool_schema_tokens
 from preloop.services.tool_usage_stats import ToolUsageStatsService
@@ -1849,7 +1850,9 @@ async def create_access_rule(
                 "account_id": str(account.id),
                 "action": rule_in.action,
                 "condition_expression": rule_in.condition_expression,
-                "condition_type": rule_in.condition_type,
+                "condition_type": _detect_condition_type(
+                    rule_in.condition_expression or ""
+                ),
                 "priority": rule_in.priority,
                 "description": rule_in.description,
                 "is_enabled": rule_in.is_enabled,
@@ -1929,6 +1932,10 @@ async def update_access_rule(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Action must be 'allow', 'deny', or 'require_approval'",
         )
+
+    if "condition_expression" in update_data or "condition_type" in update_data:
+        expression = update_data.get("condition_expression", rule.condition_expression)
+        update_data["condition_type"] = _detect_condition_type(expression or "")
 
     try:
         old_snapshot = {

--- a/backend/tests/services/test_policy_condition_type.py
+++ b/backend/tests/services/test_policy_condition_type.py
@@ -1,0 +1,19 @@
+"""CEL vs simple detection must match the access-rule create/update path."""
+
+from preloop.services.policy.loader import _detect_condition_type
+
+
+def test_simple_comparisons_stay_simple() -> None:
+    assert _detect_condition_type("moderation.flagged == true") == "simple"
+    assert _detect_condition_type("injection.score > 0.7") == "simple"
+    assert _detect_condition_type("pii.found != true") == "simple"
+    assert _detect_condition_type("") == "simple"
+
+
+def test_cel_operators_and_functions_are_cel() -> None:
+    assert _detect_condition_type("!args.enabled") == "cel"
+    assert _detect_condition_type("args.priority in ['critical','high']") == "cel"
+    assert _detect_condition_type("args.ok ? true : false") == "cel"
+    assert _detect_condition_type('args.name.contains("x")') == "cel"
+    assert _detect_condition_type("a && b") == "cel"
+    assert _detect_condition_type("items[0]") == "cel"

--- a/frontend/src/components/policy-generate-dialog.test.ts
+++ b/frontend/src/components/policy-generate-dialog.test.ts
@@ -310,6 +310,32 @@ describe('PolicyGenerateDialog', () => {
     expect(el.open).to.be.false;
   });
 
+  it('resets state when the dialog itself hides, not nested details', async () => {
+    stubGenerate('');
+    const el = (await fixture(
+      html`<policy-generate-dialog .open=${true}></policy-generate-dialog>`
+    )) as PolicyGenerateDialog;
+    await el.updateComplete;
+
+    (el as any)._generatedYaml = 'version: "1.0"';
+    el.requestUpdate();
+    await el.updateComplete;
+
+    const nested = document.createElement('div');
+    el.shadowRoot!.querySelector('sl-dialog')!.appendChild(nested);
+    nested.dispatchEvent(
+      new Event('sl-after-hide', { bubbles: true, composed: true })
+    );
+    await el.updateComplete;
+    expect((el as any)._generatedYaml).to.equal('version: "1.0"');
+
+    const dialog = el.shadowRoot!.querySelector('sl-dialog') as HTMLElement;
+    dialog.dispatchEvent(new Event('sl-after-hide', { bubbles: true }));
+    await el.updateComplete;
+    expect((el as any)._generatedYaml).to.equal('');
+    expect(el.open).to.be.false;
+  });
+
   it('shows a unified YAML diff before Save and does not apply on Discard', async () => {
     const current = 'version: "1.0"\nmetadata:\n  name: current';
     const yamlContent = 'version: "1.0"\nmetadata:\n  name: edited';

--- a/frontend/src/components/policy-generate-dialog.ts
+++ b/frontend/src/components/policy-generate-dialog.ts
@@ -172,6 +172,7 @@ export class PolicyGenerateDialog extends LitElement {
         label="Describe a change"
         ?open=${this.open}
         @sl-request-close=${this._handleClose}
+        @sl-after-hide=${this._handleAfterHide}
       >
         <p class="description">
           Describe the policy you want, or the edits to the current policy. The
@@ -489,6 +490,19 @@ export class PolicyGenerateDialog extends LitElement {
 
   private _handleClose() {
     this.open = false;
+    this._resetGenerateState();
+    this.dispatchEvent(new CustomEvent('closed'));
+  }
+
+  private _handleAfterHide(event: Event) {
+    // Nested sl-details also fire sl-after-hide; only reset when the dialog
+    // itself hides (including a programmatic close that skips request-close).
+    if (event.target !== event.currentTarget) return;
+    this.open = false;
+    this._resetGenerateState();
+  }
+
+  private _resetGenerateState() {
     this._prompt = '';
     this._generatedYaml = '';
     this._unifiedDiff = '';
@@ -497,7 +511,6 @@ export class PolicyGenerateDialog extends LitElement {
     this._error = '';
     this._warnings = [];
     this._loading = false;
-    this.dispatchEvent(new CustomEvent('closed'));
   }
 }
 

--- a/frontend/src/components/policy-generate-dialog.ts
+++ b/frontend/src/components/policy-generate-dialog.ts
@@ -172,7 +172,6 @@ export class PolicyGenerateDialog extends LitElement {
         label="Describe a change"
         ?open=${this.open}
         @sl-request-close=${this._handleClose}
-        @sl-after-hide=${this._handleClose}
       >
         <p class="description">
           Describe the policy you want, or the edits to the current policy. The

--- a/frontend/src/components/tool-card.ts
+++ b/frontend/src/components/tool-card.ts
@@ -8,6 +8,7 @@ import {
   getToolApprovalCondition,
   fetchWithAuth,
 } from '../api';
+import type { AccessRule } from '../api';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
@@ -49,6 +50,7 @@ export interface Tool {
   approval_workflow_id: string | null;
   has_approval_condition: boolean;
   config_id: string | null;
+  access_rules?: AccessRule[];
   justification_mode?: string | null;
   /** Estimated tokens for this tool's schema as served (incl. justification). */
   schema_tokens_estimate?: number;

--- a/frontend/src/views/authed/policies-view.repro.test.ts
+++ b/frontend/src/views/authed/policies-view.repro.test.ts
@@ -70,6 +70,12 @@ function stubFetch(opts: StubOpts) {
       if (url.includes('/access-rules') && method === 'POST') {
         return json({ id: 'rule-new', ...body }, 201);
       }
+      if (url.includes('/api/v1/access-rules/') && method === 'PUT') {
+        return json({ id: url.split('/').pop(), ...body });
+      }
+      if (url.includes('/api/v1/access-rules/') && method === 'DELETE') {
+        return new Response(null, { status: 204 });
+      }
       if (url.includes('/api/v1/policies/export')) {
         return new Response('version: "1.0"\n', { status: 200 });
       }
@@ -230,7 +236,7 @@ describe('Policies page repro', () => {
     expect(form.id).to.equal('flag-injection');
   });
 
-  it('R5 a saved tool access rule is shown as allow / true', async () => {
+  it('R5 a saved tool access rule is shown as deny with its condition', async () => {
     const m = await mount({ tools: [toolWithDenyRule] });
     stub = m.stub;
     const card = m.element.shadowRoot!.querySelector(
@@ -238,12 +244,13 @@ describe('Policies page repro', () => {
     ) as HTMLElement;
     expect(card).to.exist;
     const badge = card.querySelector('sl-badge') as HTMLElement;
-    expect(badge.textContent?.trim()).to.equal('allow');
-    expect(card.querySelector('code')?.textContent).to.equal('true');
-    expect(card.textContent).to.not.contain('contains("rm")');
+    expect(badge.textContent?.trim()).to.equal('deny');
+    expect(card.querySelector('code')?.textContent).to.contain(
+      'contains("rm")'
+    );
   });
 
-  it('R6 clicking a tool rule opens a blank model rule form', async () => {
+  it('R6 clicking a tool rule opens it for edit with card actions', async () => {
     const m = await mount({ tools: [toolWithDenyRule] });
     stub = m.stub;
     const card = m.element.shadowRoot!.querySelector(
@@ -252,16 +259,15 @@ describe('Policies page repro', () => {
     card.click();
     await m.element.updateComplete;
     expect(ruleDialog(m.element).open).to.be.true;
-    expect(ruleDialog(m.element).getAttribute('label')).to.equal('Add rule');
+    expect(ruleDialog(m.element).getAttribute('label')).to.equal('Edit rule');
     const form = (m.element as any)._modelIOForm;
-    expect(form.ruleType).to.equal('model');
-    expect(form.toolName).to.equal('');
-    expect((m.element as any)._editingModelIOId).to.be.null;
-    // No edit, disable, or delete control exists for a tool rule.
+    expect(form.ruleType).to.equal('tool');
+    expect(form.toolName).to.equal('shell');
+    expect((m.element as any)._editingAccessRuleId).to.equal('ar-1');
     const cardEl = m.element.shadowRoot!.querySelector(
       '[data-rule-id="shell"]'
     ) as HTMLElement;
-    expect(cardEl.querySelectorAll('sl-button')).to.have.length(0);
+    expect(cardEl.querySelectorAll('sl-button')).to.have.length(2);
   });
 
   it('R7 tool rule Save posts condition_type simple with a CEL expression', async () => {

--- a/frontend/src/views/authed/policies-view.repro.test.ts
+++ b/frontend/src/views/authed/policies-view.repro.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Repro suite for the Policies page bug hunt (2026-09-04). Every case drives
+ * the real controls (clicks, Shoelace events) instead of private methods so
+ * a pass or fail says something about what a user sees.
+ */
+import { html, fixture, expect, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
+
+import '../../components/view-header.ts';
+import './policies-view';
+import type { PoliciesView } from './policies-view';
+import '../../components/policy-generate-dialog';
+import type { PolicyGenerateDialog } from '../../components/policy-generate-dialog';
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+interface StubOpts {
+  tools?: unknown[];
+  workflows?: unknown[];
+  modelIORules?: unknown[];
+  createStatus?: number;
+  calls: Array<{ url: string; method: string; body: any }>;
+}
+
+function stubFetch(opts: StubOpts) {
+  return sinon
+    .stub(window, 'fetch')
+    .callsFake(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = (init?.method || 'GET').toUpperCase();
+      let body: any = null;
+      if (typeof init?.body === 'string') {
+        try {
+          body = JSON.parse(init.body);
+        } catch {
+          body = init.body;
+        }
+      }
+      opts.calls.push({ url, method, body });
+
+      if (url.endsWith('/api/v1/tools') && method === 'GET') {
+        return json(opts.tools ?? []);
+      }
+      if (url.endsWith('/api/v1/approval-workflows') && method === 'GET') {
+        return json(opts.workflows ?? []);
+      }
+      if (url.includes('/api/v1/features')) {
+        return json({ plugins: [], features: {} });
+      }
+      if (url.includes('/api/v1/policies/model-io-rules') && method === 'GET') {
+        return json({ rules: opts.modelIORules ?? [] });
+      }
+      if (
+        url.endsWith('/api/v1/policies/model-io-rules') &&
+        method === 'POST'
+      ) {
+        if (opts.createStatus && opts.createStatus >= 400) {
+          return json({ detail: 'Permission denied' }, opts.createStatus);
+        }
+        return json(body);
+      }
+      if (url.endsWith('/api/v1/tool-configurations') && method === 'POST') {
+        return json({ id: 'cfg-new', ...body });
+      }
+      if (url.includes('/access-rules') && method === 'POST') {
+        return json({ id: 'rule-new', ...body }, 201);
+      }
+      if (url.includes('/api/v1/policies/export')) {
+        return new Response('version: "1.0"\n', { status: 200 });
+      }
+      if (url.includes('/api/v1/policies/versions')) {
+        return json([]);
+      }
+      if (url.includes('/api/v1/policies/generate') && method === 'POST') {
+        return json({ yaml: 'version: "1.0"\ntools: []\n', warnings: [] });
+      }
+      if (url.endsWith('/api/v1/policies/diff') && method === 'POST') {
+        return json({
+          summary: '1 change',
+          has_changes: true,
+          changes: { added: [], removed: [], modified: [] },
+        });
+      }
+      return json({ detail: `Unhandled: ${method} ${url}` }, 500);
+    });
+}
+
+const toolWithDenyRule = {
+  name: 'shell',
+  description: 'Run a command',
+  source: 'builtin',
+  source_id: null,
+  source_name: 'Built-in',
+  schema: {},
+  is_enabled: true,
+  approval_workflow_id: null,
+  has_approval_condition: false,
+  config_id: 'cfg-1',
+  access_rules: [
+    {
+      id: 'ar-1',
+      action: 'deny',
+      condition_expression: 'args.command.contains("rm")',
+      condition_type: 'cel',
+      priority: 0,
+      description: null,
+      is_enabled: true,
+      approval_workflow_id: null,
+    },
+  ],
+};
+
+function headerButton(element: PoliciesView, label: string) {
+  const buttons = Array.from(
+    element.shadowRoot!.querySelectorAll('view-header sl-button')
+  );
+  return buttons.find((b) => b.textContent?.includes(label)) as HTMLElement;
+}
+
+function ruleDialog(element: PoliciesView) {
+  return element.shadowRoot!.querySelector(
+    '[data-testid="rule-dialog"]'
+  ) as any;
+}
+
+function dialogSave(element: PoliciesView) {
+  return ruleDialog(element).querySelector(
+    'sl-button[slot="footer"][variant="primary"]'
+  ) as HTMLElement;
+}
+
+async function mount(opts: Partial<StubOpts> = {}) {
+  const calls: StubOpts['calls'] = [];
+  const stub = stubFetch({ ...opts, calls });
+  const element = (await fixture(
+    html`<policies-view></policies-view>`
+  )) as PoliciesView;
+  await waitUntil(() => !(element as any)._loading, 'still loading');
+  await element.updateComplete;
+  return { element, calls, stub };
+}
+
+describe('Policies page repro', () => {
+  let stub: sinon.SinonStub | undefined;
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+  });
+
+  afterEach(() => {
+    stub?.restore();
+    (window.fetch as any).restore?.();
+    localStorage.clear();
+  });
+
+  it('R1 header Add rule button opens the rule dialog', async () => {
+    const m = await mount();
+    stub = m.stub;
+    headerButton(m.element, 'Add rule').click();
+    await m.element.updateComplete;
+    expect(ruleDialog(m.element).open).to.be.true;
+  });
+
+  it('R2 Save with the default form gives no feedback inside the dialog', async () => {
+    const m = await mount();
+    stub = m.stub;
+    headerButton(m.element, 'Add rule').click();
+    await m.element.updateComplete;
+    // Default form: preset selected, id empty. A user clicks Save.
+    dialogSave(m.element).click();
+    await waitUntil(() => Boolean((m.element as any)._error), 'no error set');
+    await m.element.updateComplete;
+
+    const posted = m.calls.filter(
+      (c) => c.url.endsWith('/policies/model-io-rules') && c.method === 'POST'
+    );
+    expect(posted).to.have.length(0);
+    expect((m.element as any)._error).to.contain('Rule id is required');
+    expect(ruleDialog(m.element).open, 'dialog stays open').to.be.true;
+    // The message is rendered outside the modal, behind the overlay.
+    expect(ruleDialog(m.element).textContent).to.not.contain(
+      'Rule id is required'
+    );
+  });
+
+  it('R3 API 403 on Save leaves the dialog open with the error behind it', async () => {
+    const m = await mount({ createStatus: 403 });
+    stub = m.stub;
+    headerButton(m.element, 'Add rule').click();
+    await m.element.updateComplete;
+    const idInput = ruleDialog(m.element).querySelector('sl-input') as any;
+    idInput.value = 'deny-pii';
+    idInput.dispatchEvent(new CustomEvent('sl-input', { bubbles: true }));
+    await m.element.updateComplete;
+
+    dialogSave(m.element).click();
+    await waitUntil(() => Boolean((m.element as any)._error), 'no error set');
+    await m.element.updateComplete;
+
+    expect((m.element as any)._error).to.contain('Permission denied');
+    expect(ruleDialog(m.element).open).to.be.true;
+    expect(ruleDialog(m.element).textContent).to.not.contain(
+      'Permission denied'
+    );
+  });
+
+  it('R4 picking a second preset keeps the first preset id', async () => {
+    const m = await mount();
+    stub = m.stub;
+    headerButton(m.element, 'Add rule').click();
+    await m.element.updateComplete;
+    const card = (id: string) =>
+      ruleDialog(m.element).querySelector(
+        `[data-preset="${id}"]`
+      ) as HTMLElement;
+    card('block-pii-prompts').click();
+    await m.element.updateComplete;
+    card('flag-injection').click();
+    await m.element.updateComplete;
+    const form = (m.element as any)._modelIOForm;
+    expect(form.presetId).to.equal('flag-injection');
+    expect(form.id).to.equal('block-pii-prompts');
+  });
+
+  it('R5 a saved tool access rule is shown as allow / true', async () => {
+    const m = await mount({ tools: [toolWithDenyRule] });
+    stub = m.stub;
+    const card = m.element.shadowRoot!.querySelector(
+      '[data-rule-id="shell"]'
+    ) as HTMLElement;
+    expect(card).to.exist;
+    const badge = card.querySelector('sl-badge') as HTMLElement;
+    expect(badge.textContent?.trim()).to.equal('allow');
+    expect(card.querySelector('code')?.textContent).to.equal('true');
+    expect(card.textContent).to.not.contain('contains("rm")');
+  });
+
+  it('R6 clicking a tool rule opens a blank model rule form', async () => {
+    const m = await mount({ tools: [toolWithDenyRule] });
+    stub = m.stub;
+    const card = m.element.shadowRoot!.querySelector(
+      '[data-rule-id="shell"] .access-rule-header'
+    ) as HTMLElement;
+    card.click();
+    await m.element.updateComplete;
+    expect(ruleDialog(m.element).open).to.be.true;
+    expect(ruleDialog(m.element).getAttribute('label')).to.equal('Add rule');
+    const form = (m.element as any)._modelIOForm;
+    expect(form.ruleType).to.equal('model');
+    expect(form.toolName).to.equal('');
+    expect((m.element as any)._editingModelIOId).to.be.null;
+    // No edit, disable, or delete control exists for a tool rule.
+    const cardEl = m.element.shadowRoot!.querySelector(
+      '[data-rule-id="shell"]'
+    ) as HTMLElement;
+    expect(cardEl.querySelectorAll('sl-button')).to.have.length(0);
+  });
+
+  it('R7 tool rule Save posts condition_type simple with a CEL expression', async () => {
+    const m = await mount({
+      tools: [{ ...toolWithDenyRule, config_id: null, access_rules: [] }],
+    });
+    stub = m.stub;
+    headerButton(m.element, 'Add rule').click();
+    await m.element.updateComplete;
+    (m.element as any)._patchModelIOForm({
+      ruleType: 'tool',
+      toolName: 'shell',
+      action: 'deny',
+      expression: 'args.command.contains("rm")',
+    });
+    await m.element.updateComplete;
+    dialogSave(m.element).click();
+    await waitUntil(
+      () => m.calls.some((c) => c.url.includes('/access-rules')),
+      'no access rule POST'
+    );
+    const post = m.calls.find((c) => c.url.includes('/access-rules'))!;
+    expect(post.url).to.contain(
+      '/api/v1/tool-configurations/cfg-new/access-rules'
+    );
+    expect(post.body.condition_type).to.equal('simple');
+    expect(post.body.condition_expression).to.contain('contains(');
+  });
+
+  it('R8 editing a rule then choosing Start from a preset selects nothing', async () => {
+    const rule = {
+      id: 'r1',
+      target: 'model.request',
+      enabled: true,
+      detectors: { pii: true },
+      conditions: [{ expression: 'pii.found == true', action: 'deny' }],
+    };
+    const m = await mount({ modelIORules: [rule] });
+    stub = m.stub;
+    const card = m.element.shadowRoot!.querySelector(
+      '[data-rule-id="r1"] .access-rule-header'
+    ) as HTMLElement;
+    card.click();
+    await m.element.updateComplete;
+    expect(ruleDialog(m.element).getAttribute('label')).to.equal('Edit rule');
+    (m.element as any)._setConditionMode('preset');
+    await m.element.updateComplete;
+    expect((m.element as any)._modelIOForm.conditionMode).to.equal('preset');
+    expect(ruleDialog(m.element).querySelector('.preset-card.selected')).to.not
+      .exist;
+  });
+
+  it('R9 header Describe a change opens the generate dialog', async () => {
+    const m = await mount();
+    stub = m.stub;
+    headerButton(m.element, 'Describe a change').click();
+    await waitUntil(
+      () => (m.element as any)._showGenerateDialog === true,
+      'generate dialog never opened'
+    );
+    await m.element.updateComplete;
+    const gen = m.element.shadowRoot!.querySelector(
+      'policy-generate-dialog'
+    ) as PolicyGenerateDialog;
+    expect(gen.open).to.be.true;
+  });
+
+  it('R10 collapsing Full generated YAML closes the generate dialog and wipes the result', async () => {
+    const calls: StubOpts['calls'] = [];
+    stub = stubFetch({ calls });
+    const gen = (await fixture(
+      html`<policy-generate-dialog
+        open
+        currentYaml=""
+      ></policy-generate-dialog>`
+    )) as PolicyGenerateDialog;
+    (gen as any)._prompt = 'deny everything';
+    await gen.updateComplete;
+    const generate = Array.from(
+      gen.shadowRoot!.querySelectorAll('sl-button')
+    ).find((b) => b.textContent?.includes('Generate')) as HTMLElement;
+    generate.click();
+    await waitUntil(() => Boolean((gen as any)._generatedYaml), 'no yaml');
+    await gen.updateComplete;
+
+    const details = gen.shadowRoot!.querySelector('sl-details') as any;
+    expect(details).to.exist;
+    await details.show();
+    await details.hide();
+    await gen.updateComplete;
+
+    expect(gen.open, 'dialog closed by inner sl-details').to.be.false;
+    expect((gen as any)._generatedYaml).to.equal('');
+  });
+});

--- a/frontend/src/views/authed/policies-view.repro.test.ts
+++ b/frontend/src/views/authed/policies-view.repro.test.ts
@@ -167,29 +167,30 @@ describe('Policies page repro', () => {
     expect(ruleDialog(m.element).open).to.be.true;
   });
 
-  it('R2 Save with the default form gives no feedback inside the dialog', async () => {
+  it('R2 Save with the default form shows the error inside the dialog', async () => {
     const m = await mount();
     stub = m.stub;
     headerButton(m.element, 'Add rule').click();
     await m.element.updateComplete;
-    // Default form: preset selected, id empty. A user clicks Save.
-    dialogSave(m.element).click();
-    await waitUntil(() => Boolean((m.element as any)._error), 'no error set');
+    // Default form: preset selected, id empty. Save is disabled; calling
+    // save still writes the message into the dialog, not the page overlay.
+    const save = dialogSave(m.element) as HTMLButtonElement;
+    expect(save.disabled, 'Save stays off until the id is filled').to.be.true;
+    await (m.element as any).saveModelIORule();
     await m.element.updateComplete;
 
     const posted = m.calls.filter(
       (c) => c.url.endsWith('/policies/model-io-rules') && c.method === 'POST'
     );
     expect(posted).to.have.length(0);
-    expect((m.element as any)._error).to.contain('Rule id is required');
-    expect(ruleDialog(m.element).open, 'dialog stays open').to.be.true;
-    // The message is rendered outside the modal, behind the overlay.
-    expect(ruleDialog(m.element).textContent).to.not.contain(
+    expect((m.element as any)._ruleDialogError).to.contain(
       'Rule id is required'
     );
+    expect(ruleDialog(m.element).open, 'dialog stays open').to.be.true;
+    expect(ruleDialog(m.element).textContent).to.contain('Rule id is required');
   });
 
-  it('R3 API 403 on Save leaves the dialog open with the error behind it', async () => {
+  it('R3 API 403 on Save shows the error inside the dialog', async () => {
     const m = await mount({ createStatus: 403 });
     stub = m.stub;
     headerButton(m.element, 'Add rule').click();
@@ -200,14 +201,15 @@ describe('Policies page repro', () => {
     await m.element.updateComplete;
 
     dialogSave(m.element).click();
-    await waitUntil(() => Boolean((m.element as any)._error), 'no error set');
+    await waitUntil(
+      () => Boolean((m.element as any)._ruleDialogError),
+      'no error set'
+    );
     await m.element.updateComplete;
 
-    expect((m.element as any)._error).to.contain('Permission denied');
+    expect((m.element as any)._ruleDialogError).to.contain('Permission denied');
     expect(ruleDialog(m.element).open).to.be.true;
-    expect(ruleDialog(m.element).textContent).to.not.contain(
-      'Permission denied'
-    );
+    expect(ruleDialog(m.element).textContent).to.contain('Permission denied');
   });
 
   it('R4 picking a second preset keeps the first preset id', async () => {

--- a/frontend/src/views/authed/policies-view.repro.test.ts
+++ b/frontend/src/views/authed/policies-view.repro.test.ts
@@ -212,7 +212,7 @@ describe('Policies page repro', () => {
     expect(ruleDialog(m.element).textContent).to.contain('Permission denied');
   });
 
-  it('R4 picking a second preset keeps the first preset id', async () => {
+  it('R4 picking a second preset updates the id to match', async () => {
     const m = await mount();
     stub = m.stub;
     headerButton(m.element, 'Add rule').click();
@@ -227,7 +227,7 @@ describe('Policies page repro', () => {
     await m.element.updateComplete;
     const form = (m.element as any)._modelIOForm;
     expect(form.presetId).to.equal('flag-injection');
-    expect(form.id).to.equal('block-pii-prompts');
+    expect(form.id).to.equal('flag-injection');
   });
 
   it('R5 a saved tool access rule is shown as allow / true', async () => {

--- a/frontend/src/views/authed/policies-view.repro.test.ts
+++ b/frontend/src/views/authed/policies-view.repro.test.ts
@@ -329,7 +329,7 @@ describe('Policies page repro', () => {
     expect(gen.open).to.be.true;
   });
 
-  it('R10 collapsing Full generated YAML closes the generate dialog and wipes the result', async () => {
+  it('R10 collapsing Full generated YAML keeps the generate dialog and yaml', async () => {
     const calls: StubOpts['calls'] = [];
     stub = stubFetch({ calls });
     const gen = (await fixture(
@@ -353,7 +353,7 @@ describe('Policies page repro', () => {
     await details.hide();
     await gen.updateComplete;
 
-    expect(gen.open, 'dialog closed by inner sl-details').to.be.false;
-    expect((gen as any)._generatedYaml).to.equal('');
+    expect(gen.open, 'inner sl-details must not close the dialog').to.be.true;
+    expect((gen as any)._generatedYaml).to.contain('version:');
   });
 });

--- a/frontend/src/views/authed/policies-view.repro.test.ts
+++ b/frontend/src/views/authed/policies-view.repro.test.ts
@@ -297,7 +297,7 @@ describe('Policies page repro', () => {
     expect(post.body.condition_expression).to.contain('contains(');
   });
 
-  it('R8 editing a rule then choosing Start from a preset selects nothing', async () => {
+  it('R8 editing a rule then choosing Start from a preset selects one', async () => {
     const rule = {
       id: 'r1',
       target: 'model.request',
@@ -316,7 +316,7 @@ describe('Policies page repro', () => {
     (m.element as any)._setConditionMode('preset');
     await m.element.updateComplete;
     expect((m.element as any)._modelIOForm.conditionMode).to.equal('preset');
-    expect(ruleDialog(m.element).querySelector('.preset-card.selected')).to.not
+    expect(ruleDialog(m.element).querySelector('.preset-card.selected')).to
       .exist;
   });
 

--- a/frontend/src/views/authed/policies-view.repro.test.ts
+++ b/frontend/src/views/authed/policies-view.repro.test.ts
@@ -270,7 +270,7 @@ describe('Policies page repro', () => {
     expect(cardEl.querySelectorAll('sl-button')).to.have.length(2);
   });
 
-  it('R7 tool rule Save posts condition_type simple with a CEL expression', async () => {
+  it('R7 tool rule Save posts condition_type cel for a CEL expression', async () => {
     const m = await mount({
       tools: [{ ...toolWithDenyRule, config_id: null, access_rules: [] }],
     });
@@ -293,7 +293,7 @@ describe('Policies page repro', () => {
     expect(post.url).to.contain(
       '/api/v1/tool-configurations/cfg-new/access-rules'
     );
-    expect(post.body.condition_type).to.equal('simple');
+    expect(post.body.condition_type).to.equal('cel');
     expect(post.body.condition_expression).to.contain('contains(');
   });
 

--- a/frontend/src/views/authed/policies-view.test.ts
+++ b/frontend/src/views/authed/policies-view.test.ts
@@ -406,6 +406,8 @@ describe('PoliciesView', () => {
     const current = 'version: "1.0"\nmetadata:\n  name: current';
     const generated = 'version: "1.0"\nmetadata:\n  name: edited';
     let uploaded = false;
+    let previewed = false;
+    let uploadBeforeDiff = false;
     fetchStub = sinon
       .stub(window, 'fetch')
       .callsFake(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -433,9 +435,17 @@ describe('PoliciesView', () => {
           return json({ yaml: generated, warnings: [] });
         }
         if (url.endsWith('/api/v1/policies/diff') && method === 'POST') {
-          return json({ summary: '1 modified', has_changes: true });
+          previewed = true;
+          return json({
+            summary: '1 modified',
+            has_changes: true,
+            changes: { added: [], removed: [], modified: [] },
+          });
         }
         if (url.endsWith('/api/v1/policies/upload') && method === 'POST') {
+          if (!previewed) {
+            uploadBeforeDiff = true;
+          }
           uploaded = true;
           return json({ success: true, policy_name: 'edited' });
         }
@@ -471,8 +481,19 @@ describe('PoliciesView', () => {
     await dialog._generate();
     await dialog.updateComplete;
     dialog._applyPolicy();
-    await waitUntil(() => uploaded, 'Save did not apply');
+    await waitUntil(
+      () => (element as any)._showDiffDialog === true,
+      'Save did not open the diff dialog'
+    );
+    expect(previewed).to.be.true;
+    expect(uploaded).to.be.false;
+    expect((element as any)._showGenerateDialog).to.be.true;
+
+    await (element as any).applyPolicyFile();
+    await waitUntil(() => uploaded, 'Confirm did not apply');
     expect(uploaded).to.be.true;
+    expect(uploadBeforeDiff).to.be.false;
+    expect((element as any)._showGenerateDialog).to.be.false;
   });
 
   describe('YAML tab', () => {

--- a/frontend/src/views/authed/policies-view.test.ts
+++ b/frontend/src/views/authed/policies-view.test.ts
@@ -767,6 +767,14 @@ describe('PoliciesView', () => {
       return element;
     }
 
+    it('shows Manage workflows when the action is require_approval', async () => {
+      const element = await mountWithDialog();
+      (element as any)._patchModelIOForm({ action: 'require_approval' });
+      await element.updateComplete;
+
+      expect(element.shadowRoot?.textContent).to.contain('Manage workflows');
+    });
+
     it('stays open when an inner select hides', async () => {
       const element = await mountWithDialog();
 

--- a/frontend/src/views/authed/policies-view.test.ts
+++ b/frontend/src/views/authed/policies-view.test.ts
@@ -3,7 +3,26 @@ import sinon from 'sinon';
 
 import '../../components/view-header.ts';
 import './policies-view';
+import { conditionTypeFor } from './policies-view';
 import type { PoliciesView } from './policies-view';
+
+describe('conditionTypeFor', () => {
+  it('classifies simple comparisons as simple', () => {
+    expect(conditionTypeFor('moderation.flagged == true')).to.equal('simple');
+    expect(conditionTypeFor('injection.score > 0.7')).to.equal('simple');
+    expect(conditionTypeFor('pii.found != true')).to.equal('simple');
+  });
+
+  it('classifies CEL operators and functions as cel', () => {
+    expect(conditionTypeFor('!args.enabled')).to.equal('cel');
+    expect(conditionTypeFor("args.priority in ['critical','high']")).to.equal(
+      'cel'
+    );
+    expect(conditionTypeFor('args.ok ? true : false')).to.equal('cel');
+    expect(conditionTypeFor('args.name.contains("x")')).to.equal('cel');
+    expect(conditionTypeFor('a && b')).to.equal('cel');
+  });
+});
 
 describe('PoliciesView', () => {
   let fetchStub: sinon.SinonStub;

--- a/frontend/src/views/authed/policies-view.test.ts
+++ b/frontend/src/views/authed/policies-view.test.ts
@@ -83,6 +83,23 @@ describe('PoliciesView', () => {
           });
         }
 
+        if (
+          url.includes('/api/v1/policies/versions/') &&
+          url.includes('/rollback') &&
+          method === 'POST'
+        ) {
+          return json({
+            success: true,
+            message: 'preview',
+            preview_only: true,
+            changes: {
+              summary: '1 change',
+              has_changes: true,
+              changes: { added: [], removed: [], modified: [] },
+            },
+          });
+        }
+
         if (url.includes('/api/v1/policies/versions')) {
           if (opts.emptyVersions) {
             return json([]);
@@ -767,6 +784,18 @@ describe('PoliciesView', () => {
       return element;
     }
 
+    it('encodes tool option values so names with spaces stay intact', async () => {
+      const element = await mountWithDialog();
+      (element as any)._patchModelIOForm({ ruleType: 'tool' });
+      await element.updateComplete;
+      const option = element.shadowRoot?.querySelector(
+        '[data-testid="rule-dialog"] sl-option'
+      );
+      expect(option?.getAttribute('value')).to.equal(
+        encodeURIComponent('search_issues')
+      );
+    });
+
     it('shows Manage workflows when the action is require_approval', async () => {
       const element = await mountWithDialog();
       (element as any)._patchModelIOForm({ action: 'require_approval' });
@@ -941,5 +970,44 @@ describe('PoliciesView', () => {
         );
       expect(posted).to.have.length(0);
     });
+  });
+
+  it('View Diff opens the preview without a Confirm Rollback button', async () => {
+    fetchStub = createFetchStub();
+    const element = (await fixture(
+      html`<policies-view></policies-view>`
+    )) as PoliciesView;
+    await waitUntil(() => !(element as any)._loading, 'still loading');
+    (element as any)._activeTab = 'files';
+    await (element as any).loadVersions();
+    await element.updateComplete;
+
+    const version = {
+      id: 'ver-2',
+      version_number: 2,
+      tag: null,
+      description: 'Older',
+      created_at: '2026-05-01T10:00:00Z',
+      created_by_username: 'alice',
+      is_active: false,
+      snapshot_summary: {
+        mcp_servers_count: 0,
+        tools_count: 1,
+        policies_count: 0,
+      },
+    };
+    await (element as any).openRollbackPreview(version, false);
+    await waitUntil(
+      () => (element as any)._showRollbackDialog === true,
+      'diff dialog did not open'
+    );
+    await element.updateComplete;
+
+    const dialog = element.shadowRoot?.querySelector(
+      'sl-dialog[label="Version Diff"]'
+    );
+    expect(dialog).to.exist;
+    expect(dialog?.textContent).to.not.contain('Confirm Rollback');
+    expect((element as any)._rollbackConfirmVisible).to.be.false;
   });
 });

--- a/frontend/src/views/authed/policies-view.test.ts
+++ b/frontend/src/views/authed/policies-view.test.ts
@@ -901,7 +901,7 @@ describe('PoliciesView', () => {
       });
       await (element as any).saveModelIORule();
 
-      expect((element as any)._error).to.contain('needs a condition');
+      expect((element as any)._ruleDialogError).to.contain('needs a condition');
       expect((element as any)._showModelIODialog).to.be.true;
       const posted = fetchStub
         .getCalls()

--- a/frontend/src/views/authed/policies-view.ts
+++ b/frontend/src/views/authed/policies-view.ts
@@ -264,6 +264,7 @@ export class PoliciesView extends LitElement {
   @state() private _showPruneDialog = false;
   @state() private _showTagDialog = false;
   @state() private _showRollbackDialog = false;
+  @state() private _rollbackConfirmVisible = true;
   @state() private _rollbackPreview: RollbackResponse | null = null;
   @state() private _savingVersion = false;
   @state() private _pruningVersions = false;
@@ -1723,7 +1724,8 @@ export class PoliciesView extends LitElement {
     this._showTagDialog = true;
   }
 
-  private openRollbackPreview(version: PolicyVersion) {
+  private openRollbackPreview(version: PolicyVersion, confirmRollback = true) {
+    this._rollbackConfirmVisible = confirmRollback;
     this._versionToRollback = version;
     this.rollbackToVersion(version.id, true);
   }
@@ -1982,7 +1984,7 @@ export class PoliciesView extends LitElement {
           <p class="model-io-hint">
             ${
               isTool
-                ? 'Runs when an agent calls a tool through the firewall.'
+                ? 'Runs when an agent calls a tool through the firewall. Saving a tool rule needs the Tools permission, not only Policies.'
                 : 'Runs on text going to or coming back from a model.'
             }
           </p>
@@ -1994,13 +1996,17 @@ export class PoliciesView extends LitElement {
                 <div class="form-group">
                   <label>Tool</label>
                   <sl-select
-                    .value=${form.toolName}
+                    .value=${
+                      form.toolName ? encodeURIComponent(form.toolName) : ''
+                    }
                     @sl-change=${(e: any) =>
-                      this._patchModelIOForm({ toolName: e.target.value })}
+                      this._patchModelIOForm({
+                        toolName: decodeURIComponent(e.target.value),
+                      })}
                   >
                     ${this._tools.map(
                       (tool) =>
-                        html`<sl-option value=${tool.name}
+                        html`<sl-option value=${encodeURIComponent(tool.name)}
                           >${tool.name}</sl-option
                         >`
                     )}
@@ -2572,14 +2578,14 @@ defaults:
             <sl-tooltip content="View Diff">
               <sl-icon-button
                 name="file-diff"
-                @click=${() => this.openRollbackPreview(version)}
+                @click=${() => this.openRollbackPreview(version, false)}
                 ?disabled=${version.is_active}
               ></sl-icon-button>
             </sl-tooltip>
             <sl-tooltip content="Rollback to this version">
               <sl-icon-button
                 name="arrow-counterclockwise"
-                @click=${() => this.openRollbackPreview(version)}
+                @click=${() => this.openRollbackPreview(version, true)}
                 ?disabled=${version.is_active}
               ></sl-icon-button>
             </sl-tooltip>
@@ -2824,7 +2830,9 @@ defaults:
   private renderRollbackConfirmDialog() {
     return html`
       <sl-dialog
-        label="Rollback to Version"
+        label=${
+          this._rollbackConfirmVisible ? 'Rollback to Version' : 'Version Diff'
+        }
         ?open=${this._showRollbackDialog}
         @sl-request-close=${() => {
           this._showRollbackDialog = false;
@@ -2836,16 +2844,27 @@ defaults:
         ${
           this._versionToRollback
             ? html`
-                <div class="rollback-warning">
-                  <sl-icon name="exclamation-triangle"></sl-icon>
-                  <div>
-                    <strong>Warning:</strong> Rolling back will replace your
-                    current policy configuration with the snapshot from version
-                    ${this._versionToRollback.version_number}. This action
-                    cannot be automatically undone.
-                  </div>
-                </div>
-
+                ${
+                  this._rollbackConfirmVisible
+                    ? html`
+                        <div class="rollback-warning">
+                          <sl-icon name="exclamation-triangle"></sl-icon>
+                          <div>
+                            <strong>Warning:</strong> Rolling back will replace
+                            your current policy configuration with the snapshot
+                            from version
+                            ${this._versionToRollback.version_number}. This
+                            action cannot be automatically undone.
+                          </div>
+                        </div>
+                      `
+                    : html`
+                        <p style="margin-top: 0;">
+                          Diff for version
+                          ${this._versionToRollback.version_number}.
+                        </p>
+                      `
+                }
                 ${
                   this._rollbackPreview
                     ? html`
@@ -2973,18 +2992,25 @@ defaults:
                   >
                     Cancel
                   </sl-button>
-                  <sl-button
-                    variant="danger"
-                    @click=${() =>
-                      this.rollbackToVersion(
-                        this._versionToRollback!.id,
-                        false
-                      )}
-                    ?loading=${this._rollingBack}
-                    ?disabled=${!this._rollbackPreview?.changes?.has_changes}
-                  >
-                    Confirm Rollback
-                  </sl-button>
+                  ${
+                    this._rollbackConfirmVisible
+                      ? html`
+                          <sl-button
+                            variant="danger"
+                            @click=${() =>
+                              this.rollbackToVersion(
+                                this._versionToRollback!.id,
+                                false
+                              )}
+                            ?loading=${this._rollingBack}
+                            ?disabled=${!this._rollbackPreview?.changes
+                              ?.has_changes}
+                          >
+                            Confirm Rollback
+                          </sl-button>
+                        `
+                      : ''
+                  }
                 </div>
               `
             : ''

--- a/frontend/src/views/authed/policies-view.ts
+++ b/frontend/src/views/authed/policies-view.ts
@@ -4,9 +4,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import {
   getTools,
   getApprovalWorkflows,
-  deleteApprovalWorkflow,
   createToolConfiguration,
-  updateToolConfiguration,
   getFeatures,
   fetchWithAuth,
   listModelIORules,
@@ -22,7 +20,6 @@ import type { AccessRule, ModelIORule } from '../../api';
 import type { Tool, ApprovalWorkflow } from '../../components/tool-card';
 import '../../components/policy-generate-dialog';
 import '../../components/view-header';
-import '../../components/approval-workflow-dialog';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
@@ -62,15 +59,6 @@ interface ToolAccessRule {
   configId: string | null;
   accessRuleId: string | null;
   accessRule: AccessRule | null;
-}
-
-// Types for policy file history
-interface PolicyFileHistory {
-  id: string;
-  filename: string;
-  appliedAt: string;
-  summary: string;
-  status: 'applied' | 'pending' | 'failed';
 }
 
 // Types for diff result
@@ -220,7 +208,6 @@ export class PoliciesView extends LitElement {
 
   // Access policies state
   @state() private _toolAccessRules: ToolAccessRule[] = [];
-  @state() private _expandedTools: Set<string> = new Set();
 
   // Model I/O content policies
   @state() private _modelIORules: ModelIORule[] = [];
@@ -247,12 +234,7 @@ export class PoliciesView extends LitElement {
     idTouched: false,
   };
 
-  // Approval workflows state
-  @state() private _showPolicyDialog = false;
-  @state() private _editingPolicy: ApprovalWorkflow | null = null;
-
   // Policy files state
-  @state() private _policyFileHistory: PolicyFileHistory[] = [];
   @state() private _showDiffDialog = false;
   @state() private _diffResult: PolicyDiffResult | null = null;
   @state() private _pendingFile: File | null = null;
@@ -565,137 +547,11 @@ export class PoliciesView extends LitElement {
         flex: 1;
       }
 
-      /* Approval Workflows Tab */
-      .policies-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-        gap: var(--sl-spacing-large);
-      }
-
-      .policy-card {
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-      }
-
-      .policy-card-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        margin-bottom: var(--sl-spacing-small);
-      }
-
-      .policy-name {
-        font-size: var(--sl-font-size-large);
-        font-weight: var(--sl-font-weight-semibold);
-        margin: 0;
-      }
-
-      .policy-description {
-        font-size: var(--sl-font-size-small);
-        color: var(--sl-color-neutral-600);
-        margin: 0 0 var(--sl-spacing-medium) 0;
-        line-height: 1.5;
-      }
-
-      .policy-meta {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--sl-spacing-small);
-        font-size: var(--sl-font-size-x-small);
-        color: var(--sl-color-neutral-600);
-      }
-
-      .policy-meta-item {
-        display: flex;
-        align-items: center;
-        gap: var(--sl-spacing-2x-small);
-      }
-
-      sl-card::part(footer) {
-        display: flex;
-        justify-content: flex-end;
-        gap: var(--sl-spacing-small);
-        padding: var(--sl-spacing-medium);
-        border-top: 1px solid var(--sl-color-neutral-200);
-      }
-
       /* Policy Files Tab */
       .policy-files-container {
         display: flex;
         flex-direction: column;
         gap: var(--sl-spacing-large);
-      }
-
-      .upload-area {
-        border: 2px dashed var(--sl-color-neutral-300);
-        border-radius: var(--sl-border-radius-large);
-        padding: var(--sl-spacing-2x-large);
-        text-align: center;
-        background: var(--sl-color-neutral-50);
-        transition: all 0.2s;
-      }
-
-      .upload-area:hover {
-        border-color: var(--sl-color-primary-400);
-        background: var(--sl-color-primary-50);
-      }
-
-      .upload-area.drag-over {
-        border-color: var(--sl-color-primary-600);
-        background: var(--sl-color-primary-100);
-      }
-
-      .upload-icon {
-        font-size: 3rem;
-        color: var(--sl-color-neutral-400);
-        margin-bottom: var(--sl-spacing-medium);
-      }
-
-      .upload-text {
-        font-size: var(--sl-font-size-medium);
-        color: var(--sl-color-neutral-700);
-        margin-bottom: var(--sl-spacing-small);
-      }
-
-      .upload-hint {
-        font-size: var(--sl-font-size-small);
-        color: var(--sl-color-neutral-500);
-      }
-
-      .history-list {
-        display: flex;
-        flex-direction: column;
-        gap: var(--sl-spacing-small);
-      }
-
-      .history-item {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: var(--sl-spacing-medium);
-        background: var(--sl-color-neutral-50);
-        border-radius: var(--sl-border-radius-medium);
-        border-left: 3px solid var(--sl-color-primary-600);
-      }
-
-      .history-item.failed {
-        border-left-color: var(--sl-color-danger-600);
-      }
-
-      .history-info {
-        display: flex;
-        flex-direction: column;
-        gap: var(--sl-spacing-2x-small);
-      }
-
-      .history-filename {
-        font-weight: var(--sl-font-weight-semibold);
-      }
-
-      .history-meta {
-        font-size: var(--sl-font-size-small);
-        color: var(--sl-color-neutral-600);
       }
 
       /* Diff view */
@@ -1002,102 +858,6 @@ export class PoliciesView extends LitElement {
     }
   }
 
-  private hasAdvancedApprovals(): boolean {
-    return this._features['advanced_approvals'] === true;
-  }
-
-  private toggleToolExpanded(toolKey: string) {
-    const newExpanded = new Set(this._expandedTools);
-    if (newExpanded.has(toolKey)) {
-      newExpanded.delete(toolKey);
-    } else {
-      newExpanded.add(toolKey);
-    }
-    this._expandedTools = newExpanded;
-  }
-
-  private getToolKey(rule: ToolAccessRule): string {
-    return `${rule.toolName}-${rule.source}-${rule.sourceId || 'null'}`;
-  }
-
-  private async handleAccessActionChange(
-    rule: ToolAccessRule,
-    newAction: 'allow' | 'deny' | 'require_approval'
-  ) {
-    try {
-      const tool = this._tools.find(
-        (t) =>
-          t.name === rule.toolName &&
-          t.source === rule.source &&
-          t.source_id === rule.sourceId
-      );
-
-      if (!tool) return;
-
-      if (newAction === 'deny') {
-        // Disable the tool
-        if (tool.config_id) {
-          await updateToolConfiguration(tool.config_id, {
-            is_enabled: false,
-            approval_workflow_id: null,
-          });
-        } else {
-          await createToolConfiguration({
-            tool_name: tool.name,
-            tool_source: tool.source,
-            mcp_server_id: tool.source_id,
-            is_enabled: false,
-            account_id: '',
-          });
-        }
-      } else if (newAction === 'allow') {
-        // Enable the tool without approval
-        if (tool.config_id) {
-          await updateToolConfiguration(tool.config_id, {
-            is_enabled: true,
-            approval_workflow_id: null,
-          });
-        } else {
-          await createToolConfiguration({
-            tool_name: tool.name,
-            tool_source: tool.source,
-            mcp_server_id: tool.source_id,
-            is_enabled: true,
-            account_id: '',
-          });
-        }
-      } else if (newAction === 'require_approval') {
-        // Enable with default approval workflow
-        const defaultPolicy =
-          this._approvalPolicies.find((p) => p.is_default) ||
-          this._approvalPolicies[0];
-        if (tool.config_id) {
-          await updateToolConfiguration(tool.config_id, {
-            is_enabled: true,
-            approval_workflow_id: defaultPolicy?.id || null,
-          });
-        } else {
-          await createToolConfiguration({
-            tool_name: tool.name,
-            tool_source: tool.source,
-            mcp_server_id: tool.source_id,
-            is_enabled: true,
-            approval_workflow_id: defaultPolicy?.id || null,
-            account_id: '',
-          });
-        }
-      }
-
-      await this.loadData();
-    } catch (err: any) {
-      this._error = err.message || 'Failed to update tool access';
-    }
-  }
-
-  /**
-   * Pull the active policy YAML. Returns false when the export failed so
-   * callers can surface the problem instead of opening an empty editor.
-   */
   private async _refreshCurrentExport(): Promise<boolean> {
     try {
       const response = await fetchWithAuth(
@@ -1503,33 +1263,6 @@ export class PoliciesView extends LitElement {
 
   private primaryModelIOAction(rule: ModelIORule): string {
     return rule.conditions?.[0]?.action || 'allow';
-  }
-
-  private openPolicyDialog(policy: ApprovalWorkflow | null = null) {
-    this._editingPolicy = policy;
-    this._showPolicyDialog = true;
-  }
-
-  private closePolicyDialog() {
-    this._showPolicyDialog = false;
-    this._editingPolicy = null;
-  }
-
-  private async deletePolicy(policy: ApprovalWorkflow) {
-    if (
-      !confirm(
-        `Are you sure you want to delete the policy "${policy.name}"? This cannot be undone.`
-      )
-    ) {
-      return;
-    }
-
-    try {
-      await deleteApprovalWorkflow(policy.id);
-      await this.loadData();
-    } catch (err: any) {
-      this._error = err.message || 'Failed to delete policy';
-    }
   }
 
   private async handleFileUpload(event: Event) {
@@ -2219,108 +1952,6 @@ export class PoliciesView extends LitElement {
     `;
   }
 
-  private renderModelIOTab() {
-    return html`
-      <div style="margin-bottom: var(--sl-spacing-large);">
-        <sl-button variant="primary" @click=${() => this.openModelIODialog()}>
-          <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-          Add model I/O rule
-        </sl-button>
-      </div>
-      <p class="model-io-hint">
-        Inspect model prompts and completions with the same allow, deny, and
-        require_approval actions as tools. Attributes:
-        <code>pii.found</code>, <code>pii.types_found</code>,
-        <code>injection.score</code>, <code>moderation.flagged</code>,
-        <code>model.id</code>, <code>session.id</code>,
-        <code>request.text</code>, <code>response.text</code>.
-      </p>
-      ${
-        this._modelIORules.length === 0
-          ? html`
-              <div class="empty-state">
-                <sl-icon name="shield-lock"></sl-icon>
-                <p>No model I/O rules yet.</p>
-                <p class="model-io-hint">
-                  Add a rule here or import YAML. Traffic is allowed when no
-                  rule matches.
-                </p>
-              </div>
-            `
-          : html`
-              <div class="access-rules-list">
-                ${repeat(
-                  this._modelIORules,
-                  (rule) => rule.id,
-                  (rule) => this.renderModelIORuleCard(rule)
-                )}
-              </div>
-            `
-      }
-      ${this.renderModelIODialog()}
-    `;
-  }
-
-  private renderModelIORuleCard(rule: ModelIORule) {
-    const action = this.primaryModelIOAction(rule);
-    return html`
-      <div class="access-rule-card" data-model-io-id=${rule.id}>
-        <div class="access-rule-header">
-          <div class="access-rule-info">
-            <div>
-              <div class="access-rule-name">${rule.id}</div>
-              <div class="access-rule-source">${rule.target}</div>
-            </div>
-          </div>
-          <div class="access-rule-actions">
-            <sl-badge
-              variant=${
-                action === 'allow'
-                  ? 'success'
-                  : action === 'deny'
-                    ? 'danger'
-                    : 'warning'
-              }
-            >
-              ${action}
-            </sl-badge>
-            <sl-badge variant=${rule.enabled !== false ? 'neutral' : 'neutral'}>
-              ${rule.enabled !== false ? 'Enabled' : 'Disabled'}
-            </sl-badge>
-            <sl-button
-              size="small"
-              @click=${() => this.openModelIODialog(rule)}
-            >
-              Edit
-            </sl-button>
-            <sl-button
-              size="small"
-              @click=${() => this.toggleModelIOEnabled(rule)}
-            >
-              ${rule.enabled !== false ? 'Disable' : 'Enable'}
-            </sl-button>
-            <sl-button
-              size="small"
-              variant="danger"
-              outline
-              @click=${() => this.removeModelIORule(rule)}
-            >
-              Delete
-            </sl-button>
-          </div>
-        </div>
-        <div class="access-rule-details">
-          <div class="rule-row">
-            <span class="rule-label">Condition:</span>
-            <span class="rule-value">
-              <code>${rule.conditions?.[0]?.expression || 'true'}</code>
-            </span>
-          </div>
-        </div>
-      </div>
-    `;
-  }
-
   private renderModelIODialog() {
     const form = this._modelIOForm;
     const isTool = form.ruleType === 'tool';
@@ -2428,20 +2059,38 @@ export class PoliciesView extends LitElement {
             ? html`
                 <div class="form-group">
                   <label>Approval workflow</label>
-                  <sl-select
-                    .value=${form.approvalWorkflow}
-                    @sl-change=${(e: any) =>
-                      this._patchModelIOForm({
-                        approvalWorkflow: e.target.value,
-                      })}
+                  ${
+                    this._approvalPolicies.length === 0
+                      ? html`
+                          <p class="model-io-hint">
+                            No approval workflows yet. Create one before you can
+                            require approval.
+                          </p>
+                        `
+                      : html`
+                          <sl-select
+                            .value=${form.approvalWorkflow}
+                            @sl-change=${(e: any) =>
+                              this._patchModelIOForm({
+                                approvalWorkflow: e.target.value,
+                              })}
+                          >
+                            ${this._approvalPolicies.map(
+                              (policy) =>
+                                html`<sl-option value=${policy.name}
+                                  >${policy.name}</sl-option
+                                >`
+                            )}
+                          </sl-select>
+                        `
+                  }
+                  <sl-button
+                    size="small"
+                    variant="text"
+                    href="/console/approvals"
                   >
-                    ${this._approvalPolicies.map(
-                      (policy) =>
-                        html`<sl-option value=${policy.name}
-                          >${policy.name}</sl-option
-                        >`
-                    )}
-                  </sl-select>
+                    Manage workflows
+                  </sl-button>
                 </div>
               `
             : ''
@@ -2656,299 +2305,6 @@ export class PoliciesView extends LitElement {
     `;
   }
 
-  private renderAccessPoliciesTab() {
-    const sortedRules = [...this._toolAccessRules].sort((a, b) => {
-      // Sort by source first, then by name
-      if (a.source !== b.source) {
-        if (a.source === 'builtin') return -1;
-        if (b.source === 'builtin') return 1;
-      }
-      return a.toolName.localeCompare(b.toolName);
-    });
-
-    return html`
-      <div class="access-rules-list">
-        ${
-          sortedRules.length === 0
-            ? html`
-                <div class="empty-state">
-                  <sl-icon name="tools"></sl-icon>
-                  <p>No tools configured. Add an MCP server to get started.</p>
-                  <sl-button href="/console/tools" variant="primary">
-                    Go to Tools
-                  </sl-button>
-                </div>
-              `
-            : repeat(
-                sortedRules,
-                (rule) => this.getToolKey(rule),
-                (rule) => this.renderAccessRuleCard(rule)
-              )
-        }
-      </div>
-    `;
-  }
-
-  private renderAccessRuleCard(rule: ToolAccessRule) {
-    const toolKey = this.getToolKey(rule);
-    const isExpanded = this._expandedTools.has(toolKey);
-    const assignedPolicy = this._approvalPolicies.find(
-      (p) => p.id === rule.workflowId
-    );
-
-    return html`
-      <div class="access-rule-card">
-        <div
-          class="access-rule-header"
-          @click=${() => this.toggleToolExpanded(toolKey)}
-        >
-          <div class="access-rule-info">
-            <sl-icon
-              name=${isExpanded ? 'chevron-down' : 'chevron-right'}
-            ></sl-icon>
-            <div>
-              <div class="access-rule-name">${rule.toolName}</div>
-              <div class="access-rule-source">${rule.sourceName}</div>
-            </div>
-          </div>
-          <div
-            class="access-rule-actions"
-            @click=${(e: Event) => e.stopPropagation()}
-          >
-            <sl-badge
-              variant=${
-                rule.action === 'allow'
-                  ? 'success'
-                  : rule.action === 'deny'
-                    ? 'danger'
-                    : 'warning'
-              }
-            >
-              ${
-                rule.action === 'allow'
-                  ? 'Allowed'
-                  : rule.action === 'deny'
-                    ? 'Denied'
-                    : 'Approval Required'
-              }
-            </sl-badge>
-            <sl-select
-              size="small"
-              value=${rule.action}
-              @sl-change=${(e: any) =>
-                this.handleAccessActionChange(rule, e.target.value)}
-              style="min-width: 160px;"
-            >
-              <sl-option value="allow">Allow</sl-option>
-              <sl-option value="deny">Deny</sl-option>
-              <sl-option value="require_approval">Require Approval</sl-option>
-            </sl-select>
-          </div>
-        </div>
-        ${
-          isExpanded
-            ? html`
-                <div class="access-rule-details">
-                  <div class="rule-row">
-                    <span class="rule-label">Source:</span>
-                    <span class="rule-value">
-                      <sl-badge variant="neutral" size="small">
-                        ${rule.source}
-                      </sl-badge>
-                    </span>
-                  </div>
-                  <div class="rule-row">
-                    <span class="rule-label">Enabled:</span>
-                    <span class="rule-value">
-                      ${rule.isEnabled ? 'Yes' : 'No'}
-                    </span>
-                  </div>
-                  ${
-                    rule.action === 'require_approval'
-                      ? html`
-                          <div class="rule-row">
-                            <span class="rule-label">Policy:</span>
-                            <span class="rule-value">
-                              ${
-                                assignedPolicy
-                                  ? assignedPolicy.name
-                                  : 'Default Policy'
-                              }
-                            </span>
-                          </div>
-                          ${
-                            rule.condition
-                              ? html`
-                                  <div class="rule-row">
-                                    <span class="rule-label">Condition:</span>
-                                    <span class="rule-value">
-                                      <code>${rule.condition}</code>
-                                    </span>
-                                  </div>
-                                `
-                              : ''
-                          }
-                        `
-                      : ''
-                  }
-                </div>
-              `
-            : ''
-        }
-      </div>
-    `;
-  }
-
-  private renderApprovalPoliciesTab() {
-    return html`
-      <div style="margin-bottom: var(--sl-spacing-large);">
-        <sl-button variant="primary" @click=${() => this.openPolicyDialog()}>
-          <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-          Create Approval Workflow
-        </sl-button>
-      </div>
-
-      ${
-        this._approvalPolicies.length === 0
-          ? html`
-              <div class="empty-state">
-                <sl-icon name="shield-check"></sl-icon>
-                <p>No approval workflows configured yet.</p>
-                <p
-                  style="font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-500);"
-                >
-                  Create an approval workflow to define how tool executions are
-                  approved (human, AI, Slack, etc.).
-                </p>
-              </div>
-            `
-          : html`
-              <div class="policies-grid">
-                ${repeat(
-                  this._approvalPolicies,
-                  (policy) => policy.id,
-                  (policy) => this.renderPolicyCard(policy)
-                )}
-              </div>
-            `
-      }
-
-      <approval-workflow-dialog
-        ?open=${this._showPolicyDialog}
-        .policy=${this._editingPolicy}
-        .existingPolicies=${this._approvalPolicies}
-        .features=${this._features}
-        @close=${this.closePolicyDialog}
-        @saved=${this._handlePolicySaved}
-        @add-model=${this._handleAddModel}
-      ></approval-workflow-dialog>
-    `;
-  }
-
-  private async _handlePolicySaved() {
-    await this.loadData();
-  }
-
-  private _handleAddModel() {
-    // Navigate to model configuration
-    window.location.href = '/console/settings/models';
-  }
-
-  private renderPolicyCard(policy: ApprovalWorkflow) {
-    const isAiDriven = policy.approval_type === 'ai_driven';
-    return html`
-      <sl-card class="policy-card">
-        <div class="card-content">
-          <div class="policy-card-header">
-            <h3 class="policy-name">${policy.name}</h3>
-            <div style="display: flex; gap: var(--sl-spacing-x-small);">
-              ${
-                isAiDriven
-                  ? html`<sl-badge variant="warning">
-                      <sl-icon
-                        name="robot"
-                        style="margin-right: 4px;"
-                      ></sl-icon>
-                      AI-Driven
-                    </sl-badge>`
-                  : ''
-              }
-              ${
-                policy.is_default
-                  ? html`<sl-badge variant="primary">Default</sl-badge>`
-                  : ''
-              }
-            </div>
-          </div>
-          <p class="policy-description">
-            ${policy.description || 'No description'}
-          </p>
-          <div class="policy-meta">
-            ${
-              isAiDriven
-                ? html`
-                    <div class="policy-meta-item">
-                      <sl-icon name="cpu"></sl-icon>
-                      <span>${policy.ai_model || 'No model set'}</span>
-                    </div>
-                    <div class="policy-meta-item">
-                      <sl-icon name="speedometer2"></sl-icon>
-                      <span>
-                        ${Math.round(
-                          (policy.ai_confidence_threshold || 0.8) * 100
-                        )}%
-                        threshold
-                      </span>
-                    </div>
-                    <div class="policy-meta-item">
-                      <sl-badge variant="neutral" size="small">
-                        ${
-                          policy.ai_fallback_behavior === 'escalate'
-                            ? 'Escalates when uncertain'
-                            : policy.ai_fallback_behavior === 'approve'
-                              ? 'Auto-approves when uncertain'
-                              : 'Auto-denies when uncertain'
-                        }
-                      </sl-badge>
-                    </div>
-                  `
-                : html`
-                    <div class="policy-meta-item">
-                      <sl-icon name="clock"></sl-icon>
-                      <span>${policy.timeout_seconds || 300}s timeout</span>
-                    </div>
-                    <div class="policy-meta-item">
-                      <sl-icon name="people"></sl-icon>
-                      <span>${policy.approvals_required || 1} approval(s)</span>
-                    </div>
-                    <div class="policy-meta-item">
-                      <sl-badge variant="neutral" size="small">
-                        ${policy.approval_type}
-                      </sl-badge>
-                    </div>
-                  `
-            }
-          </div>
-        </div>
-        <div slot="footer">
-          <sl-button
-            size="small"
-            variant="danger"
-            outline
-            @click=${() => this.deletePolicy(policy)}
-          >
-            <sl-icon slot="prefix" name="trash"></sl-icon>
-            Delete
-          </sl-button>
-          <sl-button size="small" @click=${() => this.openPolicyDialog(policy)}>
-            <sl-icon slot="prefix" name="pencil"></sl-icon>
-            Edit
-          </sl-button>
-        </div>
-      </sl-card>
-    `;
-  }
-
   private renderPolicyFilesTab() {
     // Load versions once when the tab is first shown. Guard on `_versionsLoaded`
     // (not `_versions.length`) so an empty result does not retrigger the fetch
@@ -3091,50 +2447,6 @@ defaults:
   require_approval: false
   enabled: true</code></pre>
         </sl-details>
-
-        ${
-          this._policyFileHistory.length > 0
-            ? html`
-                <sl-card>
-                  <div slot="header">Import History</div>
-                  <div class="history-list">
-                    ${repeat(
-                      this._policyFileHistory,
-                      (item) => item.id,
-                      (item) => html`
-                        <div
-                          class="history-item ${
-                            item.status === 'failed' ? 'failed' : ''
-                          }"
-                        >
-                          <div class="history-info">
-                            <span class="history-filename"
-                              >${item.filename}</span
-                            >
-                            <span class="history-meta">
-                              ${item.appliedAt} - ${item.summary}
-                            </span>
-                          </div>
-                          <sl-badge
-                            variant=${
-                              item.status === 'applied'
-                                ? 'success'
-                                : item.status === 'failed'
-                                  ? 'danger'
-                                  : 'neutral'
-                            }
-                          >
-                            ${item.status}
-                          </sl-badge>
-                        </div>
-                      `
-                    )}
-                  </div>
-                </sl-card>
-              `
-            : ''
-        }
-
         <!-- Version Management Section -->
         ${this.renderVersionsSection()}
       </div>

--- a/frontend/src/views/authed/policies-view.ts
+++ b/frontend/src/views/authed/policies-view.ts
@@ -218,6 +218,7 @@ export class PoliciesView extends LitElement {
   @state() private _showModelIODialog = false;
   @state() private _editingModelIOId: string | null = null;
   @state() private _savingModelIO = false;
+  @state() private _ruleDialogError = '';
   @state() private _modelIOForm = {
     id: '',
     ruleType: 'model' as 'tool' | 'model',
@@ -1118,6 +1119,7 @@ export class PoliciesView extends LitElement {
   }
 
   private openModelIODialog(rule: ModelIORule | null = null) {
+    this._ruleDialogError = '';
     if (rule) {
       const condition = rule.conditions?.[0];
       const action = (condition?.action || 'deny') as
@@ -1150,6 +1152,7 @@ export class PoliciesView extends LitElement {
   private closeModelIODialog() {
     this._showModelIODialog = false;
     this._editingModelIOId = null;
+    this._ruleDialogError = '';
   }
 
   /**
@@ -1274,14 +1277,14 @@ export class PoliciesView extends LitElement {
       return;
     }
     if (!form.expression.trim() && form.action !== 'allow') {
-      this._error =
+      this._ruleDialogError =
         `A ${form.action} rule needs a condition. An empty condition would ` +
         'match every scanned request.';
       return;
     }
     const rule = this.buildModelIORuleFromForm();
     if (!rule.id) {
-      this._error = 'Rule id is required';
+      this._ruleDialogError = 'Rule id is required';
       return;
     }
     this._savingModelIO = true;
@@ -1294,7 +1297,7 @@ export class PoliciesView extends LitElement {
       this.closeModelIODialog();
       await this.loadData();
     } catch (err: any) {
-      this._error = err.message || 'Failed to save model I/O rule';
+      this._ruleDialogError = err.message || 'Failed to save model I/O rule';
     } finally {
       this._savingModelIO = false;
     }
@@ -1304,7 +1307,7 @@ export class PoliciesView extends LitElement {
     const form = this._modelIOForm;
     const tool = this._tools.find((item) => item.name === form.toolName);
     if (!tool) {
-      this._error = 'Choose a tool';
+      this._ruleDialogError = 'Choose a tool';
       return;
     }
     this._savingModelIO = true;
@@ -1343,7 +1346,7 @@ export class PoliciesView extends LitElement {
       this.closeModelIODialog();
       await this.loadData();
     } catch (err: any) {
-      this._error = err.message || 'Failed to save tool rule';
+      this._ruleDialogError = err.message || 'Failed to save tool rule';
     } finally {
       this._savingModelIO = false;
     }
@@ -2325,6 +2328,16 @@ export class PoliciesView extends LitElement {
               `
             : ''
         }
+        ${
+          this._ruleDialogError
+            ? html`
+                <sl-alert variant="danger" open data-testid="rule-dialog-error">
+                  <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
+                  ${this._ruleDialogError}
+                </sl-alert>
+              `
+            : ''
+        }
 
         <sl-button slot="footer" @click=${this.closeModelIODialog}>
           Cancel
@@ -2333,6 +2346,7 @@ export class PoliciesView extends LitElement {
           slot="footer"
           variant="primary"
           ?loading=${this._savingModelIO}
+          ?disabled=${form.ruleType === 'model' && !form.id.trim()}
           @click=${() => this.saveModelIORule()}
         >
           Save

--- a/frontend/src/views/authed/policies-view.ts
+++ b/frontend/src/views/authed/policies-view.ts
@@ -165,9 +165,28 @@ export const MODEL_IO_PRESETS = [
   },
 ];
 
-/** CEL when the expression uses grouping or boolean operators. */
+/** CEL when the expression uses CEL functions or operators. */
 export function conditionTypeFor(expr: string): 'cel' | 'simple' {
-  return /[()&|]/.test(expr) ? 'cel' : 'simple';
+  if (!expr) return 'simple';
+  const lower = expr.toLowerCase();
+  const celFunctions = [
+    'contains(',
+    'startswith(',
+    'endswith(',
+    'matches(',
+    'exists(',
+    'all(',
+    'filter(',
+    'map(',
+    'size(',
+    'type(',
+    'has(',
+    '.in(',
+    ' in ',
+  ];
+  if (celFunctions.some((fn) => lower.includes(fn))) return 'cel';
+  if (/&&|\|\||\?|\[|\{|(?<!=)!(?!=)/.test(expr)) return 'cel';
+  return 'simple';
 }
 
 /** What each detector adds to the attributes a condition can read. */

--- a/frontend/src/views/authed/policies-view.ts
+++ b/frontend/src/views/authed/policies-view.ts
@@ -1363,13 +1363,10 @@ export class PoliciesView extends LitElement {
     if (!yaml) {
       return;
     }
-    this._pendingFile = new File([yaml], 'generated.yaml', {
+    const file = new File([yaml], 'generated.yaml', {
       type: 'application/x-yaml',
     });
-    // The generated policy becomes the new truth, so the editor resyncs.
-    this._yamlDirty = false;
-    await this.applyPolicyFile();
-    this._showGenerateDialog = false;
+    await this.previewPolicyFile(file);
   }
 
   private async toggleModelIOEnabled(rule: ModelIORule) {
@@ -1491,13 +1488,17 @@ export class PoliciesView extends LitElement {
       }
 
       const fromYamlEditor = this._pendingYamlSave;
+      const fromGenerate = this._showGenerateDialog;
       this._pendingYamlSave = false;
       this._showDiffDialog = false;
       this._pendingFile = null;
       this._diffResult = null;
-      if (fromYamlEditor) {
+      if (fromYamlEditor || fromGenerate) {
         // Resync the editor from the applied export after loadData.
         this._yamlDirty = false;
+      }
+      if (fromGenerate) {
+        this._showGenerateDialog = false;
       }
 
       await this.loadData();

--- a/frontend/src/views/authed/policies-view.ts
+++ b/frontend/src/views/authed/policies-view.ts
@@ -15,8 +15,10 @@ import {
   patchModelIORule,
   deleteModelIORule,
   createAccessRule,
+  updateAccessRule,
+  deleteAccessRule,
 } from '../../api';
-import type { ModelIORule } from '../../api';
+import type { AccessRule, ModelIORule } from '../../api';
 import type { Tool, ApprovalWorkflow } from '../../components/tool-card';
 import '../../components/policy-generate-dialog';
 import '../../components/view-header';
@@ -58,6 +60,8 @@ interface ToolAccessRule {
   condition: string | null;
   isEnabled: boolean;
   configId: string | null;
+  accessRuleId: string | null;
+  accessRule: AccessRule | null;
 }
 
 // Types for policy file history
@@ -217,6 +221,7 @@ export class PoliciesView extends LitElement {
   @state() private _modelIORules: ModelIORule[] = [];
   @state() private _showModelIODialog = false;
   @state() private _editingModelIOId: string | null = null;
+  @state() private _editingAccessRuleId: string | null = null;
   @state() private _savingModelIO = false;
   @state() private _ruleDialogError = '';
   @state() private _modelIOForm = {
@@ -942,22 +947,48 @@ export class PoliciesView extends LitElement {
       this._modelIORules = modelIORules;
       await this._refreshCurrentExport();
 
-      // Build tool access rules from tools
-      this._toolAccessRules = this._tools.map((tool) => ({
-        toolName: tool.name,
-        source: tool.source,
-        sourceId: tool.source_id,
-        sourceName: tool.source_name,
-        action: tool.approval_workflow_id
-          ? 'require_approval'
-          : tool.is_enabled
-            ? 'allow'
-            : 'deny',
-        workflowId: tool.approval_workflow_id,
-        condition: tool.has_approval_condition ? '(condition set)' : null,
-        isEnabled: tool.is_enabled,
-        configId: tool.config_id,
-      }));
+      // One row per access rule. Tools with a config but no rules keep a
+      // derived row so a disabled tool or a workflow-only config still shows.
+      this._toolAccessRules = this._tools.flatMap((tool) => {
+        const accessRules = tool.access_rules ?? [];
+        if (accessRules.length > 0) {
+          return accessRules.map((rule) => ({
+            toolName: tool.name,
+            source: tool.source,
+            sourceId: tool.source_id,
+            sourceName: tool.source_name,
+            action: rule.action,
+            workflowId: rule.approval_workflow_id,
+            condition: rule.condition_expression,
+            isEnabled: rule.is_enabled,
+            configId: tool.config_id,
+            accessRuleId: rule.id,
+            accessRule: rule,
+          }));
+        }
+        if (!tool.config_id) {
+          return [];
+        }
+        return [
+          {
+            toolName: tool.name,
+            source: tool.source,
+            sourceId: tool.source_id,
+            sourceName: tool.source_name,
+            action: tool.approval_workflow_id
+              ? 'require_approval'
+              : tool.is_enabled
+                ? 'allow'
+                : 'deny',
+            workflowId: tool.approval_workflow_id,
+            condition: tool.has_approval_condition ? '(condition set)' : null,
+            isEnabled: tool.is_enabled,
+            configId: tool.config_id,
+            accessRuleId: null,
+            accessRule: null,
+          },
+        ];
+      });
     } catch (err: any) {
       this._error = err.message || 'Failed to load data';
       console.error('Error loading policies data:', err);
@@ -1120,9 +1151,35 @@ export class PoliciesView extends LitElement {
     };
   }
 
-  private openModelIODialog(rule: ModelIORule | null = null) {
+  private openModelIODialog(
+    rule: ModelIORule | { toolRule: ToolAccessRule } | null = null
+  ) {
     this._ruleDialogError = '';
-    if (rule) {
+    this._editingAccessRuleId = null;
+    if (rule && 'toolRule' in rule) {
+      const toolRule = rule.toolRule;
+      this._editingModelIOId = null;
+      this._editingAccessRuleId = toolRule.accessRuleId;
+      const workflowName =
+        this._approvalPolicies.find(
+          (policy) => policy.id === toolRule.workflowId
+        )?.name || '';
+      this._modelIOForm = {
+        ...this._emptyModelIOForm(),
+        ruleType: 'tool',
+        toolName: toolRule.toolName,
+        action: toolRule.action,
+        expression:
+          toolRule.condition && toolRule.condition !== '(condition set)'
+            ? toolRule.condition
+            : '',
+        enabled: toolRule.isEnabled,
+        approvalWorkflow: workflowName,
+        conditionMode: 'custom',
+        presetId: '',
+        idTouched: true,
+      };
+    } else if (rule) {
       const condition = rule.conditions?.[0];
       const action = (condition?.action || 'deny') as
         'allow' | 'deny' | 'require_approval';
@@ -1155,6 +1212,7 @@ export class PoliciesView extends LitElement {
   private closeModelIODialog() {
     this._showModelIODialog = false;
     this._editingModelIOId = null;
+    this._editingAccessRuleId = null;
     this._ruleDialogError = '';
   }
 
@@ -1337,10 +1395,10 @@ export class PoliciesView extends LitElement {
         });
         configId = created.id;
       }
-      await createAccessRule(configId, {
+      const payload = {
         action: form.action,
         condition_expression: form.expression.trim() || null,
-        condition_type: 'simple',
+        condition_type: 'simple' as const,
         is_enabled: form.enabled,
         approval_workflow_id:
           form.action === 'require_approval'
@@ -1348,7 +1406,12 @@ export class PoliciesView extends LitElement {
                 (p) => p.name === form.approvalWorkflow
               )?.id || null
             : null,
-      });
+      };
+      if (this._editingAccessRuleId) {
+        await updateAccessRule(this._editingAccessRuleId, payload);
+      } else {
+        await createAccessRule(configId, payload);
+      }
       this.closeModelIODialog();
       await this.loadData();
     } catch (err: any) {
@@ -1389,6 +1452,39 @@ export class PoliciesView extends LitElement {
       await this.loadData();
     } catch (err: any) {
       this._error = err.message || 'Failed to delete model I/O rule';
+    }
+  }
+
+  private async toggleToolAccessRule(rule: ToolAccessRule) {
+    if (!rule.accessRuleId) {
+      return;
+    }
+    try {
+      await updateAccessRule(rule.accessRuleId, {
+        is_enabled: !rule.isEnabled,
+      });
+      await this.loadData();
+    } catch (err: any) {
+      this._error = err.message || 'Failed to update tool rule';
+    }
+  }
+
+  private async removeToolAccessRule(rule: ToolAccessRule) {
+    if (!rule.accessRuleId) {
+      return;
+    }
+    if (
+      !confirm(
+        `Delete tool rule for "${rule.toolName}"? This cannot be undone.`
+      )
+    ) {
+      return;
+    }
+    try {
+      await deleteAccessRule(rule.accessRuleId);
+      await this.loadData();
+    } catch (err: any) {
+      this._error = err.message || 'Failed to delete tool rule';
     }
   }
 
@@ -1906,7 +2002,7 @@ export class PoliciesView extends LitElement {
           Boolean(rule.condition)
       )
       .map((rule) => ({
-        key: `tool:${rule.toolName}`,
+        key: `tool:${rule.toolName}:${rule.accessRuleId || 'config'}`,
         kind: 'tools' as const,
         target: `tool:${rule.toolName}`,
         id: rule.toolName,
@@ -1997,7 +2093,11 @@ export class PoliciesView extends LitElement {
                       @click=${() =>
                         rule.modelRule
                           ? this.openModelIODialog(rule.modelRule)
-                          : this.openModelIODialog()}
+                          : rule.toolRule
+                            ? this.openModelIODialog({
+                                toolRule: rule.toolRule,
+                              })
+                            : this.openModelIODialog()}
                     >
                       <div class="access-rule-header">
                         <div class="access-rule-info">
@@ -2058,7 +2158,34 @@ export class PoliciesView extends LitElement {
                                     Delete
                                   </sl-button>
                                 `
-                              : ''
+                              : rule.toolRule?.accessRuleId
+                                ? html`
+                                    <sl-button
+                                      size="small"
+                                      @click=${(e: Event) => {
+                                        e.stopPropagation();
+                                        this.toggleToolAccessRule(
+                                          rule.toolRule!
+                                        );
+                                      }}
+                                    >
+                                      ${rule.enabled ? 'Disable' : 'Enable'}
+                                    </sl-button>
+                                    <sl-button
+                                      size="small"
+                                      variant="danger"
+                                      outline
+                                      @click=${(e: Event) => {
+                                        e.stopPropagation();
+                                        this.removeToolAccessRule(
+                                          rule.toolRule!
+                                        );
+                                      }}
+                                    >
+                                      Delete
+                                    </sl-button>
+                                  `
+                                : ''
                           }
                         </div>
                       </div>
@@ -2188,7 +2315,11 @@ export class PoliciesView extends LitElement {
     return html`
       <sl-dialog
         class="rule-dialog"
-        label=${this._editingModelIOId ? 'Edit rule' : 'Add rule'}
+        label=${
+          this._editingModelIOId || this._editingAccessRuleId
+            ? 'Edit rule'
+            : 'Add rule'
+        }
         data-testid="rule-dialog"
         ?open=${this._showModelIODialog}
         @sl-request-close=${this._handleModelIORequestClose}

--- a/frontend/src/views/authed/policies-view.ts
+++ b/frontend/src/views/authed/policies-view.ts
@@ -177,6 +177,11 @@ export const MODEL_IO_PRESETS = [
   },
 ];
 
+/** CEL when the expression uses grouping or boolean operators. */
+export function conditionTypeFor(expr: string): 'cel' | 'simple' {
+  return /[()&|]/.test(expr) ? 'cel' : 'simple';
+}
+
 /** What each detector adds to the attributes a condition can read. */
 const DETECTOR_FACTS: Array<{
   key: 'pii' | 'injection' | 'moderation';
@@ -1398,7 +1403,7 @@ export class PoliciesView extends LitElement {
       const payload = {
         action: form.action,
         condition_expression: form.expression.trim() || null,
-        condition_type: 'simple' as const,
+        condition_type: conditionTypeFor(form.expression),
         is_enabled: form.enabled,
         approval_workflow_id:
           form.action === 'require_approval'
@@ -2509,10 +2514,10 @@ export class PoliciesView extends LitElement {
             this._patchModelIOForm({ expression: e.target.value })}
         ></sl-textarea>
         <p class="model-io-hint">
-          Reads the call itself, for example
-          <code>args.command.contains("rm")</code> or
-          <code>session.id != ''</code>. An empty condition applies to every
-          call to this tool.
+          Simple matches a field, for example
+          <code>session.id != ''</code>. CEL can call methods and combine
+          checks, for example <code>args.command.contains("rm")</code>. An empty
+          condition applies to every call to this tool.
         </p>
       </div>
     `;

--- a/frontend/src/views/authed/policies-view.ts
+++ b/frontend/src/views/authed/policies-view.ts
@@ -1267,8 +1267,16 @@ export class PoliciesView extends LitElement {
    * still looks selected, and Save would persist a mismatch.
    */
   private _setConditionMode(mode: 'preset' | 'custom') {
-    if (mode === 'preset' && this._modelIOForm.presetId) {
-      this._applyPreset(this._modelIOForm.presetId);
+    if (mode === 'preset') {
+      const matching =
+        MODEL_IO_PRESETS.find(
+          (item) => item.id === this._modelIOForm.presetId
+        ) ||
+        MODEL_IO_PRESETS.find(
+          (item) => item.target === this._modelIOForm.target
+        ) ||
+        MODEL_IO_PRESETS[0];
+      this._applyPreset(matching.id);
       return;
     }
     this._patchModelIOForm({ conditionMode: mode });

--- a/frontend/src/views/authed/policies-view.ts
+++ b/frontend/src/views/authed/policies-view.ts
@@ -234,6 +234,7 @@ export class PoliciesView extends LitElement {
     onDetectorTimeout: 'deny' as 'allow' | 'deny',
     conditionMode: 'preset' as 'preset' | 'custom',
     presetId: MODEL_IO_PRESETS[0].id,
+    idTouched: false,
   };
 
   // Approval workflows state
@@ -1115,6 +1116,7 @@ export class PoliciesView extends LitElement {
       onDetectorTimeout: 'deny' as 'allow' | 'deny',
       conditionMode: 'preset' as 'preset' | 'custom',
       presetId: preset.id,
+      idTouched: false,
     };
   }
 
@@ -1141,6 +1143,7 @@ export class PoliciesView extends LitElement {
         // An existing rule is shown as it is stored, not as a preset.
         conditionMode: 'custom',
         presetId: '',
+        idTouched: true,
       };
     } else {
       this._editingModelIOId = null;
@@ -1188,7 +1191,10 @@ export class PoliciesView extends LitElement {
       detectPii: preset.detectPii,
       detectInjection: preset.detectInjection,
       detectModeration: preset.detectModeration,
-      id: this._modelIOForm.id.trim() || preset.id,
+      id:
+        this._modelIOForm.idTouched && this._modelIOForm.id.trim()
+          ? this._modelIOForm.id
+          : preset.id,
     });
   }
 
@@ -2250,7 +2256,10 @@ export class PoliciesView extends LitElement {
                     placeholder="deny-pii-in-prompts"
                     ?disabled=${Boolean(this._editingModelIOId)}
                     @sl-input=${(e: any) =>
-                      this._patchModelIOForm({ id: e.target.value })}
+                      this._patchModelIOForm({
+                        id: e.target.value,
+                        idTouched: true,
+                      })}
                   ></sl-input>
                 </div>
               `


### PR DESCRIPTION
Fixes the Policies console page after #337.

- Validation and API errors now render inside the rule dialog instead of behind the modal overlay
- Tool access rules are read back into the list and can be edited and deleted
- Generate dialog no longer closes when the inner YAML details panel collapses
- Preset id follows the preset; CEL vs simple condition detected from the expression
- Dead pre-#337 tabs removed (3779 to 3284 lines); repro suite added and flipped to expect-fixed

Factory UX round 2 (2026-09-04).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Both previously flagged medium-severity issues are fixed: server-side condition-type detection prevents CEL misclassification, and the generate dialog resets state on hide.
>
> **Overview**
> Cleans up the Policies console page: scopes rule-dialog errors, reads back tool access rules with edit/delete, prevents the generate dialog from closing on inner-detail collapse, and removes dead pre-#337 tabs. Includes a control-driven repro suite.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 21539106. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->