### PR TITLE
Overview: dedupe and defer requests, take budget fetch off the critical path, coalesce websocket refetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parallel with wave 1, and the page waited for it before drawing. Attention
   now starts after the fold and still uses the shared 30-day window, so
   Overview and ``/console/attention`` stay in agreement. Wave 2's selected
-  range is a separate query for the cards.
+  range is a separate query for the cards; a calendar-month Overview range
+  is not reused as the 30-day attention window. The background refresh
+  also bumps the "Updated … ago" stamp. `relative-time-label` does not
+  start its timer until a timestamp is set.
 - **CLI runner interrupt test no longer races `exec.Cmd`**: GitLab
   `test:unit:cli` (`-race`) failed because the test read `Process` /
   `ProcessState` while the runner called `Start`/`Wait`. It now watches a

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -243,6 +243,65 @@ describe('api', () => {
         'recovered-refresh-token'
       );
     });
+
+    it('asks once when two callers want the same GET at the same time', async () => {
+      let release = () => {};
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      fetchStub.callsFake(async () => {
+        await gate;
+        return new Response(JSON.stringify({ users: [{ id: 'user-1' }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+
+      const both = Promise.all([
+        fetchWithAuth('/api/v1/users?skip=0&limit=100'),
+        fetchWithAuth('/api/v1/users?skip=0&limit=100'),
+      ]);
+      release();
+      const [first, second] = await both;
+
+      expect(fetchStub.callCount, 'one network request').to.equal(1);
+      // Each caller reads its own body: a shared response consumed once
+      // would leave the second caller with a locked stream.
+      expect(await first.json()).to.eql({ users: [{ id: 'user-1' }] });
+      expect(await second.json()).to.eql({ users: [{ id: 'user-1' }] });
+    });
+
+    it('asks again once the shared request has settled', async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      await fetchWithAuth('/api/v1/features');
+      await fetchWithAuth('/api/v1/features');
+
+      // A coalescer, not a cache: nothing is remembered after a response
+      // lands, so nobody can read a stale body.
+      expect(fetchStub.callCount).to.equal(2);
+    });
+
+    it('never joins two writes to the same URL', async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      await Promise.all([
+        fetchWithAuth('/api/v1/flows', { method: 'POST', body: '{}' }),
+        fetchWithAuth('/api/v1/flows', { method: 'POST', body: '{}' }),
+      ]);
+
+      expect(fetchStub.callCount).to.equal(2);
+    });
   });
 
   describe('getFlowExecutions', () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -62,7 +62,6 @@ import type {
   AIModelRuntimeSessionListResponse,
   AIModelGatewayUsageSearchResponse,
   AIModel,
-  DashboardTelemetryResponse,
   CostAnalyticsSummaryResponse,
   CostReconciliationResponse,
   ProviderBillingConnection,
@@ -284,7 +283,48 @@ async function refreshToken(): Promise<RefreshResult> {
   return refreshPromise;
 }
 
+/**
+ * GETs that are in the air right now, keyed by URL.
+ *
+ * Two components asking the same endpoint for the same thing in the same
+ * moment (the Overview and the activity feed both wanting `/api/v1/users`,
+ * a card and the attention loader both wanting the budget policies) is one
+ * question, not two. The second caller joins the first request and gets a
+ * clone of its response; nothing is remembered once it settles, so this is a
+ * coalescer, not a cache, and no caller can ever read a stale body.
+ */
+const inFlightGets = new Map<string, Promise<Response>>();
+
 export async function fetchWithAuth(
+  url: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  const method = (options.method || 'GET').toUpperCase();
+  // Only plain reads: a body, a signal or a custom header makes the call the
+  // caller's own, and anything that is not a GET may change something.
+  const coalescable =
+    method === 'GET' &&
+    !options.body &&
+    !options.signal &&
+    !options.headers &&
+    options.cache !== 'reload' &&
+    options.cache !== 'no-store';
+  if (coalescable) {
+    const pending = inFlightGets.get(url);
+    if (pending) {
+      return (await pending).clone();
+    }
+    const request = performFetchWithAuth(url, options).finally(() => {
+      inFlightGets.delete(url);
+    });
+    inFlightGets.set(url, request);
+    // The first caller gets a clone too, so every caller reads its own body.
+    return (await request).clone();
+  }
+  return performFetchWithAuth(url, options);
+}
+
+async function performFetchWithAuth(
   url: string,
   options: RequestInit = {}
 ): Promise<Response> {
@@ -1061,14 +1101,6 @@ export async function refreshToolCostFlags(): Promise<ToolCostFlag[]> {
     return data.flags as ToolCostFlag[];
   }
   return Array.isArray(data) ? (data as ToolCostFlag[]) : [];
-}
-
-export async function getDashboardTelemetry(): Promise<DashboardTelemetryResponse> {
-  const response = await fetchWithAuth('/api/v1/account/telemetry/dashboard');
-  if (!response.ok) {
-    throw new Error('Failed to fetch dashboard telemetry');
-  }
-  return response.json();
 }
 
 export async function getFlowGatewayUsageSummary(

--- a/frontend/src/components/activity-feed.test.ts
+++ b/frontend/src/components/activity-feed.test.ts
@@ -483,6 +483,49 @@ describe('activity-feed', () => {
       localStorage.removeItem('accessToken');
     });
 
+    it('asks for at most three audit pages, the last two together', async () => {
+      // A busy account whose whole timeline is successful gateway calls: the
+      // fill used to walk four pages one after the other for rows that were
+      // never going to be news.
+      localStorage.setItem('accessToken', 'test-token');
+      const { restore, urls } = stubFetch([gatewayNoise(AUDIT_PAGE_SIZE)]);
+      const el = await fixture<ActivityFeed>(
+        html`<activity-feed></activity-feed>`
+      );
+      await waitUntil(
+        () => !el.shadowRoot!.querySelector('.skeleton-row'),
+        'the fill finishes'
+      );
+      const audit = urls.filter((url) => url.includes('/audit-logs/grouped'));
+      expect(audit.length).to.equal(3);
+      expect(audit[1]).to.contain(`skip=${AUDIT_PAGE_SIZE}`);
+      expect(audit[2]).to.contain(`skip=${AUDIT_PAGE_SIZE * 2}`);
+      restore();
+      localStorage.removeItem('accessToken');
+    });
+
+    it('uses the people list the host already fetched', async () => {
+      localStorage.setItem('accessToken', 'test-token');
+      const { restore, urls } = stubFetch([
+        [auditGroup('api_key_created', { id: 'k3' }, 'success')],
+      ]);
+      const el = await fixture<ActivityFeed>(html`
+        <activity-feed
+          usersFromHost
+          .users=${[{ id: 'user-1', username: 'dimo' }]}
+        ></activity-feed>
+      `);
+      await waitUntil(() => rowText(el).length === 1, 'the row is there');
+
+      expect(rowText(el)[0]).to.contain('API key created by dimo');
+      expect(
+        urls.some((url) => url.includes('/api/v1/users')),
+        'no second users request'
+      ).to.be.false;
+      restore();
+      localStorage.removeItem('accessToken');
+    });
+
     it('keeps paging when a page folds down to one row', async () => {
       // Staging at 03:00: twelve events, all of them the same agent calling
       // the same two tools, so the fill hit its twelve and the rail showed

--- a/frontend/src/components/activity-feed.ts
+++ b/frontend/src/components/activity-feed.ts
@@ -150,8 +150,16 @@ export const FEED_INITIAL_ROWS = 12;
  * until it has enough rows or it runs out of patience.
  */
 export const AUDIT_PAGE_SIZE = 50;
-export const AUDIT_MAX_PAGES = 4;
+/**
+ * Three pages, and only the first one is on its own: page 0 decides whether
+ * more are needed, and pages 1 and 2 are then asked for together rather than
+ * one after the other. A fourth page was two more round trips for rows that
+ * were already off the bottom of a 12-row rail.
+ */
+export const AUDIT_MAX_PAGES = 3;
 const AUDIT_WINDOW_HOURS = 24;
+/** How long the feed waits for a host that says it is fetching the users. */
+const HOST_USERS_WAIT_MS = 1500;
 
 /**
  * Consecutive identical lines become one row with a count.
@@ -1166,18 +1174,39 @@ export class ActivityFeed extends LitElement {
   @property({ type: Array }) budgetPolicies: FeedContext['budgetPolicies'] = [];
   /** Skips the audit fetch in tests and in previews. */
   @property({ type: Boolean }) autoload = true;
+  /**
+   * The account's people, when the host already has them.
+   *
+   * `null` means nobody handed them over and the feed looks them up itself,
+   * which is what a standalone feed does. The Overview fetches the same list
+   * for its Inventory, and two components asking the same endpoint for the
+   * same list is one request too many.
+   */
+  @property({ type: Array }) users: FeedContext['users'] | null = null;
+  /**
+   * True when the host fetches the people list itself and will set `users`.
+   *
+   * The feed then waits briefly for that list instead of asking for the same
+   * one. It still falls back to its own lookup if the host comes back with
+   * nothing (an operator without `view_users`, an older server), so the
+   * standalone behaviour is never lost.
+   */
+  @property({ type: Boolean }) usersFromHost = false;
 
   @state() private events: FeedEvent[] = [];
   /** The one open row, by row id. One at a time: this is a rail, not a page. */
   @state() private openId: string | null = null;
   @state() private loading = true;
   @state() private connected = false;
-  @state() private users: FeedContext['users'] = [];
+  /** The list the feed looked up itself, when the host provided none. */
+  @state() private fetchedUsers: FeedContext['users'] = [];
 
   private unsubscribes: (() => void)[] = [];
   private seen = new Set<string>();
   /** Resolved (never rejected) once the user lookup has had its turn. */
   private usersReady: Promise<void> = Promise.resolve();
+  /** Called when the host sets a non-empty `users`, so the wait can end. */
+  private hostUsersArrived: (() => void) | null = null;
   private scrollAnchor: { top: number; height: number } | null = null;
 
   static styles = [
@@ -1542,7 +1571,7 @@ export class ActivityFeed extends LitElement {
       );
     }
     if (this.autoload) {
-      this.usersReady = this.loadUsers();
+      this.usersReady = this.resolveUsers();
       void this.loadInitial();
     } else {
       this.loading = false;
@@ -1566,7 +1595,7 @@ export class ActivityFeed extends LitElement {
       flows: this.flows,
       agents: this.agents,
       executions: this.executions,
-      users: this.users,
+      users: this.users?.length ? this.users : this.fetchedUsers,
       budgetPolicies: this.budgetPolicies,
     };
   }
@@ -1578,13 +1607,35 @@ export class ActivityFeed extends LitElement {
    * a nicety, and a lookup that fails, 403s or answers in a shape nobody
    * expected must not cost the operator the whole timeline.
    */
+  /**
+   * The people list, from the host when it has one and from the API when it
+   * does not. Never rejects: a name is a nicety, not a row.
+   */
+  private async resolveUsers(): Promise<void> {
+    if (this.users?.length) return;
+    if (this.usersFromHost) {
+      await Promise.race([
+        new Promise<void>((resolve) => {
+          this.hostUsersArrived = resolve;
+        }),
+        new Promise((resolve) => setTimeout(resolve, HOST_USERS_WAIT_MS)),
+      ]);
+      if (this.users?.length) return;
+    }
+    await this.loadUsers();
+  }
+
   private async loadUsers(): Promise<void> {
     try {
-      const response = await fetchWithAuth('/api/v1/users');
+      // The same URL the console's other readers use, so a lookup that
+      // overlaps one of theirs is coalesced into a single request.
+      const response = await fetchWithAuth('/api/v1/users?skip=0&limit=100');
       if (!response.ok) return;
       const data = await response.json();
       const users = Array.isArray(data) ? data : data?.users;
-      this.users = Array.isArray(users) ? (users as FeedContext['users']) : [];
+      this.fetchedUsers = Array.isArray(users)
+        ? (users as FeedContext['users'])
+        : [];
     } catch {
       // The feed degrades to "by" nothing rather than failing.
     }
@@ -1634,25 +1685,45 @@ export class ActivityFeed extends LitElement {
 
   private async loadInitial(): Promise<void> {
     this.loading = true;
-    // The actor's name belongs on the first paint, not the second, but a
-    // lookup that never answers must not hold the timeline hostage either.
-    await Promise.race([
-      this.usersReady,
-      new Promise((resolve) => setTimeout(resolve, 2000)),
-    ]);
     try {
       const since = new Date(
         Date.now() - AUDIT_WINDOW_HOURS * 60 * 60 * 1000
       ).toISOString();
+      // The timeline and the actor names are asked for at the same time:
+      // the names used to be awaited first, so the feed's first row waited
+      // on a request it does not need in order to draw a row.
+      const firstPage = await this.fetchAuditPage(0, since);
+      // The actor's name belongs on the first paint, not the second, but a
+      // lookup that never answers must not hold the timeline hostage either.
+      await Promise.race([
+        this.usersReady,
+        new Promise((resolve) => setTimeout(resolve, 2000)),
+      ]);
       const events: FeedEvent[] = [];
       let emptyWindow = false;
-      for (let page = 0; page < AUDIT_MAX_PAGES; page += 1) {
-        const groups = await this.fetchAuditPage(page * AUDIT_PAGE_SIZE, since);
-        if (groups === null) break;
-        if (page === 0 && groups.length === 0) emptyWindow = true;
-        this.rowsFrom(groups, events);
-        if (foldRows(events).length >= FEED_INITIAL_ROWS) break;
-        if (groups.length < AUDIT_PAGE_SIZE) break;
+      if (firstPage !== null) {
+        emptyWindow = firstPage.length === 0;
+        this.rowsFrom(firstPage, events);
+        // Page 0 decides whether the rest are needed. When they are, they
+        // are asked for together instead of one after the other, and there
+        // are two of them: a fourth page was two more round trips for rows
+        // that were already off the bottom of a twelve-row rail.
+        if (
+          firstPage.length >= AUDIT_PAGE_SIZE &&
+          foldRows(events).length < FEED_INITIAL_ROWS
+        ) {
+          const more = await Promise.all(
+            Array.from({ length: AUDIT_MAX_PAGES - 1 }, (_, index) =>
+              this.fetchAuditPage((index + 1) * AUDIT_PAGE_SIZE, since)
+            )
+          );
+          for (const groups of more) {
+            if (groups === null) break;
+            if (foldRows(events).length >= FEED_INITIAL_ROWS) break;
+            this.rowsFrom(groups, events);
+            if (groups.length < AUDIT_PAGE_SIZE) break;
+          }
+        }
       }
       // A quiet account has nothing in the last day and still has a history.
       // Rather than say "Nothing yet" to an account that worked yesterday,
@@ -1679,6 +1750,11 @@ export class ActivityFeed extends LitElement {
    * exactly the height that was added.
    */
   protected willUpdate(changed: Map<string, unknown>): void {
+    if (changed.has('users') && this.users?.length && this.hostUsersArrived) {
+      const arrived = this.hostUsersArrived;
+      this.hostUsersArrived = null;
+      arrived();
+    }
     if (!changed.has('events')) return;
     const list = this.renderRoot?.querySelector<HTMLElement>('.rows');
     this.scrollAnchor = list

--- a/frontend/src/components/inventory-card.test.ts
+++ b/frontend/src/components/inventory-card.test.ts
@@ -464,6 +464,38 @@ describe('inventory-card', () => {
     expect(el.shadowRoot?.querySelector('.empty')).to.not.exist;
   });
 
+  it('lets one tab wait while another already has its rows', async () => {
+    // Agents arrive with the first wave, flows a moment later. One flag for
+    // the whole card kept the rows it already had behind a skeleton.
+    const el = await fixture<InventoryCard>(html`
+      <inventory-card
+        .agentRows=${[agentRow()]}
+        .flowRows=${[]}
+        .modelRows=${[]}
+        .toolRows=${[]}
+        .agentsTotal=${10}
+        .flowsTotal=${30}
+        .modelsTotal=${16}
+        .toolsTotal=${16}
+        .loadingAgents=${false}
+        .loadingFlows=${true}
+        rangeLabel="30d"
+      ></inventory-card>
+    `);
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelectorAll('tbody tr').length).to.equal(1);
+    expect(el.shadowRoot?.querySelector('sl-skeleton')).to.not.exist;
+
+    await showTab(el, 'flows');
+    expect(
+      el.shadowRoot?.querySelectorAll('sl-skeleton').length,
+      'flows still waiting'
+    ).to.be.greaterThan(0);
+    expect(el.shadowRoot?.querySelector('.empty'), 'no premature empty state')
+      .to.not.exist;
+  });
+
   it('caps the table and points at the full list', async () => {
     const rows = Array.from({ length: 12 }, (_, index) =>
       agentRow({ id: `agent-${index}`, name: `Agent ${index}` })

--- a/frontend/src/components/inventory-card.ts
+++ b/frontend/src/components/inventory-card.ts
@@ -261,6 +261,21 @@ export class InventoryCard extends LitElement {
 
   @property({ type: Boolean }) loading = false;
   /**
+   * Per-tab overrides for {@link loading}.
+   *
+   * The tabs are filled by different requests that land at different times:
+   * agents arrive with the first wave, flows and their runs a moment later,
+   * models and tools last. One flag for all five meant the whole card stayed
+   * a skeleton until the slowest of them answered, hiding rows it already
+   * had. `null` means "no answer yet, use the card-wide flag", so a host that
+   * sets nothing behaves exactly as before.
+   */
+  @property({ type: Boolean }) loadingAgents: boolean | null = null;
+  @property({ type: Boolean }) loadingFlows: boolean | null = null;
+  @property({ type: Boolean }) loadingModels: boolean | null = null;
+  @property({ type: Boolean }) loadingTools: boolean | null = null;
+  @property({ type: Boolean }) loadingUsers: boolean | null = null;
+  /**
    * The usage breakdown is a second, slower request than the lists it fills.
    * While it is in flight the identity of a row (who, which role, when they
    * were last here, how many agents they own) is already known and is shown;
@@ -659,6 +674,21 @@ export class InventoryCard extends LitElement {
     return this.visibleTabs.includes(this.tab) ? this.tab : 'agents';
   }
 
+  /** Whether the rows of one tab are still on their way. */
+  private isTabLoading(tab: InventoryTab): boolean {
+    const perTab =
+      tab === 'agents'
+        ? this.loadingAgents
+        : tab === 'flows'
+          ? this.loadingFlows
+          : tab === 'models'
+            ? this.loadingModels
+            : tab === 'users'
+              ? this.loadingUsers
+              : this.loadingTools;
+    return perTab === null || perTab === undefined ? this.loading : perTab;
+  }
+
   private countFor(tab: InventoryTab): number {
     if (tab === 'agents') return this.agentsTotal;
     if (tab === 'flows') return this.flowsTotal;
@@ -929,7 +959,7 @@ export class InventoryCard extends LitElement {
           </tr>
         </thead>
         ${
-          this.loading && rows.length === 0
+          this.isTabLoading('agents') && rows.length === 0
             ? this.renderSkeleton(6)
             : html`
                 <tbody>
@@ -1043,7 +1073,7 @@ export class InventoryCard extends LitElement {
           </tr>
         </thead>
         ${
-          this.loading && rows.length === 0
+          this.isTabLoading('flows') && rows.length === 0
             ? this.renderSkeleton(5)
             : html`
                 <tbody>
@@ -1116,7 +1146,7 @@ export class InventoryCard extends LitElement {
           </tr>
         </thead>
         ${
-          this.loading && rows.length === 0
+          this.isTabLoading('models') && rows.length === 0
             ? this.renderSkeleton(5)
             : html`
                 <tbody>
@@ -1196,7 +1226,7 @@ export class InventoryCard extends LitElement {
           </tr>
         </thead>
         ${
-          this.loading && rows.length === 0
+          this.isTabLoading('users') && rows.length === 0
             ? this.renderSkeleton(6)
             : html`
                 <tbody>
@@ -1265,7 +1295,7 @@ export class InventoryCard extends LitElement {
           </tr>
         </thead>
         ${
-          this.loading && rows.length === 0
+          this.isTabLoading('tools') && rows.length === 0
             ? this.renderSkeleton(4)
             : html`
                 <tbody>
@@ -1313,7 +1343,7 @@ export class InventoryCard extends LitElement {
   }
 
   private renderBody() {
-    if (!this.loading && this.currentRowCount() === 0) {
+    if (!this.isTabLoading(this.activeTab) && this.currentRowCount() === 0) {
       return this.renderEmpty();
     }
     if (this.activeTab === 'agents') return this.renderAgents();

--- a/frontend/src/components/relative-time-label.test.ts
+++ b/frontend/src/components/relative-time-label.test.ts
@@ -1,0 +1,55 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import './relative-time-label';
+import { formatRelativeTime } from './relative-time-label';
+
+describe('relative-time-label', () => {
+  it('reads as part of the sentence around it', async () => {
+    const el = await fixture(
+      html`<span
+        >Updated
+        <relative-time-label
+          .timestamp=${new Date(Date.now() - 4 * 60000).toISOString()}
+        ></relative-time-label
+      ></span>`
+    );
+    // Light DOM on purpose: the host reads one string, not two shadow roots.
+    expect(el.textContent?.replace(/\s+/g, ' ').trim()).to.equal(
+      'Updated 4m ago'
+    );
+  });
+
+  it('says what the host tells it to say before there is a time', async () => {
+    const el = await fixture(
+      html`<relative-time-label .fallback=${'Loading…'}></relative-time-label>`
+    );
+    expect(el.textContent).to.equal('Loading…');
+  });
+
+  it('ages on its own clock', async () => {
+    const el = (await fixture(
+      html`<relative-time-label
+        .timestamp=${new Date().toISOString()}
+      ></relative-time-label>`
+    )) as HTMLElement & { updateComplete: Promise<unknown> };
+    expect(el.textContent).to.equal('just now');
+
+    // The page has been open a while and nothing has re-rendered it.
+    (el as unknown as { tick: number }).tick += 1;
+    (el as unknown as { timestamp: string }).timestamp = new Date(
+      Date.now() - 3 * 3600 * 1000
+    ).toISOString();
+    await el.updateComplete;
+    expect(el.textContent).to.equal('3h ago');
+  });
+
+  it('counts in minutes, then hours, then days', () => {
+    const minutes = (n: number) =>
+      new Date(Date.now() - n * 60000).toISOString();
+    expect(formatRelativeTime(minutes(0.2))).to.equal('just now');
+    expect(formatRelativeTime(minutes(45))).to.equal('45m ago');
+    expect(formatRelativeTime(minutes(60 * 5))).to.equal('5h ago');
+    expect(formatRelativeTime(minutes(60 * 24 * 3))).to.equal('3d ago');
+    expect(formatRelativeTime(null)).to.equal('Never');
+  });
+});

--- a/frontend/src/components/relative-time-label.test.ts
+++ b/frontend/src/components/relative-time-label.test.ts
@@ -24,6 +24,20 @@ describe('relative-time-label', () => {
       html`<relative-time-label .fallback=${'Loading…'}></relative-time-label>`
     );
     expect(el.textContent).to.equal('Loading…');
+    expect((el as unknown as { timer: number | null }).timer).to.equal(null);
+  });
+
+  it('starts its clock once a timestamp is set', async () => {
+    const el = (await fixture(
+      html`<relative-time-label fallback="Never"></relative-time-label>`
+    )) as HTMLElement & { updateComplete: Promise<unknown> };
+    expect((el as unknown as { timer: number | null }).timer).to.equal(null);
+    (el as unknown as { timestamp: string }).timestamp =
+      new Date().toISOString();
+    await el.updateComplete;
+    expect((el as unknown as { timer: number | null }).timer).to.not.equal(
+      null
+    );
   });
 
   it('ages on its own clock', async () => {

--- a/frontend/src/components/relative-time-label.ts
+++ b/frontend/src/components/relative-time-label.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { parseUTCDate } from '../utils/date';
 
@@ -33,17 +33,37 @@ export class RelativeTimeLabel extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
-    this.timer = window.setInterval(() => {
-      this.tick += 1;
-    }, TICK_MS);
+    this.syncTimer();
   }
 
   disconnectedCallback(): void {
+    this.clearTimer();
+    super.disconnectedCallback();
+  }
+
+  protected updated(changed: PropertyValues): void {
+    if (changed.has('timestamp')) {
+      this.syncTimer();
+    }
+  }
+
+  private syncTimer(): void {
+    if (this.timestamp) {
+      if (this.timer === null) {
+        this.timer = window.setInterval(() => {
+          this.tick += 1;
+        }, TICK_MS);
+      }
+      return;
+    }
+    this.clearTimer();
+  }
+
+  private clearTimer(): void {
     if (this.timer !== null) {
       window.clearInterval(this.timer);
       this.timer = null;
     }
-    super.disconnectedCallback();
   }
 
   render() {

--- a/frontend/src/components/relative-time-label.ts
+++ b/frontend/src/components/relative-time-label.ts
@@ -1,0 +1,81 @@
+import { LitElement, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { parseUTCDate } from '../utils/date';
+
+/** How often the label re-reads the clock. */
+const TICK_MS = 30000;
+
+/**
+ * "3m ago", kept honest by its own timer.
+ *
+ * The Overview used to age this label by bumping a state field on the view
+ * itself, which re-rendered the whole page, cards and tables included, every
+ * thirty seconds. The clock belongs to the text that shows it, so the timer
+ * lives here and nothing above this element renders when it ticks.
+ *
+ * Renders into the light DOM so the surrounding text stays one readable
+ * string for the host and for anything reading `textContent`.
+ */
+@customElement('relative-time-label')
+export class RelativeTimeLabel extends LitElement {
+  /** ISO timestamp; when absent the fallback is shown and no timer runs. */
+  @property({ type: String }) timestamp: string | null = null;
+  /** What to show when there is no timestamp yet. */
+  @property({ type: String }) fallback = 'Never';
+
+  @state() private tick = 0;
+
+  private timer: number | null = null;
+
+  protected createRenderRoot() {
+    return this;
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.timer = window.setInterval(() => {
+      this.tick += 1;
+    }, TICK_MS);
+  }
+
+  disconnectedCallback(): void {
+    if (this.timer !== null) {
+      window.clearInterval(this.timer);
+      this.timer = null;
+    }
+    super.disconnectedCallback();
+  }
+
+  render() {
+    return html`${formatRelativeTime(this.timestamp, this.fallback)}`;
+  }
+}
+
+/** Minutes, then hours, then days. Coarse on purpose: it is a freshness hint. */
+export function formatRelativeTime(
+  value: string | null | undefined,
+  fallback = 'Never'
+): string {
+  if (!value) {
+    return fallback;
+  }
+  const timestamp = parseUTCDate(value).getTime();
+  const deltaMinutes = Math.round((Date.now() - timestamp) / 60000);
+  if (deltaMinutes < 1) {
+    return 'just now';
+  }
+  if (deltaMinutes < 60) {
+    return `${deltaMinutes}m ago`;
+  }
+  const deltaHours = Math.round(deltaMinutes / 60);
+  if (deltaHours < 24) {
+    return `${deltaHours}h ago`;
+  }
+  return `${Math.round(deltaHours / 24)}d ago`;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'relative-time-label': RelativeTimeLabel;
+  }
+}

--- a/frontend/src/utils/attention-data.test.ts
+++ b/frontend/src/utils/attention-data.test.ts
@@ -249,4 +249,85 @@ describe('loadAttentionInputs', () => {
       requestedUrls().some((url) => url.startsWith('/api/v1/budget/policies'))
     ).to.be.false;
   });
+
+  it('does not fetch an input the caller passed', async () => {
+    const inputs = await loadAttentionInputs({
+      prefetched: {
+        approvals: [{ id: 'shared-approval', status: 'pending' } as any],
+        agents: [{ id: 'shared-agent' } as any],
+        sessions: [{ id: 'shared-session' } as any],
+        executions: [{ id: 'shared-execution', status: 'FAILED' } as any],
+        budgetPolicies: [{ id: 'shared-policy' } as any],
+        usageSummary: { total_requests: 99 } as any,
+      },
+    });
+    const urls = requestedUrls();
+
+    expect(urls.some((url) => url.startsWith('/api/v1/approval-requests'))).to
+      .be.false;
+    expect(urls.some((url) => url.startsWith('/api/v1/agents'))).to.be.false;
+    expect(urls.some((url) => url.startsWith('/api/v1/runtime-sessions'))).to.be
+      .false;
+    expect(urls.some((url) => url.startsWith('/api/v1/flows/executions'))).to.be
+      .false;
+    expect(urls.some((url) => url.startsWith('/api/v1/budget/policies'))).to.be
+      .false;
+    expect(
+      urls.some((url) =>
+        url.startsWith('/api/v1/account/gateway-usage/summary')
+      )
+    ).to.be.false;
+
+    // The two inputs nobody shared are still fetched.
+    expect(
+      urls.some((url) =>
+        url.startsWith('/api/v1/account/gateway-usage/search')
+      ),
+      'gateway failures still fetched'
+    ).to.be.true;
+    expect(urls.some((url) => url.startsWith('/api/v1/attention/dismissals')))
+      .to.be.true;
+
+    expect(inputs.approvals?.map((approval) => approval.id)).to.eql([
+      'shared-approval',
+    ]);
+    expect(inputs.agents?.[0].id).to.equal('shared-agent');
+    expect(inputs.sessions?.[0].id).to.equal('shared-session');
+    expect(inputs.executions?.[0].id).to.equal('shared-execution');
+    expect(inputs.budgetPolicies?.[0].id).to.equal('shared-policy');
+    expect(inputs.usageSummary?.total_requests).to.equal(99);
+  });
+
+  it('still filters expired approvals the caller passed', async () => {
+    const inputs = await loadAttentionInputs({
+      prefetched: {
+        approvals: [
+          { id: 'live', status: 'pending' } as any,
+          {
+            id: 'expired',
+            status: 'pending',
+            expires_at: new Date(Date.now() - 3600_000).toISOString(),
+          } as any,
+        ],
+      },
+    });
+
+    expect(inputs.approvals?.map((approval) => approval.id)).to.eql(['live']);
+  });
+
+  it('fetches the inputs the caller did not pass', async () => {
+    await loadAttentionInputs({ prefetched: { agents: [] } });
+    const urls = requestedUrls();
+
+    expect(urls.some((url) => url.startsWith('/api/v1/agents'))).to.be.false;
+    expect(urls.some((url) => url.startsWith('/api/v1/approval-requests'))).to
+      .be.true;
+    expect(urls.some((url) => url.startsWith('/api/v1/runtime-sessions'))).to.be
+      .true;
+    expect(
+      urls.some((url) =>
+        url.startsWith('/api/v1/account/gateway-usage/summary')
+      )
+    ).to.be.true;
+  });
 });

--- a/frontend/src/utils/attention-data.ts
+++ b/frontend/src/utils/attention-data.ts
@@ -82,11 +82,31 @@ export interface LoadedAttentionInputs extends AttentionInputs {
   dismissalsSupported: boolean;
 }
 
+/**
+ * Inputs the caller already has in hand.
+ *
+ * The Overview fetches approvals, agents, budget policies and a usage
+ * breakdown for its own cards, and used to make the attention loader fetch
+ * all four again a second later. Anything passed here is used as-is and
+ * costs no request; anything left out is fetched exactly as before, so a
+ * caller with nothing to share behaves identically.
+ */
+export interface PrefetchedAttentionInputs {
+  approvals?: AttentionApproval[];
+  agents?: ManagedAgentSummary[];
+  sessions?: RuntimeSessionSummary[];
+  executions?: AttentionFlowExecution[];
+  budgetPolicies?: BudgetPolicy[];
+  usageSummary?: AccountGatewayUsageSummaryResponse | null;
+}
+
 export interface LoadAttentionInputsOptions {
   /** Injected in tests and by callers that already know "now". */
   now?: Date;
   /** Skip the budget policies call when billing is off (it 403s). */
   includeBudgetPolicies?: boolean;
+  /** Data the caller already fetched; each entry removes one request. */
+  prefetched?: PrefetchedAttentionInputs;
 }
 
 /**
@@ -105,6 +125,7 @@ export async function loadAttentionInputs(
   const usageStart = new Date(
     now.getTime() - ATTENTION_QUERY.usageWindowDays * DAY_MS
   ).toISOString();
+  const prefetched = options.prefetched || {};
 
   const [
     approvals,
@@ -117,34 +138,47 @@ export async function loadAttentionInputs(
     dismissals,
     priceOverrides,
   ] = await Promise.allSettled([
-    listApprovalRequests({
-      status: 'pending',
-      limit: ATTENTION_QUERY.approvalsLimit,
-    }),
-    getAccountAgents({ status: 'all', limit: ATTENTION_QUERY.agentsLimit }),
-    getAccountRuntimeSessions({
-      status: 'all',
-      limit: ATTENTION_QUERY.sessionsLimit,
-      startDate: sessionsStart,
-    }),
-    getFlowExecutions({
-      status: 'FAILED',
-      limit: ATTENTION_QUERY.executionsLimit,
-    }),
+    prefetched.approvals
+      ? Promise.resolve(prefetched.approvals)
+      : listApprovalRequests({
+          status: 'pending',
+          limit: ATTENTION_QUERY.approvalsLimit,
+        }),
+    prefetched.agents
+      ? Promise.resolve({ items: prefetched.agents })
+      : getAccountAgents({ status: 'all', limit: ATTENTION_QUERY.agentsLimit }),
+    prefetched.sessions
+      ? Promise.resolve({ items: prefetched.sessions })
+      : getAccountRuntimeSessions({
+          status: 'all',
+          limit: ATTENTION_QUERY.sessionsLimit,
+          startDate: sessionsStart,
+        }),
+    prefetched.executions
+      ? Promise.resolve(prefetched.executions)
+      : getFlowExecutions({
+          status: 'FAILED',
+          limit: ATTENTION_QUERY.executionsLimit,
+        }),
     getAccountGatewayUsageSearch({
       limit: ATTENTION_QUERY.gatewayFailuresLimit,
     }),
-    options.includeBudgetPolicies === false
-      ? Promise.resolve([] as BudgetPolicy[])
-      : getBudgetPolicies(),
+    prefetched.budgetPolicies
+      ? Promise.resolve(prefetched.budgetPolicies)
+      : options.includeBudgetPolicies === false
+        ? Promise.resolve([] as BudgetPolicy[])
+        : getBudgetPolicies(),
     // The breakdown is what turns "336 requests unpriced" into "these seven
     // models have no price", which is the part somebody can act on. Always
     // a fixed ATTENTION_QUERY.usageWindowDays window so Overview and
-    // /console/attention agree; do not reuse the dashboard's selected range.
-    getAccountGatewayUsageSummary({
-      startDate: usageStart,
-      includeBreakdown: true,
-    }),
+    // /console/attention agree, unless the caller already holds a breakdown
+    // over the same window and hands it in.
+    prefetched.usageSummary
+      ? Promise.resolve(prefetched.usageSummary)
+      : getAccountGatewayUsageSummary({
+          startDate: usageStart,
+          includeBreakdown: true,
+        }),
     getAttentionDismissals(),
     // An override is a price, including one of $0. Without this the console
     // asks for a price somebody set a month ago. A 403 on an account without

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -14,6 +14,7 @@ import '../../components/activity-feed.ts';
 import '../../components/inventory-card.ts';
 import '../../components/usage-card.ts';
 import '../../components/view-header.ts';
+import '../../components/relative-time-label.ts';
 import {
   AuthedElement,
   fetchWithAuth,
@@ -50,10 +51,14 @@ import {
   attentionItemAnchor,
   ATTENTION_KIND_META,
   deriveAttentionItems,
+  type AttentionApproval,
   type AttentionInputs,
   type AttentionItem,
 } from '../../utils/attention';
-import { loadAttentionInputs } from '../../utils/attention-data';
+import {
+  loadAttentionInputs,
+  type PrefetchedAttentionInputs,
+} from '../../utils/attention-data';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import type {
   AccountGatewayUsageSummaryResponse,
@@ -67,6 +72,7 @@ import type {
   AIModel,
 } from '../../types';
 import { parseUTCDate } from '../../utils/date';
+import { formatRelativeTime } from '../../components/relative-time-label';
 import { executionSubjectCss } from '../../utils/execution-subject';
 import {
   hasUsageBreakdown,
@@ -144,6 +150,51 @@ interface MCPServer {
  * a capped number as if it were the range.
  */
 const FLOW_EXECUTIONS_PAGE_SIZE = 100;
+
+/**
+ * Sessions above the fold answer one question - has anything ever run here -
+ * so the first wave asks for a short page and the attention loader asks for
+ * the window it needs later.
+ */
+const FOLD_SESSIONS_LIMIT = 20;
+
+/** The page of gateway calls the failures card reads on a live refresh. */
+const GATEWAY_FAILURES_REFRESH_LIMIT = 25;
+
+/** How long a burst of events on one topic is collected before it is served. */
+const REALTIME_DEBOUNCE_MS = 250;
+
+/**
+ * The floor between two refreshes of the same topic. `gateway_activity` is
+ * published once per model call, so without a floor a single busy agent is a
+ * refresh loop.
+ */
+const REALTIME_TOPIC_INTERVAL_MS = 10000;
+
+/** How often the expensive background reads run while the tab is visible. */
+const BACKGROUND_REFRESH_MS = 60000;
+
+/**
+ * How much of each long list the sessionStorage cache keeps. The cards read
+ * the first rows only; keeping every row is what pushed the cache over the
+ * per origin quota on busy accounts.
+ */
+const CACHED_SESSIONS = 20;
+const CACHED_INTERACTIONS = 25;
+const CACHED_FLOW_EXECUTIONS = 25;
+
+/**
+ * Timestamps for the Overview load, read by the performance spec. Free when
+ * nothing is measuring, and never a reason for a failure here.
+ */
+export function markOverviewTiming(name: string): void {
+  try {
+    performance.mark(name);
+  } catch {
+    // performance.mark is unavailable or the buffer is full; timings are
+    // diagnostics only.
+  }
+}
 
 interface FlowExecution {
   id: string;
@@ -224,7 +275,6 @@ interface DashboardMetric {
 
 @customElement('dashboard-view')
 export class DashboardView extends AuthedElement {
-  private initialLoadTime = Date.now();
   @state() private loading = true;
   @state() private fetchingGatewaySummary = true;
   /**
@@ -234,6 +284,13 @@ export class DashboardView extends AuthedElement {
    */
   @state() private updatingUsage = false;
   @state() private fetchingRecentExecutions = true;
+  /**
+   * Flows, their runs, the resolved approvals and the gateway call log: the
+   * cards below the fold. They are fetched after the first paint, so the
+   * Inventory tabs that read them say "still coming" while the tabs that are
+   * already filled show their rows.
+   */
+  @state() private fetchingInventory = true;
   @state() private fetchingApprovals = true;
   @state() private fetchingAudit = true;
   @state() private fetchingMCPAndTools = true;
@@ -344,18 +401,25 @@ export class DashboardView extends AuthedElement {
   };
 
   private unsubscribeRealtime?: () => void;
-  private refreshTimer: number | null = null;
   private refreshInFlight = false;
-  /**
-   * Makes "Updated just now" age.
-   *
-   * The label is a relative time, and a relative time that only recomputes
-   * when its data changes is a lie by the second minute: a page left open
-   * over lunch claimed the numbers under it were a minute old. Bumping this
-   * every 30s re-renders the header and nothing else.
-   */
-  @state() private updatedTick = 0;
-  private updatedTimer: number | null = null;
+  /** When the last full load started, which is what the event gate reads. */
+  private lastFetchStartedAt = 0;
+  /** One pending timer per topic key, so topics never queue behind each other. */
+  private refreshTimers: Record<string, number> = {};
+  /** When each topic key last ran, for its 10s floor. */
+  private lastTopicRefresh: Record<string, number> = {};
+  private backgroundTimer: number | null = null;
+  /** The budget fetch, for the parts of the page that do need to wait on it. */
+  private budgetReady: Promise<void> = Promise.resolve();
+  /** Set while a coalesced sessionStorage write is pending. */
+  private cacheWriteScheduled = false;
+  /** So a full cache is reported once per session, not once per write. */
+  private cacheQuotaWarned = false;
+  /** Memoised attention derivation; see `attentionItems`. */
+  private attentionMemo: {
+    inputs: AttentionInputs | null;
+    items: AttentionItem[];
+  } | null = null;
 
   private formatDate(dateStr: string | null | undefined): string {
     if (!dateStr) return '';
@@ -1269,14 +1333,10 @@ export class DashboardView extends AuthedElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.initialLoadTime = Date.now(); // Reset load time on DOM connection to gate initial WebSocket reloads
     this.loadDismissedState();
     this.loadCachedDashboardData();
     void this.fetchDashboardData();
     this.connectRealtime();
-    this.updatedTimer = window.setInterval(() => {
-      if (this.lastUpdatedAt) this.updatedTick += 1;
-    }, 30000);
   }
 
   private async fetchAdminStatus() {
@@ -1309,6 +1369,18 @@ export class DashboardView extends AuthedElement {
     );
   }
 
+  /**
+   * Whether this page will ask for the people list itself. The activity feed
+   * asks for the same list to put names on rows, so when the answer is yes it
+   * waits for this one instead of making a second identical request.
+   */
+  private get fetchesUsers(): boolean {
+    return (
+      hasPermission(this.permissions, 'view_users') &&
+      (isSaaS() || this.userManagementEnabled)
+    );
+  }
+
   private async fetchFeatures() {
     try {
       const res = await getFeatures();
@@ -1329,13 +1401,13 @@ export class DashboardView extends AuthedElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.unsubscribeRealtime?.();
-    if (this.refreshTimer !== null) {
-      window.clearTimeout(this.refreshTimer);
-      this.refreshTimer = null;
+    for (const key of Object.keys(this.refreshTimers)) {
+      window.clearTimeout(this.refreshTimers[key]);
+      delete this.refreshTimers[key];
     }
-    if (this.updatedTimer !== null) {
-      window.clearInterval(this.updatedTimer);
-      this.updatedTimer = null;
+    if (this.backgroundTimer !== null) {
+      window.clearInterval(this.backgroundTimer);
+      this.backgroundTimer = null;
     }
   }
 
@@ -1411,6 +1483,33 @@ export class DashboardView extends AuthedElement {
     }
   }
 
+  /**
+   * The cache write is a full JSON.stringify of every list on the page, and
+   * the load used to call it once per finished pass. Coalesce them into one
+   * write when the browser is next idle so no fetch handler pays for it.
+   */
+  private scheduleCacheWrite(): void {
+    if (this.cacheWriteScheduled) return;
+    this.cacheWriteScheduled = true;
+    const write = () => {
+      this.cacheWriteScheduled = false;
+      this.saveDashboardCache();
+    };
+    const idle = (
+      window as Window & {
+        requestIdleCallback?: (
+          cb: () => void,
+          opts?: { timeout: number }
+        ) => number;
+      }
+    ).requestIdleCallback;
+    if (typeof idle === 'function') {
+      idle(write, { timeout: 2000 });
+    } else {
+      window.setTimeout(write, 0);
+    }
+  }
+
   private saveDashboardCache(): void {
     try {
       const sub = this.getUsernameFromToken();
@@ -1418,9 +1517,15 @@ export class DashboardView extends AuthedElement {
       const key = `preloop:dashboard:${sub}`;
       const cacheObj = {
         gatewaySummary: this.gatewaySummary,
-        runtimeSessions: this.runtimeSessions,
+        // Only what the cards actually show is worth keeping: the full lists
+        // pushed this object past the sessionStorage quota on busy accounts,
+        // and a quota failure threw away the whole cache.
+        runtimeSessions: this.runtimeSessions.slice(0, CACHED_SESSIONS),
         managedAgents: this.managedAgents,
-        gatewayInteractions: this.gatewayInteractions,
+        gatewayInteractions: this.gatewayInteractions.slice(
+          0,
+          CACHED_INTERACTIONS
+        ),
         auditGroups: this.auditGroups,
         trackers: this.trackers,
         totalIssues: this.totalIssues,
@@ -1428,7 +1533,7 @@ export class DashboardView extends AuthedElement {
         tools: this.tools,
         aiModels: this.aiModels,
         aiModelOverview: this.aiModelOverview,
-        flowExecutions: this.flowExecutions,
+        flowExecutions: this.flowExecutions.slice(0, CACHED_FLOW_EXECUTIONS),
         flows: this.flows,
         flowExecutionsCount: this.flowExecutionsCount,
         failedExecutionsCount: this.failedExecutionsCount,
@@ -1445,14 +1550,51 @@ export class DashboardView extends AuthedElement {
         hasAIModels: this.hasAIModels,
         lastUpdatedAt: this.lastUpdatedAt,
         approvalStats: this.approvalStats,
-        attentionInputs: this.attentionInputs,
+        attentionInputs: this.trimAttentionInputsForCache(),
         budgetPolicies: this.budgetPolicies,
         budgetAgents: this.budgetAgents,
       };
       sessionStorage.setItem(key, JSON.stringify(cacheObj));
     } catch (e) {
+      if (e instanceof DOMException && e.name === 'QuotaExceededError') {
+        // A half written cache is worse than none: drop it and carry on with
+        // network data only for this session.
+        try {
+          const sub = this.getUsernameFromToken();
+          sessionStorage.removeItem(`preloop:dashboard:${sub}`);
+        } catch {
+          // sessionStorage is unavailable; nothing left to clean up.
+        }
+        if (!this.cacheQuotaWarned) {
+          this.cacheQuotaWarned = true;
+          console.warn(
+            'Dashboard cache disabled for this session: storage full'
+          );
+        }
+        return;
+      }
       console.warn('Failed to save dashboard cache to sessionStorage', e);
     }
+  }
+
+  /**
+   * The usage summary inside the attention inputs carries per interaction
+   * detail that the rules never read back; keep only the per model rollup.
+   */
+  private trimAttentionInputsForCache(): AttentionInputs | null {
+    if (!this.attentionInputs) return null;
+    const usage = this.attentionInputs.usageSummary;
+    if (!usage) return this.attentionInputs;
+    return {
+      ...this.attentionInputs,
+      usageSummary: {
+        ...usage,
+        requests_by_day: [],
+        usage_by_flow: [],
+        usage_by_session: [],
+        usage_by_tool: [],
+      },
+    };
   }
 
   private loadDismissedState(): void {
@@ -1513,61 +1655,218 @@ export class DashboardView extends AuthedElement {
     }
   }
 
+  /**
+   * One subscription per topic, each mapped to the smallest refresh that can
+   * answer it.
+   *
+   * Every topic used to run the whole page again: 24 requests, and
+   * `gateway_activity` is published once per model call, so one agent working
+   * turned an open Overview into a refresh loop against the API. A topic now
+   * costs at most the handful of requests that topic can change, at most once
+   * every REALTIME_TOPIC_INTERVAL_MS. The attention inputs and the usage
+   * breakdown are not on this path at all; they are on the visible-tab timer
+   * below.
+   */
   private connectRealtime(): void {
-    const scheduleRefresh = () => this.scheduleRefresh();
-    const unsubscribers = [
-      unifiedWebSocketManager.subscribe('runtime_sessions', scheduleRefresh),
-      unifiedWebSocketManager.subscribe('managed_agents', scheduleRefresh),
-      unifiedWebSocketManager.subscribe('gateway_activity', scheduleRefresh),
-      unifiedWebSocketManager.subscribe('budget_health', scheduleRefresh),
-      unifiedWebSocketManager.subscribe('audit', scheduleRefresh),
-      unifiedWebSocketManager.subscribe('approvals', scheduleRefresh),
-      unifiedWebSocketManager.subscribe('flow_executions', scheduleRefresh),
-      unifiedWebSocketManager.subscribe(
-        'system',
-        scheduleRefresh,
-        (message) => message?.type === 'authenticated'
-      ),
+    const routes: Array<{
+      topic: string;
+      /** Topics that change the same data share a key and a floor. */
+      key: string;
+      run: () => Promise<void>;
+    }> = [
+      {
+        topic: 'gateway_activity',
+        key: 'gateway',
+        run: () => this.refreshGatewayFold(),
+      },
+      {
+        topic: 'runtime_sessions',
+        key: 'fleet',
+        run: () => this.refreshFleet(),
+      },
+      { topic: 'managed_agents', key: 'fleet', run: () => this.refreshFleet() },
+      {
+        topic: 'approvals',
+        key: 'approvals',
+        run: () => this.refreshPendingApprovals(),
+      },
+      {
+        topic: 'flow_executions',
+        key: 'flows',
+        run: () => this.refreshFlowRuns(),
+      },
+      {
+        topic: 'budget_health',
+        key: 'budget',
+        run: () => this.fetchBudgetSummary(),
+      },
     ];
+    // Not subscribed: `audit` (the feed ingests the event itself and the
+    // exceptions card is on the background timer) and `system:authenticated`
+    // (the initial fetch has already run by the time it arrives).
+    const unsubscribers = routes.map((route) =>
+      unifiedWebSocketManager.subscribe(route.topic, () =>
+        this.scheduleTopicRefresh(route.key, route.run)
+      )
+    );
     this.unsubscribeRealtime = () => {
       for (const unsubscribe of unsubscribers) {
         unsubscribe();
       }
     };
     void unifiedWebSocketManager.connect();
+
+    // The two expensive reads (attention inputs, usage breakdown) are worth
+    // a minute of staleness and nothing more; a hidden tab is worth nothing.
+    this.backgroundTimer = window.setInterval(() => {
+      if (document.visibilityState !== 'visible') return;
+      void this.refreshBackgroundInputs();
+    }, BACKGROUND_REFRESH_MS);
   }
 
-  private scheduleRefresh(): void {
-    const timeSinceLoad = Date.now() - this.initialLoadTime;
-    if (timeSinceLoad < 5000) {
-      // Skip redundant WebSocket auth/event reloads on initial page load
+  /**
+   * Run one topic's refresher, coalesced and rate limited.
+   *
+   * Events arriving while a run is scheduled are the same news, so they are
+   * dropped rather than queued; a topic that has just run waits out the rest
+   * of its floor instead of running again.
+   */
+  private scheduleTopicRefresh(key: string, run: () => Promise<void>): void {
+    if (Date.now() - this.lastFetchStartedAt < 5000) {
+      // The initial load is still landing; its data is newer than this event.
       return;
     }
-    if (this.lastUpdatedAt) {
-      const elapsed = Date.now() - new Date(this.lastUpdatedAt).getTime();
-      if (elapsed < 5000) {
-        // Skip redundant WebSocket auth reload on initial page load
-        return;
-      }
+    if (this.refreshTimers[key] !== undefined) {
+      return;
     }
-    if (this.refreshTimer !== null) {
-      window.clearTimeout(this.refreshTimer);
-    }
-    this.refreshTimer = window.setTimeout(() => {
-      this.refreshTimer = null;
-      if (this.refreshInFlight) {
-        // A fetch is already running and will return data from before this
-        // event; dropping the event here is what left "Updated 4m ago" on
-        // a page that had just been told something changed. Wait for the
-        // one in flight to land, then take our turn.
-        this.refreshTimer = window.setTimeout(() => {
-          this.refreshTimer = null;
-          void this.fetchDashboardData({ preserveLoadingState: true });
-        }, 1000);
-        return;
-      }
-      void this.fetchDashboardData({ preserveLoadingState: true });
-    }, 250);
+    const sinceLast = Date.now() - (this.lastTopicRefresh[key] || 0);
+    const delay = Math.max(
+      REALTIME_DEBOUNCE_MS,
+      REALTIME_TOPIC_INTERVAL_MS - sinceLast
+    );
+    this.refreshTimers[key] = window.setTimeout(() => {
+      delete this.refreshTimers[key];
+      this.lastTopicRefresh[key] = Date.now();
+      void run()
+        .then(() => {
+          this.lastUpdatedAt = new Date().toISOString();
+          this.scheduleCacheWrite();
+        })
+        .catch((error) => {
+          console.error(
+            `Failed to refresh ${key} from a realtime event`,
+            error
+          );
+        });
+    }, delay);
+  }
+
+  /** What a gateway call can change: the totals, the deltas, the failures. */
+  private async refreshGatewayFold(): Promise<void> {
+    const startDateStr = this.getGatewayStartDate();
+    const priorWindow = this.getPriorGatewayWindow(startDateStr);
+    const [summary, priorSummary, rateLimitReport, interactions] =
+      await Promise.all([
+        this.catchWith403Handling(
+          getAccountGatewayUsageSummary({
+            startDate: startDateStr,
+            includeBreakdown: false,
+          }),
+          null
+        ),
+        this.catchWith403Handling(
+          getAccountGatewayUsageSummary({
+            startDate: priorWindow.startDate,
+            endDate: priorWindow.endDate,
+            includeBreakdown: false,
+          }),
+          null
+        ),
+        this.catchWith403Handling(
+          getAccountRateLimitReport({ startDate: startDateStr }),
+          null
+        ),
+        this.catchWith403Handling(
+          getAccountGatewayUsageSearch({
+            limit: GATEWAY_FAILURES_REFRESH_LIMIT,
+            startDate: startDateStr,
+          }),
+          { items: [] } as Awaited<
+            ReturnType<typeof getAccountGatewayUsageSearch>
+          >
+        ),
+      ]);
+    // Merge, never replace: the breakdown on screen came from a heavier
+    // request that this one does not make.
+    this.gatewaySummary = mergeGatewaySummaryPreservingBreakdown(
+      this.gatewaySummary,
+      summary
+    );
+    this.priorGatewaySummary = priorSummary;
+    this.rateLimitReport = rateLimitReport;
+    this.gatewayInteractions = interactions.items || [];
+  }
+
+  /** What a session or agent event can change. */
+  private async refreshFleet(): Promise<void> {
+    const [runtimeSessions, managedAgents] = await Promise.all([
+      this.catchWith403Handling(
+        getAccountRuntimeSessions({
+          status: 'all',
+          limit: FOLD_SESSIONS_LIMIT,
+          startDate: this.getGatewayStartDate(),
+        }),
+        { items: [] } as Awaited<ReturnType<typeof getAccountRuntimeSessions>>
+      ),
+      this.catchWith403Handling(
+        getAccountAgents({ status: 'all', limit: 100 }),
+        { items: [], total: 0 } as Awaited<ReturnType<typeof getAccountAgents>>
+      ),
+    ]);
+    this.runtimeSessions = runtimeSessions.items || [];
+    this.totalRuntimeSessionsCount =
+      runtimeSessions.total ?? this.runtimeSessions.length;
+    this.applyAgentsList(managedAgents);
+  }
+
+  /** What an approval event can change. */
+  private async refreshPendingApprovals(): Promise<void> {
+    const pending = await this.catchWith403Handling(
+      this.fetchApprovalRequests('pending', 100),
+      [] as ApprovalRequest[]
+    );
+    this.pendingApprovals = pending.filter((approval) =>
+      this.isUnexpiredPendingApproval(approval)
+    );
+  }
+
+  /** What a flow execution event can change. */
+  private async refreshFlowRuns(): Promise<void> {
+    const [flows, flowExecutions] = await Promise.all([
+      this.catchWith403Handling(getFlows(), [] as any[]),
+      this.catchWith403Handling(
+        getFlowExecutions({ limit: FLOW_EXECUTIONS_PAGE_SIZE }),
+        [] as FlowExecution[]
+      ),
+    ]);
+    this.applyFlows(flows);
+    this.applyFlowExecutions(flowExecutions);
+  }
+
+  /**
+   * The reads that are too expensive for an event: the 30-day attention
+   * breakdown and the selected range's breakdown. Once a minute, and only
+   * while somebody is looking.
+   */
+  private async refreshBackgroundInputs(): Promise<void> {
+    const startDateStr = this.getGatewayStartDate();
+    const breakdown = await this.refreshUsageBreakdown(startDateStr);
+    await this.refreshAttentionInputs({
+      usageSummary:
+        this.gatewayTimeRange === 'month' ? breakdown || undefined : undefined,
+    });
+    await this.refreshAuditExceptions();
+    this.scheduleCacheWrite();
   }
 
   private getGatewayStartDate(): string {
@@ -1691,6 +1990,16 @@ export class DashboardView extends AuthedElement {
     }
   }
 
+  /**
+   * The first wave: what the top of the page needs and nothing else.
+   *
+   * Eight small requests in parallel, then `loading` is off. Everything
+   * heavier - the flows and their runs, the gateway call log, the tools, the
+   * usage breakdown, the attention inputs - runs after the first paint in
+   * {@link fetchDeferredData}. Nothing here is awaited twice: budget policies
+   * used to sit between the wave and `loading = false`, so the whole page
+   * waited on a request only the Usage card and the checklist read.
+   */
   private async fetchDashboardData(
     options: { preserveLoadingState?: boolean } = {}
   ) {
@@ -1698,10 +2007,13 @@ export class DashboardView extends AuthedElement {
       return;
     }
     this.refreshInFlight = true;
+    this.lastFetchStartedAt = Date.now();
+    markOverviewTiming('overview-fetch-start');
 
     if (!options.preserveLoadingState) {
       this.fetchingGatewaySummary = true;
       this.fetchingRecentExecutions = true;
+      this.fetchingInventory = true;
       this.fetchingApprovals = true;
       this.fetchingAgents = true;
       this.fetchingBudget = true;
@@ -1712,138 +2024,82 @@ export class DashboardView extends AuthedElement {
     this.error = null;
 
     const startDateStr = this.getGatewayStartDate();
+    const priorWindow = this.getPriorGatewayWindow(startDateStr);
 
     try {
-      // Wave 1 (above-the-fold): gateway metrics, budget, recent executions,
-      // active agents, approvals, features/admin — each unique resource once.
-      const agentsPromise = this.catchWith403Handling(
-        getAccountAgents({ status: 'all', limit: 100 }),
-        {
-          items: [],
-          total: 0,
-        } as Awaited<ReturnType<typeof getAccountAgents>>
-      );
-      const gatewaySummaryPromise = this.catchWith403Handling(
-        getAccountGatewayUsageSummary({
-          startDate: startDateStr,
-          includeBreakdown: false,
-        }),
-        null
-      );
-      const priorWindow = this.getPriorGatewayWindow(startDateStr);
-      const priorSummaryPromise = this.catchWith403Handling(
-        getAccountGatewayUsageSummary({
-          startDate: priorWindow.startDate,
-          endDate: priorWindow.endDate,
-          includeBreakdown: false,
-        }),
-        null
-      );
-      // One call, same window as the summary: without it the model row cannot
-      // say how many requests a provider throttled.
-      const rateLimitPromise = this.catchWith403Handling(
-        getAccountRateLimitReport({ startDate: startDateStr }),
-        null
-      );
-      const featuresPromise = this.fetchFeatures();
       const adminPromise = this.fetchAdminStatus();
-
       const [
         gatewaySummary,
-        gatewayInteractions,
-        flows,
-        flowExecutions,
+        priorGatewaySummary,
+        rateLimitReport,
         pendingApprovals,
-        allApprovalRequests,
         runtimeSessions,
         managedAgents,
         featuresRes,
-        priorGatewaySummary,
-        rateLimitReport,
       ] = await Promise.all([
-        gatewaySummaryPromise,
-        // The failures card shows a handful, and it should be the handful
-        // that happened in the range the page is showing: a full page of
-        // in-range calls is far likelier to contain the current failures
-        // than the last twelve calls of any age were.
         this.catchWith403Handling(
-          getAccountGatewayUsageSearch({
-            limit: 100,
+          getAccountGatewayUsageSummary({
             startDate: startDateStr,
+            includeBreakdown: false,
           }),
-          {
-            items: [],
-          } as Awaited<ReturnType<typeof getAccountGatewayUsageSearch>>
+          null
         ),
-        this.catchWith403Handling(getFlows(), [] as any[]),
-        // The Inventory Flows tab needs a last run, a run count and a failure
-        // count for every flow in the account, so this reads the server's
-        // maximum page rather than the five rows the old card showed.
         this.catchWith403Handling(
-          getFlowExecutions({ limit: FLOW_EXECUTIONS_PAGE_SIZE }),
-          [] as FlowExecution[]
+          getAccountGatewayUsageSummary({
+            startDate: priorWindow.startDate,
+            endDate: priorWindow.endDate,
+            includeBreakdown: false,
+          }),
+          null
+        ),
+        // One call, same window as the summary: without it the model row
+        // cannot say how many requests a provider throttled.
+        this.catchWith403Handling(
+          getAccountRateLimitReport({ startDate: startDateStr }),
+          null
         ),
         this.catchWith403Handling(
           this.fetchApprovalRequests('pending', 100),
-          []
+          [] as ApprovalRequest[]
         ),
-        this.catchWith403Handling(
-          this.fetchApprovalRequests(undefined, 100),
-          []
-        ),
+        // Above the fold a session answers one question - has anything ever
+        // run on this account - so a short page is enough. The attention
+        // loader asks for the window and the depth its rules need.
         this.catchWith403Handling(
           getAccountRuntimeSessions({
             status: 'all',
-            limit: 100,
+            limit: FOLD_SESSIONS_LIMIT,
             startDate: startDateStr,
           }),
           {
             items: [],
           } as Awaited<ReturnType<typeof getAccountRuntimeSessions>>
         ),
-        agentsPromise,
-        featuresPromise,
-        priorSummaryPromise,
-        rateLimitPromise,
+        this.catchWith403Handling(
+          getAccountAgents({ status: 'all', limit: 100 }),
+          {
+            items: [],
+            total: 0,
+          } as Awaited<ReturnType<typeof getAccountAgents>>
+        ),
+        this.fetchFeatures(),
       ]);
       await adminPromise;
-      this.rateLimitReport = rateLimitReport;
 
+      // One batch of assignments with no await between them, so Lit renders
+      // the finished fold once instead of eight times.
+      this.rateLimitReport = rateLimitReport;
       this.gatewaySummary = mergeGatewaySummaryPreservingBreakdown(
         this.gatewaySummary,
         gatewaySummary
       );
       this.priorGatewaySummary = priorGatewaySummary;
-      this.gatewayInteractions = gatewayInteractions.items || [];
       this.fetchingGatewaySummary = false;
       this.updatingUsage = false;
-
-      this.hasFlows = (flows || []).length > 0;
-      this.totalFlowsCount = (flows || []).length;
-      this.flows = (flows || []).map((flow: { id: string; name?: string }) => ({
-        id: flow.id,
-        name: flow.name || 'Untitled flow',
-      }));
-      const sortedFlowExecutions = [...(flowExecutions || [])].sort(
-        (left, right) =>
-          new Date(right.start_time).getTime() -
-          new Date(left.start_time).getTime()
-      );
-      this.flowExecutionsCount = sortedFlowExecutions.length;
-      this.failedExecutionsCount = sortedFlowExecutions.filter(
-        (execution) => execution.status === 'FAILED'
-      ).length;
-      this.succeededFlowExecutionsCount = sortedFlowExecutions.filter(
-        (execution) =>
-          execution.status === 'SUCCEEDED' || execution.status === 'COMPLETED'
-      ).length;
-      this.flowExecutions = sortedFlowExecutions;
-      this.fetchingRecentExecutions = false;
 
       this.pendingApprovals = pendingApprovals.filter((approval) =>
         this.isUnexpiredPendingApproval(approval)
       );
-      this.calculateApprovalStats(allApprovalRequests);
       this.fetchingApprovals = false;
 
       this.runtimeSessions = runtimeSessions.items || [];
@@ -1852,31 +2108,19 @@ export class DashboardView extends AuthedElement {
       this.applyAgentsList(managedAgents);
       this.fetchingAgents = false;
 
-      await this.fetchBudgetSummary({
+      this.lastUpdatedAt = new Date().toISOString();
+      this.loading = false;
+      markOverviewTiming('overview-fold-ready');
+
+      // Not awaited: the Usage card and the checklist wait on
+      // `fetchingBudget` themselves, and nothing above the fold does.
+      this.budgetReady = this.fetchBudgetSummary({
         sharedAgents: managedAgents,
         features: featuresRes,
       });
+      this.scheduleCacheWrite();
 
-      this.lastUpdatedAt = new Date().toISOString();
-      this.loading = false;
-      this.saveDashboardCache();
-
-      // After the fold, not during wave 1: attention used to fetch its own
-      // usage breakdown in parallel and first paint waited for it. The
-      // loader still uses a fixed 30-day window so the strip matches
-      // /console/attention; wave 2's selected range is a different query.
-      void this.refreshAttentionInputs();
-
-      // Wave 2 is slow (full session breakdown + audit/tools). On a live
-      // websocket refresh only upgrade the top-models breakdown so the card
-      // does not flash empty while the rest of the dashboard stays put.
-      if (options.preserveLoadingState) {
-        void this.refreshUsageBreakdown(startDateStr).then(() =>
-          this.saveDashboardCache()
-        );
-      } else {
-        void this.fetchSecondaryDashboardData(startDateStr);
-      }
+      void this.fetchDeferredData(startDateStr);
     } catch (error) {
       console.error(
         'Failed to complete background loading of overview dashboard',
@@ -1886,6 +2130,7 @@ export class DashboardView extends AuthedElement {
       this.fetchingGatewaySummary = false;
       this.updatingUsage = false;
       this.fetchingRecentExecutions = false;
+      this.fetchingInventory = false;
       this.fetchingApprovals = false;
       this.fetchingAgents = false;
       this.fetchingBudget = false;
@@ -1897,7 +2142,117 @@ export class DashboardView extends AuthedElement {
     }
   }
 
-  private async fetchSecondaryDashboardData(gatewayStartDate: string) {
+  /**
+   * Everything below the fold, after the first paint.
+   *
+   * The three groups run in parallel; the attention loader runs last because
+   * it is handed the approvals, agents, policies and breakdown the rest of
+   * this pass already fetched, instead of fetching its own copies of all
+   * four.
+   */
+  private async fetchDeferredData(startDateStr: string): Promise<void> {
+    const inventoryPromise = this.fetchInventoryData(startDateStr);
+    const breakdownPromise = this.refreshUsageBreakdown(startDateStr);
+    const secondaryPromise = this.fetchSecondaryDashboardData();
+
+    const [, breakdown] = await Promise.all([
+      inventoryPromise,
+      breakdownPromise,
+    ]);
+    markOverviewTiming('overview-inventory-ready');
+    // The policies are one of the attention inputs, so this is the one place
+    // that does wait for them.
+    await this.budgetReady.catch(() => undefined);
+    await this.refreshAttentionInputs({
+      // The attention rules want a 30-day breakdown. When the page is on its
+      // default month range that is the request that just ran, give or take
+      // a day, so the second copy of it is not worth a second heavy query.
+      usageSummary:
+        this.gatewayTimeRange === 'month' ? breakdown || undefined : undefined,
+    });
+    await secondaryPromise;
+    this.scheduleCacheWrite();
+    markOverviewTiming('overview-deferred-ready');
+  }
+
+  /** Flows, their runs, resolved approvals and the gateway call log. */
+  private async fetchInventoryData(startDateStr: string): Promise<void> {
+    this.fetchingInventory = true;
+    this.fetchingRecentExecutions = true;
+    try {
+      const [flows, flowExecutions, allApprovalRequests, gatewayInteractions] =
+        await Promise.all([
+          this.catchWith403Handling(getFlows(), [] as any[]),
+          // The Inventory Flows tab needs a last run, a run count and a
+          // failure count for every flow in the account, so this reads the
+          // server's maximum page rather than the five rows the old card
+          // showed.
+          this.catchWith403Handling(
+            getFlowExecutions({ limit: FLOW_EXECUTIONS_PAGE_SIZE }),
+            [] as FlowExecution[]
+          ),
+          this.catchWith403Handling(
+            this.fetchApprovalRequests(undefined, 100),
+            [] as ApprovalRequest[]
+          ),
+          // The failures card shows a handful, and it should be the handful
+          // that happened in the range the page is showing.
+          this.catchWith403Handling(
+            getAccountGatewayUsageSearch({
+              limit: 100,
+              startDate: startDateStr,
+            }),
+            {
+              items: [],
+            } as Awaited<ReturnType<typeof getAccountGatewayUsageSearch>>
+          ),
+        ]);
+
+      this.applyFlows(flows);
+      this.applyFlowExecutions(flowExecutions);
+      this.calculateApprovalStats(allApprovalRequests);
+      this.gatewayInteractions = gatewayInteractions.items || [];
+    } catch (error) {
+      console.error('Failed to load the Inventory data', error);
+    } finally {
+      this.fetchingInventory = false;
+      this.fetchingRecentExecutions = false;
+    }
+  }
+
+  private applyFlows(flows: Array<{ id: string; name?: string }>): void {
+    const list = flows || [];
+    this.hasFlows = list.length > 0;
+    this.totalFlowsCount = list.length;
+    this.flows = list.map((flow) => ({
+      id: flow.id,
+      name: flow.name || 'Untitled flow',
+    }));
+  }
+
+  private applyFlowExecutions(flowExecutions: FlowExecution[]): void {
+    const sorted = [...(flowExecutions || [])].sort(
+      (left, right) =>
+        new Date(right.start_time).getTime() -
+        new Date(left.start_time).getTime()
+    );
+    this.flowExecutionsCount = sorted.length;
+    this.failedExecutionsCount = sorted.filter(
+      (execution) => execution.status === 'FAILED'
+    ).length;
+    this.succeededFlowExecutionsCount = sorted.filter(
+      (execution) =>
+        execution.status === 'SUCCEEDED' || execution.status === 'COMPLETED'
+    ).length;
+    this.flowExecutions = sorted;
+  }
+
+  /**
+   * Audit exceptions, teammates, the tool catalogue and the model list. The
+   * usage breakdown used to be awaited here too; it is now started beside
+   * this pass so the attention loader can reuse it.
+   */
+  private async fetchSecondaryDashboardData() {
     this.fetchingAudit = true;
     this.fetchingMCPAndTools = true;
 
@@ -1953,8 +2308,7 @@ export class DashboardView extends AuthedElement {
           // view_users. Both the flags and the profile have answered by
           // the time this secondary fetch runs, so a reader without the
           // permission does not spend a request on a certain 403.
-          hasPermission(this.permissions, 'view_users') &&
-            (isSaaS() || this.userManagementEnabled)
+          this.fetchesUsers
             ? getUsers()
             : Promise.resolve({
                 users: [],
@@ -2028,16 +2382,18 @@ export class DashboardView extends AuthedElement {
       }
     })();
 
-    await Promise.all([
-      pAudit,
-      pTools,
-      pUsers,
-      this.refreshUsageBreakdown(gatewayStartDate),
-    ]);
-    this.saveDashboardCache();
+    await Promise.all([pAudit, pTools, pUsers]);
+    this.scheduleCacheWrite();
   }
 
-  private async refreshUsageBreakdown(gatewayStartDate: string) {
+  /**
+   * The breakdown behind the top-models card and the usage columns, plus the
+   * per-model overview. Returns the breakdown so the attention loader can be
+   * handed it instead of asking for a second one.
+   */
+  private async refreshUsageBreakdown(
+    gatewayStartDate: string
+  ): Promise<AccountGatewayUsageSummaryResponse | null> {
     this.fetchingUsageBreakdown = true;
     try {
       // Both in the deferred pass, so the fold is unaffected: the breakdown
@@ -2060,11 +2416,13 @@ export class DashboardView extends AuthedElement {
         this.aiModelOverview = overview.models;
       }
       if (!detailed) {
-        return;
+        return null;
       }
       this.gatewaySummary = detailed;
+      return detailed;
     } catch (error) {
       console.error('Failed to load gateway breakdown for top models', error);
+      return null;
     } finally {
       // Off whatever happened: a 403 on this endpoint means the columns will
       // never fill, and a skeleton that never resolves is worse than a zero.
@@ -2223,28 +2581,22 @@ export class DashboardView extends AuthedElement {
   }
 
   private formatRelativeTime(value: string | null | undefined): string {
-    if (!value) {
-      return 'Never';
-    }
-    const timestamp = parseUTCDate(value).getTime();
-    const deltaMinutes = Math.round((Date.now() - timestamp) / 60000);
-    if (deltaMinutes < 1) {
-      return 'just now';
-    }
-    if (deltaMinutes < 60) {
-      return `${deltaMinutes}m ago`;
-    }
-    const deltaHours = Math.round(deltaMinutes / 60);
-    if (deltaHours < 24) {
-      return `${deltaHours}h ago`;
-    }
-    return `${Math.round(deltaHours / 24)}d ago`;
+    return formatRelativeTime(value);
   }
 
-  private formatLastUpdatedLabel(): string {
-    if (this.lastUpdatedAt) {
-      return this.formatRelativeTime(this.lastUpdatedAt);
-    }
+  /**
+   * The freshness stamp beside the title. The element owns its own thirty
+   * second timer, so ageing the label no longer re-renders this page.
+   */
+  private renderLastUpdated() {
+    return html`<relative-time-label
+      .timestamp=${this.lastUpdatedAt}
+      .fallback=${this.lastUpdatedFallback}
+    ></relative-time-label>`;
+  }
+
+  /** What the header shows when there is no timestamp to age yet. */
+  private get lastUpdatedFallback(): string {
     if (
       this.loading ||
       this.fetchingGatewaySummary ||
@@ -2287,21 +2639,50 @@ export class DashboardView extends AuthedElement {
     if (!this.attentionInputs) {
       return [];
     }
-    return deriveAttentionItems(this.attentionInputs).items;
+    // Memoised on the inputs object: the derivation is a thousand-line rules
+    // module and this getter is read from the template, so it used to run on
+    // every render, including the forty a load causes.
+    if (this.attentionMemo?.inputs === this.attentionInputs) {
+      return this.attentionMemo.items;
+    }
+    const items = deriveAttentionItems(this.attentionInputs).items;
+    this.attentionMemo = { inputs: this.attentionInputs, items };
+    return items;
   }
 
   /**
-   * Same loader, same parameters as the Attention page, including the
-   * fixed 30-day usage breakdown. Starts after the first paint so a slow
-   * attention input never holds up the cards above the fold.
+   * Same loader, same rules as the Attention page, over the inputs this page
+   * already has where it has them: approvals, agents and budget policies come
+   * from the fold, and on the default month range the usage breakdown comes
+   * from the deferred pass. The rest is fetched exactly as before. Starts
+   * after the first paint so a slow attention input never holds up the cards
+   * above the fold.
    */
-  private async refreshAttentionInputs(): Promise<void> {
+  private async refreshAttentionInputs(
+    shared: PrefetchedAttentionInputs = {}
+  ): Promise<void> {
     try {
-      this.attentionInputs = await loadAttentionInputs();
-      this.saveDashboardCache();
+      this.attentionInputs = await loadAttentionInputs({
+        prefetched: {
+          approvals: this.pendingApprovals as AttentionApproval[],
+          agents: this.managedAgents,
+          budgetPolicies: this.budgetPolicies,
+          ...shared,
+        },
+      });
+      this.scheduleCacheWrite();
     } catch (error) {
       console.error('Failed to load attention inputs', error);
     }
+  }
+
+  /** The exceptions card on its own, for the background timer. */
+  private async refreshAuditExceptions(): Promise<void> {
+    const audit = await this.catchWith403Handling(this.fetchAuditExceptions(), {
+      groups: [],
+      total: 0,
+    });
+    this.auditGroups = audit.groups || [];
   }
 
   private get gatewayRangeLabel(): string {
@@ -3279,6 +3660,11 @@ export class DashboardView extends AuthedElement {
         .rangeLabel=${this.gatewayRangeLabel}
         .flowRunsCapped=${this.flowRunsCapped}
         ?loading=${this.loading || this.fetchingMCPAndTools}
+        .loadingAgents=${this.loading}
+        .loadingFlows=${this.loading || this.fetchingInventory}
+        .loadingModels=${this.loading || this.fetchingMCPAndTools}
+        .loadingTools=${this.loading || this.fetchingMCPAndTools}
+        .loadingUsers=${this.loading || this.fetchingUsers}
         ?usageLoading=${this.usageColumnsPending}
       ></inventory-card>
     `;
@@ -3292,6 +3678,8 @@ export class DashboardView extends AuthedElement {
         .agents=${this.managedAgents}
         .executions=${this.flowExecutions}
         .budgetPolicies=${this.budgetPolicies}
+        .users=${this.accountUsers}
+        ?usersFromHost=${this.fetchesUsers}
         @open-budget-limits=${() => (this.showBudgetDialog = true)}
       ></activity-feed>
     `;
@@ -3325,7 +3713,7 @@ export class DashboardView extends AuthedElement {
               ? parseUTCDate(this.lastUpdatedAt).toLocaleString()
               : 'Not loaded yet'
           }
-          >Updated ${this.formatLastUpdatedLabel()}</span
+          >Updated ${this.renderLastUpdated()}</span
         >
       </view-header>
       <div class="extra-wide" style="margin-bottom: var(--sl-spacing-large);">

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -1860,12 +1860,10 @@ export class DashboardView extends AuthedElement {
    */
   private async refreshBackgroundInputs(): Promise<void> {
     const startDateStr = this.getGatewayStartDate();
-    const breakdown = await this.refreshUsageBreakdown(startDateStr);
-    await this.refreshAttentionInputs({
-      usageSummary:
-        this.gatewayTimeRange === 'month' ? breakdown || undefined : undefined,
-    });
+    await this.refreshUsageBreakdown(startDateStr);
+    await this.refreshAttentionInputs();
     await this.refreshAuditExceptions();
+    this.lastUpdatedAt = new Date().toISOString();
     this.scheduleCacheWrite();
   }
 
@@ -2171,21 +2169,14 @@ export class DashboardView extends AuthedElement {
     const breakdownPromise = this.refreshUsageBreakdown(startDateStr);
     const secondaryPromise = this.fetchSecondaryDashboardData();
 
-    const [, breakdown] = await Promise.all([
-      inventoryPromise,
-      breakdownPromise,
-    ]);
+    await Promise.all([inventoryPromise, breakdownPromise]);
     markOverviewTiming('overview-inventory-ready');
     // The policies are one of the attention inputs, so this is the one place
     // that does wait for them.
     await this.budgetReady.catch(() => undefined);
-    await this.refreshAttentionInputs({
-      // The attention rules want a 30-day breakdown. When the page is on its
-      // default month range that is the request that just ran, give or take
-      // a day, so the second copy of it is not worth a second heavy query.
-      usageSummary:
-        this.gatewayTimeRange === 'month' ? breakdown || undefined : undefined,
-    });
+    // Attention always uses its own rolling 30-day window. The Overview
+    // "month" range is a calendar month, which is not the same 30 days.
+    await this.refreshAttentionInputs();
     await secondaryPromise;
     this.scheduleCacheWrite();
     markOverviewTiming('overview-deferred-ready');

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -2148,9 +2148,9 @@ export class DashboardView extends AuthedElement {
    * Everything below the fold, after the first paint.
    *
    * The three groups run in parallel; the attention loader runs last because
-   * it is handed the approvals, agents, policies and breakdown the rest of
-   * this pass already fetched, instead of fetching its own copies of all
-   * four.
+   * it is handed the approvals, agents, and budget policies this pass already
+   * fetched. The usage breakdown is not shared: attention always loads its
+   * own rolling 30-day window, which is not the Overview calendar-month range.
    */
   private async fetchDeferredData(
     startDateStr: string,
@@ -2662,12 +2662,11 @@ export class DashboardView extends AuthedElement {
   }
 
   /**
-   * Same loader, same rules as the Attention page, over the inputs this page
-   * already has where it has them: approvals, agents and budget policies come
-   * from the fold, and on the default month range the usage breakdown comes
-   * from the deferred pass. The rest is fetched exactly as before. Starts
-   * after the first paint so a slow attention input never holds up the cards
-   * above the fold.
+   * Same loader, same rules as the Attention page. Approvals, agents and
+   * budget policies come from the fold; the usage breakdown is never reused
+   * from the Overview range (a calendar month is not a rolling 30 days).
+   * Starts after the first paint so a slow attention input never holds up
+   * the cards above the fold.
    */
   private async refreshAttentionInputs(
     shared: PrefetchedAttentionInputs = {}

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -1968,7 +1968,7 @@ export class DashboardView extends AuthedElement {
 
       this.budgetPolicies = Array.isArray(policies) ? policies : [];
       this.budgetAgents = budgetAgents.items || [];
-      this.saveDashboardCache();
+      this.scheduleCacheWrite();
     } finally {
       this.fetchingBudget = false;
     }
@@ -2120,7 +2120,11 @@ export class DashboardView extends AuthedElement {
       });
       this.scheduleCacheWrite();
 
-      void this.fetchDeferredData(startDateStr);
+      void this.fetchDeferredData(startDateStr, {
+        // A range change reloads what the range changes; the flows, the
+        // people and the tool catalogue are the same at any range.
+        rangeChangeOnly: options.preserveLoadingState === true,
+      });
     } catch (error) {
       console.error(
         'Failed to complete background loading of overview dashboard',
@@ -2150,7 +2154,19 @@ export class DashboardView extends AuthedElement {
    * this pass already fetched, instead of fetching its own copies of all
    * four.
    */
-  private async fetchDeferredData(startDateStr: string): Promise<void> {
+  private async fetchDeferredData(
+    startDateStr: string,
+    options: { rangeChangeOnly?: boolean } = {}
+  ): Promise<void> {
+    if (options.rangeChangeOnly) {
+      await Promise.all([
+        this.refreshGatewayInteractions(startDateStr),
+        this.refreshUsageBreakdown(startDateStr),
+      ]);
+      this.scheduleCacheWrite();
+      markOverviewTiming('overview-deferred-ready');
+      return;
+    }
     const inventoryPromise = this.fetchInventoryData(startDateStr);
     const breakdownPromise = this.refreshUsageBreakdown(startDateStr);
     const secondaryPromise = this.fetchSecondaryDashboardData();
@@ -2175,43 +2191,47 @@ export class DashboardView extends AuthedElement {
     markOverviewTiming('overview-deferred-ready');
   }
 
+  /**
+   * The page of gateway calls behind the failures card. Its rows are the ones
+   * that happened inside the range on screen, so a range change reloads it.
+   */
+  private async refreshGatewayInteractions(
+    startDateStr: string
+  ): Promise<void> {
+    const interactions = await this.catchWith403Handling(
+      getAccountGatewayUsageSearch({ limit: 100, startDate: startDateStr }),
+      { items: [] } as Awaited<ReturnType<typeof getAccountGatewayUsageSearch>>
+    );
+    this.gatewayInteractions = interactions.items || [];
+  }
+
   /** Flows, their runs, resolved approvals and the gateway call log. */
   private async fetchInventoryData(startDateStr: string): Promise<void> {
     this.fetchingInventory = true;
     this.fetchingRecentExecutions = true;
     try {
-      const [flows, flowExecutions, allApprovalRequests, gatewayInteractions] =
-        await Promise.all([
-          this.catchWith403Handling(getFlows(), [] as any[]),
-          // The Inventory Flows tab needs a last run, a run count and a
-          // failure count for every flow in the account, so this reads the
-          // server's maximum page rather than the five rows the old card
-          // showed.
-          this.catchWith403Handling(
-            getFlowExecutions({ limit: FLOW_EXECUTIONS_PAGE_SIZE }),
-            [] as FlowExecution[]
-          ),
-          this.catchWith403Handling(
-            this.fetchApprovalRequests(undefined, 100),
-            [] as ApprovalRequest[]
-          ),
-          // The failures card shows a handful, and it should be the handful
-          // that happened in the range the page is showing.
-          this.catchWith403Handling(
-            getAccountGatewayUsageSearch({
-              limit: 100,
-              startDate: startDateStr,
-            }),
-            {
-              items: [],
-            } as Awaited<ReturnType<typeof getAccountGatewayUsageSearch>>
-          ),
-        ]);
+      const [flows, flowExecutions, allApprovalRequests] = await Promise.all([
+        this.catchWith403Handling(getFlows(), [] as any[]),
+        // The Inventory Flows tab needs a last run, a run count and a
+        // failure count for every flow in the account, so this reads the
+        // server's maximum page rather than the five rows the old card
+        // showed.
+        this.catchWith403Handling(
+          getFlowExecutions({ limit: FLOW_EXECUTIONS_PAGE_SIZE }),
+          [] as FlowExecution[]
+        ),
+        this.catchWith403Handling(
+          this.fetchApprovalRequests(undefined, 100),
+          [] as ApprovalRequest[]
+        ),
+        // The failures card shows a handful, and it should be the handful
+        // that happened in the range the page is showing.
+        this.refreshGatewayInteractions(startDateStr),
+      ]);
 
       this.applyFlows(flows);
       this.applyFlowExecutions(flowExecutions);
       this.calculateApprovalStats(allApprovalRequests);
-      this.gatewayInteractions = gatewayInteractions.items || [];
     } catch (error) {
       console.error('Failed to load the Inventory data', error);
     } finally {

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -542,7 +542,8 @@ describe('DashboardView', () => {
       () =>
         !element['loading'] &&
         !element['fetchingAudit'] &&
-        !element['fetchingMCPAndTools'],
+        !element['fetchingMCPAndTools'] &&
+        element['attentionInputs'] != null,
       'dashboard did not finish loading'
     );
     await element.updateComplete;
@@ -571,8 +572,9 @@ describe('DashboardView', () => {
     );
 
     expect(connectStub).to.have.been.calledOnce;
-    // Eight for the page's own refresh, seven for the Activity feed's topics.
-    expect(subscribeStub.callCount).to.equal(15);
+    // Six for the page's own topic refreshers (audit and the authenticated
+    // signal no longer cost a request), seven for the Activity feed's topics.
+    expect(subscribeStub.callCount).to.equal(13);
 
     const urls = fetchStub.getCalls().map((call) => String(call.args[0]));
     expect(
@@ -580,21 +582,24 @@ describe('DashboardView', () => {
         url.startsWith('/api/v1/account/gateway-usage/summary')
       )
     ).to.be.true;
-    // Two for the cards (summary + breakdown upgrade), one for the prior
-    // window behind the Usage delta, and one 30-day breakdown for attention.
+    // Two for the cards (summary + breakdown upgrade) and one for the prior
+    // window behind the Usage delta. The attention rules read the same
+    // breakdown rather than asking for a second one.
     expect(
       urls.filter((url) =>
         url.startsWith('/api/v1/account/gateway-usage/summary')
       ).length
-    ).to.equal(4);
+    ).to.equal(3);
     expect(urls.some((url) => url.includes('include_breakdown=false'))).to.be
       .true;
     expect(
       urls.filter((url) => url.includes('include_breakdown=true')).length
-    ).to.equal(2);
+    ).to.equal(1);
+    // One list of agents for the whole load: the attention rules are handed
+    // the list the fold already fetched.
     expect(
       urls.filter((url) => url.startsWith('/api/v1/agents')).length
-    ).to.equal(2);
+    ).to.equal(1);
     expect(urls.some((url) => url === '/api/v1/auth/api-usage')).to.be.false;
     expect(urls.some((url) => url.startsWith('/api/v1/audit-logs/grouped'))).to
       .be.true;
@@ -1690,13 +1695,17 @@ describe('DashboardView', () => {
         (
           element.shadowRoot?.querySelector('view-header .updated-at')
             ?.textContent || ''
-        ).trim();
+        )
+          .replace(/\s+/g, ' ')
+          .trim();
       expect(label()).to.equal('Updated just now');
 
       // The page has been open for four minutes and nothing has changed.
       element['lastUpdatedAt'] = new Date(Date.now() - 4 * 60000).toISOString();
-      element['updatedTick'] += 1;
       await element.updateComplete;
+      const stamp = element.shadowRoot?.querySelector('relative-time-label');
+      await (stamp as unknown as { updateComplete: Promise<unknown> })
+        .updateComplete;
       expect(label()).to.equal('Updated 4m ago');
       expect(
         element.shadowRoot
@@ -1709,15 +1718,107 @@ describe('DashboardView', () => {
       const element = await mountLoaded();
       // A socket event arriving mid-refresh used to be dropped, leaving the
       // header claiming numbers older than the event that announced them.
-      element['refreshInFlight'] = true;
-      element['initialLoadTime'] = Date.now() - 60000;
+      element['lastFetchStartedAt'] = Date.now() - 60000;
       element['lastUpdatedAt'] = new Date(Date.now() - 60000).toISOString();
-      element['scheduleRefresh']();
+      let ran = 0;
+      element['scheduleTopicRefresh']('gateway', async () => {
+        ran += 1;
+      });
+      expect(element['refreshTimers']['gateway']).to.not.equal(undefined);
+      await waitUntil(() => ran === 1, 'queued refresh never ran');
+    });
+
+    it('loads the fold without asking for the same thing twice', async () => {
+      // Hold the deferred pass so what is counted is exactly what the reader
+      // waits for before the page is usable.
+      const proto = customElements.get('dashboard-view')!
+        .prototype as unknown as Record<string, unknown>;
+      const deferred = sinon.stub(proto, 'fetchDeferredData').resolves();
+      let element: DashboardView;
+      try {
+        element = await mountDashboard();
+        await waitUntil(() => !element['loading'], 'fold never finished');
+        await waitUntil(() => deferred.called, 'deferred pass never started');
+      } finally {
+        deferred.restore();
+      }
+
+      const foldUrls = fetchStub
+        .getCalls()
+        .map((call) => String(call.args[0]))
+        // The feed and the dialogs in the template are separate elements that
+        // fetch their own reference data on connect; this counts the page.
+        .filter(
+          (url) =>
+            !url.startsWith('/api/v1/audit-logs') &&
+            !url.startsWith('/api/v1/teams') &&
+            !url.startsWith('/api/v1/roles') &&
+            !url.startsWith('/api/v1/ai-models')
+        );
+      const duplicates = foldUrls.filter(
+        (url, index) => foldUrls.indexOf(url) !== index
+      );
+      expect(duplicates, 'a URL was fetched twice before the fold').to.eql([]);
+      // Eight above the fold plus the two assignment reads behind the
+      // approvals card. The wave before this one took twenty three.
+      expect(foldUrls.length, foldUrls.join('\n')).to.be.at.most(12);
+    });
+
+    it('answers a gateway event with four requests, not the page', async () => {
+      const element = await mountLoaded();
+      await waitUntil(
+        () => element['attentionInputs'] != null,
+        'deferred pass never finished'
+      );
+      const handler = subscribeStub
+        .getCalls()
+        .find(
+          (call) =>
+            call.args[0] === 'gateway_activity' &&
+            call.thisValue === unifiedWebSocketManager
+        )?.args[1] as (message: unknown) => void;
+      expect(handler, 'nothing listens to gateway_activity').to.be.a(
+        'function'
+      );
+
+      // The load's own five second grace period is what the gate reads.
+      element['lastFetchStartedAt'] = Date.now() - 30000;
+      fetchStub.resetHistory();
+      handler({ type: 'gateway_activity' });
+      // A busy agent publishes one of these per model call.
+      handler({ type: 'gateway_activity' });
+      handler({ type: 'gateway_activity' });
+      await waitUntil(
+        () => fetchStub.callCount > 0,
+        'the event was never served'
+      );
       await new Promise((resolve) => setTimeout(resolve, 300));
-      expect(element['refreshTimer']).to.not.equal(null);
-      element['refreshInFlight'] = false;
-      window.clearTimeout(element['refreshTimer'] as number);
-      element['refreshTimer'] = null;
+
+      const urls = fetchStub.getCalls().map((call) => String(call.args[0]));
+      expect(urls.length, urls.join('\n')).to.be.at.most(4);
+      expect(urls.some((url) => url.startsWith('/api/v1/flows'))).to.be.false;
+      expect(urls.some((url) => url.includes('include_breakdown=true'))).to.be
+        .false;
+    });
+
+    it('derives the attention list once per set of inputs', async () => {
+      const element = await mountLoaded();
+      await waitUntil(
+        () => element['attentionInputs'] != null,
+        'deferred pass never finished'
+      );
+
+      const first = element['attentionItems'];
+      // Something unrelated changes and the page renders again.
+      element['showBudgetDialog'] = true;
+      await element.updateComplete;
+      expect(element['attentionItems']).to.equal(first);
+
+      element['attentionInputs'] = {
+        ...element['attentionInputs']!,
+      };
+      await element.updateComplete;
+      expect(element['attentionItems']).to.not.equal(first);
     });
 
     it('opens the budget dialog when the feed asks for it', async () => {

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -1571,6 +1571,44 @@ describe('DashboardView', () => {
       expect(usage.updating).to.be.false;
     });
 
+    it('reloads what the range changes and nothing else', async () => {
+      const element = await mountDashboard();
+      await waitUntil(
+        () => element['attentionInputs'] != null,
+        'first pass did not finish'
+      );
+
+      fetchStub.resetHistory();
+      const usage = element.shadowRoot?.querySelector('usage-card') as any;
+      usage.dispatchEvent(
+        new CustomEvent('range-change', {
+          detail: { value: 'year' },
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await waitUntil(
+        () => !element['updatingUsage'] && !element['fetchingUsageBreakdown'],
+        'the range change never settled'
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const urls = fetchStub.getCalls().map((call) => String(call.args[0]));
+      // The flows, the people and the tool catalogue read the same at any
+      // range, so a range change does not ask for them again.
+      expect(urls.some((url) => url === '/api/v1/flows')).to.be.false;
+      expect(urls.some((url) => url === '/api/v1/tools')).to.be.false;
+      expect(urls.some((url) => url.startsWith('/api/v1/users'))).to.be.false;
+      // The gateway call log is scoped to the range, so it does.
+      expect(
+        urls.some((url) =>
+          url.startsWith('/api/v1/account/gateway-usage/search')
+        )
+      ).to.be.true;
+      expect(urls.some((url) => url.includes('include_breakdown=true'))).to.be
+        .true;
+    });
+
     it('keeps the Models tab on a skeleton until the second pass lands', async () => {
       // The models arrive in the slow secondary pass, after `loading` has
       // cleared. Hold that pass open and the card must still be waiting, not

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -582,19 +582,19 @@ describe('DashboardView', () => {
         url.startsWith('/api/v1/account/gateway-usage/summary')
       )
     ).to.be.true;
-    // Two for the cards (summary + breakdown upgrade) and one for the prior
-    // window behind the Usage delta. The attention rules read the same
-    // breakdown rather than asking for a second one.
+    // Two for the cards (summary + breakdown upgrade), one for the prior
+    // window behind the Usage delta, and one rolling 30-day breakdown for
+    // attention (a calendar month is not those 30 days).
     expect(
       urls.filter((url) =>
         url.startsWith('/api/v1/account/gateway-usage/summary')
       ).length
-    ).to.equal(3);
+    ).to.equal(4);
     expect(urls.some((url) => url.includes('include_breakdown=false'))).to.be
       .true;
     expect(
       urls.filter((url) => url.includes('include_breakdown=true')).length
-    ).to.equal(1);
+    ).to.equal(2);
     // One list of agents for the whole load: the attention rules are handed
     // the list the fold already fetched.
     expect(

--- a/frontend/tests/e2e/overview-perf.spec.ts
+++ b/frontend/tests/e2e/overview-perf.spec.ts
@@ -1,0 +1,357 @@
+/**
+ * What the Overview costs to open.
+ *
+ * The console's first screen had grown to roughly forty requests before it
+ * showed a number, and every websocket event replayed most of them. This spec
+ * is the measurement that keeps that from coming back: it counts what the page
+ * asks for, how much of it is the same question twice, how deep the request
+ * chain goes, what a burst of gateway traffic costs, and how long the main
+ * thread is blocked while all of that happens.
+ *
+ * ---------------------------------------------------------------------------
+ * HOW TO RUN
+ * ---------------------------------------------------------------------------
+ * Same local harness as tests/e2e/custom-agent-session.spec.ts:
+ *
+ *   1. Postgres.
+ *   2. cd preloop/backend
+ *      python -m tests.e2e_support.fake_upstream --port 8081
+ *   3. INIT_TEST_DATA=true TESTING=true python -m preloop.server        # :8000
+ *      PRELOOP_E2E_FAKE_UPSTREAM=http://127.0.0.1:8081/v1 \
+ *        python -m tests.e2e_support.seed_gateway_model
+ *   4. Give the account something to show. An empty account renders empty
+ *      cards and measures nothing: loop a few hundred completions through the
+ *      gateway with the `preloop-fake` alias, and run a few flows.
+ *   5. cd preloop/frontend && npx playwright test --project=e2e-ci \
+ *        tests/e2e/overview-perf.spec.ts
+ *
+ * The frontend dev server on :5173 is started by Playwright's `webServer`.
+ *
+ * Set PRELOOP_PERF_RUNS to change the sample size (default 3; the report in
+ * factory/reports uses 5). Numbers are printed per run and as a median so a
+ * regression can be read off the console output, not just the pass or fail.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const IS_STAGING = process.env.PRELOOP_E2E_TARGET === 'staging';
+const RUNS = Number(process.env.PRELOOP_PERF_RUNS || 3);
+const GATEWAY_MODEL = process.env.PRELOOP_E2E_MODEL || 'preloop-fake';
+
+/**
+ * Budgets. These are the numbers section 4 of the Overview performance report
+ * asks for; a change that crosses one of them is a product decision, not an
+ * accident, so it should move this line deliberately.
+ */
+const BUDGET = {
+  firstUsableMs: 1000,
+  coldRequests: 20,
+  duplicateUrls: 0,
+  longestChain: 2,
+  requestsAfterBurst: 12,
+  longTaskTotalMs: 200,
+};
+
+interface Creds {
+  username: string;
+  password: string;
+}
+
+function resolveCreds(): Creds {
+  const envUser = process.env.PRELOOP_E2E_USERNAME;
+  const envPass = process.env.PRELOOP_E2E_PASSWORD;
+  if (envUser && envPass) {
+    return { username: envUser, password: envPass };
+  }
+  const credsPath = path.resolve(process.cwd(), 'tmp', 'staging-creds.json');
+  if (fs.existsSync(credsPath)) {
+    const raw = JSON.parse(fs.readFileSync(credsPath, 'utf-8'));
+    if (raw.username && raw.password) {
+      return { username: raw.username, password: raw.password };
+    }
+  }
+  return { username: 'admin', password: 'admin' };
+}
+
+/** Log in through the real /login UI and land on /console. */
+async function login(page: Page, creds: Creds): Promise<void> {
+  await page.goto('/login');
+  const username = page.locator('sl-input[name="username"]');
+  const password = page.locator('sl-input[name="password"]');
+  await username.waitFor({ state: 'visible' });
+  await username.click();
+  await page.keyboard.type(creds.username);
+  await password.click();
+  await page.keyboard.type(creds.password);
+  await page.locator('sl-button[type="submit"]').click();
+  await page.waitForURL(/\/console/, { timeout: 30_000 });
+  await expect
+    .poll(
+      async () => page.evaluate(() => localStorage.getItem('accessToken')),
+      {
+        timeout: 30_000,
+      }
+    )
+    .not.toBeNull();
+}
+
+interface ApiCall {
+  url: string;
+  start: number;
+  end: number;
+}
+
+interface RunResult {
+  firstUsableMs: number;
+  inventoryReadyMs: number;
+  requests: number;
+  duplicates: string[];
+  longestChain: number;
+  longTaskCount: number;
+  longTaskTotalMs: number;
+}
+
+/** Strip the moving parts so two asks for the same thing compare equal. */
+function normalise(url: string): string {
+  const parsed = new URL(url);
+  const params = new URLSearchParams(parsed.search);
+  // Range boundaries are computed per call and differ by milliseconds; the
+  // question is still the same question.
+  for (const key of ['start_date', 'end_date', '_']) {
+    if (params.has(key)) {
+      params.set(key, 'T');
+    }
+  }
+  params.sort();
+  return `${parsed.pathname}?${params.toString()}`;
+}
+
+/**
+ * The longest chain of requests that had to happen one after another: how many
+ * round trips deep the load is. A request counts as a link when it started
+ * after another one finished.
+ */
+function longestChain(calls: ApiCall[]): number {
+  const ordered = [...calls].sort((a, b) => a.start - b.start);
+  const depth: number[] = [];
+  let longest = 0;
+  ordered.forEach((call, index) => {
+    let best = 1;
+    for (let prior = 0; prior < index; prior += 1) {
+      if (ordered[prior].end <= call.start) {
+        best = Math.max(best, depth[prior] + 1);
+      }
+    }
+    depth[index] = best;
+    longest = Math.max(longest, best);
+  });
+  return longest;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+}
+
+function p95(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[
+    Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)
+  ];
+}
+
+/** Watch the main thread and the API traffic for one load of /console. */
+async function measureLoad(page: Page, cold: boolean): Promise<RunResult> {
+  const calls: ApiCall[] = [];
+  const started = new Map<string, number>();
+  const onRequest = (request: { url: () => string }) => {
+    if (!request.url().includes('/api/v1')) return;
+    started.set(request.url(), Date.now());
+  };
+  const onResponse = (response: { url: () => string }) => {
+    const url = response.url();
+    if (!url.includes('/api/v1')) return;
+    const start = started.get(url);
+    if (start === undefined) return;
+    calls.push({ url, start, end: Date.now() });
+  };
+  page.on('request', onRequest);
+  page.on('response', onResponse);
+
+  await page.addInitScript(() => {
+    const store = window as unknown as { __longTasks: number[] };
+    store.__longTasks = [];
+    try {
+      new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          store.__longTasks.push(entry.duration);
+        }
+      }).observe({ entryTypes: ['longtask'] });
+    } catch {
+      // Long tasks are not observable in this browser; the rest still runs.
+    }
+  });
+
+  if (cold) {
+    await page.evaluate(() => sessionStorage.clear());
+    await page.goto('/console');
+  } else {
+    await page.reload();
+  }
+
+  // First usable: the gateway card shows a request count instead of a
+  // skeleton. Read the page's own clock so navigation is the zero point.
+  const firstUsableMs = await page
+    .waitForFunction(
+      () => {
+        const view = document
+          .querySelector('lit-app')
+          ?.shadowRoot?.querySelector('dashboard-view');
+        const stats = view?.shadowRoot?.querySelector('.plane-stats');
+        const text = stats?.textContent || '';
+        return /\d[\d.,KM]*\s+requests/.test(text) ? performance.now() : false;
+      },
+      undefined,
+      { timeout: 30_000 }
+    )
+    .then((handle) => handle.jsonValue() as Promise<number>);
+
+  const inventoryReadyMs = await page
+    .waitForFunction(
+      () => {
+        const view = document
+          .querySelector('lit-app')
+          ?.shadowRoot?.querySelector('dashboard-view');
+        const card = view?.shadowRoot?.querySelector('inventory-card');
+        const rows =
+          card?.shadowRoot?.querySelectorAll('tbody tr:not(.skeleton-row)') ||
+          [];
+        return rows.length > 0 ? performance.now() : false;
+      },
+      undefined,
+      { timeout: 30_000 }
+    )
+    .then((handle) => handle.jsonValue() as Promise<number>);
+
+  // Let the deferred pass finish before counting: a load that defers work is
+  // only cheaper if the deferred work is cheaper too.
+  await page.waitForTimeout(3000);
+
+  const longTasks = await page.evaluate(
+    () => (window as unknown as { __longTasks: number[] }).__longTasks || []
+  );
+
+  page.off('request', onRequest);
+  page.off('response', onResponse);
+
+  const seen = new Map<string, number>();
+  for (const call of calls) {
+    const key = normalise(call.url);
+    seen.set(key, (seen.get(key) || 0) + 1);
+  }
+  const duplicates = [...seen.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([key, count]) => `${key} x${count}`);
+
+  return {
+    firstUsableMs,
+    inventoryReadyMs,
+    requests: calls.length,
+    duplicates,
+    longestChain: longestChain(calls),
+    longTaskCount: longTasks.length,
+    longTaskTotalMs: longTasks.reduce((sum, value) => sum + value, 0),
+  };
+}
+
+test.describe('Overview performance', () => {
+  test.skip(IS_STAGING, 'Timings are only meaningful against the local stack.');
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(240_000);
+
+  test('opens quickly, without asking twice', async ({ page }) => {
+    await login(page, resolveCreds());
+
+    const cold: RunResult[] = [];
+    const warm: RunResult[] = [];
+    for (let run = 0; run < RUNS; run += 1) {
+      cold.push(await measureLoad(page, true));
+      warm.push(await measureLoad(page, false));
+    }
+
+    const report = (label: string, runs: RunResult[]) => {
+      const usable = runs.map((r) => r.firstUsableMs);
+      const inventory = runs.map((r) => r.inventoryReadyMs);
+      console.log(
+        `${label}: first usable median ${Math.round(median(usable))}ms ` +
+          `p95 ${Math.round(p95(usable))}ms, inventory median ` +
+          `${Math.round(median(inventory))}ms, requests median ` +
+          `${median(runs.map((r) => r.requests))}, chain ` +
+          `${Math.max(...runs.map((r) => r.longestChain))}, long tasks ` +
+          `${Math.round(median(runs.map((r) => r.longTaskTotalMs)))}ms`
+      );
+      for (const run of runs) {
+        if (run.duplicates.length) {
+          console.log(`${label} duplicates: ${run.duplicates.join(', ')}`);
+        }
+      }
+    };
+    report('cold', cold);
+    report('warm', warm);
+
+    expect(median(cold.map((r) => r.firstUsableMs))).toBeLessThan(
+      BUDGET.firstUsableMs
+    );
+    expect(median(cold.map((r) => r.requests))).toBeLessThanOrEqual(
+      BUDGET.coldRequests
+    );
+    expect(cold.flatMap((r) => r.duplicates)).toHaveLength(
+      BUDGET.duplicateUrls
+    );
+    expect(Math.max(...cold.map((r) => r.longestChain))).toBeLessThanOrEqual(
+      BUDGET.longestChain
+    );
+    expect(median(cold.map((r) => r.longTaskTotalMs))).toBeLessThan(
+      BUDGET.longTaskTotalMs
+    );
+  });
+
+  test('stays quiet while the gateway is busy', async ({ page, request }) => {
+    await login(page, resolveCreds());
+    await measureLoad(page, true);
+
+    const key = await page.evaluate(() => localStorage.getItem('accessToken'));
+    // Twenty model calls over ten seconds: each one publishes a
+    // gateway_activity event to the open page.
+    const burst = (async () => {
+      for (let call = 0; call < 20; call += 1) {
+        await request.post('/openai/v1/chat/completions', {
+          headers: { Authorization: `Bearer ${key}` },
+          data: {
+            model: GATEWAY_MODEL,
+            messages: [{ role: 'user', content: 'perf burst' }],
+          },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    })();
+
+    let count = 0;
+    const onRequest = (req: { url: () => string }) => {
+      if (req.url().includes('/api/v1')) count += 1;
+    };
+    page.on('request', onRequest);
+    await burst;
+    // The refresh floor is ten seconds per topic; watch three of them.
+    await page.waitForTimeout(30_000);
+    page.off('request', onRequest);
+
+    console.log(`burst: ${count} API requests over the 40s window`);
+    expect(count).toBeLessThanOrEqual(BUDGET.requestsAfterBurst);
+  });
+});


### PR DESCRIPTION
Frontend phase of the Overview performance plan (factory UX round 2, 2026-09-04).

- Attention loader reuses the fold data instead of re-fetching it
- Below-the-fold inventory fetches restored to small limits or deferred until the tab opens
- budget-policies no longer gates loading=false
- Websocket-driven refresh coalesced instead of re-running the whole page per event
- Measurement hooks for the follow-up backend fold endpoint

Before/after request counts are in the PR description follow-up comment.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Well-tested frontend performance refactor (request coalescing, deferred fetches, per-topic websocket refresh) with no security issues. All previously reported issues — the calendar-month vs rolling-30-day consistency concern and the doc-cleanup nits — are now addressed; only a dead-type cleanup remains.
>
> **Overview**
> Dedupes and defers the Overview's requests to take budget fetch and below-the-fold data off the critical path, coalesces websocket-driven refreshes per topic, and adds request-count budgets via a new e2e spec. The final commit corrects the stale doc comments describing the removed breakdown-sharing.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 727aed4e. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->