### PR TITLE
Tools: rework the Native tool approvals card (copy, hierarchy, error and load states)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Native tool approval workflow select reverts on a failed save**: the
+  dropdown no longer keeps an unsaved pick after "Could not save", and the
+  account default workflow is listed once (the empty option).
 - **Spending-limit save no longer posts a null notify user**: `/auth/users/me`
   has no `id`, so the limits editor used to send `notification_user_ids: [null]`
   and the API rejected the create. Recipients now come from the users list

--- a/frontend/src/views/authed/tools-view.test.ts
+++ b/frontend/src/views/authed/tools-view.test.ts
@@ -7,8 +7,14 @@ import { invalidateApiCaches } from '../../api';
 
 describe('ToolsView (approvals + conditions)', () => {
   let fetchStub: sinon.SinonStub;
+  let overrideAgentIds: string[];
+  let accountAgents: { id: string; display_name: string }[];
 
   beforeEach(() => {
+    overrideAgentIds = ['agent-override-1'];
+    accountAgents = [
+      { id: 'agent-override-1', display_name: 'Claude Code Workspace' },
+    ];
     // fetchWithAuth requires an access token to exist
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
@@ -103,7 +109,7 @@ describe('ToolsView (approvals + conditions)', () => {
                 native_tool_approvals: null,
                 approval_workflow_id: null,
               },
-              override_agent_ids: ['agent-override-1'],
+              override_agent_ids: overrideAgentIds,
             }),
             { status: 200, headers: { 'Content-Type': 'application/json' } }
           );
@@ -116,15 +122,10 @@ describe('ToolsView (approvals + conditions)', () => {
               agent_kind: null,
               last_seen_after: null,
               status: 'all',
-              total: 1,
+              total: accountAgents.length,
               limit: 100,
               offset: 0,
-              items: [
-                {
-                  id: 'agent-override-1',
-                  display_name: 'Claude Code Workspace',
-                },
-              ],
+              items: accountAgents,
             }),
             { status: 200, headers: { 'Content-Type': 'application/json' } }
           );
@@ -250,8 +251,12 @@ describe('ToolsView (approvals + conditions)', () => {
       '#native-approvals-defaults-card'
     );
     expect(card).to.exist;
+    expect(card?.textContent).to.not.include('\u2014');
+    expect(card?.textContent?.replace(/\s+/g, ' ')).to.include(
+      'Ask a human before running'
+    );
 
-    // Default (null) renders as enforce: switch on, no bypass warning.
+    // Default (null) renders as enforce: switch on, no bypass notice.
     const switchEl = element.shadowRoot?.querySelector(
       '#native-approvals-default-switch'
     ) as any;
@@ -263,6 +268,7 @@ describe('ToolsView (approvals + conditions)', () => {
       '#native-approvals-override-list'
     );
     expect(overrides).to.exist;
+    expect(overrides?.textContent).to.include('1 agent uses its own setting');
     const link = overrides?.querySelector('a');
     expect(link?.getAttribute('href')).to.equal(
       '/console/agents/agent-override-1'
@@ -285,6 +291,104 @@ describe('ToolsView (approvals + conditions)', () => {
     expect(
       JSON.parse(String(putCall!.args[1]!.body)).native_tool_approvals
     ).to.equal('off');
+  });
+
+  it('shows the resolved default workflow name in the workflow select', async () => {
+    const element = await fixture<ToolsView>(html`<tools-view></tools-view>`);
+    await waitUntil(
+      () =>
+        !(element as any).loading &&
+        (element as any).governanceDefaults !== null,
+      'Tools view did not load governance defaults'
+    );
+    await element.updateComplete;
+
+    const select = element.shadowRoot?.querySelector(
+      '#native-approvals-default-workflow'
+    );
+    expect(select).to.exist;
+    const options = Array.from(select!.querySelectorAll('sl-option'));
+    expect(options.length).to.be.greaterThan(0);
+    expect(options[0]?.textContent).to.include('Default workflow (Default)');
+    for (const option of options) {
+      expect(option.textContent).to.not.include('(account default)');
+    }
+  });
+
+  it('hides the workflow select and shows a notice when approvals are off', async () => {
+    const element = await fixture<ToolsView>(html`<tools-view></tools-view>`);
+    await waitUntil(
+      () =>
+        !(element as any).loading &&
+        (element as any).governanceDefaults !== null,
+      'Tools view did not load governance defaults'
+    );
+    await element.updateComplete;
+
+    await (element as any)._saveGovernanceDefaults({
+      native_tool_approvals: 'off',
+    });
+    await element.updateComplete;
+
+    expect(
+      element.shadowRoot?.querySelector('#native-approvals-default-workflow')
+    ).to.be.null;
+    const notice = element.shadowRoot?.querySelector('.governance-notice');
+    expect(notice).to.exist;
+    expect(notice?.textContent).to.include('run without asking');
+
+    await (element as any)._saveGovernanceDefaults({
+      native_tool_approvals: 'enforce',
+    });
+    await element.updateComplete;
+
+    expect(
+      element.shadowRoot?.querySelector('#native-approvals-default-workflow')
+    ).to.exist;
+    expect(element.shadowRoot?.querySelector('.governance-notice')).to.be.null;
+  });
+
+  it('caps the override list at 5 agents and links the remainder', async () => {
+    overrideAgentIds = [
+      'agent-1',
+      'agent-2',
+      'agent-3',
+      'agent-4',
+      'agent-5',
+      'agent-6',
+      'agent-7',
+    ];
+    accountAgents = overrideAgentIds.map((id, index) => ({
+      id,
+      display_name: `Agent ${index + 1}`,
+    }));
+
+    const element = await fixture<ToolsView>(html`<tools-view></tools-view>`);
+    await waitUntil(
+      () =>
+        !(element as any).loading &&
+        (element as any).governanceDefaults !== null,
+      'Tools view did not load governance defaults'
+    );
+    await element.updateComplete;
+
+    const overrides = element.shadowRoot?.querySelector(
+      '#native-approvals-override-list'
+    );
+    expect(overrides).to.exist;
+    expect(overrides?.textContent).to.include('7 agents use their own setting');
+
+    const links = Array.from(overrides!.querySelectorAll('a'));
+    expect(links.length).to.equal(6);
+    const agentLinks = links.slice(0, 5);
+    agentLinks.forEach((agentLink, index) => {
+      expect(agentLink.getAttribute('href')).to.equal(
+        `/console/agents/agent-${index + 1}`
+      );
+    });
+    const moreLink = links[5];
+    expect(moreLink.getAttribute('href')).to.equal('/console/agents');
+    expect(moreLink.textContent).to.include('and 2 more');
   });
 
   it('does not create tool configuration twice when adding a rule immediately after toggling enabled', async () => {

--- a/frontend/src/views/authed/tools-view.test.ts
+++ b/frontend/src/views/authed/tools-view.test.ts
@@ -46,6 +46,13 @@ describe('ToolsView (approvals + conditions)', () => {
       approval_type: 'standard',
       is_default: true,
     };
+    const extraPolicy = {
+      id: 'policy-2',
+      name: 'Security',
+      description: 'Security policy',
+      approval_type: 'standard',
+      is_default: false,
+    };
 
     fetchStub.callsFake(
       async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -68,7 +75,7 @@ describe('ToolsView (approvals + conditions)', () => {
         }
 
         if (url.endsWith('/api/v1/approval-workflows') && method === 'GET') {
-          return new Response(JSON.stringify([defaultPolicy]), {
+          return new Response(JSON.stringify([defaultPolicy, extraPolicy]), {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
           });
@@ -326,8 +333,11 @@ describe('ToolsView (approvals + conditions)', () => {
     );
     expect(select).to.exist;
     const options = Array.from(select!.querySelectorAll('sl-option'));
-    expect(options.length).to.be.greaterThan(0);
+    expect(options.map((option) => option.getAttribute('value'))).to.deep.equal(
+      ['', 'policy-2']
+    );
     expect(options[0]?.textContent).to.include('Default workflow (Default)');
+    expect(options[1]?.textContent).to.include('Security');
     for (const option of options) {
       expect(option.textContent).to.not.include('(account default)');
     }
@@ -440,6 +450,37 @@ describe('ToolsView (approvals + conditions)', () => {
     expect(saveError?.textContent).to.include('Could not save');
     expect(switchEl.checked).to.be.true;
     expect((element as any).error).to.equal(null);
+  });
+
+  it('reverts the workflow select when saving fails', async () => {
+    const element = await fixture<ToolsView>(html`<tools-view></tools-view>`);
+    await waitUntil(
+      () =>
+        !(element as any).loading &&
+        (element as any).governanceDefaults !== null,
+      'Tools view did not load governance defaults'
+    );
+    await element.updateComplete;
+
+    failGovernancePut = true;
+
+    const select = element.shadowRoot?.querySelector(
+      '#native-approvals-default-workflow'
+    ) as HTMLSelectElement;
+    expect(select).to.exist;
+    expect(select.value || '').to.equal('');
+
+    select.value = 'policy-2';
+    select.dispatchEvent(new CustomEvent('sl-change'));
+    await waitUntil(
+      () => !(element as any).savingGovernanceDefaults,
+      'Save did not finish'
+    );
+    await element.updateComplete;
+
+    expect(select.value || '').to.equal('');
+    const saveError = element.shadowRoot?.querySelector('.governance-error');
+    expect(saveError?.textContent).to.include('Could not save');
   });
 
   it('renders a retry fallback when governance defaults fail to load', async () => {

--- a/frontend/src/views/authed/tools-view.test.ts
+++ b/frontend/src/views/authed/tools-view.test.ts
@@ -9,12 +9,16 @@ describe('ToolsView (approvals + conditions)', () => {
   let fetchStub: sinon.SinonStub;
   let overrideAgentIds: string[];
   let accountAgents: { id: string; display_name: string }[];
+  let failGovernanceGet: boolean;
+  let failGovernancePut: boolean;
 
   beforeEach(() => {
     overrideAgentIds = ['agent-override-1'];
     accountAgents = [
       { id: 'agent-override-1', display_name: 'Claude Code Workspace' },
     ];
+    failGovernanceGet = false;
+    failGovernancePut = false;
     // fetchWithAuth requires an access token to exist
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
@@ -95,12 +99,26 @@ describe('ToolsView (approvals + conditions)', () => {
         // Native tool approvals account-defaults card
         if (url.endsWith('/api/v1/account/governance-defaults')) {
           if (method === 'PUT') {
+            if (failGovernancePut) {
+              failGovernancePut = false;
+              return new Response(
+                JSON.stringify({ detail: 'Simulated PUT failure' }),
+                { status: 500, headers: { 'Content-Type': 'application/json' } }
+              );
+            }
             return new Response(
               JSON.stringify({
                 defaults: JSON.parse(String(init?.body)),
                 override_agent_ids: [],
               }),
               { status: 200, headers: { 'Content-Type': 'application/json' } }
+            );
+          }
+          if (failGovernanceGet) {
+            failGovernanceGet = false;
+            return new Response(
+              JSON.stringify({ detail: 'Simulated GET failure' }),
+              { status: 500, headers: { 'Content-Type': 'application/json' } }
             );
           }
           return new Response(
@@ -389,6 +407,86 @@ describe('ToolsView (approvals + conditions)', () => {
     const moreLink = links[5];
     expect(moreLink.getAttribute('href')).to.equal('/console/agents');
     expect(moreLink.textContent).to.include('and 2 more');
+  });
+
+  it('shows an inline error and reverts the switch when saving fails', async () => {
+    const element = await fixture<ToolsView>(html`<tools-view></tools-view>`);
+    await waitUntil(
+      () =>
+        !(element as any).loading &&
+        (element as any).governanceDefaults !== null,
+      'Tools view did not load governance defaults'
+    );
+    await element.updateComplete;
+
+    failGovernancePut = true;
+
+    const switchEl = element.shadowRoot?.querySelector(
+      '#native-approvals-default-switch'
+    ) as any;
+    expect(switchEl).to.exist;
+    expect(switchEl.checked).to.be.true;
+
+    switchEl.checked = false;
+    switchEl.dispatchEvent(new CustomEvent('sl-change'));
+    await waitUntil(
+      () => !(element as any).savingGovernanceDefaults,
+      'Save did not finish'
+    );
+    await element.updateComplete;
+
+    const saveError = element.shadowRoot?.querySelector('.governance-error');
+    expect(saveError).to.exist;
+    expect(saveError?.textContent).to.include('Could not save');
+    expect(switchEl.checked).to.be.true;
+    expect((element as any).error).to.equal(null);
+  });
+
+  it('renders a retry fallback when governance defaults fail to load', async () => {
+    failGovernanceGet = true;
+
+    const element = await fixture<ToolsView>(html`<tools-view></tools-view>`);
+    await waitUntil(
+      () => !(element as any).loading && (element as any).governanceLoadFailed,
+      'Governance load failure was not recorded'
+    );
+    await element.updateComplete;
+
+    const card = element.shadowRoot?.querySelector(
+      '#native-approvals-defaults-card'
+    );
+    expect(card).to.exist;
+    expect(card?.textContent).to.include('Could not load this setting');
+
+    const governanceGetCalls = () =>
+      fetchStub
+        .getCalls()
+        .filter(
+          (call) =>
+            String(call.args[0]).endsWith(
+              '/api/v1/account/governance-defaults'
+            ) &&
+            String(
+              (call.args[1] as RequestInit | undefined)?.method || 'GET'
+            ).toUpperCase() === 'GET'
+        );
+    expect(governanceGetCalls().length).to.equal(1);
+
+    const retry = card?.querySelector('a') as HTMLElement;
+    expect(retry).to.exist;
+    expect(retry.textContent).to.include('Retry');
+    retry.click();
+
+    await waitUntil(
+      () => (element as any).governanceDefaults !== null,
+      'Retry did not reload governance defaults'
+    );
+    await element.updateComplete;
+
+    expect(governanceGetCalls().length).to.equal(2);
+    expect(
+      element.shadowRoot?.querySelector('#native-approvals-default-switch')
+    ).to.exist;
   });
 
   it('does not create tool configuration twice when adding a rule immediately after toggling enabled', async () => {

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -86,6 +86,8 @@ export class ToolsView extends LitElement {
     setting: string;
   }[] = [];
   @state() private savingGovernanceDefaults = false;
+  @state() private governanceSaveError: string | null = null;
+  @state() private governanceLoadFailed = false;
   @state() private isAddingMCPServer = false;
   @state() private editingMCPServer: MCPServer | null = null;
   @state() private currentUser: { id?: string } | null = null;
@@ -133,6 +135,42 @@ export class ToolsView extends LitElement {
     css`
       mcp-setup-dialog {
         display: contents;
+      }
+
+      /* Native tool approvals account-default card */
+      .governance-card {
+        padding: var(--sl-spacing-medium);
+        border-top: 1px solid var(--sl-color-neutral-200);
+        margin-bottom: var(--sl-spacing-medium);
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-x-small);
+      }
+
+      .governance-card .meta-line {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+      }
+
+      .governance-card .governance-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--sl-spacing-medium);
+        flex-wrap: wrap;
+      }
+
+      .governance-card .governance-notice {
+        color: var(--sl-color-warning-700);
+        font-size: var(--sl-font-size-small);
+        display: flex;
+        gap: 6px;
+        align-items: center;
+      }
+
+      .governance-card .governance-error {
+        color: var(--sl-color-danger-600);
+        font-size: var(--sl-font-size-small);
       }
 
       /* Top section: summary + MCP card side by side */
@@ -1691,95 +1729,128 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     }
   }
 
+  private _defaultWorkflowLabel(): string {
+    const name = this.approvalPolicies.find((p) => p.is_default)?.name;
+    return name ? `Default workflow (${name})` : 'Default workflow';
+  }
+
   /**
    * Account-default card for native tool-call approvals (hook-based Bash /
    * Edit / shell approvals), rendered above the MCP tool groups so both
    * policy planes are visible — and distinguishable — on one page.
    */
   private _renderNativeApprovalDefaultsCard() {
+    if (this.governanceLoadFailed) {
+      return html`
+        <div
+          class="stat-card governance-card"
+          id="native-approvals-defaults-card"
+        >
+          <div
+            class="stat-label"
+            style="display: flex; align-items: center; gap: 6px;"
+          >
+            <sl-icon name="shield-lock"></sl-icon>
+            Native tool approvals
+          </div>
+          <div class="meta-line">
+            Shell commands, file edits and other tools inside the agent. MCP
+            tools use the rules below.
+          </div>
+          <div class="governance-error">
+            Could not load this setting.
+            <a
+              href="#"
+              @click=${(e: Event) => {
+                e.preventDefault();
+                void this._loadGovernanceDefaults();
+              }}
+              >Retry</a
+            >
+          </div>
+        </div>
+      `;
+    }
     if (!this.governanceDefaults) {
       return html``;
     }
     const defaults = this.governanceDefaults;
     const enforced = defaults.native_tool_approvals !== 'off';
     const overrides = this.governanceOverrideAgents;
+    const shownOverrides = overrides.slice(0, 5);
+    const hiddenOverrideCount = overrides.length - shownOverrides.length;
     return html`
       <div
-        class="stat-card"
+        class="stat-card governance-card"
         id="native-approvals-defaults-card"
-        style="display: flex; flex-direction: column; gap: var(--sl-spacing-x-small); margin-bottom: var(--sl-spacing-medium);"
       >
         <div
-          style="display: flex; align-items: center; justify-content: space-between; gap: var(--sl-spacing-medium); flex-wrap: wrap;"
+          class="stat-label"
+          style="display: flex; align-items: center; gap: 6px;"
         >
-          <div>
-            <div
-              class="stat-label"
-              style="display: flex; align-items: center; gap: 6px;"
-            >
-              <sl-icon name="shield-lock"></sl-icon>
-              Native tool approvals — account default
-            </div>
-            <div class="meta-line">
-              Native tool calls (shell commands, file edits) from agents
-              onboarded with approval hooks. Agents inherit this unless
-              overridden on their detail page. MCP tools are governed separately
-              by the access rules below.
-            </div>
-          </div>
-          <div
-            style="display: flex; align-items: center; gap: var(--sl-spacing-medium); flex-shrink: 0;"
+          <sl-icon name="shield-lock"></sl-icon>
+          Native tool approvals
+        </div>
+        <div class="meta-line">
+          Shell commands, file edits and other tools inside the agent. MCP tools
+          use the rules below.
+        </div>
+        <div class="governance-row">
+          <sl-switch
+            id="native-approvals-default-switch"
+            size="small"
+            ?checked=${enforced}
+            ?disabled=${this.savingGovernanceDefaults}
+            @sl-change=${(e: Event) =>
+              this._saveGovernanceDefaults({
+                native_tool_approvals: (e.target as HTMLInputElement).checked
+                  ? 'enforce'
+                  : 'off',
+              })}
           >
-            <sl-switch
-              id="native-approvals-default-switch"
-              size="small"
-              ?checked=${enforced}
-              ?disabled=${this.savingGovernanceDefaults}
-              @sl-change=${(e: Event) =>
-                this._saveGovernanceDefaults({
-                  native_tool_approvals: (e.target as HTMLInputElement).checked
-                    ? 'enforce'
-                    : 'off',
-                })}
-            >
-              Require approval
-            </sl-switch>
-            <sl-select
-              id="native-approvals-default-workflow"
-              size="small"
-              hoist
-              style="min-width: 260px;${enforced ? '' : ' opacity: 0.5;'}"
-              ?disabled=${!enforced || this.savingGovernanceDefaults}
-              .value=${defaults.approval_workflow_id ?? ''}
-              @sl-change=${(e: Event) =>
-                this._saveGovernanceDefaults({
-                  approval_workflow_id:
-                    (e.target as HTMLSelectElement).value || null,
-                })}
-            >
-              <sl-option value="">Account default workflow</sl-option>
-              ${this.approvalPolicies.map(
-                (workflow) => html`
-                  <sl-option value=${workflow.id}>
-                    ${workflow.name}${
-                      workflow.is_default ? ' (account default)' : ''
-                    }
-                  </sl-option>
+            Ask a human before
+            running${this.savingGovernanceDefaults ? ' Saving...' : ''}
+          </sl-switch>
+          ${
+            enforced
+              ? html`
+                  <sl-select
+                    id="native-approvals-default-workflow"
+                    size="small"
+                    hoist
+                    label="Send requests to"
+                    style="min-width: 260px;"
+                    ?disabled=${this.savingGovernanceDefaults}
+                    .value=${defaults.approval_workflow_id ?? ''}
+                    @sl-change=${(e: Event) =>
+                      this._saveGovernanceDefaults({
+                        approval_workflow_id:
+                          (e.target as HTMLSelectElement).value || null,
+                      })}
+                  >
+                    <sl-option value=""
+                      >${this._defaultWorkflowLabel()}</sl-option
+                    >
+                    ${this.approvalPolicies.map(
+                      (workflow) => html`
+                        <sl-option value=${workflow.id}>
+                          ${workflow.name}
+                        </sl-option>
+                      `
+                    )}
+                  </sl-select>
                 `
-              )}
-            </sl-select>
-          </div>
+              : ''
+          }
         </div>
         ${
           !enforced
             ? html`
-                <sl-alert variant="warning" open>
-                  <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
-                  Approvals are bypassed account-wide: Preloop auto-approves
-                  escalated native tool calls without asking anyone (still
-                  recorded and audited). Agents with an explicit per-agent
-                  "enforce" keep asking.
-                </sl-alert>
+                <div class="governance-notice" role="status">
+                  <sl-icon name="exclamation-triangle"></sl-icon>
+                  Native tool calls run without asking. Calls are still
+                  recorded. Agents set to always ask keep asking.
+                </div>
               `
             : ''
         }
@@ -1787,17 +1858,34 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
           overrides.length > 0
             ? html`
                 <div class="meta-line" id="native-approvals-override-list">
-                  ${overrides.length} agent${overrides.length === 1 ? '' : 's'}
-                  override${overrides.length === 1 ? 's' : ''} this default:
-                  ${overrides.map(
+                  ${
+                    overrides.length === 1
+                      ? '1 agent uses its own setting: '
+                      : `${overrides.length} agents use their own setting: `
+                  }
+                  ${shownOverrides.map(
                     (agent, index) =>
                       html`${index > 0 ? ', ' : ''}<a
                           href="/console/agents/${agent.id}"
                           >${agent.name}</a
                         >`
-                  )}
+                  )}${
+                    hiddenOverrideCount > 0
+                      ? html`,
+                          <a href="/console/agents"
+                            >and ${hiddenOverrideCount} more</a
+                          >`
+                      : ''
+                  }
                 </div>
               `
+            : ''
+        }
+        ${
+          this.governanceSaveError
+            ? html`<div class="governance-error">
+                ${this.governanceSaveError}
+              </div>`
             : ''
         }
       </div>

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -83,7 +83,6 @@ export class ToolsView extends LitElement {
   @state() private governanceOverrideAgents: {
     id: string;
     name: string;
-    setting: string;
   }[] = [];
   @state() private savingGovernanceDefaults = false;
   @state() private governanceSaveError: string | null = null;
@@ -1681,10 +1680,11 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     try {
       const response = await getAccountGovernanceDefaults();
       this.governanceDefaults = response.defaults;
+      this.governanceLoadFailed = false;
       if (response.override_agent_ids.length > 0) {
-        // Resolve override agent names for the "N agents override" line.
-        // One list call covers typical fleets; unknown ids degrade to
-        // showing the id so the link still works.
+        // Resolve override agent names for the override line. One list call
+        // covers typical fleets; unknown ids degrade to showing the id so
+        // the link still works.
         try {
           const agents = await getAccountAgents({ limit: 100 });
           const byId = new Map(
@@ -1694,12 +1694,11 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
             (id) => ({
               id,
               name: byId.get(id)?.display_name || id,
-              setting: '',
             })
           );
         } catch {
           this.governanceOverrideAgents = response.override_agent_ids.map(
-            (id) => ({ id, name: id, setting: '' })
+            (id) => ({ id, name: id })
           );
         }
       } else {
@@ -1708,12 +1707,13 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     } catch {
       // Card is additive; a load failure must not degrade the Tools page.
       this.governanceDefaults = null;
+      this.governanceLoadFailed = true;
     }
   }
 
   private async _saveGovernanceDefaults(
     patch: Partial<AccountGovernanceDefaults>
-  ) {
+  ): Promise<boolean> {
     const next: AccountGovernanceDefaults = {
       ...(this.governanceDefaults || {}),
       ...patch,
@@ -1722,8 +1722,11 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     try {
       const response = await updateAccountGovernanceDefaults(next);
       this.governanceDefaults = response.defaults;
+      this.governanceSaveError = null;
+      return true;
     } catch {
-      this.error = 'Failed to save native tool approval defaults';
+      this.governanceSaveError = 'Could not save. Try again.';
+      return false;
     } finally {
       this.savingGovernanceDefaults = false;
     }
@@ -1801,12 +1804,16 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
             size="small"
             ?checked=${enforced}
             ?disabled=${this.savingGovernanceDefaults}
-            @sl-change=${(e: Event) =>
-              this._saveGovernanceDefaults({
-                native_tool_approvals: (e.target as HTMLInputElement).checked
-                  ? 'enforce'
-                  : 'off',
-              })}
+            @sl-change=${async (e: Event) => {
+              const target = e.target as HTMLInputElement;
+              const saved = await this._saveGovernanceDefaults({
+                native_tool_approvals: target.checked ? 'enforce' : 'off',
+              });
+              if (!saved) {
+                // The server kept the old value; flip the switch back.
+                target.checked = enforced;
+              }
+            }}
           >
             Ask a human before
             running${this.savingGovernanceDefaults ? ' Saving...' : ''}

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -1737,6 +1737,14 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     return name ? `Default workflow (${name})` : 'Default workflow';
   }
 
+  private _nativeWorkflowSelectValue(defaults: {
+    approval_workflow_id?: string | null;
+  }): string {
+    const selected = defaults.approval_workflow_id ?? '';
+    const defaultId = this.approvalPolicies.find((p) => p.is_default)?.id;
+    return selected && selected === defaultId ? '' : selected;
+  }
+
   /**
    * Account-default card for native tool-call approvals (hook-based Bash /
    * Edit / shell approvals), rendered above the MCP tool groups so both
@@ -1828,23 +1836,32 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
                     label="Send requests to"
                     style="min-width: 260px;"
                     ?disabled=${this.savingGovernanceDefaults}
-                    .value=${defaults.approval_workflow_id ?? ''}
-                    @sl-change=${(e: Event) =>
-                      this._saveGovernanceDefaults({
-                        approval_workflow_id:
-                          (e.target as HTMLSelectElement).value || null,
-                      })}
+                    .value=${this._nativeWorkflowSelectValue(defaults)}
+                    @sl-change=${(e: Event) => {
+                      const select = e.target as HTMLSelectElement;
+                      const previous =
+                        this._nativeWorkflowSelectValue(defaults);
+                      void this._saveGovernanceDefaults({
+                        approval_workflow_id: select.value || null,
+                      }).then((saved) => {
+                        if (!saved) {
+                          select.value = previous;
+                        }
+                      });
+                    }}
                   >
                     <sl-option value=""
                       >${this._defaultWorkflowLabel()}</sl-option
                     >
-                    ${this.approvalPolicies.map(
-                      (workflow) => html`
-                        <sl-option value=${workflow.id}>
-                          ${workflow.name}
-                        </sl-option>
-                      `
-                    )}
+                    ${this.approvalPolicies
+                      .filter((workflow) => !workflow.is_default)
+                      .map(
+                        (workflow) => html`
+                          <sl-option value=${workflow.id}>
+                            ${workflow.name}
+                          </sl-option>
+                        `
+                      )}
                   </sl-select>
                 `
               : ''


### PR DESCRIPTION
Implements the Tools page review (factory UX round 2, 2026-09-04): one meaning of "Require approval", "native" defined where it is used, inline save error and load-failure state, switch reverts on failed save. Two commits: presentation, then behaviour. Tests added.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes important settings UI (approval defaults) with new error/load state handling; no security implications, well-tested.
>
> **Overview**
> Reworks the native tool approvals card on the Tools page: clarifies the "Require approval" copy, defines "native" inline, adds inline save-error and load-failure states with retry, and reverts the switch on failed save. Includes thorough tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit c2db771. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->