### PR TITLE
Post-execution push: use the GitHub App installation token when the tracker has no API key

### DIFF
--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -3277,9 +3277,15 @@ MREOF
                     )
                     return None
 
-                # Get token from tracker (we always have tokens for GitHub/GitLab)
-                token = tracker.resolved_api_key
-                if not token:
+                # A tracker with no usable credential cannot clone a private
+                # repository, so refusing here gives a clearer error than a
+                # failed clone. App-authenticated trackers are the exception:
+                # they legitimately store no key, their token is minted by the
+                # orchestrator and delivered through the execution context.
+                if (
+                    not tracker.resolved_api_key
+                    and (tracker.auth_type or "").lower() not in APP_AUTH_TYPES
+                ):
                     self.logger.warning(
                         f"Tracker {tracker.id} has no API key configured"
                     )

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -26,6 +26,7 @@ from .base import AgentExecutionResult, AgentExecutor, AgentStatus
 from .errors import AgentStartError
 from .failure_analysis import analyze_agent_failure
 from preloop.services.mcp_config_service import MCPConfigService
+from preloop.services.tracker_git_token import APP_AUTH_TYPES
 from preloop.utils.git_credentials import (
     GitCredential,
     build_credential_env,
@@ -2405,20 +2406,51 @@ class ContainerAgentExecutor(AgentExecutor):
         repo_config: Dict[str, Any],
         execution_context: Dict[str, Any],
     ) -> tuple[Optional[str], Optional[str]]:
-        """Return ``(token, tracker_type)`` for one repository entry."""
+        """Return ``(token, tracker_type)`` for one repository entry.
 
-        tracker_id = repo_config.get("tracker_id")
-        git_credentials_map = execution_context.get("git_credentials_map", {})
+        Sources, in order:
 
-        if tracker_id and tracker_id in git_credentials_map:
-            tracker_creds = git_credentials_map.get(tracker_id, {})
-            return tracker_creds.get("token"), tracker_creds.get("tracker_type")
+        1. the repository's own tracker, as resolved by the orchestrator,
+        2. the triggering project's tracker, also resolved by the orchestrator
+           (the only source that works for a GitHub App tracker, whose token is
+           a short-lived installation token that cannot be read from the
+           database),
+        3. a direct database lookup of the triggering project's stored key.
+
+        An entry with an empty token does not stop the search: the orchestrator
+        records a tracker it could not get a key for, and falling through gives
+        the remaining sources a chance instead of running with no credential.
+        """
+
+        git_credentials_map = execution_context.get("git_credentials_map") or {}
+
+        candidate_ids = [
+            repo_config.get("tracker_id"),
+            execution_context.get("trigger_tracker_id"),
+        ]
+        for tracker_id in candidate_ids:
+            if not tracker_id:
+                continue
+            tracker_creds = git_credentials_map.get(tracker_id) or {}
+            if tracker_creds.get("token"):
+                return tracker_creds.get("token"), tracker_creds.get("tracker_type")
 
         trigger_project_id = execution_context.get("trigger_project_id")
         if trigger_project_id:
-            return self._get_token_from_project(
+            token, tracker_type = self._get_token_from_project(
                 trigger_project_id, execution_context.get("account_id")
             )
+            if token:
+                return token, tracker_type
+
+        # Nothing usable: return the tracker type when known, so the caller can
+        # still log which host kind was expected.
+        for tracker_id in candidate_ids:
+            tracker_creds = (
+                (git_credentials_map.get(tracker_id) or {}) if tracker_id else {}
+            )
+            if tracker_creds.get("tracker_type"):
+                return None, tracker_creds.get("tracker_type")
 
         return None, None
 
@@ -3337,6 +3369,17 @@ MREOF
                 tracker = crud_tracker.get(db, id=organization.tracker_id)
                 resolved_token = tracker.resolved_api_key if tracker else ""
                 if not tracker or not resolved_token:
+                    if tracker and (tracker.auth_type or "").lower() in APP_AUTH_TYPES:
+                        # App trackers store no key: their credential is an
+                        # installation token minted asynchronously by the
+                        # orchestrator and delivered through
+                        # `git_credentials_map` / `trigger_tracker_id`.
+                        self.logger.warning(
+                            "Tracker %s authenticates through an app installation, "
+                            "so no token can be read here; expected the execution "
+                            "context to carry it",
+                            tracker.id,
+                        )
                     return None, None
 
                 return resolved_token, tracker.tracker_type.lower()

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -58,6 +58,7 @@ from preloop.services.flow_runtime_token import (
     create_flow_runtime_token,
     revoke_flow_runtime_tokens,
 )
+from preloop.services.tracker_git_token import resolve_tracker_git_token
 from preloop.sync.event_normalizer import attach_trigger_subject
 from preloop.services.model_runtime_resolver import resolve_ai_model_runtime
 from preloop.utils.git_credentials import (
@@ -1714,10 +1715,22 @@ class FlowExecutionOrchestrator:
                 logger.warning(f"Tracker {tracker_id} not found")
                 return None
 
-            # Return credentials (api_key is encrypted in DB, should be decrypted here)
+            # Not `resolved_api_key`: a GitHub App tracker stores no key, its
+            # credential is a short-lived installation token minted here. Using
+            # the raw column left App-installed repositories with no git
+            # credential at all, so the post-execution push failed with
+            # "could not read Username for 'https://github.com'".
+            token = await resolve_tracker_git_token(tracker)
+            if not token:
+                logger.warning(
+                    "Tracker %s has no usable git token (auth_type=%s)",
+                    tracker_id,
+                    tracker.auth_type,
+                )
+
             return {
-                "tracker_id": tracker_id,
-                "token": tracker.resolved_api_key,
+                "tracker_id": str(tracker_id),
+                "token": token or "",
                 "tracker_type": tracker.tracker_type,
             }
 
@@ -1727,6 +1740,65 @@ class FlowExecutionOrchestrator:
                 exc_info=True,
             )
             return None
+
+    def _resolve_project_tracker_id(self, project_id: Optional[str]) -> Optional[str]:
+        """Return the tracker owning ``project_id``, or None."""
+
+        if not project_id:
+            return None
+        try:
+            from preloop.models.crud import crud_project
+
+            project = crud_project.get(self.db, id=str(project_id))
+            organization = project.organization if project else None
+            tracker_id = getattr(organization, "tracker_id", None)
+            return str(tracker_id) if tracker_id else None
+        except Exception as e:
+            logger.warning(
+                "Could not resolve the tracker for project %s: %s", project_id, e
+            )
+            return None
+
+    async def _attach_trigger_tracker_credentials(
+        self, execution_context: Dict[str, Any]
+    ) -> None:
+        """Add the triggering project's tracker credentials to the context.
+
+        The agent container resolves a repository's token from
+        ``git_credentials_map[tracker_id]`` and otherwise falls back to a
+        database lookup that reads the stored key only. That fallback returns
+        nothing for a GitHub App tracker, which has no stored key, so a flow
+        whose repository entry carries no ``tracker_id`` ran with no git
+        credential: the clone of a public repository still worked and the
+        post-execution push then failed to authenticate.
+
+        Minting an App installation token is async and must happen here, in
+        the orchestrator, not in the synchronous container code path.
+        """
+
+        tracker_id = self._resolve_project_tracker_id(
+            execution_context.get("trigger_project_id")
+        ) or self.trigger_event_data.get("tracker_id")
+        if not tracker_id:
+            return
+
+        tracker_id = str(tracker_id)
+        credentials_map = execution_context.get("git_credentials_map") or {}
+        if not (credentials_map.get(tracker_id) or {}).get("token"):
+            creds = await self._get_tracker_credentials_by_id(tracker_id)
+            if not creds or not creds.get("token"):
+                logger.warning(
+                    "No git token available for the triggering tracker %s; "
+                    "the post-execution push will have no credentials",
+                    tracker_id,
+                )
+                return
+            credentials_map[tracker_id] = creds
+
+        execution_context["git_credentials_map"] = credentials_map
+        # Read by container.py when a repository entry declares no tracker.
+        execution_context["trigger_tracker_id"] = tracker_id
+        logger.info("Attached trigger tracker %s git credentials", tracker_id)
 
     def _build_clone_credential(
         self, repo_url: str, credentials: Dict[str, str]
@@ -1935,6 +2007,14 @@ class FlowExecutionOrchestrator:
                     logger.warning(
                         "Git clone enabled but could not get tracker credentials"
                     )
+
+            # Repositories declared without a tracker_id (and the
+            # trigger-project fallback used when none are declared at all)
+            # resolved their token inside the agent container, which reads the
+            # stored key only and therefore finds nothing for a GitHub App
+            # tracker. Resolve it here, where minting an installation token is
+            # possible, and hand it over with the rest of the credentials.
+            await self._attach_trigger_tracker_credentials(execution_context)
 
         # Add AI model details if available
         if self.ai_model:

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -1774,6 +1774,12 @@ class FlowExecutionOrchestrator:
 
         Minting an App installation token is async and must happen here, in
         the orchestrator, not in the synchronous container code path.
+
+        GitHub App installation tokens expire within an hour. They are minted
+        at execution start and delivered in the container environment; the
+        post-execution ``git push`` is the same container script, so a run
+        longer than that window can still fail the push with an expired
+        token. The recovery bundle is written before the push.
         """
 
         tracker_id = self._resolve_project_tracker_id(

--- a/backend/preloop/services/tracker_git_token.py
+++ b/backend/preloop/services/tracker_git_token.py
@@ -87,7 +87,9 @@ async def resolve_tracker_git_token(tracker: Any) -> Optional[str]:
         return None
 
     logger.info(
-        "Resolved a GitHub App installation token for tracker %s (expires within the hour)",
+        "Resolved a GitHub App installation token for tracker %s "
+        "(expires within the hour; minted at execution start and consumed "
+        "by the same container's post-execution git push)",
         getattr(tracker, "id", "unknown"),
     )
     return token

--- a/backend/preloop/services/tracker_git_token.py
+++ b/backend/preloop/services/tracker_git_token.py
@@ -1,0 +1,93 @@
+"""Resolve a git-usable token for a tracker.
+
+A tracker authenticates in one of two ways:
+
+* ``api_token``: a personal access token stored (encrypted) on the tracker row
+  and read through ``Tracker.resolved_api_key``.
+* ``github_app`` / ``oauth_app``: no token is stored at all. The credential is
+  a short-lived installation access token minted on demand from the GitHub App
+  installation attached to the tracker.
+
+Every git path (clone inside the agent container, the post-execution push,
+PR/MR creation) needs the second case too. Reading ``resolved_api_key``
+directly returns an empty string for App-authenticated trackers, which is why
+an App-installed repository cloned fine (public repository, no credential
+needed) and then failed the post-execution push with "could not read Username
+for 'https://github.com'".
+
+The token is returned to the caller and never logged.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Tracker auth types whose credential is an installation access token rather
+# than a stored secret.
+APP_AUTH_TYPES = {"github_app", "oauth_app"}
+
+
+async def resolve_tracker_git_token(tracker: Any) -> Optional[str]:
+    """Return a token usable for git and REST calls against ``tracker``.
+
+    Args:
+        tracker: A ``Tracker`` ORM instance (or any object exposing
+            ``resolved_api_key``, ``auth_type`` and ``oauth_installation``).
+
+    Returns:
+        The token, or None when the tracker has neither a stored key nor a
+        usable App installation. Never raises: a failure to mint the App token
+        degrades to "no credential", exactly as a missing PAT does today.
+    """
+
+    if tracker is None:
+        return None
+
+    stored = getattr(tracker, "resolved_api_key", None)
+    if stored:
+        return stored
+
+    auth_type = (getattr(tracker, "auth_type", None) or "").lower()
+    if auth_type not in APP_AUTH_TYPES:
+        return None
+
+    installation = getattr(tracker, "oauth_installation", None)
+    installation_id = getattr(installation, "external_id", None)
+    if not installation_id:
+        logger.warning(
+            "Tracker %s uses %s auth but has no OAuth installation; "
+            "git operations will run unauthenticated",
+            getattr(tracker, "id", "unknown"),
+            auth_type,
+        )
+        return None
+
+    try:
+        # Imported lazily: the GitHub App service ships as a proprietary
+        # plugin, so open-source deployments simply have no App trackers.
+        from preloop.plugins.proprietary.github_app.service import (
+            get_github_app_service,
+        )
+
+        token = await get_github_app_service().get_installation_access_token(
+            installation_id
+        )
+    except Exception as exc:  # noqa: BLE001 - degrade, never fail the flow
+        logger.warning(
+            "Could not mint an installation access token for tracker %s: %s",
+            getattr(tracker, "id", "unknown"),
+            exc,
+        )
+        return None
+
+    if not token:
+        return None
+
+    logger.info(
+        "Resolved a GitHub App installation token for tracker %s (expires within the hour)",
+        getattr(tracker, "id", "unknown"),
+    )
+    return token

--- a/backend/preloop/utils/git_credentials.py
+++ b/backend/preloop/utils/git_credentials.py
@@ -248,7 +248,7 @@ password={token_ref}
 PRELOOP_GIT_CRED_EOF
     echo "Installed git credential helper from tracker token for push"
 else
-    echo "WARNING: no git credentials available for push"
+    echo "WARNING: no git credentials available for push (no {GIT_CREDENTIALS_ENV_VAR}, no store at {GIT_CREDENTIALS_FILE}, no tracker token in the environment). The tracker for this repository resolved no token when the execution started."
 fi
 """.strip()
 

--- a/backend/tests/agents/test_container.py
+++ b/backend/tests/agents/test_container.py
@@ -1418,6 +1418,120 @@ class TestGitApiTokensNotInScript:
         assert "origin/preloop/fix" not in commands
 
 
+class TestPushCredentialsWithoutRepositoryTracker:
+    """Reproduces the post-execution push that had no credentials.
+
+    Production execution 85b67a24: the repository entry declared no
+    ``tracker_id`` and the triggering project's tracker was a GitHub App
+    installation, which stores no API key. Both the clone credential and the
+    push token resolved empty, the public repository still cloned, and the push
+    printed "WARNING: no git credentials available for push" followed by
+    "could not read Username for 'https://github.com'".
+
+    The orchestrator now resolves that tracker (minting an installation token
+    when needed) and passes it as ``trigger_tracker_id``.
+    """
+
+    APP_TOKEN = "ghs_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+
+    def _context(self, *, with_trigger_tracker=True):
+        context = {
+            "flow_id": "flow-1",
+            "execution_id": "exec-1",
+            "flow_name": "Automated Issue Implementation (GitHub)",
+            "account_id": "account-1",
+            "_git_target_branch": "preloop/automated-issue-implementation-85b67a24",
+            "_git_source_branch": "main",
+            "trigger_project_id": "daa4a88a-0dfa-4fd6-95bc-664f363ad033",
+            "git_clone_config": {
+                "enabled": True,
+                "repositories": [
+                    {
+                        "repository_url": "https://github.com/preloop/preloop.git",
+                        "clone_path": "workspace",
+                    }
+                ],
+            },
+            "trigger_event_data": {},
+        }
+        if with_trigger_tracker:
+            context["trigger_tracker_id"] = "tracker-app"
+            context["git_credentials_map"] = {
+                "tracker-app": {
+                    "token": self.APP_TOKEN,
+                    "tracker_type": "github",
+                }
+            }
+        return context
+
+    def test_push_token_reaches_the_container_environment(self, container_executor):
+        context = self._context()
+        with patch.object(
+            container_executor, "_get_token_from_project", return_value=(None, None)
+        ):
+            commands = container_executor._prepare_git_post_execution_commands(context)
+
+        assert "${PRELOOP_GIT_TOKEN_1}" in commands
+        assert self.APP_TOKEN not in commands
+        env = container_executor._apply_git_credential_env({}, context)
+        assert env["PRELOOP_GIT_TOKEN_1"] == self.APP_TOKEN
+
+    def test_clone_installs_the_credential_helper(self, container_executor):
+        context = self._context()
+        with patch.object(
+            container_executor, "_get_token_from_project", return_value=(None, None)
+        ):
+            command = container_executor._prepare_git_clone_command(context)
+
+        assert self.APP_TOKEN not in command
+        env = container_executor._git_credential_env(context)
+        assert self.APP_TOKEN in env["PRELOOP_GIT_CREDENTIALS"]
+        assert "x-access-token" in env["PRELOOP_GIT_CREDENTIALS"]
+
+    def test_without_the_trigger_tracker_the_push_has_no_token(
+        self, container_executor
+    ):
+        """The pre-fix behaviour, kept as the contrast case."""
+        context = self._context(with_trigger_tracker=False)
+        with patch.object(
+            container_executor, "_get_token_from_project", return_value=(None, None)
+        ):
+            commands = container_executor._prepare_git_post_execution_commands(context)
+
+        assert "${PRELOOP_GIT_TOKEN_1}" not in commands
+        assert "no git credentials available for push" in commands
+        assert container_executor._apply_git_credential_env({}, context) == {}
+
+    def test_repository_tracker_still_wins(self, container_executor):
+        """A repository with its own tracker keeps using that tracker's token."""
+        context = self._context()
+        context["git_clone_config"]["repositories"][0]["tracker_id"] = "tracker-repo"
+        context["git_credentials_map"]["tracker-repo"] = {
+            "token": "github_pat_repo_specific_token",
+            "tracker_type": "github",
+        }
+        container_executor._prepare_git_post_execution_commands(context)
+
+        env = container_executor._apply_git_credential_env({}, context)
+        assert env["PRELOOP_GIT_TOKEN_1"] == "github_pat_repo_specific_token"
+
+    def test_empty_map_entry_falls_through_to_the_project_lookup(
+        self, container_executor
+    ):
+        """A tracker recorded without a token must not shadow other sources."""
+        context = self._context()
+        context["git_credentials_map"]["tracker-app"]["token"] = ""
+        with patch.object(
+            container_executor,
+            "_get_token_from_project",
+            return_value=("github_pat_from_project", "github"),
+        ):
+            container_executor._prepare_git_post_execution_commands(context)
+
+        env = container_executor._apply_git_credential_env({}, context)
+        assert env["PRELOOP_GIT_TOKEN_1"] == "github_pat_from_project"
+
+
 class TestLogScrubbing:
     """Logs are scrubbed on read as well, so a token already present in a
     running container's output never reaches the API or the console (#173).

--- a/backend/tests/agents/test_container.py
+++ b/backend/tests/agents/test_container.py
@@ -1532,6 +1532,55 @@ class TestPushCredentialsWithoutRepositoryTracker:
         assert env["PRELOOP_GIT_TOKEN_1"] == "github_pat_from_project"
 
 
+class TestProjectRepoUrlForAppTrackers:
+    """An app-installed tracker stores no API key.
+
+    The project lookup used to refuse to build a clone URL in that case, so a
+    flow relying on the trigger project (rather than an explicit
+    repository_url) could not clone at all.
+    """
+
+    def _db(self, tracker):
+        project = MagicMock()
+        project.id = "project-1"
+        project.slug = "preloop/preloop"
+        project.organization = MagicMock(tracker_id="tracker-app")
+        db = MagicMock()
+        return project, tracker, db
+
+    def _lookup(self, container_executor, tracker):
+        project, tracker, db = self._db(tracker)
+        with (
+            patch("preloop.models.db.session.get_db_session", return_value=iter([db])),
+            patch("preloop.models.crud.crud_project.get", return_value=project),
+            patch("preloop.models.crud.crud_tracker.get", return_value=tracker),
+        ):
+            return container_executor._get_repo_url_from_project(
+                "project-1", "account-1"
+            )
+
+    def test_app_tracker_without_a_key_still_yields_a_url(self, container_executor):
+        tracker = MagicMock(
+            id="tracker-app",
+            resolved_api_key="",
+            auth_type="github_app",
+            tracker_type="github",
+        )
+        assert (
+            self._lookup(container_executor, tracker)
+            == "https://github.com/preloop/preloop.git"
+        )
+
+    def test_pat_tracker_without_a_key_is_still_refused(self, container_executor):
+        tracker = MagicMock(
+            id="tracker-pat",
+            resolved_api_key="",
+            auth_type="api_token",
+            tracker_type="github",
+        )
+        assert self._lookup(container_executor, tracker) is None
+
+
 class TestLogScrubbing:
     """Logs are scrubbed on read as well, so a token already present in a
     running container's output never reaches the API or the console (#173).

--- a/backend/tests/services/test_flow_orchestrator_git_credentials.py
+++ b/backend/tests/services/test_flow_orchestrator_git_credentials.py
@@ -145,3 +145,163 @@ class TestPerformGitCloneCommand:
         assert "; echo pwned" not in captured["cmd"].replace(
             "'https://github.com/acme/repo.git; echo pwned'", ""
         )
+
+
+APP_TOKEN = "ghs_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+
+
+class TestTrackerCredentialResolution:
+    """The tracker token must be resolved here, where minting is possible.
+
+    A GitHub App tracker stores no API key. Reading ``resolved_api_key`` left
+    the agent container with no credential at all: a public repository still
+    cloned and the post-execution push then failed to authenticate
+    (production execution 85b67a24).
+    """
+
+    def _tracker(self, *, api_key="", auth_type="github_app"):
+        tracker = MagicMock()
+        tracker.id = "tracker-app"
+        tracker.resolved_api_key = api_key
+        tracker.auth_type = auth_type
+        tracker.tracker_type = "github"
+        return tracker
+
+    async def test_app_tracker_yields_a_minted_token(self, orchestrator):
+        tracker = self._tracker()
+        with (
+            patch(
+                "preloop.models.crud.crud_tracker.get",
+                return_value=tracker,
+            ),
+            patch(
+                "preloop.services.flow_orchestrator.resolve_tracker_git_token",
+                AsyncMock(return_value=APP_TOKEN),
+            ),
+        ):
+            creds = await orchestrator._get_tracker_credentials_by_id("tracker-app")
+
+        assert creds == {
+            "tracker_id": "tracker-app",
+            "token": APP_TOKEN,
+            "tracker_type": "github",
+        }
+
+    async def test_tracker_without_any_token_reports_an_empty_token(self, orchestrator):
+        with (
+            patch(
+                "preloop.models.crud.crud_tracker.get",
+                return_value=self._tracker(),
+            ),
+            patch(
+                "preloop.services.flow_orchestrator.resolve_tracker_git_token",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            creds = await orchestrator._get_tracker_credentials_by_id("tracker-app")
+
+        assert creds["token"] == ""
+
+
+class TestAttachTriggerTrackerCredentials:
+    """Repositories configured without a ``tracker_id`` still need a token."""
+
+    async def test_project_tracker_credentials_land_in_the_context(self, orchestrator):
+        context = {"trigger_project_id": "project-1"}
+        with (
+            patch.object(
+                orchestrator, "_resolve_project_tracker_id", return_value="tracker-app"
+            ),
+            patch.object(
+                orchestrator,
+                "_get_tracker_credentials_by_id",
+                AsyncMock(
+                    return_value={
+                        "tracker_id": "tracker-app",
+                        "token": APP_TOKEN,
+                        "tracker_type": "github",
+                    }
+                ),
+            ),
+        ):
+            await orchestrator._attach_trigger_tracker_credentials(context)
+
+        assert context["trigger_tracker_id"] == "tracker-app"
+        assert context["git_credentials_map"]["tracker-app"]["token"] == APP_TOKEN
+
+    async def test_trigger_event_tracker_is_the_fallback(self, orchestrator):
+        orchestrator.trigger_event_data = {"tracker_id": "tracker-from-event"}
+        context = {}
+        with (
+            patch.object(
+                orchestrator, "_resolve_project_tracker_id", return_value=None
+            ),
+            patch.object(
+                orchestrator,
+                "_get_tracker_credentials_by_id",
+                AsyncMock(
+                    return_value={
+                        "tracker_id": "tracker-from-event",
+                        "token": PAT,
+                        "tracker_type": "github",
+                    }
+                ),
+            ),
+        ):
+            await orchestrator._attach_trigger_tracker_credentials(context)
+
+        assert context["trigger_tracker_id"] == "tracker-from-event"
+
+    async def test_no_tracker_leaves_the_context_untouched(self, orchestrator):
+        orchestrator.trigger_event_data = {}
+        context = {}
+        with patch.object(
+            orchestrator, "_resolve_project_tracker_id", return_value=None
+        ):
+            await orchestrator._attach_trigger_tracker_credentials(context)
+
+        assert context == {}
+
+    async def test_a_tokenless_tracker_is_not_recorded(self, orchestrator):
+        context = {"trigger_project_id": "project-1"}
+        with (
+            patch.object(
+                orchestrator, "_resolve_project_tracker_id", return_value="tracker-app"
+            ),
+            patch.object(
+                orchestrator,
+                "_get_tracker_credentials_by_id",
+                AsyncMock(return_value={"token": "", "tracker_type": "github"}),
+            ),
+        ):
+            await orchestrator._attach_trigger_tracker_credentials(context)
+
+        assert "trigger_tracker_id" not in context
+        assert "git_credentials_map" not in context
+
+    async def test_existing_repository_credentials_are_preserved(self, orchestrator):
+        context = {
+            "trigger_project_id": "project-1",
+            "git_credentials_map": {
+                "tracker-repo": {"token": PAT, "tracker_type": "github"}
+            },
+        }
+        with (
+            patch.object(
+                orchestrator, "_resolve_project_tracker_id", return_value="tracker-app"
+            ),
+            patch.object(
+                orchestrator,
+                "_get_tracker_credentials_by_id",
+                AsyncMock(
+                    return_value={
+                        "tracker_id": "tracker-app",
+                        "token": APP_TOKEN,
+                        "tracker_type": "github",
+                    }
+                ),
+            ),
+        ):
+            await orchestrator._attach_trigger_tracker_credentials(context)
+
+        assert set(context["git_credentials_map"]) == {"tracker-repo", "tracker-app"}

--- a/backend/tests/services/test_tracker_git_token.py
+++ b/backend/tests/services/test_tracker_git_token.py
@@ -1,0 +1,96 @@
+"""Tests for tracker git token resolution.
+
+Regression cover for the post-execution push that ran with no credentials:
+a GitHub App tracker stores no API key, so every caller that read
+``Tracker.resolved_api_key`` directly resolved an empty token, the agent
+container got no credential helper, and ``git push`` failed with "could not
+read Username for 'https://github.com'".
+"""
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from preloop.services.tracker_git_token import resolve_tracker_git_token
+
+pytestmark = pytest.mark.asyncio
+
+PAT = "github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+APP_TOKEN = "ghs_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+
+
+def _tracker(*, api_key="", auth_type="api_token", installation_id=None):
+    tracker = MagicMock()
+    tracker.id = "tracker-1"
+    tracker.resolved_api_key = api_key
+    tracker.auth_type = auth_type
+    if installation_id is None:
+        tracker.oauth_installation = None
+    else:
+        tracker.oauth_installation = MagicMock(external_id=installation_id)
+    return tracker
+
+
+@pytest.fixture
+def github_app_plugin(monkeypatch):
+    """Install a stand-in for the proprietary GitHub App plugin."""
+
+    service = MagicMock()
+    service.get_installation_access_token = AsyncMock(return_value=APP_TOKEN)
+
+    module = types.ModuleType("preloop.plugins.proprietary.github_app.service")
+    module.get_github_app_service = lambda: service
+
+    for name in (
+        "preloop.plugins.proprietary",
+        "preloop.plugins.proprietary.github_app",
+    ):
+        if name not in sys.modules:
+            package = types.ModuleType(name)
+            package.__path__ = []  # mark as a package
+            monkeypatch.setitem(sys.modules, name, package)
+    monkeypatch.setitem(
+        sys.modules, "preloop.plugins.proprietary.github_app.service", module
+    )
+    return service
+
+
+class TestResolveTrackerGitToken:
+    async def test_stored_key_is_returned_as_is(self):
+        assert await resolve_tracker_git_token(_tracker(api_key=PAT)) == PAT
+
+    async def test_app_tracker_mints_an_installation_token(self, github_app_plugin):
+        tracker = _tracker(auth_type="github_app", installation_id=4242)
+
+        assert await resolve_tracker_git_token(tracker) == APP_TOKEN
+        github_app_plugin.get_installation_access_token.assert_awaited_once_with(4242)
+
+    async def test_oauth_app_auth_type_is_also_supported(self, github_app_plugin):
+        tracker = _tracker(auth_type="oauth_app", installation_id=7)
+        assert await resolve_tracker_git_token(tracker) == APP_TOKEN
+
+    async def test_stored_key_wins_without_calling_the_plugin(self, github_app_plugin):
+        tracker = _tracker(api_key=PAT, auth_type="github_app", installation_id=4242)
+
+        assert await resolve_tracker_git_token(tracker) == PAT
+        github_app_plugin.get_installation_access_token.assert_not_awaited()
+
+    async def test_app_tracker_without_installation_returns_none(self):
+        tracker = _tracker(auth_type="github_app")
+        assert await resolve_tracker_git_token(tracker) is None
+
+    async def test_minting_failure_degrades_to_no_token(self, github_app_plugin):
+        github_app_plugin.get_installation_access_token.side_effect = RuntimeError(
+            "GitHub is down"
+        )
+        tracker = _tracker(auth_type="github_app", installation_id=4242)
+
+        assert await resolve_tracker_git_token(tracker) is None
+
+    async def test_api_token_tracker_without_key_returns_none(self):
+        assert await resolve_tracker_git_token(_tracker()) is None
+
+    async def test_missing_tracker_returns_none(self):
+        assert await resolve_tracker_git_token(None) is None


### PR DESCRIPTION
Root cause of the failed push in flow execution 85b67a24: the tracker is a GitHub App installation, which stores no API key, so the post-exec credential helper had nothing to install and git prompted for a username.

The post-exec push now resolves an installation token for App trackers (same path the MCP tools use), installs it via the credential helper without logging it, and keeps the recovery bundle behaviour. Unit tests cover the empty-credential path before and after.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium**
> Changes important push/credential logic; the App installation token is minted at execution start and may expire before the post-execution push for long-running flows.
>
> **Overview**
> Resolves an installation token for GitHub App trackers in the flow orchestrator (where async minting is possible) and threads it into the agent container via the execution context, fixing the post-execution push that had no credential. Keeps tokens out of URLs, command lines, and logs, with thorough unit tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit ed88493. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->