### PR TITLE
Cost analytics: name unpriced models, honest reprice outcome, override route

### DIFF
--- a/backend/preloop/api/endpoints/cost.py
+++ b/backend/preloop/api/endpoints/cost.py
@@ -34,6 +34,7 @@ from preloop.schemas.cost_analytics import (
     PriceCatalogInfo,
     RepriceRequest,
     RepriceResponse,
+    UnpricedModelUsage,
 )
 from preloop.services.gateway_accounting_check import run_accounting_checks
 from preloop.services.ledger_backfill import (
@@ -55,6 +56,11 @@ REPRICE_MAX_WINDOW_DAYS = 92
 
 #: Explore exports are one row per (day, model); even a year is tiny.
 MAX_LEDGER_CSV_BYTES = 2 * 1024 * 1024
+
+#: How many unpriced models the summary names for the banner. Capped so a
+#: long tail of one-off aliases cannot bloat every cost-summary response;
+#: the biggest token offenders sort first.
+UNPRICED_MODELS_LIMIT = 10
 
 
 def _price_catalog_info() -> Optional[PriceCatalogInfo]:
@@ -146,6 +152,17 @@ def get_cost_summary(
         estimated_cost=summary.estimated_cost,
         unpriced_requests=summary.unpriced_requests,
         unpriced_tokens=summary.unpriced_tokens,
+        unpriced_models=[
+            UnpricedModelUsage(**row)
+            for row in crud_api_usage.get_unpriced_model_breakdown(
+                db,
+                account_id=str(account.id),
+                start_date=summary.period_start,
+                end_date=summary.period_end,
+                runtime_principal_id=runtime_principal_id,
+                limit=UNPRICED_MODELS_LIMIT,
+            )
+        ],
         price_catalog=_price_catalog_info(),
         budget=summary.budget,
         requests_by_day=summary.requests_by_day,

--- a/backend/preloop/api/endpoints/cost.py
+++ b/backend/preloop/api/endpoints/cost.py
@@ -160,6 +160,7 @@ def get_cost_summary(
                 start_date=summary.period_start,
                 end_date=summary.period_end,
                 runtime_principal_id=runtime_principal_id,
+                exclude_retries=exclude_retries,
                 limit=UNPRICED_MODELS_LIMIT,
             )
         ],

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -930,6 +930,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         start_date: datetime,
         end_date: datetime,
         runtime_principal_id: Optional[str] = None,
+        exclude_retries: bool = False,
         limit: int = 10,
     ) -> List[Dict[str, Any]]:
         """Group still-unpriced gateway rows by model for the cost banner.
@@ -945,6 +946,11 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             start_date: Inclusive lower bound on usage timestamp.
             end_date: Exclusive upper bound on usage timestamp.
             runtime_principal_id: Restrict to a single runtime principal.
+            exclude_retries: When True, rows marked as retries of an earlier
+                identical request are excluded. Mirrors the predicate in
+                :meth:`get_gateway_usage_summary` exactly, so with
+                ``exclude_retries=True`` the per-model rows cannot sum above
+                the headline counts.
             limit: Maximum number of models returned, ordered by unpriced
                 tokens descending so the biggest offenders name themselves
                 first.
@@ -969,6 +975,10 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         )
         if runtime_principal_id:
             query = query.filter(ApiUsage.runtime_principal_id == runtime_principal_id)
+        if exclude_retries:
+            query = query.filter(
+                or_(ApiUsage.is_retry.is_(None), ApiUsage.is_retry.is_(False))
+            )
         query = (
             query.group_by(model_label)
             .order_by(func.coalesce(func.sum(ApiUsage.total_tokens), 0).desc())

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -922,6 +922,67 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             "unpriced_tokens": int(row.unpriced_tokens or 0),
         }
 
+    def get_unpriced_model_breakdown(
+        self,
+        db: Session,
+        *,
+        account_id: str,
+        start_date: datetime,
+        end_date: datetime,
+        runtime_principal_id: Optional[str] = None,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """Group still-unpriced gateway rows by model for the cost banner.
+
+        Uses the exact ``unpriced`` predicate of
+        :meth:`get_gateway_usage_summary` (``estimated_cost IS NULL AND
+        total_tokens > 0``) so the per-model rows explain the aggregate
+        ``unpriced_requests``/``unpriced_tokens`` counts shown next to them.
+
+        Args:
+            db: Database session.
+            account_id: Account whose gateway usage is aggregated.
+            start_date: Inclusive lower bound on usage timestamp.
+            end_date: Exclusive upper bound on usage timestamp.
+            runtime_principal_id: Restrict to a single runtime principal.
+            limit: Maximum number of models returned, ordered by unpriced
+                tokens descending so the biggest offenders name themselves
+                first.
+
+        Returns:
+            One dict per model with ``model``, ``requests`` and ``tokens``,
+            ordered by tokens descending.
+        """
+        model_label = func.coalesce(ApiUsage.model_alias, "unknown")
+        query = db.query(
+            model_label.label("model"),
+            func.count(ApiUsage.id).label("requests"),
+            func.coalesce(func.sum(ApiUsage.total_tokens), 0).label("tokens"),
+        ).filter(
+            ApiUsage.action_type == "model_gateway",
+            ApiUsage.account_id == account_id,
+            exclude_replay_usage_condition(),
+            ApiUsage.timestamp >= start_date,
+            ApiUsage.timestamp < end_date,
+            ApiUsage.estimated_cost.is_(None),
+            ApiUsage.total_tokens > 0,
+        )
+        if runtime_principal_id:
+            query = query.filter(ApiUsage.runtime_principal_id == runtime_principal_id)
+        query = (
+            query.group_by(model_label)
+            .order_by(func.coalesce(func.sum(ApiUsage.total_tokens), 0).desc())
+            .limit(limit)
+        )
+        return [
+            {
+                "model": str(row.model),
+                "requests": int(row.requests or 0),
+                "tokens": int(row.tokens or 0),
+            }
+            for row in query.all()
+        ]
+
     def get_rate_limit_summary(
         self,
         db: Session,

--- a/backend/preloop/schemas/cost_analytics.py
+++ b/backend/preloop/schemas/cost_analytics.py
@@ -262,6 +262,19 @@ class ImportedUsageSummary(BaseModel):
     )
 
 
+class UnpricedModelUsage(BaseModel):
+    """One model's share of the window's unpriced gateway usage.
+
+    Names the models behind ``unpriced_requests``/``unpriced_tokens`` so the
+    console can say WHICH models are missing from the price catalog instead
+    of only how many requests are affected.
+    """
+
+    model: str
+    requests: int = 0
+    tokens: int = 0
+
+
 class CostAnalyticsSummaryResponse(BaseModel):
     """Open-source cost overview response."""
 
@@ -274,6 +287,7 @@ class CostAnalyticsSummaryResponse(BaseModel):
     estimated_cost: float = 0.0
     unpriced_requests: int = 0
     unpriced_tokens: int = 0
+    unpriced_models: List[UnpricedModelUsage] = Field(default_factory=list)
     price_catalog: Optional[PriceCatalogInfo] = None
     budget: GatewayBudgetSummary
     requests_by_day: List[GatewayUsageByDay] = Field(default_factory=list)

--- a/backend/tests/endpoints/test_cost.py
+++ b/backend/tests/endpoints/test_cost.py
@@ -260,3 +260,56 @@ def test_cost_summary_requires_authentication(app, db_session):
     with TestClient(app) as anon_client:
         response = anon_client.get(COST_SUMMARY)
     assert response.status_code in (401, 403)
+
+
+def test_cost_summary_names_unpriced_models(client, db_session, test_user):
+    """Unpriced rows must surface their model names next to the counts."""
+    _log_usage(
+        db_session,
+        account_id=test_user.account_id,
+        user_id=test_user.id,
+        model_alias="openai-compatible/muse-spark",
+        estimated_cost=None,
+        cost_source="unpriced",
+        total_tokens=5000,
+    )
+    _log_usage(
+        db_session,
+        account_id=test_user.account_id,
+        user_id=test_user.id,
+        model_alias="openai-compatible/muse-spark",
+        estimated_cost=None,
+        cost_source="unpriced",
+        total_tokens=1000,
+    )
+    _log_usage(
+        db_session,
+        account_id=test_user.account_id,
+        user_id=test_user.id,
+        model_alias="openai/gpt-5",
+        estimated_cost=0.05,
+        cost_source="catalog",
+        total_tokens=7000,
+    )
+    db_session.commit()
+
+    body = client.get(COST_SUMMARY).json()
+
+    assert body["unpriced_requests"] == 2
+    assert body["unpriced_tokens"] == 6000
+    assert body["unpriced_models"] == [
+        {"model": "openai-compatible/muse-spark", "requests": 2, "tokens": 6000}
+    ]
+
+
+def test_cost_summary_unpriced_models_empty_when_all_priced(
+    client, db_session, test_user
+):
+    """A fully priced window reports an empty unpriced model list."""
+    _log_usage(db_session, account_id=test_user.account_id, user_id=test_user.id)
+    db_session.commit()
+
+    body = client.get(COST_SUMMARY).json()
+
+    assert body["unpriced_requests"] == 0
+    assert body["unpriced_models"] == []

--- a/backend/tests/models/crud/test_unpriced_usage_reporting.py
+++ b/backend/tests/models/crud/test_unpriced_usage_reporting.py
@@ -12,9 +12,12 @@ These tests pin the reporting contract:
   2. An aggregate mixing priced and unpriced rows reports the priced subtotal
      plus an explicit unpriced qualifier, never one misleadingly-low number.
   3. ``cost_source='subscription'`` remains a legitimate, complete $0.00.
+  4. The account-level breakdown names WHICH models are unpriced, ordered by
+     token volume and capped, so the banner can point at a fix.
 """
 
 import uuid
+from datetime import UTC, datetime, timedelta
 
 from preloop.models.crud import crud_ai_model, crud_flow, crud_flow_execution
 from preloop.models.crud.api_usage import crud_api_usage
@@ -171,3 +174,144 @@ def test_subscription_zero_is_a_complete_zero(db_session, create_account, create
     assert usage["cost_is_partial"] is False
     assert usage["unpriced_requests"] == 0
     assert usage["unpriced_tokens"] == 0
+
+
+def _window():
+    """A bracketing window around freshly logged rows."""
+    now = datetime.now(UTC)
+    return now - timedelta(days=1), now + timedelta(days=1)
+
+
+def test_unpriced_model_breakdown_names_models_by_token_volume(
+    db_session, create_account, create_user
+):
+    """The breakdown names the unpriced models, biggest token offender first."""
+    account = create_account()
+    user = create_user(account=account)
+    _, flow, execution = _setup_execution(db_session, account)
+
+    _log(
+        db_session,
+        account=account,
+        user=user,
+        flow=flow,
+        execution=execution,
+        model_alias="openai-compatible/muse-spark",
+        estimated_cost=None,
+        cost_source="unpriced",
+        total_tokens=9000,
+    )
+    _log(
+        db_session,
+        account=account,
+        user=user,
+        flow=flow,
+        execution=execution,
+        model_alias="openai-compatible/muse-spark",
+        estimated_cost=None,
+        cost_source="unpriced",
+        total_tokens=1000,
+    )
+    _log(
+        db_session,
+        account=account,
+        user=user,
+        flow=flow,
+        execution=execution,
+        model_alias="openai-compatible/muse-nano",
+        estimated_cost=None,
+        cost_source="unpriced",
+        total_tokens=500,
+    )
+    # Priced rows, even for the same provider, must not appear.
+    _log(
+        db_session,
+        account=account,
+        user=user,
+        flow=flow,
+        execution=execution,
+        model_alias="openai-compatible/priced-model",
+        estimated_cost=0.25,
+        cost_source="catalog",
+        total_tokens=7000,
+    )
+
+    start, end = _window()
+    rows = crud_api_usage.get_unpriced_model_breakdown(
+        db_session,
+        account_id=str(account.id),
+        start_date=start,
+        end_date=end,
+    )
+
+    assert rows == [
+        {"model": "openai-compatible/muse-spark", "requests": 2, "tokens": 10000},
+        {"model": "openai-compatible/muse-nano", "requests": 1, "tokens": 500},
+    ]
+
+
+def test_unpriced_model_breakdown_empty_when_everything_priced(
+    db_session, create_account, create_user
+):
+    """A fully priced window has no unpriced models to name."""
+    account = create_account()
+    user = create_user(account=account)
+    _, flow, execution = _setup_execution(db_session, account)
+
+    _log(
+        db_session,
+        account=account,
+        user=user,
+        flow=flow,
+        execution=execution,
+        estimated_cost=0.25,
+        cost_source="catalog",
+    )
+
+    start, end = _window()
+    rows = crud_api_usage.get_unpriced_model_breakdown(
+        db_session,
+        account_id=str(account.id),
+        start_date=start,
+        end_date=end,
+    )
+
+    assert rows == []
+
+
+def test_unpriced_model_breakdown_respects_limit(
+    db_session, create_account, create_user
+):
+    """The cap keeps a long tail of one-off aliases out of the response."""
+    account = create_account()
+    user = create_user(account=account)
+    _, flow, execution = _setup_execution(db_session, account)
+
+    for index in range(12):
+        _log(
+            db_session,
+            account=account,
+            user=user,
+            flow=flow,
+            execution=execution,
+            model_alias=f"openai-compatible/model-{index:02d}",
+            estimated_cost=None,
+            cost_source="unpriced",
+            total_tokens=100 + index,
+        )
+
+    start, end = _window()
+    rows = crud_api_usage.get_unpriced_model_breakdown(
+        db_session,
+        account_id=str(account.id),
+        start_date=start,
+        end_date=end,
+        limit=10,
+    )
+
+    assert len(rows) == 10
+    # Tokens descending: model-11 (111 tokens) leads, model-02 is cut off.
+    assert rows[0]["model"] == "openai-compatible/model-11"
+    assert {row["model"] for row in rows} == {
+        f"openai-compatible/model-{index:02d}" for index in range(2, 12)
+    }

--- a/backend/tests/models/crud/test_unpriced_usage_reporting.py
+++ b/backend/tests/models/crud/test_unpriced_usage_reporting.py
@@ -315,3 +315,59 @@ def test_unpriced_model_breakdown_respects_limit(
     assert {row["model"] for row in rows} == {
         f"openai-compatible/model-{index:02d}" for index in range(2, 12)
     }
+
+
+def test_unpriced_model_breakdown_exclude_retries_matches_summary(
+    db_session, create_account, create_user
+):
+    """exclude_retries drops retry rows so the models match the headline."""
+    account = create_account()
+    user = create_user(account=account)
+    _, flow, execution = _setup_execution(db_session, account)
+
+    _log(
+        db_session,
+        account=account,
+        user=user,
+        flow=flow,
+        execution=execution,
+        model_alias="openai-compatible/muse-spark",
+        estimated_cost=None,
+        cost_source="unpriced",
+        total_tokens=1000,
+    )
+    _log(
+        db_session,
+        account=account,
+        user=user,
+        flow=flow,
+        execution=execution,
+        model_alias="openai-compatible/muse-spark",
+        estimated_cost=None,
+        cost_source="unpriced",
+        total_tokens=4000,
+        is_retry=True,
+    )
+
+    start, end = _window()
+    included = crud_api_usage.get_unpriced_model_breakdown(
+        db_session,
+        account_id=str(account.id),
+        start_date=start,
+        end_date=end,
+        exclude_retries=False,
+    )
+    excluded = crud_api_usage.get_unpriced_model_breakdown(
+        db_session,
+        account_id=str(account.id),
+        start_date=start,
+        end_date=end,
+        exclude_retries=True,
+    )
+
+    assert included == [
+        {"model": "openai-compatible/muse-spark", "requests": 2, "tokens": 5000}
+    ]
+    assert excluded == [
+        {"model": "openai-compatible/muse-spark", "requests": 1, "tokens": 1000}
+    ]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1164,9 +1164,20 @@ export interface ImportedUsageSummary {
   usage_by_conversation?: ImportedUsageByConversation[];
 }
 
+// One model's share of the window's unpriced gateway usage. Names the models
+// behind `unpriced_requests`/`unpriced_tokens` so the banner can point at a
+// fix instead of only counting the damage.
+export interface UnpricedModelUsage {
+  model: string;
+  requests: number;
+  tokens: number;
+}
+
 export interface CostAnalyticsSummaryResponse extends AccountGatewayUsageSummaryResponse {
   // Absent (null) when the window contains no imported usage.
   imported_usage?: ImportedUsageSummary | null;
+  // Absent on older servers; the console treats missing as "none named".
+  unpriced_models?: UnpricedModelUsage[];
 }
 
 export interface ProviderBillingConnection {

--- a/frontend/src/views/authed/cost-view.test.ts
+++ b/frontend/src/views/authed/cost-view.test.ts
@@ -704,5 +704,78 @@ describe('CostView', () => {
       // The banner reloads to the grown count, still naming the model.
       expect(banner(element)?.textContent).to.contain('5');
     });
+
+    it('async reprice finishing after the last poll still reports the decrease', async () => {
+      const viewClass = CostView as unknown as {
+        REPRICE_POLL_MAX_ATTEMPTS: number;
+      };
+      viewClass.REPRICE_POLL_MAX_ATTEMPTS = 3;
+      repriceResult = {
+        ...repriceResult,
+        submitted_async: true,
+        rows_examined: null,
+        rows_updated: null,
+        rows_skipped: null,
+      };
+      // Every poll sees the stale count, so the poll times out; the worker
+      // finishes before the final reload, which shows one of the two
+      // requests got priced. The notice must come from the reloaded
+      // summary, not from the poll's early-stop signal.
+      let summaryFetches = 0;
+      summaryResponder = () => {
+        summaryFetches += 1;
+        // Initial load, previous-range fetch and 3 polls see the stale
+        // count; the final reload (fetch 6) sees the decrease.
+        return summaryFetches > 5
+          ? { ...summaryPayload, unpriced_requests: 1, unpriced_tokens: 2000 }
+          : summaryPayload;
+      };
+      const element = await loadView();
+
+      const reprice = bannerButton(element, 'Reprice now');
+      expect(reprice).to.exist;
+      (reprice as HTMLElement).click();
+
+      await waitUntil(() => {
+        const state = element as unknown as {
+          repriceNotice: string | null;
+          repricing: boolean;
+        };
+        return (
+          !state.repricing && state.repriceNotice?.includes('Reprice finished')
+        );
+      });
+      await element.updateComplete;
+
+      const state = element as unknown as { repriceNotice: string | null };
+      expect(state.repriceNotice).to.contain('1 requests priced');
+      expect(state.repriceNotice).to.contain('1 still unpriced');
+      // One row remains unpriced, so the banner stays up.
+      expect(banner(element)).to.exist;
+    });
+
+    it('override CTA does not pre-fill the coalesced unknown model', async () => {
+      summaryPayload = {
+        ...summary,
+        unpriced_requests: 3,
+        unpriced_tokens: 4200,
+        unpriced_models: [{ model: 'unknown', requests: 3, tokens: 4200 }],
+      };
+      const element = await loadView();
+
+      const cta = bannerButton(element, 'Set price override');
+      expect(cta, 'override CTA must be present').to.exist;
+      (cta as HTMLElement).click();
+      await element.updateComplete;
+
+      const state = element as unknown as {
+        priceDialogOpen: boolean;
+        priceModelAlias: string;
+      };
+      expect(state.priceDialogOpen).to.equal(true);
+      // "unknown" is the backend placeholder for rows with no model alias;
+      // pre-filling it would create a no-op override, so the field is empty.
+      expect(state.priceModelAlias).to.equal('');
+    });
   });
 });

--- a/frontend/src/views/authed/cost-view.test.ts
+++ b/frontend/src/views/authed/cost-view.test.ts
@@ -665,5 +665,44 @@ describe('CostView', () => {
         'openai-compatible/muse-spark'
       );
     });
+
+    it('async reprice never reports a negative priced count', async () => {
+      repriceResult = {
+        ...repriceResult,
+        submitted_async: true,
+        rows_examined: null,
+        rows_updated: null,
+        rows_skipped: null,
+      };
+      // Live traffic adds unpriced rows during the poll window: the count
+      // moves (2 -> 5), so the poll stops early, but nothing was priced.
+      let summaryFetches = 0;
+      summaryResponder = () => {
+        summaryFetches += 1;
+        return summaryFetches > 1
+          ? { ...summaryPayload, unpriced_requests: 5, unpriced_tokens: 9000 }
+          : summaryPayload;
+      };
+      const element = await loadView();
+
+      const reprice = bannerButton(element, 'Reprice now');
+      expect(reprice).to.exist;
+      (reprice as HTMLElement).click();
+
+      await waitUntil(() => {
+        const state = element as unknown as {
+          repriceNotice: string | null;
+          repricing: boolean;
+        };
+        return !state.repricing && state.repriceNotice?.includes('No change');
+      });
+      await element.updateComplete;
+
+      const state = element as unknown as { repriceNotice: string | null };
+      expect(state.repriceNotice).to.not.match(/-\d+ requests priced/);
+      expect(state.repriceNotice).to.contain('price override');
+      // The banner reloads to the grown count, still naming the model.
+      expect(banner(element)?.textContent).to.contain('5');
+    });
   });
 });

--- a/frontend/src/views/authed/cost-view.test.ts
+++ b/frontend/src/views/authed/cost-view.test.ts
@@ -3,7 +3,7 @@ import type { LitElement } from 'lit';
 import sinon from 'sinon';
 import '../../components/view-header.ts';
 import './cost-view.ts';
-import type { CostView } from './cost-view';
+import { CostView } from './cost-view';
 import { invalidateApiCaches } from '../../api';
 
 describe('CostView', () => {
@@ -11,6 +11,14 @@ describe('CostView', () => {
   // Per-test copy of the payload so a test can add fields (e.g. the imported
   // usage block) without leaking into the others.
   let summaryPayload: Record<string, unknown>;
+  // Per-test feature flags; banner tests enable the override UI.
+  let featuresPayload: Record<string, unknown>;
+  // Per-test reprice POST response; set by banner tests.
+  let repriceResult: Record<string, unknown>;
+  // Optional per-test hooks: onReprice runs when the reprice POST arrives,
+  // summaryResponder (when set) replaces the summary payload per fetch.
+  let onReprice: (() => void) | null;
+  let summaryResponder: (() => Record<string, unknown>) | null;
 
   const summary = {
     period_start: '2026-03-01T00:00:00Z',
@@ -77,12 +85,38 @@ describe('CostView', () => {
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
     summaryPayload = { ...summary };
+    featuresPayload = { billing: true };
+    onReprice = null;
+    summaryResponder = null;
+    repriceResult = {
+      submitted_async: false,
+      rows_examined: 0,
+      rows_updated: 0,
+      rows_skipped: 0,
+      cost_before: null,
+      cost_after: null,
+      dry_run: false,
+    };
     fetchStub = sinon.stub(window, 'fetch');
     fetchStub.callsFake(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
 
+      if (url.includes('/api/v1/billing/cost/reprice')) {
+        onReprice?.();
+        return new Response(JSON.stringify(repriceResult), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/v1/billing/cost/pricing-overrides')) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/v1/cost/summary')) {
-        return new Response(JSON.stringify(summaryPayload), {
+        const payload = summaryResponder ? summaryResponder() : summaryPayload;
+        return new Response(JSON.stringify(payload), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
@@ -94,7 +128,7 @@ describe('CostView', () => {
         });
       }
       if (url.includes('/api/v1/features')) {
-        return new Response(JSON.stringify({ features: { billing: true } }), {
+        return new Response(JSON.stringify({ features: featuresPayload }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
@@ -409,5 +443,227 @@ describe('CostView', () => {
     expect(description?.textContent).to.contain(
       'Understand gateway spend by model, agent, session, flow, and API key.'
     );
+  });
+
+  describe('unpriced reprice banner', () => {
+    const unpricedSummary = {
+      unpriced_requests: 2,
+      unpriced_tokens: 6000,
+      unpriced_models: [
+        {
+          model: 'openai-compatible/muse-spark',
+          requests: 2,
+          tokens: 6000,
+        },
+      ],
+    };
+
+    let originalInterval: number;
+    let originalAttempts: number;
+
+    beforeEach(() => {
+      // Shrink the async poll so tests do not wait real minutes. The
+      // statics are readonly at compile time only; restore them after.
+      const viewClass = CostView as unknown as {
+        REPRICE_POLL_INTERVAL_MS: number;
+        REPRICE_POLL_MAX_ATTEMPTS: number;
+      };
+      originalInterval = viewClass.REPRICE_POLL_INTERVAL_MS;
+      originalAttempts = viewClass.REPRICE_POLL_MAX_ATTEMPTS;
+      viewClass.REPRICE_POLL_INTERVAL_MS = 1;
+      featuresPayload = { billing: true, model_price_overrides: true };
+      summaryPayload = { ...summary, ...unpricedSummary };
+    });
+
+    afterEach(() => {
+      const viewClass = CostView as unknown as {
+        REPRICE_POLL_INTERVAL_MS: number;
+        REPRICE_POLL_MAX_ATTEMPTS: number;
+      };
+      viewClass.REPRICE_POLL_INTERVAL_MS = originalInterval;
+      viewClass.REPRICE_POLL_MAX_ATTEMPTS = originalAttempts;
+    });
+
+    async function loadView(): Promise<CostView> {
+      const element = (await fixture(
+        html`<cost-view></cost-view>`
+      )) as CostView;
+      await waitUntil(
+        () => (element as unknown as { loading: boolean }).loading === false
+      );
+      await element.updateComplete;
+      return element;
+    }
+
+    function banner(element: CostView) {
+      return element.shadowRoot?.querySelector('#panel-pricing-catalog');
+    }
+
+    function bannerButton(element: CostView, label: string) {
+      return [...(banner(element)?.querySelectorAll('sl-button') ?? [])].find(
+        (button) => button.textContent?.trim() === label
+      );
+    }
+
+    it('renders the unpriced count and names the affected models', async () => {
+      const element = await loadView();
+
+      const text = banner(element)?.textContent ?? '';
+      expect(text).to.contain('2');
+      expect(text).to.contain('6,000');
+      expect(text).to.contain('openai-compatible/muse-spark');
+      expect(text).to.contain('missing from the price catalog');
+      expect(bannerButton(element, 'Reprice now')).to.exist;
+    });
+
+    it('wires the override CTA to the price override dialog, pre-filled', async () => {
+      const element = await loadView();
+
+      const cta = bannerButton(element, 'Set price override');
+      expect(cta, 'override CTA must be present').to.exist;
+      (cta as HTMLElement).click();
+      await element.updateComplete;
+
+      const state = element as unknown as {
+        priceDialogOpen: boolean;
+        priceModelAlias: string;
+      };
+      expect(state.priceDialogOpen).to.equal(true);
+      expect(state.priceModelAlias).to.equal('openai-compatible/muse-spark');
+
+      const dialog = element.shadowRoot?.querySelector(
+        'sl-dialog[label="Add Price Override"]'
+      );
+      expect(dialog).to.exist;
+      expect((dialog as unknown as { open: boolean }).open).to.equal(true);
+    });
+
+    it('sync reprice reports the actual counts and reloads the banner', async () => {
+      repriceResult = {
+        ...repriceResult,
+        submitted_async: false,
+        rows_examined: 2,
+        rows_updated: 2,
+      };
+      // The reprice "works": after the POST the window is fully priced.
+      onReprice = () => {
+        summaryPayload = {
+          ...summaryPayload,
+          unpriced_requests: 0,
+          unpriced_tokens: 0,
+          unpriced_models: [],
+        };
+      };
+      const element = await loadView();
+
+      const reprice = bannerButton(element, 'Reprice now');
+      expect(reprice).to.exist;
+      (reprice as HTMLElement).click();
+
+      await waitUntil(() => {
+        const state = element as unknown as {
+          repriceNotice: string | null;
+          repricing: boolean;
+        };
+        return (
+          !state.repricing && state.repriceNotice?.includes('Reprice finished')
+        );
+      });
+      await element.updateComplete;
+
+      const state = element as unknown as { repriceNotice: string | null };
+      expect(state.repriceNotice).to.contain('2 of 2 requests priced');
+
+      // The reloaded summary has nothing unpriced: the warning banner is
+      // replaced by the success notice.
+      expect(banner(element)).to.not.exist;
+      const success = element.shadowRoot?.querySelector(
+        'sl-alert[variant="success"]'
+      );
+      expect(success?.textContent).to.contain('2 of 2 requests priced');
+    });
+
+    it('async reprice polls the summary, then reloads and reports', async () => {
+      repriceResult = {
+        ...repriceResult,
+        submitted_async: true,
+        rows_examined: null,
+        rows_updated: null,
+        rows_skipped: null,
+      };
+      // The background worker finishes before the first poll: from the
+      // second summary fetch on, the window comes back fully priced.
+      let summaryFetches = 0;
+      summaryResponder = () => {
+        summaryFetches += 1;
+        return summaryFetches > 1
+          ? {
+              ...summaryPayload,
+              unpriced_requests: 0,
+              unpriced_tokens: 0,
+              unpriced_models: [],
+            }
+          : summaryPayload;
+      };
+      const element = await loadView();
+
+      const reprice = bannerButton(element, 'Reprice now');
+      expect(reprice).to.exist;
+      (reprice as HTMLElement).click();
+
+      await waitUntil(() => {
+        const state = element as unknown as {
+          repriceNotice: string | null;
+          repricing: boolean;
+        };
+        return (
+          !state.repricing && state.repriceNotice?.includes('Reprice finished')
+        );
+      });
+      await element.updateComplete;
+
+      const state = element as unknown as { repriceNotice: string | null };
+      expect(state.repriceNotice).to.contain(
+        'every request in this window now has a cost estimate'
+      );
+      // The summary was polled and then reloaded, not left stale.
+      expect(summaryFetches).to.be.greaterThan(1);
+      expect(banner(element)).to.not.exist;
+    });
+
+    it('async reprice with no change says so instead of claiming success', async () => {
+      const viewClass = CostView as unknown as {
+        REPRICE_POLL_MAX_ATTEMPTS: number;
+      };
+      viewClass.REPRICE_POLL_MAX_ATTEMPTS = 3;
+      repriceResult = {
+        ...repriceResult,
+        submitted_async: true,
+        rows_examined: null,
+        rows_updated: null,
+        rows_skipped: null,
+      };
+      const element = await loadView();
+
+      const reprice = bannerButton(element, 'Reprice now');
+      expect(reprice).to.exist;
+      (reprice as HTMLElement).click();
+
+      await waitUntil(() => {
+        const state = element as unknown as {
+          repriceNotice: string | null;
+          repricing: boolean;
+        };
+        return !state.repricing && state.repriceNotice?.includes('No change');
+      });
+      await element.updateComplete;
+
+      const state = element as unknown as { repriceNotice: string | null };
+      expect(state.repriceNotice).to.contain('price override');
+      // The banner stays, still naming the unpriceable model.
+      expect(banner(element)?.textContent).to.contain(
+        'openai-compatible/muse-spark'
+      );
+    });
   });
 });

--- a/frontend/src/views/authed/cost-view.ts
+++ b/frontend/src/views/authed/cost-view.ts
@@ -119,6 +119,11 @@ const DATE_RANGE_PRESETS: DateRangePreset[] = [
 
 @customElement('cost-view')
 export class CostView extends AuthedElement {
+  // Async reprice follow-up: check the summary every 5s for up to about a
+  // minute, then stop and say so instead of polling forever.
+  private static readonly REPRICE_POLL_INTERVAL_MS = 5000;
+  private static readonly REPRICE_POLL_MAX_ATTEMPTS = 12;
+
   @state() private summary: CostAnalyticsSummaryResponse | null = null;
   @state() private previousRangeSummary: CostAnalyticsSummaryResponse | null =
     null;
@@ -857,15 +862,27 @@ export class CostView extends AuthedElement {
     this.repriceNotice = null;
     try {
       const range = this.getDateParams();
+      const previousUnpriced = this.summary?.unpriced_requests ?? 0;
       const result = await repriceCost({
         start_date: range.startDate,
         end_date: range.endDate,
         only_unpriced: true,
       });
-      this.repriceNotice = result.submitted_async
-        ? 'Repricing scheduled in the background; refresh in a few minutes.'
-        : `Repriced ${result.rows_updated} of ${result.rows_examined} rows.`;
-      if (!result.submitted_async) {
+      if (result.submitted_async) {
+        this.repriceNotice =
+          'Repricing is running in the background. Checking for results...';
+        const changed = await this.pollRepriceOutcome(previousUnpriced);
+        await this.load();
+        const remaining = this.summary?.unpriced_requests ?? 0;
+        this.repriceNotice = this.repriceOutcomeNotice(
+          previousUnpriced,
+          remaining,
+          changed
+        );
+      } else {
+        this.repriceNotice =
+          `Reprice finished: ${result.rows_updated ?? 0} of ` +
+          `${result.rows_examined ?? 0} requests priced.`;
         await this.load();
       }
     } catch (error) {
@@ -874,6 +891,66 @@ export class CostView extends AuthedElement {
     } finally {
       this.repricing = false;
     }
+  }
+
+  // The async reprice path (windows over 7 days) acknowledges before anything
+  // is scanned, so the response carries no counts. Poll the summary on a
+  // bounded interval until the unpriced count moves or the attempts run out;
+  // the notice must reflect what actually happened, not a bare "scheduled".
+  private async pollRepriceOutcome(previousUnpriced: number): Promise<boolean> {
+    for (
+      let attempt = 0;
+      attempt < CostView.REPRICE_POLL_MAX_ATTEMPTS;
+      attempt++
+    ) {
+      await new Promise((resolve) =>
+        window.setTimeout(resolve, CostView.REPRICE_POLL_INTERVAL_MS)
+      );
+      try {
+        const summary = await getCostAnalyticsSummary(this.getDateParams());
+        if ((summary.unpriced_requests ?? 0) !== previousUnpriced) {
+          return true;
+        }
+      } catch {
+        // A failed poll is not a failed reprice; keep watching.
+      }
+    }
+    return false;
+  }
+
+  private repriceOutcomeNotice(
+    previousUnpriced: number,
+    remaining: number,
+    changed: boolean
+  ): string {
+    if (remaining === 0) {
+      return 'Reprice finished: every request in this window now has a cost estimate.';
+    }
+    if (changed) {
+      return (
+        `Reprice finished: ${this.formatNumber(previousUnpriced - remaining)} ` +
+        `requests priced, ${this.formatNumber(remaining)} still unpriced. ` +
+        'Set a price override for the models named below, then reprice again.'
+      );
+    }
+    return (
+      'No change after checking for about a minute. If the models named ' +
+      'below are missing from the price catalog, repricing cannot price ' +
+      'them: set a price override (a $0 price is fine for free models), ' +
+      'then reprice again.'
+    );
+  }
+
+  // Route from the unpriced banner into the existing price-override dialog
+  // with the highest-volume unpriced model pre-filled. A $0 override is
+  // honored by repricing, which is the supported escape hatch for custom
+  // models that will never appear in a shared price catalog.
+  private openPriceOverrideForUnpriced() {
+    const top = this.summary?.unpriced_models?.[0];
+    if (top) {
+      this.priceModelAlias = top.model;
+    }
+    this.priceDialogOpen = true;
   }
 
   private formatCurrency(value?: number | null): string {
@@ -1138,7 +1215,9 @@ export class CostView extends AuthedElement {
 
   // Warning banner when usage rows carry tokens but no cost (model missing
   // from the price catalog at request time). Repricing re-derives their cost
-  // from stored tokens against current prices/overrides (billing flag).
+  // from stored tokens against current prices/overrides (billing flag), and
+  // the named models route into the price-override dialog for the models no
+  // catalog will ever price.
   private renderUnpricedNotice() {
     const unpricedRequests = this.summary?.unpriced_requests ?? 0;
     if (!unpricedRequests) {
@@ -1153,14 +1232,35 @@ export class CostView extends AuthedElement {
           >`
         : nothing;
     }
+    const unpricedModels = this.summary?.unpriced_models ?? [];
     return html`
       <sl-alert id="panel-pricing-catalog" variant="warning" open role="alert">
         <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
         ${this.formatNumber(unpricedRequests)}
         request${unpricedRequests === 1 ? '' : 's'}
         (${this.formatNumber(this.summary?.unpriced_tokens)} tokens) in this
-        window have no cost estimate: their model was missing from the price
-        catalog when recorded, so total spend is understated.
+        window have no cost estimate, so total spend is understated.
+        ${
+          unpricedModels.length
+            ? html`<div class="unpriced-models">
+                These models are missing from the price catalog, so their cost
+                cannot be estimated automatically:
+                ${unpricedModels.map(
+                  (entry, index) =>
+                    html`${index > 0 ? ', ' : ''}<code>${entry.model}</code>
+                      (${this.formatNumber(entry.tokens)} tokens)`
+                )}.
+              </div>`
+            : nothing
+        }
+        ${
+          unpricedModels.length && this.modelPriceOverridesEnabled
+            ? html`<div>
+                Set a price override (a $0 price is fine for free models), then
+                reprice.
+              </div>`
+            : nothing
+        }
         ${
           this.billingEnabled
             ? html`<sl-button
@@ -1169,6 +1269,17 @@ export class CostView extends AuthedElement {
                 .loading=${this.repricing}
                 @click=${() => void this.handleReprice()}
                 >Reprice now</sl-button
+              >`
+            : nothing
+        }
+        ${
+          unpricedModels.length && this.modelPriceOverridesEnabled
+            ? html`<sl-button
+                size="small"
+                variant="warning"
+                outline
+                @click=${() => this.openPriceOverrideForUnpriced()}
+                >Set price override</sl-button
               >`
             : nothing
         }

--- a/frontend/src/views/authed/cost-view.ts
+++ b/frontend/src/views/authed/cost-view.ts
@@ -926,7 +926,11 @@ export class CostView extends AuthedElement {
     if (remaining === 0) {
       return 'Reprice finished: every request in this window now has a cost estimate.';
     }
-    if (changed) {
+    // Live traffic can add unpriced rows during the poll window, leaving
+    // `remaining` at or above `previousUnpriced` even when the count moved.
+    // A negative "requests priced" would be nonsense, so only the strictly
+    // decreased case reports a priced count; the rest reads as no change.
+    if (changed && remaining < previousUnpriced) {
       return (
         `Reprice finished: ${this.formatNumber(previousUnpriced - remaining)} ` +
         `requests priced, ${this.formatNumber(remaining)} still unpriced. ` +

--- a/frontend/src/views/authed/cost-view.ts
+++ b/frontend/src/views/authed/cost-view.ts
@@ -871,13 +871,12 @@ export class CostView extends AuthedElement {
       if (result.submitted_async) {
         this.repriceNotice =
           'Repricing is running in the background. Checking for results...';
-        const changed = await this.pollRepriceOutcome(previousUnpriced);
+        await this.pollRepriceOutcome(previousUnpriced);
         await this.load();
         const remaining = this.summary?.unpriced_requests ?? 0;
         this.repriceNotice = this.repriceOutcomeNotice(
           previousUnpriced,
-          remaining,
-          changed
+          remaining
         );
       } else {
         this.repriceNotice =
@@ -895,9 +894,9 @@ export class CostView extends AuthedElement {
 
   // The async reprice path (windows over 7 days) acknowledges before anything
   // is scanned, so the response carries no counts. Poll the summary on a
-  // bounded interval until the unpriced count moves or the attempts run out;
-  // the notice must reflect what actually happened, not a bare "scheduled".
-  private async pollRepriceOutcome(previousUnpriced: number): Promise<boolean> {
+  // bounded interval and stop early once the unpriced count moves; the notice
+  // is computed from the reloaded summary afterwards, not from this poll.
+  private async pollRepriceOutcome(previousUnpriced: number): Promise<void> {
     for (
       let attempt = 0;
       attempt < CostView.REPRICE_POLL_MAX_ATTEMPTS;
@@ -909,28 +908,27 @@ export class CostView extends AuthedElement {
       try {
         const summary = await getCostAnalyticsSummary(this.getDateParams());
         if ((summary.unpriced_requests ?? 0) !== previousUnpriced) {
-          return true;
+          return;
         }
       } catch {
         // A failed poll is not a failed reprice; keep watching.
       }
     }
-    return false;
   }
 
+  // In a fixed window the unpriced count can only DECREASE via pricing, so a
+  // lower remaining count is the precise partial-success signal even when
+  // the job finished after the last poll. Live traffic can add unpriced rows
+  // during the poll window, so an equal-or-higher count reads as no change
+  // (a negative "requests priced" would be nonsense).
   private repriceOutcomeNotice(
     previousUnpriced: number,
-    remaining: number,
-    changed: boolean
+    remaining: number
   ): string {
     if (remaining === 0) {
       return 'Reprice finished: every request in this window now has a cost estimate.';
     }
-    // Live traffic can add unpriced rows during the poll window, leaving
-    // `remaining` at or above `previousUnpriced` even when the count moved.
-    // A negative "requests priced" would be nonsense, so only the strictly
-    // decreased case reports a priced count; the rest reads as no change.
-    if (changed && remaining < previousUnpriced) {
+    if (remaining < previousUnpriced) {
       return (
         `Reprice finished: ${this.formatNumber(previousUnpriced - remaining)} ` +
         `requests priced, ${this.formatNumber(remaining)} still unpriced. ` +
@@ -948,10 +946,12 @@ export class CostView extends AuthedElement {
   // Route from the unpriced banner into the existing price-override dialog
   // with the highest-volume unpriced model pre-filled. A $0 override is
   // honored by repricing, which is the supported escape hatch for custom
-  // models that will never appear in a shared price catalog.
+  // models that will never appear in a shared price catalog. The backend
+  // coalesces rows with no model alias to "unknown"; pre-filling that
+  // placeholder would invite a no-op override, so the field stays empty.
   private openPriceOverrideForUnpriced() {
     const top = this.summary?.unpriced_models?.[0];
-    if (top) {
+    if (top && top.model !== 'unknown') {
       this.priceModelAlias = top.model;
     }
     this.priceDialogOpen = true;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12767,6 +12767,11 @@ components:
           type: integer
           title: Unpriced Tokens
           default: 0
+        unpriced_models:
+          items:
+            $ref: '#/components/schemas/UnpricedModelUsage'
+          type: array
+          title: Unpriced Models
         price_catalog:
           anyOf:
           - $ref: '#/components/schemas/PriceCatalogInfo'
@@ -20629,6 +20634,31 @@ components:
       type: object
       title: TrackerUpdate
       description: Model for updating an existing tracker.
+    UnpricedModelUsage:
+      properties:
+        model:
+          type: string
+          title: Model
+        requests:
+          type: integer
+          title: Requests
+          default: 0
+        tokens:
+          type: integer
+          title: Tokens
+          default: 0
+      type: object
+      required:
+      - model
+      title: UnpricedModelUsage
+      description: 'One model''s share of the window''s unpriced gateway usage.
+
+
+        Names the models behind ``unpriced_requests``/``unpriced_tokens`` so the
+
+        console can say WHICH models are missing from the price catalog instead
+
+        of only how many requests are affected.'
     UpdateTagRequest:
       properties:
         tag:


### PR DESCRIPTION
## Problem

A customer clicked **Reprice now** on the Cost Analytics unpriced-usage banner and the banner never went away.

Two root causes:

- Repricing re-derives cost from the same price catalog that missed at record time. The live-price fallback (litellm + OpenRouter) never sees custom `openai-compatible` endpoints, so those rows stay unpriced with no marker, and every click rescans them futilely.
- For windows over 7 days the reprice endpoint only enqueues, and the console showed a static "scheduled in the background" notice without ever reloading or polling, so nothing visibly changed even when the job finished.

The banner also never mentioned the existing price-override mechanism ($0 allowed, honored by repricing), which is the supported escape hatch for custom models that no shared catalog will ever price.

## Changes

Backend:

- `GET /api/v1/cost/summary` now returns `unpriced_models` (`{model, requests, tokens}`, tokens-desc, capped at 10) using the exact unpriced predicate of the banner count, so the UI can say WHICH models are affected.

Console (`cost-view.ts`):

- Sync reprice reports the actual "X of Y requests priced" and reloads.
- Async reprice polls the summary (every 5s, about a minute, stops early when the count moves), reloads, and reports the real outcome: all priced / partially priced / no change. It never reports a negative priced count when live traffic grows the unpriced count mid-poll.
- The banner names the unpriced models with per-model token counts and offers a **Set price override** action that opens the existing override dialog with the biggest offender pre-filled. Copy notes that a $0 price is fine for free models.

## Test plan

- Backend: new CRUD + endpoint tests. `pytest tests/models/crud/test_unpriced_usage_reporting.py tests/endpoints/test_cost.py tests/endpoints/test_cost_reprice_backfill.py tests/services/test_usage_repricing.py` → 43 passed.
- Frontend: 6 new banner tests in `cost-view.test.ts` (previously zero coverage), including the negative-count edge case. `cost-view.test.ts` → 20 passed; full suite → 1344 passed.
- `pre-commit run --files <all changed files>` → all hooks passed, `openapi.yaml` regenerated.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium**
> No security issues; the change is additive and well-tested, but it modifies cost-analytics reporting (a financial surface) and adds a new summary field plus async polling logic.
>
> **Overview**
> Makes the Cost Analytics unpriced-usage banner honest: the summary now names unpriced models, sync reprice reports real counts, async reprice polls and reports the true outcome (never a negative count), and the banner routes users into the existing price-override dialog pre-filled with the biggest offender.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 5f761d45. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->