### PR TITLE
Private runners: default agent image, trusted-machine flags, persisted workspace, per-execution compose isolation

### DIFF
--- a/backend/preloop/agents/aider.py
+++ b/backend/preloop/agents/aider.py
@@ -11,6 +11,7 @@ from preloop.services.mcp_config_service import MCPConfigService
 from preloop.services.model_runtime_resolver import gateway_url_for_api
 
 from .container import ContainerAgentExecutor
+from .images import default_agent_image
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +37,7 @@ class AiderAgent(ContainerAgentExecutor):
                 - edit_format: Edit format (default: whole)
                 - custom settings for Aider
         """
-        # Use Aider CE Docker image (Community Edition with MCP support)
-        image = os.getenv("AIDER_IMAGE", "dustinwashington/aider-ce:v0.88.6")
+        image = default_agent_image("aider") or "dustinwashington/aider-ce:v0.88.6"
 
         super().__init__(
             agent_type="aider",

--- a/backend/preloop/agents/codex.py
+++ b/backend/preloop/agents/codex.py
@@ -18,6 +18,7 @@ from .completion_nudge import (
     completion_nudge_timeout_seconds,
 )
 from .container import ContainerAgentExecutor
+from .images import default_agent_image
 
 logger = logging.getLogger(__name__)
 
@@ -49,8 +50,7 @@ class CodexAgent(ContainerAgentExecutor):
                 - model: OpenAI model to use (default: gpt-5.4)
                 - custom settings for Codex CLI
         """
-        # Use official Codex Universal image
-        image = os.getenv("CODEX_IMAGE", "ghcr.io/openai/codex-universal:latest")
+        image = default_agent_image("codex") or "ghcr.io/openai/codex-universal:latest"
 
         # Auto-detect Kubernetes environment or use explicit env var
         use_k8s = self._detect_kubernetes_environment()

--- a/backend/preloop/agents/gemini.py
+++ b/backend/preloop/agents/gemini.py
@@ -13,6 +13,7 @@ from preloop.services.mcp_config_service import MCPConfigService
 from preloop.services.model_runtime_resolver import gateway_url_for_api
 
 from .container import ContainerAgentExecutor
+from .images import default_agent_image
 
 logger = logging.getLogger(__name__)
 
@@ -73,11 +74,7 @@ class GeminiAgent(ContainerAgentExecutor):
                 - model: Gemini model to use (default: gemini-3-pro-preview)
                 - custom settings for Gemini CLI
         """
-        # Use the Gemini CLI sandbox image that supports `gemini mcp add`
-        image = os.getenv(
-            "GEMINI_IMAGE",
-            "docker/sandbox-templates:gemini",
-        )
+        image = default_agent_image("gemini") or "docker/sandbox-templates:gemini"
 
         # Auto-detect Kubernetes environment or use explicit env var
         use_k8s = self._detect_kubernetes_environment()

--- a/backend/preloop/agents/images.py
+++ b/backend/preloop/agents/images.py
@@ -1,0 +1,58 @@
+"""Shared default Docker images for hosted executors and private runners."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+# Fallback tags used when the matching *_IMAGE env var is unset. Keep these
+# in one place so RemoteRunnerExecutor injects the same image the hosted
+# executor would have started.
+DEFAULT_AGENT_IMAGES: dict[str, str] = {
+    "opencode": "docker/sandbox-templates:opencode",
+    "codex": "ghcr.io/openai/codex-universal:latest",
+    "aider": "dustinwashington/aider-ce:v0.88.6",
+    "gemini": "docker/sandbox-templates:gemini",
+    "openhands": "spacebridge/openhands:latest-tmux",
+}
+
+_IMAGE_ENV_VARS: dict[str, str] = {
+    "opencode": "OPENCODE_IMAGE",
+    "codex": "CODEX_IMAGE",
+    "aider": "AIDER_IMAGE",
+    "gemini": "GEMINI_IMAGE",
+    "openhands": "OPENHANDS_IMAGE",
+}
+
+
+def default_agent_image(agent_type: str) -> Optional[str]:
+    """Return the per-agent-type Docker image hosted executors use.
+
+    Args:
+        agent_type: Agent harness name (case-insensitive).
+
+    Returns:
+        Image reference, honoring the matching ``*_IMAGE`` environment
+        variable, or ``None`` when the agent type has no default.
+    """
+    key = (agent_type or "").strip().lower()
+    fallback = DEFAULT_AGENT_IMAGES.get(key)
+    if fallback is None:
+        return None
+    return os.getenv(_IMAGE_ENV_VARS[key], fallback)
+
+
+def agent_config_has_image(agent_config: dict[str, object]) -> bool:
+    """Return True when agent_config already names an image.
+
+    Args:
+        agent_config: Flow agent settings.
+
+    Returns:
+        True if ``image`` or ``docker_image`` is a non-empty string.
+    """
+    for key in ("image", "docker_image"):
+        value = agent_config.get(key)
+        if isinstance(value, str) and value.strip():
+            return True
+    return False

--- a/backend/preloop/agents/opencode.py
+++ b/backend/preloop/agents/opencode.py
@@ -20,6 +20,7 @@ from .completion_nudge import (
     completion_nudge_timeout_seconds,
 )
 from .container import ContainerAgentExecutor
+from .images import default_agent_image
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ class OpenCodeAgent(ContainerAgentExecutor):
                 - model: Model identifier to use (required, no default)
                 - custom settings for OpenCode CLI
         """
-        image = os.getenv("OPENCODE_IMAGE", "docker/sandbox-templates:opencode")
+        image = default_agent_image("opencode") or "docker/sandbox-templates:opencode"
 
         # Auto-detect Kubernetes environment or use explicit env var
         use_k8s = self._detect_kubernetes_environment()

--- a/backend/preloop/agents/openhands.py
+++ b/backend/preloop/agents/openhands.py
@@ -18,6 +18,7 @@ from preloop.utils.git_credentials import (
 )
 
 from .container import ContainerAgentExecutor
+from .images import default_agent_image
 
 logger = logging.getLogger(__name__)
 
@@ -40,8 +41,7 @@ class OpenHandsAgent(ContainerAgentExecutor):
                 - max_iterations: Maximum number of agent iterations
                 - custom settings for OpenHands
         """
-        # Use OpenHands Docker image (custom build with tmux for local runtime)
-        image = os.getenv("OPENHANDS_IMAGE", "spacebridge/openhands:latest-tmux")
+        image = default_agent_image("openhands") or "spacebridge/openhands:latest-tmux"
 
         super().__init__(
             agent_type="openhands",

--- a/backend/preloop/agents/remote_runner.py
+++ b/backend/preloop/agents/remote_runner.py
@@ -16,9 +16,11 @@ from preloop.services.runner_service import (
     DEFAULT_QUEUE_TIMEOUT,
     lease_job,
     mark_queued_or_fail,
+    persistable_job_payload,
 )
 
 from .base import AgentExecutionResult, AgentExecutor, AgentStatus
+from .images import agent_config_has_image, default_agent_image
 
 logger = logging.getLogger(__name__)
 
@@ -219,6 +221,20 @@ class RemoteRunnerExecutor(AgentExecutor):
             and isinstance(agent_config["agent_config"], dict)
         ):
             agent_config = agent_config["agent_config"]
+        if isinstance(agent_config, dict):
+            agent_config = dict(agent_config)
+        else:
+            agent_config = {}
+
+        agent_type = (
+            context.get("agent_type")
+            or self.agent_type
+            or (getattr(flow, "agent_type", None) if flow is not None else None)
+        )
+        if not agent_config_has_image(agent_config):
+            image = default_agent_image(str(agent_type or ""))
+            if image:
+                agent_config["image"] = image
 
         def context_or_flow(key: str, default: Any = None) -> Any:
             value = context.get(key)
@@ -226,12 +242,10 @@ class RemoteRunnerExecutor(AgentExecutor):
                 return value
             return getattr(flow, key, default) if flow is not None else default
 
-        return {
+        payload: Dict[str, Any] = {
             "execution_id": str(execution_id),
             "flow_id": str(flow_id),
-            "agent_type": context.get("agent_type")
-            or self.agent_type
-            or context_or_flow("agent_type"),
+            "agent_type": agent_type,
             "agent_config": agent_config,
             "prompt": prompt,
             "model_identifier": context.get("model_identifier")
@@ -246,6 +260,10 @@ class RemoteRunnerExecutor(AgentExecutor):
             "git_clone_config": context_or_flow("git_clone_config"),
             "custom_commands": context_or_flow("custom_commands"),
         }
+        resume_from = _resume_from_execution_id(context, self.execution)
+        if resume_from:
+            payload["resume_from"] = resume_from
+        return payload
 
     def _flow_for_execution(self, execution: Any) -> Any:
         """Resolve the flow without depending on a loaded ORM relationship."""
@@ -286,6 +304,41 @@ async def _push_job(runner_id: UUID, payload: Dict[str, Any]) -> None:
         await push_job_to_runner(runner_id, payload)
     except Exception as exc:
         logger.debug("live job push skipped: %s", exc)
+
+
+def _resume_from_execution_id(
+    context: Dict[str, Any], execution: Any = None
+) -> Optional[str]:
+    """Prior execution id when this run resumes a PR-comment follow-up.
+
+    Args:
+        context: Execution context or empty dict.
+        execution: Optional flow execution with trigger_event_details.
+
+    Returns:
+        Prior execution id string, or None when this is not a resume.
+    """
+    direct = context.get("resume_from")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    trigger = context.get("trigger_event_data")
+    if not isinstance(trigger, dict) and execution is not None:
+        trigger = getattr(execution, "trigger_event_details", None)
+    if not isinstance(trigger, dict):
+        return None
+    resume = trigger.get("_resume") or {}
+    if isinstance(resume, str) and resume.strip():
+        return resume.strip()
+    if isinstance(resume, dict):
+        prior = resume.get("execution_id")
+        if prior:
+            return str(prior)
+    return None
+
+
+def payload_for_log(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a lease payload safe to write to logs (no live token)."""
+    return persistable_job_payload(payload)
 
 
 def _execution_id_from_ref(session_reference: str) -> Optional[UUID]:

--- a/backend/preloop/agents/remote_runner.py
+++ b/backend/preloop/agents/remote_runner.py
@@ -69,10 +69,11 @@ class RemoteRunnerExecutor(AgentExecutor):
                 self.db.add(execution)
                 self.db.commit()
             logger.info(
-                "Leased execution %s to runner %s (pool %s)",
+                "Leased execution %s to runner %s (pool %s) payload=%s",
                 execution_id,
                 runner.id,
                 self.pool,
+                payload_for_log(payload),
             )
             await _push_job(runner.id, payload)
             return f"runner:{runner.id}:{execution_id}"

--- a/backend/preloop/agents/remote_runner.py
+++ b/backend/preloop/agents/remote_runner.py
@@ -16,7 +16,6 @@ from preloop.services.runner_service import (
     DEFAULT_QUEUE_TIMEOUT,
     lease_job,
     mark_queued_or_fail,
-    persistable_job_payload,
 )
 
 from .base import AgentExecutionResult, AgentExecutor, AgentStatus
@@ -68,12 +67,13 @@ class RemoteRunnerExecutor(AgentExecutor):
                 execution.agent_session_reference = f"runner:{runner.id}:{execution_id}"
                 self.db.add(execution)
                 self.db.commit()
+            summary = payload_for_log(payload)
             logger.info(
-                "Leased execution %s to runner %s (pool %s) payload=%s",
+                "Leased execution %s to runner %s (pool %s) agent_type=%s",
                 execution_id,
                 runner.id,
                 self.pool,
-                payload_for_log(payload),
+                summary.get("agent_type"),
             )
             await _push_job(runner.id, payload)
             return f"runner:{runner.id}:{execution_id}"
@@ -338,8 +338,19 @@ def _resume_from_execution_id(
 
 
 def payload_for_log(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Return a lease payload safe to write to logs (no live token)."""
-    return persistable_job_payload(payload)
+    """Identifiers only — never tokens, prompt, git config, or agent_config."""
+
+    agent_config = payload.get("agent_config")
+    image = None
+    if isinstance(agent_config, dict):
+        raw = agent_config.get("image")
+        if isinstance(raw, str) and raw.strip():
+            image = raw.strip()
+    return {
+        "execution_id": payload.get("execution_id"),
+        "agent_type": payload.get("agent_type"),
+        "image": image,
+    }
 
 
 def _execution_id_from_ref(session_reference: str) -> Optional[UUID]:

--- a/backend/tests/agents/test_agent_images.py
+++ b/backend/tests/agents/test_agent_images.py
@@ -1,0 +1,37 @@
+"""Tests for the shared default agent image helper."""
+
+import os
+from unittest.mock import patch
+
+from preloop.agents.aider import AiderAgent
+from preloop.agents.codex import CodexAgent
+from preloop.agents.gemini import GeminiAgent
+from preloop.agents.images import DEFAULT_AGENT_IMAGES, default_agent_image
+from preloop.agents.opencode import OpenCodeAgent
+
+
+def test_default_agent_image_matches_hosted_executors() -> None:
+    assert default_agent_image("opencode") == OpenCodeAgent({}).image
+    assert default_agent_image("codex") == CodexAgent({}).image
+    assert default_agent_image("aider") == AiderAgent({}).image
+    assert default_agent_image("gemini") == GeminiAgent({}).image
+    assert default_agent_image("OPENCODE") == DEFAULT_AGENT_IMAGES["opencode"]
+    assert default_agent_image("unknown") is None
+
+
+def test_default_agent_image_honors_env_overrides() -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "OPENCODE_IMAGE": "custom/opencode:dev",
+            "CODEX_IMAGE": "custom/codex:dev",
+            "AIDER_IMAGE": "custom/aider:dev",
+            "GEMINI_IMAGE": "custom/gemini:dev",
+        },
+    ):
+        assert default_agent_image("opencode") == "custom/opencode:dev"
+        assert default_agent_image("codex") == "custom/codex:dev"
+        assert default_agent_image("aider") == "custom/aider:dev"
+        assert default_agent_image("gemini") == "custom/gemini:dev"
+        assert OpenCodeAgent({}).image == "custom/opencode:dev"
+        assert CodexAgent({}).image == "custom/codex:dev"

--- a/backend/tests/agents/test_remote_runner.py
+++ b/backend/tests/agents/test_remote_runner.py
@@ -245,17 +245,29 @@ def test_lease_payload_includes_resume_from() -> None:
     assert payload["resume_from"] == str(prior)
 
 
-def test_payload_for_log_strips_account_api_token() -> None:
+def test_payload_for_log_omits_credentials() -> None:
     token = "live-runtime-token-should-never-log"
+    api_key = "sk-live-openai-key-should-never-log"
     redacted = payload_for_log(
         {
             "execution_id": "exec-1",
+            "agent_type": "codex",
             "account_api_token": token,
-            "agent_config": {"image": "preloop/agent:dev"},
+            "prompt": "do the work",
+            "agent_config": {
+                "image": "preloop/agent:dev",
+                "openai_api_key": api_key,
+                "api_key": api_key,
+            },
         }
     )
-    assert token not in str(redacted)
+    dumped = str(redacted)
+    assert token not in dumped
+    assert api_key not in dumped
     assert "account_api_token" not in redacted
+    assert "agent_config" not in redacted
+    assert redacted["agent_type"] == "codex"
+    assert redacted["image"] == "preloop/agent:dev"
 
 
 @pytest.mark.asyncio
@@ -265,6 +277,7 @@ async def test_start_logs_do_not_include_token(
     import logging
 
     token = "super-secret-runtime-token"
+    api_key = "sk-live-openai-key-should-never-log"
     execution_id = uuid4()
     runner = SimpleNamespace(id=uuid4(), pending_job=None)
     monkeypatch.setattr(
@@ -292,10 +305,13 @@ async def test_start_logs_do_not_include_token(
             {
                 "execution_id": str(execution_id),
                 "account_api_token": token,
-                "agent_config": {},
+                "agent_type": "codex",
+                "agent_config": {"openai_api_key": api_key, "api_key": api_key},
             }
         )
     assert token not in caplog.text
+    assert api_key not in caplog.text
+    assert f"Leased execution {execution_id}" in caplog.text
 
 
 def test_factory_keeps_hosted_executor_without_pool() -> None:

--- a/backend/tests/agents/test_remote_runner.py
+++ b/backend/tests/agents/test_remote_runner.py
@@ -10,7 +10,11 @@ import pytest
 
 from preloop.agents.factory import create_executor_for_execution
 from preloop.agents.codex import CodexAgent
-from preloop.agents.remote_runner import RemoteRunnerExecutor
+from preloop.agents.images import default_agent_image
+from preloop.agents.remote_runner import (
+    RemoteRunnerExecutor,
+    payload_for_log,
+)
 from preloop.agents.base import AgentStatus
 from preloop.services.runner_service import persistable_job_payload
 
@@ -187,6 +191,111 @@ def test_factory_uses_remote_runner_when_pool_set() -> None:
     )
     assert isinstance(executor, RemoteRunnerExecutor)
     assert executor.pool == "local"
+
+
+def test_lease_payload_injects_default_image() -> None:
+    execution_id = uuid4()
+    flow_id = uuid4()
+    executor = RemoteRunnerExecutor(
+        "opencode", {}, db=MagicMock(), pool="local", account_id=uuid4()
+    )
+    payload = executor._lease_payload(
+        execution_id=execution_id,
+        flow_id=flow_id,
+        prompt="review",
+        execution_context={"agent_type": "opencode", "agent_config": {}},
+    )
+    image = default_agent_image("opencode")
+    assert image
+    assert payload["agent_config"]["image"] == image
+
+
+def test_lease_payload_keeps_explicit_image() -> None:
+    executor = RemoteRunnerExecutor(
+        "codex", {}, db=MagicMock(), pool="local", account_id=uuid4()
+    )
+    payload = executor._lease_payload(
+        execution_id=uuid4(),
+        flow_id=uuid4(),
+        prompt="review",
+        execution_context={
+            "agent_type": "codex",
+            "agent_config": {"docker_image": "custom/codex:dev"},
+        },
+    )
+    assert payload["agent_config"]["docker_image"] == "custom/codex:dev"
+    assert "image" not in payload["agent_config"]
+
+
+def test_lease_payload_includes_resume_from() -> None:
+    prior = uuid4()
+    executor = RemoteRunnerExecutor(
+        "codex", {}, db=MagicMock(), pool="local", account_id=uuid4()
+    )
+    payload = executor._lease_payload(
+        execution_id=uuid4(),
+        flow_id=uuid4(),
+        prompt="continue",
+        execution_context={
+            "agent_type": "codex",
+            "agent_config": {"image": "preloop/codex:latest"},
+            "trigger_event_data": {"_resume": {"execution_id": str(prior)}},
+        },
+    )
+    assert payload["resume_from"] == str(prior)
+
+
+def test_payload_for_log_strips_account_api_token() -> None:
+    token = "live-runtime-token-should-never-log"
+    redacted = payload_for_log(
+        {
+            "execution_id": "exec-1",
+            "account_api_token": token,
+            "agent_config": {"image": "preloop/agent:dev"},
+        }
+    )
+    assert token not in str(redacted)
+    assert "account_api_token" not in redacted
+
+
+@pytest.mark.asyncio
+async def test_start_logs_do_not_include_token(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    token = "super-secret-runtime-token"
+    execution_id = uuid4()
+    runner = SimpleNamespace(id=uuid4(), pending_job=None)
+    monkeypatch.setattr(
+        "preloop.agents.remote_runner.lease_job",
+        lambda *args, **kwargs: runner,
+    )
+    monkeypatch.setattr(
+        "preloop.agents.remote_runner.crud_flow_execution.get",
+        lambda *args, **kwargs: SimpleNamespace(
+            id=execution_id,
+            runner_id=None,
+            agent_session_reference=None,
+        ),
+    )
+
+    async def fake_push(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("preloop.agents.remote_runner._push_job", fake_push)
+    executor = RemoteRunnerExecutor(
+        "codex", {}, db=MagicMock(), pool="local", account_id=uuid4()
+    )
+    with caplog.at_level(logging.DEBUG):
+        await executor.start(
+            {
+                "execution_id": str(execution_id),
+                "account_api_token": token,
+                "agent_config": {},
+            }
+        )
+    assert token not in caplog.text
 
 
 def test_factory_keeps_hosted_executor_without_pool() -> None:

--- a/cli/internal/cmd/runner.go
+++ b/cli/internal/cmd/runner.go
@@ -537,6 +537,17 @@ func beginLeasedJob(
 		return writeJobOutcome(conn, outcome)
 	}
 
+	opts, optsErr := runnerDockerOptsFromJob(job)
+	resumeFrom := jobResumeFrom(job)
+	if optsErr == nil && opts.PersistWorkspace {
+		if hostDir, persistErr := preparePersistWorkspace(executionID, resumeFrom); persistErr == nil {
+			opts.WorkspaceHostDir = hostDir
+		} else {
+			optsErr = fmt.Errorf("persist workspace: %w", persistErr)
+		}
+	}
+	_ = cleanupStaleWorkspaces(map[string]bool{executionID: true})
+
 	image := runnerImageFromJob(job)
 	dockerOK := image != "" && runnerHasDocker()
 	if reason := leasedJobFailureReason(job, dockerOK); reason != "" {
@@ -564,7 +575,31 @@ func beginLeasedJob(
 	}
 
 	env := runnerJobEnv(job, apiURL)
-	cmd := newRunnerJobCmd(image, env)
+	if optsErr != nil {
+		reason := optsErr.Error()
+		outcome := leasedJobOutcome{
+			executionID: executionID,
+			status:      "FAILED",
+			errMsg:      reason,
+			lines:       []string{reason},
+		}
+		rememberOutcome(lastComplete, outcome)
+		return writeJobOutcome(conn, outcome)
+	}
+	if opts.Network != "" {
+		if netErr := ensureDockerNetwork(opts.Network); netErr != nil {
+			reason := netErr.Error()
+			outcome := leasedJobOutcome{
+				executionID: executionID,
+				status:      "FAILED",
+				errMsg:      reason,
+				lines:       []string{reason},
+			}
+			rememberOutcome(lastComplete, outcome)
+			return writeJobOutcome(conn, outcome)
+		}
+	}
+	cmd := newRunnerJobCmd(image, env, opts)
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
@@ -669,6 +704,9 @@ func runnerJobEnv(job map[string]any, apiURL string) map[string]string {
 	if apiURL != "" {
 		env["PRELOOP_URL"] = apiURL
 	}
+	if executionID, ok := job["execution_id"].(string); ok && executionID != "" {
+		env["COMPOSE_PROJECT_NAME"] = composeProjectName(executionID)
+	}
 	if cfg, ok := job["agent_config"].(map[string]any); ok && len(cfg) > 0 {
 		sanitized := sanitizeAgentConfig(cfg)
 		if len(sanitized) > 0 {
@@ -708,21 +746,6 @@ func isAgentConfigSecretKey(key string) bool {
 	}
 }
 
-// dockerRunArgs passes env keys with bare -e flags so values are read
-// from the runner process environment and never show up in `ps` output.
-func dockerRunArgs(image string, env map[string]string) []string {
-	args := []string{"run", "--rm"}
-	keys := make([]string, 0, len(env))
-	for key := range env {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		args = append(args, "-e", key)
-	}
-	return append(args, image)
-}
-
 func formatJobEnv(env map[string]string) []string {
 	pairs := make([]string, 0, len(env))
 	for key, value := range env {
@@ -747,12 +770,6 @@ func runnerControlPlaneURL() (string, error) {
 func dockerAvailable() bool {
 	cmd := exec.Command("docker", "info")
 	return cmd.Run() == nil
-}
-
-func defaultNewRunnerJobCmd(image string, env map[string]string) *exec.Cmd {
-	cmd := exec.Command("docker", dockerRunArgs(image, env)...)
-	cmd.Env = append(os.Environ(), formatJobEnv(env)...)
-	return cmd
 }
 
 func runnerWebsocketURL(runnerID string) (string, error) {

--- a/cli/internal/cmd/runner_docker.go
+++ b/cli/internal/cmd/runner_docker.go
@@ -1,0 +1,340 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/preloop/preloop/cli/internal/config"
+)
+
+const (
+	dockerSocketPath         = "/var/run/docker.sock"
+	runnerWorkspaceMount     = "/workspace"
+	defaultWorkspaceTTLHours = 24
+	workspaceTTLHoursEnv     = "PRELOOP_RUNNER_WORKSPACE_TTL_HOURS"
+	composeProjectPrefix     = "preloop-"
+	dockerSocketMount        = dockerSocketPath + ":" + dockerSocketPath
+)
+
+// runnerDockerOpts is the private-runner-only docker run surface. Hosted
+// executors ignore agent_config.runner; only this CLI honors these flags.
+type runnerDockerOpts struct {
+	MountDockerSocket bool
+	PersistWorkspace  bool
+	WorkspaceHostDir  string
+	ExtraMounts       []string
+	Network           string
+	ComposeProject    string
+}
+
+var dockerCLI = func(args ...string) error {
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run()
+}
+
+func defaultNewRunnerJobCmd(image string, env map[string]string, opts runnerDockerOpts) *exec.Cmd {
+	cmd := exec.Command("docker", dockerRunArgs(image, env, opts)...)
+	cmd.Env = append(os.Environ(), formatJobEnv(env)...)
+	return cmd
+}
+
+// dockerRunArgs passes env keys with bare -e flags so values are read
+// from the runner process environment and never show up in `ps` output.
+func dockerRunArgs(image string, env map[string]string, opts runnerDockerOpts) []string {
+	args := []string{"run", "--rm"}
+	if opts.MountDockerSocket {
+		args = append(args, "-v", dockerSocketMount)
+	}
+	if opts.PersistWorkspace && opts.WorkspaceHostDir != "" {
+		args = append(args, "-v", opts.WorkspaceHostDir+":"+runnerWorkspaceMount)
+	}
+	for _, mount := range opts.ExtraMounts {
+		args = append(args, "-v", mount)
+	}
+	if opts.Network != "" {
+		args = append(args, "--network", opts.Network)
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		args = append(args, "-e", key)
+	}
+	return append(args, image)
+}
+
+func runnerDockerOptsFromJob(job map[string]any) (runnerDockerOpts, error) {
+	opts := runnerDockerOpts{}
+	executionID, _ := job["execution_id"].(string)
+	opts.ComposeProject = composeProjectName(executionID)
+
+	cfg, _ := job["agent_config"].(map[string]any)
+	if cfg == nil {
+		return opts, nil
+	}
+	runner, _ := cfg["runner"].(map[string]any)
+	if runner == nil {
+		return opts, nil
+	}
+
+	opts.MountDockerSocket = truthy(runner["mount_docker_socket"])
+	opts.PersistWorkspace = truthy(runner["persist_workspace"])
+	if network, ok := runner["network"].(string); ok {
+		opts.Network = strings.TrimSpace(network)
+	}
+
+	rawMounts, ok := runner["extra_mounts"]
+	if !ok || rawMounts == nil {
+		return opts, nil
+	}
+	items, err := stringList(rawMounts)
+	if err != nil {
+		return opts, fmt.Errorf("agent_config.runner.extra_mounts: %w", err)
+	}
+	validated := make([]string, 0, len(items))
+	for _, spec := range items {
+		mount, err := validateExtraMount(spec)
+		if err != nil {
+			return opts, err
+		}
+		validated = append(validated, mount)
+	}
+	opts.ExtraMounts = validated
+	return opts, nil
+}
+
+func validateExtraMount(spec string) (string, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return "", fmt.Errorf("extra_mount is empty")
+	}
+	parts := strings.Split(spec, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return "", fmt.Errorf("extra_mount %q must be host:container[:ro]", spec)
+	}
+	host := parts[0]
+	container := parts[1]
+	if !filepath.IsAbs(host) {
+		return "", fmt.Errorf("extra_mount host path must be absolute: %q", spec)
+	}
+	if !filepath.IsAbs(container) {
+		return "", fmt.Errorf("extra_mount container path must be absolute: %q", spec)
+	}
+	if strings.Contains(filepath.Clean(host), "..") {
+		return "", fmt.Errorf("extra_mount host path must not contain ..: %q", spec)
+	}
+	if len(parts) == 3 {
+		mode := strings.ToLower(parts[2])
+		if mode != "ro" && mode != "rw" {
+			return "", fmt.Errorf("extra_mount mode must be ro or rw: %q", spec)
+		}
+	}
+	return spec, nil
+}
+
+func truthy(value any) bool {
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "1", "true", "yes", "on":
+			return true
+		}
+	}
+	return false
+}
+
+func stringList(value any) ([]string, error) {
+	switch items := value.(type) {
+	case []string:
+		return items, nil
+	case []any:
+		out := make([]string, 0, len(items))
+		for _, item := range items {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("entries must be strings")
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("must be a list of strings")
+	}
+}
+
+func composeProjectName(executionID string) string {
+	return composeProjectPrefix + shortExecutionID(executionID)
+}
+
+func shortExecutionID(executionID string) string {
+	compact := strings.ReplaceAll(strings.TrimSpace(executionID), "-", "")
+	if compact == "" {
+		return "unknown"
+	}
+	if len(compact) > 8 {
+		return compact[:8]
+	}
+	return compact
+}
+
+func jobResumeFrom(job map[string]any) string {
+	if s, ok := job["resume_from"].(string); ok {
+		return strings.TrimSpace(s)
+	}
+	return ""
+}
+
+func runnerWorkspacesRoot() (string, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "workspaces"), nil
+}
+
+func runnerWorkspaceDir(executionID string) (string, error) {
+	if strings.TrimSpace(executionID) == "" {
+		return "", fmt.Errorf("execution_id is required for a persisted workspace")
+	}
+	root, err := runnerWorkspacesRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, executionID), nil
+}
+
+func preparePersistWorkspace(executionID, resumeFrom string) (string, error) {
+	dest, err := runnerWorkspaceDir(executionID)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		return "", err
+	}
+	if resumeFrom != "" && resumeFrom != executionID {
+		src, err := runnerWorkspaceDir(resumeFrom)
+		if err != nil {
+			return "", err
+		}
+		if info, err := os.Stat(src); err == nil && info.IsDir() {
+			if _, err := os.Stat(dest); os.IsNotExist(err) {
+				if err := os.Rename(src, dest); err != nil {
+					if copyErr := copyDir(src, dest); copyErr != nil {
+						return "", copyErr
+					}
+				}
+			}
+		}
+	}
+	if err := os.MkdirAll(dest, 0o700); err != nil {
+		return "", err
+	}
+	return dest, nil
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o700)
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close() //nolint:errcheck
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer out.Close() //nolint:errcheck
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func workspaceTTL() time.Duration {
+	hours := defaultWorkspaceTTLHours
+	raw := strings.TrimSpace(os.Getenv(workspaceTTLHoursEnv))
+	if raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			hours = parsed
+		}
+	}
+	return time.Duration(hours) * time.Hour
+}
+
+func cleanupStaleWorkspaces(keep map[string]bool) error {
+	root, err := runnerWorkspacesRoot()
+	if err != nil {
+		return err
+	}
+	return cleanupStaleWorkspacesAt(root, workspaceTTL(), time.Now(), keep)
+}
+
+func cleanupStaleWorkspacesAt(root string, ttl time.Duration, now time.Time, keep map[string]bool) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if keep != nil && keep[entry.Name()] {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) <= ttl {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(root, entry.Name()))
+	}
+	return nil
+}
+
+func ensureDockerNetwork(name string) error {
+	if name == "" {
+		return nil
+	}
+	if dockerCLI("network", "inspect", name) == nil {
+		return nil
+	}
+	if err := dockerCLI("network", "create", name); err != nil {
+		return fmt.Errorf("create docker network %q: %w", name, err)
+	}
+	return nil
+}

--- a/cli/internal/cmd/runner_docker.go
+++ b/cli/internal/cmd/runner_docker.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -22,6 +23,10 @@ const (
 	composeProjectPrefix     = "preloop-"
 	dockerSocketMount        = dockerSocketPath + ":" + dockerSocketPath
 )
+
+// Canonical UUID form. Workspace dirs and resume_from join this into a host
+// path, so anything else (path separators, "..") is rejected.
+var workspaceIDRe = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 // runnerDockerOpts is the private-runner-only docker run surface. Hosted
 // executors ignore agent_config.runner; only this CLI honors these flags.
@@ -125,14 +130,11 @@ func validateExtraMount(spec string) (string, error) {
 	}
 	host := parts[0]
 	container := parts[1]
-	if !filepath.IsAbs(host) {
+	if !isDockerAbsPath(host) {
 		return "", fmt.Errorf("extra_mount host path must be absolute: %q", spec)
 	}
-	if !filepath.IsAbs(container) {
+	if !isDockerAbsPath(container) {
 		return "", fmt.Errorf("extra_mount container path must be absolute: %q", spec)
-	}
-	if strings.Contains(filepath.Clean(host), "..") {
-		return "", fmt.Errorf("extra_mount host path must not contain ..: %q", spec)
 	}
 	if len(parts) == 3 {
 		mode := strings.ToLower(parts[2])
@@ -175,19 +177,37 @@ func stringList(value any) ([]string, error) {
 	}
 }
 
+func isDockerAbsPath(p string) bool {
+	if filepath.IsAbs(p) {
+		return true
+	}
+	// Linux bind specs and container paths are Unix-absolute. filepath.IsAbs
+	// rejects them on Windows, where this CLI still has to parse the same
+	// job payload a Linux runner would.
+	return strings.HasPrefix(p, "/")
+}
+
 func composeProjectName(executionID string) string {
 	return composeProjectPrefix + shortExecutionID(executionID)
 }
 
 func shortExecutionID(executionID string) string {
-	compact := strings.ReplaceAll(strings.TrimSpace(executionID), "-", "")
+	compact := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(executionID), "-", ""))
 	if compact == "" {
 		return "unknown"
 	}
-	if len(compact) > 8 {
-		return compact[:8]
-	}
 	return compact
+}
+
+func validateWorkspaceID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("execution_id is required for a persisted workspace")
+	}
+	if !workspaceIDRe.MatchString(id) {
+		return "", fmt.Errorf("workspace id must be a UUID: %q", id)
+	}
+	return id, nil
 }
 
 func jobResumeFrom(job map[string]any) string {
@@ -206,14 +226,15 @@ func runnerWorkspacesRoot() (string, error) {
 }
 
 func runnerWorkspaceDir(executionID string) (string, error) {
-	if strings.TrimSpace(executionID) == "" {
-		return "", fmt.Errorf("execution_id is required for a persisted workspace")
+	id, err := validateWorkspaceID(executionID)
+	if err != nil {
+		return "", err
 	}
 	root, err := runnerWorkspacesRoot()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(root, executionID), nil
+	return filepath.Join(root, id), nil
 }
 
 func preparePersistWorkspace(executionID, resumeFrom string) (string, error) {
@@ -262,7 +283,7 @@ func copyDir(src, dst string) error {
 	})
 }
 
-func copyFile(src, dst string) error {
+func copyFile(src, dst string) (err error) {
 	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
 		return err
 	}
@@ -275,7 +296,11 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close() //nolint:errcheck
+	defer func() {
+		if cerr := out.Close(); err == nil {
+			err = cerr
+		}
+	}()
 	_, err = io.Copy(out, in)
 	return err
 }

--- a/cli/internal/cmd/runner_test.go
+++ b/cli/internal/cmd/runner_test.go
@@ -79,14 +79,15 @@ func TestRunnerJobEnvMatchesHostedContract(t *testing.T) {
 	}
 	env := runnerJobEnv(job, "https://review.preloop.ai")
 	want := map[string]string{
-		"EXECUTION_ID":      "exec-1",
-		"FLOW_ID":           "flow-1",
-		"AGENT_PROMPT":      "review the PR",
-		"AI_MODEL":          "claude-sonnet-4-5",
-		"AI_MODEL_PROVIDER": "anthropic",
-		"PRELOOP_API_TOKEN": "secret-token",
-		"PRELOOP_URL":       "https://review.preloop.ai",
-		"AGENT_CONFIG":      `{"image":"preloop/agent:dev"}`,
+		"EXECUTION_ID":         "exec-1",
+		"FLOW_ID":              "flow-1",
+		"AGENT_PROMPT":         "review the PR",
+		"AI_MODEL":             "claude-sonnet-4-5",
+		"AI_MODEL_PROVIDER":    "anthropic",
+		"PRELOOP_API_TOKEN":    "secret-token",
+		"PRELOOP_URL":          "https://review.preloop.ai",
+		"AGENT_CONFIG":         `{"image":"preloop/agent:dev"}`,
+		"COMPOSE_PROJECT_NAME": "preloop-exec1",
 	}
 	if len(env) != len(want) {
 		t.Fatalf("env = %v, want %v", env, want)
@@ -100,7 +101,10 @@ func TestRunnerJobEnvMatchesHostedContract(t *testing.T) {
 
 func TestRunnerJobEnvSkipsMissingFields(t *testing.T) {
 	env := runnerJobEnv(map[string]any{"execution_id": "exec-1"}, "")
-	if len(env) != 1 || env["EXECUTION_ID"] != "exec-1" {
+	if env["EXECUTION_ID"] != "exec-1" || env["COMPOSE_PROJECT_NAME"] != "preloop-exec1" {
+		t.Fatalf("env = %v", env)
+	}
+	if len(env) != 2 {
 		t.Fatalf("env = %v", env)
 	}
 }
@@ -109,7 +113,7 @@ func TestDockerRunArgsUsesBareEnvFlags(t *testing.T) {
 	args := dockerRunArgs("preloop/agent:dev", map[string]string{
 		"PRELOOP_API_TOKEN": "secret-token",
 		"EXECUTION_ID":      "exec-1",
-	})
+	}, runnerDockerOpts{})
 	want := []string{
 		"run", "--rm",
 		"-e", "EXECUTION_ID",
@@ -773,7 +777,7 @@ func TestRunnerFgInterruptDuringBackoffKillsJob(t *testing.T) {
 	oldDocker, oldCmd := runnerHasDocker, newRunnerJobCmd
 	pidPath := filepath.Join(t.TempDir(), "job.pid")
 	runnerHasDocker = func() bool { return true }
-	newRunnerJobCmd = func(image string, env map[string]string) *exec.Cmd {
+	newRunnerJobCmd = func(image string, env map[string]string, opts runnerDockerOpts) *exec.Cmd {
 		// Pid file instead of sharing *exec.Cmd: the runner calls Start/Wait
 		// on that Cmd, and -race flags unsynchronized reads of Process /
 		// ProcessState from the test goroutine (GitLab test:unit:cli).
@@ -983,4 +987,170 @@ func TestRunnerControlPlaneURLFailsClosedOnBadConfig(t *testing.T) {
 	if _, err := runnerControlPlaneURL(); err == nil {
 		t.Fatal("expected resolve failure")
 	}
+}
+
+func TestDockerRunArgsHonorTrustedRunnerFlags(t *testing.T) {
+	args := dockerRunArgs("preloop/agent:dev", map[string]string{
+		"COMPOSE_PROJECT_NAME": "preloop-abcd1234",
+		"EXECUTION_ID":         "abcd1234-0000-4000-8000-000000000001",
+	}, runnerDockerOpts{
+		MountDockerSocket: true,
+		PersistWorkspace:  true,
+		WorkspaceHostDir:  "/tmp/preloop-workspaces/exec-1",
+		ExtraMounts:       []string{"/var/cache/builds:/cache:ro"},
+		Network:           "preloop-trusted",
+	})
+	joined := strings.Join(args, " ")
+	if args[0] != "run" || args[1] != "--rm" {
+		t.Fatalf("jobs must keep docker run --rm: %v", args)
+	}
+	if !containsPair(args, "-v", "/var/run/docker.sock:/var/run/docker.sock") {
+		t.Fatalf("missing docker.sock mount: %v", args)
+	}
+	if !containsPair(args, "-v", "/tmp/preloop-workspaces/exec-1:/workspace") {
+		t.Fatalf("missing workspace mount: %v", args)
+	}
+	if !containsPair(args, "-v", "/var/cache/builds:/cache:ro") {
+		t.Fatalf("missing extra mount: %v", args)
+	}
+	if !containsPair(args, "--network", "preloop-trusted") {
+		t.Fatalf("missing network: %v", args)
+	}
+	if !containsPair(args, "-e", "COMPOSE_PROJECT_NAME") {
+		t.Fatalf("missing compose project env flag: %v", args)
+	}
+	if strings.Contains(joined, "secret") {
+		t.Fatalf("unexpected secret in argv: %v", args)
+	}
+}
+
+func TestDockerRunArgsOmitsTrustMountsWhenDisabled(t *testing.T) {
+	args := dockerRunArgs("preloop/agent:dev", map[string]string{"EXECUTION_ID": "e1"}, runnerDockerOpts{})
+	joined := strings.Join(args, " ")
+	if !strings.HasPrefix(joined, "run --rm ") {
+		t.Fatalf("default job must use docker run --rm: %v", args)
+	}
+	if strings.Contains(joined, "/var/run/docker.sock") || strings.Contains(joined, "/workspace") {
+		t.Fatalf("trust mounts must default off: %v", args)
+	}
+}
+
+func TestValidateExtraMountRequiresAbsoluteHost(t *testing.T) {
+	if _, err := validateExtraMount("/var/cache:/cache:ro"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := validateExtraMount("cache:/cache"); err == nil {
+		t.Fatal("relative host path must be rejected")
+	}
+	if _, err := validateExtraMount("/var/cache"); err == nil {
+		t.Fatal("container path is required")
+	}
+	if _, err := validateExtraMount("/var/cache:/cache:shared"); err == nil {
+		t.Fatal("unknown mode must be rejected")
+	}
+}
+
+func TestRunnerDockerOptsFromJobDefaultsOff(t *testing.T) {
+	opts, err := runnerDockerOptsFromJob(map[string]any{
+		"execution_id": "11111111-1111-4111-8111-111111111111",
+		"agent_config": map[string]any{"image": "preloop/agent:dev"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.MountDockerSocket || opts.PersistWorkspace || opts.Network != "" || len(opts.ExtraMounts) != 0 {
+		t.Fatalf("opts = %#v", opts)
+	}
+	if opts.ComposeProject != "preloop-11111111" {
+		t.Fatalf("compose project = %q", opts.ComposeProject)
+	}
+}
+
+func TestPreparePersistWorkspaceReusesResumeFrom(t *testing.T) {
+	testenv.SetTempHome(t)
+	prior := "exec-prior"
+	current := "exec-next"
+	src, err := runnerWorkspaceDir(prior)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(src, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(src, "notes.txt")
+	if err := os.WriteFile(marker, []byte("kept"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest, err := preparePersistWorkspace(current, prior)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("resume_from dir should be moved, stat err = %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "notes.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "kept" {
+		t.Fatalf("workspace contents = %q", got)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("workspace mode = %o", info.Mode().Perm())
+	}
+}
+
+func TestCleanupStaleWorkspacesHonorsTTLAndKeep(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(root, "old-exec")
+	fresh := filepath.Join(root, "fresh-exec")
+	current := filepath.Join(root, "current-exec")
+	for _, dir := range []string{stale, fresh, current} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(current, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanupStaleWorkspacesAt(root, 24*time.Hour, time.Now(), map[string]bool{"current-exec": true}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatal("stale workspace older than TTL should be removed")
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("fresh workspace should remain: %v", err)
+	}
+	if _, err := os.Stat(current); err != nil {
+		t.Fatalf("current job workspace should remain: %v", err)
+	}
+}
+
+func TestWorkspaceTTLReadsEnv(t *testing.T) {
+	t.Setenv(workspaceTTLHoursEnv, "6")
+	if workspaceTTL() != 6*time.Hour {
+		t.Fatalf("ttl = %s", workspaceTTL())
+	}
+	t.Setenv(workspaceTTLHoursEnv, "nope")
+	if workspaceTTL() != 24*time.Hour {
+		t.Fatalf("invalid ttl should default, got %s", workspaceTTL())
+	}
+}
+
+func containsPair(args []string, flag, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/internal/cmd/runner_test.go
+++ b/cli/internal/cmd/runner_test.go
@@ -1050,6 +1050,18 @@ func TestValidateExtraMountRequiresAbsoluteHost(t *testing.T) {
 	}
 }
 
+func TestValidateWorkspaceIDRejectsTraversal(t *testing.T) {
+	if _, err := validateWorkspaceID("../../.."); err == nil {
+		t.Fatal("parent traversal must be rejected")
+	}
+	if _, err := validateWorkspaceID("exec-prior"); err == nil {
+		t.Fatal("non-UUID workspace id must be rejected")
+	}
+	if _, err := validateWorkspaceID("11111111-1111-4111-8111-111111111111"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRunnerDockerOptsFromJobDefaultsOff(t *testing.T) {
 	opts, err := runnerDockerOptsFromJob(map[string]any{
 		"execution_id": "11111111-1111-4111-8111-111111111111",
@@ -1061,15 +1073,15 @@ func TestRunnerDockerOptsFromJobDefaultsOff(t *testing.T) {
 	if opts.MountDockerSocket || opts.PersistWorkspace || opts.Network != "" || len(opts.ExtraMounts) != 0 {
 		t.Fatalf("opts = %#v", opts)
 	}
-	if opts.ComposeProject != "preloop-11111111" {
+	if opts.ComposeProject != "preloop-11111111111141118111111111111111" {
 		t.Fatalf("compose project = %q", opts.ComposeProject)
 	}
 }
 
 func TestPreparePersistWorkspaceReusesResumeFrom(t *testing.T) {
 	testenv.SetTempHome(t)
-	prior := "exec-prior"
-	current := "exec-next"
+	prior := "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	current := "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
 	src, err := runnerWorkspaceDir(prior)
 	if err != nil {
 		t.Fatal(err)
@@ -1099,7 +1111,7 @@ func TestPreparePersistWorkspaceReusesResumeFrom(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0o700 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o700 {
 		t.Fatalf("workspace mode = %o", info.Mode().Perm())
 	}
 }

--- a/docs/guide/runners/quickstart-linux.md
+++ b/docs/guide/runners/quickstart-linux.md
@@ -126,12 +126,52 @@ window. `AGENT_CONFIG` is the flow's agent settings (image, type); the
 runner strips credential-shaped keys before injecting it. Model and MCP
 credentials stay on the control plane and are used through that token.
 
+When the flow omits `image` / `docker_image`, the control plane injects
+the same per-agent-type default the hosted executors use
+(`OPENCODE_IMAGE`, `CODEX_IMAGE`, `AIDER_IMAGE`, `GEMINI_IMAGE`).
+
+## Trusted runner options
+
+Private runners are machines you operate. Hosted executors ignore the
+`agent_config.runner` block; only `preloop runner` honors it. Every flag
+defaults off.
+
+```yaml
+agent_config:
+  runner:
+    mount_docker_socket: true
+    persist_workspace: true
+    extra_mounts:
+      - /var/cache/builds:/cache:ro
+    network: preloop-trusted
+```
+
+- `mount_docker_socket`: bind `/var/run/docker.sock` into the agent so
+  it can start sibling containers (for example `docker compose up`).
+- `persist_workspace`: keep `/workspace` on the host at
+  `~/.preloop/workspaces/<execution_id>` (mode 0700). A later job whose
+  payload includes `resume_from` reuses that directory. Directories
+  older than 24 hours that are not the current job are deleted on each
+  lease; override the window with `PRELOOP_RUNNER_WORKSPACE_TTL_HOURS`.
+- `extra_mounts`: `host:container[:ro]` bind mounts. Host paths must be
+  absolute.
+- `network`: Docker network to join (`--network`). Created if missing.
+
+Every job also sets `COMPOSE_PROJECT_NAME=preloop-<short execution id>`
+so `docker compose up` gets isolated containers, networks, and volumes
+per execution. When more than one runner can run at the same time,
+compose files should avoid fixed host ports and reach services by
+container-network name instead.
+
+Enable these options only on machines you own. Mounting the Docker
+socket gives the agent the same privileges as the runner user.
+
 ## Troubleshooting
 
 | Symptom | Fix |
 | --- | --- |
 | `docker is not available` in execution log | `docker info` must work as the runner user (add to `docker` group, or fix LXC nesting). |
-| `no agent image in payload` | The flow's agent config has no `image`/`docker_image`; check the flow's agent settings. |
+| `no agent image in payload` | The flow's agent type has no default image and no `image`/`docker_image` was set. |
 | Execution FAILED after ~15 min queued | No runner matching `runner_pool` was online; check `preloop runner status` and labels. |
 | Service dies after SSH logout | `sudo loginctl enable-linger $USER`. |
 | Runner shows offline after IP change | Restart: `preloop runner restart` — registration resumes from `~/.preloop/runner.json`. |


### PR DESCRIPTION
Server injects the per-agent-type default image into runner job payloads (runner.go previously failed with "no agent image in payload" when agent_config had none).

agent_config.runner flags, honored only by the private runner, all off by default: mount_docker_socket, persist_workspace (~/.preloop/workspaces/<execution>, reused on resume, 24h TTL cleanup), extra_mounts, network. Every job gets COMPOSE_PROJECT_NAME=preloop-<execution> so docker compose stays isolated per execution. Docs: "Trusted runner options" with the security note and the host-port guidance. Go and Python tests.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Lease logging now emits identifiers only (no credentials), and the trusted-machine flags are opt-in and documented; the remaining risk is the inherent trust implied by mounting the docker socket / host mounts, which is gated behind explicit opt-in.
>
> **Overview**
> The server injects per-agent-type default images into runner job payloads, and the private runner gains opt-in flags (docker socket mount, persisted workspace, extra mounts, network) plus per-execution `COMPOSE_PROJECT_NAME` isolation, with docs and Go/Python tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 66f91f95. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->