### PR TITLE
Resume: rebase the PR branch on the base branch before the agent starts; force-with-lease only after a rebase

### DIFF
--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -2327,6 +2327,11 @@ class ContainerAgentExecutor(AgentExecutor):
             # the existing review, not a new branch off main.
             source_branch = resume_branch
             target_branch = resume_branch
+            if not execution_context.get("resume_from"):
+                prior = resume.get("execution_id") if isinstance(resume, dict) else None
+                execution_context["resume_from"] = (
+                    str(prior) if prior else resume_branch
+                )
             self.logger.info(
                 "Resume clone: using existing PR branch %s as source and target",
                 resume_branch,
@@ -2350,6 +2355,39 @@ class ContainerAgentExecutor(AgentExecutor):
             )
 
         return source_branch, target_branch, commit_sha, git_user_name, git_user_email
+
+    def _is_resume_execution(self, execution_context: Dict[str, Any]) -> bool:
+        """True when this run continues a prior PR-comment execution."""
+
+        if execution_context.get("resume_from"):
+            return True
+        trigger_data = execution_context.get("trigger_event_data")
+        if not isinstance(trigger_data, dict):
+            return False
+        resume = trigger_data.get("_resume")
+        return isinstance(resume, dict) and bool(
+            resume.get("execution_id") or resume.get("source_branch")
+        )
+
+    def _resolve_resume_base_branch(
+        self,
+        git_config: Dict[str, Any],
+        repo_config: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Return the flow base branch a resume rebase should land on.
+
+        Prefers ``repositories[].branch``, then top-level ``git_clone_config.branch``,
+        then ``source_branch``, then ``main``.
+        """
+
+        if repo_config:
+            repo_branch = repo_config.get("branch")
+            if repo_branch:
+                return str(repo_branch)
+        configured = git_config.get("branch") or git_config.get("source_branch")
+        if configured:
+            return str(configured)
+        return "main"
 
     def _build_git_global_setup_commands(
         self, git_user_name: str, git_user_email: str
@@ -2699,6 +2737,66 @@ echo "  Branch: {q_target} (from {q_source})"{sha_display}
 echo "========================================="
 """.strip()
 
+    def _build_git_resume_rebase_shell(
+        self, *, full_path: str, base_branch: str
+    ) -> str:
+        """Fetch the flow base branch and rebase the cloned PR branch onto it.
+
+        On conflict the rebase is aborted (not auto-resolved), conflicting
+        paths are written to ``/workspace/evidence/rebase-conflict.txt``, and
+        ``PRELOOP_RESUME_REBASE_CONFLICT=1`` is exported for the agent prompt.
+        The block always exits 0 so a conflict does not abort init.
+        """
+
+        safe_base = _validated_git_ref(base_branch)
+        if not safe_base:
+            self.logger.warning(
+                "Skipping resume rebase: unsafe base branch %r", base_branch
+            )
+            return ""
+
+        q_path = shlex.quote(full_path)
+        conflict_file = f"{EVIDENCE_DIR_PATH}/rebase-conflict.txt"
+        rebased_marker = f"{EVIDENCE_DIR_PATH}/resume-rebased"
+        return f"""
+cd {q_path}
+echo "Resume rebase: fetching origin/{safe_base} and rebasing the PR branch onto it"
+if git fetch origin {safe_base}; then
+    if git rebase origin/{safe_base}; then
+        echo "Resume rebase onto origin/{safe_base} succeeded"
+        mkdir -p {EVIDENCE_DIR_PATH}
+        touch {rebased_marker}
+        export PRELOOP_RESUME_REBASED=1
+    else
+        echo "Resume rebase onto origin/{safe_base} conflicted; leaving rebase aborted"
+        mkdir -p {EVIDENCE_DIR_PATH}
+        git diff --name-only --diff-filter=U > {conflict_file} 2>/dev/null || true
+        git rebase --abort || true
+        export PRELOOP_RESUME_REBASE_CONFLICT=1
+        echo "Wrote conflicting files to {conflict_file}"
+    fi
+else
+    echo "Resume rebase: could not fetch origin/{safe_base}; skipping rebase"
+fi
+cd /workspace
+true
+""".strip()
+
+    def _build_git_push_shell(self, safe_target: str, *, resume_rebase: bool) -> str:
+        """Build the post-exec push. Force-with-lease only after a resume rebase."""
+
+        if not resume_rebase:
+            return f"  git push origin {safe_target}"
+        rebased_marker = f"{EVIDENCE_DIR_PATH}/resume-rebased"
+        return (
+            f"  if [ -f {rebased_marker} ] || "
+            f'[ "${{PRELOOP_RESUME_REBASED:-}}" = "1" ]; then\n'
+            f"    git push --force-with-lease origin {safe_target}\n"
+            f"  else\n"
+            f"    git push origin {safe_target}\n"
+            f"  fi"
+        )
+
     def _build_repository_clone_command_block(
         self,
         *,
@@ -2747,7 +2845,7 @@ echo "========================================="
             trigger_data=trigger_data,
         )
 
-        return [
+        commands = [
             self._build_git_pre_clone_shell(full_path),
             self._build_git_clone_shell(repo_url, full_path, clone_branch),
             self._build_git_branch_setup_shell(
@@ -2764,6 +2862,19 @@ echo "========================================="
                 commit_sha=commit_sha,
             ),
         ]
+        if self._is_resume_execution(execution_context):
+            git_config = execution_context.get("git_clone_config") or {}
+            if not isinstance(git_config, dict):
+                git_config = {}
+            base_branch = self._resolve_resume_base_branch(git_config, repo_config)
+            rebase_shell = self._build_git_resume_rebase_shell(
+                full_path=full_path, base_branch=base_branch
+            )
+            if rebase_shell:
+                commands.append(rebase_shell)
+                execution_context["_git_resume_rebase"] = True
+                execution_context["_git_base_branch"] = base_branch
+        return commands
 
     def _prepare_git_clone_command(self, execution_context: Dict[str, Any]) -> str:
         """
@@ -2973,7 +3084,13 @@ echo "========================================="
                     ),
                     f'  echo "Wrote git recovery artifacts under {EVIDENCE_DIR_PATH}"',
                     push_auth,
-                    f"  git push origin {safe_target}",
+                    self._build_git_push_shell(
+                        safe_target,
+                        resume_rebase=bool(
+                            execution_context.get("_git_resume_rebase")
+                            or self._is_resume_execution(execution_context)
+                        ),
+                    ),
                 ]
 
                 # Add PR/MR creation if enabled

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -2879,7 +2879,6 @@ true
             if rebase_shell:
                 commands.append(rebase_shell)
                 execution_context["_git_resume_rebase"] = True
-                execution_context["_git_base_branch"] = base_branch
         return commands
 
     def _prepare_git_clone_command(self, execution_context: Dict[str, Any]) -> str:

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -2742,12 +2742,12 @@ echo "========================================="
     ) -> str:
         """Fetch the flow base branch and rebase the cloned PR branch onto it.
 
-        On conflict the rebase is aborted (not auto-resolved), conflicting
-        paths are written to ``/workspace/evidence/rebase-conflict.txt``, and
-        ``PRELOOP_RESUME_REBASE_CONFLICT=1`` is exported in the container
-        so the agent can inspect that file. The control-plane prompt
-        resolver never sees the env var. The block always exits 0 so a
-        conflict does not abort init.
+        On conflict the rebase is aborted (not auto-resolved). Conflicting
+        paths are written to ``/workspace/evidence/rebase-conflict.txt``
+        (prefixed with an instruction to resolve them). Resume prompts tell
+        the agent to inspect that file if it exists. ``PRELOOP_RESUME_REBASE_CONFLICT=1``
+        is exported in the container for in-container processes. The block
+        always exits 0 so a conflict does not abort init.
         """
 
         safe_base = _validated_git_ref(base_branch)
@@ -2772,7 +2772,11 @@ if git fetch origin {safe_base}; then
     else
         echo "Resume rebase onto origin/{safe_base} conflicted; leaving rebase aborted"
         mkdir -p {EVIDENCE_DIR_PATH}
-        git diff --name-only --diff-filter=U > {conflict_file} 2>/dev/null || true
+        {{
+            echo "git rebase onto the flow base branch conflicted and was aborted."
+            echo "Resolve these paths before continuing:"
+            git diff --name-only --diff-filter=U 2>/dev/null || true
+        }} > {conflict_file}
         git rebase --abort || true
         export PRELOOP_RESUME_REBASE_CONFLICT=1
         echo "Wrote conflicting files to {conflict_file}"

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -2744,8 +2744,10 @@ echo "========================================="
 
         On conflict the rebase is aborted (not auto-resolved), conflicting
         paths are written to ``/workspace/evidence/rebase-conflict.txt``, and
-        ``PRELOOP_RESUME_REBASE_CONFLICT=1`` is exported for the agent prompt.
-        The block always exits 0 so a conflict does not abort init.
+        ``PRELOOP_RESUME_REBASE_CONFLICT=1`` is exported in the container
+        so the agent can inspect that file. The control-plane prompt
+        resolver never sees the env var. The block always exits 0 so a
+        conflict does not abort init.
         """
 
         safe_base = _validated_git_ref(base_branch)

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -53,6 +53,7 @@ from preloop.services.prompt_resolvers import (
     AccountResolver,
     ExecutionResolver,
 )
+from preloop.services.prompt_resolvers.execution import resume_rebase_conflict_hint
 from preloop.services.flow_execution_logger import FlowExecutionLogger
 from preloop.services.flow_runtime_token import (
     create_flow_runtime_token,
@@ -1108,6 +1109,13 @@ class FlowExecutionOrchestrator:
                     logger.warning(
                         f"No resolver found for prefix '{prefix}' and simple resolution failed for {{{{{placeholder}}}}}"
                     )
+
+        # Resume runs always learn to inspect rebase-conflict.txt, because
+        # the rebase happens after this prompt is resolved. Keep this before
+        # the success-confirmation instruction, which must stay last.
+        resolved_prompt = resolved_prompt + resume_rebase_conflict_hint(
+            self.trigger_event_data
+        )
 
         # Append the success-confirmation instruction so the agent can signal
         # completion. MUST stay at the very END of the prompt (recency): after

--- a/backend/preloop/services/prompt_resolvers/execution.py
+++ b/backend/preloop/services/prompt_resolvers/execution.py
@@ -24,6 +24,9 @@ class ExecutionResolver(PromptResolver):
     - ``{{execution.url}}`` — console URL
     - ``{{execution.resume_from}}`` — prior execution id when this run
       was started from a PR comment on a PR this flow opened
+    - ``{{execution.rebase_conflict}}``: ``1`` when the resume rebase
+      onto the flow base branch was aborted due to conflicts
+      (``PRELOOP_RESUME_REBASE_CONFLICT=1``). Empty otherwise.
     """
 
     @property
@@ -41,5 +44,8 @@ class ExecutionResolver(PromptResolver):
             resume = context.trigger_event_data.get("_resume") or {}
             prior = resume.get("execution_id")
             return str(prior) if prior else None
+        if path == "rebase_conflict":
+            flag = os.getenv("PRELOOP_RESUME_REBASE_CONFLICT")
+            return flag if flag else None
         self.logger.warning("Unknown execution field: %s", path)
         return None

--- a/backend/preloop/services/prompt_resolvers/execution.py
+++ b/backend/preloop/services/prompt_resolvers/execution.py
@@ -24,9 +24,11 @@ class ExecutionResolver(PromptResolver):
     - ``{{execution.url}}`` — console URL
     - ``{{execution.resume_from}}`` — prior execution id when this run
       was started from a PR comment on a PR this flow opened
-    - ``{{execution.rebase_conflict}}``: ``1`` when the resume rebase
-      onto the flow base branch was aborted due to conflicts
-      (``PRELOOP_RESUME_REBASE_CONFLICT=1``). Empty otherwise.
+
+    Resume rebase conflicts are not a prompt placeholder: they are
+    written to ``/workspace/evidence/rebase-conflict.txt`` inside the
+    container (and ``PRELOOP_RESUME_REBASE_CONFLICT=1`` is exported
+    there). The control plane never sees that env var.
     """
 
     @property
@@ -44,8 +46,5 @@ class ExecutionResolver(PromptResolver):
             resume = context.trigger_event_data.get("_resume") or {}
             prior = resume.get("execution_id")
             return str(prior) if prior else None
-        if path == "rebase_conflict":
-            flag = os.getenv("PRELOOP_RESUME_REBASE_CONFLICT")
-            return flag if flag else None
         self.logger.warning("Unknown execution field: %s", path)
         return None

--- a/backend/preloop/services/prompt_resolvers/execution.py
+++ b/backend/preloop/services/prompt_resolvers/execution.py
@@ -9,6 +9,28 @@ from .base import PromptResolver, ResolverContext
 
 DEFAULT_PRELOOP_URL = "http://localhost:8000"
 
+RESUME_REBASE_CONFLICT_HINT = (
+    "If /workspace/evidence/rebase-conflict.txt exists, git rebase onto "
+    "the flow base branch conflicted and was aborted. Inspect that file "
+    "and resolve the listed paths before continuing."
+)
+
+
+def resume_rebase_conflict_hint(trigger_event_data: Optional[dict]) -> str:
+    """Instruction appended to resume prompts so the agent inspects conflicts.
+
+    The rebase runs inside the container after this prompt is resolved, so
+    the hint is always present on resume runs and the agent checks the
+    evidence file if it appears.
+    """
+
+    if not isinstance(trigger_event_data, dict):
+        return ""
+    resume = trigger_event_data.get("_resume")
+    if not resume:
+        return ""
+    return "\n\n" + RESUME_REBASE_CONFLICT_HINT
+
 
 def execution_console_url(execution_id: str) -> str:
     """Return the console URL for a flow execution."""
@@ -25,10 +47,11 @@ class ExecutionResolver(PromptResolver):
     - ``{{execution.resume_from}}`` — prior execution id when this run
       was started from a PR comment on a PR this flow opened
 
-    Resume rebase conflicts are not a prompt placeholder: they are
-    written to ``/workspace/evidence/rebase-conflict.txt`` inside the
-    container (and ``PRELOOP_RESUME_REBASE_CONFLICT=1`` is exported
-    there). The control plane never sees that env var.
+    Resume rebase conflicts are not a prompt placeholder. Resume runs
+    always get an instruction to inspect
+    ``/workspace/evidence/rebase-conflict.txt`` if that file exists after
+    init. The container also exports ``PRELOOP_RESUME_REBASE_CONFLICT=1``
+    for in-container processes; the control plane never sees that env var.
     """
 
     @property

--- a/backend/tests/agents/test_container.py
+++ b/backend/tests/agents/test_container.py
@@ -1625,6 +1625,136 @@ class TestLogScrubbing:
         ]
 
 
+class TestResumeRebaseShell:
+    """Resume rebase is present only on resume; force-with-lease only after rebase."""
+
+    def _clone_context(self, **overrides):
+        context = {
+            "flow_id": "flow-1",
+            "execution_id": "exec-1",
+            "flow_name": "Automated Issue Implementation",
+            "git_clone_config": {
+                "enabled": True,
+                "source_branch": "main",
+                "repositories": [
+                    {
+                        "repository_url": "https://github.com/acme/private.git",
+                        "clone_path": "/workspace",
+                    }
+                ],
+            },
+            "trigger_event_data": {},
+        }
+        context.update(overrides)
+        return context
+
+    def _post_context(self, **overrides):
+        context = {
+            "flow_id": "flow-1",
+            "execution_id": "exec-1",
+            "flow_name": "PR Reviewer",
+            "_git_target_branch": "preloop/issue-353",
+            "_git_source_branch": "preloop/issue-353",
+            "git_clone_config": {
+                "enabled": True,
+                "source_branch": "main",
+                "repositories": [
+                    {
+                        "repository_url": "https://github.com/acme/private.git",
+                        "clone_path": "/workspace",
+                    }
+                ],
+            },
+            "trigger_event_data": {},
+        }
+        context.update(overrides)
+        return context
+
+    def test_clone_omits_rebase_when_not_resuming(self, container_executor):
+        command = container_executor._prepare_git_clone_command(self._clone_context())
+        assert "git rebase" not in command
+        assert "PRELOOP_RESUME_REBASE_CONFLICT" not in command
+
+    def test_clone_rebases_when_resume_from_set(self, container_executor):
+        context = self._clone_context(resume_from="prior-exec")
+        command = container_executor._prepare_git_clone_command(context)
+        assert "git fetch origin main" in command
+        assert "git rebase origin/main" in command
+        assert "/workspace/evidence/rebase-conflict.txt" in command
+        assert "git rebase --abort" in command
+        assert "export PRELOOP_RESUME_REBASE_CONFLICT=1" in command
+        assert context.get("_git_resume_rebase") is True
+
+    def test_clone_rebases_when_resume_metadata_present(self, container_executor):
+        context = self._clone_context(
+            trigger_event_data={
+                "_resume": {
+                    "execution_id": "prior-exec",
+                    "source_branch": "preloop/issue-353",
+                }
+            }
+        )
+        command = container_executor._prepare_git_clone_command(context)
+        assert "git rebase origin/main" in command
+        assert context.get("resume_from") == "prior-exec"
+
+    def test_clone_rebases_onto_repo_branch(self, container_executor):
+        context = self._clone_context()
+        context["git_clone_config"]["repositories"][0]["branch"] = "develop"
+        context["resume_from"] = "prior-exec"
+        command = container_executor._prepare_git_clone_command(context)
+        assert "git fetch origin develop" in command
+        assert "git rebase origin/develop" in command
+        assert "git rebase origin/main" not in command
+
+    def test_clone_rebases_onto_config_branch(self, container_executor):
+        context = self._clone_context(resume_from="prior-exec")
+        context["git_clone_config"]["branch"] = "release"
+        command = container_executor._prepare_git_clone_command(context)
+        assert "git rebase origin/release" in command
+
+    def test_unsafe_base_branch_skips_rebase(self, container_executor):
+        context = self._clone_context(resume_from="prior-exec")
+        context["git_clone_config"]["source_branch"] = "main; echo pwned"
+        command = container_executor._prepare_git_clone_command(context)
+        assert "git rebase" not in command
+        assert "origin/main; echo pwned" not in command
+
+    def test_post_exec_omits_force_with_lease_when_not_resuming(
+        self, container_executor
+    ):
+        commands = container_executor._prepare_git_post_execution_commands(
+            self._post_context(
+                _git_target_branch="preloop/fix",
+                _git_source_branch="main",
+            )
+        )
+        assert "--force-with-lease" not in commands
+        assert "git push origin preloop/fix" in commands
+
+    def test_post_exec_force_with_lease_only_after_rebase(self, container_executor):
+        commands = container_executor._prepare_git_post_execution_commands(
+            self._post_context(resume_from="prior-exec")
+        )
+        assert "git push --force-with-lease origin preloop/issue-353" in commands
+        assert "/workspace/evidence/resume-rebased" in commands
+        assert "PRELOOP_RESUME_REBASED" in commands
+        force_at = commands.index("git push --force-with-lease origin")
+        plain_at = commands.index("git push origin preloop/issue-353")
+        assert force_at < plain_at
+
+    def test_resume_rebase_shell_records_conflict_and_aborts(self, container_executor):
+        shell = container_executor._build_git_resume_rebase_shell(
+            full_path="/workspace", base_branch="main"
+        )
+        assert "git fetch origin main" in shell
+        assert "git rebase origin/main" in shell
+        assert "git rebase --abort" in shell
+        assert "/workspace/evidence/rebase-conflict.txt" in shell
+        assert "export PRELOOP_RESUME_REBASE_CONFLICT=1" in shell
+        assert "export PRELOOP_RESUME_REBASED=1" in shell
+
+
 class TestResolveGitBranchPlan:
     def test_resume_overrides_config_source_branch(self, container_executor):
         source, target, _, _, _ = container_executor._resolve_git_branch_plan(

--- a/backend/tests/agents/test_container.py
+++ b/backend/tests/agents/test_container.py
@@ -1751,6 +1751,7 @@ class TestResumeRebaseShell:
         assert "git rebase origin/main" in shell
         assert "git rebase --abort" in shell
         assert "/workspace/evidence/rebase-conflict.txt" in shell
+        assert "Resolve these paths before continuing:" in shell
         assert "export PRELOOP_RESUME_REBASE_CONFLICT=1" in shell
         assert "export PRELOOP_RESUME_REBASED=1" in shell
 

--- a/backend/tests/services/prompt_resolvers/test_execution.py
+++ b/backend/tests/services/prompt_resolvers/test_execution.py
@@ -49,6 +49,23 @@ class TestExecutionResolver:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_rebase_conflict_unset(self):
+        result = await ExecutionResolver().resolve("rebase_conflict", _context())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_rebase_conflict_set(self, monkeypatch):
+        monkeypatch.setenv("PRELOOP_RESUME_REBASE_CONFLICT", "1")
+        result = await ExecutionResolver().resolve("rebase_conflict", _context())
+        assert result == "1"
+
+    @pytest.mark.asyncio
+    async def test_rebase_conflict_empty_env_is_absent(self, monkeypatch):
+        monkeypatch.setenv("PRELOOP_RESUME_REBASE_CONFLICT", "")
+        result = await ExecutionResolver().resolve("rebase_conflict", _context())
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_unknown_field(self):
         result = await ExecutionResolver().resolve("nope", _context())
         assert result is None

--- a/backend/tests/services/prompt_resolvers/test_execution.py
+++ b/backend/tests/services/prompt_resolvers/test_execution.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from preloop.services.prompt_resolvers.base import ResolverContext
-from preloop.services.prompt_resolvers.execution import ExecutionResolver
+from preloop.services.prompt_resolvers.execution import (
+    ExecutionResolver,
+    RESUME_REBASE_CONFLICT_HINT,
+    resume_rebase_conflict_hint,
+)
 
 
 def _context(**event):
@@ -47,6 +51,13 @@ class TestExecutionResolver:
     async def test_resume_from_absent(self):
         result = await ExecutionResolver().resolve("resume_from", _context())
         assert result is None
+
+    def test_resume_prompt_tells_the_agent_to_inspect_rebase_conflicts(self):
+        hint = resume_rebase_conflict_hint({"_resume": {"execution_id": "prior"}})
+        assert RESUME_REBASE_CONFLICT_HINT in hint
+        assert "/workspace/evidence/rebase-conflict.txt" in hint
+        assert resume_rebase_conflict_hint({}) == ""
+        assert resume_rebase_conflict_hint(None) == ""
 
     @pytest.mark.asyncio
     async def test_rebase_conflict_is_not_a_prompt_placeholder(self, monkeypatch):

--- a/backend/tests/services/prompt_resolvers/test_execution.py
+++ b/backend/tests/services/prompt_resolvers/test_execution.py
@@ -49,19 +49,8 @@ class TestExecutionResolver:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_rebase_conflict_unset(self):
-        result = await ExecutionResolver().resolve("rebase_conflict", _context())
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_rebase_conflict_set(self, monkeypatch):
+    async def test_rebase_conflict_is_not_a_prompt_placeholder(self, monkeypatch):
         monkeypatch.setenv("PRELOOP_RESUME_REBASE_CONFLICT", "1")
-        result = await ExecutionResolver().resolve("rebase_conflict", _context())
-        assert result == "1"
-
-    @pytest.mark.asyncio
-    async def test_rebase_conflict_empty_env_is_absent(self, monkeypatch):
-        monkeypatch.setenv("PRELOOP_RESUME_REBASE_CONFLICT", "")
         result = await ExecutionResolver().resolve("rebase_conflict", _context())
         assert result is None
 

--- a/backend/tests/test_flow_orchestrator.py
+++ b/backend/tests/test_flow_orchestrator.py
@@ -294,6 +294,33 @@ class TestFlowExecutionOrchestrator:
         assert '"pass"' in resolved_prompt
         assert '"fail"' in resolved_prompt
 
+    @pytest.mark.asyncio
+    async def test_resume_prompt_includes_rebase_conflict_hint_before_success(self):
+        """Resume prompts tell the agent to inspect rebase-conflict.txt.
+
+        The rebase runs in the container after this prompt is resolved, so
+        the hint is always present and the success instruction stays last.
+        """
+        from preloop.services.prompt_resolvers.execution import (
+            RESUME_REBASE_CONFLICT_HINT,
+        )
+
+        orchestrator = FlowExecutionOrchestrator(
+            db=MagicMock(spec=Session),
+            flow_id=uuid4(),
+            trigger_event_data={"_resume": {"execution_id": "prior"}},
+            nats_client=MagicMock(),
+        )
+        orchestrator.flow = MagicMock(prompt_template="Continue the implementation.")
+
+        resolved_prompt = await orchestrator._resolve_prompt()
+
+        assert RESUME_REBASE_CONFLICT_HINT in resolved_prompt
+        hint_at = resolved_prompt.index(RESUME_REBASE_CONFLICT_HINT)
+        success_at = resolved_prompt.index(FLOW_SUCCESS_INSTRUCTION)
+        assert hint_at < success_at
+        assert resolved_prompt.endswith(FLOW_SUCCESS_INSTRUCTION)
+
     @pytest.mark.parametrize(
         "eval_contract",
         [


### PR DESCRIPTION
On resume, fetch the base branch and rebase the PR branch onto it. Conflicts are not resolved silently: the rebase is aborted, conflicting paths are written to `/workspace/evidence/rebase-conflict.txt`, and the resume prompt tells the agent to inspect that file. Post-exec push uses `--force-with-lease` only when a rebase happened. Tests for the shell builder, the resolver, and prompt order.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> No security concerns and no high-severity issues remain; the resume-time rebase, conflict handling, and force-with-lease gating are sound and tested. Only minor cleanup remains.
>
> **Overview**
> Adds a resume-time rebase of the PR branch onto the flow base branch, aborts on conflict (writing conflicting paths to evidence), and gates `--force-with-lease` on a successful rebase marker. Resume prompts now instruct the agent to inspect `rebase-conflict.txt` after init.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 4ef6f72b. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->