### PR TITLE
Skip unchanged GitHub CI suites and cancel superseded PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,16 @@
 # Preloop Open Source - CI Pipeline
 # Runs unit tests on pull requests and pushes to main
-# Builds and pushes Docker images on releases and main branch
+# Builds and pushes Docker images on main and version tags (not on PRs —
+# release.yml already publishes images, and a multi-arch QEMU build is the
+# long tail after tests go green).
+#
+# PR jobs are path-filtered so a docs-only or frontend-only change does not
+# pay for eight Postgres shards. Filters are job-level, not workflow-level:
+# a workflow `on.pull_request.paths` skip made stacked PRs look clean because
+# no checks ran at all. `main` and tags always run every suite.
+#
+# Make the `CI` aggregator the required check. Individual shards may be
+# skipped; skipped-because-paths-did-not-change is success, a red shard is not.
 
 name: CI
 
@@ -14,6 +24,10 @@ on:
   # looked clean because nothing had examined them.
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   PYTHON_VERSION: "3.11"
   NODE_VERSION: "22"
@@ -24,6 +38,84 @@ permissions:
   contents: read
 
 jobs:
+  # ==========================================================================
+  # Changed paths (PRs only; push/tag forces every output true)
+  # ==========================================================================
+
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.out.outputs.backend }}
+      frontend: ${{ steps.out.outputs.frontend }}
+      cli: ${{ steps.out.outputs.cli }}
+      plugins: ${{ steps.out.outputs.plugins }}
+      helm: ${{ steps.out.outputs.helm }}
+      workflow: ${{ steps.out.outputs.workflow }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        if: github.event_name == 'pull_request'
+
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'tests/**'
+              - 'presets/**'
+              - 'test_agent_overrides.py'
+              - 'pyproject.toml'
+              - 'requirements/**'
+              - '.github/requirements/app-dev.txt'
+              - '.github/requirements/coverage.txt'
+              - '.github/requirements/test.txt'
+              - '.github/requirements/test.in'
+              - 'scripts/init_db.py'
+            frontend:
+              - 'frontend/**'
+            cli:
+              - 'cli/**'
+            plugins:
+              - 'runtime-plugins/**'
+              - 'pyproject.toml'
+              - '.github/requirements/runtime-plugin-test.txt'
+              - '.github/requirements/runtime-test.txt'
+              - '.github/requirements/runtime-test.in'
+            helm:
+              - 'helm/**'
+              - 'scripts/helm-render-check.sh'
+            workflow:
+              - '.github/workflows/ci.yml'
+
+      - name: Set job outputs
+        id: out
+        env:
+          EVENT: ${{ github.event_name }}
+          BACKEND: ${{ steps.filter.outputs.backend }}
+          FRONTEND: ${{ steps.filter.outputs.frontend }}
+          CLI: ${{ steps.filter.outputs.cli }}
+          PLUGINS: ${{ steps.filter.outputs.plugins }}
+          HELM: ${{ steps.filter.outputs.helm }}
+          WORKFLOW: ${{ steps.filter.outputs.workflow }}
+        run: |
+          if [ "$EVENT" != "pull_request" ] || [ "$WORKFLOW" = "true" ]; then
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+            echo "cli=true" >> "$GITHUB_OUTPUT"
+            echo "plugins=true" >> "$GITHUB_OUTPUT"
+            echo "helm=true" >> "$GITHUB_OUTPUT"
+            echo "workflow=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "backend=${BACKEND:-false}" >> "$GITHUB_OUTPUT"
+            echo "frontend=${FRONTEND:-false}" >> "$GITHUB_OUTPUT"
+            echo "cli=${CLI:-false}" >> "$GITHUB_OUTPUT"
+            echo "plugins=${PLUGINS:-false}" >> "$GITHUB_OUTPUT"
+            echo "helm=${HELM:-false}" >> "$GITHUB_OUTPUT"
+            echo "workflow=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # ==========================================================================
   # Backend Tests
   # ==========================================================================
@@ -68,6 +160,8 @@ jobs:
   helm-lint:
     name: Helm Chart Checks
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.helm == 'true'
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
@@ -91,6 +185,8 @@ jobs:
   test-backend:
     name: Backend Tests (${{ matrix.group }}/8)
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -171,7 +267,8 @@ jobs:
   test-backend-coverage:
     name: Backend Coverage
     runs-on: ubuntu-latest
-    needs: test-backend
+    needs: [changes, test-backend]
+    if: needs.changes.outputs.backend == 'true'
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
@@ -230,6 +327,8 @@ jobs:
   test-frontend:
     name: Frontend Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     defaults:
       run:
         working-directory: frontend
@@ -263,6 +362,8 @@ jobs:
   test-runtime-plugins:
     name: Runtime Plugin Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.plugins == 'true'
 
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -359,6 +460,8 @@ jobs:
     name: CLI Tests (Windows)
     runs-on: windows-latest
     continue-on-error: true
+    needs: changes
+    if: needs.changes.outputs.cli == 'true'
 
     defaults:
       run:
@@ -393,6 +496,9 @@ jobs:
   build-and-push:
     name: Build & Push Docker Images
     runs-on: ubuntu-latest
+    # PRs do not build images: this job is a multi-arch QEMU build that does
+    # not push, and release.yml already publishes from main/tags.
+    if: github.event_name != 'pull_request'
     needs: [lint, test-backend-coverage, test-frontend, test-runtime-plugins]
     permissions:
       contents: read
@@ -475,3 +581,48 @@ jobs:
             BRAND=preloop
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Required check. Per-suite jobs may skip when their tree did not change;
+  # a failed suite must still fail this job (skipped-because-needs-failed
+  # would otherwise look like a path-filter skip).
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    if: always() && !cancelled()
+    needs:
+      - lint
+      - helm-lint
+      - test-backend
+      - test-backend-coverage
+      - test-frontend
+      - test-runtime-plugins
+    steps:
+      - name: Require every suite to have passed or been skipped
+        env:
+          LINT: ${{ needs.lint.result }}
+          HELM: ${{ needs.helm-lint.result }}
+          BACKEND: ${{ needs.test-backend.result }}
+          COVERAGE: ${{ needs.test-backend-coverage.result }}
+          FRONTEND: ${{ needs.test-frontend.result }}
+          PLUGINS: ${{ needs.test-runtime-plugins.result }}
+        run: |
+          failed=0
+          check() {
+            name="$1"
+            result="$2"
+            echo "$name=$result"
+            case "$result" in
+              success|skipped) ;;
+              *)
+                echo "::error::$name ended $result"
+                failed=1
+                ;;
+            esac
+          }
+          check lint "$LINT"
+          check helm-lint "$HELM"
+          check test-backend "$BACKEND"
+          check test-backend-coverage "$COVERAGE"
+          check test-frontend "$FRONTEND"
+          check test-runtime-plugins "$PLUGINS"
+          exit "$failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
           filters: |
             backend:
               - 'backend/**'
-              - 'tests/**'
-              - 'presets/**'
-              - 'test_agent_overrides.py'
               - 'pyproject.toml'
               - 'requirements/**'
               - '.github/requirements/app-dev.txt'
@@ -584,12 +581,14 @@ jobs:
 
   # Required check. Per-suite jobs may skip when their tree did not change;
   # a failed suite must still fail this job (skipped-because-needs-failed
-  # would otherwise look like a path-filter skip).
+  # would otherwise look like a path-filter skip). `changes` is in `needs`
+  # so a checkout/filter crash cannot leave this job green with no tests.
   ci:
     name: CI
     runs-on: ubuntu-latest
     if: always() && !cancelled()
     needs:
+      - changes
       - lint
       - helm-lint
       - test-backend
@@ -599,6 +598,7 @@ jobs:
     steps:
       - name: Require every suite to have passed or been skipped
         env:
+          CHANGES: ${{ needs.changes.result }}
           LINT: ${{ needs.lint.result }}
           HELM: ${{ needs.helm-lint.result }}
           BACKEND: ${{ needs.test-backend.result }}
@@ -619,6 +619,7 @@ jobs:
                 ;;
             esac
           }
+          check changes "$CHANGES"
           check lint "$LINT"
           check helm-lint "$HELM"
           check test-backend "$BACKEND"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,11 @@
 # In-repo CodeQL so Scorecard sees github/codeql-action on every
 # pull_request and every push to main. Default setup only covers some
 # merged PRs (Scorecard SAST: "not run on all commits").
+#
+# Language jobs are path-filtered on PRs. `actions` always runs so a docs-only
+# PR still produces a CodeQL check. Push to main and the weekly schedule scan
+# every language. The matrix is built as JSON so we do not rely on a job-level
+# `if: matrix.language == ...` (that is evaluated before matrix expansion).
 name: CodeQL
 
 on:
@@ -11,13 +16,78 @@ on:
   schedule:
     - cron: '17 5 * * 2'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.out.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        if: github.event_name == 'pull_request'
+
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            go:
+              - 'cli/**'
+              - '**/*.go'
+              - '**/*.mod'
+              - '**/*.sum'
+            javascript:
+              - 'frontend/**'
+              - 'runtime-plugins/**/*.ts'
+              - 'runtime-plugins/**/*.js'
+              - 'runtime-plugins/**/*.json'
+            python:
+              - 'backend/**'
+              - 'tests/**'
+              - 'presets/**'
+              - '**/*.py'
+              - 'pyproject.toml'
+              - 'runtime-plugins/**/*.py'
+            workflow:
+              - '.github/workflows/codeql.yml'
+
+      - name: Build language matrix
+        id: out
+        env:
+          EVENT: ${{ github.event_name }}
+          GO: ${{ steps.filter.outputs.go }}
+          JAVASCRIPT: ${{ steps.filter.outputs.javascript }}
+          PYTHON: ${{ steps.filter.outputs.python }}
+          WORKFLOW: ${{ steps.filter.outputs.workflow }}
+        run: |
+          python3 - <<'PY'
+          import json, os
+          event = os.environ["EVENT"]
+          force = event != "pull_request" or os.environ.get("WORKFLOW") == "true"
+          include = [{"language": "actions", "build-mode": "none"}]
+          if force or os.environ.get("GO") == "true":
+              include.append({"language": "go", "build-mode": "autobuild"})
+          if force or os.environ.get("JAVASCRIPT") == "true":
+              include.append({"language": "javascript-typescript", "build-mode": "none"})
+          if force or os.environ.get("PYTHON") == "true":
+              include.append({"language": "python", "build-mode": "none"})
+          matrix = json.dumps({"include": include})
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"matrix={matrix}\n")
+          print(matrix)
+          PY
+
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    needs: changes
     permissions:
       security-events: write
       packages: read
@@ -25,16 +95,7 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - language: actions
-            build-mode: none
-          - language: go
-            build-mode: autobuild
-          - language: javascript-typescript
-            build-mode: none
-          - language: python
-            build-mode: none
+      matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/TESTING.md
+++ b/TESTING.md
@@ -93,11 +93,16 @@ Significant progress has been made in increasing unit test coverage for the back
 ### CI/CD Integration
 
 GitHub Actions (`.github/workflows/ci.yml`) shards backend unit tests
-(`pytest -m "not integration"`) across four jobs with
+(`pytest -m "not integration"`) across eight jobs with
 [pytest-split](https://pypi.org/project/pytest-split/). Each shard has
 its own Postgres service. Coverage data is combined in a follow-up
 **Backend Coverage** job before the 60% floor is applied; a single shard
 only exercises part of the tree, so `--cov-fail-under` cannot run there.
+Pull requests skip backend, frontend, CLI, plugin, and Helm jobs when
+those trees did not change; `main` always runs every suite. The
+required check is the **CI** aggregator (a skipped suite is success; a
+failed suite is not). A new push to the same PR cancels the in-progress
+run. Docker image builds run on `main` and tags, not on pull requests.
 
 GitLab CI (`.gitlab-ci.yml`) splits the same suite into per-component
 jobs for parallel execution and reporting, such as

--- a/backend/tests/test_github_ci_backend_shards.py
+++ b/backend/tests/test_github_ci_backend_shards.py
@@ -75,7 +75,7 @@ def test_backend_coverage_job_combines_shards_before_floor() -> None:
     """The 60% floor applies only to the combined coverage data."""
     jobs = _load_ci_jobs()
     coverage = jobs["test-backend-coverage"]
-    assert coverage["needs"] == "test-backend"
+    assert coverage["needs"] == ["changes", "test-backend"]
 
     install = _step_script(coverage, "Install coverage")
     assert ".github/requirements/coverage.txt" in install
@@ -127,3 +127,16 @@ def test_build_and_push_waits_for_combined_backend_coverage() -> None:
     needs = _load_ci_jobs()["build-and-push"]["needs"]
     assert "test-backend-coverage" in needs
     assert "test-backend" not in needs
+
+
+def test_ci_aggregator_fails_when_changes_fails() -> None:
+    """A crashed path-filter job must not leave the required check green."""
+    jobs = _load_ci_jobs()
+    aggregator = jobs["ci"]
+    assert aggregator["needs"][0] == "changes"
+    assert "changes" in aggregator["needs"]
+    script = _step_script(
+        aggregator, "Require every suite to have passed or been skipped"
+    )
+    assert "check changes" in script
+    assert "needs.changes.result" in str(aggregator)

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -530,6 +530,7 @@ describe('DashboardView', () => {
     connectStub.restore();
     subscribeStub.restore();
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   async function mountDashboard(): Promise<DashboardView> {
@@ -1678,6 +1679,13 @@ describe('DashboardView', () => {
         const first = await mountLoaded();
         expect(first['aiModels'].length).to.equal(1);
 
+        // Writes are coalesced onto requestIdleCallback (2s timeout), so a
+        // busy CI runner can finish the second pass before the cache lands.
+        await waitUntil(
+          () => JSON.parse(sessionStorage.getItem(key) || '{}').tools != null,
+          'dashboard cache did not persist tools',
+          { timeout: 4000 }
+        );
         const cached = JSON.parse(sessionStorage.getItem(key) || '{}');
         expect(cached.tools, 'tools were already cached').to.exist;
         expect(cached.aiModels?.[0]?.name).to.equal('OpenAI GPT-5.4');


### PR DESCRIPTION
## Summary
- Path-filter backend, frontend, CLI, plugin, and Helm jobs on PRs (job-level, not workflow-level) so a docs-only change does not pay for eight Postgres shards. `main` and tags still run every suite. Changing `ci.yml` itself forces every suite.
- Cancel in-progress CI/CodeQL runs when a PR is pushed again. `main` is never cancelled.
- Skip the multi-arch Docker build on PRs (`release.yml` already publishes from main/tags).
- Add a `CI` aggregator as the required check: skipped-because-paths is success; a red shard is not.
- Path-filter CodeQL languages on PRs; `actions` always runs so a docs-only PR still produces a CodeQL check.

## Test plan
- [ ] This PR changes `ci.yml`, so it should still run the full backend/frontend/plugin matrix (workflow-change override).
- [ ] After merge, open a docs-only PR: lint + `CI` aggregator + CodeQL `actions` should run; backend shards, frontend, plugins, Helm, Windows CLI, Docker, and CodeQL go/js/python should skip.
- [ ] After merge, a frontend-only PR should run lint + frontend tests + `CI`, not backend shards.
- [ ] A second push to the same PR should cancel the previous CI/CodeQL runs.
- [ ] Switch branch protection from individual shard names to the `CI` check if those shards are currently required.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> CI-only change with no application code or security surface; path-filtering and cancellation logic is well-reasoned with a clear manual test plan.
>
> **Overview**
> Makes GitHub Actions path-aware on PRs (job-level path filters), cancels superseded PR runs, skips the multi-arch Docker build on PRs, and adds a `CI` aggregator as the required check.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 0ec7c6b1. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->