### PR TITLE
Alias GitLab iid as object_attributes.number so OSS presets work on both trackers

### DIFF
--- a/backend/preloop/services/prompt_resolvers/trigger_event.py
+++ b/backend/preloop/services/prompt_resolvers/trigger_event.py
@@ -8,6 +8,51 @@ from .base import PromptResolver, ResolverContext
 logger = logging.getLogger(__name__)
 
 
+def _alias_object_attribute_ids(attrs: Dict[str, Any]) -> None:
+    """Expose both GitHub ``number`` and GitLab ``iid`` on object_attributes.
+
+    Presets (including Automated Issue Implementation) use
+    ``object_attributes.number`` so ``Closes #N`` resolves. GitHub issue and
+    pull-request payloads already set both keys when mapped into
+    object_attributes. GitLab native object_attributes only have ``iid``.
+    """
+    if not isinstance(attrs, dict):
+        return
+    number = attrs.get("number")
+    iid = attrs.get("iid")
+    if number is None and iid is not None:
+        attrs["number"] = iid
+    if iid is None and number is not None:
+        attrs["iid"] = number
+
+
+def _lift_gitlab_noteable_ids(payload: Dict[str, Any], attrs: Dict[str, Any]) -> None:
+    """Copy the issue/MR iid off a GitLab Note hook onto object_attributes.
+
+    Note hooks put the note in ``object_attributes`` (no iid) and the
+    issue or merge request beside it. Without this, resume prompts leave
+    ``{{trigger_event.payload.object_attributes.number}}`` unresolved.
+    """
+    if attrs.get("number") is not None or attrs.get("iid") is not None:
+        return
+    for key in ("issue", "merge_request"):
+        nested = payload.get(key)
+        if not isinstance(nested, dict):
+            continue
+        iid = nested.get("iid")
+        if iid is None:
+            continue
+        attrs["number"] = iid
+        attrs["iid"] = iid
+        if not attrs.get("title") and nested.get("title"):
+            attrs["title"] = nested["title"]
+        if not attrs.get("description") and nested.get("description"):
+            attrs["description"] = nested["description"]
+        if not attrs.get("url") and nested.get("url"):
+            attrs["url"] = nested["url"]
+        break
+
+
 class TriggerEventResolver(PromptResolver):
     """
     Resolver for trigger event data.
@@ -41,8 +86,14 @@ class TriggerEventResolver(PromptResolver):
         payload = normalized.get("payload", {})
         source = normalized.get("source", "").lower()
 
-        # If object_attributes already exists (GitLab), keep it
+        # GitLab (and other trackers that already ship object_attributes):
+        # keep the native object but alias number/iid and lift Note-hook
+        # issue/MR identifiers so the same placeholders resolve everywhere.
         if "object_attributes" in payload:
+            attrs = payload.get("object_attributes")
+            if isinstance(attrs, dict):
+                _lift_gitlab_noteable_ids(payload, attrs)
+                _alias_object_attribute_ids(attrs)
             return normalized
 
         # For GitHub, create object_attributes from pull_request or issue

--- a/backend/preloop/services/prompt_resolvers/trigger_event.py
+++ b/backend/preloop/services/prompt_resolvers/trigger_event.py
@@ -48,8 +48,11 @@ def _lift_gitlab_noteable_ids(payload: Dict[str, Any], attrs: Dict[str, Any]) ->
             attrs["title"] = nested["title"]
         if not attrs.get("description") and nested.get("description"):
             attrs["description"] = nested["description"]
-        if not attrs.get("url") and nested.get("url"):
-            attrs["url"] = nested["url"]
+        # Do not copy nested url. Real GitLab Note hooks already set
+        # object_attributes.url to the note's own anchor, so a missing-url
+        # guard never fires and overwriting would hide the comment that
+        # triggered resume. The issue/MR URL stays on payload.issue.url or
+        # payload.merge_request.url.
         break
 
 

--- a/backend/tests/services/prompt_resolvers/test_trigger_event.py
+++ b/backend/tests/services/prompt_resolvers/test_trigger_event.py
@@ -197,6 +197,103 @@ class TestTriggerEventResolver:
         # Verify nested structures are preserved
         assert parsed["payload"]["object_attributes"]["title"] == "Add new feature"
         assert len(parsed["payload"]["labels"]) == 2
+        # No iid/number on this fixture, so aliasing is a no-op.
+        assert "number" not in parsed["payload"]["object_attributes"]
+        assert "iid" not in parsed["payload"]["object_attributes"]
+
+
+class TestCrossTrackerObjectAttributes:
+    """GitHub number and GitLab iid must both resolve in presets."""
+
+    @pytest.mark.asyncio
+    async def test_gitlab_issue_iid_aliases_as_number(self):
+        resolver = TriggerEventResolver()
+        context = ResolverContext(
+            db=MagicMock(),
+            trigger_event_data={
+                "source": "gitlab",
+                "payload": {
+                    "object_kind": "issue",
+                    "object_attributes": {
+                        "title": "Add login",
+                        "description": "Please implement OAuth",
+                        "iid": 12,
+                        "url": "https://gitlab.example/group/proj/-/issues/12",
+                    },
+                    "repository": {"name": "proj"},
+                },
+            },
+            flow_id="flow-1",
+            execution_id="exec-1",
+        )
+
+        assert await resolver.resolve("payload.object_attributes.iid", context) == "12"
+        assert (
+            await resolver.resolve("payload.object_attributes.number", context) == "12"
+        )
+        assert (
+            await resolver.resolve("payload.object_attributes.title", context)
+            == "Add login"
+        )
+
+    @pytest.mark.asyncio
+    async def test_github_issue_number_aliases_as_iid(self):
+        resolver = TriggerEventResolver()
+        context = ResolverContext(
+            db=MagicMock(),
+            trigger_event_data={
+                "source": "github",
+                "payload": {
+                    "issue": {
+                        "title": "Add login",
+                        "body": "Please implement OAuth",
+                        "number": 12,
+                    }
+                },
+            },
+            flow_id="flow-1",
+            execution_id="exec-1",
+        )
+
+        assert (
+            await resolver.resolve("payload.object_attributes.number", context) == "12"
+        )
+        assert await resolver.resolve("payload.object_attributes.iid", context) == "12"
+
+    @pytest.mark.asyncio
+    async def test_gitlab_note_lifts_issue_iid(self):
+        resolver = TriggerEventResolver()
+        context = ResolverContext(
+            db=MagicMock(),
+            trigger_event_data={
+                "source": "gitlab",
+                "payload": {
+                    "object_kind": "note",
+                    "object_attributes": {
+                        "id": 9001,
+                        "note": "please also add tests",
+                        "noteable_type": "Issue",
+                    },
+                    "issue": {
+                        "iid": 12,
+                        "title": "Add login",
+                        "description": "Please implement OAuth",
+                        "url": "https://gitlab.example/group/proj/-/issues/12",
+                    },
+                },
+            },
+            flow_id="flow-1",
+            execution_id="exec-1",
+        )
+
+        assert (
+            await resolver.resolve("payload.object_attributes.number", context) == "12"
+        )
+        assert await resolver.resolve("payload.object_attributes.iid", context) == "12"
+        assert (
+            await resolver.resolve("payload.object_attributes.title", context)
+            == "Add login"
+        )
 
 
 class TestWorkspaceFilesRedaction:

--- a/backend/tests/services/prompt_resolvers/test_trigger_event.py
+++ b/backend/tests/services/prompt_resolvers/test_trigger_event.py
@@ -273,6 +273,7 @@ class TestCrossTrackerObjectAttributes:
                         "id": 9001,
                         "note": "please also add tests",
                         "noteable_type": "Issue",
+                        "url": "https://gitlab.example/group/proj/-/issues/12#note_9001",
                     },
                     "issue": {
                         "iid": 12,
@@ -293,6 +294,54 @@ class TestCrossTrackerObjectAttributes:
         assert (
             await resolver.resolve("payload.object_attributes.title", context)
             == "Add login"
+        )
+        assert (
+            await resolver.resolve("payload.object_attributes.url", context)
+            == "https://gitlab.example/group/proj/-/issues/12#note_9001"
+        )
+
+    @pytest.mark.asyncio
+    async def test_gitlab_note_lifts_merge_request_iid(self):
+        resolver = TriggerEventResolver()
+        context = ResolverContext(
+            db=MagicMock(),
+            trigger_event_data={
+                "source": "gitlab",
+                "payload": {
+                    "object_kind": "note",
+                    "object_attributes": {
+                        "id": 9002,
+                        "note": "please rebase",
+                        "noteable_type": "MergeRequest",
+                        "url": "https://gitlab.example/group/proj/-/merge_requests/8#note_9002",
+                    },
+                    "merge_request": {
+                        "iid": 8,
+                        "title": "Implements: Add login",
+                        "description": "Closes #12",
+                        "url": "https://gitlab.example/group/proj/-/merge_requests/8",
+                    },
+                },
+            },
+            flow_id="flow-1",
+            execution_id="exec-1",
+        )
+
+        assert (
+            await resolver.resolve("payload.object_attributes.number", context) == "8"
+        )
+        assert await resolver.resolve("payload.object_attributes.iid", context) == "8"
+        assert (
+            await resolver.resolve("payload.object_attributes.title", context)
+            == "Implements: Add login"
+        )
+        assert (
+            await resolver.resolve("payload.object_attributes.description", context)
+            == "Closes #12"
+        )
+        assert (
+            await resolver.resolve("payload.object_attributes.url", context)
+            == "https://gitlab.example/group/proj/-/merge_requests/8#note_9002"
         )
 
 

--- a/backend/tests/test_automated_issue_implementation_preset.py
+++ b/backend/tests/test_automated_issue_implementation_preset.py
@@ -231,7 +231,10 @@ class TestPromptPlaceholders:
         template = preset["prompt_template"]
         assert "{{trigger_event.payload.object_attributes.title}}" in template
         assert "{{trigger_event.payload.object_attributes.description}}" in template
+        # GitHub-native field. TriggerEventResolver aliases GitLab iid onto
+        # number so this same placeholder resolves on both trackers.
         assert "{{trigger_event.payload.object_attributes.number}}" in template
+        assert "{{trigger_event.payload.object_attributes.iid}}" not in template
         assert "{{trigger_event.payload.issue.description}}" not in template
 
 


### PR DESCRIPTION
## Summary
- GitHub issue/PR payloads already map `number` onto GitLab-style `object_attributes`. GitLab native `object_attributes` only have `iid`, so OSS preset 011 left `{{trigger_event.payload.object_attributes.number}}` unresolved (and `Closes #N` broke).
- The trigger resolver now aliases `iid`/`number` both ways, and lifts the issue/MR iid off GitLab Note hooks so resume prompts resolve the same placeholders.
- After this lands, EE can delete overlay preset 003 and fall through to OSS 011. Companion: https://gitlab.spacecode.ai/spacecode/preloop-ee/-/merge_requests/42

## Test plan
- [x] `pytest backend/tests/services/prompt_resolvers/test_trigger_event.py backend/tests/test_automated_issue_implementation_preset.py` (42 passed)
- [ ] Confirm a GitLab `issue_labeled` run fills Issue number / `Closes #N` from `object_attributes.iid`
- [ ] Confirm a GitLab Note resume still resolves the issue iid from the nested `issue` / `merge_request` object

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Well-tested, low-risk normalization change with no security implications; only minor test-coverage and dead-code observations remain.
>
> **Overview**
> Aliases `object_attributes.number`/`iid` both ways and lifts the noteable iid off GitLab Note hooks so OSS presets (e.g. Automated Issue Implementation) resolve `{{trigger_event.payload.object_attributes.number}}` and `Closes #N` on both GitHub and GitLab.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 1914d4f1. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->