### PR TITLE
Console: shared list toolbar with filter bar and list/cards views on Trackers and Models

### DIFF
--- a/frontend/src/components/list-toolbar.test.ts
+++ b/frontend/src/components/list-toolbar.test.ts
@@ -1,0 +1,134 @@
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import '@shoelace-style/shoelace/dist/components/select/select.js';
+
+import './list-toolbar.ts';
+import type { ListToolbar } from './list-toolbar';
+
+describe('list-toolbar', () => {
+  async function render(
+    props: Partial<ListToolbar> = {}
+  ): Promise<ListToolbar> {
+    const element = await fixture<ListToolbar>(html`
+      <list-toolbar
+        search=${props.search ?? ''}
+        searchPlaceholder=${props.searchPlaceholder ?? 'Search'}
+        view=${props.view ?? 'list'}
+        .views=${props.views ?? ['list', 'cards']}
+      >
+        <sl-select placeholder="All kinds"></sl-select>
+        <span slot="count">2 trackers</span>
+      </list-toolbar>
+    `);
+    await element.updateComplete;
+    return element;
+  }
+
+  it('renders the search input with the search prefix icon', async () => {
+    const element = await render({ searchPlaceholder: 'Search trackers' });
+    const input = element.shadowRoot!.querySelector('sl-input.search-input')!;
+    expect(input).to.exist;
+    expect(input.getAttribute('placeholder')).to.equal('Search trackers');
+    const icon = input.querySelector('sl-icon[name="search"]');
+    expect(icon).to.exist;
+  });
+
+  it('projects page-specific filters into the default slot', async () => {
+    const element = await render();
+    const slotted = element.querySelector('sl-select');
+    expect(slotted).to.exist;
+    expect(slotted?.getAttribute('placeholder')).to.equal('All kinds');
+  });
+
+  it('renders list and cards toggle buttons with the Flows icons', async () => {
+    const element = await render();
+    const buttons = [
+      ...element.shadowRoot!.querySelectorAll('sl-button[data-view]'),
+    ];
+    expect(
+      buttons.map((button) => button.getAttribute('data-view'))
+    ).to.deep.equal(['list', 'cards']);
+    expect(buttons[0].querySelector('sl-icon')?.getAttribute('name')).to.equal(
+      'list-ul'
+    );
+    expect(buttons[1].querySelector('sl-icon')?.getAttribute('name')).to.equal(
+      'grid-3x3-gap'
+    );
+    expect(buttons[0].getAttribute('variant')).to.equal('primary');
+    expect(buttons[1].getAttribute('variant')).to.equal('default');
+  });
+
+  it('emits search-change as the input value changes', async () => {
+    const element = await render();
+    const input = element.shadowRoot!.querySelector('sl-input.search-input')!;
+    (input as unknown as { value: string }).value = 'github';
+
+    setTimeout(() =>
+      input.dispatchEvent(new CustomEvent('sl-input', { bubbles: true }))
+    );
+    const event = (await oneEvent(element, 'search-change')) as CustomEvent<{
+      value: string;
+    }>;
+
+    expect(event.detail.value).to.equal('github');
+    expect(element.search).to.equal('github');
+  });
+
+  it('emits search-change with an empty string on clear', async () => {
+    const element = await render({ search: 'jira' });
+    const input = element.shadowRoot!.querySelector('sl-input.search-input')!;
+
+    setTimeout(() =>
+      input.dispatchEvent(new CustomEvent('sl-clear', { bubbles: true }))
+    );
+    const event = (await oneEvent(element, 'search-change')) as CustomEvent<{
+      value: string;
+    }>;
+
+    expect(event.detail.value).to.equal('');
+    expect(element.search).to.equal('');
+  });
+
+  it('emits view-change when the other view is pressed', async () => {
+    const element = await render({ view: 'list' });
+    const cards = element.shadowRoot!.querySelector(
+      'sl-button[data-view="cards"]'
+    ) as HTMLElement;
+
+    setTimeout(() => cards.click());
+    const event = (await oneEvent(element, 'view-change')) as CustomEvent<{
+      value: string;
+    }>;
+
+    expect(event.detail.value).to.equal('cards');
+    expect(element.view).to.equal('cards');
+  });
+
+  it('does not emit view-change when the active view is pressed again', async () => {
+    const element = await render({ view: 'list' });
+    let emitted = 0;
+    element.addEventListener('view-change', () => {
+      emitted += 1;
+    });
+    const list = element.shadowRoot!.querySelector(
+      'sl-button[data-view="list"]'
+    ) as HTMLElement;
+    list.click();
+    await element.updateComplete;
+    expect(emitted).to.equal(0);
+  });
+
+  it('hides the toggle when only one view is offered', async () => {
+    const element = await render({ views: ['list'] });
+    expect(element.shadowRoot!.querySelector('sl-button-group')).to.equal(null);
+    expect(element.shadowRoot!.querySelector('.toolbar-divider')).to.equal(
+      null
+    );
+    expect(element.shadowRoot!.querySelector('sl-input.search-input')).to.exist;
+  });
+
+  it('renders the count slot next to the switcher', async () => {
+    const element = await render();
+    const count = element.querySelector('[slot="count"]');
+    expect(count?.textContent?.trim()).to.equal('2 trackers');
+  });
+});

--- a/frontend/src/components/list-toolbar.test.ts
+++ b/frontend/src/components/list-toolbar.test.ts
@@ -12,6 +12,7 @@ describe('list-toolbar', () => {
       <list-toolbar
         search=${props.search ?? ''}
         searchPlaceholder=${props.searchPlaceholder ?? 'Search'}
+        toggleLabel=${props.toggleLabel ?? 'View'}
         view=${props.view ?? 'list'}
         .views=${props.views ?? ['list', 'cards']}
       >
@@ -28,8 +29,15 @@ describe('list-toolbar', () => {
     const input = element.shadowRoot!.querySelector('sl-input.search-input')!;
     expect(input).to.exist;
     expect(input.getAttribute('placeholder')).to.equal('Search trackers');
+    expect(input.getAttribute('label')).to.equal('Search trackers');
     const icon = input.querySelector('sl-icon[name="search"]');
     expect(icon).to.exist;
+  });
+
+  it('names the view switcher from toggleLabel', async () => {
+    const element = await render({ toggleLabel: 'Trackers view' });
+    const group = element.shadowRoot!.querySelector('sl-button-group');
+    expect(group?.getAttribute('label')).to.equal('Trackers view');
   });
 
   it('projects page-specific filters into the default slot', async () => {

--- a/frontend/src/components/list-toolbar.ts
+++ b/frontend/src/components/list-toolbar.ts
@@ -32,11 +32,25 @@ export class ListToolbar extends LitElement {
   @property({ type: String }) searchPlaceholder = 'Search';
   @property({ type: String }) view: ListViewMode = 'list';
   @property({ type: Array }) views: ListViewMode[] = ['list', 'cards'];
+  @property({ type: String }) toggleLabel = 'View';
 
   static styles = css`
     :host {
       display: block;
       width: 100%;
+    }
+
+    /* Names the search field for assistive tech without a visible label. */
+    sl-input::part(form-control-label) {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
     }
 
     /* --- Filter bar (copied from flows-view) --- */
@@ -163,6 +177,7 @@ export class ListToolbar extends LitElement {
         >
           <sl-input
             class="search-input"
+            label=${this.searchPlaceholder}
             placeholder=${this.searchPlaceholder}
             clearable
             .value=${this.search}
@@ -182,7 +197,7 @@ export class ListToolbar extends LitElement {
             this.showToggle
               ? html`
                   <span class="toolbar-divider" aria-hidden="true"></span>
-                  <sl-button-group label="View">
+                  <sl-button-group label=${this.toggleLabel}>
                     ${VIEW_OPTIONS.filter((option) =>
                       this.visibleViews.includes(option.value)
                     ).map(

--- a/frontend/src/components/list-toolbar.ts
+++ b/frontend/src/components/list-toolbar.ts
@@ -1,0 +1,218 @@
+import { LitElement, css, html, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/button-group/button-group.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/input/input.js';
+
+import type { ListViewMode } from '../utils/view-mode';
+
+const VIEW_OPTIONS: Array<{
+  value: ListViewMode;
+  label: string;
+  icon: string;
+}> = [
+  { value: 'list', label: 'List', icon: 'list-ul' },
+  { value: 'cards', label: 'Cards', icon: 'grid-3x3-gap' },
+];
+
+/**
+ * Shared collection toolbar: search, a slot for page filters, and the
+ * list/cards switcher. Spacing and the 900px / 640px collapse match the
+ * Flows filter bar pixel-for-pixel so Trackers and Models feel like the
+ * same product.
+ *
+ * @fires search-change - `{ detail: { value } }` when the search input changes
+ * @fires view-change - `{ detail: { value } }` when a view button is pressed
+ */
+@customElement('list-toolbar')
+export class ListToolbar extends LitElement {
+  @property({ type: String }) search = '';
+  @property({ type: String }) searchPlaceholder = 'Search';
+  @property({ type: String }) view: ListViewMode = 'list';
+  @property({ type: Array }) views: ListViewMode[] = ['list', 'cards'];
+
+  static styles = css`
+    :host {
+      display: block;
+      width: 100%;
+    }
+
+    /* --- Filter bar (copied from flows-view) --- */
+    .list-toolbar {
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: var(--sl-spacing-medium);
+      flex-wrap: wrap;
+      width: 100%;
+    }
+    .filters {
+      display: flex;
+      gap: var(--sl-spacing-medium);
+      flex-wrap: wrap;
+      align-items: end;
+      flex: 1 1 520px;
+      min-width: 0;
+    }
+    .filters sl-input,
+    .filters ::slotted(sl-select),
+    .filters ::slotted(sl-input) {
+      min-width: 180px;
+    }
+    .filters sl-input {
+      flex: 1 1 260px;
+    }
+    .view-switcher-group {
+      display: flex;
+      align-items: center;
+      gap: var(--sl-spacing-medium);
+      margin-left: auto;
+    }
+    /* Says how many rows the filters matched, right where the eye already
+       goes to switch views. */
+    .results-count {
+      color: var(--console-meta-color);
+      font-size: var(--console-text-meta);
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+    .toolbar-divider {
+      width: 1px;
+      height: 32px;
+      background: var(--console-hairline);
+    }
+    @media (max-width: 900px) {
+      .view-switcher-group {
+        margin-left: 0;
+        width: 100%;
+        justify-content: flex-end;
+      }
+      .toolbar-divider {
+        display: none;
+      }
+    }
+    /* Phones: the filters take the full width one after another, and the
+       switcher goes away. Below this width a multi-column table cannot be
+       read, so cards are the only view on offer and a switcher that could
+       not honour a click would be a lie. Matches LIST_TO_CARDS_BREAKPOINT. */
+    @media (max-width: 640px) {
+      .filters sl-input,
+      .filters ::slotted(sl-select),
+      .filters ::slotted(sl-input) {
+        flex: 1 1 100%;
+      }
+      .view-switcher-group sl-button-group {
+        display: none;
+      }
+    }
+  `;
+
+  private get visibleViews(): ListViewMode[] {
+    const allowed = new Set(this.views);
+    return VIEW_OPTIONS.map((option) => option.value).filter((value) =>
+      allowed.has(value)
+    );
+  }
+
+  private get showToggle(): boolean {
+    return this.visibleViews.length > 1;
+  }
+
+  private handleSearchInput(event: Event) {
+    const input = event.target as HTMLInputElement;
+    this.emitSearch(input.value);
+  }
+
+  private handleSearchClear() {
+    this.emitSearch('');
+  }
+
+  private emitSearch(value: string) {
+    this.search = value;
+    this.dispatchEvent(
+      new CustomEvent('search-change', {
+        detail: { value },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private handleViewClick(view: ListViewMode) {
+    if (view === this.view) {
+      return;
+    }
+    this.view = view;
+    this.dispatchEvent(
+      new CustomEvent('view-change', {
+        detail: { value: view },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  render() {
+    return html`
+      <div class="list-toolbar">
+        <form
+          class="filters"
+          @submit=${(event: Event) => event.preventDefault()}
+        >
+          <sl-input
+            class="search-input"
+            placeholder=${this.searchPlaceholder}
+            clearable
+            .value=${this.search}
+            @sl-input=${this.handleSearchInput}
+            @sl-clear=${this.handleSearchClear}
+          >
+            <sl-icon name="search" slot="prefix"></sl-icon>
+          </sl-input>
+          <slot></slot>
+        </form>
+
+        <div class="view-switcher-group">
+          <span class="results-count" aria-live="polite">
+            <slot name="count"></slot>
+          </span>
+          ${
+            this.showToggle
+              ? html`
+                  <span class="toolbar-divider" aria-hidden="true"></span>
+                  <sl-button-group label="View">
+                    ${VIEW_OPTIONS.filter((option) =>
+                      this.visibleViews.includes(option.value)
+                    ).map(
+                      (option) => html`
+                        <sl-button
+                          size="small"
+                          data-view=${option.value}
+                          variant=${
+                            this.view === option.value ? 'primary' : 'default'
+                          }
+                          aria-pressed=${this.view === option.value}
+                          @click=${() => this.handleViewClick(option.value)}
+                        >
+                          <sl-icon slot="prefix" name=${option.icon}></sl-icon>
+                          ${option.label}
+                        </sl-button>
+                      `
+                    )}
+                  </sl-button-group>
+                `
+              : nothing
+          }
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'list-toolbar': ListToolbar;
+  }
+}

--- a/frontend/src/components/tracker-item.ts
+++ b/frontend/src/components/tracker-item.ts
@@ -15,7 +15,6 @@ export interface Tracker {
   created: string;
   is_valid: boolean;
   url?: string | null;
-  is_active?: boolean;
   last_validation?: string | null;
   last_updated?: string;
   scope_rules?: Array<{

--- a/frontend/src/components/tracker-item.ts
+++ b/frontend/src/components/tracker-item.ts
@@ -14,6 +14,15 @@ export interface Tracker {
   tracker_type: string;
   created: string;
   is_valid: boolean;
+  url?: string | null;
+  is_active?: boolean;
+  last_validation?: string | null;
+  last_updated?: string;
+  scope_rules?: Array<{
+    scope_type: string;
+    rule_type: string;
+    identifier: string;
+  }>;
 }
 
 @customElement('tracker-item')

--- a/frontend/src/components/tracker-list.test.ts
+++ b/frontend/src/components/tracker-list.test.ts
@@ -5,6 +5,7 @@ import './tracker-list';
 import {
   filterTrackers,
   trackerKindLabel,
+  trackerLastCheckedAt,
   trackerProjectsCount,
   type TrackerList,
 } from './tracker-list';
@@ -72,7 +73,37 @@ describe('filterTrackers', () => {
         ],
       })
     ).to.equal(2);
-    expect(trackerProjectsCount(trackers[0])).to.equal(null);
+    expect(trackerProjectsCount(trackers[0])).to.equal('all');
+    expect(
+      trackerProjectsCount({
+        ...trackers[0],
+        scope_rules: [
+          {
+            scope_type: 'ORGANIZATION',
+            rule_type: 'INCLUDE',
+            identifier: 'ORG',
+          },
+        ],
+      })
+    ).to.equal('all');
+  });
+
+  it('uses last_validation only for last checked', () => {
+    expect(trackerLastCheckedAt(trackers[0])).to.equal(null);
+    expect(
+      trackerLastCheckedAt({
+        ...trackers[0],
+        last_updated: '2024-06-01T00:00:00Z',
+        created: '2024-01-01T00:00:00Z',
+      })
+    ).to.equal(null);
+    expect(
+      trackerLastCheckedAt({
+        ...trackers[0],
+        last_validation: '2024-03-15T12:00:00Z',
+        last_updated: '2024-06-01T00:00:00Z',
+      })
+    ).to.equal('2024-03-15T12:00:00Z');
   });
 });
 
@@ -97,12 +128,14 @@ describe('TrackerList', () => {
   ];
 
   beforeEach(() => {
+    localStorage.removeItem('preloop.trackers.view_mode');
     localStorage.setItem('accessToken', 'test-access-token');
     fetchStub = sinon.stub(window, 'fetch');
   });
 
   afterEach(() => {
     fetchStub.restore();
+    localStorage.removeItem('preloop.trackers.view_mode');
     localStorage.clear();
   });
 
@@ -151,6 +184,54 @@ describe('TrackerList', () => {
     const rows = el.shadowRoot?.querySelectorAll('.tracker-row');
     expect(rows).to.have.lengthOf(2);
     expect(el.shadowRoot?.querySelector('list-toolbar')).to.exist;
+    expect(el.shadowRoot?.textContent).to.contain('Last checked');
+    expect(el.shadowRoot?.textContent).to.contain('All');
+    expect(el.shadowRoot?.textContent).to.not.contain('None');
+    expect(el.shadowRoot?.textContent).to.not.contain('Never');
+    const kindSelect = el.shadowRoot?.querySelector('sl-select.kind-filter');
+    expect(kindSelect?.getAttribute('label')).to.equal('Kind');
+  });
+
+  it('keeps the toolbar while refetching existing trackers', async () => {
+    fetchStub.resolves(
+      new Response(JSON.stringify(mockTrackers), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const el = (await fixture(
+      html`<tracker-list></tracker-list>`
+    )) as TrackerList;
+
+    await waitUntil(
+      () => el.shadowRoot?.querySelector('.tracker-row') !== null,
+      'Tracker list did not render'
+    );
+
+    let resolveFetch!: (value: Response) => void;
+    fetchStub.resetBehavior();
+    fetchStub.returns(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    const refetch = el.fetchTrackers();
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('list-toolbar')).to.exist;
+    expect(el.shadowRoot?.querySelector('sl-spinner')).to.exist;
+
+    resolveFetch(
+      new Response(JSON.stringify(mockTrackers), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    await refetch;
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector('.tracker-row')).to.exist;
   });
 
   it('switches to the existing cards template', async () => {

--- a/frontend/src/components/tracker-list.test.ts
+++ b/frontend/src/components/tracker-list.test.ts
@@ -2,8 +2,79 @@ import { html, fixture, expect, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon';
 
 import './tracker-list';
-import type { TrackerList } from './tracker-list';
+import {
+  filterTrackers,
+  trackerKindLabel,
+  trackerProjectsCount,
+  type TrackerList,
+} from './tracker-list';
 import type { Tracker } from './tracker-item';
+
+describe('filterTrackers', () => {
+  const trackers: Tracker[] = [
+    {
+      id: 'tracker-1',
+      name: 'Jira Production',
+      tracker_type: 'jira',
+      created: '2024-01-01T00:00:00Z',
+      is_valid: true,
+      url: 'https://jira.example.com',
+    },
+    {
+      id: 'tracker-2',
+      name: 'GitHub Repos',
+      tracker_type: 'github',
+      created: '2024-01-02T00:00:00Z',
+      is_valid: true,
+      url: 'https://github.com/example',
+    },
+  ];
+
+  it('filters by name, kind, and url', () => {
+    expect(filterTrackers(trackers, 'Jira', '').map((t) => t.id)).to.deep.equal(
+      ['tracker-1']
+    );
+    expect(
+      filterTrackers(trackers, 'github', '').map((t) => t.id)
+    ).to.deep.equal(['tracker-2']);
+    expect(
+      filterTrackers(trackers, 'jira.example.com', '').map((t) => t.id)
+    ).to.deep.equal(['tracker-1']);
+  });
+
+  it('filters by tracker kind', () => {
+    expect(
+      filterTrackers(trackers, '', 'github').map((t) => t.id)
+    ).to.deep.equal(['tracker-2']);
+  });
+
+  it('labels known tracker kinds', () => {
+    expect(trackerKindLabel('github')).to.equal('GitHub');
+    expect(trackerKindLabel('gitlab')).to.equal('GitLab');
+    expect(trackerKindLabel('jira')).to.equal('Jira');
+  });
+
+  it('counts included projects from scope rules', () => {
+    expect(
+      trackerProjectsCount({
+        ...trackers[0],
+        scope_rules: [
+          {
+            scope_type: 'PROJECT',
+            rule_type: 'INCLUDE',
+            identifier: 'ONE',
+          },
+          {
+            scope_type: 'PROJECT',
+            rule_type: 'INCLUDE',
+            identifier: 'TWO',
+          },
+        ],
+      })
+    ).to.equal(2);
+    expect(trackerProjectsCount(trackers[0])).to.equal(null);
+  });
+});
 
 describe('TrackerList', () => {
   let fetchStub: sinon.SinonStub;
@@ -73,12 +144,42 @@ describe('TrackerList', () => {
     )) as TrackerList;
 
     await waitUntil(
-      () => el.shadowRoot?.querySelector('.tracker-grid') !== null,
-      'Tracker grid did not render'
+      () => el.shadowRoot?.querySelector('.tracker-row') !== null,
+      'Tracker list did not render'
     );
 
-    const trackerItems = el.shadowRoot?.querySelectorAll('tracker-item');
-    expect(trackerItems).to.have.lengthOf(2);
+    const rows = el.shadowRoot?.querySelectorAll('.tracker-row');
+    expect(rows).to.have.lengthOf(2);
+    expect(el.shadowRoot?.querySelector('list-toolbar')).to.exist;
+  });
+
+  it('switches to the existing cards template', async () => {
+    fetchStub.resolves(
+      new Response(JSON.stringify(mockTrackers), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const el = (await fixture(
+      html`<tracker-list></tracker-list>`
+    )) as TrackerList;
+
+    await waitUntil(
+      () => el.shadowRoot?.querySelector('.tracker-row') !== null,
+      'Tracker list did not render'
+    );
+
+    const toolbar = el.shadowRoot?.querySelector('list-toolbar');
+    const cards = toolbar?.shadowRoot?.querySelector(
+      'sl-button[data-view="cards"]'
+    ) as HTMLElement;
+    cards.click();
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('.tracker-grid')).to.exist;
+    expect(el.shadowRoot?.querySelectorAll('tracker-item')).to.have.lengthOf(2);
+    expect(el.shadowRoot?.querySelector('.tracker-row')).to.equal(null);
   });
 
   it('renders an informative empty state when no trackers', async () => {

--- a/frontend/src/components/tracker-list.ts
+++ b/frontend/src/components/tracker-list.ts
@@ -41,7 +41,7 @@ export function trackerKindLabel(kind: string): string {
   return KIND_LABELS[kind.toLowerCase()] || kind;
 }
 
-export function trackerProjectsCount(tracker: Tracker): number | null {
+export function trackerProjectsCount(tracker: Tracker): number | 'all' {
   const rules = tracker.scope_rules ?? [];
   const projectIncludes = rules.filter(
     (rule) =>
@@ -51,13 +51,11 @@ export function trackerProjectsCount(tracker: Tracker): number | null {
   if (projectIncludes.length > 0) {
     return projectIncludes.length;
   }
-  return null;
+  return 'all';
 }
 
-export function trackerLastSyncAt(tracker: Tracker): string | null {
-  return (
-    tracker.last_validation || tracker.last_updated || tracker.created || null
-  );
+export function trackerLastCheckedAt(tracker: Tracker): string | null {
+  return tracker.last_validation ?? null;
 }
 
 export function filterTrackers(
@@ -451,6 +449,18 @@ export class TrackerList extends LitElement {
         clip: rect(0 0 0 0);
         white-space: nowrap;
       }
+
+      sl-select::part(form-control-label) {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+        border: 0;
+      }
     `,
   ];
 
@@ -460,13 +470,14 @@ export class TrackerList extends LitElement {
         <list-toolbar
           .search=${this.search}
           searchPlaceholder="Search trackers"
+          toggleLabel="Trackers view"
           .view=${this.currentView}
-          .views=${['list', 'cards']}
           @search-change=${this.handleSearchChange}
           @view-change=${this.handleViewChange}
         >
           <sl-select
             class="kind-filter"
+            label="Kind"
             clearable
             placeholder="All kinds"
             .value=${this.kindFilter}
@@ -495,7 +506,7 @@ export class TrackerList extends LitElement {
               <th>Kind</th>
               <th class="numeric">Projects</th>
               <th>Sync</th>
-              <th>Last sync</th>
+              <th>Last checked</th>
               <th class="actions-cell">
                 <span class="visually-hidden">Actions</span>
               </th>
@@ -515,7 +526,7 @@ export class TrackerList extends LitElement {
 
   private renderListRow(tracker: Tracker) {
     const projects = trackerProjectsCount(tracker);
-    const lastSync = trackerLastSyncAt(tracker);
+    const lastChecked = trackerLastCheckedAt(tracker);
     const connected = tracker.is_valid !== false;
     return html`
       <tr
@@ -542,8 +553,8 @@ export class TrackerList extends LitElement {
         </td>
         <td class="numeric">
           ${
-            projects === null
-              ? html`<span class="muted-cell">None</span>`
+            projects === 'all'
+              ? html`<span class="muted-cell">All</span>`
               : projects
           }
         </td>
@@ -553,7 +564,7 @@ export class TrackerList extends LitElement {
           </sl-badge>
         </td>
         <td class="muted-cell">
-          ${lastSync ? formatRelativeTime(lastSync) : html`<span>Never</span>`}
+          ${lastChecked ? formatRelativeTime(lastChecked) : nothing}
         </td>
         <td class="actions-cell">
           <div
@@ -605,7 +616,7 @@ export class TrackerList extends LitElement {
   }
 
   render() {
-    if (this.isLoading) {
+    if (this.isLoading && this.trackers.length === 0) {
       return html`<div class="loading-indicator">
         <sl-spinner></sl-spinner>
       </div>`;
@@ -646,8 +657,11 @@ export class TrackerList extends LitElement {
     }
 
     const visible = this.visibleTrackers;
-    const body =
-      visible.length === 0
+    const body = this.isLoading
+      ? html`<div class="loading-indicator">
+          <sl-spinner></sl-spinner>
+        </div>`
+      : visible.length === 0
         ? html`<div class="filter-empty">No trackers match these filters.</div>`
         : this.effectiveView === 'cards'
           ? this.renderCardsView(visible)

--- a/frontend/src/components/tracker-list.ts
+++ b/frontend/src/components/tracker-list.ts
@@ -1,12 +1,89 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing, unsafeCSS } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
+import { Router } from '@vaadin/router';
 import { fetchWithAuth } from '../api.js';
+import { formatRelativeTime } from '../utils/date';
+import {
+  effectiveViewMode,
+  loadViewMode,
+  saveViewMode,
+  subscribeNarrowViewport,
+  type ListViewMode,
+  type NarrowViewportSubscription,
+} from '../utils/view-mode';
+import type { ResourceAction } from './resource-actions.ts';
+import consoleStyles from '../styles/console-styles.css?inline';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
+import '@shoelace-style/shoelace/dist/components/badge/badge.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/card/card.js';
+import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/option/option.js';
+import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import './tracker-item.ts';
+import './list-toolbar.ts';
+import './resource-actions.ts';
 import type { Tracker } from './tracker-item.ts';
+import { consoleDialogStyles } from '../styles/console-dialog';
+
+const VIEW_MODE_KEY = 'preloop.trackers.view_mode';
+
+const KIND_LABELS: Record<string, string> = {
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  jira: 'Jira',
+};
+
+export function trackerKindLabel(kind: string): string {
+  return KIND_LABELS[kind.toLowerCase()] || kind;
+}
+
+export function trackerProjectsCount(tracker: Tracker): number | null {
+  const rules = tracker.scope_rules ?? [];
+  const projectIncludes = rules.filter(
+    (rule) =>
+      rule.scope_type?.toUpperCase() === 'PROJECT' &&
+      rule.rule_type?.toUpperCase() === 'INCLUDE'
+  );
+  if (projectIncludes.length > 0) {
+    return projectIncludes.length;
+  }
+  return null;
+}
+
+export function trackerLastSyncAt(tracker: Tracker): string | null {
+  return (
+    tracker.last_validation || tracker.last_updated || tracker.created || null
+  );
+}
+
+export function filterTrackers(
+  trackers: Tracker[],
+  search: string,
+  kind: string
+): Tracker[] {
+  const query = search.trim().toLowerCase();
+  return trackers.filter((tracker) => {
+    if (kind && tracker.tracker_type !== kind) {
+      return false;
+    }
+    if (!query) {
+      return true;
+    }
+    const haystack = [
+      tracker.name,
+      tracker.tracker_type,
+      trackerKindLabel(tracker.tracker_type),
+      tracker.url ?? '',
+    ]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(query);
+  });
+}
 
 @customElement('tracker-list')
 export class TrackerList extends LitElement {
@@ -19,9 +96,36 @@ export class TrackerList extends LitElement {
   @state()
   private error: string | null = null;
 
+  @state()
+  private search = '';
+
+  @state()
+  private kindFilter = '';
+
+  @state()
+  private currentView: ListViewMode = loadViewMode(VIEW_MODE_KEY);
+
+  @state()
+  private narrowViewport = false;
+
+  @state()
+  private trackerPendingDelete: Tracker | null = null;
+
+  private narrowViewportSubscription: NarrowViewportSubscription | null = null;
+
   connectedCallback() {
     super.connectedCallback();
+    this.narrowViewportSubscription = subscribeNarrowViewport((narrow) => {
+      this.narrowViewport = narrow;
+    });
+    this.narrowViewport = this.narrowViewportSubscription.matches;
     this.fetchTrackers();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.narrowViewportSubscription?.disconnect();
+    this.narrowViewportSubscription = null;
   }
 
   async fetchTrackers() {
@@ -35,7 +139,7 @@ export class TrackerList extends LitElement {
       this.trackers = await response.json();
       this.dispatchEvent(
         new CustomEvent('trackers-changed', {
-          detail: { count: this.trackers.length },
+          detail: { count: this.trackers.length, trackers: this.trackers },
           bubbles: true,
           composed: true,
         })
@@ -46,6 +150,30 @@ export class TrackerList extends LitElement {
     } finally {
       this.isLoading = false;
     }
+  }
+
+  private get visibleTrackers(): Tracker[] {
+    return filterTrackers(this.trackers, this.search, this.kindFilter);
+  }
+
+  private get effectiveView(): ListViewMode {
+    return effectiveViewMode(this.currentView, this.narrowViewport);
+  }
+
+  private get kindOptions(): string[] {
+    return [...new Set(this.trackers.map((tracker) => tracker.tracker_type))]
+      .filter(Boolean)
+      .sort((a, b) => trackerKindLabel(a).localeCompare(trackerKindLabel(b)));
+  }
+
+  private get resultsLabel(): string {
+    const shown = this.visibleTrackers.length;
+    const total = this.trackers.length;
+    const noun = total === 1 ? 'tracker' : 'trackers';
+    if (shown === total) {
+      return `${shown} ${noun}`;
+    }
+    return `${shown} of ${total} ${noun}`;
   }
 
   private _handleTrackerEdit(event: CustomEvent) {
@@ -67,8 +195,37 @@ export class TrackerList extends LitElement {
     );
   }
 
+  private _editTracker(tracker: Tracker) {
+    this.dispatchEvent(
+      new CustomEvent('tracker-edit', {
+        detail: { tracker },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _requestDelete(tracker: Tracker) {
+    this.trackerPendingDelete = tracker;
+  }
+
+  private _cancelDelete() {
+    this.trackerPendingDelete = null;
+  }
+
+  private async _confirmDelete() {
+    const tracker = this.trackerPendingDelete;
+    this.trackerPendingDelete = null;
+    if (!tracker) return;
+    await this._deleteTracker(tracker.id);
+  }
+
   private async _handleTrackerDeleted(event: CustomEvent) {
     const { id } = event.detail;
+    await this._deleteTracker(id);
+  }
+
+  private async _deleteTracker(id: string) {
     try {
       const response = await fetchWithAuth(`/api/v1/trackers/${id}`, {
         method: 'DELETE',
@@ -83,89 +240,369 @@ export class TrackerList extends LitElement {
     }
   }
 
-  static styles = css`
-    .tracker-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-      gap: var(--sl-spacing-large);
-      padding-top: var(--sl-spacing-medium);
-    }
+  private handleSearchChange(event: CustomEvent<{ value: string }>) {
+    this.search = event.detail.value;
+  }
 
-    .loading-indicator {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100px;
-    }
+  private handleViewChange(event: CustomEvent<{ value: ListViewMode }>) {
+    this.currentView = event.detail.value;
+    saveViewMode(VIEW_MODE_KEY, event.detail.value);
+  }
 
-    .empty-state-wrapper {
-      display: flex;
-      justify-content: center;
-      width: 100%;
-      margin-top: var(--sl-spacing-large);
-    }
+  private handleKindChange(event: Event) {
+    const select = event.target as HTMLElement & { value: string | string[] };
+    const value = Array.isArray(select.value) ? select.value[0] : select.value;
+    this.kindFilter = value || '';
+  }
 
-    .empty-card {
-      width: 100%;
-      max-width: 580px;
-    }
-
-    .empty-card::part(base) {
-      border: 1px solid
-        color-mix(in srgb, var(--sl-color-primary-600) 35%, transparent);
-      box-shadow: var(--sl-shadow-large);
-      border-radius: var(--sl-border-radius-large);
-      overflow: hidden;
-    }
-
-    .empty-card-body {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      text-align: center;
-      padding: var(--sl-spacing-large);
-    }
-
-    .empty-icon-circle {
-      width: 72px;
-      height: 72px;
-      border-radius: 50%;
-      background: color-mix(
-        in srgb,
-        var(--sl-color-primary-600) 15%,
-        transparent
+  private handleRowClick(event: MouseEvent, tracker: Tracker) {
+    const path = event.composedPath();
+    const blocked = path.some((node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const tag = node.tagName.toLowerCase();
+      return (
+        tag === 'a' ||
+        tag === 'sl-button' ||
+        tag === 'resource-actions' ||
+        tag === 'sl-dropdown'
       );
-      color: var(--sl-color-primary-600);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin-bottom: var(--sl-spacing-medium);
-    }
+    });
+    if (blocked) return;
+    Router.go(`/console/trackers/${tracker.id}`);
+  }
 
-    .empty-icon-circle sl-icon {
-      font-size: 2.5rem;
-    }
+  private rowActions(tracker: Tracker): ResourceAction[] {
+    return [
+      {
+        id: 'edit',
+        label: 'Edit',
+        icon: 'pencil',
+        onClick: () => this._editTracker(tracker),
+      },
+      {
+        id: 'delete',
+        label: 'Delete',
+        icon: 'trash',
+        variant: 'danger',
+        onClick: () => this._requestDelete(tracker),
+      },
+    ];
+  }
 
-    .empty-card-title {
-      margin: 0 0 var(--sl-spacing-2x-small);
-      font-size: 1.25rem;
-      font-weight: 700;
-      color: var(--sl-color-neutral-900);
-    }
+  static styles = [
+    consoleDialogStyles,
+    unsafeCSS(consoleStyles),
+    css`
+      :host {
+        display: block;
+      }
 
-    .empty-card-desc {
-      margin: 0 0 var(--sl-spacing-large);
-      max-width: 440px;
-      font-size: 0.95rem;
-      line-height: 1.55;
-      color: var(--sl-color-neutral-600);
-    }
+      .toolbar-wrap {
+        margin-bottom: var(--sl-spacing-medium);
+      }
 
-    .empty-cta-btn {
-      width: 100%;
-      max-width: 280px;
-    }
-  `;
+      .tracker-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+        gap: var(--sl-spacing-large);
+        padding-top: var(--sl-spacing-medium);
+      }
+
+      .loading-indicator {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100px;
+      }
+
+      .empty-state-wrapper {
+        display: flex;
+        justify-content: center;
+        width: 100%;
+        margin-top: var(--sl-spacing-large);
+      }
+
+      .empty-card {
+        width: 100%;
+        max-width: 580px;
+      }
+
+      .empty-card::part(base) {
+        border: 1px solid
+          color-mix(in srgb, var(--sl-color-primary-600) 35%, transparent);
+        box-shadow: var(--sl-shadow-large);
+        border-radius: var(--sl-border-radius-large);
+        overflow: hidden;
+      }
+
+      .empty-card-body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        padding: var(--sl-spacing-large);
+      }
+
+      .empty-icon-circle {
+        width: 72px;
+        height: 72px;
+        border-radius: 50%;
+        background: color-mix(
+          in srgb,
+          var(--sl-color-primary-600) 15%,
+          transparent
+        );
+        color: var(--sl-color-primary-600);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: var(--sl-spacing-medium);
+      }
+
+      .empty-icon-circle sl-icon {
+        font-size: 2.5rem;
+      }
+
+      .empty-card-title {
+        margin: 0 0 var(--sl-spacing-2x-small);
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: var(--sl-color-neutral-900);
+      }
+
+      .empty-card-desc {
+        margin: 0 0 var(--sl-spacing-large);
+        max-width: 440px;
+        font-size: 0.95rem;
+        line-height: 1.55;
+        color: var(--sl-color-neutral-600);
+      }
+
+      .empty-cta-btn {
+        width: 100%;
+        max-width: 280px;
+      }
+
+      .filter-empty {
+        color: var(--console-meta-color);
+        font-size: var(--console-text-body);
+        padding: var(--sl-spacing-large) 0;
+      }
+
+      .trackers-table {
+        table-layout: fixed;
+        width: 100%;
+      }
+
+      .trackers-table th.actions-cell,
+      .trackers-table td.actions-cell {
+        width: 72px;
+        text-align: right;
+        padding-left: var(--sl-spacing-x-small);
+        padding-right: var(--sl-spacing-x-small);
+        overflow: visible;
+      }
+
+      .actions-cell resource-actions::part(container) {
+        overflow: visible;
+      }
+
+      .tracker-row {
+        cursor: pointer;
+      }
+
+      .row-link {
+        color: var(--console-link-color);
+        display: block;
+        font-weight: var(--sl-font-weight-semibold);
+        overflow: hidden;
+        text-decoration: none;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .row-link:hover,
+      .row-link:focus-visible {
+        text-decoration: underline;
+      }
+
+      .row-subtitle {
+        color: var(--console-meta-color);
+        font-size: var(--console-text-meta);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .muted-cell {
+        color: var(--console-meta-color);
+      }
+
+      .numeric {
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+      }
+
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+      }
+    `,
+  ];
+
+  private renderToolbar() {
+    return html`
+      <div class="toolbar-wrap">
+        <list-toolbar
+          .search=${this.search}
+          searchPlaceholder="Search trackers"
+          .view=${this.currentView}
+          .views=${['list', 'cards']}
+          @search-change=${this.handleSearchChange}
+          @view-change=${this.handleViewChange}
+        >
+          <sl-select
+            class="kind-filter"
+            clearable
+            placeholder="All kinds"
+            .value=${this.kindFilter}
+            @sl-change=${this.handleKindChange}
+          >
+            ${this.kindOptions.map(
+              (kind) =>
+                html`<sl-option value=${kind}
+                  >${trackerKindLabel(kind)}</sl-option
+                >`
+            )}
+          </sl-select>
+          <span slot="count">${this.resultsLabel}</span>
+        </list-toolbar>
+      </div>
+    `;
+  }
+
+  private renderListView(trackers: Tracker[]) {
+    return html`
+      <sl-card class="table-card">
+        <table class="styled-table trackers-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Kind</th>
+              <th class="numeric">Projects</th>
+              <th>Sync</th>
+              <th>Last sync</th>
+              <th class="actions-cell">
+                <span class="visually-hidden">Actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            ${repeat(
+              trackers,
+              (tracker) => tracker.id,
+              (tracker) => this.renderListRow(tracker)
+            )}
+          </tbody>
+        </table>
+      </sl-card>
+    `;
+  }
+
+  private renderListRow(tracker: Tracker) {
+    const projects = trackerProjectsCount(tracker);
+    const lastSync = trackerLastSyncAt(tracker);
+    const connected = tracker.is_valid !== false;
+    return html`
+      <tr
+        class="tracker-row"
+        data-tracker-id=${tracker.id}
+        @click=${(event: MouseEvent) => this.handleRowClick(event, tracker)}
+      >
+        <td>
+          <a class="row-link" href=${`/console/trackers/${tracker.id}`}
+            >${tracker.name}</a
+          >
+          ${
+            tracker.url
+              ? html`<div class="row-subtitle" title=${tracker.url}>
+                  ${tracker.url}
+                </div>`
+              : nothing
+          }
+        </td>
+        <td>
+          <sl-badge variant="neutral" pill
+            >${trackerKindLabel(tracker.tracker_type)}</sl-badge
+          >
+        </td>
+        <td class="numeric">
+          ${
+            projects === null
+              ? html`<span class="muted-cell">None</span>`
+              : projects
+          }
+        </td>
+        <td>
+          <sl-badge variant=${connected ? 'success' : 'danger'} pill>
+            ${connected ? 'Connected' : 'Action Required'}
+          </sl-badge>
+        </td>
+        <td class="muted-cell">
+          ${lastSync ? formatRelativeTime(lastSync) : html`<span>Never</span>`}
+        </td>
+        <td class="actions-cell">
+          <div
+            class="row-actions"
+            @click=${(event: Event) => event.stopPropagation()}
+          >
+            <resource-actions
+              .actions=${this.rowActions(tracker)}
+              menu-only
+            ></resource-actions>
+          </div>
+        </td>
+      </tr>
+    `;
+  }
+
+  private renderCardsView(trackers: Tracker[]) {
+    return html`
+      <div class="tracker-grid">
+        ${repeat(
+          trackers,
+          (tracker) => tracker.id,
+          (tracker) =>
+            html`<tracker-item
+              .tracker=${tracker}
+              @tracker-deleted=${this._handleTrackerDeleted}
+              @tracker-edit=${this._handleTrackerEdit}
+            ></tracker-item>`
+        )}
+      </div>
+    `;
+  }
+
+  private renderDeleteDialog() {
+    return html`
+      <sl-dialog
+        label="Confirm Deletion"
+        ?open=${this.trackerPendingDelete !== null}
+        @sl-hide=${this._cancelDelete}
+      >
+        Are you sure you want to delete the tracker
+        "${this.trackerPendingDelete?.name}"?
+        <sl-button slot="footer" @click=${this._cancelDelete}>Cancel</sl-button>
+        <sl-button slot="footer" variant="danger" @click=${this._confirmDelete}
+          >Delete</sl-button
+        >
+      </sl-dialog>
+    `;
+  }
 
   render() {
     if (this.isLoading) {
@@ -208,19 +645,14 @@ export class TrackerList extends LitElement {
       `;
     }
 
-    return html`
-      <div class="tracker-grid">
-        ${repeat(
-          this.trackers,
-          (tracker) => tracker.id,
-          (tracker) =>
-            html`<tracker-item
-              .tracker=${tracker}
-              @tracker-deleted=${this._handleTrackerDeleted}
-              @tracker-edit=${this._handleTrackerEdit}
-            ></tracker-item>`
-        )}
-      </div>
-    `;
+    const visible = this.visibleTrackers;
+    const body =
+      visible.length === 0
+        ? html`<div class="filter-empty">No trackers match these filters.</div>`
+        : this.effectiveView === 'cards'
+          ? this.renderCardsView(visible)
+          : this.renderListView(visible);
+
+    return html` ${this.renderToolbar()} ${body} ${this.renderDeleteDialog()} `;
   }
 }

--- a/frontend/src/utils/tracker-scope.test.ts
+++ b/frontend/src/utils/tracker-scope.test.ts
@@ -31,6 +31,14 @@ describe('describeTrackerScope', () => {
     },
   ];
 
+  it('describes an empty rule set without an em dash', () => {
+    const summary = describeTrackerScope(undefined, orgs, []);
+    expect(summary).to.equal(
+      'No scope configured. Sync to discover groups and projects from your tracker.'
+    );
+    expect(summary).to.not.include('\u2014');
+  });
+
   it('describes org-wide scope with human-readable group names', () => {
     const summary = describeTrackerScope(
       [

--- a/frontend/src/utils/tracker-scope.ts
+++ b/frontend/src/utils/tracker-scope.ts
@@ -39,7 +39,7 @@ export function describeTrackerScope(
   if (!rules?.length) {
     return synced > 0
       ? `${synced} project${synced === 1 ? '' : 's'} synced from this tracker.`
-      : 'No scope configured — sync to discover groups and projects from your tracker.';
+      : 'No scope configured. Sync to discover groups and projects from your tracker.';
   }
 
   const orgIncludes = rules.filter(

--- a/frontend/src/utils/view-mode.test.ts
+++ b/frontend/src/utils/view-mode.test.ts
@@ -1,0 +1,121 @@
+import { expect } from '@open-wc/testing';
+import sinon from 'sinon';
+
+import {
+  DEFAULT_LIST_VIEW,
+  LIST_TO_CARDS_BREAKPOINT,
+  effectiveViewMode,
+  isListViewMode,
+  loadViewMode,
+  saveViewMode,
+  subscribeNarrowViewport,
+} from './view-mode';
+
+describe('view-mode', () => {
+  const key = 'preloop.test.view_mode';
+
+  afterEach(() => {
+    localStorage.removeItem(key);
+  });
+
+  it('treats list and cards as valid modes', () => {
+    expect(isListViewMode('list')).to.equal(true);
+    expect(isListViewMode('cards')).to.equal(true);
+    expect(isListViewMode('canvas')).to.equal(false);
+    expect(isListViewMode(null)).to.equal(false);
+  });
+
+  it('loads a stored view when it is in the allowed set', () => {
+    localStorage.setItem(key, 'cards');
+    expect(loadViewMode(key)).to.equal('cards');
+  });
+
+  it('falls back to list when nothing is stored', () => {
+    expect(loadViewMode(key)).to.equal(DEFAULT_LIST_VIEW);
+    expect(loadViewMode(key)).to.equal('list');
+  });
+
+  it('falls back when the stored value is not allowed', () => {
+    localStorage.setItem(key, 'carousel');
+    expect(loadViewMode(key)).to.equal('list');
+  });
+
+  it('honours a page-specific allowed set and fallback', () => {
+    localStorage.setItem(key, 'cards');
+    expect(loadViewMode(key, ['list'], 'list')).to.equal('list');
+    expect(loadViewMode(key, ['list', 'cards'], 'list')).to.equal('cards');
+  });
+
+  it('falls back when localStorage throws', () => {
+    const stub = sinon.stub(window.localStorage, 'getItem').throws();
+    try {
+      expect(loadViewMode(key)).to.equal('list');
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it('saves the view for the next visit', () => {
+    saveViewMode(key, 'cards');
+    expect(localStorage.getItem(key)).to.equal('cards');
+  });
+
+  it('swallows save failures', () => {
+    const stub = sinon.stub(window.localStorage, 'setItem').throws();
+    try {
+      expect(() => saveViewMode(key, 'cards')).not.to.throw();
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it('paints cards on a narrow viewport without changing the stored choice', () => {
+    expect(effectiveViewMode('list', true)).to.equal('cards');
+    expect(effectiveViewMode('list', false)).to.equal('list');
+    expect(effectiveViewMode('cards', true)).to.equal('cards');
+    expect(effectiveViewMode('cards', false)).to.equal('cards');
+  });
+
+  it('subscribes to the Flows list-to-cards breakpoint', () => {
+    const listeners: Array<(event: MediaQueryListEvent) => void> = [];
+    const matchMedia = sinon.stub(window, 'matchMedia').callsFake(
+      (query: string) =>
+        ({
+          matches: query === LIST_TO_CARDS_BREAKPOINT,
+          media: query,
+          addEventListener: (
+            _type: string,
+            handler: (event: MediaQueryListEvent) => void
+          ) => {
+            listeners.push(handler);
+          },
+          removeEventListener: (
+            _type: string,
+            handler: (event: MediaQueryListEvent) => void
+          ) => {
+            const index = listeners.indexOf(handler);
+            if (index >= 0) listeners.splice(index, 1);
+          },
+          addListener: () => undefined,
+          removeListener: () => undefined,
+          onchange: null,
+          dispatchEvent: () => false,
+        }) as unknown as MediaQueryList
+    );
+
+    try {
+      const seen: boolean[] = [];
+      const subscription = subscribeNarrowViewport((narrow) => {
+        seen.push(narrow);
+      });
+      expect(subscription.matches).to.equal(true);
+      expect(matchMedia).to.have.been.calledWith(LIST_TO_CARDS_BREAKPOINT);
+      listeners[0]?.({ matches: false } as MediaQueryListEvent);
+      expect(seen).to.deep.equal([false]);
+      subscription.disconnect();
+      expect(listeners).to.deep.equal([]);
+    } finally {
+      matchMedia.restore();
+    }
+  });
+});

--- a/frontend/src/utils/view-mode.ts
+++ b/frontend/src/utils/view-mode.ts
@@ -1,0 +1,102 @@
+/**
+ * Persisted list/cards view mode for collection pages.
+ *
+ * Copied from the Flows page so Trackers and Models (and, later, Agents and
+ * Flows themselves) share one storage contract. List is the default
+ * (DESIGN.md, "Tables and views"): a table compares rows; cards are for
+ * browsing and for phones. A stored choice wins. The narrow-viewport
+ * fallback never overwrites that choice.
+ */
+
+export type ListViewMode = 'list' | 'cards';
+
+export const LIST_VIEW_MODES: readonly ListViewMode[] = ['list', 'cards'];
+
+/** List is the default so thirty items are compared, not browsed. */
+export const DEFAULT_LIST_VIEW: ListViewMode = 'list';
+
+/**
+ * Below this width a multi-column table cannot hold its content, so cards
+ * take over. Matches the Flows switcher hide rule.
+ */
+export const LIST_TO_CARDS_BREAKPOINT = '(max-width: 640px)';
+
+export function isListViewMode(
+  value: string | null | undefined,
+  allowed: readonly string[] = LIST_VIEW_MODES
+): value is ListViewMode {
+  return Boolean(value && allowed.includes(value));
+}
+
+/**
+ * Read the stored view for a page. Invalid or missing values fall back to
+ * `fallback` (list, unless a page opts out).
+ */
+export function loadViewMode(
+  storageKey: string,
+  allowed: readonly string[] = LIST_VIEW_MODES,
+  fallback: ListViewMode = DEFAULT_LIST_VIEW
+): ListViewMode {
+  try {
+    const saved = localStorage.getItem(storageKey);
+    if (isListViewMode(saved, allowed)) {
+      return saved;
+    }
+  } catch {
+    // Private mode and quota errors must not take the page down.
+  }
+  return fallback;
+}
+
+/** Persist the user's view choice. Failures are ignored. */
+export function saveViewMode(storageKey: string, view: string): void {
+  try {
+    localStorage.setItem(storageKey, view);
+  } catch {
+    // Same as load: storage is a preference, not a requirement.
+  }
+}
+
+/**
+ * The view actually painted. On a phone a multi-column table would either
+ * scroll sideways or crush every cell, so `list` renders as cards.
+ */
+export function effectiveViewMode(
+  current: ListViewMode,
+  narrowViewport: boolean
+): ListViewMode {
+  if (current === 'list' && narrowViewport) {
+    return 'cards';
+  }
+  return current;
+}
+
+export interface NarrowViewportSubscription {
+  matches: boolean;
+  disconnect: () => void;
+}
+
+/**
+ * Subscribe to the list-to-cards breakpoint. Returns the current match and
+ * a disconnect function for `disconnectedCallback`.
+ */
+export function subscribeNarrowViewport(
+  onChange: (narrow: boolean) => void,
+  query: string = LIST_TO_CARDS_BREAKPOINT
+): NarrowViewportSubscription {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return { matches: false, disconnect: () => undefined };
+  }
+  const mediaQuery = window.matchMedia(query);
+  const handler = (event: MediaQueryListEvent) => {
+    onChange(event.matches);
+  };
+  mediaQuery.addEventListener('change', handler);
+  return {
+    matches: mediaQuery.matches,
+    disconnect: () => mediaQuery.removeEventListener('change', handler),
+  };
+}

--- a/frontend/src/views/authed/settings/ai-models-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.test.ts
@@ -3,7 +3,12 @@ import sinon from 'sinon';
 
 import { unifiedWebSocketManager } from '../../../services/unified-websocket-manager';
 import './ai-models-view';
-import type { AIModelsView } from './ai-models-view';
+import {
+  filterModels,
+  isGatewayEnabled,
+  type AIModelsView,
+} from './ai-models-view';
+import type { AIModel } from '../../../types';
 
 describe('AIModelsView', () => {
   let fetchStub: sinon.SinonStub;
@@ -147,5 +152,140 @@ describe('AIModelsView', () => {
     expect(viewButton).to.not.equal(null);
     expect(connectStub).to.have.been.calledOnce;
     expect(subscribeStub.callCount).to.equal(5);
+  });
+
+  const secondModel = {
+    id: 'model-2',
+    name: 'GPT-4o Mini',
+    provider_name: 'OpenAI',
+    model_identifier: 'gpt-4o-mini',
+    meta_data: {
+      gateway: { enabled: false, model_alias: 'preloop/openai/gpt-4o-mini' },
+    },
+    is_default: false,
+    created_at: '2026-03-01T10:00:00Z',
+    updated_at: '2026-03-09T18:30:00Z',
+  };
+
+  it('filters models by name and provider', () => {
+    const models = [
+      {
+        id: 'model-1',
+        name: 'Claude Sonnet Primary',
+        provider_name: 'Anthropic',
+        model_identifier: 'claude-sonnet-4',
+        created_at: '2026-03-01T10:00:00Z',
+        updated_at: '2026-03-09T18:30:00Z',
+      },
+      secondModel,
+    ] as AIModel[];
+    expect(
+      filterModels(models, 'claude', '', '').map((m) => m.id)
+    ).to.deep.equal(['model-1']);
+    expect(
+      filterModels(models, '', 'OpenAI', '').map((m) => m.id)
+    ).to.deep.equal(['model-2']);
+    expect(
+      filterModels(models, '', '', 'disabled').map((m) => m.id)
+    ).to.deep.equal(['model-2']);
+    expect(isGatewayEnabled(secondModel as AIModel)).to.equal(false);
+  });
+
+  it('narrows list rows when search matches one model', async () => {
+    fetchStub.restore();
+    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub.callsFake(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url === '/api/v1/ai-models') {
+        return new Response(
+          JSON.stringify([
+            {
+              id: 'model-1',
+              name: 'Claude Sonnet Primary',
+              provider_name: 'Anthropic',
+              model_identifier: 'claude-sonnet-4',
+              meta_data: { gateway: { enabled: true } },
+              is_default: true,
+              created_at: '2026-03-01T10:00:00Z',
+              updated_at: '2026-03-09T18:30:00Z',
+            },
+            secondModel,
+          ]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (url.startsWith('/api/v1/ai-models/overview')) {
+        return new Response(
+          JSON.stringify({
+            period_start: '2026-02-09T00:00:00Z',
+            period_end: '2026-03-09T23:59:59Z',
+            models: [],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      return new Response(JSON.stringify({ detail: url }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const element = (await fixture(
+      html`<ai-models-view></ai-models-view>`
+    )) as AIModelsView;
+    await waitUntil(
+      () => !(element as any).isLoading,
+      'AI models view did not finish loading'
+    );
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.querySelectorAll('.model-row')).to.have.lengthOf(
+      2
+    );
+
+    const toolbar = element.shadowRoot?.querySelector('list-toolbar');
+    expect(toolbar).to.exist;
+    toolbar!.dispatchEvent(
+      new CustomEvent('search-change', {
+        detail: { value: 'openai' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await element.updateComplete;
+
+    const rows = element.shadowRoot?.querySelectorAll('.model-row');
+    expect(rows).to.have.lengthOf(1);
+    expect(rows?.[0].textContent).to.include('GPT-4o Mini');
+  });
+
+  it('switches from list rows to cards', async () => {
+    const element = (await fixture(
+      html`<ai-models-view></ai-models-view>`
+    )) as AIModelsView;
+    await waitUntil(
+      () => !(element as any).isLoading,
+      'AI models view did not finish loading'
+    );
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.querySelector('.model-row')).to.exist;
+    expect(element.shadowRoot?.querySelector('.models-grid')).to.equal(null);
+
+    const toolbar = element.shadowRoot?.querySelector('list-toolbar');
+    toolbar!.dispatchEvent(
+      new CustomEvent('view-change', {
+        detail: { value: 'cards' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.querySelector('.models-grid')).to.exist;
+    expect(element.shadowRoot?.querySelector('.model-card')).to.exist;
+    expect(element.shadowRoot?.querySelector('.model-row')).to.equal(null);
+    expect(element.shadowRoot?.textContent).to.contain('Default');
+    expect(element.shadowRoot?.textContent).to.contain('View');
   });
 });

--- a/frontend/src/views/authed/settings/ai-models-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.test.ts
@@ -215,10 +215,12 @@ describe('AIModelsView', () => {
     expect(
       filterModels(models, '', 'OpenAI', '').map((m) => m.id)
     ).to.deep.equal(['model-2']);
+    expect(isGatewayEnabled(models[0])).to.equal(false);
+    expect(isGatewayEnabled(secondModel as AIModel)).to.equal(false);
     expect(
       filterModels(models, '', '', 'disabled').map((m) => m.id)
-    ).to.deep.equal(['model-2']);
-    expect(isGatewayEnabled(secondModel as AIModel)).to.equal(false);
+    ).to.deep.equal(['model-1', 'model-2']);
+    expect(filterModels(models, '', '', 'enabled')).to.deep.equal([]);
   });
 
   it('narrows list rows when search matches one model', async () => {

--- a/frontend/src/views/authed/settings/ai-models-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.test.ts
@@ -16,6 +16,7 @@ describe('AIModelsView', () => {
   let subscribeStub: sinon.SinonStub;
 
   beforeEach(() => {
+    localStorage.removeItem('preloop.models.view_mode');
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
 
@@ -105,6 +106,7 @@ describe('AIModelsView', () => {
     fetchStub.restore();
     connectStub.restore();
     subscribeStub.restore();
+    localStorage.removeItem('preloop.models.view_mode');
     localStorage.clear();
   });
 
@@ -152,6 +154,34 @@ describe('AIModelsView', () => {
     expect(viewButton).to.not.equal(null);
     expect(connectStub).to.have.been.calledOnce;
     expect(subscribeStub.callCount).to.equal(5);
+
+    const providerSelect = element.shadowRoot?.querySelector(
+      'sl-select.provider-filter'
+    );
+    const statusSelect = element.shadowRoot?.querySelector(
+      'sl-select.status-filter'
+    );
+    expect(providerSelect?.getAttribute('label')).to.equal('Provider');
+    expect(statusSelect?.getAttribute('label')).to.equal('Status');
+  });
+
+  it('hides the toolbar when a refresh fails with models still loaded', async () => {
+    const element = (await fixture(
+      html`<ai-models-view></ai-models-view>`
+    )) as AIModelsView;
+
+    await waitUntil(
+      () => !(element as any).isLoading,
+      'AI models view did not finish loading'
+    );
+    await element.updateComplete;
+    expect(element.shadowRoot?.querySelector('list-toolbar')).to.exist;
+
+    (element as any).error = 'Failed to refresh models';
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.querySelector('list-toolbar')).to.equal(null);
+    expect(element.shadowRoot?.querySelector('sl-alert')).to.exist;
   });
 
   const secondModel = {

--- a/frontend/src/views/authed/settings/ai-models-view.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.ts
@@ -14,14 +14,60 @@ import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/option/option.js';
+import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '../../../components/add-ai-model-modal';
+import '../../../components/list-toolbar';
 import { unifiedWebSocketManager } from '../../../services/unified-websocket-manager';
 import { formatRelativeTime } from '../../../utils/date';
+import {
+  effectiveViewMode,
+  loadViewMode,
+  saveViewMode,
+  subscribeNarrowViewport,
+  type ListViewMode,
+  type NarrowViewportSubscription,
+} from '../../../utils/view-mode';
 import consoleStyles from '../../../styles/console-styles.css?inline';
 import { consoleDialogStyles } from '../../../styles/console-dialog';
+
+const VIEW_MODE_KEY = 'preloop.models.view_mode';
+
+export function isGatewayEnabled(model: AIModel): boolean {
+  const gateway = model.meta_data?.gateway;
+  if (!gateway || typeof gateway !== 'object') {
+    return true;
+  }
+  return (gateway as { enabled?: boolean }).enabled !== false;
+}
+
+export function filterModels(
+  models: AIModel[],
+  search: string,
+  provider: string,
+  status: string
+): AIModel[] {
+  const query = search.trim().toLowerCase();
+  return models.filter((model) => {
+    if (provider && model.provider_name !== provider) {
+      return false;
+    }
+    if (status === 'enabled' && !isGatewayEnabled(model)) {
+      return false;
+    }
+    if (status === 'disabled' && isGatewayEnabled(model)) {
+      return false;
+    }
+    if (!query) {
+      return true;
+    }
+    const haystack = [model.name, model.provider_name].join(' ').toLowerCase();
+    return haystack.includes(query);
+  });
+}
 
 @customElement('ai-models-view')
 export class AIModelsView extends LitElement {
@@ -57,9 +103,25 @@ export class AIModelsView extends LitElement {
   @state()
   private modelOverview = new Map<string, AIModelOverviewItem>();
 
+  @state()
+  private search = '';
+
+  @state()
+  private providerFilter = '';
+
+  @state()
+  private statusFilter = '';
+
+  @state()
+  private currentView: ListViewMode = loadViewMode(VIEW_MODE_KEY);
+
+  @state()
+  private narrowViewport = false;
+
   private unsubscribeRealtime?: () => void;
   private refreshTimer: number | null = null;
   private refreshInFlight = false;
+  private narrowViewportSubscription: NarrowViewportSubscription | null = null;
 
   static styles = [
     consoleDialogStyles,
@@ -73,6 +135,9 @@ export class AIModelsView extends LitElement {
         display: flex;
         flex-direction: column;
         gap: var(--sl-spacing-large);
+      }
+      .toolbar-wrap {
+        width: 100%;
       }
       .summary-grid {
         display: grid;
@@ -103,10 +168,10 @@ export class AIModelsView extends LitElement {
       .styled-table td {
         padding: var(--sl-spacing-medium);
         text-align: left;
-        border-bottom: 1px solid var(--sl-color-neutral-200);
+        border-bottom: 1px solid var(--console-hairline);
       }
       .styled-table th {
-        background-color: var(--sl-color-neutral-50);
+        background-color: transparent;
         font-weight: var(--sl-font-weight-semibold);
       }
       .styled-table td {
@@ -222,6 +287,33 @@ export class AIModelsView extends LitElement {
         color: var(--sl-color-neutral-600);
         font-size: var(--sl-font-size-small);
       }
+      .filter-empty {
+        color: var(--console-meta-color);
+        font-size: var(--console-text-body);
+        padding: var(--sl-spacing-large) 0;
+      }
+      .models-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        gap: var(--sl-spacing-large);
+      }
+      .model-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-small);
+      }
+      .model-card-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--sl-spacing-small);
+      }
+      .model-card-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sl-spacing-x-small);
+        justify-content: flex-end;
+      }
     `,
   ];
 
@@ -229,12 +321,18 @@ export class AIModelsView extends LitElement {
     super.connectedCallback();
     const isDismissed = localStorage.getItem(this.INFO_ALERT_DISMISSED_KEY);
     this._isInfoAlertOpen = isDismissed !== 'true';
+    this.narrowViewportSubscription = subscribeNarrowViewport((narrow) => {
+      this.narrowViewport = narrow;
+    });
+    this.narrowViewport = this.narrowViewportSubscription.matches;
     void this.fetchModels();
     this.connectRealtime();
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    this.narrowViewportSubscription?.disconnect();
+    this.narrowViewportSubscription = null;
     this.unsubscribeRealtime?.();
     if (this.refreshTimer !== null) {
       window.clearTimeout(this.refreshTimer);
@@ -432,6 +530,56 @@ export class AIModelsView extends LitElement {
     }
   }
 
+  private get visibleModels(): AIModel[] {
+    return filterModels(
+      this.models,
+      this.search,
+      this.providerFilter,
+      this.statusFilter
+    );
+  }
+
+  private get effectiveView(): ListViewMode {
+    return effectiveViewMode(this.currentView, this.narrowViewport);
+  }
+
+  private get providerOptions(): string[] {
+    return [...new Set(this.models.map((model) => model.provider_name))]
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b));
+  }
+
+  private get resultsLabel(): string {
+    const shown = this.visibleModels.length;
+    const total = this.models.length;
+    const noun = total === 1 ? 'model' : 'models';
+    if (shown === total) {
+      return `${shown} ${noun}`;
+    }
+    return `${shown} of ${total} ${noun}`;
+  }
+
+  private handleSearchChange(event: CustomEvent<{ value: string }>) {
+    this.search = event.detail.value;
+  }
+
+  private handleViewChange(event: CustomEvent<{ value: ListViewMode }>) {
+    this.currentView = event.detail.value;
+    saveViewMode(VIEW_MODE_KEY, event.detail.value);
+  }
+
+  private handleProviderChange(event: Event) {
+    const select = event.target as HTMLElement & { value: string | string[] };
+    const value = Array.isArray(select.value) ? select.value[0] : select.value;
+    this.providerFilter = value || '';
+  }
+
+  private handleStatusChange(event: Event) {
+    const select = event.target as HTMLElement & { value: string | string[] };
+    const value = Array.isArray(select.value) ? select.value[0] : select.value;
+    this.statusFilter = value || '';
+  }
+
   private renderFleetOverview() {
     return html`
       <div class="summary-grid">
@@ -519,6 +667,7 @@ export class AIModelsView extends LitElement {
                 ? null
                 : this.renderFleetOverview()
             }
+            ${this.models.length > 0 ? this.renderToolbar() : null}
             ${renderContent()}
           </div>
         </div>
@@ -534,6 +683,45 @@ export class AIModelsView extends LitElement {
       ${this.renderDeleteConfirm()}
     `;
   }
+  private renderToolbar() {
+    return html`
+      <div class="toolbar-wrap">
+        <list-toolbar
+          .search=${this.search}
+          searchPlaceholder="Search models"
+          .view=${this.currentView}
+          .views=${['list', 'cards']}
+          @search-change=${this.handleSearchChange}
+          @view-change=${this.handleViewChange}
+        >
+          <sl-select
+            class="provider-filter"
+            clearable
+            placeholder="All providers"
+            .value=${this.providerFilter}
+            @sl-change=${this.handleProviderChange}
+          >
+            ${this.providerOptions.map(
+              (provider) =>
+                html`<sl-option value=${provider}>${provider}</sl-option>`
+            )}
+          </sl-select>
+          <sl-select
+            class="status-filter"
+            clearable
+            placeholder="Any status"
+            .value=${this.statusFilter}
+            @sl-change=${this.handleStatusChange}
+          >
+            <sl-option value="enabled">Enabled</sl-option>
+            <sl-option value="disabled">Disabled</sl-option>
+          </sl-select>
+          <span slot="count">${this.resultsLabel}</span>
+        </list-toolbar>
+      </div>
+    `;
+  }
+
   renderModelsList() {
     return html`
       ${when(
@@ -562,179 +750,235 @@ export class AIModelsView extends LitElement {
             </sl-card>
           </div>
         `,
-        () => html`
-          <sl-card class="table-card">
-            <table class="styled-table">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Provider</th>
-                  <th>Fleet health</th>
-                  <th>Usage</th>
-                  <th>Default</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                ${repeat(
-                  this.models,
-                  (model) => model.id,
-                  (model) => html`
-                    <tr>
-                      <td>
-                        <a
-                          class="model-link"
-                          href=${`/console/ai-models/${model.id}`}
-                        >
-                          ${model.name}
-                        </a>
-                        <div class="model-meta">${model.model_identifier}</div>
-                        ${
-                          this.getGatewayAlias(model)
-                            ? html`
-                                <div class="model-meta">
-                                  Gateway alias:
-                                  <code>${this.getGatewayAlias(model)}</code>
-                                </div>
-                              `
-                            : null
-                        }
-                        ${
-                          this.getManagedAgentDisplayName(model)
-                            ? html`
-                                <div class="model-meta">
-                                  Managed agent:
-                                  ${this.getManagedAgentDisplayName(model)}
-                                </div>
-                              `
-                            : null
-                        }
-                      </td>
-                      <td>
-                        <div class="cell-stack">
-                          <div class="cell-primary">${model.provider_name}</div>
-                          <div class="cell-secondary">
-                            ${this.getModelKindLabel(model)}
-                          </div>
-                          <div class="cell-secondary">
-                            ${this.getPricingSourceLabel(model.id)}
-                          </div>
-                        </div>
-                      </td>
-                      <td>
-                        <div class="cell-stack">
-                          <div class="badge-row">
-                            <sl-badge
-                              variant=${this.getHealthVariant(model.id)}
-                              pill
-                            >
-                              ${this.getHealthLabel(model.id)}
-                            </sl-badge>
-                            ${
-                              this.getModelOverview(model.id)
-                                ?.active_session_count
-                                ? html`
-                                    <sl-badge variant="primary" pill>
-                                      ${this.formatNumber(
-                                        this.getModelOverview(model.id)
-                                          ?.active_session_count
-                                      )}
-                                      active sessions
-                                    </sl-badge>
-                                  `
-                                : null
-                            }
-                          </div>
-                          <div class="cell-secondary">
-                            ${this.formatNumber(
-                              this.getModelOverview(model.id)
-                                ?.successful_requests
-                            )}
-                            successful ·
-                            ${this.formatNumber(
-                              this.getModelOverview(model.id)?.failed_requests
-                            )}
-                            failed
-                          </div>
-                        </div>
-                      </td>
-                      <td>
-                        <div class="cell-stack">
-                          <div class="cell-primary">
-                            ${this.formatNumber(
-                              this.getModelOverview(model.id)?.total_requests
-                            )}
-                            requests
-                          </div>
-                          <div class="cell-secondary">
-                            ${this.formatNumber(
-                              this.getModelOverview(model.id)?.token_usage
-                                .total_tokens
-                            )}
-                            tokens ·
-                            ${this.formatCurrency(
-                              this.getModelOverview(model.id)?.estimated_cost
-                            )}
-                          </div>
-                          ${
-                            this.getLastRequestLabel(model.id)
-                              ? html`<div class="cell-secondary">
-                                  ${this.getLastRequestLabel(model.id)}
-                                </div>`
-                              : null
-                          }
-                        </div>
-                      </td>
-                      <td>
-                        ${when(
-                          model.is_default,
-                          () =>
-                            html`<sl-badge variant="success" pill
-                              >Default</sl-badge
-                            >`,
-                          () => html`
-                            <sl-button
-                              size="small"
-                              @click=${() => this.handleSetDefault(model)}
-                            >
-                              Set as default
-                            </sl-button>
-                          `
-                        )}
-                      </td>
-                      <td>
-                        <div class="actions">
-                          <sl-button
-                            size="small"
-                            href=${`/console/ai-models/${model.id}`}
-                          >
-                            View
-                          </sl-button>
-                          <sl-button
-                            size="small"
-                            circle
-                            @click=${() => this.openEditModal(model)}
-                          >
-                            <sl-icon name="pencil"></sl-icon>
-                          </sl-button>
-                          <sl-button
-                            variant="danger"
-                            size="small"
-                            circle
-                            @click=${() => this.openDeleteConfirm(model)}
-                          >
-                            <sl-icon name="trash"></sl-icon>
-                          </sl-button>
-                        </div>
-                      </td>
-                    </tr>
-                  `
-                )}
-              </tbody>
-            </table>
-          </sl-card>
-        `
+        () => this.renderFilteredModels()
       )}
+    `;
+  }
+
+  private renderFilteredModels() {
+    const models = this.visibleModels;
+    if (models.length === 0) {
+      return html`<div class="filter-empty">
+        No models match these filters.
+      </div>`;
+    }
+    return this.effectiveView === 'cards'
+      ? this.renderCardsView(models)
+      : this.renderListView(models);
+  }
+
+  private renderDefaultControl(model: AIModel) {
+    return when(
+      model.is_default,
+      () => html`<sl-badge variant="success" pill>Default</sl-badge>`,
+      () => html`
+        <sl-button size="small" @click=${() => this.handleSetDefault(model)}>
+          Set as default
+        </sl-button>
+      `
+    );
+  }
+
+  private renderModelActions(model: AIModel) {
+    return html`
+      <div class="actions">
+        <sl-button size="small" href=${`/console/ai-models/${model.id}`}>
+          View
+        </sl-button>
+        <sl-button
+          size="small"
+          circle
+          @click=${() => this.openEditModal(model)}
+        >
+          <sl-icon name="pencil"></sl-icon>
+        </sl-button>
+        <sl-button
+          variant="danger"
+          size="small"
+          circle
+          @click=${() => this.openDeleteConfirm(model)}
+        >
+          <sl-icon name="trash"></sl-icon>
+        </sl-button>
+      </div>
+    `;
+  }
+
+  private renderListView(models: AIModel[]) {
+    return html`
+      <sl-card class="table-card">
+        <table class="styled-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Provider</th>
+              <th>Fleet health</th>
+              <th>Usage</th>
+              <th>Default</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${repeat(
+              models,
+              (model) => model.id,
+              (model) => this.renderModelRow(model)
+            )}
+          </tbody>
+        </table>
+      </sl-card>
+    `;
+  }
+
+  private renderModelRow(model: AIModel) {
+    return html`
+      <tr class="model-row" data-model-id=${model.id}>
+        <td>
+          <a class="model-link" href=${`/console/ai-models/${model.id}`}>
+            ${model.name}
+          </a>
+          <div class="model-meta">${model.model_identifier}</div>
+          ${
+            this.getGatewayAlias(model)
+              ? html`
+                  <div class="model-meta">
+                    Gateway alias:
+                    <code>${this.getGatewayAlias(model)}</code>
+                  </div>
+                `
+              : null
+          }
+          ${
+            this.getManagedAgentDisplayName(model)
+              ? html`
+                  <div class="model-meta">
+                    Managed agent: ${this.getManagedAgentDisplayName(model)}
+                  </div>
+                `
+              : null
+          }
+        </td>
+        <td>
+          <div class="cell-stack">
+            <div class="cell-primary">${model.provider_name}</div>
+            <div class="cell-secondary">${this.getModelKindLabel(model)}</div>
+            <div class="cell-secondary">
+              ${this.getPricingSourceLabel(model.id)}
+            </div>
+          </div>
+        </td>
+        <td>
+          <div class="cell-stack">
+            <div class="badge-row">
+              <sl-badge variant=${this.getHealthVariant(model.id)} pill>
+                ${this.getHealthLabel(model.id)}
+              </sl-badge>
+              ${
+                this.getModelOverview(model.id)?.active_session_count
+                  ? html`
+                      <sl-badge variant="primary" pill>
+                        ${this.formatNumber(
+                          this.getModelOverview(model.id)?.active_session_count
+                        )}
+                        active sessions
+                      </sl-badge>
+                    `
+                  : null
+              }
+            </div>
+            <div class="cell-secondary">
+              ${this.formatNumber(
+                this.getModelOverview(model.id)?.successful_requests
+              )}
+              successful ·
+              ${this.formatNumber(
+                this.getModelOverview(model.id)?.failed_requests
+              )}
+              failed
+            </div>
+          </div>
+        </td>
+        <td>
+          <div class="cell-stack">
+            <div class="cell-primary">
+              ${this.formatNumber(
+                this.getModelOverview(model.id)?.total_requests
+              )}
+              requests
+            </div>
+            <div class="cell-secondary">
+              ${this.formatNumber(
+                this.getModelOverview(model.id)?.token_usage.total_tokens
+              )}
+              tokens ·
+              ${this.formatCurrency(
+                this.getModelOverview(model.id)?.estimated_cost
+              )}
+            </div>
+            ${
+              this.getLastRequestLabel(model.id)
+                ? html`<div class="cell-secondary">
+                    ${this.getLastRequestLabel(model.id)}
+                  </div>`
+                : null
+            }
+          </div>
+        </td>
+        <td>${this.renderDefaultControl(model)}</td>
+        <td>${this.renderModelActions(model)}</td>
+      </tr>
+    `;
+  }
+
+  private renderCardsView(models: AIModel[]) {
+    return html`
+      <div class="models-grid">
+        ${repeat(
+          models,
+          (model) => model.id,
+          (model) => this.renderModelCard(model)
+        )}
+      </div>
+    `;
+  }
+
+  private renderModelCard(model: AIModel) {
+    return html`
+      <sl-card class="model-card" data-model-id=${model.id}>
+        <div class="model-card-body">
+          <div class="model-card-header">
+            <a class="model-link" href=${`/console/ai-models/${model.id}`}>
+              ${model.name}
+            </a>
+            ${this.renderDefaultControl(model)}
+          </div>
+          <div class="cell-primary">${model.provider_name}</div>
+          <div class="cell-secondary">${this.getModelKindLabel(model)}</div>
+          <div class="cell-secondary">
+            ${this.getPricingSourceLabel(model.id)}
+          </div>
+          <div class="badge-row">
+            <sl-badge variant=${this.getHealthVariant(model.id)} pill>
+              ${this.getHealthLabel(model.id)}
+            </sl-badge>
+            ${
+              isGatewayEnabled(model)
+                ? html`<sl-badge variant="neutral" pill>Enabled</sl-badge>`
+                : html`<sl-badge variant="neutral" pill>Disabled</sl-badge>`
+            }
+          </div>
+          <div class="cell-secondary">
+            ${this.formatNumber(this.getModelOverview(model.id)?.total_requests)}
+            requests ·
+            ${this.formatCurrency(
+              this.getModelOverview(model.id)?.estimated_cost
+            )}
+          </div>
+          <div class="model-card-actions">
+            ${this.renderModelActions(model)}
+          </div>
+        </div>
+      </sl-card>
     `;
   }
 

--- a/frontend/src/views/authed/settings/ai-models-view.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.ts
@@ -39,9 +39,9 @@ const VIEW_MODE_KEY = 'preloop.models.view_mode';
 export function isGatewayEnabled(model: AIModel): boolean {
   const gateway = model.meta_data?.gateway;
   if (!gateway || typeof gateway !== 'object') {
-    return true;
+    return false;
   }
-  return (gateway as { enabled?: boolean }).enabled !== false;
+  return (gateway as { enabled?: boolean }).enabled === true;
 }
 
 export function filterModels(

--- a/frontend/src/views/authed/settings/ai-models-view.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.ts
@@ -314,6 +314,17 @@ export class AIModelsView extends LitElement {
         gap: var(--sl-spacing-x-small);
         justify-content: flex-end;
       }
+      sl-select::part(form-control-label) {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+        border: 0;
+      }
     `,
   ];
 
@@ -667,7 +678,11 @@ export class AIModelsView extends LitElement {
                 ? null
                 : this.renderFleetOverview()
             }
-            ${this.models.length > 0 ? this.renderToolbar() : null}
+            ${
+              !this.error && this.models.length > 0
+                ? this.renderToolbar()
+                : null
+            }
             ${renderContent()}
           </div>
         </div>
@@ -689,13 +704,14 @@ export class AIModelsView extends LitElement {
         <list-toolbar
           .search=${this.search}
           searchPlaceholder="Search models"
+          toggleLabel="Models view"
           .view=${this.currentView}
-          .views=${['list', 'cards']}
           @search-change=${this.handleSearchChange}
           @view-change=${this.handleViewChange}
         >
           <sl-select
             class="provider-filter"
+            label="Provider"
             clearable
             placeholder="All providers"
             .value=${this.providerFilter}
@@ -708,6 +724,7 @@ export class AIModelsView extends LitElement {
           </sl-select>
           <sl-select
             class="status-filter"
+            label="Status"
             clearable
             placeholder="Any status"
             .value=${this.statusFilter}

--- a/frontend/src/views/authed/trackers-view.test.ts
+++ b/frontend/src/views/authed/trackers-view.test.ts
@@ -78,6 +78,7 @@ describe('TrackersView', () => {
   }
 
   beforeEach(async () => {
+    localStorage.removeItem('preloop.trackers.view_mode');
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
 
@@ -98,6 +99,7 @@ describe('TrackersView', () => {
 
   afterEach(() => {
     fetchStub.restore();
+    localStorage.removeItem('preloop.trackers.view_mode');
     localStorage.clear();
     sessionStorage.clear();
     // Reset URL

--- a/frontend/src/views/authed/trackers-view.test.ts
+++ b/frontend/src/views/authed/trackers-view.test.ts
@@ -13,7 +13,26 @@ describe('TrackersView', () => {
   let element: TrackersView;
   let fetchStub: sinon.SinonStub;
 
-  function createFetchStub() {
+  const mockTrackers = [
+    {
+      id: 'tracker-1',
+      name: 'Jira Production',
+      tracker_type: 'jira',
+      created: '2024-01-01T00:00:00Z',
+      is_valid: true,
+      url: 'https://jira.example.com',
+    },
+    {
+      id: 'tracker-2',
+      name: 'GitHub Repos',
+      tracker_type: 'github',
+      created: '2024-01-02T00:00:00Z',
+      is_valid: true,
+      url: 'https://github.com/example',
+    },
+  ];
+
+  function createFetchStub(trackers: unknown[] = []) {
     return sinon
       .stub(window, 'fetch')
       .callsFake(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -27,7 +46,7 @@ describe('TrackersView', () => {
           });
 
         if (url.includes('/api/v1/trackers') && method === 'GET') {
-          return json([]);
+          return json(trackers);
         }
         if (url.includes('/api/v1/tools') && method === 'GET') {
           return json([
@@ -260,5 +279,68 @@ describe('TrackersView', () => {
     ) as UnlockedToolsReviewDialog;
     expect(review.open).to.be.true;
     expect(review.toolNames).to.deep.equal(['get_issue']);
+  });
+
+  async function renderWithTrackers() {
+    fetchStub.restore();
+    fetchStub = createFetchStub(mockTrackers);
+    element = await fixture(html`<trackers-view></trackers-view>`);
+    const trackerList = element.shadowRoot?.querySelector(
+      'tracker-list'
+    ) as any;
+    await waitUntil(
+      () => !trackerList.isLoading,
+      'Tracker list did not finish loading'
+    );
+    await trackerList.updateComplete;
+    await element.updateComplete;
+    return trackerList;
+  }
+
+  it('narrows list rows when search matches one tracker', async () => {
+    const trackerList = await renderWithTrackers();
+    expect(
+      trackerList.shadowRoot?.querySelectorAll('.tracker-row')
+    ).to.have.lengthOf(2);
+
+    const toolbar = trackerList.shadowRoot?.querySelector('list-toolbar');
+    toolbar!.dispatchEvent(
+      new CustomEvent('search-change', {
+        detail: { value: 'github' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await trackerList.updateComplete;
+
+    const rows = trackerList.shadowRoot?.querySelectorAll('.tracker-row');
+    expect(rows).to.have.lengthOf(1);
+    expect(rows?.[0].textContent).to.include('GitHub Repos');
+  });
+
+  it('switches from list rows to the existing cards template', async () => {
+    const trackerList = await renderWithTrackers();
+    expect(trackerList.shadowRoot?.querySelector('.tracker-row')).to.exist;
+    expect(trackerList.shadowRoot?.querySelector('.tracker-grid')).to.equal(
+      null
+    );
+
+    const toolbar = trackerList.shadowRoot?.querySelector('list-toolbar');
+    toolbar!.dispatchEvent(
+      new CustomEvent('view-change', {
+        detail: { value: 'cards' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await trackerList.updateComplete;
+
+    expect(trackerList.shadowRoot?.querySelector('.tracker-grid')).to.exist;
+    expect(
+      trackerList.shadowRoot?.querySelectorAll('tracker-item')
+    ).to.have.lengthOf(2);
+    expect(trackerList.shadowRoot?.querySelector('.tracker-row')).to.equal(
+      null
+    );
   });
 });


### PR DESCRIPTION
## Why
Trackers and Models did not have the filter bar and list/cards toggle that Agents and Flows have. This extracts the Flows toolbar into a shared component and applies it to both pages, so the four collection pages share one look.

## What changed
- `components/list-toolbar.ts`: search input with prefix icon, default slot for page filters, `count` slot, divider, list/cards `sl-button-group` (hidden when only one view). Props `search`, `searchPlaceholder`, `view`, `views`; events `search-change`, `view-change`. Spacing and the 900px / 640px responsive collapse copied from Flows.
- `utils/view-mode.ts`: persisted view mode per page (localStorage), default `list`, cards fallback under 640px without writing the fallback back, `subscribeNarrowViewport`.
- Trackers (`tracker-list.ts`): search over name, kind, url; kind select built from the payload; list view with hairline rows (name + url, kind badge, projects count from INCLUDE PROJECT scope rules, Connected / Action Required, last sync, kebab actions); cards view unchanged. Key `preloop.trackers.view_mode`.
- Models (`ai-models-view.ts`): search over name and provider; provider and status (gateway enabled/disabled) selects; existing table restyled with hairlines and no filled header band; new cards view with the same fields and View / Edit / Delete / Set as default. Fleet overview and default-model behaviour unchanged. Key `preloop.models.view_mode`.
- `agents-view.ts` and `flows-view.ts` untouched. Follow-up: migrate both onto `list-toolbar` (Agents needs a `canvas` view option added to the toggle).

## Tests
`cd frontend && npm test`: 132 files, 1439 passed, 0 failed. New `list-toolbar.test.ts`, `view-mode.test.ts`; updated `tracker-list.test.ts`, `trackers-view.test.ts`, `ai-models-view.test.ts`.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Well-factored UI refactor with no security, API, or config changes; comprehensive test coverage.
>
> **Overview**
> Extracts the Flows filter toolbar into a shared `list-toolbar` component and a persisted `view-mode` helper, then applies list/cards views and filtering to the Trackers and Models pages so all four collection pages share one look.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 69fcd610. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->