### PR TITLE
Landing: align the hero visual to the H1, center the demo CTA under the grid, move the legal disclaimer to the footer

### DIFF
--- a/frontend/src/brand-config.ts
+++ b/frontend/src/brand-config.ts
@@ -183,6 +183,11 @@ export interface BrandRuntimeConfig {
    * routes by dropping files; OSS never lists pages it does not ship.
    */
   static_markdown_pages?: Array<{ path: string; src: string }>;
+  /**
+   * Optional legal disclaimer from the landing content knob. The shared
+   * footer renders it above the copyright row when this is set.
+   */
+  legal_disclaimer?: string;
 }
 
 // Full config - used at build time only (includes landing content)

--- a/frontend/src/components/app-footer.test.ts
+++ b/frontend/src/components/app-footer.test.ts
@@ -1,0 +1,71 @@
+import { html, fixture, expect } from '@open-wc/testing';
+import sinon from 'sinon';
+import './app-footer';
+import type { AppFooter } from './app-footer';
+
+const BRAND_CONFIG: Record<string, unknown> = {
+  name: 'Test Brand',
+  domain: 'test.example.com',
+  edition: 'saas',
+  company: { legal_name: 'Test Co', address: '123 Test', city: 'Test' },
+  branding: {
+    logo_light: '/logo.svg',
+    logo_dark: '/logo-dark.svg',
+    favicon: '/favicon.ico',
+    primary_color: '#000',
+    gradient_product: '',
+    gradient_ai: '',
+  },
+  social: { twitter: '', linkedin: '', instagram: '' },
+};
+
+function stubFetch(): sinon.SinonStub {
+  return sinon
+    .stub(window, 'fetch')
+    .callsFake(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/v1/features')) {
+        return new Response(JSON.stringify({ features: {} }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+}
+
+describe('AppFooter legal disclaimer', () => {
+  let fetchStub: sinon.SinonStub;
+
+  afterEach(() => {
+    fetchStub.restore();
+    delete (window as unknown as { BRAND_CONFIG?: unknown }).BRAND_CONFIG;
+  });
+
+  it('renders p.legal-disclaimer from runtime BRAND_CONFIG when the property is unset', async () => {
+    (
+      window as unknown as { BRAND_CONFIG: Record<string, unknown> }
+    ).BRAND_CONFIG = {
+      ...BRAND_CONFIG,
+      legal_disclaimer:
+        'Preloop is not a law firm and does not provide legal advice.',
+    };
+    fetchStub = stubFetch();
+    const el = (await fixture(html`<app-footer></app-footer>`)) as AppFooter;
+    await el.updateComplete;
+
+    const disclaimer = el.shadowRoot?.querySelector('p.legal-disclaimer');
+    expect(disclaimer, 'disclaimer from runtime brand config').to.exist;
+    expect((disclaimer?.textContent || '').trim()).to.equal(
+      'Preloop is not a law firm and does not provide legal advice.'
+    );
+  });
+
+  it('renders no disclaimer p when neither the property nor BRAND_CONFIG.legal_disclaimer is set', async () => {
+    (
+      window as unknown as { BRAND_CONFIG: Record<string, unknown> }
+    ).BRAND_CONFIG = { ...BRAND_CONFIG };
+    fetchStub = stubFetch();
+    const el = (await fixture(html`<app-footer></app-footer>`)) as AppFooter;
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('p.legal-disclaimer')).to.equal(null);
+  });
+});

--- a/frontend/src/components/app-footer.ts
+++ b/frontend/src/components/app-footer.ts
@@ -1,13 +1,15 @@
 import { LitElement, html, css } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { router } from '../router';
-import { getBrandConfig, isSaaS } from '../brand-config';
+import { getBrandConfig, hasBrandConfig, isSaaS } from '../brand-config';
 import { getFeatures } from '../api';
 import './logo-component';
 
 @customElement('app-footer')
 export class AppFooter extends LitElement {
   @state() private _registrationEnabled = true;
+  /** Same `legal_disclaimer` knob as landing content. Empty falls back to brand config. */
+  @property({ type: String }) legalDisclaimer = '';
 
   async connectedCallback() {
     super.connectedCallback();
@@ -94,6 +96,18 @@ export class AppFooter extends LitElement {
         font-size: 0.85rem;
       }
 
+      .legal-disclaimer {
+        margin: 0 0 16px;
+        font-size: 13px;
+        line-height: 1.5;
+        color: rgb(161, 161, 170);
+        text-align: left;
+      }
+
+      .legal-disclaimer + .footer-bottom {
+        margin-top: 16px;
+      }
+
       .copyright-text a {
         color: inherit;
         text-decoration: none;
@@ -115,6 +129,17 @@ export class AppFooter extends LitElement {
       }
     `,
   ];
+
+  private _disclaimerText(): string {
+    const fromProp = (this.legalDisclaimer || '').trim();
+    if (fromProp) {
+      return fromProp;
+    }
+    if (!hasBrandConfig()) {
+      return '';
+    }
+    return (getBrandConfig().legal_disclaimer || '').trim();
+  }
 
   handleLinkClick(event: MouseEvent) {
     event.preventDefault();
@@ -193,6 +218,11 @@ export class AppFooter extends LitElement {
           </nav>
         </div>
         <div class="divider"></div>
+        ${
+          this._disclaimerText()
+            ? html`<p class="legal-disclaimer">${this._disclaimerText()}</p>`
+            : ''
+        }
         <div class="footer-bottom">
           ${
             hasCompanyInfo

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -105,7 +105,6 @@ p.lead {
    Start-align so the visual is not vertically centered against a taller
    copy column. The visual then gets a cap-line offset (see below). */
 .hero-inner.has-visual {
-  align-items: start;
   gap: 3rem;
 }
 
@@ -124,6 +123,10 @@ p.lead {
    so the copy column top is the H1 box top and the 0.12em visual offset
    hits the cap line. Stacked hero keeps its own h1 margins (D18). */
 @media (min-width: 1151px) {
+  .hero-inner.has-visual {
+    align-items: start;
+  }
+
   .hero-inner.has-visual .hero-content h1 {
     margin-top: 0;
   }
@@ -335,10 +338,6 @@ p.lead {
   flex-wrap: wrap;
   gap: 0.75rem 1.25rem;
   margin: 2.5rem auto 0;
-  padding: 0 1rem;
-  max-width: 1200px;
-  width: 100%;
-  box-sizing: border-box;
 }
 
 .hero-secondary-text {
@@ -1134,6 +1133,7 @@ summary.faq-question:hover sl-icon {
   .hero-inner {
     display: flex;
     flex-direction: column;
+    align-items: stretch;
     text-align: center;
     gap: 1rem;
   }

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -120,6 +120,15 @@ p.lead {
   font-size: 3.4rem;
 }
 
+/* Two-column only: zero the UA h1 margin-top (measured 0.67em / 36.4px)
+   so the copy column top is the H1 box top and the 0.12em visual offset
+   hits the cap line. Stacked hero keeps its own h1 margins (D18). */
+@media (min-width: 1151px) {
+  .hero-inner.has-visual .hero-content h1 {
+    margin-top: 0;
+  }
+}
+
 .hero-visual {
   flex: 1.75 1 0;
   min-width: 0;

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -101,9 +101,11 @@ p.lead {
   margin: 0 0 2rem 0;
 }
 
-/* Two-column hero: copy on the left, static product shot on the right. */
+/* Two-column hero: copy on the left, static product shot on the right.
+   Start-align so the visual is not vertically centered against a taller
+   copy column. The visual then gets a cap-line offset (see below). */
 .hero-inner.has-visual {
-  align-items: center;
+  align-items: start;
   gap: 3rem;
 }
 
@@ -124,6 +126,13 @@ p.lead {
   flex-shrink: 0;
   cursor: pointer;
   transition: transform 0.2s ease-out;
+}
+
+/* Cap-line offset: two-column H1 is 3.4rem / line-height 1.1. Inter's
+   first-line cap sits 0.12em of that size below the copy column top
+   (0.12 * 3.4rem = 0.408rem). Stacked hero resets this (D18). */
+.hero-inner.has-visual .hero-visual {
+  margin-top: 0.408rem;
 }
 
 .hero-visual:hover {
@@ -307,15 +316,20 @@ p.lead {
   line-height: 1.4;
 }
 
-/* Secondary CTA ("Book a Demo") rendered under the install command.
-   Mirrors the install widget: same small uppercase label typography with
-   the action button directly underneath. */
+/* Secondary CTA ("Book a Demo") as a centered row below the hero grid.
+   D23 label typography (install-label style) is unchanged. */
 .hero-secondary-cta {
-  margin-top: 1.75rem;
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.5rem;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  margin: 2.5rem auto 0;
+  padding: 0 1rem;
+  max-width: 1200px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .hero-secondary-text {
@@ -1145,7 +1159,8 @@ summary.faq-question:hover sl-icon {
     margin-right: auto;
   }
 
-  .hero-visual {
+  .hero-visual,
+  .hero-inner.has-visual .hero-visual {
     order: 3;
     display: block;
     width: 100%;
@@ -1182,13 +1197,13 @@ summary.faq-question:hover sl-icon {
     font-size: 0.8rem;
   }
 
+  /* CTA row lives below .hero-inner. Keep label + button inline on
+     tablet widths; mobile stacking is in the 768px query. */
   .hero-secondary-cta {
-    order: 6;
     align-items: center;
     width: 100%;
-    margin-top: 0;
-    margin-bottom: 1rem;
-    gap: 0.3rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0;
   }
 
   .hero-trust-tags {
@@ -1200,6 +1215,13 @@ summary.faq-question:hover sl-icon {
 }
 
 @media (max-width: 768px) {
+  .hero-secondary-cta {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+  }
+
   .hero-content h1 {
     font-size: 2.8rem;
     word-wrap: break-word;

--- a/frontend/src/views/public/landing-view.test.ts
+++ b/frontend/src/views/public/landing-view.test.ts
@@ -384,6 +384,10 @@ describe('LandingView hero CTA row and footer disclaimer', () => {
     const inner = hero?.querySelector('.hero-inner');
     const cta = hero?.querySelector('.hero-secondary-cta');
     expect(cta, 'secondary CTA container exists').to.exist;
+    expect(
+      cta?.classList.contains('section-container'),
+      'CTA row reuses the shared section width'
+    ).to.be.true;
     expect(hero?.contains(cta as Node)).to.be.true;
     expect(
       inner?.contains(cta as Node),

--- a/frontend/src/views/public/landing-view.test.ts
+++ b/frontend/src/views/public/landing-view.test.ts
@@ -341,3 +341,91 @@ describe('LandingView hero video', () => {
     expect(el.shadowRoot?.querySelector('iframe')).to.not.exist;
   });
 });
+
+describe('LandingView hero CTA row and footer disclaimer', () => {
+  let fetchStub: sinon.SinonStub;
+
+  const HERO_WITH_INSTALL_AND_LEGAL = {
+    hero: {
+      title: 'Hero',
+      lead: 'Lead',
+      install_command: 'curl -fsSL https://example.com/install | sh',
+      install_caption: 'macOS, Linux, and WSL.',
+      cta_secondary: 'Book a Demo',
+      cta_secondary_url: '/request-demo',
+      trust_tags: ['Apache-2.0', 'Self-hostable'],
+      image: '/img.png',
+      image_alt: 'Product screenshot',
+    },
+    features: [],
+    faqs: [{ q: 'Question?', a: 'Answer.' }],
+    legal_disclaimer:
+      'Preloop is not a law firm and does not provide legal advice.',
+  };
+
+  beforeEach(() => {
+    (window as any).BRAND_CONFIG = BRAND_CONFIG;
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    delete (window as any).BRAND_CONFIG;
+  });
+
+  it('renders the secondary CTA below the hero grid, not in the copy column', async () => {
+    fetchStub = stubFetch(HERO_WITH_INSTALL_AND_LEGAL);
+    const el = (await fixture(
+      html`<landing-view></landing-view>`
+    )) as LandingView;
+    await tick();
+    await el.updateComplete;
+
+    const hero = el.shadowRoot?.querySelector('.hero');
+    const inner = hero?.querySelector('.hero-inner');
+    const cta = hero?.querySelector('.hero-secondary-cta');
+    expect(cta, 'secondary CTA container exists').to.exist;
+    expect(hero?.contains(cta as Node)).to.be.true;
+    expect(
+      inner?.contains(cta as Node),
+      'CTA is not inside the two-column grid'
+    ).to.be.false;
+    expect(
+      inner?.nextElementSibling,
+      'CTA is the row immediately below the grid'
+    ).to.equal(cta);
+    expect(el.shadowRoot?.querySelector('.hero-content .hero-secondary-cta')).to
+      .not.exist;
+    const demoBtn = cta?.querySelector('sl-button');
+    expect(demoBtn?.getAttribute('data-track')).to.equal('cta_demo_hero');
+    expect((cta?.textContent || '').replace(/\s+/g, ' ')).to.contain(
+      'Want a guided tour first?'
+    );
+  });
+
+  it('keeps the disclaimer out of the FAQ and renders it in the footer', async () => {
+    fetchStub = stubFetch(HERO_WITH_INSTALL_AND_LEGAL);
+    const el = (await fixture(
+      html`<landing-view></landing-view>`
+    )) as LandingView;
+    await tick();
+    await el.updateComplete;
+
+    const faq = el.shadowRoot?.querySelector('.faq-section');
+    expect(faq).to.exist;
+    expect(faq?.nextElementSibling?.classList.contains('legal-disclaimer')).to
+      .be.false;
+    expect(el.shadowRoot?.querySelector('main .legal-disclaimer')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.faq-section + p.legal-disclaimer')).to
+      .not.exist;
+
+    const footer = el.shadowRoot?.querySelector('app-footer');
+    expect(footer).to.exist;
+    await (footer as HTMLElement & { updateComplete: Promise<unknown> })
+      .updateComplete;
+    const disclaimer = footer?.shadowRoot?.querySelector('.legal-disclaimer');
+    expect(disclaimer, 'disclaimer present in the footer').to.exist;
+    expect((disclaimer?.textContent || '').trim()).to.equal(
+      HERO_WITH_INSTALL_AND_LEGAL.legal_disclaimer
+    );
+  });
+});

--- a/frontend/src/views/public/landing-view.ts
+++ b/frontend/src/views/public/landing-view.ts
@@ -6,6 +6,7 @@ import landingStyles from '../../styles/landing.css?inline';
 import { reducedMotionStyles } from '../../styles/reduced-motion';
 import './../../components/news-capsule';
 import './../../components/ide-setup-tabs';
+import './../../components/app-footer';
 import { trackGoal } from '../../services/web-analytics';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/carousel/carousel.js';
@@ -212,16 +213,6 @@ export class LandingView extends LitElement {
         font-weight: 500;
         font-size: 1.1rem;
         color: rgb(161, 161, 170);
-      }
-
-      .legal-disclaimer {
-        max-width: 720px;
-        margin: 0 auto 48px;
-        padding: 0 16px;
-        font-size: 1rem;
-        line-height: 1.6;
-        color: rgb(161, 161, 170);
-        text-align: center;
       }
 
       .feature-stacked-block {
@@ -1832,13 +1823,6 @@ export class LandingView extends LitElement {
                     </div>
                   </div>
                 </section>
-                ${
-                  this._legalDisclaimer
-                    ? html`<p class="legal-disclaimer">
-                        ${this._legalDisclaimer}
-                      </p>`
-                    : ''
-                }
               `
             : ''
         }
@@ -1871,7 +1855,7 @@ export class LandingView extends LitElement {
             : ''
         }
       </main>
-      <app-footer></app-footer>
+      <app-footer .legalDisclaimer=${this._legalDisclaimer}></app-footer>
 
       <sl-dialog
         class="lightbox-dialog"

--- a/frontend/src/views/public/landing-view.ts
+++ b/frontend/src/views/public/landing-view.ts
@@ -1218,26 +1218,6 @@ export class LandingView extends LitElement {
                             : ''
                         }
                       </div>
-                      ${
-                        this._ctaSecondary
-                          ? html`<div class="hero-secondary-cta">
-                              <span class="hero-secondary-text"
-                                >Want a guided tour first?</span
-                              >
-                              <sl-button
-                                variant="default"
-                                size="large"
-                                href=${this._ctaSecondaryUrl}
-                                target=${
-                                  this._ctaSecondaryUrl.startsWith('http')
-                                    ? '_blank'
-                                    : '_self'
-                                }
-                                >${this._ctaSecondary}</sl-button
-                              >
-                            </div>`
-                          : ''
-                      }
                     `
                   : ''
               }
@@ -1313,6 +1293,28 @@ export class LandingView extends LitElement {
                   : ''
             }
           </div>
+          ${
+            this._heroInstall && this._ctaSecondary
+              ? html`<div class="hero-secondary-cta">
+                  <span class="hero-secondary-text"
+                    >Want a guided tour first?</span
+                  >
+                  <sl-button
+                    variant="default"
+                    size="large"
+                    href=${this._ctaSecondaryUrl}
+                    target=${
+                      this._ctaSecondaryUrl.startsWith('http')
+                        ? '_blank'
+                        : '_self'
+                    }
+                    @click=${this._handleSecondaryCta}
+                    data-track="cta_demo_hero"
+                    >${this._ctaSecondary}</sl-button
+                  >
+                </div>`
+              : ''
+          }
         </section>
 
         <section

--- a/frontend/src/views/public/landing-view.ts
+++ b/frontend/src/views/public/landing-view.ts
@@ -1286,7 +1286,7 @@ export class LandingView extends LitElement {
           </div>
           ${
             this._heroInstall && this._ctaSecondary
-              ? html`<div class="hero-secondary-cta">
+              ? html`<div class="section-container hero-secondary-cta">
                   <span class="hero-secondary-text"
                     >Want a guided tour first?</span
                   >

--- a/frontend/vite-plugin-brand.ts
+++ b/frontend/vite-plugin-brand.ts
@@ -876,6 +876,9 @@ export function brandPlugin(
             ? get_regulation_nav_links(loadRegulationSlugs())
             : [],
         static_markdown_pages: loadStaticMarkdownPages(),
+        legal_disclaimer:
+          (brandConfig.landing as { legal_disclaimer?: string })
+            .legal_disclaimer || '',
       };
 
       const brandScript = `


### PR DESCRIPTION
## Why
At 1440 the hero screenshot/video was vertically centered against a copy column made taller by the "Want a guided tour first?" + Book a Demo pair, so its top missed the H1 and its bottom landed on the demo label. The legal disclaimer rendered as a stray dark band between the FAQ and the final CTA with no margin.

## What changed
- `styles/landing.css`: `.hero-inner.has-visual { align-items: start }`, H1 `margin-top: 0` on the two-column hero (the UA gave it 0.67em), visual `margin-top: 0.408rem` (0.12 x 3.4rem H1) so its top edge sits on the H1 cap line. The stacked hero (<= 1150px) resets the offset; the visual stays `display: block` (D18).
- `.hero-secondary-cta` is now a centered row under the grid, still inside the hero and above the agent marquee: inline at 1024+, stacked at <= 768. D23 label typography is unchanged. The moved Book a Demo button adds `@click` and `data-track="cta_demo_hero"` so the Demo Click goal fires from the install-widget hero. H1 and lead copy unchanged. The copy column ends with the install caption and trust tags.
- Disclaimer: removed the `<p class="legal-disclaimer">` after the FAQ and its full-bleed CSS. `app-footer` gains a `legalDisclaimer` property with a `BrandRuntimeConfig.legal_disclaimer` fallback (`brand-config.ts`, `vite-plugin-brand.ts`) and renders it above the copyright row at 13px muted, so every public page that uses the footer shows it.

## Measured (Playwright against `vite --port 5173`, selfhosted brand)
| Width | align-items | visual margin-top | H1 top to visual top | visual shown |
|---:|---|---:|---:|---|
| 1440 | start | 6.528px | 6.516px | 632 x 377 |
| 1024 / 768 / 390 | stacked | 0 | n/a | yes |

`npm test`: 1414 passed, 0 failed (landing-view.test.ts 21; app-footer.test.ts 2 new: runtime `BRAND_CONFIG.legal_disclaimer` with no property, and neither set renders no `<p>`).

The selfhosted brand has no install widget, demo pair, or disclaimer, so those three are covered by unit tests; the SaaS staging deploy is the visual check for them.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low risk**
> Frontend-only layout refinement and content propagation; well tested with no security, quality, or performance issues.
>
> **Overview**
> Aligns the hero visual to the H1 cap line on the two-column hero, centers the "Book a Demo" CTA under the grid (gated on the install widget), and moves the legal disclaimer from below the FAQ into the shared footer via a `BrandRuntimeConfig.legal_disclaimer` fallback. Previously flagged footer fallback test gap now covered.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 1f1f3c48. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->