### PR TITLE
Flows: replace the preset radio and card grid with a Start from picker

### DIFF
--- a/frontend/src/components/preloop-flow-form-presets.test.ts
+++ b/frontend/src/components/preloop-flow-form-presets.test.ts
@@ -187,8 +187,33 @@ describe('PreloopFlowForm presets', () => {
     );
     expect(element.shadowRoot!.textContent).to.include('Keep editing');
     expect(element.shadowRoot!.textContent).to.include('Switch preset');
+    const keepEditing = element.shadowRoot!.querySelector(
+      'sl-button[autofocus]'
+    );
+    expect(keepEditing).to.exist;
+    expect(keepEditing!.textContent).to.contain('Keep editing');
     expect((element as any).pickerSelectedId).to.equal('preset-002');
     expect(element.flow.prompt_template).to.equal('A rewritten review prompt.');
+  });
+
+  it('collapses the picker when the already-selected row is chosen again', async () => {
+    const element = await mount();
+    await (element as any).applyPresetSelection('preset-002');
+    await element.updateComplete;
+    expect((element as any).pickerCollapsed).to.be.true;
+
+    (element as any).handlePickerChangeRequest();
+    await element.updateComplete;
+    expect((element as any).pickerCollapsed).to.be.false;
+
+    (element as any).handlePickerSelect(
+      new CustomEvent('preset-select', { detail: { presetId: 'preset-002' } })
+    );
+    await element.updateComplete;
+
+    expect((element as any).pickerCollapsed).to.be.true;
+    expect((element as any).pickerSelectedId).to.equal('preset-002');
+    expect(element.flow.prompt_template).to.equal('Review this pull request.');
   });
 
   it('collapses the picker when opened with ?preset_id=', async () => {
@@ -203,5 +228,33 @@ describe('PreloopFlowForm presets', () => {
     expect((element as any).pickerCollapsed).to.be.true;
     expect(picker(element).collapsed).to.be.true;
     expect(picker(element).selectedId).to.equal('preset-002');
+  });
+
+  it('warns on the next pick after typing into an unknown ?preset_id= draft', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/console/flows/new?preset_id=missing-preset'
+    );
+    const element = await mount();
+    expect((element as any).presetSnapshot).to.not.equal(null);
+
+    element.flow = {
+      ...element.flow,
+      prompt_template: 'A typed prompt.',
+    };
+    await element.updateComplete;
+
+    (element as any).handlePickerSelect(
+      new CustomEvent('preset-select', { detail: { presetId: 'preset-002' } })
+    );
+    await element.updateComplete;
+
+    expect(
+      element.shadowRoot!.querySelector(
+        'sl-dialog[label="Replace your edits?"]'
+      )
+    ).to.exist;
+    expect(element.flow.prompt_template).to.equal('A typed prompt.');
   });
 });

--- a/frontend/src/components/preloop-flow-form-presets.test.ts
+++ b/frontend/src/components/preloop-flow-form-presets.test.ts
@@ -4,6 +4,7 @@ import {
   fixtureCleanup,
   html,
   oneEvent,
+  waitUntil,
 } from '@open-wc/testing';
 import sinon, { SinonSandbox } from 'sinon';
 
@@ -132,16 +133,14 @@ describe('PreloopFlowForm presets', () => {
     expect(element.flow.trigger_event_source).to.equal(GITHUB_TRACKER.id);
   });
 
-  it('still applies GitHub PR defaults to a blank draft', async () => {
+  it('does not turn Observe / Eval into a PR tracker flow', async () => {
     const element = await mount();
     await (element as any).applyPresetSelection('preset-003');
     await element.updateComplete;
 
-    expect(element.flow.trigger_event_types).to.deep.equal([
-      'pull_request_opened',
-      'pull_request_updated',
-    ]);
-    expect(element.flow.trigger_event_source).to.equal(GITHUB_TRACKER.id);
+    expect(element.flow.trigger_event_types).to.deep.equal([]);
+    expect(element.flow.trigger_event_source).to.equal(undefined);
+    expect((element as any).triggerType).to.equal('webhook');
   });
 
   it('clears the prompt when Blank flow is chosen after a preset', async () => {
@@ -194,6 +193,35 @@ describe('PreloopFlowForm presets', () => {
     expect(keepEditing!.textContent).to.contain('Keep editing');
     expect((element as any).pickerSelectedId).to.equal('preset-002');
     expect(element.flow.prompt_template).to.equal('A rewritten review prompt.');
+  });
+
+  it('replaces the prompt when Switch preset is confirmed', async () => {
+    const element = await mount();
+    await (element as any).applyPresetSelection('preset-002');
+    await element.updateComplete;
+
+    element.flow = {
+      ...element.flow,
+      prompt_template: 'A rewritten review prompt.',
+    };
+    await element.updateComplete;
+
+    (element as any).handlePickerSelect(
+      new CustomEvent('preset-select', { detail: { presetId: 'preset-001' } })
+    );
+    await element.updateComplete;
+    expect(element.flow.prompt_template).to.equal('A rewritten review prompt.');
+
+    (element as any).confirmSwitchPreset();
+    await waitUntil(
+      () => (element as any).pickerSelectedId === 'preset-001',
+      'Switch preset did not apply the Issue Triage selection'
+    );
+    await element.updateComplete;
+
+    expect(element.flow.prompt_template).to.equal('Triage this issue.');
+    expect((element as any).pickerSelectedId).to.equal('preset-001');
+    expect((element as any).replaceEditsOpen).to.be.false;
   });
 
   it('collapses the picker when the already-selected row is chosen again', async () => {

--- a/frontend/src/components/preloop-flow-form-presets.test.ts
+++ b/frontend/src/components/preloop-flow-form-presets.test.ts
@@ -1,0 +1,207 @@
+import {
+  expect,
+  fixture,
+  fixtureCleanup,
+  html,
+  oneEvent,
+} from '@open-wc/testing';
+import sinon, { SinonSandbox } from 'sinon';
+
+import './preloop-flow-form.ts';
+import type { PreloopFlowForm } from './preloop-flow-form';
+
+const GITHUB_TRACKER = {
+  id: 'tracker-github',
+  name: 'GitHub',
+  tracker_type: 'github',
+};
+
+const ISSUE_TRIAGE = {
+  id: 'preset-001',
+  name: 'Issue Triage Assistant',
+  description: 'Automatically analyze new issues.',
+  icon: 'funnel',
+  prompt_template: 'Triage this issue.',
+  trigger_event_types: ['issue.opened'],
+  allowed_mcp_tools: [{ name: 'get_issue' }],
+  agent_type: 'codex',
+  agent_config: {},
+};
+
+const PR_REVIEWER = {
+  id: 'preset-002',
+  name: 'Pull Request Reviewer',
+  description: 'Review a pull request when it opens.',
+  icon: 'code-square',
+  prompt_template: 'Review this pull request.',
+  trigger_event_types: ['pull_request_opened'],
+  allowed_mcp_tools: [{ name: 'get_pull_request' }],
+  agent_type: 'codex',
+  agent_config: {},
+  git_clone_config: { enabled: true, create_pull_request: false },
+};
+
+const OBSERVE_EVAL = {
+  id: 'preset-003',
+  name: 'Observe / Eval',
+  description: 'Watch a repository on a schedule.',
+  icon: 'eye',
+  prompt_template: 'Observe the repository.',
+  trigger_event_types: [],
+  allowed_mcp_tools: [],
+  agent_type: 'codex',
+  agent_config: {},
+};
+
+const PRESETS = [ISSUE_TRIAGE, PR_REVIEWER, OBSERVE_EVAL];
+
+describe('PreloopFlowForm presets', () => {
+  let sandbox: SinonSandbox;
+  let previousUrl: string;
+
+  beforeEach(() => {
+    previousUrl = `${window.location.pathname}${window.location.search}`;
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    sandbox = sinon.createSandbox();
+    sandbox.stub(window, 'fetch').callsFake(async (url: any) => {
+      const target = String(url);
+      if (target.includes('/api/v1/flows/presets')) {
+        return new Response(JSON.stringify(PRESETS));
+      }
+      if (target.includes('/api/v1/trackers')) {
+        return new Response(JSON.stringify([GITHUB_TRACKER]));
+      }
+      if (target.includes('/api/v1/agents')) {
+        return new Response(JSON.stringify({ items: [] }));
+      }
+      if (target.includes('/api/v1/organizations')) {
+        return new Response(JSON.stringify({ items: [] }));
+      }
+      return new Response(JSON.stringify([]));
+    });
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', previousUrl);
+    fixtureCleanup();
+    sandbox.restore();
+    localStorage.clear();
+  });
+
+  const mount = async (flow: Record<string, unknown> = {}) => {
+    const element = await fixture<PreloopFlowForm>(
+      html`<preloop-flow-form .flow=${flow}></preloop-flow-form>`
+    );
+    while ((element as any)._loadingReferenceData) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    await element.updateComplete;
+    return element;
+  };
+
+  const submit = async (element: PreloopFlowForm) => {
+    const submitted = oneEvent(element, 'flow-submit');
+    void (element as any).handleFormSubmit(new Event('submit'));
+    const event = await submitted;
+    return event.detail.flow;
+  };
+
+  const picker = (element: PreloopFlowForm) =>
+    element.shadowRoot!.querySelector('preloop-flow-preset-picker') as any;
+
+  it('does not set flow.id when selecting a preset and submits source_preset_id without id', async () => {
+    const element = await mount();
+    await (element as any).applyPresetSelection('preset-002');
+    await element.updateComplete;
+
+    expect(element.flow.id).to.equal(undefined);
+    expect((element as any).sourcePresetId).to.equal('preset-002');
+
+    const payload = await submit(element);
+    expect(payload.source_preset_id).to.equal('preset-002');
+    expect(payload).to.not.have.property('id');
+  });
+
+  it('keeps issue.opened when Issue Triage is selected on a GitHub tracker', async () => {
+    const element = await mount();
+    await (element as any).applyPresetSelection('preset-001');
+    await element.updateComplete;
+
+    expect(element.flow.trigger_event_types).to.deep.equal(['issue.opened']);
+    expect(element.flow.trigger_event_source).to.equal(GITHUB_TRACKER.id);
+  });
+
+  it('still applies GitHub PR defaults to a blank draft', async () => {
+    const element = await mount();
+    await (element as any).applyPresetSelection('preset-003');
+    await element.updateComplete;
+
+    expect(element.flow.trigger_event_types).to.deep.equal([
+      'pull_request_opened',
+      'pull_request_updated',
+    ]);
+    expect(element.flow.trigger_event_source).to.equal(GITHUB_TRACKER.id);
+  });
+
+  it('clears the prompt when Blank flow is chosen after a preset', async () => {
+    const element = await mount();
+    await (element as any).applyPresetSelection('preset-002');
+    await element.updateComplete;
+    expect(element.flow.prompt_template).to.equal('Review this pull request.');
+
+    await (element as any).applyPresetSelection('blank');
+    await element.updateComplete;
+
+    expect(element.flow.prompt_template).to.be.undefined;
+    expect((element as any).sourcePresetId).to.equal(null);
+    expect((element as any).pickerSelectedId).to.equal('blank');
+  });
+
+  it('shows Replace your edits? after an edited prompt is switched', async () => {
+    const element = await mount();
+    await (element as any).applyPresetSelection('preset-002');
+    await element.updateComplete;
+
+    element.flow = {
+      ...element.flow,
+      prompt_template: 'A rewritten review prompt.',
+    };
+    await element.updateComplete;
+
+    (element as any).handlePickerSelect(
+      new CustomEvent('preset-select', { detail: { presetId: 'preset-001' } })
+    );
+    await element.updateComplete;
+
+    const dialog = element.shadowRoot!.querySelector(
+      'sl-dialog[label="Replace your edits?"]'
+    );
+    expect(dialog).to.exist;
+    const dialogText = (element.shadowRoot!.textContent || '').replace(
+      /\s+/g,
+      ' '
+    );
+    expect(dialogText).to.include(
+      'Switching presets replaces the prompt, tools and trigger you changed.'
+    );
+    expect(element.shadowRoot!.textContent).to.include('Keep editing');
+    expect(element.shadowRoot!.textContent).to.include('Switch preset');
+    expect((element as any).pickerSelectedId).to.equal('preset-002');
+    expect(element.flow.prompt_template).to.equal('A rewritten review prompt.');
+  });
+
+  it('collapses the picker when opened with ?preset_id=', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/console/flows/new?preset_id=preset-002'
+    );
+    const element = await mount();
+
+    expect((element as any).pickerSelectedId).to.equal('preset-002');
+    expect((element as any).pickerCollapsed).to.be.true;
+    expect(picker(element).collapsed).to.be.true;
+    expect(picker(element).selectedId).to.equal('preset-002');
+  });
+});

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -22,10 +22,13 @@ import {
 import { getAgentControlState } from '../utils/agent-control';
 import { getTrackerEventOptions } from '../constants/tracker-event-types';
 import consoleStyles from '../styles/console-styles.css?inline';
+import { consoleDialogStyles } from '../styles/console-dialog';
 import './add-tracker-modal';
 import './add-ai-model-modal';
 import './schedule-config-editor';
 import { defaultScheduleConfig } from './schedule-config-editor';
+import './preloop-flow-preset-picker';
+import { BLANK_PRESET_ID } from './preloop-flow-preset-picker';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
@@ -39,11 +42,13 @@ import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
+import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 
 @customElement('preloop-flow-form')
 export class PreloopFlowForm extends LitElement {
   static styles = [
     unsafeCSS(consoleStyles),
+    consoleDialogStyles,
     css`
       :host {
         display: block;
@@ -117,31 +122,6 @@ export class PreloopFlowForm extends LitElement {
         color: var(--sl-color-neutral-600);
         font-size: var(--sl-font-size-small);
       }
-
-      .creation-mode-toggle {
-        margin-bottom: var(--sl-spacing-large);
-        padding: var(--sl-spacing-medium);
-        background: var(--sl-color-neutral-50);
-        border-radius: 8px;
-        border: 1px solid var(--sl-color-neutral-200);
-      }
-      .creation-mode-toggle h3 {
-        margin: 0 0 var(--sl-spacing-small) 0;
-        font-size: 1rem;
-      }
-      .preset-card {
-        cursor: pointer;
-        transition:
-          transform 0.2s ease,
-          box-shadow 0.2s ease;
-      }
-      .preset-card::part(base) {
-        height: 100%;
-      }
-      .preset-card:hover {
-        transform: translateY(-2px);
-        box-shadow: var(--sl-shadow-large);
-      }
     `,
   ];
 
@@ -200,10 +180,24 @@ export class PreloopFlowForm extends LitElement {
   private presets: any[] = [];
 
   @state()
-  private creationMode: 'scratch' | 'preset' = 'preset';
+  private sourcePresetId: string | null = null;
 
   @state()
-  private sourcePresetId: string | null = null;
+  private pickerSelectedId = '';
+
+  @state()
+  private pickerCollapsed = false;
+
+  @state()
+  private replaceEditsOpen = false;
+
+  private pendingPresetId: string | null = null;
+
+  private presetSnapshot: {
+    prompt_template: string;
+    tools: string;
+    trigger: string;
+  } | null = null;
 
   @state()
   private isAddingTracker = false;
@@ -229,9 +223,6 @@ export class PreloopFlowForm extends LitElement {
 
   willUpdate(changedProperties: Map<string | number | symbol, unknown>) {
     if (changedProperties.has('flow')) {
-      if (this.flow?.id) {
-        this.creationMode = 'scratch';
-      }
       void this.syncTriggerStateFromFlow();
     }
   }
@@ -254,9 +245,6 @@ export class PreloopFlowForm extends LitElement {
       'github-oauth-starting',
       this.handleGithubOauthStarting
     );
-    if (this.flow && this.flow.id) {
-      this.creationMode = 'scratch';
-    }
     await this.loadReferenceData();
   }
 
@@ -334,11 +322,18 @@ export class PreloopFlowForm extends LitElement {
       // Check if preset_id URL parameter is present
       const urlParams = new URLSearchParams(window.location.search);
       const presetId = urlParams.get('preset_id');
-      if (presetId && this.presets.length > 0) {
+      if (presetId) {
         const preset = this.presets.find((p) => p.id === presetId);
         if (preset) {
-          this.selectPreset(preset);
+          await this.selectPreset(preset);
+          this.pickerSelectedId = preset.id;
+          this.pickerCollapsed = true;
+        } else {
+          this.pickerSelectedId = presetId;
+          this.pickerCollapsed = false;
         }
+      } else {
+        this.capturePresetSnapshot();
       }
 
       // Check if agent_id URL parameter is present
@@ -346,7 +341,6 @@ export class PreloopFlowForm extends LitElement {
       if (urlAgentId) {
         this.targetAgentId = urlAgentId;
         this.flowExecutionPath = 'persistent';
-        this.creationMode = 'scratch';
       }
 
       // Initialize flow fields if empty
@@ -845,28 +839,139 @@ export class PreloopFlowForm extends LitElement {
     this.requestUpdate();
   }
 
-  private selectPreset(preset: any) {
-    this.flow = { ...preset };
-    this.sourcePresetId = preset.id;
+  private mapPresetTools(
+    tools: unknown
+  ): Array<{ server_name: string; tool_name: string }> {
+    if (!Array.isArray(tools)) {
+      return [];
+    }
+    return tools.map((tool) => {
+      if (tool && typeof tool === 'object') {
+        const rec = tool as {
+          name?: string;
+          tool_name?: string;
+          server_name?: string;
+        };
+        return {
+          server_name: rec.server_name || 'preloop-mcp',
+          tool_name: rec.tool_name || rec.name || '',
+        };
+      }
+      return { server_name: 'preloop-mcp', tool_name: String(tool) };
+    });
+  }
 
-    if (preset.allowed_mcp_tools && Array.isArray(preset.allowed_mcp_tools)) {
-      this.flow.allowed_mcp_tools = preset.allowed_mcp_tools.map(
-        (tool: { name: string }) => ({
-          server_name: 'preloop-mcp',
-          tool_name: tool.name,
-        })
-      );
+  private capturePresetSnapshot() {
+    this.presetSnapshot = {
+      prompt_template: this.flow.prompt_template || '',
+      tools: JSON.stringify(this.flow.allowed_mcp_tools || []),
+      trigger: JSON.stringify(this.flow.trigger_event_types || []),
+    };
+  }
+
+  private hasPresetEdits(): boolean {
+    if (!this.presetSnapshot) {
+      return false;
+    }
+    return (
+      (this.flow.prompt_template || '') !==
+        this.presetSnapshot.prompt_template ||
+      JSON.stringify(this.flow.allowed_mcp_tools || []) !==
+        this.presetSnapshot.tools ||
+      JSON.stringify(this.flow.trigger_event_types || []) !==
+        this.presetSnapshot.trigger
+    );
+  }
+
+  private handlePickerSelect(event: CustomEvent<{ presetId: string }>) {
+    const presetId = event.detail?.presetId;
+    if (!presetId || presetId === this.pickerSelectedId) {
+      return;
+    }
+    if (this.hasPresetEdits()) {
+      this.pendingPresetId = presetId;
+      this.replaceEditsOpen = true;
+      return;
+    }
+    void this.applyPresetSelection(presetId);
+  }
+
+  private handlePickerChangeRequest() {
+    this.pickerCollapsed = false;
+  }
+
+  private keepEditing() {
+    this.replaceEditsOpen = false;
+    this.pendingPresetId = null;
+  }
+
+  private confirmSwitchPreset() {
+    const presetId = this.pendingPresetId;
+    this.replaceEditsOpen = false;
+    this.pendingPresetId = null;
+    if (presetId) {
+      void this.applyPresetSelection(presetId);
+    }
+  }
+
+  private async applyPresetSelection(presetId: string) {
+    if (presetId === BLANK_PRESET_ID) {
+      this.selectBlankFlow();
     } else {
-      this.flow.allowed_mcp_tools = [];
+      const preset = this.presets.find((item) => item.id === presetId);
+      if (!preset) {
+        return;
+      }
+      await this.selectPreset(preset);
+    }
+    this.pickerSelectedId = presetId;
+    this.pickerCollapsed = true;
+  }
+
+  private selectBlankFlow() {
+    this.sourcePresetId = null;
+    this.flow = {
+      allowed_mcp_servers: ['preloop-mcp'],
+      allowed_mcp_tools: [],
+      git_clone_config: { enabled: false },
+      notifications: defaultFlowNotifications(),
+      is_enabled: true,
+    };
+    this.triggerType = 'webhook';
+    this.capturePresetSnapshot();
+  }
+
+  private async selectPreset(preset: any) {
+    const servers = Array.isArray(preset.allowed_mcp_servers)
+      ? [...preset.allowed_mcp_servers]
+      : [];
+    if (!servers.includes('preloop-mcp')) {
+      servers.push('preloop-mcp');
     }
 
-    if (!this.flow.allowed_mcp_servers?.includes('preloop-mcp')) {
-      this.flow.allowed_mcp_servers = ['preloop-mcp'];
-    }
-
-    this.flow.is_enabled = true;
-    this._autoPopulatePresetFields();
-    this.creationMode = 'scratch';
+    this.flow = {
+      name: preset.name,
+      description: preset.description,
+      icon: preset.icon,
+      prompt_template: preset.prompt_template,
+      trigger_event_types: Array.isArray(preset.trigger_event_types)
+        ? [...preset.trigger_event_types]
+        : undefined,
+      trigger_config: preset.trigger_config ?? undefined,
+      allowed_mcp_servers: servers,
+      allowed_mcp_tools: this.mapPresetTools(preset.allowed_mcp_tools),
+      agent_type: preset.agent_type,
+      agent_config: preset.agent_config,
+      git_clone_config: preset.git_clone_config,
+      timeout_seconds: preset.timeout_seconds,
+      max_iterations: preset.max_iterations,
+      max_budget: preset.max_budget,
+      custom_commands: preset.custom_commands,
+      is_enabled: true,
+    };
+    this.sourcePresetId = preset.id;
+    await this._autoPopulatePresetFields();
+    this.capturePresetSnapshot();
   }
 
   private async _autoPopulatePresetFields() {
@@ -875,16 +980,18 @@ export class PreloopFlowForm extends LitElement {
       this.flow.trigger_event_source = tracker.id;
       this.triggerType = 'tracker';
 
-      if (tracker.tracker_type === 'github') {
-        this.flow.trigger_event_types = [
-          'pull_request_opened',
-          'pull_request_updated',
-        ];
-      } else if (tracker.tracker_type === 'gitlab') {
-        this.flow.trigger_event_types = [
-          'merge_request_opened',
-          'merge_request_updated',
-        ];
+      if (!this.flow.trigger_event_types?.length) {
+        if (tracker.tracker_type === 'github') {
+          this.flow.trigger_event_types = [
+            'pull_request_opened',
+            'pull_request_updated',
+          ];
+        } else if (tracker.tracker_type === 'gitlab') {
+          this.flow.trigger_event_types = [
+            'merge_request_opened',
+            'merge_request_updated',
+          ];
+        }
       }
 
       const allOrganizations = await listOrganizations().catch(() => []);
@@ -934,82 +1041,6 @@ export class PreloopFlowForm extends LitElement {
     }
 
     this.requestUpdate();
-  }
-
-  private renderCreationModeSelector() {
-    return html`
-      <div class="creation-mode-toggle">
-        <h3
-          style="margin: 0 0 var(--sl-spacing-small) 0; font-size: 1rem; font-weight: 600;"
-        >
-          How would you like to start?
-        </h3>
-        <p
-          style="margin: 0 0 var(--sl-spacing-small) 0; color: var(--sl-color-neutral-600); font-size: var(--sl-font-size-small);"
-        >
-          Choose whether to build a flow from scratch or start from a preset
-          template.
-        </p>
-        <sl-radio-group
-          value=${this.creationMode}
-          @sl-change=${(event: CustomEvent) => {
-            this.creationMode = (event.target as HTMLInputElement).value as
-              'scratch' | 'preset';
-            this.requestUpdate();
-          }}
-        >
-          <sl-radio value="scratch">Create from scratch</sl-radio>
-          <sl-radio value="preset">Use a preset template</sl-radio>
-        </sl-radio-group>
-      </div>
-    `;
-  }
-
-  private renderPresets() {
-    const sortedPresets = [...this.presets].sort((a, b) => {
-      const aIsPR = a.name?.toLowerCase().includes('pull request reviewer')
-        ? 0
-        : 1;
-      const bIsPR = b.name?.toLowerCase().includes('pull request reviewer')
-        ? 0
-        : 1;
-      return aIsPR - bIsPR;
-    });
-
-    return html`
-      ${this.renderCreationModeSelector()}
-      <h2
-        style="font-size: var(--sl-font-size-large); font-weight: 600; color: var(--sl-color-neutral-800); margin: var(--sl-spacing-large) 0 var(--sl-spacing-medium) 0;"
-      >
-        Select a Preset
-      </h2>
-      <div class="form-grid" style="margin-bottom: var(--sl-spacing-large);">
-        ${sortedPresets.map(
-          (preset) => html`
-            <sl-card
-              class="preset-card"
-              @click=${() => this.selectPreset(preset)}
-            >
-              <div slot="header" style="font-weight: 600;">${preset.name}</div>
-              ${preset.description}
-            </sl-card>
-          `
-        )}
-      </div>
-      <div
-        style="display: flex; gap: var(--sl-spacing-medium); justify-content: flex-end; margin-bottom: var(--sl-spacing-2x-large);"
-      >
-        <sl-button variant="default" @click=${this.handleCancel}>
-          Cancel
-        </sl-button>
-        <sl-button
-          variant="primary"
-          @click=${() => (this.creationMode = 'scratch')}
-        >
-          Create from scratch
-        </sl-button>
-      </div>
-    `;
   }
 
   private renderEventFilters() {
@@ -1422,10 +1453,6 @@ export class PreloopFlowForm extends LitElement {
       `;
     }
 
-    if (!this.flow.id && this.creationMode === 'preset') {
-      return this.renderPresets();
-    }
-
     let selectableModels = this.models.filter(
       (m) => m.model_kind !== 'stt' && m.model_kind !== 'tts'
     );
@@ -1461,9 +1488,53 @@ export class PreloopFlowForm extends LitElement {
         @close-modal=${this.closeAIModelDialog}
       ></add-ai-model-modal>
 
-      ${!this.flow.id ? this.renderCreationModeSelector() : ''}
+      ${
+        this.replaceEditsOpen
+          ? html`
+              <sl-dialog
+                label="Replace your edits?"
+                open
+                @sl-request-close=${this.keepEditing}
+              >
+                <p>
+                  Switching presets replaces the prompt, tools and trigger you
+                  changed.
+                </p>
+                <sl-button
+                  slot="footer"
+                  variant="default"
+                  type="button"
+                  @click=${this.keepEditing}
+                >
+                  Keep editing
+                </sl-button>
+                <sl-button
+                  slot="footer"
+                  variant="primary"
+                  type="button"
+                  @click=${this.confirmSwitchPreset}
+                >
+                  Switch preset
+                </sl-button>
+              </sl-dialog>
+            `
+          : nothing
+      }
 
       <form @submit=${this.handleFormSubmit}>
+        ${
+          !this.flow.id
+            ? html`
+                <preloop-flow-preset-picker
+                  .presets=${this.presets}
+                  .selectedId=${this.pickerSelectedId}
+                  ?collapsed=${this.pickerCollapsed}
+                  @preset-select=${this.handlePickerSelect}
+                  @preset-change-request=${this.handlePickerChangeRequest}
+                ></preloop-flow-preset-picker>
+              `
+            : nothing
+        }
         <sl-card>
           <div slot="header" class="card-header-title">
             <sl-icon name="info-circle"></sl-icon> Flow Information

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -980,24 +980,15 @@ export class PreloopFlowForm extends LitElement {
   }
 
   private async _autoPopulatePresetFields() {
-    if (this.trackers.length > 0 && !this.flow.trigger_event_source) {
+    const hasTrackerEvents = Boolean(this.flow.trigger_event_types?.length);
+    if (
+      hasTrackerEvents &&
+      this.trackers.length > 0 &&
+      !this.flow.trigger_event_source
+    ) {
       const tracker = this.trackers[this.trackers.length - 1];
       this.flow.trigger_event_source = tracker.id;
       this.triggerType = 'tracker';
-
-      if (!this.flow.trigger_event_types?.length) {
-        if (tracker.tracker_type === 'github') {
-          this.flow.trigger_event_types = [
-            'pull_request_opened',
-            'pull_request_updated',
-          ];
-        } else if (tracker.tracker_type === 'gitlab') {
-          this.flow.trigger_event_types = [
-            'merge_request_opened',
-            'merge_request_updated',
-          ];
-        }
-      }
 
       const allOrganizations = await listOrganizations().catch(() => []);
       this.organizations = allOrganizations.filter(
@@ -1021,6 +1012,8 @@ export class PreloopFlowForm extends LitElement {
       } else {
         this.startPollingOrganizations(tracker.id);
       }
+    } else if (!hasTrackerEvents) {
+      this.triggerType = 'webhook';
     }
 
     if (!this.flow.ai_model_id) {

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -331,6 +331,7 @@ export class PreloopFlowForm extends LitElement {
         } else {
           this.pickerSelectedId = presetId;
           this.pickerCollapsed = false;
+          this.capturePresetSnapshot();
         }
       } else {
         this.capturePresetSnapshot();
@@ -885,7 +886,11 @@ export class PreloopFlowForm extends LitElement {
 
   private handlePickerSelect(event: CustomEvent<{ presetId: string }>) {
     const presetId = event.detail?.presetId;
-    if (!presetId || presetId === this.pickerSelectedId) {
+    if (!presetId) {
+      return;
+    }
+    if (presetId === this.pickerSelectedId) {
+      this.pickerCollapsed = true;
       return;
     }
     if (this.hasPresetEdits()) {
@@ -1504,6 +1509,7 @@ export class PreloopFlowForm extends LitElement {
                   slot="footer"
                   variant="default"
                   type="button"
+                  autofocus
                   @click=${this.keepEditing}
                 >
                   Keep editing

--- a/frontend/src/components/preloop-flow-preset-picker.test.ts
+++ b/frontend/src/components/preloop-flow-preset-picker.test.ts
@@ -219,6 +219,9 @@ describe('preloop-flow-preset-picker', () => {
     const text = (el.shadowRoot!.textContent || '').replace(/\s+/g, ' ');
     expect(text).to.include('Started from Pull Request Reviewer.');
     expect(text).to.include('Change');
+    expect(el.shadowRoot!.querySelector('a[href="/console/flows"]')).to.equal(
+      null
+    );
     const change = el.shadowRoot!.querySelector('sl-button');
     expect(change).to.exist;
     expect(change!.textContent).to.contain('Change');

--- a/frontend/src/components/preloop-flow-preset-picker.test.ts
+++ b/frontend/src/components/preloop-flow-preset-picker.test.ts
@@ -1,0 +1,248 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import './preloop-flow-preset-picker';
+import {
+  firstSentence,
+  presetChips,
+  presetGroups,
+  type FlowPresetRecord,
+  type PreloopFlowPresetPicker,
+} from './preloop-flow-preset-picker';
+
+const RELEASE_SECURITY_DESCRIPTION =
+  'The full release-time audit in one execution: verify the CI-emitted SBOM ' +
+  '(validity, minimum elements, build cross-checks, license flags), then ' +
+  'match its components against public vulnerability sources (OSV.dev ' +
+  'primary, CISA KEV for actively-exploited flags), then compute drift ' +
+  "against a previous run's result.json when provided. Emits one combined " +
+  '/workspace/result.json (preloop.cra.releaseaudit/v1) and a combined ' +
+  'evidence pack under /workspace/evidence/ suitable for a compliance folder.';
+
+const CATALOG: FlowPresetRecord[] = [
+  {
+    id: 'preset-001',
+    name: 'Issue Triage Assistant',
+    description: 'Automatically analyze new issues, suggest labels.',
+    icon: 'funnel',
+    trigger_event_types: ['issue.opened'],
+    allowed_mcp_tools: [
+      { name: 'a' },
+      { name: 'b' },
+      { name: 'c' },
+      { name: 'd' },
+      { name: 'e' },
+    ],
+  },
+  {
+    id: 'preset-002',
+    name: 'Pull Request Reviewer',
+    description: 'Review a pull request when it opens.',
+    icon: 'code-square',
+    trigger_event_types: ['pull_request_opened'],
+    allowed_mcp_tools: [
+      { name: 'a' },
+      { name: 'b' },
+      { name: 'c' },
+      { name: 'd' },
+    ],
+    git_clone_config: { enabled: true, create_pull_request: false },
+  },
+  {
+    id: 'preset-003',
+    name: 'Observe / Eval',
+    description: 'Watch a repository on a schedule.',
+    icon: 'eye',
+    trigger_event_types: [],
+    allowed_mcp_tools: [],
+  },
+  {
+    id: 'preset-004',
+    name: 'SBOM Verify',
+    description: 'Verify an SBOM.',
+    icon: 'shield-check',
+  },
+  {
+    id: 'preset-006',
+    name: 'Release Security Audit',
+    description: RELEASE_SECURITY_DESCRIPTION,
+    icon: 'shield-lock',
+  },
+  {
+    id: 'preset-007',
+    name: 'Component Due Diligence Record',
+    description: 'Record due diligence.',
+    icon: 'clipboard-check',
+  },
+  {
+    id: 'preset-011',
+    name: 'Automated Issue Implementation',
+    description:
+      'Turn a tracker issue into a working change: read the issue, implement it.',
+    icon: 'lightning',
+    trigger_event_types: ['issue_labeled', 'comment_created'],
+    allowed_mcp_tools: [
+      { name: 'a' },
+      { name: 'b' },
+      { name: 'c' },
+      { name: 'd' },
+      { name: 'e' },
+    ],
+    git_clone_config: { enabled: true, create_pull_request: true },
+  },
+];
+
+const ACCOUNT_PRESET: FlowPresetRecord = {
+  id: 'preset-account',
+  name: 'Office Reviewer',
+  account_id: 'acct-1',
+  description: 'An account-specific preset.',
+  trigger_event_types: ['pull_request_opened'],
+};
+
+describe('presetGroups', () => {
+  it('puts account presets first and keeps catalog order without a PR-reviewer hack', () => {
+    const groups = presetGroups([...CATALOG, ACCOUNT_PRESET]);
+
+    expect(groups.map((group) => group.label)).to.deep.equal([
+      'Your presets',
+      'Tracker automation',
+      'Scheduled review',
+      'Security and compliance',
+    ]);
+    expect(groups[0].presets.map((preset) => preset.id)).to.deep.equal([
+      'preset-account',
+    ]);
+    expect(groups[1].presets.map((preset) => preset.name)).to.deep.equal([
+      'Issue Triage Assistant',
+      'Pull Request Reviewer',
+      'Automated Issue Implementation',
+    ]);
+    expect(groups[2].presets.map((preset) => preset.name)).to.deep.equal([
+      'Observe / Eval',
+    ]);
+    expect(groups[3].presets.map((preset) => preset.name)).to.deep.equal([
+      'SBOM Verify',
+      'Release Security Audit',
+      'Component Due Diligence Record',
+    ]);
+  });
+});
+
+describe('presetChips', () => {
+  it('lists chips for 001, 002, 011 and a tool-less preset', () => {
+    expect(presetChips(CATALOG[0]).map((chip) => chip.label)).to.deep.equal([
+      'Tracker',
+      'Model',
+      '5 tools',
+    ]);
+    expect(presetChips(CATALOG[1]).map((chip) => chip.label)).to.deep.equal([
+      'Tracker',
+      'Model',
+      '4 tools',
+      'Clones repo',
+    ]);
+    expect(presetChips(CATALOG[6]).map((chip) => chip.label)).to.deep.equal([
+      'Tracker',
+      'Model',
+      '5 tools',
+      'Clones repo',
+      'Opens PRs',
+    ]);
+    expect(presetChips(CATALOG[2]).map((chip) => chip.label)).to.deep.equal([
+      'Model',
+    ]);
+    expect(
+      presetChips({ allowed_mcp_tools: [{ name: 'ask_user' }] }).map(
+        (chip) => chip.label
+      )
+    ).to.deep.equal(['Model', '1 tool']);
+  });
+});
+
+describe('firstSentence', () => {
+  it('yields one sentence from the 006 description', () => {
+    const sentence = firstSentence(RELEASE_SECURITY_DESCRIPTION);
+    expect(sentence.startsWith('The full release-time audit')).to.be.true;
+    expect(sentence.endsWith('when provided.')).to.be.true;
+    expect(sentence.includes('Emits one combined')).to.be.false;
+  });
+});
+
+describe('preloop-flow-preset-picker', () => {
+  it('filters search and hides empty groups but keeps Blank flow', async () => {
+    const el = await fixture<PreloopFlowPresetPicker>(
+      html`<preloop-flow-preset-picker
+        .presets=${CATALOG}
+      ></preloop-flow-preset-picker>`
+    );
+    const search = el.shadowRoot!.querySelector('sl-input') as HTMLInputElement;
+    search.value = 'sbom';
+    search.dispatchEvent(new CustomEvent('sl-input', { bubbles: true }));
+    await el.updateComplete;
+
+    const text = el.shadowRoot!.textContent || '';
+    expect(text).to.include('Blank flow');
+    expect(text).to.include('SBOM Verify');
+    expect(text).to.include('Security and compliance');
+    expect(text).to.not.include('Tracker automation');
+    expect(text).to.not.include('Pull Request Reviewer');
+    expect(text).to.not.include('Observe / Eval');
+  });
+
+  it('marks the selected row with aria-selected and the tint class', async () => {
+    const el = await fixture<PreloopFlowPresetPicker>(
+      html`<preloop-flow-preset-picker
+        .presets=${CATALOG}
+        selectedId="preset-002"
+      ></preloop-flow-preset-picker>`
+    );
+    const row = el.shadowRoot!.querySelector(
+      '[data-preset-id="preset-002"]'
+    ) as HTMLElement;
+    expect(row).to.exist;
+    expect(row.getAttribute('aria-selected')).to.equal('true');
+    expect(row.classList.contains('selected')).to.be.true;
+    expect(row.getAttribute('role')).to.equal('option');
+    expect(el.shadowRoot!.querySelector('[role="listbox"]')).to.exist;
+  });
+
+  it('collapses to Started from Pull Request Reviewer. with a Change button', async () => {
+    const el = await fixture<PreloopFlowPresetPicker>(
+      html`<preloop-flow-preset-picker
+        .presets=${CATALOG}
+        selectedId="preset-002"
+        collapsed
+      ></preloop-flow-preset-picker>`
+    );
+    const text = (el.shadowRoot!.textContent || '').replace(/\s+/g, ' ');
+    expect(text).to.include('Started from Pull Request Reviewer.');
+    expect(text).to.include('Change');
+    const change = el.shadowRoot!.querySelector('sl-button');
+    expect(change).to.exist;
+    expect(change!.textContent).to.contain('Change');
+  });
+
+  it('renders the missing note for an unknown preset_id', async () => {
+    const el = await fixture<PreloopFlowPresetPicker>(
+      html`<preloop-flow-preset-picker
+        .presets=${CATALOG}
+        selectedId="missing-preset"
+      ></preloop-flow-preset-picker>`
+    );
+    expect(el.shadowRoot!.textContent).to.include(
+      'That preset is no longer available.'
+    );
+    expect(el.shadowRoot!.querySelector('[role="listbox"]')).to.exist;
+  });
+
+  it('renders no em dash in visible copy', async () => {
+    const el = await fixture<PreloopFlowPresetPicker>(
+      html`<preloop-flow-preset-picker
+        .presets=${[...CATALOG, ACCOUNT_PRESET]}
+      ></preloop-flow-preset-picker>`
+    );
+    const text = el.shadowRoot!.textContent || '';
+    expect(text).to.not.include('\u2014');
+    expect(text).to.not.include('—');
+  });
+});

--- a/frontend/src/components/preloop-flow-preset-picker.test.ts
+++ b/frontend/src/components/preloop-flow-preset-picker.test.ts
@@ -1,4 +1,5 @@
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import type SlInput from '@shoelace-style/shoelace/dist/components/input/input.js';
 
 import './preloop-flow-preset-picker';
 import {
@@ -175,7 +176,7 @@ describe('preloop-flow-preset-picker', () => {
         .presets=${CATALOG}
       ></preloop-flow-preset-picker>`
     );
-    const search = el.shadowRoot!.querySelector('sl-input') as HTMLInputElement;
+    const search = el.shadowRoot!.querySelector('sl-input') as SlInput;
     search.value = 'sbom';
     search.dispatchEvent(new CustomEvent('sl-input', { bubbles: true }));
     await el.updateComplete;
@@ -202,6 +203,7 @@ describe('preloop-flow-preset-picker', () => {
     expect(row).to.exist;
     expect(row.getAttribute('aria-selected')).to.equal('true');
     expect(row.classList.contains('selected')).to.be.true;
+    expect(row.classList.contains('active')).to.be.true;
     expect(row.getAttribute('role')).to.equal('option');
     expect(el.shadowRoot!.querySelector('[role="listbox"]')).to.exist;
   });
@@ -243,6 +245,38 @@ describe('preloop-flow-preset-picker', () => {
     );
     const text = el.shadowRoot!.textContent || '';
     expect(text).to.not.include('\u2014');
-    expect(text).to.not.include('—');
+  });
+
+  it('moves the active row with ArrowDown and selects it with Enter', async () => {
+    const el = await fixture<PreloopFlowPresetPicker>(
+      html`<preloop-flow-preset-picker
+        .presets=${CATALOG}
+      ></preloop-flow-preset-picker>`
+    );
+    const listbox = el.shadowRoot!.querySelector(
+      '[role="listbox"]'
+    ) as HTMLElement;
+    listbox.focus();
+
+    listbox.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
+    );
+    await el.updateComplete;
+    listbox.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
+    );
+    await el.updateComplete;
+
+    const row = el.shadowRoot!.querySelector(
+      '[data-preset-id="preset-002"]'
+    ) as HTMLElement;
+    expect(row.classList.contains('active')).to.be.true;
+
+    const selected = oneEvent(el, 'preset-select');
+    listbox.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    );
+    const event = await selected;
+    expect(event.detail.presetId).to.equal('preset-002');
   });
 });

--- a/frontend/src/components/preloop-flow-preset-picker.ts
+++ b/frontend/src/components/preloop-flow-preset-picker.ts
@@ -482,10 +482,7 @@ export class PreloopFlowPresetPicker extends LitElement {
     }
     return html`
       <div class="summary">
-        <span>
-          Started from
-          <a href="/console/flows">${preset.name}</a>.
-        </span>
+        <span> Started from ${preset.name}. </span>
         <sl-button
           variant="text"
           size="small"

--- a/frontend/src/components/preloop-flow-preset-picker.ts
+++ b/frontend/src/components/preloop-flow-preset-picker.ts
@@ -183,8 +183,9 @@ export class PreloopFlowPresetPicker extends LitElement {
         margin-bottom: 0;
       }
 
-      .listbox {
-        outline: none;
+      .listbox:focus-visible {
+        outline: 2px solid var(--sl-color-primary-600);
+        outline-offset: 2px;
       }
 
       .group-label {
@@ -220,6 +221,10 @@ export class PreloopFlowPresetPicker extends LitElement {
           var(--sl-color-primary-600) 16%,
           transparent
         );
+      }
+
+      .row.active {
+        box-shadow: inset 0 0 0 2px var(--sl-color-primary-600);
       }
 
       .row-icon {
@@ -308,6 +313,16 @@ export class PreloopFlowPresetPicker extends LitElement {
 
   @state()
   private activeId: string = BLANK_PRESET_ID;
+
+  willUpdate(changedProperties: Map<string | number | symbol, unknown>): void {
+    if (
+      changedProperties.has('selectedId') &&
+      this.selectedId &&
+      this.visibleOptionIds().includes(this.selectedId)
+    ) {
+      this.activeId = this.selectedId;
+    }
+  }
 
   private filteredGroups(): PresetGroup[] {
     const query = this.search.trim().toLowerCase();
@@ -426,10 +441,11 @@ export class PreloopFlowPresetPicker extends LitElement {
     preset?: FlowPresetRecord;
   }) {
     const selected = this.selectedId === options.optionId;
+    const active = this.activeId === options.optionId;
     return html`
       <div
         id=${`preset-option-${options.optionId}`}
-        class=${classMap({ row: true, selected })}
+        class=${classMap({ row: true, selected, active })}
         role="option"
         data-preset-id=${options.optionId}
         aria-selected=${selected ? 'true' : 'false'}

--- a/frontend/src/components/preloop-flow-preset-picker.ts
+++ b/frontend/src/components/preloop-flow-preset-picker.ts
@@ -1,0 +1,554 @@
+import { LitElement, css, html, nothing, unsafeCSS } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import '@shoelace-style/shoelace/dist/components/badge/badge.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/input/input.js';
+
+import consoleStyles from '../styles/console-styles.css?inline';
+
+export const BLANK_PRESET_ID = 'blank';
+
+export const PRESET_GROUP_LABELS = {
+  yours: 'Your presets',
+  tracker: 'Tracker automation',
+  scheduled: 'Scheduled review',
+  security: 'Security and compliance',
+} as const;
+
+export interface FlowPresetRecord {
+  id?: string;
+  name?: string;
+  description?: string;
+  icon?: string;
+  account_id?: string | null;
+  slug?: string;
+  trigger_event_types?: string[] | null;
+  allowed_mcp_tools?: unknown[] | null;
+  git_clone_config?: {
+    enabled?: boolean;
+    create_pull_request?: boolean;
+  } | null;
+}
+
+export interface PresetChip {
+  key: string;
+  label: string;
+}
+
+export interface PresetGroup {
+  id: string;
+  label: string;
+  presets: FlowPresetRecord[];
+}
+
+/** Derive a grouping slug. Presets from the API have no slug field (loader-internal). */
+export function presetSlug(preset: FlowPresetRecord): string {
+  if (typeof preset.slug === 'string' && preset.slug.trim()) {
+    return preset.slug.trim().toLowerCase();
+  }
+  return String(preset.name || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function isSecuritySlug(slug: string): boolean {
+  return (
+    slug.startsWith('sbom-') ||
+    slug === 'release-security-audit' ||
+    slug.startsWith('component-due-diligence')
+  );
+}
+
+/**
+ * Group catalog presets client-side until YAML carries `category`.
+ *
+ * Account presets first. Catalog order is kept inside each group.
+ */
+export function presetGroups(presets: FlowPresetRecord[]): PresetGroup[] {
+  const yours: FlowPresetRecord[] = [];
+  const tracker: FlowPresetRecord[] = [];
+  const scheduled: FlowPresetRecord[] = [];
+  const security: FlowPresetRecord[] = [];
+
+  for (const preset of presets) {
+    if (preset.account_id) {
+      yours.push(preset);
+      continue;
+    }
+    const slug = presetSlug(preset);
+    if (isSecuritySlug(slug)) {
+      security.push(preset);
+      continue;
+    }
+    if (preset.trigger_event_types && preset.trigger_event_types.length > 0) {
+      tracker.push(preset);
+      continue;
+    }
+    scheduled.push(preset);
+  }
+
+  const groups: PresetGroup[] = [];
+  if (yours.length) {
+    groups.push({
+      id: 'yours',
+      label: PRESET_GROUP_LABELS.yours,
+      presets: yours,
+    });
+  }
+  if (tracker.length) {
+    groups.push({
+      id: 'tracker',
+      label: PRESET_GROUP_LABELS.tracker,
+      presets: tracker,
+    });
+  }
+  if (scheduled.length) {
+    groups.push({
+      id: 'scheduled',
+      label: PRESET_GROUP_LABELS.scheduled,
+      presets: scheduled,
+    });
+  }
+  if (security.length) {
+    groups.push({
+      id: 'security',
+      label: PRESET_GROUP_LABELS.security,
+      presets: security,
+    });
+  }
+  return groups;
+}
+
+export function presetChips(preset: FlowPresetRecord): PresetChip[] {
+  const chips: PresetChip[] = [];
+  if (preset.trigger_event_types && preset.trigger_event_types.length > 0) {
+    chips.push({ key: 'tracker', label: 'Tracker' });
+  }
+  chips.push({ key: 'model', label: 'Model' });
+  const tools = preset.allowed_mcp_tools || [];
+  if (tools.length > 0) {
+    chips.push({
+      key: 'tools',
+      label: tools.length === 1 ? '1 tool' : `${tools.length} tools`,
+    });
+  }
+  if (preset.git_clone_config?.enabled) {
+    chips.push({ key: 'clone', label: 'Clones repo' });
+  }
+  if (preset.git_clone_config?.create_pull_request) {
+    chips.push({ key: 'pr', label: 'Opens PRs' });
+  }
+  return chips;
+}
+
+export function firstSentence(description: string | null | undefined): string {
+  const text = (description || '').replace(/\s+/g, ' ').trim();
+  if (!text) {
+    return '';
+  }
+  const match = text.match(/^.*?[.!?](?:\s|$)/);
+  return (match ? match[0] : text).trim();
+}
+
+@customElement('preloop-flow-preset-picker')
+export class PreloopFlowPresetPicker extends LitElement {
+  static styles = [
+    unsafeCSS(consoleStyles),
+    css`
+      :host {
+        display: block;
+      }
+
+      .header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--sl-spacing-medium);
+        margin-bottom: var(--sl-spacing-small);
+      }
+
+      .label {
+        font-size: var(--console-text-card-title);
+        font-weight: 600;
+        color: var(--console-body-color);
+      }
+
+      .search {
+        width: 14rem;
+        max-width: 50%;
+        margin-bottom: 0;
+      }
+
+      .listbox {
+        outline: none;
+      }
+
+      .group-label {
+        font-size: var(--console-text-meta);
+        font-weight: 600;
+        color: var(--console-meta-color);
+        padding: var(--sl-spacing-small) 0 var(--sl-spacing-2x-small);
+      }
+
+      .row {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto auto;
+        grid-template-rows: auto auto;
+        column-gap: var(--sl-spacing-small);
+        row-gap: 2px;
+        align-items: center;
+        padding: var(--sl-spacing-small) var(--sl-spacing-2x-small);
+        border-bottom: 1px solid var(--console-hairline);
+        cursor: pointer;
+      }
+
+      .row:last-child {
+        border-bottom: none;
+      }
+
+      .row:hover:not(.selected) {
+        background: var(--console-hover-tint);
+      }
+
+      .row.selected {
+        background: color-mix(
+          in srgb,
+          var(--sl-color-primary-600) 16%,
+          transparent
+        );
+      }
+
+      .row-icon {
+        grid-column: 1;
+        grid-row: 1 / span 2;
+        color: var(--console-meta-color);
+        font-size: 1rem;
+      }
+
+      .row.selected .row-icon {
+        color: var(--sl-color-primary-800);
+      }
+
+      .row-name {
+        grid-column: 2;
+        grid-row: 1;
+        font-size: var(--console-text-body);
+        font-weight: 500;
+        color: var(--console-body-color);
+        min-width: 0;
+      }
+
+      .row.selected .row-name {
+        color: var(--sl-color-primary-800);
+      }
+
+      .row-desc {
+        grid-column: 2 / span 2;
+        grid-row: 2;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        font-size: var(--console-text-meta);
+        color: var(--console-meta-color);
+      }
+
+      .chips {
+        grid-column: 3;
+        grid-row: 1;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 4px;
+      }
+
+      .row-check {
+        grid-column: 4;
+        grid-row: 1 / span 2;
+        color: var(--sl-color-primary-800);
+        font-size: 1rem;
+      }
+
+      .missing {
+        margin: 0 0 var(--sl-spacing-small);
+        color: var(--sl-color-neutral-600);
+        font-size: var(--console-text-meta);
+      }
+
+      .summary {
+        display: flex;
+        align-items: center;
+        gap: var(--sl-spacing-2x-small);
+        font-size: var(--console-text-body);
+        color: var(--console-body-color);
+      }
+
+      .summary a {
+        color: var(--console-link-color);
+      }
+    `,
+  ];
+
+  @property({ type: Array })
+  presets: FlowPresetRecord[] = [];
+
+  /** `''` none, `blank` for Blank flow, otherwise a preset id. */
+  @property({ type: String })
+  selectedId = '';
+
+  @property({ type: Boolean })
+  collapsed = false;
+
+  @state()
+  private search = '';
+
+  @state()
+  private activeId: string = BLANK_PRESET_ID;
+
+  private filteredGroups(): PresetGroup[] {
+    const query = this.search.trim().toLowerCase();
+    const groups = presetGroups(this.presets);
+    if (!query) {
+      return groups;
+    }
+    return groups
+      .map((group) => ({
+        ...group,
+        presets: group.presets.filter((preset) => {
+          const name = (preset.name || '').toLowerCase();
+          const description = (preset.description || '').toLowerCase();
+          return name.includes(query) || description.includes(query);
+        }),
+      }))
+      .filter((group) => group.presets.length > 0);
+  }
+
+  private visibleOptionIds(): string[] {
+    const ids = [BLANK_PRESET_ID];
+    for (const group of this.filteredGroups()) {
+      for (const preset of group.presets) {
+        if (preset.id) {
+          ids.push(preset.id);
+        }
+      }
+    }
+    return ids;
+  }
+
+  private isUnknownSelected(): boolean {
+    return Boolean(
+      this.selectedId &&
+      this.selectedId !== BLANK_PRESET_ID &&
+      !this.presets.some((preset) => preset.id === this.selectedId)
+    );
+  }
+
+  private selectedPreset(): FlowPresetRecord | undefined {
+    if (!this.selectedId || this.selectedId === BLANK_PRESET_ID) {
+      return undefined;
+    }
+    return this.presets.find((preset) => preset.id === this.selectedId);
+  }
+
+  private emitSelect(presetId: string): void {
+    this.dispatchEvent(
+      new CustomEvent('preset-select', {
+        detail: { presetId },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private requestChange(): void {
+    this.dispatchEvent(
+      new CustomEvent('preset-change-request', {
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private handleSearch(event: Event): void {
+    const target = event.target as HTMLInputElement;
+    this.search = target.value || '';
+  }
+
+  private handleListKeydown(event: KeyboardEvent): void {
+    const ids = this.visibleOptionIds();
+    if (ids.length === 0) {
+      return;
+    }
+    const current = ids.includes(this.activeId) ? this.activeId : ids[0];
+    const index = ids.indexOf(current);
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.activeId = ids[Math.min(index + 1, ids.length - 1)];
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.activeId = ids[Math.max(index - 1, 0)];
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      this.activeId = ids[0];
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      this.activeId = ids[ids.length - 1];
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.emitSelect(current);
+    }
+  }
+
+  private renderChips(preset: FlowPresetRecord) {
+    const chips = presetChips(preset);
+    if (chips.length === 0) {
+      return nothing;
+    }
+    return html`
+      <div class="chips">
+        ${chips.map(
+          (chip) => html` <sl-badge class="chip" pill>${chip.label}</sl-badge> `
+        )}
+      </div>
+    `;
+  }
+
+  private renderRow(options: {
+    optionId: string;
+    icon: string;
+    name: string;
+    description: string;
+    preset?: FlowPresetRecord;
+  }) {
+    const selected = this.selectedId === options.optionId;
+    return html`
+      <div
+        id=${`preset-option-${options.optionId}`}
+        class=${classMap({ row: true, selected })}
+        role="option"
+        data-preset-id=${options.optionId}
+        aria-selected=${selected ? 'true' : 'false'}
+        @click=${() => this.emitSelect(options.optionId)}
+      >
+        <sl-icon class="row-icon" name=${options.icon}></sl-icon>
+        <div class="row-name">${options.name}</div>
+        ${options.preset ? this.renderChips(options.preset) : html`<div></div>`}
+        ${
+          selected
+            ? html`<sl-icon class="row-check" name="check-lg"></sl-icon>`
+            : html`<div></div>`
+        }
+        <div class="row-desc">${options.description}</div>
+      </div>
+    `;
+  }
+
+  private renderCollapsed() {
+    const preset = this.selectedPreset();
+    if (this.selectedId === BLANK_PRESET_ID || !preset) {
+      return html`
+        <div class="summary">
+          <span>Blank flow.</span>
+          <sl-button
+            variant="text"
+            size="small"
+            @click=${() => this.requestChange()}
+          >
+            Change
+          </sl-button>
+        </div>
+      `;
+    }
+    return html`
+      <div class="summary">
+        <span>
+          Started from
+          <a href="/console/flows">${preset.name}</a>.
+        </span>
+        <sl-button
+          variant="text"
+          size="small"
+          @click=${() => this.requestChange()}
+        >
+          Change
+        </sl-button>
+      </div>
+    `;
+  }
+
+  private renderList() {
+    const groups = this.filteredGroups();
+    const activeId = this.visibleOptionIds().includes(this.activeId)
+      ? this.activeId
+      : BLANK_PRESET_ID;
+
+    return html`
+      <div class="header">
+        <div class="label">Start from</div>
+        <sl-input
+          class="search"
+          size="small"
+          clearable
+          placeholder="Search presets"
+          .value=${this.search}
+          @sl-input=${this.handleSearch}
+          @sl-clear=${() => {
+            this.search = '';
+          }}
+        ></sl-input>
+      </div>
+      ${
+        this.isUnknownSelected()
+          ? html`<p class="missing">That preset is no longer available.</p>`
+          : nothing
+      }
+      <div
+        class="listbox"
+        role="listbox"
+        tabindex="0"
+        aria-label="Start from"
+        aria-activedescendant=${`preset-option-${activeId}`}
+        @keydown=${this.handleListKeydown}
+      >
+        ${this.renderRow({
+          optionId: BLANK_PRESET_ID,
+          icon: 'pencil',
+          name: 'Blank flow',
+          description: 'Write the prompt and choose the trigger yourself.',
+        })}
+        ${groups.map(
+          (group) => html`
+            <div class="group-label">${group.label}</div>
+            ${group.presets.map((preset) =>
+              this.renderRow({
+                optionId: preset.id || '',
+                icon: preset.icon || 'gear',
+                name: preset.name || 'Untitled preset',
+                description: firstSentence(preset.description),
+                preset,
+              })
+            )}
+          `
+        )}
+      </div>
+    `;
+  }
+
+  render() {
+    if (this.collapsed && !this.isUnknownSelected()) {
+      return this.renderCollapsed();
+    }
+    return this.renderList();
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'preloop-flow-preset-picker': PreloopFlowPresetPicker;
+  }
+}

--- a/frontend/src/views/authed/flows-view.test.ts
+++ b/frontend/src/views/authed/flows-view.test.ts
@@ -986,14 +986,34 @@ describe('FlowsView', () => {
       expect(element.shadowRoot?.querySelector('table.flows-table')).to.exist;
     });
   });
-});
 
-describe('FlowsView preset action copy', () => {
   it('labels the preset card action Use preset', async () => {
-    const res = await fetch(new URL('./flows-view.ts', import.meta.url).href);
-    expect(res.ok).to.be.true;
-    const source = await res.text();
-    expect(source).to.include('Use preset');
-    expect(source).to.not.include('Use template');
+    fetchStub = createFetchStub(
+      [],
+      [{ id: 'preset-1', name: 'Office Reviewer' }]
+    );
+    const element = (await fixture(
+      html`<flows-view></flows-view>`
+    )) as FlowsView;
+
+    await waitUntil(
+      () => !(element as any).isLoading,
+      'Flows view did not finish loading'
+    );
+    await waitUntil(
+      () => (element as any).presets?.length === 1,
+      'Presets did not load'
+    );
+    await element.updateComplete;
+
+    const buttons = Array.from(
+      element.shadowRoot!.querySelectorAll('.flow-card sl-button')
+    );
+    expect(
+      buttons.some((button) =>
+        (button.textContent || '').includes('Use preset')
+      )
+    ).to.be.true;
+    expect(element.shadowRoot!.textContent).to.not.include('Use template');
   });
 });

--- a/frontend/src/views/authed/flows-view.test.ts
+++ b/frontend/src/views/authed/flows-view.test.ts
@@ -987,3 +987,13 @@ describe('FlowsView', () => {
     });
   });
 });
+
+describe('FlowsView preset action copy', () => {
+  it('labels the preset card action Use preset', async () => {
+    const res = await fetch(new URL('./flows-view.ts', import.meta.url).href);
+    expect(res.ok).to.be.true;
+    const source = await res.text();
+    expect(source).to.include('Use preset');
+    expect(source).to.not.include('Use template');
+  });
+});

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -2034,7 +2034,7 @@ export class FlowsView extends LitElement {
           </div>
           <div class="flow-footer-actions">
             <sl-button size="small" @click=${() => this.clonePreset(preset.id)}>
-              Use template
+              Use preset
             </sl-button>
             ${
               preset.account_id


### PR DESCRIPTION
## Why
The new-flow form opened with a "How would you like to start?" radio and a grid of preset cards that was hard to scan and easy to misread, and choosing a preset spread the preset's own `id` into the draft.

## What changed
- New `components/preloop-flow-preset-picker.ts`: a **Start from** section at the top of the form. One hairline list, one click, no mode switch. **Blank flow** first, then presets grouped as Your presets / Tracker automation / Scheduled review / Security and compliance (client-side rule until presets carry a category), each row with icon, name, one-line description and chips derived from the preset (Tracker, Model, N tools, Clones repo, Opens PRs). Search box filters name and description and hides empty groups. Selected row uses the D27 state tint; keyboard: one tab stop, arrows / Home / End move, Enter or Space selects, visible focus ring and active row.
- After a choice the section collapses to `Started from {name}. Change` (or `Blank flow. Change`). `?preset_id=` preselects and collapses; an unknown id shows "That preset is no longer available."
- Switching presets after editing prompt, tools or trigger opens "Replace your edits?" with Keep editing / Switch preset.
- `selectPreset` builds the draft from an allow-list of preset fields and never copies `id`, `is_preset`, `account_id`, timestamps, lineage flags, `ai_model_id`, `trigger_event_source` or `runner_pool`. `_autoPopulatePresetFields` applies the GitHub/GitLab PR trigger defaults only when the preset left `trigger_event_types` empty.
- Removed `creationMode`, the radio, the card grid and their CSS. Flows page: "Use template" is now "Use preset".

## Tests
Full suite: 132 files, 1428 passed, 0 failed. New: 8 picker tests (groups, chips, first sentence, search, selected state, collapse, unknown preset, no em dash) plus keyboard navigation, 6 form tests (payload carries `source_preset_id` and no `id`; triage keeps `issue.opened`; blank draft still gets PR defaults; Blank after preset clears; edited prompt then switch shows the dialog; `?preset_id=` collapses), 1 flows-view string test.

Companion: the runner pool select rework (separate PR, touches a different region of `preloop-flow-form.ts`).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> UI refactor with strong test coverage. The prior tracker/PR-defaults concern for scheduled and security presets has been resolved: webhook/schedule presets now correctly stay on the webhook trigger.
>
> **Overview**
> Replaces the new-flow "How would you like to start?" radio and preset card grid with a single searchable, keyboard-navigable Start from picker, and rewrites `selectPreset` to copy an allow-list of preset fields (never `id`) while forwarding `source_preset_id`. Adds a "Replace your edits?" guard when switching presets after edits, and collapses the picker to a summary line after selection.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit d77398fd. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
