### PR TITLE
Tools: MCP and Native tabs, summary strip, shared list toolbar

### DIFF
--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -70,11 +70,11 @@ Every console background comes from one surface ladder declared per theme at doc
 
 ### Tools Page (`src/views/authed/tools-view.ts`)
 
-The Tools page has been redesigned from a card-based layout to a tree-style list view:
+The Tools page is MCP and Native tabs, a summary strip of filterable counts, and the shared `list-toolbar`:
 
-*   **Summary stats table:** Interactive statistics panel showing tool counts (total, available/unavailable, enabled/disabled, built-in/proxied, with rules/no rules, require approval/no approval, approval workflows). Each stat is a clickable filter link.
-*   **Unified filter system:** Single active filter at a time, text search, and approval workflow filter dropdown.
-*   **Tool groups:** Tools grouped by source — external MCP servers listed first, then HTTP tools, then built-in tools.
+*   **Tabs:** MCP (proxied and built-in tools) is the default, restored from `?tab=` or `localStorage`. Native is the agent-source catalogue (Bash, Edit, Write, and others). The Native list body ships in a follow-up; this page keeps the tab, the Native defaults card, and a zero count until then.
+*   **Summary strip:** Clickable counts (total, available, enabled, with rules, require approval). Each button is `aria-pressed` and toggles a single filter. The count slot is `aria-live="polite"`. Unavailable reasons stay in the tool-row tooltip.
+*   **Toolbar:** Search plus Status, Server, Rules, and Workflow filters on `list-toolbar`, matching Models and Trackers. The List/Cards toggle is hidden (`views=['cards']`) until the flat table lands, so a stored view choice cannot change the page.
 *   **Import/Export:** Full configuration export/import as YAML.
 *   **Key components:**
     *   `tool-list-item.ts` — Individual tool row with expand/collapse, enable/disable toggle, rule summary badges, and drag-and-drop rule reordering.

--- a/frontend/src/views/authed/tools-view.test.ts
+++ b/frontend/src/views/authed/tools-view.test.ts
@@ -254,9 +254,19 @@ describe('ToolsView (approvals + conditions)', () => {
     expect(stripText).to.not.contain('toolss');
     expect(stripText).to.not.contain('Total tools');
 
-    const note = el.shadowRoot?.querySelector('.unavailable-note');
-    expect(note).to.exist;
-    expect(note?.textContent).to.contain('Requires a connected tracker');
+    const tooltip = el.shadowRoot?.querySelector(
+      '.summary-strip sl-tooltip'
+    ) as HTMLElement | null;
+    expect(tooltip).to.exist;
+    expect(tooltip?.getAttribute('content')).to.contain(
+      'Requires a connected tracker'
+    );
+    expect(el.shadowRoot?.querySelector('.unavailable-note')).to.equal(null);
+
+    const unavailableButton = tooltip?.querySelector(
+      '.strip-count'
+    ) as HTMLButtonElement | null;
+    expect(unavailableButton?.getAttribute('aria-pressed')).to.equal('false');
 
     const contextTax = el.shadowRoot?.querySelector('.context-tax');
     expect(contextTax).to.exist;
@@ -698,6 +708,7 @@ describe('ToolsView – tabs and toolbar', () => {
   }
 
   beforeEach(() => {
+    localStorage.removeItem('preloop.tools.view_mode');
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
     tools = [makeTool()];
@@ -723,6 +734,7 @@ describe('ToolsView – tabs and toolbar', () => {
 
   afterEach(() => {
     fetchStub.restore();
+    localStorage.removeItem('preloop.tools.view_mode');
     localStorage.clear();
     window.history.replaceState({}, '', window.location.pathname);
     invalidateApiCaches();
@@ -810,6 +822,26 @@ describe('ToolsView – tabs and toolbar', () => {
 
     const toolbar = el.shadowRoot?.querySelector('list-toolbar') as HTMLElement;
     expect(toolbar).to.exist;
+    expect(
+      el.shadowRoot
+        ?.querySelector('sl-select.status-filter')
+        ?.getAttribute('label')
+    ).to.equal('Status');
+    expect(
+      el.shadowRoot
+        ?.querySelector('sl-select.server-filter')
+        ?.getAttribute('label')
+    ).to.equal('Server');
+    expect(
+      el.shadowRoot
+        ?.querySelector('sl-select.rules-filter')
+        ?.getAttribute('label')
+    ).to.equal('Rules');
+    expect(
+      el.shadowRoot
+        ?.querySelector('sl-select.workflow-filter')
+        ?.getAttribute('label')
+    ).to.equal('Workflow');
     toolbar.dispatchEvent(
       new CustomEvent('search-change', {
         detail: { value: 'alpha' },
@@ -878,7 +910,7 @@ describe('ToolsView – tabs and toolbar', () => {
     expect((el as any).showSetupDialog).to.equal(true);
     const dialog = el.shadowRoot?.querySelector('mcp-setup-dialog');
     expect(dialog).to.exist;
-    expect((dialog as any).open).to.not.equal(false);
+    expect((dialog as any).open).to.equal(true);
   });
 
   it('add MCP server opens the server form', async () => {
@@ -927,6 +959,64 @@ describe('ToolsView – tabs and toolbar', () => {
 
     expect((el as any).showPolicyDialog).to.equal(true);
     expect((el as any).editingPolicy).to.equal(null);
+  });
+
+  it('view toggle persists to preloop.tools.view_mode', async () => {
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(() => !(el as any).loading, 'Still loading');
+    await el.updateComplete;
+
+    const toolbar = el.shadowRoot?.querySelector(
+      'list-toolbar'
+    ) as HTMLElement & {
+      view: string;
+      views: string[];
+    };
+    expect(toolbar).to.exist;
+    expect(toolbar.views).to.deep.equal(['cards']);
+    expect(toolbar.view).to.equal('cards');
+    expect(toolbar.shadowRoot?.querySelector('sl-button-group')).to.equal(null);
+
+    toolbar.dispatchEvent(
+      new CustomEvent('view-change', {
+        detail: { value: 'list' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await el.updateComplete;
+
+    expect(localStorage.getItem('preloop.tools.view_mode')).to.equal('list');
+    expect((el as any).viewMode).to.equal('list');
+  });
+
+  it('strip counts set and clear the matching filter', async () => {
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(() => !(el as any).loading, 'Still loading');
+    await el.updateComplete;
+
+    const enabled = [
+      ...(el.shadowRoot?.querySelectorAll('.strip-count') || []),
+    ].find((button) => button.textContent?.includes('enabled')) as
+      HTMLButtonElement | undefined;
+    expect(enabled).to.exist;
+    enabled!.click();
+    await el.updateComplete;
+
+    expect((el as any).filters.statuses).to.deep.equal(['enabled']);
+    expect(enabled!.getAttribute('aria-pressed')).to.equal('true');
+
+    const toolsCount = [
+      ...(el.shadowRoot?.querySelectorAll('.strip-count') || []),
+    ].find((button) => /^\s*\d+\s+tools\s*$/.test(button.textContent || '')) as
+      HTMLButtonElement | undefined;
+    expect(toolsCount).to.exist;
+    toolsCount!.click();
+    await el.updateComplete;
+
+    expect((el as any).filters.statuses).to.deep.equal([]);
+    expect(toolsCount!.getAttribute('aria-pressed')).to.equal('true');
+    expect(enabled!.getAttribute('aria-pressed')).to.equal('false');
   });
 });
 

--- a/frontend/src/views/authed/tools-view.test.ts
+++ b/frontend/src/views/authed/tools-view.test.ts
@@ -192,10 +192,11 @@ describe('ToolsView (approvals + conditions)', () => {
   afterEach(() => {
     fetchStub.restore();
     localStorage.clear();
+    window.history.replaceState({}, '', window.location.pathname);
     invalidateApiCaches();
   });
 
-  it('renders the summary stats with correct labels and an unavailable note', async () => {
+  it('renders the summary strip counts and the unavailable count', async () => {
     const availableTool = {
       name: 'example_tool',
       description: 'Example tool',
@@ -241,13 +242,17 @@ describe('ToolsView (approvals + conditions)', () => {
 
     const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
     await waitUntil(
-      () => el.shadowRoot?.querySelector('.summary-table') !== null,
-      'Summary table did not render'
+      () => el.shadowRoot?.querySelector('.summary-strip') !== null,
+      'Summary strip did not render'
     );
 
-    const summary = el.shadowRoot?.querySelector('.summary-table');
-    expect(summary?.textContent).to.contain('Total tools');
-    expect(summary?.textContent).to.not.contain('toolss');
+    const summary = el.shadowRoot?.querySelector('.summary-strip');
+    const stripText = summary?.textContent?.replace(/\s+/g, ' ') || '';
+    expect(stripText).to.contain('2 tools');
+    expect(stripText).to.contain('1 enabled');
+    expect(stripText).to.contain('1 unavailable');
+    expect(stripText).to.not.contain('toolss');
+    expect(stripText).to.not.contain('Total tools');
 
     const note = el.shadowRoot?.querySelector('.unavailable-note');
     expect(note).to.exist;
@@ -259,7 +264,7 @@ describe('ToolsView (approvals + conditions)', () => {
     expect(contextTax?.textContent?.replace(/\s+/g, ' ')).to.contain(
       '~1,200 tokens'
     );
-    expect(contextTax?.textContent).to.contain('to every agent request');
+    expect(contextTax?.textContent).to.contain('to every request');
   });
 
   it('renders the native tool approvals account-default card with override links', async () => {
@@ -605,10 +610,30 @@ describe('ToolsView (approvals + conditions)', () => {
   });
 });
 
-describe('ToolsView – filter persistence', () => {
+describe('ToolsView – tabs and toolbar', () => {
   let fetchStub: sinon.SinonStub;
+  let tools: Record<string, unknown>[];
+  let workflows: Record<string, unknown>[];
 
-  const STORAGE_KEY = 'preloop:tools-filter';
+  function makeTool(
+    overrides: Record<string, unknown> = {}
+  ): Record<string, unknown> {
+    return {
+      name: 'example_tool',
+      description: 'Example tool',
+      source: 'builtin',
+      source_id: null,
+      source_name: 'Built-in',
+      schema: {},
+      is_enabled: true,
+      is_supported: true,
+      approval_workflow_id: null,
+      has_approval_condition: false,
+      config_id: null,
+      access_rules: [],
+      ...overrides,
+    };
+  }
 
   function stubLoadData() {
     fetchStub.callsFake(
@@ -617,7 +642,7 @@ describe('ToolsView – filter persistence', () => {
         const method = (init?.method || 'GET').toUpperCase();
 
         if (url.endsWith('/api/v1/tools') && method === 'GET') {
-          return new Response(JSON.stringify([]), {
+          return new Response(JSON.stringify(tools), {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
           });
@@ -629,7 +654,7 @@ describe('ToolsView – filter persistence', () => {
           });
         }
         if (url.endsWith('/api/v1/approval-workflows') && method === 'GET') {
-          return new Response(JSON.stringify([]), {
+          return new Response(JSON.stringify(workflows), {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
           });
@@ -652,6 +677,18 @@ describe('ToolsView – filter persistence', () => {
             headers: { 'Content-Type': 'application/json' },
           });
         }
+        if (url.endsWith('/api/v1/account/governance-defaults')) {
+          return new Response(
+            JSON.stringify({
+              defaults: {
+                native_tool_approvals: null,
+                approval_workflow_id: null,
+              },
+              override_agent_ids: [],
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
         return new Response(JSON.stringify({}), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -663,6 +700,23 @@ describe('ToolsView – filter persistence', () => {
   beforeEach(() => {
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
+    tools = [makeTool()];
+    workflows = [
+      {
+        id: 'policy-1',
+        name: 'Default',
+        description: 'Default policy',
+        approval_type: 'standard',
+        is_default: true,
+      },
+      {
+        id: 'policy-2',
+        name: 'Security',
+        description: 'Security policy',
+        approval_type: 'standard',
+        is_default: false,
+      },
+    ];
     fetchStub = sinon.stub(window, 'fetch');
     stubLoadData();
   });
@@ -670,50 +724,209 @@ describe('ToolsView – filter persistence', () => {
   afterEach(() => {
     fetchStub.restore();
     localStorage.clear();
+    window.history.replaceState({}, '', window.location.pathname);
     invalidateApiCaches();
   });
 
-  it('defaults to "available" filter when no saved preference', async () => {
+  it('defaults to the MCP tab and restores the native tab from localStorage', async () => {
     const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
     await waitUntil(() => !(el as any).loading, 'Still loading');
     await el.updateComplete;
 
-    expect((el as any).activeFilter).to.equal('available');
+    expect((el as any).activeTab).to.equal('mcp');
+    const mcpTab = el.shadowRoot?.querySelector('sl-tab[panel="mcp"]');
+    expect(mcpTab?.textContent).to.contain('MCP tools');
+    el.remove();
+
+    window.history.replaceState({}, '', window.location.pathname);
+    localStorage.setItem('preloop.tools.tab', 'native');
+
+    const restored = (await fixture(
+      html`<tools-view></tools-view>`
+    )) as ToolsView;
+    await waitUntil(() => !(restored as any).loading, 'Still loading');
+    await restored.updateComplete;
+
+    expect((restored as any).activeTab).to.equal('native');
+    expect(localStorage.getItem('preloop.tools.tab')).to.equal('native');
   });
 
-  it('restores saved filter from localStorage on mount', async () => {
-    localStorage.setItem(STORAGE_KEY, 'prelooped');
+  it('?tab=native opens the native tab', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      `${window.location.pathname}?tab=native`
+    );
 
     const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
     await waitUntil(() => !(el as any).loading, 'Still loading');
     await el.updateComplete;
 
-    expect((el as any).activeFilter).to.equal('prelooped');
+    expect((el as any).activeTab).to.equal('native');
+    expect(localStorage.getItem('preloop.tools.tab')).to.equal('native');
   });
 
-  it('persists filter to localStorage when changed', async () => {
+  it('native tab renders the defaults strip with the three stable ids', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      `${window.location.pathname}?tab=native`
+    );
+
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(
+      () => !(el as any).loading && (el as any).governanceDefaults !== null,
+      'Governance defaults did not load'
+    );
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('#native-approvals-defaults-card')).to
+      .exist;
+    expect(el.shadowRoot?.querySelector('#native-approvals-default-switch')).to
+      .exist;
+    expect(el.shadowRoot?.querySelector('#native-approvals-default-workflow'))
+      .to.exist;
+    expect((el as any).activeTab).to.equal('native');
+    expect(el.shadowRoot?.textContent).to.contain(
+      'No native tool calls have reached Preloop yet'
+    );
+    expect(
+      el.shadowRoot?.querySelector('sl-tab[panel="native"]')?.textContent
+    ).to.contain('Native tools 0');
+  });
+
+  it('toolbar search narrows the tool list', async () => {
+    tools = [
+      makeTool({ name: 'alpha_search', description: 'First' }),
+      makeTool({ name: 'beta_other', description: 'Second' }),
+    ];
+
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(
+      () => (el as any).tools?.length === 2,
+      'Tools did not load'
+    );
+    await el.updateComplete;
+
+    const toolbar = el.shadowRoot?.querySelector('list-toolbar') as HTMLElement;
+    expect(toolbar).to.exist;
+    toolbar.dispatchEvent(
+      new CustomEvent('search-change', {
+        detail: { value: 'alpha' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await el.updateComplete;
+
+    const names = ((el as any)._getFilteredTools() as { name: string }[]).map(
+      (tool) => tool.name
+    );
+    expect(names).to.deep.equal(['alpha_search']);
+  });
+
+  it('workflow filter shows only tools whose rules use that workflow', async () => {
+    tools = [
+      makeTool({
+        name: 'secured_tool',
+        access_rules: [
+          {
+            id: 'rule-1',
+            action: 'require_approval',
+            is_enabled: true,
+            approval_workflow_id: 'policy-2',
+          },
+        ],
+      }),
+      makeTool({ name: 'open_tool', access_rules: [] }),
+    ];
+
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(
+      () => (el as any).tools?.length === 2,
+      'Tools did not load'
+    );
+    await el.updateComplete;
+
+    const select = el.shadowRoot?.querySelector(
+      'sl-select.workflow-filter'
+    ) as HTMLSelectElement;
+    expect(select).to.exist;
+    select.value = 'policy-2';
+    select.dispatchEvent(new CustomEvent('sl-change'));
+    await el.updateComplete;
+
+    const names = ((el as any)._getFilteredTools() as { name: string }[]).map(
+      (tool) => tool.name
+    );
+    expect(names).to.deep.equal(['secured_tool']);
+  });
+
+  it('connect an agent opens the setup dialog', async () => {
     const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
     await waitUntil(() => !(el as any).loading, 'Still loading');
     await el.updateComplete;
 
-    (el as any)._setFilter('prelooped');
-    expect(localStorage.getItem(STORAGE_KEY)).to.equal('prelooped');
-    expect((el as any).activeFilter).to.equal('prelooped');
+    const button = Array.from(
+      el.shadowRoot!.querySelectorAll('sl-button')
+    ).find((item) => item.textContent?.includes('Connect an agent')) as
+      HTMLElement | undefined;
+    expect(button).to.exist;
+    button!.click();
+    await el.updateComplete;
+
+    expect((el as any).showSetupDialog).to.equal(true);
+    const dialog = el.shadowRoot?.querySelector('mcp-setup-dialog');
+    expect(dialog).to.exist;
+    expect((dialog as any).open).to.not.equal(false);
   });
 
-  it('survives round-trip: set filter → remount → filter restored', async () => {
-    // Mount first instance, set filter
-    const el1 = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
-    await waitUntil(() => !(el1 as any).loading, 'Still loading');
-    (el1 as any)._setFilter('mcp');
-    el1.remove();
+  it('add MCP server opens the server form', async () => {
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(() => !(el as any).loading, 'Still loading');
+    await el.updateComplete;
 
-    // Mount second instance — should pick up the saved filter
-    const el2 = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
-    await waitUntil(() => !(el2 as any).loading, 'Still loading');
-    await el2.updateComplete;
+    const button = Array.from(
+      el.shadowRoot!.querySelectorAll('sl-button')
+    ).find((item) => item.textContent?.includes('Add MCP server')) as
+      HTMLElement | undefined;
+    expect(button).to.exist;
+    button!.click();
+    await el.updateComplete;
 
-    expect((el2 as any).activeFilter).to.equal('mcp');
+    expect((el as any).isAddingMCPServer).to.equal(true);
+    expect(el.shadowRoot?.querySelector('mcp-server-form')).to.exist;
+  });
+
+  it('workflows menu opens the workflow dialog for edit and for new', async () => {
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(() => !(el as any).loading, 'Still loading');
+    await el.updateComplete;
+
+    const menu = el.shadowRoot?.querySelector('.workflows-menu sl-menu');
+    expect(menu).to.exist;
+    const editItem = menu?.querySelector(
+      'sl-menu-item[data-workflow-edit="policy-2"]'
+    ) as HTMLElement;
+    expect(editItem).to.exist;
+    editItem.click();
+    await el.updateComplete;
+
+    expect((el as any).showPolicyDialog).to.equal(true);
+    expect((el as any).editingPolicy?.id).to.equal('policy-2');
+
+    (el as any)._closePolicyDialog();
+    await el.updateComplete;
+
+    const newItem = menu?.querySelector(
+      'sl-menu-item[data-workflow-new]'
+    ) as HTMLElement;
+    expect(newItem).to.exist;
+    newItem.click();
+    await el.updateComplete;
+
+    expect((el as any).showPolicyDialog).to.equal(true);
+    expect((el as any).editingPolicy).to.equal(null);
   });
 });
 

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -25,7 +25,6 @@ import {
 } from '../../api';
 import type { AccountGovernanceDefaults } from '../../types';
 import '../../components/mcp-server-form';
-import '../../components/mcp-server-card';
 import '../../components/tools-editor-component';
 import '../../components/mcp-setup-dialog';
 import '../../components/approval-workflow-dialog';
@@ -80,6 +79,9 @@ interface ToolsFilters {
 
 const TAB_STORAGE_KEY = 'preloop.tools.tab';
 const VIEW_MODE_KEY = 'preloop.tools.view_mode';
+// Cards only until the flat table lands; a List/Cards toggle would persist
+// a choice that does not change the page.
+const TOOLS_VIEWS: ListViewMode[] = ['cards'];
 const EMPTY_FILTERS: ToolsFilters = {
   query: '',
   statuses: [],
@@ -149,7 +151,6 @@ export class ToolsView extends LitElement {
   @state() private starterPolicyDiff: StarterPolicyDiff | null = null;
   @state() private starterPolicyReviewConfirmed = false;
   @state() private toolUsageStats: GatewayUsageByTool[] = [];
-  @state() private toolStatsLoading = false;
 
   // Approval workflow dialog
   @state() private showPolicyDialog = false;
@@ -212,13 +213,7 @@ export class ToolsView extends LitElement {
         color: var(--sl-color-primary-700);
       }
 
-      .strip-count.muted {
-        opacity: 0.4;
-        cursor: default;
-      }
-
-      .context-tax,
-      .unavailable-note {
+      .context-tax {
         color: var(--console-meta-color, var(--sl-color-neutral-600));
       }
 
@@ -230,6 +225,18 @@ export class ToolsView extends LitElement {
       .toolbar-wrap {
         width: 100%;
         margin-bottom: var(--sl-spacing-medium);
+      }
+
+      sl-select::part(form-control-label) {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+        border: 0;
       }
 
       .defaults-strip {
@@ -599,7 +606,6 @@ export class ToolsView extends LitElement {
   }
 
   private async _loadToolUsageStats() {
-    this.toolStatsLoading = true;
     try {
       const end = new Date();
       const start = new Date(end);
@@ -611,8 +617,6 @@ export class ToolsView extends LitElement {
       this.toolUsageStats = stats.tools || [];
     } catch {
       this.toolUsageStats = [];
-    } finally {
-      this.toolStatsLoading = false;
     }
   }
 
@@ -1658,7 +1662,6 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     label: string,
     options: {
       active?: boolean;
-      muted?: boolean;
       tooltip?: string;
       onClick?: () => void;
     } = {}
@@ -1666,11 +1669,9 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     const button = html`
       <button
         type="button"
-        class="strip-count${options.active ? ' active' : ''}${
-          options.muted ? ' muted' : ''
-        }"
-        ?disabled=${options.muted}
-        @click=${options.muted ? undefined : options.onClick}
+        class="strip-count${options.active ? ' active' : ''}"
+        aria-pressed=${String(Boolean(options.active))}
+        @click=${options.onClick}
       >
         ${count} ${label}
       </button>
@@ -1739,8 +1740,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
                   tooltip: unavailableTooltip,
                   onClick: () =>
                     this._toggleSingleFilter('statuses', 'unavailable'),
-                })}
-                <span class="unavailable-note">${unavailableTooltip}</span>`
+                })}`
             : ''
         }
       </div>
@@ -1751,9 +1751,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     const count = this.approvalPolicies.length;
     return html`
       <sl-dropdown class="workflows-menu" hoist>
-        <sl-button slot="trigger" size="small" caret>
-          Workflows (${count})
-        </sl-button>
+        <sl-button slot="trigger" caret> Workflows (${count}) </sl-button>
         <sl-menu>
           ${this.approvalPolicies.map(
             (policy) => html`
@@ -1788,13 +1786,15 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
         <list-toolbar
           .search=${this.filters.query}
           searchPlaceholder="Search tools"
-          .view=${this.effectiveView}
-          .views=${['list', 'cards']}
+          toggleLabel="Tools view"
+          .view=${'cards'}
+          .views=${TOOLS_VIEWS}
           @search-change=${this._handleSearchChange}
           @view-change=${this._handleViewChange}
         >
           <sl-select
             class="status-filter"
+            label="Status"
             clearable
             placeholder="Any status"
             .value=${this.filters.statuses[0] || ''}
@@ -1806,6 +1806,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
           </sl-select>
           <sl-select
             class="server-filter"
+            label="Server"
             clearable
             placeholder="Any server"
             .value=${this.filters.servers[0] || ''}
@@ -1819,6 +1820,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
           </sl-select>
           <sl-select
             class="rules-filter"
+            label="Rules"
             clearable
             placeholder="Any rules"
             .value=${this.filters.rules[0] || ''}
@@ -1830,6 +1832,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
           </sl-select>
           <sl-select
             class="workflow-filter"
+            label="Workflow"
             clearable
             placeholder="Any workflow"
             .value=${this.filters.workflows[0] || ''}

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css, unsafeCSS, type TemplateResult } from 'lit';
+import { LitElement, html, css, unsafeCSS } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import {
   getTools,
@@ -29,16 +29,23 @@ import '../../components/mcp-server-card';
 import '../../components/tools-editor-component';
 import '../../components/mcp-setup-dialog';
 import '../../components/approval-workflow-dialog';
+import '../../components/list-toolbar';
 import type { Tool, ApprovalWorkflow } from '../../components/tool-card';
 import type { MCPServer } from '../../components/mcp-server-card';
 import type { AccessRuleSummary } from '../../components/governance-rule-set-editor';
 import type { RuleFormData } from '../../components/tool-rule-editor';
+import {
+  effectiveViewMode,
+  loadViewMode,
+  saveViewMode,
+  subscribeNarrowViewport,
+  type ListViewMode,
+  type NarrowViewportSubscription,
+} from '../../utils/view-mode';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
-import '@shoelace-style/shoelace/dist/components/badge/badge.js';
-import '@shoelace-style/shoelace/dist/components/divider/divider.js';
 import '@shoelace-style/shoelace/dist/components/icon-button/icon-button.js';
 import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
@@ -46,17 +53,50 @@ import '@shoelace-style/shoelace/dist/components/copy-button/copy-button.js';
 import '@shoelace-style/shoelace/dist/components/dropdown/dropdown.js';
 import '@shoelace-style/shoelace/dist/components/menu/menu.js';
 import '@shoelace-style/shoelace/dist/components/menu-item/menu-item.js';
+import '@shoelace-style/shoelace/dist/components/menu-label/menu-label.js';
 import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
-import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
 import '@shoelace-style/shoelace/dist/components/switch/switch.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
+import '@shoelace-style/shoelace/dist/components/tab-group/tab-group.js';
+import '@shoelace-style/shoelace/dist/components/tab/tab.js';
+import '@shoelace-style/shoelace/dist/components/tab-panel/tab-panel.js';
 import consoleStyles from '../../styles/console-styles.css?inline';
 
 import type { ToolWithRules } from '../../components/tools-editor-component';
 import type { GatewayUsageByTool } from '../../types';
 import { consoleDialogStyles } from '../../styles/console-dialog';
+
+type ToolsTab = 'mcp' | 'native';
+
+interface ToolsFilters {
+  query: string;
+  statuses: string[];
+  servers: string[];
+  rules: string[];
+  workflows: string[];
+}
+
+const TAB_STORAGE_KEY = 'preloop.tools.tab';
+const VIEW_MODE_KEY = 'preloop.tools.view_mode';
+const EMPTY_FILTERS: ToolsFilters = {
+  query: '',
+  statuses: [],
+  servers: [],
+  rules: [],
+  workflows: [],
+};
+
+function isToolsTab(value: string | null | undefined): value is ToolsTab {
+  return value === 'mcp' || value === 'native';
+}
+
+function selectValue(event: Event): string {
+  const select = event.target as HTMLElement & { value: string | string[] };
+  const value = Array.isArray(select.value) ? select.value[0] : select.value;
+  return value || '';
+}
 
 interface StarterPolicyDiffChange {
   path: string;
@@ -92,7 +132,9 @@ export class ToolsView extends LitElement {
   @state() private currentUser: { id?: string } | null = null;
   @state() private showSetupDialog = false;
   @state() private features: { [key: string]: boolean | string[] } = {};
-  @state() private filterText = '';
+  @state() private activeTab: ToolsTab = 'mcp';
+  @state() private viewMode: ListViewMode = loadViewMode(VIEW_MODE_KEY);
+  @state() private filters: ToolsFilters = { ...EMPTY_FILTERS };
   @state() private isExporting = false;
   @state() private oauthAlert: 'success' | 'error' | null = null;
   @state() private hasDefaultAIModel = false;
@@ -109,24 +151,12 @@ export class ToolsView extends LitElement {
   @state() private toolUsageStats: GatewayUsageByTool[] = [];
   @state() private toolStatsLoading = false;
 
-  // Single active filter — only one at a time (besides text/policy)
-  @state() private activeFilter:
-    | 'all'
-    | 'available'
-    | 'enabled'
-    | 'disabled'
-    | 'unavailable'
-    | 'builtin'
-    | 'mcp'
-    | 'has_rules'
-    | 'no_rules'
-    | 'require_approval'
-    | 'no_approval' = 'available';
-  @state() private filterPolicyId: string | null = null;
-
   // Approval workflow dialog
   @state() private showPolicyDialog = false;
   @state() private editingPolicy: ApprovalWorkflow | null = null;
+
+  @state() private narrowViewport = false;
+  private narrowViewportSubscription: NarrowViewportSubscription | null = null;
 
   static styles = [
     consoleDialogStyles,
@@ -136,161 +166,60 @@ export class ToolsView extends LitElement {
         display: contents;
       }
 
-      /* Native tool approvals account-default card */
-      .governance-card {
-        padding: var(--sl-spacing-medium);
-        border-top: 1px solid var(--sl-color-neutral-200);
-        margin-bottom: var(--sl-spacing-medium);
-        display: flex;
-        flex-direction: column;
-        gap: var(--sl-spacing-x-small);
+      .tab-intro {
+        color: var(--console-meta-color, var(--sl-color-neutral-600));
+        font-size: var(--console-text-meta, var(--sl-font-size-small));
+        margin: 0 0 var(--sl-spacing-small);
       }
 
-      .governance-card .meta-line {
-        color: var(--sl-color-neutral-600);
-        font-size: var(--sl-font-size-small);
-      }
-
-      .governance-card .governance-row {
+      .summary-strip {
         display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: var(--sl-spacing-medium);
         flex-wrap: wrap;
-      }
-
-      .governance-card .governance-notice {
-        color: var(--sl-color-warning-700);
-        font-size: var(--sl-font-size-small);
-        display: flex;
-        gap: 6px;
-        align-items: center;
-      }
-
-      .governance-card .governance-error {
-        color: var(--sl-color-danger-600);
-        font-size: var(--sl-font-size-small);
-      }
-
-      /* Top section: summary + MCP card side by side */
-      .top-section {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        gap: var(--sl-spacing-large);
-      }
-
-      @media (max-width: 900px) {
-        .top-section {
-          flex-direction: column;
-          margin-bottom: var(--sl-spacing-small);
-          gap: var(--sl-spacing-small);
-        }
-      }
-
-      /* MCP Server card */
-      .builtin-server-card {
-        flex: 0 1 400px;
-        max-width: 400px;
-      }
-
-      @media (max-width: 900px) {
-        .builtin-server-card {
-          max-width: none;
-          width: 100%;
-        }
-      }
-
-      .builtin-server-card::part(body) {
-        padding: var(--sl-spacing-small) var(--sl-spacing-medium);
-      }
-
-      .builtin-server-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        margin-bottom: var(--sl-spacing-2x-small);
-      }
-
-      .builtin-server-name {
-        font-size: var(--sl-font-size-medium);
-        font-weight: var(--sl-font-weight-semibold);
-        margin: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      .info-row {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 0.15rem 0;
-        font-size: var(--sl-font-size-x-small);
-      }
-
-      .info-label {
-        font-weight: 600;
-        color: var(--sl-color-neutral-700);
-      }
-
-      .info-value-container {
-        display: flex;
-        align-items: center;
-        gap: var(--sl-spacing-x-small);
-      }
-
-      .info-value {
+        align-items: baseline;
+        gap: 8px 0;
+        padding: 12px 0;
+        border-top: 1px solid
+          var(--console-hairline, var(--sl-color-neutral-200));
+        border-bottom: 1px solid
+          var(--console-hairline, var(--sl-color-neutral-200));
+        margin-bottom: var(--sl-spacing-medium);
         color: var(--sl-color-neutral-900);
-        font-family: monospace;
-        background: var(--sl-color-neutral-50);
-        padding: 0.15rem 0.4rem;
-        border-radius: 4px;
-        font-size: var(--sl-font-size-x-small);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        max-width: 220px;
+        font-size: var(--console-text-body, var(--sl-font-size-small));
+        font-variant-numeric: tabular-nums;
       }
 
-      .info-link {
-        color: var(--sl-color-primary-600);
-        text-decoration: none;
-        font-size: var(--sl-font-size-x-small);
-        white-space: nowrap;
+      .strip-sep {
+        color: var(--console-meta-color, var(--sl-color-neutral-500));
+        margin: 0 8px;
       }
 
-      .info-link:hover {
-        text-decoration: underline;
+      .strip-count {
+        background: none;
+        border: none;
+        padding: 0;
+        color: inherit;
+        font: inherit;
+        font-variant-numeric: tabular-nums;
+        cursor: pointer;
       }
 
-      sl-card::part(footer) {
-        padding: var(--sl-spacing-x-small) var(--sl-spacing-medium);
-        border-top: 1px solid var(--sl-color-neutral-200);
+      .strip-count:hover {
+        color: var(--sl-color-primary-700);
       }
 
-      /* Summary table */
-      .summary-table-wrapper {
-        flex: 0 1 auto;
+      .strip-count.active {
+        font-weight: var(--sl-font-weight-semibold);
+        color: var(--sl-color-primary-700);
       }
 
-      .summary-table {
-        border-collapse: collapse;
-        font-size: var(--sl-font-size-small);
+      .strip-count.muted {
+        opacity: 0.4;
+        cursor: default;
       }
 
+      .context-tax,
       .unavailable-note {
-        margin-top: var(--sl-spacing-x-small);
-        color: var(--sl-color-neutral-500);
-        font-size: var(--sl-font-size-small);
-      }
-
-      .context-tax {
-        margin-top: var(--sl-spacing-small);
-        color: var(--sl-color-neutral-700);
-        font-size: var(--sl-font-size-small);
-        line-height: 1.4;
-        max-width: 28rem;
+        color: var(--console-meta-color, var(--sl-color-neutral-600));
       }
 
       .context-tax strong {
@@ -298,153 +227,52 @@ export class ToolsView extends LitElement {
         color: var(--sl-color-neutral-900);
       }
 
-      .summary-table td {
-        padding: 0;
-        vertical-align: middle;
-        white-space: nowrap;
-      }
-
-      .summary-stat {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: var(--sl-spacing-medium);
-        color: var(--sl-color-neutral-700);
-        cursor: pointer;
-        padding: 4px 8px;
-        border-radius: var(--sl-border-radius-small);
-        transition: background 0.1s ease;
-        white-space: nowrap;
-      }
-
-      .summary-stat:hover {
-        background: var(--sl-color-neutral-100);
-      }
-
-      .summary-stat.active {
-        background: var(--sl-color-primary-100);
-        color: var(--sl-color-primary-700);
-        font-weight: var(--sl-font-weight-semibold);
-      }
-
-      .summary-stat strong {
-        font-variant-numeric: tabular-nums;
-        color: var(--sl-color-neutral-900);
-      }
-
-      .summary-stat.active strong {
-        color: var(--sl-color-primary-700);
-      }
-
-      .summary-stat.muted {
-        opacity: 0.4;
-        cursor: default;
-      }
-
-      .summary-stat.muted:hover {
-        background: none;
-      }
-
-      /* Filter area: policy row + search row */
-      .filter-area {
-        display: flex;
-        flex-direction: column;
-        gap: var(--sl-spacing-x-small);
-        margin-bottom: var(--sl-spacing-large);
-      }
-
-      .policy-row {
-        display: flex;
-        justify-content: flex-end;
-        margin-bottom: 0.6em;
-      }
-
-      .filter-bar {
-        display: flex;
-        align-items: center;
-        gap: var(--sl-spacing-small);
-        flex-wrap: wrap;
-      }
-
-      .filter-search {
-        flex: 1;
-        min-width: 200px;
-      }
-
-      .filter-buttons {
-        display: flex;
-        gap: var(--sl-spacing-2x-small);
-        flex-shrink: 0;
-        flex-wrap: wrap;
-      }
-
-      .filter-chip {
-        font-size: var(--sl-font-size-x-small);
-      }
-
-      .filter-chip[variant='primary']::part(base) {
-        font-weight: 600;
-      }
-
-      /* Section headers */
-      .section-header {
-        display: flex;
-        align-items: center;
-        gap: var(--sl-spacing-small);
-        padding: var(--sl-spacing-small) 0;
-        margin-top: var(--sl-spacing-medium);
-        cursor: pointer;
-        user-select: none;
-      }
-
-      .section-header:first-of-type {
-        margin-top: 0;
-      }
-
-      .section-header:hover .section-title {
-        color: var(--sl-color-neutral-900);
-      }
-
-      .section-icon {
-        color: var(--sl-color-neutral-500);
-        transition: transform 0.2s ease;
-        flex-shrink: 0;
-      }
-
-      .section-icon.open {
-        transform: rotate(90deg);
-      }
-
-      .section-title {
-        font-size: var(--sl-font-size-small);
-        font-weight: var(--sl-font-weight-bold);
-        color: var(--sl-color-neutral-600);
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-      }
-
-      .section-meta {
-        font-size: var(--sl-font-size-x-small);
-        color: var(--sl-color-neutral-500);
-      }
-
-      .section-actions {
-        display: flex;
-        gap: var(--sl-spacing-2x-small);
-      }
-
-      .section-line {
-        flex: 1;
-        height: 1px;
-        background: var(--sl-color-neutral-200);
-      }
-
-      /* Tool list */
-      .tool-list {
-        display: flex;
-        flex-direction: column;
-        gap: var(--sl-spacing-x-small);
+      .toolbar-wrap {
+        width: 100%;
         margin-bottom: var(--sl-spacing-medium);
+      }
+
+      .defaults-strip {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-x-small);
+        padding: 12px 0;
+        border-top: 1px solid
+          var(--console-hairline, var(--sl-color-neutral-200));
+        border-bottom: 1px solid
+          var(--console-hairline, var(--sl-color-neutral-200));
+        margin-bottom: var(--sl-spacing-medium);
+      }
+
+      .defaults-strip-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px 12px;
+      }
+
+      .defaults-strip .meta-line {
+        color: var(--console-meta-color, var(--sl-color-neutral-600));
+        font-size: var(--console-text-meta, var(--sl-font-size-small));
+      }
+
+      .defaults-strip .governance-notice {
+        color: var(--sl-color-warning-700);
+        font-size: var(--sl-font-size-small);
+        display: flex;
+        gap: 6px;
+        align-items: center;
+      }
+
+      .defaults-strip .governance-error {
+        color: var(--sl-color-danger-600);
+        font-size: var(--sl-font-size-small);
+      }
+
+      .native-empty {
+        color: var(--console-meta-color, var(--sl-color-neutral-600));
+        font-size: var(--console-text-body, var(--sl-font-size-small));
+        padding: var(--sl-spacing-large) 0;
       }
 
       .loading-indicator {
@@ -458,130 +286,6 @@ export class ToolsView extends LitElement {
         text-align: center;
         padding: var(--sl-spacing-x-large);
         color: var(--sl-color-neutral-500);
-      }
-
-      /* Policy chip bar (above filter bar, right-aligned) */
-      .policy-chip-bar {
-        display: flex;
-        align-items: center;
-        gap: var(--sl-spacing-x-small);
-        flex-wrap: wrap;
-        font-size: var(--sl-font-size-small);
-      }
-
-      .policy-chip-bar-label {
-        color: var(--sl-color-neutral-500);
-        font-size: var(--sl-font-size-x-small);
-        font-weight: var(--sl-font-weight-semibold);
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-        white-space: nowrap;
-        padding-right: var(--sl-spacing-2x-small);
-      }
-
-      .policy-chip {
-        display: inline-flex;
-        align-items: center;
-        gap: 4px;
-        padding: 2px 4px 2px 10px;
-        border: 1px solid var(--sl-color-neutral-200);
-        border-radius: var(--sl-border-radius-pill);
-        font-size: var(--sl-font-size-x-small);
-        color: var(--sl-color-neutral-700);
-        cursor: pointer;
-        transition: all 0.15s ease;
-        white-space: nowrap;
-        background: var(--sl-color-neutral-0);
-      }
-
-      .policy-chip:hover {
-        border-color: var(--sl-color-neutral-400);
-        background: var(--sl-color-neutral-50);
-      }
-
-      .policy-chip.active {
-        border-color: var(--sl-color-primary-400);
-        background: var(--sl-color-primary-50);
-        color: var(--sl-color-primary-700);
-      }
-
-      .policy-chip .policy-chip-name {
-        max-width: 180px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-
-      .policy-chip sl-icon-button {
-        font-size: 0.65rem;
-        color: var(--sl-color-neutral-500);
-      }
-
-      .policy-chip sl-icon-button:hover {
-        color: var(--sl-color-neutral-900);
-      }
-
-      .policy-chip .policy-chip-type {
-        font-size: 0.6rem;
-        padding: 1px 5px;
-        border-radius: var(--sl-border-radius-pill);
-        background: var(--sl-color-neutral-100);
-        color: var(--sl-color-neutral-500);
-      }
-
-      .policy-chip.active .policy-chip-type {
-        background: var(--sl-color-primary-100);
-        color: var(--sl-color-primary-600);
-      }
-
-      .policy-chip-add {
-        display: inline-flex;
-        align-items: center;
-        gap: 3px;
-        padding: 2px 10px;
-        border: 1px dashed var(--sl-color-neutral-300);
-        border-radius: var(--sl-border-radius-pill);
-        font-size: var(--sl-font-size-x-small);
-        color: var(--sl-color-neutral-500);
-        cursor: pointer;
-        transition: all 0.15s ease;
-        background: none;
-        white-space: nowrap;
-      }
-
-      .policy-chip-add:hover {
-        border-color: var(--sl-color-primary-400);
-        color: var(--sl-color-primary-600);
-        background: var(--sl-color-primary-50);
-      }
-
-      .policy-chip-empty {
-        color: var(--sl-color-neutral-400);
-        font-size: var(--sl-font-size-x-small);
-        font-style: italic;
-      }
-
-      /* Active filter tags */
-      .active-filters {
-        display: flex;
-        align-items: center;
-        gap: var(--sl-spacing-2x-small);
-        flex-wrap: wrap;
-      }
-
-      .active-filter-tag {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--sl-spacing-2x-small);
-        padding: 2px 8px;
-        background: var(--sl-color-primary-100);
-        color: var(--sl-color-primary-700);
-        border-radius: var(--sl-border-radius-pill);
-        font-size: var(--sl-font-size-x-small);
-        font-weight: 500;
-      }
-
-      .active-filter-tag sl-icon-button {
-        font-size: 0.7rem;
       }
 
       .starter-policy-description {
@@ -742,58 +446,20 @@ export class ToolsView extends LitElement {
         justify-content: flex-end;
         gap: var(--sl-spacing-small);
       }
-
-      .tool-stats-panel {
-        margin-top: var(--sl-spacing-medium);
-        border-top: 1px solid var(--sl-color-neutral-200);
-        padding-top: var(--sl-spacing-medium);
-      }
-
-      .tool-stats-title {
-        font-size: var(--sl-font-size-x-small);
-        font-weight: var(--sl-font-weight-bold);
-        color: var(--sl-color-neutral-600);
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        margin-bottom: var(--sl-spacing-x-small);
-      }
-
-      .tool-stats-table {
-        width: 100%;
-        border-collapse: collapse;
-        font-size: var(--sl-font-size-x-small);
-      }
-
-      .tool-stats-table th,
-      .tool-stats-table td {
-        padding: 4px 8px;
-        text-align: left;
-        border-bottom: 1px solid var(--sl-color-neutral-100);
-      }
-
-      .tool-stats-table th {
-        color: var(--sl-color-neutral-500);
-        font-weight: 600;
-      }
-
-      .tool-stats-table td:last-child,
-      .tool-stats-table th:last-child {
-        text-align: right;
-      }
     `,
   ];
 
-  private static readonly _FILTER_STORAGE_KEY = 'preloop:tools-filter';
   private _pendingStarterPolicyServerId: string | null = null;
   private _pendingStarterPolicyFallbackToLatest = false;
   private _handledOauthStarterPolicy = false;
 
   connectedCallback() {
     super.connectedCallback();
-    const saved = localStorage.getItem(ToolsView._FILTER_STORAGE_KEY);
-    if (saved) {
-      this.activeFilter = saved as typeof this.activeFilter;
-    }
+    this.activeTab = this._resolveInitialTab();
+    this.narrowViewportSubscription = subscribeNarrowViewport((narrow) => {
+      this.narrowViewport = narrow;
+    });
+    this.narrowViewport = this.narrowViewportSubscription.matches;
 
     // Check for OAuth callback hash (#setup_mcp=success or #setup_mcp=error)
     if (window.location.hash) {
@@ -809,19 +475,60 @@ export class ToolsView extends LitElement {
       // dropping the reviewer into the full catalogue.
       const tool = hashParams.get('tool');
       if (tool) {
-        this.filterText = tool;
-        this.activeFilter = 'all';
+        this.filters = { ...this.filters, query: tool };
       }
-      // Clean up the hash
-      window.history.replaceState({}, '', window.location.pathname);
+      // Clean up the hash without dropping ?tab=.
+      const url = new URL(window.location.href);
+      url.hash = '';
+      window.history.replaceState({}, '', `${url.pathname}${url.search}`);
     }
 
+    this._rememberTab(this.activeTab);
     this.loadData();
   }
 
-  private _setFilter(filter: typeof this.activeFilter) {
-    this.activeFilter = filter;
-    localStorage.setItem(ToolsView._FILTER_STORAGE_KEY, filter);
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.narrowViewportSubscription?.disconnect();
+    this.narrowViewportSubscription = null;
+  }
+
+  private _resolveInitialTab(): ToolsTab {
+    const fromUrl = new URLSearchParams(window.location.search).get('tab');
+    if (isToolsTab(fromUrl)) {
+      return fromUrl;
+    }
+    try {
+      const remembered = window.localStorage.getItem(TAB_STORAGE_KEY);
+      if (isToolsTab(remembered)) {
+        return remembered;
+      }
+    } catch {
+      // Private-mode storage failures must not keep the page from rendering.
+    }
+    return 'mcp';
+  }
+
+  private _rememberTab(tab: ToolsTab) {
+    try {
+      window.localStorage.setItem(TAB_STORAGE_KEY, tab);
+    } catch {
+      // Remembering the tab is a convenience, not a requirement.
+    }
+    const url = new URL(window.location.href);
+    if (url.searchParams.get('tab') !== tab) {
+      url.searchParams.set('tab', tab);
+      window.history.replaceState({}, '', `${url.pathname}${url.search}`);
+    }
+  }
+
+  private _handleTabShow(event: CustomEvent<{ name: string }>) {
+    const name = event.detail?.name;
+    if (!isToolsTab(name)) {
+      return;
+    }
+    this.activeTab = name;
+    this._rememberTab(name);
   }
 
   private async loadData() {
@@ -913,37 +620,88 @@ export class ToolsView extends LitElement {
     return new Map(this.toolUsageStats.map((row) => [row.tool_name, row]));
   }
 
-  private _formatCurrency(value?: number | null): string {
-    const amount = Number(value || 0);
-    if (amount === 0) return '$0.00';
-    return amount >= 0.01 ? `$${amount.toFixed(2)}` : `$${amount.toFixed(4)}`;
+  private _isMcpTool(tool: ToolWithRules): boolean {
+    // Native rows (source "agent") arrive in PR 3. Compare as a string so
+    // this tab stays MCP-only once those rows exist.
+    return (tool.source as string) !== 'agent';
+  }
+
+  private _mcpTools(): ToolWithRules[] {
+    return this.tools.filter((tool) => this._isMcpTool(tool));
+  }
+
+  private _toolHasRules(tool: ToolWithRules): boolean {
+    return Boolean(
+      (tool.access_rules && tool.access_rules.length > 0) ||
+      tool.approval_workflow_id ||
+      tool.has_approval_condition
+    );
+  }
+
+  private _toolRequiresApproval(tool: ToolWithRules): boolean {
+    return Boolean(
+      tool.access_rules?.some(
+        (rule) => rule.action === 'require_approval' && rule.is_enabled
+      ) || tool.approval_workflow_id
+    );
+  }
+
+  private _toolUsesWorkflow(tool: ToolWithRules, workflowId: string): boolean {
+    return (
+      tool.approval_workflow_id === workflowId ||
+      Boolean(
+        tool.access_rules?.some(
+          (rule) => rule.approval_workflow_id === workflowId
+        )
+      )
+    );
+  }
+
+  private _toolMatchesStatus(tool: ToolWithRules, status: string): boolean {
+    const available = tool.is_supported !== false;
+    if (status === 'enabled') {
+      return available && tool.is_enabled;
+    }
+    if (status === 'disabled') {
+      return available && !tool.is_enabled;
+    }
+    if (status === 'unavailable') {
+      return !available;
+    }
+    return true;
+  }
+
+  private _toolMatchesServer(tool: ToolWithRules, server: string): boolean {
+    if (server === 'preloop') {
+      return tool.source === 'builtin';
+    }
+    return tool.source === 'mcp' && tool.source_id === server;
+  }
+
+  private _toolMatchesRuleFilter(tool: ToolWithRules, rule: string): boolean {
+    if (rule === 'with_rules') {
+      return this._toolHasRules(tool);
+    }
+    if (rule === 'no_rules') {
+      return !this._toolHasRules(tool);
+    }
+    if (rule === 'require_approval') {
+      return this._toolRequiresApproval(tool);
+    }
+    return true;
   }
 
   // ─── Stats helpers ──────────────────────────────────
 
   private _getStats() {
-    const all = this.tools;
-    const available = all.filter((t) => t.is_supported !== false);
-    const unavailable = all.filter((t) => t.is_supported === false);
-    const enabled = available.filter((t) => t.is_enabled);
-    const disabled = available.filter((t) => !t.is_enabled);
-    const builtin = available.filter((t) => t.source === 'builtin');
-    const proxied = available.filter((t) => t.source === 'mcp');
-    const withRules = all.filter(
-      (t) =>
-        (t.access_rules && t.access_rules.length > 0) ||
-        t.approval_workflow_id ||
-        t.has_approval_condition
+    const all = this._mcpTools();
+    const available = all.filter((tool) => tool.is_supported !== false);
+    const unavailable = all.filter((tool) => tool.is_supported === false);
+    const enabled = available.filter((tool) => tool.is_enabled);
+    const withRules = all.filter((tool) => this._toolHasRules(tool));
+    const requireApproval = all.filter((tool) =>
+      this._toolRequiresApproval(tool)
     );
-    const withoutRules = all.length - withRules.length;
-    const requireApproval = all.filter(
-      (t) =>
-        t.access_rules?.some(
-          (r) => r.action === 'require_approval' && r.is_enabled
-        ) || t.approval_workflow_id
-    );
-    const noApproval = all.length - requireApproval.length;
-    // Sum schemas that are actually advertised (enabled + supported).
     const contextTaxTokens = enabled.reduce((sum, tool) => {
       const tokens = tool.schema_tokens_estimate;
       return sum + (typeof tokens === 'number' && tokens > 0 ? tokens : 0);
@@ -951,101 +709,52 @@ export class ToolsView extends LitElement {
 
     return {
       total: all.length,
-      available: available.length,
       unavailable: unavailable.length,
       enabled: enabled.length,
-      disabled: disabled.length,
-      builtin: builtin.length,
-      proxied: proxied.length,
       withRules: withRules.length,
-      withoutRules,
       requireApproval: requireApproval.length,
-      noApproval,
       contextTaxTokens,
       unavailableReasons: [
         ...new Set(
           unavailable
-            .map((t) => t.unsupported_reason)
-            .filter((r): r is string => !!r)
+            .map((tool) => tool.unsupported_reason)
+            .filter((reason): reason is string => !!reason)
         ),
       ],
     };
   }
 
   private _getFilteredTools(): ToolWithRules[] {
-    let tools = this.tools;
+    let tools = this._mcpTools();
+    const { query, statuses, servers, rules, workflows } = this.filters;
 
-    // Single active filter
-    switch (this.activeFilter) {
-      case 'all':
-        break;
-      case 'available':
-        tools = tools.filter((t) => t.is_supported !== false);
-        break;
-      case 'enabled':
-        tools = tools.filter((t) => t.is_supported !== false && t.is_enabled);
-        break;
-      case 'disabled':
-        tools = tools.filter((t) => t.is_supported !== false && !t.is_enabled);
-        break;
-      case 'unavailable':
-        tools = tools.filter((t) => t.is_supported === false);
-        break;
-      case 'builtin':
-        tools = tools.filter((t) => t.source === 'builtin');
-        break;
-      case 'mcp':
-        tools = tools.filter((t) => t.source === 'mcp');
-        break;
-      case 'has_rules':
-        tools = tools.filter(
-          (t) =>
-            (t.access_rules && t.access_rules.length > 0) ||
-            t.approval_workflow_id ||
-            t.has_approval_condition
-        );
-        break;
-      case 'no_rules':
-        tools = tools.filter(
-          (t) =>
-            (!t.access_rules || t.access_rules.length === 0) &&
-            !t.approval_workflow_id &&
-            !t.has_approval_condition
-        );
-        break;
-      case 'require_approval':
-        tools = tools.filter(
-          (t) =>
-            t.access_rules?.some(
-              (r) => r.action === 'require_approval' && r.is_enabled
-            ) || t.approval_workflow_id
-        );
-        break;
-      case 'no_approval':
-        tools = tools.filter(
-          (t) =>
-            !t.access_rules?.some(
-              (r) => r.action === 'require_approval' && r.is_enabled
-            ) && !t.approval_workflow_id
-        );
-        break;
-    }
-
-    // Text filter
-    if (this.filterText) {
-      const search = this.filterText.toLowerCase();
-      tools = tools.filter(
-        (t) =>
-          t.name.toLowerCase().includes(search) ||
-          t.description?.toLowerCase().includes(search) ||
-          t.source_name?.toLowerCase().includes(search)
+    if (statuses.length > 0) {
+      tools = tools.filter((tool) =>
+        statuses.some((status) => this._toolMatchesStatus(tool, status))
       );
     }
-
-    // Policy filter
-    if (this.filterPolicyId) {
+    if (servers.length > 0) {
+      tools = tools.filter((tool) =>
+        servers.some((server) => this._toolMatchesServer(tool, server))
+      );
+    }
+    if (rules.length > 0) {
+      tools = tools.filter((tool) =>
+        rules.some((rule) => this._toolMatchesRuleFilter(tool, rule))
+      );
+    }
+    if (workflows.length > 0) {
+      tools = tools.filter((tool) =>
+        workflows.some((workflowId) => this._toolUsesWorkflow(tool, workflowId))
+      );
+    }
+    if (query) {
+      const search = query.toLowerCase();
       tools = tools.filter(
-        (t) => t.approval_workflow_id === this.filterPolicyId
+        (tool) =>
+          tool.name.toLowerCase().includes(search) ||
+          tool.description?.toLowerCase().includes(search) ||
+          tool.source_name?.toLowerCase().includes(search)
       );
     }
 
@@ -1660,8 +1369,11 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     }
     try {
       await deleteApprovalWorkflow(policy.id);
-      if (this.filterPolicyId === policy.id) {
-        this.filterPolicyId = null;
+      if (this.filters.workflows.includes(policy.id)) {
+        this.filters = {
+          ...this.filters,
+          workflows: this.filters.workflows.filter((id) => id !== policy.id),
+        };
       }
       await this.loadData();
     } catch (err: any) {
@@ -1672,8 +1384,53 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
   // ─── Render helpers ──────────────────────────────────
 
   private _clearFilters() {
-    this._setFilter('available');
-    this.filterPolicyId = null;
+    this.filters = { ...EMPTY_FILTERS };
+  }
+
+  private _setFilterValues(patch: Partial<ToolsFilters>) {
+    this.filters = { ...this.filters, ...patch };
+  }
+
+  private _toggleSingleFilter(
+    key: 'statuses' | 'servers' | 'rules' | 'workflows',
+    value: string
+  ) {
+    const current = this.filters[key];
+    const already = current.length === 1 && current[0] === value;
+    this._setFilterValues({ [key]: already ? [] : [value] });
+  }
+
+  private _handleSearchChange(event: CustomEvent<{ value: string }>) {
+    this._setFilterValues({ query: event.detail.value });
+  }
+
+  private get effectiveView(): ListViewMode {
+    return effectiveViewMode(this.viewMode, this.narrowViewport);
+  }
+
+  private _handleViewChange(event: CustomEvent<{ value: ListViewMode }>) {
+    this.viewMode = event.detail.value;
+    saveViewMode(VIEW_MODE_KEY, event.detail.value);
+  }
+
+  private _handleStatusFilterChange(event: Event) {
+    const value = selectValue(event);
+    this._setFilterValues({ statuses: value ? [value] : [] });
+  }
+
+  private _handleServerFilterChange(event: Event) {
+    const value = selectValue(event);
+    this._setFilterValues({ servers: value ? [value] : [] });
+  }
+
+  private _handleRulesFilterChange(event: Event) {
+    const value = selectValue(event);
+    this._setFilterValues({ rules: value ? [value] : [] });
+  }
+
+  private _handleWorkflowFilterChange(event: Event) {
+    const value = selectValue(event);
+    this._setFilterValues({ workflows: value ? [value] : [] });
   }
 
   private async _loadGovernanceDefaults() {
@@ -1746,28 +1503,13 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
   }
 
   /**
-   * Account-default card for native tool-call approvals (hook-based Bash /
-   * Edit / shell approvals), rendered above the MCP tool groups so both
-   * policy planes are visible — and distinguishable — on one page.
+   * Account-default strip for native tool-call approvals. Same three ids as
+   * the PR 382 card, flattened to one hairline row on the Native tab.
    */
   private _renderNativeApprovalDefaultsCard() {
     if (this.governanceLoadFailed) {
       return html`
-        <div
-          class="stat-card governance-card"
-          id="native-approvals-defaults-card"
-        >
-          <div
-            class="stat-label"
-            style="display: flex; align-items: center; gap: 6px;"
-          >
-            <sl-icon name="shield-lock"></sl-icon>
-            Native tool approvals
-          </div>
-          <div class="meta-line">
-            Shell commands, file edits and other tools inside the agent. MCP
-            tools use the rules below.
-          </div>
+        <div class="defaults-strip" id="native-approvals-defaults-card">
           <div class="governance-error">
             Could not load this setting.
             <a
@@ -1791,22 +1533,8 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     const shownOverrides = overrides.slice(0, 5);
     const hiddenOverrideCount = overrides.length - shownOverrides.length;
     return html`
-      <div
-        class="stat-card governance-card"
-        id="native-approvals-defaults-card"
-      >
-        <div
-          class="stat-label"
-          style="display: flex; align-items: center; gap: 6px;"
-        >
-          <sl-icon name="shield-lock"></sl-icon>
-          Native tool approvals
-        </div>
-        <div class="meta-line">
-          Shell commands, file edits and other tools inside the agent. MCP tools
-          use the rules below.
-        </div>
-        <div class="governance-row">
+      <div class="defaults-strip" id="native-approvals-defaults-card">
+        <div class="defaults-strip-row">
           <sl-switch
             id="native-approvals-default-switch"
             size="small"
@@ -1818,7 +1546,6 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
                 native_tool_approvals: target.checked ? 'enforce' : 'off',
               });
               if (!saved) {
-                // The server kept the old value; flip the switch back.
                 target.checked = enforced;
               }
             }}
@@ -1829,6 +1556,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
           ${
             enforced
               ? html`
+                  <span class="strip-sep" aria-hidden="true">·</span>
                   <sl-select
                     id="native-approvals-default-workflow"
                     size="small"
@@ -1866,6 +1594,34 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
                 `
               : ''
           }
+          ${
+            overrides.length > 0
+              ? html`
+                  <span class="strip-sep" aria-hidden="true">·</span>
+                  <div class="meta-line" id="native-approvals-override-list">
+                    ${
+                      overrides.length === 1
+                        ? '1 agent uses its own setting: '
+                        : `${overrides.length} agents use their own setting: `
+                    }
+                    ${shownOverrides.map(
+                      (agent, index) =>
+                        html`${index > 0 ? ', ' : ''}<a
+                            href="/console/agents/${agent.id}"
+                            >${agent.name}</a
+                          >`
+                    )}${
+                      hiddenOverrideCount > 0
+                        ? html`,
+                            <a href="/console/agents"
+                              >and ${hiddenOverrideCount} more</a
+                            >`
+                        : ''
+                    }
+                  </div>
+                `
+              : ''
+          }
         </div>
         ${
           !enforced
@@ -1874,33 +1630,6 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
                   <sl-icon name="exclamation-triangle"></sl-icon>
                   Native tool calls run without asking. Calls are still
                   recorded. Agents set to always ask keep asking.
-                </div>
-              `
-            : ''
-        }
-        ${
-          overrides.length > 0
-            ? html`
-                <div class="meta-line" id="native-approvals-override-list">
-                  ${
-                    overrides.length === 1
-                      ? '1 agent uses its own setting: '
-                      : `${overrides.length} agents use their own setting: `
-                  }
-                  ${shownOverrides.map(
-                    (agent, index) =>
-                      html`${index > 0 ? ', ' : ''}<a
-                          href="/console/agents/${agent.id}"
-                          >${agent.name}</a
-                        >`
-                  )}${
-                    hiddenOverrideCount > 0
-                      ? html`,
-                          <a href="/console/agents"
-                            >and ${hiddenOverrideCount} more</a
-                          >`
-                      : ''
-                  }
                 </div>
               `
             : ''
@@ -1916,336 +1645,283 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     `;
   }
 
-  private _renderTopSection() {
-    const apiUrl = window.location.origin;
-    const mcpUrl = `${apiUrl}/mcp`;
+  private _resultsLabel(shown: number, total: number): string {
+    const noun = total === 1 ? 'tool' : 'tools';
+    if (shown === total) {
+      return `${shown} ${noun}`;
+    }
+    return `${shown} of ${total} ${noun}`;
+  }
+
+  private _renderStripCount(
+    count: number,
+    label: string,
+    options: {
+      active?: boolean;
+      muted?: boolean;
+      tooltip?: string;
+      onClick?: () => void;
+    } = {}
+  ) {
+    const button = html`
+      <button
+        type="button"
+        class="strip-count${options.active ? ' active' : ''}${
+          options.muted ? ' muted' : ''
+        }"
+        ?disabled=${options.muted}
+        @click=${options.muted ? undefined : options.onClick}
+      >
+        ${count} ${label}
+      </button>
+    `;
+    if (options.tooltip) {
+      return html`<sl-tooltip content=${options.tooltip}
+        >${button}</sl-tooltip
+      >`;
+    }
+    return button;
+  }
+
+  private _renderSummaryStrip() {
     const stats = this._getStats();
-
-    // Helper: renders a single table cell with label left, number right, full-cell hover
-    const statCell = (
-      label: string | TemplateResult,
-      value: number,
-      filterKey: typeof this.activeFilter | '__none__',
-      opts?: { muted?: boolean; tooltip?: string }
-    ) => {
-      const isActive =
-        filterKey !== '__none__' && this.activeFilter === filterKey;
-      const isMuted = opts?.muted || false;
-      const onClick =
-        filterKey === '__none__' || isMuted
-          ? undefined
-          : () => {
-              this._setFilter(
-                this.activeFilter === filterKey ? 'available' : filterKey
-              );
-              this.filterPolicyId = null;
-            };
-
-      const inner = html`
-        <span
-          class="summary-stat ${isActive ? 'active' : ''} ${
-            isMuted ? 'muted' : ''
-          }"
-          @click=${onClick}
-        >
-          <span>${label}</span>
-          <strong>${value}</strong>
-        </span>
-      `;
-
-      return html`<td>
-        ${
-          opts?.tooltip
-            ? html`<sl-tooltip content=${opts.tooltip}>${inner}</sl-tooltip>`
-            : inner
-        }
-      </td>`;
-    };
+    const status = this.filters.statuses[0] || '';
+    const rule = this.filters.rules[0] || '';
+    const noFilters =
+      this.filters.statuses.length === 0 &&
+      this.filters.servers.length === 0 &&
+      this.filters.rules.length === 0 &&
+      this.filters.workflows.length === 0 &&
+      !this.filters.query;
+    const unavailableTooltip =
+      stats.unavailableReasons.length > 0
+        ? stats.unavailableReasons.join('; ')
+        : 'Some tools require trackers to be configured';
 
     return html`
-      <div class="top-section">
-        <!-- Left: Summary table -->
-        <div class="summary-table-wrapper">
-          <table class="summary-table">
-            <tr>
-              ${statCell('Total tools', stats.total, 'all')}
-              ${statCell('Available', stats.available, 'available')}
-              ${statCell('Unavailable', stats.unavailable, 'unavailable', {
-                muted: stats.unavailable === 0,
-                tooltip:
-                  stats.unavailableReasons.length > 0
-                    ? stats.unavailableReasons.join('; ')
-                    : 'Some tools require trackers to be configured',
-              })}
-            </tr>
-            <tr>
-              <td></td>
-              ${statCell('Enabled', stats.enabled, 'enabled')}
-              ${statCell('Disabled', stats.disabled, 'disabled')}
-            </tr>
-            <tr>
-              <td></td>
-              ${statCell('Built-in', stats.builtin, 'builtin')}
-              ${statCell('Proxied', stats.proxied, 'mcp')}
-            </tr>
-            <tr>
-              <td></td>
-              ${statCell('With rules', stats.withRules, 'has_rules')}
-              ${statCell('No rules', stats.withoutRules, 'no_rules')}
-            </tr>
-            <tr>
-              <td></td>
-              ${statCell(
-                'Require approval',
-                stats.requireApproval,
-                'require_approval'
-              )}
-              ${statCell('No approval', stats.noApproval, 'no_approval')}
-            </tr>
-          </table>
-          ${
-            stats.contextTaxTokens > 0
-              ? html`<div class="context-tax">
+      <div class="summary-strip">
+        ${this._renderStripCount(stats.total, 'tools', {
+          active: noFilters,
+          onClick: () => this._clearFilters(),
+        })}
+        <span class="strip-sep" aria-hidden="true">·</span>
+        ${this._renderStripCount(stats.enabled, 'enabled', {
+          active: status === 'enabled',
+          onClick: () => this._toggleSingleFilter('statuses', 'enabled'),
+        })}
+        <span class="strip-sep" aria-hidden="true">·</span>
+        ${this._renderStripCount(stats.withRules, 'with rules', {
+          active: rule === 'with_rules',
+          onClick: () => this._toggleSingleFilter('rules', 'with_rules'),
+        })}
+        <span class="strip-sep" aria-hidden="true">·</span>
+        ${this._renderStripCount(stats.requireApproval, 'require approval', {
+          active: rule === 'require_approval',
+          onClick: () => this._toggleSingleFilter('rules', 'require_approval'),
+        })}
+        ${
+          stats.contextTaxTokens > 0
+            ? html`<span class="strip-sep" aria-hidden="true">·</span>
+                <span class="context-tax">
                   Enabled tools add
                   <strong
                     >~${stats.contextTaxTokens.toLocaleString()} tokens</strong
                   >
-                  to every agent request
-                </div>`
-              : ''
-          }
-          ${
-            stats.unavailable > 0
-              ? html`<div class="unavailable-note">
-                  ${
-                    stats.unavailableReasons.length > 0
-                      ? stats.unavailableReasons.join('; ')
-                      : `${stats.unavailable} tool${stats.unavailable === 1 ? ' is' : 's are'} unavailable until a tracker is connected.`
-                  }
-                </div>`
-              : ''
-          }
-          ${0 ? this._renderToolUsageStatsPanel() : ''}
-        </div>
-
-        <!-- Right: MCP Server card -->
-        <sl-card class="builtin-server-card">
-          <div class="card-content">
-            <div class="builtin-server-header">
-              <h3 class="builtin-server-name">Preloop MCP Server</h3>
-              <sl-badge variant="primary" size="small">Built-in</sl-badge>
-            </div>
-            <div class="info-row">
-              <span class="info-label">URL:</span>
-              <code class="info-value" title=${mcpUrl}>${mcpUrl}</code>
-              <sl-tooltip content="Copy URL">
-                <sl-icon-button
-                  name="clipboard"
-                  style="font-size: 1rem;"
-                  @click=${() => {
-                    navigator.clipboard.writeText(mcpUrl);
-                    this.dispatchEvent(
-                      new CustomEvent('show-toast', {
-                        bubbles: true,
-                        composed: true,
-                        detail: { message: 'MCP URL copied!' },
-                      })
-                    );
-                  }}
-                ></sl-icon-button>
-              </sl-tooltip>
-            </div>
-            <div class="info-row">
-              <span class="info-label">Auth:</span>
-              <div class="info-value-container">
-                <code class="info-value">Bearer Token</code>
-                <a href="/console/settings/api-keys" class="info-link">
-                  Keys &rarr;
-                </a>
-              </div>
-            </div>
-          </div>
-          <div slot="footer">
-            <sl-button
-              size="small"
-              style="width: 100%;"
-              @click=${() => (this.showSetupDialog = true)}
-            >
-              <sl-icon slot="prefix" name="info-circle"></sl-icon>
-              Setup Instructions
-            </sl-button>
-          </div>
-        </sl-card>
-
-        <mcp-setup-dialog
-          ?open=${this.showSetupDialog}
-          @close=${() => (this.showSetupDialog = false)}
-        ></mcp-setup-dialog>
-      </div>
-    `;
-  }
-
-  private _renderToolUsageStatsPanel() {
-    const rows = this.toolUsageStats.slice(0, 8);
-    if (this.toolStatsLoading) {
-      return html`<div class="tool-stats-panel">
-        <div class="tool-stats-title">Tool activity (30 days)</div>
-        <sl-spinner style="font-size: 1rem;"></sl-spinner>
-      </div>`;
-    }
-    if (!rows.length) {
-      return html`<div class="tool-stats-panel">
-        <div class="tool-stats-title">Tool activity (30 days)</div>
-        <span
-          style="color: var(--sl-color-neutral-500); font-size: var(--sl-font-size-x-small);"
-          >No tool invocations recorded yet.</span
-        >
-      </div>`;
-    }
-    return html`
-      <div class="tool-stats-panel">
-        <div class="tool-stats-title">Tool activity (30 days)</div>
-        <table class="tool-stats-table" aria-label="Tool activity stats">
-          <thead>
-            <tr>
-              <th scope="col">Tool</th>
-              <th scope="col">Calls</th>
-              <th scope="col">Schema cost</th>
-              <th scope="col">Avg / call</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${rows.map(
-              (row) => html`
-                <tr>
-                  <td>${row.tool_name}</td>
-                  <td>${row.invocation_count.toLocaleString()}</td>
-                  <td>${this._formatCurrency(row.estimated_schema_cost)}</td>
-                  <td>${this._formatCurrency(row.avg_cost_per_invocation)}</td>
-                </tr>
-              `
-            )}
-          </tbody>
-        </table>
-      </div>
-    `;
-  }
-
-  private _renderFilterBar() {
-    const filteredPolicy = this.filterPolicyId
-      ? this.approvalPolicies.find((p) => p.id === this.filterPolicyId)
-      : null;
-
-    // Labels for the active filter tag display
-    const filterLabels: Record<string, string> = {
-      all: 'All tools',
-      available: 'Available',
-      enabled: 'Enabled',
-      disabled: 'Disabled',
-      unavailable: 'Unavailable',
-      builtin: 'Built-in',
-      mcp: 'Proxied',
-      has_rules: 'With rules',
-      no_rules: 'No rules',
-      require_approval: 'Require approval',
-      no_approval: 'No approval',
-    };
-
-    return html`
-      <div class="filter-area">
-        <div class="policy-row">${this._renderPolicyChipBar()}</div>
-        <div class="filter-bar">
-          <sl-input
-            class="filter-search"
-            size="small"
-            placeholder="Filter tools..."
-            clearable
-            @sl-input=${(e: Event) =>
-              (this.filterText = (e.target as any).value)}
-          >
-            <sl-icon slot="prefix" name="search"></sl-icon>
-          </sl-input>
-
-          <div class="active-filters">
-            ${
-              this.activeFilter !== 'all'
-                ? html`<span class="active-filter-tag">
-                    ${filterLabels[this.activeFilter] || this.activeFilter}
-                    <sl-icon-button
-                      name="x-lg"
-                      @click=${() => this._setFilter('available')}
-                    ></sl-icon-button>
-                  </span>`
-                : ''
-            }
-            ${
-              this.filterPolicyId && filteredPolicy
-                ? html`<span class="active-filter-tag">
-                    Policy: ${filteredPolicy.name}
-                    <sl-icon-button
-                      name="x-lg"
-                      @click=${() => (this.filterPolicyId = null)}
-                    ></sl-icon-button>
-                  </span>`
-                : ''
-            }
-          </div>
-        </div>
-      </div>
-    `;
-  }
-
-  private _renderPolicyChipBar() {
-    const policies = this.approvalPolicies;
-
-    return html`
-      <div class="policy-chip-bar">
-        <span class="policy-chip-bar-label">Approval Workflows</span>
-        ${
-          policies.length === 0
-            ? html`<span class="policy-chip-empty">None defined</span>`
-            : policies.map((policy) => {
-                const isActive = this.filterPolicyId === policy.id;
-                const isAi = policy.approval_type === 'ai_driven';
-                return html`
-                  <span
-                    class="policy-chip ${isActive ? 'active' : ''}"
-                    @click=${() => {
-                      this.filterPolicyId = isActive ? null : policy.id;
-                    }}
-                  >
-                    <span class="policy-chip-name">${policy.name}</span>
-                    <span class="policy-chip-type"
-                      >${isAi ? 'AI' : 'Human'}</span
-                    >
-                    <sl-icon-button
-                      name="pencil"
-                      label="Edit policy"
-                      @click=${(e: Event) => {
-                        e.stopPropagation();
-                        this._openPolicyDialog(policy);
-                      }}
-                    ></sl-icon-button>
-                    <sl-icon-button
-                      name="x-lg"
-                      label="Delete policy"
-                      @click=${(e: Event) => {
-                        e.stopPropagation();
-                        this._handleDeletePolicy(policy);
-                      }}
-                    ></sl-icon-button>
-                  </span>
-                `;
-              })
+                  to every request
+                </span>`
+            : ''
         }
-        <span
-          class="policy-chip-add"
-          @click=${() => this._openPolicyDialog(null)}
-        >
-          <sl-icon name="plus-lg" style="font-size: 0.7rem;"></sl-icon>
-          New
-        </span>
+        ${
+          stats.unavailable > 0
+            ? html`<span class="strip-sep" aria-hidden="true">·</span>
+                ${this._renderStripCount(stats.unavailable, 'unavailable', {
+                  active: status === 'unavailable',
+                  tooltip: unavailableTooltip,
+                  onClick: () =>
+                    this._toggleSingleFilter('statuses', 'unavailable'),
+                })}
+                <span class="unavailable-note">${unavailableTooltip}</span>`
+            : ''
+        }
       </div>
+    `;
+  }
+
+  private _renderWorkflowsMenu() {
+    const count = this.approvalPolicies.length;
+    return html`
+      <sl-dropdown class="workflows-menu" hoist>
+        <sl-button slot="trigger" size="small" caret>
+          Workflows (${count})
+        </sl-button>
+        <sl-menu>
+          ${this.approvalPolicies.map(
+            (policy) => html`
+              <sl-menu-label>${policy.name}</sl-menu-label>
+              <sl-menu-item
+                data-workflow-edit=${policy.id}
+                @click=${() => this._openPolicyDialog(policy)}
+                >Edit</sl-menu-item
+              >
+              <sl-menu-item
+                data-workflow-delete=${policy.id}
+                @click=${() => this._handleDeletePolicy(policy)}
+                >Delete</sl-menu-item
+              >
+            `
+          )}
+          <sl-menu-item
+            data-workflow-new
+            @click=${() => this._openPolicyDialog(null)}
+            >New workflow</sl-menu-item
+          >
+        </sl-menu>
+      </sl-dropdown>
+    `;
+  }
+
+  private _renderMcpToolbar() {
+    const filtered = this._getFilteredTools();
+    const total = this._mcpTools().length;
+    return html`
+      <div class="toolbar-wrap">
+        <list-toolbar
+          .search=${this.filters.query}
+          searchPlaceholder="Search tools"
+          .view=${this.effectiveView}
+          .views=${['list', 'cards']}
+          @search-change=${this._handleSearchChange}
+          @view-change=${this._handleViewChange}
+        >
+          <sl-select
+            class="status-filter"
+            clearable
+            placeholder="Any status"
+            .value=${this.filters.statuses[0] || ''}
+            @sl-change=${this._handleStatusFilterChange}
+          >
+            <sl-option value="enabled">Enabled</sl-option>
+            <sl-option value="disabled">Disabled</sl-option>
+            <sl-option value="unavailable">Unavailable</sl-option>
+          </sl-select>
+          <sl-select
+            class="server-filter"
+            clearable
+            placeholder="Any server"
+            .value=${this.filters.servers[0] || ''}
+            @sl-change=${this._handleServerFilterChange}
+          >
+            <sl-option value="preloop">Preloop</sl-option>
+            ${this.mcpServers.map(
+              (server) =>
+                html`<sl-option value=${server.id}>${server.name}</sl-option>`
+            )}
+          </sl-select>
+          <sl-select
+            class="rules-filter"
+            clearable
+            placeholder="Any rules"
+            .value=${this.filters.rules[0] || ''}
+            @sl-change=${this._handleRulesFilterChange}
+          >
+            <sl-option value="with_rules">With rules</sl-option>
+            <sl-option value="no_rules">No rules</sl-option>
+            <sl-option value="require_approval">Requires approval</sl-option>
+          </sl-select>
+          <sl-select
+            class="workflow-filter"
+            clearable
+            placeholder="Any workflow"
+            .value=${this.filters.workflows[0] || ''}
+            @sl-change=${this._handleWorkflowFilterChange}
+          >
+            ${this.approvalPolicies.map(
+              (policy) =>
+                html`<sl-option value=${policy.id}>${policy.name}</sl-option>`
+            )}
+          </sl-select>
+          ${this._renderWorkflowsMenu()}
+          <span slot="count"
+            >${this._resultsLabel(filtered.length, total)}</span
+          >
+        </list-toolbar>
+      </div>
+    `;
+  }
+
+  private _renderMcpEditor() {
+    return html`
+      <tools-editor-component
+        .tools=${this._getFilteredTools()}
+        .toolStats=${Object.fromEntries(this._getToolStatsMap())}
+        .mcpServers=${this.mcpServers}
+        .approvalPolicies=${this.approvalPolicies}
+        .features=${this.features}
+        .hasDefaultAIModel=${this.hasDefaultAIModel}
+        mode="global"
+        @toggle-enabled=${this._handleToggleEnabled}
+        @save-rule=${this._handleSaveRule}
+        @delete-rule=${this._handleDeleteRule}
+        @policy-created=${this._handlePolicyCreated}
+        @reorder-rules=${this._handleReorderRules}
+        @tool-updated=${() => this.loadData()}
+        @scan-server=${(e: CustomEvent) => this._handleScanMCPServer(e.detail)}
+        @suggest-starter-policy=${(e: CustomEvent) =>
+          this._openStarterPolicySuggestion(e.detail, {
+            manual: true,
+          })}
+        @edit-server=${(e: CustomEvent) => (this.editingMCPServer = e.detail)}
+        @delete-server=${(e: CustomEvent) =>
+          this._handleDeleteMCPServer(e.detail)}
+      ></tools-editor-component>
+    `;
+  }
+
+  private _renderMcpTab() {
+    return html`
+      <p class="tab-intro">
+        Served through Preloop's MCP firewall: the Preloop server and any MCP
+        server you add.
+      </p>
+      ${this._renderSummaryStrip()} ${this._renderMcpToolbar()}
+      ${this._renderMcpEditor()}
+    `;
+  }
+
+  private _renderNativeTab() {
+    return html`
+      <p class="tab-intro">
+        Built into the agent itself, such as Bash, Edit and Write. Governed by
+        the Preloop hook that "preloop agents onboard --approvals" installs.
+      </p>
+      ${this._renderNativeApprovalDefaultsCard()}
+      <p class="native-empty">
+        No native tool calls have reached Preloop yet. Onboard an agent with
+        "preloop agents onboard --approvals" and its Bash, Edit and Write calls
+        will show up here.
+      </p>
+    `;
+  }
+
+  private _renderTabs() {
+    const mcpCount = this._mcpTools().length;
+    // Native catalogue rows arrive in PR 3. Keep the tab count at 0 until then.
+    const nativeCount = 0;
+    return html`
+      <sl-tab-group @sl-tab-show=${this._handleTabShow}>
+        <sl-tab slot="nav" panel="mcp" ?active=${this.activeTab === 'mcp'}
+          >MCP tools ${mcpCount}</sl-tab
+        >
+        <sl-tab slot="nav" panel="native" ?active=${this.activeTab === 'native'}
+          >Native tools ${nativeCount}</sl-tab
+        >
+        <sl-tab-panel name="mcp" ?active=${this.activeTab === 'mcp'}>
+          ${this._renderMcpTab()}
+        </sl-tab-panel>
+        <sl-tab-panel name="native" ?active=${this.activeTab === 'native'}>
+          ${this._renderNativeTab()}
+        </sl-tab-panel>
+      </sl-tab-group>
     `;
   }
 
@@ -2256,26 +1932,22 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     return html`
       <view-header
         headerText="Tools"
-        description="Every MCP tool your agents can call, routed through Preloop's firewall. Enable or disable tools, set policy rules, and require human approval for sensitive calls."
+        description="Tools your agents can call and the rules that govern them."
         width="extra-wide"
       >
         <div slot="main-column">
-          <sl-dropdown>
-            <sl-button slot="trigger" size="small" variant="primary" caret>
-              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-              Add Source
-            </sl-button>
-            <sl-menu>
-              <sl-menu-item @click=${() => (this.isAddingMCPServer = true)}>
-                <sl-icon slot="prefix" name="hdd-network"></sl-icon>
-                MCP Server
-              </sl-menu-item>
-              <sl-menu-item disabled>
-                <sl-icon slot="prefix" name="globe"></sl-icon>
-                HTTP Tool (coming soon)
-              </sl-menu-item>
-            </sl-menu>
-          </sl-dropdown>
+          <sl-button
+            size="small"
+            variant="primary"
+            @click=${() => (this.isAddingMCPServer = true)}
+          >
+            <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+            Add MCP server
+          </sl-button>
+
+          <sl-button size="small" @click=${() => (this.showSetupDialog = true)}>
+            Connect an agent
+          </sl-button>
 
           <sl-tooltip content="Import configuration from YAML">
             <sl-button size="small" @click=${this._triggerImport}>
@@ -2339,8 +2011,8 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
                   @sl-after-hide=${() => (this.oauthAlert = null)}
                 >
                   <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
-                  <strong>OAuth Failed</strong> — Could not authenticate with
-                  the external MCP server. Please try again.
+                  <strong>OAuth failed.</strong> Could not authenticate with the
+                  external MCP server. Try again.
                 </sl-alert>`
               : ''
           }
@@ -2362,37 +2034,12 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
               ? html`<div class="loading-indicator">
                   <sl-spinner></sl-spinner>
                 </div>`
-              : html` ${this._renderTopSection()}
-                  ${this._renderNativeApprovalDefaultsCard()}
-                  <div class="tool-groups">
-                    ${this._renderFilterBar()}
-                    <tools-editor-component
-                      .tools=${this._getFilteredTools()}
-                      .toolStats=${Object.fromEntries(this._getToolStatsMap())}
-                      .mcpServers=${this.mcpServers}
-                      .approvalPolicies=${this.approvalPolicies}
-                      .features=${this.features}
-                      .hasDefaultAIModel=${this.hasDefaultAIModel}
-                      mode="global"
-                      @toggle-enabled=${this._handleToggleEnabled}
-                      @save-rule=${this._handleSaveRule}
-                      @delete-rule=${this._handleDeleteRule}
-                      @policy-created=${this._handlePolicyCreated}
-                      @reorder-rules=${this._handleReorderRules}
-                      @tool-updated=${() => this.loadData()}
-                      @scan-server=${(e: CustomEvent) =>
-                        this._handleScanMCPServer(e.detail)}
-                      @suggest-starter-policy=${(e: CustomEvent) =>
-                        this._openStarterPolicySuggestion(e.detail, {
-                          manual: true,
-                        })}
-                      @edit-server=${(e: CustomEvent) =>
-                        (this.editingMCPServer = e.detail)}
-                      @delete-server=${(e: CustomEvent) =>
-                        this._handleDeleteMCPServer(e.detail)}
-                    ></tools-editor-component>
-                  </div>`
+              : this._renderTabs()
           }
+          <mcp-setup-dialog
+            ?open=${this.showSetupDialog}
+            @close=${() => (this.showSetupDialog = false)}
+          ></mcp-setup-dialog>
         </div>
         <div class="side-column"></div>
       </div>

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -34,12 +34,9 @@ import type { MCPServer } from '../../components/mcp-server-card';
 import type { AccessRuleSummary } from '../../components/governance-rule-set-editor';
 import type { RuleFormData } from '../../components/tool-rule-editor';
 import {
-  effectiveViewMode,
   loadViewMode,
   saveViewMode,
-  subscribeNarrowViewport,
   type ListViewMode,
-  type NarrowViewportSubscription,
 } from '../../utils/view-mode';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
@@ -155,9 +152,6 @@ export class ToolsView extends LitElement {
   // Approval workflow dialog
   @state() private showPolicyDialog = false;
   @state() private editingPolicy: ApprovalWorkflow | null = null;
-
-  @state() private narrowViewport = false;
-  private narrowViewportSubscription: NarrowViewportSubscription | null = null;
 
   static styles = [
     consoleDialogStyles,
@@ -463,10 +457,6 @@ export class ToolsView extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.activeTab = this._resolveInitialTab();
-    this.narrowViewportSubscription = subscribeNarrowViewport((narrow) => {
-      this.narrowViewport = narrow;
-    });
-    this.narrowViewport = this.narrowViewportSubscription.matches;
 
     // Check for OAuth callback hash (#setup_mcp=success or #setup_mcp=error)
     if (window.location.hash) {
@@ -492,12 +482,6 @@ export class ToolsView extends LitElement {
 
     this._rememberTab(this.activeTab);
     this.loadData();
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.narrowViewportSubscription?.disconnect();
-    this.narrowViewportSubscription = null;
   }
 
   private _resolveInitialTab(): ToolsTab {
@@ -1406,10 +1390,6 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
 
   private _handleSearchChange(event: CustomEvent<{ value: string }>) {
     this._setFilterValues({ query: event.detail.value });
-  }
-
-  private get effectiveView(): ListViewMode {
-    return effectiveViewMode(this.viewMode, this.narrowViewport);
   }
 
   private _handleViewChange(event: CustomEvent<{ value: ListViewMode }>) {


### PR DESCRIPTION
Stacked on #398 (base branch is `ux/list-toolbar-trackers-models`; retarget to main once that merges).

## Why
The Tools page mixed MCP servers, native tool approvals, an 11-cell stats table, a workflows chip bar and a filter row into one column. The founder's read: confusing, especially the native approvals part.

## What changed (`tools-view.ts`, analysis section 3 "Proposed IA", PR 1 of 5)
- Header: "Tools your agents can call and the rules that govern them." Actions: **Add MCP server** (replaces the Add Source dropdown), **Connect an agent** (opens the existing setup dialog, replaces the Preloop MCP Server card), Import, Export.
- Two tabs, counts in the labels, active tab in `?tab=` and `localStorage['preloop.tools.tab']`: **MCP tools** and **Native tools**.
- MCP tab: one-line intro; a one-row summary strip (`16 tools · 12 enabled · 5 with rules · 3 require approval · ~2,300 tokens · 2 unavailable`) where each count is an `aria-pressed` filter button and the unavailable reasons live in a tooltip; the shared `list-toolbar` (search, Any status / Any server / Any rules / Any workflow selects, results count); a **Workflows (n)** menu (Edit / Delete / New workflow) replacing the chip bar; the existing `tools-editor-component` grouped by server with the same header actions. The view toggle is hidden until the flat table lands (PR 3), so it cannot persist a choice that changes nothing.
- Native tab: intro line, the defaults card from #382 flattened to one hairline row (same three ids), toolbar, and the empty state ("No native tool calls have reached Preloop yet...") until the native list arrives (PR 3 + backend PR).
- Deleted: the stats table, the Preloop server card, the chip bar, the old filter bar, dead `_renderToolUsageStatsPanel` and `toolStatsLoading`. OAuth error copy lost its em dash.

## Tests
`tools-view.test.ts`: 23 passed (replaced the four filter-persistence tests; new: default tab and restore from storage, `?tab=native`, defaults strip ids, search narrows, workflow filter, Connect an agent opens setup, Add MCP server opens the form, Workflows menu edit and new, strip button aria-pressed). Full suite: 132 files, 1450 passed, 0 failed.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Substantial UI redesign of a core governance surface (Tools page); no security or functional defects found, and both previously flagged gaps (stale docs, dead `effectiveView`/`narrowViewport` scaffolding) are now fixed.
>
> **Overview**
> Splits the Tools page into MCP/Native tabs with a summary filter strip and the shared list-toolbar, replacing the old stats table, chip bar, and filter bar. Code is clean and well-tested (23 tests); documentation and the dead view-toggle scaffolding have been cleaned up.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit b2afdac3. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->