### PR TITLE
Flows: one runner pool select with Auto, hosted, labels and specific runners

### DIFF
--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -1024,6 +1024,13 @@ class AccountDetailsResponse(BaseModel):
             "online private runner."
         ),
     )
+    hosted_minutes_remaining: Optional[int] = Field(
+        default=None,
+        description=(
+            "Hosted runner minutes remaining for this account. "
+            "Null when quota is not configured."
+        ),
+    )
     created_at: str
     updated_at: str
 
@@ -1077,6 +1084,7 @@ async def get_account_details(
         id=str(account.id),
         organization_name=account.organization_name,
         default_runner_pool=getattr(account, "default_runner_pool", None),
+        hosted_minutes_remaining=getattr(account, "hosted_minutes_remaining", None),
         created_at=account.created_at.isoformat(),
         updated_at=account.updated_at.isoformat(),
     )
@@ -1108,6 +1116,9 @@ async def update_account_details(
         id=str(updated_account.id),
         organization_name=updated_account.organization_name,
         default_runner_pool=getattr(updated_account, "default_runner_pool", None),
+        hosted_minutes_remaining=getattr(
+            updated_account, "hosted_minutes_remaining", None
+        ),
         created_at=updated_account.created_at.isoformat(),
         updated_at=updated_account.updated_at.isoformat(),
     )

--- a/backend/tests/endpoints/test_account_details_schema.py
+++ b/backend/tests/endpoints/test_account_details_schema.py
@@ -26,3 +26,23 @@ def test_account_details_response_includes_default_runner_pool() -> None:
     assert body.default_runner_pool == "server"
     dumped = body.model_dump()
     assert dumped["default_runner_pool"] == "server"
+
+
+def test_account_details_response_includes_hosted_minutes_remaining() -> None:
+    body = AccountDetailsResponse(
+        id="11111111-1111-4111-8111-111111111111",
+        organization_name="Example Org",
+        created_at="2026-09-04T00:00:00",
+        updated_at="2026-09-04T00:00:00",
+    )
+    assert body.hosted_minutes_remaining is None
+    assert body.model_dump()["hosted_minutes_remaining"] is None
+
+    with_minutes = AccountDetailsResponse(
+        id="11111111-1111-4111-8111-111111111111",
+        organization_name="Example Org",
+        hosted_minutes_remaining=340,
+        created_at="2026-09-04T00:00:00",
+        updated_at="2026-09-04T00:00:00",
+    )
+    assert with_minutes.hosted_minutes_remaining == 340

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4284,6 +4284,7 @@ export interface AccountOrganization {
   id: string;
   organization_name: string | null;
   default_runner_pool?: string | null;
+  hosted_minutes_remaining?: number | null;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/components/preloop-flow-form-runner-pool.test.ts
+++ b/frontend/src/components/preloop-flow-form-runner-pool.test.ts
@@ -5,6 +5,8 @@ import {
   html,
   oneEvent,
 } from '@open-wc/testing';
+import type SlInput from '@shoelace-style/shoelace/dist/components/input/input.js';
+import type SlSelect from '@shoelace-style/shoelace/dist/components/select/select.js';
 import sinon, { SinonSandbox } from 'sinon';
 import './preloop-flow-form.ts';
 import type { PreloopFlowForm } from './preloop-flow-form';
@@ -119,9 +121,7 @@ describe('PreloopFlowForm runner pool behaviour', () => {
       'Next run: a private runner (office-mac online). Falls back to Preloop hosted when none is free.'
     );
 
-    const select = control?.shadowRoot?.querySelector(
-      'sl-select'
-    ) as HTMLSelectElement;
+    const select = control?.shadowRoot?.querySelector('sl-select') as SlSelect;
     expect(select).to.exist;
     select.value = 'office-mac';
     select.dispatchEvent(new CustomEvent('sl-change'));
@@ -144,9 +144,7 @@ describe('PreloopFlowForm runner pool behaviour', () => {
       'Next run: Preloop hosted.'
     );
 
-    const custom = control?.shadowRoot?.querySelector(
-      'sl-input'
-    ) as HTMLInputElement;
+    const custom = control?.shadowRoot?.querySelector('sl-input') as SlInput;
     custom.value = 'gpu';
     custom.dispatchEvent(new CustomEvent('sl-input'));
     await element.updateComplete;

--- a/frontend/src/components/preloop-flow-form-runner-pool.test.ts
+++ b/frontend/src/components/preloop-flow-form-runner-pool.test.ts
@@ -20,16 +20,16 @@ before(async () => {
 });
 
 describe('PreloopFlowForm runner pool field', () => {
-  it('renders a runner pool select and custom label input', () => {
-    expect(source).to.include('label="Runner pool"');
-    expect(source).to.include('Or type a runner label');
+  it('renders a shared runner pool select', () => {
+    expect(source).to.include('preloop-runner-pool-select');
     expect(source).to.include('renderRunnerPoolField()');
     expect(source).to.include('runner_pool: this.normalizedFlowRunnerPool()');
   });
 
-  it('shows a next-execution hint from current online runners', () => {
-    expect(source).to.include('describeNextRunnerPool');
-    expect(source).to.include('runner-pool-hint');
+  it('passes runners and hosted minutes through to the shared select', () => {
+    expect(source).to.include('preloop-runner-pool-select');
+    expect(source).to.include('hostedMinutesLeft');
+    expect(source).to.include('context="flow"');
   });
 });
 
@@ -60,6 +60,7 @@ describe('PreloopFlowForm runner pool behaviour', () => {
             id: 'acct-1',
             organization_name: 'Example Org',
             default_runner_pool: null,
+            hosted_minutes_remaining: null,
             created_at: '2026-09-04T00:00:00Z',
             updated_at: '2026-09-04T00:00:00Z',
           })
@@ -96,6 +97,10 @@ describe('PreloopFlowForm runner pool behaviour', () => {
     return event.detail.flow;
   };
 
+  const poolSelect = (element: PreloopFlowForm) =>
+    element.shadowRoot?.querySelector('preloop-runner-pool-select') as
+      (HTMLElement & { shadowRoot: ShadowRoot }) | null;
+
   it('lists online runners and submits a selected pool', async () => {
     const element = await mount({
       id: 'flow-1',
@@ -103,17 +108,19 @@ describe('PreloopFlowForm runner pool behaviour', () => {
       prompt_template: 'review',
       agent_type: 'codex',
     });
-    expect(element.shadowRoot?.textContent).to.contain(
-      'Any online private runner (default)'
+    const control = poolSelect(element);
+    expect(control).to.exist;
+    expect(control?.shadowRoot?.textContent).to.contain(
+      'Account default: Auto (private runners first, then Preloop hosted)'
     );
-    expect(element.shadowRoot?.textContent).to.contain('Preloop hosted');
-    expect(element.shadowRoot?.textContent).to.contain('office-mac');
-    expect(element.shadowRoot?.textContent).to.contain(
-      'Next execution will use any online private runner (currently office-mac).'
+    expect(control?.shadowRoot?.textContent).to.contain('Preloop hosted only');
+    expect(control?.shadowRoot?.textContent).to.contain('office-mac');
+    expect(control?.shadowRoot?.textContent).to.contain(
+      'Next run: a private runner (office-mac online). Falls back to Preloop hosted when none is free.'
     );
 
-    const select = element.shadowRoot?.querySelector(
-      'sl-select[label="Runner pool"]'
+    const select = control?.shadowRoot?.querySelector(
+      'sl-select'
     ) as HTMLSelectElement;
     expect(select).to.exist;
     select.value = 'office-mac';
@@ -132,12 +139,13 @@ describe('PreloopFlowForm runner pool behaviour', () => {
       agent_type: 'codex',
       runner_pool: 'server',
     });
-    expect(element.shadowRoot?.textContent).to.contain(
-      'Next execution will use Preloop hosted.'
+    const control = poolSelect(element);
+    expect(control?.shadowRoot?.textContent).to.contain(
+      'Next run: Preloop hosted.'
     );
 
-    const custom = element.shadowRoot?.querySelector(
-      'sl-input[label="Or type a runner label"]'
+    const custom = control?.shadowRoot?.querySelector(
+      'sl-input'
     ) as HTMLInputElement;
     custom.value = 'gpu';
     custom.dispatchEvent(new CustomEvent('sl-input'));
@@ -145,5 +153,15 @@ describe('PreloopFlowForm runner pool behaviour', () => {
 
     const payload = await submit(element);
     expect(payload.runner_pool).to.equal('gpu');
+  });
+
+  it('submits runner_pool null when a new flow is untouched', async () => {
+    const element = await mount({
+      name: 'Review',
+      prompt_template: 'review',
+      agent_type: 'codex',
+    });
+    const payload = await submit(element);
+    expect(payload.runner_pool).to.equal(null);
   });
 });

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -15,15 +15,12 @@ import {
 } from '../api';
 import type { Flow } from '../types';
 import { defaultFlowNotifications } from '../types';
-import {
-  buildRunnerPoolOptions,
-  describeNextRunnerPool,
-} from '../utils/runner-pool';
 import { getAgentControlState } from '../utils/agent-control';
 import { getTrackerEventOptions } from '../constants/tracker-event-types';
 import consoleStyles from '../styles/console-styles.css?inline';
 import './add-tracker-modal';
 import './add-ai-model-modal';
+import './preloop-runner-pool-select';
 import './schedule-config-editor';
 import { defaultScheduleConfig } from './schedule-config-editor';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
@@ -91,17 +88,6 @@ export class PreloopFlowForm extends LitElement {
       sl-textarea.prompt {
         max-height: 50rem;
         overflow: auto;
-      }
-
-      .runner-pool-hint {
-        margin: 0 0 var(--sl-spacing-medium);
-        color: var(--sl-color-neutral-600);
-        font-size: 0.85rem;
-        line-height: 1.45;
-      }
-
-      .runner-pool-custom {
-        margin-top: calc(-1 * var(--sl-spacing-small));
       }
 
       .card-header-title {
@@ -218,7 +204,7 @@ export class PreloopFlowForm extends LitElement {
   private accountDefaultRunnerPool: string | null = null;
 
   @state()
-  private customRunnerPool = '';
+  private hostedMinutesLeft: number | null = null;
 
   @state()
   private isAddingAIModel = false;
@@ -321,6 +307,7 @@ export class PreloopFlowForm extends LitElement {
       this.presets = presets;
       this.runners = runners;
       this.accountDefaultRunnerPool = account?.default_runner_pool ?? null;
+      this.hostedMinutesLeft = account?.hosted_minutes_remaining ?? null;
 
       if (
         restoredFromOAuth &&
@@ -725,66 +712,27 @@ export class PreloopFlowForm extends LitElement {
   }
 
   private normalizedFlowRunnerPool(): string | null {
-    const typed = (this.customRunnerPool || '').trim();
-    if (typed) {
-      return typed;
-    }
     const selected = (this.flow.runner_pool || '').trim();
     return selected || null;
   }
 
-  private runnerPoolSelectValue(): string {
-    return (this.flow.runner_pool || '').trim();
-  }
-
-  private handleRunnerPoolSelect(event: Event) {
-    const target = event.target as HTMLSelectElement;
-    const value = (target.value || '').trim();
-    this.flow.runner_pool = value || null;
-    this.customRunnerPool = '';
-    this.requestUpdate();
-  }
-
-  private handleCustomRunnerPool(event: Event) {
-    const target = event.target as HTMLInputElement;
-    const value = target.value;
-    this.customRunnerPool = value;
-    this.flow.runner_pool = value.trim() || null;
+  private handleRunnerPoolChange(event: CustomEvent<{ value: string | null }>) {
+    this.flow.runner_pool = event.detail.value;
     this.requestUpdate();
   }
 
   private renderRunnerPoolField() {
-    const options = buildRunnerPoolOptions(this.runners);
-    const current = (this.flow.runner_pool || '').trim();
-    const known = new Set(options.map((option) => option.value));
-    if (current && !known.has(current)) {
-      options.push({ value: current, label: current });
-    }
-    const hint = describeNextRunnerPool({
-      flowPool: this.normalizedFlowRunnerPool(),
-      accountPool: this.accountDefaultRunnerPool,
-      runners: this.runners,
-    });
     return html`
-      <sl-select
+      <preloop-runner-pool-select
         label="Runner pool"
-        help-text="Pin a private runner, a label, or Preloop hosted. Leave the default to follow the account setting."
-        .value=${this.runnerPoolSelectValue()}
-        @sl-change=${this.handleRunnerPoolSelect}
-      >
-        ${options.map(
-          (option) =>
-            html`<sl-option value=${option.value}>${option.label}</sl-option>`
-        )}
-      </sl-select>
-      <sl-input
-        class="runner-pool-custom"
-        label="Or type a runner label"
-        placeholder="gpu"
-        .value=${this.customRunnerPool}
-        @sl-input=${this.handleCustomRunnerPool}
-      ></sl-input>
-      <p class="runner-pool-hint">${hint}</p>
+        .helpText=${'Where the next run executes. Leave the account default unless this flow needs a particular machine.'}
+        context="flow"
+        .value=${this.normalizedFlowRunnerPool()}
+        .runners=${this.runners}
+        .accountPool=${this.accountDefaultRunnerPool}
+        .hostedMinutesLeft=${this.hostedMinutesLeft}
+        @pool-change=${this.handleRunnerPoolChange}
+      ></preloop-runner-pool-select>
     `;
   }
 

--- a/frontend/src/components/preloop-runner-pool-select.test.ts
+++ b/frontend/src/components/preloop-runner-pool-select.test.ts
@@ -1,4 +1,7 @@
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import type SlDetails from '@shoelace-style/shoelace/dist/components/details/details.js';
+import type SlInput from '@shoelace-style/shoelace/dist/components/input/input.js';
+import type SlSelect from '@shoelace-style/shoelace/dist/components/select/select.js';
 
 import './preloop-runner-pool-select.ts';
 import type { PreloopRunnerPoolSelect } from './preloop-runner-pool-select';
@@ -62,16 +65,14 @@ describe('PreloopRunnerPoolSelect', () => {
 
   it('preselects the empty inherit row in flow context and auto for a null account value', async () => {
     const flow = await mount({ context: 'flow', value: null });
-    const flowSelect = flow.shadowRoot?.querySelector(
-      'sl-select'
-    ) as HTMLSelectElement;
+    const flowSelect = flow.shadowRoot?.querySelector('sl-select') as SlSelect;
     expect(flowSelect.value).to.equal('');
     expect(optionValues(flow)[0]).to.equal('');
 
     const account = await mount({ context: 'account', value: null });
     const accountSelect = account.shadowRoot?.querySelector(
       'sl-select'
-    ) as HTMLSelectElement;
+    ) as SlSelect;
     expect(accountSelect.value).to.equal('auto');
     expect(optionValues(account)).to.not.include('');
     expect(optionValues(account)[0]).to.equal('auto');
@@ -79,9 +80,7 @@ describe('PreloopRunnerPoolSelect', () => {
 
   it('emits null for the flow default row and server for hosted', async () => {
     const element = await mount({ context: 'flow', value: 'office-mac' });
-    const select = element.shadowRoot?.querySelector(
-      'sl-select'
-    ) as HTMLSelectElement;
+    const select = element.shadowRoot?.querySelector('sl-select') as SlSelect;
 
     const inherit = oneEvent(element, 'pool-change');
     select.value = '';
@@ -96,17 +95,49 @@ describe('PreloopRunnerPoolSelect', () => {
 
   it('emits a typed value and shows the not registered row', async () => {
     const element = await mount({ context: 'flow', value: null });
-    const input = element.shadowRoot?.querySelector(
-      'sl-input'
-    ) as HTMLInputElement;
+    const input = element.shadowRoot?.querySelector('sl-input') as SlInput;
     const changed = oneEvent(element, 'pool-change');
     input.value = 'legacy-pin';
     input.dispatchEvent(new CustomEvent('sl-input'));
-    expect((await changed).detail.value).to.equal('legacy-pin');
+    const event = await changed;
+    expect(event.detail.value).to.equal('legacy-pin');
+    element.value = event.detail.value;
     await element.updateComplete;
     expect(element.shadowRoot?.textContent).to.contain(
       'legacy-pin (not registered)'
     );
+  });
+
+  it('keeps customDraft while typing a prefix of a known label', async () => {
+    const element = await mount({ context: 'flow', value: null });
+    element.addEventListener('pool-change', (event: Event) => {
+      const detail = (event as CustomEvent<{ value: string | null }>).detail;
+      element.value = detail.value;
+    });
+    const input = element.shadowRoot?.querySelector('sl-input') as SlInput;
+    expect(input.label).to.equal('Label or runner id');
+
+    input.value = 'gpu';
+    input.dispatchEvent(new CustomEvent('sl-input'));
+    await element.updateComplete;
+    expect(input.value).to.equal('gpu');
+
+    input.value = 'gpu-large';
+    input.dispatchEvent(new CustomEvent('sl-input'));
+    await element.updateComplete;
+    expect(input.value).to.equal('gpu-large');
+    expect(element.value).to.equal('gpu-large');
+  });
+
+  it('opens free-text details when the current value is not a selectable token', async () => {
+    const element = await mount({ context: 'flow', value: 'office gpu' });
+    const details = element.shadowRoot?.querySelector(
+      'sl-details'
+    ) as SlDetails;
+    const input = element.shadowRoot?.querySelector('sl-input') as SlInput;
+    expect(input.value).to.equal('office gpu');
+    expect(details.open).to.equal(true);
+    expect(element.shadowRoot?.textContent).to.not.contain('(not registered)');
   });
 
   it('disables the select and free-text field', async () => {

--- a/frontend/src/components/preloop-runner-pool-select.test.ts
+++ b/frontend/src/components/preloop-runner-pool-select.test.ts
@@ -1,0 +1,132 @@
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+
+import './preloop-runner-pool-select.ts';
+import type { PreloopRunnerPoolSelect } from './preloop-runner-pool-select';
+
+const RUNNERS = [
+  {
+    name: 'office-mac',
+    labels: ['gpu'],
+    status: 'online',
+  },
+  {
+    name: 'lab-1',
+    labels: ['local'],
+    status: 'offline',
+  },
+];
+
+async function mount(
+  props: Partial<{
+    value: string | null;
+    context: 'flow' | 'account';
+    accountPool: string | null;
+    hostedMinutesLeft: number | null;
+    label: string;
+    helpText: string;
+    disabled: boolean;
+  }> = {}
+): Promise<PreloopRunnerPoolSelect> {
+  return fixture<PreloopRunnerPoolSelect>(html`
+    <preloop-runner-pool-select
+      .value=${props.value ?? null}
+      .context=${props.context ?? 'flow'}
+      .runners=${RUNNERS}
+      .accountPool=${props.accountPool ?? null}
+      .hostedMinutesLeft=${props.hostedMinutesLeft ?? null}
+      .label=${props.label ?? 'Runner pool'}
+      .helpText=${props.helpText ?? 'Where the next run executes.'}
+      ?disabled=${props.disabled ?? false}
+    ></preloop-runner-pool-select>
+  `);
+}
+
+function optionValues(element: PreloopRunnerPoolSelect): string[] {
+  const select = element.shadowRoot?.querySelector('sl-select');
+  return Array.from(select?.querySelectorAll('sl-option') || []).map(
+    (option) => option.getAttribute('value') ?? ''
+  );
+}
+
+describe('PreloopRunnerPoolSelect', () => {
+  it('renders grouped options and headers', async () => {
+    const element = await mount();
+    const text = element.shadowRoot?.textContent || '';
+    expect(text).to.contain('Account default:');
+    expect(text).to.contain('Runners by label');
+    expect(text).to.contain('Specific runner');
+    expect(text).to.contain('Runners labelled gpu (1 online)');
+    expect(text).to.contain('office-mac (online)');
+    expect(element.shadowRoot?.querySelector('sl-divider')).to.exist;
+  });
+
+  it('preselects the empty inherit row in flow context and auto for a null account value', async () => {
+    const flow = await mount({ context: 'flow', value: null });
+    const flowSelect = flow.shadowRoot?.querySelector(
+      'sl-select'
+    ) as HTMLSelectElement;
+    expect(flowSelect.value).to.equal('');
+    expect(optionValues(flow)[0]).to.equal('');
+
+    const account = await mount({ context: 'account', value: null });
+    const accountSelect = account.shadowRoot?.querySelector(
+      'sl-select'
+    ) as HTMLSelectElement;
+    expect(accountSelect.value).to.equal('auto');
+    expect(optionValues(account)).to.not.include('');
+    expect(optionValues(account)[0]).to.equal('auto');
+  });
+
+  it('emits null for the flow default row and server for hosted', async () => {
+    const element = await mount({ context: 'flow', value: 'office-mac' });
+    const select = element.shadowRoot?.querySelector(
+      'sl-select'
+    ) as HTMLSelectElement;
+
+    const inherit = oneEvent(element, 'pool-change');
+    select.value = '';
+    select.dispatchEvent(new CustomEvent('sl-change'));
+    expect((await inherit).detail.value).to.equal(null);
+
+    const hosted = oneEvent(element, 'pool-change');
+    select.value = 'server';
+    select.dispatchEvent(new CustomEvent('sl-change'));
+    expect((await hosted).detail.value).to.equal('server');
+  });
+
+  it('emits a typed value and shows the not registered row', async () => {
+    const element = await mount({ context: 'flow', value: null });
+    const input = element.shadowRoot?.querySelector(
+      'sl-input'
+    ) as HTMLInputElement;
+    const changed = oneEvent(element, 'pool-change');
+    input.value = 'legacy-pin';
+    input.dispatchEvent(new CustomEvent('sl-input'));
+    expect((await changed).detail.value).to.equal('legacy-pin');
+    await element.updateComplete;
+    expect(element.shadowRoot?.textContent).to.contain(
+      'legacy-pin (not registered)'
+    );
+  });
+
+  it('disables the select and free-text field', async () => {
+    const element = await mount({ disabled: true });
+    const select = element.shadowRoot?.querySelector('sl-select');
+    const input = element.shadowRoot?.querySelector('sl-input');
+    expect(select?.hasAttribute('disabled')).to.equal(true);
+    expect(input?.hasAttribute('disabled')).to.equal(true);
+  });
+
+  it('renders the next-run hint', async () => {
+    const element = await mount({
+      context: 'flow',
+      value: null,
+      accountPool: null,
+    });
+    const hint = element.shadowRoot?.querySelector('.runner-pool-hint');
+    expect(hint).to.exist;
+    expect(hint?.textContent).to.equal(
+      'Next run: a private runner (office-mac online). Falls back to Preloop hosted when none is free.'
+    );
+  });
+});

--- a/frontend/src/components/preloop-runner-pool-select.ts
+++ b/frontend/src/components/preloop-runner-pool-select.ts
@@ -5,10 +5,14 @@ import '@shoelace-style/shoelace/dist/components/divider/divider.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
+import type SlDetails from '@shoelace-style/shoelace/dist/components/details/details.js';
+import type SlInput from '@shoelace-style/shoelace/dist/components/input/input.js';
+import type SlSelect from '@shoelace-style/shoelace/dist/components/select/select.js';
 import {
   AUTO_RUNNER_POOL,
   buildRunnerPoolGroups,
   describeNextRunnerPool,
+  isSelectableToken,
   type RunnerPoolSource,
 } from '../utils/runner-pool';
 import consoleStyles from '../styles/console-styles.css?inline';
@@ -85,34 +89,46 @@ export class PreloopRunnerPoolSelect extends LitElement {
   disabled = false;
 
   @state()
-  private localValue: string | null = null;
-
-  @state()
   private customDraft = '';
+
+  private customDraftFromUser = false;
 
   protected willUpdate(
     changedProperties: Map<string | number | symbol, unknown>
   ): void {
-    if (changedProperties.has('value')) {
-      this.localValue = this.value;
-      const current = (this.value || '').trim();
-      const known = new Set(
-        this.groupsFor(current).flatMap((group) =>
-          group.options
-            .filter((option) => !option.label.endsWith('(not registered)'))
-            .map((option) => option.value)
-        )
-      );
-      if (!current || known.has(current)) {
-        this.customDraft = '';
-      } else if (!this.customDraft) {
-        this.customDraft = current;
-      }
+    if (!changedProperties.has('value') || this.customDraftFromUser) {
+      return;
+    }
+    const current = (this.value || '').trim();
+    const known = new Set(
+      this.groupsFor(current).flatMap((group) =>
+        group.options
+          .filter((option) => !option.label.endsWith('(not registered)'))
+          .map((option) => option.value)
+      )
+    );
+    if (!current || known.has(current)) {
+      this.customDraft = '';
+    } else if (!this.customDraft) {
+      this.customDraft = current;
     }
   }
 
-  private effectiveValue(): string | null {
-    return this.localValue !== null ? this.localValue : this.value;
+  protected updated(
+    changedProperties: Map<string | number | symbol, unknown>
+  ): void {
+    if (!changedProperties.has('value') || this.customDraftFromUser) {
+      return;
+    }
+    const current = (this.value || '').trim();
+    if (this.customDraft && !isSelectableToken(current)) {
+      const details = this.renderRoot.querySelector(
+        'sl-details'
+      ) as SlDetails | null;
+      if (details) {
+        details.open = true;
+      }
+    }
   }
 
   private groupsFor(current: string | null) {
@@ -126,7 +142,7 @@ export class PreloopRunnerPoolSelect extends LitElement {
   }
 
   private selectValue(): string {
-    const current = (this.effectiveValue() || '').trim();
+    const current = (this.value || '').trim();
     if (this.context === 'account') {
       return current || AUTO_RUNNER_POOL;
     }
@@ -134,7 +150,6 @@ export class PreloopRunnerPoolSelect extends LitElement {
   }
 
   private emitValue(value: string | null): void {
-    this.localValue = value;
     this.dispatchEvent(
       new CustomEvent('pool-change', {
         detail: { value },
@@ -145,14 +160,19 @@ export class PreloopRunnerPoolSelect extends LitElement {
   }
 
   private handleSelect(event: Event): void {
-    const target = event.target as HTMLSelectElement;
-    const value = (target.value || '').trim();
+    const target = event.target as SlSelect;
+    const raw = Array.isArray(target.value)
+      ? target.value[0] || ''
+      : target.value || '';
+    const value = raw.trim();
+    this.customDraftFromUser = false;
     this.customDraft = '';
     this.emitValue(value || null);
   }
 
   private handleCustom(event: Event): void {
-    const target = event.target as HTMLInputElement;
+    const target = event.target as SlInput;
+    this.customDraftFromUser = true;
     this.customDraft = target.value;
     const value = (target.value || '').trim();
     this.emitValue(value || null);
@@ -160,7 +180,7 @@ export class PreloopRunnerPoolSelect extends LitElement {
 
   private hintText(): string {
     if (this.context === 'account') {
-      const pool = (this.effectiveValue() || '').trim() || AUTO_RUNNER_POOL;
+      const pool = (this.value || '').trim() || AUTO_RUNNER_POOL;
       return describeNextRunnerPool({
         flowPool: pool,
         accountPool: pool,
@@ -169,7 +189,7 @@ export class PreloopRunnerPoolSelect extends LitElement {
       });
     }
     return describeNextRunnerPool({
-      flowPool: this.effectiveValue(),
+      flowPool: this.value,
       accountPool: this.accountPool,
       runners: this.runners,
       hostedMinutesLeft: this.hostedMinutesLeft,
@@ -177,7 +197,7 @@ export class PreloopRunnerPoolSelect extends LitElement {
   }
 
   render() {
-    const current = this.effectiveValue();
+    const current = this.value;
     const groups = this.groupsFor(current);
     return html`
       <sl-select
@@ -210,6 +230,7 @@ export class PreloopRunnerPoolSelect extends LitElement {
       </sl-select>
       <sl-details summary="Type a label or runner id">
         <sl-input
+          label="Label or runner id"
           placeholder="gpu"
           .value=${this.customDraft}
           ?disabled=${this.disabled}

--- a/frontend/src/components/preloop-runner-pool-select.ts
+++ b/frontend/src/components/preloop-runner-pool-select.ts
@@ -1,0 +1,222 @@
+import { LitElement, css, html, nothing, unsafeCSS } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import '@shoelace-style/shoelace/dist/components/details/details.js';
+import '@shoelace-style/shoelace/dist/components/divider/divider.js';
+import '@shoelace-style/shoelace/dist/components/input/input.js';
+import '@shoelace-style/shoelace/dist/components/option/option.js';
+import '@shoelace-style/shoelace/dist/components/select/select.js';
+import {
+  AUTO_RUNNER_POOL,
+  buildRunnerPoolGroups,
+  describeNextRunnerPool,
+  type RunnerPoolSource,
+} from '../utils/runner-pool';
+import consoleStyles from '../styles/console-styles.css?inline';
+
+export type RunnerPoolSelectContext = 'flow' | 'account';
+
+@customElement('preloop-runner-pool-select')
+export class PreloopRunnerPoolSelect extends LitElement {
+  static styles = [
+    unsafeCSS(consoleStyles),
+    css`
+      :host {
+        display: block;
+      }
+
+      sl-details {
+        margin-top: var(--sl-spacing-2x-small);
+      }
+
+      sl-details::part(base) {
+        border: none;
+        background: transparent;
+      }
+
+      sl-details::part(header) {
+        padding: var(--sl-spacing-2x-small) 0;
+        font-size: var(--console-text-meta, 0.8125rem);
+        color: var(--sl-color-neutral-600);
+      }
+
+      .group-label {
+        display: block;
+        padding: var(--sl-spacing-2x-small) var(--sl-spacing-x-small) 0;
+        color: var(--sl-color-neutral-600);
+        font-size: var(--console-text-meta, 0.8125rem);
+      }
+
+      sl-divider {
+        margin: var(--sl-spacing-2x-small) 0;
+        --color: var(--console-hairline, var(--sl-color-neutral-200));
+      }
+
+      .runner-pool-hint {
+        margin: var(--sl-spacing-2x-small) 0 0;
+        color: var(--sl-color-neutral-600);
+        font-size: var(--console-text-meta, 0.8125rem);
+        line-height: 1.45;
+      }
+    `,
+  ];
+
+  @property({ type: String })
+  value: string | null = null;
+
+  @property({ type: String })
+  context: RunnerPoolSelectContext = 'flow';
+
+  @property({ type: Array })
+  runners: RunnerPoolSource[] = [];
+
+  @property({ type: String })
+  accountPool: string | null = null;
+
+  @property({ type: Number })
+  hostedMinutesLeft: number | null = null;
+
+  @property({ type: String })
+  label = 'Runner pool';
+
+  @property({ type: String })
+  helpText = '';
+
+  @property({ type: Boolean })
+  disabled = false;
+
+  @state()
+  private localValue: string | null = null;
+
+  @state()
+  private customDraft = '';
+
+  protected willUpdate(
+    changedProperties: Map<string | number | symbol, unknown>
+  ): void {
+    if (changedProperties.has('value')) {
+      this.localValue = this.value;
+      const current = (this.value || '').trim();
+      const known = new Set(
+        this.groupsFor(current).flatMap((group) =>
+          group.options
+            .filter((option) => !option.label.endsWith('(not registered)'))
+            .map((option) => option.value)
+        )
+      );
+      if (!current || known.has(current)) {
+        this.customDraft = '';
+      } else if (!this.customDraft) {
+        this.customDraft = current;
+      }
+    }
+  }
+
+  private effectiveValue(): string | null {
+    return this.localValue !== null ? this.localValue : this.value;
+  }
+
+  private groupsFor(current: string | null) {
+    return buildRunnerPoolGroups({
+      runners: this.runners,
+      context: this.context,
+      accountPool: this.accountPool,
+      current,
+      hostedMinutesLeft: this.hostedMinutesLeft,
+    });
+  }
+
+  private selectValue(): string {
+    const current = (this.effectiveValue() || '').trim();
+    if (this.context === 'account') {
+      return current || AUTO_RUNNER_POOL;
+    }
+    return current;
+  }
+
+  private emitValue(value: string | null): void {
+    this.localValue = value;
+    this.dispatchEvent(
+      new CustomEvent('pool-change', {
+        detail: { value },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private handleSelect(event: Event): void {
+    const target = event.target as HTMLSelectElement;
+    const value = (target.value || '').trim();
+    this.customDraft = '';
+    this.emitValue(value || null);
+  }
+
+  private handleCustom(event: Event): void {
+    const target = event.target as HTMLInputElement;
+    this.customDraft = target.value;
+    const value = (target.value || '').trim();
+    this.emitValue(value || null);
+  }
+
+  private hintText(): string {
+    if (this.context === 'account') {
+      const pool = (this.effectiveValue() || '').trim() || AUTO_RUNNER_POOL;
+      return describeNextRunnerPool({
+        flowPool: pool,
+        accountPool: pool,
+        runners: this.runners,
+        hostedMinutesLeft: this.hostedMinutesLeft,
+      });
+    }
+    return describeNextRunnerPool({
+      flowPool: this.effectiveValue(),
+      accountPool: this.accountPool,
+      runners: this.runners,
+      hostedMinutesLeft: this.hostedMinutesLeft,
+    });
+  }
+
+  render() {
+    const current = this.effectiveValue();
+    const groups = this.groupsFor(current);
+    return html`
+      <sl-select
+        label=${this.label}
+        help-text=${this.helpText}
+        .value=${this.selectValue()}
+        ?disabled=${this.disabled}
+        @sl-change=${this.handleSelect}
+      >
+        ${groups.map(
+          (group) => html`
+            ${
+              group.label
+                ? html`<small class="group-label">${group.label}</small>
+                    <sl-divider></sl-divider>`
+                : nothing
+            }
+            ${group.options.map(
+              (option) => html`
+                <sl-option
+                  value=${option.value}
+                  ?disabled=${option.disabled === true}
+                >
+                  ${option.label}
+                </sl-option>
+              `
+            )}
+          `
+        )}
+      </sl-select>
+      <sl-details summary="Type a label or runner id">
+        <sl-input
+          placeholder="gpu"
+          .value=${this.customDraft}
+          ?disabled=${this.disabled}
+          @sl-input=${this.handleCustom}
+        ></sl-input>
+      </sl-details>
+      <p class="runner-pool-hint">${this.hintText()}</p>
+    `;
+  }
+}

--- a/frontend/src/utils/runner-pool.test.ts
+++ b/frontend/src/utils/runner-pool.test.ts
@@ -10,7 +10,6 @@ import {
   HOSTED_ONLY_LABEL,
   SERVER_RUNNER_POOL,
   buildRunnerPoolGroups,
-  buildRunnerPoolOptions,
   describeNextRunnerPool,
   isSelectableToken,
   resolveAccountPoolLabel,
@@ -60,7 +59,6 @@ describe('runner-pool options', () => {
     });
     expect(flattenValues(groups)).to.not.include(AUTO_RUNNER_POOL);
     expect(flattenLabels(groups)).to.not.include(FLOW_AUTO_OVERRIDE_LABEL);
-    expect(buildRunnerPoolOptions([OFFICE])[0]).to.deep.equal(first);
   });
 
   it('flow context, account default server: inherit hosted and offer explicit auto', () => {
@@ -158,6 +156,19 @@ describe('runner-pool options', () => {
       value: 'legacy-pin',
       label: 'legacy-pin (not registered)',
     });
+  });
+
+  it('skips the not registered row when the current value has whitespace', () => {
+    const groups = buildRunnerPoolGroups({
+      runners: [OFFICE],
+      context: 'flow',
+      current: 'office gpu',
+    });
+    const labels = flattenLabels(groups);
+    expect(labels.some((label) => label.includes('(not registered)'))).to.equal(
+      false
+    );
+    expect(flattenValues(groups)).to.not.include('office gpu');
   });
 
   it('disables the hosted row when hosted minutes are exhausted', () => {
@@ -275,7 +286,20 @@ describe('runner-pool next-run hint', () => {
       'Next run: Preloop hosted. (account default) Hosted minutes left: 340.'
     );
     expect(hints[1]).to.equal(
-      'Next run: a private runner (lab-1, office-mac online). No hosted minutes left, so the run queues if none is free. Hosted minutes left: 0.'
+      'Next run: a private runner (lab-1, office-mac online). No hosted minutes left, so the run queues if none is free.'
+    );
+  });
+
+  it('does not restate hosted minutes left when the exhausted clause is already present', () => {
+    expect(
+      describeNextRunnerPool({
+        flowPool: 'auto',
+        accountPool: null,
+        runners: [OFFICE, LAB],
+        hostedMinutesLeft: 0,
+      })
+    ).to.equal(
+      'Next run: a private runner (lab-1, office-mac online). No hosted minutes left, so the run queues if none is free.'
     );
   });
 });

--- a/frontend/src/utils/runner-pool.test.ts
+++ b/frontend/src/utils/runner-pool.test.ts
@@ -145,6 +145,25 @@ describe('runner-pool options', () => {
     ]);
   });
 
+  it('treats a stored runner id as registered and selects that runner', () => {
+    const groups = buildRunnerPoolGroups({
+      runners: [{ ...OFFICE, id: 'runner-office-1' }],
+      context: 'flow',
+      current: 'runner-office-1',
+    });
+    expect(flattenValues(groups)).to.include('runner-office-1');
+    expect(
+      flattenLabels(groups).some((label) => label.includes('(not registered)'))
+    ).to.equal(false);
+    const runnerGroup = groups.find(
+      (group) => group.label === 'Specific runner'
+    );
+    expect(runnerGroup?.options[0]).to.deep.equal({
+      value: 'runner-office-1',
+      label: 'office-mac (online)',
+    });
+  });
+
   it('appends the current unknown value as not registered', () => {
     const groups = buildRunnerPoolGroups({
       runners: [OFFICE],
@@ -300,6 +319,27 @@ describe('runner-pool next-run hint', () => {
       })
     ).to.equal(
       'Next run: a private runner (lab-1, office-mac online). No hosted minutes left, so the run queues if none is free.'
+    );
+  });
+
+  it('does not claim the next run is hosted when hosted minutes are exhausted', () => {
+    expect(
+      describeNextRunnerPool({
+        flowPool: 'server',
+        accountPool: null,
+        runners: [OFFICE],
+        hostedMinutesLeft: 0,
+      })
+    ).to.equal('Next run: Preloop hosted, but no hosted minutes are left.');
+    expect(
+      describeNextRunnerPool({
+        flowPool: 'auto',
+        accountPool: null,
+        runners: [OFFLINE],
+        hostedMinutesLeft: 0,
+      })
+    ).to.equal(
+      'Next run: Preloop hosted, but no hosted minutes are left. No private runner is online.'
     );
   });
 });

--- a/frontend/src/utils/runner-pool.test.ts
+++ b/frontend/src/utils/runner-pool.test.ts
@@ -1,11 +1,19 @@
 import { expect } from '@open-wc/testing';
 
 import {
-  ANY_ONLINE_RUNNER_LABEL,
-  PRELOOP_HOSTED_LABEL,
+  ACCOUNT_AUTO_OPTION_LABEL,
+  ACCOUNT_AUTO_RESOLVED,
+  ACCOUNT_HOSTED_RESOLVED,
+  AUTO_RUNNER_POOL,
+  FLOW_AUTO_OVERRIDE_LABEL,
+  HOSTED_ONLY_EXHAUSTED_LABEL,
+  HOSTED_ONLY_LABEL,
   SERVER_RUNNER_POOL,
+  buildRunnerPoolGroups,
   buildRunnerPoolOptions,
   describeNextRunnerPool,
+  isSelectableToken,
+  resolveAccountPoolLabel,
 } from './runner-pool';
 
 const OFFICE = {
@@ -14,94 +22,260 @@ const OFFICE = {
   status: 'online',
 };
 
+const LAB = {
+  name: 'lab-1',
+  labels: ['gpu'],
+  status: 'online',
+};
+
+const OFFLINE = {
+  name: 'lab-offline',
+  labels: ['spare'],
+  status: 'offline',
+};
+
+function flattenValues(
+  groups: ReturnType<typeof buildRunnerPoolGroups>
+): string[] {
+  return groups.flatMap((group) => group.options.map((option) => option.value));
+}
+
+function flattenLabels(
+  groups: ReturnType<typeof buildRunnerPoolGroups>
+): string[] {
+  return groups.flatMap((group) => group.options.map((option) => option.label));
+}
+
 describe('runner-pool options', () => {
-  it('lists the default and hosted sentinels plus online names and labels', () => {
-    const options = buildRunnerPoolOptions([
-      OFFICE,
-      { name: 'offline-box', labels: ['spare'], status: 'offline' },
-    ]);
-    expect(options[0]).to.deep.equal({
+  it('flow context, account default auto: first row is inherit and has no separate auto row', () => {
+    const groups = buildRunnerPoolGroups({
+      runners: [OFFICE],
+      context: 'flow',
+      accountPool: null,
+    });
+    const first = groups[0].options[0];
+    expect(first).to.deep.equal({
       value: '',
-      label: ANY_ONLINE_RUNNER_LABEL,
+      label: `Account default: ${ACCOUNT_AUTO_RESOLVED}`,
     });
-    expect(options[1]).to.deep.equal({
-      value: SERVER_RUNNER_POOL,
-      label: PRELOOP_HOSTED_LABEL,
+    expect(flattenValues(groups)).to.not.include(AUTO_RUNNER_POOL);
+    expect(flattenLabels(groups)).to.not.include(FLOW_AUTO_OVERRIDE_LABEL);
+    expect(buildRunnerPoolOptions([OFFICE])[0]).to.deep.equal(first);
+  });
+
+  it('flow context, account default server: inherit hosted and offer explicit auto', () => {
+    const groups = buildRunnerPoolGroups({
+      runners: [OFFICE],
+      context: 'flow',
+      accountPool: SERVER_RUNNER_POOL,
     });
-    expect(options.map((option) => option.value)).to.include.members([
-      'office-mac',
-      'local',
+    const primary = groups[0].options;
+    expect(primary[0]).to.deep.equal({
+      value: '',
+      label: `Account default: ${ACCOUNT_HOSTED_RESOLVED}`,
+    });
+    expect(primary[1]).to.deep.equal({
+      value: AUTO_RUNNER_POOL,
+      label: FLOW_AUTO_OVERRIDE_LABEL,
+    });
+    expect(primary[2].value).to.equal(SERVER_RUNNER_POOL);
+    expect(primary[2].label).to.equal(HOSTED_ONLY_LABEL);
+  });
+
+  it('account context: first row is auto default and has no empty inherit row', () => {
+    const groups = buildRunnerPoolGroups({
+      runners: [OFFICE],
+      context: 'account',
+      accountPool: null,
+    });
+    expect(groups[0].options[0]).to.deep.equal({
+      value: AUTO_RUNNER_POOL,
+      label: ACCOUNT_AUTO_OPTION_LABEL,
+    });
+    expect(flattenValues(groups)).to.not.include('');
+  });
+
+  it('includes labels from offline runners and sorts by online count then name', () => {
+    const groups = buildRunnerPoolGroups({
+      runners: [OFFLINE, OFFICE, LAB],
+      context: 'flow',
+      accountPool: null,
+    });
+    const labelGroup = groups.find(
+      (group) => group.label === 'Runners by label'
+    );
+    expect(labelGroup).to.exist;
+    expect(labelGroup?.options.map((option) => option.value)).to.deep.equal([
       'gpu',
+      'local',
+      'spare',
     ]);
-    expect(options.map((option) => option.value)).to.not.include('offline-box');
-    expect(options.map((option) => option.value)).to.not.include('spare');
+    expect(labelGroup?.options.map((option) => option.label)).to.deep.equal([
+      'Runners labelled gpu (2 online)',
+      'Runners labelled local (1 online)',
+      'Runners labelled spare (0 online)',
+    ]);
+  });
+
+  it('excludes labels with whitespace from selectable options', () => {
+    const groups = buildRunnerPoolGroups({
+      runners: [
+        { name: 'office-mac', labels: ['office gpu', 'gpu'], status: 'online' },
+      ],
+      context: 'flow',
+    });
+    const values = flattenValues(groups);
+    expect(values).to.include('gpu');
+    expect(values).to.not.include('office gpu');
+    expect(isSelectableToken('office gpu')).to.equal(false);
+    expect(isSelectableToken('gpu')).to.equal(true);
+  });
+
+  it('lists specific runners online first with a status suffix', () => {
+    const groups = buildRunnerPoolGroups({
+      runners: [OFFLINE, OFFICE, { name: 'zebra', status: 'offline' }],
+      context: 'flow',
+    });
+    const runnerGroup = groups.find(
+      (group) => group.label === 'Specific runner'
+    );
+    expect(runnerGroup).to.exist;
+    expect(runnerGroup?.options.map((option) => option.label)).to.deep.equal([
+      'office-mac (online)',
+      'lab-offline (offline)',
+      'zebra (offline)',
+    ]);
+  });
+
+  it('appends the current unknown value as not registered', () => {
+    const groups = buildRunnerPoolGroups({
+      runners: [OFFICE],
+      context: 'flow',
+      current: 'legacy-pin',
+    });
+    const last = groups[groups.length - 1].options[0];
+    expect(last).to.deep.equal({
+      value: 'legacy-pin',
+      label: 'legacy-pin (not registered)',
+    });
+  });
+
+  it('disables the hosted row when hosted minutes are exhausted', () => {
+    const groups = buildRunnerPoolGroups({
+      runners: [OFFICE],
+      context: 'flow',
+      hostedMinutesLeft: 0,
+    });
+    const hosted = groups[0].options.find(
+      (option) => option.value === SERVER_RUNNER_POOL
+    );
+    expect(hosted).to.deep.equal({
+      value: SERVER_RUNNER_POOL,
+      label: HOSTED_ONLY_EXHAUSTED_LABEL,
+      disabled: true,
+    });
   });
 });
 
-describe('runner-pool next-execution hint', () => {
-  it('prefers an explicit flow pool', () => {
-    expect(
-      describeNextRunnerPool({
-        flowPool: 'gpu',
-        accountPool: 'server',
-        runners: [OFFICE],
-      })
-    ).to.equal('Next execution will use gpu.');
-  });
-
-  it('uses the hosted sentinel on the flow', () => {
+describe('runner-pool next-run hint', () => {
+  it('describes an explicit hosted flow', () => {
     expect(
       describeNextRunnerPool({
         flowPool: 'server',
         accountPool: 'office-mac',
         runners: [OFFICE],
       })
-    ).to.equal('Next execution will use Preloop hosted.');
+    ).to.equal('Next run: Preloop hosted.');
   });
 
-  it('falls back to the account default', () => {
+  it('describes auto when private runners are online', () => {
     expect(
       describeNextRunnerPool({
-        flowPool: null,
-        accountPool: 'office-mac',
-        runners: [OFFICE],
+        flowPool: 'auto',
+        accountPool: 'server',
+        runners: [OFFICE, LAB],
       })
-    ).to.equal('Next execution will use office-mac (account default).');
+    ).to.equal(
+      'Next run: a private runner (lab-1, office-mac online). Falls back to Preloop hosted when none is free.'
+    );
   });
 
-  it('uses any online private runner when nothing is pinned', () => {
+  it('describes auto when no private runner is online', () => {
     expect(
       describeNextRunnerPool({
         flowPool: '',
         accountPool: null,
-        runners: [OFFICE],
+        runners: [OFFLINE],
+      })
+    ).to.equal('Next run: Preloop hosted. No private runner is online.');
+  });
+
+  it('describes a labelled pool with nothing online', () => {
+    expect(
+      describeNextRunnerPool({
+        flowPool: 'gpu',
+        accountPool: null,
+        runners: [OFFLINE, { name: 'box', labels: ['gpu'], status: 'offline' }],
       })
     ).to.equal(
-      'Next execution will use any online private runner (currently office-mac).'
+      'Next run: a runner labelled gpu. None is online, so the run queues for up to 15 minutes, then fails.'
     );
   });
 
-  it('uses hosted when no private runner is online', () => {
+  it('describes a named runner that is offline', () => {
     expect(
       describeNextRunnerPool({
-        flowPool: null,
+        flowPool: 'office-mac',
         accountPool: null,
         runners: [{ name: 'office-mac', status: 'offline' }],
       })
     ).to.equal(
-      'Next execution will use Preloop hosted. No private runner is online.'
+      'Next run: office-mac. It is offline, so the run queues for up to 15 minutes, then fails.'
     );
   });
 
-  it('does not put an em dash in user-facing hint text', () => {
-    const hint = describeNextRunnerPool({
-      flowPool: null,
+  it('does not put an em dash in any produced label or hint', () => {
+    const groups = buildRunnerPoolGroups({
+      runners: [OFFICE, LAB, OFFLINE],
+      context: 'flow',
       accountPool: 'server',
-      runners: [OFFICE],
+      current: 'missing-pin',
+      hostedMinutesLeft: 0,
     });
-    expect(hint).to.equal(
-      'Next execution will use Preloop hosted (account default).'
+    const hints = [
+      describeNextRunnerPool({
+        flowPool: null,
+        accountPool: 'server',
+        runners: [OFFICE],
+        hostedMinutesLeft: 340,
+      }),
+      describeNextRunnerPool({
+        flowPool: 'auto',
+        accountPool: null,
+        runners: [OFFICE, LAB],
+        hostedMinutesLeft: 0,
+      }),
+      describeNextRunnerPool({
+        flowPool: 'gpu',
+        accountPool: null,
+        runners: [OFFICE],
+      }),
+      describeNextRunnerPool({
+        flowPool: null,
+        accountPool: 'office-mac',
+        runners: [OFFICE],
+      }),
+      resolveAccountPoolLabel('gpu', [OFFICE]),
+    ];
+    const produced = [...flattenLabels(groups), ...hints];
+    for (const text of produced) {
+      expect(text, text).to.not.contain('\u2014');
+    }
+    expect(hints[0]).to.equal(
+      'Next run: Preloop hosted. (account default) Hosted minutes left: 340.'
     );
-    expect(hint).to.not.contain('—');
+    expect(hints[1]).to.equal(
+      'Next run: a private runner (lab-1, office-mac online). No hosted minutes left, so the run queues if none is free. Hosted minutes left: 0.'
+    );
   });
 });

--- a/frontend/src/utils/runner-pool.ts
+++ b/frontend/src/utils/runner-pool.ts
@@ -171,7 +171,10 @@ function collectLabelRows(runners: RunnerPoolSource[]): RunnerPoolOption[] {
     }));
 }
 
-function collectRunnerRows(runners: RunnerPoolSource[]): RunnerPoolOption[] {
+function collectRunnerRows(
+  runners: RunnerPoolSource[],
+  current?: string
+): RunnerPoolOption[] {
   const seen = new Set<string>();
   const rows: { runner: RunnerPoolSource; name: string }[] = [];
   for (const runner of runners) {
@@ -194,10 +197,16 @@ function collectRunnerRows(runners: RunnerPoolSource[]): RunnerPoolOption[] {
     }
     return left.name.localeCompare(right.name);
   });
-  return rows.map(({ runner, name }) => ({
-    value: name,
-    label: `${name} (${isOnlineRunner(runner) ? 'online' : 'offline'})`,
-  }));
+  const currentKey = (current || '').trim().toLowerCase();
+  return rows.map(({ runner, name }) => {
+    const id = (runner.id || '').trim();
+    const value =
+      currentKey && id && id.toLowerCase() === currentKey ? id : name;
+    return {
+      value,
+      label: `${name} (${isOnlineRunner(runner) ? 'online' : 'offline'})`,
+    };
+  });
 }
 
 function optionValues(groups: RunnerPoolGroup[]): Set<string> {
@@ -255,16 +264,17 @@ export function buildRunnerPoolGroups(
     groups.push({ label: 'Runners by label', options: labelRows });
   }
 
-  const runnerRows = collectRunnerRows(runners);
+  const current = normalizedPool(args.current);
+  const runnerRows = collectRunnerRows(runners, current);
   if (runnerRows.length > 0) {
     groups.push({ label: 'Specific runner', options: runnerRows });
   }
 
-  const current = normalizedPool(args.current);
   if (
     current &&
     isSelectableToken(current) &&
-    !isKnownCurrent(current, optionValues(groups))
+    !isKnownCurrent(current, optionValues(groups)) &&
+    !findRunnerByToken(current, runners)
   ) {
     groups.push({
       options: [{ value: current, label: `${current} (not registered)` }],
@@ -312,11 +322,11 @@ function withHostedMinutes(
   if (!hostedCapable || typeof hostedMinutesLeft !== 'number') {
     return text;
   }
-  if (
-    hostedMinutesLeft === 0 &&
-    text.includes('No hosted minutes left, so the run queues if none is free.')
-  ) {
-    return text;
+  if (hostedMinutesLeft === 0) {
+    const already =
+      text.toLowerCase().includes('no hosted minutes') ||
+      text.toLowerCase().includes('hosted minutes are left');
+    return already ? text : `${text} No hosted minutes left.`;
   }
   return `${text} Hosted minutes left: ${hostedMinutesLeft}.`;
 }
@@ -342,11 +352,17 @@ export function describeNextRunnerPool(args: {
 
   let text = '';
   if (kind === 'server') {
-    text = 'Next run: Preloop hosted.';
+    text =
+      args.hostedMinutesLeft === 0
+        ? 'Next run: Preloop hosted, but no hosted minutes are left.'
+        : 'Next run: Preloop hosted.';
   } else if (kind === 'auto') {
     const names = onlinePrivateNames(runners);
     if (names.length > 0) {
       text = `Next run: a private runner (${names.join(', ')} online). ${exhaustedAuto}`;
+    } else if (args.hostedMinutesLeft === 0) {
+      text =
+        'Next run: Preloop hosted, but no hosted minutes are left. No private runner is online.';
     } else {
       text = 'Next run: Preloop hosted. No private runner is online.';
     }

--- a/frontend/src/utils/runner-pool.ts
+++ b/frontend/src/utils/runner-pool.ts
@@ -261,27 +261,17 @@ export function buildRunnerPoolGroups(
   }
 
   const current = normalizedPool(args.current);
-  if (current && !isKnownCurrent(current, optionValues(groups))) {
+  if (
+    current &&
+    isSelectableToken(current) &&
+    !isKnownCurrent(current, optionValues(groups))
+  ) {
     groups.push({
       options: [{ value: current, label: `${current} (not registered)` }],
     });
   }
 
   return groups;
-}
-
-export function buildRunnerPoolOptions(
-  runners: RunnerPoolSource[],
-  extras?: Omit<BuildRunnerPoolGroupsArgs, 'runners'>
-): RunnerPoolOption[] {
-  const groups = buildRunnerPoolGroups({
-    runners,
-    context: extras?.context ?? 'flow',
-    accountPool: extras?.accountPool,
-    current: extras?.current,
-    hostedMinutesLeft: extras?.hostedMinutesLeft,
-  });
-  return groups.flatMap((group) => group.options);
 }
 
 function onlinePrivateNames(runners: RunnerPoolSource[]): string[] {
@@ -320,6 +310,12 @@ function withHostedMinutes(
   hostedCapable?: boolean
 ): string {
   if (!hostedCapable || typeof hostedMinutesLeft !== 'number') {
+    return text;
+  }
+  if (
+    hostedMinutesLeft === 0 &&
+    text.includes('No hosted minutes left, so the run queues if none is free.')
+  ) {
     return text;
   }
   return `${text} Hosted minutes left: ${hostedMinutesLeft}.`;

--- a/frontend/src/utils/runner-pool.ts
+++ b/frontend/src/utils/runner-pool.ts
@@ -1,18 +1,49 @@
 export const SERVER_RUNNER_POOL = 'server';
 export const AUTO_RUNNER_POOL = 'auto';
 
-export const ANY_ONLINE_RUNNER_LABEL = 'Any online private runner (default)';
-export const PRELOOP_HOSTED_LABEL = 'Preloop hosted';
+export const ACCOUNT_AUTO_RESOLVED =
+  'Auto (private runners first, then Preloop hosted)';
+export const ACCOUNT_HOSTED_RESOLVED = 'Preloop hosted only';
+export const FLOW_AUTO_OVERRIDE_LABEL =
+  'Auto: private runners first, then Preloop hosted';
+export const ACCOUNT_AUTO_OPTION_LABEL =
+  'Auto (default): private runners first, then Preloop hosted';
+export const HOSTED_ONLY_LABEL = 'Preloop hosted only';
+export const HOSTED_ONLY_EXHAUSTED_LABEL =
+  'Preloop hosted only (no hosted minutes left)';
 
 export interface RunnerPoolOption {
   value: string;
   label: string;
+  disabled?: boolean;
+}
+
+export interface RunnerPoolGroup {
+  label?: string;
+  options: RunnerPoolOption[];
 }
 
 export interface RunnerPoolSource {
+  id?: string | null;
   name?: string | null;
   labels?: string[] | null;
   status?: string | null;
+}
+
+export interface BuildRunnerPoolGroupsArgs {
+  runners: RunnerPoolSource[];
+  context: 'flow' | 'account';
+  accountPool?: string | null;
+  current?: string | null;
+  hostedMinutesLeft?: number | null;
+}
+
+function normalizedPool(value?: string | null): string {
+  return (value ?? '').trim();
+}
+
+function poolKey(value?: string | null): string {
+  return normalizedPool(value).toLowerCase();
 }
 
 export function isOnlineRunner(runner: RunnerPoolSource): boolean {
@@ -20,59 +51,333 @@ export function isOnlineRunner(runner: RunnerPoolSource): boolean {
   return status === 'online' || status === 'busy';
 }
 
-export function buildRunnerPoolOptions(
+export function isSelectableToken(value: string): boolean {
+  return Boolean(value) && !/\s/.test(value);
+}
+
+export function isAccountDefaultAuto(accountPool?: string | null): boolean {
+  const key = poolKey(accountPool);
+  return key === '' || key === AUTO_RUNNER_POOL;
+}
+
+function isAutoToken(value?: string | null): boolean {
+  return poolKey(value) === AUTO_RUNNER_POOL;
+}
+
+function isServerToken(value?: string | null): boolean {
+  return poolKey(value) === SERVER_RUNNER_POOL;
+}
+
+function runnerName(runner: RunnerPoolSource): string {
+  return (runner.name || '').trim();
+}
+
+function findRunnerByToken(
+  token: string,
   runners: RunnerPoolSource[]
-): RunnerPoolOption[] {
-  const options: RunnerPoolOption[] = [
-    { value: '', label: ANY_ONLINE_RUNNER_LABEL },
-    { value: SERVER_RUNNER_POOL, label: PRELOOP_HOSTED_LABEL },
-  ];
-  const seen = new Set<string>(['', SERVER_RUNNER_POOL, AUTO_RUNNER_POOL]);
+): RunnerPoolSource | undefined {
+  const key = token.toLowerCase();
+  return runners.find((runner) => {
+    const name = runnerName(runner).toLowerCase();
+    const id = (runner.id || '').trim().toLowerCase();
+    return name === key || (id !== '' && id === key);
+  });
+}
+
+function hasLabel(token: string, runners: RunnerPoolSource[]): boolean {
+  const key = token.toLowerCase();
+  return runners.some((runner) =>
+    (runner.labels || []).some(
+      (raw) => String(raw).trim().toLowerCase() === key
+    )
+  );
+}
+
+function classifyToken(
+  token: string,
+  runners: RunnerPoolSource[]
+): 'auto' | 'server' | 'label' | 'name' {
+  if (isAutoToken(token) || token === '') {
+    return 'auto';
+  }
+  if (isServerToken(token)) {
+    return 'server';
+  }
+  if (findRunnerByToken(token, runners)) {
+    return 'name';
+  }
+  if (hasLabel(token, runners)) {
+    return 'label';
+  }
+  return 'name';
+}
+
+export function resolveAccountPoolLabel(
+  accountPool?: string | null,
+  runners: RunnerPoolSource[] = []
+): string {
+  const token = normalizedPool(accountPool);
+  if (isAccountDefaultAuto(token)) {
+    return ACCOUNT_AUTO_RESOLVED;
+  }
+  if (isServerToken(token)) {
+    return ACCOUNT_HOSTED_RESOLVED;
+  }
+  const runner = findRunnerByToken(token, runners);
+  if (runner) {
+    return `runner ${runnerName(runner) || token}`;
+  }
+  if (hasLabel(token, runners)) {
+    return `runners labelled ${token}`;
+  }
+  return `runner ${token}`;
+}
+
+function hostedOption(hostedMinutesLeft?: number | null): RunnerPoolOption {
+  const exhausted = hostedMinutesLeft === 0;
+  return {
+    value: SERVER_RUNNER_POOL,
+    label: exhausted ? HOSTED_ONLY_EXHAUSTED_LABEL : HOSTED_ONLY_LABEL,
+    disabled: exhausted || undefined,
+  };
+}
+
+function collectLabelRows(runners: RunnerPoolSource[]): RunnerPoolOption[] {
+  const counts = new Map<string, { label: string; online: number }>();
   for (const runner of runners) {
-    if (!isOnlineRunner(runner)) {
-      continue;
-    }
-    const name = (runner.name || '').trim();
-    if (name && !seen.has(name)) {
-      seen.add(name);
-      options.push({ value: name, label: name });
-    }
     for (const raw of runner.labels || []) {
       const label = String(raw).trim();
-      if (label && !seen.has(label)) {
-        seen.add(label);
-        options.push({ value: label, label: `Label: ${label}` });
+      if (!isSelectableToken(label)) {
+        continue;
       }
+      const key = label.toLowerCase();
+      const current = counts.get(key) || { label, online: 0 };
+      if (isOnlineRunner(runner)) {
+        current.online += 1;
+      }
+      counts.set(key, current);
     }
   }
-  return options;
+  return [...counts.values()]
+    .sort((left, right) => {
+      if (right.online !== left.online) {
+        return right.online - left.online;
+      }
+      return left.label.localeCompare(right.label);
+    })
+    .map((entry) => ({
+      value: entry.label,
+      label: `Runners labelled ${entry.label} (${entry.online} online)`,
+    }));
+}
+
+function collectRunnerRows(runners: RunnerPoolSource[]): RunnerPoolOption[] {
+  const seen = new Set<string>();
+  const rows: { runner: RunnerPoolSource; name: string }[] = [];
+  for (const runner of runners) {
+    const name = runnerName(runner);
+    if (!isSelectableToken(name)) {
+      continue;
+    }
+    const key = name.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    rows.push({ runner, name });
+  }
+  rows.sort((left, right) => {
+    const leftOnline = isOnlineRunner(left.runner) ? 0 : 1;
+    const rightOnline = isOnlineRunner(right.runner) ? 0 : 1;
+    if (leftOnline !== rightOnline) {
+      return leftOnline - rightOnline;
+    }
+    return left.name.localeCompare(right.name);
+  });
+  return rows.map(({ runner, name }) => ({
+    value: name,
+    label: `${name} (${isOnlineRunner(runner) ? 'online' : 'offline'})`,
+  }));
+}
+
+function optionValues(groups: RunnerPoolGroup[]): Set<string> {
+  const values = new Set<string>(['', AUTO_RUNNER_POOL, SERVER_RUNNER_POOL]);
+  for (const group of groups) {
+    for (const option of group.options) {
+      values.add(option.value);
+    }
+  }
+  return values;
+}
+
+function isKnownCurrent(current: string, values: Set<string>): boolean {
+  if (values.has(current)) {
+    return true;
+  }
+  const key = current.toLowerCase();
+  for (const value of values) {
+    if (value.toLowerCase() === key) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function buildRunnerPoolGroups(
+  args: BuildRunnerPoolGroupsArgs
+): RunnerPoolGroup[] {
+  const runners = args.runners || [];
+  const groups: RunnerPoolGroup[] = [];
+  const primary: RunnerPoolOption[] = [];
+
+  if (args.context === 'flow') {
+    primary.push({
+      value: '',
+      label: `Account default: ${resolveAccountPoolLabel(args.accountPool, runners)}`,
+    });
+    if (!isAccountDefaultAuto(args.accountPool)) {
+      primary.push({
+        value: AUTO_RUNNER_POOL,
+        label: FLOW_AUTO_OVERRIDE_LABEL,
+      });
+    }
+  } else {
+    primary.push({
+      value: AUTO_RUNNER_POOL,
+      label: ACCOUNT_AUTO_OPTION_LABEL,
+    });
+  }
+  primary.push(hostedOption(args.hostedMinutesLeft));
+  groups.push({ options: primary });
+
+  const labelRows = collectLabelRows(runners);
+  if (labelRows.length > 0) {
+    groups.push({ label: 'Runners by label', options: labelRows });
+  }
+
+  const runnerRows = collectRunnerRows(runners);
+  if (runnerRows.length > 0) {
+    groups.push({ label: 'Specific runner', options: runnerRows });
+  }
+
+  const current = normalizedPool(args.current);
+  if (current && !isKnownCurrent(current, optionValues(groups))) {
+    groups.push({
+      options: [{ value: current, label: `${current} (not registered)` }],
+    });
+  }
+
+  return groups;
+}
+
+export function buildRunnerPoolOptions(
+  runners: RunnerPoolSource[],
+  extras?: Omit<BuildRunnerPoolGroupsArgs, 'runners'>
+): RunnerPoolOption[] {
+  const groups = buildRunnerPoolGroups({
+    runners,
+    context: extras?.context ?? 'flow',
+    accountPool: extras?.accountPool,
+    current: extras?.current,
+    hostedMinutesLeft: extras?.hostedMinutesLeft,
+  });
+  return groups.flatMap((group) => group.options);
+}
+
+function onlinePrivateNames(runners: RunnerPoolSource[]): string[] {
+  return runners
+    .filter(isOnlineRunner)
+    .map(runnerName)
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function onlineLabelCount(token: string, runners: RunnerPoolSource[]): number {
+  const key = token.toLowerCase();
+  return runners.filter(
+    (runner) =>
+      isOnlineRunner(runner) &&
+      (runner.labels || []).some(
+        (raw) => String(raw).trim().toLowerCase() === key
+      )
+  ).length;
+}
+
+function withInherited(text: string, inherited: boolean): string {
+  if (!inherited) {
+    return text;
+  }
+  const period = text.indexOf('.');
+  if (period === -1) {
+    return `${text} (account default)`;
+  }
+  return `${text.slice(0, period + 1)} (account default)${text.slice(period + 1)}`;
+}
+
+function withHostedMinutes(
+  text: string,
+  hostedMinutesLeft?: number | null,
+  hostedCapable?: boolean
+): string {
+  if (!hostedCapable || typeof hostedMinutesLeft !== 'number') {
+    return text;
+  }
+  return `${text} Hosted minutes left: ${hostedMinutesLeft}.`;
 }
 
 export function describeNextRunnerPool(args: {
   flowPool?: string | null;
   accountPool?: string | null;
   runners: RunnerPoolSource[];
+  hostedMinutesLeft?: number | null;
 }): string {
-  const onlineNames = args.runners
-    .filter(isOnlineRunner)
-    .map((runner) => (runner.name || '').trim())
-    .filter(Boolean);
-  const explicit = (args.flowPool || '').trim();
-  if (explicit.toLowerCase() === SERVER_RUNNER_POOL) {
-    return 'Next execution will use Preloop hosted.';
+  const runners = args.runners || [];
+  const flow = normalizedPool(args.flowPool);
+  const inherited = flow === '';
+  const effective = inherited
+    ? normalizedPool(args.accountPool) || AUTO_RUNNER_POOL
+    : flow;
+  const kind = classifyToken(effective, runners);
+  const hostedCapable = kind === 'auto' || kind === 'server';
+  const exhaustedAuto =
+    kind === 'auto' && args.hostedMinutesLeft === 0
+      ? 'No hosted minutes left, so the run queues if none is free.'
+      : 'Falls back to Preloop hosted when none is free.';
+
+  let text = '';
+  if (kind === 'server') {
+    text = 'Next run: Preloop hosted.';
+  } else if (kind === 'auto') {
+    const names = onlinePrivateNames(runners);
+    if (names.length > 0) {
+      text = `Next run: a private runner (${names.join(', ')} online). ${exhaustedAuto}`;
+    } else {
+      text = 'Next run: Preloop hosted. No private runner is online.';
+    }
+  } else if (kind === 'label') {
+    const online = onlineLabelCount(effective, runners);
+    if (online > 0) {
+      text = `Next run: a runner labelled ${effective} (${online} online).`;
+    } else {
+      text =
+        `Next run: a runner labelled ${effective}. None is online, so the ` +
+        'run queues for up to 15 minutes, then fails.';
+    }
+  } else {
+    const runner = findRunnerByToken(effective, runners);
+    const display = runner ? runnerName(runner) || effective : effective;
+    if (runner && isOnlineRunner(runner)) {
+      text = `Next run: ${display}.`;
+    } else {
+      text =
+        `Next run: ${display}. It is offline, so the run queues for up to ` +
+        '15 minutes, then fails.';
+    }
   }
-  if (explicit && explicit.toLowerCase() !== AUTO_RUNNER_POOL) {
-    return `Next execution will use ${explicit}.`;
-  }
-  const account = (args.accountPool || '').trim();
-  if (!explicit && account.toLowerCase() === SERVER_RUNNER_POOL) {
-    return 'Next execution will use Preloop hosted (account default).';
-  }
-  if (!explicit && account && account.toLowerCase() !== AUTO_RUNNER_POOL) {
-    return `Next execution will use ${account} (account default).`;
-  }
-  if (onlineNames.length > 0) {
-    return `Next execution will use any online private runner (currently ${onlineNames.join(', ')}).`;
-  }
-  return 'Next execution will use Preloop hosted. No private runner is online.';
+
+  return withHostedMinutes(
+    withInherited(text, inherited && kind !== 'auto'),
+    args.hostedMinutesLeft,
+    hostedCapable
+  );
 }

--- a/frontend/src/views/authed/runners-view.test.ts
+++ b/frontend/src/views/authed/runners-view.test.ts
@@ -89,14 +89,14 @@ describe('RunnersView', () => {
     expect(element.shadowRoot?.textContent).to.contain('office-mac');
     expect(element.shadowRoot?.textContent).to.contain('ops@example.com');
     expect(element.shadowRoot?.textContent).to.contain('local');
-    const select = element.shadowRoot?.querySelector(
-      'sl-select[label="Default runner pool"]'
+    const control = element.shadowRoot?.querySelector(
+      'preloop-runner-pool-select'
     );
-    expect(select).to.exist;
-    expect(element.shadowRoot?.textContent).to.contain(
-      'Any online private runner (default)'
+    expect(control).to.exist;
+    expect(control?.shadowRoot?.textContent).to.contain(
+      'Auto (default): private runners first, then Preloop hosted'
     );
-    expect(element.shadowRoot?.textContent).to.contain('Preloop hosted');
+    expect(control?.shadowRoot?.textContent).to.contain('Preloop hosted only');
   });
 
   it('shows empty state when no runners', async () => {
@@ -184,8 +184,11 @@ describe('RunnersView', () => {
     );
     await element.updateComplete;
 
-    const select = element.shadowRoot?.querySelector(
-      'sl-select[label="Default runner pool"]'
+    const control = element.shadowRoot?.querySelector(
+      'preloop-runner-pool-select'
+    ) as HTMLElement;
+    const select = control.shadowRoot?.querySelector(
+      'sl-select'
     ) as HTMLSelectElement;
     select.value = 'server';
     select.dispatchEvent(new CustomEvent('sl-change'));
@@ -217,14 +220,63 @@ describe('RunnersView', () => {
     );
     await element.updateComplete;
 
-    const select = element.shadowRoot?.querySelector(
-      'sl-select[label="Default runner pool"]'
+    const control = element.shadowRoot?.querySelector(
+      'preloop-runner-pool-select'
+    ) as HTMLElement;
+    const select = control.shadowRoot?.querySelector(
+      'sl-select'
     ) as HTMLSelectElement;
     const values = Array.from(select.querySelectorAll('sl-option')).map(
       (option) => option.getAttribute('value')
     );
     expect(values).to.include('office-mac');
     expect(select.value).to.equal('office-mac');
+  });
+
+  it('saves Auto as a null account default runner pool', async () => {
+    fetchStub = createFetchStub([
+      {
+        id: '11111111-1111-4111-8111-111111111111',
+        name: 'office-mac',
+        hostname: 'mac.local',
+        os: 'darwin',
+        arch: 'arm64',
+        labels: ['local'],
+        status: 'online',
+        last_heartbeat: '2026-08-17T10:00:00Z',
+        current_execution_id: null,
+      },
+    ]);
+    const element = (await fixture(
+      html`<runners-view></runners-view>`
+    )) as RunnersView;
+    await waitUntil(
+      () => !(element as unknown as { loading: boolean }).loading
+    );
+    await element.updateComplete;
+
+    const control = element.shadowRoot?.querySelector(
+      'preloop-runner-pool-select'
+    ) as HTMLElement;
+    const select = control.shadowRoot?.querySelector(
+      'sl-select'
+    ) as HTMLSelectElement;
+    select.value = 'auto';
+    select.dispatchEvent(new CustomEvent('sl-change'));
+    await waitUntil(() =>
+      fetchStub
+        .getCalls()
+        .some(
+          (call) => String(call.args[1]?.method || '').toUpperCase() === 'PATCH'
+        )
+    );
+    const patch = fetchStub.getCalls().find((call) => {
+      const init = call.args[1] as RequestInit | undefined;
+      return String(init?.method || '').toUpperCase() === 'PATCH';
+    });
+    expect(
+      JSON.parse(String((patch?.args[1] as RequestInit).body))
+    ).to.deep.equal({ default_runner_pool: null });
   });
 
   it('shows registered-by email for a runner that arrives over websocket', async () => {

--- a/frontend/src/views/authed/runners-view.test.ts
+++ b/frontend/src/views/authed/runners-view.test.ts
@@ -1,4 +1,5 @@
 import { html, fixture, expect, waitUntil } from '@open-wc/testing';
+import type SlSelect from '@shoelace-style/shoelace/dist/components/select/select.js';
 import sinon from 'sinon';
 
 import '../../components/view-header.ts';
@@ -13,21 +14,41 @@ describe('RunnersView', () => {
 
   function createFetchStub(
     runners: unknown[] = [],
-    account: { default_runner_pool?: string | null } = {}
+    account: { default_runner_pool?: string | null } = {},
+    options: { failPatch?: boolean } = {}
   ) {
     return sinon
       .stub(window, 'fetch')
-      .callsFake(async (input: RequestInfo | URL) => {
+      .callsFake(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input.toString();
-        const json = (data: unknown) =>
+        const json = (data: unknown, status = 200) =>
           new Response(JSON.stringify(data), {
-            status: 200,
+            status,
             headers: { 'Content-Type': 'application/json' },
           });
         if (url.includes('/api/v1/runners')) {
           return json(runners);
         }
         if (url.includes('/api/v1/account/details')) {
+          const method = String(init?.method || 'GET').toUpperCase();
+          if (method === 'PATCH') {
+            if (options.failPatch) {
+              return json(
+                { detail: 'Failed to update account organization' },
+                400
+              );
+            }
+            const body = JSON.parse(String(init?.body || '{}')) as {
+              default_runner_pool?: string | null;
+            };
+            return json({
+              id: 'acct-1',
+              organization_name: 'Example Org',
+              default_runner_pool: body.default_runner_pool ?? null,
+              created_at: '2026-09-04T00:00:00Z',
+              updated_at: '2026-09-04T00:00:00Z',
+            });
+          }
           return json({
             id: 'acct-1',
             organization_name: 'Example Org',
@@ -187,9 +208,7 @@ describe('RunnersView', () => {
     const control = element.shadowRoot?.querySelector(
       'preloop-runner-pool-select'
     ) as HTMLElement;
-    const select = control.shadowRoot?.querySelector(
-      'sl-select'
-    ) as HTMLSelectElement;
+    const select = control.shadowRoot?.querySelector('sl-select') as SlSelect;
     select.value = 'server';
     select.dispatchEvent(new CustomEvent('sl-change'));
     await waitUntil(() =>
@@ -223,9 +242,7 @@ describe('RunnersView', () => {
     const control = element.shadowRoot?.querySelector(
       'preloop-runner-pool-select'
     ) as HTMLElement;
-    const select = control.shadowRoot?.querySelector(
-      'sl-select'
-    ) as HTMLSelectElement;
+    const select = control.shadowRoot?.querySelector('sl-select') as SlSelect;
     const values = Array.from(select.querySelectorAll('sl-option')).map(
       (option) => option.getAttribute('value')
     );
@@ -258,9 +275,7 @@ describe('RunnersView', () => {
     const control = element.shadowRoot?.querySelector(
       'preloop-runner-pool-select'
     ) as HTMLElement;
-    const select = control.shadowRoot?.querySelector(
-      'sl-select'
-    ) as HTMLSelectElement;
+    const select = control.shadowRoot?.querySelector('sl-select') as SlSelect;
     select.value = 'auto';
     select.dispatchEvent(new CustomEvent('sl-change'));
     await waitUntil(() =>
@@ -277,6 +292,41 @@ describe('RunnersView', () => {
     expect(
       JSON.parse(String((patch?.args[1] as RequestInit).body))
     ).to.deep.equal({ default_runner_pool: null });
+  });
+
+  it('restores the saved default when the PATCH fails', async () => {
+    fetchStub = createFetchStub(
+      [],
+      { default_runner_pool: 'office-mac' },
+      {
+        failPatch: true,
+      }
+    );
+    const element = (await fixture(
+      html`<runners-view></runners-view>`
+    )) as RunnersView;
+    await waitUntil(
+      () => !(element as unknown as { loading: boolean }).loading
+    );
+    await element.updateComplete;
+
+    const control = element.shadowRoot?.querySelector(
+      'preloop-runner-pool-select'
+    ) as HTMLElement;
+    const select = control.shadowRoot?.querySelector('sl-select') as SlSelect;
+    expect(select.value).to.equal('office-mac');
+    select.value = 'server';
+    select.dispatchEvent(new CustomEvent('sl-change'));
+    await waitUntil(() =>
+      Boolean(
+        element.shadowRoot?.textContent?.includes(
+          'Failed to update account organization'
+        )
+      )
+    );
+    await element.updateComplete;
+    const restored = control.shadowRoot?.querySelector('sl-select') as SlSelect;
+    expect(restored.value).to.equal('office-mac');
   });
 
   it('shows registered-by email for a runner that arrives over websocket', async () => {

--- a/frontend/src/views/authed/runners-view.ts
+++ b/frontend/src/views/authed/runners-view.ts
@@ -224,6 +224,8 @@ export class RunnersView extends LitElement {
   ) {
     const raw = (event.detail?.value || '').trim();
     const next = !raw || raw === AUTO_RUNNER_POOL ? null : raw;
+    const previous = this.defaultRunnerPool;
+    this.defaultRunnerPool = next;
     this.savingDefault = true;
     this.defaultError = null;
     try {
@@ -232,6 +234,7 @@ export class RunnersView extends LitElement {
       });
       this.defaultRunnerPool = updated.default_runner_pool ?? null;
     } catch (err) {
+      this.defaultRunnerPool = previous;
       this.defaultError =
         err instanceof Error ? err.message : 'Failed to save default runner';
     } finally {

--- a/frontend/src/views/authed/runners-view.ts
+++ b/frontend/src/views/authed/runners-view.ts
@@ -6,8 +6,6 @@ import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/copy-button/copy-button.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
-import '@shoelace-style/shoelace/dist/components/select/select.js';
-import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '../../components/view-header.ts';
 import {
   getAccountOrganization,
@@ -17,7 +15,8 @@ import {
 } from '../../api';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import { formatLocalDateTime } from '../../utils/date';
-import { buildRunnerPoolOptions } from '../../utils/runner-pool';
+import { AUTO_RUNNER_POOL } from '../../utils/runner-pool';
+import '../../components/preloop-runner-pool-select';
 import consoleStyles from '../../styles/console-styles.css?inline';
 
 @customElement('runners-view')
@@ -33,6 +32,9 @@ export class RunnersView extends LitElement {
 
   @state()
   private defaultRunnerPool: string | null = null;
+
+  @state()
+  private hostedMinutesLeft: number | null = null;
 
   @state()
   private savingDefault = false;
@@ -208,6 +210,7 @@ export class RunnersView extends LitElement {
       ]);
       this.runners = runners;
       this.defaultRunnerPool = account?.default_runner_pool ?? null;
+      this.hostedMinutesLeft = account?.hosted_minutes_remaining ?? null;
     } catch (err) {
       this.error =
         err instanceof Error ? err.message : 'Failed to load runners';
@@ -216,9 +219,11 @@ export class RunnersView extends LitElement {
     }
   }
 
-  private async handleDefaultPoolChange(event: Event) {
-    const target = event.target as HTMLSelectElement;
-    const next = (target.value || '').trim() || null;
+  private async handleDefaultPoolChange(
+    event: CustomEvent<{ value: string | null }>
+  ) {
+    const raw = (event.detail?.value || '').trim();
+    const next = !raw || raw === AUTO_RUNNER_POOL ? null : raw;
     this.savingDefault = true;
     this.defaultError = null;
     try {
@@ -235,25 +240,19 @@ export class RunnersView extends LitElement {
   }
 
   private renderDefaultPoolControl() {
-    const options = buildRunnerPoolOptions(this.runners);
-    const current = (this.defaultRunnerPool || '').trim();
-    if (current && !options.some((option) => option.value === current)) {
-      options.push({ value: current, label: current });
-    }
     return html`
       <div class="default-pool">
-        <sl-select
+        <preloop-runner-pool-select
           label="Default runner pool"
-          help-text="Used when a flow does not pin a runner. Private runners are preferred when one is online."
-          .value=${this.defaultRunnerPool || ''}
+          .helpText=${'Applies to every flow that does not pin a runner.'}
+          context="account"
+          .value=${this.defaultRunnerPool}
+          .runners=${this.runners}
+          .accountPool=${this.defaultRunnerPool}
+          .hostedMinutesLeft=${this.hostedMinutesLeft}
           ?disabled=${this.savingDefault}
-          @sl-change=${this.handleDefaultPoolChange}
-        >
-          ${options.map(
-            (option) =>
-              html`<sl-option value=${option.value}>${option.label}</sl-option>`
-          )}
-        </sl-select>
+          @pool-change=${this.handleDefaultPoolChange}
+        ></preloop-runner-pool-select>
         ${
           this.defaultError
             ? html`<p class="muted">${this.defaultError}</p>`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10089,6 +10089,13 @@ components:
           description: 'Account default runner pool: a runner id, name, or label;
             the literal ''server'' for Preloop hosted; null for any online private
             runner.'
+        hosted_minutes_remaining:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Hosted Minutes Remaining
+          description: Hosted runner minutes remaining for this account. Null when
+            quota is not configured.
         created_at:
           type: string
           title: Created At


### PR DESCRIPTION
## Why
The flow form offered "Any online private runner (default)" and "Preloop hosted", which did not describe what the backend does (flow pool > account default > any online private runner > hosted) and pushed people to pin runners by name. The Runners page had its own control with different words.

## What changed (frontend only, no backend semantic change, no migration)
- `utils/runner-pool.ts`: `buildRunnerPoolGroups({runners, context, accountPool, current, hostedMinutesLeft})` returns grouped options; `resolveAccountPoolLabel`; `describeNextRunnerPool` rewritten with the new copy and an optional `hostedMinutesLeft`; `isSelectableToken` (labels with whitespace fall back to free text because Shoelace rewrites option values).
- New `components/preloop-runner-pool-select.ts`, used by the flow form and the Runners page:
  - Flow: `Account default: Auto (private runners first, then Preloop hosted)` (value `''`, preselected), `Auto: private runners first, then Preloop hosted` (only when the account default is not already auto), `Preloop hosted only`, then **Runners by label** (`Runners labelled gpu (2 online)`), **Specific runner** (`office-mac (online)`), a saved value that matches nothing as `{value} (not registered)`, and a collapsed "Type a label or runner id" free-text field.
  - Runners page (`Default runner pool`): `Auto (default): ...`, `Preloop hosted only`, same label and runner groups; picking Auto writes `null`.
  - Hint under the control: `Next run: a private runner (office-mac online). Falls back to Preloop hosted when none is free.` and the other cases (hosted, label with none online queues 15 minutes then fails, offline pin, `(account default)` suffix, hosted minutes left when known).
- Stored values keep their meaning: flow `''`/null inherits, `auto` is explicit private-first, `server` is hosted, anything else is a label, name or id. A new untouched flow submits `runner_pool: null` (regression test).
- Quota hook: the control reads an optional `hostedMinutesLeft`; `AccountOrganizationResponse` gains `hosted_minutes_remaining: number | null` (null in OSS). When it is 0 the hosted row is disabled and labelled. Nothing computes it until the hosted metering work lands (EE PRD).
- Review follow-ups: the free-text draft is not cleared while typing, the input has an accessible name, a failed PATCH on the Runners page restores the saved value.

## Tests
`runner-pool.test.ts` 16, `preloop-runner-pool-select.test.ts` 8, `preloop-flow-form-runner-pool.test.ts` 5, `runners-view.test.ts` 8 (37 targeted). Full suite: 131 files, 1430 passed, 0 failed. Backend schema test: 3 passed.

Companion: the preset picker (#401) edits a different region of `preloop-flow-form.ts`.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Frontend-only UX refactor consolidating the runner-pool control with grouped options and rewritten copy, plus a forward-looking nullable `hosted_minutes_remaining` response field. Both review findings (runner-id "not registered" display, contradictory exhausted-hosted hint) have been addressed; no open issues remain.
>
> **Overview**
> Shares a single `preloop-runner-pool-select` component between the flow form and Runners page, mapping the stored runner-pool values (`''`/`auto`/`server`/label/name/id) to grouped options with accurate next-run hints. Backend change is additive and defaults to `null` in OSS. Well covered by targeted tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 1c97efb. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->