### PR TITLE
Overview: paint the Inventory lists first, fill usage as it arrives, never flash Next steps

### DIFF
--- a/frontend/src/components/inventory-card.test.ts
+++ b/frontend/src/components/inventory-card.test.ts
@@ -91,6 +91,7 @@ async function card(
     loading: boolean;
     usageLoading: boolean;
     usageLoadingFlows: boolean;
+    usageLoadingFlowCost: boolean;
     usageLoadingModels: boolean;
     usageLoadingTools: boolean;
     flowRunsCapped: boolean;
@@ -113,6 +114,7 @@ async function card(
       .loading=${props.loading ?? false}
       .usageLoading=${props.usageLoading ?? false}
       .usageLoadingFlows=${props.usageLoadingFlows ?? null}
+      .usageLoadingFlowCost=${props.usageLoadingFlowCost ?? null}
       .usageLoadingModels=${props.usageLoadingModels ?? null}
       .usageLoadingTools=${props.usageLoadingTools ?? null}
       rangeLabel="30d"
@@ -357,6 +359,20 @@ describe('inventory-card', () => {
         ?.getAttribute('href')
     ).to.equal('/console/flows/executions?flow_id=flow-1');
     expect(sort.hasAttribute('disabled')).to.be.false;
+  });
+
+  it('fills Runs when executions land while $ still waits on the breakdown', async () => {
+    const el = await card({
+      usageLoadingFlows: false,
+      usageLoadingFlowCost: true,
+      flowRows: [flowRow({ runs: 12, failed: 1, cost: 0 })],
+    });
+    await showTab(el, 'flows');
+    const row = el.shadowRoot!.querySelector('tbody tr')!;
+    const runsCell = row.querySelector('td[data-label="Runs"]')!;
+    expect(runsCell.querySelector('a')).to.exist;
+    expect(runsCell.querySelector('sl-skeleton')).to.not.exist;
+    expect(row.querySelector('sl-skeleton'), 'cost still pending').to.exist;
   });
 
   it('names a model and a tool before their usage lands', async () => {

--- a/frontend/src/components/inventory-card.test.ts
+++ b/frontend/src/components/inventory-card.test.ts
@@ -327,8 +327,21 @@ describe('inventory-card', () => {
     const row = el.shadowRoot!.querySelector('tbody tr')!;
     expect(row.textContent).to.contain('Pull Request Reviewer');
     expect(row.querySelectorAll('sl-skeleton').length).to.be.greaterThan(0);
+    const runsCell = row.querySelector('td[data-label="Runs"]')!;
+    expect(runsCell.querySelector('sl-skeleton'), 'runs still pending').to
+      .exist;
+    expect(
+      runsCell.querySelector('a'),
+      'pending runs cell is not a nameless link'
+    ).to.not.exist;
     expect(el.shadowRoot?.textContent).to.not.contain('No run in range');
     expect(el.shadowRoot?.querySelectorAll('.skeleton-row').length).to.equal(0);
+
+    const sort = el.shadowRoot!.querySelector('sl-select.sort-select')!;
+    expect(sort.hasAttribute('disabled'), 'sort held until usage').to.be.true;
+    expect(sort.getAttribute('title')).to.equal(
+      'Sort is held until usage arrives'
+    );
 
     (el as any).usageLoadingFlows = false;
     (el as any).flowRows = [flowRow()];
@@ -338,6 +351,12 @@ describe('inventory-card', () => {
     );
     expect(el.shadowRoot!.querySelector('sl-skeleton')).to.not.exist;
     expect(el.shadowRoot?.textContent).to.contain('12');
+    expect(
+      el
+        .shadowRoot!.querySelector('td[data-label="Runs"] a')
+        ?.getAttribute('href')
+    ).to.equal('/console/flows/executions?flow_id=flow-1');
+    expect(sort.hasAttribute('disabled')).to.be.false;
   });
 
   it('names a model and a tool before their usage lands', async () => {

--- a/frontend/src/components/inventory-card.test.ts
+++ b/frontend/src/components/inventory-card.test.ts
@@ -90,6 +90,9 @@ async function card(
     showUsers: boolean;
     loading: boolean;
     usageLoading: boolean;
+    usageLoadingFlows: boolean;
+    usageLoadingModels: boolean;
+    usageLoadingTools: boolean;
     flowRunsCapped: boolean;
   }> = {}
 ): Promise<InventoryCard> {
@@ -109,6 +112,9 @@ async function card(
       .toolsTotal=${16}
       .loading=${props.loading ?? false}
       .usageLoading=${props.usageLoading ?? false}
+      .usageLoadingFlows=${props.usageLoadingFlows ?? null}
+      .usageLoadingModels=${props.usageLoadingModels ?? null}
+      .usageLoadingTools=${props.usageLoadingTools ?? null}
       rangeLabel="30d"
     ></inventory-card>
   `);
@@ -308,6 +314,51 @@ describe('inventory-card', () => {
     expect(
       el.shadowRoot!.querySelectorAll('tbody tr')[0].textContent
     ).to.contain('Quiet Agent');
+    expect(el.shadowRoot!.querySelector('sl-skeleton')).to.not.exist;
+  });
+
+  it('names a flow before its runs land, without turning the row into a skeleton', async () => {
+    const el = await card({
+      usageLoadingFlows: true,
+      flowRows: [flowRow({ runs: 0, failed: 0, cost: 0, lastRun: null })],
+    });
+    await showTab(el, 'flows');
+
+    const row = el.shadowRoot!.querySelector('tbody tr')!;
+    expect(row.textContent).to.contain('Pull Request Reviewer');
+    expect(row.querySelectorAll('sl-skeleton').length).to.be.greaterThan(0);
+    expect(el.shadowRoot?.textContent).to.not.contain('No run in range');
+    expect(el.shadowRoot?.querySelectorAll('.skeleton-row').length).to.equal(0);
+
+    (el as any).usageLoadingFlows = false;
+    (el as any).flowRows = [flowRow()];
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('tbody tr')!.textContent).to.contain(
+      'Pull Request Reviewer'
+    );
+    expect(el.shadowRoot!.querySelector('sl-skeleton')).to.not.exist;
+    expect(el.shadowRoot?.textContent).to.contain('12');
+  });
+
+  it('names a model and a tool before their usage lands', async () => {
+    const el = await card({
+      usageLoadingModels: true,
+      usageLoadingTools: true,
+    });
+    await showTab(el, 'models');
+    const modelRowEl = el.shadowRoot!.querySelector('tbody tr')!;
+    expect(modelRowEl.textContent).to.contain('claude-sonnet-4');
+    expect(modelRowEl.querySelectorAll('sl-skeleton').length).to.equal(3);
+    expect(el.shadowRoot?.querySelectorAll('.skeleton-row').length).to.equal(0);
+
+    await showTab(el, 'tools');
+    const toolRowEl = el.shadowRoot!.querySelector('tbody tr')!;
+    expect(toolRowEl.textContent).to.contain('Bash');
+    expect(toolRowEl.querySelectorAll('sl-skeleton').length).to.equal(2);
+
+    (el as any).usageLoadingModels = false;
+    (el as any).usageLoadingTools = false;
+    await el.updateComplete;
     expect(el.shadowRoot!.querySelector('sl-skeleton')).to.not.exist;
   });
 

--- a/frontend/src/components/inventory-card.ts
+++ b/frontend/src/components/inventory-card.ts
@@ -286,6 +286,16 @@ export class InventoryCard extends LitElement {
    * answer, not a slow one.
    */
   @property({ type: Boolean }) usageLoading = false;
+  /**
+   * Per-tab overrides for {@link usageLoading}. The tabs do not share one
+   * usage request: Agents / Users / Tools read the account breakdown, Flows
+   * read executions plus `usage_by_flow`, Models read `ai-models/overview`.
+   * `null` means "use the shared flag", so a host that sets nothing behaves
+   * as it did when every usage column waited on the same breakdown.
+   */
+  @property({ type: Boolean }) usageLoadingFlows: boolean | null = null;
+  @property({ type: Boolean }) usageLoadingModels: boolean | null = null;
+  @property({ type: Boolean }) usageLoadingTools: boolean | null = null;
   /** The page range, already worded ("30d"), shown but not editable here. */
   @property({ type: String }) rangeLabel = '30d';
   /**
@@ -689,6 +699,22 @@ export class InventoryCard extends LitElement {
     return perTab === null || perTab === undefined ? this.loading : perTab;
   }
 
+  /**
+   * Whether this tab's usage columns are still on their way. Identity rows
+   * stay put; only the number cells wait.
+   */
+  private isUsageLoading(tab: InventoryTab): boolean {
+    const perTab =
+      tab === 'flows'
+        ? this.usageLoadingFlows
+        : tab === 'models'
+          ? this.usageLoadingModels
+          : tab === 'tools'
+            ? this.usageLoadingTools
+            : null;
+    return perTab === null || perTab === undefined ? this.usageLoading : perTab;
+  }
+
   private countFor(tab: InventoryTab): number {
     if (tab === 'agents') return this.agentsTotal;
     if (tab === 'flows') return this.flowsTotal;
@@ -782,6 +808,10 @@ export class InventoryCard extends LitElement {
 
   private get sortedFlows(): InventoryFlowRow[] {
     const rows = [...this.flowRows];
+    if (this.isUsageLoading('flows')) {
+      rows.sort((a, b) => a.name.localeCompare(b.name));
+      return rows;
+    }
     const sort = this.sorts.flows;
     if (sort === 'runs') {
       rows.sort((a, b) => b.runs - a.runs);
@@ -800,6 +830,10 @@ export class InventoryCard extends LitElement {
 
   private get sortedModels(): InventoryModelRow[] {
     const rows = [...this.modelRows];
+    if (this.isUsageLoading('models')) {
+      rows.sort((a, b) => a.alias.localeCompare(b.alias));
+      return rows;
+    }
     const sort = this.sorts.models;
     if (sort === 'requests') {
       rows.sort((a, b) => b.requests - a.requests);
@@ -821,6 +855,10 @@ export class InventoryCard extends LitElement {
 
   private get sortedTools(): InventoryToolRow[] {
     const rows = [...this.toolRows];
+    if (this.isUsageLoading('tools')) {
+      rows.sort((a, b) => a.name.localeCompare(b.name));
+      return rows;
+    }
     const sort = this.sorts.tools;
     if (sort === 'failures') {
       rows.sort((a, b) => b.failed - a.failed);
@@ -909,8 +947,8 @@ export class InventoryCard extends LitElement {
    * of a number rather than the width of the column, so the cell does not
    * shimmer across half the table while it waits.
    */
-  private renderUsageCell(value: unknown) {
-    if (this.usageLoading) {
+  private renderUsageCell(value: unknown, pending = this.usageLoading) {
+    if (pending) {
       return html`<sl-skeleton
         class="usage-skeleton"
         effect="none"
@@ -1026,6 +1064,12 @@ export class InventoryCard extends LitElement {
 
   private renderLastRun(run: InventoryFlowRun | null) {
     if (!run) {
+      if (this.isUsageLoading('flows')) {
+        return html`<sl-skeleton
+          class="usage-skeleton"
+          effect="none"
+        ></sl-skeleton>`;
+      }
       // "No run in range" is only true when the page saw the whole range.
       return this.flowRunsCapped
         ? html`<span class="muted" title=${this.flowCountTitle}
@@ -1100,7 +1144,10 @@ export class InventoryCard extends LitElement {
                           <a
                             class="row-name"
                             href="/console/flows/executions?flow_id=${row.id}"
-                            >${this.formatCompactNumber(row.runs)}</a
+                            >${this.renderUsageCell(
+                              this.formatCompactNumber(row.runs),
+                              this.isUsageLoading('flows')
+                            )}</a
                           >
                         </td>
                         <td
@@ -1108,9 +1155,17 @@ export class InventoryCard extends LitElement {
                           data-label="Failed"
                           title=${this.flowCountTitle}
                         >
-                          ${this.formatCompactNumber(row.failed)}
+                          ${this.renderUsageCell(
+                            this.formatCompactNumber(row.failed),
+                            this.isUsageLoading('flows')
+                          )}
                         </td>
-                        <td class="num">${this.formatCurrency(row.cost)}</td>
+                        <td class="num">
+                          ${this.renderUsageCell(
+                            this.formatCurrency(row.cost),
+                            this.isUsageLoading('flows')
+                          )}
+                        </td>
                       </tr>
                     `
                   )}
@@ -1180,12 +1235,23 @@ export class InventoryCard extends LitElement {
                           ${row.provider || 'Unknown'}
                         </td>
                         <td class="num" data-label="Requests">
-                          ${this.formatCompactNumber(row.requests)}
+                          ${this.renderUsageCell(
+                            this.formatCompactNumber(row.requests),
+                            this.isUsageLoading('models')
+                          )}
                         </td>
                         <td class="num" data-label="Tokens">
-                          ${this.formatCompactNumber(row.tokens)}
+                          ${this.renderUsageCell(
+                            this.formatCompactNumber(row.tokens),
+                            this.isUsageLoading('models')
+                          )}
                         </td>
-                        <td class="num">${this.formatCurrency(row.cost)}</td>
+                        <td class="num">
+                          ${this.renderUsageCell(
+                            this.formatCurrency(row.cost),
+                            this.isUsageLoading('models')
+                          )}
+                        </td>
                       </tr>
                     `
                   )}
@@ -1319,10 +1385,16 @@ export class InventoryCard extends LitElement {
                           ${row.server || 'Unknown'}
                         </td>
                         <td class="num" data-label="Calls">
-                          ${this.formatCompactNumber(row.calls)}
+                          ${this.renderUsageCell(
+                            this.formatCompactNumber(row.calls),
+                            this.isUsageLoading('tools')
+                          )}
                         </td>
                         <td class="num" data-label="Failed">
-                          ${this.formatCompactNumber(row.failed)}
+                          ${this.renderUsageCell(
+                            this.formatCompactNumber(row.failed),
+                            this.isUsageLoading('tools')
+                          )}
                         </td>
                       </tr>
                     `

--- a/frontend/src/components/inventory-card.ts
+++ b/frontend/src/components/inventory-card.ts
@@ -870,6 +870,7 @@ export class InventoryCard extends LitElement {
 
   private renderHeader() {
     const options = SORT_OPTIONS[this.activeTab];
+    const sortHeld = this.isUsageLoading(this.activeTab);
     return html`
       <div slot="header" class="card-head">
         <span class="title">Inventory</span>
@@ -879,6 +880,12 @@ export class InventoryCard extends LitElement {
             label="Sort ${TAB_LABELS[this.activeTab].toLowerCase()} by"
             size="small"
             hoist
+            ?disabled=${sortHeld}
+            title=${
+              sortHeld
+                ? 'Sort is held until usage arrives'
+                : `Sort ${TAB_LABELS[this.activeTab].toLowerCase()} by`
+            }
             value=${this.sorts[this.activeTab]}
             @sl-change=${(event: Event) => {
               const select = event.target as HTMLElement & { value: string };
@@ -1141,14 +1148,18 @@ export class InventoryCard extends LitElement {
                           data-label="Runs"
                           title=${this.flowCountTitle}
                         >
-                          <a
-                            class="row-name"
-                            href="/console/flows/executions?flow_id=${row.id}"
-                            >${this.renderUsageCell(
-                              this.formatCompactNumber(row.runs),
-                              this.isUsageLoading('flows')
-                            )}</a
-                          >
+                          ${
+                            this.isUsageLoading('flows')
+                              ? this.renderUsageCell(
+                                  this.formatCompactNumber(row.runs),
+                                  true
+                                )
+                              : html`<a
+                                  class="row-name"
+                                  href="/console/flows/executions?flow_id=${row.id}"
+                                  >${this.formatCompactNumber(row.runs)}</a
+                                >`
+                          }
                         </td>
                         <td
                           class="num"

--- a/frontend/src/components/inventory-card.ts
+++ b/frontend/src/components/inventory-card.ts
@@ -294,6 +294,7 @@ export class InventoryCard extends LitElement {
    * as it did when every usage column waited on the same breakdown.
    */
   @property({ type: Boolean }) usageLoadingFlows: boolean | null = null;
+  @property({ type: Boolean }) usageLoadingFlowCost: boolean | null = null;
   @property({ type: Boolean }) usageLoadingModels: boolean | null = null;
   @property({ type: Boolean }) usageLoadingTools: boolean | null = null;
   /** The page range, already worded ("30d"), shown but not editable here. */
@@ -715,6 +716,16 @@ export class InventoryCard extends LitElement {
     return perTab === null || perTab === undefined ? this.usageLoading : perTab;
   }
 
+  private isFlowCostLoading(): boolean {
+    if (
+      this.usageLoadingFlowCost !== null &&
+      this.usageLoadingFlowCost !== undefined
+    ) {
+      return this.usageLoadingFlowCost;
+    }
+    return this.isUsageLoading('flows');
+  }
+
   private countFor(tab: InventoryTab): number {
     if (tab === 'agents') return this.agentsTotal;
     if (tab === 'flows') return this.flowsTotal;
@@ -813,6 +824,10 @@ export class InventoryCard extends LitElement {
       return rows;
     }
     const sort = this.sorts.flows;
+    if (sort === 'spend' && this.isFlowCostLoading()) {
+      rows.sort((a, b) => a.name.localeCompare(b.name));
+      return rows;
+    }
     if (sort === 'runs') {
       rows.sort((a, b) => b.runs - a.runs);
     } else if (sort === 'spend') {
@@ -870,7 +885,10 @@ export class InventoryCard extends LitElement {
 
   private renderHeader() {
     const options = SORT_OPTIONS[this.activeTab];
-    const sortHeld = this.isUsageLoading(this.activeTab);
+    const sortHeld =
+      this.activeTab === 'flows'
+        ? this.isUsageLoading('flows') || this.isFlowCostLoading()
+        : this.isUsageLoading(this.activeTab);
     return html`
       <div slot="header" class="card-head">
         <span class="title">Inventory</span>
@@ -1174,7 +1192,7 @@ export class InventoryCard extends LitElement {
                         <td class="num">
                           ${this.renderUsageCell(
                             this.formatCurrency(row.cost),
-                            this.isUsageLoading('flows')
+                            this.isFlowCostLoading()
                           )}
                         </td>
                       </tr>

--- a/frontend/src/components/preloop-deploy-wizard.test.ts
+++ b/frontend/src/components/preloop-deploy-wizard.test.ts
@@ -199,6 +199,18 @@ describe('PreloopDeployWizard custom agent path', () => {
     return el;
   }
 
+  it('does not fetch /ai-models when the host already owns that list', async () => {
+    await fixture(
+      html`<preloop-deploy-wizard
+        ?modelsFromHost=${true}
+      ></preloop-deploy-wizard>`
+    );
+    const modelCalls = fetchStub
+      .getCalls()
+      .filter((call) => String(call.args[0]).includes('/api/v1/ai-models'));
+    expect(modelCalls).to.eql([]);
+  });
+
   function findCardByText(
     el: PreloopDeployWizard,
     text: string

--- a/frontend/src/components/preloop-deploy-wizard.ts
+++ b/frontend/src/components/preloop-deploy-wizard.ts
@@ -267,6 +267,13 @@ export class PreloopDeployWizard extends LitElement {
   @property({ type: Array })
   aiModels: AIModel[] = [];
 
+  /**
+   * When the host already fetches `GET /ai-models` (Overview), skip the
+   * connect-time lookup so the page does not pay for the list twice.
+   */
+  @property({ type: Boolean })
+  modelsFromHost = false;
+
   @property({ type: Boolean })
   computeFeatureEnabled = false;
 
@@ -381,7 +388,15 @@ export class PreloopDeployWizard extends LitElement {
     if (this.initialPath === 'custom') {
       this.resetCustomState();
     }
-    if (this.aiModels.length === 0) {
+  }
+
+  protected async firstUpdated(
+    changedProperties: Map<string, unknown>
+  ): Promise<void> {
+    super.firstUpdated(changedProperties);
+    // Host properties are assigned before firstUpdated. Overview passes
+    // modelsFromHost so this page does not fetch GET /ai-models twice.
+    if (this.aiModels.length === 0 && !this.modelsFromHost) {
       this.aiModels = await getAIModels().catch(() => []);
     }
   }

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -244,15 +244,8 @@ interface TopModelSubjectGroup {
 export const NEXT_STEPS_DISMISSED_KEY = 'dashboard_next_steps_dismissed';
 
 /**
- * What the last completed load concluded about the checklist. The card is
- * derived from four separate fetches; before they land, every step looks
- * undone, which is how a finished account saw "Next steps" flash back on
- * every refresh. Remembering the answer means the page can stay quiet until
- * it knows better.
+ * The wire formats the model gateway speaks, as URL prefixes.
  */
-export const NEXT_STEPS_DONE_KEY = 'dashboard_next_steps_all_done';
-
-/** The wire formats the model gateway speaks, as URL prefixes. */
 type GatewayFormat = '/openai/v1' | '/anthropic/v1' | '/google/v1';
 
 interface NextStep {
@@ -1645,24 +1638,6 @@ export class DashboardView extends AuthedElement {
     );
   }
 
-  /** `null` when no load has ever finished on this browser. */
-  private readCoreStepsDone(): boolean | null {
-    try {
-      const stored = localStorage.getItem(NEXT_STEPS_DONE_KEY);
-      return stored === null ? null : stored === 'true';
-    } catch {
-      return null;
-    }
-  }
-
-  private rememberCoreStepsDone(done: boolean): void {
-    try {
-      localStorage.setItem(NEXT_STEPS_DONE_KEY, done ? 'true' : 'false');
-    } catch {
-      // Private mode: the card behaves as it did before, one refresh late.
-    }
-  }
-
   private dismissNextSteps(): void {
     this.nextStepsDismissed = true;
     try {
@@ -3002,14 +2977,13 @@ export class DashboardView extends AuthedElement {
     }
     // Empty arrays before the lists answer are not "the account has
     // nothing". Hide until agents, tools, budget and the flags resolve, then
-    // decide. A finished account stays finished because allDone writes the
-    // remember flag and the next load still waits for that resolve (D31).
+    // decide. A finished account stays finished because allDone hides the
+    // card after that resolve, without a localStorage flash guard (D31).
     if (!this.nextStepsInputsResolved) {
       return nothing;
     }
     const steps = this.nextSteps;
     const allDone = steps.every((step) => step.done || step.optional);
-    this.rememberCoreStepsDone(allDone);
     if (allDone) {
       return nothing;
     }
@@ -3762,14 +3736,11 @@ export class DashboardView extends AuthedElement {
   }
 
   /**
-   * Flows usage is two requests: executions (runs / last / failed) and the
-   * breakdown (`usage_by_flow` for $). Either one still in flight, with
-   * nothing already on screen, keeps those cells as skeletons.
+   * Flows run/fail cells wait on executions. The $ cell waits on the
+   * breakdown, which is a slower sibling, so the two flags stay separate.
    */
   private get flowUsagePending(): boolean {
-    const runsPending =
-      this.fetchingFlowUsage && this.flowExecutions.length === 0;
-    return runsPending || this.usageColumnsPending;
+    return this.fetchingFlowUsage && this.flowExecutions.length === 0;
   }
 
   private get modelUsagePending(): boolean {
@@ -3804,6 +3775,7 @@ export class DashboardView extends AuthedElement {
         .loadingUsers=${this.fetchingUsers}
         ?usageLoading=${this.usageColumnsPending}
         .usageLoadingFlows=${this.flowUsagePending}
+        .usageLoadingFlowCost=${this.usageColumnsPending}
         .usageLoadingModels=${this.modelUsagePending}
         .usageLoadingTools=${this.usageColumnsPending}
       ></inventory-card>

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -284,13 +284,6 @@ export class DashboardView extends AuthedElement {
    */
   @state() private updatingUsage = false;
   @state() private fetchingRecentExecutions = true;
-  /**
-   * Flows, their runs, the resolved approvals and the gateway call log: the
-   * cards below the fold. They are fetched after the first paint, so the
-   * Inventory tabs that read them say "still coming" while the tabs that are
-   * already filled show their rows.
-   */
-  @state() private fetchingInventory = true;
   @state() private fetchingApprovals = true;
   @state() private fetchingAudit = true;
   @state() private fetchingMCPAndTools = true;
@@ -365,6 +358,12 @@ export class DashboardView extends AuthedElement {
   @state() private gatewayTimeRange: 'day' | 'week' | 'month' | 'year' =
     'month';
   @state() private fetchingBudget = false;
+  /**
+   * Starts true so Next steps and the welcome wizard stay hidden before the
+   * first fold. `!this.loading` used to be the checklist gate; the lists
+   * now run next to wave 1, so this flag is what keeps an empty agents
+   * array from reading as "the account has nothing".
+   */
   @state() private fetchingAgents = true;
   @state() private showSetupDialog = false;
   @state() private showBudgetDialog = false;
@@ -1618,6 +1617,20 @@ export class DashboardView extends AuthedElement {
   }
 
   /**
+   * Welcome chrome can paint before the fold; the deploy wizard must not.
+   * Empty agents on first paint are not "not onboarded", and mounting
+   * the wizard then fired a second `GET /ai-models` next to
+   * {@link fetchModelsList}.
+   */
+  private get showWelcomeCard(): boolean {
+    return !this.welcomeCardDismissed && !this.isOnboarded;
+  }
+
+  private get mountDeployWizard(): boolean {
+    return this.showWelcomeCard && !this.fetchingAgents;
+  }
+
+  /**
    * True once the cheap lists the checklist reads (agents, tools) plus
    * budget policies and the feature flags have all answered. Usage columns
    * are not an input: an account with agents is finished with "Onboard an
@@ -2025,7 +2038,6 @@ export class DashboardView extends AuthedElement {
     if (!options.preserveLoadingState) {
       this.fetchingGatewaySummary = true;
       this.fetchingRecentExecutions = true;
-      this.fetchingInventory = true;
       this.fetchingApprovals = true;
       this.fetchingAgents = true;
       this.fetchingBudget = true;
@@ -2157,17 +2169,11 @@ export class DashboardView extends AuthedElement {
       this.fetchingGatewaySummary = false;
       this.updatingUsage = false;
       this.fetchingRecentExecutions = false;
-      this.fetchingInventory = false;
       this.fetchingApprovals = false;
       this.fetchingAgents = false;
       this.fetchingBudget = false;
       this.fetchingAudit = false;
       this.fetchingMCPAndTools = false;
-      this.fetchingFlows = false;
-      this.fetchingModels = false;
-      this.fetchingTools = false;
-      this.fetchingFlowUsage = false;
-      this.fetchingModelUsage = false;
       this.loading = false;
     } finally {
       this.refreshInFlight = false;
@@ -2298,7 +2304,6 @@ export class DashboardView extends AuthedElement {
 
   /** Flow runs, resolved approvals and the gateway call log. */
   private async fetchInventoryData(startDateStr: string): Promise<void> {
-    this.fetchingInventory = true;
     this.fetchingRecentExecutions = true;
     this.fetchingFlowUsage = true;
     try {
@@ -2327,7 +2332,6 @@ export class DashboardView extends AuthedElement {
     } catch (error) {
       console.error('Failed to load the Inventory data', error);
     } finally {
-      this.fetchingInventory = false;
       this.fetchingRecentExecutions = false;
       this.fetchingFlowUsage = false;
     }
@@ -2933,7 +2937,7 @@ export class DashboardView extends AuthedElement {
   }
 
   private renderWelcomeCard() {
-    if (this.welcomeCardDismissed) {
+    if (!this.showWelcomeCard) {
       return nothing;
     }
 
@@ -2967,16 +2971,21 @@ export class DashboardView extends AuthedElement {
           class="welcome-content"
           style="width: 100%; display: flex; flex-direction: column; align-items: center;"
         >
-          <preloop-deploy-wizard
-            .aiModels=${this.aiModels}
-            .computeFeatureEnabled=${this.computeFeatureEnabled}
-            .isEnterprise=${this.isEnterprise}
-            .isAdmin=${this.isAdmin}
-            hide-cancel
-            @deploy-agent-success=${this.handleDeployAgentSuccess}
-            @deploy-flow-success=${this.handleDeployFlowSuccess}
-            @deploy-wizard-done=${this.handleDeployWizardDone}
-          ></preloop-deploy-wizard>
+          ${
+            this.mountDeployWizard
+              ? html`<preloop-deploy-wizard
+                  .aiModels=${this.aiModels}
+                  .modelsFromHost=${true}
+                  .computeFeatureEnabled=${this.computeFeatureEnabled}
+                  .isEnterprise=${this.isEnterprise}
+                  .isAdmin=${this.isAdmin}
+                  hide-cancel
+                  @deploy-agent-success=${this.handleDeployAgentSuccess}
+                  @deploy-flow-success=${this.handleDeployFlowSuccess}
+                  @deploy-wizard-done=${this.handleDeployWizardDone}
+                ></preloop-deploy-wizard>`
+              : nothing
+          }
         </div>
       </div>
     `;
@@ -3817,7 +3826,7 @@ export class DashboardView extends AuthedElement {
   }
 
   render() {
-    if (!this.isOnboarded && !this.welcomeCardDismissed) {
+    if (this.showWelcomeCard) {
       return html`
         <div
           class="extra-wide"

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -295,6 +295,19 @@ export class DashboardView extends AuthedElement {
   @state() private fetchingAudit = true;
   @state() private fetchingMCPAndTools = true;
   /**
+   * Cheap identity lists for the Inventory tabs. Each one is its own
+   * request and paints the moment it lands (D32), so a slow models call
+   * cannot hide a flows list the page already has. Usage columns have
+   * their own flags below.
+   */
+  @state() private fetchingFlows = true;
+  @state() private fetchingModels = true;
+  @state() private fetchingTools = true;
+  /** Flow executions that fill last-run / runs / failed. */
+  @state() private fetchingFlowUsage = true;
+  /** `GET /ai-models/overview`, the Models tab's usage. */
+  @state() private fetchingModelUsage = true;
+  /**
    * The users list is its own request now: it used to wait behind MCP
    * servers, tools, models and API keys in one `Promise.all`, so the Users
    * tab stayed a skeleton until the slowest of the five answered even though
@@ -352,7 +365,7 @@ export class DashboardView extends AuthedElement {
   @state() private gatewayTimeRange: 'day' | 'week' | 'month' | 'year' =
     'month';
   @state() private fetchingBudget = false;
-  @state() private fetchingAgents = false;
+  @state() private fetchingAgents = true;
   @state() private showSetupDialog = false;
   @state() private showBudgetDialog = false;
   @state() private welcomeCardDismissed = false;
@@ -1605,15 +1618,16 @@ export class DashboardView extends AuthedElement {
   }
 
   /**
-   * True once agents, budget policies, tools and the feature flags have all
-   * answered. Until then the checklist has nothing to read.
+   * True once the cheap lists the checklist reads (agents, tools) plus
+   * budget policies and the feature flags have all answered. Usage columns
+   * are not an input: an account with agents is finished with "Onboard an
+   * agent" whether or not this month's spend has arrived yet.
    */
   private get nextStepsInputsResolved(): boolean {
     return (
-      !this.loading &&
       !this.fetchingAgents &&
       !this.fetchingBudget &&
-      !this.fetchingMCPAndTools &&
+      !this.fetchingTools &&
       this.featuresResolved
     );
   }
@@ -2017,12 +2031,23 @@ export class DashboardView extends AuthedElement {
       this.fetchingBudget = true;
       this.fetchingAudit = true;
       this.fetchingMCPAndTools = true;
+      this.fetchingFlows = true;
+      this.fetchingModels = true;
+      this.fetchingTools = true;
+      this.fetchingFlowUsage = true;
+      this.fetchingModelUsage = true;
       this.loading = true;
     }
     this.error = null;
 
     const startDateStr = this.getGatewayStartDate();
     const priorWindow = this.getPriorGatewayWindow(startDateStr);
+
+    // Identity lists start with the fold, not after it. They do not block
+    // `loading = false`, and each tab paints the moment its list lands.
+    if (!options.preserveLoadingState) {
+      this.startInventoryListFetches();
+    }
 
     try {
       const adminPromise = this.fetchAdminStatus();
@@ -2138,6 +2163,11 @@ export class DashboardView extends AuthedElement {
       this.fetchingBudget = false;
       this.fetchingAudit = false;
       this.fetchingMCPAndTools = false;
+      this.fetchingFlows = false;
+      this.fetchingModels = false;
+      this.fetchingTools = false;
+      this.fetchingFlowUsage = false;
+      this.fetchingModelUsage = false;
       this.loading = false;
     } finally {
       this.refreshInFlight = false;
@@ -2196,21 +2226,93 @@ export class DashboardView extends AuthedElement {
     this.gatewayInteractions = interactions.items || [];
   }
 
-  /** Flows, their runs, resolved approvals and the gateway call log. */
+  /**
+   * Cheap Inventory identity. Three independent requests, each applied the
+   * moment it lands, so the Flows tab does not wait for Models and neither
+   * waits for the fold (D32).
+   */
+  private startInventoryListFetches(): void {
+    void this.fetchFlowsList();
+    void this.fetchModelsList();
+    void this.fetchToolsList();
+  }
+
+  private async fetchFlowsList(): Promise<void> {
+    this.fetchingFlows = true;
+    try {
+      const flows = await this.catchWith403Handling(getFlows(), [] as any[]);
+      this.applyFlows(flows);
+    } catch (error) {
+      console.error('Failed to load the flows list', error);
+    } finally {
+      this.fetchingFlows = false;
+    }
+  }
+
+  private async fetchModelsList(): Promise<void> {
+    this.fetchingModels = true;
+    try {
+      const aiModels = await this.catchWith403Handling(getAIModels(), []);
+      this.applyModelsList(aiModels);
+    } catch (error) {
+      console.error('Failed to load the models list', error);
+    } finally {
+      this.fetchingModels = false;
+    }
+  }
+
+  private async fetchToolsList(): Promise<void> {
+    this.fetchingTools = true;
+    try {
+      const tools = await this.catchWith403Handling(getTools(), [] as Tool[]);
+      this.applyToolsList(tools);
+    } catch (error) {
+      console.error('Failed to load the tools list', error);
+    } finally {
+      this.fetchingTools = false;
+    }
+  }
+
+  private applyModelsList(aiModels: AIModel[]): void {
+    this.aiModels = aiModels || [];
+    // Exclude speech models, then never auto-select a principal-bound
+    // OAuth model: it cannot serve server-side generation.
+    const filtered = selectableModels(
+      this.aiModels.filter(
+        (m) => m.model_kind !== 'stt' && m.model_kind !== 'tts'
+      )
+    );
+    if (
+      filtered.length > 0 &&
+      !filtered.some((m) => m.id === this.deployModel)
+    ) {
+      this.deployModel = pickDefaultModel(filtered)?.id || '';
+    }
+    this.hasAIModels = this.aiModels.length > 0;
+    this.aiModelsCount = this.aiModels.length;
+  }
+
+  private applyToolsList(tools: Tool[]): void {
+    this.tools = tools || [];
+  }
+
+  /** Flow runs, resolved approvals and the gateway call log. */
   private async fetchInventoryData(startDateStr: string): Promise<void> {
     this.fetchingInventory = true;
     this.fetchingRecentExecutions = true;
+    this.fetchingFlowUsage = true;
     try {
-      const [flows, flowExecutions, allApprovalRequests] = await Promise.all([
-        this.catchWith403Handling(getFlows(), [] as any[]),
-        // The Inventory Flows tab needs a last run, a run count and a
-        // failure count for every flow in the account, so this reads the
-        // server's maximum page rather than the five rows the old card
-        // showed.
-        this.catchWith403Handling(
+      // Executions are the Flows tab's usage. Apply them on arrival so a
+      // slow approvals or search call cannot hold the run counts at zero.
+      const executionsPromise = (async () => {
+        const flowExecutions = await this.catchWith403Handling(
           getFlowExecutions({ limit: FLOW_EXECUTIONS_PAGE_SIZE }),
           [] as FlowExecution[]
-        ),
+        );
+        this.applyFlowExecutions(flowExecutions);
+        this.fetchingFlowUsage = false;
+      })();
+      const [allApprovalRequests] = await Promise.all([
         this.catchWith403Handling(
           this.fetchApprovalRequests(undefined, 100),
           [] as ApprovalRequest[]
@@ -2218,16 +2320,16 @@ export class DashboardView extends AuthedElement {
         // The failures card shows a handful, and it should be the handful
         // that happened in the range the page is showing.
         this.refreshGatewayInteractions(startDateStr),
+        executionsPromise,
       ]);
 
-      this.applyFlows(flows);
-      this.applyFlowExecutions(flowExecutions);
       this.calculateApprovalStats(allApprovalRequests);
     } catch (error) {
       console.error('Failed to load the Inventory data', error);
     } finally {
       this.fetchingInventory = false;
       this.fetchingRecentExecutions = false;
+      this.fetchingFlowUsage = false;
     }
   }
 
@@ -2352,10 +2454,10 @@ export class DashboardView extends AuthedElement {
 
     const pTools = (async () => {
       try {
-        const [mcpServers, tools, aiModels, apiKeys] = await Promise.all([
+        // Tools and models are fetched as Inventory identity above. This
+        // pass is only the companions the Gateway card reads.
+        const [mcpServers, apiKeys] = await Promise.all([
           this.catchWith403Handling(getMCPServers(), [] as MCPServer[]),
-          this.catchWith403Handling(getTools(), [] as Tool[]),
-          this.catchWith403Handling(getAIModels(), []),
           // Already the api-keys page's endpoint; here it is only a count.
           this.catchWith403Handling(getApiKeys(), null),
         ]);
@@ -2369,23 +2471,6 @@ export class DashboardView extends AuthedElement {
             ).length
           : null;
         this.mcpServers = mcpServers;
-        this.tools = tools;
-        this.aiModels = aiModels || [];
-        // Exclude speech models, then never auto-select a principal-bound
-        // OAuth model — it cannot serve server-side generation.
-        const filtered = selectableModels(
-          this.aiModels.filter(
-            (m) => m.model_kind !== 'stt' && m.model_kind !== 'tts'
-          )
-        );
-        if (
-          filtered.length > 0 &&
-          !filtered.some((m) => m.id === this.deployModel)
-        ) {
-          this.deployModel = pickDefaultModel(filtered)?.id || '';
-        }
-        this.hasAIModels = (aiModels || []).length > 0;
-        this.aiModelsCount = Array.isArray(aiModels) ? aiModels.length : 0;
       } catch (error) {
         console.error('Failed to load MCP and tools data', error);
       } finally {
@@ -2405,27 +2490,28 @@ export class DashboardView extends AuthedElement {
   private async refreshUsageBreakdown(
     gatewayStartDate: string
   ): Promise<AccountGatewayUsageSummaryResponse | null> {
+    // Two requests, two flags: Models usage can land from the overview
+    // without waiting for the heavier account breakdown, and the other way
+    // around (D32).
+    const [detailed] = await Promise.all([
+      this.fetchGatewayBreakdown(gatewayStartDate),
+      this.fetchModelUsage(gatewayStartDate),
+    ]);
+    return detailed;
+  }
+
+  private async fetchGatewayBreakdown(
+    gatewayStartDate: string
+  ): Promise<AccountGatewayUsageSummaryResponse | null> {
     this.fetchingUsageBreakdown = true;
     try {
-      // Both in the deferred pass, so the fold is unaffected: the breakdown
-      // feeds the top-models card, the overview feeds the Inventory Models
-      // tab in one request rather than one per model.
-      const [detailed, overview] = await Promise.all([
-        this.catchWith403Handling(
-          getAccountGatewayUsageSummary({
-            startDate: gatewayStartDate,
-            includeBreakdown: true,
-          }),
-          null
-        ),
-        this.catchWith403Handling(
-          getAIModelsOverview({ startDate: gatewayStartDate }),
-          null
-        ),
-      ]);
-      if (overview?.models) {
-        this.aiModelOverview = overview.models;
-      }
+      const detailed = await this.catchWith403Handling(
+        getAccountGatewayUsageSummary({
+          startDate: gatewayStartDate,
+          includeBreakdown: true,
+        }),
+        null
+      );
       if (!detailed) {
         return null;
       }
@@ -2438,6 +2524,23 @@ export class DashboardView extends AuthedElement {
       // Off whatever happened: a 403 on this endpoint means the columns will
       // never fill, and a skeleton that never resolves is worse than a zero.
       this.fetchingUsageBreakdown = false;
+    }
+  }
+
+  private async fetchModelUsage(gatewayStartDate: string): Promise<void> {
+    this.fetchingModelUsage = true;
+    try {
+      const overview = await this.catchWith403Handling(
+        getAIModelsOverview({ startDate: gatewayStartDate }),
+        null
+      );
+      if (overview?.models) {
+        this.aiModelOverview = overview.models;
+      }
+    } catch (error) {
+      console.error('Failed to load model usage for the Inventory', error);
+    } finally {
+      this.fetchingModelUsage = false;
     }
   }
 
@@ -2888,18 +2991,16 @@ export class DashboardView extends AuthedElement {
     if (this.nextStepsDismissed) {
       return nothing;
     }
-    const remembered = this.readCoreStepsDone();
-    if (!this.nextStepsInputsResolved && remembered !== false) {
-      // Either this browser has never seen a finished load, or the last one
-      // said the checklist was done. Both cases stay quiet until the four
-      // fetches land, instead of drawing an empty checklist for a second.
+    // Empty arrays before the lists answer are not "the account has
+    // nothing". Hide until agents, tools, budget and the flags resolve, then
+    // decide. A finished account stays finished because allDone writes the
+    // remember flag and the next load still waits for that resolve (D31).
+    if (!this.nextStepsInputsResolved) {
       return nothing;
     }
     const steps = this.nextSteps;
     const allDone = steps.every((step) => step.done || step.optional);
-    if (this.nextStepsInputsResolved) {
-      this.rememberCoreStepsDone(allDone);
-    }
+    this.rememberCoreStepsDone(allDone);
     if (allDone) {
       return nothing;
     }
@@ -3383,12 +3484,14 @@ export class DashboardView extends AuthedElement {
   }
 
   /**
-   * The Inventory tabs read the page's existing fetches; none of them adds a
-   * request. Agents come from the agents list, their numbers from the gateway
-   * summary's per-session breakdown (the agents list totals are lifetime, the
-   * Inventory shows the page range). Flows come from the flows list joined to
-   * the executions the page already fetches. Models come from the AI models
-   * list joined to `usage_by_model`. Tools come from the tool catalogue joined
+   * The Inventory tabs read two phases: a cheap list (agents, flows, models,
+   * tools) that paints the row, then a usage request that fills the number
+   * cells. None of them adds a request the page did not already make. Agents
+   * come from the agents list, their numbers from the gateway summary's
+   * per-session breakdown (the agents list totals are lifetime, the Inventory
+   * shows the page range). Flows come from the flows list joined to the
+   * executions the page already fetches. Models come from the AI models list
+   * joined to `ai-models/overview`. Tools come from the tool catalogue joined
    * to `usage_by_tool`.
    */
   private get inventoryAgentRows(): InventoryAgentRow[] {
@@ -3650,6 +3753,21 @@ export class DashboardView extends AuthedElement {
   }
 
   /**
+   * Flows usage is two requests: executions (runs / last / failed) and the
+   * breakdown (`usage_by_flow` for $). Either one still in flight, with
+   * nothing already on screen, keeps those cells as skeletons.
+   */
+  private get flowUsagePending(): boolean {
+    const runsPending =
+      this.fetchingFlowUsage && this.flowExecutions.length === 0;
+    return runsPending || this.usageColumnsPending;
+  }
+
+  private get modelUsagePending(): boolean {
+    return this.fetchingModelUsage && this.aiModelOverview.length === 0;
+  }
+
+  /**
    * One box for what the account has: the counts that used to sit in the
    * stat strip now label its tabs, and the page range drives every column.
    */
@@ -3669,13 +3787,16 @@ export class DashboardView extends AuthedElement {
         ?showUsers=${this.canViewUsers}
         .rangeLabel=${this.gatewayRangeLabel}
         .flowRunsCapped=${this.flowRunsCapped}
-        ?loading=${this.loading || this.fetchingMCPAndTools}
-        .loadingAgents=${this.loading}
-        .loadingFlows=${this.loading || this.fetchingInventory}
-        .loadingModels=${this.loading || this.fetchingMCPAndTools}
-        .loadingTools=${this.loading || this.fetchingMCPAndTools}
-        .loadingUsers=${this.loading || this.fetchingUsers}
+        ?loading=${this.loading}
+        .loadingAgents=${this.fetchingAgents}
+        .loadingFlows=${this.fetchingFlows}
+        .loadingModels=${this.fetchingModels}
+        .loadingTools=${this.fetchingTools}
+        .loadingUsers=${this.fetchingUsers}
         ?usageLoading=${this.usageColumnsPending}
+        .usageLoadingFlows=${this.flowUsagePending}
+        .usageLoadingModels=${this.modelUsagePending}
+        .usageLoadingTools=${this.usageColumnsPending}
       ></inventory-card>
     `;
   }

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -1196,7 +1196,6 @@ describe('DashboardView', () => {
     // every step looks undone, so a finished account used to watch the card
     // appear and vanish on every refresh.
     it('does not flash next steps while the page is still loading', async () => {
-      localStorage.setItem('dashboard_next_steps_all_done', 'true');
       const element = await mountDashboard();
 
       // Mid-load: agents, policies and tools have not answered yet.
@@ -1220,10 +1219,6 @@ describe('DashboardView', () => {
     });
 
     it('hides next steps while inventory lists are in flight, even for an unfinished account', async () => {
-      // Last visit said the checklist was still open. Empty arrays before
-      // the lists answer used to paint "Onboard an agent" over an account
-      // that already had one.
-      localStorage.setItem('dashboard_next_steps_all_done', 'false');
       let releaseTools = () => {};
       toolsGate = new Promise<void>((resolve) => {
         releaseTools = resolve;
@@ -1248,15 +1243,6 @@ describe('DashboardView', () => {
       // Fixture has an agent, budget policies and a gated tool: done.
       expect(element.shadowRoot?.querySelector('.next-steps-card')).to.not
         .exist;
-    });
-
-    it('remembers that the checklist is finished', async () => {
-      localStorage.removeItem('dashboard_next_steps_all_done');
-      await mountLoaded();
-
-      expect(localStorage.getItem('dashboard_next_steps_all_done')).to.equal(
-        'true'
-      );
     });
 
     it('lists the open steps for a new account, with the done ones ticked', async () => {

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -30,6 +30,14 @@ describe('DashboardView', () => {
   let budgetPoliciesResponse: any[];
   /** Set by a test that wants to hold the secondary pass open. */
   let aiModelsGate: Promise<void> | null;
+  /** Holds `GET /api/v1/tools` so Next steps and the Tools tab can wait. */
+  let toolsGate: Promise<void> | null;
+  /** Holds `GET /api/v1/flows` so the Flows tab can paint identity first. */
+  let flowsGate: Promise<void> | null;
+  /** Holds flow executions so Flows usage can arrive after the list. */
+  let executionsGate: Promise<void> | null;
+  /** Holds `GET /api/v1/ai-models/overview` so Models usage can wait. */
+  let overviewGate: Promise<void> | null;
   /**
    * Holds the Overview's wave-2 breakdown call in flight. Attention also
    * asks for a 30-day copy after first paint.
@@ -43,6 +51,10 @@ describe('DashboardView', () => {
 
   beforeEach(() => {
     aiModelsGate = null;
+    toolsGate = null;
+    flowsGate = null;
+    executionsGate = null;
+    overviewGate = null;
     breakdownGate = null;
     breakdownCalls = 0;
     summaryGate = null;
@@ -476,14 +488,17 @@ describe('DashboardView', () => {
         }
 
         if (url.startsWith('/api/v1/tools')) {
+          if (toolsGate) await toolsGate;
           return json(toolsResponse);
         }
 
         if (url.startsWith('/api/v1/flows/executions')) {
+          if (executionsGate) await executionsGate;
           return json(flowExecutionsResponse);
         }
 
         if (url.startsWith('/api/v1/flows')) {
+          if (flowsGate) await flowsGate;
           return json(flowsResponse);
         }
 
@@ -496,6 +511,7 @@ describe('DashboardView', () => {
         }
 
         if (url.startsWith('/api/v1/ai-models/overview')) {
+          if (overviewGate) await overviewGate;
           return json(aiModelsOverviewResponse);
         }
 
@@ -1184,7 +1200,7 @@ describe('DashboardView', () => {
       const element = await mountDashboard();
 
       // Mid-load: agents, policies and tools have not answered yet.
-      expect(element['loading'] || element['fetchingMCPAndTools']).to.be.true;
+      expect(element['loading'] || element['fetchingTools']).to.be.true;
       expect(
         element.shadowRoot?.querySelector('.next-steps-card'),
         'no card during loading'
@@ -1195,10 +1211,41 @@ describe('DashboardView', () => {
           !element['loading'] &&
           !element['fetchingAgents'] &&
           !element['fetchingBudget'] &&
-          !element['fetchingMCPAndTools'],
+          !element['fetchingTools'],
         'dashboard did not finish loading'
       );
       await element.updateComplete;
+      expect(element.shadowRoot?.querySelector('.next-steps-card')).to.not
+        .exist;
+    });
+
+    it('hides next steps while inventory lists are in flight, even for an unfinished account', async () => {
+      // Last visit said the checklist was still open. Empty arrays before
+      // the lists answer used to paint "Onboard an agent" over an account
+      // that already had one.
+      localStorage.setItem('dashboard_next_steps_all_done', 'false');
+      let releaseTools = () => {};
+      toolsGate = new Promise<void>((resolve) => {
+        releaseTools = resolve;
+      });
+
+      const element = await mountDashboard();
+      await waitUntil(() => !element['loading'], 'fold never finished');
+      await element.updateComplete;
+
+      expect(element['fetchingTools'], 'tools list still in flight').to.be.true;
+      expect(
+        element.shadowRoot?.querySelector('.next-steps-card'),
+        'no checklist while the tools list is unanswered'
+      ).to.not.exist;
+
+      releaseTools();
+      await waitUntil(
+        () => element['nextStepsInputsResolved'],
+        'list phase never resolved'
+      );
+      await element.updateComplete;
+      // Fixture has an agent, budget policies and a gated tool: done.
       expect(element.shadowRoot?.querySelector('.next-steps-card')).to.not
         .exist;
     });
@@ -1498,14 +1545,13 @@ describe('DashboardView', () => {
       );
 
       expect(element['fetchingUsers'], 'users request finished').to.be.false;
-      expect(element['fetchingMCPAndTools'], 'tools still in flight').to.be
-        .true;
+      expect(element['fetchingModels'], 'models still in flight').to.be.true;
       expect(element['inventoryUserRows'][0].name).to.exist;
 
       releaseModels();
       await waitUntil(
-        () => !element['fetchingMCPAndTools'],
-        'second pass did not finish'
+        () => !element['fetchingModels'],
+        'models list did not finish'
       );
     });
 
@@ -1537,6 +1583,159 @@ describe('DashboardView', () => {
       await element.updateComplete;
       await inventory.updateComplete;
       expect(inventory.usageLoading).to.be.false;
+    });
+
+    it('renders inventory rows before usage arrives and fills cells without re-skeletoning rows', async () => {
+      let releaseBreakdown = () => {};
+      breakdownGate = new Promise<void>((resolve) => {
+        releaseBreakdown = resolve;
+      });
+      let releaseOverview = () => {};
+      overviewGate = new Promise<void>((resolve) => {
+        releaseOverview = resolve;
+      });
+      let releaseExecutions = () => {};
+      executionsGate = new Promise<void>((resolve) => {
+        releaseExecutions = resolve;
+      });
+      gatewaySummaryResponse.usage_by_session = [];
+      gatewaySummaryResponse.usage_by_model = [];
+      gatewaySummaryResponse.usage_by_tool = [];
+      gatewaySummaryResponse.usage_by_flow = [];
+
+      const element = await mountDashboard();
+      await waitUntil(() => !element['loading'], 'fold never finished');
+      await waitUntil(
+        () =>
+          !element['fetchingAgents'] &&
+          !element['fetchingFlows'] &&
+          !element['fetchingModels'] &&
+          !element['fetchingTools'],
+        'identity lists never landed'
+      );
+      await element.updateComplete;
+
+      const inventory = element.shadowRoot?.querySelector(
+        'inventory-card'
+      ) as any;
+      await inventory.updateComplete;
+
+      expect(element['inventoryAgentRows'][0].name).to.equal('Ops Agent');
+      expect(element['inventoryFlowRows'][0].name).to.equal('Refund Assistant');
+      expect(element['inventoryModelRows'][0].alias).to.equal('OpenAI GPT-5.4');
+      expect(
+        element['inventoryToolRows'].map((row: any) => row.name)
+      ).to.include('verify_refund_eligibility');
+
+      expect(inventory.usageLoading, 'agents usage still pending').to.be.true;
+      expect(inventory.usageLoadingFlows, 'flows usage still pending').to.be
+        .true;
+      expect(inventory.usageLoadingModels, 'models usage still pending').to.be
+        .true;
+
+      const agentRow = inventory.shadowRoot?.querySelector('tbody tr');
+      expect(agentRow?.textContent).to.contain('Ops Agent');
+      expect(agentRow?.querySelector('.skeleton-row')).to.not.exist;
+      expect(
+        agentRow?.querySelectorAll('sl-skeleton').length
+      ).to.be.greaterThan(0);
+
+      releaseExecutions();
+      releaseOverview();
+      releaseBreakdown();
+      await waitUntil(
+        () =>
+          !element['fetchingUsageBreakdown'] &&
+          !element['fetchingModelUsage'] &&
+          !element['fetchingFlowUsage'],
+        'usage never landed'
+      );
+      await element.updateComplete;
+      await inventory.updateComplete;
+
+      expect(inventory.usageLoading).to.be.false;
+      expect(inventory.usageLoadingFlows).to.be.false;
+      expect(inventory.usageLoadingModels).to.be.false;
+      const filled = inventory.shadowRoot?.querySelector('tbody tr');
+      expect(filled?.textContent).to.contain('Ops Agent');
+      expect(filled?.querySelector('sl-skeleton')).to.not.exist;
+      expect(
+        inventory.shadowRoot?.querySelectorAll('.skeleton-row').length
+      ).to.equal(0);
+    });
+
+    it('shows next steps only after a resolved empty inventory', async () => {
+      agentsResponse = { ...agentsResponse, total: 0, items: [] };
+      budgetPoliciesResponse = [];
+      toolsResponse = toolsResponse.map((tool: any) => ({
+        ...tool,
+        is_enabled: true,
+        approval_workflow_id: null,
+      }));
+      let releaseTools = () => {};
+      toolsGate = new Promise<void>((resolve) => {
+        releaseTools = resolve;
+      });
+
+      const element = await mountDashboard();
+      await waitUntil(() => !element['loading'], 'fold never finished');
+      await element.updateComplete;
+      expect(
+        element.shadowRoot?.querySelector('.next-steps-card'),
+        'hidden while the tools list is unanswered'
+      ).to.not.exist;
+
+      releaseTools();
+      await waitUntil(
+        () => element['nextStepsInputsResolved'],
+        'list phase never resolved'
+      );
+      await element.updateComplete;
+      const card = element.shadowRoot?.querySelector('.next-steps-card');
+      expect(card, 'checklist after a resolved empty inventory').to.exist;
+      expect(card?.textContent).to.contain('Onboard an agent');
+    });
+
+    it('keeps the first-paint request count at or below today', async () => {
+      const element = await mountDashboard();
+      await waitUntil(
+        () =>
+          element['attentionInputs'] != null &&
+          !element['fetchingMCPAndTools'] &&
+          !element['fetchingTools'] &&
+          !element['fetchingModels'] &&
+          !element['fetchingFlows'],
+        'cold load never finished'
+      );
+
+      const pageUrls = fetchStub
+        .getCalls()
+        .map((call) => String(call.args[0]))
+        .filter(
+          (url) =>
+            !url.startsWith('/api/v1/audit-logs') &&
+            !url.startsWith('/api/v1/teams') &&
+            !url.startsWith('/api/v1/roles')
+        );
+      // Same unique page URLs as d66122c3 (30), plus none. The identity
+      // lists moved earlier; they did not multiply.
+      expect(pageUrls.length, pageUrls.join('\n')).to.be.at.most(30);
+      expect(pageUrls.filter((url) => url === '/api/v1/flows').length).to.equal(
+        1
+      );
+      expect(pageUrls.filter((url) => url === '/api/v1/tools').length).to.equal(
+        1
+      );
+      expect(
+        pageUrls.filter((url) => url === '/api/v1/ai-models').length
+      ).to.be.at.least(1);
+      expect(
+        pageUrls.filter((url) => url.startsWith('/api/v1/ai-models/overview'))
+          .length
+      ).to.equal(1);
+      expect(
+        pageUrls.filter((url) => url.startsWith('/api/v1/agents')).length
+      ).to.equal(1);
     });
 
     it('dims the usage numbers over a range change rather than blanking them', async () => {
@@ -1617,9 +1816,9 @@ describe('DashboardView', () => {
     });
 
     it('keeps the Models tab on a skeleton until the second pass lands', async () => {
-      // The models arrive in the slow secondary pass, after `loading` has
-      // cleared. Hold that pass open and the card must still be waiting, not
-      // telling a stocked account it has no models.
+      // The models list is its own request. Hold it open after the fold
+      // has cleared and the tab must still be waiting, not telling a
+      // stocked account it has no models.
       let releaseModels = () => {};
       aiModelsGate = new Promise<void>((resolve) => {
         releaseModels = resolve;
@@ -1635,7 +1834,7 @@ describe('DashboardView', () => {
       const inventory = element.shadowRoot?.querySelector(
         'inventory-card'
       ) as any;
-      expect(inventory.loading, 'card still loading mid-flight').to.be.true;
+      expect(inventory.loadingModels, 'models tab still loading').to.be.true;
       expect(element['inventoryModelRows'].length).to.equal(0);
       inventory.shadowRoot
         ?.querySelector('sl-tab[panel="models"]')
@@ -1658,12 +1857,12 @@ describe('DashboardView', () => {
 
       releaseModels();
       await waitUntil(
-        () => !element['fetchingMCPAndTools'],
-        'second pass did not finish'
+        () => !element['fetchingModels'],
+        'models list did not finish'
       );
       await element.updateComplete;
       await inventory.updateComplete;
-      expect(inventory.loading).to.be.false;
+      expect(inventory.loadingModels).to.be.false;
       expect(element['inventoryModelRows'][0].alias).to.equal('OpenAI GPT-5.4');
     });
 
@@ -1805,7 +2004,10 @@ describe('DashboardView', () => {
             !url.startsWith('/api/v1/audit-logs') &&
             !url.startsWith('/api/v1/teams') &&
             !url.startsWith('/api/v1/roles') &&
-            !url.startsWith('/api/v1/ai-models')
+            !url.startsWith('/api/v1/ai-models') &&
+            // Identity lists start with the fold but do not block it.
+            url !== '/api/v1/flows' &&
+            url !== '/api/v1/tools'
         );
       const duplicates = foldUrls.filter(
         (url, index) => foldUrls.indexOf(url) !== index

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -1708,6 +1708,13 @@ describe('DashboardView', () => {
         'cold load never finished'
       );
 
+      // Same filter the report quotes next to the 30 from code reading.
+      // Child widgets own: activity-feed /audit-logs and /users (the
+      // feed also falls back after HOST_USERS_WAIT_MS), invite-dialog
+      // /teams /roles. The 30 includes three page audit-logs this
+      // filter drops, so the measured set is 27. /ai-models is the
+      // Inventory list once; preloop-deploy-wizard does not mount on
+      // an onboarded account.
       const pageUrls = fetchStub
         .getCalls()
         .map((call) => String(call.args[0]))
@@ -1715,11 +1722,10 @@ describe('DashboardView', () => {
           (url) =>
             !url.startsWith('/api/v1/audit-logs') &&
             !url.startsWith('/api/v1/teams') &&
-            !url.startsWith('/api/v1/roles')
+            !url.startsWith('/api/v1/roles') &&
+            !url.startsWith('/api/v1/users')
         );
-      // Same unique page URLs as d66122c3 (30), plus none. The identity
-      // lists moved earlier; they did not multiply.
-      expect(pageUrls.length, pageUrls.join('\n')).to.be.at.most(30);
+      expect(pageUrls.length, pageUrls.join('\n')).to.equal(27);
       expect(pageUrls.filter((url) => url === '/api/v1/flows').length).to.equal(
         1
       );
@@ -1728,7 +1734,7 @@ describe('DashboardView', () => {
       );
       expect(
         pageUrls.filter((url) => url === '/api/v1/ai-models').length
-      ).to.be.at.least(1);
+      ).to.equal(1);
       expect(
         pageUrls.filter((url) => url.startsWith('/api/v1/ai-models/overview'))
           .length
@@ -1736,6 +1742,31 @@ describe('DashboardView', () => {
       expect(
         pageUrls.filter((url) => url.startsWith('/api/v1/agents')).length
       ).to.equal(1);
+      expect(
+        element.shadowRoot?.querySelector('preloop-deploy-wizard'),
+        'wizard stays unmounted on an onboarded account'
+      ).to.not.exist;
+    });
+
+    it('does not clear inventory list flags when the fold fails', async () => {
+      let releaseModels = () => {};
+      aiModelsGate = new Promise<void>((resolve) => {
+        releaseModels = resolve;
+      });
+      const proto = customElements.get('dashboard-view')!
+        .prototype as unknown as Record<string, unknown>;
+      const apply = sinon
+        .stub(proto, 'applyAgentsList')
+        .throws(new Error('fold boom'));
+      try {
+        const element = await mountDashboard();
+        await waitUntil(() => element['error'] != null, 'fold never failed');
+        expect(element['fetchingModels'], 'models list still in flight').to.be
+          .true;
+      } finally {
+        apply.restore();
+        releaseModels();
+      }
     });
 
     it('dims the usage numbers over a range change rather than blanking them', async () => {
@@ -2048,7 +2079,10 @@ describe('DashboardView', () => {
       );
       await new Promise((resolve) => setTimeout(resolve, 300));
 
-      const urls = fetchStub.getCalls().map((call) => String(call.args[0]));
+      const urls = fetchStub
+        .getCalls()
+        .map((call) => String(call.args[0]))
+        .filter((url) => !url.startsWith('/api/v1/users'));
       expect(urls.length, urls.join('\n')).to.be.at.most(4);
       expect(urls.some((url) => url.startsWith('/api/v1/flows'))).to.be.false;
       expect(urls.some((url) => url.includes('include_breakdown=true'))).to.be


### PR DESCRIPTION
## Why
On staging the Inventory box waited for every request in the fold before drawing a row, and the "Next steps" checklist could appear while the lists were still loading because empty arrays before the first response read as "the account has nothing".

## What changed (`dashboard-control-plane-view.ts`, `inventory-card.ts`)
- Each Inventory tab paints as soon as its cheap list request lands (`GET /agents`, `/flows`, `/ai-models/overview`, `/tools`, `/users`), with the usage and cost columns as skeleton cells. Usage fills in when the summary breakdown and executions arrive, in arrival order (D32), without re-rendering rows back to skeleton.
- Next steps renders only once the list phase has resolved and reports zero rows for the relevant kind; while lists load it renders nothing. A finished account stays finished (D31).
- The per-tab sort select is disabled until usage arrives, so it cannot sort on columns that are still skeletons; the pending Runs cell is a placeholder, not a nameless link.
- Request count on first paint unchanged; one duplicate `GET /ai-models` removed (the page and a child component both asked). Socket refresh path unchanged from #381.
- Dropped the write-only `fetchingInventory` flag; list loading flags are cleared in their own `finally`.

## Tests
`dashboard-view.test.ts`: rows render before usage arrives; usage fills in without unmounting rows; Next steps hidden while loading and shown only on a resolved empty inventory; request count assertion measured against the same URL filter the report uses. Full suite: 130 files, 1418 passed, 0 failed.

Founder request 2026-09-05: "render the cheap stuff first, then calculate and show their usage in discrete API calls". Analysis of the request set is in the implementer report (section 1 table).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Progressive rendering refactor with no security surface, behaviour-preserving request reorganisation, and thorough test coverage; the two minor cleanup findings are now resolved.
>
> **Overview**
> Splits the Overview Inventory into a fast identity-list paint followed by usage/cost cells filling in arrival order, and keeps the "Next steps" checklist hidden until the list phase resolves. Verified the duplicate `/ai-models` removal and the fetch reorganisation against the pre-PR source; the write-only next-steps flag and the flow usage coupling were both removed in the latest commit.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 627efe39. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->
