### PR TITLE
Console: Agents and Flows use the shared list toolbar

### DIFF
--- a/frontend/src/components/list-toolbar.test.ts
+++ b/frontend/src/components/list-toolbar.test.ts
@@ -139,4 +139,29 @@ describe('list-toolbar', () => {
     const count = element.querySelector('[slot="count"]');
     expect(count?.textContent?.trim()).to.equal('2 trackers');
   });
+
+  it('renders canvas in the same switcher when the page asks for it', async () => {
+    const element = await render({
+      views: ['list', 'cards', 'canvas'],
+      view: 'canvas',
+    });
+    const buttons = [
+      ...element.shadowRoot!.querySelectorAll('sl-button[data-view]'),
+    ];
+    expect(
+      buttons.map((button) => button.getAttribute('data-view'))
+    ).to.deep.equal(['list', 'cards', 'canvas']);
+    expect(buttons.map((button) => button.textContent?.trim())).to.deep.equal([
+      'List',
+      'Cards',
+      'Canvas',
+    ]);
+    expect(buttons[2].querySelector('sl-icon')?.getAttribute('name')).to.equal(
+      'diagram-3'
+    );
+    expect(buttons[2].getAttribute('variant')).to.equal('primary');
+    expect(
+      element.shadowRoot!.querySelectorAll('sl-button-group')
+    ).to.have.lengthOf(1);
+  });
 });

--- a/frontend/src/components/list-toolbar.ts
+++ b/frontend/src/components/list-toolbar.ts
@@ -15,13 +15,15 @@ const VIEW_OPTIONS: Array<{
 }> = [
   { value: 'list', label: 'List', icon: 'list-ul' },
   { value: 'cards', label: 'Cards', icon: 'grid-3x3-gap' },
+  { value: 'canvas', label: 'Canvas', icon: 'diagram-3' },
 ];
 
 /**
  * Shared collection toolbar: search, a slot for page filters, and the
- * list/cards switcher. Spacing and the 900px / 640px collapse match the
- * Flows filter bar pixel-for-pixel so Trackers and Models feel like the
- * same product.
+ * list/cards/canvas switcher. Spacing and the 900px / 640px collapse match
+ * the Flows filter bar pixel-for-pixel so collection pages feel like the
+ * same product. Pages pass `views` to choose which buttons appear. The
+ * default is list and cards; Agents adds canvas in the same group.
  *
  * @fires search-change - `{ detail: { value } }` when the search input changes
  * @fires view-change - `{ detail: { value } }` when a view button is pressed

--- a/frontend/src/utils/view-mode.test.ts
+++ b/frontend/src/utils/view-mode.test.ts
@@ -44,6 +44,10 @@ describe('view-mode', () => {
     localStorage.setItem(key, 'cards');
     expect(loadViewMode(key, ['list'], 'list')).to.equal('list');
     expect(loadViewMode(key, ['list', 'cards'], 'list')).to.equal('cards');
+    localStorage.setItem(key, 'canvas');
+    expect(loadViewMode(key, ['list', 'cards', 'canvas'], 'list')).to.equal(
+      'canvas'
+    );
   });
 
   it('falls back when localStorage throws', () => {
@@ -74,6 +78,8 @@ describe('view-mode', () => {
     expect(effectiveViewMode('list', false)).to.equal('list');
     expect(effectiveViewMode('cards', true)).to.equal('cards');
     expect(effectiveViewMode('cards', false)).to.equal('cards');
+    expect(effectiveViewMode('canvas', true)).to.equal('canvas');
+    expect(effectiveViewMode('canvas', false)).to.equal('canvas');
   });
 
   it('subscribes to the Flows list-to-cards breakpoint', () => {

--- a/frontend/src/utils/view-mode.ts
+++ b/frontend/src/utils/view-mode.ts
@@ -1,16 +1,21 @@
 /**
- * Persisted list/cards view mode for collection pages.
+ * Persisted view mode for collection pages.
  *
- * Copied from the Flows page so Trackers and Models (and, later, Agents and
- * Flows themselves) share one storage contract. List is the default
- * (DESIGN.md, "Tables and views"): a table compares rows; cards are for
- * browsing and for phones. A stored choice wins. The narrow-viewport
- * fallback never overwrites that choice.
+ * List is the default (DESIGN.md, "Tables and views"): a table compares
+ * rows; cards are for browsing and for phones. Agents also offers canvas
+ * (topology). A stored choice wins. The narrow-viewport fallback never
+ * overwrites that choice.
  */
 
-export type ListViewMode = 'list' | 'cards';
+export type ListViewMode = 'list' | 'cards' | 'canvas';
 
 export const LIST_VIEW_MODES: readonly ListViewMode[] = ['list', 'cards'];
+
+export const AGENTS_VIEW_MODES: readonly ListViewMode[] = [
+  'list',
+  'cards',
+  'canvas',
+];
 
 /** List is the default so thirty items are compared, not browsed. */
 export const DEFAULT_LIST_VIEW: ListViewMode = 'list';

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -202,9 +202,11 @@ describe('AgentsView', () => {
     const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
     await waitForAgents(el);
 
+    const toolbar = el.shadowRoot?.querySelector('list-toolbar');
     const buttons = Array.from(
-      el.shadowRoot?.querySelectorAll('sl-button-group sl-button[data-view]') ||
-        []
+      toolbar?.shadowRoot?.querySelectorAll(
+        'sl-button-group sl-button[data-view]'
+      ) || []
     );
     expect(buttons.map((b) => b.getAttribute('data-view'))).to.deep.equal([
       'list',
@@ -328,7 +330,8 @@ describe('AgentsView', () => {
     // The switcher still reports List as the chosen view.
     expect(
       el.shadowRoot
-        ?.querySelector('sl-button[data-view="list"]')
+        ?.querySelector('list-toolbar')
+        ?.shadowRoot?.querySelector('sl-button[data-view="list"]')
         ?.getAttribute('aria-pressed')
     ).to.equal('true');
   });
@@ -734,7 +737,9 @@ describe('AgentsView', () => {
     await waitForAgents(el);
 
     expect(
-      el.shadowRoot?.querySelector('.results-count')?.textContent?.trim()
+      el.shadowRoot
+        ?.querySelector('list-toolbar [slot="count"]')
+        ?.textContent?.trim()
     ).to.equal('2 agents');
   });
 

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -336,6 +336,70 @@ describe('AgentsView', () => {
     ).to.equal('true');
   });
 
+  it('paints cards on a narrow viewport even when canvas is stored', async () => {
+    localStorage.setItem('preloop.agents.view_mode', 'canvas');
+
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+    expect(el.shadowRoot?.querySelector('.agent-node')).to.exist;
+
+    (el as unknown as { narrowViewport: boolean }).narrowViewport = true;
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('.agent-node')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.cards')).to.exist;
+    expect(localStorage.getItem('preloop.agents.view_mode')).to.equal('canvas');
+    expect(
+      el.shadowRoot
+        ?.querySelector('list-toolbar')
+        ?.shadowRoot?.querySelector('sl-button[data-view="canvas"]')
+        ?.getAttribute('aria-pressed')
+    ).to.equal('true');
+  });
+
+  it('debounces toolbar search and fetches with the query', async () => {
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const agentUrls = () =>
+      fetchStub
+        .getCalls()
+        .map((call) =>
+          typeof call.args[0] === 'string'
+            ? call.args[0]
+            : call.args[0].toString()
+        )
+        .filter((url: string) => url.startsWith('/api/v1/agents'));
+
+    const before = agentUrls();
+    expect(before.some((url: string) => url.includes('query='))).to.be.false;
+
+    const clock = sinon.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout'],
+    });
+    try {
+      el.shadowRoot?.querySelector('list-toolbar')?.dispatchEvent(
+        new CustomEvent('search-change', {
+          detail: { value: 'claude' },
+          bubbles: true,
+          composed: true,
+        })
+      );
+
+      clock.tick(399);
+      expect(agentUrls()).to.deep.equal(before);
+
+      clock.tick(1);
+    } finally {
+      clock.restore();
+    }
+
+    await waitUntil(
+      () => agentUrls().some((url: string) => url.includes('query=claude')),
+      'search fetch did not include the query'
+    );
+  });
+
   it('renders claude_desktop agents and agents of unknown kinds', async () => {
     localStorage.setItem('preloop.agents.view_mode', 'canvas');
     agentItems = [

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -1108,9 +1108,6 @@ export class AgentsView extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
 
-    // Restore saved view preference (the default is applied at field init so
-    // the very first render already knows which view to paint).
-    this.currentView = loadViewMode(VIEW_MODE_KEY, AGENTS_VIEW_MODES);
     this.narrowViewportSubscription = subscribeNarrowViewport((narrow) => {
       this.narrowViewport = narrow;
     });
@@ -1191,8 +1188,14 @@ export class AgentsView extends LitElement {
   /**
    * The view actually painted. On phone widths a seven-column table would
    * either scroll sideways or crush every cell, so `list` renders as cards.
+   * Canvas is remapped too: the toolbar hides the switcher below 640, and
+   * DESIGN.md says cards render regardless. The stored preference is left
+   * alone.
    */
   private get effectiveView(): AgentsViewMode {
+    if (this.narrowViewport && this.currentView !== 'cards') {
+      return 'cards';
+    }
     return effectiveViewMode(this.currentView, this.narrowViewport);
   }
 

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -62,7 +62,6 @@ import { formatRelativeTime } from '../../utils/date';
 import { consoleDialogStyles } from '../../styles/console-dialog';
 import {
   AGENTS_VIEW_MODES,
-  effectiveViewMode,
   loadViewMode,
   saveViewMode,
   subscribeNarrowViewport,
@@ -1196,7 +1195,7 @@ export class AgentsView extends LitElement {
     if (this.narrowViewport && this.currentView !== 'cards') {
       return 'cards';
     }
-    return effectiveViewMode(this.currentView, this.narrowViewport);
+    return this.currentView;
   }
 
   disconnectedCallback(): void {

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -6,10 +6,8 @@ import { customElement, state } from 'lit/decorators.js';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
-import '@shoelace-style/shoelace/dist/components/button-group/button-group.js';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
-import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
@@ -20,6 +18,7 @@ import '@shoelace-style/shoelace/dist/components/tab-group/tab-group.js';
 import '@shoelace-style/shoelace/dist/components/tab/tab.js';
 import '@shoelace-style/shoelace/dist/components/tab-panel/tab-panel.js';
 import '@shoelace-style/shoelace/dist/components/copy-button/copy-button.js';
+import '../../components/list-toolbar.ts';
 import '../../components/view-header.ts';
 import '../../components/preloop-agent-deployer.ts';
 import '../../components/preloop-deploy-wizard.ts';
@@ -61,6 +60,15 @@ import {
 } from '../../utils/agent-display';
 import { formatRelativeTime } from '../../utils/date';
 import { consoleDialogStyles } from '../../styles/console-dialog';
+import {
+  AGENTS_VIEW_MODES,
+  effectiveViewMode,
+  loadViewMode,
+  saveViewMode,
+  subscribeNarrowViewport,
+  type ListViewMode,
+  type NarrowViewportSubscription,
+} from '../../utils/view-mode';
 
 const AVAILABLE_AGENT_KINDS = [
   { value: 'openclaw', label: 'OpenClaw' },
@@ -119,27 +127,6 @@ function persistAgentKinds(selected: string[]): void {
 export type AgentsViewMode = 'list' | 'cards' | 'canvas';
 
 const VIEW_MODE_KEY = 'preloop.agents.view_mode';
-const AGENTS_VIEW_MODES: AgentsViewMode[] = ['list', 'cards', 'canvas'];
-
-/**
- * The list is the default: a table answers "which agents do I have and are
- * they healthy" at a glance, where cards and canvas answer "show me one" and
- * "show me the topology". A previously persisted choice still wins.
- */
-const DEFAULT_AGENTS_VIEW: AgentsViewMode = 'list';
-
-function loadInitialViewMode(): AgentsViewMode {
-  try {
-    const saved = localStorage.getItem(VIEW_MODE_KEY);
-    if (saved && (AGENTS_VIEW_MODES as string[]).includes(saved)) {
-      return saved as AgentsViewMode;
-    }
-  } catch (e) {}
-  return DEFAULT_AGENTS_VIEW;
-}
-
-/** Below this width the table cannot show its columns, so cards take over. */
-const LIST_TO_CARDS_BREAKPOINT = '(max-width: 640px)';
 
 export type AgentListSortKey =
   'agent' | 'status' | 'owner' | 'model' | 'requests' | 'spend' | 'last_seen';
@@ -341,15 +328,15 @@ export class AgentsView extends LitElement {
   private hasAutoOpenedOnboarding = false;
 
   // Switcher state
-  @state() private currentView: AgentsViewMode = loadInitialViewMode();
+  @state() private currentView: AgentsViewMode = loadViewMode(
+    VIEW_MODE_KEY,
+    AGENTS_VIEW_MODES
+  );
   @state() private sortKey: AgentListSortKey = 'last_seen';
   @state() private sortDirection: SortDirection = 'desc';
   /** True on phone-width viewports, where the table falls back to cards. */
   @state() private narrowViewport = false;
-  private narrowViewportQuery: MediaQueryList | null = null;
-  private handleNarrowViewportChange = (event: MediaQueryListEvent) => {
-    this.narrowViewport = event.matches;
-  };
+  private narrowViewportSubscription: NarrowViewportSubscription | null = null;
 
   // VM Provisioning state variables
   @state() private computeFeatureEnabled = false;
@@ -427,63 +414,6 @@ export class AgentsView extends LitElement {
         gap: var(--sl-spacing-large);
         height: 100%;
         overflow-y: auto;
-      }
-      .filters {
-        display: flex;
-        gap: var(--sl-spacing-medium);
-        flex-wrap: wrap;
-        align-items: end;
-      }
-      .filters sl-input,
-      .filters sl-select {
-        min-width: 180px;
-      }
-      .filters sl-input {
-        flex: 1 1 280px;
-      }
-      .agents-toolbar {
-        display: flex;
-        align-items: end;
-        justify-content: space-between;
-        gap: var(--sl-spacing-medium);
-        flex-wrap: wrap;
-        width: 100%;
-      }
-      .agents-toolbar .filters {
-        flex: 1 1 520px;
-        min-width: 0;
-      }
-      .view-switcher-group {
-        display: flex;
-        align-items: center;
-        gap: var(--sl-spacing-medium);
-        margin: auto;
-      }
-      .view-switcher-group sl-radio-group {
-        white-space: nowrap;
-      }
-      /* Says how many rows the filters matched, right where the eye already
-         goes to switch views. */
-      .results-count {
-        color: var(--sl-color-neutral-600);
-        font-size: var(--sl-font-size-small);
-        font-variant-numeric: tabular-nums;
-        white-space: nowrap;
-      }
-      .toolbar-divider {
-        width: 1px;
-        height: 32px;
-        background: var(--sl-color-neutral-300);
-      }
-      @media (max-width: 900px) {
-        .view-switcher-group {
-          margin-left: 0;
-          width: 100%;
-          justify-content: flex-end;
-        }
-        .toolbar-divider {
-          display: none;
-        }
       }
       .cards {
         display: grid;
@@ -1180,14 +1110,11 @@ export class AgentsView extends LitElement {
 
     // Restore saved view preference (the default is applied at field init so
     // the very first render already knows which view to paint).
-    this.currentView = loadInitialViewMode();
-
-    this.narrowViewportQuery = window.matchMedia(LIST_TO_CARDS_BREAKPOINT);
-    this.narrowViewport = this.narrowViewportQuery.matches;
-    this.narrowViewportQuery.addEventListener(
-      'change',
-      this.handleNarrowViewportChange
-    );
+    this.currentView = loadViewMode(VIEW_MODE_KEY, AGENTS_VIEW_MODES);
+    this.narrowViewportSubscription = subscribeNarrowViewport((narrow) => {
+      this.narrowViewport = narrow;
+    });
+    this.narrowViewport = this.narrowViewportSubscription.matches;
 
     // Restore saved node positions
     try {
@@ -1266,20 +1193,14 @@ export class AgentsView extends LitElement {
    * either scroll sideways or crush every cell, so `list` renders as cards.
    */
   private get effectiveView(): AgentsViewMode {
-    if (this.currentView === 'list' && this.narrowViewport) {
-      return 'cards';
-    }
-    return this.currentView;
+    return effectiveViewMode(this.currentView, this.narrowViewport);
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.unsubscribeRealtime?.();
-    this.narrowViewportQuery?.removeEventListener(
-      'change',
-      this.handleNarrowViewportChange
-    );
-    this.narrowViewportQuery = null;
+    this.narrowViewportSubscription?.disconnect();
+    this.narrowViewportSubscription = null;
     this.resizeObserver.disconnect();
     if (this.refreshTimer !== null) {
       window.clearTimeout(this.refreshTimer);
@@ -2101,9 +2022,8 @@ export class AgentsView extends LitElement {
     this.animatePositionFrameId = requestAnimationFrame(animate);
   }
 
-  private handleSearchInput(event: Event): void {
-    const target = event.target as HTMLInputElement;
-    this.searchQuery = target.value;
+  private handleSearchChange(event: CustomEvent<{ value: string }>): void {
+    this.searchQuery = event.detail.value;
 
     // Add debounce for search query filtering
     if ((this as any)._searchTimeout)
@@ -2111,11 +2031,6 @@ export class AgentsView extends LitElement {
     (this as any)._searchTimeout = setTimeout(() => {
       void this.loadAgents();
     }, 400);
-  }
-
-  private handleSearchSubmit(event: Event): void {
-    event.preventDefault();
-    void this.loadAgents();
   }
 
   private handleAgentKindChange(kind: string, checked: boolean): void {
@@ -2888,11 +2803,9 @@ export class AgentsView extends LitElement {
     }
   }
 
-  private setCurrentView(view: AgentsViewMode) {
-    this.currentView = view;
-    try {
-      localStorage.setItem(VIEW_MODE_KEY, view);
-    } catch (e) {}
+  private handleViewChange(event: CustomEvent<{ value: ListViewMode }>) {
+    this.currentView = event.detail.value;
+    saveViewMode(VIEW_MODE_KEY, event.detail.value);
   }
 
   /**
@@ -4468,113 +4381,72 @@ export class AgentsView extends LitElement {
             </div>
           </view-header>
 
-          <div class="agents-toolbar">
-            <form class="filters" @submit=${this.handleSearchSubmit}>
-              <sl-input
-                placeholder="Search name, tags:env=prod, owner:username"
-                clearable
-                .value=${this.searchQuery}
-                @sl-input=${this.handleSearchInput}
+          <list-toolbar
+            .search=${this.searchQuery}
+            searchPlaceholder="Search name, tags:env=prod, owner:username"
+            toggleLabel="Agents view"
+            .view=${this.currentView}
+            .views=${AGENTS_VIEW_MODES}
+            @search-change=${this.handleSearchChange}
+            @view-change=${this.handleViewChange}
+          >
+            <sl-dropdown stay-open-on-select>
+              <sl-button slot="trigger" caret variant="default">
+                Agent Kinds
+                (${
+                  this.agentKinds.length === AVAILABLE_AGENT_KINDS.length
+                    ? 'All'
+                    : this.agentKinds.length
+                })
+              </sl-button>
+              <div
+                style="padding: var(--sl-spacing-medium); background: var(--sl-panel-background-color); border: solid 1px var(--sl-panel-border-color); border-radius: var(--sl-border-radius-medium); box-shadow: var(--sl-shadow-large); display: flex; flex-direction: column; gap: var(--sl-spacing-small); min-width: 200px;"
               >
-                <sl-icon name="search" slot="prefix"></sl-icon>
-              </sl-input>
-
-              <sl-dropdown stay-open-on-select>
-                <sl-button slot="trigger" caret variant="default">
-                  Agent Kinds
-                  (${
+                <sl-checkbox
+                  .checked=${
                     this.agentKinds.length === AVAILABLE_AGENT_KINDS.length
-                      ? 'All'
-                      : this.agentKinds.length
-                  })
-                </sl-button>
-                <div
-                  style="padding: var(--sl-spacing-medium); background: var(--sl-panel-background-color); border: solid 1px var(--sl-panel-border-color); border-radius: var(--sl-border-radius-medium); box-shadow: var(--sl-shadow-large); display: flex; flex-direction: column; gap: var(--sl-spacing-small); min-width: 200px;"
+                  }
+                  .indeterminate=${
+                    this.agentKinds.length > 0 &&
+                    this.agentKinds.length < AVAILABLE_AGENT_KINDS.length
+                  }
+                  @sl-change=${(e: any) =>
+                    this.handleAgentKindChange('all', e.target.checked)}
                 >
-                  <sl-checkbox
-                    .checked=${
-                      this.agentKinds.length === AVAILABLE_AGENT_KINDS.length
-                    }
-                    .indeterminate=${
-                      this.agentKinds.length > 0 &&
-                      this.agentKinds.length < AVAILABLE_AGENT_KINDS.length
-                    }
-                    @sl-change=${(e: any) =>
-                      this.handleAgentKindChange('all', e.target.checked)}
-                  >
-                    Select All
-                  </sl-checkbox>
-                  <sl-divider
-                    style="margin: var(--sl-spacing-x-small) 0;"
-                  ></sl-divider>
-                  ${AVAILABLE_AGENT_KINDS.map(
-                    (kind) => html`
-                      <sl-checkbox
-                        .checked=${this.agentKinds.includes(kind.value)}
-                        @sl-change=${(e: any) =>
-                          this.handleAgentKindChange(
-                            kind.value,
-                            e.target.checked
-                          )}
-                      >
-                        ${kind.label}
-                      </sl-checkbox>
-                    `
-                  )}
-                </div>
-              </sl-dropdown>
-
-              <sl-select
-                value=${this.lastSeenAfter}
-                @sl-change=${this.handleLastSeenAfterChange}
-              >
-                <sl-option value="all">All Time</sl-option>
-                <sl-option value="last_10_minutes">Last 10 minutes</sl-option>
-                <sl-option value="last_1_hour">Last 1 hour</sl-option>
-                <sl-option value="last_24_hours">Last 24 hours</sl-option>
-                <sl-option value="last_7_days">Last 7 days</sl-option>
-              </sl-select>
-            </form>
-
-            <div class="view-switcher-group">
-              <span class="results-count" aria-live="polite"
-                >${this.resultsLabel}</span
-              >
-              <span class="toolbar-divider" aria-hidden="true"></span>
-              <sl-button-group label="Agents view">
-                ${[
-                  { value: 'list' as const, label: 'List', icon: 'list-ul' },
-                  {
-                    value: 'cards' as const,
-                    label: 'Cards',
-                    icon: 'grid-3x3-gap',
-                  },
-                  {
-                    value: 'canvas' as const,
-                    label: 'Canvas',
-                    icon: 'diagram-3',
-                  },
-                ].map(
-                  (option) => html`
-                    <sl-button
-                      size="small"
-                      data-view=${option.value}
-                      variant=${
-                        this.currentView === option.value
-                          ? 'primary'
-                          : 'default'
-                      }
-                      aria-pressed=${this.currentView === option.value}
-                      @click=${() => this.setCurrentView(option.value)}
+                  Select All
+                </sl-checkbox>
+                <sl-divider
+                  style="margin: var(--sl-spacing-x-small) 0;"
+                ></sl-divider>
+                ${AVAILABLE_AGENT_KINDS.map(
+                  (kind) => html`
+                    <sl-checkbox
+                      .checked=${this.agentKinds.includes(kind.value)}
+                      @sl-change=${(e: any) =>
+                        this.handleAgentKindChange(
+                          kind.value,
+                          e.target.checked
+                        )}
                     >
-                      <sl-icon slot="prefix" name=${option.icon}></sl-icon>
-                      ${option.label}
-                    </sl-button>
+                      ${kind.label}
+                    </sl-checkbox>
                   `
                 )}
-              </sl-button-group>
-            </div>
-          </div>
+              </div>
+            </sl-dropdown>
+
+            <sl-select
+              value=${this.lastSeenAfter}
+              @sl-change=${this.handleLastSeenAfterChange}
+            >
+              <sl-option value="all">All Time</sl-option>
+              <sl-option value="last_10_minutes">Last 10 minutes</sl-option>
+              <sl-option value="last_1_hour">Last 1 hour</sl-option>
+              <sl-option value="last_24_hours">Last 24 hours</sl-option>
+              <sl-option value="last_7_days">Last 7 days</sl-option>
+            </sl-select>
+            <span slot="count">${this.resultsLabel}</span>
+          </list-toolbar>
           ${
             this.error
               ? html`<sl-alert open variant="danger" class="mx-6 mb-4"

--- a/frontend/src/views/authed/flows-view.test.ts
+++ b/frontend/src/views/authed/flows-view.test.ts
@@ -420,22 +420,29 @@ describe('FlowsView', () => {
       expect(element.shadowRoot?.querySelector('.flows-grid')).to.not.exist;
       expect(rowNames(element)).to.have.lengthOf(3);
       expect(
-        element.shadowRoot?.querySelector('.results-count')?.textContent?.trim()
+        element.shadowRoot
+          ?.querySelector('list-toolbar [slot="count"]')
+          ?.textContent?.trim()
       ).to.equal('3 flows');
     });
 
     it('filters by the search box and says how many of how many are left', async () => {
       const element = await renderFlows();
-      const search = element.shadowRoot?.querySelector(
-        '.search-input'
-      ) as HTMLInputElement & { value: string };
-      search.value = 'nightly';
-      search.dispatchEvent(new CustomEvent('sl-input', { bubbles: true }));
+      const toolbar = element.shadowRoot?.querySelector('list-toolbar');
+      toolbar?.dispatchEvent(
+        new CustomEvent('search-change', {
+          detail: { value: 'nightly' },
+          bubbles: true,
+          composed: true,
+        })
+      );
       await element.updateComplete;
 
       expect(rowNames(element)).to.deep.equal(['Nightly Report']);
       expect(
-        element.shadowRoot?.querySelector('.results-count')?.textContent?.trim()
+        element.shadowRoot
+          ?.querySelector('list-toolbar [slot="count"]')
+          ?.textContent?.trim()
       ).to.equal('1 of 3 flows');
     });
 
@@ -472,11 +479,14 @@ describe('FlowsView', () => {
 
     it('says so when the filters match nothing', async () => {
       const element = await renderFlows();
-      const search = element.shadowRoot?.querySelector(
-        '.search-input'
-      ) as HTMLInputElement & { value: string };
-      search.value = 'no such flow';
-      search.dispatchEvent(new CustomEvent('sl-input', { bubbles: true }));
+      const toolbar = element.shadowRoot?.querySelector('list-toolbar');
+      toolbar?.dispatchEvent(
+        new CustomEvent('search-change', {
+          detail: { value: 'no such flow' },
+          bubbles: true,
+          composed: true,
+        })
+      );
       await element.updateComplete;
 
       expect(
@@ -486,7 +496,8 @@ describe('FlowsView', () => {
 
     it('switches to cards and remembers the choice for the next visit', async () => {
       const element = await renderFlows();
-      const cardsButton = element.shadowRoot?.querySelector(
+      const toolbar = element.shadowRoot?.querySelector('list-toolbar');
+      const cardsButton = toolbar?.shadowRoot?.querySelector(
         'sl-button[data-view="cards"]'
       ) as HTMLElement;
       cardsButton.click();

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -4,13 +4,12 @@ import { repeat } from 'lit/directives/repeat.js';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
-import '@shoelace-style/shoelace/dist/components/button-group/button-group.js';
-import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '@shoelace-style/shoelace/dist/components/divider/divider.js';
 import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
+import '../../components/list-toolbar.ts';
 import '../../components/resource-actions.ts';
 import '../../components/time-range-select.ts';
 import { router } from '../../router';
@@ -42,6 +41,14 @@ import {
 import consoleStyles from '../../styles/console-styles.css?inline';
 import type { Flow } from '../../types';
 import { consoleDialogStyles } from '../../styles/console-dialog';
+import {
+  effectiveViewMode,
+  loadViewMode,
+  saveViewMode,
+  subscribeNarrowViewport,
+  type ListViewMode,
+  type NarrowViewportSubscription,
+} from '../../utils/view-mode';
 
 /** A flow row from the list endpoints, where id and name are always present. */
 type FlowListItem = Flow & { id: string; name: string };
@@ -58,17 +65,6 @@ interface FlowExecution extends ExecutionSubjectSource {
 export type FlowsViewMode = 'list' | 'cards';
 
 const VIEW_MODE_KEY = 'preloop.flows.view_mode';
-const FLOWS_VIEW_MODES: FlowsViewMode[] = ['list', 'cards'];
-
-/**
- * List is the default (DESIGN.md, "Tables and views"): thirty flows are
- * compared, not browsed, and a table answers "which of these ran, which
- * failed and what did they cost" in one screen. A persisted choice wins.
- */
-const DEFAULT_FLOWS_VIEW: FlowsViewMode = 'list';
-
-/** Below this width seven columns cannot hold their content, so cards take over. */
-const LIST_TO_CARDS_BREAKPOINT = '(max-width: 640px)';
 
 /**
  * How many recent runs the page reads to build the in-range counts.
@@ -83,14 +79,9 @@ const EXECUTIONS_SAMPLE_LIMIT = 200;
 /** One day, for the ranges whose labels are counted in hours and days. */
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/** Kept for flows-view.test.ts. Storage and fallback live in view-mode.ts. */
 export function loadInitialFlowsViewMode(): FlowsViewMode {
-  try {
-    const saved = localStorage.getItem(VIEW_MODE_KEY);
-    if (saved && (FLOWS_VIEW_MODES as string[]).includes(saved)) {
-      return saved as FlowsViewMode;
-    }
-  } catch (e) {}
-  return DEFAULT_FLOWS_VIEW;
+  return loadViewMode(VIEW_MODE_KEY) as FlowsViewMode;
 }
 
 export type FlowRange = 'day' | 'week' | 'month' | 'year';
@@ -331,74 +322,6 @@ export class FlowsView extends LitElement {
     css`
       :host {
         display: block;
-      }
-
-      /* --- Filter bar --- */
-      .flows-toolbar {
-        display: flex;
-        align-items: end;
-        justify-content: space-between;
-        gap: var(--sl-spacing-medium);
-        flex-wrap: wrap;
-        width: 100%;
-      }
-      .filters {
-        display: flex;
-        gap: var(--sl-spacing-medium);
-        flex-wrap: wrap;
-        align-items: end;
-        flex: 1 1 520px;
-        min-width: 0;
-      }
-      .filters sl-input,
-      .filters sl-select {
-        min-width: 180px;
-      }
-      .filters sl-input {
-        flex: 1 1 260px;
-      }
-      .view-switcher-group {
-        display: flex;
-        align-items: center;
-        gap: var(--sl-spacing-medium);
-        margin-left: auto;
-      }
-      /* Says how many rows the filters matched, right where the eye already
-         goes to switch views. */
-      .results-count {
-        color: var(--console-meta-color);
-        font-size: var(--console-text-meta);
-        font-variant-numeric: tabular-nums;
-        white-space: nowrap;
-      }
-      .toolbar-divider {
-        width: 1px;
-        height: 32px;
-        background: var(--console-hairline);
-      }
-      @media (max-width: 900px) {
-        .view-switcher-group {
-          margin-left: 0;
-          width: 100%;
-          justify-content: flex-end;
-        }
-        .toolbar-divider {
-          display: none;
-        }
-      }
-      /* Phones: the filters take the full width one after another, and the
-         switcher goes away. Below this width a seven-column table cannot be
-         read, so cards are the only view on offer and a switcher that could
-         not honour a click would be a lie. Matches
-         LIST_TO_CARDS_BREAKPOINT. */
-      @media (max-width: 640px) {
-        .filters sl-input,
-        .filters sl-select {
-          flex: 1 1 100%;
-        }
-        .view-switcher-group sl-button-group {
-          display: none;
-        }
       }
 
       /* --- List view --- */
@@ -839,20 +762,15 @@ export class FlowsView extends LitElement {
   private presetsLoaded = false;
   private unsubscribe?: () => void;
   private hasInitializedPresetVisibility = false;
-  private narrowViewportQuery: MediaQueryList | null = null;
-  private handleNarrowViewportChange = (event: MediaQueryListEvent) => {
-    this.narrowViewport = event.matches;
-  };
+  private narrowViewportSubscription: NarrowViewportSubscription | null = null;
 
   async connectedCallback() {
     super.connectedCallback();
     this.currentView = loadInitialFlowsViewMode();
-    this.narrowViewportQuery = window.matchMedia(LIST_TO_CARDS_BREAKPOINT);
-    this.narrowViewport = this.narrowViewportQuery.matches;
-    this.narrowViewportQuery.addEventListener(
-      'change',
-      this.handleNarrowViewportChange
-    );
+    this.narrowViewportSubscription = subscribeNarrowViewport((narrow) => {
+      this.narrowViewport = narrow;
+    });
+    this.narrowViewport = this.narrowViewportSubscription.matches;
     await this.loadData();
     this.connectWebSocket();
   }
@@ -860,11 +778,8 @@ export class FlowsView extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.unsubscribe?.();
-    this.narrowViewportQuery?.removeEventListener(
-      'change',
-      this.handleNarrowViewportChange
-    );
-    this.narrowViewportQuery = null;
+    this.narrowViewportSubscription?.disconnect();
+    this.narrowViewportSubscription = null;
   }
 
   /**
@@ -872,17 +787,22 @@ export class FlowsView extends LitElement {
    * scroll sideways or crush every cell, so `list` renders as cards.
    */
   private get effectiveView(): FlowsViewMode {
-    if (this.currentView === 'list' && this.narrowViewport) {
-      return 'cards';
-    }
-    return this.currentView;
+    return effectiveViewMode(
+      this.currentView,
+      this.narrowViewport
+    ) as FlowsViewMode;
   }
 
-  private setCurrentView(view: FlowsViewMode) {
-    this.currentView = view;
-    try {
-      localStorage.setItem(VIEW_MODE_KEY, view);
-    } catch (e) {}
+  private handleSearchChange(event: CustomEvent<{ value: string }>) {
+    this.filters = { ...this.filters, query: event.detail.value };
+  }
+
+  private handleViewChange(event: CustomEvent<{ value: ListViewMode }>) {
+    if (event.detail.value === 'canvas') {
+      return;
+    }
+    this.currentView = event.detail.value;
+    saveViewMode(VIEW_MODE_KEY, event.detail.value);
   }
 
   /**
@@ -1477,131 +1397,88 @@ export class FlowsView extends LitElement {
   private renderToolbar() {
     const presetOptions = this.presetOptions;
     return html`
-      <div class="flows-toolbar">
-        <form class="filters" @submit=${(e: Event) => e.preventDefault()}>
-          <sl-input
-            class="search-input"
-            placeholder="Search flows"
-            clearable
-            .value=${this.filters.query}
-            @sl-input=${(event: Event) => {
-              const input = event.target as HTMLInputElement;
-              this.filters = { ...this.filters, query: input.value };
-            }}
-            @sl-clear=${() => {
-              this.filters = { ...this.filters, query: '' };
-            }}
-          >
-            <sl-icon name="search" slot="prefix"></sl-icon>
-          </sl-input>
+      <list-toolbar
+        .search=${this.filters.query}
+        searchPlaceholder="Search flows"
+        toggleLabel="Flows view"
+        .view=${this.currentView}
+        .views=${['list', 'cards']}
+        @search-change=${this.handleSearchChange}
+        @view-change=${this.handleViewChange}
+      >
+        <sl-select
+          class="preset-filter"
+          multiple
+          clearable
+          max-options-visible="1"
+          placeholder="All types"
+          .value=${this.filters.presets}
+          @sl-change=${(event: Event) => {
+            const select = event.target as HTMLElement & {
+              value: string | string[];
+            };
+            this.filters = {
+              ...this.filters,
+              presets: Array.isArray(select.value)
+                ? [...select.value]
+                : [select.value].filter(Boolean),
+            };
+          }}
+        >
+          ${repeat(
+            presetOptions,
+            (option) => option.value,
+            (option) =>
+              html`<sl-option value=${option.value}>${option.label}</sl-option>`
+          )}
+        </sl-select>
 
-          <sl-select
-            class="preset-filter"
-            multiple
-            clearable
-            max-options-visible="1"
-            placeholder="All types"
-            .value=${this.filters.presets}
-            @sl-change=${(event: Event) => {
-              const select = event.target as HTMLElement & {
-                value: string | string[];
-              };
-              this.filters = {
-                ...this.filters,
-                presets: Array.isArray(select.value)
-                  ? [...select.value]
-                  : [select.value].filter(Boolean),
-              };
-            }}
+        <sl-select
+          class="status-filter"
+          multiple
+          clearable
+          max-options-visible="1"
+          placeholder="Any status"
+          .value=${this.filters.statuses}
+          @sl-change=${(event: Event) => {
+            const select = event.target as HTMLElement & {
+              value: string | string[];
+            };
+            const values = Array.isArray(select.value)
+              ? select.value
+              : [select.value].filter(Boolean);
+            this.filters = {
+              ...this.filters,
+              statuses: values as FlowStatusFilter[],
+            };
+          }}
+        >
+          <sl-option value="enabled">Enabled</sl-option>
+          <sl-option value="paused">Paused</sl-option>
+          <sl-option value="draft">Draft</sl-option>
+          <!-- The count behind this is the page range, like the Failed
+               column, so the option says which window it means. -->
+          <sl-option value="failing"
+            >Failed in the last ${this.rangeLabel}</sl-option
           >
-            ${repeat(
-              presetOptions,
-              (option) => option.value,
-              (option) =>
-                html`<sl-option value=${option.value}
-                  >${option.label}</sl-option
-                >`
-            )}
-          </sl-select>
+        </sl-select>
 
-          <sl-select
-            class="status-filter"
-            multiple
-            clearable
-            max-options-visible="1"
-            placeholder="Any status"
-            .value=${this.filters.statuses}
-            @sl-change=${(event: Event) => {
-              const select = event.target as HTMLElement & {
-                value: string | string[];
-              };
-              const values = Array.isArray(select.value)
-                ? select.value
-                : [select.value].filter(Boolean);
-              this.filters = {
-                ...this.filters,
-                statuses: values as FlowStatusFilter[],
-              };
-            }}
-          >
-            <sl-option value="enabled">Enabled</sl-option>
-            <sl-option value="paused">Paused</sl-option>
-            <sl-option value="draft">Draft</sl-option>
-            <!-- The count behind this is the page range, like the Failed
-                 column, so the option says which window it means. -->
-            <sl-option value="failing"
-              >Failed in the last ${this.rangeLabel}</sl-option
-            >
-          </sl-select>
-
-          <time-range-select
-            ariaLabel="Flows time range"
-            .value=${this.range}
-            .options=${[
-              { value: 'day', label: '24h' },
-              { value: 'week', label: '7d' },
-              { value: 'month', label: '30d' },
-              { value: 'year', label: '1y' },
-            ]}
-            @range-change=${(event: CustomEvent) => {
-              this.range = event.detail.value as FlowRange;
-              void this.loadCosts();
-            }}
-          ></time-range-select>
-        </form>
-
-        <div class="view-switcher-group">
-          <span class="results-count" aria-live="polite"
-            >${this.resultsLabel}</span
-          >
-          <span class="toolbar-divider" aria-hidden="true"></span>
-          <sl-button-group label="Flows view">
-            ${[
-              { value: 'list' as const, label: 'List', icon: 'list-ul' },
-              {
-                value: 'cards' as const,
-                label: 'Cards',
-                icon: 'grid-3x3-gap',
-              },
-            ].map(
-              (option) => html`
-                <sl-button
-                  size="small"
-                  data-view=${option.value}
-                  variant=${
-                    this.currentView === option.value ? 'primary' : 'default'
-                  }
-                  aria-pressed=${this.currentView === option.value}
-                  @click=${() => this.setCurrentView(option.value)}
-                >
-                  <sl-icon slot="prefix" name=${option.icon}></sl-icon>
-                  ${option.label}
-                </sl-button>
-              `
-            )}
-          </sl-button-group>
-        </div>
-      </div>
+        <time-range-select
+          ariaLabel="Flows time range"
+          .value=${this.range}
+          .options=${[
+            { value: 'day', label: '24h' },
+            { value: 'week', label: '7d' },
+            { value: 'month', label: '30d' },
+            { value: 'year', label: '1y' },
+          ]}
+          @range-change=${(event: CustomEvent) => {
+            this.range = event.detail.value as FlowRange;
+            void this.loadCosts();
+          }}
+        ></time-range-select>
+        <span slot="count">${this.resultsLabel}</span>
+      </list-toolbar>
     `;
   }
 

--- a/frontend/src/views/authed/flows-view.ts
+++ b/frontend/src/views/authed/flows-view.ts
@@ -79,7 +79,10 @@ const EXECUTIONS_SAMPLE_LIMIT = 200;
 /** One day, for the ranges whose labels are counted in hours and days. */
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-/** Kept for flows-view.test.ts. Storage and fallback live in view-mode.ts. */
+/**
+ * Thin wrapper around `loadViewMode` so flows-view.test.ts can assert the
+ * default/cast directly. Also used to initialise and restore the page view.
+ */
 export function loadInitialFlowsViewMode(): FlowsViewMode {
   return loadViewMode(VIEW_MODE_KEY) as FlowsViewMode;
 }


### PR DESCRIPTION
Follows #398 (merged). Completes the follow-up named there so all four collection pages share one filter bar.

## What changed
- `list-toolbar.ts`: a `canvas` view option (icon `diagram-3`) so the Agents switcher stays one `sl-button-group` with List / Cards / Canvas.
- Flows: the duplicated toolbar CSS and view-mode plumbing (`VIEW_MODE_KEY`, `FLOWS_VIEW_MODES`, breakpoint subscribe) are gone; `renderToolbar()` is a `<list-toolbar>` with the existing preset, status and time-range selects slotted and the results count in the `count` slot. Pixel-identical to the old page at 1440 and 640 (the reviewer compared the deleted CSS with the component).
- Agents: same migration keyed `preloop.agents.view_mode` with `['list', 'cards', 'canvas']`. A stored `canvas` on a viewport at or below 640px now falls back to cards like `list` does, since the switcher is hidden there.
- List, cards and canvas templates untouched on both pages.

## Visual deltas on Agents (intentional, please confirm)
The old Agents bar had its own CSS that predates the DESIGN.md tokens. On the shared component its spacing tokens, hairline ladder, select sizing and divider now match Flows, Trackers and Models. The reviewer measured four such differences at 1440; none on Flows. If you want the old Agents look kept, say so and the bar gets a per-page override, but the point of the component is that it does not.

## Tests
Updated `agents-view.test.ts` and `flows-view.test.ts` where they queried the old toolbar; new list-toolbar canvas test; narrow-viewport canvas fallback test. Full suite before the rebase: 132 files, 1447 passed, 0 failed; the four touched files after rebasing onto main: see the check line in the conductor's note below.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> UI-only refactor with no security implications, well-covered by tests; both prior LOW suggestions resolved.
>
> **Overview**
> Migrates the Agents and Flows pages onto the shared `<list-toolbar>` component, adding a `canvas` view option and centralizing view-mode storage and narrow-viewport fallback in `view-mode.ts`. Templates are untouched.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit be7fba2. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->