### PR TITLE
Trackers: open pull requests and merge requests per project, with Run reviewer

### DIFF
--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -47,6 +47,7 @@ from preloop.api.endpoints import (
     policies,
     projects,
     public_approval,
+    pull_requests,
     roles,
     search as search_router,
     security_screen,
@@ -982,6 +983,12 @@ def create_app() -> FastAPI:
         )
         app.include_router(
             projects.router,
+            prefix="/api/v1",
+            tags=["Projects"],
+            dependencies=[Depends(get_current_active_user)],
+        )
+        app.include_router(
+            pull_requests.router,
             prefix="/api/v1",
             tags=["Projects"],
             dependencies=[Depends(get_current_active_user)],

--- a/backend/preloop/api/endpoints/__init__.py
+++ b/backend/preloop/api/endpoints/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "policies",
     "projects",
     "public_approval",
+    "pull_requests",
     "roles",
     "search",
     "tools",

--- a/backend/preloop/api/endpoints/pull_requests.py
+++ b/backend/preloop/api/endpoints/pull_requests.py
@@ -1,0 +1,163 @@
+"""Live pull request / merge request lists for a project."""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Literal, Optional, Tuple
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from preloop.api.auth import get_current_active_user
+from preloop.api.common import get_tracker_client
+from preloop.models.crud import crud_organization, crud_project, crud_tracker
+from preloop.models.db.session import get_db_session as get_db
+from preloop.models.models.user import User
+from preloop.schemas.pull_request import PullRequestListResponse
+from preloop.sync.exceptions import TrackerError
+from preloop.utils.permissions import require_permission
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+_PR_LIST_CACHE: Dict[Tuple[str, str, str, int, int], Tuple[float, dict]] = {}
+_PR_LIST_TTL_SECONDS = 60.0
+
+
+def clear_pull_request_list_cache() -> None:
+    """Drop the in-process PR list cache (tests)."""
+    _PR_LIST_CACHE.clear()
+
+
+def _cache_key(
+    account_id: Any, project_id: Any, state: str, page: int, limit: int
+) -> Tuple[str, str, str, int, int]:
+    return (str(account_id), str(project_id), state, page, limit)
+
+
+def _cache_get(key: Tuple[str, str, str, int, int]) -> Optional[dict]:
+    entry = _PR_LIST_CACHE.get(key)
+    if entry is None:
+        return None
+    expires_at, payload = entry
+    if time.monotonic() >= expires_at:
+        _PR_LIST_CACHE.pop(key, None)
+        return None
+    return payload
+
+
+def _cache_set(key: Tuple[str, str, str, int, int], payload: dict) -> None:
+    _PR_LIST_CACHE[key] = (time.monotonic() + _PR_LIST_TTL_SECONDS, payload)
+
+
+def _unsupported_response(page: int, limit: int) -> PullRequestListResponse:
+    return PullRequestListResponse(
+        items=[],
+        page=page,
+        limit=limit,
+        has_more=False,
+        supported=False,
+        fetched_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def _tracker_kind(tracker_type: str) -> str:
+    lowered = (tracker_type or "").lower()
+    if "jira" in lowered:
+        return "jira"
+    if "gitlab" in lowered:
+        return "gitlab"
+    if "github" in lowered:
+        return "github"
+    return "other"
+
+
+def _load_visible_project_and_tracker(
+    db: Session, project_id: UUID, account_id: UUID
+) -> Tuple[Any, Any, Any]:
+    """Return ``(project, organization, tracker)`` if the project is visible."""
+    project = crud_project.get(db, id=str(project_id), account_id=str(account_id))
+    if project is None:
+        project = crud_project.get(db, id=str(project_id))
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    user_trackers = crud_tracker.get_for_account(db, account_id=account_id)
+    tracker_ids = {str(item.id) for item in user_trackers}
+    organization = crud_organization.get(db, id=project.organization_id)
+    if not organization or str(organization.tracker_id) not in tracker_ids:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    tracker = next(
+        (
+            item
+            for item in user_trackers
+            if str(item.id) == str(organization.tracker_id)
+        ),
+        None,
+    )
+    if tracker is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project, organization, tracker
+
+
+@router.get(
+    "/projects/{project_id}/pull-requests",
+    response_model=PullRequestListResponse,
+)
+@require_permission("view_trackers")
+async def list_project_pull_requests(
+    project_id: UUID,
+    state: Literal["open"] = Query("open"),
+    limit: int = Query(20, ge=1, le=50),
+    page: int = Query(1, ge=1),
+    refresh: bool = Query(False),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PullRequestListResponse:
+    """List open pull requests (GitHub) or merge requests (GitLab) for a project."""
+    project, organization, tracker = _load_visible_project_and_tracker(
+        db, project_id, current_user.account_id
+    )
+    kind = _tracker_kind(tracker.tracker_type)
+    if kind not in ("github", "gitlab"):
+        return _unsupported_response(page, limit)
+
+    cache_key = _cache_key(current_user.account_id, project.id, state, page, limit)
+    if not refresh:
+        cached = _cache_get(cache_key)
+        if cached is not None:
+            return PullRequestListResponse.model_validate(cached)
+
+    try:
+        client = await get_tracker_client(organization.id, project.id, db, current_user)
+        if kind == "gitlab":
+            listed = await client.list_merge_requests(
+                state=state, limit=limit, page=page
+            )
+        else:
+            listed = await client.list_pull_requests(
+                state=state, limit=limit, page=page
+            )
+    except HTTPException:
+        raise
+    except TrackerError as exc:
+        logger.warning("Tracker request failed listing pull requests: %s", exc)
+        raise HTTPException(status_code=502, detail="Tracker request failed") from exc
+    except Exception as exc:
+        logger.exception("Unexpected tracker error listing pull requests")
+        raise HTTPException(status_code=502, detail="Tracker request failed") from exc
+
+    payload = {
+        "items": listed.get("items") or [],
+        "page": page,
+        "limit": limit,
+        "has_more": bool(listed.get("has_more")),
+        "supported": True,
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _cache_set(cache_key, payload)
+    return PullRequestListResponse.model_validate(payload)

--- a/backend/preloop/api/endpoints/pull_requests.py
+++ b/backend/preloop/api/endpoints/pull_requests.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from datetime import datetime, timezone
@@ -90,7 +91,7 @@ def _tracker_kind(tracker_type: str) -> str:
     response_model=PullRequestListResponse,
 )
 @require_permission("view_trackers")
-async def list_project_pull_requests(
+def list_project_pull_requests(
     project_id: UUID,
     state: Literal["open"] = Query("open"),
     limit: int = Query(20, ge=1, le=50),
@@ -116,16 +117,18 @@ async def list_project_pull_requests(
         if cached is not None:
             return PullRequestListResponse.model_validate(cached)
 
-    try:
-        client = await get_tracker_client(organization.id, project.id, db, current_user)
+    async def _fetch() -> dict:
+        client = await get_tracker_client(
+            organization.id, project.id, db, current_user
+        )
         if kind == "gitlab":
-            listed = await client.list_merge_requests(
+            return await client.list_merge_requests(
                 state=state, limit=limit, page=page
             )
-        else:
-            listed = await client.list_pull_requests(
-                state=state, limit=limit, page=page
-            )
+        return await client.list_pull_requests(state=state, limit=limit, page=page)
+
+    try:
+        listed = asyncio.run(_fetch())
     except HTTPException:
         raise
     except TrackerError as exc:

--- a/backend/preloop/api/endpoints/pull_requests.py
+++ b/backend/preloop/api/endpoints/pull_requests.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
 from datetime import datetime, timezone
 from typing import Any, Dict, Literal, Optional, Tuple
@@ -27,12 +28,14 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _PR_LIST_CACHE: Dict[Tuple[str, str, str, int, int], Tuple[float, dict]] = {}
+_PR_LIST_CACHE_LOCK = threading.Lock()
 _PR_LIST_TTL_SECONDS = 60.0
 
 
 def clear_pull_request_list_cache() -> None:
     """Drop the in-process PR list cache (tests)."""
-    _PR_LIST_CACHE.clear()
+    with _PR_LIST_CACHE_LOCK:
+        _PR_LIST_CACHE.clear()
 
 
 def _cache_key(
@@ -42,26 +45,28 @@ def _cache_key(
 
 
 def _cache_get(key: Tuple[str, str, str, int, int]) -> Optional[dict]:
-    entry = _PR_LIST_CACHE.get(key)
-    if entry is None:
-        return None
-    expires_at, payload = entry
-    if time.monotonic() >= expires_at:
-        _PR_LIST_CACHE.pop(key, None)
-        return None
-    return payload
+    with _PR_LIST_CACHE_LOCK:
+        entry = _PR_LIST_CACHE.get(key)
+        if entry is None:
+            return None
+        expires_at, payload = entry
+        if time.monotonic() >= expires_at:
+            _PR_LIST_CACHE.pop(key, None)
+            return None
+        return payload
 
 
 def _cache_set(key: Tuple[str, str, str, int, int], payload: dict) -> None:
-    now = time.monotonic()
-    expired = [
-        cached
-        for cached, (expires_at, _) in _PR_LIST_CACHE.items()
-        if expires_at <= now
-    ]
-    for cached in expired:
-        _PR_LIST_CACHE.pop(cached, None)
-    _PR_LIST_CACHE[key] = (now + _PR_LIST_TTL_SECONDS, payload)
+    with _PR_LIST_CACHE_LOCK:
+        now = time.monotonic()
+        expired = [
+            cached
+            for cached, (expires_at, _) in list(_PR_LIST_CACHE.items())
+            if expires_at <= now
+        ]
+        for cached in expired:
+            _PR_LIST_CACHE.pop(cached, None)
+        _PR_LIST_CACHE[key] = (now + _PR_LIST_TTL_SECONDS, payload)
 
 
 def _unsupported_response(page: int, limit: int) -> PullRequestListResponse:
@@ -118,13 +123,9 @@ def list_project_pull_requests(
             return PullRequestListResponse.model_validate(cached)
 
     async def _fetch() -> dict:
-        client = await get_tracker_client(
-            organization.id, project.id, db, current_user
-        )
+        client = await get_tracker_client(organization.id, project.id, db, current_user)
         if kind == "gitlab":
-            return await client.list_merge_requests(
-                state=state, limit=limit, page=page
-            )
+            return await client.list_merge_requests(state=state, limit=limit, page=page)
         return await client.list_pull_requests(state=state, limit=limit, page=page)
 
     try:

--- a/backend/preloop/api/endpoints/pull_requests.py
+++ b/backend/preloop/api/endpoints/pull_requests.py
@@ -8,15 +8,17 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Literal, Optional, Tuple
 from uuid import UUID
 
+import gitlab.exceptions
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from preloop.api.auth import get_current_active_user
 from preloop.api.common import get_tracker_client
-from preloop.models.crud import crud_organization, crud_project, crud_tracker
 from preloop.models.db.session import get_db_session as get_db
 from preloop.models.models.user import User
 from preloop.schemas.pull_request import PullRequestListResponse
+from preloop.services.preset_runner import PresetRunnerError, _load_visible_project
 from preloop.sync.exceptions import TrackerError
 from preloop.utils.permissions import require_permission
 
@@ -50,7 +52,15 @@ def _cache_get(key: Tuple[str, str, str, int, int]) -> Optional[dict]:
 
 
 def _cache_set(key: Tuple[str, str, str, int, int], payload: dict) -> None:
-    _PR_LIST_CACHE[key] = (time.monotonic() + _PR_LIST_TTL_SECONDS, payload)
+    now = time.monotonic()
+    expired = [
+        cached
+        for cached, (expires_at, _) in _PR_LIST_CACHE.items()
+        if expires_at <= now
+    ]
+    for cached in expired:
+        _PR_LIST_CACHE.pop(cached, None)
+    _PR_LIST_CACHE[key] = (now + _PR_LIST_TTL_SECONDS, payload)
 
 
 def _unsupported_response(page: int, limit: int) -> PullRequestListResponse:
@@ -75,35 +85,6 @@ def _tracker_kind(tracker_type: str) -> str:
     return "other"
 
 
-def _load_visible_project_and_tracker(
-    db: Session, project_id: UUID, account_id: UUID
-) -> Tuple[Any, Any, Any]:
-    """Return ``(project, organization, tracker)`` if the project is visible."""
-    project = crud_project.get(db, id=str(project_id), account_id=str(account_id))
-    if project is None:
-        project = crud_project.get(db, id=str(project_id))
-    if project is None:
-        raise HTTPException(status_code=404, detail="Project not found")
-
-    user_trackers = crud_tracker.get_for_account(db, account_id=account_id)
-    tracker_ids = {str(item.id) for item in user_trackers}
-    organization = crud_organization.get(db, id=project.organization_id)
-    if not organization or str(organization.tracker_id) not in tracker_ids:
-        raise HTTPException(status_code=404, detail="Project not found")
-
-    tracker = next(
-        (
-            item
-            for item in user_trackers
-            if str(item.id) == str(organization.tracker_id)
-        ),
-        None,
-    )
-    if tracker is None:
-        raise HTTPException(status_code=404, detail="Project not found")
-    return project, organization, tracker
-
-
 @router.get(
     "/projects/{project_id}/pull-requests",
     response_model=PullRequestListResponse,
@@ -119,9 +100,12 @@ async def list_project_pull_requests(
     current_user: User = Depends(get_current_active_user),
 ) -> PullRequestListResponse:
     """List open pull requests (GitHub) or merge requests (GitLab) for a project."""
-    project, organization, tracker = _load_visible_project_and_tracker(
-        db, project_id, current_user.account_id
-    )
+    try:
+        project, tracker, organization = _load_visible_project(
+            db, project_id=project_id, account_id=current_user.account_id
+        )
+    except PresetRunnerError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     kind = _tracker_kind(tracker.tracker_type)
     if kind not in ("github", "gitlab"):
         return _unsupported_response(page, limit)
@@ -147,7 +131,7 @@ async def list_project_pull_requests(
     except TrackerError as exc:
         logger.warning("Tracker request failed listing pull requests: %s", exc)
         raise HTTPException(status_code=502, detail="Tracker request failed") from exc
-    except Exception as exc:
+    except (httpx.HTTPError, gitlab.exceptions.GitlabError) as exc:
         logger.exception("Unexpected tracker error listing pull requests")
         raise HTTPException(status_code=502, detail="Tracker request failed") from exc
 

--- a/backend/preloop/schemas/pull_request.py
+++ b/backend/preloop/schemas/pull_request.py
@@ -1,0 +1,33 @@
+"""Schemas for live pull request / merge request lists."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PullRequestItem(BaseModel):
+    """One open pull request or merge request from the tracker."""
+
+    number: int
+    iid: int
+    title: str
+    description: Optional[str] = None
+    url: str
+    author: Optional[str] = None
+    source_branch: Optional[str] = None
+    target_branch: Optional[str] = None
+    state: str
+    draft: bool = False
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class PullRequestListResponse(BaseModel):
+    """Paginated live list of open pull/merge requests."""
+
+    items: List[PullRequestItem]
+    page: int
+    limit: int
+    has_more: bool
+    supported: bool
+    fetched_at: str = Field(..., description="ISO timestamp of the fetch")

--- a/backend/preloop/services/preset_runner.py
+++ b/backend/preloop/services/preset_runner.py
@@ -695,7 +695,7 @@ async def _run_preset_on_pull_request(
     trigger_service = FlowTriggerService(db)
     result = await trigger_service.trigger_flow(
         flow_id=flow.id,
-        test_mode=True,
+        test_mode=False,
         trigger_event_data=trigger_event_data,
         triggered_by=triggered_by,
     )

--- a/backend/preloop/services/preset_runner.py
+++ b/backend/preloop/services/preset_runner.py
@@ -1,7 +1,7 @@
 """Resolve a preset flow for an account and run it on a tracker target.
 
-Used by ``POST /flows/run-preset``. Issue runs are supported here. Pull
-request targets return a clear 400 until PR3 adds them.
+Used by ``POST /flows/run-preset``. Issue and pull-request (or merge-request)
+targets are supported. Both reviewer flows use preset ``pull-request-reviewer``.
 """
 
 from __future__ import annotations
@@ -15,13 +15,20 @@ from sqlalchemy.orm import Session
 
 from preloop.api.auth.permissions import has_permission
 from preloop.flow_presets import PRESET_SLUGS
-from preloop.models.crud import crud_flow, crud_issue, crud_project, crud_tracker
+from preloop.models.crud import (
+    crud_flow,
+    crud_issue,
+    crud_organization,
+    crud_project,
+    crud_tracker,
+)
 from preloop.models.models.user import User
 from preloop.services.flow_presets_service import clone_preset_for_account
 
 IMPLEMENTER_SLUG = "automated-issue-implementation"
 REVIEWER_SLUG = "pull-request-reviewer"
 ISSUE_PRESET_SLUGS = {IMPLEMENTER_SLUG}
+PR_PRESET_SLUGS = {REVIEWER_SLUG}
 
 
 class PresetRunnerError(Exception):
@@ -333,6 +340,106 @@ def build_issue_trigger_payload(
     }
 
 
+def _pr_detail_number(pr: Dict[str, Any]) -> int:
+    for key in ("number", "iid"):
+        value = pr.get(key)
+        if value is not None:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                continue
+    return 0
+
+
+def _pr_detail_author(pr: Dict[str, Any]) -> str:
+    author = pr.get("author")
+    if isinstance(author, dict):
+        return str(
+            author.get("username") or author.get("login") or author.get("name") or ""
+        )
+    return str(author or "")
+
+
+def build_pull_request_trigger_payload(
+    pr: Dict[str, Any], project: Any, tracker: Any
+) -> Dict[str, Any]:
+    """Build ``trigger_event_data`` for a reviewer run on a PR or MR.
+
+    GitHub uses ``payload.pull_request`` so ``TriggerEventResolver`` can
+    build ``object_attributes`` (title, description, author, url, branches).
+    GitLab already uses ``object_attributes`` with those same keys.
+    """
+    tracker_type = (getattr(tracker, "tracker_type", "") or "github").lower()
+    if tracker_type not in ("github", "gitlab"):
+        tracker_type = "gitlab" if "gitlab" in tracker_type else "github"
+
+    repo = _repository_clone_fields(project, tracker)
+    number = _pr_detail_number(pr)
+    title = pr.get("title") or ""
+    description = pr.get("description") or pr.get("body") or ""
+    url = pr.get("url") or pr.get("html_url") or ""
+    author = _pr_detail_author(pr)
+    source_branch = pr.get("source_branch") or ""
+    target_branch = pr.get("target_branch") or ""
+    state = pr.get("state") or "open"
+    draft = bool(pr.get("draft") or pr.get("is_draft") or pr.get("work_in_progress"))
+    payload: Dict[str, Any] = {
+        "project_id": str(project.id),
+        "repository": repo,
+    }
+
+    if "gitlab" in tracker_type:
+        project_id = getattr(project, "identifier", None) or str(project.id)
+        try:
+            gitlab_id: Any = int(str(project_id))
+        except (TypeError, ValueError):
+            gitlab_id = str(project_id)
+        payload["object_kind"] = "merge_request"
+        payload["object_attributes"] = {
+            "iid": number,
+            "number": number,
+            "title": title,
+            "description": description,
+            "url": url,
+            "source_branch": source_branch,
+            "target_branch": target_branch,
+            "state": state,
+            "author": author,
+        }
+        payload["project"] = {
+            "id": gitlab_id,
+            "name": project.name,
+            "web_url": repo.get("web_url"),
+            "path_with_namespace": repo.get("path_with_namespace"),
+            "default_branch": repo.get("default_branch"),
+            "http_url_to_repo": repo.get("http_url_to_repo"),
+            "git_http_url": repo.get("git_http_url"),
+        }
+        source = "gitlab"
+    else:
+        payload["pull_request"] = {
+            "number": number,
+            "title": title,
+            "body": description,
+            "html_url": url,
+            "state": state,
+            "draft": draft,
+            "user": {"login": author},
+            "head": {"ref": source_branch},
+            "base": {"ref": target_branch},
+        }
+        source = "github"
+
+    return {
+        "type": "pull_request_run",
+        "source": source,
+        "project_id": str(project.id),
+        "tracker_id": str(tracker.id),
+        "account_id": str(tracker.account_id),
+        "payload": payload,
+    }
+
+
 def _load_visible_issue(
     db: Session, *, issue_id: UUID, account_id: UUID
 ) -> Tuple[Any, Any, Any]:
@@ -359,6 +466,59 @@ def _load_visible_issue(
     return issue, project, tracker
 
 
+def _load_visible_project(
+    db: Session, *, project_id: UUID, account_id: UUID
+) -> Tuple[Any, Any, Any]:
+    """Return ``(project, tracker, organization)`` if the project is visible."""
+    project = crud_project.get(db, id=str(project_id), account_id=str(account_id))
+    if project is None:
+        project = crud_project.get(db, id=str(project_id))
+    if project is None:
+        raise _http(404, "Project not found")
+
+    trackers = crud_tracker.get_for_account(db, account_id=account_id)
+    tracker_ids = {str(item.id) for item in trackers}
+    organization = crud_organization.get(db, id=project.organization_id)
+    if organization is None or str(organization.tracker_id) not in tracker_ids:
+        raise _http(404, "Project not found")
+
+    tracker = next(
+        (item for item in trackers if str(item.id) == str(organization.tracker_id)),
+        None,
+    )
+    if tracker is None:
+        raise _http(404, "Project not found")
+    return project, tracker, organization
+
+
+async def _fetch_pull_request_detail(
+    db: Session,
+    *,
+    current_user: User,
+    project: Any,
+    tracker: Any,
+    organization: Any,
+    number: int,
+) -> Dict[str, Any]:
+    """Load one PR/MR from the project's tracker client."""
+    from preloop.api.common import get_tracker_client
+    from preloop.sync.exceptions import TrackerError
+
+    tracker_type = (getattr(tracker, "tracker_type", "") or "").lower()
+    try:
+        client = await get_tracker_client(organization.id, project.id, db, current_user)
+        if "gitlab" in tracker_type:
+            return await client.get_merge_request(str(number))
+        if "github" in tracker_type:
+            return await client.get_pull_request(str(number))
+    except TrackerError as exc:
+        raise _http(502, "Tracker request failed") from exc
+    raise _http(
+        400,
+        "This tracker does not support pull request reviewer runs.",
+    )
+
+
 async def run_preset_on_target(
     db: Session,
     *,
@@ -374,12 +534,14 @@ async def run_preset_on_target(
         target.get("kind") if isinstance(target, dict) else None
     )
     if kind == "pull_request":
-        raise _http(
-            400,
-            (
-                "Running a preset on a pull request is not supported yet. "
-                "Use an issue target."
-            ),
+        return await _run_preset_on_pull_request(
+            db,
+            current_user=current_user,
+            preset_slug=preset_slug,
+            target=target,
+            confirm_create=confirm_create,
+            triggered_by=triggered_by,
+            flow_crud=flow_crud,
         )
     # Schema-validated at the API; these 400s exist for direct callers.
     if kind != "issue":
@@ -447,6 +609,97 @@ async def run_preset_on_target(
     if raw_execution_id is None:
         raise _http(500, "Flow trigger did not return an execution id")
     execution_id = str(raw_execution_id)
+    return {
+        "execution_id": execution_id,
+        "flow_id": str(flow.id),
+        "flow_name": flow.name,
+        "flow_created": created,
+        "execution_url": f"/console/flows/executions/{execution_id}",
+    }
+
+
+async def _run_preset_on_pull_request(
+    db: Session,
+    *,
+    current_user: User,
+    preset_slug: str,
+    target: Any,
+    confirm_create: bool,
+    triggered_by: str,
+    flow_crud: Any = None,
+) -> Dict[str, Any]:
+    """Resolve the reviewer preset and trigger it on a pull/merge request."""
+    if preset_slug not in PR_PRESET_SLUGS:
+        if preset_slug == IMPLEMENTER_SLUG:
+            raise _http(
+                400,
+                (
+                    "The automated-issue-implementation preset cannot run on "
+                    "a pull request. Use pull-request-reviewer."
+                ),
+            )
+        if preset_slug not in PRESET_SLUGS:
+            raise _http(404, "Preset not found")
+        raise _http(
+            400,
+            f"Preset {preset_slug} does not match a pull request target.",
+        )
+
+    project_id = getattr(target, "project_id", None) or (
+        target.get("project_id") if isinstance(target, dict) else None
+    )
+    number = getattr(target, "number", None) or (
+        target.get("number") if isinstance(target, dict) else None
+    )
+    if project_id is None or number is None:
+        raise _http(
+            400,
+            "target.project_id and target.number are required when kind is "
+            "pull_request",
+        )
+
+    project, tracker, organization = _load_visible_project(
+        db, project_id=project_id, account_id=current_user.account_id
+    )
+
+    flow, created = resolve_or_create_flow(
+        db,
+        account_id=current_user.account_id,
+        preset_slug=preset_slug,
+        confirm_create=confirm_create,
+        current_user=current_user,
+        flow_crud=flow_crud,
+    )
+
+    if not confirm_create:
+        return {
+            "execution_id": None,
+            "flow_id": str(flow.id),
+            "flow_name": flow.name,
+            "flow_created": False,
+            "execution_url": None,
+        }
+
+    pr = await _fetch_pull_request_detail(
+        db,
+        current_user=current_user,
+        project=project,
+        tracker=tracker,
+        organization=organization,
+        number=int(number),
+    )
+    trigger_event_data = build_pull_request_trigger_payload(pr, project, tracker)
+
+    from preloop.services.flow_trigger_service import FlowTriggerService
+
+    trigger_service = FlowTriggerService(db)
+    result = await trigger_service.trigger_flow(
+        flow_id=flow.id,
+        test_mode=True,
+        trigger_event_data=trigger_event_data,
+        triggered_by=triggered_by,
+    )
+    execution_id = str(result.get("id") or result.get("execution_id"))
     return {
         "execution_id": execution_id,
         "flow_id": str(flow.id),

--- a/backend/preloop/services/preset_runner.py
+++ b/backend/preloop/services/preset_runner.py
@@ -699,7 +699,10 @@ async def _run_preset_on_pull_request(
         trigger_event_data=trigger_event_data,
         triggered_by=triggered_by,
     )
-    execution_id = str(result.get("id") or result.get("execution_id"))
+    raw_execution_id = result.get("id") or result.get("execution_id")
+    if raw_execution_id is None:
+        raise _http(500, "Flow trigger did not return an execution id")
+    execution_id = str(raw_execution_id)
     return {
         "execution_id": execution_id,
         "flow_id": str(flow.id),

--- a/backend/preloop/sync/trackers/github.py
+++ b/backend/preloop/sync/trackers/github.py
@@ -48,6 +48,16 @@ from preloop.models.models.project import Project
 from preloop.models.crud import crud_organization, crud_project, crud_webhook
 
 
+def _github_link_has_next(link_header: Optional[str]) -> bool:
+    """Return True when a GitHub Link header includes rel=next."""
+    if not link_header:
+        return False
+    for part in link_header.split(","):
+        if 'rel="next"' in part or "rel=next" in part or "rel='next'" in part:
+            return True
+    return False
+
+
 class GitHubTracker(BaseTracker):
     """GitHub tracker implementation.
 
@@ -252,6 +262,39 @@ class GitHubTracker(BaseTracker):
                     )
 
                 return response.json()
+            except httpx.RequestError as e:
+                raise TrackerConnectionError(f"GitHub connection error: {str(e)}")
+
+    async def _request_with_headers(
+        self,
+        method: str,
+        endpoint: str,
+        data: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Any, Dict[str, str]]:
+        """GET/POST helper that also returns response headers (for Link pagination)."""
+        url = (
+            f"{self.API_BASE_URL}{endpoint}"
+            if endpoint.startswith("/")
+            else f"{self.API_BASE_URL}/{endpoint}"
+        )
+        headers = await self._get_auth_headers()
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.request(
+                    method,
+                    url,
+                    headers=headers,
+                    json=data,
+                    params=params,
+                )
+                if response.status_code == HTTP_STATUS_UNAUTHORIZED:
+                    raise TrackerAuthenticationError("GitHub authentication failed")
+                elif response.status_code >= 400:
+                    raise TrackerResponseError(
+                        f"GitHub API error: {response.status_code} - {response.text}"
+                    )
+                return response.json(), dict(response.headers)
             except httpx.RequestError as e:
                 raise TrackerConnectionError(f"GitHub connection error: {str(e)}")
 
@@ -2014,6 +2057,70 @@ class GitHubTracker(BaseTracker):
         except Exception as e:
             logger.error(f"Error getting pull request {pr_number}: {e}")
             raise TrackerResponseError(f"Failed to get pull request: {e}")
+
+    async def list_pull_requests(
+        self,
+        state: str = "open",
+        limit: int = 20,
+        page: int = 1,
+    ) -> Dict[str, Any]:
+        """List pull requests for the connected repository.
+
+        Args:
+            state: GitHub PR state (open, closed, all).
+            limit: Page size (per_page).
+            page: 1-based page number.
+
+        Returns:
+            Dict with normalized ``items`` and ``has_more`` from the Link header.
+        """
+        owner = self.connection_details.get("owner")
+        repo = self.connection_details.get("repo")
+        if not owner or not repo:
+            raise TrackerResponseError("Owner/repo not found in connection details")
+
+        path = f"/repos/{owner}/{repo}/pulls"
+        params = {
+            "state": state,
+            "per_page": limit,
+            "page": page,
+            "sort": "updated",
+            "direction": "desc",
+        }
+        raw, headers = await self._request_with_headers("GET", path, params=params)
+        if not isinstance(raw, list):
+            raise TrackerResponseError("GitHub pull request list was not an array")
+        items = [self._normalize_listed_pull_request(pr) for pr in raw]
+        return {
+            "items": items,
+            "has_more": _github_link_has_next(
+                headers.get("Link") or headers.get("link")
+            ),
+        }
+
+    def _normalize_listed_pull_request(self, pr_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Map a GitHub pulls-list item to the shared PR list shape."""
+        user = pr_data.get("user") if isinstance(pr_data.get("user"), dict) else {}
+        head = pr_data.get("head") if isinstance(pr_data.get("head"), dict) else {}
+        base = pr_data.get("base") if isinstance(pr_data.get("base"), dict) else {}
+        number = int(pr_data.get("number") or 0)
+        state = str(pr_data.get("state") or "open")
+        if state == "opened":
+            state = "open"
+        return {
+            "number": number,
+            "iid": number,
+            "title": pr_data.get("title") or "",
+            "description": pr_data.get("body") or "",
+            "url": pr_data.get("html_url") or "",
+            "author": user.get("login") or "",
+            "source_branch": head.get("ref") or "",
+            "target_branch": base.get("ref") or "",
+            "state": state,
+            "draft": bool(pr_data.get("draft", False)),
+            "created_at": pr_data.get("created_at"),
+            "updated_at": pr_data.get("updated_at"),
+        }
 
     async def update_pull_request(
         self,

--- a/backend/preloop/sync/trackers/github.py
+++ b/backend/preloop/sync/trackers/github.py
@@ -223,47 +223,11 @@ class GitHubTracker(BaseTracker):
         data: Optional[Dict[str, Any]] = None,
         params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        """
-        Make a request to the GitHub API.
-
-        Args:
-            method: HTTP method (GET, POST, PATCH, PUT, DELETE)
-            endpoint: API endpoint path
-            data: Request body data
-            params: Query parameters
-
-        Returns:
-            Response data
-        """
-        url = (
-            f"{self.API_BASE_URL}{endpoint}"
-            if endpoint.startswith("/")
-            else f"{self.API_BASE_URL}/{endpoint}"
+        """Make a request to the GitHub API and return the JSON body."""
+        body, _headers = await self._request_with_headers(
+            method, endpoint, data, params
         )
-
-        # Get auth headers (may refresh installation token for github_app auth)
-        headers = await self._get_auth_headers()
-
-        async with httpx.AsyncClient() as client:
-            try:
-                response = await client.request(
-                    method,
-                    url,
-                    headers=headers,
-                    json=data,
-                    params=params,
-                )
-
-                if response.status_code == HTTP_STATUS_UNAUTHORIZED:
-                    raise TrackerAuthenticationError("GitHub authentication failed")
-                elif response.status_code >= 400:
-                    raise TrackerResponseError(
-                        f"GitHub API error: {response.status_code} - {response.text}"
-                    )
-
-                return response.json()
-            except httpx.RequestError as e:
-                raise TrackerConnectionError(f"GitHub connection error: {str(e)}")
+        return body
 
     async def _request_with_headers(
         self,

--- a/backend/preloop/sync/trackers/gitlab.py
+++ b/backend/preloop/sync/trackers/gitlab.py
@@ -44,6 +44,23 @@ from preloop.schemas.tracker_models import (
 )
 
 
+def _gitlab_has_next_page(gl: Any) -> bool:
+    """Return True when the last GitLab response has a next page.
+
+    python-gitlab stores the last HTTP response as ``http_last_response``
+    (or ``_http_last_response`` on older clients). ``X-Next-Page`` is set
+    when another page exists.
+    """
+    response = getattr(gl, "http_last_response", None) or getattr(
+        gl, "_http_last_response", None
+    )
+    if response is None:
+        return False
+    headers = getattr(response, "headers", None) or {}
+    next_page = headers.get("X-Next-Page") or headers.get("x-next-page")
+    return bool(str(next_page).strip()) if next_page is not None else False
+
+
 def _discussion_notes(discussion: Any) -> List[Any]:
     """Return discussion notes from python-gitlab list or manager objects."""
     notes = getattr(discussion, "notes", [])
@@ -1560,6 +1577,81 @@ class GitLabTracker(BaseTracker):
         except Exception as e:
             logger.error(f"Error getting merge request {mr_iid}: {e}")
             raise TrackerResponseError(f"Failed to get merge request: {e}")
+
+    async def list_merge_requests(
+        self,
+        state: str = "open",
+        limit: int = 20,
+        page: int = 1,
+    ) -> Dict[str, Any]:
+        """List merge requests for the connected GitLab project.
+
+        Args:
+            state: Normalized state (open maps to GitLab opened).
+            limit: Page size (per_page).
+            page: 1-based page number.
+
+        Returns:
+            Dict with normalized ``items`` and ``has_more`` from X-Next-Page.
+        """
+        project_id = self._get_project_id()
+        gitlab_state = "opened" if state == "open" else state
+        project = await self._make_request(self.gl.projects.get, project_id)
+        mrs = await self._make_request(
+            project.mergerequests.list,
+            state=gitlab_state,
+            order_by="updated_at",
+            sort="desc",
+            per_page=limit,
+            page=page,
+        )
+        items = [self._normalize_listed_merge_request(mr) for mr in mrs or []]
+        return {"items": items, "has_more": _gitlab_has_next_page(self.gl)}
+
+    def _normalize_listed_merge_request(self, mr: Any) -> Dict[str, Any]:
+        """Map a python-gitlab MR object (or dict) to the shared PR list shape."""
+        if isinstance(mr, dict):
+            data = mr
+        else:
+            data = getattr(mr, "attributes", None)
+            if not isinstance(data, dict):
+                data = {
+                    "iid": getattr(mr, "iid", None),
+                    "title": getattr(mr, "title", None),
+                    "description": getattr(mr, "description", None),
+                    "web_url": getattr(mr, "web_url", None),
+                    "author": getattr(mr, "author", None),
+                    "source_branch": getattr(mr, "source_branch", None),
+                    "target_branch": getattr(mr, "target_branch", None),
+                    "state": getattr(mr, "state", None),
+                    "draft": getattr(mr, "draft", None),
+                    "work_in_progress": getattr(mr, "work_in_progress", None),
+                    "created_at": getattr(mr, "created_at", None),
+                    "updated_at": getattr(mr, "updated_at", None),
+                }
+        author = data.get("author")
+        if isinstance(author, dict):
+            author_name = author.get("username") or author.get("name") or ""
+        else:
+            author_name = author or ""
+        iid = int(data.get("iid") or 0)
+        raw_state = str(data.get("state") or "open")
+        state = "open" if raw_state in ("opened", "open") else raw_state
+        draft = bool(data.get("draft") or data.get("work_in_progress") or False)
+        return {
+            "number": iid,
+            "iid": iid,
+            "title": data.get("title") or "",
+            "description": data.get("description") or "",
+            "url": data.get("web_url") or data.get("url") or "",
+            "author": author_name,
+            "source_branch": data.get("source_branch") or "",
+            "target_branch": data.get("target_branch") or "",
+            "state": state,
+            "draft": draft,
+            "created_at": data.get("created_at"),
+            "updated_at": data.get("updated_at"),
+        }
 
     async def update_merge_request(
         self,

--- a/backend/preloop/sync/trackers/gitlab.py
+++ b/backend/preloop/sync/trackers/gitlab.py
@@ -1575,9 +1575,10 @@ class GitLabTracker(BaseTracker):
             page: 1-based page number.
 
         Returns:
-            Dict with normalized ``items`` and ``has_more``. python-gitlab
-            7.0.0 discards the paginated list object when ``page`` is set,
-            so ``has_more`` is computed by requesting one extra item.
+            Dict with normalized ``items`` and ``has_more``. ``has_more`` is
+            a peek at the next page (``per_page=1``) so consecutive pages
+            stay contiguous. Fetching ``limit + 1`` on a page-based API
+            would skip every ``(limit + 1)``-th merge request.
         """
         project_id = self._get_project_id()
         gitlab_state = "opened" if state == "open" else state
@@ -1587,12 +1588,22 @@ class GitLabTracker(BaseTracker):
             state=gitlab_state,
             order_by="updated_at",
             sort="desc",
-            per_page=limit + 1,
+            per_page=limit,
             page=page,
         )
         rows = list(mrs or [])
-        has_more = len(rows) > limit
-        items = [self._normalize_listed_merge_request(mr) for mr in rows[:limit]]
+        has_more = False
+        if len(rows) == limit:
+            nxt = await self._make_request(
+                project.mergerequests.list,
+                state=gitlab_state,
+                order_by="updated_at",
+                sort="desc",
+                per_page=1,
+                page=page + 1,
+            )
+            has_more = bool(list(nxt or []))
+        items = [self._normalize_listed_merge_request(mr) for mr in rows]
         return {"items": items, "has_more": has_more}
 
     def _normalize_listed_merge_request(self, mr: Any) -> Dict[str, Any]:

--- a/backend/preloop/sync/trackers/gitlab.py
+++ b/backend/preloop/sync/trackers/gitlab.py
@@ -44,23 +44,6 @@ from preloop.schemas.tracker_models import (
 )
 
 
-def _gitlab_has_next_page(gl: Any) -> bool:
-    """Return True when the last GitLab response has a next page.
-
-    python-gitlab stores the last HTTP response as ``http_last_response``
-    (or ``_http_last_response`` on older clients). ``X-Next-Page`` is set
-    when another page exists.
-    """
-    response = getattr(gl, "http_last_response", None) or getattr(
-        gl, "_http_last_response", None
-    )
-    if response is None:
-        return False
-    headers = getattr(response, "headers", None) or {}
-    next_page = headers.get("X-Next-Page") or headers.get("x-next-page")
-    return bool(str(next_page).strip()) if next_page is not None else False
-
-
 def _discussion_notes(discussion: Any) -> List[Any]:
     """Return discussion notes from python-gitlab list or manager objects."""
     notes = getattr(discussion, "notes", [])
@@ -1592,7 +1575,9 @@ class GitLabTracker(BaseTracker):
             page: 1-based page number.
 
         Returns:
-            Dict with normalized ``items`` and ``has_more`` from X-Next-Page.
+            Dict with normalized ``items`` and ``has_more``. python-gitlab
+            7.0.0 discards the paginated list object when ``page`` is set,
+            so ``has_more`` is computed by requesting one extra item.
         """
         project_id = self._get_project_id()
         gitlab_state = "opened" if state == "open" else state
@@ -1602,11 +1587,13 @@ class GitLabTracker(BaseTracker):
             state=gitlab_state,
             order_by="updated_at",
             sort="desc",
-            per_page=limit,
+            per_page=limit + 1,
             page=page,
         )
-        items = [self._normalize_listed_merge_request(mr) for mr in mrs or []]
-        return {"items": items, "has_more": _gitlab_has_next_page(self.gl)}
+        rows = list(mrs or [])
+        has_more = len(rows) > limit
+        items = [self._normalize_listed_merge_request(mr) for mr in rows[:limit]]
+        return {"items": items, "has_more": has_more}
 
     def _normalize_listed_merge_request(self, mr: Any) -> Dict[str, Any]:
         """Map a python-gitlab MR object (or dict) to the shared PR list shape."""

--- a/backend/tests/endpoints/test_pull_requests.py
+++ b/backend/tests/endpoints/test_pull_requests.py
@@ -1,0 +1,189 @@
+"""Tests for GET /projects/{project_id}/pull-requests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from preloop.api.endpoints.pull_requests import clear_pull_request_list_cache
+from preloop.models.crud import crud_organization, crud_project, crud_tracker
+from preloop.models.models.user import User
+from preloop.sync.exceptions import TrackerResponseError
+
+
+@pytest.fixture(autouse=True)
+def _clear_pr_cache() -> None:
+    clear_pull_request_list_cache()
+    yield
+    clear_pull_request_list_cache()
+
+
+@pytest.fixture
+def pr_project_data(db_session: Session, test_user: User) -> dict:
+    """Create a tracker, organization, and project for PR list tests."""
+    tracker = crud_tracker.create(
+        db_session,
+        obj_in={
+            "name": "PR Tracker",
+            "tracker_type": "github",
+            "url": "https://github.com/acme",
+            "api_key": "test_key",
+            "account_id": str(test_user.account_id),
+            "is_active": True,
+        },
+    )
+    db_session.flush()
+    org = crud_organization.create(
+        db_session,
+        obj_in={
+            "name": "acme",
+            "identifier": "acme",
+            "tracker_id": str(tracker.id),
+            "is_active": True,
+        },
+    )
+    db_session.flush()
+    project = crud_project.create(
+        db_session,
+        obj_in={
+            "name": "widgets",
+            "identifier": "widgets",
+            "slug": "acme/widgets",
+            "organization_id": str(org.id),
+            "is_active": True,
+        },
+    )
+    db_session.flush()
+    return {"tracker": tracker, "organization": org, "project": project}
+
+
+def _listed_pr() -> dict:
+    return {
+        "number": 12,
+        "iid": 12,
+        "title": "Add login",
+        "description": "Please review",
+        "url": "https://github.com/acme/widgets/pull/12",
+        "author": "janedoe",
+        "source_branch": "feature",
+        "target_branch": "main",
+        "state": "open",
+        "draft": False,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-02T00:00:00Z",
+    }
+
+
+@patch(
+    "preloop.api.endpoints.pull_requests.get_tracker_client",
+    new_callable=AsyncMock,
+)
+def test_list_prs_cached_within_ttl(
+    mock_get_client: AsyncMock,
+    client: TestClient,
+    db_session: Session,
+    test_user: User,
+    pr_project_data: dict,
+) -> None:
+    """Two GETs within the TTL call the tracker client once."""
+    del db_session, test_user
+    tracker_client = MagicMock()
+    tracker_client.list_pull_requests = AsyncMock(
+        return_value={"items": [_listed_pr()], "has_more": False}
+    )
+    mock_get_client.return_value = tracker_client
+    project = pr_project_data["project"]
+    url = f"/api/v1/projects/{project.id}/pull-requests"
+
+    first = client.get(url)
+    second = client.get(url)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["items"][0]["number"] == 12
+    assert second.json()["items"][0]["number"] == 12
+    assert first.json()["supported"] is True
+    assert tracker_client.list_pull_requests.await_count == 1
+    mock_get_client.assert_awaited_once()
+
+
+@patch(
+    "preloop.api.endpoints.pull_requests.get_tracker_client",
+    new_callable=AsyncMock,
+)
+def test_refresh_bypasses_cache(
+    mock_get_client: AsyncMock,
+    client: TestClient,
+    db_session: Session,
+    test_user: User,
+    pr_project_data: dict,
+) -> None:
+    """?refresh=1 skips the TTL cache and fetches again."""
+    del db_session, test_user
+    tracker_client = MagicMock()
+    tracker_client.list_pull_requests = AsyncMock(
+        return_value={"items": [_listed_pr()], "has_more": True}
+    )
+    mock_get_client.return_value = tracker_client
+    project = pr_project_data["project"]
+    url = f"/api/v1/projects/{project.id}/pull-requests"
+
+    assert client.get(url).status_code == 200
+    refreshed = client.get(f"{url}?refresh=1")
+    assert refreshed.status_code == 200
+    assert refreshed.json()["has_more"] is True
+    assert tracker_client.list_pull_requests.await_count == 2
+
+
+def test_unsupported_tracker_returns_supported_false(
+    client: TestClient,
+    db_session: Session,
+    test_user: User,
+    pr_project_data: dict,
+) -> None:
+    """Jira projects return 200 with supported false and no items."""
+    del test_user
+    tracker = pr_project_data["tracker"]
+    tracker.tracker_type = "jira"
+    db_session.add(tracker)
+    db_session.flush()
+    project = pr_project_data["project"]
+
+    with patch(
+        "preloop.api.endpoints.pull_requests.get_tracker_client",
+        new_callable=AsyncMock,
+    ) as mock_get_client:
+        response = client.get(f"/api/v1/projects/{project.id}/pull-requests")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["supported"] is False
+    assert data["items"] == []
+    assert data["has_more"] is False
+    mock_get_client.assert_not_called()
+
+
+@patch(
+    "preloop.api.endpoints.pull_requests.get_tracker_client",
+    new_callable=AsyncMock,
+)
+def test_tracker_error_returns_502(
+    mock_get_client: AsyncMock,
+    client: TestClient,
+    db_session: Session,
+    test_user: User,
+    pr_project_data: dict,
+) -> None:
+    """Tracker failures become 502 with a stable detail string."""
+    del db_session, test_user
+    tracker_client = MagicMock()
+    tracker_client.list_pull_requests = AsyncMock(
+        side_effect=TrackerResponseError("GitHub API error: 502")
+    )
+    mock_get_client.return_value = tracker_client
+    project = pr_project_data["project"]
+
+    response = client.get(f"/api/v1/projects/{project.id}/pull-requests")
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Tracker request failed"

--- a/backend/tests/endpoints/test_pull_requests.py
+++ b/backend/tests/endpoints/test_pull_requests.py
@@ -6,8 +6,18 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from preloop.api.endpoints.pull_requests import clear_pull_request_list_cache
-from preloop.models.crud import crud_organization, crud_project, crud_tracker
+from preloop.api.auth import get_current_active_user
+from preloop.api.endpoints.pull_requests import (
+    _cache_key,
+    clear_pull_request_list_cache,
+)
+from preloop.models.crud import (
+    crud_account,
+    crud_organization,
+    crud_project,
+    crud_tracker,
+    crud_user,
+)
 from preloop.models.models.user import User
 from preloop.sync.exceptions import TrackerResponseError
 
@@ -187,3 +197,94 @@ def test_tracker_error_returns_502(
     response = client.get(f"/api/v1/projects/{project.id}/pull-requests")
     assert response.status_code == 502
     assert response.json()["detail"] == "Tracker request failed"
+
+
+def test_invalid_state_422(
+    client: TestClient,
+    db_session: Session,
+    test_user: User,
+    pr_project_data: dict,
+) -> None:
+    """state=closed is rejected by the open-only query parameter."""
+    del db_session, test_user
+    project = pr_project_data["project"]
+    response = client.get(
+        f"/api/v1/projects/{project.id}/pull-requests",
+        params={"state": "closed"},
+    )
+    assert response.status_code == 422
+
+
+@patch(
+    "preloop.api.endpoints.pull_requests.get_tracker_client",
+    new_callable=AsyncMock,
+)
+def test_cache_is_scoped_per_account(
+    mock_get_client: AsyncMock,
+    app,
+    client: TestClient,
+    db_session: Session,
+    test_user: User,
+    pr_project_data: dict,
+) -> None:
+    """A second account cannot read the first account's cached PR list."""
+    tracker_client = MagicMock()
+    tracker_client.list_pull_requests = AsyncMock(
+        return_value={"items": [_listed_pr()], "has_more": False}
+    )
+    mock_get_client.return_value = tracker_client
+    project = pr_project_data["project"]
+    url = f"/api/v1/projects/{project.id}/pull-requests"
+
+    first = client.get(url)
+    assert first.status_code == 200
+    assert first.json()["items"][0]["number"] == 12
+
+    other_account = crud_account.create(
+        db_session, obj_in={"organization_name": "Other Org", "is_active": True}
+    )
+    other_user = crud_user.create(
+        db_session,
+        obj_in={
+            "account_id": other_account.id,
+            "email": "other@example.com",
+            "username": "otheruser",
+            "full_name": "Jane Doe",
+            "is_active": True,
+            "email_verified": True,
+            "hashed_password": "x",
+            "user_source": "local",
+        },
+    )
+    db_session.flush()
+
+    assert _cache_key(test_user.account_id, project.id, "open", 1, 20) != _cache_key(
+        other_account.id, project.id, "open", 1, 20
+    )
+
+    app.dependency_overrides[get_current_active_user] = lambda: other_user
+    second = client.get(url)
+    assert second.status_code == 404
+    assert tracker_client.list_pull_requests.await_count == 1
+
+
+@patch(
+    "preloop.api.endpoints.pull_requests.get_tracker_client",
+    new_callable=AsyncMock,
+)
+def test_programming_error_is_not_mapped_to_502(
+    mock_get_client: AsyncMock,
+    client: TestClient,
+    db_session: Session,
+    test_user: User,
+    pr_project_data: dict,
+) -> None:
+    """Normalizer or client bugs must not become a tracker 502."""
+    del db_session, test_user
+    tracker_client = MagicMock()
+    tracker_client.list_pull_requests = AsyncMock(side_effect=TypeError("bug"))
+    mock_get_client.return_value = tracker_client
+    project = pr_project_data["project"]
+
+    with pytest.raises(TypeError, match="bug"):
+        client.get(f"/api/v1/projects/{project.id}/pull-requests")

--- a/backend/tests/services/test_preset_runner.py
+++ b/backend/tests/services/test_preset_runner.py
@@ -1,22 +1,25 @@
 """Tests for resolve-or-create and issue trigger payloads."""
 
 import uuid
-from unittest.mock import MagicMock, patch
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
 from preloop.services.preset_runner import (
     IMPLEMENTER_SLUG,
+    REVIEWER_SLUG,
     PresetRunnerError,
     _load_visible_issue,
     build_issue_trigger_payload,
     build_pull_request_trigger_payload,
     resolve_or_create_flow,
+    run_preset_on_target,
 )
 from preloop.services.prompt_resolvers.base import ResolverContext
 from preloop.services.prompt_resolvers.trigger_event import TriggerEventResolver
+from preloop.sync.exceptions import TrackerResponseError
 
 
 class _Simple:
@@ -448,6 +451,7 @@ def _gitlab_project_tracker():
 def _github_pr_payload(*, tracker_url: str = "https://github.com") -> dict:
     project, tracker = _github_project_tracker(tracker_url=tracker_url)
     pr = {
+        "id": "2451234567",
         "number": 12,
         "title": "Add login",
         "description": "Please review the login form",
@@ -464,6 +468,7 @@ def _github_pr_payload(*, tracker_url: str = "https://github.com") -> dict:
 def _gitlab_mr_payload() -> dict:
     project, tracker = _gitlab_project_tracker()
     mr = {
+        "id": "2451234567",
         "iid": 7,
         "title": "Fix login",
         "description": "Login 401",
@@ -503,6 +508,7 @@ async def test_github_pr_payload_resolves_object_attributes():
         "payload.object_attributes.target_branch", context
     )
     trigger = await resolver.resolve("type", context)
+    number = await resolver.resolve("payload.object_attributes.number", context)
     assert title == "Add login"
     assert description == "Please review the login form"
     assert author == "janedoe"
@@ -510,6 +516,8 @@ async def test_github_pr_payload_resolves_object_attributes():
     assert source_branch == "feature"
     assert target_branch == "main"
     assert trigger == "pull_request_run"
+    assert int(number) == 12
+    assert event["payload"]["pull_request"]["number"] == 12
 
 
 @pytest.mark.asyncio
@@ -520,6 +528,7 @@ async def test_gitlab_mr_payload_branches_and_url():
     normalized = resolver._normalize_event_data(event)
     attrs = normalized["payload"]["object_attributes"]
     assert attrs["iid"] == 7
+    assert attrs["number"] == 7
     assert attrs["source_branch"] == "feature"
     assert attrs["target_branch"] == "main"
     assert attrs["url"] == (
@@ -550,3 +559,126 @@ def test_pr_payload_sets_top_level_project_id_and_web_host_clone_fields():
     assert repo["clone_url"] == "https://github.com/example/repo.git"
     assert repo["html_url"] == "https://github.com/example/repo"
     assert event["payload"]["pull_request"]["user"]["login"] == "janedoe"
+
+
+@pytest.mark.asyncio
+async def test_run_preset_on_pull_request_probe_then_trigger() -> None:
+    account_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    flow = _account_flow(name="Pull Request Reviewer")
+    project, tracker = _github_project_tracker()
+    organization = MagicMock()
+    organization.id = uuid.uuid4()
+    user = _user(account_id)
+    target = _Simple(kind="pull_request", project_id=project_id, number=12)
+    tracker_client = MagicMock()
+    tracker_client.get_pull_request = AsyncMock(
+        return_value={
+            "id": "2451234567",
+            "number": 12,
+            "title": "Add login",
+            "description": "Please review",
+            "url": "https://github.com/example/repo/pull/12",
+            "author": {"login": "janedoe"},
+            "source_branch": "feature",
+            "target_branch": "main",
+            "state": "open",
+            "is_draft": False,
+        }
+    )
+    trigger = AsyncMock(return_value={"id": str(uuid.uuid4())})
+
+    with (
+        patch(
+            "preloop.services.preset_runner._load_visible_project",
+            return_value=(project, tracker, organization),
+        ),
+        patch(
+            "preloop.services.preset_runner.resolve_or_create_flow",
+            return_value=(flow, False),
+        ),
+        patch(
+            "preloop.api.common.get_tracker_client",
+            new_callable=AsyncMock,
+            return_value=tracker_client,
+        ),
+        patch(
+            "preloop.services.flow_trigger_service.FlowTriggerService.trigger_flow",
+            trigger,
+        ),
+    ):
+        probe = await run_preset_on_target(
+            MagicMock(),
+            current_user=user,
+            preset_slug=REVIEWER_SLUG,
+            target=target,
+            confirm_create=False,
+            triggered_by="Jane Doe",
+        )
+        assert probe["execution_id"] is None
+        tracker_client.get_pull_request.assert_not_awaited()
+        trigger.assert_not_awaited()
+
+        confirmed = await run_preset_on_target(
+            MagicMock(),
+            current_user=user,
+            preset_slug=REVIEWER_SLUG,
+            target=target,
+            confirm_create=True,
+            triggered_by="Jane Doe",
+        )
+
+    tracker_client.get_pull_request.assert_awaited_once_with("12")
+    trigger.assert_awaited_once()
+    assert trigger.await_args.kwargs["test_mode"] is False
+    payload = trigger.await_args.kwargs["trigger_event_data"]["payload"]
+    assert payload["pull_request"]["number"] == 12
+    assert confirmed["execution_id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_run_preset_on_pull_request_502_when_tracker_fails() -> None:
+    account_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    flow = _account_flow(name="Pull Request Reviewer")
+    project, tracker = _github_project_tracker()
+    organization = MagicMock()
+    organization.id = uuid.uuid4()
+    user = _user(account_id)
+    target = _Simple(kind="pull_request", project_id=project_id, number=12)
+    tracker_client = MagicMock()
+    tracker_client.get_pull_request = AsyncMock(
+        side_effect=TrackerResponseError("GitHub API error: 502")
+    )
+
+    with (
+        patch(
+            "preloop.services.preset_runner._load_visible_project",
+            return_value=(project, tracker, organization),
+        ),
+        patch(
+            "preloop.services.preset_runner.resolve_or_create_flow",
+            return_value=(flow, False),
+        ),
+        patch(
+            "preloop.api.common.get_tracker_client",
+            new_callable=AsyncMock,
+            return_value=tracker_client,
+        ),
+        patch(
+            "preloop.services.flow_trigger_service.FlowTriggerService.trigger_flow",
+        ) as trigger,
+    ):
+        with pytest.raises(PresetRunnerError) as exc:
+            await run_preset_on_target(
+                MagicMock(),
+                current_user=user,
+                preset_slug=REVIEWER_SLUG,
+                target=target,
+                confirm_create=True,
+                triggered_by="Jane Doe",
+            )
+
+    assert exc.value.status_code == 502
+    assert exc.value.detail == "Tracker request failed"
+    trigger.assert_not_awaited()

--- a/backend/tests/services/test_preset_runner.py
+++ b/backend/tests/services/test_preset_runner.py
@@ -682,3 +682,63 @@ async def test_run_preset_on_pull_request_502_when_tracker_fails() -> None:
     assert exc.value.status_code == 502
     assert exc.value.detail == "Tracker request failed"
     trigger.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_preset_on_pull_request_500_when_trigger_omits_execution_id() -> None:
+    account_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    flow = _account_flow(name="Pull Request Reviewer")
+    project, tracker = _github_project_tracker()
+    organization = MagicMock()
+    organization.id = uuid.uuid4()
+    user = _user(account_id)
+    target = _Simple(kind="pull_request", project_id=project_id, number=12)
+    tracker_client = MagicMock()
+    tracker_client.get_pull_request = AsyncMock(
+        return_value={
+            "id": "2451234567",
+            "number": 12,
+            "title": "Add login",
+            "description": "Please review",
+            "url": "https://github.com/example/repo/pull/12",
+            "author": {"login": "janedoe"},
+            "source_branch": "feature",
+            "target_branch": "main",
+            "state": "open",
+            "is_draft": False,
+        }
+    )
+    trigger = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "preloop.services.preset_runner._load_visible_project",
+            return_value=(project, tracker, organization),
+        ),
+        patch(
+            "preloop.services.preset_runner.resolve_or_create_flow",
+            return_value=(flow, False),
+        ),
+        patch(
+            "preloop.api.common.get_tracker_client",
+            new_callable=AsyncMock,
+            return_value=tracker_client,
+        ),
+        patch(
+            "preloop.services.flow_trigger_service.FlowTriggerService.trigger_flow",
+            trigger,
+        ),
+    ):
+        with pytest.raises(PresetRunnerError) as exc:
+            await run_preset_on_target(
+                MagicMock(),
+                current_user=user,
+                preset_slug=REVIEWER_SLUG,
+                target=target,
+                confirm_create=True,
+                triggered_by="Jane Doe",
+            )
+
+    assert exc.value.status_code == 500
+    assert "execution id" in str(exc.value.detail)

--- a/backend/tests/services/test_preset_runner.py
+++ b/backend/tests/services/test_preset_runner.py
@@ -12,6 +12,7 @@ from preloop.services.preset_runner import (
     PresetRunnerError,
     _load_visible_issue,
     build_issue_trigger_payload,
+    build_pull_request_trigger_payload,
     resolve_or_create_flow,
 )
 from preloop.services.prompt_resolvers.base import ResolverContext
@@ -410,3 +411,142 @@ def test_github_api_host_uses_github_com_clone_url():
     repo = event["payload"]["repository"]
     assert repo["clone_url"] == "https://github.com/example/repo.git"
     assert repo["html_url"] == "https://github.com/example/repo"
+
+
+def _github_project_tracker(*, tracker_url: str = "https://github.com"):
+    project = MagicMock()
+    project.id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    project.name = "repo"
+    project.slug = "example/repo"
+    project.identifier = "99"
+    project.settings = {}
+    project.meta_data = {"default_branch": "main"}
+    tracker = MagicMock()
+    tracker.id = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+    tracker.account_id = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+    tracker.tracker_type = "github"
+    tracker.url = tracker_url
+    return project, tracker
+
+
+def _gitlab_project_tracker():
+    project = MagicMock()
+    project.id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    project.name = "project"
+    project.slug = "group/project"
+    project.identifier = "321"
+    project.settings = {}
+    project.meta_data = {}
+    tracker = MagicMock()
+    tracker.id = uuid.UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+    tracker.account_id = uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+    tracker.tracker_type = "gitlab"
+    tracker.url = "https://gitlab.example.com"
+    return project, tracker
+
+
+def _github_pr_payload(*, tracker_url: str = "https://github.com") -> dict:
+    project, tracker = _github_project_tracker(tracker_url=tracker_url)
+    pr = {
+        "number": 12,
+        "title": "Add login",
+        "description": "Please review the login form",
+        "url": "https://github.com/example/repo/pull/12",
+        "author": {"login": "janedoe"},
+        "source_branch": "feature",
+        "target_branch": "main",
+        "state": "open",
+        "is_draft": False,
+    }
+    return build_pull_request_trigger_payload(pr, project, tracker)
+
+
+def _gitlab_mr_payload() -> dict:
+    project, tracker = _gitlab_project_tracker()
+    mr = {
+        "iid": 7,
+        "title": "Fix login",
+        "description": "Login 401",
+        "url": "https://gitlab.example.com/group/project/-/merge_requests/7",
+        "author": {"username": "janedoe"},
+        "source_branch": "feature",
+        "target_branch": "main",
+        "state": "opened",
+        "work_in_progress": False,
+    }
+    return build_pull_request_trigger_payload(mr, project, tracker)
+
+
+@pytest.mark.asyncio
+async def test_github_pr_payload_resolves_object_attributes():
+    event = _github_pr_payload()
+    assert event["type"] == "pull_request_run"
+    assert event["source"] == "github"
+    assert event["payload"]["project_id"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    resolver = TriggerEventResolver()
+    context = ResolverContext(
+        db=MagicMock(),
+        trigger_event_data=event,
+        flow_id="flow-1",
+        execution_id="exec-1",
+    )
+    title = await resolver.resolve("payload.object_attributes.title", context)
+    description = await resolver.resolve(
+        "payload.object_attributes.description", context
+    )
+    author = await resolver.resolve("payload.object_attributes.author", context)
+    url = await resolver.resolve("payload.object_attributes.url", context)
+    source_branch = await resolver.resolve(
+        "payload.object_attributes.source_branch", context
+    )
+    target_branch = await resolver.resolve(
+        "payload.object_attributes.target_branch", context
+    )
+    trigger = await resolver.resolve("type", context)
+    assert title == "Add login"
+    assert description == "Please review the login form"
+    assert author == "janedoe"
+    assert url == "https://github.com/example/repo/pull/12"
+    assert source_branch == "feature"
+    assert target_branch == "main"
+    assert trigger == "pull_request_run"
+
+
+@pytest.mark.asyncio
+async def test_gitlab_mr_payload_branches_and_url():
+    event = _gitlab_mr_payload()
+    assert event["payload"]["object_kind"] == "merge_request"
+    resolver = TriggerEventResolver()
+    normalized = resolver._normalize_event_data(event)
+    attrs = normalized["payload"]["object_attributes"]
+    assert attrs["iid"] == 7
+    assert attrs["source_branch"] == "feature"
+    assert attrs["target_branch"] == "main"
+    assert attrs["url"] == (
+        "https://gitlab.example.com/group/project/-/merge_requests/7"
+    )
+    assert attrs["author"] == "janedoe"
+    context = ResolverContext(
+        db=MagicMock(),
+        trigger_event_data=event,
+        flow_id="flow-1",
+        execution_id="exec-1",
+    )
+    source_branch = await resolver.resolve(
+        "payload.object_attributes.source_branch", context
+    )
+    url = await resolver.resolve("payload.object_attributes.url", context)
+    assert source_branch == "feature"
+    assert url == "https://gitlab.example.com/group/project/-/merge_requests/7"
+
+
+def test_pr_payload_sets_top_level_project_id_and_web_host_clone_fields():
+    event = _github_pr_payload(tracker_url="https://api.github.com")
+    assert event["project_id"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    assert event["tracker_id"] == "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    assert event["account_id"] == "dddddddd-dddd-dddd-dddd-dddddddddddd"
+    assert event["payload"]["project_id"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    repo = event["payload"]["repository"]
+    assert repo["clone_url"] == "https://github.com/example/repo.git"
+    assert repo["html_url"] == "https://github.com/example/repo"
+    assert event["payload"]["pull_request"]["user"]["login"] == "janedoe"

--- a/backend/tests/sync/trackers/test_github_list_pull_requests.py
+++ b/backend/tests/sync/trackers/test_github_list_pull_requests.py
@@ -1,0 +1,83 @@
+"""Tests for GitHubTracker.list_pull_requests."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from preloop.sync.trackers.github import GitHubTracker, _github_link_has_next
+
+
+def _raw_pr() -> dict:
+    return {
+        "number": 42,
+        "title": "Add login",
+        "body": "Please review",
+        "html_url": "https://github.com/acme/widgets/pull/42",
+        "user": {"login": "janedoe"},
+        "head": {"ref": "feature"},
+        "base": {"ref": "main"},
+        "state": "open",
+        "draft": False,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-02T12:00:00Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_open_prs_params_and_normalization():
+    tracker = GitHubTracker(
+        "tracker-1",
+        "token",
+        {"owner": "acme", "repo": "widgets"},
+    )
+    mock_request = AsyncMock(return_value=([_raw_pr()], {}))
+    with patch.object(tracker, "_request_with_headers", mock_request):
+        result = await tracker.list_pull_requests(state="open", limit=20, page=1)
+
+    mock_request.assert_awaited_once()
+    args, kwargs = mock_request.await_args
+    assert args[0] == "GET"
+    assert args[1] == "/repos/acme/widgets/pulls"
+    assert kwargs["params"] == {
+        "state": "open",
+        "per_page": 20,
+        "page": 1,
+        "sort": "updated",
+        "direction": "desc",
+    }
+    assert len(result["items"]) == 1
+    item = result["items"][0]
+    assert item["number"] == 42
+    assert item["iid"] == 42
+    assert item["title"] == "Add login"
+    assert item["description"] == "Please review"
+    assert item["url"] == "https://github.com/acme/widgets/pull/42"
+    assert item["author"] == "janedoe"
+    assert item["source_branch"] == "feature"
+    assert item["target_branch"] == "main"
+    assert item["state"] == "open"
+    assert item["draft"] is False
+    assert item["created_at"] == "2026-01-01T00:00:00Z"
+    assert item["updated_at"] == "2026-01-02T12:00:00Z"
+    assert result["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_has_more_from_link_header():
+    tracker = GitHubTracker(
+        "tracker-1",
+        "token",
+        {"owner": "acme", "repo": "widgets"},
+    )
+    link = (
+        '<https://api.github.com/repos/acme/widgets/pulls?page=2>; rel="next", '
+        '<https://api.github.com/repos/acme/widgets/pulls?page=5>; rel="last"'
+    )
+    mock_request = AsyncMock(return_value=([_raw_pr()], {"Link": link}))
+    with patch.object(tracker, "_request_with_headers", mock_request):
+        result = await tracker.list_pull_requests(state="open", limit=20, page=1)
+
+    assert result["has_more"] is True
+    assert _github_link_has_next(link) is True
+    assert _github_link_has_next(None) is False
+    assert _github_link_has_next('<https://example.com>; rel="prev"') is False

--- a/backend/tests/sync/trackers/test_gitlab_list_merge_requests.py
+++ b/backend/tests/sync/trackers/test_gitlab_list_merge_requests.py
@@ -2,23 +2,18 @@
 
 from unittest.mock import MagicMock, patch
 
+import gitlab
 import pytest
 
 from preloop.sync.trackers.gitlab import GitLabTracker
 
 
-@pytest.mark.asyncio
-async def test_list_opened_mrs_normalization():
-    mock_gl = MagicMock()
-    mock_gl.auth.return_value = None
-    mock_project = MagicMock()
-    mock_gl.projects.get.return_value = mock_project
-
+def _opened_mr(*, iid: int) -> MagicMock:
     mr = MagicMock()
-    mr.iid = 7
-    mr.title = "Fix login"
-    mr.description = "Login 401"
-    mr.web_url = "https://gitlab.example.com/group/project/-/merge_requests/7"
+    mr.iid = iid
+    mr.title = "Fix login" if iid == 7 else f"MR {iid}"
+    mr.description = "Login 401" if iid == 7 else ""
+    mr.web_url = f"https://gitlab.example.com/group/project/-/merge_requests/{iid}"
     mr.author = {"username": "janedoe"}
     mr.source_branch = "feature"
     mr.target_branch = "main"
@@ -28,10 +23,10 @@ async def test_list_opened_mrs_normalization():
     mr.created_at = "2026-01-01T00:00:00Z"
     mr.updated_at = "2026-01-02T12:00:00Z"
     mr.attributes = {
-        "iid": 7,
-        "title": "Fix login",
-        "description": "Login 401",
-        "web_url": "https://gitlab.example.com/group/project/-/merge_requests/7",
+        "iid": iid,
+        "title": mr.title,
+        "description": mr.description,
+        "web_url": mr.web_url,
         "author": {"username": "janedoe"},
         "source_branch": "feature",
         "target_branch": "main",
@@ -41,8 +36,19 @@ async def test_list_opened_mrs_normalization():
         "created_at": "2026-01-01T00:00:00Z",
         "updated_at": "2026-01-02T12:00:00Z",
     }
-    mock_project.mergerequests.list.return_value = [mr]
-    mock_gl.http_last_response.headers = {"X-Next-Page": "2"}
+    return mr
+
+
+@pytest.mark.asyncio
+async def test_list_opened_mrs_normalization():
+    mock_gl = MagicMock(spec=gitlab.Gitlab)
+    mock_gl.auth.return_value = None
+    mock_project = MagicMock()
+    mock_gl.projects = MagicMock()
+    mock_gl.projects.get.return_value = mock_project
+
+    mrs = [_opened_mr(iid=7 + index) for index in range(21)]
+    mock_project.mergerequests.list.return_value = mrs
 
     with patch("preloop.sync.trackers.gitlab.gitlab.Gitlab", return_value=mock_gl):
         tracker = GitLabTracker(
@@ -56,10 +62,10 @@ async def test_list_opened_mrs_normalization():
         state="opened",
         order_by="updated_at",
         sort="desc",
-        per_page=20,
+        per_page=21,
         page=1,
     )
-    assert len(result["items"]) == 1
+    assert len(result["items"]) == 20
     item = result["items"][0]
     assert item["number"] == 7
     assert item["iid"] == 7
@@ -74,3 +80,31 @@ async def test_list_opened_mrs_normalization():
     assert item["state"] == "open"
     assert item["draft"] is False
     assert result["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_opened_mrs_has_more_false_without_extra_item():
+    mock_gl = MagicMock(spec=gitlab.Gitlab)
+    mock_gl.auth.return_value = None
+    mock_project = MagicMock()
+    mock_gl.projects = MagicMock()
+    mock_gl.projects.get.return_value = mock_project
+    mock_project.mergerequests.list.return_value = [_opened_mr(iid=7)]
+
+    with patch("preloop.sync.trackers.gitlab.gitlab.Gitlab", return_value=mock_gl):
+        tracker = GitLabTracker(
+            "tracker-1",
+            "token",
+            {"project_id": "99", "url": "https://gitlab.example.com"},
+        )
+        result = await tracker.list_merge_requests(state="open", limit=20, page=1)
+
+    mock_project.mergerequests.list.assert_called_once_with(
+        state="opened",
+        order_by="updated_at",
+        sort="desc",
+        per_page=21,
+        page=1,
+    )
+    assert len(result["items"]) == 1
+    assert result["has_more"] is False

--- a/backend/tests/sync/trackers/test_gitlab_list_merge_requests.py
+++ b/backend/tests/sync/trackers/test_gitlab_list_merge_requests.py
@@ -1,0 +1,76 @@
+"""Tests for GitLabTracker.list_merge_requests."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from preloop.sync.trackers.gitlab import GitLabTracker
+
+
+@pytest.mark.asyncio
+async def test_list_opened_mrs_normalization():
+    mock_gl = MagicMock()
+    mock_gl.auth.return_value = None
+    mock_project = MagicMock()
+    mock_gl.projects.get.return_value = mock_project
+
+    mr = MagicMock()
+    mr.iid = 7
+    mr.title = "Fix login"
+    mr.description = "Login 401"
+    mr.web_url = "https://gitlab.example.com/group/project/-/merge_requests/7"
+    mr.author = {"username": "janedoe"}
+    mr.source_branch = "feature"
+    mr.target_branch = "main"
+    mr.state = "opened"
+    mr.draft = False
+    mr.work_in_progress = False
+    mr.created_at = "2026-01-01T00:00:00Z"
+    mr.updated_at = "2026-01-02T12:00:00Z"
+    mr.attributes = {
+        "iid": 7,
+        "title": "Fix login",
+        "description": "Login 401",
+        "web_url": "https://gitlab.example.com/group/project/-/merge_requests/7",
+        "author": {"username": "janedoe"},
+        "source_branch": "feature",
+        "target_branch": "main",
+        "state": "opened",
+        "draft": False,
+        "work_in_progress": False,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-02T12:00:00Z",
+    }
+    mock_project.mergerequests.list.return_value = [mr]
+    mock_gl.http_last_response.headers = {"X-Next-Page": "2"}
+
+    with patch("preloop.sync.trackers.gitlab.gitlab.Gitlab", return_value=mock_gl):
+        tracker = GitLabTracker(
+            "tracker-1",
+            "token",
+            {"project_id": "99", "url": "https://gitlab.example.com"},
+        )
+        result = await tracker.list_merge_requests(state="open", limit=20, page=1)
+
+    mock_project.mergerequests.list.assert_called_once_with(
+        state="opened",
+        order_by="updated_at",
+        sort="desc",
+        per_page=20,
+        page=1,
+    )
+    assert len(result["items"]) == 1
+    item = result["items"][0]
+    assert item["number"] == 7
+    assert item["iid"] == 7
+    assert item["title"] == "Fix login"
+    assert item["description"] == "Login 401"
+    assert item["url"] == (
+        "https://gitlab.example.com/group/project/-/merge_requests/7"
+    )
+    assert item["author"] == "janedoe"
+    assert item["source_branch"] == "feature"
+    assert item["target_branch"] == "main"
+    assert item["state"] == "open"
+    assert item["draft"] is False
+    assert result["has_more"] is True

--- a/backend/tests/sync/trackers/test_gitlab_list_merge_requests.py
+++ b/backend/tests/sync/trackers/test_gitlab_list_merge_requests.py
@@ -39,6 +39,13 @@ def _opened_mr(*, iid: int) -> MagicMock:
     return mr
 
 
+def _list_slice(all_mrs: list, **kwargs: object) -> list:
+    per_page = int(kwargs["per_page"])
+    page = int(kwargs["page"])
+    start = (page - 1) * per_page
+    return all_mrs[start : start + per_page]
+
+
 @pytest.mark.asyncio
 async def test_list_opened_mrs_normalization():
     mock_gl = MagicMock(spec=gitlab.Gitlab)
@@ -47,8 +54,10 @@ async def test_list_opened_mrs_normalization():
     mock_gl.projects = MagicMock()
     mock_gl.projects.get.return_value = mock_project
 
-    mrs = [_opened_mr(iid=7 + index) for index in range(21)]
-    mock_project.mergerequests.list.return_value = mrs
+    all_mrs = [_opened_mr(iid=7 + index) for index in range(21)]
+    mock_project.mergerequests.list.side_effect = lambda **kwargs: _list_slice(
+        all_mrs, **kwargs
+    )
 
     with patch("preloop.sync.trackers.gitlab.gitlab.Gitlab", return_value=mock_gl):
         tracker = GitLabTracker(
@@ -58,13 +67,15 @@ async def test_list_opened_mrs_normalization():
         )
         result = await tracker.list_merge_requests(state="open", limit=20, page=1)
 
-    mock_project.mergerequests.list.assert_called_once_with(
-        state="opened",
-        order_by="updated_at",
-        sort="desc",
-        per_page=21,
-        page=1,
-    )
+    assert mock_project.mergerequests.list.call_args_list[0].kwargs == {
+        "state": "opened",
+        "order_by": "updated_at",
+        "sort": "desc",
+        "per_page": 20,
+        "page": 1,
+    }
+    assert mock_project.mergerequests.list.call_args_list[1].kwargs["page"] == 2
+    assert mock_project.mergerequests.list.call_args_list[1].kwargs["per_page"] == 1
     assert len(result["items"]) == 20
     item = result["items"][0]
     assert item["number"] == 7
@@ -80,10 +91,36 @@ async def test_list_opened_mrs_normalization():
     assert item["state"] == "open"
     assert item["draft"] is False
     assert result["has_more"] is True
+    assert [row["iid"] for row in result["items"]] == list(range(7, 27))
 
 
 @pytest.mark.asyncio
-async def test_list_opened_mrs_has_more_false_without_extra_item():
+async def test_list_opened_mrs_page_two_is_contiguous():
+    mock_gl = MagicMock(spec=gitlab.Gitlab)
+    mock_gl.auth.return_value = None
+    mock_project = MagicMock()
+    mock_gl.projects = MagicMock()
+    mock_gl.projects.get.return_value = mock_project
+
+    all_mrs = [_opened_mr(iid=7 + index) for index in range(21)]
+    mock_project.mergerequests.list.side_effect = lambda **kwargs: _list_slice(
+        all_mrs, **kwargs
+    )
+
+    with patch("preloop.sync.trackers.gitlab.gitlab.Gitlab", return_value=mock_gl):
+        tracker = GitLabTracker(
+            "tracker-1",
+            "token",
+            {"project_id": "99", "url": "https://gitlab.example.com"},
+        )
+        result = await tracker.list_merge_requests(state="open", limit=20, page=2)
+
+    assert [row["iid"] for row in result["items"]] == [27]
+    assert result["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_opened_mrs_has_more_false_without_full_page():
     mock_gl = MagicMock(spec=gitlab.Gitlab)
     mock_gl.auth.return_value = None
     mock_project = MagicMock()
@@ -103,7 +140,7 @@ async def test_list_opened_mrs_has_more_false_without_extra_item():
         state="opened",
         order_by="updated_at",
         sort="desc",
-        per_page=21,
+        per_page=20,
         page=1,
     )
     assert len(result["items"]) == 1

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -57,6 +57,8 @@ The Tracker Detail page is the entry point for issue analytics. Clicking a track
 *   **Tracker metadata:** Name, type, connection status, creation/update dates, URL, and scope rules.
 *   **Issue Analytics cards:** Conditional links to Similarity, Compliance, and Dependencies views, gated by feature flags (`issue_duplicates`, `issue_compliance`, `issue_dependencies`). Each link pre-filters to projects belonging to that tracker via `?projects=` query parameters.
 *   **Projects list:** All projects synced under this tracker.
+*   **Issues tab:** Open issues for a selected project, with search and Run implementer on GitHub and GitLab.
+*   **Pull requests tab:** Open pull requests (GitHub) or merge requests (GitLab), hidden for Jira. The list is live from the tracker (about a one-minute cache) with Run reviewer, using the same create-from-preset path as the issue implementer.
 
 Issue analytics features are no longer accessible from the main sidebar — they are scoped to individual trackers via this detail page.
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -15,6 +15,7 @@ import type {
   Issue,
   IssueListItem,
   IssueListResponse,
+  PullRequestListResponse,
   DuplicatePair,
   DuplicatesResponse,
   IssueComplianceResult,
@@ -2127,6 +2128,29 @@ export async function listIssues(params: {
   const response = await fetchWithAuth(`/api/v1/issues?${query.toString()}`);
   if (!response.ok) {
     throw new Error('Failed to fetch issues');
+  }
+  return response.json();
+}
+
+export async function listProjectPullRequests(
+  projectId: string,
+  params?: {
+    state?: 'open';
+    limit?: number;
+    page?: number;
+    refresh?: boolean;
+  }
+): Promise<PullRequestListResponse> {
+  const query = new URLSearchParams();
+  query.set('state', params?.state || 'open');
+  if (params?.limit !== undefined) query.set('limit', String(params.limit));
+  if (params?.page !== undefined) query.set('page', String(params.page));
+  if (params?.refresh) query.set('refresh', '1');
+  const response = await fetchWithAuth(
+    `/api/v1/projects/${encodeURIComponent(projectId)}/pull-requests?${query.toString()}`
+  );
+  if (!response.ok) {
+    throw new Error('Failed to fetch pull requests');
   }
   return response.json();
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1438,6 +1438,30 @@ export interface IssueListResponse {
   limit: number;
 }
 
+export interface PullRequestListItem {
+  number: number;
+  iid: number;
+  title: string;
+  description?: string | null;
+  url: string;
+  author?: string | null;
+  source_branch?: string | null;
+  target_branch?: string | null;
+  state: string;
+  draft: boolean;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface PullRequestListResponse {
+  items: PullRequestListItem[];
+  page: number;
+  limit: number;
+  has_more: boolean;
+  supported: boolean;
+  fetched_at: string;
+}
+
 export type VerdictStatus =
   'checking' | 'done' | 'failed' | 'timeout' | 'no_model';
 

--- a/frontend/src/views/authed/tracker-detail-view.test.ts
+++ b/frontend/src/views/authed/tracker-detail-view.test.ts
@@ -26,6 +26,7 @@ interface StubOpts {
   pullRequests?: unknown[];
   prHasMore?: boolean;
   prSupported?: boolean;
+  pullRequestHandler?: (url: string) => Response | null;
 }
 
 function stubFetch(opts: StubOpts = {}) {
@@ -36,6 +37,7 @@ function stubFetch(opts: StubOpts = {}) {
     pullRequests = [],
     prHasMore = false,
     prSupported = true,
+    pullRequestHandler,
   } = opts;
   return sinon
     .stub(window, 'fetch')
@@ -65,6 +67,8 @@ function stubFetch(opts: StubOpts = {}) {
         });
       }
       if (url.includes('/pull-requests')) {
+        const override = pullRequestHandler?.(url);
+        if (override) return override;
         return json({
           items: pullRequests,
           page: 1,
@@ -399,6 +403,93 @@ describe('TrackerDetailView', () => {
     expect(text).to.contain('#7');
     const actionsHeader = el.shadowRoot?.querySelector('th .visually-hidden');
     expect(actionsHeader?.textContent?.trim()).to.equal('Actions');
+    const branches = el.shadowRoot?.querySelector('.pr-branches');
+    expect(branches?.getAttribute('aria-label')).to.equal('feature to main');
+    expect(
+      branches?.querySelector('[aria-hidden="true"]')?.textContent
+    ).to.contain('->');
+    expect(
+      branches?.querySelector('.visually-hidden')?.textContent?.trim()
+    ).to.equal('to');
+  });
+
+  it('leaves the Branches cell empty when a branch is missing', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      `/console/trackers/${trackerId}?tab=pull-requests&project=${projectA.id}`
+    );
+    fetchStub = stubFetch({
+      pullRequests: [
+        {
+          number: 12,
+          iid: 12,
+          title: 'Add login',
+          url: 'https://github.com/acme/widgets/pull/12',
+          author: 'janedoe',
+          source_branch: '',
+          target_branch: 'main',
+          state: 'open',
+          draft: false,
+          updated_at: '2026-01-03T00:00:00Z',
+        },
+      ],
+    });
+    const el = await mountView();
+    await (
+      el as unknown as { _loadPullRequests: (reset: boolean) => Promise<void> }
+    )._loadPullRequests(true);
+    await el.updateComplete;
+    const branches = el.shadowRoot?.querySelector('.pr-branches');
+    expect(branches?.textContent?.trim()).to.equal('');
+    expect(el.shadowRoot?.textContent).to.not.contain('? ->');
+  });
+
+  it('keeps rows when Load more fails', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      `/console/trackers/${trackerId}?tab=pull-requests&project=${projectA.id}`
+    );
+    fetchStub = stubFetch({
+      pullRequests: [
+        {
+          number: 12,
+          iid: 12,
+          title: 'Add login',
+          url: 'https://github.com/acme/widgets/pull/12',
+          author: 'janedoe',
+          source_branch: 'feature',
+          target_branch: 'main',
+          state: 'open',
+          draft: false,
+          updated_at: '2026-01-03T00:00:00Z',
+        },
+      ],
+      prHasMore: true,
+      pullRequestHandler: (url) => {
+        if (url.includes('page=2')) {
+          return new Response(JSON.stringify({ detail: 'fail' }), {
+            status: 502,
+          });
+        }
+        return null;
+      },
+    });
+    const el = await mountView();
+    await (
+      el as unknown as { _loadPullRequests: (reset: boolean) => Promise<void> }
+    )._loadPullRequests(true);
+    await el.updateComplete;
+    expect(el.shadowRoot?.textContent).to.contain('Add login');
+    (
+      el as unknown as { _loadMorePullRequests: () => void }
+    )._loadMorePullRequests();
+    await tick(50);
+    await el.updateComplete;
+    expect(el.shadowRoot?.textContent).to.contain('Add login');
+    expect(el.shadowRoot?.textContent).to.contain('Could not reach GitHub.');
+    expect(el.shadowRoot?.querySelector('table.styled-table')).to.exist;
   });
 
   it('hides tab for jira', async () => {

--- a/frontend/src/views/authed/tracker-detail-view.test.ts
+++ b/frontend/src/views/authed/tracker-detail-view.test.ts
@@ -397,6 +397,8 @@ describe('TrackerDetailView', () => {
     expect(text).to.contain('Live from GitLab, refreshed every minute.');
     expect(text).to.contain('Fix login');
     expect(text).to.contain('#7');
+    const actionsHeader = el.shadowRoot?.querySelector('th .visually-hidden');
+    expect(actionsHeader?.textContent?.trim()).to.equal('Actions');
   });
 
   it('hides tab for jira', async () => {

--- a/frontend/src/views/authed/tracker-detail-view.test.ts
+++ b/frontend/src/views/authed/tracker-detail-view.test.ts
@@ -1,6 +1,7 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import sinon from 'sinon';
 import '../../components/view-header.ts';
+import { resetRunPresetDialogForTests } from '../../components/run-preset-dialog';
 import './tracker-detail-view';
 import type { TrackerDetailView } from './tracker-detail-view';
 
@@ -21,13 +22,24 @@ const projectB = {
 interface StubOpts {
   issues?: unknown[];
   total?: number;
+  trackerType?: string;
+  pullRequests?: unknown[];
+  prHasMore?: boolean;
+  prSupported?: boolean;
 }
 
 function stubFetch(opts: StubOpts = {}) {
-  const { issues = [], total = issues.length } = opts;
+  const {
+    issues = [],
+    total = issues.length,
+    trackerType = 'github',
+    pullRequests = [],
+    prHasMore = false,
+    prSupported = true,
+  } = opts;
   return sinon
     .stub(window, 'fetch')
-    .callsFake(async (input: RequestInfo | URL) => {
+    .callsFake(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       const json = (data: unknown, status = 200) =>
         new Response(JSON.stringify(data), { status });
@@ -38,7 +50,7 @@ function stubFetch(opts: StubOpts = {}) {
         return json({
           id: trackerId,
           name: 'Example tracker',
-          tracker_type: 'github',
+          tracker_type: trackerType,
           created: '2026-01-01T00:00:00Z',
           last_updated: '2026-01-02T00:00:00Z',
           is_valid: true,
@@ -50,6 +62,16 @@ function stubFetch(opts: StubOpts = {}) {
       if (url.includes('/api/v1/organizations')) {
         return json({
           items: [{ id: 'org-1', name: 'Org', tracker_id: trackerId }],
+        });
+      }
+      if (url.includes('/pull-requests')) {
+        return json({
+          items: pullRequests,
+          page: 1,
+          limit: 20,
+          has_more: prHasMore,
+          supported: prSupported,
+          fetched_at: '2026-01-03T00:00:00Z',
         });
       }
       if (url.includes('/api/v1/projects')) {
@@ -65,6 +87,27 @@ function stubFetch(opts: StubOpts = {}) {
           total: listed,
           skip: 0,
           limit: 20,
+        });
+      }
+      if (url.includes('/api/v1/flows/run-preset')) {
+        const body = init?.body ? JSON.parse(String(init.body)) : {};
+        if (!body.confirm_create) {
+          return json(
+            {
+              detail: {
+                code: 'flow_missing',
+                flow_name: 'Pull Request Reviewer',
+              },
+            },
+            409
+          );
+        }
+        return json({
+          execution_id: 'exec-1',
+          flow_id: 'flow-1',
+          flow_name: 'Pull Request Reviewer',
+          flow_created: true,
+          execution_url: '/console/flows/executions/exec-1',
         });
       }
       return json({});
@@ -101,6 +144,7 @@ describe('TrackerDetailView', () => {
 
   afterEach(() => {
     fetchStub?.restore();
+    resetRunPresetDialogForTests();
     localStorage.clear();
     window.history.replaceState({}, '', '/');
   });
@@ -317,5 +361,107 @@ describe('TrackerDetailView', () => {
     expect(loadMore).to.exist;
     expect(loadMore?.textContent).to.contain('Load more');
     expect(el.shadowRoot?.querySelector('a.load-more')).to.not.exist;
+  });
+
+  it('renders MR label for gitlab trackers', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      `/console/trackers/${trackerId}?tab=pull-requests&project=${projectA.id}`
+    );
+    fetchStub = stubFetch({
+      trackerType: 'gitlab',
+      pullRequests: [
+        {
+          number: 7,
+          iid: 7,
+          title: 'Fix login',
+          url: 'https://gitlab.example.com/group/project/-/merge_requests/7',
+          author: 'janedoe',
+          source_branch: 'feature',
+          target_branch: 'main',
+          state: 'open',
+          draft: false,
+          updated_at: '2026-01-03T00:00:00Z',
+        },
+      ],
+    });
+    const el = await mountView();
+    await (
+      el as unknown as { _loadPullRequests: (reset: boolean) => Promise<void> }
+    )._loadPullRequests(true);
+    await el.updateComplete;
+    const text = el.shadowRoot?.textContent || '';
+    expect(text).to.contain('Merge requests');
+    expect(text).to.contain('Open merge requests');
+    expect(text).to.contain('Live from GitLab, refreshed every minute.');
+    expect(text).to.contain('Fix login');
+    expect(text).to.contain('#7');
+  });
+
+  it('hides tab for jira', async () => {
+    window.history.replaceState({}, '', `/console/trackers/${trackerId}`);
+    fetchStub = stubFetch({ trackerType: 'jira' });
+    const el = await mountView();
+    await el.updateComplete;
+    const tabs = Array.from(
+      el.shadowRoot?.querySelectorAll('sl-tab') || []
+    ).map((tab) => tab.textContent?.trim());
+    expect(tabs).to.include('Projects');
+    expect(tabs).to.include('Issues');
+    expect(tabs).to.not.include('Pull requests');
+    expect(tabs).to.not.include('Merge requests');
+    expect(el.shadowRoot?.textContent).to.not.contain('Run reviewer');
+  });
+
+  it('Run reviewer sends pull_request target', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      `/console/trackers/${trackerId}?tab=pull-requests&project=${projectA.id}`
+    );
+    fetchStub = stubFetch({
+      pullRequests: [
+        {
+          number: 12,
+          iid: 12,
+          title: 'Add login',
+          url: 'https://github.com/acme/widgets/pull/12',
+          author: 'janedoe',
+          source_branch: 'feature',
+          target_branch: 'main',
+          state: 'open',
+          draft: false,
+          updated_at: '2026-01-03T00:00:00Z',
+        },
+      ],
+    });
+    const el = await mountView();
+    (el as unknown as { _selectedProjectId: string })._selectedProjectId =
+      projectA.id;
+    await (
+      el as unknown as { _loadPullRequests: (reset: boolean) => Promise<void> }
+    )._loadPullRequests(true);
+    await el.updateComplete;
+    (
+      el as unknown as {
+        _runReviewer: (pr: { number: number }) => void;
+      }
+    )._runReviewer({ number: 12 });
+    await tick(50);
+    const runCalls = fetchStub
+      .getCalls()
+      .filter((call) =>
+        String(call.args[0]).includes('/api/v1/flows/run-preset')
+      );
+    expect(runCalls.length).to.be.greaterThan(0);
+    const init = runCalls[0].args[1] as RequestInit;
+    const body = JSON.parse(String(init.body));
+    expect(body.preset_slug).to.equal('pull-request-reviewer');
+    expect(body.target).to.deep.equal({
+      kind: 'pull_request',
+      project_id: projectA.id,
+      number: 12,
+    });
   });
 });

--- a/frontend/src/views/authed/tracker-detail-view.ts
+++ b/frontend/src/views/authed/tracker-detail-view.ts
@@ -1042,7 +1042,9 @@ export class TrackerDetailView extends LitElement {
                           <th>Author</th>
                           <th>Branches</th>
                           <th>Updated</th>
-                          <th></th>
+                          <th>
+                            <span class="visually-hidden">Actions</span>
+                          </th>
                         </tr>
                       </thead>
                       <tbody>

--- a/frontend/src/views/authed/tracker-detail-view.ts
+++ b/frontend/src/views/authed/tracker-detail-view.ts
@@ -22,12 +22,18 @@ import {
   deleteTracker,
   listIssues,
   listOrganizations,
+  listProjectPullRequests,
   listProjects,
   syncTracker,
   type FeaturesResponse,
 } from '../../api';
 import { openRunPresetDialog } from '../../components/run-preset-dialog';
-import type { IssueListItem, Organization, Project } from '../../types';
+import type {
+  IssueListItem,
+  Organization,
+  Project,
+  PullRequestListItem,
+} from '../../types';
 import {
   describeTrackerScope,
   groupProjectsByOrganization,
@@ -85,7 +91,7 @@ export class TrackerDetailView extends LitElement {
   private _syncMessage: string | null = null;
 
   @state()
-  private _activeTab: 'projects' | 'issues' = 'projects';
+  private _activeTab: 'projects' | 'issues' | 'pull-requests' = 'projects';
 
   @state()
   private _selectedProjectId = '';
@@ -111,10 +117,26 @@ export class TrackerDetailView extends LitElement {
   @state()
   private _issuesError: string | null = null;
 
+  @state()
+  private _pullRequests: PullRequestListItem[] = [];
+
+  @state()
+  private _prsPage = 1;
+
+  @state()
+  private _prsHasMore = false;
+
+  @state()
+  private _prsLoading = false;
+
+  @state()
+  private _prsError: string | null = null;
+
   private _trackerId = '';
   private readonly _issuesPageSize = 20;
   private _issuesRequestId = 0;
   private _issueSearchTimer: number | null = null;
+  private readonly _prsPageSize = 20;
 
   static styles = [
     unsafeCSS(consoleStyles),
@@ -250,6 +272,13 @@ export class TrackerDetailView extends LitElement {
         font-size: var(--console-text-body);
       }
 
+      .project-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sl-spacing-x-small);
+        flex-shrink: 0;
+      }
+
       .project-row:last-child {
         border-bottom: none;
       }
@@ -275,10 +304,22 @@ export class TrackerDetailView extends LitElement {
       }
 
       .issues-empty,
-      .issues-error {
+      .issues-error,
+      .prs-empty,
+      .prs-error {
         padding: var(--sl-spacing-medium) 0;
         color: var(--console-meta-color);
         font-size: var(--console-text-body);
+      }
+
+      .live-note,
+      .pr-branches {
+        font-size: 13px;
+        color: var(--console-meta-color);
+      }
+
+      .live-note {
+        margin: 0 0 var(--sl-spacing-small) 0;
       }
 
       .load-more {
@@ -370,13 +411,21 @@ export class TrackerDetailView extends LitElement {
     this._ensureSelectedProject();
     if (this._activeTab === 'issues') {
       await this._loadIssues(true);
+    } else if (this._activeTab === 'pull-requests') {
+      await this._loadPullRequests(true);
     }
   }
 
   private _readUrl() {
     const params = new URLSearchParams(window.location.search);
     const tab = params.get('tab');
-    this._activeTab = tab === 'issues' ? 'issues' : 'projects';
+    if (tab === 'issues') {
+      this._activeTab = 'issues';
+    } else if (tab === 'pull-requests') {
+      this._activeTab = 'pull-requests';
+    } else {
+      this._activeTab = 'projects';
+    }
     const status = params.get('status');
     if (status === 'open' || status === 'closed' || status === 'all') {
       this._issueStatus = status;
@@ -395,6 +444,11 @@ export class TrackerDetailView extends LitElement {
         params.set('project', this._selectedProjectId);
       }
       params.set('status', this._issueStatus);
+    } else if (this._activeTab === 'pull-requests') {
+      params.set('tab', 'pull-requests');
+      if (this._selectedProjectId) {
+        params.set('project', this._selectedProjectId);
+      }
     }
     const query = params.toString();
     const next = query
@@ -469,7 +523,7 @@ export class TrackerDetailView extends LitElement {
     return this._issues;
   }
 
-  private _showTab(name: 'projects' | 'issues') {
+  private _showTab(name: 'projects' | 'issues' | 'pull-requests') {
     this._activeTab = name;
     const group = this.renderRoot.querySelector('sl-tab-group') as {
       show?: (panel: string) => void;
@@ -479,12 +533,16 @@ export class TrackerDetailView extends LitElement {
 
   private _onTabShow(event: CustomEvent<{ name: string }>) {
     const name = event.detail.name;
-    if (name !== 'projects' && name !== 'issues') return;
+    if (name !== 'projects' && name !== 'issues' && name !== 'pull-requests') {
+      return;
+    }
     if (this._activeTab === name) return;
     this._activeTab = name;
     this._updateUrl();
     if (name === 'issues') {
       void this._loadIssues(true);
+    } else if (name === 'pull-requests') {
+      void this._loadPullRequests(true);
     }
   }
 
@@ -495,12 +553,23 @@ export class TrackerDetailView extends LitElement {
     void this._loadIssues(true);
   }
 
+  private _showPullRequestsForProject(projectId: string) {
+    this._selectedProjectId = projectId;
+    this._showTab('pull-requests');
+    this._updateUrl();
+    void this._loadPullRequests(true);
+  }
+
   private _onProjectFilter(event: Event) {
     const value = (event.target as HTMLSelectElement).value;
     if (!value || value === this._selectedProjectId) return;
     this._selectedProjectId = value;
     this._updateUrl();
-    void this._loadIssues(true);
+    if (this._activeTab === 'pull-requests') {
+      void this._loadPullRequests(true);
+    } else {
+      void this._loadIssues(true);
+    }
   }
 
   private _onStatusFilter(event: Event) {
@@ -541,6 +610,83 @@ export class TrackerDetailView extends LitElement {
     });
   }
 
+  private _isGitlab(): boolean {
+    return (this._tracker?.tracker_type || '').toLowerCase().includes('gitlab');
+  }
+
+  private _isJira(): boolean {
+    return (this._tracker?.tracker_type || '').toLowerCase().includes('jira');
+  }
+
+  private _supportsPullRequests(): boolean {
+    return !this._isJira();
+  }
+
+  private _prNoun(): string {
+    return this._isGitlab() ? 'merge requests' : 'pull requests';
+  }
+
+  private _prTabLabel(): string {
+    return this._isGitlab() ? 'Merge requests' : 'Pull requests';
+  }
+
+  private _prHost(): string {
+    return this._isGitlab() ? 'GitLab' : 'GitHub';
+  }
+
+  private async _loadPullRequests(reset = true) {
+    if (!this._selectedProjectId) {
+      this._pullRequests = [];
+      this._prsHasMore = false;
+      return;
+    }
+    if (reset) {
+      this._prsPage = 1;
+      this._pullRequests = [];
+    }
+    this._prsLoading = true;
+    this._prsError = null;
+    try {
+      const data = await listProjectPullRequests(this._selectedProjectId, {
+        state: 'open',
+        page: this._prsPage,
+        limit: this._prsPageSize,
+      });
+      if (!data.supported) {
+        this._pullRequests = [];
+        this._prsHasMore = false;
+        return;
+      }
+      this._pullRequests = reset
+        ? data.items
+        : [...this._pullRequests, ...data.items];
+      this._prsHasMore = data.has_more;
+    } catch (error) {
+      this._prsError =
+        error instanceof Error ? error.message : 'Could not reach tracker.';
+    } finally {
+      this._prsLoading = false;
+    }
+  }
+
+  private _loadMorePullRequests() {
+    this._prsPage += 1;
+    void this._loadPullRequests(false);
+  }
+
+  private _runReviewer(pr: PullRequestListItem) {
+    void openRunPresetDialog({
+      presetSlug: 'pull-request-reviewer',
+      target: {
+        kind: 'pull_request',
+        project_id: this._selectedProjectId,
+        number: pr.number,
+      },
+      issueKey: `#${pr.number}`,
+      role: 'reviewer',
+    });
+  }
+
   private async _loadData() {
     this._loading = true;
     this._error = null;
@@ -559,8 +705,17 @@ export class TrackerDetailView extends LitElement {
       this._features = featuresRes.features;
       this._featuresLoaded = true;
       await this._loadProjectsForTracker();
+      if (
+        this._activeTab === 'pull-requests' &&
+        !this._supportsPullRequests()
+      ) {
+        this._activeTab = 'projects';
+        this._updateUrl();
+      }
       if (this._activeTab === 'issues') {
         this._showTab('issues');
+      } else if (this._activeTab === 'pull-requests') {
+        this._showTab('pull-requests');
       }
     } catch (error) {
       this._error =
@@ -827,6 +982,124 @@ export class TrackerDetailView extends LitElement {
     `;
   }
 
+  private _renderPullRequestsTab() {
+    if (this._projects.length === 0) {
+      return html`<div class="no-projects">
+        No projects synced yet. Run <strong>Sync Now</strong> or edit the
+        tracker to choose groups and projects, then sync again.
+      </div>`;
+    }
+
+    const project = this._selectedProject();
+    const heading = this._isGitlab()
+      ? 'Open merge requests'
+      : 'Open pull requests';
+    const empty = `No open ${this._prNoun()} in ${project?.name || 'this project'}.`;
+    const errorHost = this._prHost();
+
+    return html`
+      <sl-card>
+        <div slot="header" class="section-header">
+          <h2 class="section-title">${heading}</h2>
+          <div class="issues-controls">
+            <sl-select
+              size="small"
+              label="Project"
+              value=${this._selectedProjectId}
+              @sl-change=${this._onProjectFilter}
+            >
+              ${this._projects.map(
+                (item) =>
+                  html`<sl-option value=${item.id}>${item.name}</sl-option>`
+              )}
+            </sl-select>
+          </div>
+        </div>
+        <p class="live-note">Live from ${errorHost}, refreshed every minute.</p>
+        ${
+          this._prsError
+            ? html`<div class="prs-error">
+                Could not reach ${errorHost}.
+                <sl-button
+                  size="small"
+                  variant="text"
+                  @click=${() => this._loadPullRequests(true)}
+                  >Retry</sl-button
+                >
+              </div>`
+            : this._prsLoading && this._pullRequests.length === 0
+              ? html`<div class="spinner-container">
+                  <sl-spinner></sl-spinner>
+                </div>`
+              : this._pullRequests.length === 0
+                ? html`<div class="prs-empty">${empty}</div>`
+                : html`
+                    <table class="styled-table">
+                      <thead>
+                        <tr>
+                          <th>Number</th>
+                          <th>Title</th>
+                          <th>Author</th>
+                          <th>Branches</th>
+                          <th>Updated</th>
+                          <th></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        ${this._pullRequests.map(
+                          (pr) => html`
+                            <tr>
+                              <td>
+                                <a
+                                  href=${pr.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  >#${pr.number}</a
+                                >
+                              </td>
+                              <td>${pr.title}</td>
+                              <td>${pr.author || ''}</td>
+                              <td class="pr-branches">
+                                ${pr.source_branch || '?'} ->
+                                ${pr.target_branch || '?'}
+                              </td>
+                              <td title=${pr.updated_at || ''}>
+                                ${
+                                  pr.updated_at
+                                    ? formatRelativeTime(pr.updated_at)
+                                    : ''
+                                }
+                              </td>
+                              <td>
+                                <sl-button
+                                  size="small"
+                                  @click=${() => this._runReviewer(pr)}
+                                  >Run reviewer</sl-button
+                                >
+                              </td>
+                            </tr>
+                          `
+                        )}
+                      </tbody>
+                    </table>
+                    ${
+                      this._prsHasMore
+                        ? html`<sl-button
+                            class="load-more"
+                            size="small"
+                            variant="text"
+                            ?loading=${this._prsLoading}
+                            @click=${() => this._loadMorePullRequests()}
+                            >Load more</sl-button
+                          >`
+                        : ''
+                    }
+                  `
+        }
+      </sl-card>
+    `;
+  }
+
   private _renderProjectGroups() {
     const groups = this._projectsByOrganization();
     if (groups.length === 0) {
@@ -867,13 +1140,27 @@ export class TrackerDetailView extends LitElement {
                         }
                       </div>
                     </div>
-                    <sl-button
-                      size="small"
-                      variant="text"
-                      @click=${() => this._showIssuesForProject(project.id)}
-                    >
-                      Issues
-                    </sl-button>
+                    <div class="project-actions">
+                      <sl-button
+                        size="small"
+                        variant="text"
+                        @click=${() => this._showIssuesForProject(project.id)}
+                      >
+                        Issues
+                      </sl-button>
+                      ${
+                        this._supportsPullRequests()
+                          ? html`<sl-button
+                              size="small"
+                              variant="text"
+                              @click=${() =>
+                                this._showPullRequestsForProject(project.id)}
+                            >
+                              ${this._prTabLabel()}
+                            </sl-button>`
+                          : ''
+                      }
+                    </div>
                   </div>
                 `
               )}
@@ -1058,6 +1345,16 @@ export class TrackerDetailView extends LitElement {
               ?active=${this._activeTab === 'issues'}
               >Issues</sl-tab
             >
+            ${
+              this._supportsPullRequests()
+                ? html`<sl-tab
+                    slot="nav"
+                    panel="pull-requests"
+                    ?active=${this._activeTab === 'pull-requests'}
+                    >${this._prTabLabel()}</sl-tab
+                  >`
+                : ''
+            }
             <sl-tab-panel name="projects">
               <div class="section-header">
                 <h2 class="section-title">
@@ -1076,6 +1373,13 @@ export class TrackerDetailView extends LitElement {
             <sl-tab-panel name="issues">
               ${this._renderIssuesTab()}
             </sl-tab-panel>
+            ${
+              this._supportsPullRequests()
+                ? html`<sl-tab-panel name="pull-requests">
+                    ${this._renderPullRequestsTab()}
+                  </sl-tab-panel>`
+                : ''
+            }
           </sl-tab-group>
 
           <sl-divider></sl-divider>

--- a/frontend/src/views/authed/tracker-detail-view.ts
+++ b/frontend/src/views/authed/tracker-detail-view.ts
@@ -674,6 +674,36 @@ export class TrackerDetailView extends LitElement {
     void this._loadPullRequests(false);
   }
 
+  private _retryPullRequests() {
+    void this._loadPullRequests(this._pullRequests.length === 0);
+  }
+
+  private _renderPrsError() {
+    return html`<div class="prs-error">
+      Could not reach ${this._prHost()}.
+      <sl-button
+        size="small"
+        variant="text"
+        @click=${() => this._retryPullRequests()}
+        >Retry</sl-button
+      >
+    </div>`;
+  }
+
+  private _renderPrBranches(pr: PullRequestListItem) {
+    const source = pr.source_branch || '';
+    const target = pr.target_branch || '';
+    if (!source || !target) {
+      return html`<td class="pr-branches"></td>`;
+    }
+    return html`<td class="pr-branches" aria-label="${source} to ${target}">
+      ${source}
+      <span aria-hidden="true"> -> </span>
+      <span class="visually-hidden">to</span>
+      ${target}
+    </td>`;
+  }
+
   private _runReviewer(pr: PullRequestListItem) {
     void openRunPresetDialog({
       presetSlug: 'pull-request-reviewer',
@@ -1017,86 +1047,76 @@ export class TrackerDetailView extends LitElement {
         </div>
         <p class="live-note">Live from ${errorHost}, refreshed every minute.</p>
         ${
-          this._prsError
-            ? html`<div class="prs-error">
-                Could not reach ${errorHost}.
-                <sl-button
-                  size="small"
-                  variant="text"
-                  @click=${() => this._loadPullRequests(true)}
-                  >Retry</sl-button
-                >
+          this._prsLoading && this._pullRequests.length === 0
+            ? html`<div class="spinner-container">
+                <sl-spinner></sl-spinner>
               </div>`
-            : this._prsLoading && this._pullRequests.length === 0
-              ? html`<div class="spinner-container">
-                  <sl-spinner></sl-spinner>
-                </div>`
-              : this._pullRequests.length === 0
-                ? html`<div class="prs-empty">${empty}</div>`
-                : html`
-                    <table class="styled-table">
-                      <thead>
-                        <tr>
-                          <th>Number</th>
-                          <th>Title</th>
-                          <th>Author</th>
-                          <th>Branches</th>
-                          <th>Updated</th>
-                          <th>
-                            <span class="visually-hidden">Actions</span>
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        ${this._pullRequests.map(
-                          (pr) => html`
-                            <tr>
-                              <td>
-                                <a
-                                  href=${pr.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  >#${pr.number}</a
-                                >
-                              </td>
-                              <td>${pr.title}</td>
-                              <td>${pr.author || ''}</td>
-                              <td class="pr-branches">
-                                ${pr.source_branch || '?'} ->
-                                ${pr.target_branch || '?'}
-                              </td>
-                              <td title=${pr.updated_at || ''}>
-                                ${
-                                  pr.updated_at
-                                    ? formatRelativeTime(pr.updated_at)
-                                    : ''
-                                }
-                              </td>
-                              <td>
-                                <sl-button
-                                  size="small"
-                                  @click=${() => this._runReviewer(pr)}
-                                  >Run reviewer</sl-button
-                                >
-                              </td>
-                            </tr>
-                          `
-                        )}
-                      </tbody>
-                    </table>
-                    ${
-                      this._prsHasMore
-                        ? html`<sl-button
-                            class="load-more"
-                            size="small"
-                            variant="text"
-                            ?loading=${this._prsLoading}
-                            @click=${() => this._loadMorePullRequests()}
-                            >Load more</sl-button
-                          >`
-                        : ''
-                    }
-                  `
+            : this._pullRequests.length === 0
+              ? this._prsError
+                ? this._renderPrsError()
+                : html`<div class="prs-empty">${empty}</div>`
+              : html`
+                  <table class="styled-table">
+                    <thead>
+                      <tr>
+                        <th>Number</th>
+                        <th>Title</th>
+                        <th>Author</th>
+                        <th>Branches</th>
+                        <th>Updated</th>
+                        <th>
+                          <span class="visually-hidden">Actions</span>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      ${this._pullRequests.map(
+                        (pr) => html`
+                          <tr>
+                            <td>
+                              <a
+                                href=${pr.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                >#${pr.number}</a
+                              >
+                            </td>
+                            <td>${pr.title}</td>
+                            <td>${pr.author || ''}</td>
+                            ${this._renderPrBranches(pr)}
+                            <td title=${pr.updated_at || ''}>
+                              ${
+                                pr.updated_at
+                                  ? formatRelativeTime(pr.updated_at)
+                                  : ''
+                              }
+                            </td>
+                            <td>
+                              <sl-button
+                                size="small"
+                                @click=${() => this._runReviewer(pr)}
+                                >Run reviewer</sl-button
+                              >
+                            </td>
+                          </tr>
+                        `
+                      )}
+                    </tbody>
+                  </table>
+                  ${
+                    this._prsHasMore
+                      ? html`<sl-button
+                          class="load-more"
+                          size="small"
+                          variant="text"
+                          ?loading=${this._prsLoading}
+                          @click=${() => this._loadMorePullRequests()}
+                          >Load more</sl-button
+                        >`
+                      : ''
+                  }
+                  ${this._prsError ? this._renderPrsError() : ''}
+                `
         }
       </sl-card>
     `;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4949,6 +4949,69 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
       security:
       - bearerAuth: []
+  /api/v1/projects/{project_id}/pull-requests:
+    get:
+      tags:
+      - Projects
+      summary: List Project Pull Requests
+      description: List open pull requests (GitHub) or merge requests (GitLab) for
+        a project.
+      operationId: list_project_pull_requests_api_v1_projects__project_id__pull_requests_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: project_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Project Id
+      - name: state
+        in: query
+        required: false
+        schema:
+          const: open
+          type: string
+          default: open
+          title: State
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 50
+          minimum: 1
+          default: 20
+          title: Limit
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+          title: Page
+      - name: refresh
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+          title: Refresh
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PullRequestListResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/issues/search:
     get:
       tags:
@@ -18050,6 +18113,99 @@ components:
       - deleted_count
       title: PruneResponse
       description: Response from a prune operation.
+    PullRequestItem:
+      properties:
+        number:
+          type: integer
+          title: Number
+        iid:
+          type: integer
+          title: Iid
+        title:
+          type: string
+          title: Title
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        url:
+          type: string
+          title: Url
+        author:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Author
+        source_branch:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source Branch
+        target_branch:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Target Branch
+        state:
+          type: string
+          title: State
+        draft:
+          type: boolean
+          title: Draft
+          default: false
+        created_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Created At
+        updated_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Updated At
+      type: object
+      required:
+      - number
+      - iid
+      - title
+      - url
+      - state
+      title: PullRequestItem
+      description: One open pull request or merge request from the tracker.
+    PullRequestListResponse:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/PullRequestItem'
+          type: array
+          title: Items
+        page:
+          type: integer
+          title: Page
+        limit:
+          type: integer
+          title: Limit
+        has_more:
+          type: boolean
+          title: Has More
+        supported:
+          type: boolean
+          title: Supported
+        fetched_at:
+          type: string
+          title: Fetched At
+          description: ISO timestamp of the fetch
+      type: object
+      required:
+      - items
+      - page
+      - limit
+      - has_more
+      - supported
+      - fetched_at
+      title: PullRequestListResponse
+      description: Paginated live list of open pull/merge requests.
     QRCodeResponse:
       properties:
         token:


### PR DESCRIPTION
Stacked on #409 (base `feat/flow-run-preset`), which is stacked on #402; retarget as they merge.

## Why
The tracker page should show what is open for review and let the user run the PR reviewer flow on any of it, with the same create-from-preset-on-first-use rule as the issue implementer.

## What changed
### Backend
- `sync/trackers/github.py`: `list_pull_requests(state="open", limit, page)` (`GET /repos/{owner}/{repo}/pulls`, sorted by updated desc); `has_more` from the `Link: rel="next"` header via a new `_request_with_headers` (the existing `_request` delegates to it).
- `sync/trackers/gitlab.py`: `list_merge_requests(...)` (`project.mergerequests.list(state="opened", order_by="updated_at")`); `has_more` computed from the list call itself, since python-gitlab 7.0 exposes no last-response object.
- Both normalise to `{number, iid, title, description, url, author, source_branch, target_branch, state, draft, created_at, updated_at}`.
- `GET /api/v1/projects/{project_id}/pull-requests?state=open&limit=20&page=1` (`view_trackers`): live fetch through the project's tracker client, 60s in-process TTL cache keyed by account, project, state, page and limit, `?refresh=1` bypasses, `supported: false` with an empty list for Jira, 502 "Tracker request failed" on client errors, visibility resolved (404) before the cache is read. Page size 20, max 50.
- `preset_runner.py`: `target.kind == "pull_request"` for `POST /flows/run-preset` with `pull-request-reviewer`. GitHub builds `payload.pull_request` (`TriggerEventResolver` derives `object_attributes`), GitLab builds `object_attributes` with `iid`, branches, url, author. Same corrections as the issue path: top-level `project_id`, web-host clone fields, `payload.project_id` for `ProjectResolver`. Runs start with `test_mode=False` like the issue path.
- `openapi.yaml` regenerated.

### Frontend
- Tracker page: **Pull requests** tab (labelled **Merge requests** on GitLab, hidden for Jira), project select, columns Number (link to the tracker) / Title / Author / Branches (`feature -> main`) / Updated / **Run reviewer**, header note "Live from GitHub, refreshed every minute", empty and error states per spec. Run reviewer reuses `run-preset-dialog` with the `pull-request-reviewer` slug and a `pull_request` target.

## Tests
Real Postgres, `test_github_list_pull_requests.py` + `test_gitlab_list_merge_requests.py` + `test_preset_runner.py` + `test_pull_requests.py` + `test_flows.py`: 100 passed, 0 failed; GitHub tracker modules after the `_request` change: 88 passed. New: params and normalisation, `has_more` from the Link header, GitLab `has_more` through the real code path, cache TTL (client called once for two requests), refresh bypass, unsupported tracker, 502, cache isolation across accounts (second account gets 404, not the first account's cached list), GitHub PR and GitLab MR payloads resolving through `TriggerEventResolver` with top-level ids and clone fields. Frontend: 136 files, 1434 passed, 0 failed (MR label on GitLab, tab hidden on Jira, Run reviewer sends the `pull_request` target).

Analysis: trackers report sections 1, 2.2, 2.3, 5 PR 3. Closes the tracker page work from the 2026-09-05 UX round.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Well-structured and well-tested feature; all review feedback (GitLab pagination off-by-one, execution-id guard, and cache concurrency) has been addressed.
>
> **Overview**
> Adds a "Pull requests" (Merge requests) tab to the tracker page that lists open PRs/MRs per project and a "Run reviewer" action backed by the `pull-request-reviewer` preset. Backend adds the `GET /projects/{id}/pull-requests` endpoint, tracker list methods, and PR/MR trigger payload builders; Jira returns `supported: false`.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 18ccfd61. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->