### PR TITLE
Claude Code: keep one OAuth lineage per agent; dev-build update check; make install-local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,14 @@ Use the Lit.dev framework for frontend code. If you create new web components en
 - **PostgreSQL access**: `docker compose exec postgres psql -U postgres -d preloop`
 - **Database migrations**: `alembic upgrade head` (from backend/preloop/models)
 
+## CLI dev builds
+
+- The only sanctioned way to update a local dev CLI is `cd cli && make install-local` (builds, then `install -m 755 build/preloop ~/.local/bin/preloop`; `PREFIX`, `BINDIR`, `INSTALL_MODE` override the defaults).
+- Never `cp` a build onto `~/.local/bin/preloop`. `cp` writes into the existing inode, which invalidates the macOS code-signature cache; the next exec dies with `SIGKILL (Code Signature Invalid)`. `install(1)` unlinks and recreates the file, which is what keeps that cache valid.
+- Never `go build -o ~/.local/bin/preloop` either: it skips the version ldflags (the binary reports the compiled-in fallback version and looks like a release to the update check) and it replaces the file even when the target is read-only, so the guard below does not catch it.
+- On macOS dev machines keep the binary guarded with `chmod a-w ~/.local/bin/preloop` (or install with `INSTALL_MODE=555`; the default 755 install drops the guard, so re-apply it). `make install-local` still works on a read-only target, a stray `cp` is refused, and `preloop update` honours the guard instead of replacing a dev build with the release.
+- A dev build reports the `git describe` version (`v0.15.0-678-g5c9e8bc3`), which the CLI treats as newer than the `0.15.0` release; `preloop update --check` prints `newer than latest release` for it.
+
 ## Git Workflow
 
 - **NEVER use git push in any form unless explicitly requested by the user**

--- a/backend/preloop/api/endpoints/issues.py
+++ b/backend/preloop/api/endpoints/issues.py
@@ -398,14 +398,6 @@ async def search_issues(
                             organization_name = issue_org.name
                     metadata_dict = dict(issue.meta_data) if issue.meta_data else {}
                     external_url = metadata_dict.get("url") or issue.external_url
-                    # Determine response ID based on project slug
-                    response_id = issue.external_id or str(
-                        issue.id
-                    )  # Fallback to internal ID string
-                    if issue_project and issue_project.slug and issue.external_id:
-                        response_id = f"{issue_project.slug}#{issue.external_id}"
-                    elif issue.external_id:
-                        response_id = issue.external_id
 
                     # Ensure required fields are present (as per task constraints, assume they are)
                     if not issue.external_id:
@@ -545,14 +537,6 @@ async def search_issues(
                             organization_name = issue_org.name
                     metadata_dict = dict(issue.meta_data) if issue.meta_data else {}
                     external_url = metadata_dict.get("url") or issue.external_url
-                    # Determine response ID based on project slug
-                    response_id = issue.external_id or str(
-                        issue.id
-                    )  # Fallback to internal ID string
-                    if issue_project and issue_project.slug and issue.external_id:
-                        response_id = f"{issue_project.slug}#{issue.external_id}"
-                    elif issue.external_id:
-                        response_id = issue.external_id
 
                     # Ensure required fields are present (as per task constraints, assume they are)
                     if not issue.external_id:

--- a/backend/preloop/models/crud/ai_model.py
+++ b/backend/preloop/models/crud/ai_model.py
@@ -635,6 +635,16 @@ class CRUDAIModel(CRUDBase[AIModel]):
                 if self._model_kind(existing_model) == target_model_kind:
                     existing_model.is_default = False
 
+        # An explicit ``credentials_secret_id: null`` survives ``exclude_unset``
+        # and would otherwise NULL the column and garbage-collect the secret
+        # it pointed at. Detaching a credential is not an update operation;
+        # treat null as "unchanged" so a stray PUT cannot destroy a live
+        # OAuth lineage shared by sibling rows.
+        if "credentials_secret_id" in obj_data and (
+            obj_data["credentials_secret_id"] is None
+        ):
+            obj_data.pop("credentials_secret_id")
+
         previous_secret_id = db_obj.credentials_secret_id
         self._apply_secret_reference_fields(
             db,

--- a/backend/preloop/models/crud/ai_model.py
+++ b/backend/preloop/models/crud/ai_model.py
@@ -635,6 +635,7 @@ class CRUDAIModel(CRUDBase[AIModel]):
                 if self._model_kind(existing_model) == target_model_kind:
                     existing_model.is_default = False
 
+        previous_secret_id = db_obj.credentials_secret_id
         self._apply_secret_reference_fields(
             db,
             obj_data=obj_data,
@@ -643,7 +644,28 @@ class CRUDAIModel(CRUDBase[AIModel]):
             existing_secret_id=db_obj.credentials_secret_id,
         )
 
-        return super().update(db, db_obj=db_obj, obj_in=obj_data)
+        updated = super().update(db, db_obj=db_obj, obj_in=obj_data)
+        if previous_secret_id is not None and str(updated.credentials_secret_id) != str(
+            previous_secret_id
+        ):
+            self._delete_unreferenced_credential_secret(db, previous_secret_id)
+            db.commit()
+        return updated
+
+    def _delete_unreferenced_credential_secret(
+        self, db: Session, secret_id: uuid.UUID
+    ) -> None:
+        """Delete a SecretReference when no AIModel still points at it."""
+        remaining_reference = (
+            db.query(self.model.id)
+            .filter(self.model.credentials_secret_id == secret_id)
+            .first()
+        )
+        if remaining_reference is not None:
+            return
+        secret_ref = crud_secret_reference.get(db, id=secret_id)
+        if secret_ref is not None:
+            db.delete(secret_ref)
 
     def remove(self, db: Session, *, id: uuid.UUID) -> Optional[AIModel]:
         """Delete an AIModel and any unreferenced credential secret."""
@@ -656,15 +678,7 @@ class CRUDAIModel(CRUDBase[AIModel]):
         db.flush()
 
         if secret_id is not None:
-            remaining_reference = (
-                db.query(self.model.id)
-                .filter(self.model.credentials_secret_id == secret_id)
-                .first()
-            )
-            if remaining_reference is None:
-                secret_ref = crud_secret_reference.get(db, id=secret_id)
-                if secret_ref is not None:
-                    db.delete(secret_ref)
+            self._delete_unreferenced_credential_secret(db, secret_id)
 
         db.commit()
         return obj

--- a/backend/preloop/models/crud/ai_model.py
+++ b/backend/preloop/models/crud/ai_model.py
@@ -665,13 +665,44 @@ class CRUDAIModel(CRUDBase[AIModel]):
     def _delete_unreferenced_credential_secret(
         self, db: Session, secret_id: uuid.UUID
     ) -> None:
-        """Delete a SecretReference when no AIModel still points at it."""
+        """Delete a SecretReference when nothing still points at it.
+
+        ``secret_reference`` is also FK'd from Tracker (API key and webhook)
+        and ProviderBillingConnection. Those use different ``secret_kind``
+        values, so sharing is not expected; still check them so a missed
+        reference cannot CASCADE-delete a billing connection or NULL a
+        tracker secret.
+        """
+        from preloop.models.models.provider_billing import (
+            ProviderBillingConnection,
+        )
+        from preloop.models.models.tracker import Tracker
+
         remaining_reference = (
             db.query(self.model.id)
             .filter(self.model.credentials_secret_id == secret_id)
             .first()
         )
         if remaining_reference is not None:
+            return
+        tracker_reference = (
+            db.query(Tracker.id)
+            .filter(
+                or_(
+                    Tracker.credentials_secret_id == secret_id,
+                    Tracker.webhook_secret_id == secret_id,
+                )
+            )
+            .first()
+        )
+        if tracker_reference is not None:
+            return
+        billing_reference = (
+            db.query(ProviderBillingConnection.id)
+            .filter(ProviderBillingConnection.secret_reference_id == secret_id)
+            .first()
+        )
+        if billing_reference is not None:
             return
         secret_ref = crud_secret_reference.get(db, id=secret_id)
         if secret_ref is not None:

--- a/backend/preloop/schemas/ai_model.py
+++ b/backend/preloop/schemas/ai_model.py
@@ -135,6 +135,14 @@ class AIModelUpdate(BaseModel):
     credentials_backend_type: Optional[str] = None
     credentials_external_ref: Optional[str] = None
     credentials_meta_data: Optional[Dict] = None
+    credentials_secret_id: Optional[uuid.UUID] = Field(
+        None,
+        description=(
+            "Repoint this model at an existing SecretReference instead of minting a "
+            "new one. Used to keep several models on one provider key or OAuth "
+            "lineage. The secret must already belong to the caller's account."
+        ),
+    )
     is_default: Optional[bool] = None
     model_parameters: Optional[Dict] = None
     meta_data: Optional[Dict] = None
@@ -152,6 +160,12 @@ class AIModelUpdate(BaseModel):
                 self.credentials_meta_data,
             )
         )
+        if self.credentials_secret_id is not None and (
+            self.api_key or has_inline_payload or has_external
+        ):
+            raise ValueError(
+                "credentials_secret_id cannot be combined with new credential material"
+            )
         if self.api_key and (has_external or has_inline_payload):
             raise ValueError("api_key cannot be combined with other credential fields")
         if has_inline_payload and has_external:

--- a/backend/preloop/services/flow_pr_binding.py
+++ b/backend/preloop/services/flow_pr_binding.py
@@ -456,12 +456,7 @@ def record_opened_pr(
         execution.result = current
         flag_modified(execution, "result")
         db.commit()
-        logger.info(
-            "Recorded opened PR %s (branch=%s) on execution %s",
-            stored_url,
-            source_branch,
-            execution_id,
-        )
+        logger.info("Recorded opened PR on execution %s", execution_id)
     except Exception:
         logger.warning(
             "Failed to record opened PR on execution %s",

--- a/backend/tests/endpoints/test_ai_models.py
+++ b/backend/tests/endpoints/test_ai_models.py
@@ -179,6 +179,37 @@ async def test_update_ai_model(mock_account: Account, mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
+async def test_update_ai_model_repoint_foreign_secret_is_400(
+    mock_account: Account, mocker: MockerFixture
+):
+    """Cross-account secret reuse is a 400, not a silent no-op."""
+    model_id = uuid.uuid4()
+    ai_model_update = AIModelUpdate(credentials_secret_id=uuid.uuid4())
+    mock_crud_ai_model = mocker.patch(
+        "preloop.api.endpoints.ai_models.crud_ai_model",
+        new_callable=MagicMock,
+    )
+    mock_ai_model = MagicMock(account_id=mock_account.account_id)
+    mock_crud_ai_model.get.return_value = mock_ai_model
+    mock_crud_ai_model.update.side_effect = ValueError(
+        "Referenced credential secret belongs to a different account"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await maybe_await(
+            ai_models.update_ai_model(
+                db=MagicMock(),
+                model_id=model_id,
+                ai_model_in=ai_model_update,
+                current_user=mock_account,
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "different account" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_delete_ai_model(mock_account: Account, mocker: MockerFixture):
     """Tests that an AI model is deleted correctly."""
     # Arrange
@@ -265,6 +296,10 @@ def test_ai_model_schema_accepts_reused_credentials_secret_id():
     assert model.credentials_secret_id == secret_id
     assert model.api_key is None
 
+    update = AIModelUpdate(credentials_secret_id=secret_id)
+    assert update.credentials_secret_id == secret_id
+    assert update.model_dump(exclude_unset=True)["credentials_secret_id"] == secret_id
+
 
 @pytest.mark.parametrize(
     "extra",
@@ -284,6 +319,30 @@ def test_ai_model_schema_rejects_secret_reuse_with_new_credentials(extra):
             name="Confused Model",
             provider_name="anthropic",
             model_identifier="claude-haiku-4-5",
+            credentials_secret_id=uuid.uuid4(),
+            **extra,
+        )
+
+    assert "credentials_secret_id cannot be combined with new credential material" in (
+        str(error.value)
+    )
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"api_key": "inline-key"},
+        {"credential_type": "oauth_openai_codex", "credential_payload": {}},
+        {
+            "credentials_backend_type": "vault_kv_v2",
+            "credentials_external_ref": "providers/anthropic/team-a",
+        },
+    ],
+)
+def test_ai_model_update_schema_rejects_secret_repoint_with_new_credentials(extra):
+    """Repointing a secret and supplying new credential material is contradictory."""
+    with pytest.raises(ValidationError) as error:
+        AIModelUpdate(
             credentials_secret_id=uuid.uuid4(),
             **extra,
         )

--- a/backend/tests/models/crud/test_ai_model_secret_repoint.py
+++ b/backend/tests/models/crud/test_ai_model_secret_repoint.py
@@ -1,0 +1,144 @@
+"""CRUD tests for AIModel credential-secret repointing.
+
+PUT /ai-models/{id} must be able to attach an existing SecretReference (one
+OAuth lineage shared across Claude family rows) and garbage-collect the
+previous secret when nothing else still points at it.
+"""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from preloop.models.crud import crud_ai_model
+from preloop.models.models import Account
+from preloop.models.models.secret_reference import SecretReference
+
+
+def test_update_repoints_credentials_secret_and_deletes_orphan(
+    db_session: Session, create_account
+):
+    """Repointing to a shared secret succeeds and reaps the abandoned secret."""
+    account: Account = create_account()
+
+    primary = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Fable",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-fable-5-1",
+            "api_key": "fable-lineage-key",
+        },
+        account_id=account.id,
+    )
+    sibling = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Sonnet",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "sonnet-lineage-key",
+        },
+        account_id=account.id,
+    )
+    live_secret_id = primary.credentials_secret_id
+    orphan_secret_id = sibling.credentials_secret_id
+    assert live_secret_id is not None
+    assert orphan_secret_id is not None
+    assert live_secret_id != orphan_secret_id
+
+    updated = crud_ai_model.update(
+        db=db_session,
+        db_obj=sibling,
+        obj_in={"credentials_secret_id": live_secret_id},
+    )
+
+    assert updated.credentials_secret_id == live_secret_id
+    assert db_session.get(SecretReference, live_secret_id) is not None
+    assert db_session.get(SecretReference, orphan_secret_id) is None
+
+
+def test_update_repoint_keeps_secret_still_referenced_by_another_model(
+    db_session: Session, create_account
+):
+    """Repointing one of two sharers must not delete the previous secret."""
+    account: Account = create_account()
+
+    first = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Model A",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "shared-old-key",
+        },
+        account_id=account.id,
+    )
+    old_secret_id = first.credentials_secret_id
+    second = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Model B",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-haiku-4-5",
+            "credentials_secret_id": old_secret_id,
+        },
+        account_id=account.id,
+    )
+    live = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Model C",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-fable-5-1",
+            "api_key": "live-key",
+        },
+        account_id=account.id,
+    )
+
+    updated = crud_ai_model.update(
+        db=db_session,
+        db_obj=second,
+        obj_in={"credentials_secret_id": live.credentials_secret_id},
+    )
+
+    assert updated.credentials_secret_id == live.credentials_secret_id
+    assert first.credentials_secret_id == old_secret_id
+    assert db_session.get(SecretReference, old_secret_id) is not None
+
+
+def test_update_repoint_rejects_secret_from_another_account(
+    db_session: Session, create_account
+):
+    """A model must not attach another account's credential secret."""
+    owner: Account = create_account()
+    intruder: Account = create_account()
+
+    owned = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Owner Model",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "owner-key",
+        },
+        account_id=owner.id,
+    )
+    stray = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Intruder Model",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-haiku-4-5",
+            "api_key": "intruder-key",
+        },
+        account_id=intruder.id,
+    )
+
+    with pytest.raises(ValueError, match="different account"):
+        crud_ai_model.update(
+            db=db_session,
+            db_obj=stray,
+            obj_in={"credentials_secret_id": owned.credentials_secret_id},
+        )
+
+    db_session.refresh(stray)
+    assert stray.credentials_secret_id != owned.credentials_secret_id

--- a/backend/tests/models/crud/test_ai_model_secret_repoint.py
+++ b/backend/tests/models/crud/test_ai_model_secret_repoint.py
@@ -142,3 +142,39 @@ def test_update_repoint_rejects_secret_from_another_account(
 
     db_session.refresh(stray)
     assert stray.credentials_secret_id != owned.credentials_secret_id
+
+
+def test_update_with_null_credentials_secret_id_keeps_secret(
+    db_session: Session, create_account
+):
+    """An explicit ``credentials_secret_id: null`` must not detach or GC the secret.
+
+    Review finding 1: now that the field survives ``exclude_unset``, a raw
+    ``PUT {"credentials_secret_id": null}`` would NULL the column and reap the
+    orphaned SecretReference, destroying a live OAuth lineage. It must stay a
+    no-op, as it was before the field existed on the update schema.
+    """
+    account: Account = create_account()
+
+    model = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Sonnet",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "sonnet-lineage-key",
+        },
+        account_id=account.id,
+    )
+    secret_id = model.credentials_secret_id
+    assert secret_id is not None
+
+    updated = crud_ai_model.update(
+        db=db_session,
+        db_obj=model,
+        obj_in={"credentials_secret_id": None, "name": "Claude Sonnet (renamed)"},
+    )
+
+    assert updated.name == "Claude Sonnet (renamed)"
+    assert updated.credentials_secret_id == secret_id
+    assert db_session.get(SecretReference, secret_id) is not None

--- a/backend/tests/models/crud/test_ai_model_secret_repoint.py
+++ b/backend/tests/models/crud/test_ai_model_secret_repoint.py
@@ -8,8 +8,12 @@ previous secret when nothing else still points at it.
 import pytest
 from sqlalchemy.orm import Session
 
-from preloop.models.crud import crud_ai_model
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from preloop.models.crud import crud_ai_model, crud_tracker
 from preloop.models.models import Account
+from preloop.models.models.provider_billing import ProviderBillingConnection
 from preloop.models.models.secret_reference import SecretReference
 
 
@@ -178,3 +182,104 @@ def test_update_with_null_credentials_secret_id_keeps_secret(
     assert updated.name == "Claude Sonnet (renamed)"
     assert updated.credentials_secret_id == secret_id
     assert db_session.get(SecretReference, secret_id) is not None
+
+
+def test_update_repoint_keeps_secret_still_referenced_by_tracker(
+    db_session: Session, create_account
+):
+    """GC must not delete a secret that a Tracker still points at."""
+    account: Account = create_account()
+
+    primary = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Fable",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-fable-5-1",
+            "api_key": "fable-lineage-key",
+        },
+        account_id=account.id,
+    )
+    sibling = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Sonnet",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "sonnet-lineage-key",
+        },
+        account_id=account.id,
+    )
+    live_secret_id = primary.credentials_secret_id
+    orphan_secret_id = sibling.credentials_secret_id
+    tracker = crud_tracker.create(
+        db_session,
+        obj_in={
+            "name": "GitHub",
+            "tracker_type": "github",
+            "url": "https://github.com/acme",
+            "account_id": str(account.id),
+            "is_active": True,
+        },
+    )
+    tracker.credentials_secret_id = orphan_secret_id
+    db_session.commit()
+
+    crud_ai_model.update(
+        db=db_session,
+        db_obj=sibling,
+        obj_in={"credentials_secret_id": live_secret_id},
+    )
+
+    assert db_session.get(SecretReference, orphan_secret_id) is not None
+
+
+def test_update_repoint_keeps_secret_still_referenced_by_billing(
+    db_session: Session, create_account
+):
+    """GC must not delete a secret that a billing connection still points at."""
+    account: Account = create_account()
+
+    primary = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Fable",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-fable-5-1",
+            "api_key": "fable-lineage-key",
+        },
+        account_id=account.id,
+    )
+    sibling = crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Claude Sonnet",
+            "provider_name": "anthropic",
+            "model_identifier": "claude-sonnet-4-5",
+            "api_key": "sonnet-lineage-key",
+        },
+        account_id=account.id,
+    )
+    live_secret_id = primary.credentials_secret_id
+    orphan_secret_id = sibling.credentials_secret_id
+    now = datetime.now(UTC).replace(tzinfo=None)
+    db_session.add(
+        ProviderBillingConnection(
+            id=uuid4(),
+            account_id=account.id,
+            provider="anthropic",
+            secret_reference_id=orphan_secret_id,
+            is_active=True,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    db_session.commit()
+
+    crud_ai_model.update(
+        db=db_session,
+        db_obj=sibling,
+        obj_in={"credentials_secret_id": live_secret_id},
+    )
+
+    assert db_session.get(SecretReference, orphan_secret_id) is not None

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -21,10 +21,18 @@ GOFMT := gofmt
 BUILD_DIR := build
 CMD_DIR := ./cmd/preloop
 
+# Where `make install-local` puts the dev binary. Override with
+# `make install-local PREFIX=/opt/preloop` or `BINDIR=/some/bin`.
+PREFIX ?= $(HOME)/.local
+BINDIR ?= $(PREFIX)/bin
+# File mode for the installed dev binary. Pass INSTALL_MODE=555 to install
+# it already write-protected (see the install-local comment).
+INSTALL_MODE ?= 755
+
 # Platforms for cross-compilation
 PLATFORMS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64
 
-.PHONY: all build build-all install clean test fmt lint tidy help
+.PHONY: all build build-all install install-local clean test fmt lint tidy help
 
 # Default target
 all: build
@@ -56,6 +64,24 @@ install:
 	@echo "Installing $(BINARY_NAME)..."
 	$(GOINSTALL) $(LDFLAGS) $(CMD_DIR)
 	@echo "Installed to $(shell go env GOPATH)/bin/$(BINARY_NAME)"
+
+# Install a dev build as the CLI on this machine (default ~/.local/bin/preloop).
+#
+# This is the only sanctioned way to update a local dev CLI. It always goes
+# through install(1), never cp: install unlinks the existing file and creates
+# a new one (new inode), so the running system never sees a binary whose
+# bytes changed underneath a cached code-signature evaluation. cp writes into
+# the existing inode, which is what makes macOS kill the next exec with
+# SIGKILL "Code Signature Invalid". Unlinking needs write access to the
+# directory, not the file, so a target guarded with `chmod a-w` still
+# installs; the fresh file gets INSTALL_MODE (pass 555 to keep the guard).
+# `go build -o <target>` is also banned: it skips the version ldflags (the
+# binary reports the compiled-in fallback version and looks like a release to
+# the update check) and it replaces a read-only target, bypassing the guard.
+install-local: build
+	@mkdir -p $(BINDIR)
+	install -m $(INSTALL_MODE) $(BUILD_DIR)/$(BINARY_NAME) $(BINDIR)/$(BINARY_NAME)
+	@echo "Installed: $(BINDIR)/$(BINARY_NAME) ($(VERSION))"
 
 # Clean build artifacts
 clean:
@@ -95,6 +121,7 @@ help:
 	@echo "  make build      Build for current platform"
 	@echo "  make build-all  Cross-compile for all platforms"
 	@echo "  make install    Install to GOPATH/bin"
+	@echo "  make install-local  Build and install(1) to BINDIR (default ~/.local/bin)"
 	@echo "  make clean      Remove build artifacts"
 	@echo "  make test       Run tests"
 	@echo "  make fmt        Format code"
@@ -103,6 +130,9 @@ help:
 	@echo "  make help       Show this help"
 	@echo ""
 	@echo "Variables:"
+	@echo "  PREFIX=$(PREFIX)"
+	@echo "  BINDIR=$(BINDIR)"
+	@echo "  INSTALL_MODE=$(INSTALL_MODE)"
 	@echo "  VERSION=$(VERSION)"
 	@echo "  COMMIT=$(COMMIT)"
 	@echo "  BUILD_DATE=$(BUILD_DATE)"

--- a/cli/README.md
+++ b/cli/README.md
@@ -33,6 +33,11 @@ cd preloop/cli
 make install   # or: make build && ./build/preloop --help
 ```
 
+To run a checkout as your everyday `preloop` (for example at
+`~/.local/bin/preloop`), use `make install-local`; see
+[Installing a dev build](#installing-a-dev-build) below. Never `cp` a build
+onto an existing binary.
+
 ### Pre-built Binaries
 
 Download the latest release from [GitHub Releases](https://github.com/preloop/preloop/releases)
@@ -258,6 +263,13 @@ in place. The daily update notice asks whether to upgrade when stdin is a
 TTY and the binary is writable; otherwise it stays silent. Version lookup
 is skipped when `PRELOOP_DISABLE_TELEMETRY` is set.
 
+A dev build made with `make build` reports the `git describe` form
+(`v0.15.0-678-g5c9e8bc3`, N commits past the last tag). That counts as newer
+than the `0.15.0` release: `preloop update --check` prints
+`newer than latest release` and the daily notice stays quiet. Real
+prereleases (`0.15.0-beta.1`, `0.15.0-rc1`) still count as older than the
+release.
+
 ### Self-hosted runner
 
 ```bash
@@ -327,6 +339,40 @@ make fmt
 # Run linter
 make lint
 ```
+
+### Installing a dev build
+
+The only sanctioned way to update a local dev CLI is:
+
+```bash
+make install-local                      # build, then install(1) to ~/.local/bin/preloop
+make install-local BINDIR=/opt/bin      # or PREFIX=... ; INSTALL_MODE=555 for a read-only file
+```
+
+Never `cp build/preloop ~/.local/bin/preloop`. `cp` writes into the existing
+file's inode, and on macOS the next exec of that binary is killed with
+`SIGKILL (Code Signature Invalid)` because the kernel's cached signature no
+longer matches the bytes. `install(1)` unlinks the target and creates a new
+file, which is what keeps the signature cache valid.
+
+Never `go build -o ~/.local/bin/preloop` either. It skips the version
+ldflags, so the binary reports the compiled-in fallback version (`0.15.0`
+today) and is indistinguishable from the release to the update check, and it
+replaces the file even when the target is read-only.
+
+On macOS dev machines, guard the installed binary:
+
+```bash
+chmod a-w ~/.local/bin/preloop          # or: make install-local INSTALL_MODE=555
+```
+
+A read-only target still installs (unlinking needs directory write access,
+not file write access), a stray `cp` fails with "Permission denied" instead
+of corrupting it, and `preloop update` honours the guard: it checks whether
+the binary is writable and stays silent (or, when invoked directly, refuses)
+rather than replacing a dev build with the release. `make install-local`
+recreates the file with `INSTALL_MODE` (default 755), so re-apply the
+`chmod` afterwards or install with `INSTALL_MODE=555`.
 
 ### Project Structure
 

--- a/cli/internal/cmd/agents_claude_family_sync.go
+++ b/cli/internal/cmd/agents_claude_family_sync.go
@@ -178,7 +178,7 @@ func syncClaudeSiblingFamilyAIModels(
 
 // ensureClaudeFamilyAIModel finds or creates the account AI model for one
 // sibling family, reusing the primary model's credential secret on create and
-// refreshing gateway metadata on reuse.
+// on reuse (subscription OAuth must stay one live lineage, never a copy).
 func ensureClaudeFamilyAIModel(
 	client *api.Client,
 	existing []aiModelResponse,
@@ -210,10 +210,19 @@ func ensureClaudeFamilyAIModel(
 		)
 		metaData["managed_by"] = "preloop agents onboard"
 		metaData["source_agent"] = siblingUpstream.SourceAgent
-		if equalJSONMap(target.MetaData, metaData) && target.HasAPIKey {
+		primarySecret := ""
+		if primaryModel != nil {
+			primarySecret = strings.TrimSpace(primaryModel.CredentialsSecretID)
+		}
+		sameSecret := primarySecret != "" &&
+			strings.TrimSpace(target.CredentialsSecretID) == primarySecret
+		if equalJSONMap(target.MetaData, metaData) && target.HasAPIKey && sameSecret {
 			return target, nil
 		}
 		update := map[string]interface{}{"meta_data": metaData}
+		if primarySecret != "" && !sameSecret {
+			update["credentials_secret_id"] = primarySecret
+		}
 		var updated aiModelResponse
 		if err := client.Put("/api/v1/ai-models/"+target.ID, update, &updated); err != nil {
 			return nil, fmt.Errorf(

--- a/cli/internal/cmd/agents_claude_family_sync.go
+++ b/cli/internal/cmd/agents_claude_family_sync.go
@@ -210,10 +210,7 @@ func ensureClaudeFamilyAIModel(
 		)
 		metaData["managed_by"] = "preloop agents onboard"
 		metaData["source_agent"] = siblingUpstream.SourceAgent
-		primarySecret := ""
-		if primaryModel != nil {
-			primarySecret = strings.TrimSpace(primaryModel.CredentialsSecretID)
-		}
+		primarySecret := strings.TrimSpace(primaryModel.CredentialsSecretID)
 		sameSecret := primarySecret != "" &&
 			strings.TrimSpace(target.CredentialsSecretID) == primarySecret
 		if equalJSONMap(target.MetaData, metaData) && target.HasAPIKey && sameSecret {

--- a/cli/internal/cmd/agents_claude_family_sync_test.go
+++ b/cli/internal/cmd/agents_claude_family_sync_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+// Tests for Claude Code sibling-family AI model sync.
+//
+// Sibling family rows must share the primary model's SecretReference. A reuse
+// that only refreshes meta_data leaves an older secret in place, which splits
+// the single-use Anthropic refresh-token lineage.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+func claudeFamilySiblingForTest(id, identifier, alias, secretID string) aiModelResponse {
+	return aiModelResponse{
+		ID:                  id,
+		Name:                "Claude Code " + alias,
+		ProviderName:        "anthropic",
+		ModelIdentifier:     identifier,
+		CredentialsSecretID: secretID,
+		HasAPIKey:           secretID != "",
+		MetaData: map[string]interface{}{
+			"gateway": map[string]interface{}{
+				"enabled":     true,
+				"model_alias": alias,
+			},
+		},
+	}
+}
+
+func claudeFamilyPrimaryForTest(secretID string) *aiModelResponse {
+	model := claudeFamilySiblingForTest(
+		"primary-fable",
+		"claude-fable-5-1",
+		"anthropic/claude-fable-5-1",
+		secretID,
+	)
+	return &model
+}
+
+func claudeFamilySiblingUpstreamForTest() *managedGatewayUpstream {
+	return &managedGatewayUpstream{
+		SourceAgent:       "claude_code",
+		ProviderName:      "anthropic",
+		ModelIdentifier:   "claude-sonnet-4-5",
+		ManagedModelAlias: "anthropic/claude-sonnet-4-5",
+	}
+}
+
+func newClaudeFamilyAIModelServer(
+	t *testing.T,
+	models []aiModelResponse,
+	puts *[]map[string]interface{},
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/api/v1/ai-models/"):
+			update := map[string]interface{}{}
+			if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
+				t.Fatalf("failed to decode ai-model update: %v", err)
+			}
+			*puts = append(*puts, update)
+			updated := models[0]
+			if secretID, ok := update["credentials_secret_id"].(string); ok {
+				updated.CredentialsSecretID = secretID
+			}
+			_ = json.NewEncoder(w).Encode(updated)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/ai-models":
+			t.Errorf("unexpected AI model create: %s", r.URL.Path)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestEnsureClaudeFamilyAIModelRepointsSiblingOnDifferentSecret(t *testing.T) {
+	primarySecret := "11111111-1111-1111-1111-111111111111"
+	siblingSecret := "22222222-2222-2222-2222-222222222222"
+	sibling := claudeFamilySiblingForTest(
+		"sibling-sonnet",
+		"claude-sonnet-4-5",
+		"anthropic/claude-sonnet-4-5",
+		siblingSecret,
+	)
+	puts := []map[string]interface{}{}
+	server := newClaudeFamilyAIModelServer(t, []aiModelResponse{sibling}, &puts)
+	defer server.Close()
+
+	got, err := ensureClaudeFamilyAIModel(
+		api.NewClientWithToken(server.URL, "tok"),
+		[]aiModelResponse{sibling},
+		&managedAgentSummary{ID: "agent-1"},
+		AgentConfig{Name: "Claude Code"},
+		claudeFamilySiblingUpstreamForTest(),
+		claudeFamilyPrimaryForTest(primarySecret),
+		server.URL+"/openai/v1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected reused sibling model, got nil")
+	}
+	if len(puts) != 1 {
+		t.Fatalf("expected one PUT to realign the sibling secret, got %d: %#v", len(puts), puts)
+	}
+	secretID, ok := puts[0]["credentials_secret_id"].(string)
+	if !ok || secretID != primarySecret {
+		t.Fatalf("expected PUT credentials_secret_id %q, got %#v", primarySecret, puts[0])
+	}
+	if _, ok := puts[0]["meta_data"]; !ok {
+		t.Fatalf("expected PUT to include meta_data alongside the secret, got %#v", puts[0])
+	}
+}
+
+func TestEnsureClaudeFamilyAIModelSkipsSecretWhenAlreadyShared(t *testing.T) {
+	sharedSecret := "11111111-1111-1111-1111-111111111111"
+	sibling := claudeFamilySiblingForTest(
+		"sibling-sonnet",
+		"claude-sonnet-4-5",
+		"anthropic/claude-sonnet-4-5",
+		sharedSecret,
+	)
+	puts := []map[string]interface{}{}
+	server := newClaudeFamilyAIModelServer(t, []aiModelResponse{sibling}, &puts)
+	defer server.Close()
+
+	got, err := ensureClaudeFamilyAIModel(
+		api.NewClientWithToken(server.URL, "tok"),
+		[]aiModelResponse{sibling},
+		&managedAgentSummary{ID: "agent-1"},
+		AgentConfig{Name: "Claude Code"},
+		claudeFamilySiblingUpstreamForTest(),
+		claudeFamilyPrimaryForTest(sharedSecret),
+		server.URL+"/openai/v1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected reused sibling model, got nil")
+	}
+	for _, update := range puts {
+		if _, ok := update["credentials_secret_id"]; ok {
+			t.Fatalf(
+				"sibling already on the primary secret must get meta-only or no PUT; got %#v",
+				update,
+			)
+		}
+	}
+}

--- a/cli/internal/cmd/agents_claude_oauth_cycle_test.go
+++ b/cli/internal/cmd/agents_claude_oauth_cycle_test.go
@@ -793,3 +793,110 @@ func TestPrintClaudeCodeOAuthOffboardNote(t *testing.T) {
 		t.Fatalf("expected no note for a fresh local bundle, got %q", out.String())
 	}
 }
+
+func TestFindManagedClaudeCodeOAuthSiblingNilAgentOnlyMatchesUntaggedRows(t *testing.T) {
+	// Review finding 2: with no managed agent yet, the finder must never
+	// attach to a row tagged with some other machine's managed_agent_id.
+	tagged := claudeManagedOAuthSiblingForTest(
+		"tagged-sonnet",
+		"claude-sonnet-4-5",
+		"anthropic/claude-sonnet-4-5",
+		"secret-other-machine",
+	)
+	untagged := claudeManagedOAuthSiblingForTest(
+		"untagged-haiku",
+		"claude-haiku-4-5",
+		"anthropic/claude-haiku-4-5",
+		"secret-untagged",
+	)
+	delete(untagged.MetaData, "managed_agent_id")
+
+	got := findManagedClaudeCodeOAuthSibling(
+		[]aiModelResponse{tagged},
+		AgentConfig{Name: "Claude Code"},
+		nil,
+		"oauth_anthropic_claude_code",
+		"",
+	)
+	if got != nil {
+		t.Fatalf("nil managed agent must not match a row tagged for another agent, got %#v", got)
+	}
+
+	got = findManagedClaudeCodeOAuthSibling(
+		[]aiModelResponse{tagged, untagged},
+		AgentConfig{Name: "Claude Code"},
+		nil,
+		"oauth_anthropic_claude_code",
+		"",
+	)
+	if got == nil || got.ID != "untagged-haiku" {
+		t.Fatalf("nil managed agent should fall back to the untagged row only, got %#v", got)
+	}
+
+	got = findManagedClaudeCodeOAuthSibling(
+		[]aiModelResponse{tagged, untagged},
+		AgentConfig{Name: "Claude Code"},
+		&managedAgentSummary{ID: "agent-1"},
+		"oauth_anthropic_claude_code",
+		"",
+	)
+	if got == nil || got.ID != "tagged-sonnet" {
+		t.Fatalf("matching managed agent should still win over the untagged fallback, got %#v", got)
+	}
+}
+
+func TestSyncManagedGatewayAIModelUpdateOmitsAPIKeyForOAuthUpstream(t *testing.T) {
+	// Review finding 3: an upstream carrying both a stray api_key and an
+	// OAuth credential type must not put api_key and credentials_secret_id
+	// on the same PUT; the backend validator rejects that combination.
+	fable := claudeManagedOAuthSiblingForTest(
+		"target-fable",
+		"claude-fable-5-1",
+		"anthropic/claude-fable-5-1",
+		"",
+	)
+	fable.HasAPIKey = false
+	fable.CredentialType = ""
+	sibling := claudeManagedOAuthSiblingForTest(
+		"sibling-sonnet",
+		"claude-sonnet-4-5",
+		"anthropic/claude-sonnet-4-5",
+		"secret-live",
+	)
+	writes := []recordedAIModelWrite{}
+	server := newClaudeFamilyLineageServer(t, []aiModelResponse{fable, sibling}, &writes)
+	defer server.Close()
+
+	staleExpiry := time.Now().UTC().Add(-24 * time.Hour).UnixMilli()
+	upstream := claudeFableUpstreamForTest(map[string]interface{}{
+		"access":  "sk-ant-oat01-stale",
+		"refresh": "sk-ant-ort01-stale",
+		"expires": staleExpiry,
+	})
+	upstream.APIKey = "sk-ant-api-stray"
+
+	if _, _, err := syncManagedGatewayAIModel(
+		api.NewClientWithToken(server.URL, "tok"),
+		&managedAgentSummary{ID: "agent-1"},
+		AgentConfig{Name: "Claude Code"},
+		upstream,
+		server.URL+"/openai/v1",
+	); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	attached := false
+	for _, write := range writes {
+		if !strings.HasSuffix(write.Path, "/target-fable") {
+			continue
+		}
+		if _, ok := write.Body["api_key"]; ok {
+			t.Fatalf("OAuth upstream must not send api_key alongside a shared secret; got %#v", write.Body)
+		}
+		if write.Body["credentials_secret_id"] == "secret-live" {
+			attached = true
+		}
+	}
+	if !attached {
+		t.Fatalf("expected a PUT attaching the sibling secret to the fable row; writes: %#v", writes)
+	}
+}

--- a/cli/internal/cmd/agents_claude_oauth_cycle_test.go
+++ b/cli/internal/cmd/agents_claude_oauth_cycle_test.go
@@ -431,7 +431,7 @@ func TestSyncManagedGatewayAIModelCreateReusesClaudeSiblingSecretWhenLocalExpire
 	}
 }
 
-func TestSyncManagedGatewayAIModelCreateReseedsClaudeSiblingThenSharesSecret(t *testing.T) {
+func TestSyncManagedGatewayAIModelCreateReusesClaudeSiblingSecretWhenLocalUnexpired(t *testing.T) {
 	sibling := claudeManagedOAuthSiblingForTest(
 		"sibling-sonnet",
 		"claude-sonnet-4-5",
@@ -444,8 +444,8 @@ func TestSyncManagedGatewayAIModelCreateReseedsClaudeSiblingThenSharesSecret(t *
 
 	freshExpiry := time.Now().UTC().Add(4 * time.Hour).UnixMilli()
 	upstream := claudeFableUpstreamForTest(map[string]interface{}{
-		"access":  "sk-ant-oat01-fresh",
-		"refresh": "sk-ant-ort01-fresh",
+		"access":  "sk-ant-oat01-cached",
+		"refresh": "sk-ant-ort01-cached",
 		"expires": freshExpiry,
 	})
 
@@ -462,22 +462,14 @@ func TestSyncManagedGatewayAIModelCreateReseedsClaudeSiblingThenSharesSecret(t *
 	if model == nil {
 		t.Fatalf("expected created fable row, got nil")
 	}
-	reseededSibling := false
 	var createBody map[string]interface{}
 	for _, write := range writes {
-		if write.Method == http.MethodPut && strings.HasSuffix(write.Path, "/sibling-sonnet") {
-			payload, _ := write.Body["credential_payload"].(map[string]interface{})
-			if payload["access"] != "sk-ant-oat01-fresh" {
-				t.Fatalf("expected fresh payload on sibling, got %#v", write.Body)
-			}
-			reseededSibling = true
+		if write.Method == http.MethodPut {
+			t.Fatalf("unexpired local bundle must not overwrite the sibling secret; got %#v", write)
 		}
 		if write.Method == http.MethodPost {
 			createBody = write.Body
 		}
-	}
-	if !reseededSibling {
-		t.Fatalf("expected a PUT of the fresh bundle onto the sibling; writes: %#v", writes)
 	}
 	if createBody == nil {
 		t.Fatalf("expected a create for the new fable row; writes: %#v", writes)
@@ -554,7 +546,7 @@ func TestSyncManagedGatewayAIModelUpdateAttachesClaudeSiblingSecretWhenTargetHas
 	}
 }
 
-func TestSyncManagedGatewayAIModelUpdateReseedsClaudeSiblingWhenTargetHasNoCredential(t *testing.T) {
+func TestSyncManagedGatewayAIModelUpdateAttachesClaudeSiblingSecretWhenLocalUnexpired(t *testing.T) {
 	fable := claudeManagedOAuthSiblingForTest(
 		"target-fable",
 		"claude-fable-5-1",
@@ -575,8 +567,8 @@ func TestSyncManagedGatewayAIModelUpdateReseedsClaudeSiblingWhenTargetHasNoCrede
 
 	freshExpiry := time.Now().UTC().Add(4 * time.Hour).UnixMilli()
 	upstream := claudeFableUpstreamForTest(map[string]interface{}{
-		"access":  "sk-ant-oat01-fresh",
-		"refresh": "sk-ant-ort01-fresh",
+		"access":  "sk-ant-oat01-cached",
+		"refresh": "sk-ant-ort01-cached",
 		"expires": freshExpiry,
 	})
 
@@ -593,18 +585,13 @@ func TestSyncManagedGatewayAIModelUpdateReseedsClaudeSiblingWhenTargetHasNoCrede
 	if model == nil {
 		t.Fatalf("expected updated fable row, got nil")
 	}
-	reseededSibling := false
 	attached := false
 	for _, write := range writes {
 		if write.Method != http.MethodPut {
 			t.Fatalf("must not create a second secret when a sibling lineage exists; got %#v", write)
 		}
 		if strings.HasSuffix(write.Path, "/sibling-sonnet") {
-			payload, _ := write.Body["credential_payload"].(map[string]interface{})
-			if payload["access"] != "sk-ant-oat01-fresh" {
-				t.Fatalf("expected fresh payload on sibling, got %#v", write.Body)
-			}
-			reseededSibling = true
+			t.Fatalf("unexpired local bundle must not overwrite the sibling secret; got %#v", write)
 		}
 		if strings.HasSuffix(write.Path, "/target-fable") {
 			if write.Body["credentials_secret_id"] != "secret-live" {
@@ -616,8 +603,8 @@ func TestSyncManagedGatewayAIModelUpdateReseedsClaudeSiblingWhenTargetHasNoCrede
 			attached = true
 		}
 	}
-	if !reseededSibling || !attached {
-		t.Fatalf("expected sibling re-seed then target attach; writes: %#v", writes)
+	if !attached {
+		t.Fatalf("expected a PUT attaching the sibling secret to the fable row; writes: %#v", writes)
 	}
 }
 

--- a/cli/internal/cmd/agents_claude_oauth_cycle_test.go
+++ b/cli/internal/cmd/agents_claude_oauth_cycle_test.go
@@ -276,6 +276,351 @@ func TestSyncManagedGatewayAIModelServerReuseScopedToClaudeCode(t *testing.T) {
 	}
 }
 
+type recordedAIModelWrite struct {
+	Method string
+	Path   string
+	Body   map[string]interface{}
+}
+
+func claudeManagedOAuthSiblingForTest(id, identifier, alias, secretID string) aiModelResponse {
+	return aiModelResponse{
+		ID:                  id,
+		Name:                "Claude Code " + alias,
+		ProviderName:        "anthropic",
+		ModelIdentifier:     identifier,
+		CredentialType:      "oauth_anthropic_claude_code",
+		CredentialsSecretID: secretID,
+		HasAPIKey:           secretID != "",
+		MetaData: map[string]interface{}{
+			"source_agent":     "claude_code",
+			"managed_by":       "preloop agents onboard",
+			"managed_agent_id": "agent-1",
+			"gateway": map[string]interface{}{
+				"enabled":     true,
+				"model_alias": alias,
+			},
+		},
+	}
+}
+
+func claudeFableUpstreamForTest(payload map[string]interface{}) *managedGatewayUpstream {
+	upstream := &managedGatewayUpstream{
+		SourceAgent:       "claude_code",
+		SourceProviderID:  "anthropic",
+		ProviderName:      "anthropic",
+		ModelIdentifier:   "claude-fable-5-1",
+		ManagedModelAlias: "anthropic/claude-fable-5-1",
+	}
+	if payload != nil {
+		upstream.CredentialType = "oauth_anthropic_claude_code"
+		upstream.CredentialPayload = payload
+	}
+	return upstream
+}
+
+func newClaudeFamilyLineageServer(
+	t *testing.T,
+	models []aiModelResponse,
+	writes *[]recordedAIModelWrite,
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/ai-models":
+			_ = json.NewEncoder(w).Encode(models)
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/api/v1/ai-models/"):
+			body := map[string]interface{}{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode ai-model update: %v", err)
+			}
+			*writes = append(*writes, recordedAIModelWrite{
+				Method: http.MethodPut,
+				Path:   r.URL.Path,
+				Body:   body,
+			})
+			updated := models[0]
+			if strings.HasSuffix(r.URL.Path, "/"+models[0].ID) {
+				updated = models[0]
+			} else if len(models) > 1 && strings.HasSuffix(r.URL.Path, "/"+models[1].ID) {
+				updated = models[1]
+			}
+			if secretID, ok := body["credentials_secret_id"].(string); ok {
+				updated.CredentialsSecretID = secretID
+				updated.HasAPIKey = true
+			}
+			_ = json.NewEncoder(w).Encode(updated)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/ai-models":
+			body := map[string]interface{}{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode ai-model create: %v", err)
+			}
+			*writes = append(*writes, recordedAIModelWrite{
+				Method: http.MethodPost,
+				Path:   r.URL.Path,
+				Body:   body,
+			})
+			created := claudeManagedOAuthSiblingForTest(
+				"created-fable",
+				"claude-fable-5-1",
+				"anthropic/claude-fable-5-1",
+				"",
+			)
+			if secretID, ok := body["credentials_secret_id"].(string); ok {
+				created.CredentialsSecretID = secretID
+				created.HasAPIKey = true
+			}
+			_ = json.NewEncoder(w).Encode(created)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestSyncManagedGatewayAIModelCreateReusesClaudeSiblingSecretWhenLocalExpired(t *testing.T) {
+	sibling := claudeManagedOAuthSiblingForTest(
+		"sibling-sonnet",
+		"claude-sonnet-4-5",
+		"anthropic/claude-sonnet-4-5",
+		"secret-live",
+	)
+	writes := []recordedAIModelWrite{}
+	server := newClaudeFamilyLineageServer(t, []aiModelResponse{sibling}, &writes)
+	defer server.Close()
+
+	staleExpiry := time.Now().UTC().Add(-24 * time.Hour).UnixMilli()
+	upstream := claudeFableUpstreamForTest(map[string]interface{}{
+		"access":  "sk-ant-oat01-stale",
+		"refresh": "sk-ant-ort01-stale",
+		"expires": staleExpiry,
+	})
+
+	model, _, err := syncManagedGatewayAIModel(
+		api.NewClientWithToken(server.URL, "tok"),
+		&managedAgentSummary{ID: "agent-1"},
+		AgentConfig{Name: "Claude Code"},
+		upstream,
+		server.URL+"/openai/v1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if model == nil {
+		t.Fatalf("expected created fable row, got nil")
+	}
+	var createBody map[string]interface{}
+	for _, write := range writes {
+		if write.Method == http.MethodPut {
+			t.Fatalf("expired local bundle must not overwrite the sibling secret; got %#v", write)
+		}
+		if write.Method == http.MethodPost {
+			createBody = write.Body
+		}
+	}
+	if createBody == nil {
+		t.Fatalf("expected a create for the new fable row; writes: %#v", writes)
+	}
+	if createBody["credentials_secret_id"] != "secret-live" {
+		t.Fatalf("expected create to reuse sibling secret, got %#v", createBody)
+	}
+	if _, ok := createBody["credential_payload"]; ok {
+		t.Fatalf("create must not mint a second OAuth secret; got %#v", createBody)
+	}
+	if _, ok := createBody["credential_type"]; ok {
+		t.Fatalf("create must not send credential_type with a reused secret; got %#v", createBody)
+	}
+}
+
+func TestSyncManagedGatewayAIModelCreateReseedsClaudeSiblingThenSharesSecret(t *testing.T) {
+	sibling := claudeManagedOAuthSiblingForTest(
+		"sibling-sonnet",
+		"claude-sonnet-4-5",
+		"anthropic/claude-sonnet-4-5",
+		"secret-live",
+	)
+	writes := []recordedAIModelWrite{}
+	server := newClaudeFamilyLineageServer(t, []aiModelResponse{sibling}, &writes)
+	defer server.Close()
+
+	freshExpiry := time.Now().UTC().Add(4 * time.Hour).UnixMilli()
+	upstream := claudeFableUpstreamForTest(map[string]interface{}{
+		"access":  "sk-ant-oat01-fresh",
+		"refresh": "sk-ant-ort01-fresh",
+		"expires": freshExpiry,
+	})
+
+	model, _, err := syncManagedGatewayAIModel(
+		api.NewClientWithToken(server.URL, "tok"),
+		&managedAgentSummary{ID: "agent-1"},
+		AgentConfig{Name: "Claude Code"},
+		upstream,
+		server.URL+"/openai/v1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if model == nil {
+		t.Fatalf("expected created fable row, got nil")
+	}
+	reseededSibling := false
+	var createBody map[string]interface{}
+	for _, write := range writes {
+		if write.Method == http.MethodPut && strings.HasSuffix(write.Path, "/sibling-sonnet") {
+			payload, _ := write.Body["credential_payload"].(map[string]interface{})
+			if payload["access"] != "sk-ant-oat01-fresh" {
+				t.Fatalf("expected fresh payload on sibling, got %#v", write.Body)
+			}
+			reseededSibling = true
+		}
+		if write.Method == http.MethodPost {
+			createBody = write.Body
+		}
+	}
+	if !reseededSibling {
+		t.Fatalf("expected a PUT of the fresh bundle onto the sibling; writes: %#v", writes)
+	}
+	if createBody == nil {
+		t.Fatalf("expected a create for the new fable row; writes: %#v", writes)
+	}
+	if createBody["credentials_secret_id"] != "secret-live" {
+		t.Fatalf("expected create to reuse sibling secret, got %#v", createBody)
+	}
+	if _, ok := createBody["credential_payload"]; ok {
+		t.Fatalf("create must not mint a second OAuth secret; got %#v", createBody)
+	}
+}
+
+func TestSyncManagedGatewayAIModelUpdateAttachesClaudeSiblingSecretWhenTargetHasNone(t *testing.T) {
+	fable := claudeManagedOAuthSiblingForTest(
+		"target-fable",
+		"claude-fable-5-1",
+		"anthropic/claude-fable-5-1",
+		"",
+	)
+	fable.HasAPIKey = false
+	fable.CredentialType = ""
+	sibling := claudeManagedOAuthSiblingForTest(
+		"sibling-sonnet",
+		"claude-sonnet-4-5",
+		"anthropic/claude-sonnet-4-5",
+		"secret-live",
+	)
+	writes := []recordedAIModelWrite{}
+	server := newClaudeFamilyLineageServer(t, []aiModelResponse{fable, sibling}, &writes)
+	defer server.Close()
+
+	staleExpiry := time.Now().UTC().Add(-24 * time.Hour).UnixMilli()
+	upstream := claudeFableUpstreamForTest(map[string]interface{}{
+		"access":  "sk-ant-oat01-stale",
+		"refresh": "sk-ant-ort01-stale",
+		"expires": staleExpiry,
+	})
+
+	model, _, err := syncManagedGatewayAIModel(
+		api.NewClientWithToken(server.URL, "tok"),
+		&managedAgentSummary{ID: "agent-1"},
+		AgentConfig{Name: "Claude Code"},
+		upstream,
+		server.URL+"/openai/v1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if model == nil || model.ID != "target-fable" {
+		t.Fatalf("expected updated fable row, got %#v", model)
+	}
+	attached := false
+	for _, write := range writes {
+		if write.Method != http.MethodPut {
+			t.Fatalf("expired local bundle must not create a new secret; got %#v", write)
+		}
+		if strings.HasSuffix(write.Path, "/sibling-sonnet") {
+			if _, ok := write.Body["credential_payload"]; ok {
+				t.Fatalf("expired local bundle must not overwrite the sibling secret; got %#v", write)
+			}
+		}
+		if strings.HasSuffix(write.Path, "/target-fable") {
+			if write.Body["credentials_secret_id"] != "secret-live" {
+				t.Fatalf("expected target to attach sibling secret, got %#v", write.Body)
+			}
+			if _, ok := write.Body["credential_payload"]; ok {
+				t.Fatalf("target must not mint a second OAuth secret; got %#v", write.Body)
+			}
+			attached = true
+		}
+	}
+	if !attached {
+		t.Fatalf("expected a PUT attaching the sibling secret to the fable row; writes: %#v", writes)
+	}
+}
+
+func TestSyncManagedGatewayAIModelUpdateReseedsClaudeSiblingWhenTargetHasNoCredential(t *testing.T) {
+	fable := claudeManagedOAuthSiblingForTest(
+		"target-fable",
+		"claude-fable-5-1",
+		"anthropic/claude-fable-5-1",
+		"",
+	)
+	fable.HasAPIKey = false
+	fable.CredentialType = ""
+	sibling := claudeManagedOAuthSiblingForTest(
+		"sibling-sonnet",
+		"claude-sonnet-4-5",
+		"anthropic/claude-sonnet-4-5",
+		"secret-live",
+	)
+	writes := []recordedAIModelWrite{}
+	server := newClaudeFamilyLineageServer(t, []aiModelResponse{fable, sibling}, &writes)
+	defer server.Close()
+
+	freshExpiry := time.Now().UTC().Add(4 * time.Hour).UnixMilli()
+	upstream := claudeFableUpstreamForTest(map[string]interface{}{
+		"access":  "sk-ant-oat01-fresh",
+		"refresh": "sk-ant-ort01-fresh",
+		"expires": freshExpiry,
+	})
+
+	model, _, err := syncManagedGatewayAIModel(
+		api.NewClientWithToken(server.URL, "tok"),
+		&managedAgentSummary{ID: "agent-1"},
+		AgentConfig{Name: "Claude Code"},
+		upstream,
+		server.URL+"/openai/v1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if model == nil {
+		t.Fatalf("expected updated fable row, got nil")
+	}
+	reseededSibling := false
+	attached := false
+	for _, write := range writes {
+		if write.Method != http.MethodPut {
+			t.Fatalf("must not create a second secret when a sibling lineage exists; got %#v", write)
+		}
+		if strings.HasSuffix(write.Path, "/sibling-sonnet") {
+			payload, _ := write.Body["credential_payload"].(map[string]interface{})
+			if payload["access"] != "sk-ant-oat01-fresh" {
+				t.Fatalf("expected fresh payload on sibling, got %#v", write.Body)
+			}
+			reseededSibling = true
+		}
+		if strings.HasSuffix(write.Path, "/target-fable") {
+			if write.Body["credentials_secret_id"] != "secret-live" {
+				t.Fatalf("expected target to attach sibling secret, got %#v", write.Body)
+			}
+			if _, ok := write.Body["credential_payload"]; ok {
+				t.Fatalf("target must not mint a second OAuth secret; got %#v", write.Body)
+			}
+			attached = true
+		}
+	}
+	if !reseededSibling || !attached {
+		t.Fatalf("expected sibling re-seed then target attach; writes: %#v", writes)
+	}
+}
+
 func TestOauthCredentialPayloadExpired(t *testing.T) {
 	now := time.Now().UTC().UnixMilli()
 	if oauthCredentialPayloadExpired(map[string]interface{}{"expires": now + 60_000}) {

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -5681,24 +5681,24 @@ func findManagedClaudeCodeOAuthSibling(
 		if strings.TrimSpace(model.CredentialsSecretID) == "" {
 			continue
 		}
-		if agentID != "" {
-			modelAgentID := ""
-			if model.MetaData != nil {
-				modelAgentID, _ = model.MetaData["managed_agent_id"].(string)
-				modelAgentID = strings.TrimSpace(modelAgentID)
-			}
-			if modelAgentID == agentID {
-				return model
-			}
-			if modelAgentID != "" {
-				continue
-			}
-			if fallback == nil {
-				fallback = model
-			}
+		modelAgentID := ""
+		if model.MetaData != nil {
+			modelAgentID, _ = model.MetaData["managed_agent_id"].(string)
+			modelAgentID = strings.TrimSpace(modelAgentID)
+		}
+		if agentID != "" && modelAgentID == agentID {
+			return model
+		}
+		// A row tagged with a different managed agent belongs to another
+		// machine's login; never attach to (or overwrite) that lineage.
+		// This also holds when the caller has no managed agent yet: only
+		// untagged rows are eligible then.
+		if modelAgentID != "" {
 			continue
 		}
-		return model
+		if fallback == nil {
+			fallback = model
+		}
 	}
 	return fallback
 }
@@ -5803,7 +5803,11 @@ func syncManagedGatewayAIModel(
 		if !equalJSONMap(target.MetaData, metaData) {
 			update["meta_data"] = metaData
 		}
-		if upstream.APIKey != "" && !target.HasAPIKey {
+		// An OAuth upstream is seeded via credential_type/credential_payload
+		// or a shared credentials_secret_id below; sending api_key alongside
+		// either would be rejected by the backend validator.
+		if upstream.APIKey != "" && !target.HasAPIKey &&
+			!isOAuthCredentialType(upstream.CredentialType) {
 			update["api_key"] = upstream.APIKey
 		}
 		// Re-seed the stored credential on re-onboard when the upstream

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -5647,6 +5647,106 @@ func syncOpenClawAIModels(
 	return bindings, notes, nil
 }
 
+// findManagedClaudeCodeOAuthSibling returns an existing managed Claude Code
+// AI model that already holds a live same-type OAuth SecretReference. Used
+// so a newly pinned family (e.g. a first-seen fable row) attaches that
+// secret instead of minting a second single-use refresh-token lineage.
+func findManagedClaudeCodeOAuthSibling(
+	existing []aiModelResponse,
+	agent AgentConfig,
+	managedAgent *managedAgentSummary,
+	credentialType string,
+	excludeID string,
+) *aiModelResponse {
+	if !isClaudeCodeAgent(agent) || !isOAuthCredentialType(credentialType) {
+		return nil
+	}
+	wantType := strings.TrimSpace(credentialType)
+	if wantType == "" {
+		return nil
+	}
+	var agentID string
+	if managedAgent != nil {
+		agentID = strings.TrimSpace(managedAgent.ID)
+	}
+	var fallback *aiModelResponse
+	for i := range existing {
+		model := &existing[i]
+		if excludeID != "" && strings.TrimSpace(model.ID) == strings.TrimSpace(excludeID) {
+			continue
+		}
+		if strings.TrimSpace(model.CredentialType) != wantType {
+			continue
+		}
+		if strings.TrimSpace(model.CredentialsSecretID) == "" {
+			continue
+		}
+		if agentID != "" {
+			modelAgentID := ""
+			if model.MetaData != nil {
+				modelAgentID, _ = model.MetaData["managed_agent_id"].(string)
+				modelAgentID = strings.TrimSpace(modelAgentID)
+			}
+			if modelAgentID == agentID {
+				return model
+			}
+			if modelAgentID != "" {
+				continue
+			}
+			if fallback == nil {
+				fallback = model
+			}
+			continue
+		}
+		return model
+	}
+	return fallback
+}
+
+func overwriteManagedClaudeCodeOAuthSecret(
+	client *api.Client,
+	sibling *aiModelResponse,
+	upstream *managedGatewayUpstream,
+) error {
+	if client == nil || sibling == nil || upstream == nil {
+		return nil
+	}
+	update := map[string]interface{}{
+		"credential_type":    upstream.CredentialType,
+		"credential_payload": upstream.CredentialPayload,
+	}
+	var updated aiModelResponse
+	if err := client.Put("/api/v1/ai-models/"+sibling.ID, update, &updated); err != nil {
+		return fmt.Errorf(
+			"failed to refresh shared Claude Code credential on %q: %w",
+			sibling.Name,
+			err,
+		)
+	}
+	return nil
+}
+
+func applySharedClaudeCodeOAuthSecret(
+	client *api.Client,
+	sibling *aiModelResponse,
+	upstream *managedGatewayUpstream,
+) (string, error) {
+	if sibling == nil {
+		return "", nil
+	}
+	secretID := strings.TrimSpace(sibling.CredentialsSecretID)
+	if secretID == "" {
+		return "", nil
+	}
+	if len(upstream.CredentialPayload) > 0 &&
+		!oauthCredentialPayloadExpired(upstream.CredentialPayload) {
+		if err := overwriteManagedClaudeCodeOAuthSecret(client, sibling, upstream); err != nil {
+			return "", err
+		}
+	}
+	return secretID, nil
+}
+
 func syncManagedGatewayAIModel(
 	client *api.Client,
 	managedAgent *managedAgentSummary,
@@ -5725,7 +5825,30 @@ func syncManagedGatewayAIModel(
 		// downgrades every later onboarding to MCP-only. When the local
 		// bundle is expired and the account already holds a same-type OAuth
 		// credential, keep the account copy — the gateway can refresh it.
-		if len(upstream.CredentialPayload) > 0 &&
+		//
+		// A second exception: when this target has no credential yet but a
+		// sibling Claude Code row already holds the same-type OAuth secret,
+		// attach that secret instead of minting a second lineage.
+		sharedSibling := findManagedClaudeCodeOAuthSibling(
+			existing,
+			agent,
+			managedAgent,
+			upstream.CredentialType,
+			target.ID,
+		)
+		if !target.HasAPIKey && sharedSibling != nil {
+			sharedSecret, shareErr := applySharedClaudeCodeOAuthSecret(
+				client,
+				sharedSibling,
+				upstream,
+			)
+			if shareErr != nil {
+				return nil, nil, shareErr
+			}
+			if sharedSecret != "" {
+				update["credentials_secret_id"] = sharedSecret
+			}
+		} else if len(upstream.CredentialPayload) > 0 &&
 			(!target.HasAPIKey ||
 				strings.TrimSpace(target.CredentialType) != strings.TrimSpace(upstream.CredentialType) ||
 				(isOAuthCredentialType(upstream.CredentialType) &&
@@ -5796,6 +5919,28 @@ func syncManagedGatewayAIModel(
 		CredentialType:  upstream.CredentialType,
 		CredentialsJSON: upstream.CredentialPayload,
 		MetaData:        metaData,
+	}
+	if sharedSibling := findManagedClaudeCodeOAuthSibling(
+		existing,
+		agent,
+		managedAgent,
+		upstream.CredentialType,
+		"",
+	); sharedSibling != nil {
+		sharedSecret, shareErr := applySharedClaudeCodeOAuthSecret(
+			client,
+			sharedSibling,
+			upstream,
+		)
+		if shareErr != nil {
+			return nil, nil, shareErr
+		}
+		if sharedSecret != "" {
+			create.CredentialsSecretID = sharedSecret
+			create.APIKey = ""
+			create.CredentialType = ""
+			create.CredentialsJSON = nil
+		}
 	}
 
 	var created aiModelResponse

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -5703,48 +5703,17 @@ func findManagedClaudeCodeOAuthSibling(
 	return fallback
 }
 
-func overwriteManagedClaudeCodeOAuthSecret(
-	client *api.Client,
-	sibling *aiModelResponse,
-	upstream *managedGatewayUpstream,
-) error {
-	if client == nil || sibling == nil || upstream == nil {
-		return nil
-	}
-	update := map[string]interface{}{
-		"credential_type":    upstream.CredentialType,
-		"credential_payload": upstream.CredentialPayload,
-	}
-	var updated aiModelResponse
-	if err := client.Put("/api/v1/ai-models/"+sibling.ID, update, &updated); err != nil {
-		return fmt.Errorf(
-			"failed to refresh shared Claude Code credential on %q: %w",
-			sibling.Name,
-			err,
-		)
-	}
-	return nil
-}
-
-func applySharedClaudeCodeOAuthSecret(
-	client *api.Client,
-	sibling *aiModelResponse,
-	upstream *managedGatewayUpstream,
-) (string, error) {
+func applySharedClaudeCodeOAuthSecret(sibling *aiModelResponse) string {
 	if sibling == nil {
-		return "", nil
+		return ""
 	}
-	secretID := strings.TrimSpace(sibling.CredentialsSecretID)
-	if secretID == "" {
-		return "", nil
-	}
-	if len(upstream.CredentialPayload) > 0 &&
-		!oauthCredentialPayloadExpired(upstream.CredentialPayload) {
-		if err := overwriteManagedClaudeCodeOAuthSecret(client, sibling, upstream); err != nil {
-			return "", err
-		}
-	}
-	return secretID, nil
+	// Attach the sibling's live lineage. Never overwrite it from the local
+	// bundle: an access token can still be inside its window after the
+	// gateway has already consumed the single-use refresh token. Putting
+	// that cached bundle back onto the shared secret bricks every sibling
+	// (invalid_grant). Recovery of a dead lineage goes through the
+	// target-already-has-a-credential re-seed path, not this attach path.
+	return strings.TrimSpace(sibling.CredentialsSecretID)
 }
 
 func syncManagedGatewayAIModel(
@@ -5841,14 +5810,7 @@ func syncManagedGatewayAIModel(
 			target.ID,
 		)
 		if !target.HasAPIKey && sharedSibling != nil {
-			sharedSecret, shareErr := applySharedClaudeCodeOAuthSecret(
-				client,
-				sharedSibling,
-				upstream,
-			)
-			if shareErr != nil {
-				return nil, nil, shareErr
-			}
+			sharedSecret := applySharedClaudeCodeOAuthSecret(sharedSibling)
 			if sharedSecret != "" {
 				update["credentials_secret_id"] = sharedSecret
 			}
@@ -5931,14 +5893,7 @@ func syncManagedGatewayAIModel(
 		upstream.CredentialType,
 		"",
 	); sharedSibling != nil {
-		sharedSecret, shareErr := applySharedClaudeCodeOAuthSecret(
-			client,
-			sharedSibling,
-			upstream,
-		)
-		if shareErr != nil {
-			return nil, nil, shareErr
-		}
+		sharedSecret := applySharedClaudeCodeOAuthSecret(sharedSibling)
 		if sharedSecret != "" {
 			create.CredentialsSecretID = sharedSecret
 			create.APIKey = ""

--- a/cli/internal/cmd/update_test.go
+++ b/cli/internal/cmd/update_test.go
@@ -231,3 +231,29 @@ func TestUpdateCheckNewerThanLatest(t *testing.T) {
 		t.Fatalf("expected newer-than-latest line, got %q", out)
 	}
 }
+
+func TestUpdateCheckDevBuildIsNewerThanLatestRelease(t *testing.T) {
+	// A `make build` binary reports the git-describe form; `preloop update
+	// --check` must say it is newer than the release, not offer a downgrade.
+	resetUpdateFlags(t)
+	oldVersion := version.Version
+	version.Version = "v0.15.0-678-g5c9e8bc3"
+	t.Cleanup(func() { version.Version = oldVersion })
+	withVersionCheckServer(t, "0.15.0")
+	if err := updateCmd.Flags().Set("check", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureUpdateStdout(t, func() error {
+		return runUpdate(updateCmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("runUpdate --check: %v", err)
+	}
+	if strings.Contains(out, "update available") {
+		t.Fatalf("dev build must not offer a downgrade to the release, got %q", out)
+	}
+	if !strings.Contains(out, "newer than latest release") {
+		t.Fatalf("expected newer-than-latest line, got %q", out)
+	}
+}

--- a/cli/internal/version/update.go
+++ b/cli/internal/version/update.go
@@ -56,10 +56,35 @@ func NormalizeVersion(v string) string {
 	return strings.TrimPrefix(strings.TrimSpace(v), "v")
 }
 
-// parsedVersion is a numeric X.Y.Z with an optional prerelease suffix.
+// parsedVersion is a numeric X.Y.Z with either an optional semver
+// prerelease suffix (beta.1, rc1) or a git-describe distance: the "N" in
+// X.Y.Z-N-g<hex>, meaning N commits after the X.Y.Z tag. The two are
+// mutually exclusive; a describe build has pre == "" and commits >= 0.
 type parsedVersion struct {
-	parts []int
-	pre   string
+	parts   []int
+	pre     string
+	commits int
+}
+
+// parseGitDescribeDistance recognises the "N-g<hex>" tail that
+// `git describe --tags` appends to the nearest tag (for example
+// "678-g5c9e8bc3") and returns N. Any other suffix is a real prerelease.
+func parseGitDescribeDistance(pre string) (int, bool) {
+	count, hash, ok := strings.Cut(pre, "-")
+	if !ok || count == "" || len(hash) < 2 || hash[0] != 'g' {
+		return 0, false
+	}
+	n, err := strconv.Atoi(count)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	for _, r := range hash[1:] {
+		isHex := (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+		if !isHex {
+			return 0, false
+		}
+	}
+	return n, true
 }
 
 func parseSemver(v string) (parsedVersion, bool) {
@@ -69,6 +94,9 @@ func parseSemver(v string) (parsedVersion, bool) {
 	if s == "" || s == "dev" {
 		return parsedVersion{}, false
 	}
+	// `git describe --dirty` appends "-dirty" to either form. Uncommitted
+	// changes do not move the build relative to the tag, so drop the marker.
+	s = strings.TrimSuffix(s, "-dirty")
 	core, pre, _ := strings.Cut(s, "-")
 	core, _, _ = strings.Cut(core, "+")
 	pre, _, _ = strings.Cut(pre, "+")
@@ -84,7 +112,12 @@ func parseSemver(v string) (parsedVersion, bool) {
 		}
 		parts[i] = n
 	}
-	return parsedVersion{parts: parts, pre: pre}, true
+	parsed := parsedVersion{parts: parts, pre: pre}
+	if commits, ok := parseGitDescribeDistance(pre); ok {
+		parsed.pre = ""
+		parsed.commits = commits
+	}
+	return parsed, true
 }
 
 func compareParsed(a, b parsedVersion) int {
@@ -114,10 +147,20 @@ func compareParsed(a, b parsedVersion) int {
 	if !aPre && bPre {
 		return 1
 	}
-	if !aPre && !bPre {
+	if aPre && bPre {
+		return comparePrerelease(a.pre, b.pre)
+	}
+	// Neither side is a prerelease. A git-describe build N commits past
+	// the tag is newer than the tag itself, and further past is newer
+	// still; two plain releases (commits == 0) compare equal.
+	switch {
+	case a.commits < b.commits:
+		return -1
+	case a.commits > b.commits:
+		return 1
+	default:
 		return 0
 	}
-	return comparePrerelease(a.pre, b.pre)
 }
 
 func comparePrerelease(a, b string) int {
@@ -175,9 +218,12 @@ func parsePrereleaseInt(s string) (int, bool) {
 	return n, true
 }
 
-// CompareVersions compares [v]X.Y.Z strings (optional prerelease after '-').
-// Returns -1 if a < b, 0 if a == b, 1 if a > b. ok is false when either
-// side is not a parseable version (for example "dev").
+// CompareVersions compares [v]X.Y.Z strings. A '-' suffix is either a
+// semver prerelease (X.Y.Z-beta.1, lower than X.Y.Z) or the git-describe
+// form X.Y.Z-N-g<hex>[-dirty] produced by `make build` on a checkout N
+// commits past the tag (higher than X.Y.Z). Returns -1 if a < b, 0 if
+// a == b, 1 if a > b. ok is false when either side is not a parseable
+// version (for example "dev" or a bare commit hash).
 func CompareVersions(a, b string) (cmp int, ok bool) {
 	pa, oka := parseSemver(a)
 	pb, okb := parseSemver(b)

--- a/cli/internal/version/update_test.go
+++ b/cli/internal/version/update_test.go
@@ -474,3 +474,61 @@ func TestForceCheckStillUsedByUpdateLookup(t *testing.T) {
 		t.Fatalf("latest = %q", info.LatestVersion)
 	}
 }
+
+func TestUpdateAvailableGitDescribeBuilds(t *testing.T) {
+	// `make build` stamps Version from `git describe --tags --always --dirty`,
+	// so a dev build N commits past the last tag reads X.Y.Z-N-g<hex>. That
+	// is newer than the X.Y.Z release, not a prerelease of it; otherwise every
+	// dev build nags "update available" daily and would downgrade itself.
+	cases := []struct {
+		name    string
+		current string
+		latest  string
+		want    bool
+	}{
+		{"describe build vs its tag", "0.15.0-678-g5c9e8bc3", "0.15.0", false},
+		{"v-prefixed describe build vs its tag", "v0.15.0-678-g5c9e8bc3", "0.15.0", false},
+		{"describe build vs next patch", "0.15.0-678-g5c9e8bc3", "0.15.1", true},
+		{"describe build vs next minor", "0.15.0-678-g5c9e8bc3", "0.16.0", true},
+		{"dirty describe build vs its tag", "0.15.0-678-g5c9e8bc3-dirty", "0.15.0", false},
+		{"dirty exact tag vs its tag", "0.15.0-dirty", "0.15.0", false},
+		{"beta prerelease vs release", "0.15.0-beta.1", "0.15.0", true},
+		{"rc prerelease vs release", "0.15.0-rc1", "0.15.0", true},
+		{"rc prerelease vs older release", "0.15.0-rc1", "0.14.9", false},
+		{"bare hash (no tags) vs release", "5c9e8bc3", "0.15.0", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := UpdateAvailable(tc.current, tc.latest); got != tc.want {
+				t.Fatalf("UpdateAvailable(%q, %q) = %v, want %v", tc.current, tc.latest, got, tc.want)
+			}
+		})
+	}
+
+	cmp := func(a, b string) int {
+		t.Helper()
+		got, ok := CompareVersions(a, b)
+		if !ok {
+			t.Fatalf("CompareVersions(%q, %q) unparseable", a, b)
+		}
+		return got
+	}
+	if got := cmp("0.15.0-678-g5c9e8bc3", "0.15.0"); got != 1 {
+		t.Errorf("describe build > release = %d", got)
+	}
+	if got := cmp("0.15.0-679-gabcdef01", "0.15.0-678-g5c9e8bc3"); got != 1 {
+		t.Errorf("more commits past tag > fewer = %d", got)
+	}
+	if got := cmp("0.15.0-0-g5c9e8bc3", "0.15.0"); got != 0 {
+		t.Errorf("describe --long on the exact tag == release = %d", got)
+	}
+	if got := cmp("0.15.0-678-g5c9e8bc3", "0.15.0-beta.1"); got != 1 {
+		t.Errorf("describe build > prerelease of same tag = %d", got)
+	}
+	if got := cmp("0.15.0-beta.1", "0.15.0"); got != -1 {
+		t.Errorf("prerelease < release = %d", got)
+	}
+	if got := cmp("0.15.0-678-g5c9e8bc3-dirty", "0.15.0-678-g5c9e8bc3"); got != 0 {
+		t.Errorf("dirty marker must not change ordering = %d", got)
+	}
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9860,6 +9860,15 @@ components:
             type: object
           - type: 'null'
           title: Credentials Meta Data
+        credentials_secret_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Credentials Secret Id
+          description: Repoint this model at an existing SecretReference instead of
+            minting a new one. Used to keep several models on one provider key or
+            OAuth lineage. The secret must already belong to the caller's account.
         is_default:
           anyOf:
           - type: boolean


### PR DESCRIPTION
## Why

Anthropic subscription refresh tokens are single-use. A re-onboard pinned to a family the account had never seen (Fable) created a second SecretReference from the local bundle while the seven sibling rows (opus, sonnet, haiku) stayed on the old one. The first copy to refresh rotated the grant and the other died with `invalid_grant`, so every model on it 401'd with "Model credentials could not be refreshed". Confirmed on prod 2026-09-05 and repaired by hand; this PR stops it from recurring.

## What

**Backend**
- `AIModelUpdate` gains `credentials_secret_id` with the same "no new credential material" validator as create, so `PUT /ai-models/{id}` can join an existing lineage (was silently dropped). An explicit `null` is treated as unchanged rather than orphaning the secret.
- After a repoint, the previous SecretReference is deleted when nothing references it (mirrors `remove()`).

**CLI**
- `ensureClaudeFamilyAIModel`: existing sibling rows are repointed to the primary's secret on reuse, not only on create.
- New-family primary path: when a Claude Code sibling already holds a same-type OAuth secret, never mint a second one. Expired local bundle: reuse the sibling's secret. Fresh local bundle: overwrite the shared secret in place through the sibling row, then create with that secret id.
- Update check: git-describe dev builds (`X.Y.Z-N-g<sha>[-dirty]`) compare as newer than `X.Y.Z` instead of as a prerelease, so dev builds stop seeing "update available" and cannot be downgraded to the tagged release by answering the daily prompt.
- `make install-local`: builds and installs with `install -m 755` (unlink + recreate; never `cp` onto the target). README and AGENTS.md document it as the only sanctioned way to update a local dev CLI, plus `chmod a-w` as the recommended guard.

## Tests
- Go: `internal/version` 33 passed; `internal/cmd` 885 passed, 1 skipped.
- Backend: `tests/endpoints/test_ai_models.py` + `tests/models/crud` 509 passed (real Postgres).
- Frontend: 1513 passed, 137 files (no frontend change).

Reviewed by a Fable pass (0 blockers, 2 should, 3 nit) with all findings addressed in the last four commits.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium**
> Well-tested fix that changes credential-secret lifecycle (repoint + orphan GC) and CLI onboarding/update-check logic; no security vulnerabilities found — account ownership of referenced secrets is enforced at the CRUD layer.
>
> **Overview**
> Prevents a second single-use Anthropic OAuth refresh-token lineage from being minted when onboarding a new Claude family, by repointing sibling AI-model rows to one shared `SecretReference` and garbage-collecting orphans. Also treats git-describe dev builds as newer than their tag (no more daily downgrade prompt) and adds `make install-local` for a safely installed dev CLI.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 8cd42086. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->