### PR TITLE
Resolve agent allowed_models by alias, id, or display name and name the denied model in the 403

### DIFF
--- a/backend/preloop/services/model_allowlist.py
+++ b/backend/preloop/services/model_allowlist.py
@@ -28,6 +28,10 @@ from preloop.services.model_runtime_resolver import (
 # How many allowlist entries a denial message spells out before eliding.
 MAX_LISTED_ALLOWED_MODELS = 5
 
+# OpenAI-shaped ``error.code`` for an allowlist denial. Distinct from
+# ``budget_limit_exceeded`` because the fix is a policy edit, not spend.
+MODEL_NOT_ALLOWED_ERROR_CODE = "model_not_allowed"
+
 
 def normalize_allowed_models(entries: Optional[Iterable[object]]) -> list[str]:
     """Return the trimmed, non-empty allowlist entries in their stored order.

--- a/backend/preloop/services/model_allowlist.py
+++ b/backend/preloop/services/model_allowlist.py
@@ -2,14 +2,31 @@
 
 Operators write allowlists in the console, which historically persisted
 whatever the model picker showed (an AI model display name such as
-``Kimi K3``), while the gateway compared those entries only against alias
-spellings (``moonshot/kimi-k3``, ``kimi-k3``). This module accepts every key an
+``Alpha Chat``), while the gateway compared those entries only against alias
+spellings (``acme/alpha-chat``, ``alpha-chat``). This module accepts every key an
 operator may reasonably have stored for one model:
 
 * a gateway alias or any spelling the gateway resolver accepts for the model
   (``gateway_model_alias_candidates``),
 * the ``AIModel`` id (uuid string), or
 * the ``AIModel`` display name (case-insensitive, trimmed).
+
+Matching contract (source of truth; CLI and console copies must stay aligned):
+
+1. Non-string entries are dropped, not stringified. After dropping, an empty
+   list is unrestricted (same as a missing allowlist). Do not coerce
+   ``null``/numbers to ``"None"``/``"3"``: that would turn ``[null]`` into a
+   deny-all.
+2. A remaining string matches a model when, after trim, it equals:
+   - any gateway alias candidate exactly (including the bare identifier tail),
+   - the AIModel id case-insensitively, or
+   - the AIModel display name case-insensitively.
+3. CLI copy: ``cli/internal/cmd/agents_allowed_models.go``
+   (``governanceAllowedModels``, ``allowedModelsCoverSelection``).
+4. Console copy: ``frontend/src/views/authed/agent-detail-view.ts``
+   (``findModelForAllowedEntry``). The console only rewrites a bare tail to a
+   gateway alias when exactly one inventory row matches that tail, so two
+   imports of the same upstream model are not silently narrowed.
 
 The gateway preflight and the console endpoints share these helpers so the
 policy that is written is the policy that is enforced.
@@ -36,17 +53,23 @@ MODEL_NOT_ALLOWED_ERROR_CODE = "model_not_allowed"
 def normalize_allowed_models(entries: Optional[Iterable[object]]) -> list[str]:
     """Return the trimmed, non-empty allowlist entries in their stored order.
 
+    Non-string values are skipped (not ``str()``-coerced) so a JSON ``null``
+    cannot become the literal ``"None"`` and fail-close the policy.
+
     Args:
         entries: The raw ``allowed_models`` value from a governance config.
 
     Returns:
         Entries with surrounding whitespace removed and blanks dropped;
-        duplicates are collapsed to their first occurrence.
+        duplicates are collapsed to their first occurrence. An empty result
+        means unrestricted.
     """
     normalized: list[str] = []
     seen: set[str] = set()
     for item in entries or []:
-        text = str(item).strip()
+        if not isinstance(item, str):
+            continue
+        text = item.strip()
         if text and text not in seen:
             normalized.append(text)
             seen.add(text)

--- a/backend/preloop/services/model_allowlist.py
+++ b/backend/preloop/services/model_allowlist.py
@@ -1,0 +1,185 @@
+"""Resolve subject ``allowed_models`` entries against account AI models.
+
+Operators write allowlists in the console, which historically persisted
+whatever the model picker showed (an AI model display name such as
+``Kimi K3``), while the gateway compared those entries only against alias
+spellings (``moonshot/kimi-k3``, ``kimi-k3``). This module accepts every key an
+operator may reasonably have stored for one model:
+
+* a gateway alias or any spelling the gateway resolver accepts for the model
+  (``gateway_model_alias_candidates``),
+* the ``AIModel`` id (uuid string), or
+* the ``AIModel`` display name (case-insensitive, trimmed).
+
+The gateway preflight and the console endpoints share these helpers so the
+policy that is written is the policy that is enforced.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from preloop.models.models.ai_model import AIModel
+from preloop.services.model_runtime_resolver import (
+    effective_gateway_alias,
+    gateway_model_alias_candidates,
+)
+
+# How many allowlist entries a denial message spells out before eliding.
+MAX_LISTED_ALLOWED_MODELS = 5
+
+
+def normalize_allowed_models(entries: Optional[Iterable[object]]) -> list[str]:
+    """Return the trimmed, non-empty allowlist entries in their stored order.
+
+    Args:
+        entries: The raw ``allowed_models`` value from a governance config.
+
+    Returns:
+        Entries with surrounding whitespace removed and blanks dropped;
+        duplicates are collapsed to their first occurrence.
+    """
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in entries or []:
+        text = str(item).strip()
+        if text and text not in seen:
+            normalized.append(text)
+            seen.add(text)
+    return normalized
+
+
+def allowlist_entry_matches_model(entry: str, ai_model: AIModel) -> bool:
+    """True when one stored allowlist entry names ``ai_model``.
+
+    Aliases compare exactly (they are gateway wire strings); ids and display
+    names compare case-insensitively because operators type them by hand.
+
+    Args:
+        entry: One stored ``allowed_models`` value.
+        ai_model: The account model to test against.
+
+    Returns:
+        Whether the entry addresses this model by alias, id, or display name.
+    """
+    text = str(entry).strip()
+    if not text:
+        return False
+    folded = text.casefold()
+    if folded == str(ai_model.id).casefold():
+        return True
+    name = (ai_model.name or "").strip()
+    if name and folded == name.casefold():
+        return True
+    return text in gateway_model_alias_candidates(ai_model)
+
+
+def resolve_allowed_model_ids(
+    entries: Optional[Iterable[object]], account_models: Iterable[AIModel]
+) -> set[str]:
+    """Map allowlist entries onto the account inventory.
+
+    Args:
+        entries: The raw ``allowed_models`` value from a governance config.
+        account_models: The models visible to the account (owned plus system).
+
+    Returns:
+        The id strings of every inventory model named by at least one entry.
+        Entries that name nothing (typos, models since deleted) resolve to no
+        id and are simply absent from the result.
+    """
+    normalized = normalize_allowed_models(entries)
+    if not normalized:
+        return set()
+    resolved: set[str] = set()
+    for model in account_models:
+        if any(allowlist_entry_matches_model(entry, model) for entry in normalized):
+            resolved.add(str(model.id))
+    return resolved
+
+
+def allowlist_permits_model(
+    entries: Optional[Iterable[object]],
+    ai_model: AIModel,
+    *,
+    requested_spellings: Optional[Iterable[str]] = None,
+) -> bool:
+    """Decide whether one subject allowlist permits a request for ``ai_model``.
+
+    An empty allowlist permits everything. Otherwise the request passes when
+    any entry names the resolved model (alias, id, or display name), or when
+    any spelling the caller supplied (typically the raw wire ``model`` string)
+    is listed verbatim, which keeps historical allowlists working.
+
+    Because the gateway always resolves a request to a model from the account
+    inventory, testing the resolved model directly is equivalent to resolving
+    the entries through ``resolve_allowed_model_ids`` and checking membership,
+    without an extra inventory query per governed request.
+
+    Args:
+        entries: The raw ``allowed_models`` value from a governance config.
+        ai_model: The model the gateway resolved the request to.
+        requested_spellings: Extra spellings that should count as naming the
+            model, such as the raw request string.
+
+    Returns:
+        True when the request may proceed under this allowlist.
+    """
+    normalized = normalize_allowed_models(entries)
+    if not normalized:
+        return True
+    entry_set = set(normalized)
+    if any(str(s).strip() in entry_set for s in requested_spellings or [] if s):
+        return True
+    return any(allowlist_entry_matches_model(entry, ai_model) for entry in normalized)
+
+
+def requested_model_label(ai_model: AIModel, requested: object) -> str:
+    """Return the spelling to quote back to a client in a denial message.
+
+    Prefers what the client actually sent; falls back to the model's gateway
+    alias, then to its identifier or display name.
+
+    Args:
+        ai_model: The resolved model.
+        requested: The raw ``model`` value from the request payload.
+
+    Returns:
+        A non-empty human-readable model label.
+    """
+    if isinstance(requested, str) and requested.strip():
+        return requested.strip()
+    alias = effective_gateway_alias(ai_model)
+    if alias:
+        return alias
+    return (ai_model.model_identifier or ai_model.name or "unknown").strip()
+
+
+def format_model_not_allowed_detail(
+    requested_model: str, allowed_models: Optional[Iterable[object]]
+) -> str:
+    """Render the client-facing detail for a ``subject_model_not_allowed`` denial.
+
+    Args:
+        requested_model: The spelling to quote (see ``requested_model_label``).
+        allowed_models: The allowlist that denied the request.
+
+    Returns:
+        One sentence naming the model and the allowlist (at most
+        ``MAX_LISTED_ALLOWED_MODELS`` entries, then ``...``) followed by the
+        remediation.
+    """
+    normalized = normalize_allowed_models(allowed_models)
+    listed = ", ".join(normalized[:MAX_LISTED_ALLOWED_MODELS])
+    if len(normalized) > MAX_LISTED_ALLOWED_MODELS:
+        listed += ", ..."
+    return (
+        f"Model '{requested_model}' is not in this agent's allowed models "
+        f"({listed}). Edit the agent's governance in the Preloop console or "
+        "pick an allowed model."
+    )
+
+
+def is_model_not_allowed_detail(detail: Optional[str]) -> bool:
+    """True when a gateway error detail was produced by ``format_model_not_allowed_detail``."""
+    return bool(detail) and "is not in this agent's allowed models" in str(detail)

--- a/backend/preloop/services/model_gateway_budget.py
+++ b/backend/preloop/services/model_gateway_budget.py
@@ -20,6 +20,11 @@ from preloop.models.crud import (
 from preloop.models.crud.plan import subscription as crud_subscription
 from preloop.models.models.ai_model import AIModel
 from preloop.models.models.flow import Flow
+from preloop.services.model_allowlist import (
+    allowlist_permits_model,
+    normalize_allowed_models,
+    requested_model_label,
+)
 from preloop.services.model_gateway_auth import ModelGatewayAuthContext
 from preloop.services.model_pricing import estimate_ai_model_usage_cost
 from preloop.services.model_runtime_resolver import gateway_model_alias_candidates
@@ -85,6 +90,10 @@ class BudgetCheckResult:
     enforcement_reason: Optional[str]
     pricing_available: bool
     reset_at: Optional[datetime] = None
+    # Populated for ``subject_model_not_allowed`` so renderers can name the
+    # requested model and the allowlist that denied it.
+    requested_model: Optional[str] = None
+    allowed_models: Optional[list[str]] = None
 
 
 class ModelGatewayBudgetService:
@@ -120,9 +129,15 @@ class ModelGatewayBudgetService:
         trial_hosted_model_current_spend_usd = None
         trial_hosted_model_estimated_total_usd = None
         governed_model_spellings = self._governed_model_spellings(ai_model, payload)
+        denied_allowed_models: Optional[list[str]] = None
 
-        # 1. Check legacy allowed models for subject
-        scoped_allowed_models: list[set[str]] = []
+        # 1. Check subject allowed models. Every scope in the chain (API key,
+        # then managed agent) must permit the resolved model; an entry may be
+        # a gateway alias, an AIModel id, or an AIModel display name (the
+        # console persisted display names historically). Fail closed: an
+        # allowlist that names neither the resolved model nor any of its
+        # spellings denies the request, including the degenerate case where
+        # the request names no model at all.
         if account is not None:
             for subject_type, subject_id in subject_scope_chain(subject_context):
                 config = get_subject_governance(
@@ -130,24 +145,22 @@ class ModelGatewayBudgetService:
                     subject_type=subject_type,
                     subject_id=subject_id,
                 )
-                allowed_models = config.get("allowed_models")
-                if isinstance(allowed_models, list) and allowed_models:
-                    scoped_allowed_models.append(
-                        {
-                            str(item).strip()
-                            for item in allowed_models
-                            if str(item).strip()
-                        }
-                    )
-
-        if scoped_allowed_models:
-            allowed_model_set = set.intersection(*scoped_allowed_models)
-            # Fail closed: an allowlist that matches none of the resolved
-            # model's spellings denies the request, including the degenerate
-            # case where the request names no model at all.
-            if not governed_model_spellings & allowed_model_set:
-                hard_limit_exceeded = True
-                enforcement_reason = "subject_model_not_allowed"
+                allowed_models = normalize_allowed_models(
+                    config.get("allowed_models")
+                    if isinstance(config.get("allowed_models"), list)
+                    else None
+                )
+                if not allowed_models:
+                    continue
+                if not allowlist_permits_model(
+                    allowed_models,
+                    ai_model,
+                    requested_spellings=governed_model_spellings,
+                ):
+                    hard_limit_exceeded = True
+                    enforcement_reason = "subject_model_not_allowed"
+                    denied_allowed_models = allowed_models
+                    break
 
         # 2. Check trial mode limitation
         subscription = crud_subscription.get_active_for_account(
@@ -235,6 +248,8 @@ class ModelGatewayBudgetService:
             enforcement_reason=enforcement_reason,
             pricing_available=pricing_available,
             reset_at=reset_at,
+            requested_model=requested_model_label(ai_model, payload.get("model")),
+            allowed_models=denied_allowed_models,
         )
 
     def enforce_or_raise(

--- a/backend/preloop/services/model_gateway_budget.py
+++ b/backend/preloop/services/model_gateway_budget.py
@@ -91,8 +91,10 @@ class BudgetCheckResult:
     enforcement_reason: Optional[str]
     pricing_available: bool
     reset_at: Optional[datetime] = None
-    # Populated for ``subject_model_not_allowed`` so renderers can name the
-    # requested model and the allowlist that denied it.
+    # ``requested_model`` is the label of the model every check ran against
+    # (alias, or the wire spelling when it differs); ``allowed_models`` is set
+    # only for ``subject_model_not_allowed`` so renderers can name the
+    # allowlist that denied it.
     requested_model: Optional[str] = None
     allowed_models: Optional[list[str]] = None
 

--- a/backend/preloop/services/model_gateway_budget.py
+++ b/backend/preloop/services/model_gateway_budget.py
@@ -22,6 +22,7 @@ from preloop.models.models.ai_model import AIModel
 from preloop.models.models.flow import Flow
 from preloop.services.model_allowlist import (
     allowlist_permits_model,
+    format_model_not_allowed_detail,
     normalize_allowed_models,
     requested_model_label,
 )
@@ -259,7 +260,11 @@ class ModelGatewayBudgetService:
         result = self.preflight_check(ai_model, payload)
         if result.hard_limit_exceeded:
             detail = "Model gateway budget exceeded"
-            if result.enforcement_reason == "account_budget_exceeded":
+            if result.enforcement_reason == "subject_model_not_allowed":
+                detail = format_model_not_allowed_detail(
+                    result.requested_model or "unknown", result.allowed_models
+                )
+            elif result.enforcement_reason == "account_budget_exceeded":
                 detail = "Model gateway budget exceeded: account monthly limit reached"
             elif result.enforcement_reason == "flow_budget_exceeded":
                 detail = "Model gateway budget exceeded: flow monthly limit reached"

--- a/backend/preloop/services/model_gateway_events.py
+++ b/backend/preloop/services/model_gateway_events.py
@@ -24,6 +24,7 @@ from preloop.services.account_realtime import (
     emit_account_event,
 )
 from preloop.services.cache_accounting import reported_cache_miss_tokens
+from preloop.services.model_allowlist import is_model_not_allowed_detail
 from preloop.sync.services.event_bus import get_nats_client
 from preloop.utils.jsonb_sanitize import sanitize_for_jsonb
 from preloop.utils.request_fingerprint import public_request_fingerprint
@@ -347,10 +348,15 @@ class ModelGatewayEventEmitter:
 
     @staticmethod
     def _derive_outcome(status_code: int, error_detail: Optional[str]) -> str:
+        # Allowlist denials reuse budget_denied: it is the only denial outcome
+        # the transcript, replay, and audit surfaces know how to render.
         if (
             status_code == 403
             and error_detail
-            and "budget exceeded" in error_detail.lower()
+            and (
+                "budget exceeded" in error_detail.lower()
+                or is_model_not_allowed_detail(error_detail)
+            )
         ):
             return "budget_denied"
         if status_code >= 400:

--- a/backend/preloop/services/openai_gateway.py
+++ b/backend/preloop/services/openai_gateway.py
@@ -82,6 +82,11 @@ from preloop.services.model_gateway_auth import (
     compute_authorized_model_ids,
     resolve_managed_agent_id_for_context,
 )
+from preloop.services.model_allowlist import (
+    MODEL_NOT_ALLOWED_ERROR_CODE,
+    format_model_not_allowed_detail,
+    is_model_not_allowed_detail,
+)
 from preloop.services.model_gateway_budget import (
     BudgetCheckResult,
     ModelGatewayBudgetService,
@@ -1128,6 +1133,7 @@ class OpenAIGatewayService:
                 provider="openai",
                 status_code=403,
                 message=detail,
+                code=self._budget_denial_code(budget_result),
             )
 
         try:
@@ -1269,6 +1275,7 @@ class OpenAIGatewayService:
                 provider="openai",
                 status_code=403,
                 message=detail,
+                code=self._budget_denial_code(budget_result),
             )
         try:
             self._emit_gateway_request_started(
@@ -1410,6 +1417,7 @@ class OpenAIGatewayService:
                 provider="anthropic",
                 status_code=403,
                 message=detail,
+                code=self._budget_denial_code(budget_result),
             )
 
         try:
@@ -1567,6 +1575,7 @@ class OpenAIGatewayService:
                 provider="anthropic",
                 status_code=403,
                 message=detail,
+                code=self._budget_denial_code(budget_result),
             )
 
         passthrough_connection: Optional[tuple[httpx.Client, httpx.Response]] = None
@@ -2009,6 +2018,7 @@ class OpenAIGatewayService:
                 provider="openai",
                 status_code=403,
                 message=detail,
+                code=self._budget_denial_code(budget_result),
             )
 
         try:
@@ -2295,6 +2305,7 @@ class OpenAIGatewayService:
                 provider="openai",
                 status_code=403,
                 message=detail,
+                code=self._budget_denial_code(budget_result),
             )
 
         try:
@@ -8238,12 +8249,23 @@ class OpenAIGatewayService:
 
     @staticmethod
     def _budget_denial_detail(budget_result: BudgetCheckResult) -> str:
+        if budget_result.enforcement_reason == "subject_model_not_allowed":
+            return format_model_not_allowed_detail(
+                budget_result.requested_model or "unknown",
+                budget_result.allowed_models,
+            )
         if budget_result.enforcement_reason == "account_budget_exceeded":
             return "Model gateway budget exceeded: account monthly limit reached"
         if budget_result.enforcement_reason == "flow_budget_exceeded":
             return "Model gateway budget exceeded: flow monthly limit reached"
         if budget_result.enforcement_reason == "trial_hosted_model_budget_exceeded":
             return "Model gateway budget exceeded: trial hosted model limit reached"
+        if budget_result.enforcement_reason == "free_hosted_model_budget_exceeded":
+            return (
+                "Model gateway budget exceeded: free-tier hosted model limit "
+                "reached. Configure your own OpenAI/Anthropic API key or upgrade "
+                "your plan."
+            )
         if (
             budget_result.enforcement_reason
             == "pricing_required_for_budget_enforcement"
@@ -8255,7 +8277,20 @@ class OpenAIGatewayService:
         return "Model gateway budget exceeded"
 
     @staticmethod
+    def _budget_denial_code(budget_result: BudgetCheckResult) -> Optional[str]:
+        """OpenAI-shaped ``error.code`` for a preflight denial.
+
+        Allowlist denials are policy, not spend, so they get their own code;
+        every other reason keeps the historical (unset) code.
+        """
+        if budget_result.enforcement_reason == "subject_model_not_allowed":
+            return MODEL_NOT_ALLOWED_ERROR_CODE
+        return None
+
+    @staticmethod
     def _audit_outcome(status_code: int, error_detail: Optional[str]) -> str:
+        # Allowlist denials share the budget_denied outcome: that is the only
+        # denial vocabulary the audit views and activity feeds understand.
         if (
             status_code == 403
             and error_detail
@@ -8263,6 +8298,7 @@ class OpenAIGatewayService:
                 "budget exceeded" in error_detail.lower()
                 or "budget enforcement requires pricing information"
                 in error_detail.lower()
+                or is_model_not_allowed_detail(error_detail)
             )
         ):
             return "budget_denied"
@@ -8270,6 +8306,8 @@ class OpenAIGatewayService:
 
     @staticmethod
     def _audit_error_type(status_code: int, error_detail: Optional[str]) -> str:
+        if status_code == 403 and is_model_not_allowed_detail(error_detail):
+            return MODEL_NOT_ALLOWED_ERROR_CODE
         if (
             status_code == 403
             and error_detail

--- a/backend/tests/endpoints/test_openai_gateway.py
+++ b/backend/tests/endpoints/test_openai_gateway.py
@@ -1093,8 +1093,8 @@ def test_sanitize_header_value_strips_crlf_and_caps_length():
 
 def _allowlist_denial_detail() -> str:
     return (
-        "Model 'moonshotai/kimi-k3' is not in this agent's allowed models "
-        "(GLM 5.3 Flash, Kimi K3). Edit the agent's governance in the Preloop "
+        "Model 'vendor/alpha-chat' is not in this agent's allowed models "
+        "(Beta Flash, Alpha Chat). Edit the agent's governance in the Preloop "
         "console or pick an allowed model."
     )
 
@@ -1127,8 +1127,8 @@ def test_budget_denial_detail_names_model_and_allowlist():
 
     denied = _result(
         "subject_model_not_allowed",
-        requested_model="moonshotai/kimi-k3",
-        allowed_models=["GLM 5.3 Flash", "Kimi K3"],
+        requested_model="vendor/alpha-chat",
+        allowed_models=["Beta Flash", "Alpha Chat"],
     )
     assert OpenAIGatewayService._budget_denial_detail(denied) == (
         _allowlist_denial_detail()
@@ -1177,14 +1177,14 @@ def test_chat_completions_endpoint_returns_model_not_allowed_for_allowlist_denia
     crud_ai_model.create_with_account(
         db=db_session,
         obj_in={
-            "name": "OpenCode moonshotai/kimi-k3",
-            "provider_name": "openai",
-            "model_identifier": "kimi-k3",
+            "name": "Imported alpha-chat",
+            "provider_name": "vendor",
+            "model_identifier": "alpha-chat",
             "api_key": "provider-secret",
             "meta_data": {
                 "gateway": {
                     "enabled": True,
-                    "model_alias": "moonshotai/kimi-k3",
+                    "model_alias": "vendor/alpha-chat",
                     "provider_adapter": "preloop",
                     "responses_api": "transcode",
                 },
@@ -1209,7 +1209,7 @@ def test_chat_completions_endpoint_returns_model_not_allowed_for_allowlist_denia
                 account.meta_data or {},
                 subject_type=SUBJECT_TYPE_API_KEYS,
                 subject_id=str(api_key.id),
-                config={"allowed_models": ["GLM 5.3 Flash", "Kimi K3"]},
+                config={"allowed_models": ["Beta Flash", "Alpha Chat"]},
             )
         },
     )
@@ -1222,7 +1222,7 @@ def test_chat_completions_endpoint_returns_model_not_allowed_for_allowlist_denia
             "/openai/v1/chat/completions",
             headers={"Authorization": "Bearer ignored"},
             json={
-                "model": "moonshotai/kimi-k3",
+                "model": "vendor/alpha-chat",
                 "messages": [{"role": "user", "content": "Hello"}],
             },
         )
@@ -1247,14 +1247,14 @@ def test_chat_completions_endpoint_allows_display_name_allowlist_match(
     crud_ai_model.create_with_account(
         db=db_session,
         obj_in={
-            "name": "Kimi K3",
-            "provider_name": "moonshot",
-            "model_identifier": "kimi-k3",
+            "name": "Alpha Chat",
+            "provider_name": "acme",
+            "model_identifier": "alpha-chat",
             "api_key": "provider-secret",
             "meta_data": {
                 "gateway": {
                     "enabled": True,
-                    "model_alias": "moonshot/kimi-k3",
+                    "model_alias": "acme/alpha-chat",
                     "provider_adapter": "preloop",
                     "responses_api": "transcode",
                 },
@@ -1279,7 +1279,7 @@ def test_chat_completions_endpoint_allows_display_name_allowlist_match(
                 account.meta_data or {},
                 subject_type=SUBJECT_TYPE_API_KEYS,
                 subject_id=str(api_key.id),
-                config={"allowed_models": ["GLM 5.3 Flash", "Kimi K3"]},
+                config={"allowed_models": ["Beta Flash", "Alpha Chat"]},
             )
         },
     )
@@ -1293,14 +1293,14 @@ def test_chat_completions_endpoint_allows_display_name_allowlist_match(
             "id": "mock_id",
             "choices": [{"message": {"content": "Hello", "role": "assistant"}}],
             "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
-            "model": "kimi-k3",
+            "model": "alpha-chat",
         }
         mock_completion.return_value = mock_response
         response = client.post(
             "/openai/v1/chat/completions",
             headers={"Authorization": "Bearer ignored"},
             json={
-                "model": "moonshot/kimi-k3",
+                "model": "acme/alpha-chat",
                 "messages": [{"role": "user", "content": "Hello"}],
             },
         )

--- a/backend/tests/endpoints/test_openai_gateway.py
+++ b/backend/tests/endpoints/test_openai_gateway.py
@@ -1089,3 +1089,221 @@ def test_sanitize_header_value_strips_crlf_and_caps_length():
 
     # Non-latin-1 characters become ASCII replacements, never raise.
     assert _sanitize_header_value("模型🚀") == "???"
+
+
+def _allowlist_denial_detail() -> str:
+    return (
+        "Model 'moonshotai/kimi-k3' is not in this agent's allowed models "
+        "(GLM 5.3 Flash, Kimi K3). Edit the agent's governance in the Preloop "
+        "console or pick an allowed model."
+    )
+
+
+def test_budget_denial_detail_names_model_and_allowlist():
+    """The gateway renderer must not fall through to the bare budget message."""
+    from preloop.services.model_gateway_budget import BudgetCheckResult
+    from preloop.services.openai_gateway import OpenAIGatewayService
+
+    def _result(reason, **extra):
+        return BudgetCheckResult(
+            account_limit_usd=None,
+            account_soft_limit_usd=None,
+            account_current_spend_usd=0.0,
+            account_estimated_total_usd=None,
+            flow_limit_usd=None,
+            flow_soft_limit_usd=None,
+            flow_current_spend_usd=0.0,
+            flow_estimated_total_usd=None,
+            estimated_request_cost_usd=None,
+            trial_hosted_model_limit_usd=None,
+            trial_hosted_model_current_spend_usd=None,
+            trial_hosted_model_estimated_total_usd=None,
+            hard_limit_exceeded=True,
+            soft_limit_exceeded=False,
+            enforcement_reason=reason,
+            pricing_available=True,
+            **extra,
+        )
+
+    denied = _result(
+        "subject_model_not_allowed",
+        requested_model="moonshotai/kimi-k3",
+        allowed_models=["GLM 5.3 Flash", "Kimi K3"],
+    )
+    assert OpenAIGatewayService._budget_denial_detail(denied) == (
+        _allowlist_denial_detail()
+    )
+    assert OpenAIGatewayService._budget_denial_code(denied) == "model_not_allowed"
+
+    free_tier = _result("free_hosted_model_budget_exceeded")
+    assert OpenAIGatewayService._budget_denial_detail(free_tier) == (
+        "Model gateway budget exceeded: free-tier hosted model limit reached. "
+        "Configure your own OpenAI/Anthropic API key or upgrade your plan."
+    )
+    assert OpenAIGatewayService._budget_denial_code(free_tier) is None
+
+    unknown = _result("something_new")
+    assert (
+        OpenAIGatewayService._budget_denial_detail(unknown)
+        == "Model gateway budget exceeded"
+    )
+
+
+def test_audit_helpers_classify_allowlist_denial():
+    """Audit keeps budget_denied (the only denial outcome the UI renders) with a policy error type."""
+    from preloop.services.openai_gateway import OpenAIGatewayService
+
+    detail = _allowlist_denial_detail()
+    assert OpenAIGatewayService._audit_outcome(403, detail) == "budget_denied"
+    assert OpenAIGatewayService._audit_error_type(403, detail) == "model_not_allowed"
+    assert (
+        OpenAIGatewayService._audit_error_type(
+            403, "Model gateway budget exceeded: account monthly limit reached"
+        )
+        == "budget_limit_exceeded"
+    )
+    assert OpenAIGatewayService._audit_outcome(403, "nope") == "failed"
+
+
+def test_chat_completions_endpoint_returns_model_not_allowed_for_allowlist_denial(
+    app, client, db_session, test_user
+):
+    """A display-name allowlist that omits the requested row yields an explicit 403."""
+    from preloop.services.subject_governance import (
+        SUBJECT_TYPE_API_KEYS,
+        set_subject_governance,
+    )
+
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "OpenCode moonshotai/kimi-k3",
+            "provider_name": "openai",
+            "model_identifier": "kimi-k3",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "moonshotai/kimi-k3",
+                    "provider_adapter": "preloop",
+                    "responses_api": "transcode",
+                },
+                "pricing": {"input_price_per_1k": 0.01, "output_price_per_1k": 0.02},
+            },
+        },
+        account_id=test_user.account_id,
+    )
+    api_key, presented_token = crud_api_key.create_runtime_key(
+        db_session,
+        name="Governed Runtime Token",
+        account_id=test_user.account_id,
+        user_id=test_user.id,
+        context_data={},
+    )
+    account = crud_account.get(db_session, id=test_user.account_id)
+    crud_account.update(
+        db_session,
+        db_obj=account,
+        obj_in={
+            "meta_data": set_subject_governance(
+                account.meta_data or {},
+                subject_type=SUBJECT_TYPE_API_KEYS,
+                subject_id=str(api_key.id),
+                config={"allowed_models": ["GLM 5.3 Flash", "Kimi K3"]},
+            )
+        },
+    )
+    app.dependency_overrides[get_model_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token=presented_token, user=test_user, api_key=api_key)
+    )
+
+    with patch("preloop.services.openai_gateway.litellm.completion") as mock_completion:
+        response = client.post(
+            "/openai/v1/chat/completions",
+            headers={"Authorization": "Bearer ignored"},
+            json={
+                "model": "moonshotai/kimi-k3",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+
+    assert response.status_code == 403
+    body = response.json()
+    assert body["error"]["message"] == _allowlist_denial_detail()
+    assert body["error"]["type"] == "permission_error"
+    assert body["error"]["code"] == "model_not_allowed"
+    mock_completion.assert_not_called()
+
+
+def test_chat_completions_endpoint_allows_display_name_allowlist_match(
+    app, client, db_session, test_user
+):
+    """The same display-name allowlist admits the row it actually names."""
+    from preloop.services.subject_governance import (
+        SUBJECT_TYPE_API_KEYS,
+        set_subject_governance,
+    )
+
+    crud_ai_model.create_with_account(
+        db=db_session,
+        obj_in={
+            "name": "Kimi K3",
+            "provider_name": "moonshot",
+            "model_identifier": "kimi-k3",
+            "api_key": "provider-secret",
+            "meta_data": {
+                "gateway": {
+                    "enabled": True,
+                    "model_alias": "moonshot/kimi-k3",
+                    "provider_adapter": "preloop",
+                    "responses_api": "transcode",
+                },
+                "pricing": {"input_price_per_1k": 0.01, "output_price_per_1k": 0.02},
+            },
+        },
+        account_id=test_user.account_id,
+    )
+    api_key, presented_token = crud_api_key.create_runtime_key(
+        db_session,
+        name="Governed Runtime Token",
+        account_id=test_user.account_id,
+        user_id=test_user.id,
+        context_data={},
+    )
+    account = crud_account.get(db_session, id=test_user.account_id)
+    crud_account.update(
+        db_session,
+        db_obj=account,
+        obj_in={
+            "meta_data": set_subject_governance(
+                account.meta_data or {},
+                subject_type=SUBJECT_TYPE_API_KEYS,
+                subject_id=str(api_key.id),
+                config={"allowed_models": ["GLM 5.3 Flash", "Kimi K3"]},
+            )
+        },
+    )
+    app.dependency_overrides[get_model_gateway_auth_context] = lambda: (
+        ModelGatewayAuthContext(token=presented_token, user=test_user, api_key=api_key)
+    )
+
+    with patch("preloop.services.openai_gateway.litellm.completion") as mock_completion:
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "mock_id",
+            "choices": [{"message": {"content": "Hello", "role": "assistant"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            "model": "kimi-k3",
+        }
+        mock_completion.return_value = mock_response
+        response = client.post(
+            "/openai/v1/chat/completions",
+            headers={"Authorization": "Bearer ignored"},
+            json={
+                "model": "moonshot/kimi-k3",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    mock_completion.assert_called_once()

--- a/backend/tests/services/test_model_allowlist.py
+++ b/backend/tests/services/test_model_allowlist.py
@@ -14,9 +14,9 @@ from preloop.services.model_allowlist import (
 
 def _model(db_session, test_user, **overrides):
     obj_in = {
-        "name": "Kimi K3",
-        "provider_name": "moonshot",
-        "model_identifier": "kimi-k3",
+        "name": "Alpha Chat",
+        "provider_name": "acme",
+        "model_identifier": "alpha-chat",
         "meta_data": {"gateway": {"enabled": True}},
     }
     obj_in.update(overrides)
@@ -26,33 +26,34 @@ def _model(db_session, test_user, **overrides):
 
 
 def test_normalize_allowed_models_trims_and_dedupes():
-    assert normalize_allowed_models([" a ", "", "b", "a", None, 3]) == [
-        "a",
-        "b",
-        "None",
-        "3",
-    ]
+    assert normalize_allowed_models([" a ", "", "b", "a"]) == ["a", "b"]
     assert normalize_allowed_models(None) == []
+
+
+def test_normalize_allowed_models_drops_non_strings():
+    """JSON null/numbers must not stringify into deny-all entries."""
+    assert normalize_allowed_models([None, 3, "", " a ", "a"]) == ["a"]
+    assert normalize_allowed_models([None]) == []
 
 
 def test_entry_matches_by_name_id_and_every_alias_spelling(db_session, test_user):
     model = _model(db_session, test_user)
-    assert allowlist_entry_matches_model("kimi k3", model)
+    assert allowlist_entry_matches_model("alpha chat", model)
     assert allowlist_entry_matches_model(str(model.id).upper(), model)
-    assert allowlist_entry_matches_model("moonshot/kimi-k3", model)
-    assert allowlist_entry_matches_model("kimi-k3", model)
-    assert not allowlist_entry_matches_model("GLM 5.3 Flash", model)
+    assert allowlist_entry_matches_model("acme/alpha-chat", model)
+    assert allowlist_entry_matches_model("alpha-chat", model)
+    assert not allowlist_entry_matches_model("Beta Flash", model)
     assert not allowlist_entry_matches_model("", model)
 
 
 def test_resolve_allowed_model_ids_maps_entries_onto_inventory(db_session, test_user):
-    kimi = _model(db_session, test_user)
-    glm = _model(
+    alpha = _model(db_session, test_user)
+    beta = _model(
         db_session,
         test_user,
-        name="GLM 5.3 Flash",
-        provider_name="zai",
-        model_identifier="glm-5.3-flash",
+        name="Beta Flash",
+        provider_name="other",
+        model_identifier="beta-flash",
     )
     other = _model(
         db_session,
@@ -61,41 +62,42 @@ def test_resolve_allowed_model_ids_maps_entries_onto_inventory(db_session, test_
         provider_name="openai",
         model_identifier="gpt-5",
     )
-    inventory = [kimi, glm, other]
+    inventory = [alpha, beta, other]
 
     resolved = resolve_allowed_model_ids(
-        ["GLM 5.3 Flash", "Kimi K3", "typo"], inventory
+        ["Beta Flash", "Alpha Chat", "typo"], inventory
     )
 
-    assert resolved == {str(kimi.id), str(glm.id)}
+    assert resolved == {str(alpha.id), str(beta.id)}
     assert resolve_allowed_model_ids([], inventory) == set()
 
 
 def test_allowlist_permits_model_semantics(db_session, test_user):
     model = _model(db_session, test_user)
     assert allowlist_permits_model([], model)
-    assert allowlist_permits_model(["Kimi K3"], model)
+    assert allowlist_permits_model([None], model)
+    assert allowlist_permits_model(["Alpha Chat"], model)
     assert allowlist_permits_model(
         ["legacy-spelling"], model, requested_spellings={"legacy-spelling"}
     )
-    assert not allowlist_permits_model(["GLM 5.3 Flash"], model)
+    assert not allowlist_permits_model(["Beta Flash"], model)
 
 
 def test_requested_model_label_prefers_wire_string_then_alias(db_session, test_user):
     model = _model(db_session, test_user)
-    assert requested_model_label(model, " moonshotai/kimi-k3 ") == "moonshotai/kimi-k3"
-    assert requested_model_label(model, None) == "moonshot/kimi-k3"
+    assert requested_model_label(model, " vendor/alpha-chat ") == "vendor/alpha-chat"
+    assert requested_model_label(model, None) == "acme/alpha-chat"
     direct = _model(db_session, test_user, name="Direct", meta_data={})
-    assert requested_model_label(direct, "") == "kimi-k3"
+    assert requested_model_label(direct, "") == "alpha-chat"
 
 
 def test_format_model_not_allowed_detail_lists_at_most_five_entries():
     detail = format_model_not_allowed_detail(
-        "moonshotai/kimi-k3", ["GLM 5.3 Flash", "Kimi K3"]
+        "vendor/alpha-chat", ["Beta Flash", "Alpha Chat"]
     )
     assert detail == (
-        "Model 'moonshotai/kimi-k3' is not in this agent's allowed models "
-        "(GLM 5.3 Flash, Kimi K3). Edit the agent's governance in the Preloop "
+        "Model 'vendor/alpha-chat' is not in this agent's allowed models "
+        "(Beta Flash, Alpha Chat). Edit the agent's governance in the Preloop "
         "console or pick an allowed model."
     )
     assert is_model_not_allowed_detail(detail)

--- a/backend/tests/services/test_model_allowlist.py
+++ b/backend/tests/services/test_model_allowlist.py
@@ -1,0 +1,106 @@
+"""Unit tests for allowlist entry resolution shared by the gateway and console."""
+
+from preloop.models.crud import crud_ai_model
+from preloop.services.model_allowlist import (
+    allowlist_entry_matches_model,
+    allowlist_permits_model,
+    format_model_not_allowed_detail,
+    is_model_not_allowed_detail,
+    normalize_allowed_models,
+    requested_model_label,
+    resolve_allowed_model_ids,
+)
+
+
+def _model(db_session, test_user, **overrides):
+    obj_in = {
+        "name": "Kimi K3",
+        "provider_name": "moonshot",
+        "model_identifier": "kimi-k3",
+        "meta_data": {"gateway": {"enabled": True}},
+    }
+    obj_in.update(overrides)
+    return crud_ai_model.create_with_account(
+        db=db_session, obj_in=obj_in, account_id=test_user.account_id
+    )
+
+
+def test_normalize_allowed_models_trims_and_dedupes():
+    assert normalize_allowed_models([" a ", "", "b", "a", None, 3]) == [
+        "a",
+        "b",
+        "None",
+        "3",
+    ]
+    assert normalize_allowed_models(None) == []
+
+
+def test_entry_matches_by_name_id_and_every_alias_spelling(db_session, test_user):
+    model = _model(db_session, test_user)
+    assert allowlist_entry_matches_model("kimi k3", model)
+    assert allowlist_entry_matches_model(str(model.id).upper(), model)
+    assert allowlist_entry_matches_model("moonshot/kimi-k3", model)
+    assert allowlist_entry_matches_model("kimi-k3", model)
+    assert not allowlist_entry_matches_model("GLM 5.3 Flash", model)
+    assert not allowlist_entry_matches_model("", model)
+
+
+def test_resolve_allowed_model_ids_maps_entries_onto_inventory(db_session, test_user):
+    kimi = _model(db_session, test_user)
+    glm = _model(
+        db_session,
+        test_user,
+        name="GLM 5.3 Flash",
+        provider_name="zai",
+        model_identifier="glm-5.3-flash",
+    )
+    other = _model(
+        db_session,
+        test_user,
+        name="Other",
+        provider_name="openai",
+        model_identifier="gpt-5",
+    )
+    inventory = [kimi, glm, other]
+
+    resolved = resolve_allowed_model_ids(
+        ["GLM 5.3 Flash", "Kimi K3", "typo"], inventory
+    )
+
+    assert resolved == {str(kimi.id), str(glm.id)}
+    assert resolve_allowed_model_ids([], inventory) == set()
+
+
+def test_allowlist_permits_model_semantics(db_session, test_user):
+    model = _model(db_session, test_user)
+    assert allowlist_permits_model([], model)
+    assert allowlist_permits_model(["Kimi K3"], model)
+    assert allowlist_permits_model(
+        ["legacy-spelling"], model, requested_spellings={"legacy-spelling"}
+    )
+    assert not allowlist_permits_model(["GLM 5.3 Flash"], model)
+
+
+def test_requested_model_label_prefers_wire_string_then_alias(db_session, test_user):
+    model = _model(db_session, test_user)
+    assert requested_model_label(model, " moonshotai/kimi-k3 ") == "moonshotai/kimi-k3"
+    assert requested_model_label(model, None) == "moonshot/kimi-k3"
+    direct = _model(db_session, test_user, name="Direct", meta_data={})
+    assert requested_model_label(direct, "") == "kimi-k3"
+
+
+def test_format_model_not_allowed_detail_lists_at_most_five_entries():
+    detail = format_model_not_allowed_detail(
+        "moonshotai/kimi-k3", ["GLM 5.3 Flash", "Kimi K3"]
+    )
+    assert detail == (
+        "Model 'moonshotai/kimi-k3' is not in this agent's allowed models "
+        "(GLM 5.3 Flash, Kimi K3). Edit the agent's governance in the Preloop "
+        "console or pick an allowed model."
+    )
+    assert is_model_not_allowed_detail(detail)
+    assert not is_model_not_allowed_detail("Model gateway budget exceeded")
+
+    long_detail = format_model_not_allowed_detail("x", [f"m{i}" for i in range(7)])
+    assert "(m0, m1, m2, m3, m4, ...)" in long_detail
+    assert "m5" not in long_detail

--- a/backend/tests/services/test_model_gateway_budget.py
+++ b/backend/tests/services/test_model_gateway_budget.py
@@ -592,3 +592,49 @@ def test_display_name_of_a_sibling_row_does_not_cover_a_different_import(
 
     assert result.hard_limit_exceeded is True
     assert result.enforcement_reason == "subject_model_not_allowed"
+
+
+def test_enforce_or_raise_names_model_and_allowlist_when_not_allowed(
+    db_session, test_user
+):
+    """The bare "budget exceeded" message is gone: the 403 says what to fix."""
+    ai_model = _governed_model(
+        db_session,
+        test_user,
+        name="OpenCode moonshotai/kimi-k3",
+        provider_name="openai",
+        model_identifier="kimi-k3",
+        meta_data={
+            "gateway": {"enabled": True, "model_alias": "moonshotai/kimi-k3"},
+            "pricing": {"input_price_per_1k": 0.01, "output_price_per_1k": 0.02},
+        },
+    )
+    api_key = _key_scoped_allowlist(db_session, test_user, ["GLM 5.3 Flash", "Kimi K3"])
+    service = _governed_service(db_session, test_user, api_key)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.enforce_or_raise(
+            ai_model, {"model": "moonshotai/kimi-k3", "input": "hi"}
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == (
+        "Model 'moonshotai/kimi-k3' is not in this agent's allowed models "
+        "(GLM 5.3 Flash, Kimi K3). Edit the agent's governance in the Preloop "
+        "console or pick an allowed model."
+    )
+
+
+def test_enforce_or_raise_elides_long_allowlists(db_session, test_user):
+    """More than five entries collapse to five plus an ellipsis."""
+    ai_model = _governed_model(db_session, test_user)
+    api_key = _key_scoped_allowlist(
+        db_session, test_user, [f"model-{index}" for index in range(8)]
+    )
+    service = _governed_service(db_session, test_user, api_key)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.enforce_or_raise(ai_model, {"model": "claude-opus-4-1"})
+
+    assert "(model-0, model-1, model-2, model-3, model-4, ...)" in exc_info.value.detail
+    assert "model-5" not in exc_info.value.detail

--- a/backend/tests/services/test_model_gateway_budget.py
+++ b/backend/tests/services/test_model_gateway_budget.py
@@ -438,3 +438,157 @@ def test_account_without_allowlist_is_unaffected(db_session, test_user):
         result = service.preflight_check(ai_model, {**payload, "input": "hi"})
         assert result.hard_limit_exceeded is False
         assert result.enforcement_reason is None
+
+
+def test_allowlist_accepts_display_name_entry(db_session, test_user):
+    """The console stored display names; ``Kimi K3`` must govern its row."""
+    ai_model = _governed_model(
+        db_session,
+        test_user,
+        name="Kimi K3",
+        provider_name="moonshot",
+        model_identifier="kimi-k3",
+    )
+    api_key = _key_scoped_allowlist(db_session, test_user, ["GLM 5.3 Flash", "Kimi K3"])
+    service = _governed_service(db_session, test_user, api_key)
+
+    result = service.preflight_check(
+        ai_model, {"model": "moonshot/kimi-k3", "input": "hi"}
+    )
+
+    assert result.hard_limit_exceeded is False
+    assert result.enforcement_reason is None
+
+
+def test_allowlist_display_name_match_is_case_insensitive_and_trimmed(
+    db_session, test_user
+):
+    """Hand-typed names differ in case and whitespace from the stored row."""
+    ai_model = _governed_model(db_session, test_user, name="Kimi K3")
+    api_key = _key_scoped_allowlist(db_session, test_user, ["  kimi k3 "])
+    service = _governed_service(db_session, test_user, api_key)
+
+    result = service.preflight_check(ai_model, {"model": "claude-opus-4-1"})
+
+    assert result.hard_limit_exceeded is False
+
+
+def test_allowlist_accepts_model_id_entry(db_session, test_user):
+    """The deploy wizard persists AIModel ids; those must govern too."""
+    ai_model = _governed_model(db_session, test_user)
+    api_key = _key_scoped_allowlist(db_session, test_user, [str(ai_model.id)])
+    service = _governed_service(db_session, test_user, api_key)
+
+    result = service.preflight_check(
+        ai_model, {"model": "anthropic/claude-opus-4-1", "input": "hi"}
+    )
+
+    assert result.hard_limit_exceeded is False
+
+
+def test_allowlist_accepts_configured_gateway_alias_entry(db_session, test_user):
+    """An explicit ``meta_data.gateway.model_alias`` is the preferred key."""
+    ai_model = _governed_model(
+        db_session,
+        test_user,
+        meta_data={
+            "gateway": {"enabled": True, "model_alias": "team/opus"},
+            "pricing": {"input_price_per_1k": 0.01, "output_price_per_1k": 0.02},
+        },
+    )
+    api_key = _key_scoped_allowlist(db_session, test_user, ["team/opus"])
+    service = _governed_service(db_session, test_user, api_key)
+
+    result = service.preflight_check(ai_model, {"model": "team/opus", "input": "hi"})
+
+    assert result.hard_limit_exceeded is False
+
+
+def test_allowlist_unrelated_display_name_still_denies(db_session, test_user):
+    """Naming a different model by display name must not open the gate."""
+    ai_model = _governed_model(db_session, test_user, name="Governed Opus")
+    _governed_model(
+        db_session,
+        test_user,
+        name="Kimi K3",
+        provider_name="moonshot",
+        model_identifier="kimi-k3",
+    )
+    api_key = _key_scoped_allowlist(db_session, test_user, ["Kimi K3"])
+    service = _governed_service(db_session, test_user, api_key)
+
+    result = service.preflight_check(
+        ai_model, {"model": "anthropic/claude-opus-4-1", "input": "hi"}
+    )
+
+    assert result.hard_limit_exceeded is True
+    assert result.enforcement_reason == "subject_model_not_allowed"
+    assert result.allowed_models == ["Kimi K3"]
+    assert result.requested_model == "anthropic/claude-opus-4-1"
+
+
+def test_allowlist_denial_names_alias_when_request_omits_model(db_session, test_user):
+    """Without a wire model the denial quotes the resolved gateway alias."""
+    ai_model = _governed_model(db_session, test_user)
+    api_key = _key_scoped_allowlist(db_session, test_user, ["Kimi K3"])
+    service = _governed_service(db_session, test_user, api_key)
+
+    result = service.preflight_check(ai_model, {"input": "hi"})
+
+    assert result.hard_limit_exceeded is True
+    assert result.requested_model == "anthropic/claude-opus-4-1"
+
+
+def test_empty_allowlist_allows_every_model(db_session, test_user):
+    """An empty list is "unrestricted", not "nothing allowed"."""
+    ai_model = _governed_model(db_session, test_user)
+    api_key = _key_scoped_allowlist(db_session, test_user, [])
+    service = _governed_service(db_session, test_user, api_key)
+
+    result = service.preflight_check(
+        ai_model, {"model": "anthropic/claude-opus-4-1", "input": "hi"}
+    )
+
+    assert result.hard_limit_exceeded is False
+    assert result.enforcement_reason is None
+    assert result.allowed_models is None
+
+
+def test_display_name_of_a_sibling_row_does_not_cover_a_different_import(
+    db_session, test_user
+):
+    """``Kimi K3`` names the moonshot row only, not a separate openai-provider import.
+
+    This is the founder's prod shape: the OpenCode onboarding created a second
+    row ``moonshotai/kimi-k3`` next to the existing ``Kimi K3``
+    (``moonshot/kimi-k3``). Governance keys on rows, so the allowlist must be
+    extended (step 4 in the CLI offers that) or the request must pick the
+    listed row's alias.
+    """
+    _governed_model(
+        db_session,
+        test_user,
+        name="Kimi K3",
+        provider_name="moonshot",
+        model_identifier="kimi-k3",
+    )
+    opencode_import = _governed_model(
+        db_session,
+        test_user,
+        name="OpenCode moonshotai/kimi-k3",
+        provider_name="openai",
+        model_identifier="kimi-k3",
+        meta_data={
+            "gateway": {"enabled": True, "model_alias": "moonshotai/kimi-k3"},
+            "pricing": {"input_price_per_1k": 0.01, "output_price_per_1k": 0.02},
+        },
+    )
+    api_key = _key_scoped_allowlist(db_session, test_user, ["GLM 5.3 Flash", "Kimi K3"])
+    service = _governed_service(db_session, test_user, api_key)
+
+    result = service.preflight_check(
+        opencode_import, {"model": "moonshotai/kimi-k3", "input": "hi"}
+    )
+
+    assert result.hard_limit_exceeded is True
+    assert result.enforcement_reason == "subject_model_not_allowed"

--- a/backend/tests/services/test_model_gateway_budget.py
+++ b/backend/tests/services/test_model_gateway_budget.py
@@ -441,19 +441,19 @@ def test_account_without_allowlist_is_unaffected(db_session, test_user):
 
 
 def test_allowlist_accepts_display_name_entry(db_session, test_user):
-    """The console stored display names; ``Kimi K3`` must govern its row."""
+    """The console stored display names; ``Alpha Chat`` must govern its row."""
     ai_model = _governed_model(
         db_session,
         test_user,
-        name="Kimi K3",
-        provider_name="moonshot",
-        model_identifier="kimi-k3",
+        name="Alpha Chat",
+        provider_name="acme",
+        model_identifier="alpha-chat",
     )
-    api_key = _key_scoped_allowlist(db_session, test_user, ["GLM 5.3 Flash", "Kimi K3"])
+    api_key = _key_scoped_allowlist(db_session, test_user, ["Beta Flash", "Alpha Chat"])
     service = _governed_service(db_session, test_user, api_key)
 
     result = service.preflight_check(
-        ai_model, {"model": "moonshot/kimi-k3", "input": "hi"}
+        ai_model, {"model": "acme/alpha-chat", "input": "hi"}
     )
 
     assert result.hard_limit_exceeded is False
@@ -464,8 +464,8 @@ def test_allowlist_display_name_match_is_case_insensitive_and_trimmed(
     db_session, test_user
 ):
     """Hand-typed names differ in case and whitespace from the stored row."""
-    ai_model = _governed_model(db_session, test_user, name="Kimi K3")
-    api_key = _key_scoped_allowlist(db_session, test_user, ["  kimi k3 "])
+    ai_model = _governed_model(db_session, test_user, name="Alpha Chat")
+    api_key = _key_scoped_allowlist(db_session, test_user, ["  alpha chat "])
     service = _governed_service(db_session, test_user, api_key)
 
     result = service.preflight_check(ai_model, {"model": "claude-opus-4-1"})
@@ -510,11 +510,11 @@ def test_allowlist_unrelated_display_name_still_denies(db_session, test_user):
     _governed_model(
         db_session,
         test_user,
-        name="Kimi K3",
-        provider_name="moonshot",
-        model_identifier="kimi-k3",
+        name="Alpha Chat",
+        provider_name="acme",
+        model_identifier="alpha-chat",
     )
-    api_key = _key_scoped_allowlist(db_session, test_user, ["Kimi K3"])
+    api_key = _key_scoped_allowlist(db_session, test_user, ["Alpha Chat"])
     service = _governed_service(db_session, test_user, api_key)
 
     result = service.preflight_check(
@@ -523,14 +523,14 @@ def test_allowlist_unrelated_display_name_still_denies(db_session, test_user):
 
     assert result.hard_limit_exceeded is True
     assert result.enforcement_reason == "subject_model_not_allowed"
-    assert result.allowed_models == ["Kimi K3"]
+    assert result.allowed_models == ["Alpha Chat"]
     assert result.requested_model == "anthropic/claude-opus-4-1"
 
 
 def test_allowlist_denial_names_alias_when_request_omits_model(db_session, test_user):
     """Without a wire model the denial quotes the resolved gateway alias."""
     ai_model = _governed_model(db_session, test_user)
-    api_key = _key_scoped_allowlist(db_session, test_user, ["Kimi K3"])
+    api_key = _key_scoped_allowlist(db_session, test_user, ["Alpha Chat"])
     service = _governed_service(db_session, test_user, api_key)
 
     result = service.preflight_check(ai_model, {"input": "hi"})
@@ -557,37 +557,36 @@ def test_empty_allowlist_allows_every_model(db_session, test_user):
 def test_display_name_of_a_sibling_row_does_not_cover_a_different_import(
     db_session, test_user
 ):
-    """``Kimi K3`` names the moonshot row only, not a separate openai-provider import.
+    """A display name covers one inventory row, not a second import of the same identifier.
 
-    This is the founder's prod shape: the OpenCode onboarding created a second
-    row ``moonshotai/kimi-k3`` next to the existing ``Kimi K3``
-    (``moonshot/kimi-k3``). Governance keys on rows, so the allowlist must be
-    extended (step 4 in the CLI offers that) or the request must pick the
-    listed row's alias.
+    Two account rows can share a model identifier while using different
+    provider names and gateway aliases. Governance keys on rows, so listing
+    the first row's display name must not admit a request that resolved to
+    the sibling.
     """
     _governed_model(
         db_session,
         test_user,
-        name="Kimi K3",
-        provider_name="moonshot",
-        model_identifier="kimi-k3",
+        name="Alpha Chat",
+        provider_name="acme",
+        model_identifier="alpha-chat",
     )
-    opencode_import = _governed_model(
+    sibling_import = _governed_model(
         db_session,
         test_user,
-        name="OpenCode moonshotai/kimi-k3",
-        provider_name="openai",
-        model_identifier="kimi-k3",
+        name="Imported alpha-chat",
+        provider_name="vendor",
+        model_identifier="alpha-chat",
         meta_data={
-            "gateway": {"enabled": True, "model_alias": "moonshotai/kimi-k3"},
+            "gateway": {"enabled": True, "model_alias": "vendor/alpha-chat"},
             "pricing": {"input_price_per_1k": 0.01, "output_price_per_1k": 0.02},
         },
     )
-    api_key = _key_scoped_allowlist(db_session, test_user, ["GLM 5.3 Flash", "Kimi K3"])
+    api_key = _key_scoped_allowlist(db_session, test_user, ["Beta Flash", "Alpha Chat"])
     service = _governed_service(db_session, test_user, api_key)
 
     result = service.preflight_check(
-        opencode_import, {"model": "moonshotai/kimi-k3", "input": "hi"}
+        sibling_import, {"model": "vendor/alpha-chat", "input": "hi"}
     )
 
     assert result.hard_limit_exceeded is True
@@ -601,26 +600,26 @@ def test_enforce_or_raise_names_model_and_allowlist_when_not_allowed(
     ai_model = _governed_model(
         db_session,
         test_user,
-        name="OpenCode moonshotai/kimi-k3",
-        provider_name="openai",
-        model_identifier="kimi-k3",
+        name="Imported alpha-chat",
+        provider_name="vendor",
+        model_identifier="alpha-chat",
         meta_data={
-            "gateway": {"enabled": True, "model_alias": "moonshotai/kimi-k3"},
+            "gateway": {"enabled": True, "model_alias": "vendor/alpha-chat"},
             "pricing": {"input_price_per_1k": 0.01, "output_price_per_1k": 0.02},
         },
     )
-    api_key = _key_scoped_allowlist(db_session, test_user, ["GLM 5.3 Flash", "Kimi K3"])
+    api_key = _key_scoped_allowlist(db_session, test_user, ["Beta Flash", "Alpha Chat"])
     service = _governed_service(db_session, test_user, api_key)
 
     with pytest.raises(HTTPException) as exc_info:
         service.enforce_or_raise(
-            ai_model, {"model": "moonshotai/kimi-k3", "input": "hi"}
+            ai_model, {"model": "vendor/alpha-chat", "input": "hi"}
         )
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == (
-        "Model 'moonshotai/kimi-k3' is not in this agent's allowed models "
-        "(GLM 5.3 Flash, Kimi K3). Edit the agent's governance in the Preloop "
+        "Model 'vendor/alpha-chat' is not in this agent's allowed models "
+        "(Beta Flash, Alpha Chat). Edit the agent's governance in the Preloop "
         "console or pick an allowed model."
     )
 

--- a/backend/tests/services/test_model_gateway_events.py
+++ b/backend/tests/services/test_model_gateway_events.py
@@ -597,3 +597,15 @@ def test_build_event_reports_zero_retries_for_a_clean_call():
             usage=usage, request_payload=None, response_payload=None
         )
     assert event["payload"]["retried"] == 0
+
+
+def test_derive_outcome_treats_allowlist_denial_as_budget_denied():
+    """No policy_denied vocabulary exists, so allowlist denials stay budget_denied."""
+    detail = (
+        "Model 'moonshotai/kimi-k3' is not in this agent's allowed models "
+        "(Kimi K3). Edit the agent's governance in the Preloop console or pick "
+        "an allowed model."
+    )
+    assert ModelGatewayEventEmitter._derive_outcome(403, detail) == "budget_denied"
+    assert ModelGatewayEventEmitter._derive_outcome(403, "forbidden") == "error"
+    assert ModelGatewayEventEmitter._derive_outcome(200, None) == "success"

--- a/backend/tests/services/test_model_gateway_events.py
+++ b/backend/tests/services/test_model_gateway_events.py
@@ -602,9 +602,9 @@ def test_build_event_reports_zero_retries_for_a_clean_call():
 def test_derive_outcome_treats_allowlist_denial_as_budget_denied():
     """No policy_denied vocabulary exists, so allowlist denials stay budget_denied."""
     detail = (
-        "Model 'moonshotai/kimi-k3' is not in this agent's allowed models "
-        "(Kimi K3). Edit the agent's governance in the Preloop console or pick "
-        "an allowed model."
+        "Model 'vendor/alpha-chat' is not in this agent's allowed models "
+        "(Alpha Chat). Edit the agent's governance in the Preloop console or "
+        "pick an allowed model."
     )
     assert ModelGatewayEventEmitter._derive_outcome(403, detail) == "budget_denied"
     assert ModelGatewayEventEmitter._derive_outcome(403, "forbidden") == "error"

--- a/cli/internal/cmd/agents_allowed_models.go
+++ b/cli/internal/cmd/agents_allowed_models.go
@@ -37,6 +37,8 @@ func fetchManagedAgentGovernance(
 }
 
 // governanceAllowedModels returns the trimmed, non-empty allowed_models entries.
+// Matching contract: backend/preloop/services/model_allowlist.py
+// Non-string JSON values are dropped, not stringified.
 func governanceAllowedModels(config map[string]interface{}) []string {
 	raw, ok := config["allowed_models"].([]interface{})
 	if !ok {
@@ -54,8 +56,9 @@ func governanceAllowedModels(config map[string]interface{}) []string {
 }
 
 // allowedModelsCoverSelection reports whether any allowlist entry names the
-// chosen model. It mirrors the backend resolver: aliases (and their bare
-// tails) compare exactly, model names and ids case-insensitively.
+// chosen model. Matching contract: backend/preloop/services/model_allowlist.py
+// Aliases (and their bare tails) compare exactly; model names and ids
+// compare case-insensitively.
 func allowedModelsCoverSelection(
 	allowed []string,
 	alias string,

--- a/cli/internal/cmd/agents_allowed_models.go
+++ b/cli/internal/cmd/agents_allowed_models.go
@@ -1,0 +1,214 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+// managedAgentGovernanceResponse mirrors GET/PUT /api/v1/agents/{id}/governance.
+// Config is kept as a raw map so a PUT round-trips every field the backend
+// knows about (model_budgets, tool_rules, approval settings) without the CLI
+// having to track the schema.
+type managedAgentGovernanceResponse struct {
+	SubjectType string                 `json:"subject_type"`
+	SubjectID   string                 `json:"subject_id"`
+	Config      map[string]interface{} `json:"config"`
+}
+
+func managedAgentGovernancePath(agentID string) string {
+	return "/api/v1/agents/" + strings.TrimSpace(agentID) + "/governance"
+}
+
+func fetchManagedAgentGovernance(
+	client *api.Client,
+	agentID string,
+) (*managedAgentGovernanceResponse, error) {
+	var response managedAgentGovernanceResponse
+	if err := client.Get(managedAgentGovernancePath(agentID), &response); err != nil {
+		return nil, err
+	}
+	if response.Config == nil {
+		response.Config = map[string]interface{}{}
+	}
+	return &response, nil
+}
+
+// governanceAllowedModels returns the trimmed, non-empty allowed_models entries.
+func governanceAllowedModels(config map[string]interface{}) []string {
+	raw, ok := config["allowed_models"].([]interface{})
+	if !ok {
+		return nil
+	}
+	entries := make([]string, 0, len(raw))
+	for _, item := range raw {
+		text, _ := item.(string)
+		text = strings.TrimSpace(text)
+		if text != "" {
+			entries = append(entries, text)
+		}
+	}
+	return entries
+}
+
+// allowedModelsCoverSelection reports whether any allowlist entry names the
+// chosen model. It mirrors the backend resolver: aliases (and their bare
+// tails) compare exactly, model names and ids case-insensitively.
+func allowedModelsCoverSelection(
+	allowed []string,
+	alias string,
+	model *aiModelResponse,
+) bool {
+	alias = strings.TrimSpace(alias)
+	tail := ""
+	if idx := strings.Index(alias, "/"); idx >= 0 {
+		tail = strings.TrimSpace(alias[idx+1:])
+	}
+	for _, entry := range allowed {
+		if alias != "" && entry == alias {
+			return true
+		}
+		if tail != "" && entry == tail {
+			return true
+		}
+		if model == nil {
+			continue
+		}
+		if name := strings.TrimSpace(model.Name); name != "" && strings.EqualFold(entry, name) {
+			return true
+		}
+		if id := strings.TrimSpace(model.ID); id != "" && strings.EqualFold(entry, id) {
+			return true
+		}
+		if modelAlias := strings.TrimSpace(gatewayAliasForAIModel(*model)); modelAlias != "" && entry == modelAlias {
+			return true
+		}
+	}
+	return false
+}
+
+func formatAllowedModelsList(allowed []string) string {
+	const maxListed = 5
+	if len(allowed) <= maxListed {
+		return strings.Join(allowed, ", ")
+	}
+	return strings.Join(allowed[:maxListed], ", ") + ", ..."
+}
+
+// ensureSelectedModelAllowed warns when the chosen gateway alias is outside the
+// managed agent's allowed_models policy, which would make the live check (and
+// every later request) fail with a 403. Interactive runs may append the alias;
+// non-interactive runs only print the note. Governance read failures are soft:
+// onboarding must not stall on an optional policy check.
+func ensureSelectedModelAllowed(
+	client *api.Client,
+	managedAgentID string,
+	alias string,
+	model *aiModelResponse,
+	input io.Reader,
+	output io.Writer,
+	interactive bool,
+) error {
+	if output == nil {
+		output = io.Discard
+	}
+	alias = strings.TrimSpace(alias)
+	if client == nil || strings.TrimSpace(managedAgentID) == "" || alias == "" {
+		return nil
+	}
+	governance, err := fetchManagedAgentGovernance(client, managedAgentID)
+	if err != nil {
+		fmt.Fprintf(
+			output,
+			"Note: could not read this agent's governance (%s); skipping the allowed-models check.\n",
+			firstErrorLine(err),
+		) //nolint:errcheck
+		return nil
+	}
+	allowed := governanceAllowedModels(governance.Config)
+	if len(allowed) == 0 || allowedModelsCoverSelection(allowed, alias, model) {
+		return nil
+	}
+	fmt.Fprintf(
+		output,
+		"Note: %s is not in this agent's allowed models (%s).\n",
+		alias,
+		formatAllowedModelsList(allowed),
+	) //nolint:errcheck
+	if !interactive {
+		fmt.Fprintln(
+			output,
+			"  Gateway requests for this model will be denied until the allowed models are updated in the Preloop console.",
+		) //nolint:errcheck
+		return nil
+	}
+	confirmed, err := confirmActionDefaultYes(
+		input,
+		output,
+		fmt.Sprintf("Add %s to the allowed models? (Y/n): ", alias),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to read allowed-models confirmation: %w", err)
+	}
+	if !confirmed {
+		fmt.Fprintln(
+			output,
+			"  Left the allowed models unchanged; gateway requests for this model will be denied.",
+		) //nolint:errcheck
+		return nil
+	}
+	updated := make([]interface{}, 0, len(allowed)+1)
+	for _, entry := range allowed {
+		updated = append(updated, entry)
+	}
+	updated = append(updated, alias)
+	governance.Config["allowed_models"] = updated
+	var saved managedAgentGovernanceResponse
+	if err := client.Put(managedAgentGovernancePath(managedAgentID), governance.Config, &saved); err != nil {
+		return fmt.Errorf("failed to update the agent's allowed models: %w", err)
+	}
+	fmt.Fprintf(output, "Added %s to the allowed models.\n", alias) //nolint:errcheck
+	return nil
+}
+
+// liveCheckDeniedByAllowedModels reports whether a live validation failure
+// was the gateway's allowed-models denial (the 403 detail names the policy).
+func liveCheckDeniedByAllowedModels(outcome *managedLiveValidationOutcome, err error) bool {
+	texts := make([]string, 0, 2)
+	if err != nil {
+		texts = append(texts, err.Error())
+	}
+	if outcome != nil {
+		if message, _ := outcome.ValidationResult["live_validation_error"].(string); message != "" {
+			texts = append(texts, message)
+		}
+	}
+	for _, text := range texts {
+		if strings.Contains(strings.ToLower(text), "allowed models") {
+			return true
+		}
+	}
+	return false
+}
+
+// allowedModelsLiveCheckHint is the one-line remediation printed under a live
+// check that the allowed-models policy denied. Empty for every other failure.
+func allowedModelsLiveCheckHint(
+	agent AgentConfig,
+	outcome *managedLiveValidationOutcome,
+	err error,
+) string {
+	if !liveCheckDeniedByAllowedModels(outcome, err) {
+		return ""
+	}
+	name := strings.TrimSpace(agent.Name)
+	if name == "" {
+		name = "<agent>"
+	}
+	return fmt.Sprintf(
+		"  Fix: preloop agents onboard %s and accept the allow-list prompt, or edit governance in the console.",
+		name,
+	)
+}

--- a/cli/internal/cmd/agents_allowed_models_test.go
+++ b/cli/internal/cmd/agents_allowed_models_test.go
@@ -1,0 +1,284 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/api"
+)
+
+type governanceTestServer struct {
+	server   *httptest.Server
+	putBody  map[string]interface{}
+	putCount int
+}
+
+func newGovernanceTestServer(t *testing.T, allowed []string) *governanceTestServer {
+	t.Helper()
+	state := &governanceTestServer{}
+	config := map[string]interface{}{
+		"allowed_models": toInterfaceSlice(allowed),
+		"model_budgets": map[string]interface{}{
+			"moonshot/kimi-k3": map[string]interface{}{"monthly_usd_limit": 25},
+		},
+		"tool_rules":             map[string]interface{}{},
+		"tool_enabled_overrides": map[string]interface{}{},
+		"approval_workflow_id":   nil,
+		"native_tool_approvals":  "off",
+	}
+	state.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/agents/agent-1/governance" {
+			http.NotFound(w, r)
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(managedAgentGovernanceResponse{
+				SubjectType: "managed_agents",
+				SubjectID:   "agent-1",
+				Config:      config,
+			})
+		case http.MethodPut:
+			state.putCount++
+			var body map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			state.putBody = body
+			_ = json.NewEncoder(w).Encode(managedAgentGovernanceResponse{
+				SubjectType: "managed_agents",
+				SubjectID:   "agent-1",
+				Config:      body,
+			})
+		default:
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(state.server.Close)
+	return state
+}
+
+func toInterfaceSlice(values []string) []interface{} {
+	out := make([]interface{}, 0, len(values))
+	for _, v := range values {
+		out = append(out, v)
+	}
+	return out
+}
+
+func stringSlice(t *testing.T, value interface{}) []string {
+	t.Helper()
+	raw, ok := value.([]interface{})
+	if !ok {
+		t.Fatalf("expected list, got %#v", value)
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		out = append(out, item.(string))
+	}
+	return out
+}
+
+func TestEnsureSelectedModelAllowedAppendsAliasWhenConfirmed(t *testing.T) {
+	t.Setenv("PRELOOP_CONFIRM", "")
+	state := newGovernanceTestServer(t, []string{"GLM 5.3 Flash", "Kimi K3"})
+	client := api.NewClientWithToken(state.server.URL, "token")
+	var out bytes.Buffer
+
+	err := ensureSelectedModelAllowed(
+		client,
+		"agent-1",
+		"moonshotai/kimi-k3",
+		&aiModelResponse{ID: "m-opencode", Name: "OpenCode moonshotai/kimi-k3"},
+		strings.NewReader("\n"),
+		&out,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := out.String()
+	if !strings.Contains(text, "Note: moonshotai/kimi-k3 is not in this agent's allowed models (GLM 5.3 Flash, Kimi K3).") {
+		t.Fatalf("expected mismatch note, got %q", text)
+	}
+	if !strings.Contains(text, "Add moonshotai/kimi-k3 to the allowed models? (Y/n): ") {
+		t.Fatalf("expected prompt, got %q", text)
+	}
+	if !strings.Contains(text, "Added moonshotai/kimi-k3 to the allowed models.") {
+		t.Fatalf("expected confirmation, got %q", text)
+	}
+	if state.putCount != 1 {
+		t.Fatalf("expected one PUT, got %d", state.putCount)
+	}
+	got := stringSlice(t, state.putBody["allowed_models"])
+	want := []string{"GLM 5.3 Flash", "Kimi K3", "moonshotai/kimi-k3"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	// Every other governance field rides along unchanged.
+	budgets, _ := state.putBody["model_budgets"].(map[string]interface{})
+	if _, ok := budgets["moonshot/kimi-k3"]; !ok {
+		t.Fatalf("expected model_budgets preserved, got %#v", state.putBody)
+	}
+	if state.putBody["native_tool_approvals"] != "off" {
+		t.Fatalf("expected native_tool_approvals preserved, got %#v", state.putBody)
+	}
+}
+
+func TestEnsureSelectedModelAllowedDeclineLeavesPolicyUnchanged(t *testing.T) {
+	t.Setenv("PRELOOP_CONFIRM", "")
+	state := newGovernanceTestServer(t, []string{"Kimi K3"})
+	client := api.NewClientWithToken(state.server.URL, "token")
+	var out bytes.Buffer
+
+	err := ensureSelectedModelAllowed(
+		client, "agent-1", "moonshotai/kimi-k3", nil, strings.NewReader("n\n"), &out, true,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.putCount != 0 {
+		t.Fatalf("expected no PUT after decline, got %d", state.putCount)
+	}
+	if !strings.Contains(out.String(), "Left the allowed models unchanged") {
+		t.Fatalf("expected decline note, got %q", out.String())
+	}
+}
+
+func TestEnsureSelectedModelAllowedNonInteractiveNotesOnly(t *testing.T) {
+	state := newGovernanceTestServer(t, []string{"GLM 5.3 Flash", "Kimi K3"})
+	client := api.NewClientWithToken(state.server.URL, "token")
+	var out bytes.Buffer
+
+	err := ensureSelectedModelAllowed(
+		client, "agent-1", "moonshotai/kimi-k3", nil, strings.NewReader("y\n"), &out, false,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.putCount != 0 {
+		t.Fatalf("non-interactive run must not write governance, got %d PUTs", state.putCount)
+	}
+	text := out.String()
+	if !strings.Contains(text, "Note: moonshotai/kimi-k3 is not in this agent's allowed models (GLM 5.3 Flash, Kimi K3).") {
+		t.Fatalf("expected note, got %q", text)
+	}
+	if strings.Contains(text, "(Y/n)") {
+		t.Fatalf("non-interactive run must not prompt, got %q", text)
+	}
+}
+
+func TestEnsureSelectedModelAllowedElidesLongLists(t *testing.T) {
+	state := newGovernanceTestServer(t, []string{"a", "b", "c", "d", "e", "f", "g"})
+	client := api.NewClientWithToken(state.server.URL, "token")
+	var out bytes.Buffer
+
+	if err := ensureSelectedModelAllowed(client, "agent-1", "x/y", nil, strings.NewReader(""), &out, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "(a, b, c, d, e, ...)") {
+		t.Fatalf("expected elided list, got %q", out.String())
+	}
+}
+
+func TestEnsureSelectedModelAllowedSilentWhenCoveredOrUnrestricted(t *testing.T) {
+	cases := []struct {
+		name    string
+		allowed []string
+		alias   string
+		model   *aiModelResponse
+	}{
+		{name: "empty list allows all", allowed: nil, alias: "moonshotai/kimi-k3"},
+		{name: "alias listed", allowed: []string{"moonshotai/kimi-k3"}, alias: "moonshotai/kimi-k3"},
+		{name: "bare tail listed", allowed: []string{"kimi-k3"}, alias: "moonshotai/kimi-k3"},
+		{
+			name:    "display name listed",
+			allowed: []string{"GLM 5.3 Flash", "Kimi K3"},
+			alias:   "moonshot/kimi-k3",
+			model:   &aiModelResponse{ID: "m1", Name: "kimi k3"},
+		},
+		{
+			name:    "model id listed",
+			allowed: []string{"M1"},
+			alias:   "moonshot/kimi-k3",
+			model:   &aiModelResponse{ID: "m1", Name: "Kimi K3"},
+		},
+		{
+			name:    "configured gateway alias listed",
+			allowed: []string{"team/kimi"},
+			alias:   "moonshot/kimi-k3",
+			model: &aiModelResponse{ID: "m1", MetaData: map[string]interface{}{
+				"gateway": map[string]interface{}{"model_alias": "team/kimi"},
+			}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := newGovernanceTestServer(t, tc.allowed)
+			client := api.NewClientWithToken(state.server.URL, "token")
+			var out bytes.Buffer
+			if err := ensureSelectedModelAllowed(client, "agent-1", tc.alias, tc.model, strings.NewReader("y\n"), &out, true); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if out.Len() != 0 {
+				t.Fatalf("expected no output, got %q", out.String())
+			}
+			if state.putCount != 0 {
+				t.Fatalf("expected no PUT, got %d", state.putCount)
+			}
+		})
+	}
+}
+
+func TestEnsureSelectedModelAllowedSoftFailsWhenGovernanceUnavailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	client := api.NewClientWithToken(server.URL, "token")
+	var out bytes.Buffer
+
+	if err := ensureSelectedModelAllowed(client, "agent-1", "x/y", nil, strings.NewReader(""), &out, true); err != nil {
+		t.Fatalf("governance read failure must not fail onboarding, got %v", err)
+	}
+	if !strings.Contains(out.String(), "skipping the allowed-models check") {
+		t.Fatalf("expected soft-fail note, got %q", out.String())
+	}
+}
+
+func TestAllowedModelsLiveCheckHint(t *testing.T) {
+	agent := AgentConfig{Name: "OpenCode", DisplayName: "OpenCode (laptop)"}
+	denied := &api.APIError{
+		StatusCode: http.StatusForbidden,
+		Body:       `{"error":{"message":"Model 'moonshotai/kimi-k3' is not in this agent's allowed models (GLM 5.3 Flash, Kimi K3). Edit the agent's governance in the Preloop console or pick an allowed model.","type":"permission_error","code":"model_not_allowed"}}`,
+	}
+	hint := allowedModelsLiveCheckHint(agent, nil, denied)
+	want := "  Fix: preloop agents onboard OpenCode and accept the allow-list prompt, or edit governance in the console."
+	if hint != want {
+		t.Fatalf("expected %q, got %q", want, hint)
+	}
+
+	// The same denial surfaced through the validation result map.
+	outcome := &managedLiveValidationOutcome{
+		Attempted: true,
+		ValidationResult: map[string]interface{}{
+			"live_validation_error": denied.Error(),
+		},
+	}
+	if got := allowedModelsLiveCheckHint(agent, outcome, nil); got != want {
+		t.Fatalf("expected hint from validation result, got %q", got)
+	}
+
+	if got := allowedModelsLiveCheckHint(agent, nil, errors.New("API error (status 403): Model gateway budget exceeded")); got != "" {
+		t.Fatalf("expected no hint for unrelated 403, got %q", got)
+	}
+	if got := allowedModelsLiveCheckHint(agent, nil, nil); got != "" {
+		t.Fatalf("expected no hint without failure, got %q", got)
+	}
+}

--- a/cli/internal/cmd/agents_allowed_models_test.go
+++ b/cli/internal/cmd/agents_allowed_models_test.go
@@ -24,7 +24,7 @@ func newGovernanceTestServer(t *testing.T, allowed []string) *governanceTestServ
 	config := map[string]interface{}{
 		"allowed_models": toInterfaceSlice(allowed),
 		"model_budgets": map[string]interface{}{
-			"moonshot/kimi-k3": map[string]interface{}{"monthly_usd_limit": 25},
+			"acme/alpha-chat": map[string]interface{}{"monthly_usd_limit": 25},
 		},
 		"tool_rules":             map[string]interface{}{},
 		"tool_enabled_overrides": map[string]interface{}{},
@@ -85,17 +85,32 @@ func stringSlice(t *testing.T, value interface{}) []string {
 	return out
 }
 
+func TestGovernanceAllowedModelsDropsNonStrings(t *testing.T) {
+	got := governanceAllowedModels(map[string]interface{}{
+		"allowed_models": []interface{}{" a ", nil, 3, "", "b"},
+	})
+	want := []string{"a", "b"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	if leftover := governanceAllowedModels(map[string]interface{}{
+		"allowed_models": []interface{}{nil},
+	}); len(leftover) != 0 {
+		t.Fatalf("non-strings only must be unrestricted, got %#v", leftover)
+	}
+}
+
 func TestEnsureSelectedModelAllowedAppendsAliasWhenConfirmed(t *testing.T) {
 	t.Setenv("PRELOOP_CONFIRM", "")
-	state := newGovernanceTestServer(t, []string{"GLM 5.3 Flash", "Kimi K3"})
+	state := newGovernanceTestServer(t, []string{"Beta Flash", "Alpha Chat"})
 	client := api.NewClientWithToken(state.server.URL, "token")
 	var out bytes.Buffer
 
 	err := ensureSelectedModelAllowed(
 		client,
 		"agent-1",
-		"moonshotai/kimi-k3",
-		&aiModelResponse{ID: "m-opencode", Name: "OpenCode moonshotai/kimi-k3"},
+		"vendor/alpha-chat",
+		&aiModelResponse{ID: "m-imported", Name: "Imported alpha-chat"},
 		strings.NewReader("\n"),
 		&out,
 		true,
@@ -104,26 +119,26 @@ func TestEnsureSelectedModelAllowedAppendsAliasWhenConfirmed(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	text := out.String()
-	if !strings.Contains(text, "Note: moonshotai/kimi-k3 is not in this agent's allowed models (GLM 5.3 Flash, Kimi K3).") {
+	if !strings.Contains(text, "Note: vendor/alpha-chat is not in this agent's allowed models (Beta Flash, Alpha Chat).") {
 		t.Fatalf("expected mismatch note, got %q", text)
 	}
-	if !strings.Contains(text, "Add moonshotai/kimi-k3 to the allowed models? (Y/n): ") {
+	if !strings.Contains(text, "Add vendor/alpha-chat to the allowed models? (Y/n): ") {
 		t.Fatalf("expected prompt, got %q", text)
 	}
-	if !strings.Contains(text, "Added moonshotai/kimi-k3 to the allowed models.") {
+	if !strings.Contains(text, "Added vendor/alpha-chat to the allowed models.") {
 		t.Fatalf("expected confirmation, got %q", text)
 	}
 	if state.putCount != 1 {
 		t.Fatalf("expected one PUT, got %d", state.putCount)
 	}
 	got := stringSlice(t, state.putBody["allowed_models"])
-	want := []string{"GLM 5.3 Flash", "Kimi K3", "moonshotai/kimi-k3"}
+	want := []string{"Beta Flash", "Alpha Chat", "vendor/alpha-chat"}
 	if strings.Join(got, "|") != strings.Join(want, "|") {
 		t.Fatalf("expected %v, got %v", want, got)
 	}
 	// Every other governance field rides along unchanged.
 	budgets, _ := state.putBody["model_budgets"].(map[string]interface{})
-	if _, ok := budgets["moonshot/kimi-k3"]; !ok {
+	if _, ok := budgets["acme/alpha-chat"]; !ok {
 		t.Fatalf("expected model_budgets preserved, got %#v", state.putBody)
 	}
 	if state.putBody["native_tool_approvals"] != "off" {
@@ -133,12 +148,12 @@ func TestEnsureSelectedModelAllowedAppendsAliasWhenConfirmed(t *testing.T) {
 
 func TestEnsureSelectedModelAllowedDeclineLeavesPolicyUnchanged(t *testing.T) {
 	t.Setenv("PRELOOP_CONFIRM", "")
-	state := newGovernanceTestServer(t, []string{"Kimi K3"})
+	state := newGovernanceTestServer(t, []string{"Alpha Chat"})
 	client := api.NewClientWithToken(state.server.URL, "token")
 	var out bytes.Buffer
 
 	err := ensureSelectedModelAllowed(
-		client, "agent-1", "moonshotai/kimi-k3", nil, strings.NewReader("n\n"), &out, true,
+		client, "agent-1", "vendor/alpha-chat", nil, strings.NewReader("n\n"), &out, true,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -152,12 +167,12 @@ func TestEnsureSelectedModelAllowedDeclineLeavesPolicyUnchanged(t *testing.T) {
 }
 
 func TestEnsureSelectedModelAllowedNonInteractiveNotesOnly(t *testing.T) {
-	state := newGovernanceTestServer(t, []string{"GLM 5.3 Flash", "Kimi K3"})
+	state := newGovernanceTestServer(t, []string{"Beta Flash", "Alpha Chat"})
 	client := api.NewClientWithToken(state.server.URL, "token")
 	var out bytes.Buffer
 
 	err := ensureSelectedModelAllowed(
-		client, "agent-1", "moonshotai/kimi-k3", nil, strings.NewReader("y\n"), &out, false,
+		client, "agent-1", "vendor/alpha-chat", nil, strings.NewReader("y\n"), &out, false,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -166,7 +181,7 @@ func TestEnsureSelectedModelAllowedNonInteractiveNotesOnly(t *testing.T) {
 		t.Fatalf("non-interactive run must not write governance, got %d PUTs", state.putCount)
 	}
 	text := out.String()
-	if !strings.Contains(text, "Note: moonshotai/kimi-k3 is not in this agent's allowed models (GLM 5.3 Flash, Kimi K3).") {
+	if !strings.Contains(text, "Note: vendor/alpha-chat is not in this agent's allowed models (Beta Flash, Alpha Chat).") {
 		t.Fatalf("expected note, got %q", text)
 	}
 	if strings.Contains(text, "(Y/n)") {
@@ -194,27 +209,27 @@ func TestEnsureSelectedModelAllowedSilentWhenCoveredOrUnrestricted(t *testing.T)
 		alias   string
 		model   *aiModelResponse
 	}{
-		{name: "empty list allows all", allowed: nil, alias: "moonshotai/kimi-k3"},
-		{name: "alias listed", allowed: []string{"moonshotai/kimi-k3"}, alias: "moonshotai/kimi-k3"},
-		{name: "bare tail listed", allowed: []string{"kimi-k3"}, alias: "moonshotai/kimi-k3"},
+		{name: "empty list allows all", allowed: nil, alias: "vendor/alpha-chat"},
+		{name: "alias listed", allowed: []string{"vendor/alpha-chat"}, alias: "vendor/alpha-chat"},
+		{name: "bare tail listed", allowed: []string{"alpha-chat"}, alias: "vendor/alpha-chat"},
 		{
 			name:    "display name listed",
-			allowed: []string{"GLM 5.3 Flash", "Kimi K3"},
-			alias:   "moonshot/kimi-k3",
-			model:   &aiModelResponse{ID: "m1", Name: "kimi k3"},
+			allowed: []string{"Beta Flash", "Alpha Chat"},
+			alias:   "acme/alpha-chat",
+			model:   &aiModelResponse{ID: "m1", Name: "alpha chat"},
 		},
 		{
 			name:    "model id listed",
 			allowed: []string{"M1"},
-			alias:   "moonshot/kimi-k3",
-			model:   &aiModelResponse{ID: "m1", Name: "Kimi K3"},
+			alias:   "acme/alpha-chat",
+			model:   &aiModelResponse{ID: "m1", Name: "Alpha Chat"},
 		},
 		{
 			name:    "configured gateway alias listed",
-			allowed: []string{"team/kimi"},
-			alias:   "moonshot/kimi-k3",
+			allowed: []string{"team/alpha"},
+			alias:   "acme/alpha-chat",
 			model: &aiModelResponse{ID: "m1", MetaData: map[string]interface{}{
-				"gateway": map[string]interface{}{"model_alias": "team/kimi"},
+				"gateway": map[string]interface{}{"model_alias": "team/alpha"},
 			}},
 		},
 	}
@@ -256,7 +271,7 @@ func TestAllowedModelsLiveCheckHint(t *testing.T) {
 	agent := AgentConfig{Name: "OpenCode", DisplayName: "OpenCode (laptop)"}
 	denied := &api.APIError{
 		StatusCode: http.StatusForbidden,
-		Body:       `{"error":{"message":"Model 'moonshotai/kimi-k3' is not in this agent's allowed models (GLM 5.3 Flash, Kimi K3). Edit the agent's governance in the Preloop console or pick an allowed model.","type":"permission_error","code":"model_not_allowed"}}`,
+		Body:       `{"error":{"message":"Model 'vendor/alpha-chat' is not in this agent's allowed models (Beta Flash, Alpha Chat). Edit the agent's governance in the Preloop console or pick an allowed model.","type":"permission_error","code":"model_not_allowed"}}`,
 	}
 	hint := allowedModelsLiveCheckHint(agent, nil, denied)
 	want := "  Fix: preloop agents onboard OpenCode and accept the allow-list prompt, or edit governance in the console."

--- a/cli/internal/cmd/agents_install_ux.go
+++ b/cli/internal/cmd/agents_install_ux.go
@@ -127,6 +127,9 @@ func formatDeferredLiveValidationRoundTrip(result deferredLiveValidationResult) 
 		seconds,
 		detail,
 	)
+	if hint := allowedModelsLiveCheckHint(result.Agent, result.Outcome, result.Err); hint != "" {
+		line += "  " + strings.TrimSpace(hint) + "\n"
+	}
 	return formatCLIError(line)
 }
 

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -1015,10 +1015,10 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 
 	// The agent's governance may restrict allowed models. Surface a mismatch
 	// with the alias we are about to route (and offer to fix it) before the
-	// live check turns it into an opaque 403.
+	// live check turns it into an opaque 403. Dry runs returned right after
+	// printing the plan, so only the confirmation flags decide interactivity.
 	if supportsManagedGateway(agent) && strings.TrimSpace(plan.ManagedModelAlias) != "" {
-		interactiveAllowlist := !opts.DryRun &&
-			!opts.AutoApprove &&
+		interactiveAllowlist := !opts.AutoApprove &&
 			!opts.SkipConfirmation &&
 			!nonInteractiveAutoConfirm() &&
 			stdinIsTerminal()

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -1013,6 +1013,28 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 		validationResult["live_validation_status"] = "pending"
 	}
 
+	// The agent's governance may restrict allowed models. Surface a mismatch
+	// with the alias we are about to route (and offer to fix it) before the
+	// live check turns it into an opaque 403.
+	if supportsManagedGateway(agent) && strings.TrimSpace(plan.ManagedModelAlias) != "" {
+		interactiveAllowlist := !opts.DryRun &&
+			!opts.AutoApprove &&
+			!opts.SkipConfirmation &&
+			!nonInteractiveAutoConfirm() &&
+			stdinIsTerminal()
+		if err := ensureSelectedModelAllowed(
+			client,
+			managedAgent.ID,
+			plan.ManagedModelAlias,
+			gatewayHints.SelectedAIModel,
+			input,
+			output,
+			interactiveAllowlist,
+		); err != nil {
+			return err
+		}
+	}
+
 	var liveValidationErr error
 	liveValidationGatewayVerified := false
 	liveValidationKeepsGatewayConfig := false
@@ -1039,6 +1061,9 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 			modelAlias,
 			liveValidationDuration,
 		)
+		if hint := allowedModelsLiveCheckHint(agent, liveOutcome, err); hint != "" {
+			fmt.Fprintln(output, formatCLIError(hint)) //nolint:errcheck
+		}
 		if liveOutcome != nil && liveOutcome.Attempted {
 			// A probe the upstream provider refused (rate limit, billing) is
 			// inconclusive, not a failure: the static config checks passed and

--- a/frontend/src/views/authed/agent-detail-view.test.ts
+++ b/frontend/src/views/authed/agent-detail-view.test.ts
@@ -6,6 +6,10 @@ import type { AgentDetailView } from './agent-detail-view';
 
 describe('AgentDetailView', () => {
   let fetchStub: sinon.SinonStub;
+  let defaultFetch: (
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ) => Promise<Response>;
 
   function getDeepText(el: Element | null | undefined): string {
     if (!el) return '';
@@ -31,193 +35,101 @@ describe('AgentDetailView', () => {
     localStorage.setItem('refreshToken', 'test-refresh-token');
 
     fetchStub = sinon.stub(window, 'fetch');
-    fetchStub.callsFake(
-      async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = typeof input === 'string' ? input : input.toString();
+    defaultFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
 
-        if (
-          url.startsWith('/api/v1/agents/agent-1') &&
-          !url.includes('/governance')
-        ) {
-          return new Response(
-            JSON.stringify({
-              agent: {
-                id: 'agent-1',
-                runtime_session_id: 'runtime-session-2',
-                display_name: 'Claude Code Workspace',
-                session_source_type: 'claude_code',
-                session_source_id: 'claude-code-agent-1',
-                session_reference: 'claude-session-2',
-                enrolled_via: 'runtime_session_token',
-                managed_mcp_servers: ['github', 'jira'],
-                lifecycle_state: 'active',
-                lifecycle_reason: null,
-                lifecycle_updated_at: '2026-03-10T10:00:00Z',
-                is_active_now: true,
-                activity_status: 'active_now',
-                last_seen_at: '2026-03-10T10:00:00Z',
-                started_at: '2026-03-10T09:00:00Z',
-                last_activity_at: '2026-03-10T10:00:00Z',
-                ended_at: null,
-                total_requests: 1,
-                estimated_cost: 0.12,
-                configured_model_alias: 'openai/gpt-5',
-                configured_model_id: 'configured-model-1',
-                latest_model_alias: 'openai/gpt-5',
-                latest_provider_name: 'openai',
-                last_request_at: '2026-03-10T09:58:00Z',
-                mcp_proxy_configured: true,
-                model_gateway_configured: true,
-                onboarding_state: 'fully_onboarded',
-                live_validation_supported: true,
-                live_validation_passed: true,
-                live_validation_status: 'passed',
-                last_validated_at: '2026-03-10T10:01:00Z',
-                owner_user_id: null,
-                owner_username: null,
-                owner_email: null,
+      if (
+        url.startsWith('/api/v1/agents/agent-1') &&
+        !url.includes('/governance')
+      ) {
+        return new Response(
+          JSON.stringify({
+            agent: {
+              id: 'agent-1',
+              runtime_session_id: 'runtime-session-2',
+              display_name: 'Claude Code Workspace',
+              session_source_type: 'claude_code',
+              session_source_id: 'claude-code-agent-1',
+              session_reference: 'claude-session-2',
+              enrolled_via: 'runtime_session_token',
+              managed_mcp_servers: ['github', 'jira'],
+              lifecycle_state: 'active',
+              lifecycle_reason: null,
+              lifecycle_updated_at: '2026-03-10T10:00:00Z',
+              is_active_now: true,
+              activity_status: 'active_now',
+              last_seen_at: '2026-03-10T10:00:00Z',
+              started_at: '2026-03-10T09:00:00Z',
+              last_activity_at: '2026-03-10T10:00:00Z',
+              ended_at: null,
+              total_requests: 1,
+              estimated_cost: 0.12,
+              configured_model_alias: 'openai/gpt-5',
+              configured_model_id: 'configured-model-1',
+              latest_model_alias: 'openai/gpt-5',
+              latest_provider_name: 'openai',
+              last_request_at: '2026-03-10T09:58:00Z',
+              mcp_proxy_configured: true,
+              model_gateway_configured: true,
+              onboarding_state: 'fully_onboarded',
+              live_validation_supported: true,
+              live_validation_passed: true,
+              live_validation_status: 'passed',
+              last_validated_at: '2026-03-10T10:01:00Z',
+              owner_user_id: null,
+              owner_username: null,
+              owner_email: null,
+            },
+            aggregate: {
+              session_count: 2,
+              total_requests: 4,
+              successful_requests: 3,
+              failed_requests: 1,
+              token_usage: {
+                prompt_tokens: 300,
+                completion_tokens: 120,
+                total_tokens: 420,
               },
-              aggregate: {
-                session_count: 2,
-                total_requests: 4,
-                successful_requests: 3,
-                failed_requests: 1,
+              estimated_cost: 0.57,
+              latest_model_alias: 'openai/gpt-5',
+              latest_provider_name: 'openai',
+              last_request_at: '2026-03-10T09:58:00Z',
+            },
+            usage_by_model: [
+              {
+                ai_model_id: 'model-1',
+                model_alias: 'openai/gpt-5',
+                provider_name: 'openai',
+                request_count: 4,
                 token_usage: {
                   prompt_tokens: 300,
                   completion_tokens: 120,
                   total_tokens: 420,
                 },
                 estimated_cost: 0.57,
-                latest_model_alias: 'openai/gpt-5',
-                latest_provider_name: 'openai',
-                last_request_at: '2026-03-10T09:58:00Z',
               },
-              usage_by_model: [
-                {
-                  ai_model_id: 'model-1',
-                  model_alias: 'openai/gpt-5',
-                  provider_name: 'openai',
-                  request_count: 4,
-                  token_usage: {
-                    prompt_tokens: 300,
-                    completion_tokens: 120,
-                    total_tokens: 420,
-                  },
-                  estimated_cost: 0.57,
-                },
-              ],
-              activity_by_server: [
-                {
-                  server_name: 'github',
-                  call_count: 2,
-                  successful_calls: 2,
-                  failed_calls: 0,
-                  last_activity_at: '2026-03-10T10:00:00Z',
-                },
-              ],
-              activity_by_tool: [
-                {
-                  server_name: 'github',
-                  tool_name: 'search_issues',
-                  call_count: 2,
-                  successful_calls: 2,
-                  failed_calls: 0,
-                  last_activity_at: '2026-03-10T10:00:00Z',
-                },
-              ],
-              sessions: [
-                {
-                  id: 'runtime-session-2',
-                  session_source_type: 'claude_code',
-                  session_source_id: 'workspace-2',
-                  session_reference: null,
-                  runtime_principal_type: 'claude_code',
-                  runtime_principal_id: 'claude-code-agent-1',
-                  runtime_principal_name: 'Claude Code Workspace',
-                  started_at: '2026-03-10T09:30:00Z',
-                  last_activity_at: '2026-03-10T09:59:00Z',
-                  ended_at: null,
-                  flow_id: null,
-                  flow_name: null,
-                  flow_execution_id: null,
-                  latest_model_alias: 'openai/gpt-5',
-                  latest_provider_name: 'openai',
-                  is_active_now: true,
-                  activity_status: 'active_now',
-                  total_requests: 1,
-                  successful_requests: 1,
-                  failed_requests: 0,
-                  token_usage: {
-                    prompt_tokens: 100,
-                    completion_tokens: 20,
-                    total_tokens: 120,
-                  },
-                  estimated_cost: 0.12,
-                  last_request_at: '2026-03-10T09:59:00Z',
-                },
-              ],
-            }),
-            { status: 200, headers: { 'Content-Type': 'application/json' } }
-          );
-        }
-
-        if (url === '/api/v1/account/governance-defaults') {
-          return new Response(
-            JSON.stringify({
-              defaults: {
-                native_tool_approvals: null,
-                approval_workflow_id: null,
+            ],
+            activity_by_server: [
+              {
+                server_name: 'github',
+                call_count: 2,
+                successful_calls: 2,
+                failed_calls: 0,
+                last_activity_at: '2026-03-10T10:00:00Z',
               },
-              override_agent_ids: [],
-            }),
-            { status: 200, headers: { 'Content-Type': 'application/json' } }
-          );
-        }
-
-        if (url === '/api/v1/agents/agent-1/governance') {
-          if (init?.method === 'PUT') {
-            // Echo the submitted config back, as the real endpoint does.
-            const submitted = JSON.parse(String(init.body));
-            return new Response(
-              JSON.stringify({
-                subject_type: 'managed_agents',
-                subject_id: 'agent-1',
-                config: {
-                  allowed_models: [],
-                  model_budgets: {},
-                  tool_rules: {},
-                  ...submitted,
-                },
-              }),
-              { status: 200, headers: { 'Content-Type': 'application/json' } }
-            );
-          }
-          return new Response(
-            JSON.stringify({
-              subject_type: 'managed_agents',
-              subject_id: 'agent-1',
-              config: {
-                allowed_models: ['openai/gpt-5'],
-                model_budgets: {
-                  'openai/gpt-5': { monthly_usd_limit: 25 },
-                },
-                tool_rules: {
-                  search_issues: [
-                    { action: 'allow', condition_type: 'simple' },
-                  ],
-                },
+            ],
+            activity_by_tool: [
+              {
+                server_name: 'github',
+                tool_name: 'search_issues',
+                call_count: 2,
+                successful_calls: 2,
+                failed_calls: 0,
+                last_activity_at: '2026-03-10T10:00:00Z',
               },
-            }),
-            { status: 200, headers: { 'Content-Type': 'application/json' } }
-          );
-        }
-
-        if (url === '/api/v1/runtime-sessions/runtime-session-2') {
-          return new Response(
-            JSON.stringify({
-              period_start: '2026-03-01T00:00:00Z',
-              period_end: '2026-03-10T23:59:59Z',
-              session: {
+            ],
+            sessions: [
+              {
                 id: 'runtime-session-2',
                 session_source_type: 'claude_code',
                 session_source_id: 'workspace-2',
@@ -246,188 +158,277 @@ describe('AgentDetailView', () => {
                 estimated_cost: 0.12,
                 last_request_at: '2026-03-10T09:59:00Z',
               },
-              usage_by_model: [],
-              interactions: {
-                period_start: '2026-03-01T00:00:00Z',
-                period_end: '2026-03-10T23:59:59Z',
-                query: null,
-                total: 0,
-                limit: 10,
-                offset: 0,
-                items: [],
-              },
-              activity_timeline: [
-                {
-                  activity_type: 'tool_call',
-                  timestamp: '2026-03-10T09:59:00Z',
-                  title: 'github / search_issues',
-                  summary: 'Completed successfully',
-                  status: 'success',
-                  api_usage_id: null,
-                  tool_name: 'search_issues',
-                  server_name: 'github',
-                  auth_subject_type: null,
-                  api_key_id: null,
-                  api_key_name: null,
-                  estimated_cost: null,
-                  total_tokens: null,
-                },
-              ],
-            }),
-            { status: 200, headers: { 'Content-Type': 'application/json' } }
-          );
-        }
-
-        if (url === '/api/v1/users') {
-          return new Response(JSON.stringify({ users: [] }), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-
-        if (url === '/api/v1/tools') {
-          return new Response(
-            JSON.stringify([
-              {
-                name: 'search_issues',
-                description: 'Search GitHub issues',
-                schema: {
-                  properties: {
-                    query: { type: 'string' },
-                  },
-                },
-              },
-            ]),
-            { status: 200, headers: { 'Content-Type': 'application/json' } }
-          );
-        }
-
-        if (url === '/api/v1/approval-workflows') {
-          return new Response(
-            JSON.stringify([
-              {
-                id: 'wf-1',
-                name: 'Default Approval',
-                approval_type: 'standard',
-              },
-            ]),
-            { status: 200, headers: { 'Content-Type': 'application/json' } }
-          );
-        }
-
-        if (url === '/api/v1/features') {
-          return new Response(JSON.stringify({ features: {} }), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-
-        if (url === '/api/v1/mcp-servers') {
-          return new Response(JSON.stringify([]), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-
-        if (url === '/api/v1/flows') {
-          return new Response(JSON.stringify([]), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-
-        if (
-          url.includes(
-            '/api/v1/runtime-sessions/runtime-session-2/gateway-events'
-          )
-        ) {
-          return new Response(
-            JSON.stringify({
-              logs: [
-                {
-                  id: 'event-1',
-                  timestamp: '2026-03-10T09:58:00Z',
-                  type: 'model_gateway_call',
-                  payload: {
-                    api_usage_id: 'usage-1',
-                    model_alias: 'openai/gpt-5',
-                    provider_name: 'openai',
-                    outcome: 'success',
-                    estimated_cost: 0.12,
-                    total_tokens: 120,
-                    prompt_tokens: 100,
-                    completion_tokens: 20,
-                    status_code: 200,
-                    method: 'POST',
-                    endpoint: '/openai/v1/responses',
-                  },
-                },
-              ],
-            }),
-            {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' },
-            }
-          );
-        }
-
-        if (
-          url.includes('/api/v1/runtime-sessions/runtime-session-2/activity')
-        ) {
-          return new Response(
-            JSON.stringify({
-              items: [
-                {
-                  activity_type: 'tool_call',
-                  timestamp: '2026-03-10T09:59:00Z',
-                  title: 'github / search_issues',
-                  summary: 'Completed successfully',
-                  status: 'success',
-                  api_usage_id: null,
-                  tool_name: 'search_issues',
-                  server_name: 'github',
-                  auth_subject_type: null,
-                  api_key_id: null,
-                  api_key_name: null,
-                  estimated_cost: null,
-                  total_tokens: null,
-                },
-              ],
-            }),
-            {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' },
-            }
-          );
-        }
-
-        if (url === '/api/v1/ai-models') {
-          return new Response(
-            JSON.stringify([
-              {
-                id: 'model-openai-gpt-5',
-                name: 'openai/gpt-5',
-                provider_name: 'openai',
-              },
-              {
-                id: 'model-anthropic-claude',
-                name: 'anthropic/claude-sonnet-4',
-                provider_name: 'anthropic',
-              },
-            ]),
-            {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' },
-            }
-          );
-        }
-
-        return new Response(
-          JSON.stringify({ detail: `Unhandled request: ${url}` }),
-          { status: 500, headers: { 'Content-Type': 'application/json' } }
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
         );
       }
-    );
+
+      if (url === '/api/v1/account/governance-defaults') {
+        return new Response(
+          JSON.stringify({
+            defaults: {
+              native_tool_approvals: null,
+              approval_workflow_id: null,
+            },
+            override_agent_ids: [],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      if (url === '/api/v1/agents/agent-1/governance') {
+        if (init?.method === 'PUT') {
+          // Echo the submitted config back, as the real endpoint does.
+          const submitted = JSON.parse(String(init.body));
+          return new Response(
+            JSON.stringify({
+              subject_type: 'managed_agents',
+              subject_id: 'agent-1',
+              config: {
+                allowed_models: [],
+                model_budgets: {},
+                tool_rules: {},
+                ...submitted,
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            subject_type: 'managed_agents',
+            subject_id: 'agent-1',
+            config: {
+              allowed_models: ['openai/gpt-5'],
+              model_budgets: {
+                'openai/gpt-5': { monthly_usd_limit: 25 },
+              },
+              tool_rules: {
+                search_issues: [{ action: 'allow', condition_type: 'simple' }],
+              },
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      if (url === '/api/v1/runtime-sessions/runtime-session-2') {
+        return new Response(
+          JSON.stringify({
+            period_start: '2026-03-01T00:00:00Z',
+            period_end: '2026-03-10T23:59:59Z',
+            session: {
+              id: 'runtime-session-2',
+              session_source_type: 'claude_code',
+              session_source_id: 'workspace-2',
+              session_reference: null,
+              runtime_principal_type: 'claude_code',
+              runtime_principal_id: 'claude-code-agent-1',
+              runtime_principal_name: 'Claude Code Workspace',
+              started_at: '2026-03-10T09:30:00Z',
+              last_activity_at: '2026-03-10T09:59:00Z',
+              ended_at: null,
+              flow_id: null,
+              flow_name: null,
+              flow_execution_id: null,
+              latest_model_alias: 'openai/gpt-5',
+              latest_provider_name: 'openai',
+              is_active_now: true,
+              activity_status: 'active_now',
+              total_requests: 1,
+              successful_requests: 1,
+              failed_requests: 0,
+              token_usage: {
+                prompt_tokens: 100,
+                completion_tokens: 20,
+                total_tokens: 120,
+              },
+              estimated_cost: 0.12,
+              last_request_at: '2026-03-10T09:59:00Z',
+            },
+            usage_by_model: [],
+            interactions: {
+              period_start: '2026-03-01T00:00:00Z',
+              period_end: '2026-03-10T23:59:59Z',
+              query: null,
+              total: 0,
+              limit: 10,
+              offset: 0,
+              items: [],
+            },
+            activity_timeline: [
+              {
+                activity_type: 'tool_call',
+                timestamp: '2026-03-10T09:59:00Z',
+                title: 'github / search_issues',
+                summary: 'Completed successfully',
+                status: 'success',
+                api_usage_id: null,
+                tool_name: 'search_issues',
+                server_name: 'github',
+                auth_subject_type: null,
+                api_key_id: null,
+                api_key_name: null,
+                estimated_cost: null,
+                total_tokens: null,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      if (url === '/api/v1/users') {
+        return new Response(JSON.stringify({ users: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (url === '/api/v1/tools') {
+        return new Response(
+          JSON.stringify([
+            {
+              name: 'search_issues',
+              description: 'Search GitHub issues',
+              schema: {
+                properties: {
+                  query: { type: 'string' },
+                },
+              },
+            },
+          ]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      if (url === '/api/v1/approval-workflows') {
+        return new Response(
+          JSON.stringify([
+            {
+              id: 'wf-1',
+              name: 'Default Approval',
+              approval_type: 'standard',
+            },
+          ]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      if (url === '/api/v1/features') {
+        return new Response(JSON.stringify({ features: {} }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (url === '/api/v1/mcp-servers') {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (url === '/api/v1/flows') {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (
+        url.includes(
+          '/api/v1/runtime-sessions/runtime-session-2/gateway-events'
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            logs: [
+              {
+                id: 'event-1',
+                timestamp: '2026-03-10T09:58:00Z',
+                type: 'model_gateway_call',
+                payload: {
+                  api_usage_id: 'usage-1',
+                  model_alias: 'openai/gpt-5',
+                  provider_name: 'openai',
+                  outcome: 'success',
+                  estimated_cost: 0.12,
+                  total_tokens: 120,
+                  prompt_tokens: 100,
+                  completion_tokens: 20,
+                  status_code: 200,
+                  method: 'POST',
+                  endpoint: '/openai/v1/responses',
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+
+      if (url.includes('/api/v1/runtime-sessions/runtime-session-2/activity')) {
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                activity_type: 'tool_call',
+                timestamp: '2026-03-10T09:59:00Z',
+                title: 'github / search_issues',
+                summary: 'Completed successfully',
+                status: 'success',
+                api_usage_id: null,
+                tool_name: 'search_issues',
+                server_name: 'github',
+                auth_subject_type: null,
+                api_key_id: null,
+                api_key_name: null,
+                estimated_cost: null,
+                total_tokens: null,
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+
+      if (url === '/api/v1/ai-models') {
+        return new Response(
+          JSON.stringify([
+            {
+              id: 'model-openai-gpt-5',
+              name: 'openai/gpt-5',
+              provider_name: 'openai',
+              model_identifier: 'gpt-5',
+            },
+            {
+              id: 'model-anthropic-claude',
+              name: 'anthropic/claude-sonnet-4',
+              provider_name: 'anthropic',
+              model_identifier: 'claude-sonnet-4',
+            },
+          ]),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+
+      return new Response(
+        JSON.stringify({ detail: `Unhandled request: ${url}` }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    };
+    fetchStub.callsFake(defaultFetch);
   });
 
   afterEach(() => {
@@ -885,5 +886,148 @@ describe('AgentDetailView', () => {
       monthly_usd_limit: 10,
     });
     expect(body.allowed_models).to.deep.equal(['openai/gpt-5']);
+  });
+
+  /**
+   * Re-stub fetch so the account models carry display names distinct from
+   * their gateway aliases and the stored allowlist uses the legacy keys
+   * (display name, model id) the console used to persist.
+   */
+  function stubDisplayNamedModels(allowedModels: string[]): void {
+    fetchStub.callsFake(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url === '/api/v1/ai-models') {
+          return new Response(
+            JSON.stringify([
+              {
+                id: 'model-kimi',
+                name: 'Kimi K3',
+                provider_name: 'moonshot',
+                model_identifier: 'kimi-k3',
+                meta_data: {
+                  gateway: { enabled: true, model_alias: 'moonshot/kimi-k3' },
+                },
+              },
+              {
+                id: 'model-glm',
+                name: 'GLM 5.3 Flash',
+                provider_name: 'zai',
+                model_identifier: 'glm-5.3-flash',
+                meta_data: { gateway: { enabled: true } },
+              },
+            ]),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        if (
+          url === '/api/v1/agents/agent-1/governance' &&
+          (!init?.method || init.method === 'GET')
+        ) {
+          return new Response(
+            JSON.stringify({
+              subject_type: 'managed_agents',
+              subject_id: 'agent-1',
+              config: {
+                allowed_models: allowedModels,
+                model_budgets: {},
+                tool_rules: {},
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        return defaultFetch(input, init);
+      }
+    );
+  }
+
+  async function loadModelsTab(): Promise<AgentDetailView> {
+    const element = await fixture<AgentDetailView>(
+      html`<agent-detail-view agentId="agent-1"></agent-detail-view>`
+    );
+    await waitUntil(
+      () => !(element as any).loading && (element as any).agent !== null,
+      'Agent detail view did not finish loading'
+    );
+    (element as any).activeTab = 'models';
+    await element.updateComplete;
+    return element;
+  }
+
+  function lastGovernancePutBody(): any {
+    const putCall = fetchStub
+      .getCalls()
+      .filter(
+        (call) =>
+          String(call.args[0]) === '/api/v1/agents/agent-1/governance' &&
+          call.args[1]?.method === 'PUT'
+      )
+      .pop();
+    expect(putCall).to.exist;
+    return JSON.parse(putCall!.args[1].body);
+  }
+
+  it('renders legacy display-name allowlist entries as checked models and persists aliases', async () => {
+    stubDisplayNamedModels(['Kimi K3']);
+    const element = await loadModelsTab();
+
+    // Toggles are keyed by gateway alias, labelled by display name.
+    const toggles = Array.from(
+      element.shadowRoot!.querySelectorAll(
+        'sl-checkbox[data-model-allow-toggle]'
+      )
+    );
+    expect(
+      toggles.map((t: any) => t.getAttribute('data-model-allow-toggle'))
+    ).to.deep.equal(['moonshot/kimi-k3', 'zai/glm-5.3-flash']);
+    const kimiToggle = toggles[0] as any;
+    expect(kimiToggle.checked).to.be.true;
+    expect(getDeepText(kimiToggle)).to.contain('Kimi K3');
+    const glmToggle = toggles[1] as any;
+    expect(glmToggle.checked).to.be.false;
+
+    // The manual override shows the policy as aliases, not display names.
+    const overrideInput = element.shadowRoot?.querySelector(
+      'sl-input[label="Allowed models"]'
+    ) as any;
+    expect(overrideInput.value).to.equal('moonshot/kimi-k3');
+
+    // Checking the second model rewrites the whole list to aliases.
+    glmToggle.checked = true;
+    glmToggle.dispatchEvent(new Event('sl-change'));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(lastGovernancePutBody().allowed_models).to.deep.equal([
+      'moonshot/kimi-k3',
+      'zai/glm-5.3-flash',
+    ]);
+  });
+
+  it('renders model-id allowlist entries as checked and converts typed names to aliases', async () => {
+    stubDisplayNamedModels(['model-glm']);
+    const element = await loadModelsTab();
+
+    const glmToggle = element.shadowRoot?.querySelector(
+      'sl-checkbox[data-model-allow-toggle="zai/glm-5.3-flash"]'
+    ) as any;
+    expect(glmToggle.checked).to.be.true;
+    const kimiToggle = element.shadowRoot?.querySelector(
+      'sl-checkbox[data-model-allow-toggle="moonshot/kimi-k3"]'
+    ) as any;
+    expect(kimiToggle.checked).to.be.false;
+
+    // Typing display names, ids, bare tails, and unknown aliases into the
+    // override persists aliases where a model is known and keeps the rest.
+    const overrideInput = element.shadowRoot?.querySelector(
+      'sl-input[label="Allowed models"]'
+    ) as any;
+    overrideInput.value = 'kimi k3, model-glm, glm-5.3-flash, other/unknown';
+    overrideInput.dispatchEvent(new Event('sl-change'));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(lastGovernancePutBody().allowed_models).to.deep.equal([
+      'moonshot/kimi-k3',
+      'zai/glm-5.3-flash',
+      'other/unknown',
+    ]);
   });
 });

--- a/frontend/src/views/authed/agent-detail-view.test.ts
+++ b/frontend/src/views/authed/agent-detail-view.test.ts
@@ -893,7 +893,7 @@ describe('AgentDetailView', () => {
    * their gateway aliases and the stored allowlist uses the legacy keys
    * (display name, model id) the console used to persist.
    */
-  function stubDisplayNamedModels(allowedModels: string[]): void {
+  function stubDisplayNamedModels(allowedModels: unknown[]): void {
     fetchStub.callsFake(
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input.toString();
@@ -901,19 +901,19 @@ describe('AgentDetailView', () => {
           return new Response(
             JSON.stringify([
               {
-                id: 'model-kimi',
-                name: 'Kimi K3',
-                provider_name: 'moonshot',
-                model_identifier: 'kimi-k3',
+                id: 'model-alpha',
+                name: 'Alpha Chat',
+                provider_name: 'acme',
+                model_identifier: 'alpha-chat',
                 meta_data: {
-                  gateway: { enabled: true, model_alias: 'moonshot/kimi-k3' },
+                  gateway: { enabled: true, model_alias: 'acme/alpha-chat' },
                 },
               },
               {
-                id: 'model-glm',
-                name: 'GLM 5.3 Flash',
-                provider_name: 'zai',
-                model_identifier: 'glm-5.3-flash',
+                id: 'model-beta',
+                name: 'Beta Flash',
+                provider_name: 'other',
+                model_identifier: 'beta-flash',
                 meta_data: { gateway: { enabled: true } },
               },
             ]),
@@ -944,8 +944,7 @@ describe('AgentDetailView', () => {
 
   /**
    * Re-stub fetch so two imports of the same upstream model share one bare
-   * tail (moonshot/kimi-k3 and moonshotai/kimi-k3), the prod shape behind
-   * the ambiguous-tail review finding.
+   * tail (acme/alpha-chat and vendor/alpha-chat).
    */
   function stubSameTailModels(allowedModels: string[]): void {
     fetchStub.callsFake(
@@ -955,31 +954,31 @@ describe('AgentDetailView', () => {
           return new Response(
             JSON.stringify([
               {
-                id: 'model-kimi',
-                name: 'Kimi K3',
-                provider_name: 'moonshot',
-                model_identifier: 'kimi-k3',
+                id: 'model-alpha',
+                name: 'Alpha Chat',
+                provider_name: 'acme',
+                model_identifier: 'alpha-chat',
                 meta_data: {
-                  gateway: { enabled: true, model_alias: 'moonshot/kimi-k3' },
+                  gateway: { enabled: true, model_alias: 'acme/alpha-chat' },
                 },
               },
               {
-                id: 'model-kimi-opencode',
-                name: 'OpenCode moonshotai/kimi-k3',
-                provider_name: 'openai',
-                model_identifier: 'kimi-k3',
+                id: 'model-alpha-import',
+                name: 'Imported alpha-chat',
+                provider_name: 'vendor',
+                model_identifier: 'alpha-chat',
                 meta_data: {
                   gateway: {
                     enabled: true,
-                    model_alias: 'moonshotai/kimi-k3',
+                    model_alias: 'vendor/alpha-chat',
                   },
                 },
               },
               {
-                id: 'model-glm',
-                name: 'GLM 5.3 Flash',
-                provider_name: 'zai',
-                model_identifier: 'glm-5.3-flash',
+                id: 'model-beta',
+                name: 'Beta Flash',
+                provider_name: 'other',
+                model_identifier: 'beta-flash',
                 meta_data: { gateway: { enabled: true } },
               },
             ]),
@@ -1035,7 +1034,7 @@ describe('AgentDetailView', () => {
   }
 
   it('renders legacy display-name allowlist entries as checked models and persists aliases', async () => {
-    stubDisplayNamedModels(['Kimi K3']);
+    stubDisplayNamedModels(['Alpha Chat']);
     const element = await loadModelsTab();
 
     // Toggles are keyed by gateway alias, labelled by display name.
@@ -1046,59 +1045,69 @@ describe('AgentDetailView', () => {
     );
     expect(
       toggles.map((t: any) => t.getAttribute('data-model-allow-toggle'))
-    ).to.deep.equal(['moonshot/kimi-k3', 'zai/glm-5.3-flash']);
-    const kimiToggle = toggles[0] as any;
-    expect(kimiToggle.checked).to.be.true;
-    expect(getDeepText(kimiToggle)).to.contain('Kimi K3');
-    const glmToggle = toggles[1] as any;
-    expect(glmToggle.checked).to.be.false;
+    ).to.deep.equal(['acme/alpha-chat', 'other/beta-flash']);
+    const alphaToggle = toggles[0] as any;
+    expect(alphaToggle.checked).to.be.true;
+    expect(getDeepText(alphaToggle)).to.contain('Alpha Chat');
+    const betaToggle = toggles[1] as any;
+    expect(betaToggle.checked).to.be.false;
 
     // The manual override shows the policy as aliases, not display names.
     const overrideInput = element.shadowRoot?.querySelector(
       'sl-input[label="Allowed models"]'
     ) as any;
-    expect(overrideInput.value).to.equal('moonshot/kimi-k3');
+    expect(overrideInput.value).to.equal('acme/alpha-chat');
 
     // Checking the second model rewrites the whole list to aliases.
-    glmToggle.checked = true;
-    glmToggle.dispatchEvent(new Event('sl-change'));
+    betaToggle.checked = true;
+    betaToggle.dispatchEvent(new Event('sl-change'));
     await new Promise((resolve) => setTimeout(resolve, 100));
     expect(lastGovernancePutBody().allowed_models).to.deep.equal([
-      'moonshot/kimi-k3',
-      'zai/glm-5.3-flash',
+      'acme/alpha-chat',
+      'other/beta-flash',
     ]);
   });
 
   it('renders model-id allowlist entries as checked and converts typed names to aliases', async () => {
-    stubDisplayNamedModels(['model-glm']);
+    stubDisplayNamedModels(['model-beta']);
     const element = await loadModelsTab();
 
-    const glmToggle = element.shadowRoot?.querySelector(
-      'sl-checkbox[data-model-allow-toggle="zai/glm-5.3-flash"]'
+    const betaToggle = element.shadowRoot?.querySelector(
+      'sl-checkbox[data-model-allow-toggle="other/beta-flash"]'
     ) as any;
-    expect(glmToggle.checked).to.be.true;
-    const kimiToggle = element.shadowRoot?.querySelector(
-      'sl-checkbox[data-model-allow-toggle="moonshot/kimi-k3"]'
+    expect(betaToggle.checked).to.be.true;
+    const alphaToggle = element.shadowRoot?.querySelector(
+      'sl-checkbox[data-model-allow-toggle="acme/alpha-chat"]'
     ) as any;
-    expect(kimiToggle.checked).to.be.false;
+    expect(alphaToggle.checked).to.be.false;
 
     // Typing display names, ids, bare tails, and unknown aliases into the
     // override persists aliases where a model is known and keeps the rest.
     const overrideInput = element.shadowRoot?.querySelector(
       'sl-input[label="Allowed models"]'
     ) as any;
-    overrideInput.value = 'kimi k3, model-glm, glm-5.3-flash, other/unknown';
+    overrideInput.value = 'alpha chat, model-beta, beta-flash, other/unknown';
     overrideInput.dispatchEvent(new Event('sl-change'));
     await new Promise((resolve) => setTimeout(resolve, 100));
     expect(lastGovernancePutBody().allowed_models).to.deep.equal([
-      'moonshot/kimi-k3',
-      'zai/glm-5.3-flash',
+      'acme/alpha-chat',
+      'other/beta-flash',
       'other/unknown',
     ]);
   });
 
+  it('drops non-string allowlist entries instead of stringifying them', async () => {
+    stubDisplayNamedModels(['Alpha Chat', null, 3]);
+    const element = await loadModelsTab();
+
+    const overrideInput = element.shadowRoot?.querySelector(
+      'sl-input[label="Allowed models"]'
+    ) as any;
+    expect(overrideInput.value).to.equal('acme/alpha-chat');
+  });
+
   it('keeps an ambiguous bare-tail entry as typed instead of narrowing it to one import', async () => {
-    stubSameTailModels(['kimi-k3']);
+    stubSameTailModels(['alpha-chat']);
     const element = await loadModelsTab();
 
     // The bare tail matches two rows, so it resolves to neither alias: the
@@ -1107,8 +1116,8 @@ describe('AgentDetailView', () => {
     const overrideInput = element.shadowRoot?.querySelector(
       'sl-input[label="Allowed models"]'
     ) as any;
-    expect(overrideInput.value).to.equal('kimi-k3');
-    for (const alias of ['moonshot/kimi-k3', 'moonshotai/kimi-k3']) {
+    expect(overrideInput.value).to.equal('alpha-chat');
+    for (const alias of ['acme/alpha-chat', 'vendor/alpha-chat']) {
       const toggle = element.shadowRoot?.querySelector(
         `sl-checkbox[data-model-allow-toggle="${alias}"]`
       ) as any;
@@ -1117,15 +1126,15 @@ describe('AgentDetailView', () => {
 
     // Toggling an unrelated model must not rewrite the bare tail to one
     // import's alias.
-    const glmToggle = element.shadowRoot?.querySelector(
-      'sl-checkbox[data-model-allow-toggle="zai/glm-5.3-flash"]'
+    const betaToggle = element.shadowRoot?.querySelector(
+      'sl-checkbox[data-model-allow-toggle="other/beta-flash"]'
     ) as any;
-    glmToggle.checked = true;
-    glmToggle.dispatchEvent(new Event('sl-change'));
+    betaToggle.checked = true;
+    betaToggle.dispatchEvent(new Event('sl-change'));
     await new Promise((resolve) => setTimeout(resolve, 100));
     expect(lastGovernancePutBody().allowed_models).to.deep.equal([
-      'kimi-k3',
-      'zai/glm-5.3-flash',
+      'alpha-chat',
+      'other/beta-flash',
     ]);
   });
 });

--- a/frontend/src/views/authed/agent-detail-view.test.ts
+++ b/frontend/src/views/authed/agent-detail-view.test.ts
@@ -942,6 +942,72 @@ describe('AgentDetailView', () => {
     );
   }
 
+  /**
+   * Re-stub fetch so two imports of the same upstream model share one bare
+   * tail (moonshot/kimi-k3 and moonshotai/kimi-k3), the prod shape behind
+   * the ambiguous-tail review finding.
+   */
+  function stubSameTailModels(allowedModels: string[]): void {
+    fetchStub.callsFake(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url === '/api/v1/ai-models') {
+          return new Response(
+            JSON.stringify([
+              {
+                id: 'model-kimi',
+                name: 'Kimi K3',
+                provider_name: 'moonshot',
+                model_identifier: 'kimi-k3',
+                meta_data: {
+                  gateway: { enabled: true, model_alias: 'moonshot/kimi-k3' },
+                },
+              },
+              {
+                id: 'model-kimi-opencode',
+                name: 'OpenCode moonshotai/kimi-k3',
+                provider_name: 'openai',
+                model_identifier: 'kimi-k3',
+                meta_data: {
+                  gateway: {
+                    enabled: true,
+                    model_alias: 'moonshotai/kimi-k3',
+                  },
+                },
+              },
+              {
+                id: 'model-glm',
+                name: 'GLM 5.3 Flash',
+                provider_name: 'zai',
+                model_identifier: 'glm-5.3-flash',
+                meta_data: { gateway: { enabled: true } },
+              },
+            ]),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        if (
+          url === '/api/v1/agents/agent-1/governance' &&
+          (!init?.method || init.method === 'GET')
+        ) {
+          return new Response(
+            JSON.stringify({
+              subject_type: 'managed_agents',
+              subject_id: 'agent-1',
+              config: {
+                allowed_models: allowedModels,
+                model_budgets: {},
+                tool_rules: {},
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        return defaultFetch(input, init);
+      }
+    );
+  }
+
   async function loadModelsTab(): Promise<AgentDetailView> {
     const element = await fixture<AgentDetailView>(
       html`<agent-detail-view agentId="agent-1"></agent-detail-view>`
@@ -1028,6 +1094,38 @@ describe('AgentDetailView', () => {
       'moonshot/kimi-k3',
       'zai/glm-5.3-flash',
       'other/unknown',
+    ]);
+  });
+
+  it('keeps an ambiguous bare-tail entry as typed instead of narrowing it to one import', async () => {
+    stubSameTailModels(['kimi-k3']);
+    const element = await loadModelsTab();
+
+    // The bare tail matches two rows, so it resolves to neither alias: the
+    // override shows it unchanged and both same-tail toggles render
+    // unchecked (the backend honours the tail for both rows).
+    const overrideInput = element.shadowRoot?.querySelector(
+      'sl-input[label="Allowed models"]'
+    ) as any;
+    expect(overrideInput.value).to.equal('kimi-k3');
+    for (const alias of ['moonshot/kimi-k3', 'moonshotai/kimi-k3']) {
+      const toggle = element.shadowRoot?.querySelector(
+        `sl-checkbox[data-model-allow-toggle="${alias}"]`
+      ) as any;
+      expect(toggle.checked).to.be.false;
+    }
+
+    // Toggling an unrelated model must not rewrite the bare tail to one
+    // import's alias.
+    const glmToggle = element.shadowRoot?.querySelector(
+      'sl-checkbox[data-model-allow-toggle="zai/glm-5.3-flash"]'
+    ) as any;
+    glmToggle.checked = true;
+    glmToggle.dispatchEvent(new Event('sl-change'));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(lastGovernancePutBody().allowed_models).to.deep.equal([
+      'kimi-k3',
+      'zai/glm-5.3-flash',
     ]);
   });
 });

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -56,15 +56,6 @@ import type {
 } from '../../types';
 import type { AccessRuleSummary } from '../../components/governance-rule-set-editor';
 import consoleStyles from '../../styles/console-styles.css?inline';
-
-/** The subset of an account AI model the allowlist editor keys on. */
-type AllowedModelCandidate = {
-  id: string;
-  name: string;
-  provider_name?: string;
-  model_identifier?: string;
-  meta_data?: Record<string, unknown> | null;
-};
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import {
   normalizeScopedToolRules,
@@ -88,6 +79,15 @@ interface GovernanceToolDefinition {
   description?: string;
   schema?: Record<string, unknown>;
 }
+
+/** The subset of an account AI model the allowlist editor keys on. */
+type AllowedModelCandidate = {
+  id: string;
+  name: string;
+  provider_name?: string;
+  model_identifier?: string;
+  meta_data?: Record<string, unknown> | null;
+};
 
 @customElement('agent-detail-view')
 export class AgentDetailView extends LitElement {
@@ -1452,14 +1452,23 @@ export class AgentDetailView extends LitElement {
     for (const model of models) {
       if ((model.name || '').trim().toLowerCase() === folded) return model;
     }
+    // A bare tail may be shared by two imports of the same upstream model
+    // (moonshot/kimi-k3 and moonshotai/kimi-k3). The backend honours the
+    // entry for both rows, so rewriting it to one alias would silently
+    // narrow the policy: only resolve when exactly one row matches.
+    let tailMatch: AllowedModelCandidate | null = null;
+    let tailMatches = 0;
     for (const model of models) {
       const alias = this.gatewayAliasForModel(model);
       const tail = alias.includes('/')
         ? alias.split('/').slice(1).join('/')
         : '';
-      if (tail && tail === needle) return model;
+      if (tail && tail === needle) {
+        tailMatch = model;
+        tailMatches += 1;
+      }
     }
-    return null;
+    return tailMatches === 1 ? tailMatch : null;
   }
 
   /** Persisted key for an allowlist entry: its model's alias, else as typed. */
@@ -2700,6 +2709,8 @@ export class AgentDetailView extends LitElement {
     }
 
     const aggregate = this.aggregate;
+    // Resolved once per render instead of once per model row.
+    const allowedModelAliases = this.getAllowedModelAliases();
 
     return html`
       <view-header headerText=${this.agent.display_name}>
@@ -3307,13 +3318,13 @@ export class AgentDetailView extends LitElement {
                             style="display: flex; flex-direction: column; gap: var(--sl-spacing-x-small); max-height: 260px; overflow-y: auto;"
                           >
                             ${this.availableModels.map((model: any) => {
-                              const allowed = this.getAllowedModelAliases();
                               const alias = this.gatewayAliasForModel(model);
                               // While unrestricted (empty list) every box
                               // renders unchecked; checking one switches to
                               // restricted mode instead of faking "checked
                               // because everything is allowed".
-                              const isChecked = allowed.includes(alias);
+                              const isChecked =
+                                allowedModelAliases.includes(alias);
                               return html`
                                 <sl-checkbox
                                   data-model-allow-toggle=${alias}

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -56,6 +56,15 @@ import type {
 } from '../../types';
 import type { AccessRuleSummary } from '../../components/governance-rule-set-editor';
 import consoleStyles from '../../styles/console-styles.css?inline';
+
+/** The subset of an account AI model the allowlist editor keys on. */
+type AllowedModelCandidate = {
+  id: string;
+  name: string;
+  provider_name?: string;
+  model_identifier?: string;
+  meta_data?: Record<string, unknown> | null;
+};
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import {
   normalizeScopedToolRules,
@@ -673,7 +682,9 @@ export class AgentDetailView extends LitElement {
       );
       this.toolEnabledOverrides =
         governance.config.tool_enabled_overrides || {};
-      this.allowedModelsText = governance.config.allowed_models.join(', ');
+      this.allowedModelsText = this.formatAllowedModelsText(
+        governance.config.allowed_models
+      );
       this.modelBudgetsText = JSON.stringify(
         governance.config.model_budgets || {},
         null,
@@ -887,7 +898,7 @@ export class AgentDetailView extends LitElement {
       if (binding.gateway_alias) models.add(binding.gateway_alias);
     }
 
-    for (const model of this.governance?.allowed_models || []) {
+    for (const model of this.getAllowedModelAliases()) {
       if (model) models.add(model);
     }
 
@@ -1287,7 +1298,9 @@ export class AgentDetailView extends LitElement {
         response.config.tool_rules
       );
       this.toolEnabledOverrides = response.config.tool_enabled_overrides || {};
-      this.allowedModelsText = response.config.allowed_models.join(', ');
+      this.allowedModelsText = this.formatAllowedModelsText(
+        response.config.allowed_models
+      );
       this.modelBudgetsText = JSON.stringify(
         response.config.model_budgets || {},
         null,
@@ -1316,7 +1329,7 @@ export class AgentDetailView extends LitElement {
       return;
     }
     this.governance = { ...this.governance, allowed_models: [...models] };
-    this.allowedModelsText = models.join(', ');
+    this.allowedModelsText = this.formatAllowedModelsText(models);
     this.actionLoading = true;
     const task = this.modelSaveChain.then(() => this.persistAllowedModels());
     this.modelSaveChain = task.then(
@@ -1344,7 +1357,9 @@ export class AgentDetailView extends LitElement {
         response.config.tool_rules
       );
       this.toolEnabledOverrides = response.config.tool_enabled_overrides || {};
-      this.allowedModelsText = response.config.allowed_models.join(', ');
+      this.allowedModelsText = this.formatAllowedModelsText(
+        response.config.allowed_models
+      );
       this.error = null;
     } catch (error) {
       console.error('Failed to update agent models:', error);
@@ -1354,38 +1369,123 @@ export class AgentDetailView extends LitElement {
       // not keep showing a selection that was never persisted.
       if (this.confirmedGovernance) {
         this.governance = { ...this.confirmedGovernance };
-        this.allowedModelsText =
-          this.confirmedGovernance.allowed_models.join(', ');
+        this.allowedModelsText = this.formatAllowedModelsText(
+          this.confirmedGovernance.allowed_models
+        );
       }
     }
   }
 
-  private handleAllowedModelToggle(modelName: string, checked: boolean): void {
+  private handleAllowedModelToggle(modelAlias: string, checked: boolean): void {
     // While unrestricted (empty allowlist) every checkbox renders unchecked,
     // so checking a model switches the agent into restricted mode with just
-    // that model. Unchecking simply removes it from the restriction.
-    const current = [...(this.governance.allowed_models || [])];
+    // that model. Unchecking simply removes it from the restriction. The
+    // list is normalised to gateway aliases on the way out, so a legacy
+    // allowlist of display names or ids is rewritten to aliases the first
+    // time it is edited.
+    const current = this.getAllowedModelAliases();
     let next: string[];
     if (checked) {
-      if (current.includes(modelName)) {
+      if (current.includes(modelAlias)) {
         return;
       }
-      next = [...current, modelName].sort();
+      next = [...current, modelAlias].sort();
     } else {
-      if (!current.includes(modelName)) {
+      if (!current.includes(modelAlias)) {
         return;
       }
-      next = current.filter((m) => m !== modelName);
+      next = current.filter((m) => m !== modelAlias);
     }
     void this.saveAllowedModels(next);
   }
 
   private handleAllowedModelsTextChange(value: string): void {
-    const models = value
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
+    const models = Array.from(
+      new Set(
+        value
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+          .map((entry) => this.resolveAllowedModelEntry(entry))
+      )
+    );
     void this.saveAllowedModels(models);
+  }
+
+  /**
+   * The gateway alias an account model answers to: the explicit
+   * ``meta_data.gateway.model_alias`` when set, else ``provider/identifier``.
+   * This is the key the governance allowlist is written with, because the
+   * gateway preflight keys on it and it reads as a policy.
+   */
+  private gatewayAliasForModel(model: AllowedModelCandidate): string {
+    const meta = (model.meta_data || {}) as Record<string, unknown>;
+    const gateway = (meta.gateway as Record<string, unknown> | undefined) || {};
+    const explicit = gateway.model_alias;
+    if (typeof explicit === 'string' && explicit.trim()) {
+      return explicit.trim();
+    }
+    const provider = (model.provider_name || 'openai').trim().toLowerCase();
+    const identifier = (model.model_identifier || '').trim();
+    return identifier ? `${provider}/${identifier}` : provider;
+  }
+
+  /**
+   * Find the account model one stored allowlist entry refers to. Entries may
+   * be a gateway alias (or its bare tail), an AI model id, or a display name
+   * (case-insensitive): the console persisted display names historically and
+   * the backend resolves all three, so the editor must too.
+   */
+  private findModelForAllowedEntry(
+    entry: string
+  ): AllowedModelCandidate | null {
+    const needle = entry.trim();
+    if (!needle) return null;
+    const folded = needle.toLowerCase();
+    const models = this.availableModels as AllowedModelCandidate[];
+    for (const model of models) {
+      if (this.gatewayAliasForModel(model) === needle) return model;
+    }
+    for (const model of models) {
+      if (String(model.id).toLowerCase() === folded) return model;
+    }
+    for (const model of models) {
+      if ((model.name || '').trim().toLowerCase() === folded) return model;
+    }
+    for (const model of models) {
+      const alias = this.gatewayAliasForModel(model);
+      const tail = alias.includes('/')
+        ? alias.split('/').slice(1).join('/')
+        : '';
+      if (tail && tail === needle) return model;
+    }
+    return null;
+  }
+
+  /** Persisted key for an allowlist entry: its model's alias, else as typed. */
+  private resolveAllowedModelEntry(entry: string): string {
+    const model = this.findModelForAllowedEntry(entry);
+    return model ? this.gatewayAliasForModel(model) : entry.trim();
+  }
+
+  /** The current allowlist expressed as gateway aliases, order preserved. */
+  private getAllowedModelAliases(): string[] {
+    const aliases: string[] = [];
+    for (const entry of this.governance?.allowed_models || []) {
+      const alias = this.resolveAllowedModelEntry(String(entry));
+      if (alias && !aliases.includes(alias)) aliases.push(alias);
+    }
+    return aliases;
+  }
+
+  /** Comma-separated alias list shown in the manual override input. */
+  private formatAllowedModelsText(entries: string[]): string {
+    const aliases: string[] = [];
+    for (const entry of entries || []) {
+      const alias = this.resolveAllowedModelEntry(String(entry));
+      if (alias && !aliases.includes(alias)) aliases.push(alias);
+    }
+    return aliases.join(', ');
   }
 
   private saveApprovalWorkflowSelection(workflowId: string | null): void {
@@ -3207,24 +3307,33 @@ export class AgentDetailView extends LitElement {
                             style="display: flex; flex-direction: column; gap: var(--sl-spacing-x-small); max-height: 260px; overflow-y: auto;"
                           >
                             ${this.availableModels.map((model: any) => {
-                              const allowed =
-                                this.governance.allowed_models || [];
+                              const allowed = this.getAllowedModelAliases();
+                              const alias = this.gatewayAliasForModel(model);
                               // While unrestricted (empty list) every box
                               // renders unchecked; checking one switches to
                               // restricted mode instead of faking "checked
                               // because everything is allowed".
-                              const isChecked = allowed.includes(model.name);
+                              const isChecked = allowed.includes(alias);
                               return html`
                                 <sl-checkbox
-                                  data-model-allow-toggle=${model.name}
+                                  data-model-allow-toggle=${alias}
                                   ?checked=${isChecked}
                                   @sl-change=${(e: Event) =>
                                     this.handleAllowedModelToggle(
-                                      model.name,
+                                      alias,
                                       (e.target as HTMLInputElement).checked
                                     )}
                                 >
                                   ${model.name}
+                                  ${
+                                    alias !== model.name
+                                      ? html`<span
+                                          class="meta-line"
+                                          style="margin: 0 0 0 var(--sl-spacing-x-small); display: inline;"
+                                          >${alias}</span
+                                        >`
+                                      : nothing
+                                  }
                                 </sl-checkbox>
                               `;
                             })}
@@ -3253,9 +3362,11 @@ export class AgentDetailView extends LitElement {
                           <div
                             style="font-size: 0.8rem; color: var(--console-meta-color);"
                           >
-                            The authoritative comma separated list behind the
-                            checkboxes above, including aliases not offered as
-                            checkboxes. Leave empty to allow all models.
+                            The authoritative comma separated list of gateway
+                            aliases behind the checkboxes above, including
+                            aliases not offered as checkboxes. Model names and
+                            ids typed here are converted to aliases on save.
+                            Leave empty to allow all models.
                           </div>
                         </div>
                       </div>

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -1431,10 +1431,10 @@ export class AgentDetailView extends LitElement {
   }
 
   /**
-   * Find the account model one stored allowlist entry refers to. Entries may
-   * be a gateway alias (or its bare tail), an AI model id, or a display name
-   * (case-insensitive): the console persisted display names historically and
-   * the backend resolves all three, so the editor must too.
+   * Find the account model one stored allowlist entry refers to.
+   * Matching contract: backend/preloop/services/model_allowlist.py
+   * Entries may be a gateway alias (or its bare tail), an AI model id, or a
+   * display name (case-insensitive).
    */
   private findModelForAllowedEntry(
     entry: string
@@ -1453,7 +1453,7 @@ export class AgentDetailView extends LitElement {
       if ((model.name || '').trim().toLowerCase() === folded) return model;
     }
     // A bare tail may be shared by two imports of the same upstream model
-    // (moonshot/kimi-k3 and moonshotai/kimi-k3). The backend honours the
+    // (acme/alpha-chat and vendor/alpha-chat). The backend honours the
     // entry for both rows, so rewriting it to one alias would silently
     // narrow the policy: only resolve when exactly one row matches.
     let tailMatch: AllowedModelCandidate | null = null;
@@ -1477,24 +1477,29 @@ export class AgentDetailView extends LitElement {
     return model ? this.gatewayAliasForModel(model) : entry.trim();
   }
 
-  /** The current allowlist expressed as gateway aliases, order preserved. */
-  private getAllowedModelAliases(): string[] {
+  /**
+   * Collect stored allowlist entries as gateway aliases, order preserved.
+   * Matching contract: backend/preloop/services/model_allowlist.py
+   * Non-string values are dropped, not stringified.
+   */
+  private collectAllowedModelAliases(entries: unknown[] | undefined): string[] {
     const aliases: string[] = [];
-    for (const entry of this.governance?.allowed_models || []) {
-      const alias = this.resolveAllowedModelEntry(String(entry));
+    for (const entry of entries || []) {
+      if (typeof entry !== 'string') continue;
+      const alias = this.resolveAllowedModelEntry(entry);
       if (alias && !aliases.includes(alias)) aliases.push(alias);
     }
     return aliases;
   }
 
+  /** The current allowlist expressed as gateway aliases, order preserved. */
+  private getAllowedModelAliases(): string[] {
+    return this.collectAllowedModelAliases(this.governance?.allowed_models);
+  }
+
   /** Comma-separated alias list shown in the manual override input. */
-  private formatAllowedModelsText(entries: string[]): string {
-    const aliases: string[] = [];
-    for (const entry of entries || []) {
-      const alias = this.resolveAllowedModelEntry(String(entry));
-      if (alias && !aliases.includes(alias)) aliases.push(alias);
-    }
-    return aliases.join(', ');
+  private formatAllowedModelsText(entries: unknown[] | undefined): string {
+    return this.collectAllowedModelAliases(entries).join(', ');
   }
 
   private saveApprovalWorkflowSelection(workflowId: string | null): void {


### PR DESCRIPTION
## Problem

Agent governance `allowed_models` was persisted from the console as AI model display names, while the gateway preflight intersected the stored entries with alias spellings only (`gateway_model_alias_candidates` plus the raw requested string). Display names are never alias candidates, so an agent with any allow-list was denied for every model. The denial reason `subject_model_not_allowed` was also the only reason with no message mapping in either renderer, so the client saw a bare `Model gateway budget exceeded` that read like a billing failure.

## Changes

1. **Backend resolution.** New `preloop/services/model_allowlist.py`: each stored entry resolves by gateway alias (exact, including bare tails), AI model id, or display name (case-insensitive, trimmed). `ModelGatewayBudgetService.preflight_check` now evaluates each scope in `subject_scope_chain` independently against the resolved model and reports the first denying scope's list, replacing the old cross-scope set intersection which also denied when two scopes spelled the same model differently. Fail-closed behaviour for blank wire models and unmatched lists is unchanged.
2. **Explicit denial.** `subject_model_not_allowed` now maps in both `enforce_or_raise` and `_budget_denial_detail` to `Model '<requested>' is not in this agent's allowed models (<list>). Edit the agent's governance in the Preloop console or pick an allowed model.` with `error.code = model_not_allowed` (HTTP 403 unchanged). `free_hosted_model_budget_exceeded` is now mapped in `_budget_denial_detail` as well. Audit outcome stays `budget_denied` (eleven existing consumers across backend and frontend) with error type `model_not_allowed` distinguishing these denials.
3. **Console.** The agent detail allow-list editor persists gateway aliases and renders display names (legacy name or id entries still render and are rewritten to aliases on first edit). A bare tail shared by two imports of the same upstream model resolves to neither alias, so editing the policy cannot silently narrow it.
4. **CLI onboarding.** After the managed model is chosen and before the live check, the CLI warns when the choice is outside the agent's allowed models and interactively offers to append the alias (non-interactive: note only, no write). When the live check fails with an allow-list 403 it prints a one-line fix hint.

## Notes

- `resolve_allowed_model_ids` is exported for console endpoint reuse but has no production caller yet.
- Follow-up, not in this PR: onboarding can import a duplicate model row when an equivalent upstream model already exists under a different provider name. A safe fix needs host plus identifier-tail matching and adoption of the existing row's alias; reusing the row naively would rewrite its alias and break existing routes.

## Tests

- Backend: 68 passed / 0 failed on the budget, gateway, events, and new allowlist suites (21 new tests), including an endpoint test asserting the exact 403 message, code, type, and that upstream is not called.
- CLI: `go test ./internal/cmd/` 889 passing checks / 0 failures (7 new test functions, httptest based).
- Frontend: 1552 passed / 0 failed across 142 files (3 new tests).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low risk**
> Well-scoped bug fix with extensive test coverage; no security or functional concerns found. All review suggestions have been addressed.
>
> **Overview**
> Fixes agent governance `allowed_models` to resolve stored entries by alias, id, or display name, and makes allow-list 403 denials explicit (message + `error.code = model_not_allowed`) across gateway, events, console, and CLI onboarding.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 61c78b87. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->