### PR TITLE
Cursor hooks: transcript token estimates, priced usage ingest, and runtime sessions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Keep Cursor transcript fixtures as LF so byte-offset assertions match
+# the JSONL Cursor actually writes (one \\n per line) on every OS.
+cli/internal/cmd/testdata/cursor-transcripts/** text eol=lf

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -2596,6 +2596,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         runtime_principal_type: Optional[str] = None,
         runtime_principal_id: Optional[str] = None,
         runtime_principal_name: Optional[str] = None,
+        runtime_session_id: Optional[Any] = None,
         import_fingerprint: Optional[str] = None,
         meta_data: Optional[Dict[str, Any]] = None,
         endpoint: Optional[str] = None,
@@ -2638,6 +2639,9 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             runtime_principal_type: Managed-agent principal type attribution.
             runtime_principal_id: Managed-agent principal id attribution.
             runtime_principal_name: Managed-agent display name attribution.
+            runtime_session_id: Runtime session the record's conversation
+                was registered as, so the row shows up in that session's
+                usage like gateway rows do.
             import_fingerprint: Stable dedupe key; when a row with the same
                 fingerprint already exists for the account, the event is
                 skipped and ``None`` is returned (re-importing the same CSV
@@ -2702,6 +2706,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             runtime_principal_type=runtime_principal_type,
             runtime_principal_id=runtime_principal_id,
             runtime_principal_name=runtime_principal_name,
+            runtime_session_id=runtime_session_id,
             meta_data=merged_meta,
             timestamp=timestamp,
         )

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -2626,7 +2626,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             cost_source: Provenance of ``cost_usd``. Defaults to
                 ``imported`` when an amount is present (the vendor charged
                 it); usage ingest passes the pricing service's source
-                (``catalog``, ``override``) for estimated amounts.
+                (``catalog``) for estimated amounts.
             cost_basis: ``estimated`` or ``reconciled``; reconciled rows
                 supersede estimated rows with the same (account, source,
                 conversation_id) in imported-cost sums. NULL rows never

--- a/backend/preloop/models/crud/api_usage.py
+++ b/backend/preloop/models/crud/api_usage.py
@@ -2587,6 +2587,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
         cache_read_tokens: Optional[int] = None,
         cache_creation_tokens: Optional[int] = None,
         cost_usd: Optional[float] = None,
+        cost_source: Optional[str] = None,
         cost_basis: Optional[str] = None,
         conversation_id: Optional[str] = None,
         parent_conversation_id: Optional[str] = None,
@@ -2618,8 +2619,13 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
                 absent.
             cache_read_tokens: Cache-read tokens reported by the source.
             cache_creation_tokens: Cache-write tokens reported by the source.
-            cost_usd: Amount the source vendor charged, in USD. Stored in
-                ``estimated_cost`` with ``cost_source='imported'``.
+            cost_usd: Amount stored in ``estimated_cost``: the source
+                vendor's charge, or a catalog estimate for hook-derived
+                records that carry tokens but no billed amount.
+            cost_source: Provenance of ``cost_usd``. Defaults to
+                ``imported`` when an amount is present (the vendor charged
+                it); usage ingest passes the pricing service's source
+                (``catalog``, ``override``) for estimated amounts.
             cost_basis: ``estimated`` or ``reconciled``; reconciled rows
                 supersede estimated rows with the same (account, source,
                 conversation_id) in imported-cost sums. NULL rows never
@@ -2686,7 +2692,7 @@ class CRUDApiUsage(CRUDBase[ApiUsage]):
             cache_creation_tokens=cache_creation_tokens,
             estimated_cost=cost_usd,
             currency="USD" if cost_usd is not None else None,
-            cost_source="imported" if cost_usd is not None else None,
+            cost_source=(cost_source or ("imported" if cost_usd is not None else None)),
             cost_basis=cost_basis,
             conversation_id=conversation_id,
             parent_conversation_id=parent_conversation_id,

--- a/backend/preloop/schemas/usage_import.py
+++ b/backend/preloop/schemas/usage_import.py
@@ -143,6 +143,25 @@ class UsageImportResponse(BaseModel):
     source: str = "cursor"
 
 
+#: Cap on transcript messages one pushed record may carry, and on their
+#: combined text. Transcript shipping is opt-in on the shipper side
+#: (`preloop usage hook --store-transcript`); these bounds keep one hook
+#: delivery small even when a generation produced a lot of text.
+MAX_INGEST_TRANSCRIPT_MESSAGES = 50
+MAX_INGEST_TRANSCRIPT_TEXT_CHARS = 4000
+MAX_INGEST_TRANSCRIPT_TOTAL_CHARS = 64 * 1024
+
+IngestTranscriptRole = Literal["user", "assistant", "tool", "tool_use"]
+
+
+class UsageIngestTranscriptMessage(BaseModel):
+    """One role-tagged text chunk of a conversation transcript."""
+
+    role: IngestTranscriptRole
+    text: str = Field(..., min_length=1, max_length=MAX_INGEST_TRANSCRIPT_TEXT_CHARS)
+    timestamp: Optional[datetime] = None
+
+
 class UsageIngestRecord(BaseModel):
     """One usage record pushed continuously by an external harness.
 
@@ -221,7 +240,41 @@ class UsageIngestRecord(BaseModel):
         ge=0,
         description="Tool calls in the conversation so far (growth tripwire).",
     )
-    metadata: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Small JSON object. Recognized session keys: `session_title` "
+            "(sets the runtime session title), `session_title_default` "
+            "(fills the title only while it is empty) and `session_summary` "
+            "(replaces the runtime session summary)."
+        ),
+    )
+    transcript: Optional[List[UsageIngestTranscriptMessage]] = Field(
+        default=None,
+        max_length=MAX_INGEST_TRANSCRIPT_MESSAGES,
+        description=(
+            "Opt-in transcript text for this record's conversation, stored "
+            "as runtime session activities. Shippers send it only when the "
+            "operator enabled transcript storage; by default only counts, "
+            "titles and short summaries leave the machine."
+        ),
+    )
+
+    @field_validator("transcript")
+    @classmethod
+    def cap_transcript_size(
+        cls, value: Optional[List[UsageIngestTranscriptMessage]]
+    ) -> Optional[List[UsageIngestTranscriptMessage]]:
+        """Reject transcript payloads whose combined text exceeds the cap."""
+        if not value:
+            return value
+        total = sum(len(message.text) for message in value)
+        if total > MAX_INGEST_TRANSCRIPT_TOTAL_CHARS:
+            raise ValueError(
+                f"transcript exceeds {MAX_INGEST_TRANSCRIPT_TOTAL_CHARS} "
+                f"characters ({total} characters)"
+            )
+        return value
 
     @field_validator("external_id")
     @classmethod

--- a/backend/preloop/services/model_pricing.py
+++ b/backend/preloop/services/model_pricing.py
@@ -559,3 +559,126 @@ def _iter_litellm_model_candidates(ai_model: AIModel) -> Iterable[str]:
                 continue
             seen.add(normalized)
             yield normalized
+
+
+# ---------------------------------------------------------------------------
+# Pricing for harness-reported model names (usage ingest)
+# ---------------------------------------------------------------------------
+#
+# Records pushed by hooks (Cursor, Codex, generic harnesses) carry the model
+# string the harness reported, not an AIModel row. Cursor spells Anthropic
+# models as ``claude-4.5-sonnet`` where the price catalog uses
+# ``claude-sonnet-4-5``; the helpers below map such spellings onto catalog
+# keys and reuse the ordinary candidate resolver through a transient
+# AIModel so the same fallbacks (vendor prefixes, undated forms) apply.
+
+_EXTERNAL_CLAUDE_VERSION_FIRST = re.compile(
+    r"^claude-(\d+)(?:\.(\d+))?-(sonnet|opus|haiku)$", re.IGNORECASE
+)
+_EXTERNAL_CLAUDE_DOTTED_MINOR = re.compile(
+    r"^(claude-(?:sonnet|opus|haiku)-\d+)\.(\d+)$", re.IGNORECASE
+)
+
+_EXTERNAL_PROVIDER_HINTS = (
+    ("claude", "anthropic"),
+    ("gpt", "openai"),
+    ("chatgpt", "openai"),
+    ("o1", "openai"),
+    ("o3", "openai"),
+    ("o4", "openai"),
+    ("gemini", "gemini"),
+    ("grok", "xai"),
+    ("deepseek", "deepseek"),
+    ("kimi", "moonshot"),
+    ("mistral", "mistral"),
+)
+
+
+def normalize_external_model_name(model_name: str) -> str:
+    """Map a harness-reported model string onto the catalog's spelling.
+
+    Cursor reports Anthropic models version-first with a dotted minor
+    (``claude-4.5-sonnet``, ``claude-4-opus``); the catalog keys them
+    family-first with dashes (``claude-sonnet-4-5``, ``claude-opus-4``).
+    Anything not matching a known alias shape is returned trimmed, so an
+    unknown spelling stays honest (unpriced) rather than guessed.
+
+    Args:
+        model_name: Model string as the harness reported it.
+
+    Returns:
+        A catalog-style model name.
+    """
+    name = (model_name or "").strip()
+    match = _EXTERNAL_CLAUDE_VERSION_FIRST.match(name)
+    if match:
+        major, minor, family = match.group(1), match.group(2), match.group(3).lower()
+        normalized = f"claude-{family}-{major}"
+        if minor:
+            normalized = f"{normalized}-{minor}"
+        return normalized
+    match = _EXTERNAL_CLAUDE_DOTTED_MINOR.match(name)
+    if match:
+        return f"{match.group(1).lower()}-{match.group(2)}"
+    return name
+
+
+def infer_provider_for_model_name(model_name: str) -> str:
+    """Guess the provider a bare model name belongs to, for catalog prefixes.
+
+    Args:
+        model_name: Catalog-style or harness-reported model name.
+
+    Returns:
+        A provider name understood by :func:`_pricing_provider_prefix`;
+        ``openai`` when nothing matches.
+    """
+    lowered = (model_name or "").strip().lower()
+    vendor, separator, _rest = lowered.partition("/")
+    if separator and vendor:
+        return vendor
+    for prefix, provider in _EXTERNAL_PROVIDER_HINTS:
+        if lowered.startswith(prefix):
+            return provider
+    return "openai"
+
+
+def estimate_external_model_usage_cost(
+    model_name: str,
+    *,
+    prompt_tokens: int,
+    completion_tokens: int,
+    pricing_override: Optional[Dict[str, Any]] = None,
+) -> CostEstimate:
+    """Price token counts for a model known only by its reported name.
+
+    Builds a transient (never persisted) :class:`AIModel` so the ordinary
+    candidate resolver and catalog lookup apply unchanged. Used by usage
+    ingest to put an estimated amount on hook-derived records that carry
+    tokens but no billed cost.
+
+    Args:
+        model_name: Model string as the harness reported it.
+        prompt_tokens: Input tokens.
+        completion_tokens: Output tokens.
+        pricing_override: Resolved account pricing override, if any.
+
+    Returns:
+        The estimate with its provenance; ``unpriced`` when the catalog
+        has no entry for any candidate spelling.
+    """
+    normalized = normalize_external_model_name(model_name)
+    if not normalized:
+        return CostEstimate(cost=None, source="unpriced")
+    ai_model = AIModel(
+        provider_name=infer_provider_for_model_name(normalized),
+        model_identifier=normalized,
+    )
+    return estimate_ai_model_usage_cost_detailed(
+        ai_model,
+        prompt_tokens=max(0, int(prompt_tokens or 0)),
+        completion_tokens=max(0, int(completion_tokens or 0)),
+        total_tokens=max(0, int(prompt_tokens or 0))
+        + max(0, int(completion_tokens or 0)),
+        pricing_override=pricing_override,
+    )

--- a/backend/preloop/services/runtime_session_explorer.py
+++ b/backend/preloop/services/runtime_session_explorer.py
@@ -55,6 +55,31 @@ MAX_TITLES_PER_LIST_REQUEST = 8
 TITLE_REFRESH_REQUEST_DELTA = 5
 
 
+_TRANSCRIPT_ROLE_TITLES = {
+    "user": "User message",
+    "assistant": "Assistant message",
+    "tool": "Tool result",
+    "tool_use": "Tool call",
+}
+
+
+def _default_activity_title(activity: Any) -> str:
+    """Human title for an activity row that names no tool.
+
+    Transcript messages (ingested from harness hooks that opted into
+    transcript storage) are titled by role so a session timeline reads as
+    a conversation; operator messages and tool calls keep their labels.
+    """
+    activity_type = getattr(activity, "activity_type", None)
+    if activity_type == "agent_control_message":
+        return "Operator message"
+    if activity_type == "transcript_message":
+        metadata = getattr(activity, "metadata_", None) or {}
+        role = str(metadata.get("role") or "").lower()
+        return _TRANSCRIPT_ROLE_TITLES.get(role, "Transcript message")
+    return "Tool call"
+
+
 class RuntimeSessionExplorerService:
     """Build runtime session explorer responses."""
 
@@ -831,12 +856,7 @@ class RuntimeSessionExplorerService:
                 RuntimeSessionActivityItem(
                     activity_type=activity.activity_type,
                     timestamp=self._normalize_timestamp(activity.timestamp),
-                    title=activity.tool_name
-                    or (
-                        "Operator message"
-                        if activity.activity_type == "agent_control_message"
-                        else "Tool call"
-                    ),
+                    title=activity.tool_name or _default_activity_title(activity),
                     summary=activity.summary or activity.server_name,
                     status=activity.status,
                     tool_name=activity.tool_name,

--- a/backend/preloop/services/usage_import.py
+++ b/backend/preloop/services/usage_import.py
@@ -326,9 +326,9 @@ def sync_runtime_session_for_record(
 
     Title and summary come from record metadata: ``session_title`` always
     wins, ``session_title_default`` only fills an empty title, and
-    ``session_summary`` replaces the summary. When the record carries an
-    opt-in ``transcript``, each message is stored as a
-    ``transcript_message`` activity on the session.
+    ``session_summary`` replaces the summary. An opt-in ``transcript`` is
+    stored separately via :func:`add_transcript_activities`, after the
+    record's usage row landed.
 
     Args:
         db: Database session (flushed, not committed).
@@ -394,8 +394,37 @@ def sync_runtime_session_for_record(
     )
     if summary:
         session.summary = summary
-        session.summary_updated_at = datetime.now(timezone.utc)
+        session.summary_updated_at = observed_at
 
+    db.add(session)
+    db.flush()
+    return session
+
+
+def add_transcript_activities(
+    db: Session,
+    *,
+    account_id: str,
+    source: str,
+    record: UsageIngestRecord,
+    session: RuntimeSession,
+    timestamp: datetime,
+) -> None:
+    """Store a record's opt-in transcript messages as session activities.
+
+    Called only after the record's usage row was actually inserted, so a
+    request that loses the dedupe race (``log_imported_usage_event``
+    returns ``None``) never attaches its transcript to the session the
+    winning request already populated.
+
+    Args:
+        db: Database session (flushed, not committed).
+        account_id: Owning account id.
+        source: Ingest source label.
+        record: The pushed record carrying the transcript.
+        session: The record's runtime session.
+        timestamp: Fallback activity timestamp (the record's).
+    """
     for message in record.transcript or []:
         db.add(
             RuntimeSessionActivity(
@@ -408,15 +437,12 @@ def sync_runtime_session_for_record(
                     "role": message.role,
                     "source": f"usage_ingest:{source}",
                     "external_id": record.external_id,
-                    "conversation_id": conversation_id,
+                    "conversation_id": record.conversation_id,
                 },
                 timestamp=message.timestamp or timestamp,
             )
         )
-
-    db.add(session)
     db.flush()
-    return session
 
 
 def push_record_fingerprint(*, source: str, external_id: str) -> str:
@@ -461,13 +487,16 @@ def ingest_push_records(
     (:meth:`~preloop.models.crud.api_usage.CRUDApiUsage.log_imported_usage_event`):
     rows land as ``action_type='imported_usage'`` / ``usage_source='imported'``,
     ``total_tokens`` derives from input+output only, and cache-read tokens
-    stay in their own column — never summed into totals or charged spend.
+    stay in their own column: never summed into totals or charged spend.
     Conversation ids, message/tool counts, and cost_basis land in their
     first-class columns; lifecycle events (``event_type != 'usage'``) land
     as zero-cost rows unless explicitly priced. Each record's conversation
     is also registered as a runtime session keyed ``(source,
     conversation_id)`` (see :func:`sync_runtime_session_for_record`) and
-    the row is linked to it.
+    the row is linked to it. Opt-in transcript messages become session
+    activities only after the row landed (see
+    :func:`add_transcript_activities`), so a lost dedupe race never
+    duplicates them.
 
     Args:
         db: Database session.
@@ -509,6 +538,7 @@ def ingest_push_records(
                 for key, value in record.metadata.items():
                     meta.setdefault(key, value)
             runtime_session_id = None
+            session: Optional[RuntimeSession] = None
             try:
                 with db.begin_nested():
                     session = sync_runtime_session_for_record(
@@ -571,6 +601,26 @@ def ingest_push_records(
             )
             if row is not None:
                 existing_by_fp[fingerprint] = row
+                if session is not None and record.transcript:
+                    try:
+                        with db.begin_nested():
+                            add_transcript_activities(
+                                db,
+                                account_id=account_id,
+                                source=source,
+                                record=record,
+                                session=session,
+                                timestamp=timestamp,
+                            )
+                    except SQLAlchemyError:
+                        # Activities are bookkeeping; the ledger row stands.
+                        logger.warning(
+                            "Transcript activity sync failed for ingest record %s "
+                            "(source=%s)",
+                            record.external_id,
+                            source,
+                            exc_info=True,
+                        )
                 results.append(UsageIngestRecordResult(external_id=record.external_id))
                 continue
             # A concurrent request landed this fingerprint between the

--- a/backend/preloop/services/usage_import.py
+++ b/backend/preloop/services/usage_import.py
@@ -28,10 +28,17 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from preloop.models.crud import crud_api_usage, crud_managed_agent
+from preloop.models.crud import (
+    crud_api_usage,
+    crud_managed_agent,
+    crud_runtime_session,
+)
 from preloop.models.models.managed_agent import ManagedAgent
+from preloop.models.models.runtime_session import RuntimeSession
+from preloop.models.models.runtime_session_activity import RuntimeSessionActivity
 from preloop.schemas.usage_import import (
     UsageImportEvent,
     UsageIngestRecord,
@@ -270,6 +277,148 @@ def price_estimated_record(record: UsageIngestRecord) -> Optional[CostEstimate]:
     return estimate
 
 
+#: Column limits on runtime_session.title / summary text taken from record
+#: metadata (see UsageIngestRecord.metadata).
+MAX_SESSION_TITLE_CHARS = 255
+MAX_SESSION_SUMMARY_CHARS = 2000
+#: Same cap as agent-control messages (MAX_AGENT_CONTROL_MESSAGE_SUMMARY_LEN).
+MAX_TRANSCRIPT_ACTIVITY_SUMMARY_CHARS = 2000
+
+TRANSCRIPT_ACTIVITY_TYPE = "transcript_message"
+
+
+def _metadata_text(
+    metadata: Optional[Dict[str, Any]], key: str, limit: int
+) -> Optional[str]:
+    value = (metadata or {}).get(key)
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    return value[:limit]
+
+
+def _as_naive_utc(value: datetime) -> datetime:
+    if value.tzinfo is not None:
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value
+
+
+def sync_runtime_session_for_record(
+    db: Session,
+    *,
+    account_id: str,
+    agent: ManagedAgent,
+    source: str,
+    record: UsageIngestRecord,
+    timestamp: datetime,
+) -> Optional[RuntimeSession]:
+    """Register, touch or close the runtime session a pushed record belongs to.
+
+    Every pushed record with a ``conversation_id`` maps onto one runtime
+    session keyed ``(source, conversation_id)``, so hook-observed
+    conversations (Cursor, Codex, generic harnesses) appear in the runtime
+    sessions explorer next to gateway-metered ones. The session's principal
+    is the managed agent the batch was attributed to. ``session_start``
+    records (re)open the session, ``session_end`` records close it, and any
+    record advances ``last_activity_at`` (never backwards).
+
+    Title and summary come from record metadata: ``session_title`` always
+    wins, ``session_title_default`` only fills an empty title, and
+    ``session_summary`` replaces the summary. When the record carries an
+    opt-in ``transcript``, each message is stored as a
+    ``transcript_message`` activity on the session.
+
+    Args:
+        db: Database session (flushed, not committed).
+        account_id: Owning account id.
+        agent: Managed agent the batch was attributed to.
+        source: Ingest source label; becomes ``session_source_type``.
+        record: The pushed record.
+        timestamp: The record's timestamp as naive UTC.
+
+    Returns:
+        The runtime session, or ``None`` when the record has no
+        conversation id.
+    """
+    conversation_id = record.conversation_id
+    if not conversation_id:
+        return None
+    observed_at = _as_naive_utc(timestamp)
+    ended_at = observed_at if record.event_type == "session_end" else None
+
+    session = crud_runtime_session.get_by_source(
+        db,
+        account_id=account_id,
+        session_source_type=source,
+        session_source_id=conversation_id,
+    )
+    if session is None:
+        session = crud_runtime_session.upsert_by_source(
+            db,
+            account_id=account_id,
+            session_source_type=source,
+            session_source_id=conversation_id,
+            runtime_principal_type=agent.session_source_type,
+            runtime_principal_id=agent.session_source_id,
+            runtime_principal_name=agent.display_name,
+            started_at=observed_at,
+            last_activity_at=observed_at,
+            ended_at=ended_at,
+        )
+    else:
+        last_activity_at = session.last_activity_at
+        if last_activity_at is None or observed_at > _as_naive_utc(last_activity_at):
+            session.last_activity_at = observed_at
+        if ended_at is not None:
+            session.ended_at = ended_at
+        elif record.event_type == "session_start" and session.ended_at is not None:
+            # The same conversation was resumed after it ended.
+            session.ended_at = None
+        if not session.runtime_principal_id:
+            session.runtime_principal_type = agent.session_source_type
+            session.runtime_principal_id = agent.session_source_id
+            session.runtime_principal_name = agent.display_name
+
+    title = _metadata_text(record.metadata, "session_title", MAX_SESSION_TITLE_CHARS)
+    default_title = _metadata_text(
+        record.metadata, "session_title_default", MAX_SESSION_TITLE_CHARS
+    )
+    if title:
+        session.title = title
+    elif default_title and not session.title:
+        session.title = default_title
+    summary = _metadata_text(
+        record.metadata, "session_summary", MAX_SESSION_SUMMARY_CHARS
+    )
+    if summary:
+        session.summary = summary
+        session.summary_updated_at = datetime.now(timezone.utc)
+
+    for message in record.transcript or []:
+        db.add(
+            RuntimeSessionActivity(
+                account_id=account_id,
+                runtime_session_id=session.id,
+                activity_type=TRANSCRIPT_ACTIVITY_TYPE,
+                status=message.role,
+                summary=message.text[:MAX_TRANSCRIPT_ACTIVITY_SUMMARY_CHARS],
+                metadata_={
+                    "role": message.role,
+                    "source": f"usage_ingest:{source}",
+                    "external_id": record.external_id,
+                    "conversation_id": conversation_id,
+                },
+                timestamp=message.timestamp or timestamp,
+            )
+        )
+
+    db.add(session)
+    db.flush()
+    return session
+
+
 def push_record_fingerprint(*, source: str, external_id: str) -> str:
     """Compute the dedupe fingerprint for one pushed usage record.
 
@@ -315,7 +464,10 @@ def ingest_push_records(
     stay in their own column — never summed into totals or charged spend.
     Conversation ids, message/tool counts, and cost_basis land in their
     first-class columns; lifecycle events (``event_type != 'usage'``) land
-    as zero-cost rows unless explicitly priced.
+    as zero-cost rows unless explicitly priced. Each record's conversation
+    is also registered as a runtime session keyed ``(source,
+    conversation_id)`` (see :func:`sync_runtime_session_for_record`) and
+    the row is linked to it.
 
     Args:
         db: Database session.
@@ -356,6 +508,27 @@ def ingest_push_records(
             if record.metadata:
                 for key, value in record.metadata.items():
                     meta.setdefault(key, value)
+            runtime_session_id = None
+            try:
+                with db.begin_nested():
+                    session = sync_runtime_session_for_record(
+                        db,
+                        account_id=account_id,
+                        agent=agent,
+                        source=source,
+                        record=record,
+                        timestamp=timestamp,
+                    )
+                runtime_session_id = session.id if session is not None else None
+            except SQLAlchemyError:
+                # The cost ledger row is the record of truth; a session
+                # bookkeeping failure must not lose it.
+                logger.warning(
+                    "Runtime session sync failed for ingest record %s (source=%s)",
+                    record.external_id,
+                    source,
+                    exc_info=True,
+                )
             # estimated_cost is a Float column; Decimal is request-only.
             cost_usd = (
                 float(record.charged_cost) if record.charged_cost is not None else None
@@ -389,6 +562,7 @@ def ingest_push_records(
                 runtime_principal_type=agent.session_source_type,
                 runtime_principal_id=agent.session_source_id,
                 runtime_principal_name=agent.display_name,
+                runtime_session_id=runtime_session_id,
                 import_fingerprint=fingerprint,
                 meta_data=meta,
                 endpoint=ingest_endpoint,

--- a/backend/preloop/services/usage_import.py
+++ b/backend/preloop/services/usage_import.py
@@ -37,6 +37,11 @@ from preloop.schemas.usage_import import (
     UsageIngestRecord,
     UsageIngestRecordResult,
 )
+from preloop.services.model_pricing import (
+    CostEstimate,
+    estimate_external_model_usage_cost,
+    normalize_external_model_name,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -226,6 +231,45 @@ def ingest_events(
     return imported, skipped
 
 
+def price_estimated_record(record: UsageIngestRecord) -> Optional[CostEstimate]:
+    """Price a pushed record that carries tokens but no billed amount.
+
+    Only ``cost_basis='estimated'`` records with a model and at least one
+    non-zero token count are priced; the result lands in ``estimated_cost``
+    with the catalog's provenance as ``cost_source`` and the basis left as
+    ``estimated``, so Cost analytics shows an estimated amount that a later
+    reconciled import supersedes and never sums with. Reconciled records
+    without an amount (for example "Included" rows) are left unpriced: an
+    estimate must never masquerade as billing truth.
+
+    Args:
+        record: The pushed record.
+
+    Returns:
+        The estimate when the catalog priced the model, otherwise ``None``.
+    """
+    if record.cost_basis != "estimated" or not record.model:
+        return None
+    prompt_tokens = record.input_tokens or 0
+    completion_tokens = record.output_tokens or 0
+    if prompt_tokens <= 0 and completion_tokens <= 0:
+        return None
+    try:
+        estimate = estimate_external_model_usage_cost(
+            record.model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+        )
+    except Exception:  # noqa: BLE001 - pricing must never fail an ingest
+        logger.debug(
+            "Pricing skipped for ingested model %s", record.model, exc_info=True
+        )
+        return None
+    if estimate.cost is None:
+        return None
+    return estimate
+
+
 def push_record_fingerprint(*, source: str, external_id: str) -> str:
     """Compute the dedupe fingerprint for one pushed usage record.
 
@@ -312,6 +356,19 @@ def ingest_push_records(
             if record.metadata:
                 for key, value in record.metadata.items():
                     meta.setdefault(key, value)
+            # estimated_cost is a Float column; Decimal is request-only.
+            cost_usd = (
+                float(record.charged_cost) if record.charged_cost is not None else None
+            )
+            cost_source: Optional[str] = None
+            if cost_usd is None:
+                priced = price_estimated_record(record)
+                if priced is not None:
+                    cost_usd, cost_source = priced.cost, priced.source
+                    meta["pricing"] = {
+                        "source": priced.source,
+                        "model": normalize_external_model_name(record.model or ""),
+                    }
             row = crud_api_usage.log_imported_usage_event(
                 db,
                 account_id=account_id,
@@ -322,12 +379,8 @@ def ingest_push_records(
                 prompt_tokens=record.input_tokens,
                 completion_tokens=record.output_tokens,
                 cache_read_tokens=record.cache_read_tokens,
-                cost_usd=(
-                    # estimated_cost is a Float column; Decimal is request-only.
-                    float(record.charged_cost)
-                    if record.charged_cost is not None
-                    else None
-                ),
+                cost_usd=cost_usd,
+                cost_source=cost_source,
                 cost_basis=record.cost_basis,
                 conversation_id=record.conversation_id,
                 parent_conversation_id=record.parent_conversation_id,

--- a/backend/tests/endpoints/test_usage_ingest.py
+++ b/backend/tests/endpoints/test_usage_ingest.py
@@ -583,3 +583,137 @@ class TestIngestRecords:
         assert lifecycle["total_tokens"] is None
         assert lifecycle["estimated_cost"] is None
         assert lifecycle["reconciled_cost"] is None
+
+
+class TestEstimatedPricing:
+    """Estimated records with tokens and no billed amount get a catalog price."""
+
+    def _ingest_one(self, client, db_session, test_user, record):
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        response = client.post(INGEST_URL, json=_payload([record]))
+        assert response.status_code == 200, response.text
+        assert response.json()["accepted"] == 1
+        row = (
+            db_session.query(ApiUsage)
+            .filter(ApiUsage.action_type == "imported_usage")
+            .one()
+        )
+        return row
+
+    def test_estimated_record_with_tokens_gets_catalog_cost(
+        self, client, db_session, test_user
+    ):
+        """gpt-5 at 1200 in / 850 out prices to $0.01 from the catalog."""
+        record = _record(external_id="turn-est", model="gpt-5")
+        del record["charged_cost"]
+        row = self._ingest_one(client, db_session, test_user, record)
+
+        assert abs(row.estimated_cost - 0.01) < 1e-9
+        assert row.cost_source == "catalog"
+        assert row.cost_basis == "estimated"
+        assert row.currency == "USD"
+        assert row.meta_data["pricing"] == {"source": "catalog", "model": "gpt-5"}
+
+    def test_cursor_model_spelling_is_priced(self, client, db_session, test_user):
+        """Cursor's claude-4.5-sonnet is priced as the catalog's claude-sonnet-4-5."""
+        record = _record(external_id="turn-cursor", model="claude-4.5-sonnet")
+        del record["charged_cost"]
+        row = self._ingest_one(client, db_session, test_user, record)
+
+        # 1200 * $3/Mtok + 850 * $15/Mtok
+        assert abs(row.estimated_cost - 0.01635) < 1e-9
+        assert row.cost_source == "catalog"
+        assert row.meta_data["pricing"]["model"] == "claude-sonnet-4-5"
+
+    def test_unpriced_model_stays_null(self, client, db_session, test_user):
+        """A model the catalog does not know stays unpriced: null, not $0."""
+        record = _record(external_id="turn-composer", model="composer")
+        del record["charged_cost"]
+        row = self._ingest_one(client, db_session, test_user, record)
+
+        assert row.estimated_cost is None
+        assert row.cost_source is None
+        assert row.currency is None
+        assert "pricing" not in row.meta_data
+
+    def test_charged_cost_is_never_replaced_by_an_estimate(
+        self, client, db_session, test_user
+    ):
+        """A vendor charge on a reconciled record is stored as-is."""
+        record = _record(
+            external_id="turn-billed",
+            model="gpt-5",
+            charged_cost="0.42",
+            cost_basis="reconciled",
+        )
+        row = self._ingest_one(client, db_session, test_user, record)
+
+        assert abs(row.estimated_cost - 0.42) < 1e-9
+        assert row.cost_source == "imported"
+        assert row.cost_basis == "reconciled"
+        assert "pricing" not in row.meta_data
+
+    def test_reconciled_without_amount_is_not_estimated(
+        self, client, db_session, test_user
+    ):
+        """An 'Included' reconciled row must not be back-filled with a guess."""
+        record = _record(
+            external_id="turn-included", model="gpt-5", cost_basis="reconciled"
+        )
+        del record["charged_cost"]
+        row = self._ingest_one(client, db_session, test_user, record)
+
+        assert row.estimated_cost is None
+        assert row.cost_source is None
+
+    def test_cursor_hook_response_record_is_priced(self, client, db_session, test_user):
+        """The shape `preloop usage hook` ships for Cursor stop events is priced."""
+        record = {
+            "external_id": "stop:gen-1:0",
+            "conversation_id": "conv-hook",
+            "timestamp": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
+            "event_type": "response",
+            "model": "claude-4.5-sonnet",
+            "cost_basis": "estimated",
+            "input_tokens": 1200,
+            "output_tokens": 850,
+            "metadata": {
+                "hook_event_name": "stop",
+                "token_estimate": {
+                    "method": "transcript_chars",
+                    "chars_per_token": 4,
+                    "transcript_bytes": 8200,
+                },
+            },
+        }
+        row = self._ingest_one(client, db_session, test_user, record)
+
+        assert abs(row.estimated_cost - 0.01635) < 1e-9
+        assert row.cost_source == "catalog"
+        assert row.cost_basis == "estimated"
+        assert row.meta_data["token_estimate"]["method"] == "transcript_chars"
+
+        summary = client.get(COST_SUMMARY_URL).json()
+        imported = summary["imported_usage"]
+        assert abs(imported["imported_cost"] - 0.01635) < 1e-9
+        conversation = imported["usage_by_conversation"][0]
+        assert conversation["conversation_id"] == "conv-hook"
+        assert abs(conversation["estimated_cost"] - 0.01635) < 1e-9
+        assert conversation["reconciled_cost"] is None
+
+    def test_lifecycle_record_without_tokens_is_not_priced(
+        self, client, db_session, test_user
+    ):
+        """A bare lifecycle marker with a model but no tokens stays unpriced."""
+        record = {
+            "external_id": "sessionStart:conv-x",
+            "conversation_id": "conv-x",
+            "timestamp": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
+            "event_type": "session_start",
+            "model": "gpt-5",
+        }
+        row = self._ingest_one(client, db_session, test_user, record)
+
+        assert row.estimated_cost is None
+        assert row.cost_source is None

--- a/backend/tests/endpoints/test_usage_ingest.py
+++ b/backend/tests/endpoints/test_usage_ingest.py
@@ -32,6 +32,19 @@ def _make_cursor_agent(db, account_id, *, source_id="cursor-ws-1", name="Cursor"
     )
 
 
+def _make_codex_agent(db, account_id, *, source_id="codex-ws-1", name="Codex"):
+    """Register a managed Codex agent like `preloop agents onboard Codex`."""
+    return crud_managed_agent.upsert_from_runtime_session(
+        db,
+        account_id=account_id,
+        runtime_session_id=None,
+        session_source_type="desktop_agent",
+        session_source_id=source_id,
+        display_name=name,
+        agent_kind="codex",
+    )
+
+
 def _record(**overrides):
     """Build one valid ingest record."""
     record = {
@@ -937,6 +950,44 @@ class TestRuntimeSessions:
             .one()
         )
         assert row.runtime_session_id is None
+
+    def test_codex_source_registers_session(self, client, db_session, test_user):
+        """A Codex rollout import registers the thread as a runtime session."""
+        agent = _make_codex_agent(db_session, test_user.account_id)
+        db_session.commit()
+        started = self._lifecycle(
+            "session_start",
+            "thread-01a054f7",
+            "codex:thread-01a054f7:session_meta",
+            10,
+            model="gpt-5",
+        )
+        usage = self._lifecycle(
+            "usage",
+            "thread-01a054f7",
+            "codex:thread-01a054f7:token_count:1",
+            9,
+            model="gpt-5",
+            input_tokens=1200,
+            output_tokens=850,
+        )
+        response = client.post(
+            INGEST_URL, json=_payload([started, usage], source="codex")
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["accepted"] == 2
+
+        session = self._session(
+            db_session, test_user.account_id, "thread-01a054f7", source="codex"
+        )
+        assert session is not None
+        assert session.runtime_principal_id == agent.session_source_id
+        rows = (
+            db_session.query(ApiUsage)
+            .filter(ApiUsage.action_type == "imported_usage")
+            .all()
+        )
+        assert {row.runtime_session_id for row in rows} == {session.id}
 
     def test_sessions_are_listed_in_the_runtime_sessions_explorer(
         self, client, db_session, test_user

--- a/backend/tests/endpoints/test_usage_ingest.py
+++ b/backend/tests/endpoints/test_usage_ingest.py
@@ -13,6 +13,7 @@ from sqlalchemy import Integer, distinct, func
 
 from preloop.models.crud import crud_managed_agent
 from preloop.models.models.api_usage import ApiUsage
+from preloop.models.models.runtime_session import RuntimeSession
 
 INGEST_URL = "/api/v1/usage/ingest"
 COST_SUMMARY_URL = "/api/v1/cost/summary"
@@ -717,3 +718,243 @@ class TestEstimatedPricing:
 
         assert row.estimated_cost is None
         assert row.cost_source is None
+
+
+class TestRuntimeSessions:
+    """Pushed records register the conversation as a runtime session."""
+
+    @staticmethod
+    def _session(db_session, account_id, conversation_id, source="cursor"):
+        return (
+            db_session.query(RuntimeSession)
+            .filter(
+                RuntimeSession.account_id == account_id,
+                RuntimeSession.session_source_type == source,
+                RuntimeSession.session_source_id == conversation_id,
+            )
+            .one_or_none()
+        )
+
+    @staticmethod
+    def _lifecycle(event_type, conversation_id, external_id, minutes_ago, **extra):
+        record = {
+            "external_id": external_id,
+            "conversation_id": conversation_id,
+            "timestamp": (
+                datetime.now(UTC) - timedelta(minutes=minutes_ago)
+            ).isoformat(),
+            "event_type": event_type,
+            "model": "claude-4.5-sonnet",
+            "cost_basis": "estimated",
+        }
+        record.update(extra)
+        return record
+
+    def test_session_start_registers_session_with_principal_and_default_title(
+        self, client, db_session, test_user
+    ):
+        agent = _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        started = self._lifecycle(
+            "session_start",
+            "conv-ses",
+            "sessionStart:conv-ses",
+            10,
+            metadata={
+                "hook_event_name": "sessionStart",
+                "session_title_default": "Cursor conversation conv-ses",
+            },
+        )
+        response = client.post(INGEST_URL, json=_payload([started]))
+        assert response.status_code == 200, response.text
+
+        session = self._session(db_session, test_user.account_id, "conv-ses")
+        assert session is not None
+        assert session.runtime_principal_type == agent.session_source_type
+        assert session.runtime_principal_id == agent.session_source_id
+        assert session.runtime_principal_name == "Cursor"
+        assert session.title == "Cursor conversation conv-ses"
+        assert session.summary is None
+        assert session.ended_at is None
+        assert session.started_at == session.last_activity_at
+        assert session.activities == []
+
+        row = (
+            db_session.query(ApiUsage)
+            .filter(ApiUsage.action_type == "imported_usage")
+            .one()
+        )
+        assert row.runtime_session_id == session.id
+
+    def test_stop_touches_activity_and_sets_title_and_summary(
+        self, client, db_session, test_user
+    ):
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        started = self._lifecycle(
+            "session_start",
+            "conv-live",
+            "sessionStart:conv-live",
+            10,
+            metadata={"session_title_default": "Cursor conversation conv-liv"},
+        )
+        stop = self._lifecycle(
+            "response",
+            "conv-live",
+            "stop:gen-1:0",
+            5,
+            input_tokens=28,
+            output_tokens=36,
+            metadata={
+                "hook_event_name": "stop",
+                "session_title": "Count the Go files in cli",
+                "session_summary": "That is the whole count; nothing else changed.",
+            },
+        )
+        assert (
+            client.post(INGEST_URL, json=_payload([started, stop])).json()["accepted"]
+            == 2
+        )
+
+        session = self._session(db_session, test_user.account_id, "conv-live")
+        assert session.title == "Count the Go files in cli"
+        assert session.summary == "That is the whole count; nothing else changed."
+        assert session.summary_updated_at is not None
+        assert session.last_activity_at > session.started_at
+        assert session.ended_at is None
+        # Summaries only: no transcript text was stored.
+        assert session.activities == []
+
+        # A later default title never overrides a real one.
+        later = self._lifecycle(
+            "response",
+            "conv-live",
+            "stop:gen-2:0",
+            4,
+            metadata={"session_title_default": "Cursor conversation conv-liv"},
+        )
+        client.post(INGEST_URL, json=_payload([later]))
+        db_session.refresh(session)
+        assert session.title == "Count the Go files in cli"
+
+    def test_session_end_closes_and_session_start_reopens(
+        self, client, db_session, test_user
+    ):
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        started = self._lifecycle(
+            "session_start", "conv-end", "sessionStart:conv-end", 10
+        )
+        ended = self._lifecycle("session_end", "conv-end", "sessionEnd:conv-end", 2)
+        client.post(INGEST_URL, json=_payload([started, ended]))
+
+        session = self._session(db_session, test_user.account_id, "conv-end")
+        assert session.ended_at is not None
+        assert session.last_activity_at == session.ended_at
+
+        # Out-of-order replays never move activity backwards.
+        older = self._lifecycle("response", "conv-end", "stop:old:0", 30)
+        client.post(INGEST_URL, json=_payload([older]))
+        db_session.refresh(session)
+        assert session.last_activity_at == session.ended_at
+
+        resumed = self._lifecycle(
+            "session_start", "conv-end", "sessionStart:conv-end:2", 1
+        )
+        client.post(INGEST_URL, json=_payload([resumed]))
+        db_session.refresh(session)
+        assert session.ended_at is None
+
+    def test_opt_in_transcript_becomes_activities_once(
+        self, client, db_session, test_user
+    ):
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        stop = self._lifecycle(
+            "response",
+            "conv-text",
+            "stop:gen-1:0",
+            5,
+            input_tokens=28,
+            output_tokens=36,
+            transcript=[
+                {"role": "user", "text": "List the Go files in cli and count them."},
+                {"role": "assistant", "text": "I will list the files first."},
+                {"role": "tool_use", "text": "Shell"},
+                {"role": "assistant", "text": "There are 12 Go files in cli."},
+            ],
+        )
+        assert client.post(INGEST_URL, json=_payload([stop])).json()["accepted"] == 1
+
+        session = self._session(db_session, test_user.account_id, "conv-text")
+        activities = sorted(session.activities, key=lambda item: item.summary)
+        assert [item.activity_type for item in activities] == ["transcript_message"] * 4
+        assert {item.status for item in activities} == {"user", "assistant", "tool_use"}
+        by_text = {item.summary: item for item in activities}
+        user = by_text["List the Go files in cli and count them."]
+        assert user.metadata_["role"] == "user"
+        assert user.metadata_["source"] == "usage_ingest:cursor"
+        assert user.metadata_["external_id"] == "stop:gen-1:0"
+
+        # Replaying the same record is deduplicated and stores nothing twice.
+        replay = client.post(INGEST_URL, json=_payload([stop])).json()
+        assert replay["deduplicated"] == 1
+        db_session.refresh(session)
+        assert len(session.activities) == 4
+
+    def test_transcript_over_cap_is_rejected(self, client, db_session, test_user):
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        stop = self._lifecycle(
+            "response",
+            "conv-big",
+            "stop:gen-1:0",
+            5,
+            transcript=[{"role": "assistant", "text": "x" * 4000} for _ in range(17)],
+        )
+        response = client.post(INGEST_URL, json=_payload([stop]))
+        assert response.status_code == 422
+        assert "transcript exceeds" in response.text
+
+    def test_record_without_conversation_registers_no_session(
+        self, client, db_session, test_user
+    ):
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        response = client.post(
+            INGEST_URL, json=_payload([_record(external_id="turn-solo")])
+        )
+        assert response.status_code == 200
+        assert (
+            db_session.query(RuntimeSession)
+            .filter(RuntimeSession.account_id == test_user.account_id)
+            .count()
+            == 0
+        )
+        row = (
+            db_session.query(ApiUsage)
+            .filter(ApiUsage.action_type == "imported_usage")
+            .one()
+        )
+        assert row.runtime_session_id is None
+
+    def test_sessions_are_listed_in_the_runtime_sessions_explorer(
+        self, client, db_session, test_user
+    ):
+        _make_cursor_agent(db_session, test_user.account_id)
+        db_session.commit()
+        started = self._lifecycle(
+            "session_start",
+            "conv-list",
+            "sessionStart:conv-list",
+            10,
+            metadata={"session_title_default": "Cursor conversation conv-lis"},
+        )
+        client.post(INGEST_URL, json=_payload([started]))
+
+        response = client.get("/api/v1/runtime-sessions?session_source_type=cursor")
+        assert response.status_code == 200, response.text
+        sessions = response.json()["items"]
+        assert [item["session_source_id"] for item in sessions] == ["conv-list"]
+        assert sessions[0]["title"] == "Cursor conversation conv-lis"
+        assert sessions[0]["runtime_principal_name"] == "Cursor"

--- a/backend/tests/services/test_model_pricing.py
+++ b/backend/tests/services/test_model_pricing.py
@@ -1027,3 +1027,96 @@ class TestUpdateModelPriceOverlays:
         assert len(stale) == 1
         assert "older than 30 days" in stale[0]
         assert script.overlay_sources_over_max_age({}, 30, now=now) == []
+
+
+# ---------------------------------------------------------------------------
+# Harness-reported model names (usage ingest pricing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("reported", "expected"),
+    [
+        ("claude-4.5-sonnet", "claude-sonnet-4-5"),
+        ("claude-4-sonnet", "claude-sonnet-4"),
+        ("claude-4-opus", "claude-opus-4"),
+        ("claude-4.5-opus", "claude-opus-4-5"),
+        ("Claude-4.5-Sonnet", "claude-sonnet-4-5"),
+        ("claude-opus-4.1", "claude-opus-4-1"),
+        ("gpt-5", "gpt-5"),
+        ("  composer ", "composer"),
+        ("", ""),
+    ],
+)
+def test_normalize_external_model_name(reported: str, expected: str) -> None:
+    """Cursor's version-first Claude spellings map onto catalog keys."""
+    from preloop.services.model_pricing import normalize_external_model_name
+
+    assert normalize_external_model_name(reported) == expected
+
+
+@pytest.mark.parametrize(
+    ("name", "provider"),
+    [
+        ("claude-sonnet-4-5", "anthropic"),
+        ("gpt-5", "openai"),
+        ("o3-mini", "openai"),
+        ("gemini-2.5-pro", "gemini"),
+        ("grok-4", "xai"),
+        ("deepseek-v3", "deepseek"),
+        ("openrouter/anthropic/claude-sonnet-4-5", "openrouter"),
+        ("composer", "openai"),
+    ],
+)
+def test_infer_provider_for_model_name(name: str, provider: str) -> None:
+    """Bare model names get the provider prefix the catalog resolver expects."""
+    from preloop.services.model_pricing import infer_provider_for_model_name
+
+    assert infer_provider_for_model_name(name) == provider
+
+
+def test_estimate_external_model_usage_cost_prices_catalog_models() -> None:
+    """A reported model name is priced through the same catalog as gateway rows."""
+    from preloop.services.model_pricing import estimate_external_model_usage_cost
+
+    estimate = estimate_external_model_usage_cost(
+        "gpt-5", prompt_tokens=1200, completion_tokens=850
+    )
+    # 1200 * $1.25/Mtok + 850 * $10/Mtok
+    assert estimate.cost == pytest.approx(0.01)
+    assert estimate.source == "catalog"
+
+
+def test_estimate_external_model_usage_cost_maps_cursor_alias() -> None:
+    """claude-4.5-sonnet (Cursor spelling) prices as claude-sonnet-4-5."""
+    from preloop.services.model_pricing import estimate_external_model_usage_cost
+
+    estimate = estimate_external_model_usage_cost(
+        "claude-4.5-sonnet", prompt_tokens=1200, completion_tokens=850
+    )
+    # 1200 * $3/Mtok + 850 * $15/Mtok
+    assert estimate.cost == pytest.approx(0.01635)
+    assert estimate.source == "catalog"
+
+
+@pytest.mark.parametrize("name", ["composer", "auto", "claude-4-sonnet", ""])
+def test_estimate_external_model_usage_cost_unknown_stays_unpriced(name: str) -> None:
+    """Unknown or catalog-less names return unpriced rather than a guess."""
+    from preloop.services.model_pricing import estimate_external_model_usage_cost
+
+    estimate = estimate_external_model_usage_cost(
+        name, prompt_tokens=1200, completion_tokens=850
+    )
+    assert estimate.cost is None
+    assert estimate.source == "unpriced"
+
+
+def test_estimate_external_model_usage_cost_zero_tokens_unpriced() -> None:
+    """Zero tokens never produce a cost."""
+    from preloop.services.model_pricing import estimate_external_model_usage_cost
+
+    estimate = estimate_external_model_usage_cost(
+        "gpt-5", prompt_tokens=0, completion_tokens=0
+    )
+    assert estimate.cost is None
+    assert estimate.source == "unpriced"

--- a/backend/tests/services/test_runtime_session_explorer.py
+++ b/backend/tests/services/test_runtime_session_explorer.py
@@ -706,3 +706,36 @@ async def test_summarize_interaction_falls_back_on_model_error(service):
     # Falls back to the local summary but records the model name.
     assert result.generated_by == "local"
     assert result.model_name == "GPT-5"
+
+
+def test_default_activity_title_for_transcript_messages() -> None:
+    """Ingested transcript messages are titled by role in the timeline."""
+    from types import SimpleNamespace
+
+    from preloop.services.runtime_session_explorer import _default_activity_title
+
+    def activity(activity_type, role=None):
+        return SimpleNamespace(
+            activity_type=activity_type,
+            metadata_={"role": role} if role else None,
+        )
+
+    assert (
+        _default_activity_title(activity("transcript_message", "user"))
+        == "User message"
+    )
+    assert (
+        _default_activity_title(activity("transcript_message", "assistant"))
+        == "Assistant message"
+    )
+    assert (
+        _default_activity_title(activity("transcript_message", "tool_use"))
+        == "Tool call"
+    )
+    assert (
+        _default_activity_title(activity("transcript_message")) == "Transcript message"
+    )
+    assert (
+        _default_activity_title(activity("agent_control_message")) == "Operator message"
+    )
+    assert _default_activity_title(activity("tool_call")) == "Tool call"

--- a/cli/internal/cmd/agents.go
+++ b/cli/internal/cmd/agents.go
@@ -772,6 +772,8 @@ func init() {
 	agentsEnrollCmd.Flags().Bool("skip-live-validate", false, "do not run a live validation prompt after onboarding (overrides --live-validate)")
 	agentsEnrollCmd.Flags().StringSlice("tags", []string{}, "add key-value tags to the enrolled agent (e.g., --tags ext=true,env=prod)")
 	agentsEnrollCmd.Flags().Bool("approvals", false, "install a native tool-permission hook that routes would-prompt tool calls to Preloop mobile/watch approvals (Claude Code, Codex CLI, Cursor)")
+	agentsEnrollCmd.Flags().Bool("no-usage-hooks", false, "Cursor only: do not install the usage hooks that store conversations as runtime sessions with a token estimate (installed by default)")
+	agentsEnrollCmd.Flags().Bool("store-transcript", false, "Cursor only: have the usage hooks also ship transcript text as session activities (default: counts, title and a short summary only)")
 	agentsEnrollCmd.Flags().String("model", "", "managed model alias to use for gateway routing (skips the interactive model picker)")
 	agentsListCmd.Flags().Bool("json", false, "output managed agents as JSON")
 	agentsStatusCmd.Flags().Bool("json", false, "output managed status as JSON")
@@ -1240,6 +1242,8 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 	tagsInput, _ := cmd.Flags().GetStringSlice("tags")
 	runAll, _ := cmd.Flags().GetBool("all")
 	approvals, _ := cmd.Flags().GetBool("approvals")
+	noUsageHooks, _ := cmd.Flags().GetBool("no-usage-hooks")
+	storeTranscript, _ := cmd.Flags().GetBool("store-transcript")
 	preferredModel, _ := cmd.Flags().GetString("model")
 
 	tags := make(map[string]string)
@@ -1263,6 +1267,8 @@ func runAgentsEnroll(cmd *cobra.Command, args []string) error {
 		LiveValidate:     liveValidate,
 		SkipLiveValidate: skipLiveValidate,
 		Approvals:        approvals,
+		NoUsageHooks:     noUsageHooks,
+		StoreTranscript:  storeTranscript,
 		PreferredModel:   strings.TrimSpace(preferredModel),
 		Tags:             tags,
 		SkipConfirmation: false,

--- a/cli/internal/cmd/agents_approval_hooks.go
+++ b/cli/internal/cmd/agents_approval_hooks.go
@@ -21,6 +21,29 @@ const permissionHookCredentialFileName = "permission_hook.json"
 // so install is idempotent and offboard removes only our entries.
 const permissionHookCommandMarker = "agents permission-hook"
 
+// usageHookCommandMarker identifies the Cursor usage/session hook entries
+// installed by onboarding, kept distinct from the permission hook marker so
+// each set is upserted and removed independently.
+const usageHookCommandMarker = "usage hook"
+
+// cursorUsageHookTimeoutSeconds bounds each usage hook process. The hook
+// posts once with a 3s client timeout and is fail-open, so 5s is ample.
+const cursorUsageHookTimeoutSeconds = 5
+
+// cursorUsageHookEvents are the Cursor hook events wired to
+// `preloop usage hook --from cursor`. beforeSubmitPrompt is included only
+// so the first prompt line can become the session title; the command never
+// posts for it and ignores the prompt otherwise.
+var cursorUsageHookEvents = []string{
+	"sessionStart",
+	"sessionEnd",
+	"subagentStart",
+	"subagentStop",
+	"stop",
+	"preCompact",
+	"beforeSubmitPrompt",
+}
+
 // approvalHookTimeoutSeconds is the legacy fallback name kept for callers that
 // still reference a constant; prefer resolveApprovalHookTimeoutSeconds().
 const approvalHookTimeoutSeconds = defaultApprovalHookTimeoutSeconds
@@ -369,6 +392,10 @@ func removeApprovalHooks(agent AgentConfig, out io.Writer) error {
 		); err != nil {
 			return err
 		}
+		// Offboarding removes the usage/session hooks installed alongside.
+		if err := removeCursorUsageHooks(agent, out); err != nil {
+			return err
+		}
 	}
 
 	if err := removePermissionHookCredential(agent); err != nil {
@@ -376,6 +403,103 @@ func removeApprovalHooks(agent AgentConfig, out io.Writer) error {
 	}
 	if out != nil {
 		fmt.Fprintf(out, "  Mobile approvals: removed %s hook\n", source) //nolint:errcheck
+	}
+	return nil
+}
+
+// cursorUsageHookCommand is the hooks.json command for the usage hook. The
+// opt-in flag is persisted in the command itself so the choice survives
+// without a credential file.
+func cursorUsageHookCommand(storeTranscript bool) string {
+	command := fmt.Sprintf("%s usage hook --from cursor", preloopExecutableForHooks())
+	if storeTranscript {
+		command += " --store-transcript"
+	}
+	return command
+}
+
+// installCursorUsageHooks wires `preloop usage hook` into Cursor's
+// lifecycle events so conversations are stored as runtime sessions with a
+// transcript-derived token estimate. Idempotent: re-running replaces our
+// entries. Non-Cursor agents are a no-op.
+func installCursorUsageHooks(agent AgentConfig, storeTranscript bool, out io.Writer) error {
+	if permissionSourceForAgent(agent) != permissionSourceCursor {
+		return nil
+	}
+	configPath, err := approvalHookConfigPath(permissionSourceCursor)
+	if err != nil {
+		return err
+	}
+	if err := upsertFlatCommandHookMarked(
+		configPath,
+		cursorUsageHookEvents,
+		cursorUsageHookCommand(storeTranscript),
+		cursorUsageHookTimeoutSeconds,
+		usageHookCommandMarker,
+	); err != nil {
+		return err
+	}
+	if err := setPermissionHookCredentialStoreTranscript(agent, storeTranscript); err != nil {
+		return err
+	}
+	if out != nil {
+		fmt.Fprintf(out, "  Usage hooks: installed Cursor session and token-estimate hooks (%s)\n", configPath) //nolint:errcheck
+		if storeTranscript {
+			fmt.Fprintln(out, "  Transcript storage: on (transcript text is shipped as session activities)") //nolint:errcheck
+		} else {
+			fmt.Fprintln(out, "  Transcript storage: off (counts, title and a short summary only; re-run with --store-transcript to opt in)") //nolint:errcheck
+		}
+	}
+	return nil
+}
+
+// removeCursorUsageHooks removes the usage hook entries installed by
+// installCursorUsageHooks, leaving any other entries (including our
+// permission hooks) untouched.
+func removeCursorUsageHooks(agent AgentConfig, out io.Writer) error {
+	if permissionSourceForAgent(agent) != permissionSourceCursor {
+		return nil
+	}
+	configPath, err := approvalHookConfigPath(permissionSourceCursor)
+	if err != nil {
+		return err
+	}
+	if err := removeFlatCommandHookMarked(configPath, cursorUsageHookEvents, usageHookCommandMarker, true); err != nil {
+		return err
+	}
+	if out != nil {
+		fmt.Fprintln(out, "  Usage hooks: removed Cursor session and token-estimate hooks") //nolint:errcheck
+	}
+	return nil
+}
+
+// setPermissionHookCredentialStoreTranscript records the transcript opt-in
+// in the per-agent credential file when one exists (approvals onboarding
+// writes it). Without a credential file the hooks.json command carries the
+// flag, so a missing file is not an error.
+func setPermissionHookCredentialStoreTranscript(agent AgentConfig, storeTranscript bool) error {
+	path, err := permissionHookCredentialPath(agent)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read permission hook credential: %w", err)
+	}
+	var cred permissionHookCredential
+	if err := json.Unmarshal(data, &cred); err != nil {
+		return fmt.Errorf("failed to parse permission hook credential: %w", err)
+	}
+	cred.StoreTranscript = &storeTranscript
+	encoded, err := json.MarshalIndent(cred, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode permission hook credential: %w", err)
+	}
+	if err := os.WriteFile(path, encoded, 0600); err != nil {
+		return fmt.Errorf("failed to write permission hook credential: %w", err)
 	}
 	return nil
 }
@@ -490,8 +614,15 @@ func removeNestedCommandHook(path, eventKey string, deleteFileIfEmpty bool) erro
 }
 
 // upsertFlatCommandHook installs flat {"command": ...} entries (used by Cursor),
-// replacing any existing Preloop entries for each event key.
+// replacing any existing Preloop permission-hook entries for each event key.
 func upsertFlatCommandHook(path string, eventKeys []string, command string, timeoutSeconds int) error {
+	return upsertFlatCommandHookMarked(path, eventKeys, command, timeoutSeconds, permissionHookCommandMarker)
+}
+
+// upsertFlatCommandHookMarked is upsertFlatCommandHook for an arbitrary
+// ownership marker: only entries whose command contains marker are
+// replaced, so the permission and usage hook sets never clobber each other.
+func upsertFlatCommandHookMarked(path string, eventKeys []string, command string, timeoutSeconds int, marker string) error {
 	doc, err := loadJSONDocumentOrEmpty(path)
 	if err != nil {
 		return err
@@ -501,7 +632,7 @@ func upsertFlatCommandHook(path string, eventKeys []string, command string, time
 	}
 	hooks := ensureObjectChild(doc, "hooks")
 	for _, key := range eventKeys {
-		list := stripPreloopFlatEntries(asArrayValue(hooks[key]))
+		list := stripFlatEntriesMatching(asArrayValue(hooks[key]), marker)
 		entry := map[string]interface{}{"command": command}
 		if timeoutSeconds > 0 {
 			entry["timeout"] = timeoutSeconds
@@ -512,6 +643,10 @@ func upsertFlatCommandHook(path string, eventKeys []string, command string, time
 }
 
 func removeFlatCommandHook(path string, eventKeys []string, deleteFileIfEmpty bool) error {
+	return removeFlatCommandHookMarked(path, eventKeys, permissionHookCommandMarker, deleteFileIfEmpty)
+}
+
+func removeFlatCommandHookMarked(path string, eventKeys []string, marker string, deleteFileIfEmpty bool) error {
 	doc, existed, err := loadJSONDocumentIfExists(path)
 	if err != nil || !existed {
 		return err
@@ -521,7 +656,7 @@ func removeFlatCommandHook(path string, eventKeys []string, deleteFileIfEmpty bo
 		return nil
 	}
 	for _, key := range eventKeys {
-		list := stripPreloopFlatEntries(asArrayValue(hooks[key]))
+		list := stripFlatEntriesMatching(asArrayValue(hooks[key]), marker)
 		if len(list) == 0 {
 			delete(hooks, key)
 		} else {
@@ -571,6 +706,10 @@ func stripPreloopNestedEntries(list []interface{}) []interface{} {
 }
 
 func stripPreloopFlatEntries(list []interface{}) []interface{} {
+	return stripFlatEntriesMatching(list, permissionHookCommandMarker)
+}
+
+func stripFlatEntriesMatching(list []interface{}, marker string) []interface{} {
 	out := make([]interface{}, 0, len(list))
 	for _, item := range list {
 		entry, ok := asObjectMap(item)
@@ -579,7 +718,7 @@ func stripPreloopFlatEntries(list []interface{}) []interface{} {
 			continue
 		}
 		command, _ := entry["command"].(string)
-		if strings.Contains(command, permissionHookCommandMarker) {
+		if strings.Contains(command, marker) {
 			continue
 		}
 		out = append(out, item)

--- a/cli/internal/cmd/agents_cursor_usage_hooks_test.go
+++ b/cli/internal/cmd/agents_cursor_usage_hooks_test.go
@@ -1,0 +1,220 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/testenv"
+)
+
+func cursorTestAgent(home string) AgentConfig {
+	return AgentConfig{Name: "Cursor", ConfigPath: filepath.Join(home, ".cursor", "mcp.json")}
+}
+
+func flatHookEntries(t *testing.T, doc map[string]interface{}, key string) []map[string]interface{} {
+	t.Helper()
+	hooks, _ := doc["hooks"].(map[string]interface{})
+	arr, _ := hooks[key].([]interface{})
+	entries := make([]map[string]interface{}, 0, len(arr))
+	for _, item := range arr {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("%s entry is not an object: %#v", key, item)
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func TestInstallCursorUsageHooksWiresEveryLifecycleEvent(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	agent := cursorTestAgent(home)
+	hooksPath := filepath.Join(home, ".cursor", "hooks.json")
+
+	if err := installCursorUsageHooks(agent, false, nil); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	// Idempotent: a second install replaces, never duplicates.
+	if err := installCursorUsageHooks(agent, false, nil); err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+	doc := readJSONDoc(t, hooksPath)
+	if v, ok := doc["version"]; !ok || (v != float64(1) && v != 1) {
+		t.Errorf("hooks version missing/wrong: %v", doc["version"])
+	}
+	want := []string{"sessionStart", "sessionEnd", "subagentStart", "subagentStop", "stop", "preCompact", "beforeSubmitPrompt"}
+	for _, key := range want {
+		entries := flatHookEntries(t, doc, key)
+		if len(entries) != 1 {
+			t.Fatalf("expected one %s entry, got %d", key, len(entries))
+		}
+		command, _ := entries[0]["command"].(string)
+		if !strings.HasSuffix(command, " usage hook --from cursor") || !filepath.IsAbs(strings.Fields(command)[0]) {
+			t.Errorf("%s command wrong: %q", key, command)
+		}
+		if entries[0]["timeout"] != float64(5) {
+			t.Errorf("%s timeout=%v, want 5", key, entries[0]["timeout"])
+		}
+	}
+	hooks := doc["hooks"].(map[string]interface{})
+	if len(hooks) != len(want) {
+		t.Errorf("unexpected extra hook keys: %v", hooks)
+	}
+}
+
+func TestInstallCursorUsageHooksStoreTranscriptPersistsInCommandAndCredential(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	agent := cursorTestAgent(home)
+	hooksPath := filepath.Join(home, ".cursor", "hooks.json")
+
+	// Approvals onboarding wrote a credential file first.
+	if err := installApprovalHooks(agent, "https://preloop.ai", "agt_z", nil); err != nil {
+		t.Fatalf("install approvals: %v", err)
+	}
+	if err := installCursorUsageHooks(agent, true, nil); err != nil {
+		t.Fatalf("install usage hooks: %v", err)
+	}
+	doc := readJSONDoc(t, hooksPath)
+	command, _ := flatHookEntries(t, doc, "stop")[0]["command"].(string)
+	if !strings.HasSuffix(command, " usage hook --from cursor --store-transcript") {
+		t.Errorf("opt-in missing from command: %q", command)
+	}
+	// Permission hooks are untouched by the usage hook install.
+	if entries := flatHookEntries(t, doc, "beforeShellExecution"); len(entries) != 1 ||
+		!strings.Contains(entries[0]["command"].(string), "permission-hook --source cursor") {
+		t.Errorf("permission hook clobbered: %#v", entries)
+	}
+
+	credPath, err := permissionHookCredentialPath(agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(credPath)
+	if err != nil {
+		t.Fatalf("read credential: %v", err)
+	}
+	var cred permissionHookCredential
+	if err := json.Unmarshal(data, &cred); err != nil {
+		t.Fatal(err)
+	}
+	if cred.StoreTranscript == nil || !*cred.StoreTranscript {
+		t.Errorf("credential store_transcript not persisted: %s", data)
+	}
+	if cred.Token != "agt_z" || cred.Source != permissionSourceCursor {
+		t.Errorf("credential fields lost on rewrite: %s", data)
+	}
+
+	// Opting back out flips the key rather than leaving it stale.
+	if err := installCursorUsageHooks(agent, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	data, _ = os.ReadFile(credPath)
+	_ = json.Unmarshal(data, &cred)
+	if cred.StoreTranscript == nil || *cred.StoreTranscript {
+		t.Errorf("credential store_transcript should be false after re-install without opt-in: %s", data)
+	}
+	command, _ = flatHookEntries(t, readJSONDoc(t, hooksPath), "stop")[0]["command"].(string)
+	if strings.Contains(command, "--store-transcript") {
+		t.Errorf("opt-in should be gone from command: %q", command)
+	}
+}
+
+func TestInstallCursorUsageHooksWithoutCredentialFile(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	agent := cursorTestAgent(home)
+	if err := installCursorUsageHooks(agent, true, nil); err != nil {
+		t.Fatalf("install without credential must succeed: %v", err)
+	}
+	credPath, _ := permissionHookCredentialPath(agent)
+	if _, err := os.Stat(credPath); !os.IsNotExist(err) {
+		t.Errorf("usage hook install must not create a credential file, stat err=%v", err)
+	}
+}
+
+func TestRemoveCursorUsageHooksLeavesPermissionHooks(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	agent := cursorTestAgent(home)
+	hooksPath := filepath.Join(home, ".cursor", "hooks.json")
+
+	if err := installApprovalHooks(agent, "https://preloop.ai", "agt_z", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := installCursorUsageHooks(agent, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeCursorUsageHooks(agent, nil); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	doc := readJSONDoc(t, hooksPath)
+	hooks := doc["hooks"].(map[string]interface{})
+	for _, key := range cursorUsageHookEvents {
+		if _, ok := hooks[key]; ok {
+			t.Errorf("%s should be gone: %v", key, hooks[key])
+		}
+	}
+	for _, key := range []string{"beforeShellExecution", "beforeMCPExecution", "preToolUse"} {
+		if len(flatHookEntries(t, doc, key)) != 1 {
+			t.Errorf("permission hook %s lost: %v", key, hooks[key])
+		}
+	}
+}
+
+func TestRemoveApprovalHooksAlsoRemovesCursorUsageHooks(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	agent := cursorTestAgent(home)
+	hooksPath := filepath.Join(home, ".cursor", "hooks.json")
+
+	if err := installApprovalHooks(agent, "https://preloop.ai", "agt_z", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := installCursorUsageHooks(agent, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeApprovalHooks(agent, nil); err != nil {
+		t.Fatalf("offboard removal: %v", err)
+	}
+	if _, err := os.Stat(hooksPath); !os.IsNotExist(err) {
+		t.Errorf("hooks.json created solely by us must be deleted, stat err=%v", err)
+	}
+}
+
+func TestCursorUsageHooksPreserveForeignEntries(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	agent := cursorTestAgent(home)
+	hooksPath := filepath.Join(home, ".cursor", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0700); err != nil {
+		t.Fatal(err)
+	}
+	foreign := `{"version":1,"hooks":{"stop":[{"command":"/usr/local/bin/notify-me"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(foreign), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := installCursorUsageHooks(agent, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if entries := flatHookEntries(t, readJSONDoc(t, hooksPath), "stop"); len(entries) != 2 ||
+		entries[0]["command"] != "/usr/local/bin/notify-me" {
+		t.Errorf("foreign stop entry must be preserved first: %#v", entries)
+	}
+	if err := removeCursorUsageHooks(agent, nil); err != nil {
+		t.Fatal(err)
+	}
+	if entries := flatHookEntries(t, readJSONDoc(t, hooksPath), "stop"); len(entries) != 1 ||
+		entries[0]["command"] != "/usr/local/bin/notify-me" {
+		t.Errorf("foreign stop entry must survive removal: %#v", entries)
+	}
+}
+
+func TestCursorUsageHooksAreNoOpForOtherAgents(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	agent := AgentConfig{Name: "Claude Code", ConfigPath: filepath.Join(home, ".claude", "settings.json")}
+	if err := installCursorUsageHooks(agent, true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".cursor", "hooks.json")); !os.IsNotExist(err) {
+		t.Errorf("non-Cursor agent must not touch ~/.cursor/hooks.json, stat err=%v", err)
+	}
+}

--- a/cli/internal/cmd/agents_openclaw.go
+++ b/cli/internal/cmd/agents_openclaw.go
@@ -303,6 +303,14 @@ type managedEnrollmentOptions struct {
 	// would-prompt tool calls to Preloop's mobile/watch approval flow. Off by
 	// default; enabled via `preloop agents onboard --approvals`.
 	Approvals bool
+	// NoUsageHooks skips the Cursor usage/session hooks that onboarding
+	// installs by default (`preloop agents onboard Cursor --no-usage-hooks`).
+	// Other agents are unaffected.
+	NoUsageHooks bool
+	// StoreTranscript opts the Cursor usage hooks into shipping transcript
+	// text as session activities (`--store-transcript`). Off by default:
+	// only counts, the title and a short summary leave the machine.
+	StoreTranscript bool
 	// PreferredModel is the operator-selected managed model alias from
 	// ``--model``. When set, the interactive model picker is skipped and this
 	// alias is used for gateway onboarding.
@@ -928,6 +936,14 @@ func executeManagedEnrollment(agent AgentConfig, opts managedEnrollmentOptions) 
 				// Non-fatal: hook-based approvals above already applied.
 				fmt.Fprintf(output, "  Warning: %v\n", err) //nolint:errcheck
 			}
+		}
+	}
+	if !opts.NoUsageHooks && permissionSourceForAgent(agent) == permissionSourceCursor {
+		// Sessions and token estimates for Cursor come only from its hooks,
+		// so they are on by default. A hooks.json problem must not fail an
+		// enrollment whose MCP and model configuration already applied.
+		if err := installCursorUsageHooks(agent, opts.StoreTranscript, output); err != nil {
+			fmt.Fprintf(output, "  Warning: Cursor usage hooks not installed: %v\n", err) //nolint:errcheck
 		}
 	}
 	pluginInstallResult := installAgentControlRuntimePlugin(agent, output)

--- a/cli/internal/cmd/agents_permission_hook.go
+++ b/cli/internal/cmd/agents_permission_hook.go
@@ -94,6 +94,12 @@ type permissionHookCredential struct {
 	// "git status". Written by onboarding; a missing field means enabled so
 	// pre-existing credential files keep the fatigue fix.
 	SafeReadAutoAllow *bool `json:"safe_read_auto_allow,omitempty"`
+	// StoreTranscript opts the Cursor usage hook into shipping transcript
+	// text (as runtime session activities) in addition to the token counts,
+	// titles and short summaries it ships by default. Written by
+	// `preloop agents onboard Cursor --store-transcript`; the hook command's
+	// own --store-transcript flag has the same effect.
+	StoreTranscript *bool `json:"store_transcript,omitempty"`
 }
 
 // safeReadAutoAllowEnabled reports whether the built-in read-only command

--- a/cli/internal/cmd/testdata/cursor-transcripts/conversation.jsonl
+++ b/cli/internal/cmd/testdata/cursor-transcripts/conversation.jsonl
@@ -1,0 +1,4 @@
+{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Saturday, Sep 5, 2026</timestamp>\n<user_query>\nList the Go files in cli and count them.\n</user_query>"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"I will list the files first."},{"type":"tool_use","name":"Shell","input":{"command":"ls cli/*.go | wc -l"}}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"There are 12 Go files in cli.\n\nThat is the whole count; nothing else changed."}]}}
+{"type":"turn_ended","status":"success"}

--- a/cli/internal/cmd/testdata/cursor-transcripts/generation2.jsonl
+++ b/cli/internal/cmd/testdata/cursor-transcripts/generation2.jsonl
@@ -1,0 +1,4 @@
+{"role":"user","message":{"content":[{"type":"text","text":"Now delete the oldest one."}]}}
+{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"git rm cli/old.go"}}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"Removed cli/old.go."}]}}
+{"type":"turn_ended","status":"success"}

--- a/cli/internal/cmd/testdata/cursor-transcripts/plain.txt
+++ b/cli/internal/cmd/testdata/cursor-transcripts/plain.txt
@@ -1,0 +1,4 @@
+User: Please rename the variable.
+Assistant: Done, renamed foo to bar.
+It compiles.
+User: Thanks

--- a/cli/internal/cmd/testdata/cursor-transcripts/subagent.jsonl
+++ b/cli/internal/cmd/testdata/cursor-transcripts/subagent.jsonl
@@ -1,0 +1,4 @@
+{"role":"user","message":{"content":[{"type":"text","text":"Explore the auth flow and summarize it."}]}}
+{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"path":"backend/auth.py"}}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"Auth uses JWT bearer tokens with a refresh endpoint."}]}}
+{"type":"turn_ended","status":"success"}

--- a/cli/internal/cmd/usage_hook.go
+++ b/cli/internal/cmd/usage_hook.go
@@ -77,15 +77,31 @@ var cursorHookEventMap = map[string]string{
 
 // cursorHookInput mirrors the fields of a Cursor hook stdin payload this
 // command uses, per the hook schemas published at cursor.com/docs/agent/
-// hooks (verified 2026-08-27). Fields we do not use (prompt text, file
-// paths, transcripts, user email) are deliberately not decoded: they never
-// leave the machine through this command.
+// hooks (verified 2026-09-05). Fields we do not use (file paths touched by
+// tools, user email, workspace roots) are deliberately not decoded.
+// transcript_path is decoded so the command can read the local transcript
+// for a token estimate; transcript text itself never leaves the machine
+// unless the operator opts in with --store-transcript.
 type cursorHookInput struct {
 	// Common fields (all agent hooks).
 	ConversationID string `json:"conversation_id"`
 	GenerationID   string `json:"generation_id"`
 	HookEventName  string `json:"hook_event_name"`
 	Model          string `json:"model"`
+	TranscriptPath string `json:"transcript_path"`
+
+	// subagentStop: the subagent's own transcript, separate from the
+	// parent conversation's.
+	AgentTranscriptPath string `json:"agent_transcript_path"`
+
+	// preCompact context measurements. context_tokens is Cursor's own
+	// count of the context about to be compacted, the only ground-truth
+	// token figure any Cursor hook reports.
+	ContextTokens       *int     `json:"context_tokens"`
+	ContextWindowSize   *int     `json:"context_window_size"`
+	ContextUsagePercent *float64 `json:"context_usage_percent"`
+	MessagesToCompact   *int     `json:"messages_to_compact"`
+	IsFirstCompaction   *bool    `json:"is_first_compaction"`
 
 	// sessionStart / sessionEnd. The docs state session_id equals
 	// conversation_id; it is decoded as a fallback only.
@@ -128,12 +144,17 @@ By default the command auto-detects the payload:
 
 Override detection with --from cursor|generic|codex.
 
-Cursor hook payloads carry no token counts and no billed amounts, so
-those records are lifecycle markers on the 'estimated' basis with no
-cost attached. Generic events and Codex rollouts may carry token
-counts; cost_basis stays 'estimated' unless the event explicitly
-includes a billed amount from a provider ledger. Null stays null,
-never 0.
+Cursor hook payloads carry no token counts and no billed amounts. When
+Cursor names a transcript file (transcript_path, or the
+CURSOR_TRANSCRIPT_PATH environment variable), stop, sessionEnd and
+subagentStop records carry a token estimate derived from the transcript
+text since the last shipped offset (4 characters per token, the same
+heuristic the gateway budget preflight uses), on the 'estimated' basis.
+Only counts leave the machine; transcript text never does unless you
+opt in with --store-transcript. Generic events and Codex rollouts may
+carry token counts; cost_basis stays 'estimated' unless the event
+explicitly includes a billed amount from a provider ledger. Null stays
+null, never 0.
 
 The command is fail-open by design: any error (unreachable server,
 missing auth, malformed payload) is reported on stderr and the command
@@ -202,7 +223,9 @@ func runUsageHook(cmd *cobra.Command, _ []string) error {
 	var records []map[string]interface{}
 	switch detected {
 	case usageHookFormatCursor:
-		records, err = recordsFromCursorHook(raws[0], parentFlag, now)
+		records, err = recordsFromCursorHook(raws[0], parentFlag, now, func(warnErr error) {
+			fmt.Fprintf(cmd.ErrOrStderr(), "preloop usage hook: %v\n", warnErr)
+		})
 	case usageHookFormatGeneric:
 		records = recordsFromGenericEvents(cmd, raws, parentFlag, now)
 	case usageHookFormatCodex:
@@ -332,7 +355,7 @@ func resolveUsageHookSource(format usageHookFormat, flagValue string, flagChange
 }
 
 func recordsFromCursorHook(
-	payload json.RawMessage, parentFlag string, now time.Time,
+	payload json.RawMessage, parentFlag string, now time.Time, warn func(error),
 ) ([]map[string]interface{}, error) {
 	var input cursorHookInput
 	if err := json.Unmarshal(payload, &input); err != nil {
@@ -348,7 +371,47 @@ func recordsFromCursorHook(
 	if err != nil {
 		return nil, err
 	}
+	enrichCursorRecordFromTranscript(input, record, now, warn)
 	return []map[string]interface{}{record}, nil
+}
+
+// enrichCursorRecordFromTranscript adds the transcript-derived token
+// estimate to lifecycle records that close a generation. Any transcript
+// problem is reported through warn and leaves the lifecycle record intact:
+// a missing or unreadable transcript must never cost the event itself.
+func enrichCursorRecordFromTranscript(
+	input cursorHookInput,
+	record map[string]interface{},
+	now time.Time,
+	warn func(error),
+) {
+	conversationID, _ := record["conversation_id"].(string)
+	switch input.HookEventName {
+	case "sessionStart":
+		pruneCursorTranscriptState(now)
+		return
+	case "stop", "sessionEnd":
+		path := resolveCursorTranscriptPath(input.TranscriptPath)
+		if path == "" {
+			return
+		}
+		estimate, _, err := estimateCursorGeneration(conversationID, path, input.GenerationID, false)
+		if err != nil {
+			warn(fmt.Errorf("transcript estimate skipped: %w", err))
+		}
+		attachCursorTokenEstimate(record, estimate)
+	case "subagentStop":
+		path := strings.TrimSpace(input.AgentTranscriptPath)
+		if path == "" {
+			return
+		}
+		key := cursorSubagentStateKey(input, path)
+		estimate, _, err := estimateCursorGeneration(key, path, input.GenerationID, false)
+		if err != nil {
+			warn(fmt.Errorf("subagent transcript estimate skipped: %w", err))
+		}
+		attachCursorTokenEstimate(record, estimate)
+	}
 }
 
 func postUsageIngestRecords(

--- a/cli/internal/cmd/usage_hook.go
+++ b/cli/internal/cmd/usage_hook.go
@@ -90,6 +90,11 @@ type cursorHookInput struct {
 	Model          string `json:"model"`
 	TranscriptPath string `json:"transcript_path"`
 
+	// beforeSubmitPrompt. Read for one purpose only: the first line of the
+	// first prompt becomes the runtime session title. The prompt itself is
+	// never shipped.
+	Prompt string `json:"prompt"`
+
 	// subagentStop: the subagent's own transcript, separate from the
 	// parent conversation's.
 	AgentTranscriptPath string `json:"agent_transcript_path"`
@@ -172,6 +177,7 @@ func init() {
 	usageHookCmd.Flags().String("parent-conversation-id", "", "conversation this chat was spawned from, when the payload reports none (also PRELOOP_PARENT_CONVERSATION_ID)")
 	usageHookCmd.Flags().String("from", "auto", "payload format: auto, cursor, generic, or codex")
 	usageHookCmd.Flags().String("file", "", "read events from a file instead of stdin (generic NDJSON or a Codex rollout JSONL)")
+	usageHookCmd.Flags().Bool("store-transcript", false, "Cursor only: also ship the transcript text since the last event as runtime session activities (default: counts, title and a short summary only; a store_transcript key in the Cursor hook credential file has the same effect)")
 }
 
 func runUsageHook(cmd *cobra.Command, _ []string) error {
@@ -180,6 +186,7 @@ func runUsageHook(cmd *cobra.Command, _ []string) error {
 	parentFlag, _ := cmd.Flags().GetString("parent-conversation-id")
 	fromRaw, _ := cmd.Flags().GetString("from")
 	filePath, _ := cmd.Flags().GetString("file")
+	storeTranscriptFlag, _ := cmd.Flags().GetBool("store-transcript")
 	sourceChanged := cmd.Flags().Changed("source")
 
 	if agentID != "" && !uuidRe.MatchString(agentID) {
@@ -223,7 +230,10 @@ func runUsageHook(cmd *cobra.Command, _ []string) error {
 	var records []map[string]interface{}
 	switch detected {
 	case usageHookFormatCursor:
-		records, err = recordsFromCursorHook(raws[0], parentFlag, now, func(warnErr error) {
+		options := cursorHookOptions{
+			StoreTranscript: storeTranscriptFlag || cursorStoreTranscriptFromCredential(),
+		}
+		records, err = recordsFromCursorHook(raws[0], parentFlag, now, options, func(warnErr error) {
 			fmt.Fprintf(cmd.ErrOrStderr(), "preloop usage hook: %v\n", warnErr)
 		})
 	case usageHookFormatGeneric:
@@ -354,12 +364,51 @@ func resolveUsageHookSource(format usageHookFormat, flagValue string, flagChange
 	}
 }
 
+// cursorHookOptions carries operator choices for Cursor hook handling.
+type cursorHookOptions struct {
+	// StoreTranscript ships the transcript delta's text as session
+	// activities. Off by default: only counts, the title and a short
+	// summary leave the machine.
+	StoreTranscript bool
+}
+
+// cursorStoreTranscriptFromCredential reports whether the newest Cursor
+// hook credential file (~/.preloop/agents/*/permission_hook.json with
+// source cursor) opted into transcript storage.
+func cursorStoreTranscriptFromCredential() bool {
+	creds, err := loadPermissionHookCredentials(permissionSourceCursor)
+	if err != nil || len(creds) == 0 {
+		return false
+	}
+	return creds[0].StoreTranscript != nil && *creds[0].StoreTranscript
+}
+
 func recordsFromCursorHook(
-	payload json.RawMessage, parentFlag string, now time.Time, warn func(error),
+	payload json.RawMessage,
+	parentFlag string,
+	now time.Time,
+	options cursorHookOptions,
+	warn func(error),
 ) ([]map[string]interface{}, error) {
 	var input cursorHookInput
 	if err := json.Unmarshal(payload, &input); err != nil {
 		return nil, fmt.Errorf("parse hook payload: %w", err)
+	}
+
+	if input.HookEventName == "beforeSubmitPrompt" {
+		// Title capture only: nothing is posted for this event, and the
+		// prompt text is reduced to its first line before it is stored
+		// locally for the next stop record.
+		conversationID := input.ConversationID
+		if conversationID == "" {
+			conversationID = input.SessionID
+		}
+		if conversationID != "" {
+			if err := rememberCursorTitleFromPrompt(conversationID, input.Prompt); err != nil {
+				warn(fmt.Errorf("session title not remembered: %w", err))
+			}
+		}
+		return nil, nil
 	}
 
 	eventType, shipped := cursorHookEventMap[input.HookEventName]
@@ -371,7 +420,7 @@ func recordsFromCursorHook(
 	if err != nil {
 		return nil, err
 	}
-	enrichCursorRecordFromTranscript(input, record, now, warn)
+	enrichCursorRecordFromTranscript(input, record, now, options, warn)
 	return []map[string]interface{}{record}, nil
 }
 
@@ -383,23 +432,30 @@ func enrichCursorRecordFromTranscript(
 	input cursorHookInput,
 	record map[string]interface{},
 	now time.Time,
+	options cursorHookOptions,
 	warn func(error),
 ) {
 	conversationID, _ := record["conversation_id"].(string)
 	switch input.HookEventName {
 	case "sessionStart":
 		pruneCursorTranscriptState(now)
+		setCursorRecordMetadata(record, "session_title_default", cursorDefaultSessionTitle(conversationID))
 		return
 	case "stop", "sessionEnd":
+		state, stateErr := loadCursorTranscriptState(conversationID)
+		if stateErr == nil && state.Title != "" {
+			setCursorRecordMetadata(record, "session_title", state.Title)
+		}
 		path := resolveCursorTranscriptPath(input.TranscriptPath)
 		if path == "" {
 			return
 		}
-		estimate, _, err := estimateCursorGeneration(conversationID, path, input.GenerationID, false)
+		estimate, _, err := estimateCursorGeneration(conversationID, path, input.GenerationID, options.StoreTranscript)
 		if err != nil {
 			warn(fmt.Errorf("transcript estimate skipped: %w", err))
 		}
 		attachCursorTokenEstimate(record, estimate)
+		attachCursorSessionText(record, estimate, options)
 	case "subagentStop":
 		path := strings.TrimSpace(input.AgentTranscriptPath)
 		if path == "" {

--- a/cli/internal/cmd/usage_hook.go
+++ b/cli/internal/cmd/usage_hook.go
@@ -63,9 +63,12 @@ const (
 // responding, the closest observable "one response happened" marker.
 //
 // Events outside this map (permission/file/observation hooks such as
-// beforeShellExecution, beforeReadFile, afterFileEdit, beforeSubmitPrompt,
-// afterAgentResponse) are acknowledged without a POST: they would inflate
-// event counts without adding any cost signal.
+// beforeShellExecution, beforeReadFile, afterFileEdit, afterAgentResponse)
+// are acknowledged without a POST: they would inflate event counts without
+// adding any cost signal. beforeSubmitPrompt is the one exception: it also
+// skips the POST, but captures the session title locally and answers
+// {"continue":true} on stdout (see the special case in
+// recordsFromCursorHook).
 var cursorHookEventMap = map[string]string{
 	"sessionStart":  "session_start",
 	"sessionEnd":    "session_end",
@@ -249,6 +252,13 @@ func runUsageHook(cmd *cobra.Command, _ []string) error {
 		return usageHookFailOpen(cmd, err)
 	}
 	if len(records) == 0 {
+		if detected == usageHookFormatCursor && isCursorBeforeSubmitPrompt(raws[0]) {
+			// Cursor's beforeSubmitPrompt contract expects a JSON decision
+			// on stdout ({"continue": true|false, "user_message"?}); empty
+			// stdout is treated as a hook failure. This hook never blocks
+			// a prompt, so the answer is always continue.
+			fmt.Fprintln(cmd.OutOrStdout(), `{"continue":true}`)
+		}
 		return nil
 	}
 
@@ -334,6 +344,19 @@ func detectUsageHookFormat(raw json.RawMessage) usageHookFormat {
 		return usageHookFormatGeneric
 	}
 	return ""
+}
+
+// isCursorBeforeSubmitPrompt reports whether a Cursor hook payload is the
+// beforeSubmitPrompt event, the one event whose contract reads a JSON
+// decision from the hook's stdout.
+func isCursorBeforeSubmitPrompt(raw json.RawMessage) bool {
+	var probe struct {
+		HookEventName string `json:"hook_event_name"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return false
+	}
+	return probe.HookEventName == "beforeSubmitPrompt"
 }
 
 func jsonRawString(raw json.RawMessage) (string, bool) {

--- a/cli/internal/cmd/usage_hook.go
+++ b/cli/internal/cmd/usage_hook.go
@@ -411,6 +411,41 @@ func enrichCursorRecordFromTranscript(
 			warn(fmt.Errorf("subagent transcript estimate skipped: %w", err))
 		}
 		attachCursorTokenEstimate(record, estimate)
+	case "preCompact":
+		attachCursorCompactionContext(input, record)
+		if input.ContextTokens == nil {
+			return
+		}
+		if err := rememberCursorContextTokens(conversationID, input.GenerationID, *input.ContextTokens); err != nil {
+			warn(fmt.Errorf("context tokens not remembered: %w", err))
+		}
+	}
+}
+
+// attachCursorCompactionContext copies preCompact's context measurements
+// into record metadata. context_tokens is Cursor's own count and the only
+// ground-truth token figure a Cursor hook ever reports; the rest describe
+// how full the window was when compaction started.
+func attachCursorCompactionContext(input cursorHookInput, record map[string]interface{}) {
+	metadata, _ := record["metadata"].(map[string]interface{})
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+		record["metadata"] = metadata
+	}
+	if input.ContextTokens != nil {
+		metadata["context_tokens"] = *input.ContextTokens
+	}
+	if input.ContextWindowSize != nil {
+		metadata["context_window_size"] = *input.ContextWindowSize
+	}
+	if input.ContextUsagePercent != nil {
+		metadata["context_usage_percent"] = *input.ContextUsagePercent
+	}
+	if input.MessagesToCompact != nil {
+		metadata["messages_to_compact"] = *input.MessagesToCompact
+	}
+	if input.IsFirstCompaction != nil {
+		metadata["is_first_compaction"] = *input.IsFirstCompaction
 	}
 }
 

--- a/cli/internal/cmd/usage_hook_cursor_transcript.go
+++ b/cli/internal/cmd/usage_hook_cursor_transcript.go
@@ -497,9 +497,12 @@ func estimateCursorGeneration(
 		state.Generations++
 		state.InputTokens += int64(estimate.InputTokens)
 		state.OutputTokens += int64(estimate.OutputTokens)
+		// The pending ground truth is consumed only when a generation
+		// actually used it. A read that found no model text (sessionEnd
+		// right after preCompact, before the next stop) must not drop it.
+		state.PendingContextTokens = nil
+		state.PendingContextGenerationID = ""
 	}
-	state.PendingContextTokens = nil
-	state.PendingContextGenerationID = ""
 	state.Offset += delta.Consumed
 	state.TotalChars += delta.totalChars()
 	if generationID != "" {

--- a/cli/internal/cmd/usage_hook_cursor_transcript.go
+++ b/cli/internal/cmd/usage_hook_cursor_transcript.go
@@ -565,3 +565,139 @@ func cursorSubagentStateKey(input cursorHookInput, transcriptPath string) string
 	sum := sha256.Sum256([]byte(transcriptPath))
 	return "subagent-" + hex.EncodeToString(sum[:8])
 }
+
+// Session presentation limits. The summary cap matches what the console
+// shows in the runtime sessions list; the title cap keeps the first prompt
+// line readable as a list row.
+const (
+	cursorSessionSummaryMaxChars = 280
+	cursorSessionTitleMaxChars   = 120
+	cursorSessionShortIDLen      = 8
+
+	// cursorTranscriptShipMaxMessages and cursorTranscriptShipMaxChars
+	// mirror MAX_INGEST_TRANSCRIPT_MESSAGES / MAX_INGEST_TRANSCRIPT_TEXT_CHARS
+	// / MAX_INGEST_TRANSCRIPT_TOTAL_CHARS in backend/preloop/schemas/
+	// usage_import.py.
+	cursorTranscriptShipMaxMessages   = 50
+	cursorTranscriptShipMaxChars      = 4000
+	cursorTranscriptShipMaxTotalChars = 64 * 1024
+)
+
+var cursorWhitespaceRun = regexp.MustCompile(`\s+`)
+
+func setCursorRecordMetadata(record map[string]interface{}, key string, value interface{}) {
+	metadata, _ := record["metadata"].(map[string]interface{})
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+		record["metadata"] = metadata
+	}
+	metadata[key] = value
+}
+
+// cursorDefaultSessionTitle is the placeholder used until the first prompt
+// line is known: "Cursor conversation <short id>".
+func cursorDefaultSessionTitle(conversationID string) string {
+	short := strings.TrimSpace(conversationID)
+	if len(short) > cursorSessionShortIDLen {
+		short = short[:cursorSessionShortIDLen]
+	}
+	return "Cursor conversation " + short
+}
+
+// truncateCursorText cuts text to max runes, marking the cut with an
+// ellipsis so a truncated summary is never mistaken for a complete one.
+func truncateCursorText(text string, max int) string {
+	if utf8.RuneCountInString(text) <= max {
+		return text
+	}
+	runes := []rune(text)
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
+}
+
+// cursorTitleFromPrompt reduces a prompt to its first non-empty line.
+func cursorTitleFromPrompt(prompt string) string {
+	for _, line := range strings.Split(prompt, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		line = cursorWhitespaceRun.ReplaceAllString(line, " ")
+		return truncateCursorText(line, cursorSessionTitleMaxChars)
+	}
+	return ""
+}
+
+// rememberCursorTitleFromPrompt stores the first prompt line as the
+// conversation title, once. Later prompts never overwrite it: the first
+// question is what the session was about.
+func rememberCursorTitleFromPrompt(conversationID, prompt string) error {
+	title := cursorTitleFromPrompt(prompt)
+	if title == "" {
+		return nil
+	}
+	state, err := loadCursorTranscriptState(conversationID)
+	if err != nil {
+		return err
+	}
+	if state.Title != "" {
+		return nil
+	}
+	state.Title = title
+	return saveCursorTranscriptState(conversationID, state)
+}
+
+// cursorSummaryFromAssistantText is the last paragraph of the assistant's
+// latest text, whitespace-collapsed and truncated to the summary cap.
+func cursorSummaryFromAssistantText(text string) string {
+	paragraphs := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n\n")
+	for i := len(paragraphs) - 1; i >= 0; i-- {
+		paragraph := strings.TrimSpace(paragraphs[i])
+		if paragraph == "" {
+			continue
+		}
+		paragraph = cursorWhitespaceRun.ReplaceAllString(paragraph, " ")
+		return truncateCursorText(paragraph, cursorSessionSummaryMaxChars)
+	}
+	return ""
+}
+
+// attachCursorSessionText adds the session summary and, when opted in, the
+// transcript delta to a stop/sessionEnd record.
+func attachCursorSessionText(record map[string]interface{}, estimate *cursorTokenEstimate, options cursorHookOptions) {
+	if estimate == nil {
+		return
+	}
+	if summary := cursorSummaryFromAssistantText(estimate.Delta.LastAssistantText); summary != "" {
+		setCursorRecordMetadata(record, "session_summary", summary)
+	}
+	if !options.StoreTranscript || len(estimate.Delta.Messages) == 0 {
+		return
+	}
+	transcript := make([]map[string]interface{}, 0, len(estimate.Delta.Messages))
+	total := 0
+	for _, message := range estimate.Delta.Messages {
+		if len(transcript) >= cursorTranscriptShipMaxMessages {
+			break
+		}
+		text := strings.TrimSpace(message.Text)
+		if text == "" {
+			continue
+		}
+		text = truncateCursorText(text, cursorTranscriptShipMaxChars)
+		length := utf8.RuneCountInString(text)
+		if total+length > cursorTranscriptShipMaxTotalChars {
+			break
+		}
+		total += length
+		transcript = append(transcript, map[string]interface{}{
+			"role": message.Role,
+			"text": text,
+		})
+	}
+	if len(transcript) > 0 {
+		record["transcript"] = transcript
+	}
+}

--- a/cli/internal/cmd/usage_hook_cursor_transcript.go
+++ b/cli/internal/cmd/usage_hook_cursor_transcript.go
@@ -511,6 +511,24 @@ func estimateCursorGeneration(
 	return estimate, state, nil
 }
 
+// rememberCursorContextTokens stores preCompact's context_tokens so the
+// next generation's input_tokens use Cursor's own measurement instead of
+// the chars heuristic. preCompact fires before the context shrinks, so
+// the figure is the size of the context that was just re-sent.
+func rememberCursorContextTokens(stateKey, generationID string, contextTokens int) error {
+	if contextTokens < 0 {
+		return nil
+	}
+	state, err := loadCursorTranscriptState(stateKey)
+	if err != nil {
+		return err
+	}
+	tokens := contextTokens
+	state.PendingContextTokens = &tokens
+	state.PendingContextGenerationID = generationID
+	return saveCursorTranscriptState(stateKey, state)
+}
+
 // attachCursorTokenEstimate puts the estimate on an ingest record. Records
 // with an estimate of zero on both sides (nothing new in the transcript)
 // keep their lifecycle meaning and ship without token fields: null stays

--- a/cli/internal/cmd/usage_hook_cursor_transcript.go
+++ b/cli/internal/cmd/usage_hook_cursor_transcript.go
@@ -34,7 +34,8 @@ import (
 //
 // The token estimate is the same chars-per-token heuristic the gateway
 // budget preflight uses (billing_budget_chars_per_token, default 4.0, in
-// backend/preloop/config.py) so client and server numbers agree.
+// backend/preloop/config.py) so client and server numbers agree at the
+// default. The hook does not read a non-default server setting.
 const (
 	cursorTranscriptCharsPerToken = 4
 

--- a/cli/internal/cmd/usage_hook_cursor_transcript.go
+++ b/cli/internal/cmd/usage_hook_cursor_transcript.go
@@ -1,0 +1,549 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// Cursor writes one transcript per conversation under
+// ~/.cursor/projects/<workspace>/agent-transcripts/<conversation_id>/
+// <conversation_id>.jsonl, with subagent transcripts beside it under
+// subagents/<subagent_id>.jsonl. The hook payload names the file in
+// transcript_path (agent_transcript_path on subagentStop); the process
+// environment also carries CURSOR_TRANSCRIPT_PATH.
+//
+// Format (169 local files inspected 2026-09-05): JSONL. Message lines are
+// {"role":"user"|"assistant","message":{"content":[block,...]}} where a
+// block is {"type":"text","text":...} or {"type":"tool_use","name":...,
+// "input":{...}}. Tool results are not recorded. Control lines look like
+// {"type":"turn_ended","status":"success"} and carry no role. A parser
+// that tolerates partial trailing lines is required: the file is appended
+// while the agent runs, and 63 of 27,795 lines seen locally were partial.
+//
+// The token estimate is the same chars-per-token heuristic the gateway
+// budget preflight uses (billing_budget_chars_per_token, default 4.0, in
+// backend/preloop/config.py) so client and server numbers agree.
+const (
+	cursorTranscriptCharsPerToken = 4
+
+	// cursorTranscriptMaxDeltaBytes bounds one read of unshipped transcript
+	// bytes. Only the delta since the last shipped offset is read, so this
+	// caps memory for a single hook process, not the transcript size.
+	cursorTranscriptMaxDeltaBytes = 8 << 20
+
+	// cursorTranscriptStateMaxAge is how long a conversation's offset
+	// state is kept after its last update before sessionStart prunes it.
+	cursorTranscriptStateMaxAge = 30 * 24 * time.Hour
+
+	cursorTranscriptStateDirName = "transcripts"
+
+	cursorTokenEstimateMethod = "transcript_chars"
+)
+
+// cursorTranscriptState is the per-conversation file under
+// ~/.preloop/agents/cursor/transcripts/<conversation_id>.json. It records
+// how far the transcript has been shipped so each generation is counted
+// once, and the running character total that becomes the next
+// generation's re-sent context.
+type cursorTranscriptState struct {
+	Offset           int64  `json:"offset"`
+	LastGenerationID string `json:"last_generation_id,omitempty"`
+	Generations      int    `json:"generations"`
+	// TotalChars counts every transcript character consumed so far. Each
+	// turn re-sends the whole conversation, so this is the input side of
+	// the next generation.
+	TotalChars   int64 `json:"total_chars"`
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+	// PendingContextTokens is the context_tokens figure from the latest
+	// preCompact payload, consumed by the next generation as ground truth
+	// for its input size (see step 2 in the guide).
+	PendingContextTokens       *int   `json:"pending_context_tokens,omitempty"`
+	PendingContextGenerationID string `json:"pending_context_generation_id,omitempty"`
+	Title                      string `json:"title,omitempty"`
+	UpdatedAt                  string `json:"updated_at"`
+}
+
+// cursorTranscriptMessage is one role-tagged text chunk from the delta.
+// It is only retained in memory when the caller opted into shipping
+// transcript text; the estimator itself never keeps text.
+type cursorTranscriptMessage struct {
+	Role string
+	Text string
+}
+
+// cursorTranscriptDelta is what one read of unshipped transcript yields.
+type cursorTranscriptDelta struct {
+	Bytes     int64
+	Consumed  int64
+	Truncated bool
+	Lines     int
+	BadLines  int
+	Format    string
+
+	// Character (rune) counts by transcript role. User text and tool
+	// results are context the model reads; assistant text and tool_use
+	// calls are what it generated.
+	UserChars          int64
+	ToolResultChars    int64
+	AssistantTextChars int64
+	ToolUseChars       int64
+
+	LastAssistantText string
+	Messages          []cursorTranscriptMessage
+}
+
+func (d cursorTranscriptDelta) inputChars() int64 {
+	return d.UserChars + d.ToolResultChars
+}
+
+func (d cursorTranscriptDelta) outputChars() int64 {
+	return d.AssistantTextChars + d.ToolUseChars
+}
+
+func (d cursorTranscriptDelta) totalChars() int64 {
+	return d.inputChars() + d.outputChars()
+}
+
+// cursorTokenEstimate is the result attached to one shipped record.
+type cursorTokenEstimate struct {
+	InputTokens  int
+	OutputTokens int
+	InputSource  string
+	Delta        cursorTranscriptDelta
+}
+
+func (e cursorTokenEstimate) metadata() map[string]interface{} {
+	meta := map[string]interface{}{
+		"method":            cursorTokenEstimateMethod,
+		"chars_per_token":   cursorTranscriptCharsPerToken,
+		"transcript_bytes":  e.Delta.Bytes,
+		"transcript_format": e.Delta.Format,
+		"input_chars":       e.Delta.inputChars(),
+		"output_chars":      e.Delta.outputChars(),
+		"input_source":      e.InputSource,
+	}
+	if e.Delta.Truncated {
+		meta["truncated"] = true
+	}
+	if e.Delta.BadLines > 0 {
+		meta["unparsed_lines"] = e.Delta.BadLines
+	}
+	return meta
+}
+
+func cursorCharsToTokens(chars int64) int {
+	if chars <= 0 {
+		return 0
+	}
+	return int(math.Ceil(float64(chars) / float64(cursorTranscriptCharsPerToken)))
+}
+
+// cursorTranscriptStateDir is ~/.preloop/agents/cursor/transcripts.
+func cursorTranscriptStateDir() (string, error) {
+	dir, err := permissionHookAgentsDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "cursor", cursorTranscriptStateDirName), nil
+}
+
+var cursorStateKeyUnsafe = regexp.MustCompile(`[^A-Za-z0-9._-]`)
+
+func cursorTranscriptStatePath(key string) (string, error) {
+	dir, err := cursorTranscriptStateDir()
+	if err != nil {
+		return "", err
+	}
+	safe := cursorStateKeyUnsafe.ReplaceAllString(strings.TrimSpace(key), "_")
+	if safe == "" || len(safe) > 200 {
+		sum := sha256.Sum256([]byte(key))
+		safe = hex.EncodeToString(sum[:16])
+	}
+	return filepath.Join(dir, safe+".json"), nil
+}
+
+func loadCursorTranscriptState(key string) (cursorTranscriptState, error) {
+	path, err := cursorTranscriptStatePath(key)
+	if err != nil {
+		return cursorTranscriptState{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cursorTranscriptState{}, nil
+		}
+		return cursorTranscriptState{}, fmt.Errorf("read transcript state: %w", err)
+	}
+	var state cursorTranscriptState
+	if err := json.Unmarshal(data, &state); err != nil {
+		// A corrupt state file must not wedge the conversation: start over
+		// from offset 0 and let the next write repair it.
+		return cursorTranscriptState{}, nil
+	}
+	return state, nil
+}
+
+func saveCursorTranscriptState(key string, state cursorTranscriptState) error {
+	path, err := cursorTranscriptStatePath(key)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create transcript state dir: %w", err)
+	}
+	state.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("write transcript state: %w", err)
+	}
+	return os.Rename(tmp, path)
+}
+
+// pruneCursorTranscriptState removes state files untouched for longer
+// than cursorTranscriptStateMaxAge. Best effort; called on sessionStart.
+func pruneCursorTranscriptState(now time.Time) {
+	dir, err := cursorTranscriptStateDir()
+	if err != nil {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) > cursorTranscriptStateMaxAge {
+			_ = os.Remove(filepath.Join(dir, entry.Name()))
+		}
+	}
+}
+
+// resolveCursorTranscriptPath picks the transcript file for an event:
+// the payload's own path first, then the CURSOR_TRANSCRIPT_PATH
+// environment variable Cursor sets for hook processes.
+func resolveCursorTranscriptPath(payloadPath string) string {
+	if p := strings.TrimSpace(payloadPath); p != "" {
+		return p
+	}
+	return strings.TrimSpace(os.Getenv("CURSOR_TRANSCRIPT_PATH"))
+}
+
+// readCursorTranscriptDelta reads the transcript from offset to the end
+// (bounded by cursorTranscriptMaxDeltaBytes) and classifies every complete
+// line. A trailing partial line is left for the next read unless the
+// file is at EOF, in which case it is consumed as-is.
+func readCursorTranscriptDelta(path string, offset int64, keepText bool) (cursorTranscriptDelta, error) {
+	var delta cursorTranscriptDelta
+	file, err := os.Open(path)
+	if err != nil {
+		return delta, fmt.Errorf("open transcript: %w", err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return delta, fmt.Errorf("stat transcript: %w", err)
+	}
+	if info.IsDir() {
+		return delta, fmt.Errorf("transcript path %s is a directory", path)
+	}
+	if offset < 0 || offset > info.Size() {
+		// The file was truncated or rotated under us: start over.
+		offset = 0
+	}
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		return delta, fmt.Errorf("seek transcript: %w", err)
+	}
+
+	limited := io.LimitReader(file, cursorTranscriptMaxDeltaBytes+1)
+	buf, err := io.ReadAll(limited)
+	if err != nil {
+		return delta, fmt.Errorf("read transcript: %w", err)
+	}
+	if int64(len(buf)) > cursorTranscriptMaxDeltaBytes {
+		delta.Truncated = true
+		buf = buf[:cursorTranscriptMaxDeltaBytes]
+	}
+	atEOF := offset+int64(len(buf)) >= info.Size() && !delta.Truncated
+	if !atEOF {
+		// Consume only complete lines so a half-written record is counted
+		// exactly once, on the next read.
+		if cut := bytes.LastIndexByte(buf, '\n'); cut >= 0 {
+			buf = buf[:cut+1]
+		} else {
+			buf = nil
+		}
+	} else if len(buf) > 0 && buf[len(buf)-1] != '\n' {
+		// Cursor appends records while the agent runs. A trailing JSON
+		// object that does not parse yet is still being written: leave it
+		// for the next read instead of counting a fragment as text.
+		cut := bytes.LastIndexByte(buf, '\n')
+		tail := bytes.TrimSpace(buf[cut+1:])
+		if bytes.HasPrefix(tail, []byte("{")) && !json.Valid(tail) {
+			buf = buf[:cut+1]
+		}
+	}
+	delta.Bytes = int64(len(buf))
+	delta.Consumed = int64(len(buf))
+	classifyCursorTranscriptLines(buf, keepText, &delta)
+	return delta, nil
+}
+
+// cursorTranscriptLine mirrors the fields of one transcript record used
+// for classification.
+type cursorTranscriptLine struct {
+	Role    string `json:"role"`
+	Type    string `json:"type"`
+	Message *struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+	Content json.RawMessage `json:"content"`
+}
+
+type cursorTranscriptBlock struct {
+	Type    string          `json:"type"`
+	Text    string          `json:"text"`
+	Name    string          `json:"name"`
+	Input   json.RawMessage `json:"input"`
+	Content json.RawMessage `json:"content"`
+}
+
+var (
+	cursorPlainAssistantMarker = regexp.MustCompile(`(?i)^\s*(?:#+\s*|\*\*)?(assistant|agent|ai)\b[:*\s]*`)
+	cursorPlainUserMarker      = regexp.MustCompile(`(?i)^\s*(?:#+\s*|\*\*)?(user|human)\b[:*\s]*`)
+)
+
+func classifyCursorTranscriptLines(buf []byte, keepText bool, delta *cursorTranscriptDelta) {
+	scanner := bufio.NewScanner(bytes.NewReader(buf))
+	scanner.Buffer(make([]byte, 0, 64*1024), cursorTranscriptMaxDeltaBytes+1)
+	sawJSON, sawText := false, false
+	plainRole := "user"
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		delta.Lines++
+		if line[0] == '{' {
+			var record cursorTranscriptLine
+			if err := json.Unmarshal(line, &record); err == nil {
+				sawJSON = true
+				classifyCursorJSONLine(record, line, keepText, delta)
+				continue
+			}
+			delta.BadLines++
+		}
+		// Plain text fallback: everything is context the model reads unless
+		// a role marker says the block is the assistant's own output.
+		sawText = true
+		text := string(line)
+		switch {
+		case cursorPlainAssistantMarker.MatchString(text):
+			plainRole = "assistant"
+			text = cursorPlainAssistantMarker.ReplaceAllString(text, "")
+		case cursorPlainUserMarker.MatchString(text):
+			plainRole = "user"
+			text = cursorPlainUserMarker.ReplaceAllString(text, "")
+		}
+		addCursorText(delta, plainRole, text, keepText)
+	}
+	switch {
+	case sawJSON && sawText:
+		delta.Format = "mixed"
+	case sawText:
+		delta.Format = "text"
+	default:
+		delta.Format = "jsonl"
+	}
+}
+
+func classifyCursorJSONLine(record cursorTranscriptLine, raw []byte, keepText bool, delta *cursorTranscriptDelta) {
+	role := strings.ToLower(strings.TrimSpace(record.Role))
+	content := record.Content
+	if record.Message != nil {
+		if role == "" {
+			role = strings.ToLower(strings.TrimSpace(record.Message.Role))
+		}
+		if len(record.Message.Content) > 0 {
+			content = record.Message.Content
+		}
+	}
+	if role == "" {
+		// Control lines ({"type":"turn_ended",...}) are not model traffic.
+		if record.Type != "" {
+			return
+		}
+		// Unknown shape: count it as context rather than drop it.
+		addCursorText(delta, "user", string(raw), keepText)
+		return
+	}
+	if role == "system" || role == "tool" {
+		// Both are context the model reads on the next turn.
+		role = "tool"
+	}
+	if role != "assistant" && role != "user" && role != "tool" {
+		role = "user"
+	}
+
+	var asString string
+	if err := json.Unmarshal(content, &asString); err == nil {
+		addCursorText(delta, role, asString, keepText)
+		return
+	}
+	var blocks []cursorTranscriptBlock
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		addCursorText(delta, role, string(content), keepText)
+		return
+	}
+	for _, block := range blocks {
+		switch block.Type {
+		case "tool_use":
+			delta.ToolUseChars += int64(utf8.RuneCountInString(block.Name)) +
+				int64(utf8.RuneCount(bytes.TrimSpace(block.Input)))
+			if keepText {
+				delta.Messages = append(delta.Messages, cursorTranscriptMessage{
+					Role: "tool_use",
+					Text: block.Name,
+				})
+			}
+		case "tool_result":
+			text := block.Text
+			if text == "" && len(block.Content) > 0 {
+				text = string(block.Content)
+			}
+			addCursorText(delta, "tool", text, keepText)
+		default:
+			// text, thinking, and anything else with a text field.
+			addCursorText(delta, role, block.Text, keepText)
+		}
+	}
+}
+
+func addCursorText(delta *cursorTranscriptDelta, role, text string, keepText bool) {
+	if text == "" {
+		return
+	}
+	chars := int64(utf8.RuneCountInString(text))
+	switch role {
+	case "assistant":
+		delta.AssistantTextChars += chars
+		if strings.TrimSpace(text) != "" {
+			delta.LastAssistantText = text
+		}
+	case "tool":
+		delta.ToolResultChars += chars
+	default:
+		delta.UserChars += chars
+	}
+	if keepText {
+		delta.Messages = append(delta.Messages, cursorTranscriptMessage{Role: role, Text: text})
+	}
+}
+
+// estimateCursorGeneration reads the unshipped transcript delta for one
+// conversation (or subagent), derives the generation's token estimate,
+// and advances the state file. inputSourceOverride, when non-nil, replaces
+// the chars-derived input count (used for preCompact context_tokens).
+//
+// Input for generation N is everything sent as context: the whole
+// transcript before N plus N's own user/tool text. Output is the
+// assistant text and tool calls N produced.
+func estimateCursorGeneration(
+	stateKey, transcriptPath, generationID string, keepText bool,
+) (*cursorTokenEstimate, cursorTranscriptState, error) {
+	state, err := loadCursorTranscriptState(stateKey)
+	if err != nil {
+		return nil, state, err
+	}
+	delta, err := readCursorTranscriptDelta(transcriptPath, state.Offset, keepText)
+	if err != nil {
+		return nil, state, err
+	}
+
+	estimate := &cursorTokenEstimate{Delta: delta}
+	if delta.totalChars() > 0 {
+		contextChars := state.TotalChars + delta.inputChars()
+		estimate.InputTokens = cursorCharsToTokens(contextChars)
+		estimate.InputSource = cursorTokenEstimateMethod
+		if state.PendingContextTokens != nil {
+			estimate.InputTokens = *state.PendingContextTokens
+			estimate.InputSource = "pre_compact_context_tokens"
+		}
+		estimate.OutputTokens = cursorCharsToTokens(delta.outputChars())
+		state.Generations++
+		state.InputTokens += int64(estimate.InputTokens)
+		state.OutputTokens += int64(estimate.OutputTokens)
+	}
+	state.PendingContextTokens = nil
+	state.PendingContextGenerationID = ""
+	state.Offset += delta.Consumed
+	state.TotalChars += delta.totalChars()
+	if generationID != "" {
+		state.LastGenerationID = generationID
+	}
+	if err := saveCursorTranscriptState(stateKey, state); err != nil {
+		return estimate, state, err
+	}
+	return estimate, state, nil
+}
+
+// attachCursorTokenEstimate puts the estimate on an ingest record. Records
+// with an estimate of zero on both sides (nothing new in the transcript)
+// keep their lifecycle meaning and ship without token fields: null stays
+// null, never 0.
+func attachCursorTokenEstimate(record map[string]interface{}, estimate *cursorTokenEstimate) {
+	if estimate == nil {
+		return
+	}
+	metadata, _ := record["metadata"].(map[string]interface{})
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+		record["metadata"] = metadata
+	}
+	if estimate.Delta.totalChars() == 0 {
+		metadata["token_estimate"] = map[string]interface{}{
+			"method":           cursorTokenEstimateMethod,
+			"chars_per_token":  cursorTranscriptCharsPerToken,
+			"transcript_bytes": estimate.Delta.Bytes,
+			"input_source":     "none",
+		}
+		return
+	}
+	record["input_tokens"] = estimate.InputTokens
+	record["output_tokens"] = estimate.OutputTokens
+	metadata["token_estimate"] = estimate.metadata()
+}
+
+// cursorSubagentStateKey keys a subagent transcript's state separately
+// from its parent conversation so the two offsets never collide.
+func cursorSubagentStateKey(input cursorHookInput, transcriptPath string) string {
+	if id := strings.TrimSpace(input.SubagentID); id != "" {
+		return "subagent-" + id
+	}
+	sum := sha256.Sum256([]byte(transcriptPath))
+	return "subagent-" + hex.EncodeToString(sum[:8])
+}

--- a/cli/internal/cmd/usage_hook_cursor_transcript_test.go
+++ b/cli/internal/cmd/usage_hook_cursor_transcript_test.go
@@ -65,6 +65,21 @@ func cursorStopPayload(conversationID, generationID, transcriptPath string) stri
 	return string(data)
 }
 
+func cursorSessionEndPayload(conversationID, generationID, transcriptPath string) string {
+	payload := map[string]interface{}{
+		"conversation_id": conversationID,
+		"generation_id":   generationID,
+		"hook_event_name": "sessionEnd",
+		"model":           "claude-4.5-sonnet",
+		"reason":          "completed",
+	}
+	if transcriptPath != "" {
+		payload["transcript_path"] = transcriptPath
+	}
+	data, _ := json.Marshal(payload)
+	return string(data)
+}
+
 func runCursorHook(t *testing.T, stdin string) (map[string]interface{}, string) {
 	t.Helper()
 	var gotBody map[string]interface{}
@@ -450,9 +465,36 @@ func TestUsageHookCursorStopAfterPreCompactUsesContextTokens(t *testing.T) {
 	}
 }
 
+func TestUsageHookCursorSessionEndWithoutNewTextKeepsPendingContextTokens(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	transcript := copyCursorFixture(t, "conversation.jsonl")
+	runCursorHook(t, cursorStopPayload("conv-9", "gen-1", transcript))
+	runCursorHook(t, cursorPreCompactPayload("conv-9", "gen-2", 121000))
+
+	// sessionEnd fires before the next generation produced any text: the
+	// read finds nothing new, and the pending ground truth must survive
+	// for the first generation of the resumed conversation.
+	runCursorHook(t, cursorSessionEndPayload("conv-9", "gen-2", transcript))
+	state := readCursorState(t, home, "conv-9")
+	if state.PendingContextTokens == nil || *state.PendingContextTokens != 121000 {
+		t.Fatalf("sessionEnd with no new text dropped the pending context tokens: %#v", state)
+	}
+
+	appendCursorFixture(t, transcript, "generation2.jsonl")
+	body, _ := runCursorHook(t, cursorStopPayload("conv-9", "gen-2", transcript))
+	record := decodeSingleIngestRecord(t, body)
+	if record["input_tokens"] != float64(121000) {
+		t.Errorf("the next generation must use the pending ground truth, got %v", record["input_tokens"])
+	}
+	if tokenEstimateMeta(t, record)["input_source"] != "pre_compact_context_tokens" {
+		t.Errorf("input_source=%v", tokenEstimateMeta(t, record)["input_source"])
+	}
+}
+
 // runCursorHookCounting is runCursorHook that also reports how many POSTs
-// reached the server, for events that must not post at all.
-func runCursorHookCounting(t *testing.T, stdin string, args ...string) (map[string]interface{}, int, string) {
+// reached the server, for events that must not post at all, plus what the
+// command wrote to stdout.
+func runCursorHookCounting(t *testing.T, stdin string, args ...string) (map[string]interface{}, int, string, string) {
 	t.Helper()
 	var gotBody map[string]interface{}
 	posts := 0
@@ -460,12 +502,12 @@ func runCursorHookCounting(t *testing.T, stdin string, args ...string) (map[stri
 		posts++
 		usageHookOKHandler(t, &gotBody)(w, r)
 	})
-	cmd, _, stderr := newUsageHookTestCmd(stdin)
+	cmd, stdout, stderr := newUsageHookTestCmd(stdin)
 	cmd.SetArgs(args)
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("hook must exit 0, got %v", err)
 	}
-	return gotBody, posts, stderr.String()
+	return gotBody, posts, stdout.String(), stderr.String()
 }
 
 func TestCursorTitleFromPrompt(t *testing.T) {
@@ -500,7 +542,7 @@ func TestCursorSummaryFromAssistantText(t *testing.T) {
 func TestUsageHookCursorSessionStartShipsDefaultTitle(t *testing.T) {
 	testenv.SetHome(t, t.TempDir())
 	payload := `{"conversation_id":"0f3c9a1e-1111-2222-3333-444444444444","hook_event_name":"sessionStart","model":"claude-4.5-sonnet"}`
-	body, posts, _ := runCursorHookCounting(t, payload)
+	body, posts, _, _ := runCursorHookCounting(t, payload)
 	if posts != 1 {
 		t.Fatalf("expected one POST, got %d", posts)
 	}
@@ -517,9 +559,12 @@ func TestUsageHookCursorSessionStartShipsDefaultTitle(t *testing.T) {
 func TestUsageHookCursorBeforeSubmitPromptCapturesTitleWithoutPosting(t *testing.T) {
 	home := testenv.SetHome(t, t.TempDir())
 	first := `{"conversation_id":"conv-t","generation_id":"g1","hook_event_name":"beforeSubmitPrompt","prompt":"Count the Go files in cli\nand report back"}`
-	_, posts, stderr := runCursorHookCounting(t, first)
+	_, posts, stdout, stderr := runCursorHookCounting(t, first)
 	if posts != 0 {
 		t.Fatalf("beforeSubmitPrompt must not POST, got %d", posts)
+	}
+	if stdout != "{\"continue\":true}\n" {
+		t.Errorf("beforeSubmitPrompt must answer Cursor's JSON contract on stdout, got %q", stdout)
 	}
 	if stderr != "" {
 		t.Errorf("unexpected stderr: %s", stderr)
@@ -535,7 +580,7 @@ func TestUsageHookCursorBeforeSubmitPromptCapturesTitleWithoutPosting(t *testing
 	}
 
 	transcript := copyCursorFixture(t, "conversation.jsonl")
-	body, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-t", "g1", transcript))
+	body, _, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-t", "g1", transcript))
 	record := decodeSingleIngestRecord(t, body)
 	metadata := record["metadata"].(map[string]interface{})
 	if metadata["session_title"] != "Count the Go files in cli" {
@@ -556,7 +601,7 @@ func TestUsageHookCursorBeforeSubmitPromptCapturesTitleWithoutPosting(t *testing
 func TestUsageHookCursorStoreTranscriptFlagShipsDeltaText(t *testing.T) {
 	testenv.SetHome(t, t.TempDir())
 	transcript := copyCursorFixture(t, "conversation.jsonl")
-	body, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-s", "g1", transcript), "--store-transcript")
+	body, _, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-s", "g1", transcript), "--store-transcript")
 	record := decodeSingleIngestRecord(t, body)
 	messages, ok := record["transcript"].([]interface{})
 	if !ok || len(messages) != 4 {
@@ -593,7 +638,7 @@ func TestUsageHookCursorStoreTranscriptFromCredentialFile(t *testing.T) {
 		StoreTranscript: &optIn,
 	})
 	transcript := copyCursorFixture(t, "conversation.jsonl")
-	body, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-c", "g1", transcript))
+	body, _, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-c", "g1", transcript))
 	record := decodeSingleIngestRecord(t, body)
 	if _, ok := record["transcript"]; !ok {
 		t.Errorf("credential store_transcript=true must ship transcript: %#v", record)
@@ -608,7 +653,7 @@ func TestUsageHookCursorCredentialWithoutOptInShipsNoText(t *testing.T) {
 		Source:  permissionSourceCursor,
 	})
 	transcript := copyCursorFixture(t, "conversation.jsonl")
-	body, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-d", "g1", transcript))
+	body, _, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-d", "g1", transcript))
 	record := decodeSingleIngestRecord(t, body)
 	if _, ok := record["transcript"]; ok {
 		t.Errorf("no opt-in must mean no transcript: %#v", record)

--- a/cli/internal/cmd/usage_hook_cursor_transcript_test.go
+++ b/cli/internal/cmd/usage_hook_cursor_transcript_test.go
@@ -356,3 +356,94 @@ func TestUsageHookCursorNoTranscriptAnywhereShipsPlainLifecycle(t *testing.T) {
 		t.Errorf("transcripts disabled is not an error: %q", stderr)
 	}
 }
+
+func cursorPreCompactPayload(conversationID, generationID string, contextTokens int) string {
+	payload := map[string]interface{}{
+		"conversation_id":       conversationID,
+		"generation_id":         generationID,
+		"hook_event_name":       "preCompact",
+		"model":                 "claude-4.5-sonnet",
+		"context_tokens":        contextTokens,
+		"context_window_size":   200000,
+		"context_usage_percent": 60.5,
+		"message_count":         40,
+		"messages_to_compact":   30,
+		"is_first_compaction":   true,
+	}
+	data, _ := json.Marshal(payload)
+	return string(data)
+}
+
+func TestUsageHookCursorPreCompactShipsContextMetadata(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	body, stderr := runCursorHook(t, cursorPreCompactPayload("conv-7", "gen-3", 121000))
+	if stderr != "" {
+		t.Errorf("unexpected stderr: %s", stderr)
+	}
+	record := decodeSingleIngestRecord(t, body)
+	if record["event_type"] != "compaction" || record["message_count"] != float64(40) {
+		t.Errorf("event_type=%v message_count=%v", record["event_type"], record["message_count"])
+	}
+	if _, ok := record["input_tokens"]; ok {
+		t.Errorf("preCompact is a marker, not a usage record: %#v", record)
+	}
+	metadata := record["metadata"].(map[string]interface{})
+	want := map[string]interface{}{
+		"context_tokens":        float64(121000),
+		"context_window_size":   float64(200000),
+		"context_usage_percent": 60.5,
+		"messages_to_compact":   float64(30),
+		"is_first_compaction":   true,
+	}
+	for key, value := range want {
+		if metadata[key] != value {
+			t.Errorf("metadata[%s]=%v, want %v", key, metadata[key], value)
+		}
+	}
+	state := readCursorState(t, home, "conv-7")
+	if state.PendingContextTokens == nil || *state.PendingContextTokens != 121000 {
+		t.Errorf("context tokens not remembered: %#v", state)
+	}
+	if state.PendingContextGenerationID != "gen-3" {
+		t.Errorf("pending generation=%q", state.PendingContextGenerationID)
+	}
+}
+
+func TestUsageHookCursorStopAfterPreCompactUsesContextTokens(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	transcript := copyCursorFixture(t, "conversation.jsonl")
+	runCursorHook(t, cursorStopPayload("conv-8", "gen-1", transcript))
+	runCursorHook(t, cursorPreCompactPayload("conv-8", "gen-2", 121000))
+
+	appendCursorFixture(t, transcript, "generation2.jsonl")
+	body, _ := runCursorHook(t, cursorStopPayload("conv-8", "gen-2", transcript))
+	record := decodeSingleIngestRecord(t, body)
+	// Cursor's own context count replaces the 71-token chars estimate;
+	// output still comes from the transcript delta.
+	if record["input_tokens"] != float64(121000) || record["output_tokens"] != float64(14) {
+		t.Errorf("tokens in=%v out=%v, want 121000/14", record["input_tokens"], record["output_tokens"])
+	}
+	estimate := tokenEstimateMeta(t, record)
+	if estimate["input_source"] != "pre_compact_context_tokens" {
+		t.Errorf("input_source=%v", estimate["input_source"])
+	}
+	if estimate["input_chars"] != float64(26) {
+		t.Errorf("chars still reported for transparency, got %v", estimate["input_chars"])
+	}
+
+	state := readCursorState(t, home, "conv-8")
+	if state.PendingContextTokens != nil {
+		t.Errorf("context tokens must be consumed by one generation: %#v", state)
+	}
+	if state.InputTokens != 28+121000 || state.OutputTokens != 36+14 {
+		t.Errorf("state totals in=%d out=%d", state.InputTokens, state.OutputTokens)
+	}
+
+	// The generation after that falls back to the chars heuristic.
+	appendCursorFixture(t, transcript, "generation2.jsonl")
+	body, _ = runCursorHook(t, cursorStopPayload("conv-8", "gen-3", transcript))
+	record = decodeSingleIngestRecord(t, body)
+	if tokenEstimateMeta(t, record)["input_source"] != "transcript_chars" {
+		t.Errorf("third generation should use chars again: %#v", record)
+	}
+}

--- a/cli/internal/cmd/usage_hook_cursor_transcript_test.go
+++ b/cli/internal/cmd/usage_hook_cursor_transcript_test.go
@@ -1,0 +1,358 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/preloop/preloop/cli/internal/testenv"
+)
+
+const cursorTranscriptFixtureDir = "testdata/cursor-transcripts"
+
+func cursorFixturePath(name string) string {
+	return filepath.Join(cursorTranscriptFixtureDir, name)
+}
+
+// copyCursorFixture copies a fixture into a temp dir so tests can append to
+// it without touching testdata.
+func copyCursorFixture(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(cursorFixturePath(name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write fixture copy: %v", err)
+	}
+	return path
+}
+
+func appendCursorFixture(t *testing.T, target, name string) {
+	t.Helper()
+	data, err := os.ReadFile(cursorFixturePath(name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	file, err := os.OpenFile(target, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatalf("open transcript for append: %v", err)
+	}
+	defer file.Close()
+	if _, err := file.Write(data); err != nil {
+		t.Fatalf("append transcript: %v", err)
+	}
+}
+
+func cursorStopPayload(conversationID, generationID, transcriptPath string) string {
+	payload := map[string]interface{}{
+		"conversation_id": conversationID,
+		"generation_id":   generationID,
+		"hook_event_name": "stop",
+		"model":           "claude-4.5-sonnet",
+		"status":          "completed",
+		"loop_count":      0,
+	}
+	if transcriptPath != "" {
+		payload["transcript_path"] = transcriptPath
+	}
+	data, _ := json.Marshal(payload)
+	return string(data)
+}
+
+func runCursorHook(t *testing.T, stdin string) (map[string]interface{}, string) {
+	t.Helper()
+	var gotBody map[string]interface{}
+	withUsageHookServer(t, usageHookOKHandler(t, &gotBody))
+	cmd, _, stderr := newUsageHookTestCmd(stdin)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hook must exit 0, got %v", err)
+	}
+	return gotBody, stderr.String()
+}
+
+func readCursorState(t *testing.T, home, key string) cursorTranscriptState {
+	t.Helper()
+	path := filepath.Join(home, ".preloop", "agents", "cursor", "transcripts", key+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read state %s: %v", path, err)
+	}
+	var state cursorTranscriptState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("decode state: %v", err)
+	}
+	return state
+}
+
+func tokenEstimateMeta(t *testing.T, record map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	metadata, _ := record["metadata"].(map[string]interface{})
+	estimate, ok := metadata["token_estimate"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected metadata.token_estimate, got %#v", record["metadata"])
+	}
+	return estimate
+}
+
+func TestCursorCharsToTokensCeil(t *testing.T) {
+	cases := map[int64]int{0: 0, 1: 1, 4: 1, 5: 2, 112: 28, 143: 36, 281: 71}
+	for chars, want := range cases {
+		if got := cursorCharsToTokens(chars); got != want {
+			t.Errorf("chars=%d: got %d tokens, want %d", chars, got, want)
+		}
+	}
+}
+
+func TestCursorTranscriptDeltaCountsJSONLFixture(t *testing.T) {
+	delta, err := readCursorTranscriptDelta(cursorFixturePath("conversation.jsonl"), 0, false)
+	if err != nil {
+		t.Fatalf("read delta: %v", err)
+	}
+	if delta.Bytes != 548 || delta.Consumed != 548 {
+		t.Errorf("bytes=%d consumed=%d, want 548/548", delta.Bytes, delta.Consumed)
+	}
+	if delta.Lines != 4 || delta.BadLines != 0 {
+		t.Errorf("lines=%d bad=%d, want 4/0", delta.Lines, delta.BadLines)
+	}
+	if delta.Format != "jsonl" {
+		t.Errorf("format=%q, want jsonl", delta.Format)
+	}
+	if delta.UserChars != 112 || delta.AssistantTextChars != 105 || delta.ToolUseChars != 38 {
+		t.Errorf("chars user=%d assistant=%d tool_use=%d, want 112/105/38",
+			delta.UserChars, delta.AssistantTextChars, delta.ToolUseChars)
+	}
+	if delta.ToolResultChars != 0 {
+		t.Errorf("tool_result chars=%d, want 0 (Cursor transcripts omit tool output)", delta.ToolResultChars)
+	}
+	if !strings.HasPrefix(delta.LastAssistantText, "There are 12 Go files") {
+		t.Errorf("last assistant text=%q", delta.LastAssistantText)
+	}
+	if len(delta.Messages) != 0 {
+		t.Errorf("text must not be retained unless requested, got %d messages", len(delta.Messages))
+	}
+}
+
+func TestCursorTranscriptDeltaPlainTextFallback(t *testing.T) {
+	delta, err := readCursorTranscriptDelta(cursorFixturePath("plain.txt"), 0, false)
+	if err != nil {
+		t.Fatalf("read delta: %v", err)
+	}
+	if delta.Format != "text" {
+		t.Errorf("format=%q, want text", delta.Format)
+	}
+	// "Please rename the variable." (27) + "Thanks" (6) are the user's.
+	if delta.UserChars != 33 {
+		t.Errorf("user chars=%d, want 33", delta.UserChars)
+	}
+	// "Done, renamed foo to bar." (25) + "It compiles." (12) follow the
+	// Assistant marker until the next User marker.
+	if delta.AssistantTextChars != 37 {
+		t.Errorf("assistant chars=%d, want 37", delta.AssistantTextChars)
+	}
+	if cursorCharsToTokens(delta.inputChars()) != 9 || cursorCharsToTokens(delta.outputChars()) != 10 {
+		t.Errorf("tokens in=%d out=%d, want 9/10",
+			cursorCharsToTokens(delta.inputChars()), cursorCharsToTokens(delta.outputChars()))
+	}
+}
+
+func TestCursorTranscriptDeltaLeavesPartialJSONLineForNextRead(t *testing.T) {
+	path := copyCursorFixture(t, "conversation.jsonl")
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(`{"role":"assistant","mess`); err != nil {
+		t.Fatal(err)
+	}
+	file.Close()
+
+	delta, err := readCursorTranscriptDelta(path, 0, false)
+	if err != nil {
+		t.Fatalf("read delta: %v", err)
+	}
+	if delta.Consumed != 548 {
+		t.Errorf("consumed=%d, want 548 (partial line left for next read)", delta.Consumed)
+	}
+	if delta.BadLines != 0 || delta.UserChars != 112 {
+		t.Errorf("partial line leaked into counts: bad=%d user=%d", delta.BadLines, delta.UserChars)
+	}
+}
+
+func TestCursorTranscriptDeltaResumesFromOffset(t *testing.T) {
+	path := copyCursorFixture(t, "conversation.jsonl")
+	appendCursorFixture(t, path, "generation2.jsonl")
+	delta, err := readCursorTranscriptDelta(path, 548, false)
+	if err != nil {
+		t.Fatalf("read delta: %v", err)
+	}
+	if delta.Bytes != 343 || delta.UserChars != 26 || delta.AssistantTextChars != 19 || delta.ToolUseChars != 36 {
+		t.Errorf("delta from offset: bytes=%d user=%d assistant=%d tool_use=%d, want 343/26/19/36",
+			delta.Bytes, delta.UserChars, delta.AssistantTextChars, delta.ToolUseChars)
+	}
+}
+
+func TestUsageHookCursorStopShipsTranscriptEstimate(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	transcript := copyCursorFixture(t, "conversation.jsonl")
+
+	body, stderr := runCursorHook(t, cursorStopPayload("conv-1", "gen-1", transcript))
+	if stderr != "" {
+		t.Errorf("unexpected stderr: %s", stderr)
+	}
+	record := decodeSingleIngestRecord(t, body)
+	if record["event_type"] != "response" || record["cost_basis"] != "estimated" {
+		t.Errorf("event_type=%v cost_basis=%v", record["event_type"], record["cost_basis"])
+	}
+	if record["input_tokens"] != float64(28) || record["output_tokens"] != float64(36) {
+		t.Errorf("tokens in=%v out=%v, want 28/36", record["input_tokens"], record["output_tokens"])
+	}
+	if record["model"] != "claude-4.5-sonnet" {
+		t.Errorf("model=%v", record["model"])
+	}
+	estimate := tokenEstimateMeta(t, record)
+	if estimate["method"] != "transcript_chars" || estimate["chars_per_token"] != float64(4) {
+		t.Errorf("estimate method/cpt wrong: %#v", estimate)
+	}
+	if estimate["transcript_bytes"] != float64(548) || estimate["input_source"] != "transcript_chars" {
+		t.Errorf("estimate bytes/source wrong: %#v", estimate)
+	}
+	if estimate["input_chars"] != float64(112) || estimate["output_chars"] != float64(143) {
+		t.Errorf("estimate chars wrong: %#v", estimate)
+	}
+	// Transcript text must not be in the record anywhere.
+	raw, _ := json.Marshal(body)
+	if strings.Contains(string(raw), "List the Go files") || strings.Contains(string(raw), "There are 12") {
+		t.Errorf("transcript text leaked into the ingest payload: %s", raw)
+	}
+
+	state := readCursorState(t, home, "conv-1")
+	if state.Offset != 548 || state.TotalChars != 255 || state.Generations != 1 {
+		t.Errorf("state offset=%d total_chars=%d generations=%d, want 548/255/1",
+			state.Offset, state.TotalChars, state.Generations)
+	}
+	if state.LastGenerationID != "gen-1" || state.InputTokens != 28 || state.OutputTokens != 36 {
+		t.Errorf("state gen=%q in=%d out=%d", state.LastGenerationID, state.InputTokens, state.OutputTokens)
+	}
+}
+
+func TestUsageHookCursorSecondStopReadsOnlyDelta(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	transcript := copyCursorFixture(t, "conversation.jsonl")
+	runCursorHook(t, cursorStopPayload("conv-2", "gen-1", transcript))
+
+	appendCursorFixture(t, transcript, "generation2.jsonl")
+	body, _ := runCursorHook(t, cursorStopPayload("conv-2", "gen-2", transcript))
+	record := decodeSingleIngestRecord(t, body)
+	// Input re-sends the 255 prior chars plus this turn's 26 user chars.
+	if record["input_tokens"] != float64(71) || record["output_tokens"] != float64(14) {
+		t.Errorf("tokens in=%v out=%v, want 71/14", record["input_tokens"], record["output_tokens"])
+	}
+	estimate := tokenEstimateMeta(t, record)
+	if estimate["transcript_bytes"] != float64(343) {
+		t.Errorf("second read must cover only the delta, got %v bytes", estimate["transcript_bytes"])
+	}
+	state := readCursorState(t, home, "conv-2")
+	if state.Offset != 891 || state.TotalChars != 336 || state.Generations != 2 {
+		t.Errorf("state offset=%d total_chars=%d generations=%d, want 891/336/2",
+			state.Offset, state.TotalChars, state.Generations)
+	}
+}
+
+func TestUsageHookCursorStopWithoutNewTranscriptOmitsTokens(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	transcript := copyCursorFixture(t, "conversation.jsonl")
+	runCursorHook(t, cursorStopPayload("conv-3", "gen-1", transcript))
+
+	body, _ := runCursorHook(t, cursorStopPayload("conv-3", "gen-1", transcript))
+	record := decodeSingleIngestRecord(t, body)
+	if _, ok := record["input_tokens"]; ok {
+		t.Errorf("no new transcript must mean no token fields (null, never 0): %#v", record)
+	}
+	estimate := tokenEstimateMeta(t, record)
+	if estimate["input_source"] != "none" || estimate["transcript_bytes"] != float64(0) {
+		t.Errorf("estimate should report nothing new: %#v", estimate)
+	}
+}
+
+func TestUsageHookCursorSubagentStopUsesAgentTranscript(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	transcript := copyCursorFixture(t, "subagent.jsonl")
+	payload := map[string]interface{}{
+		"conversation_id":       "conv-parent",
+		"generation_id":         "gen-9",
+		"hook_event_name":       "subagentStop",
+		"model":                 "claude-4.5-sonnet",
+		"subagent_id":           "sub-42",
+		"subagent_type":         "generalPurpose",
+		"status":                "completed",
+		"message_count":         3,
+		"tool_call_count":       1,
+		"agent_transcript_path": transcript,
+	}
+	stdin, _ := json.Marshal(payload)
+	body, stderr := runCursorHook(t, string(stdin))
+	if stderr != "" {
+		t.Errorf("unexpected stderr: %s", stderr)
+	}
+	record := decodeSingleIngestRecord(t, body)
+	if record["event_type"] != "subagent_stop" {
+		t.Errorf("event_type=%v", record["event_type"])
+	}
+	if record["input_tokens"] != float64(10) || record["output_tokens"] != float64(21) {
+		t.Errorf("tokens in=%v out=%v, want 10/21", record["input_tokens"], record["output_tokens"])
+	}
+	if record["message_count"] != float64(3) || record["tool_call_count"] != float64(1) {
+		t.Errorf("counters lost: %#v", record)
+	}
+	state := readCursorState(t, home, "subagent-sub-42")
+	if state.Offset != 383 {
+		t.Errorf("subagent state offset=%d, want 383", state.Offset)
+	}
+}
+
+func TestUsageHookCursorMissingTranscriptStillShipsLifecycle(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	missing := filepath.Join(t.TempDir(), "gone.jsonl")
+	body, stderr := runCursorHook(t, cursorStopPayload("conv-4", "gen-1", missing))
+	record := decodeSingleIngestRecord(t, body)
+	if record["event_type"] != "response" {
+		t.Errorf("lifecycle record must still ship: %#v", record)
+	}
+	if _, ok := record["input_tokens"]; ok {
+		t.Errorf("no transcript must mean no tokens: %#v", record)
+	}
+	if !strings.Contains(stderr, "transcript estimate skipped") {
+		t.Errorf("expected a stderr note, got %q", stderr)
+	}
+}
+
+func TestUsageHookCursorTranscriptEnvFallback(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	transcript := copyCursorFixture(t, "conversation.jsonl")
+	t.Setenv("CURSOR_TRANSCRIPT_PATH", transcript)
+	body, _ := runCursorHook(t, cursorStopPayload("conv-5", "gen-1", ""))
+	record := decodeSingleIngestRecord(t, body)
+	if record["input_tokens"] != float64(28) {
+		t.Errorf("env fallback not used: %#v", record)
+	}
+}
+
+func TestUsageHookCursorNoTranscriptAnywhereShipsPlainLifecycle(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv("CURSOR_TRANSCRIPT_PATH", "")
+	body, stderr := runCursorHook(t, cursorStopPayload("conv-6", "gen-1", ""))
+	record := decodeSingleIngestRecord(t, body)
+	if _, ok := record["input_tokens"]; ok {
+		t.Errorf("unexpected tokens: %#v", record)
+	}
+	if _, ok := record["metadata"].(map[string]interface{})["token_estimate"]; ok {
+		t.Errorf("no transcript means no token_estimate block: %#v", record)
+	}
+	if stderr != "" {
+		t.Errorf("transcripts disabled is not an error: %q", stderr)
+	}
+}

--- a/cli/internal/cmd/usage_hook_cursor_transcript_test.go
+++ b/cli/internal/cmd/usage_hook_cursor_transcript_test.go
@@ -18,6 +18,15 @@ func cursorFixturePath(name string) string {
 	return filepath.Join(cursorTranscriptFixtureDir, name)
 }
 
+func cursorFixtureSize(t *testing.T, name string) int64 {
+	t.Helper()
+	data, err := os.ReadFile(cursorFixturePath(name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return int64(len(data))
+}
+
 // copyCursorFixture copies a fixture into a temp dir so tests can append to
 // it without touching testdata.
 func copyCursorFixture(t *testing.T, name string) string {
@@ -129,8 +138,9 @@ func TestCursorTranscriptDeltaCountsJSONLFixture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read delta: %v", err)
 	}
-	if delta.Bytes != 548 || delta.Consumed != 548 {
-		t.Errorf("bytes=%d consumed=%d, want 548/548", delta.Bytes, delta.Consumed)
+	wantBytes := cursorFixtureSize(t, "conversation.jsonl")
+	if delta.Bytes != wantBytes || delta.Consumed != wantBytes {
+		t.Errorf("bytes=%d consumed=%d, want %d/%d", delta.Bytes, delta.Consumed, wantBytes, wantBytes)
 	}
 	if delta.Lines != 4 || delta.BadLines != 0 {
 		t.Errorf("lines=%d bad=%d, want 4/0", delta.Lines, delta.BadLines)
@@ -191,8 +201,9 @@ func TestCursorTranscriptDeltaLeavesPartialJSONLineForNextRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read delta: %v", err)
 	}
-	if delta.Consumed != 548 {
-		t.Errorf("consumed=%d, want 548 (partial line left for next read)", delta.Consumed)
+	wantConsumed := cursorFixtureSize(t, "conversation.jsonl")
+	if delta.Consumed != wantConsumed {
+		t.Errorf("consumed=%d, want %d (partial line left for next read)", delta.Consumed, wantConsumed)
 	}
 	if delta.BadLines != 0 || delta.UserChars != 112 {
 		t.Errorf("partial line leaked into counts: bad=%d user=%d", delta.BadLines, delta.UserChars)
@@ -202,13 +213,15 @@ func TestCursorTranscriptDeltaLeavesPartialJSONLineForNextRead(t *testing.T) {
 func TestCursorTranscriptDeltaResumesFromOffset(t *testing.T) {
 	path := copyCursorFixture(t, "conversation.jsonl")
 	appendCursorFixture(t, path, "generation2.jsonl")
-	delta, err := readCursorTranscriptDelta(path, 548, false)
+	offset := cursorFixtureSize(t, "conversation.jsonl")
+	wantBytes := cursorFixtureSize(t, "generation2.jsonl")
+	delta, err := readCursorTranscriptDelta(path, offset, false)
 	if err != nil {
 		t.Fatalf("read delta: %v", err)
 	}
-	if delta.Bytes != 343 || delta.UserChars != 26 || delta.AssistantTextChars != 19 || delta.ToolUseChars != 36 {
-		t.Errorf("delta from offset: bytes=%d user=%d assistant=%d tool_use=%d, want 343/26/19/36",
-			delta.Bytes, delta.UserChars, delta.AssistantTextChars, delta.ToolUseChars)
+	if delta.Bytes != wantBytes || delta.UserChars != 26 || delta.AssistantTextChars != 19 || delta.ToolUseChars != 36 {
+		t.Errorf("delta from offset: bytes=%d user=%d assistant=%d tool_use=%d, want %d/26/19/36",
+			delta.Bytes, delta.UserChars, delta.AssistantTextChars, delta.ToolUseChars, wantBytes)
 	}
 }
 
@@ -234,7 +247,8 @@ func TestUsageHookCursorStopShipsTranscriptEstimate(t *testing.T) {
 	if estimate["method"] != "transcript_chars" || estimate["chars_per_token"] != float64(4) {
 		t.Errorf("estimate method/cpt wrong: %#v", estimate)
 	}
-	if estimate["transcript_bytes"] != float64(548) || estimate["input_source"] != "transcript_chars" {
+	wantBytes := cursorFixtureSize(t, "conversation.jsonl")
+	if estimate["transcript_bytes"] != float64(wantBytes) || estimate["input_source"] != "transcript_chars" {
 		t.Errorf("estimate bytes/source wrong: %#v", estimate)
 	}
 	if estimate["input_chars"] != float64(112) || estimate["output_chars"] != float64(143) {
@@ -247,9 +261,10 @@ func TestUsageHookCursorStopShipsTranscriptEstimate(t *testing.T) {
 	}
 
 	state := readCursorState(t, home, "conv-1")
-	if state.Offset != 548 || state.TotalChars != 255 || state.Generations != 1 {
-		t.Errorf("state offset=%d total_chars=%d generations=%d, want 548/255/1",
-			state.Offset, state.TotalChars, state.Generations)
+	wantOffset := cursorFixtureSize(t, "conversation.jsonl")
+	if state.Offset != wantOffset || state.TotalChars != 255 || state.Generations != 1 {
+		t.Errorf("state offset=%d total_chars=%d generations=%d, want %d/255/1",
+			state.Offset, state.TotalChars, state.Generations, wantOffset)
 	}
 	if state.LastGenerationID != "gen-1" || state.InputTokens != 28 || state.OutputTokens != 36 {
 		t.Errorf("state gen=%q in=%d out=%d", state.LastGenerationID, state.InputTokens, state.OutputTokens)
@@ -269,13 +284,15 @@ func TestUsageHookCursorSecondStopReadsOnlyDelta(t *testing.T) {
 		t.Errorf("tokens in=%v out=%v, want 71/14", record["input_tokens"], record["output_tokens"])
 	}
 	estimate := tokenEstimateMeta(t, record)
-	if estimate["transcript_bytes"] != float64(343) {
+	wantDelta := cursorFixtureSize(t, "generation2.jsonl")
+	if estimate["transcript_bytes"] != float64(wantDelta) {
 		t.Errorf("second read must cover only the delta, got %v bytes", estimate["transcript_bytes"])
 	}
 	state := readCursorState(t, home, "conv-2")
-	if state.Offset != 891 || state.TotalChars != 336 || state.Generations != 2 {
-		t.Errorf("state offset=%d total_chars=%d generations=%d, want 891/336/2",
-			state.Offset, state.TotalChars, state.Generations)
+	wantOffset := cursorFixtureSize(t, "conversation.jsonl") + wantDelta
+	if state.Offset != wantOffset || state.TotalChars != 336 || state.Generations != 2 {
+		t.Errorf("state offset=%d total_chars=%d generations=%d, want %d/336/2",
+			state.Offset, state.TotalChars, state.Generations, wantOffset)
 	}
 }
 
@@ -326,8 +343,9 @@ func TestUsageHookCursorSubagentStopUsesAgentTranscript(t *testing.T) {
 		t.Errorf("counters lost: %#v", record)
 	}
 	state := readCursorState(t, home, "subagent-sub-42")
-	if state.Offset != 383 {
-		t.Errorf("subagent state offset=%d, want 383", state.Offset)
+	wantOffset := cursorFixtureSize(t, "subagent.jsonl")
+	if state.Offset != wantOffset {
+		t.Errorf("subagent state offset=%d, want %d", state.Offset, wantOffset)
 	}
 }
 

--- a/cli/internal/cmd/usage_hook_cursor_transcript_test.go
+++ b/cli/internal/cmd/usage_hook_cursor_transcript_test.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/preloop/preloop/cli/internal/testenv"
 )
@@ -445,5 +447,170 @@ func TestUsageHookCursorStopAfterPreCompactUsesContextTokens(t *testing.T) {
 	record = decodeSingleIngestRecord(t, body)
 	if tokenEstimateMeta(t, record)["input_source"] != "transcript_chars" {
 		t.Errorf("third generation should use chars again: %#v", record)
+	}
+}
+
+// runCursorHookCounting is runCursorHook that also reports how many POSTs
+// reached the server, for events that must not post at all.
+func runCursorHookCounting(t *testing.T, stdin string, args ...string) (map[string]interface{}, int, string) {
+	t.Helper()
+	var gotBody map[string]interface{}
+	posts := 0
+	withUsageHookServer(t, func(w http.ResponseWriter, r *http.Request) {
+		posts++
+		usageHookOKHandler(t, &gotBody)(w, r)
+	})
+	cmd, _, stderr := newUsageHookTestCmd(stdin)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hook must exit 0, got %v", err)
+	}
+	return gotBody, posts, stderr.String()
+}
+
+func TestCursorTitleFromPrompt(t *testing.T) {
+	cases := map[string]string{
+		"":                                 "",
+		"\n\n  Fix the   flaky test\nmore": "Fix the flaky test",
+		strings.Repeat("x", 130):           strings.Repeat("x", 117) + "...",
+		"<user_query>\nRename foo\n</user_query>": "<user_query>",
+	}
+	for prompt, want := range cases {
+		if got := cursorTitleFromPrompt(prompt); got != want {
+			t.Errorf("prompt %q: got %q, want %q", prompt, got, want)
+		}
+	}
+}
+
+func TestCursorSummaryFromAssistantText(t *testing.T) {
+	text := "There are 12 Go files in cli.\n\nThat is the whole count; nothing else changed.\n\n"
+	if got := cursorSummaryFromAssistantText(text); got != "That is the whole count; nothing else changed." {
+		t.Errorf("summary=%q", got)
+	}
+	long := strings.Repeat("word ", 100)
+	got := cursorSummaryFromAssistantText(long)
+	if utf8.RuneCountInString(got) != 280 || !strings.HasSuffix(got, "...") {
+		t.Errorf("summary not truncated to 280 with ellipsis: len=%d", utf8.RuneCountInString(got))
+	}
+	if cursorSummaryFromAssistantText("  \n\n ") != "" {
+		t.Error("blank text must give no summary")
+	}
+}
+
+func TestUsageHookCursorSessionStartShipsDefaultTitle(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	payload := `{"conversation_id":"0f3c9a1e-1111-2222-3333-444444444444","hook_event_name":"sessionStart","model":"claude-4.5-sonnet"}`
+	body, posts, _ := runCursorHookCounting(t, payload)
+	if posts != 1 {
+		t.Fatalf("expected one POST, got %d", posts)
+	}
+	record := decodeSingleIngestRecord(t, body)
+	metadata := record["metadata"].(map[string]interface{})
+	if metadata["session_title_default"] != "Cursor conversation 0f3c9a1e" {
+		t.Errorf("default title=%v", metadata["session_title_default"])
+	}
+	if _, ok := metadata["session_title"]; ok {
+		t.Errorf("sessionStart has no real title yet: %#v", metadata)
+	}
+}
+
+func TestUsageHookCursorBeforeSubmitPromptCapturesTitleWithoutPosting(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	first := `{"conversation_id":"conv-t","generation_id":"g1","hook_event_name":"beforeSubmitPrompt","prompt":"Count the Go files in cli\nand report back"}`
+	_, posts, stderr := runCursorHookCounting(t, first)
+	if posts != 0 {
+		t.Fatalf("beforeSubmitPrompt must not POST, got %d", posts)
+	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr: %s", stderr)
+	}
+	if state := readCursorState(t, home, "conv-t"); state.Title != "Count the Go files in cli" {
+		t.Errorf("title=%q", state.Title)
+	}
+
+	second := `{"conversation_id":"conv-t","generation_id":"g2","hook_event_name":"beforeSubmitPrompt","prompt":"Now delete one"}`
+	runCursorHookCounting(t, second)
+	if state := readCursorState(t, home, "conv-t"); state.Title != "Count the Go files in cli" {
+		t.Errorf("first prompt line must stay the title, got %q", state.Title)
+	}
+
+	transcript := copyCursorFixture(t, "conversation.jsonl")
+	body, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-t", "g1", transcript))
+	record := decodeSingleIngestRecord(t, body)
+	metadata := record["metadata"].(map[string]interface{})
+	if metadata["session_title"] != "Count the Go files in cli" {
+		t.Errorf("stop must carry the captured title: %#v", metadata)
+	}
+	if metadata["session_summary"] != "That is the whole count; nothing else changed." {
+		t.Errorf("stop must carry the last assistant paragraph: %#v", metadata)
+	}
+	if _, ok := record["transcript"]; ok {
+		t.Errorf("transcript text must not ship by default: %#v", record)
+	}
+	raw, _ := json.Marshal(body)
+	if strings.Contains(string(raw), "List the Go files in cli and count them") {
+		t.Errorf("prompt text leaked: %s", raw)
+	}
+}
+
+func TestUsageHookCursorStoreTranscriptFlagShipsDeltaText(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	transcript := copyCursorFixture(t, "conversation.jsonl")
+	body, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-s", "g1", transcript), "--store-transcript")
+	record := decodeSingleIngestRecord(t, body)
+	messages, ok := record["transcript"].([]interface{})
+	if !ok || len(messages) != 4 {
+		t.Fatalf("expected 4 transcript messages, got %#v", record["transcript"])
+	}
+	roles := make([]string, 0, len(messages))
+	for _, raw := range messages {
+		message := raw.(map[string]interface{})
+		roles = append(roles, message["role"].(string))
+	}
+	if strings.Join(roles, ",") != "user,assistant,tool_use,assistant" {
+		t.Errorf("roles=%v", roles)
+	}
+	last := messages[3].(map[string]interface{})
+	if !strings.HasPrefix(last["text"].(string), "There are 12 Go files") {
+		t.Errorf("last message=%v", last)
+	}
+	if messages[2].(map[string]interface{})["text"] != "Shell" {
+		t.Errorf("tool_use ships the tool name only: %v", messages[2])
+	}
+	// Token estimate is unaffected by the opt-in.
+	if record["input_tokens"] != float64(28) || record["output_tokens"] != float64(36) {
+		t.Errorf("tokens changed with opt-in: %#v", record)
+	}
+}
+
+func TestUsageHookCursorStoreTranscriptFromCredentialFile(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	optIn := true
+	writeTestPermissionCredential(t, home, "cursor-abc123", permissionHookCredential{
+		BaseURL:         "https://preloop.example",
+		Token:           "agt_test",
+		Source:          permissionSourceCursor,
+		StoreTranscript: &optIn,
+	})
+	transcript := copyCursorFixture(t, "conversation.jsonl")
+	body, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-c", "g1", transcript))
+	record := decodeSingleIngestRecord(t, body)
+	if _, ok := record["transcript"]; !ok {
+		t.Errorf("credential store_transcript=true must ship transcript: %#v", record)
+	}
+}
+
+func TestUsageHookCursorCredentialWithoutOptInShipsNoText(t *testing.T) {
+	home := testenv.SetHome(t, t.TempDir())
+	writeTestPermissionCredential(t, home, "cursor-abc123", permissionHookCredential{
+		BaseURL: "https://preloop.example",
+		Token:   "agt_test",
+		Source:  permissionSourceCursor,
+	})
+	transcript := copyCursorFixture(t, "conversation.jsonl")
+	body, _, _ := runCursorHookCounting(t, cursorStopPayload("conv-d", "g1", transcript))
+	record := decodeSingleIngestRecord(t, body)
+	if _, ok := record["transcript"]; ok {
+		t.Errorf("no opt-in must mean no transcript: %#v", record)
 	}
 }

--- a/cli/internal/cmd/usage_hook_test.go
+++ b/cli/internal/cmd/usage_hook_test.go
@@ -314,8 +314,14 @@ func TestUsageHookSkipsNonLifecycleEventsWithoutPosting(t *testing.T) {
 		if posted {
 			t.Fatalf("%s must not be shipped", hookEvent)
 		}
-		if stdout.String() != "" || stderr.String() != "" {
-			t.Fatalf("expected silence for %s, got stdout=%q stderr=%q",
+		// beforeSubmitPrompt is the one event whose contract reads a JSON
+		// decision from stdout; every other event stays silent.
+		wantStdout := ""
+		if hookEvent == "beforeSubmitPrompt" {
+			wantStdout = "{\"continue\":true}\n"
+		}
+		if stdout.String() != wantStdout || stderr.String() != "" {
+			t.Fatalf("unexpected output for %s, got stdout=%q stderr=%q",
 				hookEvent, stdout.String(), stderr.String())
 		}
 	}

--- a/cli/internal/cmd/usage_hook_test.go
+++ b/cli/internal/cmd/usage_hook_test.go
@@ -21,6 +21,7 @@ func newUsageHookTestCmd(stdin string) (*cobra.Command, *bytes.Buffer, *bytes.Bu
 	cmd.Flags().String("parent-conversation-id", "", "")
 	cmd.Flags().String("from", "auto", "")
 	cmd.Flags().String("file", "", "")
+	cmd.Flags().Bool("store-transcript", false, "")
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}

--- a/docs/guide/cursor-cli.md
+++ b/docs/guide/cursor-cli.md
@@ -52,7 +52,9 @@ Structured usage is not available in this mode. Cursor's CLI documents
 `--output-format` as valid only with `--print` (non-interactive). v1
 does not try to scrape the TUI.
 
-To record editor chats as they happen, wire `preloop usage hook` instead.
+To record editor chats as they happen, onboard Cursor instead:
+`preloop agents onboard Cursor` installs the `preloop usage hook` entries
+that store each conversation as a runtime session with a token estimate.
 
 ## Headless capture: `preloop cursor run`
 
@@ -124,7 +126,9 @@ know this run was spawned from another conversation.
 
 ## Related commands
 
-- `preloop usage hook` ships editor hook lifecycle events (no tokens).
+- `preloop usage hook` ships editor hook lifecycle events with a
+  transcript-derived token estimate and stores conversations as runtime
+  sessions (installed by `preloop agents onboard Cursor`).
 - `preloop usage import` records billed Cursor dashboard exports as
   imported spend. Reconciled per-conversation amounts supersede these
   estimates in Cost analytics summaries; the two bases are never summed.

--- a/docs/guide/cursor-usage-hooks.md
+++ b/docs/guide/cursor-usage-hooks.md
@@ -4,8 +4,10 @@ This page moved to the harness-agnostic guide:
 
 [Usage hooks](usage-hooks.md)
 
-The Cursor section there is the same wiring as before: put
-`preloop usage hook` in `hooks.json` for `sessionStart`, `sessionEnd`,
-`subagentStart`, `subagentStop`, `stop`, and `preCompact`. Generic
-harness events and Codex CLI session imports are documented on that
-page as well.
+`preloop agents onboard Cursor` now installs the `preloop usage hook`
+entries in `hooks.json` for `sessionStart`, `sessionEnd`, `subagentStart`,
+`subagentStop`, `stop`, `preCompact` and `beforeSubmitPrompt`. Each
+conversation is stored as a runtime session with a transcript-derived
+token and cost estimate; transcript text is shipped only with
+`--store-transcript`. Generic harness events and Codex CLI session imports
+are documented on that page as well.

--- a/docs/guide/usage-hooks.md
+++ b/docs/guide/usage-hooks.md
@@ -125,6 +125,11 @@ sources fill the gap:
   the compaction record's metadata and uses it as `input_tokens` for the
   next generation (`input_source: pre_compact_context_tokens`).
 
+The estimate also biases the other way after a compaction: the transcript
+keeps growing while Cursor's real context shrank, so chars-based input is
+overstated until the next `preCompact` replaces it with Cursor's own
+count.
+
 The server prices estimated records that carry tokens through the model
 pricing catalog. Cursor's version-first Claude spellings are mapped onto
 catalog keys (`claude-4.5-sonnet` prices as `claude-sonnet-4-5`). The
@@ -229,7 +234,7 @@ decides from `hook_event_name` what to do.
 | `subagentStop` | `subagent_stop` | Ships the documented `message_count` and `tool_call_count`, plus a token estimate from `agent_transcript_path`. |
 | `stop` | `response` | Token estimate, session title and summary. Fires when the agent loop finishes responding. |
 | `preCompact` | `compaction` | `context_tokens`, `context_window_size`, `context_usage_percent`, `messages_to_compact` and `is_first_compaction` in metadata; `message_count` as a column. |
-| `beforeSubmitPrompt` | not shipped | The first prompt line is kept locally for the session title; the prompt is otherwise ignored. |
+| `beforeSubmitPrompt` | not shipped | The first prompt line is kept locally for the session title; the prompt is otherwise ignored. Answers `{"continue": true}` on stdout, the decision JSON this event's contract expects. |
 | any other event | not shipped | Permission, file, and thought hooks would inflate event counts without adding cost signal. The command acknowledges them and exits 0. |
 
 Deduplication: the server deduplicates on `(source, external_id)`.
@@ -360,7 +365,10 @@ preloop usage hook --from codex < ~/.codex/sessions/2026/08/31/rollout-....jsonl
 
 Stdin is capped at 1 MiB (the same bound as live hooks). Use `--file`
 for larger rollouts. `--source` defaults to `codex` in this mode so the
-ingest API can attribute events to the onboarded Codex agent.
+ingest API can attribute events to the onboarded Codex agent. Every
+shipped record carries the thread's conversation id, so importing a
+historical rollout also registers the thread as a runtime session (source
+type `codex`) and populates the sessions explorer.
 
 ### Event mapping
 
@@ -383,8 +391,10 @@ The command is fail-open by design:
   stall). File imports use the CLI's default API timeout
 - any error (server unreachable, expired login, malformed payload) is
   printed to stderr and the command still exits 0
-- stdin hooks write nothing to stdout. `--file` prints a one-line
-  shipment summary
+- stdin hooks write nothing to stdout, except Cursor's
+  `beforeSubmitPrompt`, which answers `{"continue": true}` so Cursor
+  never treats the hook as failed. `--file` prints a one-line shipment
+  summary
 
 A failed shipment means missing events, nothing more.
 

--- a/docs/guide/usage-hooks.md
+++ b/docs/guide/usage-hooks.md
@@ -25,9 +25,13 @@ in the console), never as 0 or $0.00. Estimated and reconciled amounts
 are always displayed separately and are never summed together.
 
 Privacy: the shipper sends ids, event names, the reported model name,
-token counts, billed amounts when the source provided them, and small
-metadata. It never sends prompt text, task descriptions, file paths,
-shell commands, or workspace contents.
+token counts (reported or estimated), billed amounts when the source
+provided them, and small metadata. For Cursor it also sends a session
+title (the first line of the first prompt) and a short summary (the last
+assistant paragraph, 280 characters) so the runtime sessions list is
+readable; transcript text itself is shipped only when you opt in with
+`--store-transcript`. It never sends file paths, shell commands, or
+workspace contents.
 
 ## Generic event schema (`preloop.usage.event.v1`)
 
@@ -85,52 +89,128 @@ Example with a billed ledger amount:
 ## Cursor
 
 Cursor's bundled models never pass through the Preloop model gateway, so
-Preloop cannot meter that traffic itself. Wired into Cursor's hooks, this
-command ships conversation lifecycle events as they happen.
+Preloop cannot meter that traffic itself; Cursor's agent hooks are the
+only signal. Wired into them, this command stores every conversation as
+a runtime session and ships a per-generation token and cost estimate.
 
 Hook payload fields referenced below come from Cursor's hooks reference
-(https://cursor.com/docs/agent/hooks, checked 2026-08-27).
+(https://cursor.com/docs/agent/hooks, checked 2026-09-05).
 
 For headless cursor-agent runs, the [`preloop cursor` launcher](cursor-cli.md)
 captures print-mode output and ships estimated usage without any hook
 configuration.
 
-Cursor hook payloads carry no token counts and no billed amounts. This
-integration therefore records lifecycle facts only:
+### What Cursor reports, and what is estimated
 
-- which conversations were active, and when
-- session, response, subagent, and compaction lifecycle events
-- parent and child conversation links (`parent_conversation_id` from
-  `subagentStart` payloads)
-- message and tool-call counters where Cursor reports them
-  (`subagentStop`), as growth tripwires
+Cursor hook payloads carry no token counts and no billed amounts. Two
+sources fill the gap:
 
-Billed amounts enter the system only through a reconciled import (for
-example a Cursor dashboard Usage export via `preloop usage import`).
+- Transcript-derived estimate. Every agent hook names the conversation
+  transcript (`transcript_path`; the process environment also carries
+  `CURSOR_TRANSCRIPT_PATH`), and `subagentStop` names the subagent's own
+  transcript (`agent_transcript_path`). At `stop`, `sessionEnd` and
+  `subagentStop` the command reads the transcript from the last shipped
+  byte offset, splits the new text by role, and ships
+  `input_tokens = ceil(context characters / 4)` and
+  `output_tokens = ceil(assistant characters / 4)`. The context is the
+  whole transcript before the generation plus the generation's own prompt
+  and tool results, because Cursor re-sends the conversation each turn;
+  the output is the assistant text plus its tool calls. The divisor is
+  the same chars-per-token heuristic the gateway budget preflight uses
+  (`billing_budget_chars_per_token`, default 4), so client and server
+  numbers agree. Each record's `metadata.token_estimate` names the method
+  (`transcript_chars`), the divisor, the bytes read and the input source.
+- Cursor's own context count. `preCompact` reports `context_tokens`, the
+  only real token figure any Cursor hook carries. The command ships it in
+  the compaction record's metadata and uses it as `input_tokens` for the
+  next generation (`input_source: pre_compact_context_tokens`).
+
+The server prices estimated records that carry tokens through the model
+pricing catalog. Cursor's version-first Claude spellings are mapped onto
+catalog keys (`claude-4.5-sonnet` prices as `claude-sonnet-4-5`). The
+amount lands on the `estimated` basis with `cost_source: catalog`; models
+the catalog does not know (for example `composer` or `auto`) stay
+unpriced, never $0. A later reconciled import (a Cursor dashboard Usage
+export via `preloop usage import`) supersedes the estimates for the same
+conversation and is never summed with them.
+
+Per-conversation offsets live in
+`~/.preloop/agents/cursor/transcripts/<conversation_id>.json` (offset,
+last generation, running totals, pending context tokens, title). Files
+untouched for 30 days are pruned at the next `sessionStart`. Reads are
+bounded to the delta since the last offset (8 MiB per hook process).
+
+Transcript format, checked 2026-09-05 against 169 local files under
+`~/.cursor/projects/<workspace>/agent-transcripts/<conversation_id>/`
+(subagents under `subagents/<subagent_id>.jsonl`): JSONL, one
+`{"role": "user" | "assistant", "message": {"content": [...]}}` object per
+line with `text` and `tool_use` content blocks, plus role-less control
+lines such as `{"type": "turn_ended", "status": "success"}`. Tool output
+is not recorded. Half-written trailing lines are left for the next read.
+The parser also accepts a plain-text transcript: everything counts as
+input except lines under an `Assistant:` marker.
+
+### Sessions
+
+Every conversation is stored as a runtime session (source type `cursor`,
+source id `conversation_id`, principal = the managed Cursor agent the
+records are attributed to). It appears in the runtime sessions explorer
+next to gateway-metered sessions:
+
+- `sessionStart` opens the session with the title
+  "Cursor conversation <short id>".
+- `beforeSubmitPrompt` keeps the first line of the first prompt locally.
+  Nothing is posted for this event and the prompt is otherwise ignored.
+  The next `stop` sends that line as the session title.
+- `stop` advances the session's last activity and sets its summary to
+  the last assistant paragraph (280 characters).
+- `sessionEnd` closes the session.
+
+By default only counts, the title and that short summary leave the
+machine, matching the Claude Code plugin's summaries-only design. Full
+transcript text is opt-in: `preloop usage hook --store-transcript` (or
+`preloop agents onboard Cursor --store-transcript`, which puts the flag
+in `hooks.json` and records `store_transcript: true` in the hook
+credential file) ships the new transcript text with each `stop` as
+`transcript_message` activities on the session, capped at 50 messages
+and 64 KiB per record.
 
 ### Prerequisites
 
 1. The Preloop CLI installed and logged in (`preloop login`), with a user
    allowed to import usage.
-2. A managed Cursor agent to attribute events to. Either onboard one with
-   `preloop agents onboard cursor`, or pass `--agent-id` explicitly.
+2. A managed Cursor agent to attribute events to:
+   `preloop agents onboard Cursor`.
 
 ### Configure Cursor
 
-Cursor reads hook configuration from `hooks.json`, either user wide at
-`~/.cursor/hooks.json` or per project at `<project>/.cursor/hooks.json`.
-Create or extend it:
+`preloop agents onboard Cursor` installs the usage hooks in
+`~/.cursor/hooks.json` for `sessionStart`, `sessionEnd`, `subagentStart`,
+`subagentStop`, `stop`, `preCompact` and `beforeSubmitPrompt`, each running
+`<absolute path to preloop> usage hook --from cursor` with a 5 second
+timeout. The install is idempotent, keeps entries it does not own, and
+`preloop agents offboard Cursor` removes exactly its own entries. Flags:
+
+- `--no-usage-hooks` skips the usage hooks (approval hooks are unaffected).
+- `--store-transcript` opts into transcript storage (see Sessions).
+- Re-run `preloop agents onboard Cursor` to change either choice.
+
+To wire the hooks by hand instead, create or extend `hooks.json` (user
+wide at `~/.cursor/hooks.json` or per project at
+`<project>/.cursor/hooks.json`), using the absolute path of the binary
+so Cursor's PATH does not matter:
 
 ```json
 {
   "version": 1,
   "hooks": {
-    "sessionStart": [{ "command": "preloop usage hook" }],
-    "sessionEnd": [{ "command": "preloop usage hook" }],
-    "subagentStart": [{ "command": "preloop usage hook" }],
-    "subagentStop": [{ "command": "preloop usage hook" }],
-    "stop": [{ "command": "preloop usage hook" }],
-    "preCompact": [{ "command": "preloop usage hook" }]
+    "sessionStart": [{ "command": "/usr/local/bin/preloop usage hook --from cursor", "timeout": 5 }],
+    "sessionEnd": [{ "command": "/usr/local/bin/preloop usage hook --from cursor", "timeout": 5 }],
+    "subagentStart": [{ "command": "/usr/local/bin/preloop usage hook --from cursor", "timeout": 5 }],
+    "subagentStop": [{ "command": "/usr/local/bin/preloop usage hook --from cursor", "timeout": 5 }],
+    "stop": [{ "command": "/usr/local/bin/preloop usage hook --from cursor", "timeout": 5 }],
+    "preCompact": [{ "command": "/usr/local/bin/preloop usage hook --from cursor", "timeout": 5 }],
+    "beforeSubmitPrompt": [{ "command": "/usr/local/bin/preloop usage hook --from cursor", "timeout": 5 }]
   }
 }
 ```
@@ -143,13 +223,14 @@ decides from `hook_event_name` what to do.
 
 | Cursor hook event | Shipped as | Notes |
 | ----------------- | ---------- | ----- |
-| `sessionStart` | `session_start` | Fires when a new conversation is created. |
-| `sessionEnd` | `session_end` | End reason recorded in metadata. |
+| `sessionStart` | `session_start` | Opens the runtime session with the default title. |
+| `sessionEnd` | `session_end` | Closes the session. End reason in metadata; any transcript text not yet counted is estimated here. |
 | `subagentStart` | `subagent_start` | Carries the documented `parent_conversation_id`, which powers thread nesting in the rollup. |
-| `subagentStop` | `subagent_stop` | Ships the documented `message_count` and `tool_call_count`. |
-| `stop` | `response` | Fires when the agent loop finishes responding. |
-| `preCompact` | `compaction` | Context compaction marker. |
-| any other event | not shipped | Permission, file, prompt, and thought hooks would inflate event counts without adding cost signal. The command acknowledges them and exits 0. |
+| `subagentStop` | `subagent_stop` | Ships the documented `message_count` and `tool_call_count`, plus a token estimate from `agent_transcript_path`. |
+| `stop` | `response` | Token estimate, session title and summary. Fires when the agent loop finishes responding. |
+| `preCompact` | `compaction` | `context_tokens`, `context_window_size`, `context_usage_percent`, `messages_to_compact` and `is_first_compaction` in metadata; `message_count` as a column. |
+| `beforeSubmitPrompt` | not shipped | The first prompt line is kept locally for the session title; the prompt is otherwise ignored. |
+| any other event | not shipped | Permission, file, and thought hooks would inflate event counts without adding cost signal. The command acknowledges them and exits 0. |
 
 Deduplication: the server deduplicates on `(source, external_id)`.
 Records are keyed by conversation id (`sessionStart`/`sessionEnd`),
@@ -158,12 +239,15 @@ Records are keyed by conversation id (`sessionStart`/`sessionEnd`),
 per-fire id, so those records get a receive-time suffix; they stay unique
 across parallel workers but do not deduplicate on replay. The command
 makes a single delivery attempt, so duplicates cannot originate from it.
+The transcript offset file is the second guard: a replayed `stop` finds
+nothing new in the transcript and ships no token fields.
 
 ### Subagent conversations
 
 When Cursor spawns a subagent (Task tool), the `subagentStart` payload
 reports `parent_conversation_id`, and the rollup nests the record under
-that parent thread automatically.
+that parent thread automatically. `subagentStop` reads the subagent's own
+transcript, so its tokens are counted once, separately from the parent's.
 
 One documented ambiguity: Cursor's reference does not state whether the
 common `conversation_id` field on subagent events refers to the worker's
@@ -181,13 +265,22 @@ variable. When none is present the field is omitted; it is never guessed.
 ### Verify the wiring
 
 ```bash
-echo '{"conversation_id":"test-conv","generation_id":"test-gen-1","hook_event_name":"stop","status":"completed","loop_count":0}' \
-  | preloop usage hook
+printf '%s\n' \
+  '{"role":"user","message":{"content":[{"type":"text","text":"hello"}]}}' \
+  '{"role":"assistant","message":{"content":[{"type":"text","text":"hi there"}]}}' \
+  > /tmp/preloop-cursor-test.jsonl
+echo '{"conversation_id":"test-conv","generation_id":"test-gen-1","hook_event_name":"stop","status":"completed","loop_count":0,"model":"claude-4.5-sonnet","transcript_path":"/tmp/preloop-cursor-test.jsonl"}' \
+  | preloop usage hook --from cursor
 ```
 
 Then open Cost analytics in the console. The "Imported usage" section
-shows a "Conversations" rollup listing `test-conv` with one event and its
-tokens and costs marked "not reported" (hooks report neither).
+shows a "Conversations" rollup listing `test-conv` with one event,
+2 input tokens ("hello" is 5 characters), 2 output tokens ("hi there" is
+8 characters) and an estimated amount from the catalog price of
+`claude-sonnet-4-5`. The runtime sessions list shows a `cursor` session
+`test-conv` with the summary "hi there". Delete
+`~/.preloop/agents/cursor/transcripts/test-conv.json` afterwards if you
+want to replay the check.
 
 ## Codex CLI
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21589,6 +21589,22 @@ components:
             type: object
           - type: 'null'
           title: Metadata
+          description: 'Small JSON object. Recognized session keys: `session_title`
+            (sets the runtime session title), `session_title_default` (fills the title
+            only while it is empty) and `session_summary` (replaces the runtime session
+            summary).'
+        transcript:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/UsageIngestTranscriptMessage'
+            type: array
+            maxItems: 50
+          - type: 'null'
+          title: Transcript
+          description: Opt-in transcript text for this record's conversation, stored
+            as runtime session activities. Shippers send it only when the operator
+            enabled transcript storage; by default only counts, titles and short summaries
+            leave the machine.
       type: object
       required:
       - external_id
@@ -21704,6 +21720,33 @@ components:
         payload differs from the stored record are additionally flagged
 
         ``conflict`` (first write wins; never a 409).'
+    UsageIngestTranscriptMessage:
+      properties:
+        role:
+          type: string
+          enum:
+          - user
+          - assistant
+          - tool
+          - tool_use
+          title: Role
+        text:
+          type: string
+          maxLength: 4000
+          minLength: 1
+          title: Text
+        timestamp:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Timestamp
+      type: object
+      required:
+      - role
+      - text
+      title: UsageIngestTranscriptMessage
+      description: One role-tagged text chunk of a conversation transcript.
     ValidationError:
       properties:
         loc:


### PR DESCRIPTION
## What

Cursor cannot route model traffic through the gateway, so its usage was invisible. This branch estimates tokens from the local transcript, prices the estimated records server side, and registers Cursor conversations as runtime sessions:

1. **Transcript token estimates** (stop, sessionEnd, subagentStop hooks): delta reads from a saved offset with an 8 MiB cap, complete lines only, chars-per-token 4 matching `billing_budget_chars_per_token`, fail open. `preCompact` `context_tokens` is consumed once as ground truth for the next generation.
2. **Server-side pricing of estimated ingest records**: `estimated` records are priced through the model pricing catalog (Codex records were previously stored with `charged_cost` only and never priced); reconciled-without-amount and unpriced stay NULL, `cost_source` comes from the catalog. Cursor Claude model spellings are mapped.
3. **Runtime sessions from usage ingest**: `POST /api/v1/usage/ingest` registers a runtime session per `conversation_id` with the attributed managed agent as principal, a default or prompt-captured title, the last assistant paragraph as summary, and optional `transcript_message` activities behind the `--store-transcript` opt-in. Applies to every ingest source with a conversation id (Cursor, Codex rollout imports, generic); a Codex-source test and a docs sentence cover that scope.
4. **Onboarding**: `preloop agents onboard` installs the seven Cursor usage hooks with a marker-scoped upsert that never clobbers permission or foreign entries; `--no-usage-hooks` and offboard removal on both paths. `beforeSubmitPrompt` answers `{"continue":true}` per Cursor's hook contract and captures the prompt as the session title with zero POSTs.

## Review

APPROVE WITH NITS from the review pass; all findings folded (continue JSON, pending-token clearing on empty reads, transcript activities attached only after the ledger insert wins the dedupe race, naive-UTC timestamps, doc notes on both estimate biases).

## Tests (measured)

- CLI: 653 top-level Go tests pass, 0 fail (`go vet` clean).
- Backend: 197 passed / 0 failed across usage import, usage ingest, runtime session explorer, repricing, and model pricing suites.
- openapi.yaml regenerated and in sync. Zero em dashes introduced.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Medium Risk]**
> Changes to important cost-pricing and session-bookkeeping logic, with an opt-in transcript-shipping path; no security issues found and the code is well tested.

> **Overview**
> Estimates Cursor tokens from the local transcript, prices estimated ingest records through the model pricing catalog, registers Cursor conversations as runtime sessions, and installs the Cursor usage hooks during onboarding. Both LOW nits from the prior pass are resolved, and the CLI tests now measure fixture byte offsets (Windows CRLF fix).

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit bd0acae6. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->