### PR TITLE
Answer Cursor preToolUse Shell and MCP events locally so one command raises one approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Cursor permission hook raised two approvals per shell command**:
+  `preloop agents onboard Cursor --approvals` installs the same hook for
+  `beforeShellExecution`, `beforeMCPExecution`, and `preToolUse`, and
+  Cursor's `preToolUse` fires for every tool, so each shell command and MCP
+  call reached the permission-check endpoint twice (two approval rows, or
+  two prompts under enforce). The `preToolUse` hook now answers Shell and
+  MCP tools locally and only raises approvals for native file tools such as
+  `Write`, `StrReplace`, and `Delete`. The hook also reads the documented
+  `mcp_server_name` key when matching the Cursor MCP allowlist and
+  detecting the Preloop MCP server.
 - **Unpinned flows fall back to hosted compute when every private runner is
   busy**: a busy runner cannot be leased, so it no longer counts as online
   capacity for the account default pool. The Runners page still shows a

--- a/cli/internal/cmd/agents_permission_hook.go
+++ b/cli/internal/cmd/agents_permission_hook.go
@@ -234,6 +234,15 @@ func resolvePermissionDecision(source string, raw []byte, failOpen bool) hookDec
 		}
 	}
 
+	// Cursor's preToolUse fires for every tool, including Shell and MCP tools
+	// that beforeShellExecution / beforeMCPExecution already gate. Answer the
+	// duplicate locally so one command raises exactly one approval request.
+	if source == permissionSourceCursor {
+		if decision, ok := cursorPreToolUseDuplicateDecision(raw); ok {
+			return decision
+		}
+	}
+
 	req, err := buildPermissionRequest(source, raw, permissionHookCredential{})
 	if err != nil {
 		return failureDecision(source, failOpen, err.Error())
@@ -309,6 +318,55 @@ func resolvePermissionDecision(source string, raw []byte, failOpen bool) hookDec
 		}
 	}
 	return hookDecision{Behavior: behavior, Reason: reason}
+}
+
+// cursorPreToolUseDuplicateReason is the allow reason for a Cursor preToolUse
+// event whose tool a dedicated before* hook already gates.
+const cursorPreToolUseDuplicateReason = "Handled by beforeShellExecution/beforeMCPExecution"
+
+// cursorPreToolUseDuplicateDecision returns an immediate local allow when a
+// Cursor preToolUse event targets a tool that beforeShellExecution or
+// beforeMCPExecution already gates (Shell, or any MCP tool). The onboarding
+// installs the same hook command for all three events and preToolUse fires
+// for every tool, so without this guard each shell command and MCP call would
+// reach Preloop twice and create two approval rows (or prompt the operator
+// twice under enforce). preToolUse keeps gating native file tools (Write,
+// StrReplace, Delete, Read, ...), which is the reason it is installed at all.
+// The second return value is false when the event is not such a duplicate.
+func cursorPreToolUseDuplicateDecision(raw []byte) (hookDecision, bool) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return hookDecision{}, false
+	}
+	var event map[string]interface{}
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return hookDecision{}, false
+	}
+	if !strings.EqualFold(firstStringField(event, "hook_event_name"), "preToolUse") {
+		return hookDecision{}, false
+	}
+	if !cursorToolHasDedicatedBeforeHook(event, firstStringField(event, "tool_name")) {
+		return hookDecision{}, false
+	}
+	return hookDecision{Behavior: "allow", Reason: cursorPreToolUseDuplicateReason}, true
+}
+
+// cursorToolHasDedicatedBeforeHook reports whether Cursor fires a dedicated
+// before* hook for this tool: beforeShellExecution for Shell, and
+// beforeMCPExecution for MCP tools. An MCP tool is recognized when the event
+// names an MCP server (mcp_server_name and its aliases), when the tool uses
+// Cursor's MCP:<tool_name> matcher form, or when it targets the Preloop MCP.
+func cursorToolHasDedicatedBeforeHook(event map[string]interface{}, toolName string) bool {
+	trimmed := strings.TrimSpace(toolName)
+	if strings.EqualFold(trimmed, "Shell") {
+		return true
+	}
+	if strings.HasPrefix(strings.ToLower(trimmed), "mcp:") {
+		return true
+	}
+	if firstStringField(event, "mcp_server_name", "server_name", "mcp_server", "mcp_server_url") != "" {
+		return true
+	}
+	return isPreloopMCPTool(event, trimmed, "")
 }
 
 // permissionCheckTimeoutFor returns the HTTP client timeout for a blocking

--- a/cli/internal/cmd/agents_permission_hook.go
+++ b/cli/internal/cmd/agents_permission_hook.go
@@ -326,13 +326,10 @@ const cursorPreToolUseDuplicateReason = "Handled by beforeShellExecution/beforeM
 
 // cursorPreToolUseDuplicateDecision returns an immediate local allow when a
 // Cursor preToolUse event targets a tool that beforeShellExecution or
-// beforeMCPExecution already gates (Shell, or any MCP tool). The onboarding
-// installs the same hook command for all three events and preToolUse fires
-// for every tool, so without this guard each shell command and MCP call would
-// reach Preloop twice and create two approval rows (or prompt the operator
-// twice under enforce). preToolUse keeps gating native file tools (Write,
-// StrReplace, Delete, Read, ...), which is the reason it is installed at all.
-// The second return value is false when the event is not such a duplicate.
+// beforeMCPExecution already gates (Shell, or any MCP tool), and that
+// before* hook is still present in ~/.cursor/hooks.json. If the operator
+// removed the before* entries, this returns false so preToolUse posts
+// normally instead of fail-opening. Onboarding installs all three together.
 func cursorPreToolUseDuplicateDecision(raw []byte) (hookDecision, bool) {
 	if len(bytes.TrimSpace(raw)) == 0 {
 		return hookDecision{}, false
@@ -347,7 +344,61 @@ func cursorPreToolUseDuplicateDecision(raw []byte) (hookDecision, bool) {
 	if !cursorToolHasDedicatedBeforeHook(event, firstStringField(event, "tool_name")) {
 		return hookDecision{}, false
 	}
+	if !cursorPreloopBeforeHookInstalled(cursorDedicatedBeforeHookEvent(event, firstStringField(event, "tool_name"))) {
+		return hookDecision{}, false
+	}
 	return hookDecision{Behavior: "allow", Reason: cursorPreToolUseDuplicateReason}, true
+}
+
+// cursorDedicatedBeforeHookEvent is the Cursor before* event that already
+// gates this tool, or empty when preToolUse is the only hook for it.
+func cursorDedicatedBeforeHookEvent(event map[string]interface{}, toolName string) string {
+	trimmed := strings.TrimSpace(toolName)
+	if strings.EqualFold(trimmed, "Shell") {
+		return "beforeShellExecution"
+	}
+	if strings.HasPrefix(strings.ToLower(trimmed), "mcp:") {
+		return "beforeMCPExecution"
+	}
+	if firstStringField(event, cursorMCPServerNameKeys...) != "" {
+		return "beforeMCPExecution"
+	}
+	if isPreloopMCPTool(event, trimmed, "") {
+		return "beforeMCPExecution"
+	}
+	return ""
+}
+
+// cursorPreloopBeforeHookInstalled is true when ~/.cursor/hooks.json still
+// has a Preloop command for eventKey. Without that hook, answering preToolUse
+// locally would skip gating entirely.
+func cursorPreloopBeforeHookInstalled(eventKey string) bool {
+	if eventKey == "" {
+		return false
+	}
+	path, err := approvalHookConfigPath(permissionSourceCursor)
+	if err != nil {
+		return false
+	}
+	doc, existed, err := loadJSONDocumentIfExists(path)
+	if err != nil || !existed {
+		return false
+	}
+	hooks, ok := asObjectMap(doc["hooks"])
+	if !ok {
+		return false
+	}
+	for _, item := range asArrayValue(hooks[eventKey]) {
+		entry, ok := asObjectMap(item)
+		if !ok {
+			continue
+		}
+		command, _ := entry["command"].(string)
+		if strings.Contains(command, permissionHookCommandMarker) {
+			return true
+		}
+	}
+	return false
 }
 
 // cursorToolHasDedicatedBeforeHook reports whether Cursor fires a dedicated
@@ -356,17 +407,7 @@ func cursorPreToolUseDuplicateDecision(raw []byte) (hookDecision, bool) {
 // names an MCP server (mcp_server_name and its aliases), when the tool uses
 // Cursor's MCP:<tool_name> matcher form, or when it targets the Preloop MCP.
 func cursorToolHasDedicatedBeforeHook(event map[string]interface{}, toolName string) bool {
-	trimmed := strings.TrimSpace(toolName)
-	if strings.EqualFold(trimmed, "Shell") {
-		return true
-	}
-	if strings.HasPrefix(strings.ToLower(trimmed), "mcp:") {
-		return true
-	}
-	if firstStringField(event, "mcp_server_name", "server_name", "mcp_server", "mcp_server_url") != "" {
-		return true
-	}
-	return isPreloopMCPTool(event, trimmed, "")
+	return cursorDedicatedBeforeHookEvent(event, toolName) != ""
 }
 
 // permissionCheckTimeoutFor returns the HTTP client timeout for a blocking

--- a/cli/internal/cmd/agents_permission_hook_test.go
+++ b/cli/internal/cmd/agents_permission_hook_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1117,5 +1118,203 @@ func TestEnablePermissionPromptBuiltinPropagatesServerErrors(t *testing.T) {
 	client := api.NewClientWithToken(server.URL, "test-token")
 	if err := enablePermissionPromptBuiltin(client, "agent-123", nil); err == nil {
 		t.Fatal("expected server error to propagate")
+	}
+}
+
+// Cursor's preToolUse fires for every tool, including Shell and MCP tools
+// that beforeShellExecution / beforeMCPExecution already gate. The duplicate
+// preToolUse event must be answered locally, without a permission-check POST,
+// so one command raises exactly one approval request. Native file tools keep
+// their preToolUse gating: an out-of-workspace Write still posts, and an
+// in-workspace Write is auto-allowed locally by isLocalWorkspaceEdit.
+func TestResolvePermissionDecisionCursorPreToolUseDedupe(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+
+	var mu sync.Mutex
+	var posted []permissionCheckRequest
+	var postsAllowed bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body permissionCheckRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		posted = append(posted, body)
+		allowed := postsAllowed
+		mu.Unlock()
+		if !allowed {
+			t.Errorf("permission-check must not be called for this event, got POST for tool %q", body.ToolName)
+		}
+		_ = json.NewEncoder(w).Encode(permissionCheckResponse{
+			Decision: "allow",
+			Reason:   "approved on watch",
+		})
+	}))
+	defer server.Close()
+
+	writeTestPermissionCredential(t, home, "cursor-agent", permissionHookCredential{
+		BaseURL:       server.URL,
+		Token:         "agt_test",
+		Source:        permissionSourceCursor,
+		WorkspaceRoot: "/repo",
+	})
+
+	cases := []struct {
+		name         string
+		raw          string
+		wantBehavior string
+		wantReason   string
+		wantPosts    int
+		wantToolName string
+	}{
+		{
+			name:         "beforeShellExecution posts once",
+			raw:          `{"hook_event_name":"beforeShellExecution","command":"rm -rf build","cwd":"/repo","sandbox":false}`,
+			wantBehavior: "allow",
+			wantReason:   "approved on watch",
+			wantPosts:    1,
+			wantToolName: "Shell",
+		},
+		{
+			name:         "preToolUse Shell is answered locally",
+			raw:          `{"hook_event_name":"preToolUse","tool_name":"Shell","tool_input":{"command":"rm -rf build","working_directory":"/repo"},"cwd":"/repo"}`,
+			wantBehavior: "allow",
+			wantReason:   cursorPreToolUseDuplicateReason,
+			wantPosts:    0,
+		},
+		{
+			name:         "beforeMCPExecution posts once",
+			raw:          `{"hook_event_name":"beforeMCPExecution","tool_name":"create_issue","tool_input":"{\"title\":\"x\"}","mcp_server_name":"linear","url":"https://mcp.linear.app/sse","cwd":"/repo"}`,
+			wantBehavior: "allow",
+			wantReason:   "approved on watch",
+			wantPosts:    1,
+			wantToolName: "create_issue",
+		},
+		{
+			name:         "preToolUse MCP tool with mcp_server_name is answered locally",
+			raw:          `{"hook_event_name":"preToolUse","tool_name":"create_issue","tool_input":{"title":"x"},"mcp_server_name":"linear","cwd":"/repo"}`,
+			wantBehavior: "allow",
+			wantReason:   cursorPreToolUseDuplicateReason,
+			wantPosts:    0,
+		},
+		{
+			name:         "preToolUse MCP matcher form is answered locally",
+			raw:          `{"hook_event_name":"preToolUse","tool_name":"MCP:create_issue","tool_input":{"title":"x"},"cwd":"/repo"}`,
+			wantBehavior: "allow",
+			wantReason:   cursorPreToolUseDuplicateReason,
+			wantPosts:    0,
+		},
+		{
+			name:         "preToolUse Preloop MCP tool is answered locally",
+			raw:          `{"hook_event_name":"preToolUse","tool_name":"preloop_create_issue","tool_input":{"title":"x"},"cwd":"/repo"}`,
+			wantBehavior: "allow",
+			wantReason:   cursorPreToolUseDuplicateReason,
+			wantPosts:    0,
+		},
+		{
+			name:         "preToolUse Write outside workspace still posts",
+			raw:          `{"hook_event_name":"preToolUse","tool_name":"Write","tool_input":{"file_path":"/etc/motd"},"cwd":"/repo","workspace_roots":["/repo"]}`,
+			wantBehavior: "allow",
+			wantReason:   "approved on watch",
+			wantPosts:    1,
+			wantToolName: "Write",
+		},
+		{
+			name:         "preToolUse Write inside workspace is auto-allowed locally",
+			raw:          `{"hook_event_name":"preToolUse","tool_name":"Write","tool_input":{"file_path":"/repo/src/a.ts"},"cwd":"/repo","workspace_roots":["/repo"]}`,
+			wantBehavior: "allow",
+			wantReason:   "Allowed by the agent's own configuration.",
+			wantPosts:    0,
+		},
+		{
+			name:         "preToolUse Delete outside workspace still posts",
+			raw:          `{"hook_event_name":"preToolUse","tool_name":"Delete","tool_input":{"path":"/etc/motd"},"cwd":"/repo","workspace_roots":["/repo"]}`,
+			wantBehavior: "allow",
+			wantReason:   "approved on watch",
+			wantPosts:    1,
+			wantToolName: "Delete",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mu.Lock()
+			posted = nil
+			postsAllowed = tc.wantPosts > 0
+			mu.Unlock()
+
+			decision := resolvePermissionDecision(permissionSourceCursor, []byte(tc.raw), false)
+			if decision.Behavior != tc.wantBehavior {
+				t.Fatalf("behavior = %q (%s), want %q", decision.Behavior, decision.Reason, tc.wantBehavior)
+			}
+			if decision.Reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", decision.Reason, tc.wantReason)
+			}
+
+			mu.Lock()
+			got := append([]permissionCheckRequest(nil), posted...)
+			mu.Unlock()
+			if len(got) != tc.wantPosts {
+				t.Fatalf("permission-check POSTs = %d, want %d (%+v)", len(got), tc.wantPosts, got)
+			}
+			if tc.wantPosts > 0 && got[0].ToolName != tc.wantToolName {
+				t.Errorf("posted tool_name = %q, want %q", got[0].ToolName, tc.wantToolName)
+			}
+		})
+	}
+}
+
+// cursorPreToolUseDuplicateDecision must only short-circuit preToolUse events
+// for tools that have a dedicated before* hook; every other event falls
+// through to the normal evaluation path.
+func TestCursorPreToolUseDuplicateDecision(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "preToolUse Shell", raw: `{"hook_event_name":"preToolUse","tool_name":"Shell","tool_input":{"command":"ls"}}`, want: true},
+		{name: "preToolUse shell lower-case", raw: `{"hook_event_name":"preToolUse","tool_name":"shell","tool_input":{"command":"ls"}}`, want: true},
+		{name: "preToolUse MCP server name", raw: `{"hook_event_name":"preToolUse","tool_name":"search","mcp_server_name":"linear"}`, want: true},
+		{name: "preToolUse MCP server url", raw: `{"hook_event_name":"preToolUse","tool_name":"search","mcp_server_url":"https://mcp.example.com/sse"}`, want: true},
+		{name: "preToolUse MCP matcher prefix", raw: `{"hook_event_name":"preToolUse","tool_name":"MCP:search"}`, want: true},
+		{name: "preToolUse Preloop MCP by tool name", raw: `{"hook_event_name":"preToolUse","tool_name":"preloop_list_issues"}`, want: true},
+		{name: "preToolUse Preloop MCP by url", raw: `{"hook_event_name":"preToolUse","tool_name":"list_issues","url":"https://api.preloop.ai/mcp"}`, want: true},
+		{name: "preToolUse Write", raw: `{"hook_event_name":"preToolUse","tool_name":"Write","tool_input":{"file_path":"a.ts"}}`, want: false},
+		{name: "preToolUse StrReplace", raw: `{"hook_event_name":"preToolUse","tool_name":"StrReplace","tool_input":{"path":"a.ts"}}`, want: false},
+		{name: "preToolUse Delete", raw: `{"hook_event_name":"preToolUse","tool_name":"Delete","tool_input":{"path":"a.ts"}}`, want: false},
+		{name: "preToolUse Read", raw: `{"hook_event_name":"preToolUse","tool_name":"Read","tool_input":{"path":"a.ts"}}`, want: false},
+		{name: "preToolUse Task", raw: `{"hook_event_name":"preToolUse","tool_name":"Task"}`, want: false},
+		{name: "preToolUse without tool_name", raw: `{"hook_event_name":"preToolUse"}`, want: false},
+		{name: "beforeShellExecution", raw: `{"hook_event_name":"beforeShellExecution","command":"ls"}`, want: false},
+		{name: "beforeMCPExecution", raw: `{"hook_event_name":"beforeMCPExecution","tool_name":"search","mcp_server_name":"linear"}`, want: false},
+		{name: "missing hook_event_name", raw: `{"tool_name":"Shell","tool_input":{"command":"ls"}}`, want: false},
+		{name: "empty payload", raw: ``, want: false},
+		{name: "invalid json", raw: `{`, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			decision, got := cursorPreToolUseDuplicateDecision([]byte(tc.raw))
+			if got != tc.want {
+				t.Fatalf("duplicate = %v, want %v", got, tc.want)
+			}
+			if got && (decision.Behavior != "allow" || decision.Reason != cursorPreToolUseDuplicateReason) {
+				t.Errorf("unexpected decision %+v", decision)
+			}
+		})
+	}
+}
+
+// Cursor documents mcp_server_name as the server key on MCP hook events; it
+// must feed both the mcpAllowlist matcher and Preloop MCP detection.
+func TestCursorMCPServerNameHonorsDocumentedKey(t *testing.T) {
+	event := map[string]interface{}{"mcp_server_name": "linear", "url": "https://mcp.linear.app/sse"}
+	if got := cursorMCPServerName(event); got != "linear" {
+		t.Fatalf("cursorMCPServerName = %q, want %q", got, "linear")
+	}
+	if !matchCursorMCPAllowlist([]string{"linear:create_*"}, event, "create_issue") {
+		t.Error("mcpAllowlist should match on documented mcp_server_name")
+	}
+	preloop := map[string]interface{}{"mcp_server_name": "preloop", "command": "npx preloop-mcp"}
+	if !isPreloopMCPTool(preloop, "list_issues", "") {
+		t.Error("isPreloopMCPTool should detect Preloop via mcp_server_name")
 	}
 }

--- a/cli/internal/cmd/agents_permission_hook_test.go
+++ b/cli/internal/cmd/agents_permission_hook_test.go
@@ -1157,6 +1157,7 @@ func TestResolvePermissionDecisionCursorPreToolUseDedupe(t *testing.T) {
 		Source:        permissionSourceCursor,
 		WorkspaceRoot: "/repo",
 	})
+	writeCursorPreloopHookEvents(t, home, "beforeShellExecution", "beforeMCPExecution", "preToolUse")
 
 	cases := []struct {
 		name         string
@@ -1262,10 +1263,31 @@ func TestResolvePermissionDecisionCursorPreToolUseDedupe(t *testing.T) {
 	}
 }
 
+func writeCursorPreloopHookEvents(t *testing.T, home string, events ...string) {
+	t.Helper()
+	hooks := map[string]interface{}{}
+	for _, event := range events {
+		hooks[event] = []interface{}{
+			map[string]interface{}{"command": "preloop agents permission-hook --source cursor"},
+		}
+	}
+	path := filepath.Join(home, ".cursor", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	if err := writeJSONDocument(path, map[string]interface{}{"version": 1, "hooks": hooks}); err != nil {
+		t.Fatalf("write hooks.json: %v", err)
+	}
+}
+
 // cursorPreToolUseDuplicateDecision must only short-circuit preToolUse events
-// for tools that have a dedicated before* hook; every other event falls
-// through to the normal evaluation path.
+// for tools that have a dedicated before* hook that is still installed;
+// every other event falls through to the normal evaluation path.
 func TestCursorPreToolUseDuplicateDecision(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	writeCursorPreloopHookEvents(t, home, "beforeShellExecution", "beforeMCPExecution", "preToolUse")
+
 	cases := []struct {
 		name string
 		raw  string
@@ -1316,5 +1338,40 @@ func TestCursorMCPServerNameHonorsDocumentedKey(t *testing.T) {
 	preloop := map[string]interface{}{"mcp_server_name": "preloop", "command": "npx preloop-mcp"}
 	if !isPreloopMCPTool(preloop, "list_issues", "") {
 		t.Error("isPreloopMCPTool should detect Preloop via mcp_server_name")
+	}
+	if got := cursorMCPServerName(map[string]interface{}{"mcp_server_url": "https://mcp.example.com/sse"}); got != "https://mcp.example.com/sse" {
+		t.Errorf("mcp_server_url alias = %q", got)
+	}
+	if got := cursorMCPServerName(map[string]interface{}{"server": "legacy"}); got != "legacy" {
+		t.Errorf("server alias = %q", got)
+	}
+}
+
+func TestCursorPreToolUseDuplicateRequiresInstalledBeforeHook(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	raw := []byte(`{"hook_event_name":"preToolUse","tool_name":"Shell","tool_input":{"command":"ls"}}`)
+
+	if _, got := cursorPreToolUseDuplicateDecision(raw); got {
+		t.Fatal("missing hooks.json must not locally allow Shell preToolUse")
+	}
+
+	writeCursorPreloopHookEvents(t, home, "preToolUse")
+	if _, got := cursorPreToolUseDuplicateDecision(raw); got {
+		t.Fatal("preToolUse-only install must not locally allow Shell")
+	}
+
+	writeCursorPreloopHookEvents(t, home, "beforeShellExecution")
+	if _, got := cursorPreToolUseDuplicateDecision(raw); !got {
+		t.Fatal("beforeShellExecution install should locally allow Shell preToolUse")
+	}
+
+	mcpRaw := []byte(`{"hook_event_name":"preToolUse","tool_name":"search","mcp_server_name":"linear"}`)
+	if _, got := cursorPreToolUseDuplicateDecision(mcpRaw); got {
+		t.Fatal("Shell before-hook must not locally allow MCP preToolUse")
+	}
+	writeCursorPreloopHookEvents(t, home, "beforeMCPExecution")
+	if _, got := cursorPreToolUseDuplicateDecision(mcpRaw); !got {
+		t.Fatal("beforeMCPExecution install should locally allow MCP preToolUse")
 	}
 }

--- a/cli/internal/cmd/cursor_permission_policy.go
+++ b/cli/internal/cmd/cursor_permission_policy.go
@@ -270,7 +270,9 @@ func matchCursorMCPAllowlist(allowlist []string, event map[string]interface{}, t
 }
 
 func cursorMCPServerName(event map[string]interface{}) string {
-	if name := firstStringField(event, "server_name", "server", "mcp_server"); name != "" {
+	// mcp_server_name is the key Cursor documents for beforeMCPExecution; the
+	// rest are aliases seen in older payloads.
+	if name := firstStringField(event, "mcp_server_name", "server_name", "server", "mcp_server"); name != "" {
 		return name
 	}
 	if command := firstStringField(event, "command"); command != "" {

--- a/cli/internal/cmd/cursor_permission_policy.go
+++ b/cli/internal/cmd/cursor_permission_policy.go
@@ -269,10 +269,17 @@ func matchCursorMCPAllowlist(allowlist []string, event map[string]interface{}, t
 	return false
 }
 
+// cursorMCPServerNameKeys are JSON fields that name the MCP server on a
+// Cursor hook event. mcp_server_name is documented; the rest are aliases.
+var cursorMCPServerNameKeys = []string{
+	"mcp_server_name", "server_name", "mcp_server", "mcp_server_url", "server",
+}
+
 func cursorMCPServerName(event map[string]interface{}) string {
 	// mcp_server_name is the key Cursor documents for beforeMCPExecution; the
-	// rest are aliases seen in older payloads.
-	if name := firstStringField(event, "mcp_server_name", "server_name", "server", "mcp_server"); name != "" {
+	// rest are aliases seen in older payloads. Keep this list in lockstep with
+	// cursorToolHasDedicatedBeforeHook.
+	if name := firstStringField(event, cursorMCPServerNameKeys...); name != "" {
 		return name
 	}
 	if command := firstStringField(event, "command"); command != "" {

--- a/docs/guide/cursor-cli.md
+++ b/docs/guide/cursor-cli.md
@@ -125,6 +125,12 @@ know this run was spawned from another conversation.
 ## Related commands
 
 - `preloop usage hook` ships editor hook lifecycle events (no tokens).
+- `preloop agents onboard Cursor --approvals` installs the permission hook
+  for `beforeShellExecution`, `beforeMCPExecution`, and `preToolUse`; the
+  `preToolUse` hook answers Shell and MCP tools locally (they are already
+  gated by the two `before*` hooks) and only raises approvals for native
+  file tools such as `Write`, `StrReplace`, and `Delete`, so one command
+  creates one approval request.
 - `preloop usage import` records billed Cursor dashboard exports as
   imported spend. Reconciled per-conversation amounts supersede these
   estimates in Cost analytics summaries; the two bases are never summed.


### PR DESCRIPTION
## What

Cursor's `preToolUse` hook fired for Shell and MCP tool calls that the `beforeShellExecution` / `beforeMCPExecution` hooks already cover, so one command produced two POSTs and two approvals. The `preToolUse` hook now answers those events locally (allow) and only raises approvals for native file tools that have no dedicated hook. Includes a doc note scoping the behavior.

## Review

APPROVE WITH NITS from the review pass, 0 should findings.

## Tests (measured)

- CLI: 636 Go tests pass, 0 fail. Two POSTs per shell/MCP call down to one, asserted in tests.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low** — permission-hook dedupe is now hardened: `preToolUse` answers Shell/MCP events locally only when the matching `before*` hook is still installed, and the MCP field-alias drift is fixed. Thorough test coverage, no open findings.
>
> **Overview**
> Deduplicates Cursor approval requests by answering `preToolUse` Shell/MCP events locally, gated on the presence of the `beforeShellExecution`/`beforeMCPExecution` hooks; native file tools keep their `preToolUse` gating. MCP server-name field aliases are consolidated into a shared list honoring the documented `mcp_server_name` key. Both prior review suggestions are resolved.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 7edaa892. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->