### PR TITLE
Read runner-backed execution logs from the database and halt runners on stop

### DIFF
--- a/backend/preloop/api/endpoints/flows.py
+++ b/backend/preloop/api/endpoints/flows.py
@@ -769,9 +769,13 @@ async def get_flow_execution_logs(
     skip: int = 0,
     limit: int | None = None,
 ) -> Dict[str, Any]:
-    """Get execution logs from the container (if running) or database (if finished).
+    """Get execution logs from the live container or from persisted database rows.
 
-    For running executions, fetches logs directly from the Docker/Kubernetes container.
+    For running container-backed executions, fetches logs directly from the
+    Docker/Kubernetes container. Runner-backed executions (lease references
+    such as ``runner:{runner_id}:{execution_id}``) always return persisted
+    database logs, even while they are still running, because their output
+    arrives over the runner WebSocket rather than a container log stream.
     For finished executions, returns persisted logs from the database.
 
     Args:

--- a/backend/preloop/api/endpoints/flows.py
+++ b/backend/preloop/api/endpoints/flows.py
@@ -798,7 +798,22 @@ async def get_flow_execution_logs(
     # Check if execution is running
     is_running = execution.status in ["RUNNING", "STARTING", "INITIALIZING", "PENDING"]
 
-    if is_running and execution.agent_session_reference:
+    # Runner-backed executions carry a lease reference
+    # (``runner:{runner_id}:{execution_id}`` or
+    # ``runner:queued:{pool}:{execution_id}``), not a container or Job name.
+    # Their output arrives over the runner WebSocket into flow_execution_log,
+    # so the container path would only build an invalid Kubernetes selector
+    # (HTTP 400) and return an empty list that hides the database logs.
+    session_reference = execution.agent_session_reference
+    runner_backed = bool(
+        session_reference
+        and (
+            runner_id_from_session_reference(session_reference) is not None
+            or pool_from_session_reference(session_reference) is not None
+        )
+    )
+
+    if is_running and session_reference and not runner_backed:
         # Fetch logs directly from container
         agent = None
         try:
@@ -1109,13 +1124,36 @@ async def send_execution_command(
 
     # Handle stop command - stop container directly
     if command_data.command == "stop":
-        # Stop the container if it's running
-        if execution.agent_session_reference and execution.status in [
+        session_reference = execution.agent_session_reference
+        stoppable = execution.status in [
             "RUNNING",
             "STARTING",
             "INITIALIZING",
             "PENDING",
-        ]:
+        ]
+        runner_id = runner_id_from_session_reference(session_reference)
+        queued_pool = pool_from_session_reference(session_reference)
+        if runner_id is not None and stoppable:
+            # Runner-backed execution: the lease reference is not a container
+            # or Job name, so a container executor cannot see or stop the
+            # runner's process (and only builds an invalid Kubernetes
+            # selector trying). Flag the halt so the runner stops the job
+            # itself; its output already streams into flow_execution_log.
+            runner = crud_flow_runner.get(db, id=runner_id)
+            if runner:
+                runner.halt_requested = True
+                db.add(runner)
+                db.commit()
+                logger.info(
+                    f"Requested halt on runner {runner_id} for execution {execution_id}"
+                )
+        elif queued_pool is not None and stoppable:
+            # Queued for a private pool: nothing runs yet, so there is no
+            # container, Job, or runner to stop. The status update below is
+            # all that is needed.
+            pass
+        # Stop the container if it's running
+        elif session_reference and stoppable:
             try:
                 # Get the flow to determine agent type
                 flow = crud_flow.get(

--- a/backend/tests/endpoints/test_flows.py
+++ b/backend/tests/endpoints/test_flows.py
@@ -1323,6 +1323,242 @@ async def test_send_execution_command_stop_success(
 
 
 @pytest.mark.asyncio
+async def test_send_execution_command_stop_runner_backed_halts_runner(
+    mock_account: Account, mocker: MockerFixture
+):
+    """Stopping a runner-leased execution flags the runner halt and never
+    builds a container executor (the lease reference is not a Job name)."""
+    # Arrange
+    execution_id = uuid.uuid4()
+    runner_id = uuid.uuid4()
+
+    mock_execution = MagicMock()
+    mock_execution.id = execution_id
+    mock_execution.flow_id = uuid.uuid4()
+    mock_execution.status = "RUNNING"
+    mock_execution.agent_session_reference = f"runner:{runner_id}:{execution_id}"
+
+    mock_crud_flow_execution = mocker.patch(
+        "preloop.api.endpoints.flows.crud_flow_execution",
+        new_callable=MagicMock,
+    )
+    mock_crud_flow_execution.get.return_value = mock_execution
+    mock_crud_flow_execution.update.return_value = mock_execution
+
+    mock_runner = MagicMock()
+    mock_runner.halt_requested = False
+    mock_crud_flow_runner = mocker.patch(
+        "preloop.api.endpoints.flows.crud_flow_runner",
+        new_callable=MagicMock,
+    )
+    mock_crud_flow_runner.get.return_value = mock_runner
+
+    mock_nats_client = MagicMock()
+    mocker.patch(
+        "preloop.sync.services.event_bus.get_nats_client",
+        return_value=mock_nats_client,
+    )
+    mock_codex_agent = mocker.patch("preloop.agents.codex.CodexAgent")
+    mock_container_executor = mocker.patch(
+        "preloop.agents.container.ContainerAgentExecutor"
+    )
+    mocker.patch(
+        "preloop.services.flow_orchestrator.FlowExecutionOrchestrator.send_command",
+        new=mocker.AsyncMock(),
+    )
+
+    command_data = schemas.FlowExecutionCommand(command="stop", payload={})
+
+    # Act
+    result = await maybe_await(
+        flows.send_execution_command(
+            db=MagicMock(),
+            execution_id=execution_id,
+            command_data=command_data,
+            current_user=mock_account,
+        )
+    )
+
+    # Assert
+    assert result == {"status": "stopped"}
+    mock_crud_flow_runner.get.assert_called_once()
+    assert mock_crud_flow_runner.get.call_args.kwargs["id"] == runner_id
+    assert mock_runner.halt_requested is True
+    mock_codex_agent.assert_not_called()
+    mock_container_executor.assert_not_called()
+    final_call = mock_crud_flow_execution.update.call_args
+    assert final_call.kwargs["obj_in"].status == "STOPPED"
+
+
+@pytest.mark.asyncio
+async def test_send_execution_command_stop_queued_runner_touches_nothing(
+    mock_account: Account, mocker: MockerFixture
+):
+    """Stopping a queued (not yet leased) execution skips both the runner
+    halt and the container path; the status update alone releases it."""
+    # Arrange
+    execution_id = uuid.uuid4()
+
+    mock_execution = MagicMock()
+    mock_execution.id = execution_id
+    mock_execution.flow_id = uuid.uuid4()
+    mock_execution.status = "RUNNING"
+    mock_execution.agent_session_reference = f"runner:queued:default:{execution_id}"
+
+    mock_crud_flow_execution = mocker.patch(
+        "preloop.api.endpoints.flows.crud_flow_execution",
+        new_callable=MagicMock,
+    )
+    mock_crud_flow_execution.get.return_value = mock_execution
+    mock_crud_flow_execution.update.return_value = mock_execution
+
+    mock_crud_flow_runner = mocker.patch(
+        "preloop.api.endpoints.flows.crud_flow_runner",
+        new_callable=MagicMock,
+    )
+
+    mock_nats_client = MagicMock()
+    mocker.patch(
+        "preloop.sync.services.event_bus.get_nats_client",
+        return_value=mock_nats_client,
+    )
+    mock_codex_agent = mocker.patch("preloop.agents.codex.CodexAgent")
+    mock_container_executor = mocker.patch(
+        "preloop.agents.container.ContainerAgentExecutor"
+    )
+    mocker.patch(
+        "preloop.services.flow_orchestrator.FlowExecutionOrchestrator.send_command",
+        new=mocker.AsyncMock(),
+    )
+
+    command_data = schemas.FlowExecutionCommand(command="stop", payload={})
+
+    # Act
+    result = await maybe_await(
+        flows.send_execution_command(
+            db=MagicMock(),
+            execution_id=execution_id,
+            command_data=command_data,
+            current_user=mock_account,
+        )
+    )
+
+    # Assert
+    assert result == {"status": "stopped"}
+    mock_crud_flow_runner.get.assert_not_called()
+    mock_codex_agent.assert_not_called()
+    mock_container_executor.assert_not_called()
+    final_call = mock_crud_flow_execution.update.call_args
+    assert final_call.kwargs["obj_in"].status == "STOPPED"
+
+
+def _mock_execution_log_row(execution_id: uuid.UUID, message: str) -> MagicMock:
+    row = MagicMock()
+    row.execution_id = execution_id
+    row.timestamp = datetime(2026, 9, 5, 12, 0, 0)
+    row.log_type = "agent_log_line"
+    row.metadata_ = {}
+    row.message = message
+    return row
+
+
+@pytest.mark.asyncio
+async def test_get_flow_execution_logs_runner_backed_reads_database(
+    mock_account: Account, mocker: MockerFixture
+):
+    """A running execution leased to a private runner reads logs from the
+    database (streamed over the runner WebSocket), never from Kubernetes."""
+    # Arrange
+    execution_id = uuid.uuid4()
+
+    mock_execution = MagicMock()
+    mock_execution.id = execution_id
+    mock_execution.status = "RUNNING"
+    mock_execution.agent_session_reference = f"runner:{uuid.uuid4()}:{execution_id}"
+    mock_execution.execution_logs = None
+
+    mock_crud_flow_execution = mocker.patch(
+        "preloop.api.endpoints.flows.crud_flow_execution",
+        new_callable=MagicMock,
+    )
+    mock_crud_flow_execution.get.return_value = mock_execution
+
+    mock_log_crud = mocker.patch(
+        "preloop.api.endpoints.flows.crud_flow_execution_log",
+        new_callable=MagicMock,
+    )
+    mock_log_crud.get_by_execution_id.return_value = [
+        _mock_execution_log_row(execution_id, "line one"),
+        _mock_execution_log_row(execution_id, "line two"),
+    ]
+
+    mock_create_executor = mocker.patch("preloop.agents.create_agent_executor")
+
+    # Act
+    result = await maybe_await(
+        flows.get_flow_execution_logs(
+            db=MagicMock(),
+            execution_id=execution_id,
+            current_user=mock_account,
+        )
+    )
+
+    # Assert
+    assert result["source"] == "database"
+    assert [entry["payload"]["message"] for entry in result["logs"]] == [
+        "line one",
+        "line two",
+    ]
+    mock_create_executor.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_flow_execution_logs_queued_runner_reads_database(
+    mock_account: Account, mocker: MockerFixture
+):
+    """A queued execution (no runner yet) also skips the container path, so
+    the queue-status entries in the database stay visible."""
+    # Arrange
+    execution_id = uuid.uuid4()
+
+    mock_execution = MagicMock()
+    mock_execution.id = execution_id
+    mock_execution.status = "RUNNING"
+    mock_execution.agent_session_reference = f"runner:queued:default:{execution_id}"
+    mock_execution.execution_logs = None
+
+    mock_crud_flow_execution = mocker.patch(
+        "preloop.api.endpoints.flows.crud_flow_execution",
+        new_callable=MagicMock,
+    )
+    mock_crud_flow_execution.get.return_value = mock_execution
+
+    mock_log_crud = mocker.patch(
+        "preloop.api.endpoints.flows.crud_flow_execution_log",
+        new_callable=MagicMock,
+    )
+    mock_log_crud.get_by_execution_id.return_value = [
+        _mock_execution_log_row(execution_id, "agent_status"),
+    ]
+
+    mock_create_executor = mocker.patch("preloop.agents.create_agent_executor")
+
+    # Act
+    result = await maybe_await(
+        flows.get_flow_execution_logs(
+            db=MagicMock(),
+            execution_id=execution_id,
+            current_user=mock_account,
+        )
+    )
+
+    # Assert
+    assert result["source"] == "database"
+    assert len(result["logs"]) == 1
+    mock_create_executor.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_send_execution_command_other_command_success(
     mock_account: Account, mocker: MockerFixture
 ):

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7775,16 +7775,19 @@ paths:
       tags:
       - Flows
       summary: Get Flow Execution Logs
-      description: "Get execution logs from the container (if running) or database\
-        \ (if finished).\n\nFor running executions, fetches logs directly from the\
-        \ Docker/Kubernetes container.\nFor finished executions, returns persisted\
-        \ logs from the database.\n\nArgs:\n    execution_id: ID of the execution\n\
-        \    tail: Number of recent log lines to retrieve, or None for all logs\n\
-        \    skip: Number of logs to skip (for pagination)\n    limit: Number of logs\
-        \ to return (for pagination)\n\nReturns:\n    Dictionary with:\n    - logs:\
-        \ List of log lines\n    - source: Where logs were fetched from (\"container\"\
-        \ or \"database\")\n    - has_more: Boolean indicating if there are more logs\
-        \ (if paginated)"
+      description: "Get execution logs from the live container or from persisted database\
+        \ rows.\n\nFor running container-backed executions, fetches logs directly\
+        \ from the\nDocker/Kubernetes container. Runner-backed executions (lease references\n\
+        such as ``runner:{runner_id}:{execution_id}``) always return persisted\ndatabase\
+        \ logs, even while they are still running, because their output\narrives over\
+        \ the runner WebSocket rather than a container log stream.\nFor finished executions,\
+        \ returns persisted logs from the database.\n\nArgs:\n    execution_id: ID\
+        \ of the execution\n    tail: Number of recent log lines to retrieve, or None\
+        \ for all logs\n    skip: Number of logs to skip (for pagination)\n    limit:\
+        \ Number of logs to return (for pagination)\n\nReturns:\n    Dictionary with:\n\
+        \    - logs: List of log lines\n    - source: Where logs were fetched from\
+        \ (\"container\" or \"database\")\n    - has_more: Boolean indicating if there\
+        \ are more logs (if paginated)"
       operationId: get_flow_execution_logs_api_v1_flows_executions__execution_id__logs_get
       security:
       - bearerAuth: []


### PR DESCRIPTION
## Problem

The flow execution logs endpoint treats every running execution with an `agent_session_reference` as container backed. Executions leased to a private runner carry a lease reference (`runner:{runner_id}:{execution_id}`, or `runner:queued:{pool}:{execution_id}` while waiting), not a container id or Kubernetes Job name. The pod lookup then builds an invalid label selector (`job-name=runner:...`: colons, over 63 characters), the Kubernetes API returns 400, the error is swallowed, and the endpoint answers `source: container` with zero lines. The runner's output, which streams over the runner WebSocket into `flow_execution_log`, stays invisible in the console until the execution finishes, and every poll of the log pane generates API error noise. Queued executions are hit twice: they show nothing at all, hiding the queue-status entries that would explain the wait.

The stop command had the same container assumption with two extra effects:

- the final-log fetch 400'd the same way (harmless but noisy), and
- the halt was never flagged on the runner (`RemoteRunnerExecutor.stop` sets `halt_requested`, but the endpoint built a `ContainerAgentExecutor` directly), so cancelling a runner-backed execution left the job running on the runner until it finished or the runner process was killed.

## Changes (`api/endpoints/flows.py`)

- Logs endpoint: skip the container path when the session reference parses as a runner reference (`runner_id_from_session_reference` / `pool_from_session_reference`, both already imported) and serve the database logs instead.
- Stop command: for leased executions, flag `runner.halt_requested` (the runner learns it via its heartbeat ack) instead of constructing a container executor; for queued executions, skip both paths since nothing runs yet and the status update alone releases the orchestrator's queue wait.

## Tests (measured)

- 4 new endpoint tests: runner-leased and queued executions read logs from the database without constructing an agent executor; stop on a leased execution flags the halt and builds no container executor; stop on a queued execution touches neither.
- `backend/tests/endpoints/test_flows.py` plus the runner-related endpoint, agent, and service modules: 147 passed / 0 failed.
- pre-commit clean (ruff-format reformatted one test).

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Bug fix with no security impact and thorough test coverage; all findings addressed.
>
> **Overview**
> Routes runner-backed and queued flow executions around the container log path (serving DB logs) and flags `runner.halt_requested` on stop instead of building a container executor. Reuses existing session-reference helpers and mirrors `RemoteRunnerExecutor.stop` semantics.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 2685e5f. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->