### PR TITLE
Put Models above Tools in the console sidebar

### DIFF
--- a/frontend/src/views/authed/console-shell.test.ts
+++ b/frontend/src/views/authed/console-shell.test.ts
@@ -410,6 +410,29 @@ describe('ConsoleShell', () => {
     expect(toolsLink).to.exist;
   });
 
+  it('lists Models before Tools in the sidebar', async () => {
+    const el = (await fixture(
+      html`<console-shell></console-shell>`
+    )) as ConsoleShell;
+
+    await waitUntil(
+      () =>
+        el.shadowRoot?.querySelector('a[href="/console/ai-models"]') !== null,
+      'Sidebar models link did not render'
+    );
+
+    const hrefs = Array.from(
+      el.shadowRoot?.querySelectorAll('a.sidebar-link') ?? []
+    ).map((link) => link.getAttribute('href'));
+    const models = hrefs.indexOf('/console/ai-models');
+    const tools = hrefs.indexOf('/console/tools');
+    expect(models, 'models link is in the sidebar').to.be.greaterThan(-1);
+    expect(tools, 'tools link is in the sidebar').to.be.greaterThan(-1);
+    // Models is the everyday destination; Tools (and Policies under it) is
+    // configuration, so it reads after Models.
+    expect(models).to.be.lessThan(tools);
+  });
+
   describe('Policies preview gate', () => {
     /** Re-stub fetch with a chosen policies_console flag and superuser bit. */
     function stubShell(

--- a/frontend/src/views/authed/console-shell.ts
+++ b/frontend/src/views/authed/console-shell.ts
@@ -718,6 +718,15 @@ export class ConsoleShell extends LitElement {
                       `
                     )}
                     ${this._renderNavLink(
+                      '/console/ai-models',
+                      html`
+                        <sl-menu-item>
+                          <sl-icon name="cpu" slot="prefix"></sl-icon>
+                          <span class="sidebar-label">Models</span>
+                        </sl-menu-item>
+                      `
+                    )}
+                    ${this._renderNavLink(
                       '/console/tools',
                       html`
                         <sl-menu-item>
@@ -751,15 +760,6 @@ export class ConsoleShell extends LitElement {
                             slot="prefix"
                           ></sl-icon>
                           <span class="sidebar-label">Trackers</span>
-                        </sl-menu-item>
-                      `
-                    )}
-                    ${this._renderNavLink(
-                      '/console/ai-models',
-                      html`
-                        <sl-menu-item>
-                          <sl-icon name="cpu" slot="prefix"></sl-icon>
-                          <span class="sidebar-label">Models</span>
                         </sl-menu-item>
                       `
                     )}


### PR DESCRIPTION
## Summary
- Move the Models entry above Tools in the console sidebar so the order reads Overview, Agents, Flows, Models, Tools (Policies nested), Trackers, Cost, Audit.
- Adds a test that pins the order (`console-shell.test.ts`, "lists Models before Tools in the sidebar").

## Tests
- `console-shell.test.ts`: 26 passed.
- Full frontend suite on this branch: 1557 passed (main baseline 1556).

Fable review (V-AC1): no findings on this branch.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Minor UI ordering change with a test pinning the order; no security, quality, or performance concerns.

> **Overview**
> Moves the Models sidebar entry above Tools in the console shell (order now Overview, Agents, Flows, Models, Tools/Policies, Trackers, Cost, Audit), and adds a test asserting the new ordering via the rendered sidebar links.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 35bd919. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->