### PR TITLE
Talk window follows the latest message; Agent Control presence from a persisted heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`control_last_heartbeat_at` on managed agent summaries**: Agent Control
+  presence now exposes the last WebSocket heartbeat timestamp on
+  `ManagedAgentSummary` (list and detail, OpenAPI, TypeScript type) so the
+  age of the signal is readable when debugging replica disagreement.
+
 - **Codex ChatGPT-OAuth model auto-registration**: when Codex CLI (or any
   OpenAI-protocol client using a ChatGPT subscription-OAuth credential)
   asks for a `gpt-*` / o-series / `chatgpt-*` model the account has not
@@ -97,6 +102,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   adds a page by dropping a markdown file.
 
 ### Fixed
+
+- **Talk window follows the latest message**: new turns (including after
+  the 50-event page is full, and replies that arrive as activity rows)
+  keep the thread at the bottom unless the reader scrolled up with a
+  gesture. Session switches rebind the thread; layout growth re-sticks
+  via ResizeObserver. The Jump to latest pill remains the only way back.
+
+- **Agent Control presence is honest across replicas**: `control_online`
+  is computed from a persisted heartbeat (~90s TTL) instead of whichever
+  replica holds the WebSocket, so the badge no longer flaps offline on
+  the replica that does not own the socket. `last_seen_at` (enrollment
+  and gateway traffic) is no longer used as a stand-in for a live plugin.
 
 - **Wrapper PR/MR create no longer sends invalid JSON**:
   `git_clone_config.create_pull_request` interpolated title and body into

--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -660,8 +660,14 @@ def _managed_agent_control_fields(
         # runs more than one api replica. The socket writes a heartbeat
         # timestamp on every frame, so every replica reaches the same verdict
         # instead of the badge toggling with whichever pod answered.
-        ws_connected = bool(snapshot.get("online")) or control_heartbeat_is_fresh(
-            heartbeat_at
+        #
+        # The local registry only counts when the heartbeat agrees or has never
+        # been written (an old socket from before the column existed). A stale
+        # heartbeat with a live registry entry means the socket stopped talking:
+        # this replica must not keep claiming online while the others say
+        # offline.
+        ws_connected = control_heartbeat_is_fresh(heartbeat_at) or (
+            bool(snapshot.get("online")) and heartbeat_at is None
         )
     control_online = bool(control_enabled and ws_connected)
     if control_online:

--- a/backend/preloop/api/endpoints/account.py
+++ b/backend/preloop/api/endpoints/account.py
@@ -100,6 +100,7 @@ from preloop.services.account_realtime import (
     build_account_event,
     emit_account_event,
 )
+from preloop.services.agent_control_presence import control_heartbeat_is_fresh
 from preloop.services.account_governance_cache import (
     invalidate_account_governance_cache,
 )
@@ -647,6 +648,7 @@ def _managed_agent_control_fields(
     )
     snapshot: dict = {}
     agent_id = str(summary.get("id") or "")
+    heartbeat_at = summary.get("control_last_heartbeat_at")
     if ws_connected is None and agent_id:
         try:
             from preloop.api.endpoints.agent_control import agent_control_snapshot
@@ -654,22 +656,13 @@ def _managed_agent_control_fields(
             snapshot = agent_control_snapshot(agent_id)
         except (ImportError, AttributeError, RuntimeError):
             snapshot = {}
-        ws_connected = bool(snapshot.get("online"))
-        if not ws_connected:
-            # Sidecar heartbeats persist last_seen_at *and* session mode.
-            # Enrollment and gateway usage also stamp last_seen_at, so recency
-            # alone would mark a freshly onboarded agent online. Require a
-            # persisted sidecar mode so a REST worker that did not accept the
-            # WebSocket can still report online.
-            persisted_mode = summary.get("control_session_mode")
-            seen = summary.get("last_seen_at")
-            if persisted_mode in {"local", "remote", "queued"} and seen is not None:
-                if getattr(seen, "tzinfo", None) is None:
-                    seen = seen.replace(tzinfo=UTC)
-                try:
-                    ws_connected = datetime.now(UTC) - seen <= timedelta(seconds=45)
-                except TypeError:
-                    ws_connected = False
+        # This process may not be the one holding the agent's WebSocket: cloud
+        # runs more than one api replica. The socket writes a heartbeat
+        # timestamp on every frame, so every replica reaches the same verdict
+        # instead of the badge toggling with whichever pod answered.
+        ws_connected = bool(snapshot.get("online")) or control_heartbeat_is_fresh(
+            heartbeat_at
+        )
     control_online = bool(control_enabled and ws_connected)
     if control_online:
         control_state = AGENT_CONTROL_STATE_PLUGIN_CONNECTED
@@ -704,6 +697,7 @@ def _managed_agent_control_fields(
         "supports_voice": control_enabled,
         "supports_interrupt": supports_interrupt,
         "control_session_mode": session_mode,
+        "control_last_heartbeat_at": heartbeat_at,
         "supported_input_modes": (
             list(AGENT_CONTROL_INPUT_MODES) if control_enabled else []
         ),

--- a/backend/preloop/api/endpoints/agent_control.py
+++ b/backend/preloop/api/endpoints/agent_control.py
@@ -61,6 +61,19 @@ router = APIRouter()
 # ``integrations/agent_control/core.py``; keep them in sync.
 EVICTION_CLOSE_CODE: int = 4000
 
+# How long the control WebSocket waits for an inbound frame before it pings the
+# agent, and how many of those windows may pass in silence before the socket is
+# closed.
+#
+# Two windows is 120s, past the 90s presence TTL. A half-open socket (a closed
+# laptop lid, a network that dropped without sending a FIN) would otherwise keep
+# this replica answering "online" from its in-process registry for as long as
+# the kernel holds the connection, while every other replica has already timed
+# the heartbeat out. Closing runs the disconnect path, which drops the registry
+# entry and clears the heartbeat, so all replicas agree again.
+AGENT_CONTROL_RECEIVE_TIMEOUT_SECONDS: float = 60.0
+AGENT_CONTROL_MAX_SILENT_RECEIVES: int = 2
+
 # Operational failures on the delivery path (NATS / DB / WS). Catch these
 # instead of bare ``Exception`` so programming bugs (AttributeError, TypeError,
 # etc.) still surface.
@@ -875,15 +888,37 @@ async def managed_agent_control_websocket(
     # (or alongside) sending their capabilities envelope.
     await _redeliver_pending_commands(db, connection, websocket)
 
+    # Consecutive receive timeouts. A live plugin beats every 30s, so one
+    # timeout is a slow agent and two is a socket nobody is on the other end of.
+    silent_receives = 0
     try:
         while True:
             try:
                 raw_message = await asyncio.wait_for(
-                    websocket.receive_json(), timeout=60.0
+                    websocket.receive_json(),
+                    timeout=AGENT_CONTROL_RECEIVE_TIMEOUT_SECONDS,
                 )
             except asyncio.TimeoutError:
+                silent_receives += 1
+                if silent_receives >= AGENT_CONTROL_MAX_SILENT_RECEIVES:
+                    logger.info(
+                        "Managed agent %s control websocket silent for %ss; "
+                        "closing so presence can be retired",
+                        connection.managed_agent_id,
+                        int(AGENT_CONTROL_RECEIVE_TIMEOUT_SECONDS * silent_receives),
+                    )
+                    # Close explicitly: the client has to learn the socket is
+                    # gone so a plugin that is merely wedged can reconnect.
+                    try:
+                        await websocket.close(code=status.WS_1001_GOING_AWAY)
+                    except _WS_DELIVERY_ERRORS:
+                        logger.debug(
+                            "Silent control websocket already gone", exc_info=True
+                        )
+                    break
                 await websocket.send_json({"type": "ping"})
                 continue
+            silent_receives = 0
 
             try:
                 inbound = AgentControlInboundEnvelope.model_validate(raw_message)

--- a/backend/preloop/api/endpoints/agent_control.py
+++ b/backend/preloop/api/endpoints/agent_control.py
@@ -412,6 +412,10 @@ def _touch_presence(
         runtime_session_id=context.runtime_session.id,
         observed_at=observed_at,
         control_session_mode=session_mode,
+        # This function is only reachable from the Agent Control WebSocket, so
+        # every call here is proof the plugin is connected right now. It is the
+        # only presence signal the other api replicas can read.
+        control_heartbeat_at=observed_at,
         commit=False,
     )
     if commit:
@@ -846,6 +850,9 @@ async def managed_agent_control_websocket(
 
     now = datetime.now(UTC)
     _touch_presence(db, context, observed_at=now)
+    # The last heartbeat this connection wrote, so a clean close can retire
+    # its own presence without stealing a newer connection's.
+    last_presence_at = now
     connected = _connection_envelope(
         connection,
         envelope_type="presence",
@@ -910,10 +917,11 @@ async def managed_agent_control_websocket(
                 inbound_mode = inbound.payload.get("session_mode")
                 if inbound_mode not in {"local", "remote", "queued"}:
                     inbound_mode = None
+                last_presence_at = datetime.now(UTC)
                 _touch_presence(
                     db,
                     context,
-                    observed_at=datetime.now(UTC),
+                    observed_at=last_presence_at,
                     session_mode=inbound_mode,
                 )
                 _mark_control_verified_from_capabilities(db, context, inbound)
@@ -959,6 +967,26 @@ async def managed_agent_control_websocket(
                 )
         removed_active = await agent_control_manager.disconnect(connection_id)
         if removed_active:
+            # A clean close is presence information every replica can read, so
+            # retire the heartbeat instead of waiting out the window. This runs
+            # in a finally block: a session that already failed must not stop
+            # the disconnect bookkeeping below.
+            try:
+                crud_managed_agent.clear_control_heartbeat(
+                    db,
+                    account_id=connection.account_id,
+                    session_source_type=connection.managed_agent_session_source_type,
+                    session_source_id=connection.managed_agent_session_source_id,
+                    not_newer_than=last_presence_at,
+                    commit=True,
+                )
+            except _DB_DELIVERY_ERRORS:
+                logger.warning(
+                    "Failed to clear control heartbeat for managed agent %s",
+                    connection.managed_agent_id,
+                    exc_info=True,
+                )
+                db.rollback()
             crud_managed_agent.clear_runtime_session_binding(
                 db,
                 account_id=connection.account_id,

--- a/backend/preloop/api/endpoints/agent_control.py
+++ b/backend/preloop/api/endpoints/agent_control.py
@@ -65,12 +65,11 @@ EVICTION_CLOSE_CODE: int = 4000
 # agent, and how many of those windows may pass in silence before the socket is
 # closed.
 #
-# Two windows is 120s, past the 90s presence TTL. A half-open socket (a closed
-# laptop lid, a network that dropped without sending a FIN) would otherwise keep
-# this replica answering "online" from its in-process registry for as long as
-# the kernel holds the connection, while every other replica has already timed
-# the heartbeat out. Closing runs the disconnect path, which drops the registry
-# entry and clears the heartbeat, so all replicas agree again.
+# Presence itself is retired by the ~90s heartbeat TTL, independent of this
+# close. Two windows is 120s: that is how long a half-open socket (a closed
+# laptop lid, a network that dropped without sending a FIN) can occupy this
+# replica. Closing frees the dead connection so a wedged plugin can reconnect,
+# and the disconnect path can drop the registry entry and clear the heartbeat.
 AGENT_CONTROL_RECEIVE_TIMEOUT_SECONDS: float = 60.0
 AGENT_CONTROL_MAX_SILENT_RECEIVES: int = 2
 

--- a/backend/preloop/models/alembic/versions/20260905_control_heartbeat.py
+++ b/backend/preloop/models/alembic/versions/20260905_control_heartbeat.py
@@ -1,0 +1,35 @@
+"""Dedicated Agent Control heartbeat timestamp on managed agents.
+
+Revision ID: 20260905_control_heartbeat
+Revises: 20260904_flow_notifications
+Create Date: 2026-09-05
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260905_control_heartbeat"
+down_revision = "20260904_flow_notifications"
+branch_labels = None
+depends_on = None
+_ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)
+assert _ALEMBIC_IDENTIFIERS, "Alembic revision metadata must be defined"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "managed_agent",
+        sa.Column(
+            "control_last_heartbeat_at",
+            sa.DateTime(),
+            nullable=True,
+            comment=(
+                "Last Agent Control WebSocket heartbeat; presence for api "
+                "replicas that do not hold the socket"
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("managed_agent", "control_last_heartbeat_at")

--- a/backend/preloop/models/alembic/versions/20260905_control_heartbeat.py
+++ b/backend/preloop/models/alembic/versions/20260905_control_heartbeat.py
@@ -1,7 +1,7 @@
 """Dedicated Agent Control heartbeat timestamp on managed agents.
 
 Revision ID: 20260905_control_heartbeat
-Revises: 20260904_flow_notifications
+Revises: 20260905_flow_cli_session
 Create Date: 2026-09-05
 """
 

--- a/backend/preloop/models/alembic/versions/20260905_control_heartbeat.py
+++ b/backend/preloop/models/alembic/versions/20260905_control_heartbeat.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "20260905_control_heartbeat"
-down_revision = "20260904_flow_notifications"
+down_revision = "20260905_flow_cli_session"
 branch_labels = None
 depends_on = None
 _ALEMBIC_IDENTIFIERS = (revision, down_revision, branch_labels, depends_on)

--- a/backend/preloop/models/crud/managed_agent.py
+++ b/backend/preloop/models/crud/managed_agent.py
@@ -459,9 +459,16 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         runtime_session_id: Optional[Any] = None,
         observed_at: datetime,
         control_session_mode: Optional[str] = None,
+        control_heartbeat_at: Optional[datetime] = None,
         commit: bool = False,
     ) -> Optional[ManagedAgent]:
-        """Update last-seen timestamp for one durable managed agent."""
+        """Update last-seen timestamp for one durable managed agent.
+
+        ``control_heartbeat_at`` is passed only by the Agent Control
+        WebSocket. It is a separate column from ``last_seen_at`` because
+        enrollment and gateway traffic stamp that one too, and presence has to
+        mean "the plugin is connected", not "this agent did something".
+        """
         db_obj = self.get_by_source(
             db,
             account_id=str(account_id),
@@ -473,6 +480,8 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         if db_obj.lifecycle_state != "active":
             return db_obj
         db_obj.last_seen_at = observed_at
+        if control_heartbeat_at is not None:
+            db_obj.control_last_heartbeat_at = control_heartbeat_at
         if control_session_mode in {"local", "remote", "queued"}:
             db_obj.control_session_mode = control_session_mode
         if runtime_session_id is not None:
@@ -570,6 +579,48 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
         ):
             return db_obj
         db_obj.runtime_session_id = None
+        db.add(db_obj)
+        if commit:
+            db.commit()
+            db.refresh(db_obj)
+        else:
+            db.flush()
+        return db_obj
+
+    def clear_control_heartbeat(
+        self,
+        db: Session,
+        *,
+        account_id: str,
+        session_source_type: str,
+        session_source_id: str,
+        not_newer_than: datetime,
+        commit: bool = False,
+    ) -> Optional[ManagedAgent]:
+        """Drop the presence heartbeat when a control socket closes cleanly.
+
+        Without this the badge would keep saying online for the length of the
+        presence window after somebody quits their agent. ``not_newer_than``
+        is the last heartbeat this connection wrote: if the stored value has
+        moved past it the plugin already reconnected (possibly to another api
+        replica), and this late close must not report it offline.
+        """
+        db_obj = self.get_by_source(
+            db,
+            account_id=account_id,
+            session_source_type=session_source_type,
+            session_source_id=session_source_id,
+        )
+        if db_obj is None:
+            return None
+        stored = db_obj.control_last_heartbeat_at
+        if stored is not None:
+            if stored.tzinfo is None:
+                stored = stored.replace(tzinfo=UTC)
+            if stored > not_newer_than:
+                return db_obj
+        db_obj.control_last_heartbeat_at = None
+        db_obj.control_session_mode = None
         db.add(db_obj)
         if commit:
             db.commit()
@@ -832,6 +883,8 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
                 self.model.lifecycle_reason,
                 self.model.lifecycle_updated_at,
                 self.model.last_seen_at,
+                self.model.control_session_mode,
+                self.model.control_last_heartbeat_at,
                 self.model.tags,
                 User.username.label("owner_username"),
                 User.email.label("owner_email"),
@@ -863,6 +916,8 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
                 self.model.lifecycle_reason,
                 self.model.lifecycle_updated_at,
                 self.model.last_seen_at,
+                self.model.control_session_mode,
+                self.model.control_last_heartbeat_at,
                 self.model.tags,
                 User.username,
                 User.email,
@@ -941,6 +996,8 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
                 self.model.lifecycle_reason,
                 self.model.lifecycle_updated_at,
                 self.model.last_seen_at,
+                self.model.control_session_mode,
+                self.model.control_last_heartbeat_at,
                 self.model.tags,
                 User.username.label("owner_username"),
                 User.email.label("owner_email"),
@@ -972,6 +1029,8 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
                 self.model.lifecycle_reason,
                 self.model.lifecycle_updated_at,
                 self.model.last_seen_at,
+                self.model.control_session_mode,
+                self.model.control_last_heartbeat_at,
                 self.model.tags,
                 User.username,
                 User.email,
@@ -1156,6 +1215,9 @@ class CRUDManagedAgent(CRUDBase[ManagedAgent]):
             "last_seen_at": row.last_seen_at,
             "control_session_mode": getattr(row, "control_session_mode", None)
             or "offline",
+            "control_last_heartbeat_at": getattr(
+                row, "control_last_heartbeat_at", None
+            ),
             "started_at": row.started_at,
             "last_activity_at": row.last_activity_at,
             "ended_at": row.ended_at,

--- a/backend/preloop/models/models/managed_agent.py
+++ b/backend/preloop/models/models/managed_agent.py
@@ -77,6 +77,10 @@ class ManagedAgent(Base):
     control_session_mode: Mapped[Optional[str]] = mapped_column(
         String(16), nullable=True
     )
+    # Written only by the Agent Control WebSocket. last_seen_at is stamped by
+    # enrollment and by gateway traffic too, so it cannot answer "is the
+    # plugin connected" for a process that does not hold the socket.
+    control_last_heartbeat_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
 
     account: Mapped["Account"] = relationship(
         "Account", back_populates="managed_agents"

--- a/backend/preloop/schemas/gateway_usage.py
+++ b/backend/preloop/schemas/gateway_usage.py
@@ -327,6 +327,10 @@ class ManagedAgentSummary(BaseModel):
     supports_voice: bool = False
     supports_interrupt: bool = False
     control_session_mode: str = "offline"
+    #: Last Agent Control heartbeat this agent's plugin sent. Exposed so an
+    #: operator (and staging debugging) can tell "no plugin" from "the plugin
+    #: stopped beating", which the online flag alone cannot say.
+    control_last_heartbeat_at: Optional[datetime] = None
     supported_input_modes: List[str] = Field(default_factory=list)
     supported_output_modes: List[str] = Field(default_factory=list)
 

--- a/backend/preloop/services/agent_control_presence.py
+++ b/backend/preloop/services/agent_control_presence.py
@@ -1,0 +1,60 @@
+"""One definition of "the Agent Control plugin is connected".
+
+Presence has two sources and they must agree. The api process that holds the
+managed agent's WebSocket knows the truth first hand; every other process (the
+second api replica, a worker) can only read what the socket wrote to the
+database. Cloud runs more than one api replica, so a request answered by the
+process without the socket has to reach the same verdict or the console shows
+an agent that toggles online/offline at polling cadence.
+
+The persisted signal is ``managed_agent.control_last_heartbeat_at``, written
+only by the Agent Control WebSocket. ``last_seen_at`` is not usable for this:
+enrollment and ordinary gateway traffic stamp it too, so an agent whose plugin
+died would keep looking connected for as long as it kept making model calls.
+
+The freshness window is deliberately three heartbeats wide. Plugins beat every
+``AGENT_CONTROL_HEARTBEAT_INTERVAL`` and a single late beat (a busy Node event
+loop, a laptop asleep for a moment, a reconnect backoff) must not flip the
+badge.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any, Optional
+
+#: How often runtime plugins send a heartbeat envelope. Mirrors
+#: ``HEARTBEAT_INTERVAL_MS`` in every runtime plugin under ``runtime-plugins/``.
+AGENT_CONTROL_HEARTBEAT_INTERVAL = timedelta(seconds=30)
+
+#: How long a heartbeat keeps an agent "connected" for processes that do not
+#: hold its WebSocket. Three beats: one lost beat is noise, three is a gone
+#: plugin.
+AGENT_CONTROL_PRESENCE_TTL = AGENT_CONTROL_HEARTBEAT_INTERVAL * 3
+
+
+def control_heartbeat_is_fresh(
+    heartbeat_at: Any, *, now: Optional[datetime] = None
+) -> bool:
+    """Is this the timestamp of a heartbeat inside the presence window?
+
+    Args:
+        heartbeat_at: Persisted ``control_last_heartbeat_at``, aware or naive
+            UTC, or ``None`` when the agent has never connected.
+        now: Override for tests.
+
+    Returns:
+        True when a control heartbeat landed inside
+        :data:`AGENT_CONTROL_PRESENCE_TTL`.
+    """
+    if not isinstance(heartbeat_at, datetime):
+        return False
+    if heartbeat_at.tzinfo is None:
+        heartbeat_at = heartbeat_at.replace(tzinfo=UTC)
+    reference = now or datetime.now(UTC)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=UTC)
+    try:
+        return reference - heartbeat_at <= AGENT_CONTROL_PRESENCE_TTL
+    except TypeError:
+        return False

--- a/backend/tests/endpoints/test_account_agents.py
+++ b/backend/tests/endpoints/test_account_agents.py
@@ -259,6 +259,63 @@ def test_managed_agent_control_online_ignores_enrollment_last_seen():
     assert fields["control_session_mode"] == "offline"
 
 
+def _online_snapshot(_agent_id: str) -> dict:
+    return {"online": True, "session_mode": "local", "supports_interrupt": True}
+
+
+def test_managed_agent_control_online_ignores_a_registry_entry_gone_stale():
+    """A half-open socket must not keep one replica claiming online.
+
+    The replica holding the socket knows it is registered, but if the
+    heartbeat it writes has stopped moving then the plugin is gone and every
+    other replica already says offline. Trust the shared signal.
+    """
+    with patch(
+        "preloop.api.endpoints.agent_control.agent_control_snapshot",
+        _online_snapshot,
+    ):
+        stale = _managed_agent_control_fields(
+            {
+                "id": "agent-half-open",
+                "agent_kind": "claude_code",
+                "session_source_type": "claude_code",
+                "lifecycle_state": "active",
+                "runtime_session_id": "runtime-claude",
+                "ended_at": None,
+                "last_seen_at": datetime.now(UTC),
+                "control_session_mode": "local",
+                "control_last_heartbeat_at": (
+                    datetime.now(UTC)
+                    - AGENT_CONTROL_PRESENCE_TTL
+                    - timedelta(seconds=5)
+                ),
+            },
+            _control_enrollment(),
+        )
+
+        assert stale["control_online"] is False
+        assert stale["control_session_mode"] == "offline"
+
+        # A socket from before the heartbeat column existed still counts.
+        never_beat = _managed_agent_control_fields(
+            {
+                "id": "agent-half-open",
+                "agent_kind": "claude_code",
+                "session_source_type": "claude_code",
+                "lifecycle_state": "active",
+                "runtime_session_id": "runtime-claude",
+                "ended_at": None,
+                "last_seen_at": datetime.now(UTC),
+                "control_session_mode": "local",
+                "control_last_heartbeat_at": None,
+            },
+            _control_enrollment(),
+        )
+
+        assert never_beat["control_online"] is True
+        assert never_beat["control_session_mode"] == "local"
+
+
 def test_managed_agent_summary_coerces_null_session_mode():
     from preloop.schemas.gateway_usage import ManagedAgentSummary
 

--- a/backend/tests/endpoints/test_account_agents.py
+++ b/backend/tests/endpoints/test_account_agents.py
@@ -9,6 +9,10 @@ from preloop.api.endpoints.account import (
     _managed_agent_control_config_flags,
     _managed_agent_onboarding_flags,
 )
+from preloop.services.agent_control_presence import (
+    AGENT_CONTROL_HEARTBEAT_INTERVAL,
+    AGENT_CONTROL_PRESENCE_TTL,
+)
 from preloop.models.crud import (
     crud_ai_model,
     crud_api_usage,
@@ -170,8 +174,20 @@ def test_managed_agent_control_fields_enable_claude_code_with_sidecar_flags():
     assert no_sidecar["control_capabilities"] == []
 
 
-def test_managed_agent_control_online_uses_persisted_last_seen():
-    """REST on another worker still reports online from the sidecar heartbeat."""
+def _control_enrollment() -> dict:
+    return {
+        "validation_result": {
+            "control_channel_configured": True,
+            "control_plugin_verified": True,
+            "control_ws_url_ok": True,
+            "control_bearer_token_ok": True,
+        },
+        "managed_config": {},
+    }
+
+
+def test_managed_agent_control_online_uses_persisted_heartbeat():
+    """REST on another replica still reports online from the WS heartbeat."""
     fields = _managed_agent_control_fields(
         {
             "id": "agent-from-db",
@@ -182,24 +198,48 @@ def test_managed_agent_control_online_uses_persisted_last_seen():
             "ended_at": None,
             "last_seen_at": datetime.now(UTC) - timedelta(seconds=10),
             "control_session_mode": "local",
+            "control_last_heartbeat_at": datetime.now(UTC) - timedelta(seconds=10),
         },
-        {
-            "validation_result": {
-                "control_channel_configured": True,
-                "control_plugin_verified": True,
-                "control_ws_url_ok": True,
-                "control_bearer_token_ok": True,
-            },
-            "managed_config": {},
-        },
+        _control_enrollment(),
     )
 
     assert fields["control_online"] is True
     assert fields["control_session_mode"] == "local"
 
 
+def test_managed_agent_presence_window_survives_one_missed_heartbeat():
+    """A late beat must not flip the badge; three missed beats must."""
+    beat = AGENT_CONTROL_HEARTBEAT_INTERVAL.total_seconds()
+    assert AGENT_CONTROL_PRESENCE_TTL >= AGENT_CONTROL_HEARTBEAT_INTERVAL * 2.5
+
+    def online_after(seconds: float) -> bool:
+        return _managed_agent_control_fields(
+            {
+                "id": "agent-from-db",
+                "agent_kind": "claude_code",
+                "session_source_type": "claude_code",
+                "lifecycle_state": "active",
+                "runtime_session_id": "runtime-claude",
+                "ended_at": None,
+                "last_seen_at": datetime.now(UTC),
+                "control_session_mode": "remote",
+                "control_last_heartbeat_at": (
+                    datetime.now(UTC) - timedelta(seconds=seconds)
+                ),
+            },
+            _control_enrollment(),
+        )["control_online"]
+
+    # One beat late, then two: still connected, because plugins are allowed to
+    # be busy for a moment.
+    assert online_after(beat * 2 - 1) is True
+    assert online_after(AGENT_CONTROL_PRESENCE_TTL.total_seconds() - 1) is True
+    # Past the window the agent is gone, and it takes more than one lost beat.
+    assert online_after(AGENT_CONTROL_PRESENCE_TTL.total_seconds() + 5) is False
+
+
 def test_managed_agent_control_online_ignores_enrollment_last_seen():
-    """Token mint stamps last_seen_at; that is not a sidecar heartbeat."""
+    """Token mint and gateway traffic stamp last_seen_at; neither is presence."""
     fields = _managed_agent_control_fields(
         {
             "id": "agent-from-db",
@@ -209,16 +249,10 @@ def test_managed_agent_control_online_ignores_enrollment_last_seen():
             "runtime_session_id": "runtime-claude",
             "ended_at": None,
             "last_seen_at": datetime.now(UTC) - timedelta(seconds=10),
+            # A stale session mode from an old connection, and no heartbeat.
+            "control_session_mode": "remote",
         },
-        {
-            "validation_result": {
-                "control_channel_configured": True,
-                "control_plugin_verified": True,
-                "control_ws_url_ok": True,
-                "control_bearer_token_ok": True,
-            },
-            "managed_config": {},
-        },
+        _control_enrollment(),
     )
 
     assert fields["control_online"] is False
@@ -2257,3 +2291,141 @@ def test_account_agent_enrollment_validate_and_restore(client, db_session, test_
     assert restore_body["backup_metadata"]["restored_by"] == "test"
     assert restore_body["validation_result"]["restored"] is True
     assert restore_body["last_restored_at"] is not None
+
+
+def _enroll_control_plugin(db_session, *, account_id, agent_id, user_id) -> None:
+    """The enrollment the runtime plugin writes when it installs itself."""
+    crud_managed_agent_enrollment.create_for_agent(
+        db_session,
+        account_id=account_id,
+        agent_id=agent_id,
+        created_by_user_id=user_id,
+        enrollment_type="cli_managed_config",
+        adapter_key="claude_code",
+        status="active",
+        managed_config={},
+        validation_result={
+            "control_channel_configured": True,
+            "control_plugin_verified": True,
+            "control_ws_url_ok": True,
+            "control_bearer_token_ok": True,
+        },
+        commit=True,
+    )
+
+
+def test_agent_presence_survives_a_replica_without_the_websocket(
+    client, db_session, test_user
+):
+    """Production runs api=2, so most reads never see the connection registry.
+
+    This request is served by a process that holds no Agent Control socket for
+    this agent. It has to answer from the persisted heartbeat, otherwise the
+    badge flips every time the load balancer picks the other replica.
+    """
+    token_response = client.post(
+        "/api/v1/auth/runtime-sessions/token",
+        json={
+            "session_source_type": "claude_code",
+            "session_source_id": "workspace-presence",
+            "session_reference": "claude-session-presence",
+            "runtime_principal_name": "Presence Workspace",
+            "allowed_mcp_servers": [],
+        },
+    )
+    assert token_response.status_code == 201
+
+    agent = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="workspace-presence",
+    )
+    assert agent is not None
+    _enroll_control_plugin(
+        db_session,
+        account_id=test_user.account_id,
+        agent_id=agent.id,
+        user_id=test_user.id,
+    )
+
+    # The heartbeat the WebSocket persisted on the other replica.
+    crud_managed_agent.touch_last_seen_for_principal(
+        db_session,
+        account_id=test_user.account_id,
+        session_source_type="claude_code",
+        session_source_id="workspace-presence",
+        observed_at=datetime.now(UTC),
+        control_session_mode="local",
+        control_heartbeat_at=datetime.now(UTC),
+        commit=True,
+    )
+
+    detail = client.get(f"/api/v1/agents/{agent.id}")
+    assert detail.status_code == 200
+    body = detail.json()["agent"]
+    assert body["control_enabled"] is True
+    assert body["control_online"] is True
+    assert body["control_session_mode"] == "local"
+
+    listed = client.get("/api/v1/agents")
+    assert listed.status_code == 200
+    item = next(
+        entry
+        for entry in listed.json()["items"]
+        if entry["session_source_id"] == "workspace-presence"
+    )
+    # The list and the detail view must agree; the console reads both.
+    assert item["control_online"] is True
+    assert item["control_session_mode"] == "local"
+
+
+def test_agent_presence_goes_offline_once_the_heartbeat_window_passes(
+    client, db_session, test_user
+):
+    """A plugin that stopped beating is offline, on every replica."""
+    token_response = client.post(
+        "/api/v1/auth/runtime-sessions/token",
+        json={
+            "session_source_type": "claude_code",
+            "session_source_id": "workspace-stale",
+            "session_reference": "claude-session-stale",
+            "runtime_principal_name": "Stale Workspace",
+            "allowed_mcp_servers": [],
+        },
+    )
+    assert token_response.status_code == 201
+
+    agent = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="workspace-stale",
+    )
+    assert agent is not None
+    _enroll_control_plugin(
+        db_session,
+        account_id=test_user.account_id,
+        agent_id=agent.id,
+        user_id=test_user.id,
+    )
+
+    stale = datetime.now(UTC) - AGENT_CONTROL_PRESENCE_TTL - timedelta(seconds=5)
+    crud_managed_agent.touch_last_seen_for_principal(
+        db_session,
+        account_id=test_user.account_id,
+        session_source_type="claude_code",
+        session_source_id="workspace-stale",
+        # Gateway traffic keeps last_seen_at fresh even after the plugin died.
+        observed_at=datetime.now(UTC),
+        control_session_mode="local",
+        control_heartbeat_at=stale,
+        commit=True,
+    )
+
+    detail = client.get(f"/api/v1/agents/{agent.id}")
+    assert detail.status_code == 200
+    body = detail.json()["agent"]
+    assert body["control_enabled"] is True
+    assert body["control_online"] is False
+    assert body["control_session_mode"] == "offline"

--- a/backend/tests/endpoints/test_agent_control.py
+++ b/backend/tests/endpoints/test_agent_control.py
@@ -15,6 +15,7 @@ from preloop.models.crud import (
     crud_runtime_session,
     crud_runtime_session_activity,
 )
+from preloop.api.endpoints.agent_control import agent_control_snapshot
 from preloop.schemas.agent_control import AgentControlSendMessageRequest
 from preloop.services.agent_control_presence import control_heartbeat_is_fresh
 
@@ -1138,3 +1139,76 @@ def test_agent_control_ws_reconnect_keeps_the_newer_heartbeat(
             )
             assert refreshed is not None
             assert refreshed.control_last_heartbeat_at is not None
+
+
+def test_agent_control_ws_closes_a_socket_that_went_silent(
+    client, db_session, test_user
+):
+    """A half-open socket must be closed so presence can be retired.
+
+    The plugin beats every 30s. Two receive timeouts in a row is 120s of
+    silence, past the presence window, so the socket-holding replica has to
+    let go: otherwise its in-process registry keeps answering "online" while
+    every other replica has already timed the heartbeat out.
+    """
+    token_body = _issue_runtime_token(client, session_source_id="openclaw-silent")
+    managed_agent = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="openclaw",
+        session_source_id="openclaw-silent",
+    )
+    assert managed_agent is not None
+    url = f"/api/v1/agents/control/ws?token={token_body['token']}"
+
+    # Shrink the window so the test costs milliseconds, not four minutes.
+    with patch(
+        "preloop.api.endpoints.agent_control.AGENT_CONTROL_RECEIVE_TIMEOUT_SECONDS",
+        0.05,
+    ):
+        with client.websocket_connect(url) as websocket:
+            assert websocket.receive_json()["type"] == "presence"
+            # First timeout pings, second closes.
+            assert websocket.receive_json() == {"type": "ping"}
+            with pytest.raises(WebSocketDisconnect):
+                websocket.receive_json()
+
+    # The registry entry is gone and the heartbeat with it, so every replica
+    # reports the same agent offline.
+    assert agent_control_snapshot(str(managed_agent.id)).get("online") is not True
+    db_session.expire_all()
+    refreshed = crud_managed_agent.get_for_account(
+        db_session,
+        account_id=str(test_user.account_id),
+        agent_id=str(managed_agent.id),
+    )
+    assert refreshed is not None
+    assert refreshed.control_last_heartbeat_at is None
+
+
+def test_agent_control_ws_stays_open_while_the_agent_talks(
+    client, db_session, test_user
+):
+    """One quiet window is a busy plugin, not a dead one: the counter resets."""
+    token_body = _issue_runtime_token(client, session_source_id="openclaw-talkative")
+    url = f"/api/v1/agents/control/ws?token={token_body['token']}"
+
+    with patch(
+        "preloop.api.endpoints.agent_control.AGENT_CONTROL_RECEIVE_TIMEOUT_SECONDS",
+        0.05,
+    ):
+        with client.websocket_connect(url) as websocket:
+            assert websocket.receive_json()["type"] == "presence"
+            for index in range(3):
+                # Let one window lapse, then speak: the socket must survive.
+                assert websocket.receive_json() == {"type": "ping"}
+                websocket.send_json(
+                    {
+                        "type": "heartbeat",
+                        "message_id": f"hb-quiet-{index}",
+                        "payload": {},
+                    }
+                )
+                ack = websocket.receive_json()
+                assert ack["type"] == "ack"
+                assert ack["message_id"] == f"hb-quiet-{index}"

--- a/backend/tests/endpoints/test_agent_control.py
+++ b/backend/tests/endpoints/test_agent_control.py
@@ -16,6 +16,7 @@ from preloop.models.crud import (
     crud_runtime_session_activity,
 )
 from preloop.schemas.agent_control import AgentControlSendMessageRequest
+from preloop.services.agent_control_presence import control_heartbeat_is_fresh
 
 
 def _issue_runtime_token(client, *, session_source_id: str = "openclaw-live"):
@@ -1051,3 +1052,89 @@ def test_agent_control_ws_evicted_connection_does_not_clear_agent_binding(
         assert refreshed is not None
         # After ws2 (the active binding) disconnects, the session is cleared.
         assert refreshed.runtime_session_id is None
+
+
+def test_agent_control_ws_persists_heartbeat_for_other_replicas(
+    client, db_session, test_user
+):
+    """Presence has to outlive this process: api runs more than one replica."""
+    token_body = _issue_runtime_token(client, session_source_id="openclaw-heartbeat")
+    managed_agent = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="openclaw",
+        session_source_id="openclaw-heartbeat",
+    )
+    assert managed_agent is not None
+
+    url = f"/api/v1/agents/control/ws?token={token_body['token']}"
+    with client.websocket_connect(url) as websocket:
+        assert websocket.receive_json()["type"] == "presence"
+        websocket.send_json(
+            {
+                "type": "heartbeat",
+                "message_id": "hb-persist",
+                "payload": {"session_mode": "local"},
+            }
+        )
+        assert websocket.receive_json()["type"] == "ack"
+
+        db_session.expire_all()
+        refreshed = crud_managed_agent.get_for_account(
+            db_session,
+            account_id=str(test_user.account_id),
+            agent_id=str(managed_agent.id),
+        )
+        assert refreshed is not None
+        assert refreshed.control_last_heartbeat_at is not None
+        assert refreshed.control_session_mode == "local"
+        beat = refreshed.control_last_heartbeat_at
+        if beat.tzinfo is None:
+            beat = beat.replace(tzinfo=UTC)
+        # Fresh enough that a replica with no socket calls this agent online.
+        assert control_heartbeat_is_fresh(beat)
+
+    # A clean close retires presence instead of waiting out the window.
+    db_session.expire_all()
+    after_close = crud_managed_agent.get_for_account(
+        db_session,
+        account_id=str(test_user.account_id),
+        agent_id=str(managed_agent.id),
+    )
+    assert after_close is not None
+    assert after_close.control_last_heartbeat_at is None
+    assert control_heartbeat_is_fresh(after_close.control_last_heartbeat_at) is False
+
+
+def test_agent_control_ws_reconnect_keeps_the_newer_heartbeat(
+    client, db_session, test_user
+):
+    """A late close from an evicted socket must not report the agent offline."""
+    token_body = _issue_runtime_token(client, session_source_id="openclaw-hb-evict")
+    managed_agent = crud_managed_agent.get_by_source(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="openclaw",
+        session_source_id="openclaw-hb-evict",
+    )
+    assert managed_agent is not None
+    url = f"/api/v1/agents/control/ws?token={token_body['token']}"
+
+    with client.websocket_connect(url) as ws1:
+        assert ws1.receive_json()["type"] == "presence"
+
+        with client.websocket_connect(url) as ws2:
+            assert ws2.receive_json()["type"] == "presence"
+
+            # ws1 is evicted and tears down after ws2 already registered.
+            with pytest.raises(WebSocketDisconnect):
+                ws1.receive_json()
+
+            db_session.expire_all()
+            refreshed = crud_managed_agent.get_for_account(
+                db_session,
+                account_id=str(test_user.account_id),
+                agent_id=str(managed_agent.id),
+            )
+            assert refreshed is not None
+            assert refreshed.control_last_heartbeat_at is not None

--- a/backend/tests/models/crud/test_managed_agent_control_heartbeat.py
+++ b/backend/tests/models/crud/test_managed_agent_control_heartbeat.py
@@ -1,0 +1,96 @@
+"""Presence heartbeat rules at the CRUD level.
+
+``clear_control_heartbeat`` is what retires the Agent Control badge when a
+socket closes. Its ``not_newer_than`` guard exists for the race where the
+plugin has already reconnected (possibly to another api replica) by the time
+a closing socket gets around to its teardown: the newer heartbeat must
+survive. The endpoint tests cannot reach that comparison, because an evicted
+connection never gets as far as calling this, so it is pinned here.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from preloop.models import models
+from preloop.models.crud import crud_managed_agent
+
+
+def _make_agent(db_session, test_user, *, source_id: str) -> models.ManagedAgent:
+    """Insert one active managed agent that holds a control heartbeat."""
+    now = datetime.now(UTC).replace(tzinfo=None)
+    agent = models.ManagedAgent(
+        id=uuid4(),
+        account_id=test_user.account_id,
+        runtime_session_id=None,
+        agent_kind="claude_code",
+        session_source_type="claude_code",
+        session_source_id=source_id,
+        display_name=f"claude_code {source_id}",
+        enrolled_via="runtime_session_token",
+        lifecycle_state="active",
+        lifecycle_updated_at=now,
+        last_seen_at=now,
+        created_at=now,
+    )
+    db_session.add(agent)
+    db_session.flush()
+    return agent
+
+
+def test_clear_control_heartbeat_keeps_a_newer_beat(db_session, test_user):
+    """A late teardown must not retire presence the reconnect just wrote."""
+    agent = _make_agent(db_session, test_user, source_id="reconnect-race-host")
+    t1 = datetime.now(UTC) - timedelta(seconds=30)
+    t2 = datetime.now(UTC)
+    crud_managed_agent.touch_last_seen_for_principal(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="reconnect-race-host",
+        observed_at=t2,
+        control_session_mode="local",
+        control_heartbeat_at=t2,
+    )
+
+    # The old socket closes and offers the beat it last wrote, which is older
+    # than what the new socket has since stored.
+    crud_managed_agent.clear_control_heartbeat(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="reconnect-race-host",
+        not_newer_than=t1,
+    )
+
+    db_session.refresh(agent)
+    assert agent.control_last_heartbeat_at is not None
+    assert agent.control_session_mode == "local"
+
+
+def test_clear_control_heartbeat_retires_its_own_beat(db_session, test_user):
+    """The socket that wrote the stored beat is the one allowed to clear it."""
+    agent = _make_agent(db_session, test_user, source_id="clean-close-host")
+    t2 = datetime.now(UTC)
+    crud_managed_agent.touch_last_seen_for_principal(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="clean-close-host",
+        observed_at=t2,
+        control_session_mode="local",
+        control_heartbeat_at=t2,
+    )
+
+    crud_managed_agent.clear_control_heartbeat(
+        db_session,
+        account_id=str(test_user.account_id),
+        session_source_type="claude_code",
+        session_source_id="clean-close-host",
+        not_newer_than=t2,
+    )
+
+    db_session.refresh(agent)
+    assert agent.control_last_heartbeat_at is None
+    assert agent.control_session_mode is None

--- a/backend/tests/models/test_alembic_single_head.py
+++ b/backend/tests/models/test_alembic_single_head.py
@@ -104,4 +104,6 @@ def test_flow_runners_revision_chains_onto_approval_rule_context() -> None:
     assert notifications.down_revision == "20260904_flow_exec_workspace"
     cli_session = script.get_revision("20260905_flow_cli_session")
     assert cli_session.down_revision == "20260904_flow_notifications"
-    assert script.get_heads() == ["20260905_flow_cli_session"]
+    heartbeat = script.get_revision("20260905_control_heartbeat")
+    assert heartbeat.down_revision == "20260905_flow_cli_session"
+    assert script.get_heads() == ["20260905_control_heartbeat"]

--- a/frontend/src/components/session-chat-view.test.ts
+++ b/frontend/src/components/session-chat-view.test.ts
@@ -47,6 +47,32 @@ function previewEvent(
   } as FlowGatewayEvent;
 }
 
+function manyEvents(count: number): FlowGatewayEvent[] {
+  return Array.from({ length: count }, (_, index) =>
+    previewEvent(
+      `e${index}`,
+      `2026-08-06T10:${String(index).padStart(2, '0')}:00Z`,
+      [
+        { role: 'user', text: `prompt ${index}` },
+        { role: 'assistant', text: `answer ${index}`, source: 'response' },
+      ]
+    )
+  );
+}
+
+function distanceFromBottom(thread: HTMLElement): number {
+  return thread.scrollHeight - thread.scrollTop - thread.clientHeight;
+}
+
+/** Let the ResizeObserver and the layout it reacts to settle. */
+async function waitForStableScroll(thread: HTMLElement): Promise<void> {
+  for (let frame = 0; frame < 6; frame += 1) {
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    if (distanceFromBottom(thread) < 2) return;
+  }
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
 describe('session-chat-view', () => {
   it('renders empty state without events', async () => {
     const el = await fixture<SessionChatView>(
@@ -382,6 +408,173 @@ describe('session-chat-view in the talk window', () => {
       ) as HTMLElement
     ).click();
     expect(retried).to.deep.equal(['p1']);
+  });
+
+  it('follows a new turn when the event page size does not change', async () => {
+    // The talk view refetches a fixed page of the newest events, so once a
+    // session is longer than one page the array length stops growing while
+    // its contents keep changing. Counting events missed every one of those.
+    const page = (offset: number) =>
+      Array.from({ length: 12 }, (_, index) =>
+        previewEvent(
+          `e${offset + index}`,
+          `2026-08-06T10:${String(offset + index).padStart(2, '0')}:00Z`,
+          [
+            { role: 'user', text: `prompt ${offset + index}` },
+            {
+              role: 'assistant',
+              text: `answer ${offset + index}`,
+              source: 'response',
+            },
+          ]
+        )
+      );
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view
+        scrollable
+        followLive
+        style="height: 200px"
+        .events=${page(0)}
+      ></session-chat-view>`
+    );
+    await el.updateComplete;
+    const thread = el.shadowRoot!.querySelector('.thread') as HTMLElement;
+
+    // Same length, newer contents: one turn scrolled off the top.
+    el.events = page(1);
+    await el.updateComplete;
+    await waitForStableScroll(thread);
+
+    expect(distanceFromBottom(thread)).to.be.lessThan(2);
+    expect(thread.textContent).to.contain('answer 12');
+  });
+
+  it('stays at the bottom when content grows after the update', async () => {
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view
+        scrollable
+        followLive
+        style="height: 200px"
+        .events=${[
+          previewEvent('e1', '2026-08-06T10:00:00Z', [
+            { role: 'user', text: 'ship it' },
+            { role: 'assistant', text: 'shipped', source: 'response' },
+          ]),
+        ]}
+      ></session-chat-view>`
+    );
+    await el.updateComplete;
+    const thread = el.shadowRoot!.querySelector('.thread') as HTMLElement;
+    const content = el.shadowRoot!.querySelector(
+      '.thread-content'
+    ) as HTMLElement;
+
+    // Whatever grows after the render that scrolled (a Shoelace element
+    // rendering in its own cycle, a font, an image, a reflowing <pre>).
+    const grown = document.createElement('div');
+    grown.style.height = '800px';
+    content.appendChild(grown);
+    await waitForStableScroll(thread);
+
+    expect(thread.scrollHeight).to.be.greaterThan(thread.clientHeight);
+    expect(
+      distanceFromBottom(thread),
+      'follow mode re-sticks once the layout settles'
+    ).to.be.lessThan(2);
+  });
+
+  it('does not treat a layout-driven scroll as the reader scrolling away', async () => {
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view
+        scrollable
+        followLive
+        style="height: 200px"
+        .events=${manyEvents(12)}
+      ></session-chat-view>`
+    );
+    await el.updateComplete;
+    const thread = el.shadowRoot!.querySelector('.thread') as HTMLElement;
+
+    // No wheel, no touch, no key, no pointer: the viewport moved on its own.
+    thread.scrollTop = 0;
+    thread.dispatchEvent(new Event('scroll'));
+    await el.updateComplete;
+
+    expect(
+      el.shadowRoot!.querySelector('[data-testid="jump-latest"]'),
+      'layout must not switch following off'
+    ).to.not.exist;
+    expect(distanceFromBottom(thread)).to.be.lessThan(2);
+  });
+
+  it('never yanks a reader who scrolled up with a gesture', async () => {
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view
+        scrollable
+        followLive
+        style="height: 200px"
+        .events=${manyEvents(12)}
+      ></session-chat-view>`
+    );
+    await el.updateComplete;
+    const thread = el.shadowRoot!.querySelector('.thread') as HTMLElement;
+
+    thread.dispatchEvent(new WheelEvent('wheel', { deltaY: -400 }));
+    thread.scrollTop = 0;
+    thread.dispatchEvent(new Event('scroll'));
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('[data-testid="jump-latest"]')).to
+      .exist;
+
+    el.events = manyEvents(13);
+    await el.updateComplete;
+    await waitForStableScroll(thread);
+
+    expect(thread.scrollTop, 'the reader stays where they were').to.equal(0);
+    expect(
+      el.shadowRoot!.querySelector('[data-testid="jump-latest"]'),
+      'the pill is how they come back'
+    ).to.exist;
+  });
+
+  it('rebinds the thread after a session switch empties it', async () => {
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view
+        scrollable
+        followLive
+        style="height: 200px"
+        .events=${manyEvents(12)}
+      ></session-chat-view>`
+    );
+    await el.updateComplete;
+    const first = el.shadowRoot!.querySelector('.thread') as HTMLElement;
+    first.dispatchEvent(new WheelEvent('wheel', { deltaY: -400 }));
+    first.scrollTop = 0;
+    first.dispatchEvent(new Event('scroll'));
+    await el.updateComplete;
+
+    // Following a new session clears the thread, which removes the .thread
+    // node entirely (the empty branch), then builds a new one.
+    el.events = [];
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('.empty')).to.exist;
+    el.events = manyEvents(12);
+    await el.updateComplete;
+
+    const thread = el.shadowRoot!.querySelector('.thread') as HTMLElement;
+    await waitForStableScroll(thread);
+    expect(
+      distanceFromBottom(thread),
+      'the new session opens at the latest'
+    ).to.be.lessThan(2);
+
+    // The listeners must be on the new node, not the discarded one.
+    thread.dispatchEvent(new WheelEvent('wheel', { deltaY: -400 }));
+    thread.scrollTop = 0;
+    thread.dispatchEvent(new Event('scroll'));
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('[data-testid="jump-latest"]')).to
+      .exist;
   });
 
   it('announces the agent reply politely', async () => {

--- a/frontend/src/components/session-chat-view.test.ts
+++ b/frontend/src/components/session-chat-view.test.ts
@@ -587,6 +587,35 @@ describe('session-chat-view in the talk window', () => {
     ).to.not.exist;
   });
 
+  it('clears a latched pointer on window blur so layout can re-stick', async () => {
+    // Releasing a scrollbar thumb outside the window never fires mouseup /
+    // pointerup. Without blur, pointerDown stays true and every later layout
+    // scroll is treated as the reader dragging away.
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view
+        scrollable
+        followLive
+        style="height: 200px"
+        .events=${manyEvents(12)}
+      ></session-chat-view>`
+    );
+    await el.updateComplete;
+    const thread = el.shadowRoot!.querySelector('.thread') as HTMLElement;
+
+    thread.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    window.dispatchEvent(new Event('blur'));
+    await new Promise((resolve) => setTimeout(resolve, 750));
+
+    thread.scrollTop = 0;
+    thread.dispatchEvent(new Event('scroll'));
+    await el.updateComplete;
+    expect(
+      el.shadowRoot!.querySelector('[data-testid="jump-latest"]'),
+      'layout must not switch following off after a drag leaves the window'
+    ).to.not.exist;
+    expect(distanceFromBottom(thread)).to.be.lessThan(2);
+  });
+
   it('rebinds the thread after a session switch empties it', async () => {
     const el = await fixture<SessionChatView>(
       html`<session-chat-view

--- a/frontend/src/components/session-chat-view.test.ts
+++ b/frontend/src/components/session-chat-view.test.ts
@@ -537,6 +537,56 @@ describe('session-chat-view in the talk window', () => {
     ).to.exist;
   });
 
+  it('treats a scrollbar-thumb drag as a gesture however long the pause', async () => {
+    // A press on the scrollbar itself gets a `mousedown` and no `pointerdown`
+    // in Chromium, and a reader can hold the thumb far longer than the 700ms
+    // gesture window before they move it. Both halves have to hold: the press
+    // keeps the gesture alive, the release lets layout re-stick again.
+    const el = await fixture<SessionChatView>(
+      html`<session-chat-view
+        scrollable
+        followLive
+        style="height: 200px"
+        .events=${manyEvents(12)}
+      ></session-chat-view>`
+    );
+    await el.updateComplete;
+    const thread = el.shadowRoot!.querySelector('.thread') as HTMLElement;
+
+    thread.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    // Hold past the window, then drag.
+    await new Promise((resolve) => setTimeout(resolve, 750));
+    thread.scrollTop = 0;
+    thread.dispatchEvent(new Event('scroll'));
+    await el.updateComplete;
+
+    expect(
+      el.shadowRoot!.querySelector('[data-testid="jump-latest"]'),
+      'the drag detaches the reader'
+    ).to.exist;
+    expect(thread.scrollTop, 'the reader stays where they dragged to').to.equal(
+      0
+    );
+
+    // Releasing the thumb ends the gesture: back at the bottom, a later
+    // layout-driven scroll must not be mistaken for the reader again.
+    window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    (
+      el.shadowRoot!.querySelector('[data-testid="jump-latest"]') as HTMLElement
+    ).click();
+    await el.updateComplete;
+    await waitForStableScroll(thread);
+    await new Promise((resolve) => setTimeout(resolve, 750));
+
+    thread.scrollTop = 0;
+    thread.dispatchEvent(new Event('scroll'));
+    await el.updateComplete;
+    expect(
+      el.shadowRoot!.querySelector('[data-testid="jump-latest"]'),
+      'layout must not switch following off once the thumb is released'
+    ).to.not.exist;
+  });
+
   it('rebinds the thread after a session switch empties it', async () => {
     const el = await fixture<SessionChatView>(
       html`<session-chat-view

--- a/frontend/src/components/session-chat-view.ts
+++ b/frontend/src/components/session-chat-view.ts
@@ -452,6 +452,8 @@ export class SessionChatView extends LitElement {
     this.addEventListener('keydown', this.markGesture);
     window.addEventListener('pointerup', this.handlePointerUp);
     window.addEventListener('pointercancel', this.handlePointerUp);
+    // The release half of a scrollbar-thumb drag is a `mouseup` as well.
+    window.addEventListener('mouseup', this.handlePointerUp);
   }
 
   updated(changed: PropertyValues<this>): void {
@@ -479,6 +481,7 @@ export class SessionChatView extends LitElement {
     this.removeEventListener('keydown', this.markGesture);
     window.removeEventListener('pointerup', this.handlePointerUp);
     window.removeEventListener('pointercancel', this.handlePointerUp);
+    window.removeEventListener('mouseup', this.handlePointerUp);
     this.releaseThread();
     this.contentObserver?.disconnect();
     this.contentObserver = null;
@@ -563,7 +566,12 @@ export class SessionChatView extends LitElement {
   }
 
   private markGesture = (event?: Event): void => {
-    if (event?.type === 'pointerdown') this.pointerDown = true;
+    // Chromium fires `mousedown` and no `pointerdown` when the press lands on
+    // the scrollbar itself, so a thumb drag has to hold the flag too. Without
+    // it a reader who grabs the thumb, pauses past the gesture window, then
+    // drags would be snapped back to the bottom.
+    if (event?.type === 'pointerdown' || event?.type === 'mousedown')
+      this.pointerDown = true;
     this.lastGestureAt = performance.now();
   };
 

--- a/frontend/src/components/session-chat-view.ts
+++ b/frontend/src/components/session-chat-view.ts
@@ -454,6 +454,9 @@ export class SessionChatView extends LitElement {
     window.addEventListener('pointercancel', this.handlePointerUp);
     // The release half of a scrollbar-thumb drag is a `mouseup` as well.
     window.addEventListener('mouseup', this.handlePointerUp);
+    // A drag released outside the window never fires up events; blur unlatches
+    // `pointerDown` so a later layout scroll is not treated as a gesture.
+    window.addEventListener('blur', this.handlePointerUp);
   }
 
   updated(changed: PropertyValues<this>): void {
@@ -482,6 +485,7 @@ export class SessionChatView extends LitElement {
     window.removeEventListener('pointerup', this.handlePointerUp);
     window.removeEventListener('pointercancel', this.handlePointerUp);
     window.removeEventListener('mouseup', this.handlePointerUp);
+    window.removeEventListener('blur', this.handlePointerUp);
     this.releaseThread();
     this.contentObserver?.disconnect();
     this.contentObserver = null;

--- a/frontend/src/components/session-chat-view.ts
+++ b/frontend/src/components/session-chat-view.ts
@@ -34,6 +34,27 @@ const MESSAGE_PREVIEW_CHARS = 2000;
 const STEP_PREVIEW_CHARS = 600;
 /** How far from the bottom still counts as "reading the latest". */
 const FOLLOW_THRESHOLD_PX = 48;
+/**
+ * How long after a real gesture a scroll event still counts as user intent.
+ * Wheel and touch scrolling keep emitting scroll events for a few hundred ms
+ * after the last input event (momentum), so the window has to outlive the
+ * gesture itself.
+ */
+const USER_SCROLL_WINDOW_MS = 700;
+/**
+ * How long an expand/collapse click stops the follow re-stick. Growing a
+ * message the reader just opened must not scroll it out from under them.
+ */
+const EXPAND_SETTLE_MS = 500;
+/** Input that means the operator moved the thread themselves. */
+const GESTURE_EVENTS = [
+  'wheel',
+  'touchstart',
+  'touchmove',
+  'pointerdown',
+  'mousedown',
+  'keydown',
+] as const;
 
 /** A turn the operator sent that the server has not echoed back yet. */
 export interface PendingTalkMessage {
@@ -116,12 +137,34 @@ export class SessionChatView extends LitElement {
     },
   };
 
-  // Events seen at the last follow-live scroll; scrolling happens only when
-  // new events actually arrive, never on state-only re-renders.
-  private lastScrolledEventCount = 0;
+  // What the thread held at the last follow-live scroll; scrolling happens
+  // only when the conversation actually changed, never on state-only
+  // re-renders. This is a signature, not a count: the talk view refetches a
+  // fixed page of the newest events, so once a session is longer than one
+  // page the array length stops growing while its contents keep changing.
+  private lastContentSignature = '';
   private lastScrolledPendingCount = 0;
   private lastAnnouncedKey: string | null = null;
-  private scrollBound = false;
+  /**
+   * The `.thread` node the listeners are attached to. Not a boolean: the
+   * loading and empty render branches have no `.thread`, so switching
+   * sessions destroys it and Lit builds a new one. A latched boolean would
+   * leave the listeners on the detached node and freeze `atBottom` for good.
+   */
+  private boundThread: HTMLElement | null = null;
+  /** The thread node went away (loading or empty branch) and will come back. */
+  private threadWasDestroyed = false;
+  private contentObserver: ResizeObserver | null = null;
+  private observedContent: Element | null = null;
+  /**
+   * When the last real user gesture on the thread happened. Negative
+   * infinity, not zero: `performance.now()` starts at zero, so zero would
+   * read as "a gesture just happened" for the first second of the page.
+   */
+  private lastGestureAt = Number.NEGATIVE_INFINITY;
+  private pointerDown = false;
+  /** Re-sticking is paused until this timestamp (an expand/collapse click). */
+  private stickPausedUntil = 0;
 
   @state()
   private liveAnnouncement = '';
@@ -140,7 +183,18 @@ export class SessionChatView extends LitElement {
       position: relative;
     }
 
+    /*
+     * Two elements, not one: the thread is the scroll viewport and the
+     * content inside it is the thing whose height changes. A ResizeObserver
+     * on a scroll container never fires for content growth, and content
+     * growth after an update is exactly what used to leave the talk window
+     * short of the bottom.
+     */
     .thread {
+      display: block;
+    }
+
+    .thread-content {
       display: flex;
       flex-direction: column;
       gap: var(--sl-spacing-medium);
@@ -152,6 +206,9 @@ export class SessionChatView extends LitElement {
       min-height: 0;
       overflow-y: auto;
       overscroll-behavior: contain;
+    }
+
+    :host([scrollable]) .thread-content {
       padding: var(--sl-spacing-small) var(--sl-spacing-medium);
     }
 
@@ -388,23 +445,30 @@ export class SessionChatView extends LitElement {
     }
   }
 
+  connectedCallback(): void {
+    super.connectedCallback();
+    // Keyboard scrolling (arrows, PageDown, Home/End) targets whatever has
+    // focus inside the thread, so the host is where it can always be seen.
+    this.addEventListener('keydown', this.markGesture);
+    window.addEventListener('pointerup', this.handlePointerUp);
+    window.addEventListener('pointercancel', this.handlePointerUp);
+  }
+
   updated(changed: PropertyValues<this>): void {
-    const thread = this.renderRoot.querySelector('.thread');
-    if (thread && this.scrollable && !this.scrollBound) {
-      thread.addEventListener('scroll', this.handleScroll, { passive: true });
-      this.scrollBound = true;
-    }
+    this.bindThread();
     // A turn the operator just typed always pulls the thread down: they are
     // looking at what they sent.
     const pendingGrew = this.pending.length > this.lastScrolledPendingCount;
     this.lastScrolledPendingCount = this.pending.length;
+    const signature = this.contentSignature();
+    const contentChanged = signature !== this.lastContentSignature;
+    this.lastContentSignature = signature;
     if (!this.followLive) return;
-    // Scroll only when new events arrived (or follow-live was just switched
-    // on); a scrollTop write on every update would force a reflow — and yank
-    // the view — each time the user expands a message they are reading.
-    const newEvents = this.events.length > this.lastScrolledEventCount;
-    this.lastScrolledEventCount = this.events.length;
-    if (!newEvents && !pendingGrew && !changed.has('followLive')) return;
+    // Scroll only when the conversation changed (or follow-live was just
+    // switched on); a scrollTop write on every update would force a reflow
+    // and yank the view each time the user expands a message they are
+    // reading.
+    if (!contentChanged && !pendingGrew && !changed.has('followLive')) return;
     // Someone who scrolled up to re-read is not interrupted; the pill takes
     // them back when they want it.
     if (this.scrollable && !this.atBottom && !pendingGrew) return;
@@ -412,23 +476,149 @@ export class SessionChatView extends LitElement {
   }
 
   disconnectedCallback(): void {
-    const thread = this.renderRoot?.querySelector('.thread');
-    thread?.removeEventListener('scroll', this.handleScroll);
-    this.scrollBound = false;
+    this.removeEventListener('keydown', this.markGesture);
+    window.removeEventListener('pointerup', this.handlePointerUp);
+    window.removeEventListener('pointercancel', this.handlePointerUp);
+    this.releaseThread();
+    this.contentObserver?.disconnect();
+    this.contentObserver = null;
+    this.observedContent = null;
     super.disconnectedCallback();
+  }
+
+  /** What the thread is showing right now, cheap enough to compare per update. */
+  private contentSignature(): string {
+    const items = this.conversation.items;
+    const last = items[items.length - 1];
+    return `${items.length}|${last ? last.key : ''}|${this.events.length}|${
+      this.activity.length
+    }`;
+  }
+
+  /**
+   * Attach scroll/gesture listeners and the size observer to the current
+   * `.thread`, re-attaching whenever Lit replaces it (loading and empty
+   * branches remove it, and a session switch goes through both).
+   */
+  private bindThread(): void {
+    const thread = this.renderRoot.querySelector(
+      '.thread'
+    ) as HTMLElement | null;
+    if (thread !== this.boundThread) {
+      if (this.boundThread && !thread) this.threadWasDestroyed = true;
+      this.releaseThread();
+      this.boundThread = thread;
+      // A rebuilt thread is a different conversation (the talk view empties
+      // events when it follows the agent into a new session), so following
+      // resumes whether or not the reader had scrolled up in the old one.
+      if (thread && this.threadWasDestroyed) {
+        this.threadWasDestroyed = false;
+        if (this.followLive) this.atBottom = true;
+      }
+      if (thread && this.scrollable) {
+        thread.addEventListener('scroll', this.handleScroll, { passive: true });
+        for (const type of GESTURE_EVENTS) {
+          thread.addEventListener(type, this.markGesture, { passive: true });
+        }
+      }
+    }
+    this.observeContent();
+  }
+
+  private releaseThread(): void {
+    const thread = this.boundThread;
+    if (!thread) return;
+    thread.removeEventListener('scroll', this.handleScroll);
+    for (const type of GESTURE_EVENTS) {
+      thread.removeEventListener(type, this.markGesture);
+    }
+    if (this.observedContent) {
+      this.contentObserver?.unobserve(this.observedContent);
+      this.observedContent = null;
+    }
+    this.contentObserver?.unobserve(thread);
+    this.boundThread = null;
+  }
+
+  /**
+   * Follow the thread's own height and its content's height. Content that
+   * grows after the update that scrolled (Shoelace elements rendering in
+   * their own cycle, fonts, images, a `<pre>` reflowing) would otherwise
+   * leave the view a few hundred pixels short of the bottom, and the viewport
+   * shrinking (the composer growing, the follow banner appearing, a window
+   * resize) would do the same.
+   */
+  private observeContent(): void {
+    if (!this.scrollable || !this.boundThread) return;
+    const content = this.renderRoot.querySelector('.thread-content');
+    if (!content || content === this.observedContent) return;
+    if (!this.contentObserver) {
+      this.contentObserver = new ResizeObserver(() => this.stickIfFollowing());
+    }
+    if (this.observedContent)
+      this.contentObserver.unobserve(this.observedContent);
+    this.contentObserver.observe(content);
+    this.contentObserver.observe(this.boundThread);
+    this.observedContent = content;
+  }
+
+  private markGesture = (event?: Event): void => {
+    if (event?.type === 'pointerdown') this.pointerDown = true;
+    this.lastGestureAt = performance.now();
+  };
+
+  private handlePointerUp = (): void => {
+    if (!this.pointerDown) return;
+    this.pointerDown = false;
+    this.lastGestureAt = performance.now();
+  };
+
+  /** Did the operator's own hands move the thread just now? */
+  private gestureInFlight(): boolean {
+    if (this.pointerDown) return true;
+    return performance.now() - this.lastGestureAt <= USER_SCROLL_WINDOW_MS;
   }
 
   private handleScroll = (event: Event): void => {
     const thread = event.currentTarget as HTMLElement;
     const distance =
       thread.scrollHeight - thread.scrollTop - thread.clientHeight;
-    const atBottom = distance <= FOLLOW_THRESHOLD_PX;
-    if (atBottom !== this.atBottom) this.atBottom = atBottom;
+    if (distance <= FOLLOW_THRESHOLD_PX) {
+      // Scrolling back to the bottom always resumes following, however the
+      // view got there.
+      if (!this.atBottom) this.atBottom = true;
+      return;
+    }
+    if (!this.atBottom) return;
+    if (this.followLive && !this.gestureInFlight()) {
+      // Layout moved the viewport, not the reader: a growing composer, an
+      // inserted banner, a resize, our own write racing a height change.
+      // Following is not something the page gets to switch off. Only a live
+      // thread is put back; a static one is the reader's to move.
+      this.stickToBottom();
+      return;
+    }
+    this.atBottom = false;
   };
+
+  /** Re-pin the viewport without touching follow state. */
+  private stickToBottom(): void {
+    const thread = this.boundThread;
+    if (!thread) return;
+    thread.scrollTop = thread.scrollHeight;
+  }
+
+  private stickIfFollowing(): void {
+    if (!this.followLive || !this.scrollable || !this.atBottom) return;
+    if (performance.now() < this.stickPausedUntil) return;
+    this.stickToBottom();
+  }
 
   /** Public so the talk page can snap the thread down after it loads. */
   public scrollToLatest(): void {
-    const thread = this.renderRoot.querySelector('.thread');
+    const thread =
+      this.boundThread ??
+      (this.renderRoot.querySelector('.thread') as HTMLElement | null);
     if (!thread) return;
     thread.scrollTop = thread.scrollHeight;
     this.atBottom = true;
@@ -442,6 +632,7 @@ export class SessionChatView extends LitElement {
   }
 
   private toggleMessage(key: string): void {
+    this.pauseSticking();
     const next = new Set(this.expandedMessageKeys);
     if (next.has(key)) next.delete(key);
     else next.add(key);
@@ -449,10 +640,20 @@ export class SessionChatView extends LitElement {
   }
 
   private toggleStep(key: string): void {
+    this.pauseSticking();
     const next = new Set(this.expandedStepKeys);
     if (next.has(key)) next.delete(key);
     else next.add(key);
     this.expandedStepKeys = next;
+  }
+
+  /**
+   * Opening a message the reader is looking at grows the thread, and growing
+   * the thread re-sticks it to the bottom. That would scroll the thing they
+   * just opened out of view, so the observer keeps its hands off for a moment.
+   */
+  private pauseSticking(): void {
+    this.stickPausedUntil = performance.now() + EXPAND_SETTLE_MS;
   }
 
   private requestEarlierEvents(): void {
@@ -756,53 +957,56 @@ ${
     return html`
       ${this.renderLiveRegion()}${this.renderJumpPill()}
       <div class="thread">
-        ${
-          this.hasMoreEvents
-            ? html`
-                <sl-button
-                  class="load-earlier"
-                  size="small"
-                  ?loading=${this.loadingMoreEvents}
-                  @click=${() => this.requestEarlierEvents()}
-                >
-                  Load earlier conversation
-                </sl-button>
-              `
-            : nothing
-        }
-        ${
-          stats.eventsWithoutRawBody > 0
-            ? html`
-                <div class="coverage-note" role="note">
-                  Message structure was unavailable for
-                  ${stats.eventsWithoutRawBody} of ${stats.totalEvents}
-                  requests, so some tool results may appear as user prompts
-                  there.
-                </div>
-              `
-            : nothing
-        }
-        ${
-          stats.eventsWithPartialToolResults > 0
-            ? html`
-                <div class="coverage-note" role="note">
-                  ${stats.eventsWithPartialToolResults} of ${stats.totalEvents}
-                  requests carried tool results with no extractable text, so
-                  some of those may appear as user prompts.
-                </div>
-              `
-            : nothing
-        }
-        ${repeat(
-          items,
-          (item) => item.key,
-          (item) => this.renderItem(item)
-        )}
-        ${repeat(
-          this.pending,
-          (message) => message.id,
-          (message) => this.renderPending(message)
-        )}
+        <div class="thread-content">
+          ${
+            this.hasMoreEvents
+              ? html`
+                  <sl-button
+                    class="load-earlier"
+                    size="small"
+                    ?loading=${this.loadingMoreEvents}
+                    @click=${() => this.requestEarlierEvents()}
+                  >
+                    Load earlier conversation
+                  </sl-button>
+                `
+              : nothing
+          }
+          ${
+            stats.eventsWithoutRawBody > 0
+              ? html`
+                  <div class="coverage-note" role="note">
+                    Message structure was unavailable for
+                    ${stats.eventsWithoutRawBody} of ${stats.totalEvents}
+                    requests, so some tool results may appear as user prompts
+                    there.
+                  </div>
+                `
+              : nothing
+          }
+          ${
+            stats.eventsWithPartialToolResults > 0
+              ? html`
+                  <div class="coverage-note" role="note">
+                    ${stats.eventsWithPartialToolResults} of
+                    ${stats.totalEvents} requests carried tool results with no
+                    extractable text, so some of those may appear as user
+                    prompts.
+                  </div>
+                `
+              : nothing
+          }
+          ${repeat(
+            items,
+            (item) => item.key,
+            (item) => this.renderItem(item)
+          )}
+          ${repeat(
+            this.pending,
+            (message) => message.id,
+            (message) => this.renderPending(message)
+          )}
+        </div>
       </div>
     `;
   }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -514,6 +514,8 @@ export interface ManagedAgentSummary {
   supports_voice?: boolean;
   supports_interrupt?: boolean;
   control_session_mode?: 'local' | 'remote' | 'queued' | 'offline' | string;
+  /** Last Agent Control heartbeat, so the age of the presence signal is readable. */
+  control_last_heartbeat_at?: string | null;
   supported_input_modes?: string[];
   supported_output_modes?: string[];
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16903,6 +16903,12 @@ components:
           type: string
           title: Control Session Mode
           default: offline
+        control_last_heartbeat_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Control Last Heartbeat At
         supported_input_modes:
           items:
             type: string


### PR DESCRIPTION
# PR draft: Keep the talk window at the latest message, and make Agent Control presence honest

Branch: `fix/talk-follow-latest-and-presence` (7 commits off `778a64c8`).
14 files changed, +1285 / -108.

## Summary

Two founder-reported problems, one branch.

The talk window stopped following the conversation: new turns arrived and the
reader had to scroll down by hand, without ever having scrolled up. The Agent
Control badge flapped between online and offline for an agent whose plugin was
running the whole time.

Both are now fixed at the cause, with tests that fail without the fix. The
DESIGN.md contract holds either way: a reader who scrolled up with a gesture is
never yanked, and the "Jump to latest" pill stays the only way back.

## Root causes

Talk window (`session-chat-view.ts`):

1. New content was detected with `events.length`, but the talk view refetches a
   fixed latest-first page of 50. Past 50 gateway calls the array length is
   pinned and never grows, so a new turn looked like no change and following
   stopped for the rest of the session. The same gate ignored activity rows, so
   operator turns and agent replies delivered as activity never scrolled either.
2. The scroll listener was bound once and latched. The loading and empty render
   branches have no `.thread` node, so following a new session destroyed the
   node and left the listener on a detached element.
3. Nothing re-stuck the view after layout settled: Shoelace elements rendering
   in their own cycle, fonts, images, a growing composer or an inserted banner
   all left the thread short of the bottom.
4. Any scroll event detached the reader, including scrolls the page caused
   itself.

Presence (`account.py`, `agent_control.py`, `crud/managed_agent.py`):

5. The cross-replica fallback read `control_session_mode`, a column neither
   summary query selected, so it was always `"offline"` and the fallback could
   never fire. `control_online` was true only on the replica holding the
   WebSocket, and production runs api=2, so about half the polls said offline.
6. The freshness window was 45s against a 30s beat: one late beat flipped the
   badge.
7. `last_seen_at` is stamped by enrollment and gateway traffic too, so widening
   it would have reported a dead plugin as online for as long as the agent kept
   making model calls.
8. A half-open socket (closed lid, network dropped without a FIN) kept its
   replica claiming online from the in-process registry while every other
   replica had timed the heartbeat out.

## Changes

Talk window:

- Follow is decided by a content signature (last item key plus item, event and
  activity counts) instead of `events.length`.
- The thread listeners rebind whenever Lit replaces the `.thread` node, and a
  rebuilt thread (a session switch) reopens at the bottom.
- A `ResizeObserver` on a new `.thread-content` wrapper re-sticks the view once
  the layout settles; expanding a message pauses that for 500ms so opening a
  block does not scroll it out from under you.
- `atBottom` can only flip to false inside 700ms of a real gesture (`wheel`,
  `touchstart`, `touchmove`, `pointerdown`, `mousedown`, `keydown`) or while a
  pointer or mouse button is held, which covers scrollbar-thumb drags.

Presence:

- New `control_last_heartbeat_at` column (migration `20260905_control_heartbeat`)
  written only by the Agent Control WebSocket, on connect and on every inbound
  envelope, and cleared on a clean close (with a guard so a late teardown cannot
  retire a heartbeat a reconnect already wrote).
- New `services/agent_control_presence.py` holds the cadence and the window in
  one place: 30s beat, 90s TTL (three beats).
- Both summary queries now select `control_session_mode` and
  `control_last_heartbeat_at`, and `control_online` is computed from the
  persisted heartbeat, so every replica reaches the same verdict. The list badge
  and the detail badge share one function.
- The control WebSocket closes after two consecutive 60s receive timeouts, so a
  half-open socket cannot hold presence open past the TTL.
- `control_last_heartbeat_at` is exposed on `ManagedAgentSummary` (schema,
  `openapi.yaml`, TS type) so the age of the signal is readable when debugging.

## Tests

Measured locally, not estimated.

- Frontend: `cd frontend && npm test` gives 142 files, 1562 passed, 0 failed,
  21s. `main` measures 1556, so the 6 new scroll tests are the whole
  difference.
- Backend on a real Postgres at alembic head: the 8 touched modules
  (`test_account_agents.py`, `test_agent_control.py`,
  `test_account_agents_filtering.py`, `test_agent_control_persistence.py`,
  `models/crud/test_managed_agent_get_by_source.py`,
  `models/crud/test_managed_agent_list_by_kind.py`,
  `models/crud/test_agent_control_command_crud.py`,
  `models/crud/test_managed_agent_control_heartbeat.py`) give 99 passed,
  0 failed, 24.8s.
- `npx tsc --noEmit`: 108 errors, identical to `main`, none in the files this
  branch touches.
- Each fix was checked against the unfixed code, not just written after it. The
  page-size follow test reported the thread sitting 77px short; the rebind test
  reported the pill never coming back; the layout-scroll test hung the browser
  runner for 120s; the scrollbar-drag test reported "the drag detaches the
  reader"; removing the four new column selections fails
  `test_agent_presence_survives_a_replica_without_the_websocket`; removing the
  `not_newer_than` guard fails the new CRUD test.
- Migration round trip: `alembic downgrade 20260904_flow_notifications` then
  `alembic upgrade head`, both clean, single head.

## How to verify on staging

1. Talk follow. Pick an agent with more than 50 gateway calls, open
   `/console/agents/<id>/talk?window=1`, send a prompt and let the agent reply a
   few times without touching the wheel. Every turn should land at the bottom on
   its own, including turns that arrive while an `sl-details` block expands.
2. Talk detach. Scroll up with the wheel: the "Jump to latest" pill appears and
   nothing moves under you until you click it. Repeat by dragging the scrollbar
   thumb, pausing a second before you drag: same behaviour.
3. Session switch. Use "Follow session": the new thread opens at its latest
   message and following works on the new node.
4. Presence, single reader. With the plugin running, leave the agent detail page
   open for five minutes; the badge should stay green throughout (it previously
   went grey on roughly half the polls). `GET /api/v1/agents/<id>` now returns
   `control_last_heartbeat_at`, which should move about every 30s.
5. Presence, two replicas. `kubectl -n <ns> get pods -l app=preloop-api` should
   show 2. Hit `GET /api/v1/agents/<id>` ten times: `control_online` must be
   true every time. If one says false, read `control_last_heartbeat_at` from
   that response: fresh means the endpoint is wrong, stale means the plugin's
   beat is.
6. Presence, honest offline. Quit the agent: grey within seconds (clean close
   retires the heartbeat). `kill -9` instead: grey within 90s. Close the laptop
   lid on a running agent: grey within about 120s + one poll, because the server
   now closes the silent socket.
7. Presence, not a lie. Leave the plugin stopped and keep making model calls
   with that agent's key: the badge must stay grey. `last_seen_at` moves, the
   heartbeat does not.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Medium]**
> No security issues; the changes are well-tested, but they touch important logic — the online/offline presence verdict (now derived from a persisted heartbeat, plus a DB migration) and the talk window's scroll-follow state machine.
>
> **Overview**
> Two founder-reported fixes: the talk window now follows new turns (content signature + `ResizeObserver` re-stick + gesture-windowed detach), and Agent Control presence is answered from a persisted `control_last_heartbeat_at` so every api replica agrees. Only minor nits remain (a CHANGELOG entry, one stale code comment, a migration docstring `Revises:` line, and a scroll-thumb pointer-release edge case).
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit cd130fb5. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->