### PR TITLE
Console: gated views do not mount or fetch, native tools state the effective policy, audit filter bar

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -53,6 +53,7 @@
         "@types/sinon": "^17.0.4",
         "@web/dev-server-esbuild": "^1.0.4",
         "@web/test-runner": "^0.20.0",
+        "@web/test-runner-commands": "^0.9.0",
         "@web/test-runner-playwright": "^0.11.1",
         "chai": "^5.0.0",
         "husky": "^9.0.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -88,6 +88,7 @@
     "@types/sinon": "^17.0.4",
     "@web/dev-server-esbuild": "^1.0.4",
     "@web/test-runner": "^0.20.0",
+    "@web/test-runner-commands": "^0.9.0",
     "@web/test-runner-playwright": "^0.11.1",
     "chai": "^5.0.0",
     "husky": "^9.0.11",

--- a/frontend/src/components/tool-list-item.test.ts
+++ b/frontend/src/components/tool-list-item.test.ts
@@ -307,6 +307,27 @@ describe('ToolListItem – justification settings', () => {
     await setViewport({ width: 1280, height: 800 });
   });
 
+  it('keeps the MCP tool settings menu right of the name at 390px', async () => {
+    stubApi();
+    await setViewport({ width: 390, height: 844 });
+    const el = await createItem({
+      source: 'mcp',
+      source_name: 'GitHub',
+    } as any);
+    await el.updateComplete;
+
+    const name = el.shadowRoot?.querySelector('.tool-name') as HTMLElement;
+    const menu = el.shadowRoot?.querySelector('.tool-menu') as HTMLElement;
+    expect(menu).to.exist;
+    // The wrapper has no order of its own without .tool-menu, so it would
+    // sort with the chevron and land left of the name.
+    expect(menu.getBoundingClientRect().left).to.be.greaterThan(
+      name.getBoundingClientRect().left
+    );
+
+    await setViewport({ width: 1280, height: 800 });
+  });
+
   it('shows per-tool schema token estimate', async () => {
     stubApi();
     const el = await createItem({ schema_tokens_estimate: 245 } as any);

--- a/frontend/src/components/tool-list-item.test.ts
+++ b/frontend/src/components/tool-list-item.test.ts
@@ -223,7 +223,7 @@ describe('ToolListItem – justification settings', () => {
 
   async function createNativeItem(
     toolOverrides: Partial<typeof baseTool> = {},
-    accountAsksByDefault = false
+    accountAsksByDefault: boolean | null = false
   ) {
     const tool = {
       ...baseTool,
@@ -270,6 +270,23 @@ describe('ToolListItem – justification settings', () => {
     const el = await createNativeItem({ is_enabled: true }, false);
 
     expect(ruleSummaryText(el)).to.equal('No rules · allowed');
+    expect((el as any)._emptyRulesMessage()).to.contain(
+      'All calls to this tool are allowed'
+    );
+  });
+
+  it('says only No rules when the account default is unread', async () => {
+    stubApi();
+    const el = await createNativeItem({ is_enabled: true }, null);
+
+    expect(ruleSummaryText(el)).to.equal('No rules');
+    expect(ruleSummaryText(el)).to.not.include('allowed');
+    expect(ruleSummaryText(el)).to.not.include('asks a human');
+    expect((el as any)._emptyRulesMessage()).to.equal(
+      'No access rules configured.'
+    );
+    expect((el as any)._emptyRulesMessage()).to.not.include('allowed');
+    expect((el as any)._emptyRulesMessage()).to.not.include('ask a human');
   });
 
   it('says a ruleless native tool is blocked when the switch is on', async () => {

--- a/frontend/src/components/tool-list-item.test.ts
+++ b/frontend/src/components/tool-list-item.test.ts
@@ -1,4 +1,5 @@
 import { html, fixture, expect } from '@open-wc/testing';
+import { setViewport } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
 import './tool-list-item';
@@ -213,6 +214,97 @@ describe('ToolListItem – justification settings', () => {
     await (el as any)._saveJustificationMode();
 
     expect((el as any)._showJustificationDialog).to.be.false;
+  });
+
+  // ---------------------------------------------------------------------------
+  // B-T1 / B-T4: a native row states the effective policy, and keeps its name
+  // at phone width.
+  // ---------------------------------------------------------------------------
+
+  async function createNativeItem(
+    toolOverrides: Partial<typeof baseTool> = {},
+    accountAsksByDefault = false
+  ) {
+    const tool = {
+      ...baseTool,
+      name: 'Bash',
+      source: 'agent',
+      source_name: 'Claude Code',
+      adapters: ['Claude Code', 'OpenCode'],
+      ...toolOverrides,
+    };
+    const el = (await fixture(
+      html`<tool-list-item
+        .tool=${tool}
+        .accessRules=${[]}
+        .policies=${[]}
+        .features=${{}}
+        .accountAsksByDefault=${accountAsksByDefault}
+      ></tool-list-item>`
+    )) as ToolListItem;
+    await el.updateComplete;
+    return el;
+  }
+
+  function ruleSummaryText(el: ToolListItem) {
+    return el.shadowRoot
+      ?.querySelector('.no-rules')
+      ?.textContent?.replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  it('says a ruleless native tool asks a human when the account default is on', async () => {
+    stubApi();
+    const el = await createNativeItem({ is_enabled: true }, true);
+
+    expect(ruleSummaryText(el)).to.equal(
+      'No rules · asks a human (account default)'
+    );
+    expect((el as any)._emptyRulesMessage()).to.contain(
+      'ask a human first, from the account default'
+    );
+  });
+
+  it('says a ruleless native tool is allowed when the account default is off', async () => {
+    stubApi();
+    const el = await createNativeItem({ is_enabled: true }, false);
+
+    expect(ruleSummaryText(el)).to.equal('No rules · allowed');
+  });
+
+  it('says a ruleless native tool is blocked when the switch is on', async () => {
+    stubApi();
+    const el = await createNativeItem({ is_enabled: false }, true);
+
+    expect(ruleSummaryText(el)).to.equal('No rules · blocked');
+  });
+
+  it('labels the native switch with the verb Block', async () => {
+    stubApi();
+    const el = await createNativeItem();
+
+    const label = el.shadowRoot
+      ?.querySelector('.tool-toggle sl-switch')
+      ?.textContent?.trim();
+    expect(label).to.equal('Block');
+  });
+
+  it('keeps the tool name in the row header at 390px', async () => {
+    stubApi();
+    await setViewport({ width: 390, height: 844 });
+    const el = await createNativeItem({ is_enabled: true }, true);
+    await el.updateComplete;
+
+    const name = el.shadowRoot?.querySelector('.tool-name') as HTMLElement;
+    const badges = el.shadowRoot?.querySelector('.tool-badges') as HTMLElement;
+    expect(name.textContent?.trim()).to.equal('Bash');
+    expect(name.getBoundingClientRect().width).to.be.greaterThan(20);
+    // Tags sit on their own line beneath the name, not beside it.
+    expect(badges.getBoundingClientRect().top).to.be.greaterThan(
+      name.getBoundingClientRect().top
+    );
+
+    await setViewport({ width: 1280, height: 800 });
   });
 
   it('shows per-tool schema token estimate', async () => {

--- a/frontend/src/components/tool-list-item.ts
+++ b/frontend/src/components/tool-list-item.ts
@@ -32,10 +32,11 @@ export class ToolListItem extends LitElement {
   @property({ type: Object }) usageStat: GatewayUsageByTool | null = null;
   /**
    * Account default for native tool calls ("Ask a human before running").
-   * A native row with no rules of its own is governed by this, so the row
-   * has to say so instead of claiming every call is allowed.
+   * `true` / `false` once the defaults have loaded; `null` while unread or
+   * after a load failure. A native row with no rules of its own is governed
+   * by this, so it must not claim "allowed" until the value is known.
    */
-  @property({ type: Boolean }) accountAsksByDefault = false;
+  @property({ attribute: false }) accountAsksByDefault: boolean | null = null;
 
   @state() private _showJustificationDialog = false;
   @state() private _justificationMode: string = 'disabled';
@@ -332,13 +333,19 @@ export class ToolListItem extends LitElement {
    * What happens to a call when the tool carries no rule of its own. Native
    * tools fall through to the account default, so "No rules" alone (or
    * "allow all") states the wrong policy whenever that default is on.
+   * Returns null when the default is unread so the row claims nothing.
    */
-  private _noRulesEffect(): string {
+  private _noRulesEffect(): string | null {
     if (!this.tool.is_enabled) {
       return 'blocked';
     }
-    if (this._isNativeTool() && this.accountAsksByDefault) {
-      return 'asks a human (account default)';
+    if (this._isNativeTool()) {
+      if (this.accountAsksByDefault === null) {
+        return null;
+      }
+      if (this.accountAsksByDefault) {
+        return 'asks a human (account default)';
+      }
     }
     return 'allowed';
   }
@@ -348,8 +355,9 @@ export class ToolListItem extends LitElement {
 
     if (summary.total === 0) {
       if (this._isNativeTool()) {
+        const effect = this._noRulesEffect();
         return html`<span class="no-rules"
-          >No rules · ${this._noRulesEffect()}</span
+          >${effect ? `No rules · ${effect}` : 'No rules'}</span
         >`;
       }
       if (this.tool.is_enabled) {
@@ -435,6 +443,9 @@ export class ToolListItem extends LitElement {
   private _emptyRulesMessage(): string {
     if (!this.tool.is_enabled) {
       return 'No access rules configured. All calls to this tool are blocked (tool disabled).';
+    }
+    if (this._isNativeTool() && this.accountAsksByDefault === null) {
+      return 'No access rules configured.';
     }
     if (this._isNativeTool() && this.accountAsksByDefault) {
       return 'No access rules configured. Calls to this tool ask a human first, from the account default.';

--- a/frontend/src/components/tool-list-item.ts
+++ b/frontend/src/components/tool-list-item.ts
@@ -206,6 +206,11 @@ export class ToolListItem extends LitElement {
           order: 2;
           margin-left: auto;
         }
+        /* MCP rows carry a three-dots menu after the toggle. Without an
+           order it would default to 0 and sort ahead of the name. */
+        .tool-menu {
+          order: 2;
+        }
         .tool-badges {
           order: 3;
           flex-basis: 100%;
@@ -612,7 +617,10 @@ export class ToolListItem extends LitElement {
             this._isNativeTool()
               ? ''
               : html`
-                  <div @click=${(e: Event) => e.stopPropagation()}>
+                  <div
+                    class="tool-menu"
+                    @click=${(e: Event) => e.stopPropagation()}
+                  >
                     <sl-dropdown>
                       <sl-icon-button
                         slot="trigger"

--- a/frontend/src/components/tool-list-item.ts
+++ b/frontend/src/components/tool-list-item.ts
@@ -30,6 +30,12 @@ export class ToolListItem extends LitElement {
   @property({ type: String }) mode: 'global' | 'scoped' = 'global';
   @property({ type: Boolean }) rulesInherited = false;
   @property({ type: Object }) usageStat: GatewayUsageByTool | null = null;
+  /**
+   * Account default for native tool calls ("Ask a human before running").
+   * A native row with no rules of its own is governed by this, so the row
+   * has to say so instead of claiming every call is allowed.
+   */
+  @property({ type: Boolean }) accountAsksByDefault = false;
 
   @state() private _showJustificationDialog = false;
   @state() private _justificationMode: string = 'disabled';
@@ -179,6 +185,43 @@ export class ToolListItem extends LitElement {
         font-size: var(--sl-font-size-x-small);
         font-style: italic;
       }
+
+      /* Phone: the row header is one non-wrapping flex line, so the agent
+         tags squeezed the tool name out of a 390px row (B-T4). The name
+         keeps its content width and everything else wraps beneath it. */
+      @media (max-width: 480px) {
+        .tool-header {
+          flex-wrap: wrap;
+          row-gap: var(--sl-spacing-2x-small);
+        }
+        .expand-icon {
+          order: 0;
+        }
+        .tool-name {
+          order: 1;
+          flex: 0 0 auto;
+          max-width: calc(100% - 120px);
+        }
+        .tool-toggle {
+          order: 2;
+          margin-left: auto;
+        }
+        .tool-badges {
+          order: 3;
+          flex-basis: 100%;
+          flex-wrap: wrap;
+        }
+        .tool-description {
+          order: 4;
+          flex-basis: 100%;
+          white-space: normal;
+        }
+        .rule-summary {
+          order: 5;
+          flex-basis: 100%;
+          flex-wrap: wrap;
+        }
+      }
     `,
   ];
 
@@ -280,10 +323,30 @@ export class ToolListItem extends LitElement {
     );
   }
 
+  /**
+   * What happens to a call when the tool carries no rule of its own. Native
+   * tools fall through to the account default, so "No rules" alone (or
+   * "allow all") states the wrong policy whenever that default is on.
+   */
+  private _noRulesEffect(): string {
+    if (!this.tool.is_enabled) {
+      return 'blocked';
+    }
+    if (this._isNativeTool() && this.accountAsksByDefault) {
+      return 'asks a human (account default)';
+    }
+    return 'allowed';
+  }
+
   private _renderRuleSummaryBadges() {
     const summary = this._getRuleSummary();
 
     if (summary.total === 0) {
+      if (this._isNativeTool()) {
+        return html`<span class="no-rules"
+          >No rules · ${this._noRulesEffect()}</span
+        >`;
+      }
       if (this.tool.is_enabled) {
         return html`<span class="no-rules">No rules (allow all)</span>`;
       }
@@ -364,6 +427,16 @@ export class ToolListItem extends LitElement {
     }
   }
 
+  private _emptyRulesMessage(): string {
+    if (!this.tool.is_enabled) {
+      return 'No access rules configured. All calls to this tool are blocked (tool disabled).';
+    }
+    if (this._isNativeTool() && this.accountAsksByDefault) {
+      return 'No access rules configured. Calls to this tool ask a human first, from the account default.';
+    }
+    return 'No access rules configured. All calls to this tool are allowed.';
+  }
+
   private _renderExpandedContent() {
     return html`
       <div class="tool-content">
@@ -416,9 +489,7 @@ export class ToolListItem extends LitElement {
           .rules=${this.accessRules}
           .workflows=${this.policies}
           .features=${this.features}
-          .emptyMessage=${`No access rules configured. All calls to this tool are ${
-            this.tool.is_enabled ? 'allowed' : 'blocked (tool disabled)'
-          }.`}
+          .emptyMessage=${this._emptyRulesMessage()}
           @save-rule=${this._handleSaveRule}
           @delete-rule=${(event: CustomEvent) =>
             this._handleDeleteRule(event.detail.rule)}
@@ -533,7 +604,7 @@ export class ToolListItem extends LitElement {
               }
               ?disabled=${isUnsupported}
               @sl-change=${this._handleToggleEnabled}
-              >${this._isNativeTool() ? 'Blocked' : ''}</sl-switch
+              >${this._isNativeTool() ? 'Block' : ''}</sl-switch
             >
           </div>
 

--- a/frontend/src/components/tools-editor-component.ts
+++ b/frontend/src/components/tools-editor-component.ts
@@ -69,6 +69,8 @@ export class ToolsEditorComponent extends LitElement {
   @property({ type: Boolean }) hasDefaultAIModel: boolean = false;
   @property({ type: Boolean }) collapseByDefault: boolean = false;
   @property({ type: String }) family: ToolsEditorFamily = 'mcp';
+  /** Account default for native tool calls, stated on every native row. */
+  @property({ type: Boolean }) accountAsksByDefault = false;
   @property({ type: Object }) toolStats: Record<string, GatewayUsageByTool> =
     {};
 
@@ -491,6 +493,9 @@ export class ToolsEditorComponent extends LitElement {
                                 .usageStat=${this.toolStats[tool.name] || null}
                                 .accessRules=${rules}
                                 .rulesInherited=${rulesInherited}
+                                .accountAsksByDefault=${
+                                  this.accountAsksByDefault
+                                }
                                 .policies=${this.approvalPolicies}
                                 .features=${this.features}
                                 .expanded=${this.expandedTools.has(

--- a/frontend/src/components/tools-editor-component.ts
+++ b/frontend/src/components/tools-editor-component.ts
@@ -69,8 +69,12 @@ export class ToolsEditorComponent extends LitElement {
   @property({ type: Boolean }) hasDefaultAIModel: boolean = false;
   @property({ type: Boolean }) collapseByDefault: boolean = false;
   @property({ type: String }) family: ToolsEditorFamily = 'mcp';
-  /** Account default for native tool calls, stated on every native row. */
-  @property({ type: Boolean }) accountAsksByDefault = false;
+  /**
+   * Account default for native tool calls, stated on every native row.
+   * `null` while unread or after a load failure — rows must not claim
+   * "allowed" until this is a boolean.
+   */
+  @property({ attribute: false }) accountAsksByDefault: boolean | null = null;
   @property({ type: Object }) toolStats: Record<string, GatewayUsageByTool> =
     {};
 

--- a/frontend/src/views/authed/audit-view.test.ts
+++ b/frontend/src/views/authed/audit-view.test.ts
@@ -1,4 +1,5 @@
 import { expect, waitUntil } from '@open-wc/testing';
+import { setViewport } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
 import './audit-view';
@@ -345,6 +346,97 @@ describe('AuditView', () => {
     expect(expandedContent).to.contain('Runtime Session Id');
 
     document.body.removeChild(element);
+  });
+
+  describe('filter bar and rows (B-D1)', () => {
+    async function mountLoaded() {
+      const element = document.createElement('audit-view') as AuditView;
+      document.body.appendChild(element);
+      await waitUntil(
+        () => !(element as any)._loading,
+        'Audit view did not finish loading'
+      );
+      await element.updateComplete;
+      return element;
+    }
+
+    it('gives every filter the full width of the bar at 390px', async () => {
+      await setViewport({ width: 390, height: 844 });
+      const element = await mountLoaded();
+
+      const bar = element.shadowRoot?.querySelector(
+        '.filter-bar'
+      ) as HTMLElement;
+      const controls = Array.from(
+        bar.querySelectorAll('sl-input, sl-select')
+      ) as HTMLElement[];
+      // Search, event type, outcomes, from, to, min $, max $.
+      expect(controls.length).to.equal(7);
+
+      const barWidth = bar.getBoundingClientRect().width;
+      for (const control of controls) {
+        const rect = control.getBoundingClientRect();
+        expect(
+          Math.abs(rect.width - barWidth),
+          `${control.tagName} ${control.getAttribute('type') || ''} is not full width`
+        ).to.be.lessThan(2);
+        expect(
+          Math.abs(rect.left - bar.getBoundingClientRect().left)
+        ).to.be.lessThan(2);
+      }
+
+      element.remove();
+      await setViewport({ width: 1280, height: 800 });
+    });
+
+    it('keeps the seven filters on one grid row on desktop', async () => {
+      await setViewport({ width: 1280, height: 800 });
+      const element = await mountLoaded();
+
+      const bar = element.shadowRoot?.querySelector(
+        '.filter-bar'
+      ) as HTMLElement;
+      const columns = getComputedStyle(bar)
+        .gridTemplateColumns.split(' ')
+        .filter(Boolean);
+      expect(columns.length).to.equal(7);
+
+      // One row: the seven controls share a vertical centre (they are
+      // centre-aligned in the grid and a date input is a little taller).
+      const centres = (
+        Array.from(bar.querySelectorAll('sl-input, sl-select')) as HTMLElement[]
+      ).map((control) => {
+        const rect = control.getBoundingClientRect();
+        return rect.top + rect.height / 2;
+      });
+      for (const centre of centres) {
+        expect(Math.abs(centre - centres[0])).to.be.lessThan(2);
+      }
+
+      element.remove();
+    });
+
+    it('carries the outcome in a tint chip and leaves the row unruled', async () => {
+      const element = await mountLoaded();
+
+      const row = element.shadowRoot?.querySelector(
+        '.timeline-group'
+      ) as HTMLElement;
+      const style = getComputedStyle(row);
+      expect(style.borderLeftStyle).to.equal('none');
+      expect(parseFloat(style.borderLeftWidth)).to.equal(0);
+
+      const badges = Array.from(
+        element.shadowRoot?.querySelectorAll('.timeline-group sl-badge') || []
+      );
+      expect(badges.length).to.be.greaterThan(0);
+      for (const badge of badges) {
+        expect(badge.classList.contains('status-chip')).to.equal(true);
+        expect(badge.classList.contains('solid')).to.equal(false);
+      }
+
+      element.remove();
+    });
   });
 
   it('renders gateway request failures with readable labels and details', async () => {

--- a/frontend/src/views/authed/audit-view.ts
+++ b/frontend/src/views/authed/audit-view.ts
@@ -788,27 +788,6 @@ export class AuditView extends AuthedElement {
     }
   }
 
-  private _getOutcomeColor(outcome: string): string {
-    switch (outcome) {
-      case 'allow':
-      case 'executed':
-      case 'approved':
-      case 'success':
-        return 'var(--sl-color-success-600)';
-      case 'deny':
-      case 'declined':
-      case 'denied':
-      case 'failed':
-      case 'failure':
-      case 'budget_denied':
-        return 'var(--sl-color-danger-600)';
-      case 'require_approval':
-        return 'var(--sl-color-warning-600)';
-      default:
-        return 'var(--sl-color-neutral-400)';
-    }
-  }
-
   private _getActionIcon(action: string): string {
     if (action === 'tool_call') return 'terminal';
     if (action === 'model_gateway_request') return 'cpu';
@@ -1222,7 +1201,6 @@ export class AuditView extends AuthedElement {
     const hasSubs = group.sub_events.length > 0;
     const canExpand = this._canExpandGroup(group);
     const badge = this._getOutcomeBadge(group.outcome);
-    const borderColor = this._getOutcomeColor(group.outcome);
     const isToolCall = event.action === 'tool_call';
     const argsSummary = isToolCall ? this._getArgsSummary(event.details) : '';
     const execTime =
@@ -1234,7 +1212,6 @@ export class AuditView extends AuthedElement {
           this._highlightedKey === key ? 'linked' : ''
         }"
         data-group-key=${key}
-        style="--group-color: ${borderColor}"
       >
         <div
           class="primary-row ${canExpand ? 'has-subs' : ''}"
@@ -1259,7 +1236,9 @@ export class AuditView extends AuthedElement {
                 ? html`<span class="exec-time">${execTime}ms</span>`
                 : nothing
             }
-            <sl-badge variant=${badge.variant} pill>${badge.label}</sl-badge>
+            <sl-badge class="status-chip" variant=${badge.variant} pill
+              >${badge.label}</sl-badge
+            >
             <span class="user-name">${this._formatActorLabel(event)}</span>
             <sl-tooltip content=${this._formatFullTimestamp(event.timestamp)}>
               <span class="timestamp"
@@ -1490,7 +1469,11 @@ export class AuditView extends AuthedElement {
             }
             <span class="sub-spacer"></span>
             ${this._renderEventCostTokens(sub.details)}
-            <sl-badge variant=${badge.variant} pill size="small"
+            <sl-badge
+              class="status-chip"
+              variant=${badge.variant}
+              pill
+              size="small"
               >${badge.label}</sl-badge
             >
             <span class="sub-actor">${this._formatActorLabel(sub)}</span>
@@ -1621,25 +1604,25 @@ export class AuditView extends AuthedElement {
       }
 
       /* ── Filter bar ────────────────────────── */
+      /* Seven controls on one line at 1440: a proportional grid keeps
+         "Max $" out of a second row, and the fields keep their order. */
       .filter-bar {
-        display: flex;
+        display: grid;
+        grid-template-columns:
+          minmax(0, 1.5fr) minmax(0, 1.2fr) minmax(0, 1.2fr) minmax(0, 1fr)
+          minmax(0, 1fr) minmax(0, 0.7fr) minmax(0, 0.7fr);
         align-items: center;
         gap: 0.5rem;
         margin-bottom: 1rem;
-        flex-wrap: wrap;
       }
-      .filter-bar sl-input {
-        flex: 1 1 180px;
-        min-width: 140px;
-        max-width: 240px;
-      }
+      .filter-bar sl-input,
       .filter-bar sl-select {
-        flex: 0 1 170px;
-        min-width: 140px;
+        min-width: 0;
       }
-      .filter-bar sl-input[type='date'] {
-        flex: 0 1 150px;
-        min-width: 130px;
+      /* Clear takes its own row rather than an eighth column. */
+      .filter-bar sl-button {
+        grid-column: 1 / -1;
+        justify-self: start;
       }
 
       /* ── Loading / Empty ────────────────────── */
@@ -1663,8 +1646,9 @@ export class AuditView extends AuthedElement {
       }
 
       /* ── Group ─────────────────────────────── */
+      /* No coloured left rule: the outcome lives in the pill, and forty green
+         rules read as a wall of paint (DESIGN.md "Red lives in the pill"). */
       .timeline-group {
-        border-left: 3px solid var(--group-color, var(--sl-color-neutral-300));
         border-radius: 4px;
         background: var(--sl-color-neutral-0);
         transition: border-color 0.2s;
@@ -1945,13 +1929,18 @@ export class AuditView extends AuthedElement {
         .event-details {
           padding-left: 1rem;
         }
+        /* Phone: one field per row, each the full width of the bar. The old
+           rule left the date inputs at their fixed width and centred them,
+           which put ~250px of gap between From and To at 390px. */
         .filter-bar {
-          flex-direction: column;
+          grid-template-columns: minmax(0, 1fr);
         }
         .filter-bar sl-input,
-        .filter-bar sl-select {
+        .filter-bar sl-select,
+        .filter-bar sl-input[type='date'] {
+          width: 100%;
           max-width: 100%;
-          flex: 1 1 100%;
+          min-width: 0;
         }
         .sub-main-row {
           flex-wrap: wrap;

--- a/frontend/src/views/authed/audit-view.ts
+++ b/frontend/src/views/authed/audit-view.ts
@@ -1651,7 +1651,6 @@ export class AuditView extends AuthedElement {
       .timeline-group {
         border-radius: 4px;
         background: var(--sl-color-neutral-0);
-        transition: border-color 0.2s;
       }
       .timeline-group.tool-call {
         background: var(--sl-color-neutral-0);
@@ -1936,8 +1935,7 @@ export class AuditView extends AuthedElement {
           grid-template-columns: minmax(0, 1fr);
         }
         .filter-bar sl-input,
-        .filter-bar sl-select,
-        .filter-bar sl-input[type='date'] {
+        .filter-bar sl-select {
           width: 100%;
           max-width: 100%;
           min-width: 0;

--- a/frontend/src/views/authed/console-shell.test.ts
+++ b/frontend/src/views/authed/console-shell.test.ts
@@ -505,6 +505,55 @@ describe('ConsoleShell', () => {
       window.history.replaceState({}, '', originalPath);
     });
 
+    it('never assigns the routed child on a denied path', async () => {
+      // B-P1: the shell used to keep the outlet slot while it renders
+      // permission-denied, so the routed view painted behind the refusal.
+      const originalPath = window.location.pathname;
+      window.history.replaceState({}, '', '/console/policies');
+      stubShell();
+
+      const el = (await fixture(
+        html`<console-shell><div id="routed-view">rules</div></console-shell>`
+      )) as ConsoleShell;
+      await waitUntil(
+        () =>
+          (el as unknown as { _featuresLoaded: boolean })._featuresLoaded &&
+          (el as unknown as { _permissionsLoaded: boolean })._permissionsLoaded,
+        'Features and permissions did not load'
+      );
+      await el.updateComplete;
+
+      const child = el.querySelector('#routed-view') as HTMLElement;
+      expect(child).to.exist;
+      expect(child.assignedSlot).to.equal(null);
+      expect(child.getClientRects().length).to.equal(0);
+      expect(el.shadowRoot?.querySelector('permission-denied')).to.exist;
+
+      window.history.replaceState({}, '', originalPath);
+    });
+
+    it('holds the outlet back until permissions have loaded', async () => {
+      // Permissions in flight is not "allowed": the slot must not render
+      // before the shell knows, or a gated view mounts and fetches first.
+      const originalPath = window.location.pathname;
+      window.history.replaceState({}, '', '/console/policies');
+      stubShell();
+
+      const el = (await fixture(
+        html`<console-shell></console-shell>`
+      )) as ConsoleShell;
+      (el as unknown as { _featuresLoaded: boolean })._featuresLoaded = false;
+      (el as unknown as { _permissionsLoaded: boolean })._permissionsLoaded =
+        false;
+      el.requestUpdate();
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.main-content slot')).to.not.exist;
+      expect(el.shadowRoot?.querySelector('permission-denied')).to.not.exist;
+
+      window.history.replaceState({}, '', originalPath);
+    });
+
     it('renders the page on a direct URL when the flag is on', async () => {
       const originalPath = window.location.pathname;
       window.history.replaceState({}, '', '/console/policies');

--- a/frontend/src/views/authed/console-shell.ts
+++ b/frontend/src/views/authed/console-shell.ts
@@ -891,9 +891,16 @@ export class ConsoleShell extends LitElement {
               (this._fullBleed = !!e.detail)}
           >
             ${(() => {
-              const denied = this._permissionsLoaded
-                ? this._deniedPermissionForPath(this._currentPath)
-                : null;
+              // The outlet renders only once the answer is known and it is
+              // "yes". Rendering the slot while features and permissions are
+              // still in flight let a routed view paint (and keep painting,
+              // behind permission-denied) on a page the shell then refused.
+              // A routed view is a light-DOM child, so dropping the slot only
+              // hides it: views that carry data also check before fetching.
+              if (!this._featuresLoaded || !this._permissionsLoaded) {
+                return nothing;
+              }
+              const denied = this._deniedPermissionForPath(this._currentPath);
               return denied
                 ? html`<permission-denied
                     required-permission=${denied}

--- a/frontend/src/views/authed/policies-view.test.ts
+++ b/frontend/src/views/authed/policies-view.test.ts
@@ -1,6 +1,7 @@
 import { html, fixture, expect, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon';
 
+import { invalidateApiCaches } from '../../api';
 import '../../components/view-header.ts';
 import './policies-view';
 import { conditionTypeFor } from './policies-view';
@@ -169,11 +170,80 @@ describe('PoliciesView', () => {
   beforeEach(() => {
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
+    // The view now reads the cached profile before it fetches; a permission
+    // set must not leak from one case into the next.
+    invalidateApiCaches();
   });
 
   afterEach(() => {
     fetchStub?.restore();
     localStorage.clear();
+    invalidateApiCaches();
+  });
+
+  it('fetches nothing when the viewer lacks view_policies', async () => {
+    // B-P1: the gated view stayed connected behind the shell's
+    // permission-denied and still fetched tools, workflows and rules.
+    fetchStub = sinon
+      .stub(window, 'fetch')
+      .callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/api/v1/auth/users/me')) {
+          return json({
+            username: 'viewer',
+            email: 'viewer@example.com',
+            email_verified: true,
+            permissions: ['view_agents'],
+          });
+        }
+        return json({ detail: `Unexpected: ${url}` }, 500);
+      });
+
+    const element = (await fixture(
+      html`<policies-view></policies-view>`
+    )) as PoliciesView;
+    await waitUntil(
+      () => (element as any)._permissionDenied === true,
+      'permission check did not resolve'
+    );
+    await element.updateComplete;
+
+    const dataCalls = fetchStub
+      .getCalls()
+      .map((call) => String(call.args[0]))
+      .filter(
+        (url) => url.includes('/api/') && !url.endsWith('/api/v1/auth/users/me')
+      );
+    expect(dataCalls).to.deep.equal([]);
+    expect(element.shadowRoot?.querySelector('permission-denied')).to.exist;
+    expect(element.shadowRoot?.querySelector('sl-tab-group')).to.equal(null);
+  });
+
+  it('loads when the viewer has view_policies', async () => {
+    fetchStub = createFetchStub();
+    fetchStub
+      .withArgs(
+        sinon.match((url: unknown) =>
+          String(url).endsWith('/api/v1/auth/users/me')
+        )
+      )
+      .callsFake(async () =>
+        json({
+          username: 'admin',
+          email: 'admin@example.com',
+          email_verified: true,
+          permissions: ['view_policies'],
+        })
+      );
+
+    const element = (await fixture(
+      html`<policies-view></policies-view>`
+    )) as PoliciesView;
+    await waitUntil(() => !(element as any)._loading, 'still loading');
+    await element.updateComplete;
+
+    expect((element as any)._permissionDenied).to.equal(false);
+    expect(element.shadowRoot?.querySelector('sl-tab-group')).to.exist;
   });
 
   it('renders the Policies header and tabs after load', async () => {

--- a/frontend/src/views/authed/policies-view.ts
+++ b/frontend/src/views/authed/policies-view.ts
@@ -15,11 +15,14 @@ import {
   createAccessRule,
   updateAccessRule,
   deleteAccessRule,
+  getUserProfile,
 } from '../../api';
 import type { AccessRule, ModelIORule } from '../../api';
+import { hasPermission } from '../../permissions';
 import type { Tool, ApprovalWorkflow } from '../../components/tool-card';
 import '../../components/policy-generate-dialog';
 import '../../components/view-header';
+import '../../components/permission-denied';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
@@ -223,6 +226,7 @@ export class PoliciesView extends LitElement {
   @state() private _approvalPolicies: ApprovalWorkflow[] = [];
   @state() private _loading = false;
   @state() private _error: string | null = null;
+  @state() private _permissionDenied = false;
   @state() private _features: { [key: string]: boolean | string[] } = {};
 
   // Access policies state
@@ -806,7 +810,30 @@ export class PoliciesView extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.loadData();
+    void this._loadIfPermitted();
+  }
+
+  /**
+   * A gated route must not fetch. The shell hides the outlet, but a routed
+   * view is a light-DOM child and stays connected, so the view checks the
+   * viewer's permissions itself before asking for tools, workflows or rules.
+   * An unreadable profile is not a denial: the API gates every call anyway.
+   */
+  private async _loadIfPermitted() {
+    // Set before the first await so the view reads as loading from its first
+    // render, as it did when connectedCallback fetched straight away.
+    this._loading = true;
+    try {
+      const profile = await getUserProfile();
+      if (!hasPermission(profile?.permissions, 'view_policies')) {
+        this._permissionDenied = true;
+        this._loading = false;
+        return;
+      }
+    } catch {
+      // Profile unavailable: fall through and let the API answer.
+    }
+    await this.loadData();
   }
 
   private async loadData() {
@@ -3187,6 +3214,11 @@ defaults:
   };
 
   render() {
+    if (this._permissionDenied) {
+      return html`<permission-denied
+        required-permission="view_policies"
+      ></permission-denied>`;
+    }
     return html`
       <view-header
         headerText="Policies"

--- a/frontend/src/views/authed/tools-view.test.ts
+++ b/frontend/src/views/authed/tools-view.test.ts
@@ -296,7 +296,7 @@ describe('ToolsView (approvals + conditions)', () => {
     ) as HTMLButtonElement | null;
     expect(unavailableButton?.getAttribute('aria-pressed')).to.equal('false');
 
-    const contextTax = el.shadowRoot?.querySelector('.context-tax');
+    const contextTax = el.shadowRoot?.querySelector('.strip-note');
     expect(contextTax).to.exist;
     // Only enabled+supported tools contribute (1200), not unavailable (800).
     expect(contextTax?.textContent?.replace(/\s+/g, ' ')).to.contain(
@@ -1067,8 +1067,9 @@ describe('ToolsView – tabs and toolbar', () => {
 
     const toolsCount = [
       ...(el.shadowRoot?.querySelectorAll('.strip-count') || []),
-    ].find((button) => /^\s*\d+\s+tools\s*$/.test(button.textContent || '')) as
-      HTMLButtonElement | undefined;
+    ].find((button) =>
+      /^\s*\d+\s+tools?\s*$/.test(button.textContent || '')
+    ) as HTMLButtonElement | undefined;
     expect(toolsCount).to.exist;
     toolsCount!.click();
     await el.updateComplete;
@@ -1166,7 +1167,7 @@ describe('ToolsView – tabs and toolbar', () => {
     );
 
     const strip = el.shadowRoot?.querySelector('.summary-strip');
-    expect(strip?.textContent?.replace(/\s+/g, ' ')).to.contain('1 tools');
+    expect(strip?.textContent?.replace(/\s+/g, ' ')).to.contain('1 tool ');
 
     const nativeEditor = el.shadowRoot?.querySelector(
       'sl-tab-panel[name="native"] tools-editor-component'
@@ -1312,7 +1313,7 @@ describe('ToolsView – tabs and toolbar', () => {
         ?.textContent?.replace(/\s+/g, ' ')
         .trim()
     ).to.equal(
-      '1 tools · 1 allowed · 0 blocked · 0 with rules · runs without asking by default'
+      '1 tool · 1 allowed · 0 blocked · 0 with rules · runs without asking by default'
     );
   });
 

--- a/frontend/src/views/authed/tools-view.test.ts
+++ b/frontend/src/views/authed/tools-view.test.ts
@@ -660,6 +660,9 @@ describe('ToolsView – tabs and toolbar', () => {
   let tools: Record<string, unknown>[];
   let workflows: Record<string, unknown>[];
   let governanceDefaults: Record<string, unknown>;
+  let failGovernanceGet: boolean;
+  let holdGovernanceGet: Promise<Response> | null;
+  let releaseHeldGovernance: ((response: Response) => void) | null;
 
   function makeTool(
     overrides: Record<string, unknown> = {}
@@ -724,6 +727,15 @@ describe('ToolsView – tabs and toolbar', () => {
           });
         }
         if (url.endsWith('/api/v1/account/governance-defaults')) {
+          if (holdGovernanceGet) {
+            return holdGovernanceGet;
+          }
+          if (failGovernanceGet) {
+            return new Response(
+              JSON.stringify({ detail: 'Simulated GET failure' }),
+              { status: 500, headers: { 'Content-Type': 'application/json' } }
+            );
+          }
           return new Response(
             JSON.stringify({
               defaults: governanceDefaults,
@@ -767,6 +779,9 @@ describe('ToolsView – tabs and toolbar', () => {
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
     tools = [makeTool()];
+    failGovernanceGet = false;
+    holdGovernanceGet = null;
+    releaseHeldGovernance = null;
     governanceDefaults = {
       native_tool_approvals: null,
       approval_workflow_id: null,
@@ -792,6 +807,16 @@ describe('ToolsView – tabs and toolbar', () => {
   });
 
   afterEach(() => {
+    if (releaseHeldGovernance) {
+      releaseHeldGovernance(
+        new Response(JSON.stringify({ detail: 'teardown' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      releaseHeldGovernance = null;
+    }
+    holdGovernanceGet = null;
     fetchStub.restore();
     localStorage.removeItem('preloop.tools.view_mode');
     localStorage.clear();
@@ -1112,6 +1137,27 @@ describe('ToolsView – tabs and toolbar', () => {
     };
   }
 
+  async function nativeNoRulesText(el: ToolsView): Promise<string | undefined> {
+    await waitUntil(() => {
+      const nativeEditor = el.shadowRoot?.querySelector(
+        'sl-tab-panel[name="native"] tools-editor-component'
+      ) as LitElement | null;
+      return Boolean(nativeEditor?.shadowRoot?.querySelector('tool-list-item'));
+    }, 'Native tool row did not render');
+    const nativeEditor = el.shadowRoot?.querySelector(
+      'sl-tab-panel[name="native"] tools-editor-component'
+    ) as LitElement;
+    await nativeEditor.updateComplete;
+    const item = nativeEditor.shadowRoot?.querySelector(
+      'tool-list-item'
+    ) as LitElement;
+    await item.updateComplete;
+    return item.shadowRoot
+      ?.querySelector('.no-rules')
+      ?.textContent?.replace(/\s+/g, ' ')
+      .trim();
+  }
+
   it('native tab lists agent-source tools from the API and opens the rule editor with the tool parameters', async () => {
     tools = [
       makeTool(),
@@ -1315,6 +1361,77 @@ describe('ToolsView – tabs and toolbar', () => {
     ).to.equal(
       '1 tool · 1 allowed · 0 blocked · 0 with rules · runs without asking by default'
     );
+  });
+
+  it('ruleless native rows claim no effect while governance defaults are unread', async () => {
+    holdGovernanceGet = new Promise((resolve) => {
+      releaseHeldGovernance = resolve;
+    });
+    tools = [makeNativeTool()];
+    window.history.replaceState(
+      {},
+      '',
+      `${window.location.pathname}?tab=native`
+    );
+
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(
+      () => !(el as any).loading && (el as any).tools?.length === 1,
+      'Tools did not load'
+    );
+    await el.updateComplete;
+
+    expect((el as any).governanceDefaults).to.equal(null);
+    expect((el as any)._nativeAsksByDefault()).to.equal(null);
+    expect(await nativeNoRulesText(el)).to.equal('No rules');
+    expect(await nativeNoRulesText(el)).to.not.include('allowed');
+    expect(await nativeNoRulesText(el)).to.not.include('asks a human');
+
+    releaseHeldGovernance!(
+      new Response(
+        JSON.stringify({
+          defaults: governanceDefaults,
+          override_agent_ids: [],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    releaseHeldGovernance = null;
+    holdGovernanceGet = null;
+    await waitUntil(
+      () => (el as any).governanceDefaults !== null,
+      'Governance defaults did not load after release'
+    );
+    await el.updateComplete;
+    expect(await nativeNoRulesText(el)).to.equal(
+      'No rules · asks a human (account default)'
+    );
+  });
+
+  it('ruleless native rows do not claim allowed when governance defaults fail to load', async () => {
+    failGovernanceGet = true;
+    tools = [makeNativeTool()];
+    window.history.replaceState(
+      {},
+      '',
+      `${window.location.pathname}?tab=native`
+    );
+
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(
+      () => !(el as any).loading && (el as any).governanceLoadFailed,
+      'Governance load failure was not recorded'
+    );
+    await el.updateComplete;
+
+    expect((el as any)._nativeAsksByDefault()).to.equal(null);
+    expect(
+      el.shadowRoot?.querySelector('#native-approvals-defaults-card')
+        ?.textContent
+    ).to.include('Could not load this setting');
+    expect(await nativeNoRulesText(el)).to.equal('No rules');
+    expect(await nativeNoRulesText(el)).to.not.include('allowed');
+    expect(await nativeNoRulesText(el)).to.not.include('asks a human');
   });
 
   it('saving a native rule creates an agent-source configuration without a server id', async () => {

--- a/frontend/src/views/authed/tools-view.test.ts
+++ b/frontend/src/views/authed/tools-view.test.ts
@@ -659,6 +659,7 @@ describe('ToolsView – tabs and toolbar', () => {
   let fetchStub: sinon.SinonStub;
   let tools: Record<string, unknown>[];
   let workflows: Record<string, unknown>[];
+  let governanceDefaults: Record<string, unknown>;
 
   function makeTool(
     overrides: Record<string, unknown> = {}
@@ -725,10 +726,7 @@ describe('ToolsView – tabs and toolbar', () => {
         if (url.endsWith('/api/v1/account/governance-defaults')) {
           return new Response(
             JSON.stringify({
-              defaults: {
-                native_tool_approvals: null,
-                approval_workflow_id: null,
-              },
+              defaults: governanceDefaults,
               override_agent_ids: [],
             }),
             { status: 200, headers: { 'Content-Type': 'application/json' } }
@@ -769,6 +767,10 @@ describe('ToolsView – tabs and toolbar', () => {
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
     tools = [makeTool()];
+    governanceDefaults = {
+      native_tool_approvals: null,
+      approval_workflow_id: null,
+    };
     workflows = [
       {
         id: 'policy-1',
@@ -1249,6 +1251,71 @@ describe('ToolsView – tabs and toolbar', () => {
     expect(options).to.deep.equal(['command', 'description', 'timeout']);
   });
 
+  it('native tab summary strip states the counts and the account default', async () => {
+    // B-T2: the Native tab ran a different toolbar pattern from MCP and never
+    // stated the default that governs a ruleless row.
+    tools = [
+      makeNativeTool(),
+      makeNativeTool({ name: 'Edit' }),
+      makeNativeTool({ name: 'Write', is_enabled: false }),
+    ];
+    window.history.replaceState(
+      {},
+      '',
+      `${window.location.pathname}?tab=native`
+    );
+
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(
+      () => !(el as any).loading && (el as any).governanceDefaults !== null,
+      'Governance defaults did not load'
+    );
+    await el.updateComplete;
+
+    const strip = el.shadowRoot?.querySelector('.native-summary-strip');
+    expect(strip?.textContent?.replace(/\s+/g, ' ').trim()).to.equal(
+      '3 tools · 2 allowed · 1 blocked · 0 with rules · asks a human by default'
+    );
+
+    // The counts filter the list, as they do on the MCP strip.
+    const blocked = [...(strip?.querySelectorAll('.strip-count') || [])].find(
+      (button) => /^\s*1\s+blocked\s*$/.test(button.textContent || '')
+    ) as HTMLButtonElement | undefined;
+    expect(blocked).to.exist;
+    blocked!.click();
+    await el.updateComplete;
+    expect((el as any).nativeFilters.rules).to.deep.equal(['blocked']);
+  });
+
+  it('native summary strip says so when the account default is off', async () => {
+    tools = [makeNativeTool()];
+    governanceDefaults = {
+      native_tool_approvals: 'off',
+      approval_workflow_id: null,
+    };
+    window.history.replaceState(
+      {},
+      '',
+      `${window.location.pathname}?tab=native`
+    );
+
+    const el = (await fixture(html`<tools-view></tools-view>`)) as ToolsView;
+    await waitUntil(
+      () => !(el as any).loading && (el as any).governanceDefaults !== null,
+      'Governance defaults did not load'
+    );
+    await el.updateComplete;
+
+    expect(
+      el.shadowRoot
+        ?.querySelector('.native-summary-strip')
+        ?.textContent?.replace(/\s+/g, ' ')
+        .trim()
+    ).to.equal(
+      '1 tools · 1 allowed · 0 blocked · 0 with rules · runs without asking by default'
+    );
+  });
+
   it('saving a native rule creates an agent-source configuration without a server id', async () => {
     tools = [makeTool(), makeNativeTool()];
     window.history.replaceState(
@@ -1357,7 +1424,9 @@ describe('ToolsView – tabs and toolbar', () => {
     const blockedSwitch = bashItem.shadowRoot?.querySelector('sl-switch') as
       (HTMLElement & { checked: boolean }) | null;
     expect(blockedSwitch).to.exist;
-    expect(blockedSwitch!.textContent).to.contain('Blocked');
+    // B-T1: the switch is labelled with the verb, not with a state that read
+    // as "this tool is blocked" beside an off switch.
+    expect(blockedSwitch!.textContent?.trim()).to.equal('Block');
     expect(blockedSwitch!.checked).to.equal(false);
 
     blockedSwitch!.checked = true;

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -224,11 +224,13 @@ export class ToolsView extends LitElement {
         color: var(--sl-color-primary-700);
       }
 
-      .context-tax {
+      /* Meta note at the end of a summary strip (token cost on MCP, the
+         account default on Native). */
+      .strip-note {
         color: var(--console-meta-color, var(--sl-color-neutral-600));
       }
 
-      .context-tax strong {
+      .strip-note strong {
         font-variant-numeric: tabular-nums;
         color: var(--sl-color-neutral-900);
       }
@@ -1737,8 +1739,12 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     `;
   }
 
+  private _toolNoun(count: number): string {
+    return count === 1 ? 'tool' : 'tools';
+  }
+
   private _resultsLabel(shown: number, total: number): string {
-    const noun = total === 1 ? 'tool' : 'tools';
+    const noun = this._toolNoun(total);
     if (shown === total) {
       return `${shown} ${noun}`;
     }
@@ -1789,7 +1795,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
 
     return html`
       <div class="summary-strip">
-        ${this._renderStripCount(stats.total, 'tools', {
+        ${this._renderStripCount(stats.total, this._toolNoun(stats.total), {
           active: noFilters,
           onClick: () => this._clearFilters(),
         })}
@@ -1811,7 +1817,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
         ${
           stats.contextTaxTokens > 0
             ? html`<span class="strip-sep" aria-hidden="true">·</span>
-                <span class="context-tax">
+                <span class="strip-note">
                   Enabled tools add
                   <strong
                     >~${stats.contextTaxTokens.toLocaleString()} tokens</strong
@@ -2006,7 +2012,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
       !this.nativeFilters.query;
     return html`
       <div class="summary-strip native-summary-strip">
-        ${this._renderStripCount(stats.total, 'tools', {
+        ${this._renderStripCount(stats.total, this._toolNoun(stats.total), {
           active: noFilters,
           onClick: () => this._clearNativeFilters(),
         })}
@@ -2028,7 +2034,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
         ${
           this.governanceDefaults
             ? html`<span class="strip-sep" aria-hidden="true">·</span>
-                <span class="context-tax"
+                <span class="strip-note"
                   >${
                     this._nativeAsksByDefault()
                       ? 'asks a human by default'

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -1572,13 +1572,14 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
   }
 
   /**
-   * True when the account default asks a human before a native tool call.
-   * `null` means "not set", which the backend treats as enforced. With the
-   * defaults unread we claim nothing, and the strip states no default.
+   * Account default for a native tool with no rule of its own.
+   * `true` asks a human, `false` runs without asking, `null` is unread or
+   * failed to load — the backend treats an unset default as enforce, so we
+   * must not claim "allowed" until this value is known.
    */
-  private _nativeAsksByDefault(): boolean {
+  private _nativeAsksByDefault(): boolean | null {
     if (!this.governanceDefaults) {
-      return false;
+      return null;
     }
     return this.governanceDefaults.native_tool_approvals !== 'off';
   }
@@ -2036,7 +2037,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
             ? html`<span class="strip-sep" aria-hidden="true">·</span>
                 <span class="strip-note"
                   >${
-                    this._nativeAsksByDefault()
+                    this._nativeAsksByDefault() === true
                       ? 'asks a human by default'
                       : 'runs without asking by default'
                   }</span

--- a/frontend/src/views/authed/tools-view.ts
+++ b/frontend/src/views/authed/tools-view.ts
@@ -775,6 +775,9 @@ export class ToolsView extends LitElement {
     if (rule === 'blocked') {
       return !tool.is_enabled;
     }
+    if (rule === 'allowed') {
+      return tool.is_enabled;
+    }
     return this._toolMatchesRuleFilter(tool, rule);
   }
 
@@ -1486,6 +1489,16 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     this.nativeFilters = { ...this.nativeFilters, ...patch };
   }
 
+  private _clearNativeFilters() {
+    this.nativeFilters = { ...EMPTY_NATIVE_FILTERS };
+  }
+
+  private _toggleSingleNativeFilter(value: string) {
+    const current = this.nativeFilters.rules;
+    const already = current.length === 1 && current[0] === value;
+    this._setNativeFilterValues({ rules: already ? [] : [value] });
+  }
+
   private _handleNativeSearchChange(event: CustomEvent<{ value: string }>) {
     this._setNativeFilterValues({ query: event.detail.value });
   }
@@ -1554,6 +1567,18 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     } finally {
       this.savingGovernanceDefaults = false;
     }
+  }
+
+  /**
+   * True when the account default asks a human before a native tool call.
+   * `null` means "not set", which the backend treats as enforced. With the
+   * defaults unread we claim nothing, and the strip states no default.
+   */
+  private _nativeAsksByDefault(): boolean {
+    if (!this.governanceDefaults) {
+      return false;
+    }
+    return this.governanceDefaults.native_tool_approvals !== 'off';
   }
 
   private _defaultWorkflowLabel(): string {
@@ -1955,6 +1980,67 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
     `;
   }
 
+  private _getNativeStats() {
+    const all = this._nativeTools();
+    const blocked = all.filter((tool) => !tool.is_enabled);
+    const withRules = all.filter((tool) => this._toolHasRules(tool));
+    return {
+      total: all.length,
+      allowed: all.length - blocked.length,
+      blocked: blocked.length,
+      withRules: withRules.length,
+    };
+  }
+
+  /**
+   * The Native tab had no summary strip while MCP did, so the same page ran
+   * two toolbar patterns and never stated the account default in the list
+   * itself (B-T2).
+   */
+  private _renderNativeSummaryStrip() {
+    const stats = this._getNativeStats();
+    const rule = this.nativeFilters.rules[0] || '';
+    const noFilters =
+      this.nativeFilters.agents.length === 0 &&
+      this.nativeFilters.rules.length === 0 &&
+      !this.nativeFilters.query;
+    return html`
+      <div class="summary-strip native-summary-strip">
+        ${this._renderStripCount(stats.total, 'tools', {
+          active: noFilters,
+          onClick: () => this._clearNativeFilters(),
+        })}
+        <span class="strip-sep" aria-hidden="true">·</span>
+        ${this._renderStripCount(stats.allowed, 'allowed', {
+          active: rule === 'allowed',
+          onClick: () => this._toggleSingleNativeFilter('allowed'),
+        })}
+        <span class="strip-sep" aria-hidden="true">·</span>
+        ${this._renderStripCount(stats.blocked, 'blocked', {
+          active: rule === 'blocked',
+          onClick: () => this._toggleSingleNativeFilter('blocked'),
+        })}
+        <span class="strip-sep" aria-hidden="true">·</span>
+        ${this._renderStripCount(stats.withRules, 'with rules', {
+          active: rule === 'with_rules',
+          onClick: () => this._toggleSingleNativeFilter('with_rules'),
+        })}
+        ${
+          this.governanceDefaults
+            ? html`<span class="strip-sep" aria-hidden="true">·</span>
+                <span class="context-tax"
+                  >${
+                    this._nativeAsksByDefault()
+                      ? 'asks a human by default'
+                      : 'runs without asking by default'
+                  }</span
+                >`
+            : ''
+        }
+      </div>
+    `;
+  }
+
   private _renderNativeToolbar() {
     const filtered = this._getFilteredNativeTools();
     const total = this._nativeTools().length;
@@ -1995,6 +2081,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
             <sl-option value="with_rules">With rules</sl-option>
             <sl-option value="no_rules">No rules</sl-option>
             <sl-option value="require_approval">Requires approval</sl-option>
+            <sl-option value="allowed">Allowed</sl-option>
             <sl-option value="blocked">Blocked</sl-option>
           </sl-select>
           <span slot="count"
@@ -2010,6 +2097,7 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
       <tools-editor-component
         family="native"
         .tools=${this._getFilteredNativeTools()}
+        .accountAsksByDefault=${this._nativeAsksByDefault()}
         .approvalPolicies=${this.approvalPolicies}
         .features=${this.features}
         mode="global"
@@ -2040,7 +2128,8 @@ ${this._formatStarterPolicyDiffValue(change.new_value)}</pre>
                 Write calls will show up here.
               </p>
             `
-          : html`${this._renderNativeToolbar()} ${this._renderNativeEditor()}`
+          : html`${this._renderNativeSummaryStrip()}
+            ${this._renderNativeToolbar()} ${this._renderNativeEditor()}`
       }
     `;
   }


### PR DESCRIPTION
# Gated console views, native tool policy copy, audit filter bar (W1-7, W1-8, W1-9)

## Summary

Three wave 1 console fixes, plus the V-I3 review follow-ups.

A user without `view_policies` used to load the Policies view, fire its fetches and then see a denial: the view now neither mounts nor fetches. A native (agent) tool row used to show a switch and no statement of what actually happens when the agent calls the tool: each row now states its effective policy, including the account default, and the switch is labelled with the verb it performs. The audit filter bar used to wrap "Max $" onto a second row at 1440 and stack date inputs oddly on a phone, and every group carried a coloured left rule that turned a screen of allowed calls into a wall of green: the bar is now a seven-track grid that collapses to one column on a phone, and the outcome lives only in the pill.

No backend change: `openapi.yaml` and the migrations are untouched.

## Changes per W1 item

### W1-7: a gated view does not mount or fetch (B-P1)

- `console-shell.ts:898-911` renders the router outlet only once features and permissions have loaded and the current path is allowed. A routed view is a light-DOM child placed by the router, so withholding the `<slot>` hides it but cannot disconnect it; that is why the view-side guard below is the part that stops the fetch.
- `policies-view.ts:820-840` checks `view_policies` before `loadData()` and renders the standard `permission-denied` panel (`:3218-3220`). An unreadable profile is treated as "not a denial", consistent with `hasPermission` when RBAC is inactive.
- Tests assert zero fetch calls, `assignedSlot === null` and zero client rects, not just a flag.

### W1-8: native rows state the effective policy (B-T1, B-T4, B-T2)

- `tool-list-item.ts:333-355` row copy for the three states: "No rules, asks a human (account default)", "No rules, allowed", "No rules, blocked". Expanded-panel copy at `:435-444` and `:497`.
- The switch is labelled "Block" (`:612`), which is what it does on a native row, instead of an unlabelled enable/disable toggle.
- The account default is threaded through `tools-editor-component.ts:73, 496-498` and `tools-view.ts:1579-1590, 2106`.
- New native summary strip (`tools-view.ts:2006-2048`) with clickable counts, matched by an "Allowed" option in the Rules select (`tools-view.ts:2090`) so the strip and the select agree.
- Phone (`tool-list-item.ts:192-235`): the header wraps, the tool name keeps its width, and tags, description and rule summary move below it. Previously the agent tags squeezed the name out of a 390px row.

### W1-9: audit filter bar and rows (B-D1)

- `audit-view.ts:1606-1631` lays the bar out as seven `minmax(0, Nfr)` tracks with Clear on its own row; `:1934-1943` collapses to a single full-width column at 768px and below, date inputs included.
- The coloured left rule is gone (`.timeline-group`, `:1651-1654`), along with `_getOutcomeColor` and the `--group-color` inline style that fed it.
- Both outcome badges now carry `status-chip` (`:1239`, `:1473`), the console tint recipe in `console-styles.css:239-289`, so the outcome reads as a tint pill rather than paint on the row.

### Review follow-ups (V-I3)

- `tool-list-item.ts:208-213, 617-621`: the MCP three-dots wrapper had no class, so at 480px and below its default `order: 0` sorted it ahead of the tool name and moved the menu to the left of the name on every MCP row. It is now `.tool-menu { order: 2; }`.
- `audit-view.ts:1651-1654`: removed a `transition: border-color` left behind by the deleted left rule.
- `audit-view.ts:1937-1943`: removed a redundant `sl-input[type='date']` selector whose desktop counterpart was deleted in the same change.
- `tools-view.ts:227-236, 1820, 2037`: the strip meta note was styled with `context-tax`, a name from the MCP token-cost note. Renamed `strip-note` and used by both strips.
- `tools-view.ts:1742-1744`: tool counts pluralise, so a single tool reads "1 tool".

## Tests

`cd frontend && npm test`: **1571 passed, 0 failed, 142 test files** (main baseline 1556, so 15 new).

- console-shell (2): a gated path renders no outlet content and issues no view fetch.
- policies-view (2): without `view_policies` no data fetch fires and the denial panel renders; with it, data loads as before.
- tool-list-item (6): the three row strings, the "Block" switch label, the tool name at 390px, and the MCP settings menu staying right of the name at 390px.
- tools-view (2): the native strip's exact text and the strip counts driving the filters.
- audit-view (3): seven grid tracks and a shared vertical centre at desktop, one full-width column at 390px, outcome badges carrying `status-chip`.

The phone-width tests use `setViewport` from `@web/test-runner-commands` (now a declared devDependency, one lockfile line) and measure `getBoundingClientRect()`, so they are real viewport tests rather than media-query string reads. Negative check on the review fix: with `.tool-menu { order: 2 }` removed, the new 390px MCP test fails.

No backend tests: no backend change on the branch.

## Founder calls

1. **"N allowed" on the native strip.** The strip reads "2 allowed, asks a human by default" while each of those rows reads "asks a human (account default)". "Allowed" here means "not blocked by the switch", which is the agreed B-T2 wording and is implemented as specified, but the two readings sit next to each other on the same screen. If it grates on staging, "2 not blocked" is a one-line change to the strip label.
2. **Scope held to the brief.** B-T3 (agent tags as `tag-chip`) and B-D2/B-D3/B-D4 are not in this branch, so the dark tag pills in the after image remain. Say the word if you want them folded in here rather than in a follow-up.
3. **One addition beyond the brief:** the "Allowed" option in the native Rules select, because without it the new strip count had no matching filter and the two controls would disagree.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Frontend-only change to gated-view mounting, native tool policy copy, and the audit filter bar; well-tested, and the prior native-row copy gap (ruleless rows claiming "allowed" while the account default was unread) is now fixed.
>
> **Overview**
> Three wave-1 console fixes: gated views no longer mount or fetch without permission, native tool rows state their effective policy (including the account default), and the audit filter bar becomes a seven-track grid with the outcome shown only in a tint pill. Plus V-I3 review follow-ups. No backend change.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit e41b0ba5. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->