### PR TITLE
Approvals: decide where you see it; one honest Review link in chat notifications

### DIFF
--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -1648,11 +1648,17 @@ class ApprovalService:
                     if approval_request.expires_at
                     else None
                 ),
-                # One key, because one thing happens: the link opens the
-                # approval page. Decisions are taken with
+                # "review" is the honest name: the link opens the approval
+                # page, it does not decide anything. Decisions are taken with
                 # POST /api/v1/approval-requests/{id}/approve or /decline.
+                # "approve", "decline" and "view" are the same URL and always
+                # were; they stay for receivers that read those keys today and
+                # are deprecated, to be removed once no integration reads them.
                 "actions": {
                     "review": review_url,
+                    "approve": review_url,  # deprecated, same page as review
+                    "decline": review_url,  # deprecated, same page as review
+                    "view": review_url,  # deprecated, same page as review
                 },
             }
 

--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -1550,16 +1550,13 @@ class ApprovalService:
             )
             return False
 
-        # Generate public approval links with token (no authentication required)
+        # One public link with a token (no authentication required). A chat
+        # message offers exactly one action because there is exactly one:
+        # opening the approval page. Separate "Approve" and "Decline" links
+        # pointed at this same URL and neither of them decided anything, so
+        # the reader clicked "Approve" and still had to decide on the page.
         token = approval_request.approval_token
-        # All links go to the same approval page - user decides there
-        approve_url = urljoin(
-            self.base_url, f"/approval/{approval_request.id}?token={token}"
-        )
-        decline_url = urljoin(
-            self.base_url, f"/approval/{approval_request.id}?token={token}"
-        )
-        view_url = urljoin(
+        review_url = urljoin(
             self.base_url, f"/approval/{approval_request.id}?token={token}"
         )
 
@@ -1573,7 +1570,7 @@ class ApprovalService:
 
         # Create message based on approval type
         if approval_workflow.approval_type in ["slack", "mattermost"]:
-            # Build message text with all details — summary first when present
+            # Build message text with all details: summary first when present
             if ask_text:
                 message_text = f"⚠️ **{ask_text}**\n\n"
             else:
@@ -1589,10 +1586,7 @@ class ApprovalService:
                 )
 
             message_text += f"**Arguments:**\n```json\n{tool_args_formatted}\n```\n\n"
-            message_text += "**Actions:**\n"
-            message_text += f"• [✅ Approve]({approve_url})\n"
-            message_text += f"• [❌ Decline]({decline_url})\n"
-            message_text += f"• [👁️ View Details]({view_url})\n"
+            message_text += f"[Review this request]({review_url})\n"
 
             # Mattermost/Slack compatible message with attachments
             message = {
@@ -1602,7 +1596,7 @@ class ApprovalService:
                         "color": "#f2c744",
                         "fallback": headline,
                         "title": f"⚠️ {headline}",
-                        "title_link": view_url,
+                        "title_link": review_url,
                         "fields": [
                             {
                                 "title": "Tool",
@@ -1619,20 +1613,9 @@ class ApprovalService:
                         "actions": [
                             {
                                 "type": "button",
-                                "text": "✅ Approve",
-                                "url": approve_url,
+                                "text": "Review",
+                                "url": review_url,
                                 "style": "primary",
-                            },
-                            {
-                                "type": "button",
-                                "text": "❌ Decline",
-                                "url": decline_url,
-                                "style": "danger",
-                            },
-                            {
-                                "type": "button",
-                                "text": "👁️ View Details",
-                                "url": view_url,
                             },
                         ],
                     }
@@ -1665,10 +1648,11 @@ class ApprovalService:
                     if approval_request.expires_at
                     else None
                 ),
+                # One key, because one thing happens: the link opens the
+                # approval page. Decisions are taken with
+                # POST /api/v1/approval-requests/{id}/approve or /decline.
                 "actions": {
-                    "approve": approve_url,
-                    "decline": decline_url,
-                    "view": view_url,
+                    "review": review_url,
                 },
             }
 

--- a/backend/tests/services/test_approval_service.py
+++ b/backend/tests/services/test_approval_service.py
@@ -1149,14 +1149,14 @@ class TestPostWebhookNotification:
         assert actions[0]["url"] == review_url
 
     @patch("preloop.services.approval_service.httpx.AsyncClient")
-    async def test_post_webhook_generic_payload_has_one_review_action(
+    async def test_post_webhook_generic_payload_review_action_and_deprecated_aliases(
         self,
         mock_client_class,
         approval_service,
         sample_approval_request,
         sample_approval_workflow,
     ):
-        """The generic payload states one review link, not fake decisions."""
+        """The generic payload names the link "review" and keeps the old keys."""
         sample_approval_workflow.approval_type = "webhook"
 
         mock_response = MagicMock()
@@ -1171,11 +1171,15 @@ class TestPostWebhookNotification:
             )
 
         actions = mock_client.post.call_args[1]["json"]["actions"]
-        assert set(actions) == {"review"}
-        assert actions["review"].endswith(
+        review_url = (
             f"/approval/{sample_approval_request.id}"
             f"?token={sample_approval_request.approval_token}"
         )
+        assert actions["review"].endswith(review_url)
+        # The deprecated keys are a machine contract: a receiver doing
+        # payload["actions"]["approve"] must not start raising KeyError.
+        assert set(actions) == {"review", "approve", "decline", "view"}
+        assert len(set(actions.values())) == 1
 
     @patch("preloop.services.approval_service.httpx.AsyncClient")
     async def test_post_webhook_with_agent_reasoning(

--- a/backend/tests/services/test_approval_service.py
+++ b/backend/tests/services/test_approval_service.py
@@ -1108,6 +1108,76 @@ class TestPostWebhookNotification:
             assert "webhook_error" in update.model_dump(exclude_unset=True)
 
     @patch("preloop.services.approval_service.httpx.AsyncClient")
+    async def test_post_webhook_chat_message_offers_one_review_link(
+        self,
+        mock_client_class,
+        approval_service,
+        sample_approval_request,
+        sample_approval_workflow,
+    ):
+        """The chat message must not label a plain review link "Approve".
+
+        All three links used to point at the same tokenized approval page, so
+        "Approve" opened a page instead of approving. One honest link now.
+        """
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        with patch.object(approval_service, "update_approval_request"):
+            result = await approval_service.post_webhook_notification(
+                sample_approval_request, sample_approval_workflow
+            )
+
+        assert result is True
+        message = mock_client.post.call_args[1]["json"]
+        review_url = (
+            f"https://app.test.com/approval/{sample_approval_request.id}"
+            f"?token={sample_approval_request.approval_token}"
+        )
+
+        text = message["text"]
+        assert f"[Review this request]({review_url})" in text
+        assert "Approve](" not in text
+        assert "Decline](" not in text
+        assert text.count(review_url) == 1
+
+        actions = message["attachments"][0]["actions"]
+        assert [action["text"] for action in actions] == ["Review"]
+        assert actions[0]["url"] == review_url
+
+    @patch("preloop.services.approval_service.httpx.AsyncClient")
+    async def test_post_webhook_generic_payload_has_one_review_action(
+        self,
+        mock_client_class,
+        approval_service,
+        sample_approval_request,
+        sample_approval_workflow,
+    ):
+        """The generic payload states one review link, not fake decisions."""
+        sample_approval_workflow.approval_type = "webhook"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        with patch.object(approval_service, "update_approval_request"):
+            await approval_service.post_webhook_notification(
+                sample_approval_request, sample_approval_workflow
+            )
+
+        actions = mock_client.post.call_args[1]["json"]["actions"]
+        assert set(actions) == {"review"}
+        assert actions["review"].endswith(
+            f"/approval/{sample_approval_request.id}"
+            f"?token={sample_approval_request.approval_token}"
+        )
+
+    @patch("preloop.services.approval_service.httpx.AsyncClient")
     async def test_post_webhook_with_agent_reasoning(
         self,
         mock_client_class,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -53,6 +53,7 @@
         "@types/sinon": "^17.0.4",
         "@web/dev-server-esbuild": "^1.0.4",
         "@web/test-runner": "^0.20.0",
+        "@web/test-runner-commands": "^0.9.0",
         "@web/test-runner-playwright": "^0.11.1",
         "chai": "^5.0.0",
         "husky": "^9.0.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -88,6 +88,7 @@
     "@types/sinon": "^17.0.4",
     "@web/dev-server-esbuild": "^1.0.4",
     "@web/test-runner": "^0.20.0",
+    "@web/test-runner-commands": "^0.9.0",
     "@web/test-runner-playwright": "^0.11.1",
     "chai": "^5.0.0",
     "husky": "^9.0.11",

--- a/frontend/src/utils/approvals.test.ts
+++ b/frontend/src/utils/approvals.test.ts
@@ -1,7 +1,9 @@
 import { expect } from '@open-wc/testing';
 
 import {
+  APPROVAL_REQUESTS_PAGE_LIMIT,
   approvalStatusLabel,
+  formatNextWaitingLabel,
   isExpiringSoon,
   isUnexpiredPendingRequest,
   millisUntilExpiry,
@@ -119,5 +121,20 @@ describe('approvalStatusLabel', () => {
     expect(approvalStatusLabel('declined')).to.equal('Denied');
     expect(approvalStatusLabel('expired')).to.equal('Timed out');
     expect(approvalStatusLabel('cancelled')).to.equal('Cancelled');
+  });
+});
+
+describe('formatNextWaitingLabel', () => {
+  it('states the filtered count when the pending page is not full', () => {
+    expect(formatNextWaitingLabel(7, 8)).to.equal('Next waiting (7)');
+  });
+
+  it('says 100+ when the pending page is full, not a count that looks total', () => {
+    expect(formatNextWaitingLabel(99, APPROVAL_REQUESTS_PAGE_LIMIT)).to.equal(
+      'Next waiting (100+)'
+    );
+    expect(formatNextWaitingLabel(100, APPROVAL_REQUESTS_PAGE_LIMIT)).to.equal(
+      'Next waiting (100+)'
+    );
   });
 });

--- a/frontend/src/utils/approvals.test.ts
+++ b/frontend/src/utils/approvals.test.ts
@@ -1,0 +1,123 @@
+import { expect } from '@open-wc/testing';
+
+import {
+  approvalStatusLabel,
+  isExpiringSoon,
+  isUnexpiredPendingRequest,
+  millisUntilExpiry,
+  normalizeApprovalRequest,
+  partitionApprovalRequests,
+} from './approvals';
+import type { ApprovalRequest } from '../types';
+
+const NOW = Date.parse('2026-09-05T12:00:00Z');
+
+function request(overrides: Partial<ApprovalRequest> = {}): ApprovalRequest {
+  return {
+    id: 'ar-1',
+    account_id: 'acc-1',
+    tool_configuration_id: 'tc-1',
+    approval_workflow_id: 'aw-1',
+    execution_id: null,
+    tool_name: 'Bash',
+    tool_args: {},
+    agent_reasoning: null,
+    status: 'pending',
+    requested_at: '2026-09-05T11:55:00Z',
+    resolved_at: null,
+    expires_at: '2026-09-05T12:05:00Z',
+    approver_comment: null,
+    ...overrides,
+  } as ApprovalRequest;
+}
+
+describe('approval normalisation', () => {
+  it('treats a pending request with an expiry ahead as live', () => {
+    expect(isUnexpiredPendingRequest(request(), NOW)).to.be.true;
+    expect(normalizeApprovalRequest(request(), NOW).status).to.equal('pending');
+  });
+
+  it('treats a pending request past its expiry as timed out', () => {
+    const stale = request({ expires_at: '2026-07-13T15:04:10Z' });
+    expect(isUnexpiredPendingRequest(stale, NOW)).to.be.false;
+    const normalized = normalizeApprovalRequest(stale, NOW);
+    expect(normalized.status).to.equal('expired');
+    expect(normalized.resolved_at).to.equal('2026-07-13T15:04:10Z');
+  });
+
+  it('keeps a pending request without an expiry live', () => {
+    const open = request({ expires_at: null });
+    expect(isUnexpiredPendingRequest(open, NOW)).to.be.true;
+    expect(normalizeApprovalRequest(open, NOW).status).to.equal('pending');
+  });
+
+  it('leaves an already resolved request untouched', () => {
+    const approved = request({
+      status: 'approved',
+      resolved_at: '2026-09-05T11:58:00Z',
+    });
+    expect(normalizeApprovalRequest(approved, NOW)).to.equal(approved);
+    expect(isUnexpiredPendingRequest(approved, NOW)).to.be.false;
+  });
+
+  it('keeps an existing resolved_at when the expiry passed', () => {
+    const stale = request({
+      expires_at: '2026-07-13T15:04:10Z',
+      resolved_at: '2026-07-13T15:04:11Z',
+    });
+    expect(normalizeApprovalRequest(stale, NOW).resolved_at).to.equal(
+      '2026-07-13T15:04:11Z'
+    );
+  });
+});
+
+describe('approval expiry', () => {
+  it('reports the time left, and nothing when there is no expiry', () => {
+    expect(millisUntilExpiry(request(), NOW)).to.equal(5 * 60 * 1000);
+    expect(millisUntilExpiry(request({ expires_at: null }), NOW)).to.be.null;
+  });
+
+  it('flags an expiry inside five minutes and not one beyond it', () => {
+    expect(isExpiringSoon(request({ expires_at: '2026-09-05T12:04:00Z' }), NOW))
+      .to.be.true;
+    expect(isExpiringSoon(request({ expires_at: '2026-09-05T12:41:00Z' }), NOW))
+      .to.be.false;
+    expect(isExpiringSoon(request({ expires_at: '2026-09-05T11:59:00Z' }), NOW))
+      .to.be.false;
+  });
+});
+
+describe('partitionApprovalRequests', () => {
+  it('splits waiting from history and sorts waiting by expiry', () => {
+    const later = request({ id: 'later', expires_at: '2026-09-05T12:40:00Z' });
+    const soonest = request({
+      id: 'soonest',
+      expires_at: '2026-09-05T12:02:00Z',
+    });
+    const noExpiry = request({ id: 'no-expiry', expires_at: null });
+    const stale = request({ id: 'stale', expires_at: '2026-07-13T15:04:10Z' });
+    const approved = request({ id: 'approved', status: 'approved' });
+
+    const { waiting, history } = partitionApprovalRequests(
+      [later, approved, soonest, stale, noExpiry],
+      NOW
+    );
+
+    expect(waiting.map((r) => r.id)).to.deep.equal([
+      'soonest',
+      'later',
+      'no-expiry',
+    ]);
+    expect(history.map((r) => r.id)).to.deep.equal(['approved', 'stale']);
+  });
+});
+
+describe('approvalStatusLabel', () => {
+  it('reads declined as denied and expired as timed out, in sentence case', () => {
+    expect(approvalStatusLabel('pending')).to.equal('Pending');
+    expect(approvalStatusLabel('approved')).to.equal('Approved');
+    expect(approvalStatusLabel('declined')).to.equal('Denied');
+    expect(approvalStatusLabel('expired')).to.equal('Timed out');
+    expect(approvalStatusLabel('cancelled')).to.equal('Cancelled');
+  });
+});

--- a/frontend/src/utils/approvals.ts
+++ b/frontend/src/utils/approvals.ts
@@ -15,6 +15,26 @@ import { parseUTCDate } from './date';
 /** Requests past this margin get the amber countdown: a decision is urgent. */
 export const EXPIRING_SOON_MS = 5 * 60 * 1000;
 
+/**
+ * The approval-requests list endpoint caps here. A count at this size is a
+ * floor, not a total — there may be more waiting past the page.
+ */
+export const APPROVAL_REQUESTS_PAGE_LIMIT = 100;
+
+/**
+ * Label for the post-decision "next waiting" link. When the pending page is
+ * full the number is a floor (`100+`), not an authoritative total.
+ */
+export function formatNextWaitingLabel(
+  waitingCount: number,
+  fetchedCount: number,
+  pageLimit: number = APPROVAL_REQUESTS_PAGE_LIMIT
+): string {
+  const count =
+    fetchedCount >= pageLimit ? `${pageLimit}+` : String(waitingCount);
+  return `Next waiting (${count})`;
+}
+
 /** True when the request is pending and its expiry (if any) is still ahead. */
 export function isUnexpiredPendingRequest(
   request: ApprovalRequest,

--- a/frontend/src/utils/approvals.ts
+++ b/frontend/src/utils/approvals.ts
@@ -1,0 +1,115 @@
+import type { ApprovalRequest } from '../types';
+import { parseUTCDate } from './date';
+
+/**
+ * One reading of an approval request's state, shared by the list and the
+ * detail page.
+ *
+ * The backend expires a request with a sweeper, so a row can sit in the
+ * database as `pending` long after its `expires_at`. The list already
+ * normalised that; the detail page did not, and showed a request that timed
+ * out weeks ago as PENDING with live Approve and Deny buttons. Both surfaces
+ * now read the clock through these helpers so they cannot disagree.
+ */
+
+/** Requests past this margin get the amber countdown: a decision is urgent. */
+export const EXPIRING_SOON_MS = 5 * 60 * 1000;
+
+/** True when the request is pending and its expiry (if any) is still ahead. */
+export function isUnexpiredPendingRequest(
+  request: ApprovalRequest,
+  now: number = Date.now()
+): boolean {
+  if (request.status !== 'pending') {
+    return false;
+  }
+  if (!request.expires_at) {
+    return true;
+  }
+  return parseUTCDate(request.expires_at).getTime() > now;
+}
+
+/**
+ * Returns the request as it should be rendered: a pending request whose
+ * expiry has passed reads as timed out, resolved at its expiry.
+ */
+export function normalizeApprovalRequest(
+  request: ApprovalRequest,
+  now: number = Date.now()
+): ApprovalRequest {
+  if (request.status !== 'pending' || isUnexpiredPendingRequest(request, now)) {
+    return request;
+  }
+  return {
+    ...request,
+    status: 'expired',
+    resolved_at: request.resolved_at || request.expires_at,
+  };
+}
+
+/** Milliseconds until the request expires; null when it never does. */
+export function millisUntilExpiry(
+  request: ApprovalRequest,
+  now: number = Date.now()
+): number | null {
+  if (!request.expires_at) return null;
+  return parseUTCDate(request.expires_at).getTime() - now;
+}
+
+/** True when the request expires within five minutes (amber countdown). */
+export function isExpiringSoon(
+  request: ApprovalRequest,
+  now: number = Date.now()
+): boolean {
+  const remaining = millisUntilExpiry(request, now);
+  return remaining !== null && remaining > 0 && remaining <= EXPIRING_SOON_MS;
+}
+
+/**
+ * Splits a list into the requests that still need a decision and everything
+ * else. The waiting group is ordered by how soon it expires, so the row that
+ * will be lost first sits at the top; requests without an expiry come last.
+ * History keeps the newest-first order it arrived in.
+ */
+export function partitionApprovalRequests(
+  requests: ApprovalRequest[],
+  now: number = Date.now()
+): { waiting: ApprovalRequest[]; history: ApprovalRequest[] } {
+  const waiting: ApprovalRequest[] = [];
+  const history: ApprovalRequest[] = [];
+  for (const request of requests) {
+    if (isUnexpiredPendingRequest(request, now)) {
+      waiting.push(request);
+    } else {
+      history.push(request);
+    }
+  }
+  waiting.sort((a, b) => {
+    const aExpiry = a.expires_at
+      ? parseUTCDate(a.expires_at).getTime()
+      : Number.POSITIVE_INFINITY;
+    const bExpiry = b.expires_at
+      ? parseUTCDate(b.expires_at).getTime()
+      : Number.POSITIVE_INFINITY;
+    return aExpiry - bExpiry;
+  });
+  return { waiting, history };
+}
+
+/** Sentence-case label for a status, with `declined` read as denied. */
+export function approvalStatusLabel(status: string): string {
+  switch (status) {
+    case 'pending':
+      return 'Pending';
+    case 'approved':
+      return 'Approved';
+    case 'declined':
+      return 'Denied';
+    case 'expired':
+      return 'Timed out';
+    case 'cancelled':
+      return 'Cancelled';
+    default:
+      return status;
+  }
+}

--- a/frontend/src/views/authed/approval-view.test.ts
+++ b/frontend/src/views/authed/approval-view.test.ts
@@ -232,6 +232,48 @@ describe('ApprovalView', () => {
       );
     });
 
+    it('ignores the A key while the deny confirm is open', async () => {
+      await renderRequest(pendingRequest());
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'd' }));
+      await waitUntil(
+        () => !!document.querySelector('confirm-dialog'),
+        'no confirm dialog'
+      );
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+      await aTimeout(0);
+      expect(
+        decisionCall('approve'),
+        'A approved behind the open deny confirmation'
+      ).to.be.undefined;
+      expect(
+        document.querySelectorAll('confirm-dialog').length,
+        'the confirmation should still be the only thing asking'
+      ).to.equal(1);
+    });
+
+    it('ignores a held-down D key', async () => {
+      await renderRequest(pendingRequest());
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'd' }));
+      await waitUntil(
+        () => !!document.querySelector('confirm-dialog'),
+        'no confirm dialog'
+      );
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'd', repeat: true })
+      );
+      await aTimeout(0);
+
+      const dialog = document.querySelector('confirm-dialog') as HTMLElement;
+      const confirm = dialog.shadowRoot?.querySelector(
+        '[data-testid="confirm-dialog-confirm"]'
+      ) as HTMLElement;
+      confirm.click();
+      await waitUntil(() => !!decisionCall('decline'), 'no decline call');
+    });
+
     it('leaves the keys alone while a comment is being typed', async () => {
       const element = await renderRequest(pendingRequest());
 
@@ -249,6 +291,27 @@ describe('ApprovalView', () => {
 
       expect(decisionCall('approve'), 'a typed "a" approved the request').to.be
         .undefined;
+    });
+
+    it('does not toast twice when the websocket echoes this page own decision', async () => {
+      const element = await renderRequest(pendingRequest());
+
+      await (element as any).handleApprove();
+      await element.updateComplete;
+      const afterDecision = document.querySelectorAll('sl-alert').length;
+
+      (element as any).handleWebSocketMessage({
+        type: 'approval_approved',
+        approval_request_id: 'req-1',
+        status: 'approved',
+        resolved_at: new Date().toISOString(),
+      });
+      await element.updateComplete;
+
+      expect(
+        document.querySelectorAll('sl-alert').length,
+        'the echoed websocket update toasted the same decision again'
+      ).to.equal(afterDecision);
     });
 
     it('points at the next waiting request once a decision is taken', async () => {

--- a/frontend/src/views/authed/approval-view.test.ts
+++ b/frontend/src/views/authed/approval-view.test.ts
@@ -198,6 +198,34 @@ describe('ApprovalView', () => {
       expect(deny.hasAttribute('outline'), 'Deny must be outline').to.be.true;
     });
 
+    it('names the comment field and hides the shortcut from screen readers', async () => {
+      const element = await renderRequest(pendingRequest());
+      const bar = element.shadowRoot?.querySelector(
+        '.decision-bar'
+      ) as HTMLElement;
+
+      // Shoelace wires the label to the inner input, so a label attribute is
+      // what gives the field an accessible name; a placeholder alone does not.
+      const comment = bar.querySelector('.decision-comment') as HTMLElement;
+      expect(
+        comment.getAttribute('label'),
+        'the comment field needs an accessible name'
+      ).to.contain('Comment');
+
+      bar.querySelectorAll('kbd').forEach((key) => {
+        expect(
+          key.getAttribute('aria-hidden'),
+          'the shortcut hint is read out as part of the button label'
+        ).to.equal('true');
+      });
+      expect(
+        (bar.querySelector('.approve') as HTMLElement).getAttribute('title')
+      ).to.equal('Approve (A)');
+      expect(
+        (bar.querySelector('.deny') as HTMLElement).getAttribute('title')
+      ).to.equal('Deny (D)');
+    });
+
     it('approves on the A key', async () => {
       const element = await renderRequest(pendingRequest());
 

--- a/frontend/src/views/authed/approval-view.test.ts
+++ b/frontend/src/views/authed/approval-view.test.ts
@@ -1,7 +1,8 @@
-import { html, fixture, expect, waitUntil } from '@open-wc/testing';
+import { aTimeout, html, fixture, expect, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon';
 
 import './approval-view';
+import { resetConfirmDialogForTests } from '../../components/confirm-dialog';
 import type { ApprovalView } from './approval-view';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 
@@ -28,9 +29,11 @@ describe('ApprovalView', () => {
       tool_args: { command: 'ls -la' },
       agent_reasoning: 'Listing files to inspect the repo',
       status: 'pending',
-      requested_at: '2026-06-01T10:00:00Z',
+      // Relative to now: a pending request whose expiry has passed reads as
+      // timed out, so a fixed past date would test the wrong branch.
+      requested_at: new Date(Date.now() - 60_000).toISOString(),
       resolved_at: null,
-      expires_at: '2026-06-01T11:00:00Z',
+      expires_at: new Date(Date.now() + 60 * 60_000).toISOString(),
       approver_comment: null,
       webhook_posted_at: null,
       webhook_error: null,
@@ -76,6 +79,19 @@ describe('ApprovalView', () => {
           return json(opts.request ?? pendingRequest());
         }
 
+        if (
+          /\/api\/v1\/approval-requests\?status=pending/.test(url) &&
+          method === 'GET'
+        ) {
+          return json([
+            pendingRequest(),
+            pendingRequest({
+              id: 'req-2',
+              expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+            }),
+          ]);
+        }
+
         if (url.includes('/approve') && method === 'POST') {
           return json(
             pendingRequest({
@@ -113,7 +129,161 @@ describe('ApprovalView', () => {
     fetchStub?.restore();
     wsSubscribeStub.restore();
     wsStateStub.restore();
+    resetConfirmDialogForTests();
+    document.querySelectorAll('sl-alert[open]').forEach((a) => a.remove());
     localStorage.clear();
+  });
+
+  async function renderRequest(request: Record<string, unknown>) {
+    fetchStub = createFetchStub({ request });
+    const element = (await fixture(
+      html`<approval-view .requestId=${'req-1'}></approval-view>`
+    )) as ApprovalView;
+    await waitUntil(() => !(element as any).loading, 'still loading');
+    await element.updateComplete;
+    return element;
+  }
+
+  function decisionCall(action: 'approve' | 'decline') {
+    return fetchStub
+      .getCalls()
+      .find(
+        (c) =>
+          String(c.args[0]).includes(`/${action}`) &&
+          String((c.args[1] as RequestInit)?.method || '').toUpperCase() ===
+            'POST'
+      );
+  }
+
+  describe('an expired pending request', () => {
+    it('renders as timed out with no decision bar', async () => {
+      const element = await renderRequest(
+        pendingRequest({
+          requested_at: '2026-07-13T14:59:10Z',
+          expires_at: '2026-07-13T15:04:10Z',
+        })
+      );
+
+      expect(element.shadowRoot?.textContent).to.contain('Timed out');
+      expect(element.shadowRoot?.textContent).to.not.contain('Pending');
+      expect(element.shadowRoot?.querySelector('.decision-bar')).to.not.exist;
+    });
+
+    it('ignores the decision keys', async () => {
+      await renderRequest(
+        pendingRequest({
+          requested_at: '2026-07-13T14:59:10Z',
+          expires_at: '2026-07-13T15:04:10Z',
+        })
+      );
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+      await aTimeout(0);
+      expect(decisionCall('approve'), 'a key decided an expired request').to.be
+        .undefined;
+    });
+  });
+
+  describe('the decision bar', () => {
+    it('states what is paused and counts down to the expiry', async () => {
+      const element = await renderRequest(pendingRequest());
+
+      const bar = element.shadowRoot?.querySelector('.decision-bar');
+      expect(bar, 'expected a sticky decision bar').to.exist;
+      expect(bar?.textContent).to.contain('is paused until you decide');
+      expect(bar?.textContent).to.contain('expires in');
+      expect(bar?.querySelector('.row-approve, .approve')).to.exist;
+      const deny = bar?.querySelector('.deny') as HTMLElement;
+      expect(deny.getAttribute('variant')).to.equal('danger');
+      expect(deny.hasAttribute('outline'), 'Deny must be outline').to.be.true;
+    });
+
+    it('approves on the A key', async () => {
+      const element = await renderRequest(pendingRequest());
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+      await waitUntil(() => !!decisionCall('approve'), 'no approve call');
+      await waitUntil(
+        () => (element as any).approvalRequest?.status === 'approved',
+        'the request was not approved'
+      );
+    });
+
+    it('opens the confirm on the D key and only then denies', async () => {
+      const element = await renderRequest(pendingRequest());
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'd' }));
+      await waitUntil(
+        () => !!document.querySelector('confirm-dialog'),
+        'no confirm dialog'
+      );
+      const dialog = document.querySelector('confirm-dialog') as HTMLElement;
+      expect(decisionCall('decline'), 'denied without confirming').to.be
+        .undefined;
+
+      const confirm = dialog.shadowRoot?.querySelector(
+        '[data-testid="confirm-dialog-confirm"]'
+      ) as HTMLElement;
+      confirm.click();
+      await waitUntil(() => !!decisionCall('decline'), 'no decline call');
+      await waitUntil(
+        () => (element as any).approvalRequest?.status === 'declined',
+        'the request was not denied'
+      );
+    });
+
+    it('leaves the keys alone while a comment is being typed', async () => {
+      const element = await renderRequest(pendingRequest());
+
+      const comment = element.shadowRoot?.querySelector(
+        '.decision-comment'
+      ) as HTMLElement;
+      comment.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'a',
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await aTimeout(0);
+
+      expect(decisionCall('approve'), 'a typed "a" approved the request').to.be
+        .undefined;
+    });
+
+    it('points at the next waiting request once a decision is taken', async () => {
+      const element = await renderRequest(pendingRequest());
+
+      await (element as any).handleApprove();
+      await element.updateComplete;
+
+      const line = element.shadowRoot?.querySelector('.post-decision');
+      expect(line, 'expected the post-decision line').to.exist;
+      expect(line?.textContent).to.contain('Back to approvals');
+      expect(line?.textContent).to.contain('Next waiting (1)');
+      const next = line?.querySelector('a[href*="/console/approval/"]');
+      expect(next?.getAttribute('href')).to.equal('/console/approval/req-2');
+    });
+  });
+
+  it('keeps the status badge inside a phone viewport', async () => {
+    fetchStub = createFetchStub({ request: pendingRequest() });
+    const holder = (await fixture(
+      html`<div style="width: 375px;">
+        <approval-view .requestId=${'req-1'}></approval-view>
+      </div>`
+    )) as HTMLElement;
+    const element = holder.querySelector('approval-view') as ApprovalView;
+
+    await waitUntil(() => !(element as any).loading, 'still loading');
+    await element.updateComplete;
+
+    const badge = element.shadowRoot?.querySelector(
+      '.status-badge'
+    ) as HTMLElement;
+    const badgeRight = badge.getBoundingClientRect().right;
+    const hostRight = element.getBoundingClientRect().right;
+    expect(badgeRight).to.be.at.most(hostRight + 1);
   });
 
   it('renders a pending approval request', async () => {
@@ -126,8 +296,10 @@ describe('ApprovalView', () => {
     await element.updateComplete;
 
     expect(element.shadowRoot?.textContent).to.contain('shell_command');
-    expect(element.shadowRoot?.textContent).to.contain('PENDING');
-    const buttons = element.shadowRoot?.querySelectorAll('.actions sl-button');
+    expect(element.shadowRoot?.textContent).to.contain('Pending');
+    const buttons = element.shadowRoot?.querySelectorAll(
+      '.decision-bar sl-button'
+    );
     expect(buttons?.length).to.equal(2);
   });
 
@@ -146,11 +318,11 @@ describe('ApprovalView', () => {
     await waitUntil(() => !(element as any).loading, 'still loading');
     await element.updateComplete;
 
-    expect(element.shadowRoot?.textContent).to.contain('APPROVED');
+    expect(element.shadowRoot?.textContent).to.contain('Approved');
     expect(element.shadowRoot?.querySelector('.resolved-info')).to.exist;
     expect(element.shadowRoot?.textContent).to.contain('Looks safe');
-    // No decision buttons once resolved.
-    expect(element.shadowRoot?.querySelector('.actions')).to.not.exist;
+    // No decision bar once resolved.
+    expect(element.shadowRoot?.querySelector('.decision-bar')).to.not.exist;
   });
 
   it('shows a not-found warning when the request is missing', async () => {
@@ -193,7 +365,7 @@ describe('ApprovalView', () => {
     await element.updateComplete;
 
     expect((element as any).approvalRequest?.status).to.equal('approved');
-    expect((element as any).actionResult?.type).to.equal('success');
+    expect((element as any).decisionTaken).to.be.true;
     const approveCall = fetchStub
       .getCalls()
       .find((c) => String(c.args[0]).includes('/approve'));
@@ -225,7 +397,7 @@ describe('ApprovalView', () => {
     it('renders option buttons and the answer field for a question', async () => {
       const { element, panel } = await renderQuestion();
 
-      expect(element.shadowRoot?.textContent).to.contain('Agent Question');
+      expect(element.shadowRoot?.textContent).to.contain('Agent question');
       expect(panel.shadowRoot.textContent).to.contain('Which colour?');
 
       const options = panel.shadowRoot.querySelectorAll('.question-option');
@@ -234,10 +406,8 @@ describe('ApprovalView', () => {
       expect(options[1].textContent.trim()).to.equal('green');
       expect(panel.shadowRoot.querySelector('.answer-input')).to.exist;
 
-      // The plain approve/decline + comment UI is hidden for questions.
-      expect(element.shadowRoot?.querySelector('.actions')).to.not.exist;
-      expect(element.shadowRoot?.querySelector('.comment-section')).to.not
-        .exist;
+      // The decision bar is hidden for questions: the panel carries them.
+      expect(element.shadowRoot?.querySelector('.decision-bar')).to.not.exist;
     });
 
     it('submits selected_option when an option is clicked', async () => {
@@ -344,9 +514,9 @@ describe('ApprovalView', () => {
 
       expect(element.shadowRoot?.querySelector('question-answer-panel')).to.not
         .exist;
-      expect(element.shadowRoot?.querySelector('.comment-section')).to.exist;
+      expect(element.shadowRoot?.querySelector('.decision-comment')).to.exist;
       expect(
-        element.shadowRoot?.querySelectorAll('.actions sl-button').length
+        element.shadowRoot?.querySelectorAll('.decision-bar sl-button').length
       ).to.equal(2);
     });
   });

--- a/frontend/src/views/authed/approval-view.test.ts
+++ b/frontend/src/views/authed/approval-view.test.ts
@@ -1,5 +1,6 @@
 import { aTimeout, html, fixture, expect, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon';
+import { setViewport } from '@web/test-runner-commands';
 
 import './approval-view';
 import { resetConfirmDialogForTests } from '../../components/confirm-dialog';
@@ -357,24 +358,46 @@ describe('ApprovalView', () => {
     });
   });
 
-  it('keeps the status badge inside a phone viewport', async () => {
-    fetchStub = createFetchStub({ request: pendingRequest() });
-    const holder = (await fixture(
-      html`<div style="width: 375px;">
-        <approval-view .requestId=${'req-1'}></approval-view>
-      </div>`
-    )) as HTMLElement;
-    const element = holder.querySelector('approval-view') as ApprovalView;
+  describe('on a phone viewport', () => {
+    // The viewport is per browser page, so hand it back to the other tests.
+    afterEach(async () => {
+      await setViewport({ width: 1280, height: 800 });
+    });
 
-    await waitUntil(() => !(element as any).loading, 'still loading');
-    await element.updateComplete;
+    it('keeps the header and the decision buttons inside the page', async () => {
+      // A narrow wrapper div would not do: media queries read the window, so the
+      // 640px rules (host padding, the bar's margins, the stacked full-width
+      // buttons) only run when the viewport itself is a phone.
+      await setViewport({ width: 375, height: 800 });
+      fetchStub = createFetchStub({ request: pendingRequest() });
+      const element = (await fixture(
+        html`<approval-view .requestId=${'req-1'}></approval-view>`
+      )) as ApprovalView;
 
-    const badge = element.shadowRoot?.querySelector(
-      '.status-badge'
-    ) as HTMLElement;
-    const badgeRight = badge.getBoundingClientRect().right;
-    const hostRight = element.getBoundingClientRect().right;
-    expect(badgeRight).to.be.at.most(hostRight + 1);
+      await waitUntil(() => !(element as any).loading, 'still loading');
+      await element.updateComplete;
+
+      const hostRight = element.getBoundingClientRect().right;
+      const badge = element.shadowRoot?.querySelector(
+        '.status-badge'
+      ) as HTMLElement;
+      expect(
+        badge.getBoundingClientRect().right,
+        'the status chip overflows the page'
+      ).to.be.at.most(hostRight + 1);
+
+      const buttons = element.shadowRoot?.querySelector(
+        '.decision-buttons'
+      ) as HTMLElement;
+      expect(
+        buttons.getBoundingClientRect().right,
+        'the decision buttons overflow the page'
+      ).to.be.at.most(hostRight + 1);
+      expect(
+        buttons.getBoundingClientRect().width,
+        'the buttons should take the full row on a phone'
+      ).to.be.greaterThan(200);
+    });
   });
 
   it('renders a pending approval request', async () => {

--- a/frontend/src/views/authed/approval-view.test.ts
+++ b/frontend/src/views/authed/approval-view.test.ts
@@ -59,6 +59,7 @@ describe('ApprovalView', () => {
     opts: {
       request?: Record<string, unknown> | null;
       getFails?: boolean;
+      pendingQueue?: Record<string, unknown>[];
     } = {}
   ) {
     return sinon
@@ -84,13 +85,15 @@ describe('ApprovalView', () => {
           /\/api\/v1\/approval-requests\?status=pending/.test(url) &&
           method === 'GET'
         ) {
-          return json([
-            pendingRequest(),
-            pendingRequest({
-              id: 'req-2',
-              expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
-            }),
-          ]);
+          return json(
+            opts.pendingQueue ?? [
+              pendingRequest(),
+              pendingRequest({
+                id: 'req-2',
+                expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+              }),
+            ]
+          );
         }
 
         if (url.includes('/approve') && method === 'POST') {
@@ -355,6 +358,31 @@ describe('ApprovalView', () => {
       expect(line?.textContent).to.contain('Next waiting (1)');
       const next = line?.querySelector('a[href*="/console/approval/"]');
       expect(next?.getAttribute('href')).to.equal('/console/approval/req-2');
+    });
+
+    it('says 100+ when the pending page is full, not a count that looks total', async () => {
+      const pendingQueue = Array.from({ length: 100 }, (_, i) =>
+        pendingRequest({
+          id: `queued-${i}`,
+          expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+        })
+      );
+      fetchStub = createFetchStub({
+        request: pendingRequest(),
+        pendingQueue,
+      });
+      const element = (await fixture(
+        html`<approval-view .requestId=${'req-1'}></approval-view>`
+      )) as ApprovalView;
+      await waitUntil(() => !(element as any).loading, 'still loading');
+      await element.updateComplete;
+
+      await (element as any).handleApprove();
+      await element.updateComplete;
+
+      const line = element.shadowRoot?.querySelector('.post-decision');
+      expect(line?.textContent).to.contain('Next waiting (100+)');
+      expect(line?.textContent).to.not.contain('Next waiting (99)');
     });
   });
 

--- a/frontend/src/views/authed/approval-view.ts
+++ b/frontend/src/views/authed/approval-view.ts
@@ -66,6 +66,13 @@ export class ApprovalView extends AuthedElement {
   @state()
   private waitingNext: ApprovalRequest[] = [];
 
+  /**
+   * True while the deny confirmation is on screen. The decision keys listen on
+   * the document, so without this an A pressed over an open "Deny this
+   * request?" dialog would approve behind it.
+   */
+  private confirming = false;
+
   private unsubscribe?: () => void;
   private tickTimer?: ReturnType<typeof setInterval>;
 
@@ -352,6 +359,11 @@ export class ApprovalView extends AuthedElement {
 
   private handleKeyDown = (event: KeyboardEvent) => {
     if (!this.isLive || this.isQuestion || this.submitting) return;
+    // A confirmation is a question in its own right: answer it with the mouse
+    // or the dialog's own keys, not with the page shortcuts underneath it.
+    if (this.confirming) return;
+    // Holding the key down would re-ask the confirmation on every repeat.
+    if (event.repeat) return;
     if (event.metaKey || event.ctrlKey || event.altKey) return;
     const target = event.composedPath()[0] as HTMLElement | undefined;
     const tag = target?.tagName?.toLowerCase() ?? '';
@@ -402,7 +414,10 @@ export class ApprovalView extends AuthedElement {
         resolved_at: message.resolved_at || this.approvalRequest.resolved_at,
       };
 
-      // Report the change the way the rest of the console reports results.
+      // Report the change the way the rest of the console reports results,
+      // unless this page took the decision: submitDecision already said so and
+      // a broadcast echoed back here would toast the same thing twice.
+      if (this.decisionTaken) return;
       if (message.type === 'approval_approved') {
         showToast('This request was approved.', 'success');
       } else if (message.type === 'approval_declined') {
@@ -532,17 +547,23 @@ export class ApprovalView extends AuthedElement {
   /** Denying stops the agent, so it confirms first (DESIGN.md destructive). */
   private async handleDeny() {
     const request = this.approvalRequest;
-    if (!request) return;
-    const confirmed = await confirmDialog({
-      title: 'Deny this request?',
-      message: `${request.tool_name} will not run.`,
-      detail: `${formatApprovalRequester(
-        request.managed_agent_name,
-        request.tool_args
-      )} is told no and continues without it.`,
-      confirmLabel: 'Deny',
-      variant: 'danger',
-    });
+    if (!request || this.confirming) return;
+    this.confirming = true;
+    let confirmed = false;
+    try {
+      confirmed = await confirmDialog({
+        title: 'Deny this request?',
+        message: `${request.tool_name} will not run.`,
+        detail: `${formatApprovalRequester(
+          request.managed_agent_name,
+          request.tool_args
+        )} is told no and continues without it.`,
+        confirmLabel: 'Deny',
+        variant: 'danger',
+      });
+    } finally {
+      this.confirming = false;
+    }
     if (!confirmed) return;
     await this.submitDecision(
       'decline',

--- a/frontend/src/views/authed/approval-view.ts
+++ b/frontend/src/views/authed/approval-view.ts
@@ -1,4 +1,4 @@
-import { html, css } from 'lit';
+import { html, css, unsafeCSS } from 'lit';
 import { customElement, state, property } from 'lit/decorators.js';
 import { AuthedElement } from '../../api';
 import type { ApprovalDecisionOptions, ApprovalRequest } from '../../types';
@@ -9,9 +9,18 @@ import {
   getApprovalSource,
   withoutApprovalMetadata,
 } from '../../utils/approval-identity';
+import {
+  approvalStatusLabel,
+  isExpiringSoon,
+  isUnexpiredPendingRequest,
+  millisUntilExpiry,
+  normalizeApprovalRequest,
+} from '../../utils/approvals';
+import { confirmDialog, showToast } from '../../components/confirm-dialog';
 import '../../components/question-answer-panel';
 import '../../components/approval-rule-context-block';
 import type { QuestionAnswerDetail } from '../../components/question-answer-panel';
+import consoleStyles from '../../styles/console-styles.css?inline';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
@@ -41,128 +50,252 @@ export class ApprovalView extends AuthedElement {
   @state()
   private submitting = false;
 
+  /**
+   * Ticks once a second while the request is live, so the countdown moves and
+   * an expiry that passes while the page is open flips the page to timed out
+   * instead of leaving dead buttons on screen.
+   */
   @state()
-  private actionResult: { type: 'success' | 'error'; message: string } | null =
-    null;
+  private nowMs = Date.now();
+
+  /** Set once this page has taken a decision, to show where to go next. */
+  @state()
+  private decisionTaken = false;
+
+  /** Other requests still waiting for this operator, fetched after a decision. */
+  @state()
+  private waitingNext: ApprovalRequest[] = [];
 
   private unsubscribe?: () => void;
+  private tickTimer?: ReturnType<typeof setInterval>;
 
-  static styles = css`
-    :host {
-      display: block;
-      padding: 2rem;
-      max-width: 840px;
-      margin: 0 auto;
-    }
+  static styles = [
+    unsafeCSS(consoleStyles),
+    css`
+      :host {
+        display: block;
+        padding: 2rem;
+        max-width: 840px;
+        margin: 0 auto;
+      }
 
-    .header {
-      margin-bottom: 2rem;
-    }
+      .header {
+        margin-bottom: 2rem;
+      }
 
-    .header h1 {
-      margin: 0 0 0.5rem 0;
-      font-size: 1.75rem;
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-    }
+      .header h1 {
+        margin: 0 0 0.5rem 0;
+        font-size: 1.75rem;
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
 
-    .header p {
-      margin: 0;
-      color: var(--sl-color-neutral-600);
-    }
+      .header p {
+        margin: 0;
+        color: var(--sl-color-neutral-600);
+      }
 
-    .status-badge {
-      font-size: 0.875rem;
-    }
+      .status-badge {
+        font-size: 0.875rem;
+      }
 
-    .content-section {
-      margin-bottom: 1.5rem;
-    }
+      .content-section {
+        margin-bottom: 1.5rem;
+      }
 
-    .content-section h2 {
-      font-size: 1.125rem;
-      margin: 0 0 0.75rem 0;
-      font-weight: 600;
-    }
+      .content-section h2 {
+        font-size: 1.125rem;
+        margin: 0 0 0.75rem 0;
+        font-weight: 600;
+      }
 
-    .info-grid {
-      display: grid;
-      grid-template-columns: 150px 1fr;
-      gap: 0.75rem;
-      margin-bottom: 1rem;
-    }
+      .info-grid {
+        display: grid;
+        grid-template-columns: 150px 1fr;
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+      }
 
-    .info-label {
-      font-weight: 600;
-      color: var(--sl-color-neutral-700);
-    }
+      .info-label {
+        font-weight: 600;
+        color: var(--sl-color-neutral-700);
+      }
 
-    .info-value {
-      color: var(--sl-color-neutral-900);
-    }
+      .info-value {
+        color: var(--sl-color-neutral-900);
+      }
 
-    .code-block {
-      background: var(--sl-color-neutral-100);
-      padding: 1rem;
-      border-radius: 4px;
-      overflow-x: auto;
-      font-family: monospace;
-      font-size: 0.875rem;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
+      .code-block {
+        background: var(--sl-color-neutral-100);
+        padding: 1rem;
+        border-radius: 4px;
+        overflow-x: auto;
+        font-family: monospace;
+        font-size: 0.875rem;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
 
-    .reasoning-text {
-      background: var(--sl-color-primary-50);
-      border-left: 3px solid var(--sl-color-primary-600);
-      padding: 1rem;
-      border-radius: 4px;
-      margin-top: 0.5rem;
-      color: var(--sl-color-neutral-900);
-      line-height: 1.6;
-    }
+      .reasoning-text {
+        background: var(--sl-color-primary-50);
+        border-left: 3px solid var(--sl-color-primary-600);
+        padding: 1rem;
+        border-radius: 4px;
+        margin-top: 0.5rem;
+        color: var(--sl-color-neutral-900);
+        line-height: 1.6;
+      }
 
-    .actions {
-      display: flex;
-      gap: 1rem;
-      margin-top: 2rem;
-    }
+      .actions {
+        display: flex;
+        gap: 1rem;
+        margin-top: 2rem;
+      }
 
-    .actions sl-button {
-      flex: 1;
-    }
+      .actions sl-button {
+        flex: 1;
+      }
 
-    .comment-section {
-      margin-top: 1.5rem;
-    }
+      .comment-section {
+        margin-top: 1.5rem;
+      }
 
-    .loading-state {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: 3rem;
-    }
+      .loading-state {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 3rem;
+      }
 
-    .resolved-info {
-      margin-top: 1rem;
-      padding: 1rem;
-      background: var(--sl-color-neutral-50);
-      border-radius: 4px;
-    }
+      .resolved-info {
+        margin-top: 1rem;
+        padding: 1rem;
+        background: var(--sl-color-neutral-50);
+        border-radius: 4px;
+      }
 
-    .resolved-info h3 {
-      margin: 0 0 0.5rem 0;
-      font-size: 1rem;
-      font-weight: 600;
-    }
+      .resolved-info h3 {
+        margin: 0 0 0.5rem 0;
+        font-size: 1rem;
+        font-weight: 600;
+      }
 
-    .metadata {
-      font-size: 0.875rem;
-      color: var(--sl-color-neutral-600);
-      margin-top: 1rem;
-    }
-  `;
+      .metadata {
+        font-size: 0.875rem;
+        color: var(--sl-color-neutral-600);
+        margin-top: 1rem;
+      }
+
+      /* The decision travels with the page: whatever the operator has scrolled
+       to, the bar with the countdown and the two buttons is on screen. */
+      .decision-bar {
+        position: sticky;
+        bottom: 0;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--sl-spacing-medium);
+        margin: var(--sl-spacing-large) -2rem 0 -2rem;
+        padding: var(--sl-spacing-medium) 2rem;
+        background: var(--console-surface, var(--sl-color-neutral-0));
+        border-top: 1px solid
+          var(--console-hairline, var(--sl-color-neutral-200));
+        z-index: 1;
+      }
+
+      .decision-summary {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-2x-small);
+        flex: 1 1 260px;
+        min-width: 0;
+      }
+
+      .decision-title {
+        font-weight: 600;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .decision-title code {
+        font-family: var(--sl-font-mono);
+        font-size: var(--sl-font-size-small);
+      }
+
+      .decision-paused {
+        font-size: var(--sl-font-size-small);
+        color: var(--sl-color-neutral-600);
+      }
+
+      .decision-comment {
+        flex: 1 1 200px;
+        min-width: 160px;
+      }
+
+      .decision-buttons {
+        display: flex;
+        align-items: center;
+        gap: var(--sl-spacing-small);
+      }
+
+      /* Destructive last, after a large gap, never beside the everyday action. */
+      .decision-buttons .deny {
+        margin-left: var(--sl-spacing-large);
+      }
+
+      kbd {
+        font-family: var(--sl-font-mono);
+        font-size: var(--sl-font-size-x-small);
+        border: 1px solid var(--console-hairline, var(--sl-color-neutral-200));
+        border-radius: var(--sl-border-radius-small);
+        padding: 0 4px;
+        margin-left: 6px;
+        color: inherit;
+      }
+
+      .post-decision {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--sl-spacing-small);
+        margin-top: var(--sl-spacing-medium);
+        font-size: var(--sl-font-size-small);
+      }
+
+      .post-decision .separator,
+      .post-decision .muted {
+        color: var(--sl-color-neutral-600);
+      }
+
+      @media (max-width: 640px) {
+        :host {
+          padding: 1rem;
+        }
+
+        .decision-bar {
+          margin-left: -1rem;
+          margin-right: -1rem;
+          padding-left: 1rem;
+          padding-right: 1rem;
+        }
+
+        .decision-buttons {
+          flex: 1 1 100%;
+        }
+
+        .decision-buttons sl-button {
+          flex: 1;
+        }
+
+        .decision-buttons .deny {
+          margin-left: var(--sl-spacing-medium);
+        }
+      }
+    `,
+  ];
 
   async connectedCallback() {
     super.connectedCallback();
@@ -178,13 +311,67 @@ export class ApprovalView extends AuthedElement {
 
     // Connect to WebSocket for real-time approval updates
     this.connectWebSocket();
+
+    // The decision keys work wherever focus is, so the listener sits on the
+    // document rather than on the host: a key pressed before anything inside
+    // the page is focused never reaches the host element.
+    document.addEventListener('keydown', this.handleKeyDown);
+    this.startTicking();
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     // Disconnect from WebSocket when view is destroyed
     this.unsubscribe?.();
+    document.removeEventListener('keydown', this.handleKeyDown);
+    this.stopTicking();
   }
+
+  private startTicking() {
+    if (this.tickTimer) return;
+    this.tickTimer = setInterval(() => {
+      this.nowMs = Date.now();
+      if (!this.isLive) this.stopTicking();
+    }, 1000);
+  }
+
+  private stopTicking() {
+    if (this.tickTimer) {
+      clearInterval(this.tickTimer);
+      this.tickTimer = undefined;
+    }
+  }
+
+  /** True while the request is pending and its expiry is still ahead. */
+  private get isLive(): boolean {
+    return (
+      !!this.approvalRequest &&
+      isUnexpiredPendingRequest(this.approvalRequest, this.nowMs)
+    );
+  }
+
+  private handleKeyDown = (event: KeyboardEvent) => {
+    if (!this.isLive || this.isQuestion || this.submitting) return;
+    if (event.metaKey || event.ctrlKey || event.altKey) return;
+    const target = event.composedPath()[0] as HTMLElement | undefined;
+    const tag = target?.tagName?.toLowerCase() ?? '';
+    if (
+      ['input', 'textarea', 'select', 'sl-input', 'sl-textarea'].includes(
+        tag
+      ) ||
+      target?.isContentEditable
+    ) {
+      return;
+    }
+    const key = event.key.toLowerCase();
+    if (key === 'a') {
+      event.preventDefault();
+      void this.handleApprove();
+    } else if (key === 'd') {
+      event.preventDefault();
+      void this.handleDeny();
+    }
+  };
 
   private connectWebSocket() {
     this.unsubscribe = unifiedWebSocketManager.subscribe(
@@ -215,22 +402,13 @@ export class ApprovalView extends AuthedElement {
         resolved_at: message.resolved_at || this.approvalRequest.resolved_at,
       };
 
-      // Show notification based on event type
+      // Report the change the way the rest of the console reports results.
       if (message.type === 'approval_approved') {
-        this.actionResult = {
-          type: 'success',
-          message: 'This request was approved!',
-        };
+        showToast('This request was approved.', 'success');
       } else if (message.type === 'approval_declined') {
-        this.actionResult = {
-          type: 'error',
-          message: 'This request was declined.',
-        };
+        showToast('This request was denied.', 'neutral');
       } else if (message.type === 'approval_expired') {
-        this.actionResult = {
-          type: 'error',
-          message: 'This request has expired.',
-        };
+        showToast('This request timed out.', 'warning');
       }
     }
   }
@@ -244,7 +422,10 @@ export class ApprovalView extends AuthedElement {
         `/api/v1/approval-requests/${this.requestId}`
       );
       if (data) {
-        this.approvalRequest = data;
+        // A request the sweeper has not caught up with yet is still `pending`
+        // in the database long after its expiry. Read the clock here so the
+        // page never offers a decision that the backend would reject.
+        this.approvalRequest = normalizeApprovalRequest(data);
       } else {
         this.error = 'Approval request not found';
       }
@@ -275,7 +456,6 @@ export class ApprovalView extends AuthedElement {
     if (!this.approvalRequest) return;
 
     this.submitting = true;
-    this.actionResult = null;
 
     const body: Record<string, unknown> = {
       approved: action === 'approve',
@@ -308,15 +488,36 @@ export class ApprovalView extends AuthedElement {
 
       const updated = await response.json();
       this.approvalRequest = updated;
-      this.actionResult = { type: 'success', message: successMessage };
       this.comment = '';
+      this.decisionTaken = true;
+      showToast(successMessage, action === 'approve' ? 'success' : 'neutral');
+      await this.loadWaitingNext();
     } catch (err: any) {
-      this.actionResult = {
-        type: 'error',
-        message: err.message || `Failed to ${action} request`,
-      };
+      showToast(err.message || `Failed to ${action} request`, 'danger');
     } finally {
       this.submitting = false;
+    }
+  }
+
+  /**
+   * After a decision the page has nothing left to do, so it says where the
+   * work is: back to the list, or straight into the next request waiting.
+   */
+  private async loadWaitingNext() {
+    try {
+      const data = await this.fetchData(
+        '/api/v1/approval-requests?status=pending&limit=100'
+      );
+      if (Array.isArray(data)) {
+        this.waitingNext = (data as ApprovalRequest[]).filter(
+          (request) =>
+            request.id !== this.requestId &&
+            isUnexpiredPendingRequest(request, Date.now())
+        );
+      }
+    } catch (error) {
+      // The decision landed; a missing queue count is not worth an error.
+      console.error('Failed to load the waiting queue:', error);
     }
   }
 
@@ -324,15 +525,29 @@ export class ApprovalView extends AuthedElement {
     await this.submitDecision(
       'approve',
       { comment: this.comment },
-      'Request approved successfully!'
+      'Request approved.'
     );
   }
 
-  private async handleDecline() {
+  /** Denying stops the agent, so it confirms first (DESIGN.md destructive). */
+  private async handleDeny() {
+    const request = this.approvalRequest;
+    if (!request) return;
+    const confirmed = await confirmDialog({
+      title: 'Deny this request?',
+      message: `${request.tool_name} will not run.`,
+      detail: `${formatApprovalRequester(
+        request.managed_agent_name,
+        request.tool_args
+      )} is told no and continues without it.`,
+      confirmLabel: 'Deny',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
     await this.submitDecision(
       'decline',
       { comment: this.comment },
-      'Request declined.'
+      'Request denied.'
     );
   }
 
@@ -385,6 +600,31 @@ export class ApprovalView extends AuthedElement {
     }
   }
 
+  /** "expires in 4m 12s" while it matters, coarser once it is hours away. */
+  private formatCountdown(request: ApprovalRequest): string | null {
+    const remaining = millisUntilExpiry(request, this.nowMs);
+    if (remaining === null) return null;
+    if (remaining <= 0) return 'expired';
+    const totalSeconds = Math.floor(remaining / 1000);
+    if (totalSeconds < 60) return `expires in ${totalSeconds}s`;
+    const minutes = Math.floor(totalSeconds / 60);
+    if (minutes < 60) {
+      return `expires in ${minutes}m ${totalSeconds % 60}s`;
+    }
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `expires in ${hours}h ${minutes % 60}m`;
+    return `expires in ${Math.floor(hours / 24)}d`;
+  }
+
+  /** The one-line summary the decision bar leads with. */
+  private decisionSummary(request: ApprovalRequest): string {
+    const args = withoutApprovalMetadata(request.tool_args);
+    const firstValue = Object.values(args).find(
+      (value) => typeof value === 'string' && value.trim().length > 0
+    ) as string | undefined;
+    return request.summary?.trim() || firstValue?.trim() || request.tool_name;
+  }
+
   private formatToolArgs(args: Record<string, any>): string {
     // Convert args to JSON string with proper formatting
     const jsonStr = JSON.stringify(args, null, 2);
@@ -419,32 +659,32 @@ export class ApprovalView extends AuthedElement {
       return html`
         <sl-alert variant="warning" open>
           <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
-          <strong>Not Found:</strong> Approval request not found
+          <strong>Not found:</strong> Approval request not found
         </sl-alert>
       `;
     }
 
-    const isPending = this.approvalRequest.status === 'pending';
+    // A request whose expiry passed is timed out, whatever the record says:
+    // the buttons would post a decision the backend refuses.
+    const request = normalizeApprovalRequest(this.approvalRequest, this.nowMs);
+    const isPending = isUnexpiredPendingRequest(request, this.nowMs);
     const isResolved = [
       'approved',
       'declined',
       'expired',
       'cancelled',
-    ].includes(this.approvalRequest.status);
-    const displayStatus =
-      this.approvalRequest.status === 'expired'
-        ? 'TIMED OUT'
-        : this.approvalRequest.status.toUpperCase();
+    ].includes(request.status);
+    const displayStatus = approvalStatusLabel(request.status);
+    const countdown = isPending ? this.formatCountdown(request) : null;
+    const expiringSoon = isPending && isExpiringSoon(request, this.nowMs);
 
     const toolArgs = this.formatToolArgs(
-      withoutApprovalMetadata(this.approvalRequest.tool_args)
+      withoutApprovalMetadata(request.tool_args)
     );
-    const source = formatApprovalSource(
-      getApprovalSource(this.approvalRequest.tool_args)
-    );
+    const source = formatApprovalSource(getApprovalSource(request.tool_args));
     const requester = formatApprovalRequester(
-      this.approvalRequest.managed_agent_name,
-      this.approvalRequest.tool_args
+      request.managed_agent_name,
+      request.tool_args
     );
 
     const isQuestion = this.isQuestion;
@@ -455,13 +695,26 @@ export class ApprovalView extends AuthedElement {
           <sl-icon
             name=${isQuestion ? 'chat-left-quote' : 'shield-check'}
           ></sl-icon>
-          ${isQuestion ? 'Agent Question' : 'Tool Execution Approval'}
+          ${isQuestion ? 'Agent question' : 'Tool execution approval'}
           <sl-badge
-            variant=${this.getStatusVariant(this.approvalRequest.status)}
-            class="status-badge"
+            pill
+            class="chip status-badge"
+            variant=${this.getStatusVariant(request.status)}
           >
             ${displayStatus}
           </sl-badge>
+          ${
+            countdown
+              ? html`<sl-badge
+                  pill
+                  class="chip status-badge"
+                  variant=${expiringSoon ? 'warning' : 'neutral'}
+                >
+                  <sl-icon name="hourglass"></sl-icon>
+                  ${countdown}
+                </sl-badge>`
+              : ''
+          }
         </h1>
         <p>
           ${
@@ -472,31 +725,6 @@ export class ApprovalView extends AuthedElement {
         </p>
       </div>
 
-      ${
-        this.actionResult
-          ? html`
-              <sl-alert
-                variant=${
-                  this.actionResult.type === 'success' ? 'success' : 'danger'
-                }
-                open
-                closable
-                @sl-hide=${() => (this.actionResult = null)}
-              >
-                <sl-icon
-                  slot="icon"
-                  name=${
-                    this.actionResult.type === 'success'
-                      ? 'check-circle'
-                      : 'exclamation-octagon'
-                  }
-                ></sl-icon>
-                ${this.actionResult.message}
-              </sl-alert>
-            `
-          : ''
-      }
-
       <sl-card>
         ${
           isQuestion && isPending
@@ -504,10 +732,8 @@ export class ApprovalView extends AuthedElement {
                 <div class="content-section">
                   <question-answer-panel
                     .question=${this.questionText}
-                    .options=${this.approvalRequest.question_options ?? []}
-                    .allowFreeText=${
-                      this.approvalRequest.allow_free_text === true
-                    }
+                    .options=${request.question_options ?? []}
+                    .allowFreeText=${request.allow_free_text === true}
                     .submitting=${this.submitting}
                     @question-answer=${this.handleQuestionAnswer}
                     @question-dismiss=${this.handleQuestionDismiss}
@@ -517,13 +743,11 @@ export class ApprovalView extends AuthedElement {
             : ''
         }
         ${
-          this.approvalRequest.summary && !isQuestion
+          request.summary && !isQuestion
             ? html`
                 <div class="content-section">
                   <h2>Request</h2>
-                  <div class="reasoning-text">
-                    ${this.approvalRequest.summary}
-                  </div>
+                  <div class="reasoning-text">${request.summary}</div>
                 </div>
               `
             : ''
@@ -539,7 +763,7 @@ export class ApprovalView extends AuthedElement {
             : ''
         }
         <div class="content-section">
-          <h2>Tool Information</h2>
+          <h2>Tool information</h2>
           <div class="info-grid">
             <div class="info-label">Requested by:</div>
             <div class="info-value">
@@ -555,40 +779,38 @@ export class ApprovalView extends AuthedElement {
                 : ''
             }
 
-            <div class="info-label">Tool Name:</div>
+            <div class="info-label">Tool name:</div>
             <div class="info-value">
-              <strong>${this.approvalRequest.tool_name}</strong>
+              <strong>${request.tool_name}</strong>
             </div>
 
             <div class="info-label">Request ID:</div>
             <div class="info-value">
-              <code style="font-size: 0.75rem;"
-                >${this.approvalRequest.id}</code
-              >
+              <code style="font-size: 0.75rem;">${request.id}</code>
             </div>
 
             <div class="info-label">Requested:</div>
             <div class="info-value">
-              ${this.formatDate(this.approvalRequest.requested_at)}
+              ${this.formatDate(request.requested_at)}
             </div>
 
             ${
-              this.approvalRequest.expires_at
+              request.expires_at
                 ? html`
                     <div class="info-label">Expires:</div>
                     <div class="info-value">
-                      ${this.formatDate(this.approvalRequest.expires_at)}
+                      ${this.formatDate(request.expires_at)}
                     </div>
                   `
                 : ''
             }
             ${
-              this.approvalRequest.execution_id
+              request.execution_id
                 ? html`
                     <div class="info-label">Execution ID:</div>
                     <div class="info-value">
                       <code style="font-size: 0.75rem;"
-                        >${this.approvalRequest.execution_id}</code
+                        >${request.execution_id}</code
                       >
                     </div>
                   `
@@ -598,32 +820,30 @@ export class ApprovalView extends AuthedElement {
         </div>
 
         ${
-          this.approvalRequest.rule_context
+          request.rule_context
             ? html`
                 <div class="content-section">
                   <approval-rule-context-block
-                    .ruleContext=${this.approvalRequest.rule_context}
-                    .toolName=${this.approvalRequest.tool_name}
+                    .ruleContext=${request.rule_context}
+                    .toolName=${request.tool_name}
                   ></approval-rule-context-block>
                 </div>
               `
             : ''
         }
         ${
-          this.approvalRequest.agent_reasoning
+          request.agent_reasoning
             ? html`
                 <div class="content-section">
-                  <h2>Agent Reasoning</h2>
-                  <div class="reasoning-text">
-                    ${this.approvalRequest.agent_reasoning}
-                  </div>
+                  <h2>Agent reasoning</h2>
+                  <div class="reasoning-text">${request.agent_reasoning}</div>
                 </div>
               `
             : ''
         }
 
         <div class="content-section">
-          <h2>Tool Arguments</h2>
+          <h2>Tool arguments</h2>
           <div class="code-block">${toolArgs}</div>
         </div>
 
@@ -631,77 +851,24 @@ export class ApprovalView extends AuthedElement {
           isResolved
             ? html`
                 <div class="resolved-info">
-                  <h3>
-                    ${
-                      this.approvalRequest.status === 'approved'
-                        ? '✅ Approved'
-                        : this.approvalRequest.status === 'expired'
-                          ? '⏱️ Timed Out'
-                          : this.approvalRequest.status === 'cancelled'
-                            ? '🚫 Cancelled'
-                            : '❌ Declined'
-                    }
-                  </h3>
+                  <h3>${approvalStatusLabel(request.status)}</h3>
                   ${
-                    this.approvalRequest.resolved_at
+                    request.resolved_at
                       ? html`<p>
-                          Resolved at:
-                          ${this.formatDate(this.approvalRequest.resolved_at)}
+                          Resolved at: ${this.formatDate(request.resolved_at)}
                         </p>`
                       : ''
                   }
                   ${
-                    this.approvalRequest.approver_comment
+                    request.approver_comment
                       ? html`
                           <p><strong>Comment:</strong></p>
                           <div class="code-block">
-                            ${this.approvalRequest.approver_comment}
+                            ${request.approver_comment}
                           </div>
                         `
                       : ''
                   }
-                </div>
-              `
-            : ''
-        }
-        ${
-          isPending && !isQuestion
-            ? html`
-                <sl-divider></sl-divider>
-
-                <div class="comment-section">
-                  <h2>Your Decision</h2>
-                  <sl-textarea
-                    label="Comment (optional)"
-                    placeholder="Add a comment explaining your decision..."
-                    rows="4"
-                    .value=${this.comment}
-                    @sl-input=${(e: any) => (this.comment = e.target.value)}
-                    ?disabled=${this.submitting}
-                  ></sl-textarea>
-                </div>
-
-                <div class="actions">
-                  <sl-button
-                    variant="success"
-                    size="large"
-                    @click=${this.handleApprove}
-                    ?loading=${this.submitting}
-                    ?disabled=${this.submitting}
-                  >
-                    <sl-icon slot="prefix" name="check-circle"></sl-icon>
-                    Approve
-                  </sl-button>
-                  <sl-button
-                    variant="danger"
-                    size="large"
-                    @click=${this.handleDecline}
-                    ?loading=${this.submitting}
-                    ?disabled=${this.submitting}
-                  >
-                    <sl-icon slot="prefix" name="x-circle"></sl-icon>
-                    Decline
-                  </sl-button>
                 </div>
               `
             : ''
@@ -716,6 +883,97 @@ export class ApprovalView extends AuthedElement {
           }
         </div>
       </sl-card>
+
+      ${this.decisionTaken ? this.renderPostDecision() : ''}
+      ${
+        isPending && !isQuestion
+          ? this.renderDecisionBar(request, countdown, expiringSoon)
+          : ''
+      }
+    `;
+  }
+
+  /** The decision, always on screen, whatever the operator has scrolled to. */
+  private renderDecisionBar(
+    request: ApprovalRequest,
+    countdown: string | null,
+    expiringSoon: boolean
+  ) {
+    const requester = formatApprovalRequester(
+      request.managed_agent_name,
+      request.tool_args
+    );
+    return html`
+      <div class="decision-bar">
+        <div class="decision-summary">
+          <div class="decision-title" title=${this.decisionSummary(request)}>
+            <code>${request.tool_name}</code> ${this.decisionSummary(request)}
+          </div>
+          <div class="decision-paused">
+            ${requester} is paused until you decide
+          </div>
+          ${
+            countdown
+              ? html`<sl-badge
+                  pill
+                  class="chip countdown-chip"
+                  variant=${expiringSoon ? 'warning' : 'neutral'}
+                >
+                  <sl-icon name="hourglass"></sl-icon>
+                  ${countdown}
+                </sl-badge>`
+              : ''
+          }
+        </div>
+        <sl-input
+          class="decision-comment"
+          size="small"
+          placeholder="Comment (optional)"
+          .value=${this.comment}
+          @sl-input=${(e: any) => (this.comment = e.target.value)}
+          ?disabled=${this.submitting}
+        ></sl-input>
+        <div class="decision-buttons">
+          <sl-button
+            class="approve"
+            variant="success"
+            @click=${this.handleApprove}
+            ?loading=${this.submitting}
+            ?disabled=${this.submitting}
+          >
+            <sl-icon slot="prefix" name="check-circle"></sl-icon>
+            Approve<kbd>A</kbd>
+          </sl-button>
+          <sl-button
+            class="deny"
+            variant="danger"
+            outline
+            @click=${this.handleDeny}
+            ?disabled=${this.submitting}
+          >
+            <sl-icon slot="prefix" name="x-circle"></sl-icon>
+            Deny<kbd>D</kbd>
+          </sl-button>
+        </div>
+      </div>
+    `;
+  }
+
+  /** Where the work is now that this page has none left. */
+  private renderPostDecision() {
+    const waiting = this.waitingNext;
+    return html`
+      <div class="post-decision">
+        <a href="/console/approvals">Back to approvals</a>
+        <span class="separator">·</span>
+        ${
+          waiting.length > 0
+            ? html`<a href="/console/approval/${waiting[0].id}"
+                >Next waiting (${waiting.length})</a
+              >`
+            : html`<span class="muted">Nothing else is waiting for you</span>`
+        }
+      </div>
     `;
   }
 }

--- a/frontend/src/views/authed/approval-view.ts
+++ b/frontend/src/views/authed/approval-view.ts
@@ -10,7 +10,9 @@ import {
   withoutApprovalMetadata,
 } from '../../utils/approval-identity';
 import {
+  APPROVAL_REQUESTS_PAGE_LIMIT,
   approvalStatusLabel,
+  formatNextWaitingLabel,
   isExpiringSoon,
   isUnexpiredPendingRequest,
   millisUntilExpiry,
@@ -65,6 +67,14 @@ export class ApprovalView extends AuthedElement {
   /** Other requests still waiting for this operator, fetched after a decision. */
   @state()
   private waitingNext: ApprovalRequest[] = [];
+
+  /**
+   * How many pending rows the queue fetch returned, before client-side
+   * filtering. Used to say "100+" when the page is full rather than a
+   * count that looks total and is not.
+   */
+  @state()
+  private waitingNextFetched = 0;
 
   /**
    * True while the deny confirmation is on screen. The decision keys listen on
@@ -392,6 +402,7 @@ export class ApprovalView extends AuthedElement {
       return;
     }
     const key = event.key.toLowerCase();
+    // Founder call: Approve fires immediately; Deny confirms. No undo window.
     if (key === 'a') {
       event.preventDefault();
       void this.handleApprove();
@@ -537,9 +548,10 @@ export class ApprovalView extends AuthedElement {
   private async loadWaitingNext() {
     try {
       const data = await this.fetchData(
-        '/api/v1/approval-requests?status=pending&limit=100'
+        `/api/v1/approval-requests?status=pending&limit=${APPROVAL_REQUESTS_PAGE_LIMIT}`
       );
       if (Array.isArray(data)) {
+        this.waitingNextFetched = data.length;
         this.waitingNext = (data as ApprovalRequest[]).filter(
           (request) =>
             request.id !== this.requestId &&
@@ -1009,7 +1021,10 @@ export class ApprovalView extends AuthedElement {
         ${
           waiting.length > 0
             ? html`<a href="/console/approval/${waiting[0].id}"
-                >Next waiting (${waiting.length})</a
+                >${formatNextWaitingLabel(
+                  waiting.length,
+                  this.waitingNextFetched
+                )}</a
               >`
             : html`<span class="muted">Nothing else is waiting for you</span>`
         }

--- a/frontend/src/views/authed/approval-view.ts
+++ b/frontend/src/views/authed/approval-view.ts
@@ -242,6 +242,21 @@ export class ApprovalView extends AuthedElement {
         min-width: 160px;
       }
 
+      /*
+       * The label repeats the placeholder and would cost the bar a whole row.
+       * Keep it in the accessibility tree (Shoelace wires it to the input, so
+       * the field has a name) and take it out of the picture.
+       */
+      .decision-comment::part(form-control-label) {
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
+      }
+
       .decision-buttons {
         display: flex;
         align-items: center;
@@ -297,8 +312,9 @@ export class ApprovalView extends AuthedElement {
           flex: 1;
         }
 
+        /* The stacked buttons take the full row, so the large gap still fits. */
         .decision-buttons .deny {
-          margin-left: var(--sl-spacing-medium);
+          margin-left: var(--sl-spacing-large);
         }
       }
     `,
@@ -949,6 +965,7 @@ export class ApprovalView extends AuthedElement {
         <sl-input
           class="decision-comment"
           size="small"
+          label="Comment (optional)"
           placeholder="Comment (optional)"
           .value=${this.comment}
           @sl-input=${(e: any) => (this.comment = e.target.value)}
@@ -958,22 +975,24 @@ export class ApprovalView extends AuthedElement {
           <sl-button
             class="approve"
             variant="success"
+            title="Approve (A)"
             @click=${this.handleApprove}
             ?loading=${this.submitting}
             ?disabled=${this.submitting}
           >
             <sl-icon slot="prefix" name="check-circle"></sl-icon>
-            Approve<kbd>A</kbd>
+            Approve<kbd aria-hidden="true">A</kbd>
           </sl-button>
           <sl-button
             class="deny"
             variant="danger"
             outline
+            title="Deny (D)"
             @click=${this.handleDeny}
             ?disabled=${this.submitting}
           >
             <sl-icon slot="prefix" name="x-circle"></sl-icon>
-            Deny<kbd>D</kbd>
+            Deny<kbd aria-hidden="true">D</kbd>
           </sl-button>
         </div>
       </div>

--- a/frontend/src/views/authed/approvals-view.test.ts
+++ b/frontend/src/views/authed/approvals-view.test.ts
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 
 import '../../components/view-header.ts';
 import './approvals-view';
+import { resetConfirmDialogForTests } from '../../components/confirm-dialog';
 import type { ApprovalsView } from './approvals-view';
 
 describe('ApprovalsView', () => {
@@ -100,7 +101,120 @@ describe('ApprovalsView', () => {
 
   afterEach(() => {
     fetchStub?.restore();
+    resetConfirmDialogForTests();
+    document.querySelectorAll('sl-alert[open]').forEach((a) => a.remove());
     localStorage.clear();
+  });
+
+  function decisionCall(action: 'approve' | 'decline') {
+    return fetchStub
+      .getCalls()
+      .find(
+        (c) =>
+          String(c.args[0]).includes(`/${action}`) &&
+          String((c.args[1] as RequestInit)?.method || '').toUpperCase() ===
+            'POST'
+      );
+  }
+
+  function inMinutes(minutes: number) {
+    return new Date(Date.now() + minutes * 60_000).toISOString();
+  }
+
+  describe('waiting for you', () => {
+    it('puts the waiting group before history and sorts it by expiry', async () => {
+      const element = await renderList([
+        baseRequest({ id: 'later', expires_at: inMinutes(40) }),
+        baseRequest({
+          id: 'done',
+          status: 'approved',
+          resolved_at: new Date().toISOString(),
+        }),
+        baseRequest({ id: 'soonest', expires_at: inMinutes(3) }),
+      ]);
+
+      const headings = Array.from(
+        element.shadowRoot?.querySelectorAll('.group-header h2') ?? []
+      ).map((h) => h.textContent?.trim());
+      expect(headings).to.deep.equal(['Waiting for you', 'History']);
+
+      expect(
+        (element as any).waitingRequests.map((r: any) => r.id)
+      ).to.deep.equal(['soonest', 'later']);
+      expect(
+        (element as any).historyRequests.map((r: any) => r.id)
+      ).to.deep.equal(['done']);
+    });
+
+    it('approves from the row without leaving the list', async () => {
+      const element = await renderList([
+        baseRequest({ id: 'ar-1', expires_at: inMinutes(10) }),
+      ]);
+
+      const approve = element.shadowRoot?.querySelector(
+        '.row-approve'
+      ) as HTMLElement;
+      expect(approve, 'expected a row-level Approve').to.exist;
+      approve.click();
+
+      await waitUntil(() => !!decisionCall('approve'), 'no approve call');
+      const body = JSON.parse(
+        String((decisionCall('approve')!.args[1] as RequestInit).body)
+      );
+      expect(body.approved).to.be.true;
+      await waitUntil(
+        () => (element as any).approvalRequests[0].status === 'approved',
+        'row was not marked approved'
+      );
+    });
+
+    it('confirms before it denies from the row', async () => {
+      const element = await renderList([
+        baseRequest({ id: 'ar-1', expires_at: inMinutes(10) }),
+      ]);
+
+      const deny = element.shadowRoot?.querySelector(
+        '.row-deny'
+      ) as HTMLElement;
+      expect(deny, 'expected a row-level Deny').to.exist;
+      expect(deny.getAttribute('variant')).to.equal('danger');
+      expect(deny.hasAttribute('outline'), 'Deny must be outline').to.be.true;
+      deny.click();
+
+      await waitUntil(
+        () => !!document.querySelector('confirm-dialog'),
+        'no confirm dialog'
+      );
+      expect(decisionCall('decline'), 'denied without confirming').to.be
+        .undefined;
+
+      const dialog = document.querySelector('confirm-dialog') as HTMLElement;
+      (
+        dialog.shadowRoot?.querySelector(
+          '[data-testid="confirm-dialog-confirm"]'
+        ) as HTMLElement
+      ).click();
+
+      await waitUntil(() => !!decisionCall('decline'), 'no decline call');
+      await waitUntil(
+        () => (element as any).approvalRequests[0].status === 'declined',
+        'row was not marked denied'
+      );
+    });
+
+    it('keeps an expired pending request in history with no decision', async () => {
+      const element = await renderList([
+        baseRequest({
+          id: 'stale',
+          requested_at: '2026-07-13T14:59:10Z',
+          expires_at: '2026-07-13T15:04:10Z',
+        }),
+      ]);
+
+      expect((element as any).waitingRequests.length).to.equal(0);
+      expect(element.shadowRoot?.querySelector('.row-approve')).to.not.exist;
+      expect(element.shadowRoot?.textContent).to.contain('Timed out');
+    });
   });
 
   it('renders the approval list view', async () => {
@@ -117,7 +231,7 @@ describe('ApprovalsView', () => {
 
     const header = element.shadowRoot?.querySelector('view-header');
     expect(header).to.exist;
-    expect(header?.getAttribute('headerText')).to.equal('Approval Requests');
+    expect(header?.getAttribute('headerText')).to.equal('Approval requests');
   });
 
   it('shows empty state when no approval requests', async () => {
@@ -301,7 +415,7 @@ describe('ApprovalsView', () => {
       expect(element.shadowRoot?.querySelector('question-answer-panel')).to.not
         .exist;
       expect(element.shadowRoot?.querySelector('.approval-item')).to.exist;
-      expect(element.shadowRoot?.textContent).to.contain('Review');
+      expect(element.shadowRoot?.textContent).to.contain('Details');
     });
   });
 });

--- a/frontend/src/views/authed/approvals-view.test.ts
+++ b/frontend/src/views/authed/approvals-view.test.ts
@@ -215,6 +215,50 @@ describe('ApprovalsView', () => {
       expect(element.shadowRoot?.querySelector('.row-approve')).to.not.exist;
       expect(element.shadowRoot?.textContent).to.contain('Timed out');
     });
+
+    it('moves a pending row to history when it expires while the list is open', async () => {
+      const element = await renderList([
+        baseRequest({
+          id: 'about-to-expire',
+          expires_at: new Date(Date.now() + 400).toISOString(),
+        }),
+      ]);
+
+      expect(
+        (element as any).waitingRequests.map((r: { id: string }) => r.id)
+      ).to.deep.equal(['about-to-expire']);
+      expect(element.shadowRoot?.querySelector('.row-approve')).to.exist;
+
+      await waitUntil(
+        () => (element as any).waitingRequests.length === 0,
+        'expired row stayed in Waiting for you',
+        { timeout: 3500 }
+      );
+      await element.updateComplete;
+
+      expect(element.shadowRoot?.querySelector('.row-approve')).to.not.exist;
+      expect(element.shadowRoot?.textContent).to.contain('Timed out');
+      expect(
+        (element as any).historyRequests.map((r: { id: string }) => r.id)
+      ).to.deep.equal(['about-to-expire']);
+    });
+
+    it('does not post approve once the row has timed out', async () => {
+      const element = await renderList([
+        baseRequest({
+          id: 'ar-1',
+          expires_at: new Date(Date.now() + 60_000).toISOString(),
+        }),
+      ]);
+      const request = (element as any).waitingRequests[0];
+      request.expires_at = new Date(Date.now() - 1000).toISOString();
+
+      await (element as any).handleRowApprove(request);
+
+      expect(decisionCall('approve'), 'approved after expiry').to.be.undefined;
+      expect((element as any).waitingRequests.length).to.equal(0);
+      expect(element.shadowRoot?.querySelector('.row-approve')).to.not.exist;
+    });
   });
 
   it('renders the approval list view', async () => {

--- a/frontend/src/views/authed/approvals-view.ts
+++ b/frontend/src/views/authed/approvals-view.ts
@@ -244,9 +244,9 @@ export class ApprovalsView extends AuthedElement {
         justify-content: flex-end;
       }
 
-      /* Destructive last, after a gap, never beside the everyday action. */
+      /* Destructive last, after a large gap, never beside the everyday action. */
       .approval-actions .row-deny {
-        margin-left: var(--sl-spacing-medium);
+        margin-left: var(--sl-spacing-large);
       }
 
       .approval-actions .row-details {

--- a/frontend/src/views/authed/approvals-view.ts
+++ b/frontend/src/views/authed/approvals-view.ts
@@ -10,6 +10,14 @@ import {
   parseUTCDate,
 } from '../../utils/date';
 import { formatApprovalRequester } from '../../utils/approval-identity';
+import {
+  approvalStatusLabel,
+  isExpiringSoon,
+  isUnexpiredPendingRequest,
+  normalizeApprovalRequest,
+  partitionApprovalRequests,
+} from '../../utils/approvals';
+import { confirmDialog, showToast } from '../../components/confirm-dialog';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import '../../components/approval-rule-context-block';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
@@ -50,6 +58,18 @@ export class ApprovalsView extends AuthedElement {
 
   @state()
   private filteredRequests: ApprovalRequest[] = [];
+
+  /** Pending, not expired: the requests an operator can still decide. */
+  @state()
+  private waitingRequests: ApprovalRequest[] = [];
+
+  /** Everything already decided, expired or cancelled. */
+  @state()
+  private historyRequests: ApprovalRequest[] = [];
+
+  /** Id of the request whose row decision is in flight, if any. */
+  @state()
+  private decidingId: string | null = null;
 
   @state()
   private loading = true;
@@ -220,6 +240,41 @@ export class ApprovalsView extends AuthedElement {
         display: flex;
         align-items: center;
         gap: var(--sl-spacing-small);
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+
+      /* Destructive last, after a gap, never beside the everyday action. */
+      .approval-actions .row-deny {
+        margin-left: var(--sl-spacing-medium);
+      }
+
+      .approval-actions .row-details {
+        color: var(--sl-color-primary-600);
+        font-size: var(--sl-font-size-small);
+        text-decoration: none;
+        margin-left: var(--sl-spacing-small);
+      }
+
+      .approval-actions .row-details:hover {
+        text-decoration: underline;
+      }
+
+      .approval-group {
+        margin-bottom: var(--sl-spacing-large);
+      }
+
+      .group-header {
+        display: flex;
+        align-items: center;
+        gap: var(--sl-spacing-small);
+        margin-bottom: var(--sl-spacing-small);
+      }
+
+      .group-header h2 {
+        margin: 0;
+        font-size: var(--sl-font-size-medium);
+        font-weight: 600;
       }
 
       .rate-bar {
@@ -316,7 +371,7 @@ export class ApprovalsView extends AuthedElement {
         allow_free_text: message.allow_free_text === true,
       };
 
-      if (!this.isUnexpiredPendingRequest(newApproval)) {
+      if (!isUnexpiredPendingRequest(newApproval)) {
         return;
       }
 
@@ -364,7 +419,7 @@ export class ApprovalsView extends AuthedElement {
       if (data && Array.isArray(data)) {
         // Sort by requested_at descending (most recent first)
         this.approvalRequests = (data as ApprovalRequest[])
-          .map((request) => this.normalizeApprovalRequest(request))
+          .map((request) => normalizeApprovalRequest(request))
           .sort(
             (a, b) =>
               parseUTCDate(b.requested_at).getTime() -
@@ -470,6 +525,12 @@ export class ApprovalsView extends AuthedElement {
     }
 
     this.filteredRequests = filtered;
+
+    // What still needs a person comes first, soonest expiry at the top; the
+    // rest is history and keeps its newest-first order.
+    const { waiting, history } = partitionApprovalRequests(filtered);
+    this.waitingRequests = waiting;
+    this.historyRequests = history;
   }
 
   private getUniqueTools(): string[] {
@@ -483,30 +544,6 @@ export class ApprovalsView extends AuthedElement {
 
   private formatExpiryDate(dateStr: string): string {
     return formatFutureRelativeTime(dateStr);
-  }
-
-  private isUnexpiredPendingRequest(request: ApprovalRequest): boolean {
-    if (request.status !== 'pending') {
-      return false;
-    }
-    if (!request.expires_at) {
-      return true;
-    }
-    return parseUTCDate(request.expires_at).getTime() > Date.now();
-  }
-
-  private normalizeApprovalRequest(request: ApprovalRequest): ApprovalRequest {
-    if (
-      request.status !== 'pending' ||
-      this.isUnexpiredPendingRequest(request)
-    ) {
-      return request;
-    }
-    return {
-      ...request,
-      status: 'expired',
-      resolved_at: request.resolved_at || request.expires_at,
-    };
   }
 
   private formatFullDate(dateStr: string): string {
@@ -601,6 +638,56 @@ export class ApprovalsView extends AuthedElement {
     this.calculateStats();
   }
 
+  /**
+   * Row-level approve: the same call the detail page makes, taken where the
+   * request is seen. Approving is not destructive, so it does not confirm.
+   */
+  private async handleRowApprove(request: ApprovalRequest) {
+    this.decidingId = request.id;
+    try {
+      const updated = await approveRequest(request.id);
+      this.applyResolution(request.id, {
+        status: 'approved',
+        resolved_at: updated?.resolved_at ?? null,
+      });
+      showToast(`Approved ${request.tool_name}.`, 'success');
+    } catch (error: any) {
+      showToast(error?.message || 'Failed to approve the request', 'danger');
+      console.error('Failed to approve request:', error);
+    } finally {
+      this.decidingId = null;
+    }
+  }
+
+  /** Denying stops the agent, so it confirms first (DESIGN.md destructive). */
+  private async handleRowDeny(request: ApprovalRequest) {
+    const confirmed = await confirmDialog({
+      title: 'Deny this request?',
+      message: `${request.tool_name} will not run.`,
+      detail: `${formatApprovalRequester(
+        request.managed_agent_name,
+        request.tool_args
+      )} is told no and continues without it.`,
+      confirmLabel: 'Deny',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+    this.decidingId = request.id;
+    try {
+      const updated = await declineRequest(request.id);
+      this.applyResolution(request.id, {
+        status: 'declined',
+        resolved_at: updated?.resolved_at ?? null,
+      });
+      showToast(`Denied ${request.tool_name}.`, 'neutral');
+    } catch (error: any) {
+      showToast(error?.message || 'Failed to deny the request', 'danger');
+      console.error('Failed to deny request:', error);
+    } finally {
+      this.decidingId = null;
+    }
+  }
+
   /** An answered question is submitted as an approve carrying the answer. */
   private async handleQuestionAnswer(
     request: ApprovalRequest,
@@ -649,7 +736,7 @@ export class ApprovalsView extends AuthedElement {
   render() {
     if (this.loading) {
       return html`
-        <view-header headerText="Approval Requests" width="wide"></view-header>
+        <view-header headerText="Approval requests" width="wide"></view-header>
         <div class="loading-container">
           <sl-spinner style="font-size: 3rem;"></sl-spinner>
         </div>
@@ -658,14 +745,14 @@ export class ApprovalsView extends AuthedElement {
 
     return html`
       <view-header
-        headerText="Approval Requests"
-        description="Tool calls that waited for a human decision — who approved, who denied, and how long it took. Approval policies are configured elsewhere: MCP tool rules and native tool-call defaults live in Tools; per-agent overrides live on each agent's detail page."
+        headerText="Approval requests"
+        description="Tool calls that waited for a human decision, and what happened to them. Approval rules live in Tools; per-agent overrides live on each agent's detail page."
         width="wide"
       >
         <sl-dropdown>
           <sl-button slot="trigger" size="small" caret>
             <sl-icon slot="prefix" name="gear"></sl-icon>
-            Configure Approvals
+            Configure approvals
           </sl-button>
           <sl-menu>
             <sl-menu-item
@@ -695,7 +782,7 @@ export class ApprovalsView extends AuthedElement {
           <div class="stats-grid">
             <div class="stat-card">
               <div class="stat-value primary">${this.stats.total}</div>
-              <div class="stat-label">Total Requests</div>
+              <div class="stat-label">Total requests</div>
             </div>
             <div class="stat-card">
               <div class="stat-value warning">${this.stats.pending}</div>
@@ -712,11 +799,11 @@ export class ApprovalsView extends AuthedElement {
             </div>
             <div class="stat-card">
               <div class="stat-value danger">${this.stats.declined}</div>
-              <div class="stat-label">Declined</div>
+              <div class="stat-label">Denied</div>
             </div>
             <div class="stat-card">
               <div class="stat-value neutral">${this.stats.expired}</div>
-              <div class="stat-label">Timed Out</div>
+              <div class="stat-label">Timed out</div>
               ${
                 this.stats.expired > 0
                   ? html`<div class="stat-subtext">No response in time</div>`
@@ -733,7 +820,7 @@ export class ApprovalsView extends AuthedElement {
                     : '-'
                 }
               </div>
-              <div class="stat-label">Avg Response</div>
+              <div class="stat-label">Avg response</div>
             </div>
           </div>
 
@@ -744,7 +831,7 @@ export class ApprovalsView extends AuthedElement {
                   <sl-card style="margin-bottom: var(--sl-spacing-large);">
                     <div slot="header" class="chart-header">
                       <sl-icon name="pie-chart"></sl-icon>
-                      Approval Rate
+                      Approval rate
                     </div>
                     <div class="rate-labels">
                       <span
@@ -752,7 +839,7 @@ export class ApprovalsView extends AuthedElement {
                         (${Math.round(this.stats.approvalRate)}%)</span
                       >
                       <span
-                        >Declined: ${this.stats.declined}
+                        >Denied: ${this.stats.declined}
                         (${Math.round(100 - this.stats.approvalRate)}%)</span
                       >
                     </div>
@@ -772,11 +859,11 @@ export class ApprovalsView extends AuthedElement {
               value=${this.statusFilter}
               @sl-change=${this.handleStatusFilterChange}
             >
-              <sl-option value="all">All Statuses</sl-option>
+              <sl-option value="all">All statuses</sl-option>
               <sl-option value="pending">Pending</sl-option>
               <sl-option value="approved">Approved</sl-option>
-              <sl-option value="declined">Declined</sl-option>
-              <sl-option value="expired">Timed Out</sl-option>
+              <sl-option value="declined">Denied</sl-option>
+              <sl-option value="expired">Timed out</sl-option>
               <sl-option value="cancelled">Cancelled</sl-option>
             </sl-select>
 
@@ -785,7 +872,7 @@ export class ApprovalsView extends AuthedElement {
               value=${this.toolFilter}
               @sl-change=${this.handleToolFilterChange}
             >
-              <sl-option value="all">All Tools</sl-option>
+              <sl-option value="all">All tools</sl-option>
               ${this.getUniqueTools().map(
                 (tool) => html`<sl-option value=${tool}>${tool}</sl-option>`
               )}
@@ -826,258 +913,266 @@ export class ApprovalsView extends AuthedElement {
                       this.approvalRequests.length === 0
                         ? html`<sl-button href="/console/tools">
                             <sl-icon slot="prefix" name="gear"></sl-icon>
-                            Configure Tools
+                            Configure tools
                           </sl-button>`
                         : ''
                     }
                   </div>
                 `
               : html`
-                  <div class="approval-list">
-                    ${this.filteredRequests.map(
-                      (request) => html`
-                        <div
-                          class="approval-item ${request.status} ${
-                            this.isQuestion(request) ? 'question' : ''
-                          }"
-                        >
-                          <div class="approval-row">
-                            <div class="approval-info">
-                              <div class="approval-tool">
-                                <sl-icon
-                                  name=${
-                                    this.isQuestion(request)
-                                      ? 'chat-left-quote'
-                                      : 'tools'
-                                  }
-                                ></sl-icon>
-                                ${
-                                  this.isQuestion(request)
-                                    ? html`<span
-                                        style="font-weight: 500; max-width: 520px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
-                                        title=${this.questionText(request)}
-                                        >${this.questionText(request)}</span
-                                      >`
-                                    : request.summary
-                                      ? html`<span
-                                          style="font-weight: 500; max-width: 520px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
-                                          title=${request.summary}
-                                          >${
-                                            request.summary.length > 120
-                                              ? `${request.summary.substring(0, 120)}…`
-                                              : request.summary
-                                          }</span
-                                        >`
-                                      : html`<code>${request.tool_name}</code>`
-                                }
-                                <sl-tag
-                                  size="small"
-                                  variant=${this.getStatusVariant(request.status)}
-                                >
-                                  <sl-icon
-                                    name=${this.getStatusIcon(request.status)}
-                                    style="margin-right: 4px;"
-                                  ></sl-icon>
-                                  ${
-                                    request.status === 'expired'
-                                      ? 'timed out'
-                                      : request.status
-                                  }
-                                </sl-tag>
-                                <sl-tag size="small" variant="neutral">
-                                  <sl-icon
-                                    name="cpu"
-                                    style="margin-right: 4px;"
-                                  ></sl-icon>
-                                  ${formatApprovalRequester(
-                                    request.managed_agent_name,
-                                    request.tool_args
-                                  )}
-                                </sl-tag>
-                                ${
-                                  request.auto_approved_reason
-                                    ? html`<sl-tooltip
-                                        content="Auto-approved by a time-boxed bypass. No person reviewed this call."
-                                      >
-                                        <sl-tag size="small" variant="warning">
-                                          <sl-icon
-                                            name="exclamation-triangle"
-                                            style="margin-right: 4px;"
-                                          ></sl-icon>
-                                          not reviewed
-                                        </sl-tag>
-                                      </sl-tooltip>`
-                                    : ''
-                                }
-                              </div>
-                              ${
-                                request.summary
-                                  ? html`
-                                      <div
-                                        class="approval-meta"
-                                        style="margin-top: 2px;"
-                                      >
-                                        <span class="approval-meta-item">
-                                          <code style="font-size: 0.8em;"
-                                            >${request.tool_name}</code
-                                          >
-                                        </span>
-                                      </div>
-                                    `
-                                  : ''
-                              }
-                              ${
-                                request.rule_context
-                                  ? html`
-                                      <div
-                                        class="approval-meta"
-                                        style="margin-top: 2px;"
-                                      >
-                                        <approval-rule-context-block
-                                          compact
-                                          .ruleContext=${request.rule_context}
-                                        ></approval-rule-context-block>
-                                      </div>
-                                    `
-                                  : ''
-                              }
-                              <div class="approval-meta">
-                                <sl-tooltip
-                                  content=${this.formatFullDate(
-                                    request.requested_at
-                                  )}
-                                >
-                                  <span class="approval-meta-item">
-                                    <sl-icon name="clock"></sl-icon>
-                                    ${this.formatDate(request.requested_at)}
-                                  </span>
-                                </sl-tooltip>
-                                ${
-                                  request.execution_id
-                                    ? html`
-                                        <span class="approval-meta-item">
-                                          <sl-icon name="diagram-3"></sl-icon>
-                                          <a
-                                            href="/console/flows/executions/${request.execution_id}"
-                                            >Flow Execution</a
-                                          >
-                                        </span>
-                                      `
-                                    : ''
-                                }
-                                ${
-                                  request.resolved_at
-                                    ? html`
-                                        <sl-tooltip
-                                          content="Resolved: ${this.formatFullDate(
-                                            request.resolved_at
-                                          )}"
-                                        >
-                                          <span class="approval-meta-item">
-                                            <sl-icon
-                                              name="check2-square"
-                                            ></sl-icon>
-                                            Resolved
-                                            ${this.formatDate(request.resolved_at)}
-                                          </span>
-                                        </sl-tooltip>
-                                      `
-                                    : ''
-                                }
-                                ${
-                                  request.expires_at &&
-                                  request.status === 'pending'
-                                    ? html`
-                                        <sl-tooltip
-                                          content="Expires: ${this.formatFullDate(
-                                            request.expires_at
-                                          )}"
-                                        >
-                                          <span
-                                            class="approval-meta-item"
-                                            style="color: var(--sl-color-warning-600);"
-                                          >
-                                            <sl-icon name="hourglass"></sl-icon>
-                                            Expires
-                                            ${this.formatExpiryDate(
-                                              request.expires_at
-                                            )}
-                                          </span>
-                                        </sl-tooltip>
-                                      `
-                                    : ''
-                                }
-                              </div>
-                              ${
-                                !request.summary && request.agent_reasoning
-                                  ? html`
-                                      <div
-                                        style="font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-700); margin-top: var(--sl-spacing-2x-small); font-style: italic; max-width: 600px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
-                                      >
-                                        "${request.agent_reasoning.substring(
-                                          0,
-                                          100
-                                        )}${
-                                          request.agent_reasoning.length > 100
-                                            ? '...'
-                                            : ''
-                                        }"
-                                      </div>
-                                    `
-                                  : ''
-                              }
-                            </div>
-                            <div class="approval-actions">
-                              <sl-button
-                                size="small"
-                                variant=${
-                                  request.status === 'pending'
-                                    ? 'primary'
-                                    : 'default'
-                                }
-                                href="/console/approval/${request.id}"
-                              >
-                                ${request.status === 'pending' ? 'Review' : 'View'}
-                              </sl-button>
-                            </div>
-                          </div>
-                          ${
-                            this.isQuestion(request) &&
-                            request.status === 'pending'
-                              ? html`
-                                  <question-answer-panel
-                                    compact
-                                    .question=${this.questionText(request)}
-                                    .options=${request.question_options ?? []}
-                                    .allowFreeText=${
-                                      request.allow_free_text === true
-                                    }
-                                    .submitting=${
-                                      this.answeringId === request.id
-                                    }
-                                    @question-answer=${(
-                                      e: CustomEvent<QuestionAnswerDetail>
-                                    ) => this.handleQuestionAnswer(request, e)}
-                                    @question-dismiss=${() =>
-                                      this.handleQuestionDismiss(request)}
-                                  ></question-answer-panel>
-                                  ${
-                                    this.answerError
-                                      ? html`<div class="answer-error">
-                                          ${this.answerError}
-                                        </div>`
-                                      : ''
-                                  }
-                                `
-                              : ''
-                          }
-                        </div>
-                      `
-                    )}
-                  </div>
+                  ${this.renderGroup(
+                    'Waiting for you',
+                    this.waitingRequests,
+                    true
+                  )}
+                  ${this.renderGroup('History', this.historyRequests, false)}
                 `
           }
         </div>
+      </div>
+    `;
+  }
+
+  /**
+   * One group of rows under its own heading. "Waiting for you" carries the
+   * decision, so it is rendered first and its rows get Approve and Deny.
+   */
+  private renderGroup(
+    title: string,
+    requests: ApprovalRequest[],
+    waiting: boolean
+  ) {
+    if (requests.length === 0) return '';
+    return html`
+      <div class="approval-group">
+        <div class="group-header">
+          <h2>${title}</h2>
+          <sl-badge
+            pill
+            class="chip"
+            variant=${waiting ? 'warning' : 'neutral'}
+          >
+            ${requests.length}
+          </sl-badge>
+        </div>
+        <div class="approval-list">
+          ${requests.map((request) => this.renderRequest(request, waiting))}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderRequest(request: ApprovalRequest, waiting: boolean) {
+    return html`
+      <div
+        class="approval-item ${request.status} ${
+          this.isQuestion(request) ? 'question' : ''
+        }"
+      >
+        <div class="approval-row">
+          <div class="approval-info">
+            <div class="approval-tool">
+              <sl-icon
+                name=${this.isQuestion(request) ? 'chat-left-quote' : 'tools'}
+              ></sl-icon>
+              ${
+                this.isQuestion(request)
+                  ? html`<span
+                      style="font-weight: 500; max-width: 520px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+                      title=${this.questionText(request)}
+                      >${this.questionText(request)}</span
+                    >`
+                  : request.summary
+                    ? html`<span
+                        style="font-weight: 500; max-width: 520px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+                        title=${request.summary}
+                        >${
+                          request.summary.length > 120
+                            ? `${request.summary.substring(0, 120)}…`
+                            : request.summary
+                        }</span
+                      >`
+                    : html`<code>${request.tool_name}</code>`
+              }
+              <sl-badge
+                pill
+                class="chip"
+                variant=${this.getStatusVariant(request.status)}
+              >
+                <sl-icon name=${this.getStatusIcon(request.status)}></sl-icon>
+                ${approvalStatusLabel(request.status)}
+              </sl-badge>
+              <sl-badge pill class="tag-chip">
+                <sl-icon name="cpu"></sl-icon>
+                ${formatApprovalRequester(
+                  request.managed_agent_name,
+                  request.tool_args
+                )}
+              </sl-badge>
+              ${
+                request.auto_approved_reason
+                  ? html`<sl-tooltip
+                      content="Auto-approved by a time-boxed bypass. No person reviewed this call."
+                    >
+                      <sl-badge pill class="chip" variant="warning">
+                        <sl-icon name="exclamation-triangle"></sl-icon>
+                        Not reviewed
+                      </sl-badge>
+                    </sl-tooltip>`
+                  : ''
+              }
+            </div>
+            ${
+              request.summary
+                ? html`
+                    <div class="approval-meta" style="margin-top: 2px;">
+                      <span class="approval-meta-item">
+                        <code style="font-size: 0.8em;"
+                          >${request.tool_name}</code
+                        >
+                      </span>
+                    </div>
+                  `
+                : ''
+            }
+            ${
+              request.rule_context
+                ? html`
+                    <div class="approval-meta" style="margin-top: 2px;">
+                      <approval-rule-context-block
+                        compact
+                        .ruleContext=${request.rule_context}
+                      ></approval-rule-context-block>
+                    </div>
+                  `
+                : ''
+            }
+            <div class="approval-meta">
+              <sl-tooltip content=${this.formatFullDate(request.requested_at)}>
+                <span class="approval-meta-item">
+                  <sl-icon name="clock"></sl-icon>
+                  ${this.formatDate(request.requested_at)}
+                </span>
+              </sl-tooltip>
+              ${
+                request.execution_id
+                  ? html`
+                      <span class="approval-meta-item">
+                        <sl-icon name="diagram-3"></sl-icon>
+                        <a
+                          href="/console/flows/executions/${request.execution_id}"
+                          >Flow Execution</a
+                        >
+                      </span>
+                    `
+                  : ''
+              }
+              ${
+                request.resolved_at
+                  ? html`
+                      <sl-tooltip
+                        content="Resolved: ${this.formatFullDate(
+                          request.resolved_at
+                        )}"
+                      >
+                        <span class="approval-meta-item">
+                          <sl-icon name="check2-square"></sl-icon>
+                          Resolved ${this.formatDate(request.resolved_at)}
+                        </span>
+                      </sl-tooltip>
+                    `
+                  : ''
+              }
+              ${
+                request.expires_at && waiting
+                  ? html`
+                      <sl-tooltip
+                        content="Expires: ${this.formatFullDate(
+                          request.expires_at
+                        )}"
+                      >
+                        <sl-badge
+                          pill
+                          class="chip"
+                          variant=${
+                            isExpiringSoon(request) ? 'warning' : 'neutral'
+                          }
+                        >
+                          <sl-icon name="hourglass"></sl-icon>
+                          expires ${this.formatExpiryDate(request.expires_at)}
+                        </sl-badge>
+                      </sl-tooltip>
+                    `
+                  : ''
+              }
+            </div>
+            ${
+              !request.summary && request.agent_reasoning
+                ? html`
+                    <div
+                      style="font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-700); margin-top: var(--sl-spacing-2x-small); font-style: italic; max-width: 600px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+                    >
+                      "${request.agent_reasoning.substring(0, 100)}${
+                        request.agent_reasoning.length > 100 ? '...' : ''
+                      }"
+                    </div>
+                  `
+                : ''
+            }
+          </div>
+          <div class="approval-actions">
+            ${
+              waiting && !this.isQuestion(request)
+                ? html`
+                    <sl-button
+                      class="row-approve"
+                      size="small"
+                      variant="success"
+                      ?loading=${this.decidingId === request.id}
+                      ?disabled=${this.decidingId === request.id}
+                      @click=${() => this.handleRowApprove(request)}
+                    >
+                      Approve
+                    </sl-button>
+                    <sl-button
+                      class="row-deny"
+                      size="small"
+                      variant="danger"
+                      outline
+                      ?disabled=${this.decidingId === request.id}
+                      @click=${() => this.handleRowDeny(request)}
+                    >
+                      Deny
+                    </sl-button>
+                  `
+                : ''
+            }
+            <a class="row-details" href="/console/approval/${request.id}"
+              >${waiting ? 'Details' : 'View'}</a
+            >
+          </div>
+        </div>
+        ${
+          this.isQuestion(request) && waiting
+            ? html`
+                <question-answer-panel
+                  compact
+                  .question=${this.questionText(request)}
+                  .options=${request.question_options ?? []}
+                  .allowFreeText=${request.allow_free_text === true}
+                  .submitting=${this.answeringId === request.id}
+                  @question-answer=${(e: CustomEvent<QuestionAnswerDetail>) =>
+                    this.handleQuestionAnswer(request, e)}
+                  @question-dismiss=${() => this.handleQuestionDismiss(request)}
+                ></question-answer-panel>
+                ${
+                  this.answerError
+                    ? html`<div class="answer-error">${this.answerError}</div>`
+                    : ''
+                }
+              `
+            : ''
+        }
       </div>
     `;
   }

--- a/frontend/src/views/authed/approvals-view.ts
+++ b/frontend/src/views/authed/approvals-view.ts
@@ -11,6 +11,7 @@ import {
 } from '../../utils/date';
 import { formatApprovalRequester } from '../../utils/approval-identity';
 import {
+  APPROVAL_REQUESTS_PAGE_LIMIT,
   approvalStatusLabel,
   isExpiringSoon,
   isUnexpiredPendingRequest,
@@ -103,7 +104,16 @@ export class ApprovalsView extends AuthedElement {
   @state()
   private answerError: string | null = null;
 
+  /**
+   * Ticks once a second while anything in "Waiting for you" can still expire,
+   * so a request that times out with the list open leaves that group and
+   * loses its Approve/Deny buttons instead of offering a dead decision.
+   */
+  @state()
+  private nowMs = Date.now();
+
   private unsubscribe?: () => void;
+  private tickTimer?: ReturnType<typeof setInterval>;
 
   static styles = [
     unsafeCSS(consoleStyles),
@@ -331,6 +341,31 @@ export class ApprovalsView extends AuthedElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.unsubscribe?.();
+    this.stopTicking();
+  }
+
+  private startTicking() {
+    if (this.tickTimer) return;
+    this.tickTimer = setInterval(() => {
+      this.nowMs = Date.now();
+      this.applyFilters();
+    }, 1000);
+  }
+
+  private stopTicking() {
+    if (this.tickTimer) {
+      clearInterval(this.tickTimer);
+      this.tickTimer = undefined;
+    }
+  }
+
+  /** Tick only while a waiting row still has an expiry that can pass. */
+  private syncExpiryTick() {
+    if (this.waitingRequests.some((request) => request.expires_at)) {
+      this.startTicking();
+    } else {
+      this.stopTicking();
+    }
   }
 
   private connectWebSocket() {
@@ -414,8 +449,9 @@ export class ApprovalsView extends AuthedElement {
   private async loadApprovalRequests() {
     this.loading = true;
     try {
-      // Fetch approval requests (API max limit is 100)
-      const data = await this.fetchData('/api/v1/approval-requests?limit=100');
+      const data = await this.fetchData(
+        `/api/v1/approval-requests?limit=${APPROVAL_REQUESTS_PAGE_LIMIT}`
+      );
       if (data && Array.isArray(data)) {
         // Sort by requested_at descending (most recent first)
         this.approvalRequests = (data as ApprovalRequest[])
@@ -498,6 +534,15 @@ export class ApprovalsView extends AuthedElement {
   }
 
   private applyFilters() {
+    const now = this.nowMs;
+    const normalized = this.approvalRequests.map((request) =>
+      normalizeApprovalRequest(request, now)
+    );
+    if (normalized.some((request, i) => request !== this.approvalRequests[i])) {
+      this.approvalRequests = normalized;
+      this.calculateStats();
+    }
+
     let filtered = [...this.approvalRequests];
 
     // Status filter
@@ -528,9 +573,10 @@ export class ApprovalsView extends AuthedElement {
 
     // What still needs a person comes first, soonest expiry at the top; the
     // rest is history and keeps its newest-first order.
-    const { waiting, history } = partitionApprovalRequests(filtered);
+    const { waiting, history } = partitionApprovalRequests(filtered, now);
     this.waitingRequests = waiting;
     this.historyRequests = history;
+    this.syncExpiryTick();
   }
 
   private getUniqueTools(): string[] {
@@ -639,10 +685,22 @@ export class ApprovalsView extends AuthedElement {
   }
 
   /**
+   * Re-read the clock at click time so a row whose expiry passed between
+   * ticks cannot still post Approve or Deny.
+   */
+  private ensureStillWaiting(request: ApprovalRequest): boolean {
+    this.nowMs = Date.now();
+    if (isUnexpiredPendingRequest(request, this.nowMs)) return true;
+    this.applyFilters();
+    return false;
+  }
+
+  /**
    * Row-level approve: the same call the detail page makes, taken where the
    * request is seen. Approving is not destructive, so it does not confirm.
    */
   private async handleRowApprove(request: ApprovalRequest) {
+    if (!this.ensureStillWaiting(request)) return;
     this.decidingId = request.id;
     try {
       const updated = await approveRequest(request.id);
@@ -661,6 +719,7 @@ export class ApprovalsView extends AuthedElement {
 
   /** Denying stops the agent, so it confirms first (DESIGN.md destructive). */
   private async handleRowDeny(request: ApprovalRequest) {
+    if (!this.ensureStillWaiting(request)) return;
     const confirmed = await confirmDialog({
       title: 'Deny this request?',
       message: `${request.tool_name} will not run.`,
@@ -672,6 +731,7 @@ export class ApprovalsView extends AuthedElement {
       variant: 'danger',
     });
     if (!confirmed) return;
+    if (!this.ensureStillWaiting(request)) return;
     this.decidingId = request.id;
     try {
       const updated = await declineRequest(request.id);
@@ -1095,7 +1155,9 @@ export class ApprovalsView extends AuthedElement {
                           pill
                           class="chip"
                           variant=${
-                            isExpiringSoon(request) ? 'warning' : 'neutral'
+                            isExpiringSoon(request, this.nowMs)
+                              ? 'warning'
+                              : 'neutral'
                           }
                         >
                           <sl-icon name="hourglass"></sl-icon>


### PR DESCRIPTION
# Approvals: decide where you see it

## Summary

An approval that is waiting for a person should be decidable where the person
already is, and every label on the way should mean what it says. Today the
detail page hides the decision below a fold of JSON, the list mixes what is
waiting for you with what is already over, a pending row that has quietly timed
out still offers live buttons, and the Slack message offers "Approve" and
"Decline" links that approve and decline nothing (both open the same review
page).

This PR is section 3c of the UX report: one shared reading of approval state, a
sticky decision bar on the detail page, "Waiting for you" ahead of "History"
with the decision on the row, a post-decision line that points at the next thing
to do, sentence case and Deny (not Decline) throughout, and one honest "Review"
link in chat notifications.

Six commits, 10 files, +1678 / -583. No route changed, so `openapi.yaml` is
untouched.

## Changes per W1 item

### W1-6, E1: one reading of approval state (B-A0)

New `frontend/src/utils/approvals.ts`: `isUnexpiredPendingRequest`,
`normalizeApprovalRequest` (pending past `expires_at` becomes expired),
`millisUntilExpiry`, `isExpiringSoon` (5 minutes), `partitionApprovalRequests`
(waiting sorted by soonest expiry) and `approvalStatusLabel`. The list view had a
private copy of the expiry rule and the detail view had none, so the same request
read Pending on one screen and offered live buttons on the other. Both views now
normalise from the same place, on load and again against a one second tick.

### W1-6, E2: sticky decision bar (B-A1)

`approval-view.ts`: a sticky bar carries what will run, "<requester> is paused
until you decide", a countdown chip (amber under five minutes), an optional
comment and Approve (A) then Deny (D). Deny is `danger outline`, last, after a
`--sl-spacing-large` gap, and asks `confirmDialog` first; Approve does not
confirm. The in-card "Your Decision" block and the inline `sl-alert` are gone,
results are toasts. If the expiry passes with the page open, the bar disappears
and the page reads Timed out.

The decision keys listen on the document, stand down while the confirmation is
open, on `event.repeat`, while typing in a field, with modifiers, on questions,
while submitting and when the request is not live.

### W1-6, B-A3: heading wraps on a phone

`.header h1 { flex-wrap: wrap }` so the status chip stops overflowing at 375px.
Tested at a real 375px viewport with `setViewport`.

### W1-6, E4: "Waiting for you", then "History" (B-L1 client half)

`approvals-view.ts` partitions the list, renders "Waiting for you" first with a
count chip, and puts Approve / Deny / Details on waiting rows (Deny confirms,
Approve does not). History rows keep a "View" link. No checkboxes, no bulk
actions, no list keyboard navigation in this slice.

### W1-6, E11: after a decision, the next thing to do (B-A4)

`submitDecision` toasts the outcome and then renders "Back to approvals · Next
waiting (N)", or "Nothing else is waiting for you". The count comes from the
pending list filtered client side with the shared helper.

### W1-6, E12: terminology and the em dash

Decline is Deny everywhere in the approvals UI; statuses read Pending / Approved
/ Denied / Timed out / Cancelled. Sentence case on both views. Emoji status
labels removed. The page description drops the em dash and the "who approved,
who denied" claim the API does not back.

### W1-10, E10: one honest link in chat notifications

`approval_service.py`: the Slack / Mattermost message had "**Actions:**" with
"Approve", "Decline" and "View Details" links that were all the same review URL,
so a reader who clicked Approve had approved nothing. It now carries one
`[Review this request](...)` line and one primary "Review" button. The generic
webhook payload gained a `review` key and keeps `approve`, `decline` and `view`
(the same URL, as they always were) marked deprecated in a comment, so no
external receiver breaks; a comment points at
`POST /api/v1/approval-requests/{id}/approve|decline` for callers that want to
act.

## Review follow-ups (V-I1)

Applied on top of the first two commits:

1. The A and D keys could fire over the open deny confirmation (D then A
   approved behind the dialog, and confirming afterwards posted a decline the
   backend refused). A `confirming` flag plus an `event.repeat` guard.
2. The generic webhook payload kept its old `approve` / `decline` / `view` keys
   instead of dropping them: that is a machine contract, not a label a person
   reads. Deprecated in a comment, not removed.
3. The phone test rendered inside a 375px div, where media queries never fire.
   It now drives the browser viewport with `@web/test-runner-commands`
   `setViewport` (declared as a devDependency, it was already installed
   transitively). Verified it fails at 1280px.
4. The comment input had a placeholder and no label: it now has a visually
   hidden `label`, so the field has an accessible name.
5. `<kbd>A</kbd>` inside the button label was read out as "Approve A": the hints
   are `aria-hidden` with the shortcut in the button `title`.
6. `--sl-spacing-large` before the Deny button on the list row and in the phone
   override, matching DESIGN.md "Destructive actions".
7. The websocket handler skips its result toast once this page has taken the
   decision, so an echoed broadcast cannot toast the same outcome twice.

Deferred: the filled boxes inside the card (`.code-block`, `.reasoning-text`,
`.resolved-info`), the bordered stat cards and the bordered rows with coloured
left rules sit outside the DESIGN.md depth limit. They predate this branch and
section 3c routes them to E13, so they stay for the wave 2 brief.

Accepted as is: "Next waiting (N)" counts the first 100 pending requests. The
server side waiting count is the other half of B-L1 and is not in this slice.

Not in this PR (not in section 3c): E5 list keyboard navigation, E6 bulk
approve, E7 "Always allow this tool", E9 notification bell, B-L1 server half.

## Tests

| run | number |
| --- | --- |
| `cd frontend && npm test` | 1581 passed, 0 failed, 143 files (main baseline: 1556 / 142) |
| `src/utils/approvals.test.ts` + the two view tests | 46 passed |
| `backend/tests/services/test_approval_service.py` | 114 passed (112 on main) |
| `backend/tests/test_async_approval.py` | 30 passed |
| `pre-commit run --files` before each of the 6 commits | clean, no `openapi.yaml` diff |

New coverage: expiry normalisation and partition order; an expired pending
request renders Timed out with no bar and ignores the keys; A approves; D
confirms and only then denies; A over the open confirmation does nothing; a held
D does not re-ask; typing a comment does not fire the keys; the comment field has
a name and the key hints are hidden from screen readers; the websocket echo does
not toast twice; the post-decision line links the next waiting request; at a real
375px viewport the chip and the buttons stay inside the page; list headings and
order; row approve posts `{approved: true}`; row deny confirms first; a stale
pending row stays in History. Backend: the chat message offers exactly one review
link, the generic payload keeps its four action keys pointing at one URL.

Backend runs are against the local Postgres at alembic head. No migration was
added.

## Founder calls

1. Deprecated webhook keys. The generic payload now sends the same URL under
   four names (`review` plus the three old ones). Do we announce a removal date
   for `approve` / `decline` / `view` in the changelog, or leave them
   indefinitely?
2. Approve without a confirmation, Deny with one. The asymmetry is deliberate
   (denying stops an agent that is waiting), but it means the A key decides
   immediately. Say the word and Approve gets a confirmation too, or an undo
   window instead.
3. The decision keys are undocumented outside the small hint on the buttons. If
   we want them discoverable, that is a shortcuts legend, which is E5 territory
   and a later slice.
4. Depth limit: the card internals (finding 8 above) still use filled boxes and
   bordered stat cards. Confirm E13 is where that gets fixed rather than here.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low]**
> Changes the human-approval decision flow (list, detail, and chat notifications). Well-tested and backward-compatible; all previously raised findings are addressed.
>
> **Overview**
> Section 3c of the UX report: a shared approval-state helper, a sticky decision bar, "Waiting for you"/"History" grouping with row-level Approve/Deny, and one honest "Review" link in chat notifications. No route changed.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit b1c79a69. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->