### PR TITLE
Expose and preserve execution timeout in flow forms

### DIFF
--- a/frontend/src/components/preloop-flow-form-timeout.test.ts
+++ b/frontend/src/components/preloop-flow-form-timeout.test.ts
@@ -3,6 +3,10 @@ import sinon, { SinonSandbox } from 'sinon';
 import type SlInput from '@shoelace-style/shoelace/dist/components/input/input.js';
 import './preloop-flow-form.ts';
 import type { PreloopFlowForm } from './preloop-flow-form';
+import {
+  FLOW_TIMEOUT_MAX_SECONDS,
+  FLOW_TIMEOUT_MIN_SECONDS,
+} from './preloop-flow-form';
 
 const preset = {
   id: 'timeout-preset',
@@ -116,7 +120,11 @@ describe('PreloopFlowForm execution timeout', () => {
     expect((await submit(element)).timeout_seconds).to.equal(5400);
   });
 
-  for (const value of [60, 90, 86400]) {
+  for (const value of [
+    FLOW_TIMEOUT_MIN_SECONDS,
+    90,
+    FLOW_TIMEOUT_MAX_SECONDS,
+  ]) {
     it(`submits valid whole seconds without rounding: ${value}`, async () => {
       const element = await mount();
       await enter(element, String(value));
@@ -124,7 +132,13 @@ describe('PreloopFlowForm execution timeout', () => {
     });
   }
 
-  for (const value of [0, 59, 86401, 60.5, NaN]) {
+  for (const value of [
+    0,
+    FLOW_TIMEOUT_MIN_SECONDS - 1,
+    FLOW_TIMEOUT_MAX_SECONDS + 1,
+    60.5,
+    NaN,
+  ]) {
     it(`rejects invalid timeout ${value} before submission`, async () => {
       const element = await mount(value);
       const listener = sandbox.spy();
@@ -133,7 +147,7 @@ describe('PreloopFlowForm execution timeout', () => {
       await element.updateComplete;
       expect(listener.callCount).to.equal(0);
       expect(element.shadowRoot!.textContent).to.include(
-        'whole number between 60 and 86400 seconds'
+        `whole number between ${FLOW_TIMEOUT_MIN_SECONDS} and ${FLOW_TIMEOUT_MAX_SECONDS} seconds`
       );
     });
   }

--- a/frontend/src/components/preloop-flow-form-timeout.test.ts
+++ b/frontend/src/components/preloop-flow-form-timeout.test.ts
@@ -1,0 +1,140 @@
+import { expect, fixture, fixtureCleanup, html } from '@open-wc/testing';
+import sinon, { SinonSandbox } from 'sinon';
+import type SlInput from '@shoelace-style/shoelace/dist/components/input/input.js';
+import './preloop-flow-form.ts';
+import type { PreloopFlowForm } from './preloop-flow-form';
+
+const preset = {
+  id: 'timeout-preset',
+  name: 'Implementation',
+  prompt_template: 'Implement the issue',
+  agent_type: 'codex',
+  trigger_event_types: ['webhook'],
+  timeout_seconds: 5400,
+};
+
+describe('PreloopFlowForm execution timeout', () => {
+  let sandbox: SinonSandbox;
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    sandbox = sinon.createSandbox();
+    sandbox
+      .stub(window, 'fetch')
+      .callsFake(
+        async (url) =>
+          new Response(
+            JSON.stringify(
+              String(url).includes('/api/v1/flows/presets') ? [preset] : []
+            )
+          )
+      );
+  });
+
+  afterEach(() => {
+    fixtureCleanup();
+    sandbox.restore();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  const mount = async (timeout?: number | null): Promise<PreloopFlowForm> => {
+    const flow = {
+      name: 'Issue fixer',
+      prompt_template: 'Fix it',
+      agent_type: 'codex',
+      timeout_seconds: timeout,
+    };
+    const element = await fixture<PreloopFlowForm>(
+      html`<preloop-flow-form .flow=${flow}></preloop-flow-form>`
+    );
+    while ((element as any)._loadingReferenceData) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    await element.updateComplete;
+    return element;
+  };
+
+  const input = (element: PreloopFlowForm): SlInput => {
+    const control = element.shadowRoot!.querySelector<SlInput>(
+      'sl-input[name="timeout_seconds"]'
+    );
+    expect(control, 'Execution timeout control').to.exist;
+    return control!;
+  };
+
+  const submit = async (
+    element: PreloopFlowForm
+  ): Promise<Record<string, unknown>> => {
+    const listener = sandbox.spy();
+    element.addEventListener('flow-submit', listener);
+    await (element as any).handleFormSubmit(new Event('submit'));
+    expect(listener.callCount).to.equal(1);
+    return listener.firstCall.args[0].detail.flow;
+  };
+
+  const enter = async (
+    element: PreloopFlowForm,
+    value: string
+  ): Promise<void> => {
+    const control = input(element);
+    control.value = value;
+    control.dispatchEvent(new CustomEvent('sl-input', { bubbles: true }));
+    await element.updateComplete;
+  };
+
+  it('shows and preserves an existing timeout when editing other fields', async () => {
+    const element = await mount(5400);
+    element.flow = {
+      ...element.flow,
+      id: 'flow-1',
+      description: 'Updated description',
+    };
+    await element.updateComplete;
+    expect(input(element).value).to.equal('5400');
+    expect((await submit(element)).timeout_seconds).to.equal(5400);
+  });
+
+  it('keeps blank on a new flow and submits the deployment default explicitly', async () => {
+    const element = await mount();
+    expect(input(element).value).to.equal('');
+    expect((await submit(element)).timeout_seconds).to.equal(null);
+  });
+
+  it('clears a saved override with null', async () => {
+    const element = await mount(5400);
+    await enter(element, '');
+    expect((await submit(element)).timeout_seconds).to.equal(null);
+  });
+
+  it('preserves a selected preset timeout in the control and payload', async () => {
+    const element = await mount();
+    await (element as any).applyPresetSelection(preset.id);
+    await element.updateComplete;
+    expect(input(element).value).to.equal('5400');
+    expect((await submit(element)).timeout_seconds).to.equal(5400);
+  });
+
+  for (const value of [60, 90, 86400]) {
+    it(`submits valid whole seconds without rounding: ${value}`, async () => {
+      const element = await mount();
+      await enter(element, String(value));
+      expect((await submit(element)).timeout_seconds).to.equal(value);
+    });
+  }
+
+  for (const value of [0, 59, 86401, 60.5, NaN]) {
+    it(`rejects invalid timeout ${value} before submission`, async () => {
+      const element = await mount(value);
+      const listener = sandbox.spy();
+      element.addEventListener('flow-submit', listener);
+      await (element as any).handleFormSubmit(new Event('submit'));
+      await element.updateComplete;
+      expect(listener.callCount).to.equal(0);
+      expect(element.shadowRoot!.textContent).to.include(
+        'whole number between 60 and 86400 seconds'
+      );
+    });
+  }
+});

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -640,6 +640,18 @@ export class PreloopFlowForm extends LitElement {
       return;
     }
 
+    const timeoutSeconds = this.flow.timeout_seconds ?? null;
+    if (
+      timeoutSeconds !== null &&
+      (!Number.isInteger(timeoutSeconds) ||
+        timeoutSeconds < 60 ||
+        timeoutSeconds > 86400)
+    ) {
+      this.formError =
+        'Execution timeout must be a whole number between 60 and 86400 seconds, or blank for the deployment default.';
+      return;
+    }
+
     this.isSaving = true;
     try {
       const payload: any = {
@@ -673,6 +685,8 @@ export class PreloopFlowForm extends LitElement {
             : null,
         git_clone_config: this.flow.git_clone_config || { enabled: false },
         notifications: this.flow.notifications || defaultFlowNotifications(),
+        // Explicit null clears a saved override and restores the deployment default.
+        timeout_seconds: timeoutSeconds,
         max_iterations: this.flow.max_iterations || undefined,
         max_budget: this.flow.max_budget || undefined,
         is_enabled: this.flow.is_enabled ?? true,
@@ -1992,6 +2006,19 @@ export class PreloopFlowForm extends LitElement {
             Boundaries
           </div>
           <div class="form-grid">
+            <sl-input
+              type="number"
+              name="timeout_seconds"
+              label="Execution timeout (seconds)"
+              min="60"
+              max="86400"
+              step="1"
+              placeholder="Deployment default"
+              help-text="Maximum duration of one execution: 60–86400 seconds (1 minute–24 hours). Leave blank to use the deployment default."
+              .value=${this.flow.timeout_seconds == null ? '' : String(this.flow.timeout_seconds)}
+              @sl-input=${(e: Event) => this.handleInputChange('timeout_seconds', e)}
+            ></sl-input>
+
             <sl-input
               type="number"
               label="Maximum Iteration Count"

--- a/frontend/src/components/preloop-flow-form.ts
+++ b/frontend/src/components/preloop-flow-form.ts
@@ -41,6 +41,10 @@ import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 
+/** Matches the API `timeout_seconds` constraint `ge=60, le=86400`. */
+export const FLOW_TIMEOUT_MIN_SECONDS = 60;
+export const FLOW_TIMEOUT_MAX_SECONDS = 86400;
+
 @customElement('preloop-flow-form')
 export class PreloopFlowForm extends LitElement {
   static styles = [
@@ -644,11 +648,10 @@ export class PreloopFlowForm extends LitElement {
     if (
       timeoutSeconds !== null &&
       (!Number.isInteger(timeoutSeconds) ||
-        timeoutSeconds < 60 ||
-        timeoutSeconds > 86400)
+        timeoutSeconds < FLOW_TIMEOUT_MIN_SECONDS ||
+        timeoutSeconds > FLOW_TIMEOUT_MAX_SECONDS)
     ) {
-      this.formError =
-        'Execution timeout must be a whole number between 60 and 86400 seconds, or blank for the deployment default.';
+      this.formError = `Execution timeout must be a whole number between ${FLOW_TIMEOUT_MIN_SECONDS} and ${FLOW_TIMEOUT_MAX_SECONDS} seconds, or blank for the deployment default.`;
       return;
     }
 
@@ -2010,11 +2013,11 @@ export class PreloopFlowForm extends LitElement {
               type="number"
               name="timeout_seconds"
               label="Execution timeout (seconds)"
-              min="60"
-              max="86400"
+              min=${FLOW_TIMEOUT_MIN_SECONDS}
+              max=${FLOW_TIMEOUT_MAX_SECONDS}
               step="1"
               placeholder="Deployment default"
-              help-text="Maximum duration of one execution: 60–86400 seconds (1 minute–24 hours). Leave blank to use the deployment default."
+              help-text=${`Maximum duration of one execution: ${FLOW_TIMEOUT_MIN_SECONDS}–${FLOW_TIMEOUT_MAX_SECONDS} seconds (1 minute–24 hours). Leave blank to use the deployment default.`}
               .value=${this.flow.timeout_seconds == null ? '' : String(this.flow.timeout_seconds)}
               @sl-input=${(e: Event) => this.handleInputChange('timeout_seconds', e)}
             ></sl-input>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -110,6 +110,7 @@ export interface Flow {
   git_clone_config?: GitCloneConfig;
   notifications?: FlowNotifications | null;
   custom_commands?: FlowCustomCommands;
+  timeout_seconds?: number | null;
   max_iterations?: number | null;
   max_budget?: number | null;
   is_preset?: boolean;


### PR DESCRIPTION
## Summary

The flow form copied preset timeout values but omitted them when saving and offered no timeout control. Add execution timeout under Execution Limits, preserve saved and preset values, and send explicit null when cleared to restore the deployment default.

Validate whole seconds from 60 to 86400, matching the API. This independent fix has no continuation or environment-stack dependency.

## Testing

- [ ] Backend tests: not applicable; API behavior is unchanged.
- [x] Frontend tests: all 57 flow-form browser tests passed, including 12 new timeout cases that failed before the fix. Cases cover saved/preset values, clearing, boundaries, invalid values and non-minute values without rounding.
- [x] Manual validation: inspected isolated review diff; only three frontend files changed. Pre-commit passed. Conflict-free regrouping has identical patch ID and file blobs to the tested commit.

## Checklist

- [x] Docs updated if needed: field help documents units, bounds and deployment default.
- [ ] Changelog updated if needed: no standalone changelog entry added.
- [x] No secrets included

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Small, well-tested frontend-only change adding a validated execution-timeout field; bounds match the backend API and are now shared constants.
>
> **Overview**
> Exposes and preserves the flow `timeout_seconds` field in the flow form: shows saved/preset values, validates whole seconds 60–86400, and sends explicit `null` on clear to restore the deployment default. No outstanding issues.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 60962e8b. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->