### PR TITLE
Auth: /auth/me carries the caller's user id, account id and team ids

### DIFF
--- a/backend/preloop/api/auth/router.py
+++ b/backend/preloop/api/auth/router.py
@@ -69,6 +69,7 @@ from preloop.utils.tokens import (
 from preloop.models.crud import (
     crud_account,
     crud_audit_log,
+    crud_team,
     crud_user,
     crud_api_key,
     crud_api_usage,
@@ -82,7 +83,6 @@ from preloop.models.crud import (
 from preloop.models.db.session import get_db_session
 from preloop.models.models.user import User as UserModel
 from preloop.models.models.api_key import ApiKey
-from preloop.models.models.team import Team, TeamMembership
 from pydantic import BaseModel
 from preloop.services.account_realtime import (
     ACCOUNT_TOPIC_AUDIT,
@@ -220,22 +220,18 @@ def _resolve_team_ids(user: UserModel, db: Session) -> List[UUID]:
     caller's account scopes everything else it can see.
     """
     try:
-        rows = (
-            db.query(Team.id)
-            .join(TeamMembership, Team.id == TeamMembership.team_id)
-            .filter(
-                TeamMembership.user_id == user.id,
-                Team.account_id == user.account_id,
-            )
-            .order_by(Team.name)
-            .all()
+        teams = crud_team.get_user_teams(
+            db,
+            user_id=user.id,
+            account_id=user.account_id,
+            limit=None,
         )
     except Exception:
         # Same rule as permissions above: never 500 /users/me over an
         # optional field.
         logger.exception("Failed to resolve team memberships; returning empty list")
         return []
-    return [row[0] for row in rows]
+    return [team.id for team in teams]
 
 
 def _build_auth_user_response(user: UserModel, db: Session) -> AuthUserResponse:

--- a/backend/preloop/api/auth/router.py
+++ b/backend/preloop/api/auth/router.py
@@ -82,6 +82,7 @@ from preloop.models.crud import (
 from preloop.models.db.session import get_db_session
 from preloop.models.models.user import User as UserModel
 from preloop.models.models.api_key import ApiKey
+from preloop.models.models.team import Team, TeamMembership
 from pydantic import BaseModel
 from preloop.services.account_realtime import (
     ACCOUNT_TOPIC_AUDIT,
@@ -205,6 +206,53 @@ def _resolve_user_permissions(user: UserModel, db: Session) -> Optional[List[str
         # RBAC is optional on this path; never 500 /users/me for permission lookup.
         logger.exception("Failed to resolve user permissions; returning None")
         return None
+
+
+def _resolve_team_ids(user: UserModel, db: Session) -> List[UUID]:
+    """Return the ids of the teams the user belongs to, inside their account.
+
+    Approval workflows name their approvers as ``approver_user_ids`` and
+    ``approver_team_ids``. Without team membership a client (web, iOS,
+    Android) cannot tell whether a pending approval is waiting for the person
+    holding the session, so it is returned with the profile.
+
+    Memberships pointing at a team in another account are excluded: the
+    caller's account scopes everything else it can see.
+    """
+    try:
+        rows = (
+            db.query(Team.id)
+            .join(TeamMembership, Team.id == TeamMembership.team_id)
+            .filter(
+                TeamMembership.user_id == user.id,
+                Team.account_id == user.account_id,
+            )
+            .order_by(Team.name)
+            .all()
+        )
+    except Exception:
+        # Same rule as permissions above: never 500 /users/me over an
+        # optional field.
+        logger.exception("Failed to resolve team memberships; returning empty list")
+        return []
+    return [row[0] for row in rows]
+
+
+def _build_auth_user_response(user: UserModel, db: Session) -> AuthUserResponse:
+    """Build the profile payload returned by the ``/users/me`` endpoints."""
+    return AuthUserResponse(
+        id=user.id,
+        account_id=user.account_id,
+        username=user.username,
+        email=user.email,
+        full_name=user.full_name,
+        email_verified=user.email_verified,
+        is_superuser=bool(user.is_superuser),
+        permissions=_resolve_user_permissions(user, db),
+        avatar_url=user.avatar_url,
+        avatar_source=user.avatar_source,
+        team_ids=_resolve_team_ids(user, db),
+    )
 
 
 def _api_key_activity_status(
@@ -418,7 +466,7 @@ async def register(
     background_tasks: BackgroundTasks,
     request: Request,
     db: Session = Depends(get_db_session),
-) -> Dict[str, str]:
+) -> Dict[str, Any]:
     """Register a new user.
 
     Args:
@@ -579,11 +627,16 @@ async def register(
         logger.info("[REGISTER] Account setup tasks scheduled")
 
         logger.info("[REGISTER] Registration complete, returning response")
+        # A brand new user is in no team yet, so team_ids is empty here; the
+        # identity fields still ship so the response matches AuthUserResponse.
         return {
+            "id": new_user.id,
+            "account_id": new_account.id,
             "username": new_user.username,
             "email": new_user.email,
             "full_name": new_user.full_name,
             "email_verified": new_user.email_verified,
+            "team_ids": [],
         }
     except IntegrityError:
         session.rollback()
@@ -941,18 +994,10 @@ def read_users_me(
         current_user: The current user.
 
     Returns:
-        The current user.
+        The current user, including the identity fields (id, account_id,
+        team_ids) clients need to answer "is this waiting for me?".
     """
-    return AuthUserResponse(
-        username=current_user.username,
-        email=current_user.email,
-        full_name=current_user.full_name,
-        email_verified=current_user.email_verified,
-        is_superuser=bool(current_user.is_superuser),
-        permissions=_resolve_user_permissions(current_user, db),
-        avatar_url=current_user.avatar_url,
-        avatar_source=current_user.avatar_source,
-    )
+    return _build_auth_user_response(current_user, db)
 
 
 @router.put("/users/me", response_model=AuthUserResponse)
@@ -961,10 +1006,10 @@ def update_user_me(
     db: Session = Depends(get_db_session),
     user_update: AuthUserUpdate,
     current_user: UserModel = Depends(get_current_active_user),
-) -> Any:
+) -> AuthUserResponse:
     """Update own user."""
     user = crud_user.update(db, db_obj=current_user, obj_in=user_update)
-    return user
+    return _build_auth_user_response(user, db)
 
 
 @router.put("/users/me/password", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/preloop/models/crud/team.py
+++ b/backend/preloop/models/crud/team.py
@@ -156,27 +156,37 @@ class CRUDTeam(CRUDBase[Team]):
         return False
 
     def get_user_teams(
-        self, db: Session, *, user_id: uuid.UUID, skip: int = 0, limit: int = 100
+        self,
+        db: Session,
+        *,
+        user_id: uuid.UUID,
+        account_id: Optional[uuid.UUID] = None,
+        skip: int = 0,
+        limit: Optional[int] = 100,
     ) -> List[Team]:
         """Get all teams a user is a member of.
 
         Args:
             db: Database session.
             user_id: User ID.
+            account_id: When set, only teams belonging to this account.
             skip: Number of records to skip.
-            limit: Maximum number of records to return.
+            limit: Maximum number of records to return. ``None`` means no cap.
 
         Returns:
-            List of teams.
+            Teams ordered by name.
         """
-        return (
+        query = (
             db.query(Team)
             .join(TeamMembership, Team.id == TeamMembership.team_id)
             .filter(TeamMembership.user_id == user_id)
-            .offset(skip)
-            .limit(limit)
-            .all()
         )
+        if account_id is not None:
+            query = query.filter(Team.account_id == account_id)
+        query = query.order_by(Team.name).offset(skip)
+        if limit is not None:
+            query = query.limit(limit)
+        return query.all()
 
 
 # Create instance

--- a/backend/preloop/schemas/auth.py
+++ b/backend/preloop/schemas/auth.py
@@ -82,6 +82,15 @@ class AuthUserResponse(BaseModel):
 
     model_config = {"title": "AuthUserResponse"}
 
+    id: UUID = Field(
+        ...,
+        description=(
+            "The caller's user id. Clients compare it against an approval "
+            "workflow's approver_user_ids to tell whether a pending approval "
+            "is waiting for this person."
+        ),
+    )
+    account_id: UUID = Field(..., description="The account this user belongs to.")
     username: str
     email: EmailStr
     full_name: Optional[str] = None
@@ -90,6 +99,15 @@ class AuthUserResponse(BaseModel):
     permissions: Optional[List[str]] = None
     avatar_url: Optional[str] = None
     avatar_source: Optional[str] = None
+    team_ids: List[UUID] = Field(
+        ...,
+        description=(
+            "Ids of the teams the caller belongs to inside account_id. "
+            "Clients intersect these with an approval workflow's "
+            "approver_team_ids to tell whether a pending approval is waiting "
+            "for this person. Empty when the user is in no team."
+        ),
+    )
 
 
 class LoginRequest(BaseModel):

--- a/backend/tests/api/test_auth_me_identity.py
+++ b/backend/tests/api/test_auth_me_identity.py
@@ -1,0 +1,95 @@
+"""Real-DB tests for the identity fields on GET /api/v1/auth/users/me.
+
+Mobile and web surfaces answer "is this pending approval waiting for me?" by
+intersecting the caller's identity with an approval workflow's
+``approver_user_ids`` / ``approver_team_ids``. That needs the profile endpoint
+to carry the caller's user id, account id and team ids.
+"""
+
+from unittest.mock import MagicMock
+
+from sqlalchemy.orm import Session
+
+from preloop.api.auth import router as auth_router
+from preloop.models.crud import crud_account
+from preloop.models.models.team import Team, TeamMembership
+from preloop.models.models.user import User
+
+ME_PATH = "/api/v1/auth/users/me"
+
+
+def _make_team(db_session: Session, *, account_id, name: str) -> Team:
+    team = Team(account_id=account_id, name=name)
+    db_session.add(team)
+    db_session.flush()
+    return team
+
+
+def _join(db_session: Session, *, team: Team, user: User) -> None:
+    db_session.add(TeamMembership(team_id=team.id, user_id=user.id))
+    db_session.flush()
+
+
+def test_me_returns_identity_without_teams(client, test_user: User):
+    """A user in no team gets id, account_id and an empty team_ids."""
+    response = client.get(ME_PATH)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == str(test_user.id)
+    assert body["account_id"] == str(test_user.account_id)
+    assert body["team_ids"] == []
+    # Existing fields are untouched.
+    assert body["username"] == test_user.username
+    assert body["email"] == test_user.email
+
+
+def test_me_returns_both_team_ids(client, db_session: Session, test_user: User):
+    """A user in two teams gets both team ids."""
+    alpha = _make_team(db_session, account_id=test_user.account_id, name="Alpha team")
+    beta = _make_team(db_session, account_id=test_user.account_id, name="Beta team")
+    _join(db_session, team=alpha, user=test_user)
+    _join(db_session, team=beta, user=test_user)
+
+    body = client.get(ME_PATH).json()
+
+    assert body["team_ids"] == [str(alpha.id), str(beta.id)]
+
+
+def test_me_omits_teams_from_other_accounts(
+    client, db_session: Session, test_user: User
+):
+    """Only teams inside the caller's account are reported."""
+    mine = _make_team(db_session, account_id=test_user.account_id, name="Mine")
+    other_account = crud_account.create(
+        db_session,
+        obj_in={"organization_name": "Other Organization", "is_active": True},
+    )
+    theirs = _make_team(db_session, account_id=other_account.id, name="Theirs")
+    _join(db_session, team=mine, user=test_user)
+    _join(db_session, team=theirs, user=test_user)
+
+    body = client.get(ME_PATH).json()
+
+    assert body["team_ids"] == [str(mine.id)]
+
+
+def test_resolve_team_ids_reads_memberships(db_session: Session, test_user: User):
+    """The resolver itself returns team ids ordered by team name."""
+    zulu = _make_team(db_session, account_id=test_user.account_id, name="Zulu")
+    alpha = _make_team(db_session, account_id=test_user.account_id, name="Alpha")
+    _join(db_session, team=zulu, user=test_user)
+    _join(db_session, team=alpha, user=test_user)
+
+    assert auth_router._resolve_team_ids(test_user, db_session) == [
+        alpha.id,
+        zulu.id,
+    ]
+
+
+def test_resolve_team_ids_soft_fails_on_db_error():
+    """A broken lookup must not 500 the profile endpoint."""
+    db = MagicMock()
+    db.query.side_effect = RuntimeError("db unavailable")
+
+    assert auth_router._resolve_team_ids(MagicMock(), db) == []

--- a/backend/tests/endpoints/test_auth.py
+++ b/backend/tests/endpoints/test_auth.py
@@ -39,7 +39,29 @@ def db_session_mock():
 
 
 def test_register_user_success(db_session_mock):
-    with patch("preloop.api.auth.router.complete_new_account_setup_background"):
+    # The registration response carries the new user's identity (id,
+    # account_id), so the mocked CRUD layer must hand back rows with ids: a
+    # model built against a MagicMock session is never flushed and would
+    # otherwise keep id=None.
+    account_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    with (
+        patch("preloop.api.auth.router.complete_new_account_setup_background"),
+        patch("preloop.api.auth.router.crud_account") as mock_account,
+        patch("preloop.api.auth.router.crud_user") as mock_user_crud,
+    ):
+        mock_account.create.return_value = MagicMock(id=account_id)
+        mock_user_crud.get_by_username.return_value = None
+        mock_user_crud.get_by_email.return_value = None
+        mock_user_crud.create.return_value = MagicMock(
+            id=user_id,
+            account_id=account_id,
+            username="testuser",
+            email="test@example.com",
+            full_name="Test User",
+            email_verified=False,
+        )
+
         response = client.post(
             "/auth/register",
             json={
@@ -51,10 +73,13 @@ def test_register_user_success(db_session_mock):
         )
         assert response.status_code == 201
         data = response.json()
+        assert data["id"] == str(user_id)
+        assert data["account_id"] == str(account_id)
         assert data["username"] == "testuser"
         assert data["email"] == "test@example.com"
         assert data["full_name"] == "Test User"
         assert not data["email_verified"]
+        assert data["team_ids"] == []
 
 
 def test_register_user_username_exists(db_session_mock):

--- a/backend/tests/test_auth_schema.py
+++ b/backend/tests/test_auth_schema.py
@@ -216,24 +216,45 @@ class TestAuthUserResponse:
 
     def test_create_user_response(self):
         """Test creating AuthUserResponse."""
+        user_id = uuid4()
+        account_id = uuid4()
+        team_id = uuid4()
         response = AuthUserResponse(
+            id=user_id,
+            account_id=account_id,
             username="testuser",
             email="test@example.com",
             full_name="Test User",
             email_verified=True,
+            team_ids=[team_id],
         )
 
+        assert response.id == user_id
+        assert response.account_id == account_id
         assert response.username == "testuser"
         assert response.email == "test@example.com"
         assert response.full_name == "Test User"
         assert response.email_verified is True
+        assert response.team_ids == [team_id]
 
     def test_email_verified_required(self):
         """Test that email_verified is required."""
         with pytest.raises(ValidationError):
             AuthUserResponse(
+                id=uuid4(),
+                account_id=uuid4(),
                 username="testuser",
                 email="test@example.com",
+                team_ids=[],
+            )
+
+    def test_identity_fields_required(self):
+        """id, account_id and team_ids are part of the profile contract."""
+        with pytest.raises(ValidationError):
+            AuthUserResponse(
+                username="testuser",
+                email="test@example.com",
+                email_verified=True,
             )
 
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2297,6 +2297,9 @@ export async function commitIssueDependencies(
 }
 
 export interface UserProfile {
+  /** The caller's user id. Matches an approval workflow's approver_user_ids. */
+  id: string;
+  account_id: string;
   username: string;
   email: string;
   full_name?: string | null;
@@ -2306,6 +2309,11 @@ export interface UserProfile {
   permissions?: string[] | null;
   avatar_url?: string | null;
   avatar_source?: string | null;
+  /**
+   * Teams the caller belongs to in account_id. Intersect with an approval
+   * workflow's approver_team_ids to tell whether an approval waits on them.
+   */
+  team_ids: string[];
 }
 
 export interface AvatarResponse {

--- a/frontend/src/components/budget-policy-editor.ts
+++ b/frontend/src/components/budget-policy-editor.ts
@@ -357,8 +357,9 @@ export class BudgetPolicyEditor extends LitElement {
       this.agents = agentsResponse.items || [];
       this.availableUsers = (usersRes as UserListResponse).users || [];
       this.teams = teamsResponse.teams || [];
-      // /auth/users/me has no `id` (AuthUserResponse). Using userProfile.id
-      // anyway posted `[null]` and the API 422'd on UUID validation.
+      // /auth/users/me now returns `id`, but a server older than that field
+      // sends none: the email fallback below keeps this from posting `[null]`,
+      // which the API 422'd on UUID validation.
       const selfId = this.currentUserNotifyId(userProfile);
       if (
         selfId &&
@@ -456,9 +457,9 @@ export class BudgetPolicyEditor extends LitElement {
   }
 
   /**
-   * `/auth/users/me` does not include `id`. Prefer a real string, then the
-   * account user list matched by email (case-insensitive), otherwise leave
-   * recipients empty rather than posting `[null]`.
+   * Prefer the `id` from `/auth/users/me`, then the account user list matched
+   * by email (case-insensitive) for servers that predate that field,
+   * otherwise leave recipients empty rather than posting `[null]`.
    */
   private currentUserNotifyId(
     userProfile: { id?: unknown; email?: string } | null

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -221,7 +221,9 @@ paths:
       - Auth
       summary: Read Users Me
       description: "Get the current user.\n\nArgs:\n    current_user: The current\
-        \ user.\n\nReturns:\n    The current user."
+        \ user.\n\nReturns:\n    The current user, including the identity fields (id,\
+        \ account_id,\n    team_ids) clients need to answer \"is this waiting for\
+        \ me?\"."
       operationId: read_users_me_api_v1_auth_users_me_get
       responses:
         '200':
@@ -12341,6 +12343,18 @@ components:
       description: User creation model.
     AuthUserResponse:
       properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+          description: The caller's user id. Clients compare it against an approval
+            workflow's approver_user_ids to tell whether a pending approval is waiting
+            for this person.
+        account_id:
+          type: string
+          format: uuid
+          title: Account Id
+          description: The account this user belongs to.
         username:
           type: string
           title: Username
@@ -12377,11 +12391,24 @@ components:
           - type: string
           - type: 'null'
           title: Avatar Source
+        team_ids:
+          items:
+            type: string
+            format: uuid
+          type: array
+          title: Team Ids
+          description: Ids of the teams the caller belongs to inside account_id. Clients
+            intersect these with an approval workflow's approver_team_ids to tell
+            whether a pending approval is waiting for this person. Empty when the
+            user is in no team.
       type: object
       required:
+      - id
+      - account_id
       - username
       - email
       - email_verified
+      - team_ids
       title: AuthUserResponse
       description: Response model for user data.
     AuthUserUpdate:


### PR DESCRIPTION
Why: the iOS (preloop-ios!20) and Android (preloop-android!13) console-layout apps need to compute "Waiting for you" (pending approvals where the caller is a direct approver or a member of an approver team); the me response had no user id and no team membership.

Not Fable-reviewed (founder asked for minimal Fable use this hour); Opus implementer report follows.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Additive API change (new identity fields on `/auth/me` and `/register`) with real-DB test coverage and no security implications.
>
> **Overview**
> Adds the caller's `id`, `account_id`, and `team_ids` to the `/users/me` and `/register` responses so iOS/Android console apps can determine whether a pending approval is waiting for the current user. Account-scoped team membership is computed via a new resolver and exposed through a shared response builder.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit cd917f88. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->