### PR TITLE
Console: Sessions collection bar, Overview header and feed, agent detail chips and copy (UX round 4, wave 2)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,6 +2,7 @@ import { LitElement } from 'lit';
 import { Router } from '@vaadin/router';
 import { DEFAULT_SIMILARITY_THRESHOLD } from './config';
 import { PermissionError, permissionErrorFromResponse } from './permissions';
+import { ATTENTION_SUMMARY_STORAGE_KEY } from './utils/attention-summary';
 import type {
   ApprovalBypass,
   ApprovalBypassMode,
@@ -118,6 +119,10 @@ export function invalidateApiCaches(): void {
   if (typeof sessionStorage !== 'undefined') {
     try {
       sessionStorage.removeItem('preloop.agents.gateway_summary.v1');
+      // The bell reads these counts from sessionStorage, which survives the
+      // full page navigation sign-out does, so without this the next account
+      // could be told the previous account's attention counts.
+      sessionStorage.removeItem(ATTENTION_SUMMARY_STORAGE_KEY);
       for (let i = sessionStorage.length - 1; i >= 0; i -= 1) {
         const key = sessionStorage.key(i);
         if (key?.startsWith('preloop.cost.previous_summary.v1:')) {

--- a/frontend/src/components/activity-feed.test.ts
+++ b/frontend/src/components/activity-feed.test.ts
@@ -1026,6 +1026,29 @@ describe('activity-feed', () => {
       );
     });
 
+    it('measures after the frame, not inside the update cycle', async () => {
+      const el = await fixture<ActivityFeed>(
+        html`<activity-feed
+          style="--activity-feed-list-max-height: 90px;"
+        ></activity-feed>`
+      );
+      ingestSessions(el, 8);
+      await el.updateComplete;
+      await waitUntil(
+        () => Boolean(el.shadowRoot!.querySelector('.footer .more')),
+        'overflow count never rendered'
+      );
+      while (el.isUpdatePending) await el.updateComplete;
+
+      // One more row changes the count. The count is a @state, so writing it
+      // from updated() left the element dirty the moment the update finished,
+      // which is a second render pass per feed event plus Lit's "scheduled an
+      // update after an update completed" warning in dev.
+      ingestSessions(el, 9);
+      await el.updateComplete;
+      expect(el.isUpdatePending).to.equal(false);
+    });
+
     it('says nothing when the list fits', async () => {
       const el = await fixture<ActivityFeed>(
         html`<activity-feed></activity-feed>`

--- a/frontend/src/components/activity-feed.test.ts
+++ b/frontend/src/components/activity-feed.test.ts
@@ -1,4 +1,5 @@
 import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
 import './activity-feed.ts';
 import {
   AUDIT_PAGE_SIZE,
@@ -1047,6 +1048,33 @@ describe('activity-feed', () => {
       ingestSessions(el, 9);
       await el.updateComplete;
       expect(el.isUpdatePending).to.equal(false);
+    });
+
+    it('coalesces scroll through scheduleMeasure', async () => {
+      const el = await fixture<ActivityFeed>(
+        html`<activity-feed
+          style="--activity-feed-list-max-height: 90px;"
+        ></activity-feed>`
+      );
+      ingestSessions(el, 8);
+      await el.updateComplete;
+      await waitUntil(
+        () => Boolean(el.shadowRoot!.querySelector('.footer .more')),
+        'overflow count never rendered'
+      );
+
+      const schedule = sinon.spy(el as any, 'scheduleMeasure');
+      const measure = sinon.spy(el as any, 'measureBelowFold');
+      try {
+        el.shadowRoot!.querySelector('.rows')!.dispatchEvent(
+          new Event('scroll')
+        );
+        expect(schedule.called).to.equal(true);
+        expect(measure.called).to.equal(false);
+      } finally {
+        schedule.restore();
+        measure.restore();
+      }
     });
 
     it('says nothing when the list fits', async () => {

--- a/frontend/src/components/activity-feed.test.ts
+++ b/frontend/src/components/activity-feed.test.ts
@@ -984,6 +984,60 @@ describe('activity-feed', () => {
     });
   });
 
+  /**
+   * The rail bounds the list, so a full feed always overflows. Without a
+   * count in the footer the card read as broken rather than scrollable: no
+   * visible scrollbar, and a row clipped mid-line as the only hint.
+   */
+  describe('overflow footer', () => {
+    function ingestSessions(el: ActivityFeed, count: number): void {
+      for (let index = 0; index < count; index += 1) {
+        el.ingest('runtime_sessions', {
+          type: 'runtime_session_created',
+          timestamp: new Date(Date.now() - index * 60000).toISOString(),
+          payload: {
+            runtime_session_id: `sess-${index}`,
+            runtime_principal_name: `Agent ${index}`,
+          },
+        });
+      }
+    }
+
+    it('counts the rows below the fold', async () => {
+      const el = await fixture<ActivityFeed>(
+        html`<activity-feed
+          style="--activity-feed-list-max-height: 90px;"
+        ></activity-feed>`
+      );
+      ingestSessions(el, 8);
+      await el.updateComplete;
+      await waitUntil(
+        () => Boolean(el.shadowRoot!.querySelector('.footer .more')),
+        'overflow count never rendered'
+      );
+
+      const more = el.shadowRoot!.querySelector('.footer .more')!;
+      expect(more.textContent!.trim()).to.match(/^\d+ more$/);
+      const hidden = Number(more.textContent!.trim().split(' ')[0]);
+      expect(hidden).to.be.greaterThan(0);
+      expect(hidden).to.be.lessThan(8);
+      expect(el.shadowRoot!.querySelector('.footer a')!.textContent).to.contain(
+        'View audit'
+      );
+    });
+
+    it('says nothing when the list fits', async () => {
+      const el = await fixture<ActivityFeed>(
+        html`<activity-feed></activity-feed>`
+      );
+      ingestSessions(el, 2);
+      await el.updateComplete;
+      await el.updateComplete;
+
+      expect(el.shadowRoot!.querySelector('.footer .more')).to.not.exist;
+    });
+  });
+
   describe('outcomeLabel', () => {
     it('turns a status enum into a word a reader recognises', () => {
       expect(outcomeLabel('success')).to.equal('Succeeded');

--- a/frontend/src/components/activity-feed.ts
+++ b/frontend/src/components/activity-feed.ts
@@ -1180,7 +1180,10 @@ export class ActivityFeed extends LitElement {
   @state() private connected = false;
   /** The list the feed looked up itself, when the host provided none. */
   @state() private fetchedUsers: FeedContext['users'] = [];
+  /** Rows currently below the fold of the scroller; 0 when nothing overflows. */
+  @state() private belowFold = 0;
 
+  private sizeObserver: ResizeObserver | null = null;
   private unsubscribes: (() => void)[] = [];
   private seen = new Set<string>();
   /** Resolved (never rejected) once the user lookup has had its turn. */
@@ -1517,9 +1520,21 @@ export class ActivityFeed extends LitElement {
         height: 0.75rem;
       }
 
+      /* One hairline row: what is still below the fold on the left, the way
+         out on the right. */
       .footer {
+        align-items: baseline;
         border-top: 1px solid var(--console-hairline);
+        display: flex;
+        gap: var(--sl-spacing-small);
+        justify-content: space-between;
         padding: var(--sl-spacing-small) var(--sl-spacing-medium);
+      }
+
+      .footer .more {
+        color: var(--console-meta-color);
+        font-size: var(--console-text-meta);
+        font-variant-numeric: tabular-nums;
       }
 
       .footer a {
@@ -1559,6 +1574,8 @@ export class ActivityFeed extends LitElement {
   }
 
   disconnectedCallback(): void {
+    this.sizeObserver?.disconnect();
+    this.sizeObserver = null;
     for (const unsubscribe of this.unsubscribes) {
       try {
         unsubscribe();
@@ -1742,7 +1759,39 @@ export class ActivityFeed extends LitElement {
       : null;
   }
 
+  protected firstUpdated(): void {
+    // The rail decides the card's height, and the height decides how many
+    // rows are out of sight: re-measure whenever either moves.
+    if (typeof ResizeObserver === 'function') {
+      this.sizeObserver = new ResizeObserver(() => this.measureBelowFold());
+      this.sizeObserver.observe(this);
+    }
+    this.measureBelowFold();
+  }
+
+  /**
+   * How many rows sit entirely under the fold of the scroller.
+   *
+   * Without it the card looked broken rather than scrollable: the list has no
+   * visible scrollbar, so a row clipped mid-line was the only hint that
+   * anything followed. A row that is partly visible is not counted, because
+   * it is already saying "there is more".
+   */
+  private measureBelowFold(): void {
+    const list = this.renderRoot?.querySelector<HTMLElement>('.rows');
+    if (!list) {
+      if (this.belowFold !== 0) this.belowFold = 0;
+      return;
+    }
+    const fold = list.getBoundingClientRect().bottom;
+    const hidden = Array.from(
+      list.querySelectorAll<HTMLElement>('.row')
+    ).filter((row) => row.getBoundingClientRect().top >= fold - 1).length;
+    if (hidden !== this.belowFold) this.belowFold = hidden;
+  }
+
   protected updated(changed: Map<string, unknown>): void {
+    this.measureBelowFold();
     // An opened row whose body is below the fold of a short rail has told the
     // operator nothing, so the row moves to the top of the list and its body
     // takes the height that is left. The list is scrolled by hand rather than
@@ -1995,7 +2044,7 @@ export class ActivityFeed extends LitElement {
       </div>`;
     }
     return html`
-      <div class="rows">
+      <div class="rows" @scroll=${() => this.measureBelowFold()}>
         ${repeat(
           this.rows,
           (row) => row.event.id,
@@ -2019,7 +2068,14 @@ export class ActivityFeed extends LitElement {
           }
         </div>
         ${this.renderBody()}
-        <div class="footer"><a href="/console/audit">View audit →</a></div>
+        <div class="footer">
+          ${
+            this.belowFold > 0
+              ? html`<span class="more">${this.belowFold} more</span>`
+              : nothing
+          }
+          <a href="/console/audit">View audit →</a>
+        </div>
       </sl-card>
     `;
   }

--- a/frontend/src/components/activity-feed.ts
+++ b/frontend/src/components/activity-feed.ts
@@ -1184,6 +1184,7 @@ export class ActivityFeed extends LitElement {
   @state() private belowFold = 0;
 
   private sizeObserver: ResizeObserver | null = null;
+  private measureFrame: number | null = null;
   private unsubscribes: (() => void)[] = [];
   private seen = new Set<string>();
   /** Resolved (never rejected) once the user lookup has had its turn. */
@@ -1576,6 +1577,10 @@ export class ActivityFeed extends LitElement {
   disconnectedCallback(): void {
     this.sizeObserver?.disconnect();
     this.sizeObserver = null;
+    if (this.measureFrame !== null) {
+      cancelAnimationFrame(this.measureFrame);
+      this.measureFrame = null;
+    }
     for (const unsubscribe of this.unsubscribes) {
       try {
         unsubscribe();
@@ -1763,10 +1768,26 @@ export class ActivityFeed extends LitElement {
     // The rail decides the card's height, and the height decides how many
     // rows are out of sight: re-measure whenever either moves.
     if (typeof ResizeObserver === 'function') {
-      this.sizeObserver = new ResizeObserver(() => this.measureBelowFold());
+      this.sizeObserver = new ResizeObserver(() => this.scheduleMeasure());
       this.sizeObserver.observe(this);
     }
-    this.measureBelowFold();
+    this.scheduleMeasure();
+  }
+
+  /**
+   * Measure after the frame, never inside the update cycle.
+   *
+   * `belowFold` is a @state, so measuring straight from `updated()` wrote it
+   * during an update and cost a second render pass on every feed event (Lit
+   * says so in dev: "scheduled an update after an update completed"). One
+   * pending frame at a time, cancelled on disconnect.
+   */
+  private scheduleMeasure(): void {
+    if (this.measureFrame !== null) return;
+    this.measureFrame = requestAnimationFrame(() => {
+      this.measureFrame = null;
+      this.measureBelowFold();
+    });
   }
 
   /**
@@ -1791,7 +1812,7 @@ export class ActivityFeed extends LitElement {
   }
 
   protected updated(changed: Map<string, unknown>): void {
-    this.measureBelowFold();
+    this.scheduleMeasure();
     // An opened row whose body is below the fold of a short rail has told the
     // operator nothing, so the row moves to the top of the list and its body
     // takes the height that is left. The list is scrolled by hand rather than

--- a/frontend/src/components/activity-feed.ts
+++ b/frontend/src/components/activity-feed.ts
@@ -2065,7 +2065,7 @@ export class ActivityFeed extends LitElement {
       </div>`;
     }
     return html`
-      <div class="rows" @scroll=${() => this.measureBelowFold()}>
+      <div class="rows" @scroll=${() => this.scheduleMeasure()}>
         ${repeat(
           this.rows,
           (row) => row.event.id,

--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -9,6 +9,7 @@
 import { expect, fixture, html, waitUntil } from '@open-wc/testing';
 import './console-header.ts';
 import type { ConsoleHeader } from './console-header.ts';
+import { publishAttentionSummary } from '../utils/attention-summary';
 
 const USER = {
   id: 'user-1',
@@ -95,5 +96,107 @@ describe('console-header user menu trigger', () => {
       () => el.shadowRoot!.textContent?.includes('Alice Smith') ?? false,
       'user name never rendered'
     );
+  });
+});
+
+/**
+ * The bell's empty state. "No notifications" over an amber strip saying
+ * "2 need attention" is two true sentences that read as a contradiction, so
+ * the empty state names what is empty and repeats the attention counts the
+ * Overview or the Attention page published.
+ */
+describe('console-header bell empty state', () => {
+  let restoreFetch: () => void;
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-token');
+    restoreFetch = stubFetch();
+    sessionStorage.removeItem('preloop:attention-summary');
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    localStorage.removeItem('accessToken');
+    sessionStorage.removeItem('preloop:attention-summary');
+  });
+
+  function dropdownText(el: ConsoleHeader): string {
+    return (
+      el
+        .shadowRoot!.querySelector('.notification-dropdown')!
+        .textContent?.replace(/\s+/g, ' ')
+        .trim() || ''
+    );
+  }
+
+  it('says what is empty when nothing needs attention', async () => {
+    const el = await fixture<ConsoleHeader>(
+      html`<console-header></console-header>`
+    );
+    await el.updateComplete;
+
+    const text = dropdownText(el);
+    expect(text).to.contain('No new notifications');
+    expect(text).to.not.contain('need attention:');
+  });
+
+  it('states the attention counts published by the Overview', async () => {
+    publishAttentionSummary([
+      {
+        id: 'flow:flow-1',
+        kind: 'flow',
+        severity: 'critical',
+        title: 'Pull Request Reviewer',
+        detail: '11 failed runs',
+        href: '/console/flows',
+        at: null,
+        fingerprint: 'flow-1:11',
+        dismissable: true,
+      },
+      {
+        id: 'pricing:model-1',
+        kind: 'pricing',
+        severity: 'warning',
+        title: 'No price catalog loaded',
+        detail: 'Estimated spend is $0',
+        href: '/console/cost',
+        at: null,
+        fingerprint: 'pricing:1',
+        dismissable: true,
+      },
+    ]);
+
+    const el = await fixture<ConsoleHeader>(
+      html`<console-header></console-header>`
+    );
+    await el.updateComplete;
+
+    expect(dropdownText(el)).to.contain(
+      '2 items need attention: 1 flow, 1 pricing'
+    );
+  });
+
+  it('follows a summary published while the header is on screen', async () => {
+    const el = await fixture<ConsoleHeader>(
+      html`<console-header></console-header>`
+    );
+    await el.updateComplete;
+
+    publishAttentionSummary([
+      {
+        id: 'approval:approval-1',
+        kind: 'approval',
+        severity: 'critical',
+        title: 'read_file',
+        detail: 'waiting on you',
+        href: '/console/approvals',
+        at: null,
+        fingerprint: 'approval-1',
+        dismissable: false,
+      },
+    ]);
+    await el.updateComplete;
+
+    expect(dropdownText(el)).to.contain('1 item needs attention: 1 approval');
   });
 });

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -21,6 +21,12 @@ import {
   parseUTCDate,
 } from '../utils/date';
 import { formatApprovalRequester } from '../utils/approval-identity';
+import {
+  ATTENTION_SUMMARY_EVENT,
+  formatAttentionSummary,
+  readAttentionSummary,
+  type AttentionSummary,
+} from '../utils/attention-summary';
 
 interface UserDetails {
   username: string;
@@ -82,6 +88,18 @@ export class ConsoleHeader extends LitElement {
 
   @state()
   private _processingApproval: string | null = null;
+
+  /**
+   * Counts published by whoever last derived the attention items (the
+   * Overview strip, the Attention page). Null until one of them has run in
+   * this tab, in which case the empty state says only what it knows.
+   */
+  @state()
+  private _attentionSummary: AttentionSummary | null = null;
+
+  private handleAttentionSummary = (event: Event) => {
+    this._attentionSummary = (event as CustomEvent<AttentionSummary>).detail;
+  };
 
   private unsubscribeFlow?: () => void;
   private unsubscribeApprovals?: () => void;
@@ -304,6 +322,10 @@ export class ConsoleHeader extends LitElement {
       margin-bottom: 0.5rem;
       opacity: 0.5;
     }
+    .empty-state-detail {
+      font-size: var(--console-text-meta, 0.8125rem);
+      margin-top: 0.25rem;
+    }
     .theme-switcher-container {
       text-align: center;
     }
@@ -311,6 +333,11 @@ export class ConsoleHeader extends LitElement {
 
   async connectedCallback() {
     super.connectedCallback();
+    this._attentionSummary = readAttentionSummary();
+    window.addEventListener(
+      ATTENTION_SUMMARY_EVENT,
+      this.handleAttentionSummary as EventListener
+    );
     this.fetchUserDetails();
     this.connectToFlowUpdates();
     this.connectToApprovalUpdates();
@@ -325,6 +352,10 @@ export class ConsoleHeader extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
+    window.removeEventListener(
+      ATTENTION_SUMMARY_EVENT,
+      this.handleAttentionSummary as EventListener
+    );
     this.unsubscribeFlow?.();
     this.unsubscribeApprovals?.();
     this.unsubscribeNotifications?.();
@@ -845,7 +876,7 @@ export class ConsoleHeader extends LitElement {
         <div class="section-header">
           <div class="section-title">
             <sl-icon name="activity"></sl-icon>
-            Active Executions
+            Active executions
             <span class="section-count"
               >(${this._runningExecutions.length})</span
             >
@@ -886,7 +917,7 @@ export class ConsoleHeader extends LitElement {
         <div class="section-header">
           <div class="section-title">
             <sl-icon name="shield-check"></sl-icon>
-            Pending Approvals
+            Pending approvals
             <span class="section-count"
               >(${this._pendingApprovals.length})</span
             >
@@ -1004,11 +1035,24 @@ export class ConsoleHeader extends LitElement {
     return iconMap[type] || 'bell';
   }
 
+  /**
+   * "No notifications" over an amber strip saying "2 need attention" read as
+   * a contradiction: both were true, and the bell was the one that sounded
+   * wrong. The empty state now says what is empty (new notifications) and
+   * repeats the attention counts the strip and the footer link already point
+   * at, from the summary the Overview or the Attention page published.
+   */
   private renderEmptyState() {
+    const attention = formatAttentionSummary(this._attentionSummary);
     return html`
       <div class="empty-state">
         <sl-icon name="bell-slash"></sl-icon>
-        <div>No notifications</div>
+        <div>No new notifications</div>
+        ${
+          attention
+            ? html`<div class="empty-state-detail">${attention}</div>`
+            : ''
+        }
       </div>
     `;
   }
@@ -1120,12 +1164,12 @@ export class ConsoleHeader extends LitElement {
                   Router.go('/console/settings/notification-preferences')}
               >
                 <sl-icon name="bell" slot="prefix"></sl-icon>
-                Notification Preferences
+                Notification preferences
               </sl-menu-item>
               <sl-divider></sl-divider>
               <sl-menu-item @click=${this.signOut}>
                 <sl-icon name="box-arrow-right" slot="prefix"></sl-icon>
-                Sign Out
+                Sign out
               </sl-menu-item>
             </sl-menu>
           </sl-dropdown>

--- a/frontend/src/components/list-toolbar.test.ts
+++ b/frontend/src/components/list-toolbar.test.ts
@@ -34,6 +34,22 @@ describe('list-toolbar', () => {
     expect(icon).to.exist;
   });
 
+  it('keeps a short accessible name when the placeholder spells out the fields', async () => {
+    const element = await fixture<ListToolbar>(html`
+      <list-toolbar
+        searchPlaceholder="Principal, session reference, or source id"
+        searchLabel="Search sessions"
+      ></list-toolbar>
+    `);
+    await element.updateComplete;
+
+    const input = element.shadowRoot!.querySelector('sl-input.search-input')!;
+    expect(input.getAttribute('placeholder')).to.equal(
+      'Principal, session reference, or source id'
+    );
+    expect(input.getAttribute('label')).to.equal('Search sessions');
+  });
+
   it('names the view switcher from toggleLabel', async () => {
     const element = await render({ toggleLabel: 'Trackers view' });
     const group = element.shadowRoot!.querySelector('sl-button-group');

--- a/frontend/src/components/list-toolbar.ts
+++ b/frontend/src/components/list-toolbar.ts
@@ -32,6 +32,13 @@ const VIEW_OPTIONS: Array<{
 export class ListToolbar extends LitElement {
   @property({ type: String }) search = '';
   @property({ type: String }) searchPlaceholder = 'Search';
+  /**
+   * The name assistive tech reads for the search field. Defaults to the
+   * placeholder; pages whose placeholder spells out what is searchable
+   * ("Principal, session reference, or source id") pass the short name here
+   * so the field is still announced as "Search sessions".
+   */
+  @property({ type: String }) searchLabel = '';
   @property({ type: String }) view: ListViewMode = 'list';
   @property({ type: Array }) views: ListViewMode[] = ['list', 'cards'];
   @property({ type: String }) toggleLabel = 'View';
@@ -179,7 +186,7 @@ export class ListToolbar extends LitElement {
         >
           <sl-input
             class="search-input"
-            label=${this.searchPlaceholder}
+            label=${this.searchLabel || this.searchPlaceholder}
             placeholder=${this.searchPlaceholder}
             clearable
             .value=${this.search}

--- a/frontend/src/components/preloop-session-observer.ts
+++ b/frontend/src/components/preloop-session-observer.ts
@@ -159,6 +159,16 @@ export class PreloopSessionObserver extends LitElement {
   @property({ type: Boolean })
   hideSidebar = false;
 
+  /**
+   * Hides the sidebar's own search field.
+   *
+   * A host that already offers a search box (the Sessions page bar) would
+   * otherwise show two of them on one screen, one filtering the request and
+   * one filtering what came back.
+   */
+  @property({ type: Boolean })
+  hideListSearch = false;
+
   @property({ type: String })
   layout: 'full' | 'embedded' = 'embedded';
 
@@ -2156,19 +2166,23 @@ export class PreloopSessionObserver extends LitElement {
                 `
               : html`
                   <div class="sidebar">
-                    <sl-input
-                      placeholder="Search sessions"
-                      clearable
-                      .value=${this.searchQuery}
-                      @sl-input=${(event: Event) => {
-                        this.searchQuery = (
-                          event.target as HTMLInputElement
-                        ).value;
-                      }}
-                      style="margin-bottom: var(--sl-spacing-small);"
-                    >
-                      <sl-icon name="search" slot="prefix"></sl-icon>
-                    </sl-input>
+                    ${
+                      this.hideListSearch
+                        ? nothing
+                        : html`<sl-input
+                            placeholder="Search sessions"
+                            clearable
+                            .value=${this.searchQuery}
+                            @sl-input=${(event: Event) => {
+                              this.searchQuery = (
+                                event.target as HTMLInputElement
+                              ).value;
+                            }}
+                            style="margin-bottom: var(--sl-spacing-small);"
+                          >
+                            <sl-icon name="search" slot="prefix"></sl-icon>
+                          </sl-input>`
+                    }
                     <session-list-panel
                       .sessions=${this.filteredSessions}
                       .activeSessionId=${this.activeSessionId}

--- a/frontend/src/components/session-list-panel.test.ts
+++ b/frontend/src/components/session-list-panel.test.ts
@@ -73,6 +73,17 @@ describe('session-list-panel status chips', () => {
     });
   });
 
+  it('leaves an ended session neutral even when a request failed', async () => {
+    const el = await renderPanel([
+      makeSession({ status: 'ended', failedRequests: 3 }),
+    ]);
+
+    const badge = el.shadowRoot?.querySelector('.title-row sl-badge');
+    expect(badge?.textContent?.trim()).to.equal('Ended');
+    // Warning means "needs a person"; a finished run does not.
+    expect(badge?.getAttribute('variant')).to.equal('neutral');
+  });
+
   it('renders the waste badge through the same chip recipe', async () => {
     const el = await renderPanel([makeSession({ optimizationWasteScore: 20 })]);
 

--- a/frontend/src/components/session-list-panel.test.ts
+++ b/frontend/src/components/session-list-panel.test.ts
@@ -1,0 +1,84 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import './session-list-panel.ts';
+import type { SessionListPanel } from './session-list-panel.ts';
+import type { ObservedSession } from '../utils/session-observer';
+
+function makeSession(overrides: Partial<ObservedSession>): ObservedSession {
+  return {
+    id: 'session-1',
+    sourceId: null,
+    sourceType: 'claude_code',
+    title: 'Session one',
+    subtitle: null,
+    sessionReference: null,
+    runtimePrincipalName: null,
+    flowName: null,
+    flowExecutionId: null,
+    status: 'idle',
+    startedAt: null,
+    lastActivityAt: null,
+    endedAt: null,
+    totalRequests: 4,
+    successfulRequests: 4,
+    failedRequests: 0,
+    tokenUsage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    estimatedCost: 0,
+    latestModelAlias: null,
+    latestProviderName: null,
+    canLoadEvents: false,
+    optimizationWasteScore: null,
+    optimizationPotentialSavingsTokens: null,
+    optimizationPotentialSavingsUsd: null,
+    raw: null,
+    ...overrides,
+  };
+}
+
+async function renderPanel(
+  sessions: ObservedSession[]
+): Promise<SessionListPanel> {
+  const el = await fixture<SessionListPanel>(
+    html`<session-list-panel .sessions=${sessions}></session-list-panel>`
+  );
+  await el.updateComplete;
+  return el;
+}
+
+describe('session-list-panel status chips', () => {
+  it('renders idle sessions as a neutral chip, not a solid accent badge', async () => {
+    const el = await renderPanel([makeSession({ status: 'idle' })]);
+
+    const badge = el.shadowRoot?.querySelector('.title-row sl-badge');
+    expect(badge).to.exist;
+    expect(badge?.textContent?.trim()).to.equal('Idle');
+    expect(badge?.getAttribute('variant')).to.equal('neutral');
+    expect(badge?.classList.contains('chip')).to.be.true;
+  });
+
+  it('keeps live and failing sessions on their own tones', async () => {
+    const el = await renderPanel([
+      makeSession({ id: 'a', status: 'active_now' }),
+      makeSession({ id: 'b', status: 'idle', failedRequests: 2 }),
+    ]);
+
+    const badges = Array.from(
+      el.shadowRoot?.querySelectorAll('.title-row sl-badge') ?? []
+    );
+    expect(badges).to.have.lengthOf(2);
+    expect(badges[0].getAttribute('variant')).to.equal('success');
+    expect(badges[1].getAttribute('variant')).to.equal('warning');
+    badges.forEach((badge) => {
+      expect(badge.classList.contains('chip')).to.be.true;
+    });
+  });
+
+  it('renders the waste badge through the same chip recipe', async () => {
+    const el = await renderPanel([makeSession({ optimizationWasteScore: 20 })]);
+
+    const badge = el.shadowRoot?.querySelector('.waste-row sl-badge');
+    expect(badge).to.exist;
+    expect(badge?.getAttribute('variant')).to.equal('warning');
+    expect(badge?.classList.contains('chip')).to.be.true;
+  });
+});

--- a/frontend/src/components/session-list-panel.ts
+++ b/frontend/src/components/session-list-panel.ts
@@ -140,9 +140,13 @@ export class SessionListPanel extends LitElement {
    * "Chips"). The idle case used to return `primary`, so one page carried
    * two dialects for one word: a soft neutral chip in the agent header and a
    * solid blue badge in the session list beside it.
+   *
+   * An ended session stays neutral even if a request in it failed: warning
+   * means "needs a person" (DESIGN.md), and a finished run does not.
    */
   private getVariant(session: ObservedSession) {
     if (session.status === 'active_now') return 'success';
+    if (session.status === 'ended') return 'neutral';
     if (session.failedRequests > 0) return 'warning';
     return 'neutral';
   }

--- a/frontend/src/components/session-list-panel.ts
+++ b/frontend/src/components/session-list-panel.ts
@@ -1,10 +1,11 @@
-import { LitElement, css, html } from 'lit';
+import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import type { ObservedSession } from '../utils/session-observer';
 import { formatCost, formatNumber } from '../utils/session-observer';
+import consoleStyles from '../styles/console-styles.css?inline';
 
 @customElement('session-list-panel')
 export class SessionListPanel extends LitElement {
@@ -17,91 +18,96 @@ export class SessionListPanel extends LitElement {
   @property({ type: String })
   emptyText = '';
 
-  static styles = css`
-    :host {
-      display: block;
-      min-height: 0;
-    }
+  // The console chip recipe, so "Idle" here is the same object as "Idle" on
+  // the agent header instead of a solid Shoelace badge beside it.
+  static styles = [
+    unsafeCSS(consoleStyles),
+    css`
+      :host {
+        display: block;
+        min-height: 0;
+      }
 
-    .list {
-      display: flex;
-      flex-direction: column;
-      gap: var(--sl-spacing-small);
-    }
+      .list {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-small);
+      }
 
-    .session-card {
-      appearance: none;
-      border: 1px solid var(--sl-color-neutral-200);
-      border-radius: var(--sl-border-radius-medium);
-      background: var(--sl-color-neutral-0);
-      color: inherit;
-      cursor: pointer;
-      padding: var(--sl-spacing-small) var(--sl-spacing-medium);
-      text-align: left;
-      transition:
-        border-color 0.15s ease,
-        background 0.15s ease,
-        box-shadow 0.15s ease;
-      width: 100%;
-    }
+      .session-card {
+        appearance: none;
+        border: 1px solid var(--sl-color-neutral-200);
+        border-radius: var(--sl-border-radius-medium);
+        background: var(--sl-color-neutral-0);
+        color: inherit;
+        cursor: pointer;
+        padding: var(--sl-spacing-small) var(--sl-spacing-medium);
+        text-align: left;
+        transition:
+          border-color 0.15s ease,
+          background 0.15s ease,
+          box-shadow 0.15s ease;
+        width: 100%;
+      }
 
-    .session-card:hover,
-    .session-card.active {
-      background: var(--sl-color-primary-50);
-      border-color: var(--sl-color-primary-500);
-    }
+      .session-card:hover,
+      .session-card.active {
+        background: var(--sl-color-primary-50);
+        border-color: var(--sl-color-primary-500);
+      }
 
-    .session-card.active {
-      box-shadow: 0 0 0 1px var(--sl-color-primary-500);
-    }
+      .session-card.active {
+        box-shadow: 0 0 0 1px var(--sl-color-primary-500);
+      }
 
-    .title-row,
-    .metric-row {
-      align-items: center;
-      display: flex;
-      gap: var(--sl-spacing-small);
-      justify-content: space-between;
-    }
+      .title-row,
+      .metric-row {
+        align-items: center;
+        display: flex;
+        gap: var(--sl-spacing-small);
+        justify-content: space-between;
+      }
 
-    .title {
-      color: var(--sl-color-neutral-900);
-      font-weight: 600;
-      overflow-wrap: anywhere;
-    }
+      .title {
+        color: var(--sl-color-neutral-900);
+        font-weight: 600;
+        overflow-wrap: anywhere;
+      }
 
-    .meta {
-      color: var(--sl-color-neutral-600);
-      font-size: var(--sl-font-size-small);
-      margin-top: var(--sl-spacing-2x-small);
-      overflow-wrap: anywhere;
-    }
+      .meta {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        margin-top: var(--sl-spacing-2x-small);
+        overflow-wrap: anywhere;
+      }
 
-    .metric {
-      color: var(--sl-color-primary-700);
-      font-size: var(--sl-font-size-small);
-      font-weight: 600;
-      margin-top: var(--sl-spacing-2x-small);
-    }
+      .metric {
+        color: var(--sl-color-primary-700);
+        font-size: var(--sl-font-size-small);
+        font-weight: 600;
+        margin-top: var(--sl-spacing-2x-small);
+      }
 
-    .empty {
-      color: var(--sl-color-neutral-600);
-      padding: var(--sl-spacing-large);
-      text-align: center;
-    }
+      .empty {
+        color: var(--sl-color-neutral-600);
+        padding: var(--sl-spacing-large);
+        text-align: center;
+      }
 
-    .waste-row {
-      align-items: center;
-      display: flex;
-      gap: var(--sl-spacing-x-small);
-      margin-top: var(--sl-spacing-2x-small);
-    }
+      .waste-row {
+        align-items: center;
+        display: flex;
+        gap: var(--sl-spacing-x-small);
+        margin-top: var(--sl-spacing-2x-small);
+      }
 
-    .waste-savings {
-      color: var(--sl-color-success-700);
-      font-size: var(--sl-font-size-x-small);
-      font-weight: 600;
-    }
-  `;
+      .waste-savings {
+        color: var(--sl-color-success-700);
+        font-size: var(--sl-font-size-x-small);
+        font-weight: 600;
+      }
+    `,
+  ];
 
   private getWasteVariant(score: number) {
     if (score >= 40) return 'danger';
@@ -115,7 +121,7 @@ export class SessionListPanel extends LitElement {
     const savings = session.optimizationPotentialSavingsUsd;
     return html`
       <div class="waste-row">
-        <sl-badge variant=${this.getWasteVariant(score)} pill>
+        <sl-badge class="chip" variant=${this.getWasteVariant(score)} pill>
           Waste ${score}%
         </sl-badge>
         ${
@@ -129,11 +135,16 @@ export class SessionListPanel extends LitElement {
     `;
   }
 
+  /**
+   * A state is a tint, and idle is a state, not an outcome (DESIGN.md
+   * "Chips"). The idle case used to return `primary`, so one page carried
+   * two dialects for one word: a soft neutral chip in the agent header and a
+   * solid blue badge in the session list beside it.
+   */
   private getVariant(session: ObservedSession) {
     if (session.status === 'active_now') return 'success';
-    if (session.status === 'ended') return 'neutral';
     if (session.failedRequests > 0) return 'warning';
-    return 'primary';
+    return 'neutral';
   }
 
   private getLabel(session: ObservedSession): string {
@@ -181,7 +192,7 @@ export class SessionListPanel extends LitElement {
             >
               <div class="title-row">
                 <div class="title">${session.title}</div>
-                <sl-badge variant=${this.getVariant(session)} pill>
+                <sl-badge class="chip" variant=${this.getVariant(session)} pill>
                   ${this.getLabel(session)}
                 </sl-badge>
               </div>

--- a/frontend/src/utils/attention-summary.test.ts
+++ b/frontend/src/utils/attention-summary.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The counts the header bell repeats. They have to be the strip's counts,
+ * including the low-severity rule, or the bell and the strip disagree again.
+ */
+import { expect } from '@open-wc/testing';
+
+import type {
+  AttentionItem,
+  AttentionKind,
+  AttentionSeverity,
+} from './attention';
+import {
+  formatAttentionSummary,
+  publishAttentionSummary,
+  readAttentionSummary,
+  summariseAttentionItems,
+} from './attention-summary';
+
+function item(
+  kind: AttentionKind,
+  severity: AttentionSeverity = 'warning'
+): AttentionItem {
+  return {
+    id: `${kind}:${Math.random()}`,
+    kind,
+    severity,
+    title: 'Something',
+    detail: 'happened',
+    href: '/console/attention',
+    at: null,
+    fingerprint: 'fingerprint',
+    dismissable: true,
+  };
+}
+
+describe('attention summary', () => {
+  afterEach(() => {
+    sessionStorage.removeItem('preloop:attention-summary');
+  });
+
+  it('counts per kind in the console order', () => {
+    const summary = summariseAttentionItems([
+      item('pricing'),
+      item('flow'),
+      item('flow'),
+    ]);
+    expect(summary.total).to.equal(3);
+    expect(summary.counts).to.eql([
+      { kind: 'flow', count: 2 },
+      { kind: 'pricing', count: 1 },
+    ]);
+    expect(summary.lowOnly).to.equal(false);
+  });
+
+  it('drops low items while anything louder is open', () => {
+    const summary = summariseAttentionItems([
+      item('flow', 'critical'),
+      item('model', 'low'),
+    ]);
+    expect(summary.total).to.equal(1);
+    expect(summary.counts).to.eql([{ kind: 'flow', count: 1 }]);
+  });
+
+  it('words a list of low items as worth a look', () => {
+    const summary = summariseAttentionItems([item('model', 'low')]);
+    expect(summary.lowOnly).to.equal(true);
+    expect(formatAttentionSummary(summary)).to.equal(
+      '1 item worth a look: 1 model'
+    );
+  });
+
+  it('reads back what it published, and says nothing at zero', () => {
+    publishAttentionSummary([item('flow'), item('pricing')]);
+    const stored = readAttentionSummary();
+    expect(formatAttentionSummary(stored)).to.equal(
+      '2 items need attention: 1 flow, 1 pricing'
+    );
+
+    publishAttentionSummary([]);
+    expect(formatAttentionSummary(readAttentionSummary())).to.equal('');
+    expect(formatAttentionSummary(null)).to.equal('');
+  });
+});

--- a/frontend/src/utils/attention-summary.test.ts
+++ b/frontend/src/utils/attention-summary.test.ts
@@ -9,7 +9,9 @@ import type {
   AttentionKind,
   AttentionSeverity,
 } from './attention';
+import { invalidateApiCaches } from '../api';
 import {
+  ATTENTION_SUMMARY_STORAGE_KEY,
   formatAttentionSummary,
   publishAttentionSummary,
   readAttentionSummary,
@@ -35,7 +37,7 @@ function item(
 
 describe('attention summary', () => {
   afterEach(() => {
-    sessionStorage.removeItem('preloop:attention-summary');
+    sessionStorage.removeItem(ATTENTION_SUMMARY_STORAGE_KEY);
   });
 
   it('counts per kind in the console order', () => {
@@ -79,5 +81,16 @@ describe('attention summary', () => {
     publishAttentionSummary([]);
     expect(formatAttentionSummary(readAttentionSummary())).to.equal('');
     expect(formatAttentionSummary(null)).to.equal('');
+  });
+
+  it('is forgotten when the account changes', () => {
+    publishAttentionSummary([item('flow')]);
+    expect(readAttentionSummary()?.total).to.equal(1);
+
+    // What an auth change runs. Sign-out navigates with location.href, which
+    // keeps sessionStorage for the tab, so the counts have to be dropped here
+    // or the next account reads the previous one's.
+    invalidateApiCaches();
+    expect(readAttentionSummary()).to.equal(null);
   });
 });

--- a/frontend/src/utils/attention-summary.ts
+++ b/frontend/src/utils/attention-summary.ts
@@ -32,7 +32,12 @@ export interface AttentionSummary {
 }
 
 export const ATTENTION_SUMMARY_EVENT = 'preloop-attention-summary';
-const STORAGE_KEY = 'preloop:attention-summary';
+/**
+ * Exported so `invalidateApiCaches` can drop it on an auth change: the counts
+ * are account-scoped, and signing out keeps sessionStorage for the tab.
+ */
+export const ATTENTION_SUMMARY_STORAGE_KEY = 'preloop:attention-summary';
+const STORAGE_KEY = ATTENTION_SUMMARY_STORAGE_KEY;
 
 /** The same slice the Overview strip shows: loud items, or the low ones alone. */
 export function summariseAttentionItems(

--- a/frontend/src/utils/attention-summary.ts
+++ b/frontend/src/utils/attention-summary.ts
@@ -1,0 +1,99 @@
+/**
+ * What the console header knows about the attention items, without asking.
+ *
+ * The bell used to say "No notifications" while the amber strip one line
+ * below it said "2 need attention", which reads as a contradiction even
+ * though both are true (there are no notification rows, and there are two
+ * attention items). The header cannot afford the nine requests the attention
+ * rules need on every page, so whoever already derived the items publishes
+ * the counts here: the Overview strip and the Attention page. The header
+ * reads the last published summary and states it in the empty state.
+ *
+ * The summary lives in sessionStorage so it survives a route change inside
+ * the tab, and an event carries it to any header already on screen.
+ */
+import {
+  ATTENTION_KIND_ORDER,
+  attentionKindChipLabel,
+  type AttentionItem,
+  type AttentionKind,
+} from './attention';
+
+export interface AttentionSummary {
+  /** How many items the strip would show. */
+  total: number;
+  /** Per kind, in the console's kind order; kinds with no item are absent. */
+  counts: Array<{ kind: AttentionKind; count: number }>;
+  /**
+   * True when every item is low severity (a model priced at $0): those are a
+   * question, not a problem, and the strip words them "worth a look".
+   */
+  lowOnly: boolean;
+}
+
+export const ATTENTION_SUMMARY_EVENT = 'preloop-attention-summary';
+const STORAGE_KEY = 'preloop:attention-summary';
+
+/** The same slice the Overview strip shows: loud items, or the low ones alone. */
+export function summariseAttentionItems(
+  items: AttentionItem[]
+): AttentionSummary {
+  const loud = items.filter((item) => item.severity !== 'low');
+  const lowOnly = loud.length === 0;
+  const shown = lowOnly ? items : loud;
+  const counts = ATTENTION_KIND_ORDER.map((kind) => ({
+    kind,
+    count: shown.filter((item) => item.kind === kind).length,
+  })).filter((entry) => entry.count > 0);
+  return { total: shown.length, counts, lowOnly };
+}
+
+export function publishAttentionSummary(items: AttentionItem[]): void {
+  const summary = summariseAttentionItems(items);
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(summary));
+  } catch {
+    // A full or blocked sessionStorage costs the header its memory across
+    // route changes, nothing else.
+  }
+  window.dispatchEvent(
+    new CustomEvent<AttentionSummary>(ATTENTION_SUMMARY_EVENT, {
+      detail: summary,
+    })
+  );
+}
+
+export function readAttentionSummary(): AttentionSummary | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as AttentionSummary;
+    if (typeof parsed?.total !== 'number' || !Array.isArray(parsed.counts)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * "2 items need attention: 1 flow, 1 pricing", in the strip's own words.
+ * Empty when there is nothing to say, so the caller can render nothing.
+ */
+export function formatAttentionSummary(
+  summary: AttentionSummary | null
+): string {
+  if (!summary || summary.total < 1) return '';
+  const noun = summary.total === 1 ? 'item' : 'items';
+  const verb = summary.lowOnly
+    ? 'worth a look'
+    : summary.total === 1
+      ? 'needs attention'
+      : 'need attention';
+  const parts = summary.counts.map((entry) =>
+    attentionKindChipLabel(entry.kind, entry.count)
+  );
+  const detail = parts.length ? `: ${parts.join(', ')}` : '';
+  return `${summary.total} ${noun} ${verb}${detail}`;
+}

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -2778,7 +2778,7 @@ export class AgentDetailView extends LitElement {
             <div
               style="display: flex; justify-content: space-between; align-items: center; width: 100%;"
             >
-              ${this.renderStatLabel('Estimated Spend')}
+              ${this.renderStatLabel('Estimated spend')}
               <select
                 style="background: transparent; border: none; font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-600); cursor: pointer; outline: none;"
                 .value=${this.budgetTimeRange}

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -1789,7 +1789,7 @@ export class AgentDetailView extends LitElement {
       },
       {
         id: 'edit-tags',
-        label: 'Edit Tags',
+        label: 'Edit tags',
         icon: 'tag',
         onClick: () => this.promptEditTags(),
       },
@@ -1798,7 +1798,7 @@ export class AgentDetailView extends LitElement {
     if (this.featureFlags.user_management) {
       actions.push({
         id: 'change-owner',
-        label: 'Change Owner',
+        label: 'Change owner',
         icon: 'person-gear',
         onClick: () => this.promptChangeOwner(),
       });
@@ -2565,7 +2565,7 @@ export class AgentDetailView extends LitElement {
             <div
               style="font-weight: 700; font-size: 1.15rem; color: var(--sl-color-neutral-800);"
             >
-              Flows Using This Agent Node
+              Flows using this agent
             </div>
             ${
               this.associatedFlows.length > 0
@@ -2576,7 +2576,7 @@ export class AgentDetailView extends LitElement {
                     >
                       <sl-button variant="primary" size="small">
                         <sl-icon name="plus-lg" slot="prefix"></sl-icon>
-                        Create New Flow
+                        Create flow
                       </sl-button>
                     </a>
                   `
@@ -2603,21 +2603,20 @@ export class AgentDetailView extends LitElement {
                     <p
                       style="margin: 0; font-size: var(--sl-font-size-medium);"
                     >
-                      This agent is not currently bound to any event-driven or
-                      automated flows.
+                      No flow uses this agent yet.
                     </p>
                     <p
                       style="margin: 4px 0 0 0; font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-400);"
                     >
-                      Go to the Flows panel to bind this persistent node to an
-                      automation task.
+                      Add it as a step in a flow to have it run on a schedule or
+                      on an event.
                     </p>
                     <a
                       href="/console/flows/new?agent_id=${this.agentId}"
                       style="text-decoration: none; display: inline-block; margin-top: var(--sl-spacing-large);"
                     >
                       <sl-button variant="primary" size="small"
-                        >Create New Flow</sl-button
+                        >Create flow</sl-button
                       >
                     </a>
                   </div>
@@ -2832,19 +2831,19 @@ export class AgentDetailView extends LitElement {
                   slot="nav"
                   panel="sessions"
                   ?active=${this.activeTab === 'sessions'}
-                  >Session History</sl-tab
+                  >Session history</sl-tab
                 >
                 <sl-tab
                   slot="nav"
                   panel="tools"
                   ?active=${this.activeTab === 'tools'}
-                  >Tools & Governance</sl-tab
+                  >Tools & governance</sl-tab
                 >
                 <sl-tab
                   slot="nav"
                   panel="models"
                   ?active=${this.activeTab === 'models'}
-                  >Models & Spend</sl-tab
+                  >Models & spend</sl-tab
                 >
 
                 ${
@@ -2854,7 +2853,7 @@ export class AgentDetailView extends LitElement {
                           slot="nav"
                           panel="ssh"
                           ?active=${this.activeTab === 'ssh'}
-                          >Command Terminal (SSH)</sl-tab
+                          >Command terminal (SSH)</sl-tab
                         >
                         ${
                           isVncEnabled
@@ -2872,7 +2871,7 @@ export class AgentDetailView extends LitElement {
                           slot="nav"
                           panel="dashboard"
                           ?active=${this.activeTab === 'dashboard'}
-                          >Agent Web UI</sl-tab
+                          >Agent web UI</sl-tab
                         >
                       `
                     : nothing
@@ -2884,7 +2883,7 @@ export class AgentDetailView extends LitElement {
                           slot="nav"
                           panel="associated-flows"
                           ?active=${this.activeTab === 'associated-flows'}
-                          >Associated Flows
+                          >Associated flows
                           (${this.associatedFlows.length})</sl-tab
                         >
                       `
@@ -2968,7 +2967,7 @@ export class AgentDetailView extends LitElement {
                             style="display: flex; justify-content: space-between; align-items: center; width: 100%;"
                           >
                             <div>
-                              <div class="hero-title">Tools & Governance</div>
+                              <div class="hero-title">Tools & governance</div>
                               <div class="meta-line">
                                 Agent-specific configurations overrides applying
                                 only to this agent.
@@ -3203,7 +3202,7 @@ export class AgentDetailView extends LitElement {
                             style="display: flex; justify-content: space-between; align-items: center; width: 100%;"
                           >
                             <div>
-                              <div class="hero-title">Models & Spend</div>
+                              <div class="hero-title">Models & spend</div>
                               <div class="meta-line">
                                 Update the models this agent can use and set
                                 monthly spend limits per model.

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -259,6 +259,12 @@ describe('AgentsView', () => {
       'Actions',
     ]);
 
+    // "$ est." is short enough to read as "dollar est." out loud, so the
+    // sort button carries the full name.
+    const spendButton = headers[5].querySelector('.sort-button');
+    expect(spendButton?.getAttribute('aria-label')).to.equal('Estimated spend');
+    expect(spendButton?.getAttribute('title')).to.equal('Estimated spend');
+
     const lastSeen = headers[6];
     expect(lastSeen.getAttribute('aria-sort'), 'default sort').to.equal(
       'descending'

--- a/frontend/src/views/authed/agents-view.test.ts
+++ b/frontend/src/views/authed/agents-view.test.ts
@@ -254,7 +254,7 @@ describe('AgentsView', () => {
       'Owner',
       'Model',
       'Requests',
-      'Spend (est.)',
+      '$ est.',
       'Last seen',
       'Actions',
     ]);
@@ -758,7 +758,7 @@ describe('AgentsView', () => {
     );
   });
 
-  it('keeps last seen relative for a month and absolute after it', async () => {
+  it('keeps last seen relative to ninety days and absolute after it', async () => {
     const now = Date.now();
     const tenDaysAgo = new Date(now - 10 * 86400000).toISOString();
     const twoHundredDaysAgo = new Date(now - 200 * 86400000).toISOString();
@@ -789,6 +789,36 @@ describe('AgentsView', () => {
     expect(lastSeen).to.contain(
       new Date(twoHundredDaysAgo).toLocaleDateString()
     );
+  });
+
+  it('still reads relative at 45 days, like the Overview inventory', async () => {
+    const fortyFiveDaysAgo = new Date(Date.now() - 45 * 86400000).toISOString();
+    agentItems = [
+      {
+        ...makeAgent('agent-1', 'Quiet agent', 'claude_code'),
+        last_seen_at: fortyFiveDaysAgo,
+        last_activity_at: fortyFiveDaysAgo,
+        is_active_now: false,
+        activity_status: 'idle',
+      },
+    ];
+
+    const el = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(el);
+
+    const listCell = el
+      .shadowRoot!.querySelector('tbody tr')!
+      .children[6].textContent?.trim();
+    expect(listCell).to.equal('6w ago');
+
+    localStorage.setItem('preloop.agents.view_mode', 'cards');
+    const cards = await fixture<AgentsView>(html`<agents-view></agents-view>`);
+    await waitForAgents(cards);
+    const cardText =
+      cards.shadowRoot!.querySelector('.cards')!.textContent || '';
+    expect(cardText).to.contain('6w ago');
+    expect(cardText).to.contain('Last seen');
+    expect(cardText).to.contain('Estimated spend');
   });
 
   it('counts the rows the filters matched next to the view switcher', async () => {

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -127,6 +127,15 @@ export type AgentsViewMode = 'list' | 'cards' | 'canvas';
 
 const VIEW_MODE_KEY = 'preloop.agents.view_mode';
 
+/**
+ * One relative-time cutoff for "Last seen", in the list and on the cards.
+ * The Overview inventory says "6w ago" for an agent this page called
+ * "7/22/2026", which is one fact in two formats; 90 days is the Overview's
+ * window. Past it the absolute date is shown, with the full timestamp in the
+ * cell's title either way.
+ */
+const RELATIVE_TIME_DAYS = 90;
+
 export type AgentListSortKey =
   'agent' | 'status' | 'owner' | 'model' | 'requests' | 'spend' | 'last_seen';
 
@@ -2088,7 +2097,9 @@ export class AgentsView extends LitElement {
       return html`<span class=${className} title="Never seen">Never</span>`;
     }
     return html`<span class=${className} title=${this.formatDateTime(value)}
-      >${formatRelativeTime(value)}</span
+      >${formatRelativeTime(value, undefined, {
+        maxRelativeDays: RELATIVE_TIME_DAYS,
+      })}</span
     >`;
   }
 
@@ -3283,10 +3294,12 @@ export class AgentsView extends LitElement {
         >
           ${
             row.lastSeen
-              ? // A month of relative time: "23d ago" still reads as recent
-                // activity, "213d ago" is arithmetic, so that becomes a date.
+              ? // Ninety days of relative time, the Overview's cutoff: the
+                // same agent read "6w ago" there and "7/22/2026" here, which
+                // is one fact in two formats. The absolute value stays in the
+                // cell's title.
                 formatRelativeTime(row.lastSeen, undefined, {
-                  maxRelativeDays: 30,
+                  maxRelativeDays: RELATIVE_TIME_DAYS,
                 })
               : 'Never'
           }
@@ -3387,7 +3400,7 @@ export class AgentsView extends LitElement {
                   ${this.renderSortableHeader('owner', 'Owner')}
                   ${this.renderSortableHeader('model', 'Model')}
                   ${this.renderSortableHeader('requests', 'Requests', true)}
-                  ${this.renderSortableHeader('spend', 'Spend (est.)', true)}
+                  ${this.renderSortableHeader('spend', '$ est.', true)}
                   ${this.renderSortableHeader('last_seen', 'Last seen')}
                   <th class="actions-cell">
                     <span class="visually-hidden">Actions</span>
@@ -3671,7 +3684,7 @@ export class AgentsView extends LitElement {
           }
 
           <div class="metric-row">
-            <span class="label">Estimated Cost</span>
+            <span class="label">Estimated spend</span>
             <span class="value numeric"
               >${this.formatMoney(estimatedCost!)}</span
             >
@@ -3685,7 +3698,7 @@ export class AgentsView extends LitElement {
           </div>
 
           <div class="metric-row">
-            <span class="label">Last Seen</span>
+            <span class="label">Last seen</span>
             ${this.renderRelativeTimestamp(
               liveActivity?.lastActivityAt || lastSeen,
               'value'

--- a/frontend/src/views/authed/agents-view.ts
+++ b/frontend/src/views/authed/agents-view.ts
@@ -3188,10 +3188,16 @@ export class AgentsView extends LitElement {
     });
   }
 
+  /**
+   * `srLabel` names a column whose visible header is an abbreviation: a screen
+   * reader would otherwise read "$ est." as "dollar est." with nothing else to
+   * go on, and the sort button has no other name.
+   */
   private renderSortableHeader(
     key: AgentListSortKey,
     label: string,
-    numeric = false
+    numeric = false,
+    srLabel?: string
   ) {
     const active = this.sortKey === key;
     const ariaSort = active
@@ -3209,6 +3215,8 @@ export class AgentsView extends LitElement {
           type="button"
           class="sort-button"
           data-sort-key=${key}
+          title=${srLabel ?? label}
+          aria-label=${srLabel ?? label}
           @click=${() => this.toggleSort(key)}
         >
           <span>${label}</span>
@@ -3400,7 +3408,12 @@ export class AgentsView extends LitElement {
                   ${this.renderSortableHeader('owner', 'Owner')}
                   ${this.renderSortableHeader('model', 'Model')}
                   ${this.renderSortableHeader('requests', 'Requests', true)}
-                  ${this.renderSortableHeader('spend', '$ est.', true)}
+                  ${this.renderSortableHeader(
+                    'spend',
+                    '$ est.',
+                    true,
+                    'Estimated spend'
+                  )}
                   ${this.renderSortableHeader('last_seen', 'Last seen')}
                   <th class="actions-cell">
                     <span class="visually-hidden">Actions</span>

--- a/frontend/src/views/authed/attention-view.ts
+++ b/frontend/src/views/authed/attention-view.ts
@@ -52,6 +52,7 @@ import {
 } from '../../utils/attention';
 import { REMOVE_AGENT_CONSEQUENCE } from '../../utils/agent-display';
 import { loadAttentionInputs } from '../../utils/attention-data';
+import { publishAttentionSummary } from '../../utils/attention-summary';
 import { formatLocalDateTime, formatRelativeTime } from '../../utils/date';
 import { renderFailureCategoryChip } from '../../utils/failure-category';
 import {
@@ -645,6 +646,9 @@ export class AttentionView extends AuthedElement {
 
     this.lastUpdatedAt = new Date().toISOString();
     this.loading = false;
+    // The header's bell has no budget for these nine requests; it states the
+    // counts this page just derived.
+    publishAttentionSummary(this.items);
   }
 
   private get derived() {

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -1484,6 +1484,7 @@ export class DashboardView extends AuthedElement {
       if (data.lastUpdatedAt) this.lastUpdatedAt = data.lastUpdatedAt;
       this.approvalStats = data.approvalStats || this.approvalStats;
       this.attentionInputs = data.attentionInputs || null;
+      if (this.attentionInputs) this.publishAttentionCounts();
       this.budgetPolicies = data.budgetPolicies || [];
       this.budgetAgents = data.budgetAgents || [];
 
@@ -2745,11 +2746,18 @@ export class DashboardView extends AuthedElement {
     }
     const items = deriveAttentionItems(this.attentionInputs).items;
     this.attentionMemo = { inputs: this.attentionInputs, items };
-    // The bell in the header cannot afford this derivation's requests, and
-    // "No notifications" over a strip saying "2 need attention" reads as a
-    // contradiction. Publish the counts the strip is about to show.
-    publishAttentionSummary(items);
     return items;
+  }
+
+  /**
+   * The bell in the header cannot afford this derivation's nine requests, and
+   * "No notifications" over a strip saying "2 need attention" reads as a
+   * contradiction, so the counts go out whenever the inputs change. Called
+   * where the inputs are assigned rather than from the getter: a getter that
+   * dispatches events during render is a trap for the next editor.
+   */
+  private publishAttentionCounts(): void {
+    publishAttentionSummary(this.attentionItems);
   }
 
   /**
@@ -2771,6 +2779,7 @@ export class DashboardView extends AuthedElement {
           ...shared,
         },
       });
+      this.publishAttentionCounts();
       this.scheduleCacheWrite();
     } catch (error) {
       console.error('Failed to load attention inputs', error);

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -59,6 +59,7 @@ import {
   loadAttentionInputs,
   type PrefetchedAttentionInputs,
 } from '../../utils/attention-data';
+import { publishAttentionSummary } from '../../utils/attention-summary';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import type {
   AccountGatewayUsageSummaryResponse,
@@ -1011,10 +1012,14 @@ export class DashboardView extends AuthedElement {
            at 240px the card showed three lines and an expanded row had to be
            scrolled to be read. It is stated against the viewport as well as
            in pixels so a short laptop window shrinks the feed instead of
-           pushing the Usage card off the rail. */
+           pushing the Usage card off the rail.
+
+           360px still left three and a half rows at 1440x900, with the
+           fourth clipped mid-line, while the left column ended a screen
+           earlier: 480px (48dvh) uses the height the rail already has. */
         .column-layout.dashboard > .side-column > activity-feed {
           flex: 1 1 0;
-          min-height: min(360px, 34dvh);
+          min-height: min(480px, 48dvh);
           /* The rail is bounded and stretched above, so here (and only
              here) the column decides the feed's height and the card's own
              360px stop would only make the list shorter than the space it
@@ -2740,6 +2745,10 @@ export class DashboardView extends AuthedElement {
     }
     const items = deriveAttentionItems(this.attentionInputs).items;
     this.attentionMemo = { inputs: this.attentionInputs, items };
+    // The bell in the header cannot afford this derivation's requests, and
+    // "No notifications" over a strip saying "2 need attention" reads as a
+    // contradiction. Publish the counts the strip is about to show.
+    publishAttentionSummary(items);
     return items;
   }
 

--- a/frontend/src/views/authed/dashboard-view.test.ts
+++ b/frontend/src/views/authed/dashboard-view.test.ts
@@ -3,6 +3,10 @@ import sinon from 'sinon';
 
 import '../../components/view-header.ts';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
+import {
+  ATTENTION_SUMMARY_EVENT,
+  readAttentionSummary,
+} from '../../utils/attention-summary';
 import './dashboard-control-plane-view';
 import type { DashboardView } from './dashboard-control-plane-view';
 
@@ -573,6 +577,33 @@ describe('DashboardView', () => {
     expect(element.shadowRoot?.querySelector('activity-feed')).to.exist;
     expect(element.shadowRoot?.textContent).to.contain('Audit exceptions');
     expect(element.shadowRoot?.textContent).to.contain('need attention');
+  });
+
+  it('publishes the attention counts when the inputs land, not while rendering', async () => {
+    const element = await mountDashboard();
+    await waitUntil(
+      () => element['attentionInputs'] != null,
+      'attention inputs never loaded'
+    );
+    await element.updateComplete;
+
+    const published = readAttentionSummary();
+    expect(published, 'counts published for the header bell').to.not.equal(
+      null
+    );
+    expect(published!.total).to.be.greaterThan(0);
+
+    // Deriving the items is a pure read. It used to dispatch from the getter,
+    // which the template calls, so a render published an event.
+    let events = 0;
+    const onSummary = () => {
+      events += 1;
+    };
+    window.addEventListener(ATTENTION_SUMMARY_EVENT, onSummary);
+    element['attentionMemo'] = null;
+    void element['attentionItems'];
+    window.removeEventListener(ATTENTION_SUMMARY_EVENT, onSummary);
+    expect(events).to.equal(0);
   });
 
   it('subscribes to realtime topics and fetches dashboard data', async () => {

--- a/frontend/src/views/authed/runtime-sessions-view.test.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.test.ts
@@ -690,6 +690,100 @@ describe('RuntimeSessionsView', () => {
       expect(listCalls().pop()).to.contain('query=workspace-42');
     });
 
+    it('ignores a stale list when a later load already finished', async () => {
+      const element = (await fixture(
+        html`<runtime-sessions-view></runtime-sessions-view>`
+      )) as RuntimeSessionsView;
+
+      await waitUntil(
+        () => !(element as any).loading,
+        'Runtime sessions view did not finish loading'
+      );
+      await element.updateComplete;
+
+      const listPayload = (id: string, name: string) => ({
+        period_start: '2026-02-08T00:00:00Z',
+        period_end: '2026-03-09T23:59:59Z',
+        query: null,
+        session_source_type: null,
+        status: 'all',
+        total: 1,
+        limit: 50,
+        offset: 0,
+        items: [
+          {
+            id,
+            session_source_type: 'claude_code',
+            session_source_id: 'workspace-42',
+            session_reference: name,
+            runtime_principal_type: 'claude_code',
+            runtime_principal_id: 'workspace-42',
+            runtime_principal_name: name,
+            started_at: '2026-03-09T18:00:00Z',
+            last_activity_at: '2026-03-09T20:00:00Z',
+            ended_at: null,
+            flow_id: null,
+            flow_name: null,
+            flow_execution_id: null,
+            latest_model_alias: 'anthropic/claude-sonnet-4',
+            latest_provider_name: 'Anthropic',
+            is_active_now: true,
+            activity_status: 'active_now',
+            total_requests: 4,
+            successful_requests: 3,
+            failed_requests: 1,
+            token_usage: {
+              prompt_tokens: 1200,
+              completion_tokens: 450,
+              total_tokens: 1650,
+            },
+            estimated_cost: 0.42,
+            last_request_at: '2026-03-09T20:00:00Z',
+          },
+        ],
+      });
+
+      let releaseStale: () => void = () => undefined;
+      const staleHold = new Promise<void>((resolve) => {
+        releaseStale = resolve;
+      });
+      let listCalls = 0;
+      fetchStub.callsFake(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.startsWith('/api/v1/runtime-sessions?')) {
+          listCalls += 1;
+          if (listCalls === 1) {
+            await staleHold;
+            return new Response(
+              JSON.stringify(listPayload('stale-session', 'Stale')),
+              {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }
+            );
+          }
+          return new Response(
+            JSON.stringify(listPayload('fresh-session', 'Fresh')),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          );
+        }
+        return new Response('{}', { status: 404 });
+      });
+
+      const first = (element as any).loadSessions();
+      const second = (element as any).loadSessions();
+      releaseStale();
+      await Promise.all([first, second]);
+      await element.updateComplete;
+
+      expect((element as any).sessions.items[0].id).to.equal('fresh-session');
+      expect((element as any).selectedSessionId).to.equal('fresh-session');
+      expect((element as any).loading).to.equal(false);
+    });
+
     it('keeps the hint about what the query matches', async () => {
       const element = (await fixture(
         html`<runtime-sessions-view></runtime-sessions-view>`

--- a/frontend/src/views/authed/runtime-sessions-view.test.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.test.ts
@@ -651,6 +651,45 @@ describe('RuntimeSessionsView', () => {
       expect(text).to.not.contain('Session Observer');
     });
 
+    it('refetches on a debounced search, like the Agents bar', async () => {
+      const element = (await fixture(
+        html`<runtime-sessions-view></runtime-sessions-view>`
+      )) as RuntimeSessionsView;
+
+      await waitUntil(
+        () => !(element as any).loading,
+        'Runtime sessions view did not finish loading'
+      );
+      await element.updateComplete;
+
+      const listCalls = () =>
+        fetchStub
+          .getCalls()
+          .map((call) => String(call.args[0]))
+          .filter((url) => url.startsWith('/api/v1/runtime-sessions?'));
+      const before = listCalls().length;
+
+      const toolbar = element.shadowRoot!.querySelector('list-toolbar')!;
+      toolbar.dispatchEvent(
+        new CustomEvent('search-change', {
+          detail: { value: 'workspace-42' },
+          bubbles: true,
+          composed: true,
+        })
+      );
+
+      // Nothing goes out on the keystroke itself: the query is a server
+      // parameter, so it waits for the typing to stop.
+      expect(listCalls().length).to.equal(before);
+
+      await waitUntil(
+        () => listCalls().length > before,
+        'Search did not refetch after the debounce',
+        { timeout: 3000 }
+      );
+      expect(listCalls().pop()).to.contain('query=workspace-42');
+    });
+
     it('shows one search input on the page', async () => {
       const element = (await fixture(
         html`<runtime-sessions-view></runtime-sessions-view>`

--- a/frontend/src/views/authed/runtime-sessions-view.test.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.test.ts
@@ -690,6 +690,26 @@ describe('RuntimeSessionsView', () => {
       expect(listCalls().pop()).to.contain('query=workspace-42');
     });
 
+    it('keeps the hint about what the query matches', async () => {
+      const element = (await fixture(
+        html`<runtime-sessions-view></runtime-sessions-view>`
+      )) as RuntimeSessionsView;
+
+      await waitUntil(
+        () => !(element as any).loading,
+        'Runtime sessions view did not finish loading'
+      );
+      await element.updateComplete;
+
+      const toolbar = element.shadowRoot!.querySelector('list-toolbar')!;
+      await (toolbar as any).updateComplete;
+      const input = toolbar.shadowRoot!.querySelector('sl-input.search-input')!;
+      expect(input.getAttribute('placeholder')).to.equal(
+        'Principal, session reference, or source id'
+      );
+      expect(input.getAttribute('label')).to.equal('Search sessions');
+    });
+
     it('shows one search input on the page', async () => {
       const element = (await fixture(
         html`<runtime-sessions-view></runtime-sessions-view>`

--- a/frontend/src/views/authed/runtime-sessions-view.test.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.test.ts
@@ -615,6 +615,68 @@ describe('RuntimeSessionsView', () => {
     expect(content).to.contain('openai/gpt-5');
   });
 
+  describe('collection bar', () => {
+    it('states the matching session count in one live region', async () => {
+      const element = (await fixture(
+        html`<runtime-sessions-view></runtime-sessions-view>`
+      )) as RuntimeSessionsView;
+
+      await waitUntil(
+        () => !(element as any).loading,
+        'Runtime sessions view did not finish loading'
+      );
+      await element.updateComplete;
+
+      const toolbar = element.shadowRoot!.querySelector('list-toolbar')!;
+      expect(toolbar).to.not.equal(null);
+      const count = toolbar.querySelector('[slot="count"]')!;
+      expect(count.textContent!.trim()).to.equal('2 sessions');
+      const liveRegion = toolbar.shadowRoot!.querySelector('.results-count')!;
+      expect(liveRegion.getAttribute('aria-live')).to.equal('polite');
+    });
+
+    it('drops the filter and observer card titles', async () => {
+      const element = (await fixture(
+        html`<runtime-sessions-view></runtime-sessions-view>`
+      )) as RuntimeSessionsView;
+
+      await waitUntil(
+        () => !(element as any).loading,
+        'Runtime sessions view did not finish loading'
+      );
+      await element.updateComplete;
+
+      const text = element.shadowRoot!.textContent || '';
+      expect(text).to.not.contain('Session Explorer Filters');
+      expect(text).to.not.contain('Session Observer');
+    });
+
+    it('shows one search input on the page', async () => {
+      const element = (await fixture(
+        html`<runtime-sessions-view></runtime-sessions-view>`
+      )) as RuntimeSessionsView;
+
+      await waitUntil(
+        () => !(element as any).loading,
+        'Runtime sessions view did not finish loading'
+      );
+      await element.updateComplete;
+
+      const observer = element.shadowRoot!.querySelector(
+        'preloop-session-observer'
+      )!;
+      await (observer as any).updateComplete;
+
+      const toolbarSearches = element
+        .shadowRoot!.querySelector('list-toolbar')!
+        .shadowRoot!.querySelectorAll('sl-input.search-input');
+      const sidebarSearches =
+        observer.shadowRoot!.querySelectorAll('.sidebar sl-input');
+      expect(toolbarSearches.length).to.equal(1);
+      expect(sidebarSearches.length).to.equal(0);
+    });
+  });
+
   describe('reader-facing copy', () => {
     it('uses no em dash in the page copy', async () => {
       const element = (await fixture(

--- a/frontend/src/views/authed/runtime-sessions-view.test.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.test.ts
@@ -755,23 +755,37 @@ describe('RuntimeSessionsView', () => {
             headers: { 'Content-Type': 'application/json' },
           });
         }
-        return new Response('{}', { status: 404 });
+        return new Response('{}', { status: 200 });
       });
 
-      const first = (element as any).loadSessions();
-      const second = (element as any).loadSessions();
-      await waitUntil(
-        () => pending.length >= 2,
-        'Both session list fetches did not start'
-      );
-      pending[1](listPayload('fresh-session', 'Fresh'));
-      pending[0](listPayload('stale-session', 'Stale'));
-      await Promise.all([first, second]);
-      await element.updateComplete;
+      try {
+        // Identical GETs share one in-flight request, so the two loads need
+        // different queries or there is only one fetch to resolve.
+        (element as any).searchQuery = 'stale';
+        const first = (element as any).loadSessions();
+        await waitUntil(
+          () => pending.length >= 1,
+          'First session list fetch did not start'
+        );
+        (element as any).searchQuery = 'fresh';
+        const second = (element as any).loadSessions();
+        await waitUntil(
+          () => pending.length >= 2,
+          'Second session list fetch did not start'
+        );
+        pending[1](listPayload('fresh-session', 'Fresh'));
+        pending[0](listPayload('stale-session', 'Stale'));
+        await Promise.all([first, second]);
+        await element.updateComplete;
 
-      expect((element as any).sessions.items[0].id).to.equal('fresh-session');
-      expect((element as any).selectedSessionId).to.equal('fresh-session');
-      expect((element as any).loading).to.equal(false);
+        expect((element as any).sessions.items[0].id).to.equal('fresh-session');
+        expect((element as any).selectedSessionId).to.equal('fresh-session');
+        expect((element as any).loading).to.equal(false);
+      } finally {
+        for (const resolve of pending) {
+          resolve(listPayload('fresh-session', 'Fresh'));
+        }
+      }
     });
 
     it('keeps the hint about what the query matches', async () => {

--- a/frontend/src/views/authed/runtime-sessions-view.test.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.test.ts
@@ -743,39 +743,29 @@ describe('RuntimeSessionsView', () => {
         ],
       });
 
-      let releaseStale: () => void = () => undefined;
-      const staleHold = new Promise<void>((resolve) => {
-        releaseStale = resolve;
-      });
-      let listCalls = 0;
+      const pending: Array<(body: unknown) => void> = [];
       fetchStub.callsFake(async (input: RequestInfo | URL) => {
         const url = typeof input === 'string' ? input : input.toString();
-        if (url.startsWith('/api/v1/runtime-sessions?')) {
-          listCalls += 1;
-          if (listCalls === 1) {
-            await staleHold;
-            return new Response(
-              JSON.stringify(listPayload('stale-session', 'Stale')),
-              {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-              }
-            );
-          }
-          return new Response(
-            JSON.stringify(listPayload('fresh-session', 'Fresh')),
-            {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' },
-            }
-          );
+        if (url.includes('/api/v1/runtime-sessions?')) {
+          const body = await new Promise<unknown>((resolve) => {
+            pending.push(resolve);
+          });
+          return new Response(JSON.stringify(body), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
         }
         return new Response('{}', { status: 404 });
       });
 
       const first = (element as any).loadSessions();
       const second = (element as any).loadSessions();
-      releaseStale();
+      await waitUntil(
+        () => pending.length >= 2,
+        'Both session list fetches did not start'
+      );
+      pending[1](listPayload('fresh-session', 'Fresh'));
+      pending[0](listPayload('stale-session', 'Stale'));
       await Promise.all([first, second]);
       await element.updateComplete;
 

--- a/frontend/src/views/authed/runtime-sessions-view.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.ts
@@ -465,7 +465,7 @@ export class RuntimeSessionsView extends LitElement {
       }
 
       @media (max-width: 720px) {
-        .filters-actions {
+        .filter-actions {
           margin-left: 0;
           width: 100%;
         }
@@ -1577,7 +1577,7 @@ export class RuntimeSessionsView extends LitElement {
               </div>
             </div>
             <div class="summary-card">
-              <div class="summary-label">Estimated Cost</div>
+              <div class="summary-label">Estimated spend</div>
               <div class="summary-value">
                 ${this.formatCost(session.estimated_cost)}
               </div>
@@ -1589,7 +1589,7 @@ export class RuntimeSessionsView extends LitElement {
         </sl-card>
 
         <sl-card>
-          <div slot="header" class="session-item-title">Usage By Model</div>
+          <div slot="header" class="session-item-title">Usage by model</div>
           ${this.renderModelBreakdown(this.detail.usage_by_model)}
         </sl-card>
 
@@ -1615,7 +1615,8 @@ export class RuntimeSessionsView extends LitElement {
         <div class="main-column">
           <div class="page">
             <list-toolbar
-              searchPlaceholder="Search sessions"
+              searchPlaceholder="Principal, session reference, or source id"
+              searchLabel="Search sessions"
               .search=${this.searchQuery}
               .views=${[]}
               @search-change=${this.handleSearchChange}

--- a/frontend/src/views/authed/runtime-sessions-view.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.ts
@@ -121,6 +121,7 @@ export class RuntimeSessionsView extends LitElement {
   private unsubscribeRealtime?: () => void;
   private refreshTimer: number | null = null;
   private searchDebounce: number | null = null;
+  private loadSequence = 0;
 
   static styles = [
     unsafeCSS(consoleStyles),
@@ -692,13 +693,16 @@ export class RuntimeSessionsView extends LitElement {
   @state() private isPremium = true;
 
   private async loadSessions(isSoftRefresh = false) {
+    const seq = ++this.loadSequence;
     if (!isSoftRefresh) {
       this.loading = true;
       this.error = null;
     }
 
     try {
-      this.sessions = await getAccountRuntimeSessions(this.buildListParams());
+      const result = await getAccountRuntimeSessions(this.buildListParams());
+      if (seq !== this.loadSequence) return;
+      this.sessions = result;
       if (
         !this.selectedSessionId ||
         !this.sessions.items.some((item) => item.id === this.selectedSessionId)
@@ -710,6 +714,7 @@ export class RuntimeSessionsView extends LitElement {
       // <preloop-session-observer> and load after selection, do not block the
       // list on getAccountRuntimeSessionDetail.
     } catch (error) {
+      if (seq !== this.loadSequence) return;
       console.error('Failed to load sessions:', error);
       if (!isSoftRefresh) {
         this.error =
@@ -718,7 +723,7 @@ export class RuntimeSessionsView extends LitElement {
         this.detail = null;
       }
     } finally {
-      if (!isSoftRefresh) {
+      if (seq === this.loadSequence) {
         this.loading = false;
       }
     }

--- a/frontend/src/views/authed/runtime-sessions-view.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.ts
@@ -120,6 +120,7 @@ export class RuntimeSessionsView extends LitElement {
   private initialized = false;
   private unsubscribeRealtime?: () => void;
   private refreshTimer: number | null = null;
+  private searchDebounce: number | null = null;
 
   static styles = [
     unsafeCSS(consoleStyles),
@@ -507,6 +508,7 @@ export class RuntimeSessionsView extends LitElement {
       window.clearTimeout(this.refreshTimer);
       this.refreshTimer = null;
     }
+    this.cancelSearchDebounce();
   }
 
   private connectRealtime(): void {
@@ -864,10 +866,28 @@ export class RuntimeSessionsView extends LitElement {
     this.selectedRange = 'custom';
   }
 
-  private handleSearchQueryChange(event: Event) {
-    this.searchQuery = (
-      event.target as HTMLInputElement & { value: string }
-    ).value;
+  /**
+   * The bar filters as you type, the way the Agents bar does
+   * (agents-view.ts handleSearchChange). One bar that filters live and one
+   * that waits for a button would be two behaviours for one control, and the
+   * toolbar swallows Enter, so a typed query used to sit there doing nothing
+   * until the operator found Apply. The query is a server parameter, so the
+   * keystrokes are debounced instead of sent one per character.
+   */
+  private handleSearchChange(event: CustomEvent<{ value: string }>) {
+    this.searchQuery = event.detail.value;
+    this.cancelSearchDebounce();
+    this.searchDebounce = window.setTimeout(() => {
+      this.searchDebounce = null;
+      void this.loadSessions();
+    }, 400);
+  }
+
+  private cancelSearchDebounce(): void {
+    if (this.searchDebounce !== null) {
+      window.clearTimeout(this.searchDebounce);
+      this.searchDebounce = null;
+    }
   }
 
   private handleSessionSourceTypeChange(event: Event) {
@@ -901,10 +921,12 @@ export class RuntimeSessionsView extends LitElement {
   }
 
   private async applyFilters() {
+    this.cancelSearchDebounce();
     await this.loadSessions();
   }
 
   private async clearFilters() {
+    this.cancelSearchDebounce();
     this.selectedRange = 'last-30';
     this.applyPresetDates('last-30');
     this.searchQuery = '';
@@ -1596,9 +1618,7 @@ export class RuntimeSessionsView extends LitElement {
               searchPlaceholder="Search sessions"
               .search=${this.searchQuery}
               .views=${[]}
-              @search-change=${(event: CustomEvent) => {
-                this.searchQuery = event.detail.value;
-              }}
+              @search-change=${this.handleSearchChange}
             >
               <sl-select
                 label="Date range"

--- a/frontend/src/views/authed/runtime-sessions-view.ts
+++ b/frontend/src/views/authed/runtime-sessions-view.ts
@@ -13,6 +13,7 @@ import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '../../components/view-header.ts';
 import '../../components/json-tree.ts';
+import '../../components/list-toolbar.ts';
 import '../../components/preloop-session-observer.ts';
 import {
   getAccountRuntimeSessionDetail,
@@ -133,22 +134,19 @@ export class RuntimeSessionsView extends LitElement {
         gap: var(--sl-spacing-large);
       }
 
-      .filters-grid {
-        display: flex;
-        gap: var(--sl-spacing-medium);
-        flex-wrap: wrap;
-        align-items: end;
-      }
-
-      .filters-grid sl-select,
-      .filters-grid sl-input {
+      /* The collection bar: the same inline row the Agents and Flows lists
+         use, so the filters sit on the page instead of inside a card of
+         their own. Slotted content lives in this view's tree, so these
+         rules reach the selects and the Apply/Reset pair. */
+      list-toolbar sl-select,
+      list-toolbar sl-input[type='date'] {
         min-width: 180px;
       }
 
-      .filters-actions {
+      .filter-actions {
         display: flex;
         gap: var(--sl-spacing-small);
-        margin-left: auto;
+        align-items: end;
       }
 
       .layout {
@@ -970,6 +968,19 @@ export class RuntimeSessionsView extends LitElement {
     return typeof value === 'number' ? value.toLocaleString() : '0';
   }
 
+  /**
+   * The honest count every other collection page states, in the same place:
+   * how many sessions the filters matched. Empty while the first page is in
+   * flight so the bar never claims "0 sessions" before the answer arrives.
+   */
+  private get sessionCountLabel(): string {
+    if (this.loading || !this.sessions) {
+      return '';
+    }
+    const total = this.sessions.total ?? this.sessions.items.length;
+    return `${this.formatNumber(total)} session${total === 1 ? '' : 's'}`;
+  }
+
   private formatCost(value: number | null | undefined): string {
     if (typeof value !== 'number' || Number.isNaN(value)) {
       return '$0.00';
@@ -1581,73 +1592,70 @@ export class RuntimeSessionsView extends LitElement {
       <div class="dashboard extra-wide">
         <div class="main-column">
           <div class="page">
-            <sl-card>
-              <div slot="header" class="session-item-title">
-                Session Explorer Filters
+            <list-toolbar
+              searchPlaceholder="Search sessions"
+              .search=${this.searchQuery}
+              .views=${[]}
+              @search-change=${(event: CustomEvent) => {
+                this.searchQuery = event.detail.value;
+              }}
+            >
+              <sl-select
+                label="Date range"
+                value=${this.selectedRange}
+                @sl-change=${this.handleRangeChange}
+              >
+                <sl-option value="last-7">Last 7 days</sl-option>
+                <sl-option value="last-30">Last 30 days</sl-option>
+                <sl-option value="last-90">Last 90 days</sl-option>
+                <sl-option value="all">All time</sl-option>
+                <sl-option value="custom">Custom</sl-option>
+              </sl-select>
+              <sl-input
+                type="date"
+                label="Start date"
+                .value=${this.startDate}
+                @sl-change=${this.handleStartDateChange}
+              ></sl-input>
+              <sl-input
+                type="date"
+                label="End date"
+                .value=${this.endDate}
+                @sl-change=${this.handleEndDateChange}
+              ></sl-input>
+              <sl-select
+                label="Source type"
+                value=${this.sessionSourceType}
+                @sl-change=${this.handleSessionSourceTypeChange}
+              >
+                <sl-option value="all">All sources</sl-option>
+                <sl-option value="flow_execution">Flow execution</sl-option>
+                <sl-option value="claude_code">Claude Code</sl-option>
+                <sl-option value="claude_desktop">Claude Desktop</sl-option>
+                <sl-option value="codex">Codex</sl-option>
+                <sl-option value="openclaw">OpenClaw</sl-option>
+                <sl-option value="desktop_agent">Desktop agent</sl-option>
+                <sl-option value="custom">Custom</sl-option>
+              </sl-select>
+              <sl-select
+                label="Status"
+                value=${this.status}
+                @sl-change=${this.handleStatusChange}
+              >
+                <sl-option value="all">All</sl-option>
+                <sl-option value="active">Active</sl-option>
+                <sl-option value="ended">Ended</sl-option>
+              </sl-select>
+              <div class="filter-actions">
+                <sl-button variant="primary" @click=${this.applyFilters}>
+                  Apply
+                </sl-button>
+                <sl-button variant="default" @click=${this.clearFilters}>
+                  Reset
+                </sl-button>
               </div>
-              <div class="filters-grid">
-                <sl-select
-                  label="Date range"
-                  value=${this.selectedRange}
-                  @sl-change=${this.handleRangeChange}
-                >
-                  <sl-option value="last-7">Last 7 days</sl-option>
-                  <sl-option value="last-30">Last 30 days</sl-option>
-                  <sl-option value="last-90">Last 90 days</sl-option>
-                  <sl-option value="all">All time</sl-option>
-                  <sl-option value="custom">Custom</sl-option>
-                </sl-select>
-                <sl-input
-                  type="date"
-                  label="Start date"
-                  .value=${this.startDate}
-                  @sl-change=${this.handleStartDateChange}
-                ></sl-input>
-                <sl-input
-                  type="date"
-                  label="End date"
-                  .value=${this.endDate}
-                  @sl-change=${this.handleEndDateChange}
-                ></sl-input>
-                <sl-input
-                  label="Search sessions"
-                  placeholder="Principal, session reference, or source id"
-                  .value=${this.searchQuery}
-                  @sl-input=${this.handleSearchQueryChange}
-                ></sl-input>
-                <sl-select
-                  label="Source type"
-                  value=${this.sessionSourceType}
-                  @sl-change=${this.handleSessionSourceTypeChange}
-                >
-                  <sl-option value="all">All sources</sl-option>
-                  <sl-option value="flow_execution">Flow execution</sl-option>
-                  <sl-option value="claude_code">Claude Code</sl-option>
-                  <sl-option value="claude_desktop">Claude Desktop</sl-option>
-                  <sl-option value="codex">Codex</sl-option>
-                  <sl-option value="openclaw">OpenClaw</sl-option>
-                  <sl-option value="desktop_agent">Desktop agent</sl-option>
-                  <sl-option value="custom">Custom</sl-option>
-                </sl-select>
-                <sl-select
-                  label="Status"
-                  value=${this.status}
-                  @sl-change=${this.handleStatusChange}
-                >
-                  <sl-option value="all">All</sl-option>
-                  <sl-option value="active">Active</sl-option>
-                  <sl-option value="ended">Ended</sl-option>
-                </sl-select>
-                <div class="filters-actions">
-                  <sl-button variant="primary" @click=${this.applyFilters}>
-                    Apply
-                  </sl-button>
-                  <sl-button variant="default" @click=${this.clearFilters}>
-                    Reset
-                  </sl-button>
-                </div>
-              </div>
-            </sl-card>
+              <span slot="count">${this.sessionCountLabel}</span>
+            </list-toolbar>
 
             ${
               this.error
@@ -1674,11 +1682,9 @@ export class RuntimeSessionsView extends LitElement {
                   `
                 : html`
                     <sl-card>
-                      <div slot="header" class="session-item-title">
-                        Session Observer
-                      </div>
                       <preloop-session-observer
                         scope="account"
+                        hideListSearch
                         .sessions=${this.sessions?.items || []}
                         .emptyText=${this.emptySessionsText()}
                         .selectedSessionId=${this.selectedSessionId}


### PR DESCRIPTION
# UX round 4 wave 2: sessions bar, Overview header and feed, agent detail chips

## Summary

Three of the wave 2 console items. Sessions gets the same collection bar as
Agents and Flows, with a live result count and one search box instead of two
stacked cards. The Overview bell now says what needs attention instead of an
empty line, the activity feed shows how many rows are below the fold, and
estimated spend has one name across the agent pages. The agent detail page
stops speaking two chip dialects for "Idle" and moves its actions, tabs and
the Associated flows empty state to sentence case.

No new network requests are added anywhere; the header reads counts the
Overview and Attention views already compute.

## Changes

### W2-3. Sessions collection bar (A8)

- One `<list-toolbar>` replaces the "Session Explorer Filters" card and the
  "Session Observer" card title: search, date range, start/end, source type,
  status, Apply/Reset, and an `aria-live="polite"` "N sessions" count.
- The session observer's sidebar search is hidden here behind a new opt-in
  `hideListSearch` property, so the page has one search box while the agent
  detail embed keeps its local filter.

### W2-4. Overview header and feed (A1, A10, A13)

- New `utils/attention-summary.ts`: the Overview strip and the Attention page
  publish their derived counts (sessionStorage plus a window event) and the
  console header reads them, so the bell empty state reads "No new
  notifications" plus "2 items need attention: 1 flow, 1 pricing". Same
  low-severity rule as the strip, so bell and strip never disagree, and no
  extra fetches on any page.
- Feed rail is `min-height: min(480px, 48dvh)` and the footer shows "N more"
  beside "View audit", measured from the rows below the scroller fold.
- Estimated spend is `$ est.` in table headers (DESIGN.md:133) and
  "Estimated spend" in prose on the agents cards and the agent summary strip.
- One 90-day relative-time cutoff for "Last seen" in the agents list and
  cards.
- Account menu and header labels in sentence case.

### W2-5. Agent detail chips and copy (A6, findings 27, 32)

- `<session-list-panel>` renders its status and waste badges through the
  console `.chip` recipe and idle is `neutral`, so the header chip and the
  list chip are the same object.
- Actions ("Edit tags", "Change owner") and tabs ("Session history", "Tools &
  governance", "Models & spend", "Command terminal (SSH)", "Agent web UI",
  "Associated flows") in sentence case, with the in-tab titles matched.
- Associated flows empty state: "Flows using this agent" / "No flow uses this
  agent yet. Add it as a step in a flow to have it run on a schedule or on an
  event." / "Create flow".

## Review follow-ups

All 10 findings from the V-J2 review (APPROVE WITH NITS: 3 should, 7 nit) are
applied in 5 further commits, one per should and two grouping the nits.

Shoulds:

1. **The Sessions search now filters as you type**, debounced 400ms into a
   reload, the way the Agents bar does. Before, `search-change` only wrote
   state and the toolbar swallows Enter, so a typed query did nothing until
   the operator found Apply. Apply, Reset and disconnect cancel a pending
   keystroke. The dead `handleSearchQueryChange` went with it (nit 8).
2. **An ended session's chip is neutral again.** The chip rewrite had dropped
   the `ended` branch, so an ended session containing a failed request turned
   amber. Warning means "needs a person"; a finished run does not.
3. **The bell forgets the previous account.** `preloop:attention-summary` is
   now cleared in `invalidateApiCaches` (the auth-change handler), with the
   key exported from `attention-summary.ts` so there is one spelling. Sign-out
   navigates with `location.href`, which keeps sessionStorage for the tab.

Nits:

4. The activity feed measures the rows below the fold on an animation frame
   instead of from `updated()`, so a feed event no longer costs a second
   render pass. The Lit dev warning it printed is gone (0 occurrences).
5. The Overview publishes the attention counts where `attentionInputs` is
   assigned, not from the `attentionItems` getter the template reads.
6. The Sessions search says what it matches again: `list-toolbar` takes a
   separate `searchLabel`, so the placeholder carries "Principal, session
   reference, or source id" while the field is still announced as "Search
   sessions".
7. The 720px media block targets `.filter-actions` (renamed in the same wave),
   so Apply/Reset is full width on a phone again.
9. The Sessions summary says "Estimated spend" and the card is titled "Usage
   by model", matching the agent pages. (That template is currently
   unreferenced in the view, on this branch and on main; the copy is fixed for
   whoever wires it back.)
10. The `$ est.` sort button carries `title`/`aria-label` "Estimated spend", so
    a screen reader does not read the column as "dollar est.".

## Tests

- Full suite on the branch: 148 files, **1712 passed, 0 failed**, 20.2s.
  Baseline on main: 146 files, 1689 passed, 0 failed. Net +23 tests.
- New files: `utils/attention-summary.test.ts` (5),
  `components/session-list-panel.test.ts` (4).
- Extended: `runtime-sessions-view.test.ts` (9: count text, no old card
  titles, single search input, debounced refetch, placeholder hint),
  `console-header.test.ts` (9), `agents-view.test.ts` (32, relative time at 45
  days plus the named spend header), `activity-feed.test.ts` (34, the "N more"
  footer plus the off-cycle measurement), `list-toolbar.test.ts` (12),
  `dashboard-view.test.ts` (56, includes the publish path).
- `pre-commit run --files <changed files>` passes for each of the 8 commits.

## Founder calls

1. **Bell data path.** A1 reads as if the header already had the attention
   counts; it did not, and fetching them there is about nine requests on every
   console page. This publishes from the two views that already compute them
   and reads from sessionStorage in the header. If you would rather the header
   own the fetch, say so and it becomes a small change.
2. **Spend header wording.** Group findings suggested "Spend (est.)"; REPORT
   section 4 chose `$ est.` citing DESIGN.md:133. Shipped as `$ est.`.
3. **Which search box.** The Sessions page keeps the API query search; the
   observer sidebar filter is hidden on that page only.
4. **Ampersands.** "Tools & governance" and "Models & spend" keep the
   ampersand; only the casing changed. Happy to expand to "and" if preferred.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low risk**
> Console UX copy/layout changes only (no new network requests, no backend changes); well-tested with 1712 passing tests and no security findings.
>
> **Overview**
> Adds the Sessions collection bar (`<list-toolbar>`), the Overview header/feed "N more" and attention-summary bell, and unifies agent-detail chips/copy to sentence case, plus the 10 V-J2 review follow-ups. Both prior low-severity suggestions (scroll-measure rAF coalescing and the session-list race guard) are now fixed and tested.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 5ab0c843. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->