### PR TITLE
Preserve container termination evidence and report confirmed OOM failures

### DIFF
--- a/backend/preloop/agents/base.py
+++ b/backend/preloop/agents/base.py
@@ -23,6 +23,23 @@ class AgentStatus(str, Enum):
     STOPPED = "STOPPED"
 
 
+@dataclass(frozen=True)
+class ContainerTermination:
+    """Runtime-reported container termination, independent of agent output."""
+
+    runtime: str
+    container_name: Optional[str] = None
+    container_id: Optional[str] = None
+    pod_name: Optional[str] = None
+    exit_code: Optional[int] = None
+    reason: Optional[str] = None
+    message: Optional[str] = None
+    signal: Optional[int] = None
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    oom_killed: bool = False
+
+
 @dataclass
 class AgentExecutionResult:
     """Result of an agent execution."""
@@ -39,6 +56,7 @@ class AgentExecutionResult:
     # keeps only the generated sentence, which cannot encode the
     # transient/terminal verdict — this carries it to the retry decision.
     failure_analysis: Optional["AgentFailureAnalysis"] = None
+    termination: Optional[ContainerTermination] = None
 
 
 class AgentExecutor(ABC):

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -12,6 +12,7 @@ import random
 import re
 import shlex
 import tarfile
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 import aiodocker
@@ -23,9 +24,9 @@ from preloop.services.flow_failure_category import (
     FAILURE_CATEGORY_RUNNER_ERROR,
 )
 
-from .base import AgentExecutionResult, AgentExecutor, AgentStatus
+from .base import AgentExecutionResult, AgentExecutor, AgentStatus, ContainerTermination
 from .errors import AgentStartError
-from .failure_analysis import analyze_agent_failure
+from .failure_analysis import AgentFailureAnalysis, analyze_agent_failure
 from preloop.services.mcp_config_service import MCPConfigService
 from preloop.agents.verification import build_verification_gate_shell
 from preloop.services.tracker_git_token import APP_AUTH_TYPES
@@ -54,6 +55,29 @@ from preloop.utils.workspace_snapshot import (
 from preloop.services.verification import resolve_verification_policy
 
 logger = logging.getLogger(__name__)
+
+
+def _termination_timestamp(value: Any) -> Optional[str]:
+    """Normalize runtime timestamps for JSON persistence."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value if isinstance(value, str) else None
+
+
+def _oom_failure_analysis(termination: ContainerTermination) -> AgentFailureAnalysis:
+    """Explain a confirmed memory kill without retrying historical provider errors."""
+    return AgentFailureAnalysis(
+        message=(
+            "Agent container was OOMKilled (out of memory; "
+            f"exit code {termination.exit_code}). "
+            "Reduce the workload's memory use or increase the runner's memory "
+            "allocation before retrying."
+        ),
+        transient=False,
+        error_class="container_oom_killed",
+        evidence=f"{termination.runtime} runtime reported OOMKilled",
+    )
+
 
 # Git ref names interpolated into generated shell (origin/<branch>..HEAD).
 # Charset is unquoted-shell-safe so we never splice shlex.quote into the
@@ -1607,7 +1631,19 @@ class ContainerAgentExecutor(AgentExecutor):
             info = await container.show()
 
             # Get exit code
-            exit_code = info["State"].get("ExitCode")
+            state = info["State"]
+            exit_code = state.get("ExitCode")
+            termination = ContainerTermination(
+                runtime="docker",
+                container_name=(info.get("Name") or "").lstrip("/") or None,
+                container_id=info.get("Id") or session_reference,
+                exit_code=exit_code,
+                reason="OOMKilled" if state.get("OOMKilled") is True else None,
+                message=scrub_secrets(str(state.get("Error") or ""))[:400] or None,
+                started_at=_termination_timestamp(state.get("StartedAt")),
+                finished_at=_termination_timestamp(state.get("FinishedAt")),
+                oom_killed=state.get("OOMKilled") is True,
+            )
 
             # Get logs
             logs = await self.get_logs(session_reference, tail=1000)
@@ -1634,7 +1670,11 @@ class ContainerAgentExecutor(AgentExecutor):
                     )
 
             failure_analysis = None
-            if status == AgentStatus.FAILED:
+            if termination.oom_killed:
+                status = AgentStatus.FAILED
+                failure_analysis = _oom_failure_analysis(termination)
+                error_message = failure_analysis.message
+            elif status == AgentStatus.FAILED:
                 # Analyse the full logs once and keep the whole verdict:
                 # only the message survives into FlowExecution.error_message,
                 # so the transient/terminal classification must travel on the
@@ -1653,6 +1693,7 @@ class ContainerAgentExecutor(AgentExecutor):
                 error_message=error_message,
                 exit_code=exit_code,
                 failure_analysis=failure_analysis,
+                termination=termination,
             )
 
         except DockerError as e:
@@ -1716,24 +1757,57 @@ class ContainerAgentExecutor(AgentExecutor):
                         "Logs contain benign messages (e.g., 'no commits'), not marking as failed."
                     )
 
-            # Try to get exit code from pod
+            # Select the newest attempt and the named agent container. Sidecar
+            # termination and an older attempt must not supply the agent's cause.
             exit_code = None
+            termination = None
             try:
                 label_selector = f"job-name={job_name}"
                 pods = await self._k8s_core_api.list_namespaced_pod(
                     namespace=self.agent_namespace, label_selector=label_selector
                 )
                 if pods.items:
-                    pod = pods.items[0]
-                    if pod.status.container_statuses:
-                        container_status = pod.status.container_statuses[0]
-                        if container_status.state.terminated:
-                            exit_code = container_status.state.terminated.exit_code
+                    pod = max(
+                        pods.items,
+                        key=lambda item: _termination_timestamp(
+                            item.metadata.creation_timestamp
+                        )
+                        or "",
+                    )
+                    for container_status in pod.status.container_statuses or []:
+                        if container_status.name != "agent":
+                            continue
+                        terminated = container_status.state.terminated
+                        if terminated is not None:
+                            exit_code = terminated.exit_code
+                            termination = ContainerTermination(
+                                runtime="kubernetes",
+                                container_name=container_status.name,
+                                container_id=container_status.container_id,
+                                pod_name=pod.metadata.name,
+                                exit_code=exit_code,
+                                reason=terminated.reason,
+                                message=scrub_secrets(terminated.message or "")[:400]
+                                or None,
+                                signal=terminated.signal,
+                                started_at=_termination_timestamp(
+                                    terminated.started_at
+                                ),
+                                finished_at=_termination_timestamp(
+                                    terminated.finished_at
+                                ),
+                                oom_killed=terminated.reason == "OOMKilled",
+                            )
+                        break
             except Exception as e:
                 self.logger.warning(f"Could not get exit code for Job {job_name}: {e}")
 
             failure_analysis = None
-            if status == AgentStatus.FAILED:
+            if termination is not None and termination.oom_killed:
+                status = AgentStatus.FAILED
+                failure_analysis = _oom_failure_analysis(termination)
+                error_message = failure_analysis.message
+            elif status == AgentStatus.FAILED:
                 # Same as the Docker path: keep the full-log verdict on the
                 # result, not just the message.
                 failure_analysis = analyze_agent_failure(logs_text)
@@ -1750,6 +1824,7 @@ class ContainerAgentExecutor(AgentExecutor):
                 error_message=error_message,
                 exit_code=exit_code,
                 failure_analysis=failure_analysis,
+                termination=termination,
             )
 
         except ApiException as e:

--- a/backend/preloop/services/flow_failure_category.py
+++ b/backend/preloop/services/flow_failure_category.py
@@ -22,8 +22,8 @@ it*, not about severity:
     The agent Job/container could not be created because its name was already
     taken (Kubernetes 409 AlreadyExists). Infrastructure, always transient.
 ``runner_error``
-    Anything else that stopped the runtime from starting (bad manifest,
-    quota, oversized entrypoint).
+    Runtime infrastructure failures, including startup errors (bad manifest,
+    quota, oversized entrypoint) and confirmed container memory kills.
 ``model_transient``
     The model provider dropped, throttled or 5xx'd the request mid-run.
     Retryable, and the reason the run-level retry exists.
@@ -140,6 +140,7 @@ _CANCELLED_STATUSES = frozenset({"STOPPED", "CANCELLED", "CANCELED"})
 # Upstream taxonomy -> category. Keeps the gateway's vocabulary and the
 # execution's vocabulary from drifting apart.
 _ERROR_CLASS_CATEGORIES = {
+    "container_oom_killed": FAILURE_CATEGORY_RUNNER_ERROR,
     ERROR_CLASS_NETWORK: FAILURE_CATEGORY_MODEL_TRANSIENT,
     ERROR_CLASS_UPSTREAM_OVERLOADED: FAILURE_CATEGORY_MODEL_TRANSIENT,
     ERROR_CLASS_UPSTREAM_RATE_LIMITED: FAILURE_CATEGORY_MODEL_TRANSIENT,

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -3826,7 +3826,15 @@ class FlowExecutionOrchestrator:
 
                     self.execution_logger.log_milestone(
                         "agent_execution_completed",
-                        {"status": status.value, "exit_code": result.exit_code},
+                        {
+                            "status": result.status.value,
+                            "exit_code": result.exit_code,
+                            "container_termination": (
+                                asdict(result.termination)
+                                if result.termination is not None
+                                else None
+                            ),
+                        },
                     )
 
                     # Structured result artifact (/workspace/result.json)
@@ -3928,6 +3936,11 @@ class FlowExecutionOrchestrator:
                         "mcp_usage_logs": self.execution_logger.get_mcp_usage_logs(),
                         "result": result_artifact,
                         "exit_code": result.exit_code,
+                        "container_termination": (
+                            asdict(result.termination)
+                            if result.termination is not None
+                            else None
+                        ),
                         # First-pass failure classification made against the
                         # FULL container logs. error_message keeps only the
                         # generated sentence, which cannot encode the
@@ -4588,6 +4601,16 @@ class FlowExecutionOrchestrator:
                 getattr(self.execution_log, "result", None),
                 agent_result.get("result"),
             )
+
+            # Only the executor's runtime observation owns this key. Agent
+            # result.json claims cannot overwrite or fabricate termination.
+            if isinstance(merged_result, dict):
+                merged_result.pop("container_termination", None)
+            termination = agent_result.get("container_termination")
+            if isinstance(termination, dict):
+                if not isinstance(merged_result, dict):
+                    merged_result = {}
+                merged_result["container_termination"] = termination
 
             # Publication-gate evidence (issue #428): the runner-captured
             # verdict owns the ``verification`` key of the stored result, so

--- a/backend/tests/agents/test_container_termination.py
+++ b/backend/tests/agents/test_container_termination.py
@@ -1,0 +1,180 @@
+"""Authoritative runtime termination evidence beats historical agent logs."""
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from preloop.agents.base import AgentExecutionResult, AgentStatus
+from preloop.agents.container import ContainerAgentExecutor
+from preloop.services.flow_failure_category import derive_failure_category
+from preloop.services.flow_orchestrator import FlowExecutionOrchestrator
+
+
+FINISHED = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+LOGS = [
+    "Attempt 1 failed with status 504. Retrying...",
+    "I have completed the first change and will now run tests.",
+]
+
+
+def pod(name: str, reason: str, exit_code: int, created: int = 1) -> SimpleNamespace:
+    """Build a pod with a sidecar first and an explicitly named agent."""
+
+    def container(name: str, reason: str, exit_code: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            name=name,
+            container_id=f"containerd://{name}",
+            state=SimpleNamespace(
+                terminated=SimpleNamespace(
+                    reason=reason,
+                    message="",
+                    exit_code=exit_code,
+                    signal=9,
+                    started_at=FINISHED,
+                    finished_at=FINISHED,
+                )
+            ),
+        )
+
+    return SimpleNamespace(
+        metadata=SimpleNamespace(
+            name=name, creation_timestamp=FINISHED.replace(day=created)
+        ),
+        status=SimpleNamespace(
+            container_statuses=[
+                container("sidecar", "OOMKilled", 137),
+                container("agent", reason, exit_code),
+            ]
+        ),
+    )
+
+
+def kubernetes_executor(pods: list[SimpleNamespace]) -> ContainerAgentExecutor:
+    """Never initialize live Kubernetes clients or access the default context."""
+    executor = ContainerAgentExecutor("test", {}, "test-image", use_kubernetes=True)
+    executor._init_kubernetes_clients = AsyncMock()
+    executor._k8s_core_api = AsyncMock()
+    executor._k8s_core_api.list_namespaced_pod.return_value = SimpleNamespace(
+        items=pods
+    )
+    executor.get_status = AsyncMock(return_value=AgentStatus.FAILED)
+    executor._get_kubernetes_terminal_logs = AsyncMock(return_value=LOGS)
+    return executor
+
+
+def assert_oom(result: AgentExecutionResult) -> None:
+    assert result.status == AgentStatus.FAILED
+    assert result.exit_code == 137
+    assert "OOMKilled" in result.error_message
+    assert "memory" in result.error_message.lower()
+    assert result.failure_analysis.transient is False
+    assert (
+        derive_failure_category(
+            status="FAILED",
+            error_message=result.error_message,
+            failure_analysis=asdict(result.failure_analysis),
+        )
+        == "runner_error"
+    )
+    orchestrator = FlowExecutionOrchestrator(MagicMock(), "flow", {}, AsyncMock())
+    orchestrator.execution_logger = MagicMock()
+    orchestrator.execution_logger.get_actions_taken.return_value = []
+    orchestrator.execution_logger.get_agent_output_lines.return_value = LOGS
+    assert (
+        orchestrator._retry_decision(
+            {
+                "status": "FAILED",
+                "exit_code": 137,
+                "error_message": result.error_message,
+                "failure_analysis": asdict(result.failure_analysis),
+            }
+        )
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [AgentStatus.FAILED, AgentStatus.SUCCEEDED])
+@pytest.mark.parametrize("logs", [LOGS, []])
+async def test_kubernetes_oom_overrides_old_provider_error_and_progress(
+    status: AgentStatus, logs: list[str]
+) -> None:
+    executor = kubernetes_executor([pod("test-pod", "OOMKilled", 137)])
+    executor.get_status.return_value = status
+    executor._get_kubernetes_terminal_logs.return_value = logs
+    result = await executor.get_result("test-job")
+    assert_oom(result)
+    assert result.termination.container_name == "agent"
+    assert result.termination.container_id == "containerd://agent"
+    assert result.termination.pod_name == "test-pod"
+    assert result.termination.reason == "OOMKilled"
+    assert result.termination.signal == 9
+    assert result.termination.finished_at == FINISHED.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_bare_exit_137_does_not_prove_oom() -> None:
+    executor = kubernetes_executor([pod("test-pod", "Error", 137)])
+    result = await executor.get_result("test-job")
+    assert result.termination.oom_killed is False
+    assert "OOMKilled" not in result.error_message
+
+
+@pytest.mark.asyncio
+async def test_successful_agent_ignores_sidecar_oom_and_previous_pod() -> None:
+    executor = kubernetes_executor(
+        [
+            pod("old-pod", "OOMKilled", 137),
+            pod("new-pod", "Completed", 0, created=2),
+        ]
+    )
+    executor.get_status.return_value = AgentStatus.SUCCEEDED
+    executor._get_kubernetes_terminal_logs.return_value = ["Work completed"]
+    result = await executor.get_result("test-job")
+    assert result.status == AgentStatus.SUCCEEDED
+    assert result.exit_code == 0
+    assert result.termination.pod_name == "new-pod"
+    assert result.termination.oom_killed is False
+    assert result.error_message is None
+
+
+@pytest.mark.asyncio
+async def test_missing_agent_status_does_not_use_sidecar() -> None:
+    sidecar_only = pod("test-pod", "Completed", 0)
+    sidecar_only.status.container_statuses.pop()
+    result = await kubernetes_executor([sidecar_only]).get_result("test-job")
+    assert result.exit_code is None
+    assert result.termination is None
+    assert "OOMKilled" not in result.error_message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("oom_killed", [True, False])
+async def test_docker_uses_oom_flag_not_exit_code(oom_killed: bool) -> None:
+    executor = ContainerAgentExecutor("test", {}, "test-image", use_kubernetes=False)
+    docker = AsyncMock()
+    executor._get_docker_client = AsyncMock(return_value=docker)
+    container = docker.containers.get.return_value
+    container.show.return_value = {
+        "Id": "container-id",
+        "Name": "/agent-test",
+        "State": {
+            "ExitCode": 137,
+            "OOMKilled": oom_killed,
+            "FinishedAt": FINISHED.isoformat(),
+            "Error": "misleading error",
+        },
+    }
+    executor.get_status = AsyncMock(return_value=AgentStatus.FAILED)
+    executor.get_logs = AsyncMock(return_value=LOGS)
+    result = await executor.get_result("container-id")
+    assert result.termination.oom_killed is oom_killed
+    assert result.termination.container_name == "agent-test"
+    assert result.termination.finished_at == FINISHED.isoformat()
+    if oom_killed:
+        assert_oom(result)
+    else:
+        assert "OOMKilled" not in result.error_message

--- a/backend/tests/services/test_flow_orchestrator_retry.py
+++ b/backend/tests/services/test_flow_orchestrator_retry.py
@@ -22,6 +22,7 @@ from preloop.agents.container import (
     kubernetes_job_name,
 )
 from preloop.agents.errors import AgentStartError
+from preloop.models import models
 from preloop.models.crud import crud_account, crud_flow, crud_user
 from preloop.models.models import Account, Flow
 from preloop.models.models.user import User
@@ -890,3 +891,73 @@ class TestFailureCategoryRecorded:
 
         assert orchestrator.execution_log.status == "FAILED"
         assert orchestrator.execution_log.failure_category == "runner_conflict"
+
+
+@pytest.mark.asyncio
+async def test_runtime_oom_survives_monitor_and_terminal_storage(
+    db_session: Session,
+    test_flow: models.Flow,
+    event_data: dict,
+    mock_nats_client: AsyncMock,
+) -> None:
+    """Runtime evidence survives result.json and is stored without a retry."""
+    docker = AsyncMock()
+    docker.containers.get.return_value.show.return_value = {
+        "Id": "agent-container",
+        "Name": "/agent-test",
+        "State": {
+            "ExitCode": 137,
+            "OOMKilled": True,
+            "FinishedAt": "2026-01-01T12:00:00Z",
+        },
+    }
+    executor = ContainerAgentExecutor("test", {}, "test-image", use_kubernetes=False)
+    executor._get_docker_client = AsyncMock(return_value=docker)
+    executor.start = AsyncMock(return_value="agent-container")
+    executor.get_status = AsyncMock(return_value=AgentStatus.FAILED)
+    executor.get_logs = AsyncMock(return_value=UPSTREAM_TIMEOUT_LOGS.splitlines())
+    executor.get_result_artifact = AsyncMock(
+        return_value={
+            "status": "success",
+            "summary": "Agent progress",
+            "container_termination": {"reason": "Completed", "oom_killed": False},
+        }
+    )
+    executor.cleanup = AsyncMock()
+    with (
+        patch(
+            "preloop.services.flow_orchestrator.create_executor_for_execution",
+            return_value=executor,
+        ),
+        patch.object(FlowExecutionOrchestrator, "_stream_logs_to_nats", AsyncMock()),
+        patch.object(
+            FlowExecutionOrchestrator, "_capture_evidence_archive", AsyncMock()
+        ),
+        patch.object(
+            FlowExecutionOrchestrator, "_capture_workspace_snapshot", AsyncMock()
+        ),
+    ):
+        orchestrator = _build_orchestrator(
+            db_session, test_flow, event_data, mock_nats_client
+        )
+        await orchestrator.run()
+    executor.start.assert_awaited_once()
+    db_session.refresh(orchestrator.execution_log)
+    saved = orchestrator.execution_log
+    assert saved.status == "FAILED"
+    assert saved.failure_category == "runner_error"
+    assert "OOMKilled" in saved.error_message
+    assert saved.result["summary"] == "Agent progress"
+    assert saved.result["container_termination"] == {
+        "runtime": "docker",
+        "container_name": "agent-test",
+        "container_id": "agent-container",
+        "pod_name": None,
+        "exit_code": 137,
+        "reason": "OOMKilled",
+        "message": None,
+        "signal": None,
+        "started_at": None,
+        "finished_at": "2026-01-01T12:00:00Z",
+        "oom_killed": True,
+    }


### PR DESCRIPTION
## Summary

- A container killed for running out of memory could leave progress prose or an old provider error as its saved failure. Preserve Docker/Kubernetes termination evidence and report confirmed OOM as an actionable, non-retryable `runner_error`.
- Select the named agent container in the newest Kubernetes pod attempt, persist trusted runtime metadata, and reject agent-authored termination claims. Sidecar OOM and bare exit 137 do not prove agent OOM. Resource defaults remain unchanged.

## Testing

- [x] Backend tests: 296 passed, including local database persistence and retry coverage.
- [ ] Frontend tests: not applicable.
- [x] Manual validation: reviewed structured evidence propagation and verified clean local commit.

Root pre-commit passed with `SKIP=generate-openapi`. The generator produces an unrelated +83/-5 verification-schema split identically on untouched base and changed code (byte-for-byte `cmp`); the tracked schema is unchanged.

## Checklist

- [x] Docs updated if needed: failure-category documentation updated; no architecture change.
- [x] Changelog updated if needed: no separate changelog entry required.
- [x] No secrets included.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium**
> Well-tested change to the failure-classification and retry-decision path: it makes runtime container-termination evidence authoritative for confirmed OOM and maps it to a non-retryable `runner_error`. Low risk, no security concerns, but it does alter how a specific failure class is reported and retried.
>
> **Overview**
> Preserves Docker/Kubernetes termination evidence on agent results, reports confirmed OOMKilled as an actionable, non-retryable `runner_error`, selects the named agent container in the newest Kubernetes pod attempt, and rejects agent-authored termination claims. Sidecar OOM and bare exit 137 are correctly ignored.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 9bba4edc. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->