### PR TITLE
Add template-aware PR metadata and independently verified publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2624,3 +2624,12 @@ New migration `20260201_policy_engine_enhancements`:
 - Adds AI approval columns to `approval_workflow` table
 - Migrates existing `tool_approval_conditions` data to new schema
 - Run `alembic upgrade head` after updating
+
+### Flow publication integration preview
+
+- Select repository PR templates and validate agent-authored title/body metadata;
+  add execution attribution regardless of metadata fallback source.
+- Add an opt-in trusted publisher with scoped GitHub App credentials, clean Git
+  object import, concurrent-update protection and idempotent PR provenance.
+  Controller verification integration and private runner publication are pending;
+  unsupported isolated executions fail closed before publication.

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -4137,6 +4137,12 @@ true
                     f"mkdir -p {EVIDENCE_DIR_PATH}\n"
                     f"git bundle create {EVIDENCE_DIR_PATH}/branch.bundle HEAD || exit 1\n"
                     f"git rev-parse HEAD > {EVIDENCE_DIR_PATH}/HEAD.txt || exit 1\n"
+                    "if [ -d /preloop-publication-output ]; then\n"
+                    f"  cp {EVIDENCE_DIR_PATH}/branch.bundle /preloop-publication-output/branch.bundle || exit 1\n"
+                    "  if [ -f /workspace/result.json ] && [ $(wc -c < /workspace/result.json) -le 262144 ]; then\n"
+                    "    cp /workspace/result.json /preloop-publication-output/result.json || exit 1\n"
+                    "  fi\n"
+                    "fi\n"
                     "cd /workspace\n"
                 )
 

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -5,6 +5,7 @@ import base64
 import binascii
 import gzip
 import io
+import inspect
 import json
 import logging
 import os
@@ -19,6 +20,7 @@ import aiodocker
 from aiodocker.exceptions import DockerError
 
 from preloop.config import settings
+from preloop.utils import pr_metadata
 from preloop.services.flow_failure_category import (
     FAILURE_CATEGORY_RUNNER_CONFLICT,
     FAILURE_CATEGORY_RUNNER_ERROR,
@@ -148,118 +150,61 @@ _GIT_CONFIG_PATH_ALIASES = {
 # flow-configured title/body, then the commit subject/body (with a flow
 # execution link, and a **Commits:** list when the push is more than one
 # commit).
-WRITE_PR_PAYLOAD_PY = r"""
-import json
-import pathlib
+WRITE_PR_PAYLOAD_PY = (
+    inspect.getsource(pr_metadata)
+    + r"""
 import sys
 
-out_path, head, base, kind = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
-issue_number = sys.argv[5] if len(sys.argv) > 5 else ""
-flow_name = sys.argv[6] if len(sys.argv) > 6 else ""
-execution_link = sys.argv[7] if len(sys.argv) > 7 else ""
-try:
-    commit_count = int(sys.argv[8]) if len(sys.argv) > 8 and sys.argv[8] else 0
-except ValueError:
-    commit_count = 0
+out_path, head, base, kind = sys.argv[1:5]
+issue_number, flow_name, execution_link = sys.argv[5:8]
+commit_count = int(sys.argv[8] or "0")
+head_sha = sys.argv[9] if len(sys.argv) > 9 else ""
 
 
 def _read(path):
-    p = pathlib.Path(path)
-    if not p.is_file():
-        return ""
     try:
-        return p.read_text(encoding="utf-8").strip()
+        with open(path, "rb") as stream:
+            raw = stream.read(MAX_ARTIFACT_BYTES + 1)
+        return raw if len(raw) <= MAX_ARTIFACT_BYTES else None
     except OSError:
-        return ""
+        return None
 
 
-def _from_result():
-    path = pathlib.Path("/workspace/result.json")
-    if not path.is_file():
-        return "", ""
+def _text(path):
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return "", ""
-    if not isinstance(data, dict):
-        return "", ""
-    pr = data.get("pull_request")
-    pr = pr if isinstance(pr, dict) else {}
-
-    def _s(*values):
-        for value in values:
-            if isinstance(value, str) and value.strip():
-                return value.strip()
+        return (_read(path) or b"").decode("utf-8").strip()
+    except UnicodeDecodeError:
         return ""
 
-    title = _s(
-        data.get("pr_title"),
-        data.get("pull_request_title"),
-        pr.get("title"),
-    )
-    body = _s(
-        data.get("pr_body"),
-        data.get("pr_description"),
-        data.get("pull_request_description"),
-        pr.get("body"),
-        pr.get("description"),
-    )
-    return title, body
 
-
-def _attribution():
-    if flow_name and execution_link:
-        return f"Automated changes from Preloop flow: [{flow_name}]({execution_link})"
-    if flow_name:
-        return f"Automated changes from Preloop flow: {flow_name}"
-    if execution_link:
-        return f"Automated changes from Preloop flow: {execution_link}"
-    return ""
-
-
-def _commit_fallback_title():
-    if commit_count > 1 and flow_name:
-        return f"[Preloop] {flow_name}"
-    return _read("/tmp/preloop-commit-pr-title.txt")
-
-
-def _commit_fallback_body():
-    attr = _attribution()
-    if commit_count > 1:
-        commit_list = _read("/tmp/preloop-commit-pr-list.txt")
-        listed = f"**Commits:**\n{commit_list}" if commit_list else ""
-        return "\n\n".join(p for p in (attr, listed) if p)
-    commit_body = _read("/tmp/preloop-commit-pr-body.txt")
-    return "\n\n".join(p for p in (attr, commit_body) if p)
-
-
-result_title, result_body = _from_result()
-title = (
-    result_title
-    or _read("/tmp/preloop-flow-pr-title.txt")
-    or _commit_fallback_title()
-    or "Automated changes"
+commit_title = _text("/tmp/preloop-commit-pr-title.txt")
+commit_body = _text("/tmp/preloop-commit-pr-body.txt")
+if commit_count > 1:
+    commit_title = f"[Preloop] {flow_name}" if flow_name else commit_title
+    commit_body = "**Commits:**\n" + _text("/tmp/preloop-commit-pr-list.txt")
+title, body, warnings = select_metadata(
+    _read("/workspace/result.json"),
+    configured_title=_text("/tmp/preloop-flow-pr-title.txt"),
+    configured_body=_text("/tmp/preloop-flow-pr-body.txt"),
+    commit_title=commit_title,
+    commit_body=commit_body,
+    issue_number=issue_number,
 )
-body = (
-    result_body
-    or _read("/tmp/preloop-flow-pr-body.txt")
-    or _commit_fallback_body()
-)
-if issue_number and f"#{issue_number}" not in body:
-    body = (body + "\n\n" if body else "") + f"Closes #{issue_number}"
+for warning in warnings:
+    print("PRELOOP_PR_METADATA_WARNING: " + warning, file=sys.stderr)
+if execution_link and head_sha:
+    public_url, execution_id = execution_link.rsplit("/console/flows/executions/", 1)
+    body = upsert_provenance(body, [PublicationRecord(execution_id, head_sha)], public_url)
+elif execution_link:
+    # Compatibility for callers predating the explicit published SHA argument.
+    body += f"\n\nAutomated changes from Preloop flow: [{flow_name}]({execution_link})"
 if kind == "gitlab":
-    payload = {
-        "source_branch": head,
-        "target_branch": base,
-        "title": title,
-        "description": body,
-    }
+    payload = {"title": title, "description": body, "source_branch": head, "target_branch": base}
 else:
     payload = {"title": title, "body": body, "head": head, "base": base}
-pathlib.Path(out_path).write_text(
-    json.dumps(payload, ensure_ascii=False), encoding="utf-8"
-)
+Path(out_path).write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
 """
+)
 
 
 def build_github_pr_capture_shell(
@@ -410,7 +355,7 @@ def build_write_pr_payload_shell(
     if [ -z "$PRELOOP_PR_PY" ]; then
       echo "Cannot encode PR payload: python3 is required in the agent image"
     else
-      $PRELOOP_PR_PY - {argv} <<'PRELOOP_PR_PY'
+      $PRELOOP_PR_PY - {argv} "$(git rev-parse HEAD)" <<'PRELOOP_PR_PY'
 {WRITE_PR_PAYLOAD_PY}
 PRELOOP_PR_PY
     fi
@@ -3026,6 +2971,11 @@ class ContainerAgentExecutor(AgentExecutor):
             env.update(
                 profile_env(self.environment_profile, kubernetes=self.use_kubernetes)
             )
+        if (execution_context.get("git_clone_config") or {}).get(
+            "publication_mode"
+        ) == "isolated":
+            if execution_context.get(self.GIT_API_TOKENS_CONTEXT_KEY):
+                raise ValueError("Write API tokens cannot enter an isolated agent")
         env.update(self._git_credential_env(execution_context))
         return env
 
@@ -3089,6 +3039,36 @@ class ContainerAgentExecutor(AgentExecutor):
                 )
         else:
             self.logger.debug("No git_clone_config in execution context")
+
+        if isinstance(git_clone_config, dict) and git_clone_config.get(
+            "create_pull_request"
+        ):
+            template_root = self._primary_workspace_path(
+                execution_context, git_clone_config
+            )
+            configured = git_clone_config.get("pull_request_template") or ""
+            template_script = (
+                inspect.getsource(pr_metadata)
+                + "\n"
+                + (
+                    "import sys\n"
+                    "root = Path(sys.argv[1])\n"
+                    "provider = 'gitlab' if (root / '.gitlab').is_dir() else 'github'\n"
+                    "name, template = repository_template(root, provider=provider, configured=sys.argv[2] or None)\n"
+                    "target = Path('/workspace/evidence/pr-template.md')\n"
+                    "target.parent.mkdir(parents=True, exist_ok=True)\n"
+                    "target.write_text(template, encoding='utf-8')\n"
+                    "print('PR template: ' + (name or 'Summary and Testing fallback'))\n"
+                )
+            )
+            commands.append(
+                "python3 -c "
+                + shlex.quote(template_script)
+                + " "
+                + shlex.quote(template_root)
+                + " "
+                + shlex.quote(configured)
+            )
 
         # Seed /workspace files declared on the trigger payload. After git
         # clone (whose pre-clone backup would sweep earlier writes away) and
@@ -3447,6 +3427,22 @@ class ContainerAgentExecutor(AgentExecutor):
         records a tracker it could not get a key for, and falling through gives
         the remaining sources a chance instead of running with no credential.
         """
+
+        if (execution_context.get("git_clone_config") or {}).get(
+            "publication_mode"
+        ) == "isolated":
+            credentials = execution_context.get("git_credentials_map") or {}
+            tracker_id = str(
+                repo_config.get("tracker_id")
+                or execution_context.get("trigger_tracker_id")
+                or ""
+            )
+            credential = credentials.get(tracker_id) or {}
+            if credential.get("permission") != "read":
+                raise ValueError(
+                    "Isolated agent clone requires a controller-issued read-only credential"
+                )
+            return credential.get("token"), credential.get("tracker_type")
 
         git_credentials_map = execution_context.get("git_credentials_map") or {}
 
@@ -4123,6 +4119,26 @@ true
             target_branch = execution_context.get("_git_target_branch")
             source_branch = execution_context.get("_git_source_branch", "main")
             create_pr = git_config.get("create_pull_request", False)
+
+            if git_config.get("publication_mode") == "isolated":
+                # No publishing credentials or provider calls enter the agent.
+                # Export complete history; the trusted publisher imports only
+                # objects in a fresh bare repo, never this checkout's config.
+                if len(repositories) != 1:
+                    return "echo 'Isolated publication requires one repository' >&2; exit 1"
+                path = self._resolve_repository_clone_path(repositories[0], 0)
+                checkpoint = (
+                    "_preloop_checkpoint || { echo PRELOOP_CHECKPOINT prepublication_failed; exit 1; }\n"
+                    if execution_context.get("checkpoint_env")
+                    else ""
+                )
+                return (
+                    checkpoint + f"cd {shlex.quote(path)}\n"
+                    f"mkdir -p {EVIDENCE_DIR_PATH}\n"
+                    f"git bundle create {EVIDENCE_DIR_PATH}/branch.bundle HEAD || exit 1\n"
+                    f"git rev-parse HEAD > {EVIDENCE_DIR_PATH}/HEAD.txt || exit 1\n"
+                    "cd /workspace\n"
+                )
 
             self.logger.info(
                 f"Preparing post-execution git commands: "

--- a/backend/preloop/agents/container.py
+++ b/backend/preloop/agents/container.py
@@ -1261,6 +1261,11 @@ class ContainerAgentExecutor(AgentExecutor):
             ),
             spec=client.V1PodSpec(
                 restart_policy="Never",
+                # Isolated agents must not retain cluster authority to create
+                # residual writers after their owned Job has been removed.
+                automount_service_account_token=False
+                if (git_clone_config or {}).get("publication_mode") == "isolated"
+                else None,
                 containers=[container],
                 init_containers=self._environment_sidecars() or None,
                 security_context=client.V1PodSecurityContext(
@@ -2964,6 +2969,11 @@ class ContainerAgentExecutor(AgentExecutor):
     ) -> Dict[str, str]:
         """Merge git credential env vars into an agent's environment."""
 
+        if (execution_context.get("git_clone_config") or {}).get(
+            "publication_mode"
+        ) == "isolated":
+            if execution_context.get(self.GIT_API_TOKENS_CONTEXT_KEY):
+                raise ValueError("Write API tokens cannot enter an isolated agent")
         env.update(execution_context.get("checkpoint_env") or {})
         if self.environment_profile:
             from preloop.services.flow_environment import profile_env
@@ -2971,11 +2981,6 @@ class ContainerAgentExecutor(AgentExecutor):
             env.update(
                 profile_env(self.environment_profile, kubernetes=self.use_kubernetes)
             )
-        if (execution_context.get("git_clone_config") or {}).get(
-            "publication_mode"
-        ) == "isolated":
-            if execution_context.get(self.GIT_API_TOKENS_CONTEXT_KEY):
-                raise ValueError("Write API tokens cannot enter an isolated agent")
         env.update(self._git_credential_env(execution_context))
         return env
 
@@ -3047,13 +3052,22 @@ class ContainerAgentExecutor(AgentExecutor):
                 execution_context, git_clone_config
             )
             configured = git_clone_config.get("pull_request_template") or ""
+            # Repository directories are not provider authority. Resolve the
+            # provider from the controller's tracker binding (including
+            # self-hosted GitLab), then pass it as data to template discovery.
+            repos = git_clone_config.get("repositories") or [{}]
+            _, template_provider = self._resolve_repository_token(
+                repos[0], execution_context
+            )
+            if template_provider not in {"github", "gitlab"}:
+                template_provider = "github"
             template_script = (
                 inspect.getsource(pr_metadata)
                 + "\n"
                 + (
                     "import sys\n"
                     "root = Path(sys.argv[1])\n"
-                    "provider = 'gitlab' if (root / '.gitlab').is_dir() else 'github'\n"
+                    "provider = sys.argv[3]\n"
                     "name, template = repository_template(root, provider=provider, configured=sys.argv[2] or None)\n"
                     "target = Path('/workspace/evidence/pr-template.md')\n"
                     "target.parent.mkdir(parents=True, exist_ok=True)\n"
@@ -3068,6 +3082,8 @@ class ContainerAgentExecutor(AgentExecutor):
                 + shlex.quote(template_root)
                 + " "
                 + shlex.quote(configured)
+                + " "
+                + shlex.quote(template_provider)
             )
 
         # Seed /workspace files declared on the trigger payload. After git

--- a/backend/preloop/agents/remote_runner.py
+++ b/backend/preloop/agents/remote_runner.py
@@ -76,6 +76,8 @@ class RemoteRunnerExecutor(AgentExecutor):
         execution = crud_flow_execution.get(self.db, id=execution_id)
         if runner:
             if execution:
+                if payload.get("_publication"):
+                    execution.error_message = None
                 execution.runner_id = runner.id
                 execution.agent_session_reference = f"runner:{runner.id}:{execution_id}"
                 self.db.add(execution)
@@ -97,6 +99,16 @@ class RemoteRunnerExecutor(AgentExecutor):
             return f"runner:{runner.id}:{execution_id}"
 
         if execution:
+            if payload.get("_publication"):
+                from preloop.models.schemas.flow_execution import FlowExecutionUpdate
+
+                crud_flow_execution.update(
+                    self.db,
+                    db_obj=execution,
+                    obj_in=FlowExecutionUpdate(
+                        error_message="Waiting for a private Docker runner with publication protocol v1 and a configured ready helper image"
+                    ),
+                )
             execution.agent_session_reference = (
                 f"runner:queued:{self.pool}:{execution_id}"
             )
@@ -153,6 +165,11 @@ class RemoteRunnerExecutor(AgentExecutor):
                     execution.error_message = (
                         f"No matching self-hosted runner for pool "
                         f"{self.pool} within {DEFAULT_QUEUE_TIMEOUT}"
+                        + (
+                            "; isolated publication requires protocol v1 and a configured ready helper image"
+                            if (execution.result or {}).get("_private_publication")
+                            else ""
+                        )
                     )
                     execution.end_time = datetime.now(timezone.utc)
                     self.db.add(execution)
@@ -176,6 +193,8 @@ class RemoteRunnerExecutor(AgentExecutor):
                 )
                 if runner:
                     payload = await prepare_runner_delivery(self.db, payload)
+                    if (execution.result or {}).get("_private_publication"):
+                        execution.error_message = None
                     execution.runner_id = runner.id
                     execution.agent_session_reference = (
                         f"runner:{runner.id}:{execution.id}"
@@ -327,6 +346,22 @@ class RemoteRunnerExecutor(AgentExecutor):
             "git_clone_config": git_clone_config,
             "custom_commands": context_or_flow("custom_commands"),
         }
+        if (payload.get("git_clone_config") or {}).get(
+            "publication_mode"
+        ) == "isolated":
+            execution = crud_flow_execution.get(
+                self.db, id=execution_id, account_id=str(self.account_id), refresh=True
+            )
+            state = (
+                (execution.result or {}).get("_private_publication")
+                if execution
+                else None
+            )
+            if not isinstance(state, dict):
+                raise ValueError(
+                    "Private publication requires a trusted policy snapshot"
+                )
+            payload["_publication"] = state
         if profile:
             payload["host_exec_profile"] = profile
             timeout_seconds = context.get("timeout_seconds")

--- a/backend/preloop/agents/runner_launch.py
+++ b/backend/preloop/agents/runner_launch.py
@@ -65,6 +65,9 @@ async def prepare_runner_delivery(
     Adapter/credential errors must not strand the already committed lease. Do
     not serialize exception text: upstream client errors can contain secrets.
     """
+    from preloop.services.private_publication import public_publication_descriptor
+
+    public_job = {key: value for key, value in job.items() if key != "_publication"}
     try:
         if job.get("completion_protocol") == "host_exec":
             from preloop.services.host_exec import host_exec_profile_name
@@ -76,12 +79,15 @@ async def prepare_runner_delivery(
             ):
                 raise ValueError("Invalid native host lease")
             return dict(job)
+        state = job.get("_publication")
+        if state is not None:
+            public_job["publication"] = public_publication_descriptor(state)
         if context is None:
-            return await hydrate_runner_job(db, job)
-        return {**job, "launch": await build_runner_launch(context)}
+            return await hydrate_runner_job(db, public_job)
+        return {**public_job, "launch": await build_runner_launch(context)}
     except RunnerLaunchConfigurationChangedError:
         return {
-            **job,
+            **public_job,
             "launch_error": "Flow configuration changed after leasing; retry the execution",
         }
     except Exception:
@@ -89,7 +95,7 @@ async def prepare_runner_delivery(
             "Could not prepare private runner launch for %s", job.get("execution_id")
         )
         return {
-            **job,
+            **public_job,
             "launch_error": "Could not prepare private runner launch; verify the flow configuration and supported harness",
         }
 
@@ -185,6 +191,10 @@ async def hydrate_runner_job(db: Session, job: dict[str, Any]) -> dict[str, Any]
         "allowed_mcp_tools",
     ):
         if key in job:
+            # Private restore rebuilt the trusted, pinned branch/repository.
+            # A queued job's original flow config must not overwrite that pin.
+            if key == "git_clone_config" and job.get("publication"):
+                continue
             context[key] = job[key]
     hydrated = dict(job)
     hydrated["account_api_token"] = context.get("account_api_token")

--- a/backend/preloop/api/endpoints/runners.py
+++ b/backend/preloop/api/endpoints/runners.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import logging
 import socket
+import secrets
 from datetime import datetime, timezone
+from string import ascii_letters, digits
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -16,7 +18,7 @@ from preloop.agents.runner_launch import (
     prepare_runner_delivery,
 )
 from preloop.api.auth import get_current_active_user
-from preloop.models import schemas
+from preloop.models import models, schemas
 from preloop.models.crud import (
     crud_api_key,
     crud_flow,
@@ -26,24 +28,47 @@ from preloop.models.crud import (
 )
 from preloop.models.crud.flow_runner import crud_flow_runner
 from preloop.models.db.session import get_db_session as get_db
-from preloop.models.models.flow_runner import FlowRunner
-from preloop.models.models.user import User
+
 from preloop.services.runner_service import (
     emit_runner_updated,
     hash_runner_token,
     mint_runner_token,
 )
+from preloop.services.private_publication import (
+    PrivatePublicationController,
+    trusted_private_receipt,
+)
+from preloop.services.trusted_publisher import PublicationError
 from preloop.services.host_exec import (
     finalize_runner_completion,
     normalize_host_exec_advertisements,
 )
 from preloop.utils.permissions import require_permission
 
+FlowRunner = models.FlowRunner
+User = models.User
+
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 # runner_id -> live websocket (this process only)
 _live: Dict[str, WebSocket] = {}
+
+
+def _valid_publication_helper_image(value: object) -> bool:
+    """Validate a bounded, digest-pinned reference without regex backtracking."""
+    if not isinstance(value, str) or len(value) > 1024:
+        return False
+    name, separator, digest = value.partition("@sha256:")
+    alphanumeric = ascii_letters + digits
+    return (
+        bool(separator)
+        and bool(name)
+        and name[0] in alphanumeric
+        and all(character in alphanumeric + "._:/-" for character in name)
+        and len(digest) == 64
+        and all(character in "0123456789abcdef" for character in digest)
+    )
 
 
 def _release_live_runner(runner_key: str, connection: WebSocket) -> bool:
@@ -205,6 +230,14 @@ def job_for_heartbeat_ack(
     pending_job = getattr(runner, "pending_job", None)
     if not pending_job:
         return None
+    state = pending_job.get("_publication")
+    if state and (
+        state.get("phase") != "agent"
+        or not runner_needs_lease_token(runner)
+        or (getattr(runner, "publication_capabilities", None) or {}).get("helper_ready")
+        is not True
+    ):
+        return None
     return job_for_runner_replay(
         db,
         pending_job=pending_job,
@@ -277,11 +310,24 @@ async def runner_ws(
 
     runner_key = str(runner.id)
     _live[runner_key] = websocket
+    connection_id = secrets.token_hex(32)
+    crud_flow_runner.set_publication_capabilities(
+        db, runner_id=runner.id, capabilities={"connection_id": connection_id}
+    )
+    publication = PrivatePublicationController(
+        db,
+        runner_id=runner.id,
+        account_id=runner.account_id,
+        connection_id=connection_id,
+    )
+    if runner.current_execution_id and (runner.pending_job or {}).get("_publication"):
+        publication.execution_id = runner.current_execution_id
+        publication.nonce = runner.pending_job["_publication"]["nonce"]
     crud_flow_runner.touch_heartbeat(db, runner, status="online")
     hello: Dict[str, Any] = {"type": "hello", "runner_id": runner_key}
     db.refresh(runner)
     emit_runner_updated(runner, db)
-    if runner.pending_job:
+    if runner.pending_job and not runner.pending_job.get("_publication"):
         hello["job"] = await prepare_runner_delivery(
             db,
             job_for_runner_replay(db, pending_job=runner.pending_job, mint_token=True),
@@ -301,7 +347,57 @@ async def runner_ws(
                 await websocket.send_json({"type": "error", "error": "gone"})
                 break
 
+            if (runner.publication_capabilities or {}).get(
+                "connection_id"
+            ) != connection_id:
+                await websocket.send_json(
+                    {"type": "error", "error": "Runner connection was replaced"}
+                )
+                break
+            if msg_type.startswith("publication_"):
+                try:
+                    reply = await publication.handle(raw)
+                    await websocket.send_json(reply)
+                except (PublicationError, ValueError):
+                    await publication.close()
+                    await websocket.send_json(
+                        {
+                            "type": "error",
+                            "error": "Publication protocol rejected; recovery retained",
+                        }
+                    )
+                continue
+
             if msg_type == "heartbeat":
+                capability = raw.get("publication_capabilities")
+                ready = (
+                    isinstance(capability, dict)
+                    and type(capability.get("version")) is int
+                    and capability.get("version") == 1
+                    and capability.get("helper_ready") is True
+                    and _valid_publication_helper_image(capability.get("helper_image"))
+                )
+                updated_capability = crud_flow_runner.set_publication_capabilities(
+                    db,
+                    runner_id=runner.id,
+                    expected_connection_id=connection_id,
+                    capabilities={
+                        "connection_id": connection_id,
+                        **(
+                            {
+                                "version": 1,
+                                "helper_ready": True,
+                                "helper_image": capability["helper_image"],
+                            }
+                            if ready
+                            else {}
+                        ),
+                    },
+                )
+                if not updated_capability:
+                    break
+                if runner.halt_requested:
+                    await publication.close()
                 status = "busy" if runner.current_execution_id else "online"
                 if "host_exec_profiles" in raw:
                     runner.capabilities = normalize_host_exec_advertisements(raw)
@@ -369,13 +465,19 @@ async def runner_ws(
                 continue
 
             if msg_type == "unregister":
-                runner.status = "offline"
-                runner.pending_job = None
-                runner.current_execution_id = None
-                runner.halt_requested = False
-                db.add(runner)
-                db.commit()
-                emit_runner_updated(runner, db)
+                await publication.close()
+                if crud_flow_runner.set_publication_capabilities(
+                    db,
+                    runner_id=runner.id,
+                    capabilities={},
+                    expected_connection_id=connection_id,
+                    offline=True,
+                    clear_lease=True,
+                    execution_id=runner.current_execution_id,
+                ):
+                    fresh_runner = crud_flow_runner.get_fresh(db, runner_id=runner_id)
+                    if fresh_runner is not None:
+                        emit_runner_updated(fresh_runner, db)
                 await websocket.send_json({"type": "ack"})
                 break
 
@@ -399,11 +501,30 @@ async def runner_ws(
                 status, completion_error, result = finalize_runner_completion(
                     raw, pending_job=runner.pending_job
                 )
-                runner.reported_status = status
-                runner.pending_job = None
-                runner.current_execution_id = None
-                runner.halt_requested = False
-                runner.status = "online"
+                isolated = bool((runner.pending_job or {}).get("_publication"))
+                execution = crud_flow_execution.get(
+                    db, id=execution_id, account_id=str(runner.account_id), refresh=True
+                )
+                if isolated:
+                    if status == "SUCCEEDED":
+                        try:
+                            trusted_private_receipt(execution)
+                        except (PublicationError, AttributeError):
+                            status = "FAILED"
+                            completion_error = (
+                                "Private publication completion was not acknowledged"
+                            )
+                    await publication.close()
+                if not crud_flow_runner.set_publication_capabilities(
+                    db,
+                    runner_id=runner.id,
+                    capabilities=runner.publication_capabilities,
+                    expected_connection_id=connection_id,
+                    clear_lease=True,
+                    execution_id=execution_id,
+                    reported_status=status,
+                ):
+                    break
                 execution = crud_flow_execution.get(db, id=execution_id)
                 if execution:
                     execution.status = status
@@ -416,7 +537,18 @@ async def runner_ws(
                         execution.error_message = completion_error
 
                     if result is not None:
-                        execution.result = result
+                        clean_result = {
+                            key: value
+                            for key, value in result.items()
+                            if key
+                            not in {"trusted_publication", "_private_publication"}
+                        }
+                        protected = {
+                            key: value
+                            for key, value in (execution.result or {}).items()
+                            if key in {"trusted_publication", "_private_publication"}
+                        }
+                        execution.result = {**clean_result, **protected}
                     db.add(execution)
                     crud_api_key.deactivate_runtime_keys_for_flow_execution(
                         db,
@@ -424,9 +556,10 @@ async def runner_ws(
                         execution_id=execution_id,
                         commit=False,
                     )
-                db.add(runner)
                 db.commit()
-                emit_runner_updated(runner, db)
+                fresh_runner = crud_flow_runner.get_fresh(db, runner_id=runner_id)
+                if fresh_runner is not None:
+                    emit_runner_updated(fresh_runner, db)
                 await websocket.send_json({"type": "ack"})
                 continue
 
@@ -434,13 +567,24 @@ async def runner_ws(
     except WebSocketDisconnect:
         logger.info("runner %s disconnected", runner_id)
     finally:
-        if _release_live_runner(runner_key, websocket):
-            row = crud_flow_runner.get(db, id=runner_id)
-            if row and row.status in ("online", "busy"):
-                row.status = "offline"
-                db.add(row)
-                db.commit()
-                emit_runner_updated(row, db)
+        try:
+            await publication.close()
+        except PublicationError:
+            logger.warning(
+                "Private publication credential cleanup failed for runner %s", runner_id
+            )
+        finally:
+            _release_live_runner(runner_key, websocket)
+            if crud_flow_runner.set_publication_capabilities(
+                db,
+                runner_id=runner_id,
+                capabilities={},
+                expected_connection_id=connection_id,
+                offline=True,
+            ):
+                row = crud_flow_runner.get_fresh(db, runner_id=runner_id)
+                if row:
+                    emit_runner_updated(row, db)
 
 
 async def push_job_to_runner(runner_id: UUID, job: Dict[str, Any]) -> bool:

--- a/backend/preloop/models/alembic/versions/20260906_pub_caps_merge.py
+++ b/backend/preloop/models/alembic/versions/20260906_pub_caps_merge.py
@@ -1,0 +1,20 @@
+"""Merge publication capability history onto the approval API key head.
+
+Revision ID: 20260906_pub_caps_merge
+Revises: 20260906_approval_api_key, 20260906_publication_caps
+"""
+
+revision = "20260906_pub_caps_merge"
+down_revision = ("20260906_approval_api_key", "20260906_publication_caps")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Preserve both already-applied migration branches."""
+    pass
+
+
+def downgrade() -> None:
+    """Return to the two independent heads without modifying their data."""
+    pass

--- a/backend/preloop/models/alembic/versions/20260906_publication_caps.py
+++ b/backend/preloop/models/alembic/versions/20260906_publication_caps.py
@@ -1,0 +1,32 @@
+"""Advertise trusted private publication helper readiness.
+
+Revision ID: 20260906_publication_caps
+Revises: 20260906_flow_artifacts
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "20260906_publication_caps"
+down_revision = "20260906_flow_artifacts"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Existing runners are incapable until a ready heartbeat arrives."""
+    op.add_column(
+        "flow_runner",
+        sa.Column(
+            "publication_capabilities",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove private publication capability metadata."""
+    op.drop_column("flow_runner", "publication_capabilities")

--- a/backend/preloop/models/crud/flow_execution.py
+++ b/backend/preloop/models/crud/flow_execution.py
@@ -207,6 +207,38 @@ class CRUDFlowExecution(CRUDBase[FlowExecution]):
         logger = logging.getLogger(__name__)
 
         update_data = obj_in.model_dump(exclude_unset=True)
+        if "result" in update_data:
+            # Result writers may hold an old ORM snapshot while the runner
+            # advances publication. Lock/read the current protected state and
+            # preserve it in the same transaction as this terminal update.
+            with db.no_autoflush:
+                stored = (
+                    db.query(FlowExecution.result)
+                    .filter(FlowExecution.id == db_obj.id)
+                    .with_for_update()
+                    .first()
+                )
+            existing = stored[0] if stored is not None else None
+            incoming = update_data["result"]
+            if isinstance(incoming, dict):
+                incoming = dict(incoming)
+                incoming.pop("_private_publication", None)
+            state = (
+                existing.get("_private_publication")
+                if isinstance(existing, dict)
+                else None
+            )
+            if isinstance(state, dict):
+                incoming = dict(incoming) if isinstance(incoming, dict) else {}
+                incoming["_private_publication"] = state
+                incoming.pop("trusted_publication", None)
+                if (
+                    state.get("phase") == "complete"
+                    and isinstance(state.get("receipt"), dict)
+                    and existing.get("trusted_publication") == state["receipt"]
+                ):
+                    incoming["trusted_publication"] = state["receipt"]
+            update_data["result"] = incoming
 
         # Debug logging for metrics updates
         if "tool_calls_count" in update_data or "total_tokens" in update_data:

--- a/backend/preloop/models/crud/flow_execution.py
+++ b/backend/preloop/models/crud/flow_execution.py
@@ -261,6 +261,28 @@ class CRUDFlowExecution(CRUDBase[FlowExecution]):
         db.flush()
         return db_obj
 
+    def capture_publication_recovery(
+        self,
+        db: Session,
+        *,
+        db_obj: FlowExecution,
+        archive: bytes | None,
+        workspace: bytes | None,
+    ) -> FlowExecution:
+        """Commit recovery bytes before a publisher destroys the owned agent runtime."""
+        if archive is None and workspace is None:
+            raise ValueError("Publication recovery artifacts are missing")
+        try:
+            if archive is not None:
+                self.set_evidence_archive(db, db_obj=db_obj, archive=archive)
+            if workspace is not None:
+                self.set_workspace_snapshot(db, db_obj=db_obj, archive=workspace)
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        return db_obj
+
     def set_cli_session(
         self, db: Session, *, db_obj: FlowExecution, cli_session: Optional[dict]
     ) -> FlowExecution:

--- a/backend/preloop/models/crud/flow_runner.py
+++ b/backend/preloop/models/crud/flow_runner.py
@@ -1,5 +1,6 @@
 """CRUD operations for self-hosted flow runners."""
 
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from uuid import UUID
@@ -7,14 +8,308 @@ from uuid import UUID
 from sqlalchemy import JSON, func, or_
 from sqlalchemy.orm import Session
 
-from ..models.flow_runner import FlowRunner
+from preloop.models import models
+
 from .base import CRUDBase
+
+FlowRunner = models.FlowRunner
 
 ONLINE_HEARTBEAT_TTL = timedelta(seconds=45)
 
 
 class CRUDFlowRunner(CRUDBase[FlowRunner]):
     """CRUD helpers for FlowRunner."""
+
+    def get_fresh(self, db: Session, *, runner_id: UUID) -> Optional[models.FlowRunner]:
+        """Reload committed runner state after a compare-and-swap update."""
+        return (
+            db.query(models.FlowRunner)
+            .filter(models.FlowRunner.id == runner_id)
+            .populate_existing()
+            .first()
+        )
+
+    def set_publication_capabilities(
+        self,
+        db: Session,
+        *,
+        runner_id: UUID,
+        capabilities: Dict[str, Any],
+        expected_connection_id: Optional[str] = None,
+        offline: bool = False,
+        clear_lease: bool = False,
+        execution_id: Optional[UUID] = None,
+        reported_status: Optional[str] = None,
+    ) -> bool:
+        """CAS readiness changes so an old socket cannot clear a replacement."""
+        query = db.query(models.FlowRunner).filter(models.FlowRunner.id == runner_id)
+        if expected_connection_id is not None:
+            query = query.filter(
+                models.FlowRunner.publication_capabilities["connection_id"].astext
+                == expected_connection_id
+            )
+        if execution_id is not None:
+            query = query.filter(models.FlowRunner.current_execution_id == execution_id)
+        values: Dict[Any, Any] = {
+            models.FlowRunner.publication_capabilities: capabilities
+        }
+        if clear_lease:
+            values.update(
+                {
+                    models.FlowRunner.pending_job: None,
+                    models.FlowRunner.current_execution_id: None,
+                    models.FlowRunner.halt_requested: False,
+                    models.FlowRunner.status: "offline" if offline else "online",
+                }
+            )
+            if reported_status is not None:
+                values[models.FlowRunner.reported_status] = reported_status
+        elif offline:
+            values[models.FlowRunner.status] = "offline"
+        updated = query.update(values, synchronize_session=False)
+        db.commit()
+        return bool(updated)
+
+    def bind_publication_lease(
+        self,
+        db: Session,
+        *,
+        runner_id: UUID,
+        execution_id: UUID,
+        account_id: UUID,
+        nonce: str,
+    ) -> None:
+        """Bind the runtime owner in the same transaction that exposes its job."""
+        execution = (
+            db.query(models.FlowExecution)
+            .join(models.Flow, models.Flow.id == models.FlowExecution.flow_id)
+            .filter(
+                models.FlowExecution.id == execution_id,
+                models.Flow.account_id == account_id,
+            )
+            .populate_existing()
+            .with_for_update(of=models.FlowExecution)
+            .first()
+        )
+        state = (
+            (execution.result or {}).get("_private_publication") if execution else None
+        )
+        if (
+            not isinstance(state, dict)
+            or state.get("nonce") != nonce
+            or state.get("phase") != "agent"
+            or state.get("runner_id") not in {None, str(runner_id)}
+        ):
+            raise ValueError("Private publication lease binding is stale")
+        execution.runner_id = runner_id
+        execution.result = {
+            **(execution.result or {}),
+            "_private_publication": {**state, "runner_id": str(runner_id)},
+        }
+        db.add(execution)
+
+    def save_publication_policy(
+        self,
+        db: Session,
+        *,
+        execution_id: UUID,
+        account_id: UUID,
+        state: Dict[str, Any],
+    ) -> None:
+        """Persist a secret-free controller snapshot once before leasing."""
+        execution = (
+            db.query(models.FlowExecution)
+            .join(models.Flow, models.Flow.id == models.FlowExecution.flow_id)
+            .filter(
+                models.FlowExecution.id == execution_id,
+                models.Flow.account_id == account_id,
+            )
+            .populate_existing()
+            .with_for_update(of=models.FlowExecution)
+            .first()
+        )
+        if execution is None:
+            raise ValueError("Publication execution is not owned by this account")
+        prior = (execution.result or {}).get("_private_publication")
+        if prior:
+            if prior.get("nonce") != state["nonce"]:
+                raise ValueError("Publication policy is already bound")
+            db.commit()
+            return
+        if execution.status not in {"PENDING", "STARTING", "RUNNING", "INITIALIZING"}:
+            raise ValueError("Publication execution is no longer active")
+        execution.result = {
+            **(execution.result or {}),
+            "_private_publication": deepcopy(state),
+        }
+        db.add(execution)
+        db.commit()
+
+    def publication_state(
+        self,
+        db: Session,
+        *,
+        runner_id: UUID,
+        account_id: UUID,
+        execution_id: UUID,
+        nonce: str,
+    ) -> Dict[str, Any]:
+        """Read the live owner-bound publication state without retaining locks."""
+        runner, execution, state = self._locked_publication(
+            db,
+            runner_id=runner_id,
+            account_id=account_id,
+            execution_id=execution_id,
+            nonce=nonce,
+        )
+        result = deepcopy(state)
+        db.commit()
+        return result
+
+    def _locked_publication(
+        self,
+        db: Session,
+        *,
+        runner_id: UUID,
+        account_id: UUID,
+        execution_id: UUID,
+        nonce: str,
+    ) -> tuple[models.FlowRunner, models.FlowExecution, Dict[str, Any]]:
+        """Lock and validate the current lease and account-owned execution."""
+        runner = (
+            db.query(models.FlowRunner)
+            .filter(
+                models.FlowRunner.id == runner_id,
+                models.FlowRunner.account_id == account_id,
+            )
+            .populate_existing()
+            .with_for_update()
+            .first()
+        )
+        if (
+            runner is None
+            or runner.current_execution_id != execution_id
+            or runner.halt_requested
+        ):
+            raise ValueError("Publication lease is stale or cancelled")
+        execution = (
+            db.query(models.FlowExecution)
+            .join(models.Flow, models.Flow.id == models.FlowExecution.flow_id)
+            .filter(
+                models.FlowExecution.id == execution_id,
+                models.Flow.account_id == account_id,
+            )
+            .populate_existing()
+            .with_for_update(of=models.FlowExecution)
+            .first()
+        )
+        if execution is None or execution.status not in {
+            "PENDING",
+            "STARTING",
+            "RUNNING",
+            "INITIALIZING",
+        }:
+            raise ValueError("Publication execution is no longer active")
+        if execution.runner_id != runner_id:
+            raise ValueError("Publication execution belongs to another runtime lease")
+        state = (execution.result or {}).get("_private_publication")
+        leased = (runner.pending_job or {}).get("_publication")
+        if (
+            not isinstance(state, dict)
+            or not isinstance(leased, dict)
+            or state.get("nonce") != nonce
+            or leased.get("nonce") != nonce
+            or state.get("runner_id") not in {None, str(runner_id)}
+            or state.get("policy", {}).get("account_id") != str(account_id)
+            or state.get("policy", {}).get("execution_id") != str(execution_id)
+        ):
+            raise ValueError("Publication binding does not match the current lease")
+        if (runner.publication_capabilities or {}).get("helper_ready") is not True:
+            raise ValueError("Private publication helper is no longer ready")
+        if state.get("connection_id") not in {
+            None,
+            (runner.publication_capabilities or {}).get("connection_id"),
+        }:
+            raise ValueError("Publication connection was replaced")
+        if state.get("deadline", 0) <= datetime.now(timezone.utc).timestamp():
+            raise ValueError("Publication deadline expired")
+        return runner, execution, state
+
+    def transition_publication(
+        self,
+        db: Session,
+        *,
+        runner_id: UUID,
+        account_id: UUID,
+        execution_id: UUID,
+        nonce: str,
+        expected: Dict[str, Any],
+        updated: Dict[str, Any],
+        receipt: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Compare and consume a phase atomically before any writer is minted."""
+        runner, execution, state = self._locked_publication(
+            db,
+            runner_id=runner_id,
+            account_id=account_id,
+            execution_id=execution_id,
+            nonce=nonce,
+        )
+        if state != expected:
+            raise ValueError("Publication phase was already consumed")
+        updated = {**deepcopy(updated), "runner_id": str(runner_id)}
+        execution.result = {**(execution.result or {}), "_private_publication": updated}
+        if receipt is not None:
+            execution.result["trusted_publication"] = deepcopy(receipt)
+        runner.pending_job = {**(runner.pending_job or {}), "_publication": updated}
+        db.add(execution)
+        db.add(runner)
+        db.commit()
+        return deepcopy(updated)
+
+    def abandon_publication(
+        self,
+        db: Session,
+        *,
+        runner_id: UUID,
+        execution_id: UUID,
+        nonce: str,
+    ) -> None:
+        """Invalidate an interrupted controller phase without deleting recovery."""
+        runner = (
+            db.query(models.FlowRunner)
+            .filter(models.FlowRunner.id == runner_id)
+            .populate_existing()
+            .with_for_update()
+            .first()
+        )
+        if runner is None or runner.current_execution_id != execution_id:
+            db.commit()
+            return
+        execution = (
+            db.query(models.FlowExecution)
+            .filter(models.FlowExecution.id == execution_id)
+            .populate_existing()
+            .with_for_update()
+            .first()
+        )
+        state = (
+            (execution.result or {}).get("_private_publication") if execution else None
+        )
+        if (
+            isinstance(state, dict)
+            and state.get("nonce") == nonce
+            and state.get("phase") != "complete"
+        ):
+            state = {**state, "phase": "failed"}
+            execution.result = {
+                **(execution.result or {}),
+                "_private_publication": state,
+            }
+            runner.pending_job = {**(runner.pending_job or {}), "_publication": state}
+            db.add(execution)
+            db.add(runner)
+        db.commit()
 
     def get_by_token_hash(
         self, db: Session, *, token_hash: str

--- a/backend/preloop/models/models/flow_runner.py
+++ b/backend/preloop/models/models/flow_runner.py
@@ -57,6 +57,11 @@ class FlowRunner(Base):
         index=True,
     )
     token_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    publication_capabilities: Mapped[Dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=dict,
+    )
     pending_job: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
     halt_requested: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     reported_status: Mapped[Optional[str]] = mapped_column(String(30), nullable=True)

--- a/backend/preloop/models/schemas/flow.py
+++ b/backend/preloop/models/schemas/flow.py
@@ -85,6 +85,18 @@ class GitCloneConfig(BaseModel):
     create_pull_request: Optional[bool] = Field(
         default=False, description="Whether to create a Pull Request / Merge Request"
     )
+    publication_mode: Literal["legacy", "isolated"] = Field(
+        default="legacy",
+        description=(
+            "Legacy publishes inside the agent container. Isolated publishes from "
+            "the trusted control plane after verification, using scoped App credentials."
+        ),
+    )
+    pull_request_template: Optional[str] = Field(
+        default=None,
+        max_length=512,
+        description="Repository-relative PR template; otherwise conventional default then lexical first",
+    )
     pull_request_title: Optional[str] = Field(
         default=None, description="Title for the Pull/Merge Request"
     )

--- a/backend/preloop/models/schemas/verification.py
+++ b/backend/preloop/models/schemas/verification.py
@@ -105,6 +105,10 @@ class VerificationPolicy(BaseModel):
     profile: VerificationProfile = Field(
         description="Versioned trusted test profile driving required checks"
     )
+    image: Optional[str] = Field(
+        default=None,
+        description="Digest-pinned generic toolchain image for credential-isolated checks. Must contain dependencies required by the trusted profile.",
+    )
     # Overall wall-clock budget for the verifier inside the post-execution
     # block; per-check timeouts come from the profile commands.
     gate_budget_seconds: int = Field(

--- a/backend/preloop/services/flow_execution_runner.py
+++ b/backend/preloop/services/flow_execution_runner.py
@@ -68,6 +68,50 @@ async def resume_existing_execution(
     if flow is None:
         raise ValueError("Flow not found for resumed execution")
 
+    from preloop.services.isolated_publication import isolated_publication_enabled
+    from preloop.services.trusted_publisher import PublicationError
+
+    orchestrator._isolated_publication_policy = None
+    saved_result = getattr(orchestrator.execution_log, "result", None)
+    protected_private = isinstance(saved_result, dict) and isinstance(
+        saved_result.get("_private_publication"), dict
+    )
+    isolated = protected_private or isolated_publication_enabled(
+        getattr(flow, "git_clone_config", None)
+    )
+    if isolated:
+        try:
+            if session_reference.startswith("runner:queued:"):
+                raise PublicationError(
+                    "Queued isolated execution cannot safely replay its original runner lease after recovery; publication blocked, retry explicitly with an eligible runner"
+                )
+            if not session_reference.startswith("runner:"):
+                raise PublicationError(
+                    "Recovered hosted isolated execution has no original trusted publication policy snapshot; publication blocked and original runtime retained for recovery"
+                )
+            from preloop.services.private_publication import (
+                load_private_monitoring_policy,
+            )
+
+            orchestrator._isolated_publication_policy = load_private_monitoring_policy(
+                orchestrator.db, flow, orchestrator.execution_log
+            )
+        except PublicationError as exc:
+            await orchestrator._update_execution_log(
+                status="FAILED",
+                error_message=str(exc),
+                failure_category="verification_blocked",
+                end_time=datetime.now(timezone.utc),
+            )
+            await orchestrator._notify_terminal(
+                status="FAILED",
+                failure_category="verification_blocked",
+                result=saved_result,
+            )
+            orchestrator._sync_runtime_session(ended_at=datetime.now(timezone.utc))
+            orchestrator._revoke_execution_runtime_tokens()
+            return
+
     # Matrix-aware: _get_flow_details() above resolved any per-cell agent_type
     # override into orchestrator.agent_type; a resumed matrix cell must be
     # monitored with its own harness, never the flow default.
@@ -82,6 +126,9 @@ async def resume_existing_execution(
         agent_result = await orchestrator._monitor_agent_execution(
             session_reference, agent_executor
         )
+        if orchestrator._isolated_publication_policy is not None:
+            await orchestrator._replay_persisted_runner_logs()
+            await orchestrator._finish_isolated_publication(agent_result)
         final_status = agent_result.get("status", "FAILED")
         resume_category = derive_failure_category(
             status=final_status,

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -4905,11 +4905,9 @@ class FlowExecutionOrchestrator:
                 execution_context
             )
 
-            # Private runners persist lines on the WebSocket; the live stream
-            # skips them so they are not published twice. Fold them in before
-            # terminal PR/session/metrics binding.
+            # Fold private-runner logs before terminal binding. Isolated
+            # publication still ignores agent-controlled PR markers.
             await self._replay_persisted_runner_logs()
-
             await self._finish_isolated_publication(agent_result)
 
             # Update execution log with final results including detailed logs

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -4303,13 +4303,31 @@ class FlowExecutionOrchestrator:
         finally:
             # Always cleanup monitoring resources
             await self._cleanup_monitoring()
-            # Cleanup agent executor resources (close Kubernetes/Docker clients)
+            # Closing clients is not proof that sandbox writers are gone.
+            # Evidence/checkpoints have already been captured above.
+            self._publication_runtime_stopped = False
             try:
-                await agent_executor.cleanup()
-                self._publication_runtime_stopped = True
+                policy = getattr(self, "_isolated_publication_policy", None)
+                if policy is not None and not getattr(policy, "private", False):
+                    from preloop.services.publication_runtime import (
+                        remove_owned_publication_runtime,
+                    )
+
+                    await self._persist_isolated_recovery()
+                    await remove_owned_publication_runtime(
+                        agent_executor, session_reference, str(self.execution_log.id)
+                    )
+                    self._publication_executor = agent_executor
+                    self._publication_runtime_stopped = True
             except Exception as cleanup_error:
                 self._publication_runtime_stopped = False
-                logger.warning(f"Error during agent cleanup: {cleanup_error}")
+                logger.warning(f"Error during agent removal: {cleanup_error}")
+            finally:
+                try:
+                    await agent_executor.cleanup()
+                except Exception as cleanup_error:
+                    self._publication_runtime_stopped = False
+                    logger.warning(f"Error during agent cleanup: {cleanup_error}")
 
     def _create_execution_log(self):
         """Create an initial record in FlowExecutions.
@@ -4685,6 +4703,29 @@ class FlowExecutionOrchestrator:
                 await asyncio.sleep(delay)
 
         return agent_result, session_reference
+
+    async def _persist_isolated_recovery(self) -> None:
+        """Keep the original runtime unless recoverable work is durably saved."""
+        from preloop.services.publication_worker import inspect_bundle
+        from preloop.services.trusted_publisher import read_publication_bundle
+
+        archive = getattr(self, "_evidence_archive", None)
+        workspace = getattr(self, "_workspace_snapshot", None)
+        if workspace is None:
+            # A valid self-contained Git bundle can preserve committed work
+            # when the full workspace exceeds its capture budget.
+            await asyncio.to_thread(
+                inspect_bundle,
+                read_publication_bundle(archive or b""),
+                self._isolated_publication_policy.base_sha,
+            )
+        crud_flow_execution.capture_publication_recovery(
+            self.db, db_obj=self.execution_log, archive=archive, workspace=workspace
+        )
+        self.execution_logger.log_milestone(
+            "publication_recovery_committed",
+            {"execution_id": str(self.execution_log.id)},
+        )
 
     async def _finish_isolated_publication(self, agent_result: Dict[str, Any]) -> None:
         """Run trusted publication after runtime cleanup; failure changes status."""

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -2218,6 +2218,14 @@ class FlowExecutionOrchestrator:
             self._isolated_publication_policy = await prepare_isolated_publication(
                 self.db, self.flow, execution_context
             )
+            if self._isolated_publication_policy.private:
+                from preloop.services.private_publication import (
+                    persist_private_publication,
+                )
+
+                persist_private_publication(
+                    self.db, self.flow, self._isolated_publication_policy
+                )
 
         # Isolated mode never resolves the existing broad tracker token.
         if self.flow.git_clone_config and self._isolated_publication_policy is None:
@@ -2997,6 +3005,7 @@ class FlowExecutionOrchestrator:
         # Reserved publisher state is control-plane owned, never agent JSON.
         artifact = dict(artifact)
         artifact.pop("trusted_publication", None)
+        artifact.pop("_private_publication", None)
         self.execution_logger.log_milestone(
             "result_artifact_captured",
             {"keys": sorted(artifact.keys())[:20]},
@@ -4732,6 +4741,12 @@ class FlowExecutionOrchestrator:
         policy = getattr(self, "_isolated_publication_policy", None)
         if policy is None:
             return
+        reported_result = agent_result.get("result")
+        if isinstance(reported_result, dict):
+            reported_result = dict(reported_result)
+            reported_result.pop("trusted_publication", None)
+            reported_result.pop("_private_publication", None)
+            agent_result["result"] = reported_result
         import httpx
         from preloop.services.isolated_publication import finish_isolated_publication
         from preloop.services.publication_credentials import revoke_repository_lease
@@ -4740,42 +4755,61 @@ class FlowExecutionOrchestrator:
         try:
             if agent_result.get("status") != "SUCCEEDED":
                 return
-            if not getattr(self, "_publication_runtime_stopped", False):
-                raise PublicationError(
-                    "Agent runtime cleanup was not confirmed; refusing to issue publication credentials"
-                )
-            from preloop.services.publication_hosted_verifier import (
-                verify_hosted_publication,
-            )
-            from preloop.services.trusted_publisher import read_publication_bundle
+            if getattr(policy, "private", False):
+                from preloop.services.private_publication import trusted_private_receipt
 
-            executor = getattr(self, "_publication_executor", None)
-            if executor is None:
-                raise PublicationError("Missing trusted verifier runtime adapter")
-            try:
-                verified = await verify_hosted_publication(
-                    executor,
+                execution = crud_flow_execution.get(
+                    self.db,
+                    id=policy.execution_id,
+                    account_id=policy.account_id,
+                    refresh=True,
+                )
+                if execution is None:
+                    raise PublicationError(
+                        "Private publication execution is no longer authorized"
+                    )
+                publication = trusted_private_receipt(execution)
+                if not isinstance(publication, dict):
+                    raise PublicationError(
+                        "Private publication has no controller-accepted completion receipt"
+                    )
+            else:
+                if not getattr(self, "_publication_runtime_stopped", False):
+                    raise PublicationError(
+                        "Agent runtime cleanup was not confirmed; refusing to issue publication credentials"
+                    )
+                from preloop.services.publication_hosted_verifier import (
+                    verify_hosted_publication,
+                )
+                from preloop.services.trusted_publisher import read_publication_bundle
+
+                executor = getattr(self, "_publication_executor", None)
+                if executor is None:
+                    raise PublicationError("Missing trusted verifier runtime adapter")
+                try:
+                    verified = await verify_hosted_publication(
+                        executor,
+                        policy,
+                        read_publication_bundle(self._evidence_archive or b""),
+                    )
+                    self._publication_verification = verified.verification
+                    self.execution_logger.log_milestone(
+                        "trusted_verification_succeeded",
+                        {
+                            "manifest": verified.manifest,
+                            "checks": list(verified.checks),
+                            "image": verified.image,
+                        },
+                    )
+                finally:
+                    await executor.cleanup()
+                publication = await finish_isolated_publication(
+                    self.db,
                     policy,
-                    read_publication_bundle(self._evidence_archive or b""),
+                    agent_result,
+                    self._evidence_archive,
+                    getattr(self, "_publication_verification", None),
                 )
-                self._publication_verification = verified.verification
-                self.execution_logger.log_milestone(
-                    "trusted_verification_succeeded",
-                    {
-                        "manifest": verified.manifest,
-                        "checks": list(verified.checks),
-                        "image": verified.image,
-                    },
-                )
-            finally:
-                await executor.cleanup()
-            publication = await finish_isolated_publication(
-                self.db,
-                policy,
-                agent_result,
-                self._evidence_archive,
-                getattr(self, "_publication_verification", None),
-            )
             result = dict(agent_result.get("result") or {})
             result["trusted_publication"] = publication
             agent_result["result"] = result
@@ -4800,13 +4834,15 @@ class FlowExecutionOrchestrator:
                 failure["verification"] = exc.evidence
             self.execution_logger.log_milestone("trusted_publication_failed", failure)
         finally:
-            async with httpx.AsyncClient() as client:
-                try:
-                    await revoke_repository_lease(policy.read_lease, client)
-                except PublicationError as exc:
-                    self.execution_logger.log_milestone(
-                        "publication_credential_revocation_failed", {"reason": str(exc)}
-                    )
+            if policy.read_lease is not None:
+                async with httpx.AsyncClient() as client:
+                    try:
+                        await revoke_repository_lease(policy.read_lease, client)
+                    except PublicationError as exc:
+                        self.execution_logger.log_milestone(
+                            "publication_credential_revocation_failed",
+                            {"reason": str(exc)},
+                        )
 
     async def run(self):
         """

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -2206,8 +2206,21 @@ class FlowExecutionOrchestrator:
         if cli_session_archive is not None:
             execution_context["cli_session_restore_archive"] = cli_session_archive
 
-        # Prepare git credentials if repositories are configured
-        if self.flow.git_clone_config:
+        from preloop.services.isolated_publication import (
+            isolated_publication_enabled,
+            prepare_isolated_publication,
+        )
+
+        self._isolated_publication_policy = None
+        self._publication_verification = None
+        self._publication_runtime_stopped = False
+        if isolated_publication_enabled(self.flow.git_clone_config):
+            self._isolated_publication_policy = await prepare_isolated_publication(
+                self.db, self.flow, execution_context
+            )
+
+        # Isolated mode never resolves the existing broad tracker token.
+        if self.flow.git_clone_config and self._isolated_publication_policy is None:
             repositories = self.flow.git_clone_config.get("repositories", [])
             if repositories:
                 logger.info(
@@ -2981,6 +2994,9 @@ class FlowExecutionOrchestrator:
         # executors in tests returning non-dict values).
         if not isinstance(artifact, dict):
             return None
+        # Reserved publisher state is control-plane owned, never agent JSON.
+        artifact = dict(artifact)
+        artifact.pop("trusted_publication", None)
         self.execution_logger.log_milestone(
             "result_artifact_captured",
             {"keys": sorted(artifact.keys())[:20]},
@@ -3065,6 +3081,8 @@ class FlowExecutionOrchestrator:
 
     def _note_opened_pr(self, line: str) -> None:
         """Remember the PR/MR the wrapper opened (first one wins)."""
+        if getattr(self, "_isolated_publication_policy", None) is not None:
+            return  # Only the trusted publisher can bind an isolated execution.
         parsed = parse_pr_opened_marker(line)
         if not parsed:
             return
@@ -4288,7 +4306,9 @@ class FlowExecutionOrchestrator:
             # Cleanup agent executor resources (close Kubernetes/Docker clients)
             try:
                 await agent_executor.cleanup()
+                self._publication_runtime_stopped = True
             except Exception as cleanup_error:
+                self._publication_runtime_stopped = False
                 logger.warning(f"Error during agent cleanup: {cleanup_error}")
 
     def _create_execution_log(self):
@@ -4666,6 +4686,57 @@ class FlowExecutionOrchestrator:
 
         return agent_result, session_reference
 
+    async def _finish_isolated_publication(self, agent_result: Dict[str, Any]) -> None:
+        """Run trusted publication after runtime cleanup; failure changes status."""
+        policy = getattr(self, "_isolated_publication_policy", None)
+        if policy is None:
+            return
+        import httpx
+        from preloop.services.isolated_publication import finish_isolated_publication
+        from preloop.services.publication_credentials import revoke_repository_lease
+        from preloop.services.trusted_publisher import PublicationError
+
+        try:
+            if agent_result.get("status") != "SUCCEEDED":
+                return
+            if not getattr(self, "_publication_runtime_stopped", False):
+                raise PublicationError(
+                    "Agent runtime cleanup was not confirmed; refusing to issue publication credentials"
+                )
+            publication = await finish_isolated_publication(
+                self.db,
+                policy,
+                agent_result,
+                self._evidence_archive,
+                getattr(self, "_publication_verification", None),
+            )
+            result = dict(agent_result.get("result") or {})
+            result["trusted_publication"] = publication
+            agent_result["result"] = result
+            self._opened_pr = publication
+            self.execution_logger.log_milestone(
+                "trusted_publication_succeeded",
+                {
+                    "url": publication["url"],
+                    "head_sha": publication["head_sha"],
+                    "metadata_warnings": publication.get("metadata_warnings", []),
+                },
+            )
+        except PublicationError as exc:
+            agent_result["status"] = "FAILED"
+            agent_result["error_message"] = str(exc)
+            self.execution_logger.log_milestone(
+                "trusted_publication_failed", {"reason": str(exc)}
+            )
+        finally:
+            async with httpx.AsyncClient() as client:
+                try:
+                    await revoke_repository_lease(policy.read_lease, client)
+                except PublicationError as exc:
+                    self.execution_logger.log_milestone(
+                        "publication_credential_revocation_failed", {"reason": str(exc)}
+                    )
+
     async def run(self):
         """
         Execute the flow through its full lifecycle.
@@ -4731,6 +4802,8 @@ class FlowExecutionOrchestrator:
             # skips them so they are not published twice. Fold them in before
             # terminal PR/session/metrics binding.
             await self._replay_persisted_runner_logs()
+
+            await self._finish_isolated_publication(agent_result)
 
             # Update execution log with final results including detailed logs
             final_status = agent_result.get("status", "FAILED")

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -4703,6 +4703,31 @@ class FlowExecutionOrchestrator:
                 raise PublicationError(
                     "Agent runtime cleanup was not confirmed; refusing to issue publication credentials"
                 )
+            from preloop.services.publication_hosted_verifier import (
+                verify_hosted_publication,
+            )
+            from preloop.services.trusted_publisher import read_publication_bundle
+
+            executor = getattr(self, "_publication_executor", None)
+            if executor is None:
+                raise PublicationError("Missing trusted verifier runtime adapter")
+            try:
+                verified = await verify_hosted_publication(
+                    executor,
+                    policy,
+                    read_publication_bundle(self._evidence_archive or b""),
+                )
+                self._publication_verification = verified.verification
+                self.execution_logger.log_milestone(
+                    "trusted_verification_succeeded",
+                    {
+                        "manifest": verified.manifest,
+                        "checks": list(verified.checks),
+                        "image": verified.image,
+                    },
+                )
+            finally:
+                await executor.cleanup()
             publication = await finish_isolated_publication(
                 self.db,
                 policy,
@@ -4725,9 +4750,14 @@ class FlowExecutionOrchestrator:
         except PublicationError as exc:
             agent_result["status"] = "FAILED"
             agent_result["error_message"] = str(exc)
-            self.execution_logger.log_milestone(
-                "trusted_publication_failed", {"reason": str(exc)}
+            failure = {"reason": str(exc)}
+            from preloop.services.publication_hosted_verifier import (
+                HostedVerificationError,
             )
+
+            if isinstance(exc, HostedVerificationError):
+                failure["verification"] = exc.evidence
+            self.execution_logger.log_milestone("trusted_publication_failed", failure)
         finally:
             async with httpx.AsyncClient() as client:
                 try:

--- a/backend/preloop/services/isolated_publication.py
+++ b/backend/preloop/services/isolated_publication.py
@@ -1,0 +1,309 @@
+"""Control-plane lifecycle for isolated publication.
+
+The context sent to the agent contains only the read lease. The private policy
+object stays in the orchestrator and is never serialized into a runner job.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from sqlalchemy.orm import Session
+
+from preloop.config import settings
+from preloop.models import models
+from preloop.models.crud import crud_flow_execution, crud_project, crud_tracker
+from preloop.services.publication_credentials import (
+    mint_repository_lease,
+    revoke_repository_lease,
+    validate_publication_tracker,
+)
+from preloop.services.trusted_publisher import (
+    PublicationBinding,
+    PublicationError,
+    PublicationLease,
+    publish_verified_bundle,
+    read_publication_bundle,
+)
+from preloop.utils.pr_metadata import PublicationRecord
+
+
+@dataclass(frozen=True)
+class IsolatedPublicationPolicy:
+    """Trusted destination snapshot retained outside the agent context."""
+
+    tracker_id: str
+    account_id: str
+    repository_url: str
+    branch: str
+    base: str
+    expected_remote_sha: str | None
+    execution_id: str
+    previous_records: tuple[PublicationRecord, ...]
+    read_lease: PublicationLease
+    configured_title: str
+    configured_body: str
+    issue_number: str
+
+
+def isolated_publication_enabled(config: Any) -> bool:
+    """Whether a saved flow explicitly opts into the credential boundary."""
+    return isinstance(config, dict) and config.get("publication_mode") == "isolated"
+
+
+async def prepare_isolated_publication(
+    db: Session, flow: models.Flow, context: dict[str, Any]
+) -> IsolatedPublicationPolicy:
+    """Resolve authorized repository and readonly clone lease before agent start."""
+    from preloop.agents.container import (
+        extract_issue_number_from_trigger,
+        interpolate_git_config_text,
+    )
+    from preloop.services.runner_service import resolve_runner_pool
+
+    if resolve_runner_pool(flow, context, db=db):
+        raise PublicationError(
+            "Isolated publication on private runners requires trusted bundle/evidence upload support; use a hosted isolated runtime until that capability is available"
+        )
+    config = dict(context["git_clone_config"])
+    repositories = config.get("repositories") or []
+    if len(repositories) > 1:
+        raise PublicationError(
+            "Isolated publication currently supports one bound repository per flow"
+        )
+    repository = dict(repositories[0]) if repositories else {}
+    project_id = repository.get("project_id") or context.get("trigger_project_id")
+    project = crud_project.get(db, id=str(project_id)) if project_id else None
+    tracker_id = repository.get("tracker_id") or (
+        str(project.organization.tracker_id)
+        if project and project.organization
+        else None
+    )
+    tracker = (
+        crud_tracker.get_by_id_and_account(
+            db, id=str(tracker_id), account_id=str(flow.account_id)
+        )
+        if tracker_id
+        else None
+    )
+    if tracker is None:
+        raise PublicationError(
+            "Isolated publication requires an account-owned tracker/project binding"
+        )
+    validate_publication_tracker(tracker)
+    repository_url = repository.get("repository_url")
+    if (
+        not repository_url
+        and project
+        and project.organization
+        and str(project.organization.tracker_id) == str(tracker.id)
+        and project.slug
+    ):
+        repository_url = f"https://github.com/{project.slug}.git"
+    if not repository_url:
+        raise PublicationError(
+            "Configure a repository URL or trusted project for isolated publication; webhook clone URLs are not publication authority"
+        )
+    project_path = (
+        str(repository_url).removeprefix("https://github.com/").removesuffix(".git")
+    )
+    trigger = context.get("trigger_event_data") or {}
+    issue_number = extract_issue_number_from_trigger(trigger) or ""
+    execution_id = str(context["execution_id"])
+    branch = config.get("target_branch") or (
+        f"preloop/issue-{issue_number}-{execution_id[:8]}"
+        if issue_number
+        else f"preloop/flow-{execution_id[:8]}"
+    )
+    previous_records: tuple[PublicationRecord, ...] = ()
+    resume = trigger.get("_resume") or {}
+    prior_publication = None
+    if resume:
+        prior = crud_flow_execution.get(
+            db, id=resume.get("execution_id"), account_id=str(flow.account_id)
+        )
+        if prior is None or str(prior.flow_id) != str(flow.id):
+            raise PublicationError(
+                "Isolated continuation requires a prior execution of this flow"
+            )
+        prior_publication = (prior.result or {}).get("trusted_publication")
+        if (
+            not isinstance(prior_publication, dict)
+            or prior_publication.get("repository_url") != repository_url
+        ):
+            raise PublicationError(
+                "Continuation requires a trusted publication binding; legacy PRs must be explicitly migrated"
+            )
+        branch = prior_publication["branch"]
+        previous_records = tuple(
+            PublicationRecord(**record) for record in prior_publication["records"]
+        )
+    async with httpx.AsyncClient() as client:
+        read_lease = await mint_repository_lease(
+            tracker, repository_url, write=False, client=client
+        )
+        headers = {"Authorization": f"Bearer {read_lease.token}"}
+        try:
+            response = await client.get(
+                f"https://api.github.com/repos/{project_path}",
+                headers=headers,
+                timeout=30,
+                follow_redirects=False,
+            )
+            response.raise_for_status()
+            info = response.json()
+            if info.get("full_name") != project_path:
+                raise PublicationError(
+                    "Resolved repository does not match publication binding"
+                )
+            base = (
+                (prior_publication or {}).get("base")
+                or config.get("source_branch")
+                or info["default_branch"]
+            )
+            # Validate branch/URL before interpolating into provider requests.
+            PublicationBinding(
+                repository_url,
+                branch,
+                base,
+                "0" * 40,
+                None,
+                (PublicationRecord(execution_id, "0" * 40),),
+                settings.preloop_url,
+                "github",
+            )
+            response = await client.get(
+                f"https://api.github.com/repos/{project_path}/git/ref/heads/{branch}",
+                headers=headers,
+                timeout=30,
+                follow_redirects=False,
+            )
+            if response.status_code == 404:
+                expected_remote = None
+            else:
+                response.raise_for_status()
+                expected_remote = response.json()["object"]["sha"]
+            if not resume and expected_remote is not None:
+                raise PublicationError(
+                    "Configured publication branch already exists; use a unique target branch or resume its bound execution"
+                )
+        except (httpx.HTTPError, KeyError, ValueError) as exc:
+            await revoke_repository_lease(read_lease, client)
+            if isinstance(exc, PublicationError):
+                raise
+            raise PublicationError(
+                "Could not resolve isolated publication repository/base/head"
+            ) from exc
+    config["repositories"] = [
+        {**repository, "repository_url": repository_url, "tracker_id": str(tracker.id)}
+    ]
+    config["source_branch"] = base
+    config["target_branch"] = branch
+    context["git_clone_config"] = config
+    context["git_credentials_map"] = {
+        str(tracker.id): {
+            "token": read_lease.token,
+            "tracker_type": "github",
+            "permission": "read",
+        }
+    }
+    context["trigger_tracker_id"] = str(tracker.id)
+    # Only this validated binding may control resume checkout branches.
+    if resume:
+        context["trigger_event_data"] = {
+            **trigger,
+            "_resume": {**resume, "source_branch": branch},
+        }
+    return IsolatedPublicationPolicy(
+        str(tracker.id),
+        str(flow.account_id),
+        repository_url,
+        branch,
+        base,
+        expected_remote,
+        execution_id,
+        previous_records,
+        read_lease,
+        interpolate_git_config_text(config.get("pull_request_title"), trigger),
+        interpolate_git_config_text(config.get("pull_request_description"), trigger),
+        issue_number,
+    )
+
+
+async def finish_isolated_publication(
+    db: Session,
+    policy: IsolatedPublicationPolicy,
+    agent_result: dict[str, Any],
+    archive: bytes | None,
+    verification: Any,
+) -> dict[str, Any]:
+    """Publish only after a trusted verifier returns an exact artifact binding."""
+    # #428 adapter supplies this *control-plane* value; agent result.json must
+    # never populate it. It binds the exact bytes, commit and execution.
+    from preloop.services.publication_verification import require_verified_publication
+
+    bundle = read_publication_bundle(archive or b"")
+    head_sha = require_verified_publication(
+        verification, execution_id=policy.execution_id, bundle=bundle
+    )
+    records = (
+        *policy.previous_records,
+        PublicationRecord(policy.execution_id, head_sha),
+    )
+    binding = PublicationBinding(
+        policy.repository_url,
+        policy.branch,
+        policy.base,
+        head_sha,
+        policy.expected_remote_sha,
+        records,
+        settings.preloop_url,
+        "github",
+        policy.configured_title,
+        policy.configured_body,
+        policy.issue_number,
+    )
+    tracker = crud_tracker.get_by_id_and_account(
+        db, id=policy.tracker_id, account_id=policy.account_id
+    )
+    if tracker is None:
+        raise PublicationError(
+            "Publication tracker was removed or is no longer authorized"
+        )
+    async with httpx.AsyncClient() as client:
+        write_lease = None
+
+        async def acquire() -> PublicationLease:
+            nonlocal write_lease
+            write_lease = await mint_repository_lease(
+                tracker, policy.repository_url, write=True, client=client
+            )
+            return write_lease
+
+        try:
+            result = await publish_verified_bundle(
+                binding=binding,
+                bundle=bundle,
+                result_json=json.dumps(
+                    agent_result.get("result"), ensure_ascii=False
+                ).encode(),
+                acquire_lease=acquire,
+                client=client,
+            )
+        finally:
+            if write_lease is not None:
+                await revoke_repository_lease(write_lease, client)
+        result.update(
+            {
+                "repository_url": policy.repository_url,
+                "base": policy.base,
+                "records": [
+                    {"execution_id": record.execution_id, "head_sha": record.head_sha}
+                    for record in records
+                ],
+            }
+        )
+        return result

--- a/backend/preloop/services/isolated_publication.py
+++ b/backend/preloop/services/isolated_publication.py
@@ -7,6 +7,8 @@ object stays in the orchestrator and is never serialized into a runner job.
 from __future__ import annotations
 
 import json
+import re
+import secrets
 from dataclasses import dataclass
 from typing import Any
 
@@ -28,6 +30,8 @@ from preloop.services.trusted_publisher import (
     publish_verified_bundle,
     read_publication_bundle,
 )
+from preloop.models.schemas.verification import ResolvedVerificationPolicy
+from preloop.services.verification import resolve_verification_policy
 from preloop.utils.pr_metadata import PublicationRecord
 
 
@@ -47,6 +51,11 @@ class IsolatedPublicationPolicy:
     configured_title: str
     configured_body: str
     issue_number: str
+    base_sha: str
+    verification_policy: ResolvedVerificationPolicy
+    verification_image: str
+    private: bool = False
+    nonce: str = ""
 
 
 def isolated_publication_enabled(config: Any) -> bool:
@@ -69,6 +78,18 @@ async def prepare_isolated_publication(
             "Isolated publication on private runners requires trusted bundle/evidence upload support; use a hosted isolated runtime until that capability is available"
         )
     config = dict(context["git_clone_config"])
+    verification_policy = resolve_verification_policy(config)
+    if verification_policy.mode != "gate" or verification_policy.profile is None:
+        raise PublicationError(
+            "Isolated publication requires a trusted verification profile"
+        )
+    verification_image = (config.get("verification") or {}).get("image", "")
+    if not isinstance(verification_image, str) or not re.fullmatch(
+        r"[a-zA-Z0-9][a-zA-Z0-9._:/-]*@sha256:[a-f0-9]{64}", verification_image
+    ):
+        raise PublicationError(
+            "Isolated verification requires a digest-pinned generic toolchain image containing the configured check dependencies"
+        )
     repositories = config.get("repositories") or []
     if len(repositories) > 1:
         raise PublicationError(
@@ -176,6 +197,20 @@ async def prepare_isolated_publication(
                 "github",
             )
             response = await client.get(
+                f"https://api.github.com/repos/{project_path}/git/ref/heads/{base}",
+                headers=headers,
+                timeout=30,
+                follow_redirects=False,
+            )
+            response.raise_for_status()
+            base_sha = response.json()["object"]["sha"]
+            if not isinstance(base_sha, str) or not re.fullmatch(
+                r"[a-f0-9]{40}", base_sha
+            ):
+                raise PublicationError(
+                    "Provider did not resolve an exact trusted base commit"
+                )
+            response = await client.get(
                 f"https://api.github.com/repos/{project_path}/git/ref/heads/{branch}",
                 headers=headers,
                 timeout=30,
@@ -230,6 +265,11 @@ async def prepare_isolated_publication(
         interpolate_git_config_text(config.get("pull_request_title"), trigger),
         interpolate_git_config_text(config.get("pull_request_description"), trigger),
         issue_number,
+        base_sha,
+        verification_policy,
+        verification_image,
+        False,
+        secrets.token_hex(32),
     )
 
 

--- a/backend/preloop/services/isolated_publication.py
+++ b/backend/preloop/services/isolated_publication.py
@@ -47,7 +47,7 @@ class IsolatedPublicationPolicy:
     expected_remote_sha: str | None
     execution_id: str
     previous_records: tuple[PublicationRecord, ...]
-    read_lease: PublicationLease
+    read_lease: PublicationLease | None
     configured_title: str
     configured_body: str
     issue_number: str
@@ -73,10 +73,13 @@ async def prepare_isolated_publication(
     )
     from preloop.services.runner_service import resolve_runner_pool
 
-    if resolve_runner_pool(flow, context, db=db):
-        raise PublicationError(
-            "Isolated publication on private runners requires trusted bundle/evidence upload support; use a hosted isolated runtime until that capability is available"
-        )
+    private = bool(resolve_runner_pool(flow, context, db=db))
+    if private:
+        from preloop.services.private_publication import restore_private_publication
+
+        restored = await restore_private_publication(db, flow, context)
+        if restored is not None:
+            return restored
     config = dict(context["git_clone_config"])
     verification_policy = resolve_verification_policy(config)
     if verification_policy.mode != "gate" or verification_policy.profile is None:
@@ -268,7 +271,7 @@ async def prepare_isolated_publication(
         base_sha,
         verification_policy,
         verification_image,
-        False,
+        private,
         secrets.token_hex(32),
     )
 

--- a/backend/preloop/services/private_publication.py
+++ b/backend/preloop/services/private_publication.py
@@ -1,0 +1,636 @@
+"""Authenticated private controller protocol for credential-isolated publication.
+
+Only the registered runner socket can consume durable publication phases. Agent
+results, output markers and ordinary completion packets carry no authority.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from dataclasses import asdict
+from datetime import datetime, timezone
+import json
+import re
+from typing import Any, TYPE_CHECKING
+from uuid import UUID
+
+import httpx
+from sqlalchemy.orm import Session
+
+from preloop.agents.runner_launch import flow_launch_fingerprint
+from preloop.config import settings
+from preloop.models import models
+from preloop.models.crud import crud_flow, crud_flow_execution, crud_tracker
+from preloop.models.crud.flow_runner import crud_flow_runner
+from preloop.models.schemas.verification import ResolvedVerificationPolicy
+from preloop.services.publication_credentials import (
+    mint_repository_lease,
+    revoke_repository_lease,
+)
+from preloop.services.trusted_publisher import (
+    PublicationBinding,
+    PublicationError,
+    PublicationLease,
+)
+from preloop.services.verification import select_required_checks
+from preloop.utils.pr_metadata import PublicationRecord
+
+if TYPE_CHECKING:
+    from preloop.services.isolated_publication import IsolatedPublicationPolicy
+
+STATE_KEY = "_private_publication"
+_HEX40 = re.compile(r"[a-f0-9]{40}")
+_HEX64 = re.compile(r"[a-f0-9]{64}")
+
+
+def persist_private_publication(
+    db: Session, flow: models.Flow, policy: IsolatedPublicationPolicy
+) -> None:
+    """Persist only trusted, secret-free policy before a private runner lease."""
+    if not policy.private or not _HEX64.fullmatch(policy.nonce):
+        raise PublicationError("Invalid private publication policy")
+    snapshot = {
+        key: getattr(policy, key)
+        for key in (
+            "tracker_id",
+            "account_id",
+            "repository_url",
+            "branch",
+            "base",
+            "expected_remote_sha",
+            "execution_id",
+            "configured_title",
+            "configured_body",
+            "issue_number",
+            "base_sha",
+            "verification_image",
+        )
+    }
+    snapshot["previous_records"] = [
+        asdict(record) for record in policy.previous_records
+    ]
+    snapshot["verification_policy"] = policy.verification_policy.model_dump(mode="json")
+    snapshot["flow_id"] = str(flow.id)
+    snapshot["flow_fingerprint"] = flow_launch_fingerprint(flow)
+    state = {
+        "version": 1,
+        "nonce": policy.nonce,
+        "phase": "agent",
+        "policy": snapshot,
+        "deadline": datetime.now(timezone.utc).timestamp()
+        + (flow.timeout_seconds or settings.flow_execution_max_wait_seconds)
+        + policy.verification_policy.gate_budget_seconds
+        + 120,
+    }
+    crud_flow_runner.save_publication_policy(
+        db,
+        execution_id=UUID(policy.execution_id),
+        account_id=UUID(policy.account_id),
+        state=state,
+    )
+
+
+def public_publication_descriptor(state: dict[str, Any]) -> dict[str, Any]:
+    """The runner delegate sees the binding, never control-plane policy storage."""
+    if state.get("phase") != "agent":
+        raise PublicationError("Private publication cannot replay a consumed launch")
+    policy = state["policy"]
+    return {
+        "version": 1,
+        "nonce": state["nonce"],
+        "phase": "agent",
+        **{
+            key: policy[key]
+            for key in (
+                "repository_url",
+                "branch",
+                "base",
+                "base_sha",
+                "expected_remote_sha",
+                "verification_image",
+            )
+        },
+        "verification_budget_seconds": policy["verification_policy"][
+            "gate_budget_seconds"
+        ],
+    }
+
+
+def _authorized_flow(db: Session, policy: dict[str, Any]) -> models.Flow:
+    flow = crud_flow.get(
+        db, id=policy["flow_id"], account_id=policy["account_id"], refresh=True
+    )
+    if flow is None:
+        raise PublicationError("Publication flow is no longer authorized")
+    if flow_launch_fingerprint(flow) != policy["flow_fingerprint"]:
+        raise PublicationError("Publication configuration changed after leasing")
+    return flow
+
+
+async def restore_private_publication(
+    db: Session, flow: models.Flow, context: dict[str, Any]
+) -> IsolatedPublicationPolicy | None:
+    """Rebuild an unstarted private launch with its original pin and a read lease."""
+    from preloop.services.isolated_publication import IsolatedPublicationPolicy
+
+    execution = crud_flow_execution.get(
+        db, id=context["execution_id"], account_id=str(flow.account_id), refresh=True
+    )
+    state = (execution.result or {}).get(STATE_KEY) if execution else None
+    if not isinstance(state, dict):
+        return None
+    public_publication_descriptor(state)
+    if state["deadline"] <= datetime.now(timezone.utc).timestamp():
+        raise PublicationError("Private publication launch expired")
+    saved = state["policy"]
+    if (
+        saved["flow_id"] != str(flow.id)
+        or saved["execution_id"] != str(execution.id)
+        or saved["account_id"] != str(flow.account_id)
+    ):
+        raise PublicationError("Private publication restore binding mismatch")
+    _authorized_flow(db, saved)
+    tracker = crud_tracker.get_by_id_and_account(
+        db, id=saved["tracker_id"], account_id=saved["account_id"]
+    )
+    if tracker is None:
+        raise PublicationError("Publication tracker is no longer authorized")
+    async with httpx.AsyncClient() as client:
+        read_lease = await mint_repository_lease(
+            tracker, saved["repository_url"], write=False, client=client
+        )
+    config = dict(context.get("git_clone_config") or flow.git_clone_config or {})
+    repositories = config.get("repositories") or [{}]
+    config["repositories"] = [
+        {
+            **repositories[0],
+            "repository_url": saved["repository_url"],
+            "tracker_id": saved["tracker_id"],
+        }
+    ]
+    config["source_branch"] = saved["base"]
+    config["target_branch"] = saved["branch"]
+    context["git_clone_config"] = config
+    context["git_credentials_map"] = {
+        saved["tracker_id"]: {
+            "token": read_lease.token,
+            "tracker_type": "github",
+            "permission": "read",
+        }
+    }
+    context["trigger_tracker_id"] = saved["tracker_id"]
+    trigger = context.get("trigger_event_data") or {}
+    if trigger.get("_resume"):
+        context["trigger_event_data"] = {
+            **trigger,
+            "_resume": {**trigger["_resume"], "source_branch": saved["branch"]},
+        }
+    return IsolatedPublicationPolicy(
+        **{
+            key: saved[key]
+            for key in (
+                "tracker_id",
+                "account_id",
+                "repository_url",
+                "branch",
+                "base",
+                "expected_remote_sha",
+                "execution_id",
+                "configured_title",
+                "configured_body",
+                "issue_number",
+                "base_sha",
+                "verification_image",
+            )
+        },
+        previous_records=tuple(
+            PublicationRecord(**record) for record in saved["previous_records"]
+        ),
+        verification_policy=ResolvedVerificationPolicy.model_validate(
+            saved["verification_policy"]
+        ),
+        read_lease=read_lease,
+        private=True,
+        nonce=state["nonce"],
+    )
+
+
+def load_private_monitoring_policy(
+    db: Session,
+    flow: models.Flow,
+    execution: models.FlowExecution,
+) -> IsolatedPublicationPolicy:
+    """Recover monitoring without relaunch, replay, phase advance or credentials."""
+    from preloop.services.isolated_publication import IsolatedPublicationPolicy
+
+    execution = crud_flow_execution.get(
+        db, id=execution.id, account_id=str(flow.account_id), refresh=True
+    )
+    state = (execution.result or {}).get(STATE_KEY) if execution else None
+    if not isinstance(state, dict):
+        raise PublicationError("Private publication recovery policy unavailable")
+    saved = state["policy"]
+    if saved["flow_id"] != str(flow.id) or saved["execution_id"] != str(execution.id):
+        raise PublicationError("Private publication recovery binding mismatch")
+    _authorized_flow(db, saved)
+    return IsolatedPublicationPolicy(
+        **{
+            key: saved[key]
+            for key in (
+                "tracker_id",
+                "account_id",
+                "repository_url",
+                "branch",
+                "base",
+                "expected_remote_sha",
+                "execution_id",
+                "configured_title",
+                "configured_body",
+                "issue_number",
+                "base_sha",
+                "verification_image",
+            )
+        },
+        previous_records=tuple(
+            PublicationRecord(**record) for record in saved["previous_records"]
+        ),
+        verification_policy=ResolvedVerificationPolicy.model_validate(
+            saved["verification_policy"]
+        ),
+        read_lease=None,
+        private=True,
+        nonce=state["nonce"],
+    )
+
+
+def trusted_private_receipt(execution: models.FlowExecution) -> dict[str, Any]:
+    """Require the controller's completed durable state, not an agent claim."""
+    result = execution.result or {}
+    state = result.get(STATE_KEY)
+    receipt = result.get("trusted_publication")
+    if (
+        not isinstance(state, dict)
+        or state.get("phase") != "complete"
+        or not isinstance(receipt, dict)
+        or receipt != state.get("receipt")
+    ):
+        raise PublicationError(
+            "Private publication was not acknowledged by the controller"
+        )
+    return deepcopy(receipt)
+
+
+def _manifest(message: dict[str, Any], *, candidate: bool) -> dict[str, Any]:
+    if type(message.get("version")) is not int or message["version"] != 1:
+        raise PublicationError("Unsupported publication protocol")
+    result = {}
+    for key, pattern in (
+        ("head_sha", _HEX40),
+        ("tree_sha", _HEX40),
+        ("bundle_sha256", _HEX64),
+    ):
+        value = message.get(key)
+        if not isinstance(value, str) or not pattern.fullmatch(value):
+            raise PublicationError("Invalid publication manifest")
+        result[key] = value
+    if candidate:
+        paths = message.get("changed_files")
+        if not isinstance(paths, list) or len(paths) > 10000:
+            raise PublicationError("Invalid changed-file manifest")
+        if any(
+            not isinstance(path, str)
+            or not path
+            or len(path.encode()) > 4096
+            or path.startswith("/")
+            or "\\" in path
+            or any(ord(char) < 32 for char in path)
+            or any(part in {".", "..", ""} for part in path.split("/"))
+            for path in paths
+        ):
+            raise PublicationError("Unsafe changed-file manifest")
+        if len(json.dumps(paths).encode()) > 1024 * 1024 or len(set(paths)) != len(
+            paths
+        ):
+            raise PublicationError("Changed-file manifest exceeds bounds")
+        result["changed_files"] = paths
+    return result
+
+
+class PrivatePublicationController:
+    """One authenticated socket's transient writer and durable protocol cursor."""
+
+    def __init__(
+        self, db: Session, *, runner_id: UUID, account_id: UUID, connection_id: str
+    ) -> None:
+        self.db = db
+        self.connection_id = connection_id
+        self._lock = asyncio.Lock()
+        self.expiry_task: asyncio.Task[None] | None = None
+        self.runner_id = runner_id
+        self.account_id = account_id
+        self.writer: PublicationLease | None = None
+        self.execution_id: UUID | None = None
+        self.nonce: str | None = None
+
+    async def revoke(self) -> None:
+        """Revoke any live write credential even when runtime removal is unknown."""
+        task, self.expiry_task = self.expiry_task, None
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+        writer, self.writer = self.writer, None
+        if writer is not None:
+            async with httpx.AsyncClient() as client:
+                await revoke_repository_lease(writer, client)
+
+    async def _expire_writer(self, deadline: float) -> None:
+        """Serialize expiry with messages and use an independent DB session."""
+        from preloop.models.db.session import get_db_session
+
+        await asyncio.sleep(max(0, deadline - datetime.now(timezone.utc).timestamp()))
+        async with self._lock:
+            try:
+                await self.revoke()
+            finally:
+                if self.execution_id is not None and self.nonce is not None:
+                    sessions = get_db_session()
+                    db = next(sessions)
+                    try:
+                        crud_flow_runner.abandon_publication(
+                            db,
+                            runner_id=self.runner_id,
+                            execution_id=self.execution_id,
+                            nonce=self.nonce,
+                        )
+                    finally:
+                        sessions.close()
+
+    async def close(self) -> None:
+        """A disconnect consumes interrupted phases and never replays a writer."""
+        async with self._lock:
+            try:
+                await self.revoke()
+            finally:
+                if self.execution_id is not None and self.nonce is not None:
+                    self.db.rollback()
+                    crud_flow_runner.abandon_publication(
+                        self.db,
+                        runner_id=self.runner_id,
+                        execution_id=self.execution_id,
+                        nonce=self.nonce,
+                    )
+
+    def _read(self, execution_id: UUID, nonce: str) -> dict[str, Any]:
+        try:
+            state = crud_flow_runner.publication_state(
+                self.db,
+                runner_id=self.runner_id,
+                account_id=self.account_id,
+                execution_id=execution_id,
+                nonce=nonce,
+            )
+        except ValueError as exc:
+            self.db.rollback()
+            raise PublicationError(str(exc)) from exc
+        _authorized_flow(self.db, state["policy"])
+        if state.get("connection_id") not in {None, self.connection_id}:
+            raise PublicationError("Publication connection was replaced")
+        return state
+
+    def _transition(
+        self,
+        expected: dict[str, Any],
+        updated: dict[str, Any],
+        receipt: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        try:
+            return crud_flow_runner.transition_publication(
+                self.db,
+                runner_id=self.runner_id,
+                account_id=self.account_id,
+                execution_id=self.execution_id,
+                nonce=self.nonce,
+                expected=expected,
+                updated={**updated, "connection_id": self.connection_id},
+                receipt=receipt,
+            )
+        except ValueError as exc:
+            self.db.rollback()
+            raise PublicationError(str(exc)) from exc
+
+    async def handle(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Serialize one exact phase with token revocation and expiry."""
+        async with self._lock:
+            return await self._handle(message)
+
+    async def _handle(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Mint only after verified state is consumed."""
+        try:
+            execution_id = UUID(str(message.get("execution_id")))
+        except ValueError as exc:
+            raise PublicationError("Invalid publication execution") from exc
+        nonce = message.get("nonce")
+        if not isinstance(nonce, str) or not _HEX64.fullmatch(nonce):
+            raise PublicationError("Invalid publication nonce")
+        state = self._read(execution_id, nonce)
+        self.execution_id, self.nonce = execution_id, nonce
+        policy = state["policy"]
+        event = message.get("type")
+        identity = _manifest(message, candidate=event == "publication_candidate")
+        envelope = {
+            "version": 1,
+            "execution_id": str(execution_id),
+            "nonce": nonce,
+            **{key: identity[key] for key in ("head_sha", "tree_sha", "bundle_sha256")},
+        }
+        if event == "publication_candidate":
+            if state["phase"] != "agent":
+                raise PublicationError(
+                    "Publication candidate phase was already consumed"
+                )
+            verification = ResolvedVerificationPolicy.model_validate(
+                policy["verification_policy"]
+            )
+            if verification.mode != "gate" or verification.profile is None:
+                raise PublicationError("Publication requires a verification gate")
+            checks = [
+                {
+                    "id": check.id,
+                    "command": check.command,
+                    "timeout_seconds": check.timeout_seconds,
+                }
+                for check in select_required_checks(
+                    verification.profile, identity["changed_files"]
+                ).commands
+            ]
+            if (
+                not checks
+                or len(checks) > 100
+                or len({check["id"] for check in checks}) != len(checks)
+            ):
+                raise PublicationError("Publication requires nonempty exact checks")
+            self._transition(
+                state,
+                {
+                    **state,
+                    "phase": "verifying",
+                    "manifest": identity,
+                    "checks": checks,
+                    "verification_deadline": min(
+                        state["deadline"],
+                        datetime.now(timezone.utc).timestamp()
+                        + verification.gate_budget_seconds,
+                    ),
+                    "deadline": min(
+                        state["deadline"],
+                        datetime.now(timezone.utc).timestamp()
+                        + verification.gate_budget_seconds
+                        + 120,
+                    ),
+                },
+            )
+            return {
+                **envelope,
+                "type": "publication_verify",
+                "checks": checks,
+                "image": policy["verification_image"],
+                "budget_seconds": verification.gate_budget_seconds,
+            }
+        manifest = state.get("manifest") or {}
+        if any(identity[key] != manifest.get(key) for key in identity):
+            raise PublicationError("Publication manifest changed after freezing")
+        if event == "publication_verified":
+            if (
+                state["phase"] != "verifying"
+                or message.get("agent_removed") is not True
+                or message.get("verifiers_removed") is not True
+            ):
+                raise PublicationError("Publication verification phase is invalid")
+            if (
+                state.get("verification_deadline", 0)
+                <= datetime.now(timezone.utc).timestamp()
+            ):
+                raise PublicationError("Publication verification budget expired")
+            checks = message.get("checks")
+            expected = [{**check, "exit_code": 0} for check in state["checks"]]
+            if (
+                checks != expected
+                or not checks
+                or any(
+                    type(check.get("exit_code")) is not int
+                    or type(check.get("timeout_seconds")) is not int
+                    for check in checks
+                )
+            ):
+                raise PublicationError(
+                    "Publication checks do not match required successful commands"
+                )
+            tracker = crud_tracker.get_by_id_and_account(
+                self.db, id=policy["tracker_id"], account_id=str(self.account_id)
+            )
+            if tracker is None:
+                raise PublicationError("Publication tracker is no longer authorized")
+            publishing = self._transition(state, {**state, "phase": "publishing"})
+            binding = PublicationBinding(
+                policy["repository_url"],
+                policy["branch"],
+                policy["base"],
+                identity["head_sha"],
+                policy["expected_remote_sha"],
+                (
+                    *[
+                        PublicationRecord(**record)
+                        for record in policy["previous_records"]
+                    ],
+                    PublicationRecord(str(execution_id), identity["head_sha"]),
+                ),
+                settings.preloop_url,
+                "github",
+                policy["configured_title"],
+                policy["configured_body"],
+                policy["issue_number"],
+            )
+            try:
+                async with httpx.AsyncClient() as client:
+                    self.writer = await mint_repository_lease(
+                        tracker, binding.repository_url, write=True, client=client
+                    )
+                self.writer.validate(binding)
+                if self._read(execution_id, nonce) != publishing:
+                    raise PublicationError(
+                        "Publication lease changed during credential issuance"
+                    )
+                self.expiry_task = asyncio.create_task(
+                    self._expire_writer(publishing["deadline"])
+                )
+                return {
+                    **envelope,
+                    "type": "publication_publish",
+                    "binding": asdict(binding),
+                    "lease": {
+                        "token": self.writer.token,
+                        "repository_url": self.writer.repository_url,
+                        "expires_at": self.writer.expires_at.isoformat(),
+                    },
+                }
+            except BaseException:
+                await self.revoke()
+                raise
+        if event == "publication_complete":
+            if state["phase"] != "publishing" or self.writer is None:
+                raise PublicationError(
+                    "Publication completion has no active writer lease"
+                )
+            receipt = message.get("publication")
+            if (
+                not isinstance(receipt, dict)
+                or len(json.dumps(receipt).encode()) > 65536
+                or self.writer.token in json.dumps(receipt)
+                or set(receipt)
+                - {
+                    "url",
+                    "number",
+                    "branch",
+                    "provider",
+                    "head_sha",
+                    "metadata_warnings",
+                }
+            ):
+                raise PublicationError("Invalid publication receipt")
+            number = receipt.get("number")
+            project = (
+                policy["repository_url"]
+                .removeprefix("https://github.com/")
+                .removesuffix(".git")
+            )
+            if (
+                type(number) is not int
+                or number < 1
+                or receipt.get("url") != f"https://github.com/{project}/pull/{number}"
+                or receipt.get("branch") != policy["branch"]
+                or receipt.get("provider") != "github"
+                or receipt.get("head_sha") != identity["head_sha"]
+            ):
+                raise PublicationError(
+                    "Publication receipt does not match its verified binding"
+                )
+            receipt = {
+                **receipt,
+                "repository_url": policy["repository_url"],
+                "base": policy["base"],
+                "records": [
+                    *policy["previous_records"],
+                    {
+                        "execution_id": str(execution_id),
+                        "head_sha": identity["head_sha"],
+                    },
+                ],
+            }
+            await self.revoke()
+            self._transition(
+                state,
+                {**state, "phase": "complete", "receipt": receipt},
+                receipt=receipt,
+            )
+            return {**envelope, "type": "publication_ack"}
+        raise PublicationError("Unknown publication protocol event")

--- a/backend/preloop/services/private_publication.py
+++ b/backend/preloop/services/private_publication.py
@@ -11,6 +11,7 @@ from copy import deepcopy
 from dataclasses import asdict
 from datetime import datetime, timezone
 import json
+import logging
 import re
 from typing import Any, TYPE_CHECKING
 from uuid import UUID
@@ -35,6 +36,8 @@ from preloop.services.trusted_publisher import (
 )
 from preloop.services.verification import select_required_checks
 from preloop.utils.pr_metadata import PublicationRecord
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from preloop.services.isolated_publication import IsolatedPublicationPolicy
@@ -351,6 +354,12 @@ class PrivatePublicationController:
         async with self._lock:
             try:
                 await self.revoke()
+            except PublicationError:
+                logger.warning(
+                    "Background writer revocation failed for execution %s; "
+                    "token will expire at its deadline",
+                    self.execution_id,
+                )
             finally:
                 if self.execution_id is not None and self.nonce is not None:
                     sessions = get_db_session()

--- a/backend/preloop/services/publication_credentials.py
+++ b/backend/preloop/services/publication_credentials.py
@@ -25,7 +25,7 @@ def validate_publication_tracker(tracker: models.Tracker) -> None:
     installation = getattr(tracker, "oauth_installation", None)
     if (
         tracker.tracker_type != "github"
-        or tracker.auth_type not in {"github_app", "oauth_app"}
+        or tracker.auth_type != "github_app"
         or not getattr(installation, "external_id", None)
     ):
         raise PublicationError(
@@ -76,7 +76,7 @@ async def mint_repository_lease(
         )
     except (ValueError, jwt.PyJWTError) as exc:
         raise PublicationError("GitHub App signing failed") from exc
-    permissions = {"contents": "write" if write else "read", "metadata": "read"}
+    permissions = {"contents": "write" if write else "read"}
     if write:
         permissions["pull_requests"] = "write"
     installation_id = str(tracker.oauth_installation.external_id)
@@ -96,10 +96,18 @@ async def mint_repository_lease(
         response.raise_for_status()
         data = response.json()
         repositories = data.get("repositories", [])
+        returned = data.get("permissions")
+        # GitHub implicitly grants metadata:read. No other additional scope,
+        # including read access to issues/checks, is part of this capability.
+        allowed = {**permissions, "metadata": "read"}
+        valid_permissions = isinstance(returned, dict) and (
+            all(returned.get(key) == value for key, value in permissions.items())
+            and all(allowed.get(key) == value for key, value in returned.items())
+        )
         if (
             len(repositories) != 1
             or repositories[0].get("full_name") != project
-            or data.get("permissions") != permissions
+            or not valid_permissions
         ):
             raise PublicationError(
                 "GitHub did not return the requested repository/permission scope"

--- a/backend/preloop/services/publication_credentials.py
+++ b/backend/preloop/services/publication_credentials.py
@@ -131,7 +131,11 @@ async def revoke_repository_lease(
             timeout=15,
             follow_redirects=False,
         )
-        response.raise_for_status()
+        # The helper and controller both revoke independently. GitHub returns
+        # 401 when the known token was already revoked/expired, which proves it
+        # is unusable. Authorization/server errors still fail closed.
+        if response.status_code != 401:
+            response.raise_for_status()
     except httpx.HTTPError as exc:
         raise PublicationError(
             "Publisher token revocation failed; token will expire at its issued deadline"

--- a/backend/preloop/services/publication_credentials.py
+++ b/backend/preloop/services/publication_credentials.py
@@ -1,0 +1,138 @@
+"""Repository-scoped GitHub App leases for isolated clone/publication.
+
+No stored tracker PAT is accepted: unlike installation tokens, its permissions
+cannot be reduced before it crosses into an agent runtime.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import time
+from datetime import datetime
+from urllib.parse import urlsplit
+
+import httpx
+import jwt
+
+from preloop.config import settings
+from preloop.models import models
+from preloop.services.trusted_publisher import PublicationError, PublicationLease
+
+
+def validate_publication_tracker(tracker: models.Tracker) -> None:
+    """Reject unsupported credentials before starting an isolated flow."""
+    installation = getattr(tracker, "oauth_installation", None)
+    if (
+        tracker.tracker_type != "github"
+        or tracker.auth_type not in {"github_app", "oauth_app"}
+        or not getattr(installation, "external_id", None)
+    ):
+        raise PublicationError(
+            "Isolated publication requires a GitHub App installation; PAT/GitLab credentials cannot yet be safely downscoped. Use an App tracker or explicitly retain legacy publication mode."
+        )
+    if not settings.github_app.app_id or not settings.github_app.private_key:
+        raise PublicationError(
+            "Isolated publication requires the GitHub App signing configuration on the trusted control plane"
+        )
+
+
+async def mint_repository_lease(
+    tracker: models.Tracker,
+    repository_url: str,
+    *,
+    write: bool,
+    client: httpx.AsyncClient,
+) -> PublicationLease:
+    """Ask GitHub to enforce exact repository and read/write permissions."""
+    validate_publication_tracker(tracker)
+    parsed = urlsplit(repository_url)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "github.com"
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise PublicationError(
+            "GitHub App leases require a canonical GitHub repository URL"
+        )
+    project = parsed.path.strip("/").removesuffix(".git")
+    if len(project.split("/")) != 2:
+        raise PublicationError("Invalid GitHub repository binding")
+    key = settings.github_app.private_key
+    if not key.startswith("-----BEGIN"):
+        try:
+            key = base64.b64decode(key, validate=True).decode()
+        except (binascii.Error, UnicodeDecodeError) as exc:
+            raise PublicationError("Invalid GitHub App signing configuration") from exc
+    now = int(time.time())
+    try:
+        app_jwt = jwt.encode(
+            {"iat": now - 60, "exp": now + 540, "iss": settings.github_app.app_id},
+            key,
+            algorithm="RS256",
+        )
+    except (ValueError, jwt.PyJWTError) as exc:
+        raise PublicationError("GitHub App signing failed") from exc
+    permissions = {"contents": "write" if write else "read", "metadata": "read"}
+    if write:
+        permissions["pull_requests"] = "write"
+    installation_id = str(tracker.oauth_installation.external_id)
+    if not installation_id.isdecimal():
+        raise PublicationError("Invalid GitHub App installation identifier")
+    try:
+        response = await client.post(
+            f"https://api.github.com/app/installations/{installation_id}/access_tokens",
+            headers={
+                "Authorization": f"Bearer {app_jwt}",
+                "Accept": "application/vnd.github+json",
+            },
+            json={"repositories": [project.split("/")[1]], "permissions": permissions},
+            timeout=30,
+            follow_redirects=False,
+        )
+        response.raise_for_status()
+        data = response.json()
+        repositories = data.get("repositories", [])
+        if (
+            len(repositories) != 1
+            or repositories[0].get("full_name") != project
+            or data.get("permissions") != permissions
+        ):
+            raise PublicationError(
+                "GitHub did not return the requested repository/permission scope"
+            )
+        lease = PublicationLease(
+            token=data["token"],
+            repository_url=repository_url,
+            expires_at=datetime.fromisoformat(
+                data["expires_at"].replace("Z", "+00:00")
+            ),
+        )
+    except (httpx.HTTPError, KeyError, TypeError, ValueError) as exc:
+        if isinstance(exc, PublicationError):
+            raise
+        raise PublicationError(
+            "Could not issue a scoped GitHub App credential"
+        ) from exc
+    return lease
+
+
+async def revoke_repository_lease(
+    lease: PublicationLease, client: httpx.AsyncClient
+) -> None:
+    """Revoke the publisher credential on success or failure; expiry is fallback."""
+    try:
+        response = await client.delete(
+            "https://api.github.com/installation/token",
+            headers={"Authorization": f"Bearer {lease.token}"},
+            timeout=15,
+            follow_redirects=False,
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise PublicationError(
+            "Publisher token revocation failed; token will expire at its issued deadline"
+        ) from exc

--- a/backend/preloop/services/publication_hosted_verifier.py
+++ b/backend/preloop/services/publication_hosted_verifier.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import io
 import tarfile
+import time
 from dataclasses import dataclass
 from typing import Any
 from uuid import uuid4
@@ -66,7 +67,8 @@ def _append_tail(logs: list[str] | None, value: str) -> None:
             for char in value
             if char in "\n\t" or (ord(char) >= 32 and ord(char) != 127)
         )
-        logs[:] = [(scrub_secrets("".join(logs) + clean) or "")[-65536:]]
+        tail = scrub_secrets("".join(logs) + clean) or ""
+        logs[:] = [tail.encode("utf-8")[-65536:].decode("utf-8", errors="ignore")]
 
 
 def bundle_tar(bundle: bytes) -> bytes:
@@ -97,6 +99,7 @@ async def verify_hosted_publication(
     try:
         async with asyncio.timeout(policy.verification_policy.gate_budget_seconds):
             for check in checks:
+                started = time.monotonic()
                 logs: list[str] = []
                 outcome = {
                     "id": check.id,
@@ -114,14 +117,21 @@ async def verify_hosted_publication(
                     exit_code = await _check_docker(
                         executor, policy, bundle, manifest, check, logs
                     )
-                outcome.update(exit_code=exit_code, log_tail="".join(logs))
+                outcome.update(
+                    exit_code=exit_code,
+                    log_tail="".join(logs),
+                    duration_seconds=round(time.monotonic() - started, 3),
+                )
                 if exit_code != 0:
                     raise PublicationError(
                         f"Isolated verification check {check.id} failed with exit {exit_code}; ensure the configured generic toolchain image includes its dependencies"
                     )
     except (PublicationError, TimeoutError, DockerError, ApiException, OSError) as exc:
         if outcomes:
-            outcomes[-1]["log_tail"] = "".join(logs)
+            outcomes[-1].update(
+                log_tail="".join(logs),
+                duration_seconds=round(time.monotonic() - started, 3),
+            )
         if isinstance(exc, PublicationError):
             reason = str(exc)
         elif isinstance(exc, TimeoutError):
@@ -253,6 +263,11 @@ async def _check_kubernetes(
             ),
         ),
     )
+    await _require_isolated_network_policy(
+        network,
+        namespace,
+        {**labels, "job-name": name, "batch.kubernetes.io/job-name": name},
+    )
     network_created = False
     job_attempted = False
     try:
@@ -283,6 +298,13 @@ async def _check_kubernetes(
                 running = [pod for pod in pods.items if pod.status.phase == "Running"]
                 if len(running) == 1:
                     pod_name = running[0].metadata.name
+                    # Admission may add labels. Recheck the actual pod before
+                    # transferring source or running any repository command.
+                    await _require_isolated_network_policy(
+                        network,
+                        namespace,
+                        getattr(running[0].metadata, "labels", None) or labels,
+                    )
                     break
                 await asyncio.sleep(0.2)
             transfer = "import sys; data=sys.stdin.buffer.read(int(sys.argv[1])); len(data)==int(sys.argv[1]) or sys.exit(125); open('/tmp/branch.bundle','xb').write(data)"
@@ -319,6 +341,46 @@ async def _check_kubernetes(
         if network_created:
             await network.delete_namespaced_network_policy(
                 name=name, namespace=namespace
+            )
+
+
+async def _require_isolated_network_policy(
+    network: Any, namespace: str, labels: dict[str, str]
+) -> None:
+    """NetworkPolicy is additive: reject existing overlapping allow rules."""
+    policies = await network.list_namespaced_network_policy(namespace=namespace)
+    automatic_uid_labels = {"controller-uid", "batch.kubernetes.io/controller-uid"}
+    for policy in policies.items:
+        selector = policy.spec.pod_selector
+        if any(
+            labels.get(key) != value
+            for key, value in (selector.match_labels or {}).items()
+            if key not in automatic_uid_labels
+        ):
+            continue
+        matches = True
+        for expression in selector.match_expressions or []:
+            if expression.key in automatic_uid_labels:
+                # Controller UID is assigned during create. Treat possible
+                # matches conservatively before scheduling the workload.
+                continue
+            value = labels.get(expression.key)
+            choices = expression.values or []
+            if expression.operator == "In":
+                matches = matches and value in choices
+            elif expression.operator == "NotIn":
+                matches = matches and value not in choices
+            elif expression.operator == "Exists":
+                matches = matches and expression.key in labels
+            elif expression.operator == "DoesNotExist":
+                matches = matches and expression.key not in labels
+            else:
+                raise PublicationError(
+                    "Unknown namespace NetworkPolicy selector; isolation unconfirmed"
+                )
+        if matches and (policy.spec.ingress or policy.spec.egress):
+            raise PublicationError(
+                "Verifier namespace has an overlapping permissive NetworkPolicy; use an isolated namespace with enforced deny rules"
             )
 
 

--- a/backend/preloop/services/publication_hosted_verifier.py
+++ b/backend/preloop/services/publication_hosted_verifier.py
@@ -1,0 +1,373 @@
+"""Run selected checks in fresh credential-free runtimes on immutable input."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import tarfile
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from aiodocker.exceptions import DockerError
+from kubernetes_asyncio.client.exceptions import ApiException
+
+from preloop.services.publication_runtime import remove_owned_publication_runtime
+from preloop.services.publication_verification import VerifiedPublication
+from preloop.services.publication_worker import inspect_bundle
+from preloop.services.trusted_publisher import PublicationError
+from preloop.services.verification import select_required_checks
+from preloop.utils.secret_scrubbing import scrub_secrets
+
+# Repository code executes only inside these credential-free disposable checks.
+# Each check starts from a new clean checkout and may install bounded dependencies
+# from its generic toolchain image. No agent workspace, cache, or config is reused.
+CHECKOUT_SCRIPT = r"""
+import os, subprocess, sys
+os.makedirs('/tmp/preloop-check', exist_ok=False)
+os.chdir('/tmp/preloop-check')
+env = dict(os.environ, GIT_CONFIG_NOSYSTEM='1', GIT_CONFIG_GLOBAL='/dev/null', GIT_TERMINAL_PROMPT='0', GIT_CONFIG_COUNT='0')
+git = ['git', '-c', 'core.hooksPath=/dev/null', '-c', 'credential.helper=', '-c', 'protocol.file.allow=never', '-c', 'protocol.ext.allow=never']
+for args in [['init', '--template='], ['bundle', 'unbundle', '/tmp/branch.bundle'], ['checkout', '--detach', '--force', sys.argv[1]]]:
+    subprocess.run(git + args, env=env, check=True)
+observed = subprocess.check_output(git + ['rev-parse', 'HEAD'], env=env, text=True).strip()
+if observed != sys.argv[1]:
+    raise SystemExit(125)
+raise SystemExit(subprocess.run(['/bin/sh', '-c', sys.argv[2]], env=env).returncode)
+"""
+
+
+@dataclass(frozen=True)
+class HostedVerification:
+    """Controller result retained separately from untrusted agent artifacts."""
+
+    verification: VerifiedPublication
+    manifest: dict[str, Any]
+    checks: tuple[dict[str, Any], ...]
+    image: str
+
+
+class HostedVerificationError(PublicationError):
+    """Trusted check diagnostics; never an agent-provided attestation."""
+
+    def __init__(
+        self, reason: str, manifest: dict[str, Any], checks: list[dict[str, Any]]
+    ) -> None:
+        super().__init__(reason)
+        self.evidence = {"manifest": manifest, "checks": checks}
+
+
+def _append_tail(logs: list[str] | None, value: str) -> None:
+    if logs is not None:
+        # No credentials are supplied to verifier runtimes. Strip control bytes
+        # except newlines/tabs so repository output cannot spoof terminal UI.
+        clean = "".join(
+            char
+            for char in value
+            if char in "\n\t" or (ord(char) >= 32 and ord(char) != 127)
+        )
+        logs[:] = [(scrub_secrets("".join(logs) + clean) or "")[-65536:]]
+
+
+def bundle_tar(bundle: bytes) -> bytes:
+    """Create one controller-authored tar entry for Docker's archive endpoint."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        member = tarfile.TarInfo("branch.bundle")
+        member.mode = 0o444
+        member.size = len(bundle)
+        archive.addfile(member, io.BytesIO(bundle))
+    return buffer.getvalue()
+
+
+async def verify_hosted_publication(
+    executor: Any, policy: Any, bundle: bytes
+) -> HostedVerification:
+    """Select checks from the trusted policy and observe process exits and removal."""
+    manifest = await asyncio.to_thread(inspect_bundle, bundle, policy.base_sha)
+    profile = policy.verification_policy.profile
+    if policy.verification_policy.mode != "gate" or profile is None:
+        raise PublicationError(
+            "Isolated publication requires a trusted verification profile"
+        )
+    checks = select_required_checks(profile, manifest["changed_files"]).commands
+    if not checks:
+        raise PublicationError("No required checks selected; publication blocked")
+    outcomes = []
+    try:
+        async with asyncio.timeout(policy.verification_policy.gate_budget_seconds):
+            for check in checks:
+                logs: list[str] = []
+                outcome = {
+                    "id": check.id,
+                    "command": check.command,
+                    "timeout_seconds": check.timeout_seconds,
+                    "exit_code": None,
+                    "log_tail": "",
+                }
+                outcomes.append(outcome)
+                if executor.use_kubernetes:
+                    exit_code = await _check_kubernetes(
+                        executor, policy, bundle, manifest, check, logs
+                    )
+                else:
+                    exit_code = await _check_docker(
+                        executor, policy, bundle, manifest, check, logs
+                    )
+                outcome.update(exit_code=exit_code, log_tail="".join(logs))
+                if exit_code != 0:
+                    raise PublicationError(
+                        f"Isolated verification check {check.id} failed with exit {exit_code}; ensure the configured generic toolchain image includes its dependencies"
+                    )
+    except (PublicationError, TimeoutError, DockerError, ApiException, OSError) as exc:
+        if outcomes:
+            outcomes[-1]["log_tail"] = "".join(logs)
+        if isinstance(exc, PublicationError):
+            reason = str(exc)
+        elif isinstance(exc, TimeoutError):
+            reason = "Isolated verification exceeded its configured budget"
+        else:
+            reason = "Isolated verifier runtime unavailable or removal unconfirmed; ensure the pinned toolchain supplies Python 3, Git and the required check dependencies"
+        raise HostedVerificationError(reason, manifest, outcomes) from exc
+    return HostedVerification(
+        VerifiedPublication(
+            policy.execution_id, manifest["head_sha"], manifest["bundle_sha256"]
+        ),
+        manifest,
+        tuple(outcomes),
+        policy.verification_image,
+    )
+
+
+async def _check_docker(
+    executor: Any,
+    policy: Any,
+    bundle: bytes,
+    manifest: dict[str, Any],
+    check: Any,
+    logs: list[str] | None = None,
+) -> int:
+    docker = await executor._get_docker_client()
+    config = {
+        "Image": policy.verification_image,
+        "Entrypoint": ["python3", "-I", "-c"],
+        "Cmd": [CHECKOUT_SCRIPT, manifest["head_sha"], check.command],
+        "Env": [
+            "HOME=/tmp",
+            "PATH=/usr/local/bin:/usr/bin:/bin",
+            "PRELOOP_DISABLE_TELEMETRY=true",
+        ],
+        "Labels": {
+            "preloop.execution_id": policy.execution_id,
+            "preloop.purpose": "publication-verifier",
+        },
+        "NetworkDisabled": True,
+        "HostConfig": {
+            "NetworkMode": "none",
+            "CapDrop": ["ALL"],
+            "SecurityOpt": ["no-new-privileges"],
+            "PidsLimit": 256,
+            "Memory": 4 * 1024**3,
+            "NanoCpus": 2 * 10**9,
+            "LogConfig": {
+                "Type": "json-file",
+                "Config": {"max-size": "1m", "max-file": "1"},
+            },
+            "Privileged": False,
+            "ReadonlyRootfs": False,
+        },
+    }
+    container = await docker.containers.create(config=config)
+    try:
+        async with asyncio.timeout(check.timeout_seconds):
+            await container.put_archive("/tmp", bundle_tar(bundle))
+            await container.start()
+            result = await container.wait()
+            for line in await container.log(stdout=True, stderr=True, tail=200):
+                _append_tail(logs, line)
+            code = result.get("StatusCode")
+            if type(code) is not int or result.get("Error"):
+                raise PublicationError(
+                    "Verifier did not report an authoritative exit status"
+                )
+            return code
+    finally:
+        # Removal uses full observed ID and ownership labels, never just wait().
+        await remove_owned_publication_runtime(
+            executor, container.id, policy.execution_id
+        )
+
+
+async def _check_kubernetes(
+    executor: Any,
+    policy: Any,
+    bundle: bytes,
+    manifest: dict[str, Any],
+    check: Any,
+    logs: list[str] | None = None,
+) -> int:
+    from kubernetes_asyncio import client
+    from kubernetes_asyncio.stream import WsApiClient
+
+    await executor._init_kubernetes_clients()
+    name = "preloop-verify-" + uuid4().hex
+    labels = {"preloop.execution_id": policy.execution_id, "preloop.verifier": name}
+    network = client.NetworkingV1Api(executor._k8s_core_api.api_client)
+    namespace = executor.agent_namespace
+    job = client.V1Job(
+        metadata=client.V1ObjectMeta(name=name, labels=labels),
+        spec=client.V1JobSpec(
+            backoff_limit=0,
+            active_deadline_seconds=check.timeout_seconds + 30,
+            template=client.V1PodTemplateSpec(
+                metadata=client.V1ObjectMeta(labels=labels),
+                spec=client.V1PodSpec(
+                    restart_policy="Never",
+                    automount_service_account_token=False,
+                    containers=[
+                        client.V1Container(
+                            name="verifier",
+                            image=policy.verification_image,
+                            command=[
+                                "python3",
+                                "-I",
+                                "-c",
+                                "import time; time.sleep(14460)",
+                            ],
+                            env=[
+                                client.V1EnvVar(
+                                    name="PRELOOP_DISABLE_TELEMETRY", value="true"
+                                )
+                            ],
+                            security_context=client.V1SecurityContext(
+                                allow_privilege_escalation=False,
+                                capabilities=client.V1Capabilities(drop=["ALL"]),
+                            ),
+                            resources=client.V1ResourceRequirements(
+                                limits={"cpu": "2", "memory": "4Gi"},
+                                requests={"cpu": "100m", "memory": "256Mi"},
+                            ),
+                        )
+                    ],
+                ),
+            ),
+        ),
+    )
+    network_created = False
+    job_attempted = False
+    try:
+        await network.create_namespaced_network_policy(
+            namespace=namespace,
+            body=client.V1NetworkPolicy(
+                metadata=client.V1ObjectMeta(name=name, labels=labels),
+                spec=client.V1NetworkPolicySpec(
+                    pod_selector=client.V1LabelSelector(
+                        match_labels={"preloop.verifier": name}
+                    ),
+                    policy_types=["Ingress", "Egress"],
+                    ingress=[],
+                    egress=[],
+                ),
+            ),
+        )
+        network_created = True
+        job_attempted = True
+        await executor._k8s_batch_api.create_namespaced_job(
+            namespace=namespace, body=job
+        )
+        async with asyncio.timeout(check.timeout_seconds):
+            while True:
+                pods = await executor._k8s_core_api.list_namespaced_pod(
+                    namespace=namespace, label_selector=f"job-name={name}"
+                )
+                running = [pod for pod in pods.items if pod.status.phase == "Running"]
+                if len(running) == 1:
+                    pod_name = running[0].metadata.name
+                    break
+                await asyncio.sleep(0.2)
+            transfer = "import sys; data=sys.stdin.buffer.read(int(sys.argv[1])); len(data)==int(sys.argv[1]) or sys.exit(125); open('/tmp/branch.bundle','xb').write(data)"
+            async with WsApiClient(
+                configuration=executor._k8s_core_api.api_client.configuration
+            ) as ws_client:
+                api = client.CoreV1Api(ws_client)
+                await _pod_exec(
+                    api,
+                    namespace,
+                    pod_name,
+                    ["python3", "-I", "-c", transfer, str(len(bundle))],
+                    bundle,
+                )
+                return await _pod_exec(
+                    api,
+                    namespace,
+                    pod_name,
+                    [
+                        "python3",
+                        "-I",
+                        "-c",
+                        CHECKOUT_SCRIPT,
+                        manifest["head_sha"],
+                        check.command,
+                    ],
+                    None,
+                    logs,
+                )
+    finally:
+        # Foreground job deletion also verifies no residual pods remain.
+        if job_attempted:
+            await remove_owned_publication_runtime(executor, name, policy.execution_id)
+        if network_created:
+            await network.delete_namespaced_network_policy(
+                name=name, namespace=namespace
+            )
+
+
+async def _pod_exec(
+    api: Any,
+    namespace: str,
+    pod: str,
+    command: list[str],
+    stdin: bytes | None,
+    logs: list[str] | None = None,
+) -> int:
+    """Stream bundle input and read the API's remote-process exit channel."""
+    import aiohttp
+    from kubernetes_asyncio.stream import WsApiClient
+
+    stream = await api.connect_get_namespaced_pod_exec(
+        name=pod,
+        namespace=namespace,
+        container="verifier",
+        command=command,
+        stdin=stdin is not None,
+        stdout=True,
+        stderr=True,
+        tty=False,
+        _preload_content=False,
+    )
+    async with stream as websocket:
+        if stdin is not None:
+            for offset in range(0, len(stdin), 65536):
+                await websocket.send_bytes(b"\x00" + stdin[offset : offset + 65536])
+        async for message in websocket:
+            if (
+                message.type == aiohttp.WSMsgType.BINARY
+                and message.data
+                and message.data[0] in {1, 2}
+            ):
+                _append_tail(logs, message.data[1:].decode("utf-8", errors="replace"))
+            if (
+                message.type == aiohttp.WSMsgType.BINARY
+                and message.data
+                and message.data[0] == 3
+            ):
+                try:
+                    code = WsApiClient.parse_error_data(message.data[1:].decode())
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise PublicationError(
+                        "Verifier returned an invalid process status"
+                    ) from exc
+                if stdin is not None and code != 0:
+                    raise PublicationError("Frozen bundle transfer to verifier failed")
+                return code
+    raise PublicationError("Verifier exec ended without authoritative process status")

--- a/backend/preloop/services/publication_runtime.py
+++ b/backend/preloop/services/publication_runtime.py
@@ -1,0 +1,116 @@
+"""Confirm destruction of an owned sandbox before publication credentials exist."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Any
+from uuid import UUID
+
+from aiodocker.exceptions import DockerError
+from kubernetes_asyncio.client import V1DeleteOptions, V1Preconditions
+from kubernetes_asyncio.client.exceptions import ApiException
+
+from preloop.services.trusted_publisher import PublicationError
+
+
+async def remove_owned_publication_runtime(
+    executor: Any,
+    reference: str,
+    execution_id: str,
+    *,
+    timeout_seconds: float = 30,
+) -> None:
+    """Observe ownership, delete exact runtime, then confirm absence.
+
+    Client cleanup, generic executor status, and a missing object on the first
+    read are never removal evidence. API/authentication failures fail closed.
+    Call only after capturing the recovery checkpoint and immutable artifacts.
+    """
+    try:
+        UUID(execution_id)
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise PublicationError("Invalid publication execution identity") from exc
+    if not isinstance(reference, str) or not reference:
+        raise PublicationError("Missing publication runtime identity")
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            if executor.use_kubernetes is True:
+                await _remove_kubernetes(executor, reference, execution_id)
+            elif executor.use_kubernetes is False:
+                await _remove_docker(executor, reference, execution_id)
+            else:
+                raise PublicationError("Unknown publication runtime boundary")
+    except (TimeoutError, DockerError, ApiException) as exc:
+        raise PublicationError(
+            "Owned agent runtime removal could not be confirmed; publication blocked"
+        ) from exc
+
+
+async def _remove_docker(executor: Any, reference: str, execution_id: str) -> None:
+    if not re.fullmatch(r"[a-f0-9]{12,64}", reference):
+        raise PublicationError("Invalid Docker publication runtime identity")
+    docker = await executor._get_docker_client()
+    container = await docker.containers.get(reference)
+    info = await container.show()
+    observed_id = info.get("Id")
+    labels = (info.get("Config") or {}).get("Labels") or {}
+    if (
+        not isinstance(observed_id, str)
+        or not re.fullmatch(r"[a-f0-9]{64}", observed_id)
+        or not observed_id.startswith(reference)
+        or labels.get("preloop.execution_id") != execution_id
+    ):
+        raise PublicationError("Docker runtime is not owned by this execution")
+    # Use the already-observed full ID, never a reusable container name.
+    owned = await docker.containers.get(observed_id)
+    await owned.delete(force=True, v=False)
+    while True:
+        try:
+            await docker.containers.get(observed_id)
+        except DockerError as exc:
+            if exc.status == 404:
+                return
+            raise
+        await asyncio.sleep(0.1)
+
+
+async def _remove_kubernetes(executor: Any, reference: str, execution_id: str) -> None:
+    if not re.fullmatch(r"[a-z0-9][a-z0-9.-]{0,251}[a-z0-9]", reference):
+        raise PublicationError("Invalid Kubernetes publication runtime identity")
+    await executor._init_kubernetes_clients()
+    batch = executor._k8s_batch_api
+    core = executor._k8s_core_api
+    namespace = executor.agent_namespace
+    job = await batch.read_namespaced_job(name=reference, namespace=namespace)
+    labels = job.metadata.labels or {}
+    uid = job.metadata.uid
+    if not uid or labels.get("preloop.execution_id") != execution_id:
+        raise PublicationError("Kubernetes runtime is not owned by this execution")
+    await batch.delete_namespaced_job(
+        name=reference,
+        namespace=namespace,
+        body=V1DeleteOptions(
+            propagation_policy="Foreground", preconditions=V1Preconditions(uid=uid)
+        ),
+    )
+    while True:
+        gone = False
+        try:
+            observed = await batch.read_namespaced_job(
+                name=reference, namespace=namespace
+            )
+            if observed.metadata.uid != uid:
+                raise PublicationError(
+                    "Kubernetes runtime identity changed during removal"
+                )
+        except ApiException as exc:
+            if exc.status != 404:
+                raise
+            gone = True
+        pods = await core.list_namespaced_pod(
+            namespace=namespace, label_selector=f"job-name={reference}"
+        )
+        if gone and pods.items == []:
+            return
+        await asyncio.sleep(0.1)

--- a/backend/preloop/services/publication_verification.py
+++ b/backend/preloop/services/publication_verification.py
@@ -1,0 +1,39 @@
+"""Trusted verifier handoff; intentionally separate from agent result JSON."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from preloop.services.trusted_publisher import PublicationError
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedPublication:
+    """Controller-owned result after verification of the immutable bundle.
+
+    Construct only in the trusted runner/controller adapter after #428 checks
+    complete. This type is not a wire schema and has no JSON deserializer.
+    """
+
+    execution_id: str
+    head_sha: str
+    bundle_sha256: str
+
+
+def require_verified_publication(
+    value: object, *, execution_id: str, bundle: bytes
+) -> str:
+    """Reject sandbox claims and stale/different artifact evidence."""
+    if not isinstance(value, VerifiedPublication):
+        raise PublicationError(
+            "Isolated publication requires controller-issued verification evidence; sandbox result.json is not an attestation"
+        )
+    if (
+        value.execution_id != execution_id
+        or value.bundle_sha256 != hashlib.sha256(bundle).hexdigest()
+    ):
+        raise PublicationError(
+            "Verification evidence does not match this execution and exact commit artifact"
+        )
+    return value.head_sha

--- a/backend/preloop/services/publication_worker.py
+++ b/backend/preloop/services/publication_worker.py
@@ -1,0 +1,206 @@
+"""Fixed private-runner helper for freezing and publishing immutable Git bundles.
+
+The helper image is operator pinned. Source is mounted read-only after all agent
+writers are removed; publisher input is a distinct frozen volume. Credentials
+arrive only on stdin in the publishing process and never enter repository code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from preloop.services.publication_credentials import revoke_repository_lease
+from preloop.services.trusted_publisher import (
+    MAX_BUNDLE_BYTES,
+    CleanGitRepository,
+    PublicationBinding,
+    PublicationError,
+    PublicationLease,
+    publish_verified_bundle,
+)
+from preloop.utils.pr_metadata import PublicationRecord
+
+MAX_RESULT_BYTES = 256 * 1024
+MAX_REQUEST_BYTES = 512 * 1024
+
+
+def read_regular_file(directory: Path, name: str, limit: int) -> bytes:
+    """Open only a fixed regular file without following links or accepting aliases."""
+    if name not in {"branch.bundle", "result.json"}:
+        raise PublicationError("Unsupported publication input name")
+    directory_fd = os.open(directory, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        fd = os.open(
+            name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=directory_fd
+        )
+    finally:
+        os.close(directory_fd)
+    with os.fdopen(fd, "rb") as stream:
+        observed = os.fstat(stream.fileno())
+        if not stat.S_ISREG(observed.st_mode) or observed.st_nlink != 1:
+            raise PublicationError(
+                "Publication input must be an unaliased regular file"
+            )
+        if observed.st_size > limit:
+            raise PublicationError("Publication input exceeds size limit")
+        data = stream.read(limit + 1)
+        after = os.fstat(stream.fileno())
+        if len(data) > limit or (
+            observed.st_size,
+            observed.st_mtime_ns,
+            observed.st_ctime_ns,
+        ) != (after.st_size, after.st_mtime_ns, after.st_ctime_ns):
+            raise PublicationError("Publication input changed while freezing")
+        return data
+
+
+def inspect_bundle(bundle: bytes, base_sha: str) -> dict[str, Any]:
+    """Derive the only HEAD, tree, and diff from an independently imported bundle."""
+    if not re.fullmatch(r"[a-f0-9]{40}", base_sha):
+        raise PublicationError("Verification requires the trusted exact base commit")
+    if not bundle or len(bundle) > MAX_BUNDLE_BYTES:
+        raise PublicationError("Invalid publication bundle size")
+    with tempfile.TemporaryDirectory(prefix="preloop-freeze-") as temporary:
+        repo = CleanGitRepository(Path(temporary))
+        path = Path(temporary) / "candidate.bundle"
+        path.write_bytes(bundle)
+        heads = repo.run("bundle", "list-heads", str(path)).splitlines()
+        if len(heads) != 1:
+            raise PublicationError("Publication bundle must advertise exactly one HEAD")
+        fields = heads[0].split()
+        if (
+            len(fields) != 2
+            or fields[1] != "HEAD"
+            or not re.fullmatch(r"[a-f0-9]{40}", fields[0])
+        ):
+            raise PublicationError("Publication bundle has no unambiguous HEAD")
+        head_sha = fields[0]
+        repo.import_bundle(bundle, head_sha)
+        if repo.run("rev-parse", f"{base_sha}^{{commit}}") != base_sha:
+            raise PublicationError("Trusted base is missing from the frozen bundle")
+        tree_sha = repo.run("rev-parse", f"{head_sha}^{{tree}}")
+        changed = repo.run(
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            base_sha,
+            head_sha,
+            "--",
+        )
+        return {
+            "version": 1,
+            "head_sha": head_sha,
+            "tree_sha": tree_sha,
+            "bundle_sha256": hashlib.sha256(bundle).hexdigest(),
+            "changed_files": [name for name in changed.split("\0") if name],
+        }
+
+
+def freeze_publication(
+    source: Path, destination: Path, base_sha: str
+) -> dict[str, Any]:
+    """Copy fixed inputs to a distinct controller-owned volume and inspect bytes."""
+    if source.resolve() == destination.resolve():
+        raise PublicationError("Frozen publication input must have independent storage")
+    bundle = read_regular_file(source, "branch.bundle", MAX_BUNDLE_BYTES)
+    manifest = inspect_bundle(bundle, base_sha)
+    try:
+        result = read_regular_file(source, "result.json", MAX_RESULT_BYTES)
+    except FileNotFoundError:
+        result = None
+    destination.mkdir(parents=True, exist_ok=True)
+    for name, data in (("branch.bundle", bundle), ("result.json", result)):
+        if data is not None:
+            fd = os.open(
+                destination / name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                0o444,
+            )
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(data)
+                stream.flush()
+                os.fsync(stream.fileno())
+    return manifest
+
+
+async def publish_frozen(source: Path, request: dict[str, Any]) -> dict[str, Any]:
+    """Validate immutable bytes before using the independently issued writer lease."""
+    binding_data = dict(request["binding"])
+    binding_data["records"] = tuple(
+        PublicationRecord(**record) for record in binding_data["records"]
+    )
+    binding = PublicationBinding(**binding_data)
+    lease_data = dict(request["lease"])
+    lease_data["expires_at"] = datetime.fromisoformat(
+        lease_data["expires_at"].replace("Z", "+00:00")
+    )
+    lease = PublicationLease(**lease_data)
+    async with httpx.AsyncClient() as client:
+        try:
+            bundle = read_regular_file(source, "branch.bundle", MAX_BUNDLE_BYTES)
+            if hashlib.sha256(bundle).hexdigest() != request["bundle_sha256"]:
+                raise PublicationError("Frozen publication bundle digest changed")
+            try:
+                result = read_regular_file(source, "result.json", MAX_RESULT_BYTES)
+            except FileNotFoundError:
+                result = None
+
+            async def acquire_lease() -> PublicationLease:
+                lease.validate(binding)
+                return lease
+
+            return await publish_verified_bundle(
+                binding=binding,
+                bundle=bundle,
+                result_json=result,
+                acquire_lease=acquire_lease,
+                client=client,
+            )
+        finally:
+            await revoke_repository_lease(lease, client)
+
+
+def main() -> None:
+    """Bounded stdin/stdout protocol; never print exception content or credentials."""
+    try:
+        raw = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
+        if len(raw) > MAX_REQUEST_BYTES:
+            raise PublicationError("Helper request exceeds limit")
+        request = json.loads(raw)
+        if sys.argv[1:] == ["freeze"]:
+            result = freeze_publication(
+                Path("/source"), Path("/input"), request["base_sha"]
+            )
+        elif sys.argv[1:] == ["publish"]:
+            result = asyncio.run(publish_frozen(Path("/input"), request))
+        else:
+            raise PublicationError("Unknown helper phase")
+        output = json.dumps(result)
+        if len(output.encode()) > 1024 * 1024:
+            raise PublicationError("Helper result exceeds limit")
+        print(output)
+    except Exception:
+        print(
+            '{"error":"Trusted publication helper failed; see runner recovery status"}',
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from None
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/preloop/services/publication_worker.py
+++ b/backend/preloop/services/publication_worker.py
@@ -101,6 +101,7 @@ def inspect_bundle(bundle: bytes, base_sha: str) -> dict[str, Any]:
             base_sha,
             head_sha,
             "--",
+            strip_output=False,
         )
         return {
             "version": 1,

--- a/backend/preloop/services/runner_service.py
+++ b/backend/preloop/services/runner_service.py
@@ -256,6 +256,22 @@ def lease_job(
         runner = crud_flow_runner.claim_idle(db, runner_id=candidate.id)
         if runner is None:
             continue
+        if payload.get("_publication"):
+            capability = runner.publication_capabilities or {}
+            if (
+                capability.get("version") != 1
+                or capability.get("helper_ready") is not True
+                or payload.get("agent_type") not in {"codex", "opencode"}
+            ):
+                db.rollback()
+                continue
+            crud_flow_runner.bind_publication_lease(
+                db,
+                runner_id=runner.id,
+                execution_id=execution_id,
+                account_id=account_id,
+                nonce=payload["_publication"]["nonce"],
+            )
         runner.pending_job = stored
         runner.current_execution_id = execution_id
         runner.status = "busy"

--- a/backend/preloop/services/trusted_publisher.py
+++ b/backend/preloop/services/trusted_publisher.py
@@ -185,7 +185,11 @@ class CleanGitRepository:
         self.run("init", "--bare", "--template=", str(directory))
 
     def run(
-        self, *args: str, lease: PublicationLease | None = None, check: bool = True
+        self,
+        *args: str,
+        lease: PublicationLease | None = None,
+        check: bool = True,
+        strip_output: bool = True,
     ) -> str:
         """Run only publisher-authored Git arguments with bounded time/output."""
         environment = dict(self.environment)
@@ -252,7 +256,8 @@ class CleanGitRepository:
             )
         if not check and result.returncode:
             return ""
-        return result.stdout.decode("utf-8", errors="replace").strip()
+        decoded = result.stdout.decode("utf-8", errors="replace")
+        return decoded.strip() if strip_output else decoded
 
     def import_bundle(self, bundle: bytes, head_sha: str) -> None:
         """Verify a self-contained bundle and exact commit before any lease exists."""

--- a/backend/preloop/services/trusted_publisher.py
+++ b/backend/preloop/services/trusted_publisher.py
@@ -1,0 +1,502 @@
+"""Publish verified commit bundles outside the agent runtime.
+
+Only the control plane constructs bindings and leases. No checkout, Git config,
+credential helper, hook, filter, or command supplied by the agent is imported.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import os
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+from urllib.parse import quote, urlsplit
+
+import httpx
+
+from preloop.utils.pr_metadata import (
+    PublicationRecord,
+    select_metadata,
+    upsert_provenance,
+)
+
+MAX_BUNDLE_BYTES = 32 * 1024 * 1024
+MAX_ARCHIVE_BYTES = 4 * 1024 * 1024
+_SHA = re.compile(r"[0-9a-f]{40}")
+_REF = re.compile(r"[A-Za-z0-9][A-Za-z0-9._/-]{0,199}")
+
+
+class PublicationError(ValueError):
+    """A recoverable, safe-to-display publication failure."""
+
+
+@dataclass(frozen=True)
+class PublicationBinding:
+    """Destination and policy resolved by the trusted control plane."""
+
+    repository_url: str
+    branch: str
+    base: str
+    head_sha: str
+    expected_remote_sha: str | None
+    records: tuple[PublicationRecord, ...]
+    public_url: str
+    provider: str
+    configured_title: str = ""
+    configured_body: str = ""
+    issue_number: str = ""
+
+    def __post_init__(self) -> None:
+        parsed = urlsplit(self.repository_url)
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+            or parsed.port not in {None, 443}
+        ):
+            raise PublicationError(
+                "Publisher requires a credential-free HTTPS repository binding"
+            )
+        if self.provider not in {"github", "gitlab"}:
+            raise PublicationError("Unsupported publication provider")
+        if self.provider == "github" and parsed.hostname != "github.com":
+            raise PublicationError("GitHub publication requires github.com")
+        if not re.fullmatch(r"/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+", parsed.path):
+            raise PublicationError("Invalid repository path")
+        for branch in (self.branch, self.base):
+            if (
+                not _REF.fullmatch(branch)
+                or any(
+                    part.startswith(".") or part.endswith((".lock", "."))
+                    for part in branch.split("/")
+                )
+                or ".." in branch
+                or "//" in branch
+                or branch.endswith("/")
+            ):
+                raise PublicationError("Invalid bound branch")
+        if self.branch == self.base:
+            raise PublicationError("Publication to the base branch is prohibited")
+        if not _SHA.fullmatch(self.head_sha) or (
+            self.expected_remote_sha is not None
+            and not _SHA.fullmatch(self.expected_remote_sha)
+        ):
+            raise PublicationError("Publication requires exact full SHA-1 commit IDs")
+        if not self.records or self.records[-1].head_sha != self.head_sha:
+            raise PublicationError(
+                "Publication provenance does not match the tested head"
+            )
+
+    @property
+    def project_path(self) -> str:
+        """Provider project identifier from the trusted repository URL."""
+        return urlsplit(self.repository_url).path.lstrip("/").removesuffix(".git")
+
+
+@dataclass(frozen=True)
+class PublicationLease:
+    """Short-lived, repository-scoped credential issued after verification."""
+
+    token: str = field(repr=False)
+    repository_url: str
+    expires_at: datetime
+
+    def validate(self, binding: PublicationBinding) -> None:
+        """Reject wrong-repository or expired leases without exposing secrets."""
+        if not self.token or self.repository_url != binding.repository_url:
+            raise PublicationError(
+                "Publisher credential is not bound to this repository"
+            )
+        if (
+            self.expires_at.tzinfo is None
+            or (self.expires_at - datetime.now(timezone.utc)).total_seconds() < 30
+        ):
+            raise PublicationError(
+                "Publisher credential expired or has less than 30 seconds remaining"
+            )
+
+
+def read_publication_bundle(archive: bytes) -> bytes:
+    """Read a single regular bundle without extracting any agent-owned paths."""
+    if len(archive) > MAX_ARCHIVE_BYTES:
+        raise PublicationError("Publication archive exceeds transfer limit")
+    try:
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+            matches = []
+            expanded = 0
+            count = 0
+            for member in tar:
+                count += 1
+                expanded += max(0, member.size)
+                if expanded > MAX_BUNDLE_BYTES * 2 or count > 1024:
+                    raise PublicationError(
+                        "Publication archive exceeds expansion limit"
+                    )
+                if member.name in {
+                    "branch.bundle",
+                    "evidence/branch.bundle",
+                    "./branch.bundle",
+                    "./evidence/branch.bundle",
+                }:
+                    if not member.isfile() or member.size > MAX_BUNDLE_BYTES:
+                        raise PublicationError(
+                            "Publication bundle must be a bounded regular file"
+                        )
+                    stream = tar.extractfile(member)
+                    if stream is None:
+                        raise PublicationError("Publication bundle unreadable")
+                    matches.append(stream.read(MAX_BUNDLE_BYTES + 1))
+            if len(matches) != 1:
+                raise PublicationError(
+                    "Publication archive must contain exactly one branch.bundle"
+                )
+            return matches[0]
+    except (tarfile.TarError, OSError) as exc:
+        raise PublicationError("Invalid publication archive") from exc
+
+
+class CleanGitRepository:
+    """Disposable bare object store; never uses the sandbox repository."""
+
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+        self.environment = {
+            "PATH": os.defpath,
+            "HOME": str(directory),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_CONFIG_COUNT": "0",
+            "GIT_ALLOW_PROTOCOL": "https",
+            "LC_ALL": "C",
+        }
+        self.run("init", "--bare", "--template=", str(directory))
+
+    def run(
+        self, *args: str, lease: PublicationLease | None = None, check: bool = True
+    ) -> str:
+        """Run only publisher-authored Git arguments with bounded time/output."""
+        environment = dict(self.environment)
+        if lease:
+            header = base64.b64encode(f"x-access-token:{lease.token}".encode()).decode()
+            environment.update(
+                {
+                    "GIT_CONFIG_COUNT": "1",
+                    "GIT_CONFIG_KEY_0": f"http.{lease.repository_url}.extraHeader",
+                    "GIT_CONFIG_VALUE_0": f"Authorization: Basic {header}",
+                }
+            )
+        command = [
+            "/usr/bin/git",
+            "-c",
+            f"core.hooksPath={os.devnull}",
+            "-c",
+            "credential.helper=",
+            "-c",
+            "http.followRedirects=false",
+            "-c",
+            "protocol.file.allow=never",
+            "-c",
+            "protocol.ext.allow=never",
+            "-c",
+            "core.commitGraph=false",
+            "-C",
+            str(self.directory),
+            *args,
+        ]
+        # Apply resource limits in a dedicated child, never preexec_fn in a
+        # multithreaded server. -I prevents Python startup/PYTHONPATH hooks.
+        limit_script = (
+            "import os, resource, sys; "
+            "resource.setrlimit(resource.RLIMIT_CPU, (60, 60)); "
+            "resource.setrlimit(resource.RLIMIT_FSIZE, (268435456, 268435456)); "
+            "resource.setrlimit(resource.RLIMIT_NOFILE, (128, 128)); "
+            "resource.setrlimit(resource.RLIMIT_CORE, (0, 0)); "
+            "resource.setrlimit(resource.RLIMIT_AS, (536870912, 536870912)) "
+            "if sys.platform.startswith('linux') else None; "
+            "os.execv(sys.argv[1], sys.argv[1:])"
+        )
+        command = [sys.executable, "-I", "-c", limit_script, *command]
+        try:
+            # No stderr from Git escapes this boundary: it may include auth data.
+            result = subprocess.run(
+                command,
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                timeout=120,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise PublicationError(
+                "Publisher Git operation unavailable or timed out"
+            ) from exc
+        if len(result.stdout) > 1024 * 1024:
+            raise PublicationError("Publisher Git output exceeds limit")
+        if check and result.returncode:
+            raise PublicationError(
+                f"Publisher Git {args[0]} failed; publication can be retried"
+            )
+        if not check and result.returncode:
+            return ""
+        return result.stdout.decode("utf-8", errors="replace").strip()
+
+    def import_bundle(self, bundle: bytes, head_sha: str) -> None:
+        """Verify a self-contained bundle and exact commit before any lease exists."""
+        if not bundle or len(bundle) > MAX_BUNDLE_BYTES:
+            raise PublicationError("Invalid publication bundle size")
+        path = self.directory / "input.bundle"
+        path.write_bytes(bundle)
+        self.run("bundle", "verify", str(path))
+        self.run("bundle", "unbundle", str(path))
+        if self.run("rev-parse", f"{head_sha}^{{commit}}") != head_sha:
+            raise PublicationError("Bundle does not contain the verified commit")
+        self.run("fsck", "--strict", "--no-reflogs", head_sha)
+        path.unlink()
+
+    def publish(self, binding: PublicationBinding, lease: PublicationLease) -> None:
+        """Enforce expected-head comparison and ancestry before an atomic lease push."""
+        lease.validate(binding)
+        ref = f"refs/heads/{binding.branch}"
+        remote = self.run(
+            "ls-remote", "--refs", binding.repository_url, ref, lease=lease
+        )
+        observed = remote.split()[0] if remote else None
+        if observed == binding.head_sha:
+            return  # A retry after a successful push but failed provider call.
+        if observed != binding.expected_remote_sha:
+            raise PublicationError(
+                "Remote branch changed concurrently; resume and reverify before publishing"
+            )
+        self.run(
+            "fetch",
+            "--no-tags",
+            "--no-recurse-submodules",
+            "--depth=1",
+            binding.repository_url,
+            f"refs/heads/{binding.base}:refs/preloop/base",
+            lease=lease,
+        )
+        # Bundle contains the full history. Fetch must not introduce shallow
+        # boundaries on commits already present in that history.
+        (self.directory / "shallow").unlink(missing_ok=True)
+        if not self.run("merge-base", "refs/preloop/base", binding.head_sha):
+            raise PublicationError("Published commit is unrelated to the bound base")
+        if observed:
+            ancestor = self.run("merge-base", observed, binding.head_sha)
+            if ancestor != observed:
+                raise PublicationError(
+                    "Non-fast-forward publication requires a new verified repair"
+                )
+        lease.validate(binding)
+        # The ancestry check prohibits rewriting history. The lease also rejects
+        # a remote race between ls-remote and receive-pack, including first push.
+        self.run(
+            "push",
+            "--porcelain",
+            f"--force-with-lease={ref}:{observed or ''}",
+            binding.repository_url,
+            f"{binding.head_sha}:{ref}",
+            lease=lease,
+        )
+
+
+class PullRequestPublisher:
+    """Provider operations scoped to a trusted repository and source/base pair."""
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self.client = client
+
+    async def upsert(
+        self,
+        binding: PublicationBinding,
+        lease: PublicationLease,
+        title: str,
+        body: str,
+    ) -> dict[str, Any]:
+        """Reuse retries and update only provenance on an existing PR/MR."""
+        lease.validate(binding)
+        github = binding.provider == "github"
+        host = urlsplit(binding.repository_url).netloc
+        endpoint = (
+            f"https://api.github.com/repos/{binding.project_path}/pulls"
+            if github
+            else f"https://{host}/api/v4/projects/{quote(binding.project_path, safe='')}/merge_requests"
+        )
+        headers = (
+            {"Authorization": f"Bearer {lease.token}"}
+            if github
+            else {"PRIVATE-TOKEN": lease.token}
+        )
+        params = (
+            {
+                "state": "open",
+                "head": f"{binding.project_path.split('/')[0]}:{binding.branch}",
+                "base": binding.base,
+            }
+            if github
+            else {
+                "state": "opened",
+                "source_branch": binding.branch,
+                "target_branch": binding.base,
+            }
+        )
+
+        async def request(method: str, url: str, **kwargs: Any) -> Any:
+            try:
+                response = await self.client.request(
+                    method,
+                    url,
+                    headers=headers,
+                    timeout=30,
+                    follow_redirects=False,
+                    **kwargs,
+                )
+                response.raise_for_status()
+                if len(response.content) > 1024 * 1024:
+                    raise PublicationError("PR provider response exceeds limit")
+                return response.json()
+            except (httpx.HTTPError, ValueError) as exc:
+                if isinstance(exc, PublicationError):
+                    raise
+                raise PublicationError(
+                    "PR provider request failed; publication can be retried"
+                ) from exc
+
+        async def lookup() -> dict[str, Any] | None:
+            rows = await request("GET", endpoint, params=params)
+            if not isinstance(rows, list) or len(rows) > 1:
+                raise PublicationError(
+                    "PR lookup returned an ambiguous or invalid binding"
+                )
+            if not rows:
+                return None
+            row = rows[0]
+            if not isinstance(row, dict):
+                raise PublicationError("Invalid PR provider response")
+            if github:
+                if (
+                    row.get("head", {}).get("ref") != binding.branch
+                    or row.get("base", {}).get("ref") != binding.base
+                    or row.get("head", {}).get("repo", {}).get("full_name")
+                    != binding.project_path
+                ):
+                    raise PublicationError(
+                        "Provider PR does not match the bound repository/branches"
+                    )
+            elif (
+                row.get("source_branch") != binding.branch
+                or row.get("target_branch") != binding.base
+                or row.get("source_project_id") != row.get("target_project_id")
+            ):
+                raise PublicationError(
+                    "Provider MR does not match the bound branches/project"
+                )
+            return row
+
+        existing = await lookup()
+        field_name = "body" if github else "description"
+        if existing is None:
+            payload = {
+                "title": title,
+                field_name: upsert_provenance(
+                    body, binding.records, binding.public_url
+                ),
+            }
+            payload.update(
+                {"head": binding.branch, "base": binding.base}
+                if github
+                else {"source_branch": binding.branch, "target_branch": binding.base}
+            )
+            try:
+                created = await request("POST", endpoint, json=payload)
+            except PublicationError:
+                # A concurrent create or lost create response can still be a
+                # successful publication, but only after authoritative lookup.
+                existing = await lookup()
+                if existing is None:
+                    raise
+            else:
+                existing = created
+                if not isinstance(existing, dict):
+                    raise PublicationError("Invalid PR create response")
+        number = existing.get("number" if github else "iid")
+        if not isinstance(number, int) or number < 1:
+            raise PublicationError("Provider did not return a PR identity")
+        current_body = existing.get(field_name) or ""
+        if not isinstance(current_body, str):
+            raise PublicationError("Invalid provider PR body")
+        updated_body = upsert_provenance(
+            current_body, binding.records, binding.public_url
+        )
+        if updated_body != current_body:
+            await request(
+                "PATCH" if github else "PUT",
+                f"{endpoint}/{number}",
+                json={field_name: updated_body},
+            )
+        url = existing.get("html_url" if github else "web_url")
+        expected_prefix = f"https://{host}/{binding.project_path}/" + (
+            "pull/" if github else "-/merge_requests/"
+        )
+        if url != f"{expected_prefix}{number}":
+            raise PublicationError("Provider returned an unexpected PR URL")
+        return {
+            "url": url,
+            "number": number,
+            "branch": binding.branch,
+            "provider": binding.provider,
+            "head_sha": binding.head_sha,
+        }
+
+
+async def publish_verified_bundle(
+    *,
+    binding: PublicationBinding,
+    bundle: bytes,
+    result_json: bytes | None,
+    acquire_lease: Callable[[], Awaitable[PublicationLease]],
+    client: httpx.AsyncClient,
+) -> dict[str, Any]:
+    """Import verified artifacts first, acquire write access last, publish once.
+
+    The caller must validate #428 evidence against ``binding.head_sha`` before
+    invoking this function. Artifacts never supply destination or credentials.
+    """
+    with tempfile.TemporaryDirectory(prefix="preloop-publisher-") as temporary:
+        repo = await asyncio.to_thread(CleanGitRepository, Path(temporary))
+        await asyncio.to_thread(repo.import_bundle, bundle, binding.head_sha)
+        commit_title = await asyncio.to_thread(
+            repo.run, "show", "-s", "--format=%s", binding.head_sha
+        )
+        commit_body = await asyncio.to_thread(
+            repo.run, "show", "-s", "--format=%b", binding.head_sha
+        )
+        title, body, warnings = select_metadata(
+            result_json,
+            configured_title=binding.configured_title,
+            configured_body=binding.configured_body,
+            commit_title=commit_title,
+            commit_body=commit_body,
+            issue_number=binding.issue_number,
+        )
+        # Validate metadata/provenance before credentials are issued.
+        upsert_provenance(body, binding.records, binding.public_url)
+        lease = await acquire_lease()
+        await asyncio.to_thread(repo.publish, binding, lease)
+        result = await PullRequestPublisher(client).upsert(binding, lease, title, body)
+        result["metadata_warnings"] = warnings
+        return result

--- a/backend/preloop/utils/pr_metadata.py
+++ b/backend/preloop/utils/pr_metadata.py
@@ -69,7 +69,7 @@ def read_result_metadata(raw: bytes | None) -> tuple[str, str, list[str]]:
         data = json.loads(raw)
         if not isinstance(data, dict):
             raise ValueError("not an object")
-    except (ValueError, UnicodeDecodeError):
+    except (ValueError, UnicodeDecodeError, RecursionError):
         return (
             "",
             "",

--- a/backend/preloop/utils/pr_metadata.py
+++ b/backend/preloop/utils/pr_metadata.py
@@ -1,0 +1,290 @@
+"""Bounded PR metadata and publisher-owned execution provenance.
+
+This module uses only the standard library so the legacy container wrapper can
+carry the same validation implementation without installing the server package.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlsplit
+from uuid import UUID
+
+MAX_TITLE_BYTES = 256
+MAX_BODY_BYTES = 60000
+MAX_ARTIFACT_BYTES = 256 * 1024
+PROVENANCE_START = "<!-- preloop:executions:start -->"
+PROVENANCE_END = "<!-- preloop:executions:end -->"
+_PROVENANCE = re.compile(
+    re.escape(PROVENANCE_START) + r".*?" + re.escape(PROVENANCE_END), re.DOTALL
+)
+
+
+@dataclass(frozen=True)
+class PublicationRecord:
+    """An execution and exact published head from trusted persistence."""
+
+    execution_id: str
+    head_sha: str
+
+    def __post_init__(self) -> None:
+        UUID(self.execution_id)
+        if not re.fullmatch(r"[0-9a-f]{40}|[0-9a-f]{64}", self.head_sha):
+            raise ValueError("Publication record requires a full commit SHA")
+
+
+def bounded_text(value: Any, *, title: bool = False) -> str:
+    """Return valid metadata, or empty text so the next source can be tried."""
+    if not isinstance(value, str):
+        return ""
+    value = value.strip()
+    limit = MAX_TITLE_BYTES if title else MAX_BODY_BYTES
+    if len(value.encode("utf-8")) > limit:
+        return ""
+    if any(ord(char) < 32 and char not in "\n\t" for char in value):
+        return ""
+    if title and ("\n" in value or "\t" in value):
+        return ""
+    # An agent must not impersonate the publisher-owned region.
+    if PROVENANCE_START in value or PROVENANCE_END in value:
+        return ""
+    return value
+
+
+def read_result_metadata(raw: bytes | None) -> tuple[str, str, list[str]]:
+    """Read #420 aliases without coercion or unbounded JSON parsing."""
+    if raw is None:
+        return (
+            "",
+            "",
+            ["PR metadata artifact missing; using configured/commit fallback"],
+        )
+    try:
+        if len(raw) > MAX_ARTIFACT_BYTES:
+            raise ValueError("oversized")
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError("not an object")
+    except (ValueError, UnicodeDecodeError):
+        return (
+            "",
+            "",
+            ["PR metadata artifact invalid; using configured/commit fallback"],
+        )
+    nested = data.get("pull_request")
+    nested = nested if isinstance(nested, dict) else {}
+    title = next(
+        (
+            text
+            for value in (
+                data.get("pr_title"),
+                data.get("pull_request_title"),
+                nested.get("title"),
+            )
+            if (text := bounded_text(value, title=True))
+        ),
+        "",
+    )
+    body = next(
+        (
+            text
+            for value in (
+                data.get("pr_body"),
+                data.get("pr_description"),
+                data.get("pull_request_description"),
+                nested.get("body"),
+                nested.get("description"),
+            )
+            if (text := bounded_text(value))
+        ),
+        "",
+    )
+    warnings = []
+    if not title or not body:
+        warnings.append("PR metadata incomplete or invalid; using per-field fallback")
+    return title, body, warnings
+
+
+def select_metadata(
+    raw: bytes | None,
+    *,
+    configured_title: str = "",
+    configured_body: str = "",
+    commit_title: str = "",
+    commit_body: str = "",
+    issue_number: str = "",
+) -> tuple[str, str, list[str]]:
+    """Apply agent, configuration, commit precedence independently per field."""
+    title, body, warnings = read_result_metadata(raw)
+    title = (
+        title
+        or bounded_text(configured_title, title=True)
+        or bounded_text(commit_title, title=True)
+        or "Automated changes"
+    )
+    body = (
+        body
+        or bounded_text(configured_body)
+        or bounded_text(commit_body)
+        or "## Summary\n\nAutomated repository changes.\n\n## Testing\n\nNo test evidence supplied."
+    )
+    if issue_number and re.fullmatch(r"[1-9][0-9]*", issue_number):
+        if not re.search(rf"(?<![0-9])#{issue_number}(?![0-9])", body):
+            body += f"\n\nCloses #{issue_number}"
+    return title, body, warnings
+
+
+def provenance_block(records: Sequence[PublicationRecord], public_url: str) -> str:
+    """Build links only from the public application URL and trusted UUIDs."""
+    parsed = urlsplit(public_url)
+    if (
+        parsed.scheme not in {"https", "http"}
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError(
+            "Public application URL must not contain credentials or query data"
+        )
+    if any(char in public_url for char in "\n\r<>()[] "):
+        raise ValueError("Invalid public application URL")
+    unique = list(dict.fromkeys(records))
+    if not unique or len(unique) > 200:
+        raise ValueError("Publication requires between 1 and 200 execution records")
+    lines = [PROVENANCE_START, "### Preloop executions", ""]
+    for index, record in enumerate(unique):
+        label = "Initial execution" if index == 0 else "Repair execution"
+        url = f"{public_url.rstrip('/')}/console/flows/executions/{record.execution_id}"
+        lines.append(f"- [{label}]({url}) — published `{record.head_sha}`")
+    return "\n".join([*lines, PROVENANCE_END])
+
+
+def upsert_provenance(
+    body: str, records: Sequence[PublicationRecord], public_url: str
+) -> str:
+    """Replace only the owned region, preserving human edits byte for byte."""
+    block = provenance_block(records, public_url)
+    # Malformed delimiters are ambiguous ownership: fail without erasing text.
+    matches = list(_PROVENANCE.finditer(body))
+    if body.count(PROVENANCE_START) != len(matches) or body.count(
+        PROVENANCE_END
+    ) != len(matches):
+        raise ValueError(
+            "Malformed publisher provenance region; repair delimiters first"
+        )
+    if matches:
+        first = matches[0]
+        result = body[: first.start()] + block + body[first.end() :]
+        # Remove duplicate *owned* blocks only; all outside text stays intact.
+        offset = first.start() + len(block)
+        result = result[:offset] + _PROVENANCE.sub("", result[offset:])
+    else:
+        result = body + ("\n\n" if body else "") + block
+    if len(result.encode("utf-8")) > 65536:
+        raise ValueError("PR body plus provenance exceeds provider limit")
+    return result
+
+
+def discover_template(
+    files: Mapping[str, str], *, provider: str, configured: str | None = None
+) -> tuple[str | None, str]:
+    """Select configured template, conventional default, then lexical first.
+
+    ``files`` must come from repository text blobs, never executable metadata.
+    The fallback for no template intentionally leaves all checkboxes unchecked.
+    """
+    if configured:
+        path = Path(configured)
+        if path.is_absolute() or ".." in path.parts or configured not in files:
+            raise ValueError("Configured PR template is missing or outside repository")
+        selected = configured
+    else:
+        defaults = (
+            [
+                ".gitlab/merge_request_templates/Default.md",
+                ".gitlab/merge_request_templates/default.md",
+            ]
+            if provider == "gitlab"
+            else [
+                ".github/pull_request_template.md",
+                ".github/PULL_REQUEST_TEMPLATE.md",
+                "pull_request_template.md",
+                "PULL_REQUEST_TEMPLATE.md",
+                "docs/pull_request_template.md",
+                "docs/PULL_REQUEST_TEMPLATE.md",
+            ]
+        )
+        selected = next((path for path in defaults if path in files), None)
+        if selected is None:
+            prefix = (
+                ".gitlab/merge_request_templates/"
+                if provider == "gitlab"
+                else ".github/PULL_REQUEST_TEMPLATE/"
+            )
+            selected = next(
+                iter(
+                    sorted(
+                        path
+                        for path in files
+                        if path.startswith(prefix) and path.lower().endswith(".md")
+                    )
+                ),
+                None,
+            )
+    if selected is None:
+        return None, "## Summary\n\n## Testing\n"
+    text = bounded_text(files[selected])
+    if not text:
+        raise ValueError("PR template is empty, invalid, or exceeds metadata limit")
+    return selected, files[selected]
+
+
+def repository_template(
+    root: Path, *, provider: str, configured: str | None = None
+) -> tuple[str | None, str]:
+    """Read bounded, in-repository template files without following escapes."""
+    root = root.resolve()
+    candidates = (
+        [configured]
+        if configured
+        else [
+            ".github/pull_request_template.md",
+            ".github/PULL_REQUEST_TEMPLATE.md",
+            "pull_request_template.md",
+            "PULL_REQUEST_TEMPLATE.md",
+            "docs/pull_request_template.md",
+            "docs/PULL_REQUEST_TEMPLATE.md",
+            ".gitlab/merge_request_templates/Default.md",
+            ".gitlab/merge_request_templates/default.md",
+        ]
+    )
+    if not configured:
+        directory = root / (
+            ".gitlab/merge_request_templates"
+            if provider == "gitlab"
+            else ".github/PULL_REQUEST_TEMPLATE"
+        )
+        if directory.is_dir() and directory.resolve().is_relative_to(root):
+            candidates += [
+                str(path.relative_to(root)) for path in directory.glob("*.md")
+            ][:256]
+    files: dict[str, str] = {}
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        path = root / candidate
+        if path.is_file() and path.resolve().is_relative_to(root):
+            with path.open("rb") as stream:
+                raw = stream.read(MAX_BODY_BYTES + 1)
+            if len(raw) <= MAX_BODY_BYTES:
+                try:
+                    files[candidate] = raw.decode("utf-8")
+                except UnicodeDecodeError:
+                    continue
+    return discover_template(files, provider=provider, configured=configured)

--- a/backend/presets/011-automated-issue-implementation.yaml
+++ b/backend/presets/011-automated-issue-implementation.yaml
@@ -161,6 +161,23 @@ prompt_template: |
   `pr_body` from this file when they are present. Write a real title and a
   real description: what changed, why, and `Closes #<issue number>`.
 
+  Read `/workspace/evidence/pr-template.md`, selected during repository setup,
+  before writing the description. If it is unavailable, discover the
+  repository's PR template. Prefer
+  the configured `pull_request_template` path, then the conventional default:
+  `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, root
+  or `docs/pull_request_template.md`; GitLab uses
+  `.gitlab/merge_request_templates/Default.md`. If there are multiple named
+  templates and no configured choice, select the lexicographically first
+  Markdown path in `.github/PULL_REQUEST_TEMPLATE/` or the GitLab directory.
+  If no template exists, use Summary and Testing sections. Fill the selected
+  sections with the problem, resulting behavior, scope, acceptance evidence,
+  actual verification commands/results, and limitations. Preserve checklist
+  meaning. Never check a skipped, unavailable, or failed test as passed.
+  Include the issue link. Keep the title to one descriptive line (256 UTF-8
+  bytes maximum) and the body below 60,000 UTF-8 bytes. The publisher adds
+  trusted execution links and published SHAs; do not fabricate provenance.
+
   Use "success" when you committed a change you believe is correct, even
   if some checks could not run (list those under "skipped"). Use "failure"
   when you could not implement the issue, and say why. Never report

--- a/backend/tests/agents/test_runner_launch.py
+++ b/backend/tests/agents/test_runner_launch.py
@@ -348,3 +348,54 @@ def test_shared_completion_cases_preserve_reports_without_promoting_failure(
         and case["confirmation"] == "success"
     )
     assert result == case["result"]
+
+
+@pytest.mark.asyncio
+async def test_queued_isolated_launch_keeps_restored_pinned_git_configuration(
+    monkeypatch,
+):
+    """Raw queued flow config cannot replace restored authority or read lease."""
+    from preloop.services.flow_orchestrator import FlowExecutionOrchestrator
+
+    execution = SimpleNamespace(
+        id=uuid4(),
+        flow_id=uuid4(),
+        trigger_event_details={},
+        resolved_input_prompt="work",
+    )
+    monkeypatch.setattr(
+        "preloop.agents.runner_launch.crud_flow_execution.get",
+        lambda *args, **kwargs: execution,
+    )
+    monkeypatch.setattr(
+        FlowExecutionOrchestrator, "_get_flow_details", lambda *args, **kwargs: None
+    )
+    pinned = {"target_branch": "preloop/bound", "source_branch": "trusted-main"}
+    monkeypatch.setattr(
+        FlowExecutionOrchestrator,
+        "_prepare_execution_context",
+        AsyncMock(
+            return_value={
+                "git_clone_config": pinned,
+                "git_credentials_map": {
+                    "tracker": {"token": "read-only", "permission": "read"}
+                },
+            }
+        ),
+    )
+    build = AsyncMock(return_value={"version": 1, "script": "bootstrap", "env": {}})
+    monkeypatch.setattr("preloop.agents.runner_launch.build_runner_launch", build)
+    await hydrate_runner_job(
+        MagicMock(),
+        {
+            "launch_version": 1,
+            "execution_id": str(execution.id),
+            "publication": {"version": 1},
+            "git_clone_config": {"target_branch": "raw-unbound"},
+        },
+    )
+    assert build.await_args.args[0]["git_clone_config"] == pinned
+    assert (
+        build.await_args.args[0]["git_credentials_map"]["tracker"]["permission"]
+        == "read"
+    )

--- a/backend/tests/endpoints/test_runners_helpers.py
+++ b/backend/tests/endpoints/test_runners_helpers.py
@@ -13,11 +13,47 @@ from preloop.api.endpoints.runners import (
     _live,
     _parse_runner_execution_id,
     _release_live_runner,
+    _valid_publication_helper_image,
     job_for_heartbeat_ack,
     job_for_runner_replay,
     runner_needs_lease_token,
 )
 from preloop.services.websocket_manager import WebSocketManager
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        "helper@sha256:" + "a" * 64,
+        "registry.example:5000/team/helper:v1.2-rc_1@sha256:" + "0123456789abcdef" * 4,
+    ],
+)
+def test_publication_helper_image_accepts_pinned_references(image: str) -> None:
+    assert _valid_publication_helper_image(image)
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        None,
+        123,
+        "",
+        "helper:latest",
+        "@sha256:" + "a" * 64,
+        "-helper@sha256:" + "a" * 64,
+        "helper@sha256:" + "A" * 64,
+        "helper@sha256:" + "a" * 63,
+        "helper@sha256:" + "a" * 65,
+        "helper@sha256:" + "a" * 64 + "\n",
+        "helper@sha256:helper@sha256:" + "a" * 64,
+        "hélper@sha256:" + "a" * 64,
+        "helper name@sha256:" + "a" * 64,
+        "0" * 1_000_000,
+        "0" * 1_000_000 + "@sha256:" + "a" * 64,
+    ],
+)
+def test_publication_helper_image_rejects_invalid_references(image: object) -> None:
+    assert not _valid_publication_helper_image(image)
 
 
 def test_parse_runner_execution_id_ignores_malformed_values() -> None:
@@ -202,7 +238,36 @@ async def test_completion_confirms_stop_only_on_terminal_owner_ack(
         halt_requested=True,
         status="online",
         reported_status="RUNNING",
+        publication_capabilities=None,
     )
+
+    def set_publication_capabilities(
+        db: object,
+        *,
+        runner_id: UUID,
+        capabilities: dict | None,
+        expected_connection_id: str | None = None,
+        offline: bool = False,
+        clear_lease: bool = False,
+        execution_id: UUID | None = None,
+        reported_status: str | None = None,
+    ) -> bool:
+        """In-memory stand-in for the compare-and-swap capability write."""
+        current = (runner.publication_capabilities or {}).get("connection_id")
+        if expected_connection_id is not None and current != expected_connection_id:
+            return False
+        if execution_id is not None and runner.current_execution_id != execution_id:
+            return False
+        runner.publication_capabilities = capabilities
+        if clear_lease:
+            runner.pending_job = None
+            runner.current_execution_id = None
+            runner.halt_requested = False
+            runner.status = "offline" if offline else "online"
+            if reported_status is not None:
+                runner.reported_status = reported_status
+        return True
+
     execution = SimpleNamespace(status="RUNNING")
     websocket = MagicMock()
     websocket.accept = AsyncMock()
@@ -217,6 +282,11 @@ async def test_completion_confirms_stop_only_on_terminal_owner_ack(
     monkeypatch.setattr(runners, "emit_runner_updated", MagicMock())
     monkeypatch.setattr(runners.crud_flow_runner, "get", lambda *args, **kwargs: runner)
     monkeypatch.setattr(runners.crud_flow_runner, "touch_heartbeat", MagicMock())
+    monkeypatch.setattr(
+        runners.crud_flow_runner,
+        "set_publication_capabilities",
+        set_publication_capabilities,
+    )
     monkeypatch.setattr(
         runners.crud_flow_execution, "get", lambda *args, **kwargs: execution
     )

--- a/backend/tests/fixtures/pr_templates/github/pull_request_template.md
+++ b/backend/tests/fixtures/pr_templates/github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+-
+
+## Testing
+
+- [ ] Backend tests
+- [ ] Frontend tests
+- [ ] Manual validation
+
+## Checklist
+
+- [ ] Docs updated if needed
+- [ ] Changelog updated if needed
+- [ ] No secrets included

--- a/backend/tests/fixtures/pr_templates/gitlab/Default.md
+++ b/backend/tests/fixtures/pr_templates/gitlab/Default.md
@@ -1,0 +1,7 @@
+## Problem
+
+## Result
+
+## Testing
+
+- [ ] Integration tests passed

--- a/backend/tests/fixtures/private_publication_protocol.json
+++ b/backend/tests/fixtures/private_publication_protocol.json
@@ -1,0 +1,130 @@
+{
+  "job": {
+    "execution_id": "11111111-1111-4111-8111-111111111111",
+    "agent_type": "codex",
+    "launch_version": 1,
+    "publication": {
+      "version": 1,
+      "nonce": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "phase": "agent",
+      "repository_url": "https://github.com/example/project.git",
+      "branch": "preloop/change",
+      "base": "main",
+      "base_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "expected_remote_sha": null,
+      "verification_image": "example/helper@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "verification_budget_seconds": 30
+    }
+  },
+  "requests": [
+    {
+      "version": 1,
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "tree_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "bundle_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "type": "publication_candidate",
+      "execution_id": "11111111-1111-4111-8111-111111111111",
+      "nonce": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "changed_files": [
+        "backend/api.py"
+      ]
+    },
+    {
+      "version": 1,
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "tree_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "bundle_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "type": "publication_verified",
+      "execution_id": "11111111-1111-4111-8111-111111111111",
+      "nonce": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "checks": [
+        {
+          "id": "unit",
+          "command": "pytest -q",
+          "timeout_seconds": 900,
+          "exit_code": 0
+        }
+      ],
+      "agent_removed": true,
+      "verifiers_removed": true
+    },
+    {
+      "version": 1,
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "tree_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "bundle_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "type": "publication_complete",
+      "execution_id": "11111111-1111-4111-8111-111111111111",
+      "nonce": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "publication": {
+        "url": "https://github.com/example/project/pull/7",
+        "number": 7,
+        "branch": "preloop/change",
+        "provider": "github",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "metadata_warnings": []
+      }
+    }
+  ],
+  "replies": [
+    {
+      "version": 1,
+      "execution_id": "11111111-1111-4111-8111-111111111111",
+      "nonce": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "tree_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "bundle_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "type": "publication_verify",
+      "checks": [
+        {
+          "id": "unit",
+          "command": "pytest -q",
+          "timeout_seconds": 900
+        }
+      ],
+      "image": "example/helper@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "budget_seconds": 30
+    },
+    {
+      "version": 1,
+      "execution_id": "11111111-1111-4111-8111-111111111111",
+      "nonce": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "tree_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "bundle_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "type": "publication_publish",
+      "binding": {
+        "repository_url": "https://github.com/example/project.git",
+        "branch": "preloop/change",
+        "base": "main",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "expected_remote_sha": null,
+        "records": [
+          {
+            "execution_id": "11111111-1111-4111-8111-111111111111",
+            "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          }
+        ],
+        "public_url": "http://localhost:8000",
+        "provider": "github",
+        "configured_title": "",
+        "configured_body": "",
+        "issue_number": "1"
+      },
+      "lease": {
+        "token": "write-only-secret",
+        "repository_url": "https://github.com/example/project.git",
+        "expires_at": "2099-01-01T00:00:00+00:00"
+      }
+    },
+    {
+      "version": 1,
+      "execution_id": "11111111-1111-4111-8111-111111111111",
+      "nonce": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "tree_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "bundle_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "type": "publication_ack"
+    }
+  ]
+}

--- a/backend/tests/fixtures/publication_publish_request.json
+++ b/backend/tests/fixtures/publication_publish_request.json
@@ -1,0 +1,18 @@
+{
+  "binding": {
+    "repository_url": "https://github.com/example/project.git",
+    "branch": "preloop/issue-1",
+    "base": "main",
+    "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "expected_remote_sha": null,
+    "records": [{"execution_id": "11111111-1111-4111-8111-111111111111", "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}],
+    "public_url": "https://preloop.example.invalid",
+    "provider": "github"
+  },
+  "lease": {
+    "token": "fixture-test-token",
+    "repository_url": "https://github.com/example/project.git",
+    "expires_at": "2099-01-01T00:00:00Z"
+  },
+  "bundle_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}

--- a/backend/tests/models/crud/test_publication_result_authority.py
+++ b/backend/tests/models/crud/test_publication_result_authority.py
@@ -1,0 +1,71 @@
+"""Terminal writes preserve current controller state under a real database lock."""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import update
+
+from preloop.models import models
+from preloop.models.crud import crud_flow, crud_flow_execution
+from preloop.models.schemas.flow import FlowCreate
+from preloop.models.schemas.flow_execution import (
+    FlowExecutionCreate,
+    FlowExecutionUpdate,
+)
+
+
+@pytest.mark.parametrize("phase", ["verifying", "complete"])
+def test_stale_execution_result_cannot_replace_durable_publication(
+    db_session, create_account, phase
+):
+    account = create_account()
+    flow = crud_flow.create(
+        db_session,
+        flow_in=FlowCreate(
+            name=f"Publication result {uuid4()}",
+            prompt_template="Test",
+            trigger_event_source="manual",
+            trigger_event_types=["test"],
+            agent_type="codex",
+            agent_config={},
+            allowed_mcp_servers=[],
+            allowed_mcp_tools=[],
+            account_id=account.id,
+        ),
+        account_id=account.id,
+    )
+    execution = crud_flow_execution.create(
+        db_session, FlowExecutionCreate(flow_id=flow.id, status="RUNNING")
+    )
+    execution.result = {"_private_publication": {"phase": "agent"}}
+    db_session.flush()
+    receipt = {"url": "https://github.com/example/project/pull/1", "head_sha": "a" * 40}
+    protected = {"phase": phase, "nonce": "b" * 64, "receipt": receipt}
+    current = {"_private_publication": protected, "trusted_publication": receipt}
+    # Model another controller write while this ORM instance remains stale.
+    db_session.execute(
+        update(models.FlowExecution)
+        .where(models.FlowExecution.id == execution.id)
+        .values(result=current)
+        .execution_options(synchronize_session=False)
+    )
+    assert execution.result["_private_publication"]["phase"] == "agent"
+    crud_flow_execution.update(
+        db_session,
+        execution,
+        FlowExecutionUpdate(
+            status="SUCCEEDED",
+            result={
+                "summary": "finished",
+                "_private_publication": {"phase": "complete"},
+                "trusted_publication": {"url": "forged"},
+            },
+        ),
+    )
+    db_session.expire(execution, ["result"])
+    assert execution.result["_private_publication"] == protected
+    assert execution.result["summary"] == "finished"
+    if phase == "complete":
+        assert execution.result["trusted_publication"] == receipt
+    else:
+        assert "trusted_publication" not in execution.result

--- a/backend/tests/models/test_alembic_single_head.py
+++ b/backend/tests/models/test_alembic_single_head.py
@@ -130,21 +130,18 @@ def test_flow_runners_revision_chains_onto_approval_rule_context() -> None:
     }
     launch_intent = script.get_revision("20260906_halt_launch_intent")
     assert launch_intent.down_revision == "20260906_halt_artifact_merge"
-    capabilities = script.get_revision("20260906_publication_caps")
-    assert capabilities.down_revision == "20260906_flow_artifacts"
-    publication = script.get_revision("20260906_halt_publication_merge")
-    assert set(publication.down_revision) == {
-        "20260906_halt_launch_intent",
-        "20260906_publication_caps",
-    }
-    runner = script.get_revision("20260906_halt_runner_merge")
-    assert set(runner.down_revision) == {
+    joined = script.get_revision("20260906_halt_runner_merge")
+    assert set(joined.down_revision) == {
         "20260906_halt_launch_intent",
         "20260906_runner_artifact_merge",
     }
-    joined = script.get_revision("20260906_halt_pub_runner_merge")
-    assert set(joined.down_revision) == {
-        "20260906_halt_publication_merge",
-        "20260906_halt_runner_merge",
+    approval_api_key = script.get_revision("20260906_approval_api_key")
+    assert approval_api_key.down_revision == "20260906_halt_runner_merge"
+    capabilities = script.get_revision("20260906_publication_caps")
+    assert capabilities.down_revision == "20260906_flow_artifacts"
+    publication = script.get_revision("20260906_pub_caps_merge")
+    assert set(publication.down_revision) == {
+        "20260906_approval_api_key",
+        "20260906_publication_caps",
     }
-    assert script.get_heads() == ["20260906_halt_pub_runner_merge"]
+    assert script.get_heads() == ["20260906_pub_caps_merge"]

--- a/backend/tests/models/test_alembic_single_head.py
+++ b/backend/tests/models/test_alembic_single_head.py
@@ -130,11 +130,21 @@ def test_flow_runners_revision_chains_onto_approval_rule_context() -> None:
     }
     launch_intent = script.get_revision("20260906_halt_launch_intent")
     assert launch_intent.down_revision == "20260906_halt_artifact_merge"
-    joined = script.get_revision("20260906_halt_runner_merge")
-    assert set(joined.down_revision) == {
+    capabilities = script.get_revision("20260906_publication_caps")
+    assert capabilities.down_revision == "20260906_flow_artifacts"
+    publication = script.get_revision("20260906_halt_publication_merge")
+    assert set(publication.down_revision) == {
+        "20260906_halt_launch_intent",
+        "20260906_publication_caps",
+    }
+    runner = script.get_revision("20260906_halt_runner_merge")
+    assert set(runner.down_revision) == {
         "20260906_halt_launch_intent",
         "20260906_runner_artifact_merge",
     }
-    approval_api_key = script.get_revision("20260906_approval_api_key")
-    assert approval_api_key.down_revision == "20260906_halt_runner_merge"
-    assert script.get_heads() == ["20260906_approval_api_key"]
+    joined = script.get_revision("20260906_halt_pub_runner_merge")
+    assert set(joined.down_revision) == {
+        "20260906_halt_publication_merge",
+        "20260906_halt_runner_merge",
+    }
+    assert script.get_heads() == ["20260906_halt_pub_runner_merge"]

--- a/backend/tests/services/test_isolated_publication.py
+++ b/backend/tests/services/test_isolated_publication.py
@@ -170,6 +170,7 @@ def test_agent_receives_read_credential_without_db_fallback_or_post_push() -> No
 async def test_orchestrator_publication_failure_changes_terminal_status() -> None:
     orchestrator = object.__new__(FlowExecutionOrchestrator)
     orchestrator.db = MagicMock()
+    orchestrator._publication_executor = SimpleNamespace(cleanup=AsyncMock())
     orchestrator._evidence_archive = b"archive"
     orchestrator._publication_verification = None
     orchestrator._publication_runtime_stopped = True
@@ -183,6 +184,18 @@ async def test_orchestrator_publication_failure_changes_terminal_status() -> Non
     )
     result = {"status": "SUCCEEDED", "result": {"status": "success"}}
     with (
+        patch(
+            "preloop.services.publication_hosted_verifier.verify_hosted_publication",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    verification=object(), manifest={}, checks=(), image="toolchain"
+                )
+            ),
+        ),
+        patch(
+            "preloop.services.trusted_publisher.read_publication_bundle",
+            return_value=b"bundle",
+        ),
         patch(
             "preloop.services.isolated_publication.finish_isolated_publication",
             new=AsyncMock(side_effect=PublicationError("verification not attested")),
@@ -208,6 +221,17 @@ async def test_prepare_policy_never_resolves_broad_pat(tracker: Any) -> None:
         "execution_id": "11111111-1111-4111-8111-111111111111",
         "git_clone_config": {
             "publication_mode": "isolated",
+            "verification": {
+                "mode": "gate",
+                "image": "toolchain@sha256:" + "a" * 64,
+                "profile": {
+                    "profile_id": "test",
+                    "version": "v1",
+                    "always": [
+                        {"id": "check", "command": "true", "reason": "required"}
+                    ],
+                },
+            },
             "repositories": [
                 {
                     "repository_url": "https://github.com/example/project.git",
@@ -227,6 +251,11 @@ async def test_prepare_policy_never_resolves_broad_pat(tracker: Any) -> None:
         httpx.Response(
             200,
             json={"full_name": "example/project", "default_branch": "main"},
+            request=httpx.Request("GET", "https://api.github.com"),
+        ),
+        httpx.Response(
+            200,
+            json={"object": {"sha": "b" * 40}},
             request=httpx.Request("GET", "https://api.github.com"),
         ),
         httpx.Response(404, request=httpx.Request("GET", "https://api.github.com")),

--- a/backend/tests/services/test_isolated_publication.py
+++ b/backend/tests/services/test_isolated_publication.py
@@ -392,3 +392,248 @@ async def test_failed_recovery_commit_does_not_authorize_removal():
         await orchestrator._persist_isolated_recovery()
     orchestrator.db.rollback.assert_called_once()
     orchestrator.execution_logger.log_milestone.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_private_restore_preserves_snapshot_without_provider_reresolution():
+    from preloop.services.isolated_publication import prepare_isolated_publication
+
+    restored = object()
+    flow = SimpleNamespace(account_id="account", id="flow")
+    context = {
+        "execution_id": "execution",
+        "git_clone_config": {"publication_mode": "isolated"},
+    }
+    with (
+        patch(
+            "preloop.services.runner_service.resolve_runner_pool",
+            return_value="private",
+        ),
+        patch(
+            "preloop.services.private_publication.restore_private_publication",
+            new=AsyncMock(return_value=restored),
+        ) as restore,
+        patch(
+            "preloop.services.isolated_publication.mint_repository_lease",
+            new=AsyncMock(),
+        ) as mint,
+    ):
+        assert (
+            await prepare_isolated_publication(MagicMock(), flow, context) is restored
+        )
+    restore.assert_awaited_once()
+    mint.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("accepted", [False, True])
+async def test_private_success_requires_trusted_receipt_not_agent_claim(accepted):
+    orchestrator = object.__new__(FlowExecutionOrchestrator)
+    orchestrator.db = MagicMock()
+    orchestrator.execution_logger = MagicMock()
+    orchestrator._publication_runtime_stopped = False
+    orchestrator._isolated_publication_policy = SimpleNamespace(
+        private=True,
+        execution_id="execution",
+        account_id="account",
+        read_lease=object(),
+    )
+    receipt = (
+        {"url": "https://github.com/example/project/pull/1", "head_sha": "a" * 40}
+        if accepted
+        else None
+    )
+    result = {
+        "status": "SUCCEEDED",
+        "result": {"trusted_publication": {"url": "forged"}},
+    }
+    execution = object()
+    with (
+        patch(
+            "preloop.services.private_publication.trusted_private_receipt",
+            return_value=receipt,
+        ) as read,
+        patch(
+            "preloop.services.flow_orchestrator.crud_flow_execution.get",
+            return_value=execution,
+        ) as get,
+        patch(
+            "preloop.services.publication_credentials.revoke_repository_lease",
+            new=AsyncMock(),
+        ),
+        patch(
+            "preloop.services.publication_hosted_verifier.verify_hosted_publication",
+            new=AsyncMock(),
+        ) as verify,
+        patch(
+            "preloop.services.isolated_publication.finish_isolated_publication",
+            new=AsyncMock(),
+        ) as publish,
+    ):
+        await orchestrator._finish_isolated_publication(result)
+    get.assert_called_once_with(
+        orchestrator.db, id="execution", account_id="account", refresh=True
+    )
+    read.assert_called_once_with(execution)
+    verify.assert_not_awaited()
+    publish.assert_not_awaited()
+    assert result["status"] == ("SUCCEEDED" if accepted else "FAILED")
+    if accepted:
+        assert result["result"]["trusted_publication"] == receipt
+    else:
+        assert "trusted_publication" not in result["result"]
+
+
+@pytest.mark.asyncio
+async def test_helper_then_controller_revocation_is_idempotent():
+    from preloop.services.publication_credentials import revoke_repository_lease
+
+    replies = iter([204, 401])
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(next(replies)))
+    ) as client:
+        lease = PublicationLease(
+            "known-token",
+            "https://github.com/example/project.git",
+            datetime.now(timezone.utc) + timedelta(minutes=10),
+        )
+        await revoke_repository_lease(lease, client)
+        await revoke_repository_lease(lease, client)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code", [403, 500])
+async def test_revocation_authorization_or_provider_failure_is_not_success(code):
+    from preloop.services.publication_credentials import revoke_repository_lease
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(code))
+    ) as client:
+        lease = PublicationLease(
+            "known-token",
+            "https://github.com/example/project.git",
+            datetime.now(timezone.utc) + timedelta(minutes=10),
+        )
+        with pytest.raises(PublicationError, match="revocation failed"):
+            await revoke_repository_lease(lease, client)
+
+
+@pytest.mark.parametrize("phase", ["verifying", "complete"])
+def test_terminal_crud_preserves_current_private_state_over_stale_result(phase):
+    from uuid import uuid4
+    from preloop.models import schemas
+    from preloop.models.crud import crud_flow_execution
+
+    receipt = {"url": "https://github.com/example/project/pull/1", "head_sha": "a" * 40}
+    state = {"phase": phase, "nonce": "b" * 64, "receipt": receipt}
+    db = MagicMock()
+    db.query.return_value.filter.return_value.with_for_update.return_value.first.return_value = (
+        {"_private_publication": state, "trusted_publication": receipt},
+    )
+    execution = SimpleNamespace(
+        id=uuid4(), result={"_private_publication": {"phase": "agent"}}
+    )
+    crud_flow_execution.update(
+        db,
+        db_obj=execution,
+        obj_in=schemas.FlowExecutionUpdate(
+            result={
+                "summary": "done",
+                "_private_publication": {"phase": "complete"},
+                "trusted_publication": {"url": "forged"},
+            }
+        ),
+    )
+    assert execution.result["_private_publication"] == state
+    assert execution.result["summary"] == "done"
+    if phase == "complete":
+        assert execution.result["trusted_publication"] == receipt
+    else:
+        assert "trusted_publication" not in execution.result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reference,diagnostic",
+    [
+        ("hosted-job", "runtime retained"),
+        (
+            "runner:queued:original-pool:11111111-1111-4111-8111-111111111111",
+            "Queued isolated execution",
+        ),
+    ],
+)
+async def test_recovery_without_replay_authority_fails_closed(reference, diagnostic):
+    from preloop.services.flow_execution_runner import resume_existing_execution
+
+    orchestrator = MagicMock()
+    orchestrator.flow = SimpleNamespace(
+        agent_type="codex",
+        agent_config={},
+        git_clone_config={"publication_mode": "isolated"},
+    )
+    orchestrator.execution_log = SimpleNamespace(id="execution", result={})
+    orchestrator._update_execution_log = AsyncMock()
+    orchestrator._notify_terminal = AsyncMock()
+    orchestrator._monitor_agent_execution = AsyncMock()
+    with patch("preloop.agents.create_agent_executor") as create:
+        await resume_existing_execution(orchestrator, reference)
+    create.assert_not_called()
+    orchestrator._monitor_agent_execution.assert_not_awaited()
+    assert orchestrator._update_execution_log.call_args.kwargs["status"] == "FAILED"
+    assert (
+        diagnostic
+        in orchestrator._update_execution_log.call_args.kwargs["error_message"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_private_recovered_monitor_restores_policy_and_finalizes_before_status():
+    from uuid import uuid4
+    from preloop.services.flow_execution_runner import resume_existing_execution
+
+    orchestrator = MagicMock()
+    orchestrator.flow = SimpleNamespace(
+        account_id=uuid4(),
+        agent_type="codex",
+        agent_config={},
+        git_clone_config={"publication_mode": "isolated"},
+    )
+    orchestrator.agent_type = "codex"
+    orchestrator.execution_log = SimpleNamespace(
+        id=uuid4(), result={"_private_publication": {"phase": "verifying"}}
+    )
+    events = []
+
+    async def monitor(*args):
+        events.append("monitor")
+        return {"status": "SUCCEEDED", "result": {}}
+
+    async def finish(result):
+        events.append("finalize")
+        result["status"] = "FAILED"
+
+    async def update(**kwargs):
+        events.append(kwargs["status"])
+
+    orchestrator._monitor_agent_execution = AsyncMock(side_effect=monitor)
+    orchestrator._finish_isolated_publication = AsyncMock(side_effect=finish)
+    orchestrator._replay_persisted_runner_logs = AsyncMock()
+    orchestrator._update_execution_log = AsyncMock(side_effect=update)
+    orchestrator._notify_terminal = AsyncMock()
+    executor = SimpleNamespace(cleanup=AsyncMock())
+    with (
+        patch(
+            "preloop.services.private_publication.load_private_monitoring_policy",
+            return_value=object(),
+        ) as restore,
+        patch(
+            "preloop.agents.remote_runner.RemoteRunnerExecutor", return_value=executor
+        ) as create,
+    ):
+        await resume_existing_execution(
+            orchestrator, f"runner:{uuid4()}:{orchestrator.execution_log.id}"
+        )
+    restore.assert_called_once()
+    create.assert_called_once()
+    assert events == ["monitor", "finalize", "FAILED"]

--- a/backend/tests/services/test_isolated_publication.py
+++ b/backend/tests/services/test_isolated_publication.py
@@ -1,0 +1,300 @@
+"""Credential issuance, context separation, and terminal lifecycle contracts."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from preloop.agents.container import ContainerAgentExecutor
+from preloop.services.flow_orchestrator import FlowExecutionOrchestrator
+from preloop.services.publication_credentials import (
+    mint_repository_lease,
+    validate_publication_tracker,
+)
+from preloop.services.trusted_publisher import PublicationError, PublicationLease
+
+
+@pytest.fixture
+def tracker() -> Any:
+    return SimpleNamespace(
+        tracker_type="github",
+        auth_type="github_app",
+        oauth_installation=SimpleNamespace(external_id="123"),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("write", [False, True])
+async def test_app_credential_is_explicitly_scoped_to_repository_and_permissions(
+    tracker: Any, write: bool
+) -> None:
+    permissions = {"metadata": "read", "contents": "write" if write else "read"}
+    if write:
+        permissions["pull_requests"] = "write"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload == {"repositories": ["project"], "permissions": permissions}
+        assert request.headers["Authorization"] == "Bearer app-jwt"
+        return httpx.Response(
+            201,
+            json={
+                "token": "scoped-lease",
+                "expires_at": "2099-01-01T00:00:00Z",
+                "repositories": [{"full_name": "example/project"}],
+                "permissions": permissions,
+            },
+        )
+
+    with (
+        patch(
+            "preloop.services.publication_credentials.settings.github_app",
+            SimpleNamespace(app_id="1", private_key="-----BEGIN KEY-----"),
+        ),
+        patch(
+            "preloop.services.publication_credentials.jwt.encode",
+            return_value="app-jwt",
+        ),
+    ):
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            token = await mint_repository_lease(
+                tracker,
+                "https://github.com/example/project.git",
+                write=write,
+                client=client,
+            )
+    assert token.token == "scoped-lease"
+    assert "scoped-lease" not in repr(token)
+
+
+@pytest.mark.asyncio
+async def test_broker_rejects_provider_ignoring_permission_reduction(
+    tracker: Any,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            201,
+            json={
+                "token": "overscoped",
+                "expires_at": "2099-01-01T00:00:00Z",
+                "repositories": [{"full_name": "example/project"}],
+                "permissions": {"contents": "write", "metadata": "read"},
+            },
+        )
+
+    with (
+        patch(
+            "preloop.services.publication_credentials.settings.github_app",
+            SimpleNamespace(app_id="1", private_key="-----BEGIN KEY-----"),
+        ),
+        patch(
+            "preloop.services.publication_credentials.jwt.encode",
+            return_value="app-jwt",
+        ),
+    ):
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(PublicationError, match="scope"):
+                await mint_repository_lease(
+                    tracker,
+                    "https://github.com/example/project.git",
+                    write=False,
+                    client=client,
+                )
+
+
+def test_pat_cannot_be_relabelled_readonly(tracker: Any) -> None:
+    tracker.auth_type = "api_token"
+    tracker.resolved_api_key = "write-pat"
+    with pytest.raises(PublicationError, match="PAT"):
+        validate_publication_tracker(tracker)
+
+
+def test_agent_receives_read_credential_without_db_fallback_or_post_push() -> None:
+    executor = ContainerAgentExecutor(agent_type="codex", config={}, image="test")
+    context = {
+        "git_clone_config": {
+            "publication_mode": "isolated",
+            "repositories": [
+                {
+                    "tracker_id": "tracker",
+                    "repository_url": "https://github.com/example/project.git",
+                    "clone_path": "/workspace",
+                }
+            ],
+        },
+        "git_credentials_map": {
+            "tracker": {
+                "token": "read-lease",
+                "tracker_type": "github",
+                "permission": "read",
+            }
+        },
+        "_git_target_branch": "preloop/issue-1",
+        "_git_source_branch": "main",
+        "trigger_project_id": "project",
+    }
+    with patch.object(
+        executor,
+        "_get_token_from_project",
+        side_effect=AssertionError("Broad token lookup forbidden"),
+    ):
+        assert executor._resolve_repository_token(
+            {"tracker_id": "tracker"}, context
+        ) == ("read-lease", "github")
+        context["git_credentials_map"]["tracker"]["permission"] = "write"
+        with pytest.raises(ValueError, match="read-only"):
+            executor._resolve_repository_token({"tracker_id": "tracker"}, context)
+    script = executor._prepare_git_post_execution_commands(context)
+    assert "git bundle create" in script
+    assert " HEAD " in script
+    for forbidden in ["git push", "curl", "PRELOOP_GIT_TOKEN", "contents:write"]:
+        assert forbidden not in script
+    context["checkpoint_env"] = {"PRELOOP_CHECKPOINT_ENABLED": "1"}
+    checkpointed = executor._prepare_git_post_execution_commands(context)
+    assert checkpointed.index("_preloop_checkpoint ||") < checkpointed.index(
+        "git bundle create"
+    )
+    assert "prepublication_failed; exit 1" in checkpointed
+    context[executor.GIT_API_TOKENS_CONTEXT_KEY] = {0: "write-secret"}
+    with pytest.raises(ValueError, match="Write API tokens"):
+        executor._apply_git_credential_env({}, context)
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_publication_failure_changes_terminal_status() -> None:
+    orchestrator = object.__new__(FlowExecutionOrchestrator)
+    orchestrator.db = MagicMock()
+    orchestrator._evidence_archive = b"archive"
+    orchestrator._publication_verification = None
+    orchestrator._publication_runtime_stopped = True
+    orchestrator.execution_logger = MagicMock()
+    orchestrator._isolated_publication_policy = SimpleNamespace(
+        read_lease=PublicationLease(
+            "read",
+            "https://github.com/example/project.git",
+            datetime.now(timezone.utc) + timedelta(minutes=10),
+        )
+    )
+    result = {"status": "SUCCEEDED", "result": {"status": "success"}}
+    with (
+        patch(
+            "preloop.services.isolated_publication.finish_isolated_publication",
+            new=AsyncMock(side_effect=PublicationError("verification not attested")),
+        ),
+        patch(
+            "preloop.services.publication_credentials.revoke_repository_lease",
+            new=AsyncMock(),
+        ) as revoke,
+    ):
+        await orchestrator._finish_isolated_publication(result)
+    assert result["status"] == "FAILED"
+    assert result["error_message"] == "verification not attested"
+    revoke.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_prepare_policy_never_resolves_broad_pat(tracker: Any) -> None:
+    from preloop.services.isolated_publication import prepare_isolated_publication
+
+    tracker.id = "tracker"
+    flow = SimpleNamespace(account_id="account", id="flow")
+    context = {
+        "execution_id": "11111111-1111-4111-8111-111111111111",
+        "git_clone_config": {
+            "publication_mode": "isolated",
+            "repositories": [
+                {
+                    "repository_url": "https://github.com/example/project.git",
+                    "tracker_id": "tracker",
+                }
+            ],
+        },
+        "trigger_event_data": {},
+    }
+    read = PublicationLease(
+        "read-only",
+        "https://github.com/example/project.git",
+        datetime.now(timezone.utc) + timedelta(minutes=10),
+    )
+    client = AsyncMock()
+    client.get.side_effect = [
+        httpx.Response(
+            200,
+            json={"full_name": "example/project", "default_branch": "main"},
+            request=httpx.Request("GET", "https://api.github.com"),
+        ),
+        httpx.Response(404, request=httpx.Request("GET", "https://api.github.com")),
+    ]
+    with (
+        patch("preloop.services.runner_service.resolve_runner_pool", return_value=None),
+        patch(
+            "preloop.services.isolated_publication.crud_tracker.get_by_id_and_account",
+            return_value=tracker,
+        ),
+        patch("preloop.services.isolated_publication.validate_publication_tracker"),
+        patch(
+            "preloop.services.isolated_publication.mint_repository_lease",
+            new=AsyncMock(return_value=read),
+        ) as mint,
+        patch("preloop.services.isolated_publication.httpx.AsyncClient") as factory,
+    ):
+        factory.return_value.__aenter__.return_value = client
+        policy = await prepare_isolated_publication(MagicMock(), flow, context)
+    assert mint.call_args.kwargs["write"] is False
+    assert context["git_credentials_map"]["tracker"]["permission"] == "read"
+    assert policy.repository_url == "https://github.com/example/project.git"
+    assert "write" not in json.dumps(context)
+    assert policy.expected_remote_sha is None
+
+
+@pytest.mark.asyncio
+async def test_agent_cannot_forge_trusted_publication_state_or_binding() -> None:
+    orchestrator = object.__new__(FlowExecutionOrchestrator)
+    orchestrator.execution_logger = MagicMock()
+    orchestrator._isolated_publication_policy = object()
+    orchestrator._opened_pr = None
+    orchestrator._capture_evidence_archive = AsyncMock()
+    orchestrator._capture_workspace_snapshot = AsyncMock()
+    executor = SimpleNamespace(
+        get_result_artifact=AsyncMock(
+            return_value={
+                "status": "success",
+                "trusted_publication": {"branch": "main"},
+            }
+        )
+    )
+    result = await orchestrator._capture_result_artifact(executor, "runtime")
+    assert result == {"status": "success"}
+    orchestrator._note_opened_pr(
+        'PRELOOP_PR_OPENED {"url":"https://github.com/example/project/pull/1","branch":"main","provider":"github"}'
+    )
+    assert orchestrator._opened_pr is None
+
+
+@pytest.mark.asyncio
+async def test_failed_runtime_cleanup_never_issues_publication_credentials() -> None:
+    orchestrator = object.__new__(FlowExecutionOrchestrator)
+    orchestrator._isolated_publication_policy = SimpleNamespace(read_lease=object())
+    orchestrator._publication_runtime_stopped = False
+    orchestrator.execution_logger = MagicMock()
+    result = {"status": "SUCCEEDED"}
+    with (
+        patch(
+            "preloop.services.isolated_publication.finish_isolated_publication",
+            new=AsyncMock(),
+        ) as publish,
+        patch(
+            "preloop.services.publication_credentials.revoke_repository_lease",
+            new=AsyncMock(),
+        ),
+    ):
+        await orchestrator._finish_isolated_publication(result)
+    publish.assert_not_awaited()
+    assert result["status"] == "FAILED"
+    assert "cleanup" in result["error_message"]

--- a/backend/tests/services/test_isolated_publication.py
+++ b/backend/tests/services/test_isolated_publication.py
@@ -628,7 +628,8 @@ async def test_private_recovered_monitor_restores_policy_and_finalizes_before_st
             return_value=object(),
         ) as restore,
         patch(
-            "preloop.agents.remote_runner.RemoteRunnerExecutor", return_value=executor
+            "preloop.agents.create_executor_for_execution",
+            return_value=executor,
         ) as create,
     ):
         await resume_existing_execution(

--- a/backend/tests/services/test_isolated_publication.py
+++ b/backend/tests/services/test_isolated_publication.py
@@ -40,7 +40,12 @@ async def test_app_credential_is_explicitly_scoped_to_repository_and_permissions
 
     def handler(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content)
-        assert payload == {"repositories": ["project"], "permissions": permissions}
+        assert payload == {
+            "repositories": ["project"],
+            "permissions": {
+                key: value for key, value in permissions.items() if key != "metadata"
+            },
+        }
         assert request.headers["Authorization"] == "Bearer app-jwt"
         return httpx.Response(
             201,
@@ -106,6 +111,71 @@ async def test_broker_rejects_provider_ignoring_permission_reduction(
                     write=False,
                     client=client,
                 )
+
+
+@pytest.mark.parametrize(
+    "permissions",
+    [
+        {"contents": "read"},
+        {"contents": "read", "metadata": "read"},
+        {"contents": "read", "issues": "read"},
+        {"contents": "read", "checks": "write"},
+        {"contents": "read", "metadata": "write"},
+        {},
+        None,
+    ],
+)
+@pytest.mark.asyncio
+async def test_app_lease_allows_only_implicit_metadata_read(tracker, permissions):
+    allowed = permissions in (
+        {"contents": "read"},
+        {"contents": "read", "metadata": "read"},
+    )
+
+    def handler(request):
+        return httpx.Response(
+            201,
+            json={
+                "token": "scoped",
+                "expires_at": "2099-01-01T00:00:00Z",
+                "repositories": [{"full_name": "example/project"}],
+                "permissions": permissions,
+            },
+        )
+
+    with (
+        patch(
+            "preloop.services.publication_credentials.settings.github_app",
+            SimpleNamespace(app_id="1", private_key="-----BEGIN KEY-----"),
+        ),
+        patch(
+            "preloop.services.publication_credentials.jwt.encode",
+            return_value="app-jwt",
+        ),
+    ):
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            if allowed:
+                lease = await mint_repository_lease(
+                    tracker,
+                    "https://github.com/example/project.git",
+                    write=False,
+                    client=client,
+                )
+                assert lease.token == "scoped"
+            else:
+                with pytest.raises(PublicationError, match="scope"):
+                    await mint_repository_lease(
+                        tracker,
+                        "https://github.com/example/project.git",
+                        write=False,
+                        client=client,
+                    )
+
+
+def test_oauth_app_is_not_an_installation_credential(tracker):
+    tracker.auth_type = "oauth_app"
+    with pytest.raises(PublicationError, match="GitHub App"):
+        validate_publication_tracker(tracker)
 
 
 def test_pat_cannot_be_relabelled_readonly(tracker: Any) -> None:

--- a/backend/tests/services/test_isolated_publication.py
+++ b/backend/tests/services/test_isolated_publication.py
@@ -327,3 +327,68 @@ async def test_failed_runtime_cleanup_never_issues_publication_credentials() -> 
     publish.assert_not_awaited()
     assert result["status"] == "FAILED"
     assert "cleanup" in result["error_message"]
+
+
+@pytest.mark.parametrize("provider", ["github", "gitlab"])
+def test_template_provider_comes_from_tracker_not_checkout_markers(tmp_path, provider):
+    import shlex
+    from preloop.utils.pr_metadata import repository_template
+
+    for directory in (
+        ".github/PULL_REQUEST_TEMPLATE",
+        ".gitlab/merge_request_templates",
+    ):
+        path = tmp_path / directory
+        path.mkdir(parents=True)
+        (path / "custom.md").write_text(directory)
+    executor = ContainerAgentExecutor("codex", {}, image="example/harness:stable")
+    context = {
+        "git_clone_config": {
+            "enabled": False,
+            "create_pull_request": True,
+            "repositories": [{"tracker_id": "tracker", "clone_path": str(tmp_path)}],
+        },
+        "git_credentials_map": {
+            "tracker": {"tracker_type": provider, "token": "read-only"}
+        },
+    }
+    command = executor._prepare_init_commands(context)
+    arguments = shlex.split(command)
+    assert arguments[-1] == provider
+    assert any("provider = sys.argv[3]" in argument for argument in arguments)
+    name, template = repository_template(tmp_path, provider=arguments[-1])
+    assert name == (
+        ".gitlab/merge_request_templates/custom.md"
+        if provider == "gitlab"
+        else ".github/PULL_REQUEST_TEMPLATE/custom.md"
+    )
+    assert template
+
+
+@pytest.mark.asyncio
+async def test_recovery_is_committed_before_runtime_may_be_destroyed():
+    orchestrator = object.__new__(FlowExecutionOrchestrator)
+    orchestrator.db = MagicMock()
+    orchestrator.execution_log = SimpleNamespace(id="execution")
+    orchestrator.execution_logger = MagicMock()
+    orchestrator._evidence_archive = b"evidence"
+    orchestrator._workspace_snapshot = b"workspace"
+    await orchestrator._persist_isolated_recovery()
+    assert orchestrator.execution_log.evidence_archive == b"evidence"
+    assert orchestrator.execution_log.workspace_snapshot == b"workspace"
+    orchestrator.db.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_failed_recovery_commit_does_not_authorize_removal():
+    orchestrator = object.__new__(FlowExecutionOrchestrator)
+    orchestrator.db = MagicMock()
+    orchestrator.db.commit.side_effect = RuntimeError("local database unavailable")
+    orchestrator.execution_log = SimpleNamespace(id="execution")
+    orchestrator.execution_logger = MagicMock()
+    orchestrator._evidence_archive = b"evidence"
+    orchestrator._workspace_snapshot = b"workspace"
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await orchestrator._persist_isolated_recovery()
+    orchestrator.db.rollback.assert_called_once()
+    orchestrator.execution_logger.log_milestone.assert_not_called()

--- a/backend/tests/services/test_private_publication.py
+++ b/backend/tests/services/test_private_publication.py
@@ -635,6 +635,28 @@ async def test_watchdog_serializes_with_messages_and_uses_independent_session(
 
 
 @pytest.mark.asyncio
+async def test_expire_writer_abandons_when_revoke_fails(case, monkeypatch, caplog):
+    from preloop.models.db import session as sessions
+
+    independent = MagicMock(spec=Session)
+
+    def get_session():
+        yield independent
+
+    monkeypatch.setattr(sessions, "get_db_session", get_session)
+    abandon = MagicMock()
+    monkeypatch.setattr(crud_flow_runner, "abandon_publication", abandon)
+    case.controller.execution_id = case.execution.id
+    case.controller.nonce = case.policy.nonce
+    case.revoke.side_effect = PublicationError("writer already gone")
+    with caplog.at_level("WARNING"):
+        await case.controller._expire_writer(0)
+    case.revoke.assert_awaited_once()
+    assert abandon.call_args.args[0] is independent
+    assert "Background writer revocation failed" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_connection_replacement_during_unregister_preserves_new_owner(
     case, monkeypatch
 ):

--- a/backend/tests/services/test_private_publication.py
+++ b/backend/tests/services/test_private_publication.py
@@ -1,0 +1,702 @@
+"""Real database and WebSocket contracts for trusted private publication."""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+from starlette.websockets import WebSocketDisconnect
+
+from preloop.api.endpoints import runners
+from preloop.models.crud import crud_flow, crud_flow_execution
+from preloop.models.crud.flow_runner import crud_flow_runner
+from preloop.models.schemas.flow import FlowCreate
+from preloop.models.schemas.flow_execution import FlowExecutionCreate
+from preloop.models.schemas.verification import (
+    ResolvedVerificationPolicy,
+    VerificationProfile,
+)
+from preloop.services.isolated_publication import IsolatedPublicationPolicy
+from preloop.services import private_publication as publication
+from preloop.services.runner_service import hash_runner_token, lease_job
+from preloop.services.trusted_publisher import PublicationError, PublicationLease
+
+MANIFEST = {
+    "version": 1,
+    "head_sha": "a" * 40,
+    "tree_sha": "b" * 40,
+    "bundle_sha256": "c" * 64,
+}
+IMAGE = "example/helper@sha256:" + "d" * 64
+
+
+@pytest.fixture
+def case(db_session: Session, test_user, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(publication.settings, "preloop_url", "http://localhost:8000")
+    flow = crud_flow.create(
+        db_session,
+        account_id=test_user.account_id,
+        flow_in=FlowCreate(
+            name="Private publication",
+            account_id=test_user.account_id,
+            agent_type="codex",
+            agent_config={},
+            prompt_template="implement",
+            trigger_event_source="github",
+            trigger_event_types=["issue_updated"],
+            timeout_seconds=600,
+            git_clone_config={"publication_mode": "isolated"},
+        ),
+    )
+    execution = crud_flow_execution.create(
+        db_session, obj_in=FlowExecutionCreate(flow_id=flow.id, status="RUNNING")
+    )
+    policy = IsolatedPublicationPolicy(
+        tracker_id=str(uuid4()),
+        account_id=str(test_user.account_id),
+        repository_url="https://github.com/example/project.git",
+        branch="preloop/change",
+        base="main",
+        expected_remote_sha=None,
+        execution_id=str(execution.id),
+        previous_records=(),
+        read_lease=PublicationLease(
+            "read-only",
+            "https://github.com/example/project.git",
+            datetime.now(timezone.utc) + timedelta(hours=1),
+        ),
+        configured_title="",
+        configured_body="",
+        issue_number="1",
+        base_sha="e" * 40,
+        verification_policy=ResolvedVerificationPolicy(
+            mode="gate",
+            gate_budget_seconds=30,
+            profile=VerificationProfile(
+                profile_id="tests",
+                always=[
+                    {
+                        "id": "unit",
+                        "command": "pytest -q",
+                        "reason": "tests",
+                        "timeout_seconds": 900,
+                    }
+                ],
+            ),
+        ),
+        verification_image=IMAGE,
+        private=True,
+        nonce="f" * 64,
+    )
+    publication.persist_private_publication(db_session, flow, policy)
+    state = deepcopy(execution.result[publication.STATE_KEY])
+    runner = crud_flow_runner.create(
+        db_session,
+        obj_in={
+            "account_id": test_user.account_id,
+            "name": "private",
+            "token_hash": hash_runner_token("runner-token"),
+            "status": "online",
+            "reported_status": "RUNNING",
+            "last_heartbeat": datetime.now(timezone.utc),
+            "current_execution_id": execution.id,
+            "pending_job": {
+                "_publication": state,
+                "launch_version": 1,
+                "agent_type": "codex",
+                "execution_id": str(execution.id),
+            },
+            "publication_capabilities": {
+                "connection_id": "conn",
+                "version": 1,
+                "helper_ready": True,
+                "helper_image": IMAGE,
+            },
+        },
+    )
+    execution.runner_id = runner.id
+    db_session.commit()
+    broker = AsyncMock(
+        return_value=PublicationLease(
+            "write-only-secret",
+            policy.repository_url,
+            datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+    )
+    revoke = AsyncMock()
+    monkeypatch.setattr(publication, "mint_repository_lease", broker)
+    monkeypatch.setattr(publication, "revoke_repository_lease", revoke)
+    monkeypatch.setattr(
+        publication.crud_tracker,
+        "get_by_id_and_account",
+        lambda *args, **kwargs: SimpleNamespace(id=policy.tracker_id),
+    )
+    events = []
+    monkeypatch.setattr(
+        runners,
+        "emit_runner_updated",
+        lambda row, db: events.append((row.status, row.current_execution_id)),
+    )
+    controller = publication.PrivatePublicationController(
+        db_session,
+        runner_id=runner.id,
+        account_id=runner.account_id,
+        connection_id="conn",
+    )
+    return SimpleNamespace(
+        flow=flow,
+        execution=execution,
+        policy=policy,
+        runner=runner,
+        controller=controller,
+        broker=broker,
+        revoke=revoke,
+        events=events,
+        db=db_session,
+    )
+
+
+def message(case, kind: str, **extra):
+    return {
+        **MANIFEST,
+        "type": kind,
+        "execution_id": str(case.execution.id),
+        "nonce": case.policy.nonce,
+        **extra,
+    }
+
+
+async def verified_reply(case):
+    verify = await case.controller.handle(
+        message(case, "publication_candidate", changed_files=["backend/api.py"])
+    )
+    return message(
+        case,
+        "publication_verified",
+        checks=[{**check, "exit_code": 0} for check in verify["checks"]],
+        agent_removed=True,
+        verifiers_removed=True,
+    )
+
+
+def receipt():
+    return {
+        "url": "https://github.com/example/project/pull/7",
+        "number": 7,
+        "branch": "preloop/change",
+        "provider": "github",
+        "head_sha": "a" * 40,
+        "metadata_warnings": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_success_consumes_state_before_broker_and_preserves_independent_budgets(
+    case,
+):
+    verified = await verified_reply(case)
+    assert verified["checks"][0]["timeout_seconds"] == 900
+    issued = case.broker.return_value
+
+    async def mint(*args, **kwargs):
+        case.db.refresh(case.execution)
+        assert case.execution.result[publication.STATE_KEY]["phase"] == "publishing"
+        return issued
+
+    case.broker.side_effect = mint
+    reply = await case.controller.handle(verified)
+    assert reply["lease"]["token"] == "write-only-secret"
+    assert "write-only-secret" not in json.dumps(case.runner.pending_job)
+    assert "write-only-secret" not in json.dumps(case.execution.result)
+    ack = await case.controller.handle(
+        message(case, "publication_complete", publication=receipt())
+    )
+    assert ack["type"] == "publication_ack"
+    case.revoke.assert_awaited_once()
+    assert publication.trusted_private_receipt(case.execution)["number"] == 7
+    await case.controller.close()
+    case.db.refresh(case.execution)
+    assert case.execution.result[publication.STATE_KEY]["phase"] == "complete"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mutation",
+    ["nonce", "execution", "account", "cancelled", "expired", "reconnected", "config"],
+)
+async def test_stale_authority_never_mints(case, mutation):
+    verified = await verified_reply(case)
+    if mutation == "nonce":
+        verified["nonce"] = "0" * 64
+    elif mutation == "execution":
+        verified["execution_id"] = str(uuid4())
+    elif mutation == "account":
+        case.controller.account_id = uuid4()
+    elif mutation == "cancelled":
+        case.runner.halt_requested = True
+    elif mutation == "expired":
+        state = deepcopy(case.execution.result[publication.STATE_KEY])
+        state["deadline"] = 0
+        case.execution.result = {publication.STATE_KEY: state}
+    elif mutation == "reconnected":
+        case.runner.publication_capabilities = {
+            "connection_id": "new",
+            "helper_ready": True,
+        }
+    elif mutation == "config":
+        case.flow.prompt_template = "new"
+        case.flow.agent_config = {"model": "changed"}
+    case.db.commit()
+    with pytest.raises(PublicationError):
+        await case.controller.handle(verified)
+    case.broker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing",
+        "extra",
+        "command",
+        "exit",
+        "bool_exit",
+        "agent",
+        "verifier",
+        "head",
+        "tree",
+        "bundle",
+    ],
+)
+async def test_verification_requires_exact_manifest_checks_and_removal(case, mutation):
+    verified = await verified_reply(case)
+    if mutation == "missing":
+        verified["checks"] = []
+    elif mutation == "extra":
+        verified["checks"].append(
+            {"id": "extra", "command": "true", "timeout_seconds": 1, "exit_code": 0}
+        )
+    elif mutation == "command":
+        verified["checks"][0]["command"] = "true"
+    elif mutation == "exit":
+        verified["checks"][0]["exit_code"] = 1
+    elif mutation == "bool_exit":
+        verified["checks"][0]["exit_code"] = False
+    elif mutation == "agent":
+        verified["agent_removed"] = False
+    elif mutation == "verifier":
+        verified["verifiers_removed"] = False
+    else:
+        verified[
+            {"head": "head_sha", "tree": "tree_sha", "bundle": "bundle_sha256"}[
+                mutation
+            ]
+        ] = "0" * (64 if mutation == "bundle" else 40)
+    with pytest.raises(PublicationError):
+        await case.controller.handle(verified)
+    case.broker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "paths",
+    [["../escape"], ["/etc/passwd"], ["x", "x"], ["x\\y"], ["x\nsecret"], [None]],
+)
+async def test_invalid_manifest_rejected(case, paths):
+    with pytest.raises(PublicationError):
+        await case.controller.handle(
+            message(case, "publication_candidate", changed_files=paths)
+        )
+    case.broker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_verified_event_never_reissues_writer(case):
+    verified = await verified_reply(case)
+    await case.controller.handle(verified)
+    with pytest.raises(PublicationError):
+        await case.controller.handle(verified)
+    assert case.broker.await_count == 1
+    await case.controller.close()
+    assert case.revoke.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_broker_revokes_before_delivery(case):
+    verified = await verified_reply(case)
+    lease = case.broker.return_value
+
+    async def cancel(*args, **kwargs):
+        case.runner.halt_requested = True
+        case.db.commit()
+        return lease
+
+    case.broker.side_effect = cancel
+    with pytest.raises(PublicationError):
+        await case.controller.handle(verified)
+    case.revoke.assert_awaited_once()
+    assert case.controller.writer is None
+
+
+def test_connection_cleanup_is_compare_and_clear(case):
+    assert not crud_flow_runner.set_publication_capabilities(
+        case.db,
+        runner_id=case.runner.id,
+        capabilities={},
+        expected_connection_id="old",
+        offline=True,
+    )
+    case.db.refresh(case.runner)
+    assert case.runner.publication_capabilities["connection_id"] == "conn"
+    assert case.runner.status == "online"
+
+
+@pytest.mark.parametrize("capable", [False, True])
+def test_lease_requires_ready_publication_helper(case, capable):
+    case.runner.pending_job = None
+    case.runner.current_execution_id = None
+    case.execution.runner_id = None
+    case.runner.publication_capabilities = {
+        "version": 1,
+        "helper_ready": capable,
+        "helper_image": IMAGE,
+    }
+    case.db.commit()
+    leased = lease_job(
+        case.db,
+        account_id=case.runner.account_id,
+        pool="auto",
+        execution_id=case.execution.id,
+        payload={
+            "_publication": case.execution.result[publication.STATE_KEY],
+            "agent_type": "codex",
+        },
+    )
+    assert (leased is not None) is capable
+    case.db.refresh(case.execution)
+    assert case.execution.runner_id == (case.runner.id if capable else None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "ending", ["success", "FAILED", "STOPPED", "disconnect", "unregister", "forged"]
+)
+async def test_real_ws_protocol_and_all_terminal_credential_paths(
+    case, ending, monkeypatch
+):
+    frames = []
+    requests = []
+    initial_job = {
+        "execution_id": str(case.execution.id),
+        "agent_type": "codex",
+        "launch_version": 1,
+        "publication": publication.public_publication_descriptor(
+            case.execution.result[publication.STATE_KEY]
+        ),
+    }
+    verify = None
+
+    async def send(frame):
+        nonlocal verify
+        frames.append(frame)
+        if frame.get("type") == "publication_verify":
+            verify = frame
+
+    stage = 0
+
+    async def receive():
+        nonlocal stage
+        stage += 1
+        if stage == 1:
+            return {
+                "type": "heartbeat",
+                "publication_capabilities": {
+                    "version": 1,
+                    "helper_ready": True,
+                    "helper_image": IMAGE,
+                },
+            }
+        if stage == 2 and ending == "forged":
+            return message(
+                case,
+                "complete",
+                status="SUCCEEDED",
+                completion_protocol="docker_v1",
+                launch_version=1,
+                exit_code=0,
+                result={
+                    "status": "success",
+                    "trusted_publication": receipt(),
+                    "_private_publication": {"phase": "complete"},
+                },
+            )
+        if stage == 2:
+            return message(
+                case, "publication_candidate", changed_files=["backend/api.py"]
+            )
+        if stage == 3:
+            if ending == "forged":
+                raise WebSocketDisconnect()
+            return message(
+                case,
+                "publication_verified",
+                checks=[{**check, "exit_code": 0} for check in verify["checks"]],
+                agent_removed=True,
+                verifiers_removed=True,
+            )
+        if stage == 4:
+            if ending == "success":
+                return message(case, "publication_complete", publication=receipt())
+            if ending == "disconnect":
+                raise WebSocketDisconnect()
+            if ending == "unregister":
+                return {"type": "unregister"}
+            return message(case, "complete", status=ending, result={"status": "failed"})
+        if stage == 5 and ending == "success":
+            return message(
+                case,
+                "complete",
+                status="SUCCEEDED",
+                completion_protocol="docker_v1",
+                launch_version=1,
+                exit_code=0,
+                result={
+                    "status": "success",
+                    "trusted_publication": {"forged": True},
+                    "_private_publication": {"forged": True},
+                },
+            )
+        raise WebSocketDisconnect()
+
+    websocket = MagicMock()
+    websocket.query_params = {"token": "runner-token"}
+    websocket.headers = {}
+    websocket.accept = AsyncMock()
+    websocket.send_json = send
+
+    async def record_receive():
+        frame = await receive()
+        if frame.get("type") in {
+            "publication_candidate",
+            "publication_verified",
+            "publication_complete",
+        }:
+            requests.append(deepcopy(frame))
+        return frame
+
+    websocket.receive_json = record_receive
+    monkeypatch.setattr(
+        runners.crud_api_key, "deactivate_runtime_keys_for_flow_execution", MagicMock()
+    )
+    await runners.runner_ws(websocket, case.runner.id, case.db)
+    case.db.refresh(case.execution)
+    if ending == "success":
+        assert case.execution.status == "SUCCEEDED"
+        assert ("online", None) in case.events
+        assert publication.trusted_private_receipt(case.execution)["number"] == 7
+        captured = {
+            "job": initial_job,
+            "requests": requests,
+            "replies": [
+                frame
+                for frame in frames
+                if frame.get("type")
+                in {"publication_verify", "publication_publish", "publication_ack"}
+            ],
+        }
+        captured["replies"][1]["lease"]["expires_at"] = "2099-01-01T00:00:00+00:00"
+        serialized = (
+            json.dumps(captured, indent=2).replace(
+                str(case.execution.id), "11111111-1111-4111-8111-111111111111"
+            )
+            + "\n"
+        )
+        if os.getenv("PRELOOP_WRITE_PUBLICATION_FIXTURE"):
+            Path(os.environ["PRELOOP_WRITE_PUBLICATION_FIXTURE"]).write_text(serialized)
+        fixture_path = (
+            Path(__file__).parents[1] / "fixtures" / "private_publication_protocol.json"
+        )
+        assert json.loads(serialized) == json.loads(fixture_path.read_text())
+        assert any(frame.get("type") == "publication_ack" for frame in frames)
+    elif ending == "forged":
+        assert case.execution.status == "FAILED"
+        assert "trusted_publication" not in case.execution.result
+        case.broker.assert_not_awaited()
+    else:
+        assert case.execution.result[publication.STATE_KEY]["phase"] == "failed"
+    assert case.revoke.await_count == (0 if ending == "forged" else 1)
+
+
+@pytest.mark.asyncio
+async def test_zero_selected_checks_cannot_mint(case):
+    state = deepcopy(case.execution.result[publication.STATE_KEY])
+    state["policy"]["verification_policy"]["profile"]["always"] = []
+    case.execution.result = {publication.STATE_KEY: state}
+    case.db.commit()
+    with pytest.raises(PublicationError, match="nonempty"):
+        await case.controller.handle(
+            message(case, "publication_candidate", changed_files=["README.md"])
+        )
+    case.broker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_atomic_phase_compare_and_swap_rejects_duplicate_snapshot(case):
+    old = deepcopy(case.execution.result[publication.STATE_KEY])
+    await verified_reply(case)
+    with pytest.raises(ValueError, match="already consumed"):
+        crud_flow_runner.transition_publication(
+            case.db,
+            runner_id=case.runner.id,
+            account_id=case.runner.account_id,
+            execution_id=case.execution.id,
+            nonce=case.policy.nonce,
+            expected=old,
+            updated={**old, "phase": "publishing"},
+        )
+    case.db.rollback()
+    case.broker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_restore_uses_saved_binding_and_read_only_credentials(case):
+    context = {
+        "execution_id": str(case.execution.id),
+        "git_clone_config": {},
+        "trigger_event_data": {"_resume": {"source_branch": "untrusted"}},
+    }
+    restored = await publication.restore_private_publication(
+        case.db, case.flow, context
+    )
+    assert restored.base_sha == case.policy.base_sha
+    assert restored.nonce == case.policy.nonce
+    assert context["git_clone_config"]["target_branch"] == case.policy.branch
+    assert (
+        context["trigger_event_data"]["_resume"]["source_branch"] == case.policy.branch
+    )
+    assert case.broker.await_args.kwargs["write"] is False
+    publication.persist_private_publication(case.db, case.flow, restored)
+    await verified_reply(case)
+    with pytest.raises(PublicationError, match="consumed launch"):
+        await publication.restore_private_publication(case.db, case.flow, context)
+    assert case.broker.await_count == 1
+    monitoring = publication.load_private_monitoring_policy(
+        case.db, case.flow, case.execution
+    )
+    assert monitoring.read_lease is None
+    assert case.broker.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_watchdog_serializes_with_messages_and_uses_independent_session(
+    case, monkeypatch
+):
+    from preloop.models.db import session as sessions
+
+    entered, release = asyncio.Event(), asyncio.Event()
+    independent = MagicMock(spec=Session)
+
+    def get_session():
+        yield independent
+
+    monkeypatch.setattr(sessions, "get_db_session", get_session)
+    abandon = MagicMock()
+    monkeypatch.setattr(crud_flow_runner, "abandon_publication", abandon)
+
+    async def pending(_):
+        entered.set()
+        await release.wait()
+        return {}
+
+    monkeypatch.setattr(case.controller, "_handle", pending)
+    case.controller.execution_id = case.execution.id
+    case.controller.nonce = case.policy.nonce
+    case.controller.writer = case.broker.return_value
+    task = asyncio.create_task(case.controller.handle({}))
+    await entered.wait()
+    timer = asyncio.create_task(case.controller._expire_writer(0))
+    await asyncio.sleep(0)
+    case.revoke.assert_not_awaited()
+    release.set()
+    await task
+    await timer
+    case.revoke.assert_awaited_once()
+    assert abandon.call_args.args[0] is independent
+    assert abandon.call_args.args[0] is not case.db
+
+
+@pytest.mark.asyncio
+async def test_connection_replacement_during_unregister_preserves_new_owner(
+    case, monkeypatch
+):
+    verified = await verified_reply(case)
+    await case.controller.handle(verified)
+
+    async def replace(*args):
+        crud_flow_runner.set_publication_capabilities(
+            case.db,
+            runner_id=case.runner.id,
+            capabilities={
+                "connection_id": "replacement",
+                "helper_ready": True,
+                "version": 1,
+            },
+        )
+
+    case.revoke.side_effect = replace
+    await case.controller.close()
+    assert not crud_flow_runner.set_publication_capabilities(
+        case.db,
+        runner_id=case.runner.id,
+        capabilities={},
+        expected_connection_id="conn",
+        clear_lease=True,
+        offline=True,
+    )
+    case.db.refresh(case.runner)
+    assert case.runner.current_execution_id == case.execution.id
+    assert case.runner.publication_capabilities["connection_id"] == "replacement"
+
+
+@pytest.mark.asyncio
+async def test_verification_deadline_does_not_include_publisher_allowance(case):
+    verified = await verified_reply(case)
+    state = deepcopy(case.execution.result[publication.STATE_KEY])
+    state["verification_deadline"] = 0
+    assert state["deadline"] > datetime.now(timezone.utc).timestamp()
+    case.execution.result = {publication.STATE_KEY: state}
+    case.db.commit()
+    with pytest.raises(PublicationError, match="verification budget"):
+        await case.controller.handle(verified)
+    case.broker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_runner_delivery_strips_internal_snapshot_and_rejects_consumed_launch(
+    case, monkeypatch
+):
+    from preloop.agents.runner_launch import prepare_runner_delivery
+
+    monkeypatch.setattr(
+        "preloop.agents.runner_launch.build_runner_launch",
+        AsyncMock(return_value={"version": 1, "script": "bootstrap", "env": {}}),
+    )
+    job = deepcopy(case.runner.pending_job)
+    delivered = await prepare_runner_delivery(case.db, job, {})
+    assert "_publication" not in delivered
+    assert "policy" not in json.dumps(delivered["publication"])
+    assert delivered["publication"]["base_sha"] == case.policy.base_sha
+    await verified_reply(case)
+    delivered = await prepare_runner_delivery(case.db, case.runner.pending_job, {})
+    assert "launch_error" in delivered
+    assert "launch" not in delivered
+    assert "_publication" not in delivered

--- a/backend/tests/services/test_private_publication.py
+++ b/backend/tests/services/test_private_publication.py
@@ -648,6 +648,7 @@ async def test_expire_writer_abandons_when_revoke_fails(case, monkeypatch, caplo
     monkeypatch.setattr(crud_flow_runner, "abandon_publication", abandon)
     case.controller.execution_id = case.execution.id
     case.controller.nonce = case.policy.nonce
+    case.controller.writer = case.broker.return_value
     case.revoke.side_effect = PublicationError("writer already gone")
     with caplog.at_level("WARNING"):
         await case.controller._expire_writer(0)

--- a/backend/tests/services/test_publication_hosted_verifier.py
+++ b/backend/tests/services/test_publication_hosted_verifier.py
@@ -1,0 +1,214 @@
+"""Credential-free verification adapters and authoritative remote process status."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import aiohttp
+import pytest
+
+from preloop.services.publication_hosted_verifier import (
+    _check_kubernetes,
+    _pod_exec,
+    verify_hosted_publication,
+)
+from preloop.services.trusted_publisher import PublicationError
+from preloop.services.verification import resolve_verification_policy
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_adapter_streams_input_and_deletes_job_before_return():
+    execution = str(uuid4())
+    batch = SimpleNamespace(create_namespaced_job=AsyncMock())
+    core = SimpleNamespace(
+        api_client=SimpleNamespace(configuration=object()),
+        list_namespaced_pod=AsyncMock(
+            return_value=SimpleNamespace(
+                items=[
+                    SimpleNamespace(
+                        metadata=SimpleNamespace(name="owned-pod"),
+                        status=SimpleNamespace(phase="Running"),
+                    )
+                ]
+            )
+        ),
+    )
+    executor = SimpleNamespace(
+        _init_kubernetes_clients=AsyncMock(),
+        _k8s_batch_api=batch,
+        _k8s_core_api=core,
+        agent_namespace="isolated",
+        use_kubernetes=True,
+    )
+    policy = SimpleNamespace(
+        execution_id=execution, verification_image="generic@sha256:" + "a" * 64
+    )
+    check = SimpleNamespace(command="pytest tests/unit", timeout_seconds=10)
+    network = SimpleNamespace(
+        create_namespaced_network_policy=AsyncMock(),
+        delete_namespaced_network_policy=AsyncMock(),
+    )
+    with (
+        patch("kubernetes_asyncio.client.NetworkingV1Api", return_value=network),
+        patch("kubernetes_asyncio.client.CoreV1Api"),
+        patch("kubernetes_asyncio.stream.WsApiClient") as websocket,
+        patch(
+            "preloop.services.publication_hosted_verifier._pod_exec",
+            new=AsyncMock(side_effect=[0, 7]),
+        ) as execute,
+        patch(
+            "preloop.services.publication_hosted_verifier.remove_owned_publication_runtime",
+            new=AsyncMock(),
+        ) as remove,
+    ):
+        websocket.return_value.__aenter__ = AsyncMock(return_value=object())
+        websocket.return_value.__aexit__ = AsyncMock(return_value=False)
+        code = await _check_kubernetes(
+            executor, policy, b"frozen-bundle", {"head_sha": "b" * 40}, check
+        )
+    assert code == 7
+    job = batch.create_namespaced_job.call_args.kwargs["body"]
+    spec = job.spec.template.spec
+    assert spec.automount_service_account_token is False
+    assert not spec.volumes and not spec.host_pid and not spec.host_network
+    assert spec.containers[0].security_context.allow_privilege_escalation is False
+    assert spec.containers[0].security_context.capabilities.drop == ["ALL"]
+    assert [env.name for env in spec.containers[0].env] == ["PRELOOP_DISABLE_TELEMETRY"]
+    deny = network.create_namespaced_network_policy.call_args.kwargs["body"]
+    assert deny.spec.policy_types == ["Ingress", "Egress"]
+    assert deny.spec.egress == []
+    assert execute.call_args_list[0].args[-1] == b"frozen-bundle"
+    assert execute.call_args_list[1].args[-1] is None
+    remove.assert_awaited_once_with(executor, job.metadata.name, execution)
+    network.delete_namespaced_network_policy.assert_awaited_once()
+
+
+class Socket:
+    def __init__(self, messages):
+        self.messages = iter(messages)
+        self.send_bytes = AsyncMock()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self.messages)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        (b'{"status":"Success"}', 0),
+        (b'{"status":"Failure","details":{"causes":[{"message":"9"}]}}', 9),
+    ],
+)
+async def test_pod_exec_uses_remote_exit_channel_not_stdout(status, expected):
+    socket = Socket(
+        [
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.BINARY, data=b'\x01{"status":"success"}'
+            ),
+            SimpleNamespace(type=aiohttp.WSMsgType.BINARY, data=b"\x03" + status),
+        ]
+    )
+    api = SimpleNamespace(
+        connect_get_namespaced_pod_exec=AsyncMock(return_value=socket)
+    )
+    assert await _pod_exec(api, "namespace", "pod", ["command"], None) == expected
+
+
+@pytest.mark.asyncio
+async def test_pod_exec_missing_exit_is_not_success():
+    api = SimpleNamespace(
+        connect_get_namespaced_pod_exec=AsyncMock(return_value=Socket([]))
+    )
+    with pytest.raises(PublicationError, match="authoritative"):
+        await _pod_exec(api, "namespace", "pod", ["command"], None)
+
+
+@pytest.mark.asyncio
+async def test_empty_selection_cannot_create_verifier_or_attestation():
+    policy = SimpleNamespace(
+        base_sha="a" * 40,
+        verification_policy=resolve_verification_policy(
+            {
+                "verification": {
+                    "mode": "gate",
+                    "profile": {"version": "v1", "profile_id": "empty"},
+                }
+            }
+        ),
+    )
+    with (
+        patch(
+            "preloop.services.publication_hosted_verifier.inspect_bundle",
+            return_value={"changed_files": ["unknown"]},
+        ),
+        patch(
+            "preloop.services.publication_hosted_verifier._check_docker",
+            new=AsyncMock(),
+        ) as check,
+    ):
+        with pytest.raises(PublicationError, match="No required checks"):
+            await verify_hosted_publication(MagicMock(), policy, b"bundle")
+    check.assert_not_awaited()
+
+
+def test_diagnostic_tail_is_bounded_and_scrubs_tokens_and_controls():
+    from preloop.services.publication_hosted_verifier import _append_tail
+
+    logs = []
+    _append_tail(logs, "x" * 100000)
+    _append_tail(logs, "\x1b\x00Authorization: Bearer test-secret\n")
+    assert len(logs[0]) <= 65536
+    assert "\x1b" not in logs[0] and "\x00" not in logs[0]
+    assert "test-secret" not in logs[0]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_job_create_keeps_network_denial_until_removal_proven():
+    executor = SimpleNamespace(
+        _init_kubernetes_clients=AsyncMock(),
+        _k8s_batch_api=SimpleNamespace(
+            create_namespaced_job=AsyncMock(side_effect=TimeoutError())
+        ),
+        _k8s_core_api=SimpleNamespace(
+            api_client=SimpleNamespace(configuration=object())
+        ),
+        agent_namespace="isolated",
+        use_kubernetes=True,
+    )
+    policy = SimpleNamespace(
+        execution_id=str(uuid4()), verification_image="generic@sha256:" + "a" * 64
+    )
+    network = SimpleNamespace(
+        create_namespaced_network_policy=AsyncMock(),
+        delete_namespaced_network_policy=AsyncMock(),
+    )
+    with (
+        patch("kubernetes_asyncio.client.NetworkingV1Api", return_value=network),
+        patch(
+            "preloop.services.publication_hosted_verifier.remove_owned_publication_runtime",
+            new=AsyncMock(side_effect=PublicationError("removal unconfirmed")),
+        ) as remove,
+    ):
+        with pytest.raises(PublicationError, match="removal unconfirmed"):
+            await _check_kubernetes(
+                executor,
+                policy,
+                b"bundle",
+                {"head_sha": "a" * 40},
+                SimpleNamespace(command="true", timeout_seconds=10),
+            )
+    remove.assert_awaited_once()
+    network.delete_namespaced_network_policy.assert_not_awaited()

--- a/backend/tests/services/test_publication_hosted_verifier.py
+++ b/backend/tests/services/test_publication_hosted_verifier.py
@@ -45,6 +45,9 @@ async def test_kubernetes_adapter_streams_input_and_deletes_job_before_return():
     )
     check = SimpleNamespace(command="pytest tests/unit", timeout_seconds=10)
     network = SimpleNamespace(
+        list_namespaced_network_policy=AsyncMock(
+            return_value=SimpleNamespace(items=[])
+        ),
         create_namespaced_network_policy=AsyncMock(),
         delete_namespaced_network_policy=AsyncMock(),
     )
@@ -173,6 +176,8 @@ def test_diagnostic_tail_is_bounded_and_scrubs_tokens_and_controls():
     assert len(logs[0]) <= 65536
     assert "\x1b" not in logs[0] and "\x00" not in logs[0]
     assert "test-secret" not in logs[0]
+    _append_tail(logs, "界" * 100000)
+    assert len(logs[0].encode("utf-8")) <= 65536
 
 
 @pytest.mark.asyncio
@@ -192,6 +197,9 @@ async def test_ambiguous_job_create_keeps_network_denial_until_removal_proven():
         execution_id=str(uuid4()), verification_image="generic@sha256:" + "a" * 64
     )
     network = SimpleNamespace(
+        list_namespaced_network_policy=AsyncMock(
+            return_value=SimpleNamespace(items=[])
+        ),
         create_namespaced_network_policy=AsyncMock(),
         delete_namespaced_network_policy=AsyncMock(),
     )
@@ -212,3 +220,36 @@ async def test_ambiguous_job_create_keeps_network_denial_until_removal_proven():
             )
     remove.assert_awaited_once()
     network.delete_namespaced_network_policy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "selector,blocked",
+    [({}, True), ({"app": "another"}, False), ({"job-name": "owned"}, True)],
+)
+async def test_additive_network_policies_cannot_override_verifier_denial(
+    selector, blocked
+):
+    from kubernetes_asyncio import client
+    from preloop.services.publication_hosted_verifier import (
+        _require_isolated_network_policy,
+    )
+
+    policy = client.V1NetworkPolicy(
+        spec=client.V1NetworkPolicySpec(
+            pod_selector=client.V1LabelSelector(match_labels=selector),
+            egress=[client.V1NetworkPolicyEgressRule()],
+        )
+    )
+    api = SimpleNamespace(
+        list_namespaced_network_policy=AsyncMock(
+            return_value=SimpleNamespace(items=[policy])
+        )
+    )
+    if blocked:
+        with pytest.raises(PublicationError, match="overlapping"):
+            await _require_isolated_network_policy(
+                api, "namespace", {"job-name": "owned"}
+            )
+    else:
+        await _require_isolated_network_policy(api, "namespace", {"job-name": "owned"})

--- a/backend/tests/services/test_publication_runtime.py
+++ b/backend/tests/services/test_publication_runtime.py
@@ -1,0 +1,171 @@
+"""Destruction proof uses actual runtime configs, not generic success states."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from aiodocker.exceptions import DockerError
+from kubernetes_asyncio.client.exceptions import ApiException
+
+from preloop.agents.container import ContainerAgentExecutor
+from preloop.services.publication_runtime import remove_owned_publication_runtime
+from preloop.services.trusted_publisher import PublicationError
+
+
+@pytest.mark.asyncio
+async def test_docker_removal_uses_labels_created_by_real_start(monkeypatch):
+    execution = str(uuid4())
+    executor = ContainerAgentExecutor("codex", {}, "example/harness:stable")
+    container = SimpleNamespace(id="a" * 64, start=AsyncMock(), delete=AsyncMock())
+    docker = SimpleNamespace(images=SimpleNamespace(inspect=AsyncMock()))
+    captured = {}
+
+    async def create(*, config):
+        captured.update(config)
+        return container
+
+    docker.containers = SimpleNamespace(create=AsyncMock(side_effect=create))
+    monkeypatch.setattr(executor, "_get_docker_client", AsyncMock(return_value=docker))
+    monkeypatch.setattr(executor, "_restore_docker_workspace", AsyncMock())
+    reference = await executor._start_docker_container(
+        {"execution_id": execution, "flow_id": str(uuid4()), "prompt": "question"}
+    )
+    container.show = AsyncMock(return_value={"Id": reference, "Config": captured})
+    docker.containers.get = AsyncMock(
+        side_effect=[container, container, DockerError(404, {"message": "missing"})]
+    )
+    await remove_owned_publication_runtime(executor, reference, execution)
+    container.delete.assert_awaited_once_with(force=True, v=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode",
+    ["initial_missing", "wrong_owner", "delete_failed", "still_present", "auth_error"],
+)
+async def test_docker_errors_never_confirm_removal(mode, monkeypatch):
+    execution = str(uuid4())
+    executor = ContainerAgentExecutor("codex", {}, "example/harness:stable")
+    container = SimpleNamespace(
+        show=AsyncMock(
+            return_value={
+                "Id": "a" * 64,
+                "Config": {"Labels": {"preloop.execution_id": execution}},
+            }
+        ),
+        delete=AsyncMock(),
+    )
+    get = AsyncMock(return_value=container)
+    if mode == "initial_missing":
+        get.side_effect = DockerError(404, {"message": "missing"})
+    elif mode == "wrong_owner":
+        container.show.return_value["Config"]["Labels"]["preloop.execution_id"] = str(
+            uuid4()
+        )
+    elif mode == "delete_failed":
+        container.delete.side_effect = DockerError(500, {"message": "failed"})
+    elif mode == "auth_error":
+        get.side_effect = [
+            container,
+            container,
+            DockerError(403, {"message": "denied"}),
+        ]
+    monkeypatch.setattr(
+        executor,
+        "_get_docker_client",
+        AsyncMock(return_value=SimpleNamespace(containers=SimpleNamespace(get=get))),
+    )
+    with pytest.raises(PublicationError):
+        await remove_owned_publication_runtime(
+            executor, "a" * 64, execution, timeout_seconds=0.02
+        )
+    if mode in {"initial_missing", "wrong_owner"}:
+        container.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_removal_uses_actual_job_uid_labels_and_pods(monkeypatch):
+    execution = str(uuid4())
+    executor = ContainerAgentExecutor(
+        "codex", {}, "example/harness:stable", use_kubernetes=True
+    )
+    captured = {}
+
+    async def create(job, *, job_name, execution_id):
+        job.metadata.uid = "owned-job-uid"
+        captured["job"] = job
+        return job_name
+
+    monkeypatch.setattr(executor, "_init_kubernetes_clients", AsyncMock())
+    monkeypatch.setattr(
+        executor, "_create_kubernetes_job", AsyncMock(side_effect=create)
+    )
+    reference = await executor._start_kubernetes_pod(
+        {
+            "execution_id": execution,
+            "flow_id": str(uuid4()),
+            "prompt": "question",
+            "git_clone_config": {"publication_mode": "isolated"},
+        }
+    )
+    assert captured["job"].spec.template.spec.automount_service_account_token is False
+    batch = SimpleNamespace(
+        read_namespaced_job=AsyncMock(
+            side_effect=[captured["job"], ApiException(status=404)]
+        ),
+        delete_namespaced_job=AsyncMock(),
+    )
+    core = SimpleNamespace(
+        list_namespaced_pod=AsyncMock(return_value=SimpleNamespace(items=[]))
+    )
+    executor._k8s_batch_api, executor._k8s_core_api = batch, core
+    await remove_owned_publication_runtime(executor, reference, execution)
+    assert (
+        batch.delete_namespaced_job.call_args.kwargs["body"].preconditions.uid
+        == "owned-job-uid"
+    )
+    core.list_namespaced_pod.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode",
+    ["initial_missing", "delete_failed", "residual_pod", "auth_error", "replacement"],
+)
+async def test_kubernetes_incomplete_removal_blocks(mode, monkeypatch):
+    execution = str(uuid4())
+    executor = ContainerAgentExecutor(
+        "codex", {}, "example/harness:stable", use_kubernetes=True
+    )
+    job = SimpleNamespace(
+        metadata=SimpleNamespace(
+            uid="original", labels={"preloop.execution_id": execution}
+        )
+    )
+    batch = SimpleNamespace(
+        read_namespaced_job=AsyncMock(side_effect=[job, ApiException(status=404)]),
+        delete_namespaced_job=AsyncMock(),
+    )
+    core = SimpleNamespace(
+        list_namespaced_pod=AsyncMock(return_value=SimpleNamespace(items=[]))
+    )
+    if mode == "initial_missing":
+        batch.read_namespaced_job.side_effect = ApiException(status=404)
+    elif mode == "delete_failed":
+        batch.delete_namespaced_job.side_effect = ApiException(status=403)
+    elif mode == "residual_pod":
+        core.list_namespaced_pod.return_value.items = [object()]
+    elif mode == "auth_error":
+        core.list_namespaced_pod.side_effect = ApiException(status=403)
+    else:
+        batch.read_namespaced_job.side_effect = [
+            job,
+            SimpleNamespace(metadata=SimpleNamespace(uid="replacement")),
+        ]
+    monkeypatch.setattr(executor, "_init_kubernetes_clients", AsyncMock())
+    executor._k8s_batch_api, executor._k8s_core_api = batch, core
+    with pytest.raises(PublicationError):
+        await remove_owned_publication_runtime(
+            executor, "owned-job", execution, timeout_seconds=0.02
+        )

--- a/backend/tests/services/test_publication_worker.py
+++ b/backend/tests/services/test_publication_worker.py
@@ -1,0 +1,227 @@
+"""Exercise frozen helper boundaries using real local Git bundles."""
+
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from preloop.services.publication_worker import (
+    freeze_publication,
+    inspect_bundle,
+    read_regular_file,
+)
+from preloop.services.trusted_publisher import PublicationError
+
+
+@pytest.fixture
+def candidate(tmp_path):
+    repository = tmp_path / "repo"
+    repository.mkdir()
+
+    def git(*args):
+        return subprocess.check_output(
+            ["git", "-C", str(repository), *args], stderr=subprocess.DEVNULL, text=True
+        ).strip()
+
+    git("init")
+    git("config", "user.name", "Local test")
+    git("config", "user.email", "test@example.invalid")
+    (repository / "initial.txt").write_text("base")
+    git("add", ".")
+    git("commit", "-m", "Base")
+    base = git("rev-parse", "HEAD")
+    (repository / "test with spaces.py").write_text("pass\n")
+    git("add", ".")
+    git("commit", "-m", "Implementation")
+    source = tmp_path / "source"
+    source.mkdir()
+    git("bundle", "create", str(source / "branch.bundle"), "HEAD")
+    return source, base, git("rev-parse", "HEAD"), git
+
+
+def test_freeze_derives_real_commit_and_preserves_independent_bytes(
+    candidate, tmp_path
+):
+    source, base, head, _ = candidate
+    destination = tmp_path / "frozen"
+    original = (source / "branch.bundle").read_bytes()
+    manifest = freeze_publication(source, destination, base)
+    assert manifest["head_sha"] == head
+    assert manifest["changed_files"] == ["test with spaces.py"]
+    assert manifest["bundle_sha256"] == hashlib.sha256(original).hexdigest()
+    (source / "branch.bundle").write_bytes(b"agent rewrites source")
+    assert (destination / "branch.bundle").read_bytes() == original
+    assert (destination / "branch.bundle").stat().st_mode & 0o222 == 0
+
+
+@pytest.mark.parametrize("kind", ["symlink", "hardlink", "fifo", "oversize"])
+def test_fixed_input_rejects_filesystem_aliases_and_special_files(tmp_path, kind):
+    target = tmp_path / "branch.bundle"
+    other = tmp_path / "other"
+    other.write_bytes(b"contents")
+    if kind == "symlink":
+        target.symlink_to(other)
+    elif kind == "hardlink":
+        os.link(other, target)
+    elif kind == "fifo":
+        os.mkfifo(target)
+    else:
+        target.write_bytes(b"x" * 20)
+    with pytest.raises((OSError, PublicationError)):
+        read_regular_file(tmp_path, "branch.bundle", 10)
+
+
+def test_freeze_rejects_missing_base_and_ambiguous_head(candidate, tmp_path):
+    source, base, _, git = candidate
+    bundle = (source / "branch.bundle").read_bytes()
+    with pytest.raises(PublicationError):
+        inspect_bundle(bundle, "a" * 40)
+    git("bundle", "create", str(source / "branch.bundle"), "--all")
+    with pytest.raises(PublicationError, match="exactly one HEAD"):
+        freeze_publication(source, tmp_path / "frozen", base)
+
+
+def test_freeze_never_reuses_existing_destination(candidate, tmp_path):
+    source, base, _, _ = candidate
+    destination = tmp_path / "frozen"
+    destination.mkdir()
+    (destination / "branch.bundle").write_bytes(b"previous attempt")
+    with pytest.raises(FileExistsError):
+        freeze_publication(source, destination, base)
+    assert (destination / "branch.bundle").read_bytes() == b"previous attempt"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("PRELOOP_PUBLICATION_DOCKER_IMAGE"),
+    reason="Explicit local Docker fixture image required",
+)
+async def test_real_docker_checks_run_fresh_without_credentials_and_fail_closed(
+    candidate,
+):
+    from types import SimpleNamespace
+    from uuid import uuid4
+    from preloop.agents.container import ContainerAgentExecutor
+    from preloop.services.publication_hosted_verifier import verify_hosted_publication
+    from preloop.services.verification import resolve_verification_policy
+
+    source, base, head, _ = candidate
+    executor = ContainerAgentExecutor(
+        "codex", {}, os.environ["PRELOOP_PUBLICATION_DOCKER_IMAGE"]
+    )
+    checks = [
+        {
+            "id": "first",
+            "command": 'test -z "$GITHUB_TOKEN$PRELOOP_API_TOKEN" && test ! -e /var/run/docker.sock && echo changed > "test with spaces.py"',
+            "reason": "isolation",
+        },
+        {
+            "id": "second",
+            "command": 'test "$(cat "test with spaces.py")" = pass',
+            "reason": "fresh checkout",
+        },
+    ]
+    policy = SimpleNamespace(
+        execution_id=str(uuid4()),
+        base_sha=base,
+        verification_image=executor.image,
+        verification_policy=resolve_verification_policy(
+            {
+                "verification": {
+                    "mode": "gate",
+                    "profile": {
+                        "profile_id": "local",
+                        "version": "v1",
+                        "always": checks,
+                    },
+                }
+            }
+        ),
+    )
+    try:
+        result = await verify_hosted_publication(
+            executor, policy, (source / "branch.bundle").read_bytes()
+        )
+        assert result.verification.head_sha == head
+        assert [check["exit_code"] for check in result.checks] == [0, 0]
+        policy.verification_policy.profile.always[0].command = "exit 7"
+        with pytest.raises(PublicationError, match="exit 7"):
+            await verify_hosted_publication(
+                executor, policy, (source / "branch.bundle").read_bytes()
+            )
+        docker = await executor._get_docker_client()
+        residual = await docker.containers.list(
+            all=True, filters={"label": [f"preloop.execution_id={policy.execution_id}"]}
+        )
+        assert residual == []
+    finally:
+        await executor.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_publish_wire_fixture_rejects_digest_before_using_lease(candidate):
+    import json
+    from unittest.mock import AsyncMock, patch
+    from preloop.services.publication_worker import publish_frozen
+
+    source, _, _, _ = candidate
+    request = json.loads(
+        (
+            Path(__file__).parents[1] / "fixtures/publication_publish_request.json"
+        ).read_text()
+    )
+    with (
+        patch(
+            "preloop.services.publication_worker.publish_verified_bundle",
+            new=AsyncMock(),
+        ) as publish,
+        patch(
+            "preloop.services.publication_worker.revoke_repository_lease",
+            new=AsyncMock(),
+        ) as revoke,
+    ):
+        with pytest.raises(PublicationError, match="digest changed"):
+            await publish_frozen(source, request)
+    publish.assert_not_awaited()
+    revoke.assert_awaited_once()
+    assert revoke.call_args.args[0].token == "fixture-test-token"
+
+
+@pytest.mark.asyncio
+async def test_publish_wire_fixture_binds_exact_bytes_and_revokes_on_success(candidate):
+    import json
+    from unittest.mock import AsyncMock, patch
+    from preloop.services.publication_worker import publish_frozen
+
+    source, _, head, _ = candidate
+    request = json.loads(
+        (
+            Path(__file__).parents[1] / "fixtures/publication_publish_request.json"
+        ).read_text()
+    )
+    bundle = (source / "branch.bundle").read_bytes()
+    request["bundle_sha256"] = hashlib.sha256(bundle).hexdigest()
+    request["binding"]["head_sha"] = head
+    request["binding"]["records"][0]["head_sha"] = head
+
+    async def publish(**kwargs):
+        assert kwargs["bundle"] == bundle
+        assert kwargs["binding"].head_sha == head
+        lease = await kwargs["acquire_lease"]()
+        assert lease.token == "fixture-test-token"
+        return {"url": "https://github.com/example/project/pull/1"}
+
+    with (
+        patch(
+            "preloop.services.publication_worker.publish_verified_bundle", new=publish
+        ),
+        patch(
+            "preloop.services.publication_worker.revoke_repository_lease",
+            new=AsyncMock(),
+        ) as revoke,
+    ):
+        result = await publish_frozen(source, request)
+    assert result["url"].endswith("/pull/1")
+    revoke.assert_awaited_once()

--- a/backend/tests/services/test_publication_worker.py
+++ b/backend/tests/services/test_publication_worker.py
@@ -225,3 +225,12 @@ async def test_publish_wire_fixture_binds_exact_bytes_and_revokes_on_success(can
         result = await publish_frozen(source, request)
     assert result["url"].endswith("/pull/1")
     revoke.assert_awaited_once()
+
+
+def test_changed_path_preserves_leading_whitespace_for_check_selection(candidate):
+    source, base, _, git = candidate
+    git("mv", "test with spaces.py", " leading.py")
+    git("commit", "-m", "Leading whitespace filename")
+    git("bundle", "create", str(source / "branch.bundle"), "HEAD")
+    manifest = inspect_bundle((source / "branch.bundle").read_bytes(), base)
+    assert manifest["changed_files"] == [" leading.py"]

--- a/backend/tests/services/test_trusted_publication.py
+++ b/backend/tests/services/test_trusted_publication.py
@@ -1,0 +1,489 @@
+"""Adversarial publication boundary and provider behavior tests."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import subprocess
+import tarfile
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from preloop.services.publication_verification import (
+    VerifiedPublication,
+    require_verified_publication,
+)
+from preloop.services.trusted_publisher import (
+    CleanGitRepository,
+    PublicationBinding,
+    PublicationError,
+    PublicationLease,
+    PullRequestPublisher,
+    publish_verified_bundle,
+    read_publication_bundle,
+)
+from preloop.utils.pr_metadata import (
+    PROVENANCE_START,
+    PublicationRecord,
+    discover_template,
+    select_metadata,
+    upsert_provenance,
+)
+
+EXECUTION = "11111111-1111-4111-8111-111111111111"
+REPAIR = "22222222-2222-4222-8222-222222222222"
+HEAD = "a" * 40
+BASE = "b" * 40
+PUBLIC_URL = "https://app.example.com"
+
+
+def binding(**kwargs: Any) -> PublicationBinding:
+    values = dict(
+        repository_url="https://github.com/example/project.git",
+        branch="preloop/issue-1",
+        base="main",
+        head_sha=HEAD,
+        expected_remote_sha=None,
+        records=(PublicationRecord(EXECUTION, HEAD),),
+        public_url=PUBLIC_URL,
+        provider="github",
+    )
+    values.update(kwargs)
+    return PublicationBinding(**values)
+
+
+def lease(
+    repository_url: str = "https://github.com/example/project.git",
+) -> PublicationLease:
+    return PublicationLease(
+        "test-write-secret",
+        repository_url,
+        datetime.now(timezone.utc) + timedelta(minutes=10),
+    )
+
+
+def archive_bundle(
+    data: bytes, *, name: str = "evidence/branch.bundle", symlink: bool = False
+) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name)
+        if symlink:
+            info.type = tarfile.SYMTYPE
+            info.linkname = "/etc/passwd"
+            tar.addfile(info)
+        else:
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buffer.getvalue()
+
+
+def test_metadata_precedence_and_unicode() -> None:
+    title, body, warnings = select_metadata(
+        json.dumps(
+            {
+                "pr_title": "Fix résumé 🚀",
+                "pr_body": '## Summary\n\nPreserve "quotes".\n\n## Testing\n- [ ] UI unavailable',
+            }
+        ).encode(),
+        configured_title="configured",
+        configured_body="configured",
+        issue_number="12",
+    )
+    assert title == "Fix résumé 🚀"
+    assert "\n" in body and "Closes #12" in body
+    assert "- [ ] UI unavailable" in body
+    assert not warnings
+    assert (
+        select_metadata(
+            b'{"pr_title": "Only title"}', configured_body="Configured body"
+        )[1]
+        == "Configured body"
+    )
+    assert select_metadata(
+        b"broken", configured_title="configured", commit_body="commit"
+    )[0:2] == ("configured", "commit")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        b"[]",
+        b"false",
+        b'"text"',
+        b"\xff",
+        b"{" * (256 * 1024 + 1),
+        b'{"pr_title":42,"pr_body":{}}',
+    ],
+)
+def test_invalid_metadata_falls_back_visibly(raw: bytes | None) -> None:
+    title, body, warnings = select_metadata(raw, commit_title="Commit title")
+    assert title == "Commit title"
+    assert "## Summary" in body and "No test evidence supplied" in body
+    assert warnings
+
+
+@pytest.mark.parametrize(
+    "bad", ["x" * 257, "title\nsecond line", "x\x00y", PROVENANCE_START + "pretend"]
+)
+def test_invalid_title_falls_back_without_truncating(bad: str) -> None:
+    assert (
+        select_metadata(
+            json.dumps({"pr_title": bad}).encode(), configured_title="Valid"
+        )[0]
+        == "Valid"
+    )
+
+
+def test_provenance_all_sources_idempotent_and_preserves_human_edits() -> None:
+    record = PublicationRecord(EXECUTION, HEAD)
+    repaired = PublicationRecord(REPAIR, BASE)
+    for raw, config, commit in [
+        (b'{"pr_body":"Agent"}', "", ""),
+        (None, "Configured", ""),
+        (None, "", "Commit"),
+    ]:
+        _, body, _ = select_metadata(raw, configured_body=config, commit_body=commit)
+        first = upsert_provenance(body, [record], PUBLIC_URL)
+        edited = "Human prefix\n" + first + "\nHuman suffix 🚀\n"
+        updated = upsert_provenance(edited, [record, repaired, repaired], PUBLIC_URL)
+        assert updated.startswith("Human prefix\n" + body)
+        assert updated.endswith("\nHuman suffix 🚀\n")
+        assert updated.count(PROVENANCE_START) == 1
+        assert updated.count(REPAIR) == 1
+        assert updated == upsert_provenance(updated, [record, repaired], PUBLIC_URL)
+        assert HEAD in updated and BASE in updated
+
+
+def test_malformed_owned_block_fails_without_overwriting_humans() -> None:
+    with pytest.raises(ValueError, match="Malformed"):
+        upsert_provenance(
+            "Human\n" + PROVENANCE_START,
+            [PublicationRecord(EXECUTION, HEAD)],
+            PUBLIC_URL,
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://token@example.com",
+        "https://example.com/?token=secret",
+        "https://example.com/#secret",
+        "javascript:evil",
+        "https://example.com/)",
+    ],
+)
+def test_execution_url_never_exposes_credentials(url: str) -> None:
+    with pytest.raises(ValueError):
+        upsert_provenance("Body", [PublicationRecord(EXECUTION, HEAD)], url)
+
+
+def test_repository_templates_and_deterministic_selection() -> None:
+    fixtures = Path(__file__).parents[1] / "fixtures/pr_templates"
+    github = (fixtures / "github/pull_request_template.md").read_text()
+    gitlab = (fixtures / "gitlab/Default.md").read_text()
+    files = {
+        ".github/pull_request_template.md": github,
+        ".github/PULL_REQUEST_TEMPLATE/z.md": "Z",
+        ".github/PULL_REQUEST_TEMPLATE/a.md": "A",
+    }
+    assert discover_template(files, provider="github") == (
+        ".github/pull_request_template.md",
+        github,
+    )
+    assert (
+        discover_template(
+            files, provider="github", configured=".github/PULL_REQUEST_TEMPLATE/z.md"
+        )[1]
+        == "Z"
+    )
+    del files[".github/pull_request_template.md"]
+    assert discover_template(files, provider="github")[1] == "A"
+    assert discover_template({}, provider="github") == (
+        None,
+        "## Summary\n\n## Testing\n",
+    )
+    assert (
+        discover_template(
+            {".gitlab/merge_request_templates/Default.md": gitlab}, provider="gitlab"
+        )[1]
+        == gitlab
+    )
+    assert "- [ ]" in github and "- [ ]" in gitlab
+    with pytest.raises(ValueError):
+        discover_template(files, provider="github", configured="../outside")
+
+
+def test_verification_requires_controller_type_exact_execution_and_bundle() -> None:
+    bundle = b"immutable bundle"
+    envelope = VerifiedPublication(EXECUTION, HEAD, hashlib.sha256(bundle).hexdigest())
+    assert (
+        require_verified_publication(envelope, execution_id=EXECUTION, bundle=bundle)
+        == HEAD
+    )
+    for value in [
+        None,
+        {"status": "passed", "head_sha": HEAD},
+        replace(envelope, execution_id=REPAIR),
+        replace(envelope, bundle_sha256="0" * 64),
+    ]:
+        with pytest.raises(PublicationError):
+            require_verified_publication(value, execution_id=EXECUTION, bundle=bundle)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"repository_url": "https://evil.example/path.git"},
+        {"repository_url": "https://secret@github.com/example/project.git"},
+        {"repository_url": "ext::sh -c evil"},
+        {"branch": "main"},
+        {"branch": "-x"},
+        {"branch": "a/../b"},
+        {"head_sha": "short"},
+        {"expected_remote_sha": "wrong"},
+    ],
+)
+def test_forged_destinations_and_unsafe_bindings_rejected(
+    kwargs: dict[str, Any],
+) -> None:
+    with pytest.raises(PublicationError):
+        binding(**kwargs)
+
+
+def test_archive_never_extracts_links_or_traversal(tmp_path: Path) -> None:
+    assert read_publication_bundle(archive_bundle(b"bundle")) == b"bundle"
+    for archive in [
+        archive_bundle(b"", symlink=True),
+        archive_bundle(b"bad", name="../../branch.bundle"),
+        b"bad",
+    ]:
+        with pytest.raises(PublicationError):
+            read_publication_bundle(archive)
+    assert list(tmp_path.iterdir()) == []
+
+
+def git(cwd: Path, *args: str) -> str:
+    env = {
+        "PATH": os.defpath,
+        "HOME": str(cwd),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "PRELOOP_DISABLE_TELEMETRY": "true",
+    }
+    return subprocess.run(
+        ["/usr/bin/git", "-C", str(cwd), *args],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def malicious_checkout(tmp_path: Path) -> tuple[bytes, str, Path]:
+    source = tmp_path / "agent"
+    source.mkdir()
+    git(source, "init", "--template=")
+    git(source, "config", "user.name", "Test User")
+    git(source, "config", "user.email", "test@example.com")
+    (source / "file").write_text("safe content")
+    (source / ".gitattributes").write_text("* filter=steal")
+    git(source, "add", "file", ".gitattributes")
+    git(source, "commit", "-m", "Verified change")
+    head = git(source, "rev-parse", "HEAD")
+    marker = tmp_path / "credential-extracted"
+    malicious = f"touch {marker}"
+    git(source, "config", "credential.helper", "!" + malicious)
+    git(source, "config", "filter.steal.smudge", malicious)
+    git(source, "config", "core.sshCommand", malicious)
+    hooks = source / ".git/hooks"
+    hooks.mkdir(exist_ok=True)
+    (hooks / "pre-push").write_text("#!/bin/sh\n" + malicious)
+    (hooks / "pre-push").chmod(0o755)
+    git(source, "bundle", "create", str(tmp_path / "agent.bundle"), "HEAD")
+    return (tmp_path / "agent.bundle").read_bytes(), head, marker
+
+
+def test_bundle_import_does_not_import_config_or_execute_checkout(
+    malicious_checkout: tuple[bytes, str, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle, head, marker = malicious_checkout
+    monkeypatch.setenv("PRELOOP_GIT_TOKEN_1", "old-agent-token")
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "credential.helper")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", "!touch " + str(marker))
+    clean = tmp_path / "clean"
+    clean.mkdir()
+    repo = CleanGitRepository(clean)
+    repo.import_bundle(bundle, head)
+    assert "PRELOOP_GIT_TOKEN_1" not in repo.environment
+    assert repo.environment["GIT_CONFIG_COUNT"] == "0"
+    assert "credential" not in (clean / "config").read_text()
+    assert not (clean / "file").exists()
+    assert not marker.exists()
+    with pytest.raises(PublicationError):
+        repo.import_bundle(bundle, "f" * 40)
+
+
+def test_publication_rejects_concurrent_remote_and_non_fast_forward(
+    tmp_path: Path,
+) -> None:
+    repo = CleanGitRepository(tmp_path)
+    with patch.object(
+        repo, "run", return_value=BASE + "\trefs/heads/preloop/issue-1"
+    ) as run:
+        with pytest.raises(PublicationError, match="concurrently"):
+            repo.publish(binding(), lease())
+        assert not any(call.args[0] == "push" for call in run.call_args_list)
+    with patch.object(
+        repo, "run", side_effect=[BASE + "\tref", "", BASE, "c" * 40]
+    ) as run:
+        with pytest.raises(PublicationError, match="Non-fast-forward"):
+            repo.publish(binding(expected_remote_sha=BASE), lease())
+        assert not any(call.args[0] == "push" for call in run.call_args_list)
+
+
+def test_publication_retry_skips_push_and_wrong_lease_rejected(tmp_path: Path) -> None:
+    repo = CleanGitRepository(tmp_path)
+    with patch.object(repo, "run", return_value=HEAD + "\tref") as run:
+        repo.publish(binding(), lease())
+        assert run.call_count == 1
+    with pytest.raises(PublicationError, match="bound"):
+        repo.publish(binding(), lease("https://github.com/example/other.git"))
+    with pytest.raises(PublicationError, match="expired"):
+        repo.publish(binding(), replace(lease(), expires_at=datetime.now(timezone.utc)))
+
+
+def provider_row(provider: str, body: str) -> dict[str, Any]:
+    if provider == "github":
+        return {
+            "number": 5,
+            "html_url": "https://github.com/example/project/pull/5",
+            "body": body,
+            "head": {
+                "ref": "preloop/issue-1",
+                "repo": {"full_name": "example/project"},
+            },
+            "base": {"ref": "main"},
+        }
+    return {
+        "iid": 5,
+        "web_url": "https://gitlab.example.com/example/project/-/merge_requests/5",
+        "description": body,
+        "source_branch": "preloop/issue-1",
+        "target_branch": "main",
+        "source_project_id": 10,
+        "target_project_id": 10,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["github", "gitlab"])
+async def test_provider_create_retry_metadata_update_preserves_human_edits(
+    provider: str,
+) -> None:
+    url = (
+        "https://github.com/example/project.git"
+        if provider == "github"
+        else "https://gitlab.example.com/example/project.git"
+    )
+    contract = binding(provider=provider, repository_url=url)
+    calls: list[httpx.Request] = []
+    row: dict[str, Any] | None = None
+    field = "body" if provider == "github" else "description"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal row
+        calls.append(request)
+        if request.method == "GET":
+            return httpx.Response(200, json=[row] if row else [])
+        payload = json.loads(request.content)
+        if request.method == "POST":
+            assert payload["title"] == "Fix résumé"
+            assert (
+                payload["head" if provider == "github" else "source_branch"]
+                == contract.branch
+            )
+            row = provider_row(provider, payload[field])
+            return httpx.Response(201, json=row)
+        assert list(payload) == [field]
+        assert row is not None
+        row[field] = payload[field]
+        return httpx.Response(200, json=row)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        publisher = PullRequestPublisher(client)
+        first = await publisher.upsert(
+            contract, lease(url), "Fix résumé", "## Summary\nInitial"
+        )
+        assert first["number"] == 5
+        assert row is not None
+        row[field] = "Human before\n" + row[field] + "\nHuman after"
+        repaired = replace(
+            contract, records=(*contract.records, PublicationRecord(REPAIR, HEAD))
+        )
+        await publisher.upsert(
+            repaired, lease(url), "Ignored agent rewrite", "Overwrite human body"
+        )
+        await publisher.upsert(repaired, lease(url), "Retry", "Retry")
+        assert row[field].startswith("Human before\n## Summary\nInitial")
+        assert row[field].endswith("\nHuman after")
+        assert row[field].count(REPAIR) == 1
+        assert sum(call.method == "POST" for call in calls) == 1
+        assert sum(call.method in {"PATCH", "PUT"} for call in calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_is_observable() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return (
+            httpx.Response(200, json=[provider_row("github", "Human body")])
+            if request.method == "GET"
+            else httpx.Response(503)
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(PublicationError, match="provider request failed"):
+            await PullRequestPublisher(client).upsert(
+                binding(), lease(), "Title", "Body"
+            )
+
+
+@pytest.mark.asyncio
+async def test_invalid_bundle_never_acquires_write_credentials() -> None:
+    acquire = AsyncMock()
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(PublicationError):
+            await publish_verified_bundle(
+                binding=binding(),
+                bundle=b"bad bundle",
+                result_json=b"{}",
+                acquire_lease=acquire,
+                client=client,
+            )
+    acquire.assert_not_awaited()
+
+
+def test_repository_template_reader_rejects_symlink_escape(tmp_path: Path) -> None:
+    from preloop.utils.pr_metadata import repository_template
+
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    outside = tmp_path / "private"
+    outside.write_text("secret")
+    (repository / "template.md").symlink_to(outside)
+    with pytest.raises(ValueError, match="missing or outside"):
+        repository_template(repository, provider="github", configured="template.md")

--- a/backend/tests/services/test_trusted_publication.py
+++ b/backend/tests/services/test_trusted_publication.py
@@ -31,9 +31,11 @@ from preloop.services.trusted_publisher import (
     read_publication_bundle,
 )
 from preloop.utils.pr_metadata import (
+    MAX_ARTIFACT_BYTES,
     PROVENANCE_START,
     PublicationRecord,
     discover_template,
+    read_result_metadata,
     select_metadata,
     upsert_provenance,
 )
@@ -130,6 +132,32 @@ def test_invalid_metadata_falls_back_visibly(raw: bytes | None) -> None:
     assert title == "Commit title"
     assert "## Summary" in body and "No test evidence supplied" in body
     assert warnings
+
+
+def test_deeply_nested_metadata_falls_back_on_recursion_error() -> None:
+    nested = "0"
+    for _ in range(4000):
+        nested = "[" + nested + "]"
+    raw = nested.encode()
+    assert len(raw) < MAX_ARTIFACT_BYTES
+    title, body, warnings = select_metadata(raw, commit_title="Commit title")
+    assert title == "Commit title"
+    assert warnings
+
+
+def test_json_loads_recursion_error_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    def explode(_raw: Any) -> Any:
+        raise RecursionError("maximum recursion depth exceeded")
+
+    monkeypatch.setattr("preloop.utils.pr_metadata.json.loads", explode)
+    title, body, warnings = read_result_metadata(
+        b'{"pr_title":"Deep","pr_body":"Nested"}'
+    )
+    assert title == ""
+    assert body == ""
+    assert warnings == [
+        "PR metadata artifact invalid; using configured/commit fallback"
+    ]
 
 
 @pytest.mark.parametrize(

--- a/cli/internal/cmd/runner.go
+++ b/cli/internal/cmd/runner.go
@@ -162,6 +162,8 @@ func runRunnerFg(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Runner %s (%s) connecting...\n", state.Name, state.ID)
 
+	reapOrphanedPublicationRuntimes()
+
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
 	return runnerForegroundLoop(state, interrupt, cmd.OutOrStdout())
@@ -633,6 +635,11 @@ func beginLeasedJob(
 	if executionID == "" {
 		return fmt.Errorf("job missing execution_id")
 	}
+	if err := isolatedPublicationHostExecError(job); err != nil {
+		outcome := leasedJobOutcome{executionID: executionID, status: "FAILED", errMsg: err.Error()}
+		rememberOutcome(lastComplete, outcome)
+		return writeJobOutcome(conn, outcome)
+	}
 	if halted != nil {
 		halted.Store(false)
 	}
@@ -839,6 +846,17 @@ func waitDockerJob(cmd *exec.Cmd, executionID string, buf interface{ String() st
 		outcome.status = "FAILED"
 	}
 	return outcome
+}
+
+func isolatedPublicationHostExecError(job map[string]any) error {
+	if jobHostExecProfileName(job) == "" {
+		return nil
+	}
+	raw, exists := job["publication"]
+	if !exists || raw == nil {
+		return nil
+	}
+	return errors.New("native host execution cannot use isolated publication")
 }
 
 func splitNonEmptyLines(output string) []string {

--- a/cli/internal/cmd/runner.go
+++ b/cli/internal/cmd/runner.go
@@ -123,6 +123,18 @@ type runnerAPIRecord struct {
 }
 
 type runnerWSMessage struct {
+	Version       int                `json:"version,omitempty"`
+	ExecutionID   string             `json:"execution_id,omitempty"`
+	Nonce         string             `json:"nonce,omitempty"`
+	HeadSHA       string             `json:"head_sha,omitempty"`
+	TreeSHA       string             `json:"tree_sha,omitempty"`
+	BundleSHA256  string             `json:"bundle_sha256,omitempty"`
+	Image         string             `json:"image,omitempty"`
+	BudgetSeconds int                `json:"budget_seconds,omitempty"`
+	Checks        []publicationCheck `json:"checks,omitempty"`
+	Binding       map[string]any     `json:"binding,omitempty"`
+	Lease         map[string]any     `json:"lease,omitempty"`
+
 	Type            string         `json:"type"`
 	Job             map[string]any `json:"job,omitempty"`
 	Halt            bool           `json:"halt,omitempty"`
@@ -193,15 +205,17 @@ func loadOrRegisterRunner(client *api.Client, name, hostname string, labels []st
 }
 
 type leasedJobOutcome struct {
-	hostExec    bool
-	profile     string
-	logBuffer   *runnerLogBuffer
-	result      map[string]any
-	exitCode    int
-	executionID string
-	status      string
-	errMsg      string
-	lines       []string
+	publicationRequired     bool
+	publicationAcknowledged bool
+	hostExec                bool
+	profile                 string
+	logBuffer               *runnerLogBuffer
+	result                  map[string]any
+	exitCode                int
+	executionID             string
+	status                  string
+	errMsg                  string
+	lines                   []string
 }
 
 func nextRunnerBackoff(current time.Duration) time.Duration {
@@ -238,6 +252,10 @@ func dialRunnerWebsocket(wsURL, token string) (*websocket.Conn, error) {
 }
 
 func writeJobOutcome(conn *websocket.Conn, outcome leasedJobOutcome) error {
+	if outcome.publicationRequired && !outcome.publicationAcknowledged && outcome.status == "SUCCEEDED" {
+		outcome.status = "FAILED"
+		outcome.errMsg = "isolated publication was not confirmed; write requests are never replayed automatically"
+	}
 	if conn == nil {
 		return nil
 	}
@@ -429,11 +447,20 @@ func runRunnerSession(
 	halted *atomic.Bool,
 	lastComplete **leasedJobOutcome,
 ) error {
+	var publication *runnerPublication
+	var publicationEvents <-chan publicationEvent
+	defer func() {
+		if publication != nil {
+			publication.abort()
+		}
+	}()
 	_ = conn.SetReadDeadline(time.Now().Add(runnerReadWait))
 	conn.SetPongHandler(func(string) error {
 		return conn.SetReadDeadline(time.Now().Add(runnerReadWait))
 	})
 
+	sessionDone := make(chan struct{})
+	defer close(sessionDone)
 	incoming := make(chan runnerWSMessage, 8)
 	readErr := make(chan error, 1)
 	go func() {
@@ -444,9 +471,20 @@ func runRunnerSession(
 				return
 			}
 			_ = conn.SetReadDeadline(time.Now().Add(runnerReadWait))
-			incoming <- msg
+			select {
+			case incoming <- msg:
+			case <-sessionDone:
+				if msg.Lease != nil {
+					delete(msg.Lease, "token")
+				}
+				return
+			}
 		}
 	}()
+
+	if err := conn.WriteJSON(runnerHeartbeatMessage()); err != nil {
+		return fmt.Errorf("initial heartbeat: %w", err)
+	}
 
 	flushPendingOutcome(
 		conn, jobDone, runningCmd, runningExecID, halt, halted, lastComplete,
@@ -478,7 +516,21 @@ func runRunnerSession(
 					}
 				}
 			}
+		case event := <-publicationEvents:
+			if event.outcome != nil {
+				applyJobOutcome(conn, *event.outcome, runningCmd, runningExecID, jobDone, halt, halted, lastComplete)
+				publication.cancel()
+				publication = nil
+				publicationEvents = nil
+			} else if event.message != nil {
+				if err := conn.WriteJSON(event.message); err != nil {
+					return err
+				}
+			}
 		case <-ticker.C:
+			if publication == nil {
+				_ = cleanupPublicationRecovery(time.Now())
+			}
 			// Retention progresses even when the runner receives no new jobs.
 			keep := map[string]bool{}
 			if *runningExecID != "" {
@@ -496,10 +548,33 @@ func runRunnerSession(
 			return fmt.Errorf("runner read: %w", err)
 		case outcome := <-*jobDone:
 			releaseWorkspaceLease(outcome.executionID)
+			if publication != nil {
+				*jobDone = nil
+				*runningCmd = nil
+				publication.start(outcome)
+				continue
+			}
 			applyJobOutcome(
 				conn, outcome, runningCmd, runningExecID, jobDone, halt, halted, lastComplete,
 			)
 		case msg := <-incoming:
+			if strings.HasPrefix(msg.Type, "publication_") {
+				if publication == nil {
+					return errors.New("unexpected publication message without active lease")
+				}
+				if msg.Error != "" {
+					publication.abort()
+					return errors.New("publication controller rejected transition")
+				}
+				if err := publication.accept(msg); err != nil {
+					if msg.Lease != nil {
+						delete(msg.Lease, "token")
+					}
+					publication.abort()
+					return err
+				}
+				continue
+			}
 			if msg.Error != "" {
 				return &runnerFatalError{fmt.Errorf("runner server: %s", msg.Error)}
 			}
@@ -507,6 +582,10 @@ func runRunnerSession(
 				*halt = true
 				fmt.Fprintf(out, "Halt received for %s\n", msg.HaltExecutionID)
 				killRunning()
+				if publication != nil {
+					publication.stopRequested.Store(true)
+					publication.abort()
+				}
 				continue
 			}
 			if msg.Job == nil {
@@ -523,12 +602,15 @@ func runRunnerSession(
 				continue
 			}
 			if err := beginLeasedJob(
-				conn, msg.Job, *halt, out, runningCmd, runningExecID, jobDone, halted, lastComplete,
+				conn, msg.Job, *halt, out, runningCmd, runningExecID, jobDone, halted, lastComplete, &publication,
 			); err != nil {
 				fmt.Fprintf(out, "Job error: %v\n", err)
 				*runningCmd = nil
 				*runningExecID = ""
 				*jobDone = nil
+			}
+			if publication != nil {
+				publicationEvents = publication.events
 			}
 			*halt = false
 		}
@@ -545,6 +627,7 @@ func beginLeasedJob(
 	jobDone *<-chan leasedJobOutcome,
 	halted *atomic.Bool,
 	lastComplete **leasedJobOutcome,
+	publication **runnerPublication,
 ) error {
 	executionID, _ := job["execution_id"].(string)
 	if executionID == "" {
@@ -575,6 +658,25 @@ func beginLeasedJob(
 	}
 
 	opts, optsErr := runnerDockerOptsFromJob(job)
+	var isolated *runnerPublication
+	if optsErr == nil {
+		isolated, optsErr = publicationFromJob(job, opts)
+	}
+	if optsErr != nil {
+		outcome := leasedJobOutcome{executionID: executionID, status: "FAILED", errMsg: optsErr.Error()}
+		rememberOutcome(lastComplete, outcome)
+		return writeJobOutcome(conn, outcome)
+	}
+	if isolated != nil {
+		opts.Publication = isolated
+	}
+	launched := false
+	defer func() {
+		if isolated != nil && !launched {
+			isolated.cancel()
+			_ = isolated.removeVolume(isolated.exportVolume)
+		}
+	}()
 	resumeFrom := jobResumeFrom(job)
 	if optsErr == nil && opts.PersistWorkspace {
 		if hostDir, persistErr := preparePersistWorkspace(executionID, resumeFrom); persistErr == nil {
@@ -670,12 +772,18 @@ func beginLeasedJob(
 		rememberOutcome(lastComplete, outcome)
 		return writeJobOutcome(conn, outcome)
 	}
+	launched = true
+	if publication != nil {
+		*publication = isolated
+	}
 	*runningCmd = cmd
 	*runningExecID = executionID
 	done := make(chan leasedJobOutcome, 1)
 	*jobDone = done
 	go func() {
-		done <- waitDockerJob(cmd, executionID, &buf, halted)
+		outcome := waitDockerJob(cmd, executionID, &buf, halted)
+		outcome.publicationRequired = isolated != nil
+		done <- outcome
 	}()
 	return nil
 }

--- a/cli/internal/cmd/runner_docker.go
+++ b/cli/internal/cmd/runner_docker.go
@@ -61,6 +61,8 @@ func dockerRunArgs(image string, env map[string]string, opts runnerDockerOpts) [
 	args := []string{"run", "--rm"}
 	if opts.Publication != nil {
 		p := opts.Publication
+		// Named publication agents omit --rm so run() can inspect ownership and
+		// prove removal. SIGKILL leftovers are reaped at runner startup.
 		args = []string{"run", "--log-driver", "local", "--log-opt", "max-size=1m", "--log-opt", "max-file=2", "--name", p.agentName, "--label", "preloop.publication_execution=" + p.executionID, "--label", "preloop.publication_nonce=" + p.spec.Nonce, "--mount", "type=volume,src=" + p.exportVolume + ",dst=/preloop-publication-output", "--cap-drop=ALL", "--security-opt=no-new-privileges"}
 	}
 	if opts.Launch && !opts.PreserveEntrypoint {

--- a/cli/internal/cmd/runner_docker.go
+++ b/cli/internal/cmd/runner_docker.go
@@ -31,6 +31,7 @@ var workspaceIDRe = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}
 // runnerDockerOpts is the private-runner-only docker run surface. Hosted
 // executors ignore agent_config.runner; only this CLI honors these flags.
 type runnerDockerOpts struct {
+	Publication        *runnerPublication
 	Launch             bool
 	PreserveEntrypoint bool
 	MountDockerSocket  bool
@@ -58,6 +59,10 @@ func defaultNewRunnerJobCmd(image string, env map[string]string, opts runnerDock
 // from the runner process environment and never show up in `ps` output.
 func dockerRunArgs(image string, env map[string]string, opts runnerDockerOpts) []string {
 	args := []string{"run", "--rm"}
+	if opts.Publication != nil {
+		p := opts.Publication
+		args = []string{"run", "--log-driver", "local", "--log-opt", "max-size=1m", "--log-opt", "max-file=2", "--name", p.agentName, "--label", "preloop.publication_execution=" + p.executionID, "--label", "preloop.publication_nonce=" + p.spec.Nonce, "--mount", "type=volume,src=" + p.exportVolume + ",dst=/preloop-publication-output", "--cap-drop=ALL", "--security-opt=no-new-privileges"}
+	}
 	if opts.Launch && !opts.PreserveEntrypoint {
 		args = append(args, "--entrypoint", "/bin/bash")
 	}

--- a/cli/internal/cmd/runner_host_exec.go
+++ b/cli/internal/cmd/runner_host_exec.go
@@ -487,10 +487,9 @@ func newHostExecJobCmd(job map[string]any) (*exec.Cmd, string, time.Duration, er
 }
 
 func runnerHeartbeatMessage() map[string]any {
-	return map[string]any{
-		"type":               "heartbeat",
-		"host_exec_profiles": hostExecAdvertisements(),
-	}
+	msg := publicationHeartbeat()
+	msg["host_exec_profiles"] = hostExecAdvertisements()
+	return msg
 }
 
 func hostExecStructuredResult(raw []byte) (map[string]any, error) {

--- a/cli/internal/cmd/runner_publication.go
+++ b/cli/internal/cmd/runner_publication.go
@@ -31,6 +31,14 @@ var publicationSHA = regexp.MustCompile(`^[a-f0-9]{40}$`)
 var publicationImageRE = regexp.MustCompile(`^[A-Za-z0-9][^\s]*@sha256:[a-f0-9]{64}$`)
 var publicationVolumeRE = regexp.MustCompile(`^preloop-pub-[a-f0-9]{32}-(export|frozen)$`)
 
+type publicationHelperProbeCache struct {
+	mu    sync.Mutex
+	image string
+	ready bool
+}
+
+var publicationHelperProbe publicationHelperProbeCache
+
 // The Docker daemon belongs to the trusted runner. Helpers never inherit its
 // client environment inside their container. Their stdout is bounded and stderr
 // discarded; credential-bearing stdin is never included in errors or logs.
@@ -65,6 +73,24 @@ func (b *publicationBoundedOutput) Write(p []byte) (int, error) {
 	return n, nil
 }
 
+func publicationHelperReady(helper string) bool {
+	publicationHelperProbe.mu.Lock()
+	if publicationHelperProbe.image == helper && publicationHelperProbe.ready {
+		publicationHelperProbe.mu.Unlock()
+		return true
+	}
+	publicationHelperProbe.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	_, err := publicationDocker(ctx, nil, "image", "inspect", "--format", "{{.Id}}", helper)
+	cancel()
+	ready := err == nil
+	publicationHelperProbe.mu.Lock()
+	publicationHelperProbe.image = helper
+	publicationHelperProbe.ready = ready
+	publicationHelperProbe.mu.Unlock()
+	return ready
+}
+
 // Existing servers safely ignore this heartbeat extension. Readiness is local
 // operator configuration plus a bounded probe of an immutable helper image.
 func publicationHeartbeat() map[string]any {
@@ -72,10 +98,7 @@ func publicationHeartbeat() map[string]any {
 	capabilities := map[string]any{"version": 1, "helper_ready": false}
 	if publicationImageRE.MatchString(helper) {
 		capabilities["helper_image"] = helper
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		_, err := publicationDocker(ctx, nil, "image", "inspect", "--format", "{{.Id}}", helper)
-		cancel()
-		capabilities["helper_ready"] = err == nil
+		capabilities["helper_ready"] = publicationHelperReady(helper)
 	}
 	return map[string]any{"type": "heartbeat", "publication_capabilities": capabilities}
 }

--- a/cli/internal/cmd/runner_publication.go
+++ b/cli/internal/cmd/runner_publication.go
@@ -1,0 +1,697 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/preloop/preloop/cli/internal/config"
+)
+
+const publicationHelperEnv = "PRELOOP_RUNNER_PUBLICATION_HELPER_IMAGE"
+const publicationOutputLimit = 1024 * 1024
+const publicationRetention = 24 * time.Hour
+
+var publicationDigestRE = regexp.MustCompile(`^[a-f0-9]{64}$`)
+var publicationSHA = regexp.MustCompile(`^[a-f0-9]{40}$`)
+var publicationImageRE = regexp.MustCompile(`^[A-Za-z0-9][^\s]*@sha256:[a-f0-9]{64}$`)
+var publicationVolumeRE = regexp.MustCompile(`^preloop-pub-[a-f0-9]{32}-(export|frozen)$`)
+
+// The Docker daemon belongs to the trusted runner. Helpers never inherit its
+// client environment inside their container. Their stdout is bounded and stderr
+// discarded; credential-bearing stdin is never included in errors or logs.
+var publicationDocker = func(ctx context.Context, input []byte, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdin = bytes.NewReader(input)
+	output := &publicationBoundedOutput{}
+	cmd.Stdout, cmd.Stderr = output, io.Discard
+	err := cmd.Run()
+	if output.overflow {
+		return nil, errors.New("publication helper output exceeded limit")
+	}
+	if err != nil {
+		return output.data.Bytes(), errors.New("publication Docker command failed")
+	}
+	return output.data.Bytes(), nil
+}
+
+type publicationBoundedOutput struct {
+	data     bytes.Buffer
+	overflow bool
+}
+
+func (b *publicationBoundedOutput) Write(p []byte) (int, error) {
+	n := len(p)
+	remaining := publicationOutputLimit - b.data.Len()
+	if len(p) > remaining {
+		b.overflow = true
+		p = p[:remaining]
+	}
+	_, _ = b.data.Write(p)
+	return n, nil
+}
+
+// Existing servers safely ignore this heartbeat extension. Readiness is local
+// operator configuration plus a bounded probe of an immutable helper image.
+func publicationHeartbeat() map[string]any {
+	helper := os.Getenv(publicationHelperEnv)
+	capabilities := map[string]any{"version": 1, "helper_ready": false}
+	if publicationImageRE.MatchString(helper) {
+		capabilities["helper_image"] = helper
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		_, err := publicationDocker(ctx, nil, "image", "inspect", "--format", "{{.Id}}", helper)
+		cancel()
+		capabilities["helper_ready"] = err == nil
+	}
+	return map[string]any{"type": "heartbeat", "publication_capabilities": capabilities}
+}
+
+type publicationLeaseSpec struct {
+	Version                   int     `json:"version"`
+	Nonce                     string  `json:"nonce"`
+	Phase                     string  `json:"phase"`
+	RepositoryURL             string  `json:"repository_url"`
+	Branch                    string  `json:"branch"`
+	Base                      string  `json:"base"`
+	BaseSHA                   string  `json:"base_sha"`
+	ExpectedRemoteSHA         *string `json:"expected_remote_sha"`
+	VerificationImage         string  `json:"verification_image"`
+	VerificationBudgetSeconds int     `json:"verification_budget_seconds"`
+}
+type publicationManifest struct {
+	Version      int      `json:"version"`
+	HeadSHA      string   `json:"head_sha"`
+	TreeSHA      string   `json:"tree_sha"`
+	BundleSHA256 string   `json:"bundle_sha256"`
+	ChangedFiles []string `json:"changed_files"`
+}
+type publicationCheck struct {
+	ID             string `json:"id"`
+	Command        string `json:"command"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+	ExitCode       int    `json:"exit_code"`
+}
+type publicationEvent struct {
+	message map[string]any
+	outcome *leasedJobOutcome
+}
+type runnerPublication struct {
+	executionID       string
+	spec              publicationLeaseSpec
+	helperImage       string
+	agentName         string
+	exportVolume      string
+	frozenVolume      string
+	frozenReady       bool
+	frozenCreated     bool
+	manifest          publicationManifest
+	ctx               context.Context
+	cancel            context.CancelFunc
+	events            chan publicationEvent
+	replies           chan runnerWSMessage
+	phase             string
+	started           bool
+	stopRequested     atomic.Bool
+	mu                sync.Mutex
+	activeHelpers     map[string]bool
+	removalMu         sync.Mutex
+	removedContainers map[string]bool
+}
+
+func publicationFromJob(job map[string]any, opts runnerDockerOpts) (*runnerPublication, error) {
+	raw, exists := job["publication"]
+	if !exists || raw == nil {
+		return nil, nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil || len(encoded) > 16384 {
+		return nil, errors.New("invalid publication lease")
+	}
+	var spec publicationLeaseSpec
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&spec) != nil || spec.Version != 1 || spec.Phase != "agent" || !publicationDigestRE.MatchString(spec.Nonce) || !publicationSHA.MatchString(spec.BaseSHA) {
+		return nil, errors.New("invalid publication lease identity")
+	}
+	executionID, _ := job["execution_id"].(string)
+	if !workspaceIDRe.MatchString(executionID) {
+		return nil, errors.New("publication requires execution UUID")
+	}
+	if spec.ExpectedRemoteSHA != nil && !publicationSHA.MatchString(*spec.ExpectedRemoteSHA) {
+		return nil, errors.New("invalid publication remote revision")
+	}
+	repository, err := url.Parse(spec.RepositoryURL)
+	if err != nil || repository.Scheme != "https" || repository.Hostname() == "" || repository.User != nil || repository.RawQuery != "" || repository.Fragment != "" {
+		return nil, errors.New("publication requires credential-free repository binding")
+	}
+	if spec.Branch == "" || spec.Base == "" || spec.Branch == spec.Base || strings.HasPrefix(spec.Branch, "-") || strings.ContainsAny(spec.Branch+spec.Base, "\x00\r\n") {
+		return nil, errors.New("invalid publication branch binding")
+	}
+	if spec.VerificationBudgetSeconds < 30 || spec.VerificationBudgetSeconds > 14400 || !publicationImageRE.MatchString(spec.VerificationImage) {
+		return nil, errors.New("publication requires trusted verification image and bounded budget")
+	}
+	if opts.MountDockerSocket || opts.PersistWorkspace || len(opts.ExtraMounts) != 0 || opts.Network != "" {
+		return nil, errors.New("isolated publication rejects socket, workspace, network and extra mount access")
+	}
+	if mode, _ := job["execution_mode"].(string); mode == "host_exec" {
+		return nil, errors.New("native host execution cannot use isolated publication")
+	}
+	if cfg, ok := job["agent_config"].(map[string]any); ok {
+		if mode, _ := cfg["execution_mode"].(string); mode == "host_exec" {
+			return nil, errors.New("native host execution cannot use isolated publication")
+		}
+		if runner, ok := cfg["runner"].(map[string]any); ok {
+			for key := range runner {
+				switch key {
+				case "mount_docker_socket", "persist_workspace", "extra_mounts", "network", "preserve_image_entrypoint":
+				default:
+					return nil, errors.New("unsupported runner access in isolated publication")
+				}
+			}
+		}
+	}
+	helper := os.Getenv(publicationHelperEnv)
+	if !publicationImageRE.MatchString(helper) {
+		return nil, fmt.Errorf("set %s to a locally available trusted immutable helper image", publicationHelperEnv)
+	}
+	if err := cleanupPublicationRecovery(time.Now()); err != nil {
+		return nil, errors.New("publication recovery store could not be inspected")
+	}
+	root, err := publicationRecoveryRoot()
+	if err != nil {
+		return nil, err
+	}
+	retained, _ := os.ReadDir(root)
+	if len(retained) >= 64 {
+		return nil, errors.New("publication recovery retention limit reached; inspect retained work before retrying")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	suffix := make([]byte, 16)
+	if _, err := rand.Read(suffix); err != nil {
+		cancel()
+		return nil, errors.New("publication identity generation failed")
+	}
+	name := "preloop-pub-" + hex.EncodeToString(suffix)
+	p := &runnerPublication{executionID: executionID, spec: spec, helperImage: helper, agentName: name + "-agent", exportVolume: name + "-export", frozenVolume: name + "-frozen", ctx: ctx, cancel: cancel, events: make(chan publicationEvent, 2), replies: make(chan runnerWSMessage, 1), phase: "agent", activeHelpers: make(map[string]bool)}
+	probe, stop := context.WithTimeout(ctx, 15*time.Second)
+	defer stop()
+	if _, err := publicationDocker(probe, nil, "image", "inspect", "--format", "{{.Id}}", helper); err != nil {
+		cancel()
+		return nil, errors.New("trusted publication helper image is not available locally")
+	}
+	if _, err := publicationDocker(probe, nil, "image", "inspect", "--format", "{{.Id}}", spec.VerificationImage); err != nil {
+		cancel()
+		return nil, errors.New("trusted publication verification image is not available locally")
+	}
+
+	if _, err := publicationDocker(probe, nil, "volume", "create", "--label", "preloop.publication_execution="+executionID, p.exportVolume); err != nil {
+		cancel()
+		return nil, errors.New("publication export volume could not be created")
+	}
+	return p, nil
+}
+
+func (p *runnerPublication) ownedContainerID(ctx context.Context, name string) (string, error) {
+	data, err := publicationDocker(ctx, nil, "inspect", "--format", "{{json .}}", name)
+	if err != nil {
+		return "", errors.New("publication runtime ownership could not be inspected")
+	}
+	var state struct {
+		ID     string `json:"Id"`
+		Config struct {
+			Labels map[string]string `json:"Labels"`
+		} `json:"Config"`
+	}
+	if json.Unmarshal(data, &state) != nil || !publicationDigestRE.MatchString(state.ID) || state.Config.Labels["preloop.publication_execution"] != p.executionID || state.Config.Labels["preloop.publication_nonce"] != p.spec.Nonce {
+		return "", errors.New("publication runtime ownership mismatch")
+	}
+	return state.ID, nil
+}
+
+func (p *runnerPublication) removeOwned(name string) error {
+	// Serialize cancellation and worker cleanup. Only previously proven removal
+	// permits an absent runtime to count as removed on a concurrent cleanup path.
+	p.removalMu.Lock()
+	defer p.removalMu.Unlock()
+	if p.removedContainers[name] {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	id, err := p.ownedContainerID(ctx, name)
+	if err != nil {
+		return err
+	}
+	for attempt := 0; attempt < 3; attempt++ {
+		_, _ = publicationDocker(ctx, nil, "rm", "--force", id)
+		remaining, inspectErr := publicationDocker(ctx, nil, "ps", "--all", "--quiet", "--no-trunc", "--filter", "id="+id)
+		if inspectErr == nil && strings.TrimSpace(string(remaining)) == "" {
+			if p.removedContainers == nil {
+				p.removedContainers = map[string]bool{}
+			}
+			p.removedContainers[name] = true
+			return nil
+		}
+		if attempt < 2 {
+			select {
+			case <-time.After(100 * time.Millisecond):
+			case <-ctx.Done():
+				return errors.New("publication runtime removal timed out")
+			}
+		}
+	}
+	return errors.New("publication runtime removal was not confirmed")
+}
+func (p *runnerPublication) volumeUnused(volume string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	data, err := publicationDocker(ctx, nil, "ps", "--all", "--quiet", "--filter", "volume="+volume)
+	if err != nil || strings.TrimSpace(string(data)) != "" {
+		return errors.New("publication volume still has runtime users")
+	}
+	return nil
+}
+func (p *runnerPublication) removeVolume(volume string) error {
+	if err := p.volumeUnused(volume); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := publicationDocker(ctx, nil, "volume", "rm", volume)
+	return err
+}
+
+// Named containers are never --rm: inspect real process exit and destroy the
+// actual owned ID explicitly. A failed client connection cannot prove removal.
+func (p *runnerPublication) runContainer(ctx context.Context, mode, image string, input []byte, mounts []string, command []string, network bool) ([]byte, error) {
+	suffix := make([]byte, 8)
+	if _, err := rand.Read(suffix); err != nil {
+		return nil, errors.New("publication helper identity failed")
+	}
+	name := p.agentName + "-" + mode + "-" + hex.EncodeToString(suffix)
+	args := []string{"run", "--log-driver", "none", "--name", name, "--label", "preloop.publication_execution=" + p.executionID, "--label", "preloop.publication_nonce=" + p.spec.Nonce, "--read-only", "--cap-drop=ALL", "--security-opt=no-new-privileges", "--pids-limit=256", "--memory=2g", "--cpus=2", "--tmpfs", "/tmp:rw,nosuid,size=256m", "--tmpfs", "/work:rw,nosuid,size=1g", "--env", "HOME=/tmp", "--env", "GIT_CONFIG_NOSYSTEM=1", "--env", "GIT_CONFIG_GLOBAL=/dev/null", "--env", "GIT_TERMINAL_PROMPT=0"}
+	if !network {
+		args = append(args, "--network", "none")
+	}
+	for _, mount := range mounts {
+		args = append(args, "--mount", mount)
+	}
+	args = append(args, "--entrypoint", command[0], "-i", image)
+	args = append(args, command[1:]...)
+	p.mu.Lock()
+	p.activeHelpers[name] = true
+	p.mu.Unlock()
+	output, runErr := publicationDocker(ctx, input, args...)
+	stateCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	stateData, inspectErr := publicationDocker(stateCtx, nil, "inspect", "--format", "{{json .State}}", name)
+	cancel()
+	var state struct {
+		Status   string
+		Running  *bool
+		ExitCode *int
+	}
+	stateErr := json.Unmarshal(stateData, &state)
+	removeErr := p.removeOwned(name)
+	if removeErr == nil {
+		p.mu.Lock()
+		delete(p.activeHelpers, name)
+		p.mu.Unlock()
+	}
+	if removeErr != nil {
+		return nil, removeErr
+	}
+	if runErr != nil || inspectErr != nil || stateErr != nil || (state.Status != "exited" && state.Status != "dead") || state.Running == nil || *state.Running || state.ExitCode == nil || *state.ExitCode != 0 {
+		message := "publication " + mode + " did not exit successfully; ensure the trusted image supplies required tools and test dependencies"
+		if mode == "verify" && len(output) > 0 {
+			message += ": " + publicationDiagnosticTail(output)
+		}
+		return nil, errors.New(message)
+	}
+	return output, nil
+}
+
+func (p *runnerPublication) envelope(kind string) map[string]any {
+	return map[string]any{"type": kind, "version": 1, "execution_id": p.executionID, "nonce": p.spec.Nonce, "head_sha": p.manifest.HeadSHA, "tree_sha": p.manifest.TreeSHA, "bundle_sha256": p.manifest.BundleSHA256}
+}
+func (p *runnerPublication) send(message map[string]any) error {
+	select {
+	case p.events <- publicationEvent{message: message}:
+		return nil
+	case <-p.ctx.Done():
+		return errors.New("publication cancelled or disconnected")
+	}
+}
+func (p *runnerPublication) reply(kind string) (runnerWSMessage, error) {
+	select {
+	case msg := <-p.replies:
+		if msg.Type != kind || msg.ExecutionID != p.executionID || msg.Nonce != p.spec.Nonce || msg.Version != 1 || msg.HeadSHA != p.manifest.HeadSHA || msg.BundleSHA256 != p.manifest.BundleSHA256 || (kind != "publication_ack" && msg.TreeSHA != p.manifest.TreeSHA) {
+			if msg.Lease != nil {
+				delete(msg.Lease, "token")
+			}
+			return runnerWSMessage{}, errors.New("publication reply phase or immutable identity mismatch")
+		}
+		return msg, nil
+	case <-p.ctx.Done():
+		return runnerWSMessage{}, errors.New("publication cancelled, disconnected or expired")
+	}
+}
+func (p *runnerPublication) accept(msg runnerWSMessage) error {
+	p.mu.Lock()
+	phase := p.phase
+	p.mu.Unlock()
+	if msg.ExecutionID != p.executionID || msg.Nonce != p.spec.Nonce || msg.Type != phase {
+		return errors.New("unexpected or stale publication reply")
+	}
+	select {
+	case p.replies <- msg:
+		return nil
+	default:
+		return errors.New("duplicate publication reply")
+	}
+}
+func (p *runnerPublication) awaitPhase(phase string, message map[string]any) (runnerWSMessage, error) {
+	p.mu.Lock()
+	p.phase = phase
+	p.mu.Unlock()
+	if err := p.send(message); err != nil {
+		return runnerWSMessage{}, err
+	}
+	reply, err := p.reply(phase)
+	p.mu.Lock()
+	p.phase = "working"
+	p.mu.Unlock()
+	return reply, err
+}
+
+func (p *runnerPublication) start(outcome leasedJobOutcome) {
+	p.started = true
+	go func() {
+		err := p.run(outcome.status == "SUCCEEDED")
+		if err != nil {
+			if outcome.status != "STOPPED" {
+				outcome.status = "FAILED"
+			}
+			if p.stopRequested.Load() {
+				outcome.status = "STOPPED"
+			}
+			outcome.errMsg = err.Error()
+			if reference, retainErr := p.retainRecovery(); retainErr == nil {
+				if outcome.result == nil {
+					outcome.result = map[string]any{}
+				}
+				outcome.result["publication_recovery"] = reference
+				outcome.errMsg += "; local recovery retained: " + reference
+			} else {
+				outcome.errMsg += "; recovery retention requires operator attention"
+			}
+		}
+		if err == nil {
+			outcome.publicationAcknowledged = true
+		}
+		// On success run has received the controller ack. Only now may ordinary
+		// completion finalize the execution. Failures never request another lease.
+		select {
+		case p.events <- publicationEvent{outcome: &outcome}:
+		default:
+		}
+	}()
+}
+
+func (p *runnerPublication) run(agentSucceeded bool) error {
+	if err := p.removeOwned(p.agentName); err != nil {
+		return err
+	}
+	if err := p.volumeUnused(p.exportVolume); err != nil {
+		return err
+	}
+	if !agentSucceeded {
+		return errors.New("agent did not produce a successful publication candidate")
+	}
+	if p.ctx.Err() != nil {
+		return errors.New("publication cancelled before freezing output")
+	}
+	ctx, cancel := context.WithTimeout(p.ctx, time.Duration(p.spec.VerificationBudgetSeconds)*time.Second+120*time.Second)
+	defer cancel()
+	// This deadline includes remote replies, not only Docker subprocesses.
+	timer := time.AfterFunc(time.Duration(p.spec.VerificationBudgetSeconds)*time.Second+120*time.Second, p.cancel)
+	defer timer.Stop()
+	if _, err := publicationDocker(ctx, nil, "volume", "create", "--label", "preloop.publication_execution="+p.executionID, p.frozenVolume); err != nil {
+		return errors.New("publication frozen volume creation failed")
+	}
+	p.frozenCreated = true
+	input, _ := json.Marshal(map[string]any{"base_sha": p.spec.BaseSHA})
+	output, err := p.runContainer(ctx, "freeze", p.helperImage, input, []string{"type=volume,src=" + p.exportVolume + ",dst=/source,readonly", "type=volume,src=" + p.frozenVolume + ",dst=/input"}, []string{"python", "-m", "preloop.services.publication_worker", "freeze"}, false)
+	if err != nil {
+		return err
+	}
+	if json.Unmarshal(output, &p.manifest) != nil || p.manifest.Version != 1 || !publicationSHA.MatchString(p.manifest.HeadSHA) || !publicationSHA.MatchString(p.manifest.TreeSHA) || !publicationDigestRE.MatchString(p.manifest.BundleSHA256) || len(p.manifest.ChangedFiles) > 10000 {
+		return errors.New("invalid frozen publication manifest")
+	}
+	p.frozenReady = true
+	if err := p.removeVolume(p.exportVolume); err != nil {
+		return err
+	}
+	p.exportVolume = ""
+	candidate := p.envelope("publication_candidate")
+	candidate["changed_files"] = p.manifest.ChangedFiles
+	verify, err := p.awaitPhase("publication_verify", candidate)
+	if err != nil {
+		return err
+	}
+	if verify.Image != p.spec.VerificationImage || verify.BudgetSeconds < 1 || verify.BudgetSeconds > p.spec.VerificationBudgetSeconds || len(verify.Checks) == 0 || len(verify.Checks) > 100 {
+		return errors.New("publication verification policy is missing or does not match trusted lease")
+	}
+	verificationCtx, stopChecks := context.WithTimeout(ctx, time.Duration(verify.BudgetSeconds)*time.Second)
+	defer stopChecks()
+	seen := map[string]bool{}
+	checks := make([]publicationCheck, 0, len(verify.Checks))
+	for _, check := range verify.Checks {
+		if check.ID == "" || len(check.ID) > 200 || seen[check.ID] || check.Command == "" || len(check.Command) > 32768 || check.TimeoutSeconds < 1 || check.TimeoutSeconds > 3600 {
+			return errors.New("invalid publication verification check")
+		}
+		seen[check.ID] = true
+		checkCtx, stop := context.WithTimeout(verificationCtx, time.Duration(check.TimeoutSeconds)*time.Second)
+		script := publicationVerifierScript(p.manifest.HeadSHA, check.Command)
+		_, err = p.runContainer(checkCtx, "verify", verify.Image, []byte(script), []string{"type=volume,src=" + p.frozenVolume + ",dst=/input,readonly"}, []string{"/bin/bash", "-se"}, false)
+		stop()
+		if err != nil {
+			return err
+		}
+		check.ExitCode = 0
+		checks = append(checks, check)
+	}
+	if err := p.volumeUnused(p.frozenVolume); err != nil {
+		return err
+	}
+	verified := p.envelope("publication_verified")
+	verified["checks"] = checks
+	verified["agent_removed"] = true
+	verified["verifiers_removed"] = true
+	publish, err := p.awaitPhase("publication_publish", verified)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if publish.Lease != nil {
+			delete(publish.Lease, "token")
+		}
+	}()
+	if err = p.validateWriteReply(publish); err != nil {
+		return err
+	}
+	payload, err := publicationPublishInput(publish.Binding, publish.Lease, p.manifest.BundleSHA256)
+	if err != nil {
+		return errors.New("invalid publication helper request")
+	}
+	expiry, _ := time.Parse(time.RFC3339Nano, publish.Lease["expires_at"].(string))
+	publishCtx, stopPublish := context.WithDeadline(ctx, expiry)
+	output, err = p.runContainer(publishCtx, "publish", p.helperImage, payload, []string{"type=volume,src=" + p.frozenVolume + ",dst=/input,readonly"}, []string{"python", "-m", "preloop.services.publication_worker", "publish"}, true)
+	stopPublish()
+	for i := range payload {
+		payload[i] = 0
+	}
+	if err != nil {
+		return err
+	}
+	var receipt map[string]any
+	if json.Unmarshal(output, &receipt) != nil || receipt["head_sha"] != p.manifest.HeadSHA || receipt["branch"] != p.spec.Branch {
+		return errors.New("invalid publication receipt")
+	}
+	if token, _ := publish.Lease["token"].(string); token != "" && bytes.Contains(output, []byte(token)) {
+		return errors.New("unsafe publication receipt")
+	}
+	delete(publish.Lease, "token")
+	completed := p.envelope("publication_complete")
+	completed["publication"] = receipt
+	if _, err = p.awaitPhase("publication_ack", completed); err != nil {
+		return err
+	}
+	if err = p.removeVolume(p.frozenVolume); err != nil {
+		_, _ = p.retainRecovery()
+	} else {
+		p.frozenVolume = ""
+	}
+	return nil
+}
+
+func (p *runnerPublication) validateWriteReply(msg runnerWSMessage) error {
+	if msg.Binding["repository_url"] != p.spec.RepositoryURL || msg.Binding["head_sha"] != p.manifest.HeadSHA || msg.Binding["branch"] != p.spec.Branch || msg.Binding["base"] != p.spec.Base || msg.Lease["repository_url"] != p.spec.RepositoryURL {
+		return errors.New("publication write binding mismatch")
+	}
+	expected := msg.Binding["expected_remote_sha"]
+	if (p.spec.ExpectedRemoteSHA == nil && expected != nil) || (p.spec.ExpectedRemoteSHA != nil && expected != *p.spec.ExpectedRemoteSHA) {
+		return errors.New("publication remote compare-and-swap mismatch")
+	}
+	token, ok := msg.Lease["token"].(string)
+	expires, _ := msg.Lease["expires_at"].(string)
+	deadline, err := time.Parse(time.RFC3339Nano, expires)
+	if !ok || token == "" || len(token) > 16384 || err != nil || !deadline.After(time.Now()) || deadline.After(time.Now().Add(65*time.Minute)) {
+		return errors.New("publication write lease invalid or expired")
+	}
+	return nil
+}
+
+func publicationVerifierScript(head, command string) string {
+	return "set -euo pipefail\nexec 2>&1\numask 077\nexport HOME=/tmp GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_TERMINAL_PROMPT=0\nunset GIT_CONFIG GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS GIT_DIR GIT_WORK_TREE\nmkdir -p /work\ngit -c core.hooksPath=/dev/null -c init.templateDir=/dev/null clone --no-checkout /input/branch.bundle /work/repo\ncd /work/repo\ngit config --local core.hooksPath /dev/null\ngit -c core.hooksPath=/dev/null checkout --detach " + head + "\ntest \"$(git rev-parse HEAD)\" = " + head + "\n" + command + "\n"
+}
+
+func (p *runnerPublication) abort() {
+	p.cancel()
+	p.mu.Lock()
+	names := make([]string, 0, len(p.activeHelpers))
+	for name := range p.activeHelpers {
+		names = append(names, name)
+	}
+	p.mu.Unlock()
+	for _, name := range names {
+		_ = p.removeOwned(name)
+	}
+	if !p.started {
+		_ = p.removeOwned(p.agentName)
+		_, _ = p.retainRecovery()
+	}
+}
+
+type publicationRecovery struct {
+	ExecutionID string    `json:"execution_id"`
+	Volume      string    `json:"volume"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
+func (p *runnerPublication) retainRecovery() (string, error) {
+	volume := p.exportVolume
+	if p.frozenReady {
+		volume = p.frozenVolume
+	}
+	if volume == "" || !publicationVolumeRE.MatchString(volume) {
+		return "", errors.New("publication recovery volume unavailable")
+	}
+	secondary := p.frozenVolume
+	if p.frozenReady {
+		secondary = p.exportVolume
+	}
+	if secondary != "" && secondary != volume && (p.frozenCreated || p.frozenReady) {
+		if err := p.removeVolume(secondary); err != nil {
+			if _, retainErr := p.retainVolume(secondary); retainErr != nil {
+				return "", retainErr
+			}
+		}
+	}
+	return p.retainVolume(volume)
+}
+
+func (p *runnerPublication) retainVolume(volume string) (string, error) {
+	root, err := publicationRecoveryRoot()
+	if err != nil {
+		return "", err
+	}
+	if err = os.MkdirAll(root, 0700); err != nil {
+		return "", err
+	}
+	record := publicationRecovery{ExecutionID: p.executionID, Volume: volume, ExpiresAt: time.Now().Add(publicationRetention)}
+	data, _ := json.Marshal(record)
+	name := volume + ".json"
+	if err = os.WriteFile(filepath.Join(root, name), data, 0600); err != nil {
+		return "", err
+	}
+	return "runner-local:" + p.executionID + ":" + volume, nil
+}
+
+var publicationRecoveryRoot = func() (string, error) {
+	root, err := config.GetConfigDir()
+	return filepath.Join(root, "publication-recovery"), err
+}
+
+func cleanupPublicationRecovery(now time.Time) error {
+	root, err := publicationRecoveryRoot()
+	if err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		info, err := os.Lstat(path)
+		if err != nil || !info.Mode().IsRegular() || info.Size() > 4096 {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var record publicationRecovery
+		if json.Unmarshal(data, &record) != nil || !publicationVolumeRE.MatchString(record.Volume) || !workspaceIDRe.MatchString(record.ExecutionID) || now.Before(record.ExpiresAt) {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		labelsRaw, err := publicationDocker(ctx, nil, "volume", "inspect", "--format", "{{json .Labels}}", record.Volume)
+		cancel()
+		var labels map[string]string
+		if err != nil || json.Unmarshal(labelsRaw, &labels) != nil || labels["preloop.publication_execution"] != record.ExecutionID {
+			continue
+		}
+		p := runnerPublication{executionID: record.ExecutionID}
+		if p.removeVolume(record.Volume) == nil {
+			_ = os.Remove(path)
+		}
+	}
+	return nil
+}
+
+func publicationPublishInput(binding, lease map[string]any, digest string) ([]byte, error) {
+	return json.Marshal(map[string]any{"binding": binding, "lease": lease, "bundle_sha256": digest})
+}
+
+func publicationDiagnosticTail(output []byte) string {
+	if len(output) > 4096 {
+		output = output[len(output)-4096:]
+	}
+	return strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' || r >= 32 && r != 127 {
+			return r
+		}
+		return -1
+	}, strings.ToValidUTF8(string(output), "?"))
+}

--- a/cli/internal/cmd/runner_publication.go
+++ b/cli/internal/cmd/runner_publication.go
@@ -447,10 +447,9 @@ func (p *runnerPublication) start(outcome leasedJobOutcome) {
 		}
 		// On success run has received the controller ack. Only now may ordinary
 		// completion finalize the execution. Failures never request another lease.
-		select {
-		case p.events <- publicationEvent{outcome: &outcome}:
-		default:
-		}
+		// Block until the session loop accepts this terminal outcome. A
+		// non-blocking send can drop it when the buffered events channel is full.
+		p.events <- publicationEvent{outcome: &outcome}
 	}()
 }
 
@@ -701,6 +700,64 @@ func cleanupPublicationRecovery(now time.Time) error {
 		}
 	}
 	return nil
+}
+
+func retainedPublicationVolumes() map[string]bool {
+	keep := map[string]bool{}
+	root, err := publicationRecoveryRoot()
+	if err != nil {
+		return keep
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return keep
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(root, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var record publicationRecovery
+		if json.Unmarshal(data, &record) != nil || !publicationVolumeRE.MatchString(record.Volume) {
+			continue
+		}
+		keep[record.Volume] = true
+	}
+	return keep
+}
+
+// reapOrphanedPublicationRuntimes removes publication containers and unretained
+// volumes left behind when the runner is SIGKILL'd. Named agent containers omit
+// --rm so ownership can be inspected; this startup pass is the bounded
+// replacement for that missing auto-remove. Recovery volumes listed in local
+// metadata are kept so 24-hour retain still works.
+func reapOrphanedPublicationRuntimes() {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	listed, err := publicationDocker(ctx, nil, "ps", "--all", "--quiet", "--no-trunc", "--filter", "label=preloop.publication_execution")
+	if err == nil {
+		for _, id := range splitNonEmptyLines(string(listed)) {
+			if publicationDigestRE.MatchString(id) {
+				_, _ = publicationDocker(ctx, nil, "rm", "--force", id)
+			}
+		}
+	}
+	_ = cleanupPublicationRecovery(time.Now())
+	keep := retainedPublicationVolumes()
+	volumes, err := publicationDocker(ctx, nil, "volume", "ls", "--quiet", "--filter", "label=preloop.publication_execution")
+	if err != nil {
+		return
+	}
+	for _, volume := range splitNonEmptyLines(string(volumes)) {
+		if keep[volume] || !publicationVolumeRE.MatchString(volume) {
+			continue
+		}
+		p := runnerPublication{}
+		_ = p.removeVolume(volume)
+	}
 }
 
 func publicationPublishInput(binding, lease map[string]any, digest string) ([]byte, error) {

--- a/cli/internal/cmd/runner_publication_test.go
+++ b/cli/internal/cmd/runner_publication_test.go
@@ -903,6 +903,122 @@ func TestPublicationHaltRetainsStoppedOutcome(t *testing.T) {
 	}
 }
 
+func TestIsolatedPublicationHostExecError(t *testing.T) {
+	job := testPublicationJob()
+	if err := isolatedPublicationHostExecError(job); err != nil {
+		t.Fatal(err)
+	}
+	job["host_exec_profile"] = "native"
+	if err := isolatedPublicationHostExecError(job); err == nil || !strings.Contains(err.Error(), "native host execution cannot use isolated publication") {
+		t.Fatalf("err = %v", err)
+	}
+	delete(job, "publication")
+	if err := isolatedPublicationHostExecError(job); err != nil {
+		t.Fatal(err)
+	}
+	job["publication"] = nil
+	if err := isolatedPublicationHostExecError(job); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBeginLeasedJobRejectsHostExecIsolatedPublication(t *testing.T) {
+	job := testPublicationJob()
+	job["host_exec_profile"] = "native"
+	var last *leasedJobOutcome
+	var running *exec.Cmd
+	var execID string
+	var jobDone <-chan leasedJobOutcome
+	halted := atomic.Bool{}
+	err := beginLeasedJob(nil, job, false, io.Discard, &running, &execID, &jobDone, &halted, &last, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if running != nil || execID != "" || jobDone != nil {
+		t.Fatal("host-exec routing started an isolated publication job")
+	}
+	if last == nil || last.status != "FAILED" || !strings.Contains(last.errMsg, "native host execution cannot use isolated publication") {
+		t.Fatalf("outcome = %#v", last)
+	}
+}
+
+func TestPublicationTerminalOutcomeIsNotDroppedWhenEventsBuffered(t *testing.T) {
+	p, _ := setupPublication(t)
+	p.cancel()
+	p.events <- publicationEvent{message: map[string]any{"type": "stale-one"}}
+	p.events <- publicationEvent{message: map[string]any{"type": "stale-two"}}
+	p.start(leasedJobOutcome{executionID: p.executionID, status: "FAILED", errMsg: "agent failed"})
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case event := <-p.events:
+			if event.outcome != nil {
+				if event.outcome.status != "FAILED" || event.outcome.publicationAcknowledged {
+					t.Fatalf("outcome = %#v", event.outcome)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("terminal publication outcome was dropped")
+		}
+	}
+}
+
+func TestReapOrphanedPublicationRuntimesRemovesContainersAndUnretainedVolumes(t *testing.T) {
+	root := t.TempDir()
+	priorRoot := publicationRecoveryRoot
+	publicationRecoveryRoot = func() (string, error) { return root, nil }
+	t.Cleanup(func() { publicationRecoveryRoot = priorRoot })
+
+	orphanID := strings.Repeat("a", 64)
+	kept := "preloop-pub-" + strings.Repeat("b", 32) + "-export"
+	orphanVol := "preloop-pub-" + strings.Repeat("c", 32) + "-frozen"
+	record, err := json.Marshal(publicationRecovery{
+		ExecutionID: "12345678-1234-1234-1234-123456789012",
+		Volume:      kept,
+		ExpiresAt:   time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, kept+".json"), record, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var removedIDs []string
+	var removedVolumes []string
+	prior := publicationDocker
+	publicationDocker = func(ctx context.Context, input []byte, args ...string) ([]byte, error) {
+		switch {
+		case args[0] == "ps" && args[len(args)-1] == "label=preloop.publication_execution":
+			return []byte(orphanID), nil
+		case args[0] == "rm":
+			removedIDs = append(removedIDs, args[len(args)-1])
+			return nil, nil
+		case args[0] == "volume" && args[1] == "ls":
+			return []byte(kept + "\n" + orphanVol), nil
+		case args[0] == "volume" && args[1] == "inspect":
+			return json.Marshal(map[string]string{"preloop.publication_execution": "12345678-1234-1234-1234-123456789012"})
+		case args[0] == "ps" && strings.HasPrefix(args[len(args)-1], "volume="):
+			return nil, nil
+		case args[0] == "volume" && args[1] == "rm":
+			removedVolumes = append(removedVolumes, args[2])
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unexpected docker args %v", args)
+		}
+	}
+	t.Cleanup(func() { publicationDocker = prior })
+
+	reapOrphanedPublicationRuntimes()
+	if len(removedIDs) != 1 || removedIDs[0] != orphanID {
+		t.Fatalf("containers removed = %v", removedIDs)
+	}
+	if len(removedVolumes) != 1 || removedVolumes[0] != orphanVol {
+		t.Fatalf("volumes removed = %v", removedVolumes)
+	}
+}
+
 func TestPublicationConsumesPythonControllerProtocolFixture(t *testing.T) {
 	raw, err := os.ReadFile("../../../backend/tests/fixtures/private_publication_protocol.json")
 	if err != nil {

--- a/cli/internal/cmd/runner_publication_test.go
+++ b/cli/internal/cmd/runner_publication_test.go
@@ -771,6 +771,7 @@ func TestPublicationHeartbeatReportsOnlyLocallyReadyImmutableHelper(t *testing.T
 		{name: "ready", image: "helper@sha256:" + strings.Repeat("a", 64), ready: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			publicationHelperProbe = publicationHelperProbeCache{}
 			t.Setenv(publicationHelperEnv, tc.image)
 			fake.helperMissing = tc.missing
 			before := len(fake.calls)
@@ -783,6 +784,15 @@ func TestPublicationHeartbeatReportsOnlyLocallyReadyImmutableHelper(t *testing.T
 				t.Fatal("probed unconfigured helper")
 			}
 		})
+	}
+	t.Setenv(publicationHelperEnv, "helper@sha256:"+strings.Repeat("a", 64))
+	fake.helperMissing = false
+	publicationHelperProbe = publicationHelperProbeCache{}
+	publicationHeartbeat()
+	before := len(fake.calls)
+	publicationHeartbeat()
+	if len(fake.calls) != before {
+		t.Fatal("re-probed a helper image that was already ready")
 	}
 }
 

--- a/cli/internal/cmd/runner_publication_test.go
+++ b/cli/internal/cmd/runner_publication_test.go
@@ -1,0 +1,980 @@
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"reflect"
+	"sync/atomic"
+
+	"github.com/gorilla/websocket"
+	"github.com/preloop/preloop/cli/internal/testenv"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type publicationFakeContainer struct {
+	id      string
+	labels  map[string]string
+	args    []string
+	removed bool
+	running bool
+	exit    int
+}
+type publicationFakeDocker struct {
+	mu             sync.Mutex
+	containers     map[string]*publicationFakeContainer
+	calls          [][]string
+	inputs         [][]byte
+	failDelete     bool
+	delayedDelete  bool
+	failVerifier   bool
+	blockVerifier  bool
+	badManifest    bool
+	residual       bool
+	helperMissing  bool
+	removedVolumes []string
+}
+
+func (f *publicationFakeDocker) run(ctx context.Context, input []byte, args ...string) ([]byte, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, append([]string(nil), args...))
+	f.inputs = append(f.inputs, append([]byte(nil), input...))
+	if args[0] == "image" {
+		f.mu.Unlock()
+		if f.helperMissing {
+			return nil, errors.New("missing")
+		}
+		return []byte("image"), nil
+	}
+	if args[0] == "volume" {
+		if args[1] == "rm" {
+			f.removedVolumes = append(f.removedVolumes, args[2])
+		}
+		f.mu.Unlock()
+		return []byte("volume"), nil
+	}
+	if args[0] == "run" {
+		name := ""
+		labels := map[string]string{}
+		for i, arg := range args {
+			if arg == "--name" {
+				name = args[i+1]
+			}
+			if arg == "--label" {
+				kv := strings.SplitN(args[i+1], "=", 2)
+				labels[kv[0]] = kv[1]
+			}
+		}
+		c := &publicationFakeContainer{id: fmt.Sprintf("%064x", len(f.containers)+1), labels: labels, args: append([]string(nil), args...)}
+		f.containers[name] = c
+		mode := args[len(args)-1]
+		if mode == "-se" && f.failVerifier {
+			c.exit = 1
+		}
+		if mode == "-se" && f.blockVerifier {
+			c.running = true
+			f.mu.Unlock()
+			<-ctx.Done()
+			return nil, errors.New("cancelled")
+		}
+		f.mu.Unlock()
+		if mode == "freeze" {
+			if f.badManifest {
+				return []byte(`{"version":1,"head_sha":"bad"}`), nil
+			}
+			b, _ := json.Marshal(testPublicationManifest())
+			return b, nil
+		}
+		if mode == "publish" {
+			return []byte(`{"url":"https://github.com/example/repo/pull/1","number":1,"branch":"implementation","provider":"github","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata_warnings":[]}`), nil
+		}
+		return []byte("test output"), nil
+	}
+	if args[0] == "inspect" {
+		name := args[len(args)-1]
+		c := f.containers[name]
+		if c == nil || c.removed {
+			f.mu.Unlock()
+			return nil, errors.New("not found")
+		}
+		var data []byte
+		if args[2] == "{{json .State}}" {
+			data, _ = json.Marshal(map[string]any{"Status": "exited", "Running": c.running, "ExitCode": c.exit})
+		} else {
+			data, _ = json.Marshal(map[string]any{"Id": c.id, "Config": map[string]any{"Labels": c.labels}})
+		}
+		f.mu.Unlock()
+		return data, nil
+	}
+	if args[0] == "rm" {
+		for _, c := range f.containers {
+			if c.id == args[len(args)-1] && !f.failDelete && !f.delayedDelete {
+				c.removed = true
+			}
+		}
+		f.mu.Unlock()
+		if f.failDelete {
+			return nil, errors.New("delete failed")
+		}
+		return nil, nil
+	}
+	if args[0] == "ps" {
+		filter := args[len(args)-1]
+		ids := []string{}
+		for _, c := range f.containers {
+			if c.removed {
+				continue
+			}
+			if filter == "id="+c.id || (strings.HasPrefix(filter, "volume=") && strings.Contains(strings.Join(c.args, " "), strings.TrimPrefix(filter, "volume="))) {
+				ids = append(ids, c.id)
+			}
+		}
+		if f.residual && strings.HasPrefix(filter, "volume=") {
+			ids = append(ids, strings.Repeat("f", 64))
+		}
+		f.mu.Unlock()
+		return []byte(strings.Join(ids, "\n")), nil
+	}
+	f.mu.Unlock()
+	return nil, fmt.Errorf("unexpected fake Docker command %q", args[0])
+}
+func testPublicationManifest() publicationManifest {
+	return publicationManifest{Version: 1, HeadSHA: strings.Repeat("a", 40), TreeSHA: strings.Repeat("b", 40), BundleSHA256: strings.Repeat("c", 64), ChangedFiles: []string{"app.py"}}
+}
+func testPublicationJob() map[string]any {
+	return map[string]any{"execution_id": "12345678-1234-1234-1234-123456789012", "agent_type": "codex", "publication": map[string]any{"version": 1, "nonce": strings.Repeat("d", 64), "phase": "agent", "repository_url": "https://github.com/example/repo.git", "branch": "implementation", "base": "main", "base_sha": strings.Repeat("e", 40), "expected_remote_sha": nil, "verification_image": "trusted/tests@sha256:" + strings.Repeat("f", 64), "verification_budget_seconds": 30}}
+}
+func setupPublication(t *testing.T) (*runnerPublication, *publicationFakeDocker) {
+	t.Helper()
+	fake := &publicationFakeDocker{containers: map[string]*publicationFakeContainer{}}
+	prior := publicationDocker
+	publicationDocker = fake.run
+	t.Cleanup(func() { publicationDocker = prior })
+	priorRoot := publicationRecoveryRoot
+	root := t.TempDir()
+	publicationRecoveryRoot = func() (string, error) { return root, nil }
+	t.Cleanup(func() { publicationRecoveryRoot = priorRoot })
+	t.Setenv(publicationHelperEnv, "trusted/helper@sha256:"+strings.Repeat("f", 64))
+	p, err := publicationFromJob(testPublicationJob(), runnerDockerOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(p.cancel)
+	fake.containers[p.agentName] = &publicationFakeContainer{id: strings.Repeat("1", 64), labels: map[string]string{"preloop.publication_execution": p.executionID, "preloop.publication_nonce": p.spec.Nonce}, args: []string{p.exportVolume}}
+	return p, fake
+}
+func publicationReply(p *runnerPublication, kind string) runnerWSMessage {
+	m := p.manifest
+	reply := runnerWSMessage{Type: kind, Version: 1, ExecutionID: p.executionID, Nonce: p.spec.Nonce, HeadSHA: m.HeadSHA, TreeSHA: m.TreeSHA, BundleSHA256: m.BundleSHA256}
+	switch kind {
+	case "publication_verify":
+		reply.Image = p.spec.VerificationImage
+		reply.BudgetSeconds = 30
+		reply.Checks = []publicationCheck{{ID: "unit", Command: "true", TimeoutSeconds: 2}}
+	case "publication_publish":
+		reply.Binding = map[string]any{"repository_url": p.spec.RepositoryURL, "head_sha": m.HeadSHA, "branch": p.spec.Branch, "base": p.spec.Base, "expected_remote_sha": nil}
+		reply.Lease = map[string]any{"repository_url": p.spec.RepositoryURL, "token": "private-write-token", "expires_at": time.Now().Add(time.Minute).UTC().Format(time.RFC3339)}
+	}
+	return reply
+}
+func servePublication(p *runnerPublication, mutate func(*runnerWSMessage)) <-chan []string {
+	done := make(chan []string, 1)
+	go func() {
+		var seen []string
+		for {
+			select {
+			case event := <-p.events:
+				if event.message == nil {
+					continue
+				}
+				kind := event.message["type"].(string)
+				seen = append(seen, kind)
+				replyKind := map[string]string{"publication_candidate": "publication_verify", "publication_verified": "publication_publish", "publication_complete": "publication_ack"}[kind]
+				reply := publicationReply(p, replyKind)
+				if mutate != nil {
+					mutate(&reply)
+				}
+				_ = p.accept(reply)
+				if kind == "publication_complete" {
+					done <- seen
+					return
+				}
+			case <-p.ctx.Done():
+				done <- seen
+				return
+			}
+		}
+	}()
+	return done
+}
+func TestPublicationCompleteOnlyAfterRemovalVerificationAndAck(t *testing.T) {
+	p, fake := setupPublication(t)
+	done := servePublication(p, nil)
+	if err := p.run(true); err != nil {
+		t.Fatal(err)
+	}
+	seen := <-done
+	if strings.Join(seen, ",") != "publication_candidate,publication_verified,publication_complete" {
+		t.Fatal(seen)
+	}
+	var publicationRun int
+	var verifierRuns int
+	for i, args := range fake.calls {
+		if args[0] != "run" {
+			continue
+		}
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "private-write-token") {
+			t.Fatal("write token in Docker argv")
+		}
+		if strings.Contains(joined, "/var/run/docker.sock") || strings.Contains(joined, "--pid ") || strings.Contains(joined, "--privileged") {
+			t.Fatal("unsafe helper access")
+		}
+		mode := args[len(args)-1]
+		if mode == "publish" {
+			publicationRun++
+			var request map[string]any
+			if json.Unmarshal(fake.inputs[i], &request) != nil || request["bundle_sha256"] != testPublicationManifest().BundleSHA256 {
+				t.Fatal("publish stdin contract")
+			}
+			if !strings.Contains(string(fake.inputs[i]), "private-write-token") {
+				t.Fatal("missing stdin-only lease")
+			}
+			if strings.Contains(joined, "dst=/source") {
+				t.Fatal("publisher can read agent source")
+			}
+		} else {
+			if !strings.Contains(joined, "--network none") {
+				t.Fatal("verification/freeze has network")
+			}
+			if strings.Contains(string(fake.inputs[i]), "private-write-token") {
+				t.Fatal("write token before publishing")
+			}
+		}
+		if mode == "-se" {
+			verifierRuns++
+			if !strings.Contains(joined, "dst=/input,readonly") {
+				t.Fatal("mutable verifier input")
+			}
+		}
+	}
+	if publicationRun != 1 || verifierRuns != 1 {
+		t.Fatal("missing verifier or publisher")
+	}
+	for name, c := range fake.containers {
+		if !c.removed {
+			t.Fatalf("runtime left behind: %s", name)
+		}
+	}
+}
+func TestPublicationRefusesUnprovenRemoval(t *testing.T) {
+	for _, kind := range []string{"failed", "delayed", "residual"} {
+		t.Run(kind, func(t *testing.T) {
+			p, f := setupPublication(t)
+			f.failDelete = kind == "failed"
+			f.delayedDelete = kind == "delayed"
+			f.residual = kind == "residual"
+			if p.run(true) == nil {
+				t.Fatal("unsafe publication allowed")
+			}
+			if len(p.events) != 0 {
+				t.Fatal("requested authority before teardown")
+			}
+		})
+	}
+}
+func TestPublicationRefusesBadRepliesAndFailedChecks(t *testing.T) {
+	for _, kind := range []string{"nonce", "head", "digest", "no-checks", "failed-check", "missing-tools", "wrong-image", "expired-lease"} {
+		t.Run(kind, func(t *testing.T) {
+			p, f := setupPublication(t)
+			f.failVerifier = kind == "failed-check" || kind == "missing-tools"
+			done := servePublication(p, func(msg *runnerWSMessage) {
+				if msg.Type == "publication_verify" {
+					switch kind {
+					case "nonce":
+						msg.Nonce = "wrong"
+					case "head":
+						msg.HeadSHA = strings.Repeat("f", 40)
+					case "digest":
+						msg.BundleSHA256 = strings.Repeat("f", 64)
+					case "no-checks":
+						msg.Checks = nil
+					case "wrong-image":
+						msg.Image = "untrusted"
+					}
+				}
+				if msg.Type == "publication_publish" && kind == "expired-lease" {
+					msg.Lease["expires_at"] = time.Now().Add(-time.Minute).Format(time.RFC3339)
+				}
+			})
+			if kind == "nonce" {
+				time.AfterFunc(20*time.Millisecond, p.cancel)
+			}
+			if p.run(true) == nil {
+				t.Fatal("invalid transition accepted")
+			}
+			p.cancel()
+			seen := <-done
+			for _, event := range seen {
+				if event == "publication_complete" {
+					t.Fatal("published invalid candidate")
+				}
+			}
+			for _, args := range f.calls {
+				if len(args) > 0 && args[0] == "run" && args[len(args)-1] == "publish" {
+					t.Fatal("publisher ran on failed verification/binding")
+				}
+			}
+		})
+	}
+}
+func TestPublicationCancellationStopsVerifierAndRetainsFrozenWork(t *testing.T) {
+	p, f := setupPublication(t)
+	f.blockVerifier = true
+	done := servePublication(p, nil)
+	time.AfterFunc(30*time.Millisecond, p.cancel)
+	if p.run(true) == nil {
+		t.Fatal("cancelled verifier passed")
+	}
+	<-done
+	for _, c := range f.containers {
+		if !c.removed {
+			t.Fatal("cancelled runtime remains")
+		}
+	}
+	reference, err := p.retainRecovery()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(reference, "runner-local:") {
+		t.Fatal(reference)
+	}
+	root, _ := publicationRecoveryRoot()
+	files, _ := os.ReadDir(root)
+	if len(files) != 1 {
+		t.Fatal("recovery not retained")
+	}
+	raw, _ := os.ReadFile(filepath.Join(root, files[0].Name()))
+	var record publicationRecovery
+	if json.Unmarshal(raw, &record) != nil || !record.ExpiresAt.After(time.Now()) || record.ExpiresAt.After(time.Now().Add(publicationRetention+time.Second)) {
+		t.Fatal("recovery TTL invalid")
+	}
+	if bytesContain(raw, "private-write-token") {
+		t.Fatal("token retained")
+	}
+}
+func bytesContain(data []byte, value string) bool { return strings.Contains(string(data), value) }
+func TestPublicationRejectsUnsafeRunnerAndUnavailableHelper(t *testing.T) {
+	p, f := setupPublication(t)
+	_ = p
+	for _, opts := range []runnerDockerOpts{{MountDockerSocket: true}, {PersistWorkspace: true}, {ExtraMounts: []string{"/tmp:/host"}}, {Network: "host"}} {
+		if _, err := publicationFromJob(testPublicationJob(), opts); err == nil {
+			t.Fatal("unsafe runner accepted")
+		}
+	}
+	for _, nested := range []bool{false, true} {
+		job := testPublicationJob()
+		if nested {
+			job["agent_config"] = map[string]any{"execution_mode": "host_exec"}
+		} else {
+			job["execution_mode"] = "host_exec"
+		}
+		if _, err := publicationFromJob(job, runnerDockerOpts{}); err == nil {
+			t.Fatal("native host execution accepted")
+		}
+	}
+	f.helperMissing = true
+	if _, err := publicationFromJob(testPublicationJob(), runnerDockerOpts{}); err == nil {
+		t.Fatal("missing helper accepted")
+	}
+	t.Setenv(publicationHelperEnv, "helper:latest")
+	if _, err := publicationFromJob(testPublicationJob(), runnerDockerOpts{}); err == nil {
+		t.Fatal("mutable helper accepted")
+	}
+}
+func TestPublicationRepliesRejectReplayAndOutOfOrder(t *testing.T) {
+	p, _ := setupPublication(t)
+	p.manifest = testPublicationManifest()
+	p.phase = "publication_verify"
+	wrong := publicationReply(p, "publication_publish")
+	if p.accept(wrong) == nil {
+		t.Fatal("out of order reply accepted")
+	}
+	valid := publicationReply(p, "publication_verify")
+	if err := p.accept(valid); err != nil {
+		t.Fatal(err)
+	}
+	if p.accept(valid) == nil {
+		t.Fatal("duplicate reply accepted")
+	}
+}
+
+func TestPublicationPublishStdinMatchesSharedPythonFixture(t *testing.T) {
+	raw, err := os.ReadFile("../../../backend/tests/fixtures/publication_publish_request.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var expected map[string]any
+	if json.Unmarshal(raw, &expected) != nil {
+		t.Fatal("invalid fixture")
+	}
+	encoded, err := publicationPublishInput(expected["binding"].(map[string]any), expected["lease"].(map[string]any), expected["bundle_sha256"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var actual map[string]any
+	_ = json.Unmarshal(encoded, &actual)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatal("Go/Python private publish contract drift")
+	}
+}
+
+func TestPublicationSessionWaitsForControllerAckBeforeOrdinaryComplete(t *testing.T) {
+	testPublicationSession(t, false)
+}
+func TestPublicationDockerFullLifecycleSmoke(t *testing.T) {
+	if os.Getenv("PRELOOP_PRIVATE_PUBLICATION_DOCKER_SMOKE") != "1" {
+		t.Skip("requires owned local Docker and explicit smoke opt-in")
+	}
+	testPublicationSession(t, true)
+}
+func testPublicationSession(t *testing.T, realDocker bool) {
+	testenv.SetTempHome(t)
+	var fake *publicationFakeDocker
+	job := testPublicationJob()
+	job["agent_config"] = map[string]any{"image": "trusted/agent:1"}
+	job["launch"] = map[string]any{"version": 1, "script": "fake", "env": map[string]any{}}
+	if realDocker {
+		helper := os.Getenv("PRELOOP_PRIVATE_PUBLICATION_FIXTURE_IMAGE")
+		if !publicationImageRE.MatchString(helper) {
+			t.Fatal("set PRELOOP_PRIVATE_PUBLICATION_FIXTURE_IMAGE to the pinned local fake-provider helper")
+		}
+		t.Setenv(publicationHelperEnv, helper)
+		image := "preloop-env-recovery-test@sha256:611bb81177af3e439215f51adfefb3fd433918a39c5ed34769ab55b3d13b6c2d"
+		directory := t.TempDir()
+		git := func(args ...string) string {
+			command := exec.Command("git", append([]string{"-C", directory}, args...)...)
+			output, err := command.CombinedOutput()
+			if err != nil {
+				t.Fatalf("fixture git: %s", output)
+			}
+			return strings.TrimSpace(string(output))
+		}
+		git("init", "-b", "main")
+		git("config", "user.name", "Publication fixture")
+		git("config", "user.email", "fixture@example.invalid")
+		if err := os.WriteFile(filepath.Join(directory, "acceptance.txt"), []byte("base\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		git("add", "acceptance.txt")
+		git("commit", "-m", "local base")
+		base := git("rev-parse", "HEAD")
+		if err := os.WriteFile(filepath.Join(directory, "acceptance.txt"), []byte("implemented\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		git("add", "acceptance.txt")
+		git("commit", "-m", "local implementation")
+		git("bundle", "create", filepath.Join(directory, "branch.bundle"), "HEAD")
+		bundle, err := os.ReadFile(filepath.Join(directory, "branch.bundle"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		spec := job["publication"].(map[string]any)
+		spec["base_sha"], spec["verification_image"], spec["repository_url"] = base, image, "https://github.com/example/project.git"
+		spec["verification_budget_seconds"] = 120
+		job["agent_config"] = map[string]any{"image": image}
+		script := `set -eu
+python3 - <<'FIXTURE_EXPORT'
+import base64, json, os, pathlib
+pathlib.Path('/preloop-publication-output/branch.bundle').write_bytes(base64.b64decode(os.environ['FIXTURE_BUNDLE']))
+result = {'status':'success','summary':'original result','pr_title':'Implement acceptance fixture','pr_body':'Verifies the local trusted publication lifecycle.'}
+for path in ['/workspace/result.json','/preloop-publication-output/result.json']:
+    pathlib.Path(path).write_text(json.dumps(result))
+FIXTURE_EXPORT
+`
+		job["launch"] = map[string]any{"version": 1, "script": script, "env": map[string]any{"FIXTURE_BUNDLE": base64.StdEncoding.EncodeToString(bundle), "PRELOOP_DISABLE_TELEMETRY": "true", "KUBECONFIG": "/dev/null"}}
+	} else {
+		_, fake = setupPublication(t)
+	}
+	oldURL, oldDocker, oldCommand := FlagURL, runnerHasDocker, newRunnerJobCmd
+	t.Cleanup(func() { FlagURL = oldURL; runnerHasDocker = oldDocker; newRunnerJobCmd = oldCommand })
+	runnerHasDocker = func() bool { return true }
+	var active *runnerPublication
+	if realDocker {
+		defer func() {
+			if active != nil {
+				active.abort()
+				_ = active.removeVolume(active.exportVolume)
+				_ = active.removeVolume(active.frozenVolume)
+			}
+		}()
+	}
+	newRunnerJobCmd = func(image string, env map[string]string, opts runnerDockerOpts) *exec.Cmd {
+		active = opts.Publication
+		if active == nil {
+			t.Fatal("publication was dropped at Docker launch")
+		}
+		if realDocker {
+			return defaultNewRunnerJobCmd(image, env, opts)
+		}
+		fake.mu.Lock()
+		fake.containers[active.agentName] = &publicationFakeContainer{id: strings.Repeat("2", 64), labels: map[string]string{"preloop.publication_execution": active.executionID, "preloop.publication_nonce": active.spec.Nonce}, args: []string{active.exportVolume}}
+		fake.mu.Unlock()
+		command := exec.Command("sh", "-c", "printf '%s\n' "+shellTestQuote(resultLine(`{"status":"success","summary":"original result"}`, 0)))
+		return command
+	}
+	messages := make(chan map[string]any, 20)
+	ackRelease := make(chan struct{})
+	serverDone := make(chan struct{})
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		defer close(serverDone)
+		_ = conn.WriteJSON(map[string]any{"type": "job", "job": job})
+		for {
+			var msg map[string]any
+			if conn.ReadJSON(&msg) != nil {
+				return
+			}
+			messages <- msg
+			kind, _ := msg["type"].(string)
+			if strings.HasPrefix(kind, "publication_") {
+				target := map[string]string{"publication_candidate": "publication_verify", "publication_verified": "publication_publish", "publication_complete": "publication_ack"}[kind]
+				if kind == "publication_complete" {
+					<-ackRelease
+				}
+				reply := publicationReply(active, target)
+				if realDocker {
+					if target == "publication_verify" {
+						reply.BudgetSeconds = 90
+						reply.Checks = []publicationCheck{{ID: "acceptance", Command: "test \"$(cat acceptance.txt)\" = implemented; echo modified > acceptance.txt; ! touch /input/forbidden", TimeoutSeconds: 30}, {ID: "fresh-source", Command: "test \"$(cat acceptance.txt)\" = implemented", TimeoutSeconds: 30}}
+					}
+					if target == "publication_publish" {
+						reply.Binding["records"] = []map[string]any{{"execution_id": active.executionID, "head_sha": active.manifest.HeadSHA}}
+						reply.Binding["public_url"], reply.Binding["provider"] = "https://preloop.example.invalid", "github"
+						reply.Lease["token"], reply.Lease["expires_at"] = "fixture-test-token", time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+					}
+				}
+				_ = conn.WriteJSON(reply)
+			}
+			if kind == "unregister" {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+	FlagURL = server.URL
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	var running *exec.Cmd
+	var executionID string
+	var done <-chan leasedJobOutcome
+	var last *leasedJobOutcome
+	halt := false
+	interrupt := make(chan os.Signal, 1)
+	stopped := make(chan error, 1)
+	go func() {
+		stopped <- runRunnerSession(conn, interrupt, io.Discard, &running, &executionID, &done, &halt, &atomic.Bool{}, &last)
+	}()
+	limit := 5 * time.Second
+	if realDocker {
+		limit = 150 * time.Second
+	}
+	timeout := time.After(limit)
+	acked := false
+	defer func() {
+		if !acked {
+			close(ackRelease)
+		}
+		select {
+		case interrupt <- os.Interrupt:
+		default:
+		}
+		select {
+		case <-stopped:
+		case <-time.After(time.Second):
+		}
+	}()
+	receivedHeartbeat := false
+	for {
+		select {
+		case msg := <-messages:
+			if realDocker && msg["type"] == "logs" {
+				t.Log(msg["lines"])
+			}
+			if !receivedHeartbeat {
+				if msg["type"] != "heartbeat" || msg["publication_capabilities"].(map[string]any)["helper_ready"] != true {
+					t.Fatalf("capability must precede job processing: %v", msg)
+				}
+				receivedHeartbeat = true
+			}
+			switch msg["type"] {
+			case "publication_complete":
+				select {
+				case early := <-messages:
+					if early["type"] == "complete" {
+						t.Fatal("ordinary complete preceded authority acknowledgment")
+					}
+				case <-time.After(20 * time.Millisecond):
+				}
+				close(ackRelease)
+				acked = true
+			case "complete":
+				if !acked || msg["status"] != "SUCCEEDED" {
+					t.Fatalf("publication completion order/status: %v", msg)
+				}
+				if msg["result"].(map[string]any)["summary"] != "original result" {
+					t.Fatal("agent result was not preserved")
+				}
+				if realDocker {
+					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					defer cancel()
+					remaining, err := publicationDocker(ctx, nil, "ps", "--all", "--quiet", "--filter", "label=preloop.publication_execution="+active.executionID)
+					if err != nil || strings.TrimSpace(string(remaining)) != "" {
+						t.Fatal("owned runtime remains", err, string(remaining))
+					}
+					remaining, err = publicationDocker(ctx, nil, "volume", "ls", "--quiet", "--filter", "label=preloop.publication_execution="+active.executionID)
+					if err != nil || strings.TrimSpace(string(remaining)) != "" {
+						t.Fatal("owned volume remains", err, string(remaining))
+					}
+				}
+				return
+			}
+		case <-timeout:
+			t.Fatal("publication session did not complete")
+		}
+	}
+}
+func shellTestQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func TestPublicationDockerIsolatedVerifierSmoke(t *testing.T) {
+	if os.Getenv("PRELOOP_PRIVATE_PUBLICATION_DOCKER_SMOKE") != "1" {
+		t.Skip("requires owned local Docker and explicit smoke opt-in")
+	}
+	image := "preloop-env-recovery-test@sha256:611bb81177af3e439215f51adfefb3fd433918a39c5ed34769ab55b3d13b6c2d"
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	if _, err := publicationDocker(ctx, nil, "image", "inspect", "--format", "{{.Id}}", image); err != nil {
+		t.Fatal("local smoke image unavailable")
+	}
+	directory := t.TempDir()
+	git := func(args ...string) string {
+		cmd := exec.Command("git", append([]string{"-C", directory}, args...)...)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("local fixture git failed: %s", output)
+		}
+		return strings.TrimSpace(string(output))
+	}
+	git("init", "-b", "main")
+	git("config", "user.name", "Publication fixture")
+	git("config", "user.email", "fixture@example.invalid")
+	if err := os.WriteFile(filepath.Join(directory, "acceptance.txt"), []byte("original\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "acceptance.txt")
+	git("commit", "-m", "local verification fixture")
+	head := git("rev-parse", "HEAD")
+	git("bundle", "create", filepath.Join(directory, "branch.bundle"), "HEAD")
+	random := make([]byte, 16)
+	if _, err := rand.Read(random); err != nil {
+		t.Fatal(err)
+	}
+	p := &runnerPublication{executionID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", agentName: "preloop-pub-" + hex.EncodeToString(random) + "-test", spec: publicationLeaseSpec{Nonce: strings.Repeat("a", 64)}, activeHelpers: map[string]bool{}}
+	volume := "preloop-pub-" + hex.EncodeToString(random) + "-frozen"
+	if _, err := publicationDocker(ctx, nil, "volume", "create", "--label", "preloop.publication_execution="+p.executionID, volume); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := p.removeVolume(volume); err != nil {
+			t.Errorf("smoke volume cleanup failed: %v", err)
+		}
+	}()
+	if _, err := publicationDocker(ctx, nil, "run", "--rm", "--network", "none", "--log-driver", "none", "--mount", "type=bind,src="+directory+",dst=/seed,readonly", "--mount", "type=volume,src="+volume+",dst=/input", "--entrypoint", "/bin/bash", image, "-ec", "cp /seed/branch.bundle /input/branch.bundle"); err != nil {
+		t.Fatal(err)
+	}
+	mounts := []string{"type=volume,src=" + volume + ",dst=/input,readonly"}
+	for _, command := range []string{"test \"$(cat acceptance.txt)\" = original; echo changed > acceptance.txt; ! touch /input/untrusted-write", "test \"$(cat acceptance.txt)\" = original"} {
+		if _, err := p.runContainer(ctx, "verify", image, []byte(publicationVerifierScript(head, command)), mounts, []string{"/bin/bash", "-se"}, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := p.runContainer(ctx, "verify", image, []byte(publicationVerifierScript(head, "echo actionable-test-failure >&2; exit 7")), mounts, []string{"/bin/bash", "-se"}, false); err == nil || !strings.Contains(err.Error(), "actionable-test-failure") {
+		t.Fatalf("real exit/diagnostic missing: %v", err)
+	}
+	if err := p.volumeUnused(volume); err != nil {
+		t.Fatal("verifier remained after failure")
+	}
+}
+
+func TestPublicationRequiresCompleteDockerExitEvidence(t *testing.T) {
+	for _, raw := range []string{`{}`, `{"Status":"exited","Running":false}`, `{"Status":"exited","ExitCode":0}`, `{"Running":false,"ExitCode":0}`, `{"Status":"running","Running":false,"ExitCode":0}`} {
+		t.Run(raw, func(t *testing.T) {
+			p, f := setupPublication(t)
+			publicationDocker = func(ctx context.Context, input []byte, args ...string) ([]byte, error) {
+				if len(args) > 2 && args[0] == "inspect" && args[2] == "{{json .State}}" {
+					return []byte(raw), nil
+				}
+				return f.run(ctx, input, args...)
+			}
+			if _, err := p.runContainer(p.ctx, "verify", p.spec.VerificationImage, []byte("true"), nil, []string{"/bin/bash", "-se"}, false); err == nil {
+				t.Fatal("unproven process exit accepted")
+			}
+		})
+	}
+}
+func TestPublicationAcceptsRealGitHubExpiryWithinSeparateOperationBudget(t *testing.T) {
+	p, _ := setupPublication(t)
+	p.manifest = testPublicationManifest()
+	reply := publicationReply(p, "publication_publish")
+	reply.Lease["expires_at"] = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	if err := p.validateWriteReply(reply); err != nil {
+		t.Fatal("provider1h installation expiry rejected", err)
+	}
+	reply.Lease["expires_at"] = time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+	if p.validateWriteReply(reply) == nil {
+		t.Fatal("unbounded provider lease accepted")
+	}
+}
+
+func TestPublicationHeartbeatReportsOnlyLocallyReadyImmutableHelper(t *testing.T) {
+	_, fake := setupPublication(t)
+	for _, tc := range []struct {
+		name, image    string
+		missing, ready bool
+	}{
+		{name: "absent"},
+		{name: "mutable", image: "helper:latest"},
+		{name: "unavailable", image: "helper@sha256:" + strings.Repeat("a", 64), missing: true},
+		{name: "ready", image: "helper@sha256:" + strings.Repeat("a", 64), ready: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(publicationHelperEnv, tc.image)
+			fake.helperMissing = tc.missing
+			before := len(fake.calls)
+			msg := publicationHeartbeat()
+			caps := msg["publication_capabilities"].(map[string]any)
+			if msg["type"] != "heartbeat" || caps["version"] != 1 || caps["helper_ready"] != tc.ready {
+				t.Fatal(msg)
+			}
+			if !publicationImageRE.MatchString(tc.image) && len(fake.calls) != before {
+				t.Fatal("probed unconfigured helper")
+			}
+		})
+	}
+}
+
+func TestPublicationCleanupHandlesLostRemovalReplyAndConcurrentRemoval(t *testing.T) {
+	p, fake := setupPublication(t)
+	publicationDocker = func(ctx context.Context, input []byte, args ...string) ([]byte, error) {
+		out, err := fake.run(ctx, input, args...)
+		if args[0] == "rm" {
+			return nil, errors.New("lost Docker response")
+		}
+		return out, err
+	}
+	failures := make(chan error, 2)
+	for range 2 {
+		go func() { failures <- p.removeOwned(p.agentName) }()
+	}
+	for range 2 {
+		if err := <-failures; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if p.removeOwned("unowned-missing-container") == nil {
+		t.Fatal("unknown absence accepted as owned removal")
+	}
+}
+
+func TestPublicationFreezeFailureCleansPartialVolumeAndRetainsSource(t *testing.T) {
+	p, fake := setupPublication(t)
+	fake.badManifest = true
+	if p.run(true) == nil {
+		t.Fatal("invalid manifest accepted")
+	}
+	reference, err := p.retainRecovery()
+	if err != nil || !strings.Contains(reference, p.exportVolume) {
+		t.Fatal(reference, err)
+	}
+	if !containsPublicationVolume(fake.removedVolumes, p.frozenVolume) {
+		t.Fatal("partial frozen volume leaked")
+	}
+}
+func containsPublicationVolume(volumes []string, volume string) bool {
+	for _, v := range volumes {
+		if v == volume {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPublicationRecoveryCleanupRequiresExpiryOwnershipAndNoUsers(t *testing.T) {
+	for _, kind := range []string{"not-expired", "wrong-owner", "in-use", "expired-owned"} {
+		t.Run(kind, func(t *testing.T) {
+			p, fake := setupPublication(t)
+			if err := p.removeOwned(p.agentName); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := p.retainRecovery(); err != nil {
+				t.Fatal(err)
+			}
+			root, _ := publicationRecoveryRoot()
+			metadata := filepath.Join(root, p.exportVolume+".json")
+			expiry := time.Now().Add(-time.Second)
+			if kind == "not-expired" {
+				expiry = time.Now().Add(time.Hour)
+			}
+			data, _ := json.Marshal(publicationRecovery{ExecutionID: p.executionID, Volume: p.exportVolume, ExpiresAt: expiry})
+			if err := os.WriteFile(metadata, data, 0600); err != nil {
+				t.Fatal(err)
+			}
+			publicationDocker = func(ctx context.Context, input []byte, args ...string) ([]byte, error) {
+				if args[0] == "volume" && args[1] == "inspect" {
+					owner := p.executionID
+					if kind == "wrong-owner" {
+						owner = "other"
+					}
+					return json.Marshal(map[string]string{"preloop.publication_execution": owner})
+				}
+				return fake.run(ctx, input, args...)
+			}
+			fake.residual = kind == "in-use"
+			if err := cleanupPublicationRecovery(time.Now()); err != nil {
+				t.Fatal(err)
+			}
+			removed := containsPublicationVolume(fake.removedVolumes, p.exportVolume)
+			if removed != (kind == "expired-owned") {
+				t.Fatalf("unsafe/absent expiry cleanup: %v", fake.removedVolumes)
+			}
+			_, err := os.Stat(metadata)
+			if os.IsNotExist(err) != removed {
+				t.Fatal("metadata removed before owned volume")
+			}
+		})
+	}
+}
+
+func TestPublicationHaltRetainsStoppedOutcome(t *testing.T) {
+	p, _ := setupPublication(t)
+	p.stopRequested.Store(true)
+	p.cancel()
+	p.start(leasedJobOutcome{executionID: p.executionID, status: "SUCCEEDED"})
+	select {
+	case event := <-p.events:
+		if event.outcome == nil || event.outcome.status != "STOPPED" || event.outcome.publicationAcknowledged {
+			t.Fatal("halt status lost", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("halt did not emit terminal result")
+	}
+}
+
+func TestPublicationConsumesPythonControllerProtocolFixture(t *testing.T) {
+	raw, err := os.ReadFile("../../../backend/tests/fixtures/private_publication_protocol.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture struct {
+		Job      map[string]any    `json:"job"`
+		Requests []map[string]any  `json:"requests"`
+		Replies  []json.RawMessage `json:"replies"`
+	}
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	if len(fixture.Requests) != 3 || len(fixture.Replies) != 3 {
+		t.Fatal("incomplete controller protocol fixture")
+	}
+	_, fake := setupPublication(t)
+	p, err := publicationFromJob(fixture.Job, runnerDockerOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(p.cancel)
+	fake.containers = map[string]*publicationFakeContainer{
+		p.agentName: {id: strings.Repeat("1", 64), labels: map[string]string{"preloop.publication_execution": p.executionID, "preloop.publication_nonce": p.spec.Nonce}, args: []string{p.exportVolume}},
+	}
+	// Fake only local Docker evidence; all wire messages came from the Python
+	// controller's real database/WebSocket regression, including selected checks.
+	manifest, _ := json.Marshal(fixture.Requests[0])
+	receipt, _ := json.Marshal(fixture.Requests[2]["publication"])
+	publicationDocker = func(ctx context.Context, input []byte, args ...string) ([]byte, error) {
+		output, err := fake.run(ctx, input, args...)
+		if err == nil && args[0] == "run" {
+			switch args[len(args)-1] {
+			case "freeze":
+				return manifest, nil
+			case "publish":
+				return receipt, nil
+			}
+		}
+		return output, err
+	}
+	done := make(chan error, 1)
+	go func() { done <- p.run(true) }()
+	timeout := time.After(3 * time.Second)
+	for index, expected := range fixture.Requests {
+		select {
+		case event := <-p.events:
+			serialized, err := json.Marshal(event.message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var actual map[string]any
+			if err := json.Unmarshal(serialized, &actual); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(actual, expected) {
+				t.Fatalf("Go request %d differs from Python-accepted request: got %s", index, serialized)
+			}
+			var reply runnerWSMessage
+			if err := json.Unmarshal(fixture.Replies[index], &reply); err != nil {
+				t.Fatal(err)
+			}
+			if reply.Lease != nil {
+				// Only time is rebased: a checked-in fixture must remain usable while the
+				// production validator continues enforcing a real provider expiry bound.
+				reply.Lease["expires_at"] = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+			}
+			if err := p.accept(reply); err != nil {
+				t.Fatal(err)
+			}
+		case err := <-done:
+			t.Fatalf("publication ended before phase%d: %v", index, err)
+		case <-timeout:
+			t.Fatal("controller fixture publication timed out")
+		}
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-timeout:
+		t.Fatal("controller fixture acknowledgement was not consumed")
+	}
+}

--- a/docs/architecture/flows.md
+++ b/docs/architecture/flows.md
@@ -167,8 +167,29 @@ that repository: `contents:read` for the agent, then `contents:write` and
 `pull_requests:write` for the publisher after verification. Stored PATs and
 GitLab publication are rejected in this mode until a broker can enforce their
 scope and lifetime. The standalone metadata/provider client supports both
-GitHub and GitLab. Unsupported private runners fail before agent execution;
-private source must remain local, not be uploaded to bypass this restriction.
+GitHub and GitLab. Private runners require an authenticated current capability
+advertisement confirming protocol v1 and a locally available digest-pinned
+trusted helper image. Older runners cannot receive an isolated lease. Private
+source stays on the runner; the controller receives only bounded manifests,
+check outcomes, and the provider receipt.
+
+Private verification is an ordered, nonce-bound handshake. The runner removes
+the agent and residual volume writers, freezes the bundle in independent
+storage, runs the exact controller-selected checks, and confirms verifier
+removal. Only then does the controller issue a repository-scoped writer to the
+trusted publisher helper. Agent result files and ordinary completion messages
+cannot advance publication. Both helper and controller revoke the writer;
+already-invalid token responses make repeated revocation safe.
+
+Recovered private monitoring restores the protected policy and accepted receipt
+without relaunching the agent or replaying credentials. Queued isolated
+executions fail closed on worker recovery because their original lease cannot
+be safely replayed; retry explicitly after an eligible runner is available.
+Private frozen recovery artifacts remain local with a fixed 24-hour retention
+limit after verification or publication failure. A recovered hosted isolated
+execution currently cannot reconstruct its original trusted policy
+snapshot: it fails closed with an explicit diagnostic and retains its original
+runtime for recovery. It does not silently switch to ungated publication.
 
 After runtime cleanup, the control-plane publisher imports a bounded,
 self-contained `branch.bundle` into a fresh bare object store. It never checks

--- a/docs/architecture/flows.md
+++ b/docs/architecture/flows.md
@@ -125,9 +125,36 @@ promote `PRELOOP_VERIFICATION` JSON directly to trusted publication authorizatio
 compatibility. Legacy mode executes publication in the agent container and
 shares tracker write credentials with that runtime; it is not a credential
 isolation boundary. Operators must explicitly migrate a flow to `isolated`.
-The integration is not yet ready to enable: the trusted #428 verification
-adapter and private runner publisher are still required. An isolated execution
-without controller-issued evidence fails closed before issuing write access.
+Hosted execution has a controller-owned verification adapter. Private runner
+publication additionally requires the authenticated runner-host protocol. An
+isolated execution without controller-issued evidence fails closed before
+issuing write access.
+
+Isolated flows require `verification.mode: gate`, a nonempty trusted profile,
+and `verification.image` set to a digest-pinned generic toolchain image. That
+image must provide Python 3, Git, a shell, and the dependencies needed by its
+configured checks. Verification does not reuse the agent's virtual environment,
+node_modules, writable caches, or workspace. A check may perform bounded setup
+using dependencies already available in the image, including local package
+caches and service binaries; it cannot download dependencies during verification.
+This is a generic toolchain contract, not a requirement to bake an application
+or its database into the harness image. Missing dependencies fail the check and
+leave the captured work recoverable.
+
+The controller resolves the exact base commit before starting the agent. After
+capturing recovery artifacts it deletes the owned agent runtime and confirms
+its absence, including residual Kubernetes pods. It derives changed paths from
+the frozen bundle, selects relevant checks from the trusted profile, and runs
+each check in a fresh credential-free checkout of the same head. Docker has no
+network, host mounts, or host namespaces. Kubernetes disables service-account
+automount and applies a deny-all NetworkPolicy; hosted clusters must enforce
+NetworkPolicy. The controller observes process exit codes and confirms every
+verifier runtime was removed before minting writer credentials. Check diagnostics
+retain a bounded output tail and Docker log rotation limits runtime log growth.
+If Kubernetes deletion cannot be confirmed, the deny-all NetworkPolicy remains
+with the execution's verifier label for operator recovery; removing it first
+would restore network access to residual pods. Log markers and result files
+never authorize publication.
 
 The isolated path binds a single repository and its base/target branches from
 account-owned flow/project records. It never accepts a webhook clone URL as
@@ -155,9 +182,9 @@ The controller handoff is `VerifiedPublication(execution_id, head_sha,
 bundle_sha256)`. It is an internal type, not an agent JSON schema. A trusted
 verifier adapter must construct it only after verifying the immutable artifact
 in an environment the agent cannot modify. Agent-written result files or log
-markers cannot establish this attestation. Production wiring of this adapter
-remains an explicit prerequisite, and must not be replaced with a parse of
-sandbox claims. Deploy the control plane separately from agent workloads;
+markers cannot establish this attestation. Hosted adapters construct it only
+after the complete trusted verification lifecycle. Deploy the control plane
+separately from agent workloads;
 never mount its process namespace, filesystem, Docker socket or signing keys
 into those workloads.
 

--- a/docs/architecture/flows.md
+++ b/docs/architecture/flows.md
@@ -118,3 +118,72 @@ Agents or repository commands can reproduce a marker. Credential-isolated
 publication must use a separate controller/runner-host verifier that observes
 command completion outside that sandbox on an immutable commit artifact. Never
 promote `PRELOOP_VERIFICATION` JSON directly to trusted publication authorization.
+
+### Isolated publication (integration preview)
+
+`git_clone_config.publication_mode` defaults to `legacy` for saved-flow
+compatibility. Legacy mode executes publication in the agent container and
+shares tracker write credentials with that runtime; it is not a credential
+isolation boundary. Operators must explicitly migrate a flow to `isolated`.
+The integration is not yet ready to enable: the trusted #428 verification
+adapter and private runner publisher are still required. An isolated execution
+without controller-issued evidence fails closed before issuing write access.
+
+The isolated path binds a single repository and its base/target branches from
+account-owned flow/project records. It never accepts a webhook clone URL as
+publication authority. GitHub App installation tokens are minted for exactly
+that repository: `contents:read` for the agent, then `contents:write` and
+`pull_requests:write` for the publisher after verification. Stored PATs and
+GitLab publication are rejected in this mode until a broker can enforce their
+scope and lifetime. The standalone metadata/provider client supports both
+GitHub and GitLab. Unsupported private runners fail before agent execution;
+private source must remain local, not be uploaded to bypass this restriction.
+
+After runtime cleanup, the control-plane publisher imports a bounded,
+self-contained `branch.bundle` into a fresh bare object store. It never checks
+out repository code, imports agent Git configuration, or runs repository hooks,
+filters, credential helpers or shell commands. Each Git child has a clean
+environment and CPU, memory (Linux), file-size and time limits. HTTPS redirects
+are disabled. The publisher validates the exact verified head, checks the
+expected remote SHA and ancestry, then uses an atomic lease to reject concurrent
+remote changes. It never rewrites unexpected remote history. Provider failures
+mark publication failed and retain captured recovery evidence; retry reuses the
+existing branch and PR. Write tokens are revoked on success/failure and expire
+at the provider-issued deadline if revocation is unavailable.
+
+The controller handoff is `VerifiedPublication(execution_id, head_sha,
+bundle_sha256)`. It is an internal type, not an agent JSON schema. A trusted
+verifier adapter must construct it only after verifying the immutable artifact
+in an environment the agent cannot modify. Agent-written result files or log
+markers cannot establish this attestation. Production wiring of this adapter
+remains an explicit prerequisite, and must not be replaced with a parse of
+sandbox claims. Deploy the control plane separately from agent workloads;
+never mount its process namespace, filesystem, Docker socket or signing keys
+into those workloads.
+
+### PR descriptions and execution provenance
+
+Repository setup selects `git_clone_config.pull_request_template` when set,
+then the conventional GitHub/GitLab default, then the lexicographically first
+named Markdown template. It writes `/workspace/evidence/pr-template.md` for the
+agent to fill. No template uses Summary and Testing. Configured missing,
+invalid, oversized or escaping template paths fail setup. Tests that did not
+run remain unchecked. The implementation preset asks for problem, resulting
+behavior, acceptance evidence, verified commands, limitations and an issue link.
+
+`result.json` retains #420's `pr_title`/`pr_body` fields and aliases. Valid agent
+text wins per field over configured text and commit text. Titles are one line,
+at most 256 UTF-8 bytes; bodies are at most 60,000 UTF-8 bytes. Invalid/missing
+metadata falls back with a diagnostic; no truncation silently changes meaning.
+All publication sources receive execution attribution. The isolated publisher
+owns only the `preloop:executions` HTML-comment region. It upserts trusted
+initial/repair execution links and published SHAs while preserving human edits
+outside that region, including metadata-only repairs. Links use `PRELOOP_URL`
+and existing authorization-protected console routes; tokens and transcripts
+are never provenance inputs. Legacy publication adds the current execution
+block on creation; continuation provenance updates require the isolated path.
+
+Preset synchronization updates uncustomized fields and marks customized saved
+flows as having an available update. Inspect the effective saved prompt and
+configuration before expecting template behavior. The publication-mode switch
+is deliberate and is not silently enabled by updating the prompt.

--- a/docs/architecture/flows.md
+++ b/docs/architecture/flows.md
@@ -142,15 +142,19 @@ or its database into the harness image. Missing dependencies fail the check and
 leave the captured work recoverable.
 
 The controller resolves the exact base commit before starting the agent. After
-capturing recovery artifacts it deletes the owned agent runtime and confirms
-its absence, including residual Kubernetes pods. It derives changed paths from
+committing recovery artifacts to durable storage it deletes the owned agent
+runtime and confirms its absence, including residual Kubernetes pods. A missing
+or failed recovery capture retains the original runtime and blocks publication. It derives changed paths from
 the frozen bundle, selects relevant checks from the trusted profile, and runs
 each check in a fresh credential-free checkout of the same head. Docker has no
 network, host mounts, or host namespaces. Kubernetes disables service-account
-automount and applies a deny-all NetworkPolicy; hosted clusters must enforce
-NetworkPolicy. The controller observes process exit codes and confirms every
+automount and applies a deny-all NetworkPolicy. Because policies are additive,
+existing permissive policies matching the verifier's labels block startup.
+Hosted clusters must enforce NetworkPolicy and prevent concurrent policy or
+admission changes from weakening the verifier namespace's isolation. The controller observes process exit codes and confirms every
 verifier runtime was removed before minting writer credentials. Check diagnostics
-retain a bounded output tail and Docker log rotation limits runtime log growth.
+retain a bounded scrubbed output tail, per-check elapsed time, and Docker log
+rotation limits runtime log growth.
 If Kubernetes deletion cannot be confirmed, the deny-all NetworkPolicy remains
 with the execution's verifier label for operator recovery; removing it first
 would restore network access to residual pods. Log markers and result files

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15620,6 +15620,23 @@ components:
           title: Create Pull Request
           description: Whether to create a Pull Request / Merge Request
           default: false
+        publication_mode:
+          type: string
+          enum:
+          - legacy
+          - isolated
+          title: Publication Mode
+          description: Legacy publishes inside the agent container. Isolated publishes
+            from the trusted control plane after verification, using scoped App credentials.
+          default: legacy
+        pull_request_template:
+          anyOf:
+          - type: string
+            maxLength: 512
+          - type: 'null'
+          title: Pull Request Template
+          description: Repository-relative PR template; otherwise conventional default
+            then lexical first
         pull_request_title:
           anyOf:
           - type: string
@@ -15697,6 +15714,23 @@ components:
           title: Create Pull Request
           description: Whether to create a Pull Request / Merge Request
           default: false
+        publication_mode:
+          type: string
+          enum:
+          - legacy
+          - isolated
+          title: Publication Mode
+          description: Legacy publishes inside the agent container. Isolated publishes
+            from the trusted control plane after verification, using scoped App credentials.
+          default: legacy
+        pull_request_template:
+          anyOf:
+          - type: string
+            maxLength: 512
+          - type: 'null'
+          title: Pull Request Template
+          description: Repository-relative PR template; otherwise conventional default
+            then lexical first
         pull_request_title:
           anyOf:
           - type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22687,6 +22687,13 @@ components:
         profile:
           $ref: '#/components/schemas/VerificationProfile'
           description: Versioned trusted test profile driving required checks
+        image:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Image
+          description: Digest-pinned generic toolchain image for credential-isolated
+            checks. Must contain dependencies required by the trusted profile.
         gate_budget_seconds:
           type: integer
           maximum: 14400.0

--- a/scripts/tests/publication_helper_fixture/Dockerfile
+++ b/scripts/tests/publication_helper_fixture/Dockerfile
@@ -1,0 +1,7 @@
+# Local tests only. Never use this image as a production publication helper.
+ARG HELPER_BASE=ghcr.io/preloop/preloop@sha256:07aea6618eb032c4e4fd7cea3334761dfabf93282f65e1fd7668d1d851850b07
+FROM ${HELPER_BASE}
+COPY backend/preloop /app/backend/preloop
+COPY scripts/tests/publication_helper_fixture/sitecustomize.py /fixture/sitecustomize.py
+ENV PYTHONPATH=/fixture:/app/backend PRELOOP_DISABLE_TELEMETRY=true
+ENTRYPOINT ["python"]

--- a/scripts/tests/publication_helper_fixture/README.md
+++ b/scripts/tests/publication_helper_fixture/README.md
@@ -1,0 +1,37 @@
+# Local private publication lifecycle fixture
+
+This test-only image runs the actual freeze/publish Python helper, local Git
+bundle validation, ancestry checks, metadata, and credential revocation. A
+`sitecustomize` fixture replaces only provider HTTP and Git network operations.
+Git fetch establishes the local two-commit fixture's `HEAD~1` as the base ref;
+local Git operations and the publisher's ancestry checks remain real. No real
+provider credentials, model calls, pushes, or pull requests are used.
+
+Never configure this image as an operational runner's publication helper.
+The fake adapter deliberately reports provider writes as successful.
+
+From the repository root with a local Docker engine:
+
+```sh
+docker build -f scripts/tests/publication_helper_fixture/Dockerfile \
+  -t preloop-publication-helper-fixture:local .
+docker image inspect preloop-publication-helper-fixture:local \
+  --format '{{json .RepoDigests}}'
+```
+
+Use the returned immutable repository digest as
+`PRELOOP_PRIVATE_PUBLICATION_FIXTURE_IMAGE` when running the opt-in CLI Docker
+publication test. The test retains the production digest validator and exercises
+real agent removal, bundle freeze, fresh verifier containers, private protocol,
+publisher helper, acknowledgement, and completion. The test base image is pinned;
+`--build-arg HELPER_BASE=...` can select an equivalent local Preloop runtime image
+containing Python, Git, and backend dependencies.
+
+From `cli/`, run the full lifecycle using that digest:
+
+```sh
+PRELOOP_DISABLE_TELEMETRY=true KUBECONFIG=/dev/null \
+PRELOOP_PRIVATE_PUBLICATION_DOCKER_SMOKE=1 \
+PRELOOP_PRIVATE_PUBLICATION_FIXTURE_IMAGE=<local-helper-repository-digest> \
+go test ./internal/cmd -run '^TestPublicationDockerFullLifecycleSmoke$' -count=1 -v
+```

--- a/scripts/tests/publication_helper_fixture/sitecustomize.py
+++ b/scripts/tests/publication_helper_fixture/sitecustomize.py
@@ -1,0 +1,60 @@
+"""LOCAL TEST IMAGE ONLY: intercept provider/Git network, preserve real Git IO."""
+
+import json
+from typing import Any
+import httpx
+from preloop.services.trusted_publisher import CleanGitRepository
+
+real_run = CleanGitRepository.run
+
+
+def fake_network_git(self: CleanGitRepository, *args: str, **kwargs: Any) -> str:
+    if args[0] == "ls-remote":
+        return ""
+    if args[0] == "push":
+        return ""
+    if args[0] == "fsck":
+        self._fixture_head = args[-1]
+    if args[0] == "fetch":
+        base = real_run(self, "rev-parse", self._fixture_head + "~1")
+        real_run(self, "update-ref", "refs/preloop/base", base)
+        return ""
+    return real_run(self, *args, **kwargs)
+
+
+CleanGitRepository.run = fake_network_git
+
+
+def fake_provider(request: httpx.Request) -> httpx.Response:
+    if request.url.host != "api.github.com":
+        raise RuntimeError("Non-fixture provider forbidden")
+    if request.method == "DELETE" and request.url.path == "/installation/token":
+        return httpx.Response(204)
+    if request.url.path == "/repos/example/project/pulls":
+        if request.method == "GET":
+            return httpx.Response(200, json=[])
+        if request.method == "POST":
+            payload = json.loads(request.content)
+            return httpx.Response(
+                201,
+                json={
+                    "number": 1,
+                    "html_url": "https://github.com/example/project/pull/1",
+                    "body": payload["body"],
+                },
+            )
+    if (
+        request.method == "PATCH"
+        and request.url.path == "/repos/example/project/pulls/1"
+    ):
+        return httpx.Response(200, json={})
+    raise RuntimeError("Unexpected fixture provider request")
+
+
+class FixtureClient(httpx.AsyncClient):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs["transport"] = httpx.MockTransport(fake_provider)
+        super().__init__(*args, **kwargs)
+
+
+httpx.AsyncClient = FixtureClient


### PR DESCRIPTION
## Summary

Flow-generated PRs use the repository's template and a bounded agent-written title/body, with configuration and commit metadata as fallbacks. Trusted execution links and published commit SHAs provide provenance. Existing PR updates preserve human text outside the publisher-owned attribution block.

The opt-in isolated publication path separates implementation, verification and publishing. The controller pins the repository, base commit, destination and test policy before execution. After capturing recovery data and confirming the agent has stopped, a trusted adapter freezes the Git bundle and runs each relevant check in a fresh credential-free checkout. Only successful checks and confirmed verifier removal authorize a repository-scoped writer credential. The publisher imports the bundle into a clean bare repository, checks history and concurrent remote changes, then pushes and creates or updates the PR without running repository code.

Hosted Docker/Kubernetes verification and the private Docker runner use the same immutable head/digest contract. Private source stays on the runner: authenticated phase messages carry the manifest, selected checks and publication receipt. A dedicated helper receives the write credential on stdin. Cancellation, disconnect, stale phases, mismatched artifacts and missing termination evidence block publication. Failed verification/publication retains recoverable source on the private runner for 24 hours; hosted recovery artifacts are saved before agent teardown.

Refs #431 and #432.

## Configuration and boundaries

- Legacy publication remains the default; select isolated mode explicitly.
- Isolated mode requires a GitHub App tracker and a trusted verification profile/image pinned by digest. The image supplies the dependencies needed by the selected checks. Default harness images remain generic, and private custom images remain supported.
- Private isolated publication requires the updated API/CLI and an operator-pinned helper image. Native host execution, broad PAT credentials and GitLab isolated publication are unsupported. Metadata/template handling supports GitHub and GitLab.
- Kubernetes requires an enforcing network-policy implementation. Exact network-policy validation and recovery behavior are documented in the architecture guide.
- Active private execution recovery restores monitoring from the stored policy without issuing another writer. A recovered hosted run lacking its original policy snapshot, or an interrupted queued isolated run, blocks publication and requires explicit recovery/retry.
- GitLab templates and provider metadata payloads are covered, but GitLab continuation attribution is follow-up work until a scoped isolated broker is available.
- No real provider write, production rollout or paid implementation run was used for validation.

## Testing

- [x] 462 combined backend tests passed on disposable PostgreSQL, including private controller/WebSocket, immutable hosted checks, recovery and result authority.
- [x] Full CLI suite: 1,153 passed, 4 skipped; focused race suite passed.
- [x] Rebuilt the tracked helper fixture and passed the full real Docker lifecycle with fake provider calls: actual bootstrap, freeze, two fresh verifiers, bare Git publication and cleanup, with acknowledgment required before ordinary success.
- [x] Go consumes the actual Python-generated controller messages under race detection; provider-shaped one-hour leases and idempotent duplicate revocation are covered.
- [x] Migration upgrade/downgrade/re-upgrade and all applicable hooks, including generated OpenAPI, passed.
- Existing validation covers repository templates and metadata limits, real Git bundle imports, preservation of human edits, scope reduction, malicious Git configuration, destination/history races, and missing or forged verification evidence.

## Checklist

- [x] Architecture and changelog updated.
- [x] Generic harness and private custom-image behavior retained.
- [x] No secrets included.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low risk**
> Incremental review of the single follow-up commit confirms all previously raised findings are resolved with regression tests; no new issues found.
>
> **Overview**
> Completes the credential-isolated publication path (template-aware PR metadata, repository-scoped GitHub App write leases, nonce-bound private runner handshake, durable recovery boundaries). The follow-up commit fails closed on host-exec isolated publication, guarantees terminal outcome delivery, handles recursion limits, and reaps orphaned publication runtimes at startup.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 8a8354c6. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->