### PR TITLE
Add issue readiness and independent merge-audit foundations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,3 +78,18 @@ graph LR
 
 Execution environment profiles and hosted checkpoint recovery are documented in
 [Environments and recovery](docs/guide/flows/environments-and-recovery.md).
+
+### Issue lifecycle controller
+
+`services/issue_lifecycle.py` coordinates structured readiness, one authorized
+implementation pickup, and independent merge/deployment acceptance audits.
+`IssueLifecycle` records live scope revisions, immutable merge references,
+execution bindings, evidence and follow-up identities through the CRUD layer.
+Transaction locks serialize each tenant/issue; provider markers recover external
+writes after local rollback. The trigger service prepares lifecycle executions
+before ordinary dispatch, and the orchestrator consumes durable structured output
+at completion. The GitHub adapter revalidates closing-commit/merged-PR authority;
+manual completion alone does not start an audit. Readiness consumes approved
+execution-environment capabilities rather than implementing test setup. See
+[Issue readiness and completion audits](docs/guide/flows/issue-lifecycle.md) for
+policy, API and recovery configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   console banner, frozen approval deadlines and durable managed runtime stop
   requests with explicit termination confirmation. Recovery is staged, records
   a reason and preserves outstanding stops across process restart or re-enable.
+- **Issue readiness and merge completion audits**: store reviewable acceptance
+  contracts, authorize pickup using an existing project-configured label, and
+  independently audit provider-verified merged code at its exact SHA. Explicit
+  reconciliation can authorize revised scope after a prior implementation ends,
+  preserving execution history; audit comments and bounded follow-ups deduplicate.
 
 - **Approved flow environments and workspace recovery**: optional pinned profiles
   provide bounded setup and isolated services. Hosted executions can retain encrypted,

--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -30,6 +30,7 @@ from fastapi.encoders import jsonable_encoder
 from preloop.api.auth import auth_router, get_current_active_user
 from preloop.api.endpoints import (
     account,
+    issue_lifecycle,
     agent_control,
     agent_permission,
     anthropic_gateway,
@@ -1015,6 +1016,12 @@ def create_app() -> FastAPI:
         )
         app.include_router(
             issues.router,
+            prefix="/api/v1",
+            tags=["Issues"],
+            dependencies=[Depends(get_current_active_user)],
+        )
+        app.include_router(
+            issue_lifecycle.router,
             prefix="/api/v1",
             tags=["Issues"],
             dependencies=[Depends(get_current_active_user)],

--- a/backend/preloop/api/endpoints/issue_lifecycle.py
+++ b/backend/preloop/api/endpoints/issue_lifecycle.py
@@ -5,7 +5,7 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from preloop.api.auth import get_current_active_user
@@ -116,6 +116,84 @@ def ready_issue(
                 current_user=current_user,
             )
             return await service.ready(request.issue_revision)
+        except ValueError as exc:
+            raise HTTPException(409, str(exc)) from exc
+
+    return run_lifecycle_endpoint(operation)
+
+
+class PickupReconciliationRequest(BaseModel):
+    """Approve a new revision while naming the exact implementation it replaces."""
+
+    issue_revision: str
+    previous_execution_id: UUID
+    reason: str = Field(min_length=1, max_length=2000)
+
+
+@router.post("/pickup/reconcile")
+@require_permission("edit_issues")
+@require_permission("execute_flows")
+def reconcile_pickup(
+    issue_id: UUID,
+    request: PickupReconciliationRequest,
+    db: Session = Depends(get_db_session),
+    current_user: models.User = Depends(get_current_active_user),
+) -> dict[str, Any]:
+    """Authorize and durably dispatch changed scope after the prior run ends."""
+
+    async def operation() -> dict[str, Any]:
+        from preloop.services.flow_trigger_service import FlowTriggerService
+
+        try:
+            service = await build_lifecycle_service(
+                db,
+                issue_id=issue_id,
+                account_id=current_user.account_id,
+                current_user=current_user,
+            )
+            flow_id = service.policy.get("implementation_flow_id")
+            flow = (
+                crud_flow.get(db, id=UUID(flow_id), account_id=current_user.account_id)
+                if flow_id
+                else None
+            )
+            if flow is None or not flow.is_enabled:
+                raise ValueError("implementation_flow_unavailable")
+            result = await service.reconcile_pickup(
+                request.issue_revision, request.previous_execution_id, request.reason
+            )
+            if result["state"] not in {"ready", "dispatched", "label_pending"}:
+                return result
+            trigger = FlowTriggerService(db)
+
+            async def dispatch(execution: models.FlowExecution) -> None:
+                _ = flow.id, execution.id
+                await on_application_loop(
+                    partial(
+                        trigger._start_flow_execution,
+                        flow,
+                        execution.trigger_event_details,
+                        None,
+                        precreated_execution=execution,
+                    )
+                )
+
+            # The ready label can already be present. Do not remove/re-add it
+            # to manufacture another webhook; dispatch the new durable intent.
+            execution = await service.schedule_pickup(
+                flow,
+                {
+                    "type": "issue_updated",
+                    "project_id": str(service.issue.project_id),
+                    "payload": {"issue": {"id": service.issue.external_id}},
+                },
+                dispatch,
+            )
+            return {
+                **result,
+                "state": "dispatched" if execution else "needs_reconciliation",
+                "execution_id": str(execution.id) if execution else None,
+            }
         except ValueError as exc:
             raise HTTPException(409, str(exc)) from exc
 

--- a/backend/preloop/api/endpoints/issue_lifecycle.py
+++ b/backend/preloop/api/endpoints/issue_lifecycle.py
@@ -1,5 +1,6 @@
 """Authenticated lifecycle refinement, readiness and audit recovery endpoints."""
 
+from functools import partial
 from typing import Any
 from uuid import UUID
 
@@ -13,6 +14,10 @@ from preloop.models.crud import crud_flow, crud_flow_execution, crud_issue_lifec
 from preloop.models.db.session import get_db_session
 from preloop.schemas.issue_lifecycle import ReadinessContract
 from preloop.services.issue_lifecycle_runtime import build_lifecycle_service
+from preloop.services.issue_lifecycle_worker import (
+    run_lifecycle_endpoint,
+    on_application_loop,
+)
 from preloop.utils.permissions import require_permission
 
 router = APIRouter(prefix="/issues/{issue_id}/lifecycle")
@@ -26,135 +31,158 @@ class ReadyRequest(BaseModel):
 
 @router.get("")
 @require_permission("view_issues")
-async def lifecycle_status(
+def lifecycle_status(
     issue_id: UUID,
     db: Session = Depends(get_db_session),
     current_user: models.User = Depends(get_current_active_user),
 ) -> dict[str, Any]:
     """Read live scope plus durable readiness, pickup and audit history."""
-    try:
-        service = await build_lifecycle_service(
-            db,
-            issue_id=issue_id,
-            account_id=current_user.account_id,
-            current_user=current_user,
-        )
-        snapshot = await service.provider.issue(service.number)
-        rows = crud_issue_lifecycle.list_for_issue(
-            db, account_id=current_user.account_id, issue_id=issue_id
-        )
-        return {
-            "issue_revision": snapshot.revision,
-            "issue_url": snapshot.url,
-            "history": [
-                {
-                    "kind": row.kind,
-                    "revision": row.revision,
-                    "state": row.state,
-                    "execution_id": str(row.execution_id) if row.execution_id else None,
-                    "data": row.data,
-                }
-                for row in rows
-            ],
-        }
-    except ValueError as exc:
-        raise HTTPException(409, str(exc)) from exc
+
+    async def operation() -> dict[str, Any]:
+        try:
+            service = await build_lifecycle_service(
+                db,
+                issue_id=issue_id,
+                account_id=current_user.account_id,
+                current_user=current_user,
+            )
+            snapshot = await service.provider.issue(service.number)
+            rows = crud_issue_lifecycle.list_for_issue(
+                db, account_id=current_user.account_id, issue_id=issue_id
+            )
+            return {
+                "issue_revision": snapshot.revision,
+                "issue_url": snapshot.url,
+                "history": [
+                    {
+                        "kind": row.kind,
+                        "revision": row.revision,
+                        "state": row.state,
+                        "execution_id": str(row.execution_id)
+                        if row.execution_id
+                        else None,
+                        "data": row.data,
+                    }
+                    for row in rows
+                ],
+            }
+        except ValueError as exc:
+            raise HTTPException(409, str(exc)) from exc
+
+    return run_lifecycle_endpoint(operation)
 
 
 @router.post("/refine")
 @require_permission("edit_issues")
-async def refine_issue(
+def refine_issue(
     issue_id: UUID,
     contract: ReadinessContract,
     db: Session = Depends(get_db_session),
     current_user: models.User = Depends(get_current_active_user),
 ) -> dict[str, Any]:
     """Store a reviewable proposal; this operation cannot launch implementation."""
-    try:
-        service = await build_lifecycle_service(
-            db,
-            issue_id=issue_id,
-            account_id=current_user.account_id,
-            current_user=current_user,
-        )
-        return await service.refine(contract)
-    except ValueError as exc:
-        raise HTTPException(409, str(exc)) from exc
+
+    async def operation() -> dict[str, Any]:
+        try:
+            service = await build_lifecycle_service(
+                db,
+                issue_id=issue_id,
+                account_id=current_user.account_id,
+                current_user=current_user,
+            )
+            return await service.refine(contract)
+        except ValueError as exc:
+            raise HTTPException(409, str(exc)) from exc
+
+    return run_lifecycle_endpoint(operation)
 
 
 @router.post("/ready")
 @require_permission("edit_issues")
-async def ready_issue(
+def ready_issue(
     issue_id: UUID,
     request: ReadyRequest,
     db: Session = Depends(get_db_session),
     current_user: models.User = Depends(get_current_active_user),
 ) -> dict[str, Any]:
     """Apply the configured readiness policy once to an approved scope."""
-    try:
-        service = await build_lifecycle_service(
-            db,
-            issue_id=issue_id,
-            account_id=current_user.account_id,
-            current_user=current_user,
-        )
-        return await service.ready(request.issue_revision)
-    except ValueError as exc:
-        raise HTTPException(409, str(exc)) from exc
+
+    async def operation() -> dict[str, Any]:
+        try:
+            service = await build_lifecycle_service(
+                db,
+                issue_id=issue_id,
+                account_id=current_user.account_id,
+                current_user=current_user,
+            )
+            return await service.ready(request.issue_revision)
+        except ValueError as exc:
+            raise HTTPException(409, str(exc)) from exc
+
+    return run_lifecycle_endpoint(operation)
 
 
 @router.post("/audit/reconcile")
 @require_permission("execute_flows")
-async def reconcile_audit(
+def reconcile_audit(
     issue_id: UUID,
     db: Session = Depends(get_db_session),
     current_user: models.User = Depends(get_current_active_user),
 ) -> dict[str, Any]:
     """Recover dispatch/publication after a transient provider or worker failure."""
-    from preloop.services.flow_trigger_service import FlowTriggerService
 
-    try:
-        service = await build_lifecycle_service(
-            db,
-            issue_id=issue_id,
-            account_id=current_user.account_id,
-            current_user=current_user,
-        )
-        flow_id = service.policy.get("audit_flow_id")
-        flow = (
-            crud_flow.get(db, id=UUID(flow_id), account_id=current_user.account_id)
-            if flow_id
-            else None
-        )
-        if not flow or not flow.is_enabled:
-            raise ValueError("audit_flow_not_configured")
-        trigger = FlowTriggerService(db)
+    async def operation() -> dict[str, Any]:
+        from preloop.services.flow_trigger_service import FlowTriggerService
 
-        async def dispatch(execution: models.FlowExecution) -> None:
-            await trigger._start_flow_execution(
-                flow,
-                execution.trigger_event_details,
-                None,
-                precreated_execution=execution,
+        try:
+            service = await build_lifecycle_service(
+                db,
+                issue_id=issue_id,
+                account_id=current_user.account_id,
+                current_user=current_user,
             )
+            flow_id = service.policy.get("audit_flow_id")
+            flow = (
+                crud_flow.get(db, id=UUID(flow_id), account_id=current_user.account_id)
+                if flow_id
+                else None
+            )
+            if not flow or not flow.is_enabled:
+                raise ValueError("audit_flow_not_configured")
+            trigger = FlowTriggerService(db)
 
-        execution = await service.schedule_audit(flow, dispatch)
-        if execution and execution.status in {
-            "SUCCEEDED",
-            "FAILED",
-            "CANCELLED",
-            "TIMED_OUT",
-            "ABORTED",
-        }:
-            # Reload after any concurrent worker update, through the CRUD layer.
-            execution = crud_flow_execution.get(db, id=execution.id)
-            return await service.finish_audit(execution)
-        return {
-            "execution_id": str(execution.id) if execution else None,
-            "state": execution.status if execution else "no_pending_merge_audit",
-        }
-    except ValueError as exc:
-        raise HTTPException(409, str(exc)) from exc
+            async def dispatch(execution: models.FlowExecution) -> None:
+                # Resolve expired ORM attributes in this worker before dispatch.
+                _ = flow.id, execution.id
+                await on_application_loop(
+                    partial(
+                        trigger._start_flow_execution,
+                        flow,
+                        execution.trigger_event_details,
+                        None,
+                        precreated_execution=execution,
+                    )
+                )
+
+            execution = await service.schedule_audit(flow, dispatch)
+            if execution and execution.status in {
+                "SUCCEEDED",
+                "FAILED",
+                "CANCELLED",
+                "TIMED_OUT",
+                "ABORTED",
+            }:
+                # Reload after any concurrent worker update, through the CRUD layer.
+                execution = crud_flow_execution.get(db, id=execution.id)
+                return await service.finish_audit(execution)
+            return {
+                "execution_id": str(execution.id) if execution else None,
+                "state": execution.status if execution else "no_pending_merge_audit",
+            }
+        except ValueError as exc:
+            raise HTTPException(409, str(exc)) from exc
+
+    return run_lifecycle_endpoint(operation)
 
 
 class DeploymentVerificationRequest(BaseModel):
@@ -168,65 +196,75 @@ class DeploymentVerificationRequest(BaseModel):
 
 @router.post("/deployment/verify")
 @require_permission("execute_flows")
-async def verify_deployment(
+def verify_deployment(
     issue_id: UUID,
     request: DeploymentVerificationRequest,
     db: Session = Depends(get_db_session),
     current_user: models.User = Depends(get_current_active_user),
 ) -> dict[str, Any]:
     """Trigger a separately approved target/scope after recording deployment."""
-    import re
 
-    from preloop.services.flow_trigger_service import FlowTriggerService
+    async def operation() -> dict[str, Any]:
+        import re
 
-    if (
-        not re.fullmatch(r"[0-9a-f]{40}", request.deployed_revision)
-        or not re.fullmatch(r"[0-9a-f]{40}", request.merge_sha)
-        or not request.deployment_evidence
-    ):
-        raise HTTPException(
-            422, "Exact merge/deployed revisions and deployment evidence are required"
-        )
-    try:
-        service = await build_lifecycle_service(
-            db,
-            issue_id=issue_id,
-            account_id=current_user.account_id,
-            current_user=current_user,
-        )
-        target = (service.policy.get("deployment_targets") or {}).get(
-            request.target
-        ) or {}
-        flow = (
-            crud_flow.get(
-                db, id=UUID(target["flow_id"]), account_id=current_user.account_id
+        from preloop.services.flow_trigger_service import FlowTriggerService
+
+        if (
+            not re.fullmatch(r"[0-9a-f]{40}", request.deployed_revision)
+            or not re.fullmatch(r"[0-9a-f]{40}", request.merge_sha)
+            or not request.deployment_evidence
+        ):
+            raise HTTPException(
+                422,
+                "Exact merge/deployed revisions and deployment evidence are required",
             )
-            if target.get("flow_id")
-            else None
-        )
-        if flow is None:
-            raise ValueError("deployment_scope_not_authorized")
-        trigger = FlowTriggerService(db)
-
-        async def dispatch(execution: models.FlowExecution) -> None:
-            await trigger._start_flow_execution(
-                flow,
-                execution.trigger_event_details,
-                None,
-                precreated_execution=execution,
+        try:
+            service = await build_lifecycle_service(
+                db,
+                issue_id=issue_id,
+                account_id=current_user.account_id,
+                current_user=current_user,
             )
+            target = (service.policy.get("deployment_targets") or {}).get(
+                request.target
+            ) or {}
+            flow = (
+                crud_flow.get(
+                    db, id=UUID(target["flow_id"]), account_id=current_user.account_id
+                )
+                if target.get("flow_id")
+                else None
+            )
+            if flow is None:
+                raise ValueError("deployment_scope_not_authorized")
+            trigger = FlowTriggerService(db)
 
-        execution = await service.schedule_deployment_audit(
-            flow=flow, dispatch=dispatch, **request.model_dump()
-        )
-        if execution.status in {
-            "SUCCEEDED",
-            "FAILED",
-            "CANCELLED",
-            "TIMED_OUT",
-            "ABORTED",
-        }:
-            return await service.finish_audit(execution)
-        return {"execution_id": str(execution.id), "state": execution.status}
-    except ValueError as exc:
-        raise HTTPException(409, str(exc)) from exc
+            async def dispatch(execution: models.FlowExecution) -> None:
+                # Resolve expired ORM attributes in this worker before dispatch.
+                _ = flow.id, execution.id
+                await on_application_loop(
+                    partial(
+                        trigger._start_flow_execution,
+                        flow,
+                        execution.trigger_event_details,
+                        None,
+                        precreated_execution=execution,
+                    )
+                )
+
+            execution = await service.schedule_deployment_audit(
+                flow=flow, dispatch=dispatch, **request.model_dump()
+            )
+            if execution.status in {
+                "SUCCEEDED",
+                "FAILED",
+                "CANCELLED",
+                "TIMED_OUT",
+                "ABORTED",
+            }:
+                return await service.finish_audit(execution)
+            return {"execution_id": str(execution.id), "state": execution.status}
+        except ValueError as exc:
+            raise HTTPException(409, str(exc)) from exc
+
+    return run_lifecycle_endpoint(operation)

--- a/backend/preloop/api/endpoints/issue_lifecycle.py
+++ b/backend/preloop/api/endpoints/issue_lifecycle.py
@@ -15,9 +15,8 @@ from preloop.models.db.session import get_db_session
 from preloop.schemas.issue_lifecycle import ReadinessContract
 from preloop.services.issue_lifecycle_runtime import build_lifecycle_service
 from preloop.services.issue_lifecycle_worker import (
-    run_lifecycle_endpoint,
     dispatch_lifecycle_execution,
-    on_application_loop,
+    run_lifecycle_endpoint,
 )
 from preloop.utils.permissions import require_permission
 
@@ -244,16 +243,23 @@ def reconcile_audit(
             trigger = FlowTriggerService(db)
 
             async def dispatch(execution: models.FlowExecution) -> None:
-                # Resolve expired ORM attributes in this worker before dispatch.
+                # Halt and ORM reads stay on this worker. NATS publish (or
+                # local dispatch) crosses to the application loop without the
+                # request Session.
                 _ = flow.id, execution.id
-                await on_application_loop(
+                from preloop.services.kill_switch import flows_halted
+
+                if isinstance(db, Session) and flows_halted(db, flow.account_id):
+                    return
+                await dispatch_lifecycle_execution(
+                    execution.id,
                     partial(
                         trigger._start_flow_execution,
                         flow,
                         execution.trigger_event_details,
                         None,
                         precreated_execution=execution,
-                    )
+                    ),
                 )
 
             execution = await service.schedule_audit(flow, dispatch)
@@ -332,16 +338,23 @@ def verify_deployment(
             trigger = FlowTriggerService(db)
 
             async def dispatch(execution: models.FlowExecution) -> None:
-                # Resolve expired ORM attributes in this worker before dispatch.
+                # Halt and ORM reads stay on this worker. NATS publish (or
+                # local dispatch) crosses to the application loop without the
+                # request Session.
                 _ = flow.id, execution.id
-                await on_application_loop(
+                from preloop.services.kill_switch import flows_halted
+
+                if isinstance(db, Session) and flows_halted(db, flow.account_id):
+                    return
+                await dispatch_lifecycle_execution(
+                    execution.id,
                     partial(
                         trigger._start_flow_execution,
                         flow,
                         execution.trigger_event_details,
                         None,
                         precreated_execution=execution,
-                    )
+                    ),
                 )
 
             execution = await service.schedule_deployment_audit(

--- a/backend/preloop/api/endpoints/issue_lifecycle.py
+++ b/backend/preloop/api/endpoints/issue_lifecycle.py
@@ -1,0 +1,232 @@
+"""Authenticated lifecycle refinement, readiness and audit recovery endpoints."""
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from preloop.api.auth import get_current_active_user
+from preloop.models import models
+from preloop.models.crud import crud_flow, crud_flow_execution, crud_issue_lifecycle
+from preloop.models.db.session import get_db_session
+from preloop.schemas.issue_lifecycle import ReadinessContract
+from preloop.services.issue_lifecycle_runtime import build_lifecycle_service
+from preloop.utils.permissions import require_permission
+
+router = APIRouter(prefix="/issues/{issue_id}/lifecycle")
+
+
+class ReadyRequest(BaseModel):
+    """The reviewer approves one exact issue revision."""
+
+    issue_revision: str
+
+
+@router.get("")
+@require_permission("view_issues")
+async def lifecycle_status(
+    issue_id: UUID,
+    db: Session = Depends(get_db_session),
+    current_user: models.User = Depends(get_current_active_user),
+) -> dict[str, Any]:
+    """Read live scope plus durable readiness, pickup and audit history."""
+    try:
+        service = await build_lifecycle_service(
+            db,
+            issue_id=issue_id,
+            account_id=current_user.account_id,
+            current_user=current_user,
+        )
+        snapshot = await service.provider.issue(service.number)
+        rows = crud_issue_lifecycle.list_for_issue(
+            db, account_id=current_user.account_id, issue_id=issue_id
+        )
+        return {
+            "issue_revision": snapshot.revision,
+            "issue_url": snapshot.url,
+            "history": [
+                {
+                    "kind": row.kind,
+                    "revision": row.revision,
+                    "state": row.state,
+                    "execution_id": str(row.execution_id) if row.execution_id else None,
+                    "data": row.data,
+                }
+                for row in rows
+            ],
+        }
+    except ValueError as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+@router.post("/refine")
+@require_permission("edit_issues")
+async def refine_issue(
+    issue_id: UUID,
+    contract: ReadinessContract,
+    db: Session = Depends(get_db_session),
+    current_user: models.User = Depends(get_current_active_user),
+) -> dict[str, Any]:
+    """Store a reviewable proposal; this operation cannot launch implementation."""
+    try:
+        service = await build_lifecycle_service(
+            db,
+            issue_id=issue_id,
+            account_id=current_user.account_id,
+            current_user=current_user,
+        )
+        return await service.refine(contract)
+    except ValueError as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+@router.post("/ready")
+@require_permission("edit_issues")
+async def ready_issue(
+    issue_id: UUID,
+    request: ReadyRequest,
+    db: Session = Depends(get_db_session),
+    current_user: models.User = Depends(get_current_active_user),
+) -> dict[str, Any]:
+    """Apply the configured readiness policy once to an approved scope."""
+    try:
+        service = await build_lifecycle_service(
+            db,
+            issue_id=issue_id,
+            account_id=current_user.account_id,
+            current_user=current_user,
+        )
+        return await service.ready(request.issue_revision)
+    except ValueError as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+@router.post("/audit/reconcile")
+@require_permission("execute_flows")
+async def reconcile_audit(
+    issue_id: UUID,
+    db: Session = Depends(get_db_session),
+    current_user: models.User = Depends(get_current_active_user),
+) -> dict[str, Any]:
+    """Recover dispatch/publication after a transient provider or worker failure."""
+    from preloop.services.flow_trigger_service import FlowTriggerService
+
+    try:
+        service = await build_lifecycle_service(
+            db,
+            issue_id=issue_id,
+            account_id=current_user.account_id,
+            current_user=current_user,
+        )
+        flow_id = service.policy.get("audit_flow_id")
+        flow = (
+            crud_flow.get(db, id=UUID(flow_id), account_id=current_user.account_id)
+            if flow_id
+            else None
+        )
+        if not flow or not flow.is_enabled:
+            raise ValueError("audit_flow_not_configured")
+        trigger = FlowTriggerService(db)
+
+        async def dispatch(execution: models.FlowExecution) -> None:
+            await trigger._start_flow_execution(
+                flow,
+                execution.trigger_event_details,
+                None,
+                precreated_execution=execution,
+            )
+
+        execution = await service.schedule_audit(flow, dispatch)
+        if execution and execution.status in {
+            "SUCCEEDED",
+            "FAILED",
+            "CANCELLED",
+            "TIMED_OUT",
+            "ABORTED",
+        }:
+            # Reload after any concurrent worker update, through the CRUD layer.
+            execution = crud_flow_execution.get(db, id=execution.id)
+            return await service.finish_audit(execution)
+        return {
+            "execution_id": str(execution.id) if execution else None,
+            "state": execution.status if execution else "no_pending_merge_audit",
+        }
+    except ValueError as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+class DeploymentVerificationRequest(BaseModel):
+    """An authenticated deployment record, never inferred from issue closure."""
+
+    merge_sha: str
+    target: str
+    deployed_revision: str
+    deployment_evidence: str
+
+
+@router.post("/deployment/verify")
+@require_permission("execute_flows")
+async def verify_deployment(
+    issue_id: UUID,
+    request: DeploymentVerificationRequest,
+    db: Session = Depends(get_db_session),
+    current_user: models.User = Depends(get_current_active_user),
+) -> dict[str, Any]:
+    """Trigger a separately approved target/scope after recording deployment."""
+    import re
+
+    from preloop.services.flow_trigger_service import FlowTriggerService
+
+    if (
+        not re.fullmatch(r"[0-9a-f]{40}", request.deployed_revision)
+        or not re.fullmatch(r"[0-9a-f]{40}", request.merge_sha)
+        or not request.deployment_evidence
+    ):
+        raise HTTPException(
+            422, "Exact merge/deployed revisions and deployment evidence are required"
+        )
+    try:
+        service = await build_lifecycle_service(
+            db,
+            issue_id=issue_id,
+            account_id=current_user.account_id,
+            current_user=current_user,
+        )
+        target = (service.policy.get("deployment_targets") or {}).get(
+            request.target
+        ) or {}
+        flow = (
+            crud_flow.get(
+                db, id=UUID(target["flow_id"]), account_id=current_user.account_id
+            )
+            if target.get("flow_id")
+            else None
+        )
+        if flow is None:
+            raise ValueError("deployment_scope_not_authorized")
+        trigger = FlowTriggerService(db)
+
+        async def dispatch(execution: models.FlowExecution) -> None:
+            await trigger._start_flow_execution(
+                flow,
+                execution.trigger_event_details,
+                None,
+                precreated_execution=execution,
+            )
+
+        execution = await service.schedule_deployment_audit(
+            flow=flow, dispatch=dispatch, **request.model_dump()
+        )
+        if execution.status in {
+            "SUCCEEDED",
+            "FAILED",
+            "CANCELLED",
+            "TIMED_OUT",
+            "ABORTED",
+        }:
+            return await service.finish_audit(execution)
+        return {"execution_id": str(execution.id), "state": execution.status}
+    except ValueError as exc:
+        raise HTTPException(409, str(exc)) from exc

--- a/backend/preloop/api/endpoints/issue_lifecycle.py
+++ b/backend/preloop/api/endpoints/issue_lifecycle.py
@@ -16,6 +16,7 @@ from preloop.schemas.issue_lifecycle import ReadinessContract
 from preloop.services.issue_lifecycle_runtime import build_lifecycle_service
 from preloop.services.issue_lifecycle_worker import (
     run_lifecycle_endpoint,
+    dispatch_lifecycle_execution,
     on_application_loop,
 )
 from preloop.utils.permissions import require_permission
@@ -162,20 +163,26 @@ def reconcile_pickup(
             result = await service.reconcile_pickup(
                 request.issue_revision, request.previous_execution_id, request.reason
             )
-            if result["state"] not in {"ready", "dispatched", "label_pending"}:
+            if result["state"] not in {
+                "ready",
+                "dispatched",
+                "dispatch_pending",
+                "label_pending",
+            }:
                 return result
             trigger = FlowTriggerService(db)
 
             async def dispatch(execution: models.FlowExecution) -> None:
                 _ = flow.id, execution.id
-                await on_application_loop(
+                await dispatch_lifecycle_execution(
+                    execution.id,
                     partial(
                         trigger._start_flow_execution,
                         flow,
                         execution.trigger_event_details,
                         None,
                         precreated_execution=execution,
-                    )
+                    ),
                 )
 
             # The ready label can already be present. Do not remove/re-add it
@@ -189,9 +196,16 @@ def reconcile_pickup(
                 },
                 dispatch,
             )
+            pickup = crud_issue_lifecycle.get(
+                db,
+                account_id=current_user.account_id,
+                issue_id=issue_id,
+                kind="pickup",
+                revision="once",
+            )
             return {
                 **result,
-                "state": "dispatched" if execution else "needs_reconciliation",
+                "state": pickup.state if pickup else "needs_reconciliation",
                 "execution_id": str(execution.id) if execution else None,
             }
         except ValueError as exc:

--- a/backend/preloop/models/alembic/versions/20260906_issue_lifecycle.py
+++ b/backend/preloop/models/alembic/versions/20260906_issue_lifecycle.py
@@ -1,0 +1,58 @@
+"""Persist readiness pickups and independent merge-audit operations."""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20260906_issue_lifecycle"
+down_revision = "20260906_flow_artifacts"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create tenant-scoped, idempotent lifecycle operation storage."""
+    op.create_table(
+        "issue_lifecycle",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "account_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("account.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "issue_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("issue.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.String(30), nullable=False),
+        sa.Column("revision", sa.String(64), nullable=False),
+        sa.Column("state", sa.String(30), nullable=False),
+        sa.Column("data", sa.JSON(), nullable=False),
+        sa.Column(
+            "execution_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("flow_execution.id", ondelete="SET NULL"),
+        ),
+        sa.UniqueConstraint(
+            "account_id",
+            "issue_id",
+            "kind",
+            "revision",
+            name="uq_issue_lifecycle_revision",
+        ),
+    )
+    op.create_index("ix_issue_lifecycle_id", "issue_lifecycle", ["id"])
+
+
+def downgrade() -> None:
+    """Remove lifecycle operation storage."""
+    op.drop_table("issue_lifecycle")

--- a/backend/preloop/models/alembic/versions/20260906_lifecycle_key_merge.py
+++ b/backend/preloop/models/alembic/versions/20260906_lifecycle_key_merge.py
@@ -1,0 +1,20 @@
+"""Merge publication-capability and issue-lifecycle histories.
+
+Revision ID: 20260906_lifecycle_key_merge
+Revises: 20260906_pub_caps_merge, 20260906_issue_lifecycle
+"""
+
+revision = "20260906_lifecycle_key_merge"
+down_revision = ("20260906_pub_caps_merge", "20260906_issue_lifecycle")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Preserve both already-applied migration branches."""
+    pass
+
+
+def downgrade() -> None:
+    """Return to the two independent heads without modifying their data."""
+    pass

--- a/backend/preloop/models/crud/__init__.py
+++ b/backend/preloop/models/crud/__init__.py
@@ -48,6 +48,7 @@ from .flow_execution import CRUDFlowExecution
 from .flow_execution_log import CRUDFlowExecutionLog
 from .flow_runner import CRUDFlowRunner, crud_flow_runner
 from .issue import CRUDIssue
+from .issue_lifecycle import crud_issue_lifecycle
 from .organization import CRUDOrganization  # Removed create_organization import
 from .project import CRUDProject
 from .tracker import CRUDTracker, crud_tracker
@@ -196,8 +197,10 @@ crud_mcp_tool = CRUDMCPTool()  # Instantiate CRUDMCPTool
 crud_approval_workflow = CRUDApprovalWorkflow()  # Instantiate CRUDApprovalWorkflow
 crud_tool_access_rule = CRUDToolAccessRule()  # Instantiate CRUDToolAccessRule
 
+
 __all__ = [
     "crud_flow_feedback",
+    "crud_issue_lifecycle",
     "CRUDBase",
     "CRUDAccount",
     "CRUDAccountHalt",

--- a/backend/preloop/models/crud/issue_lifecycle.py
+++ b/backend/preloop/models/crud/issue_lifecycle.py
@@ -1,0 +1,151 @@
+"""Transactional lifecycle persistence and per-issue serialization."""
+
+import asyncio
+from contextlib import asynccontextmanager
+from time import monotonic
+from hashlib import sha256
+from typing import Any, AsyncIterator
+from uuid import UUID
+
+from sqlalchemy import select, text
+from sqlalchemy.orm import Session
+
+from preloop.models import models
+
+
+class CRUDIssueLifecycle:
+    """Serialize decisions through transaction locks, including first insert."""
+
+    def get_issue(
+        self, db: Session, *, account_id: UUID, issue_id: UUID
+    ) -> models.Issue | None:
+        """Resolve indirect tenant ownership explicitly rather than CRUDBase.get."""
+        return db.scalar(
+            select(models.Issue)
+            .join(models.Tracker, models.Issue.tracker_id == models.Tracker.id)
+            .where(models.Issue.id == issue_id, models.Tracker.account_id == account_id)
+        )
+
+    def get_project(
+        self, db: Session, *, account_id: UUID, project_id: UUID
+    ) -> models.Project | None:
+        """Resolve project ownership through organization and tracker."""
+        return db.scalar(
+            select(models.Project)
+            .join(
+                models.Organization,
+                models.Project.organization_id == models.Organization.id,
+            )
+            .join(models.Tracker, models.Organization.tracker_id == models.Tracker.id)
+            .where(
+                models.Project.id == project_id, models.Tracker.account_id == account_id
+            )
+        )
+
+    @asynccontextmanager
+    async def locked(
+        self, db: Session, account_id: UUID, issue_id: UUID
+    ) -> AsyncIterator[None]:
+        """Keep provider effects and their local acknowledgment serialized.
+
+        Provider effects MUST additionally be idempotent by operation marker;
+        database rollback cannot undo a successful remote API call.
+        """
+        key = int.from_bytes(
+            sha256(f"{account_id}:{issue_id}".encode()).digest()[:8], "big", signed=True
+        )
+        deadline = monotonic() + 10
+        while not db.scalar(
+            text("SELECT pg_try_advisory_xact_lock(:key)"), {"key": key}
+        ):
+            if monotonic() >= deadline:
+                db.rollback()
+                raise ValueError("lifecycle_operation_in_progress")
+            # A blocking advisory lock would deadlock the event loop while the
+            # lock owner is awaiting its provider response. Retry without
+            # blocking the async request/worker that currently owns the lock.
+            await asyncio.sleep(0.05)
+        try:
+            yield
+            db.commit()
+        except BaseException:
+            db.rollback()
+            raise
+
+    def get(
+        self, db: Session, *, account_id: UUID, issue_id: UUID, kind: str, revision: str
+    ) -> models.IssueLifecycle | None:
+        """Load a tenant-scoped operation."""
+        return db.scalar(
+            select(models.IssueLifecycle).where(
+                models.IssueLifecycle.account_id == account_id,
+                models.IssueLifecycle.issue_id == issue_id,
+                models.IssueLifecycle.kind == kind,
+                models.IssueLifecycle.revision == revision,
+            )
+        )
+
+    def list_for_issue(
+        self, db: Session, *, account_id: UUID, issue_id: UUID
+    ) -> list[models.IssueLifecycle]:
+        """Return operation history for reconciliation."""
+        return list(
+            db.scalars(
+                select(models.IssueLifecycle)
+                .where(
+                    models.IssueLifecycle.account_id == account_id,
+                    models.IssueLifecycle.issue_id == issue_id,
+                )
+                .order_by(models.IssueLifecycle.created_at)
+            )
+        )
+
+    def put(
+        self,
+        db: Session,
+        *,
+        account_id: UUID,
+        issue_id: UUID,
+        kind: str,
+        revision: str,
+        state: str,
+        data: dict[str, Any],
+    ) -> models.IssueLifecycle:
+        """Upsert while the caller holds the issue lock; do not commit."""
+        row = self.get(
+            db, account_id=account_id, issue_id=issue_id, kind=kind, revision=revision
+        )
+        if row is None:
+            row = models.IssueLifecycle(
+                account_id=account_id, issue_id=issue_id, kind=kind, revision=revision
+            )
+            db.add(row)
+        row.state, row.data = state, data
+        db.flush()
+        return row
+
+    def create_execution(
+        self,
+        db: Session,
+        *,
+        row: models.IssueLifecycle,
+        flow_id: UUID,
+        event: dict[str, Any],
+    ) -> models.FlowExecution:
+        """Atomically attach one fresh conversation to an audit operation."""
+        if row.execution_id:
+            execution = db.get(models.FlowExecution, row.execution_id)
+            if execution is None:
+                raise ValueError("lifecycle_execution_missing")
+            return execution
+        execution = models.FlowExecution(
+            flow_id=flow_id, status="PENDING", trigger_event_details=event
+        )
+        db.add(execution)
+        db.flush()
+        row.execution_id = execution.id
+        db.flush()
+        return execution
+
+
+crud_issue_lifecycle = CRUDIssueLifecycle()

--- a/backend/preloop/models/crud/issue_lifecycle.py
+++ b/backend/preloop/models/crud/issue_lifecycle.py
@@ -124,6 +124,29 @@ class CRUDIssueLifecycle:
         db.flush()
         return row
 
+    def archive_pickup(self, db: Session, *, row: models.IssueLifecycle) -> None:
+        """Preserve authorization/execution history before an explicit replacement."""
+        archived = self.put(
+            db,
+            account_id=row.account_id,
+            issue_id=row.issue_id,
+            kind="pickup",
+            revision=row.data.get("authorization_id", row.data["issue_revision"]),
+            state="superseded",
+            data=dict(row.data),
+        )
+        archived.execution_id = row.execution_id
+        row.execution_id = None
+        db.flush()
+
+    def pickup_execution(
+        self, db: Session, *, row: models.IssueLifecycle
+    ) -> models.FlowExecution | None:
+        """Read the bound execution inside the issue authorization transaction."""
+        return (
+            db.get(models.FlowExecution, row.execution_id) if row.execution_id else None
+        )
+
     def create_execution(
         self,
         db: Session,

--- a/backend/preloop/models/models/__init__.py
+++ b/backend/preloop/models/models/__init__.py
@@ -84,9 +84,12 @@ from .oauth_mcp_token import (
 )
 from .budget import BudgetPolicy, BudgetSpendActivity, BudgetPeriod
 
+from .issue_lifecycle import IssueLifecycle
+
 __all__ = [
     "FlowFeedback",
     "FlowThread",
+    "IssueLifecycle",
     "Base",
     "Account",
     "AccountHalt",

--- a/backend/preloop/models/models/issue_lifecycle.py
+++ b/backend/preloop/models/models/issue_lifecycle.py
@@ -1,0 +1,36 @@
+"""Durable readiness and merge-audit operations, scoped to an issue and tenant."""
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, JSON, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class IssueLifecycle(Base):
+    """One readiness pickup or audit per immutable merge revision."""
+
+    __tablename__ = "issue_lifecycle"
+    __table_args__ = (
+        UniqueConstraint(
+            "account_id",
+            "issue_id",
+            "kind",
+            "revision",
+            name="uq_issue_lifecycle_revision",
+        ),
+    )
+
+    account_id: Mapped[UUID] = mapped_column(
+        ForeignKey("account.id", ondelete="CASCADE")
+    )
+    issue_id: Mapped[UUID] = mapped_column(ForeignKey("issue.id", ondelete="CASCADE"))
+    kind: Mapped[str] = mapped_column(String(30))
+    revision: Mapped[str] = mapped_column(String(64))
+    state: Mapped[str] = mapped_column(String(30), default="pending")
+    data: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+    execution_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("flow_execution.id", ondelete="SET NULL"), nullable=True
+    )

--- a/backend/preloop/schemas/issue_lifecycle.py
+++ b/backend/preloop/schemas/issue_lifecycle.py
@@ -1,0 +1,65 @@
+"""Contracts shared by triage, readiness and independent completion audits."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Criterion(BaseModel):
+    """Observable acceptance, independently addressable by evidence."""
+
+    id: str = Field(min_length=1, max_length=80)
+    outcome: str = Field(min_length=1, max_length=2000)
+    verification: str = Field(min_length=1, max_length=2000)
+    deployment_required: bool = False
+
+
+class ReadinessContract(BaseModel):
+    """A proposal can be incomplete; readiness explains each missing decision."""
+
+    model_config = ConfigDict(extra="forbid")
+    issue_revision: str
+    problem: str = ""
+    user_outcome: str = ""
+    constraints: list[str] = Field(default_factory=list)
+    non_goals: list[str] = Field(default_factory=list)
+    assumptions: list[str] = Field(default_factory=list)
+    blocking_decisions: list[str] = Field(default_factory=list)
+    conflicts: list[str] = Field(default_factory=list)
+    criteria: list[Criterion] = Field(default_factory=list)
+    code_entry_points: list[str] = Field(default_factory=list)
+    test_entry_points: list[str] = Field(default_factory=list)
+    dependencies: list[int] = Field(default_factory=list)
+    environment_profile: str = ""
+    test_commands: list[str] = Field(default_factory=list)
+
+
+class CriterionEvidence(BaseModel):
+    """Evidence is classified explicitly; code inspection is not a test run."""
+
+    criterion_id: str
+    verdict: Literal["complete", "gap", "unknown"]
+    code: list[str] = Field(default_factory=list)
+    tests: list[str] = Field(default_factory=list)
+    observations: list[str] = Field(default_factory=list)
+    reason: str
+
+
+class FollowUp(BaseModel):
+    """A bounded, confirmed defect or enhancement; never auto-ready."""
+
+    criterion_id: str
+    kind: Literal["defect", "enhancement"]
+    title: str = Field(min_length=1, max_length=200)
+    description: str = Field(min_length=1, max_length=6000)
+    evidence: list[str] = Field(min_length=1)
+
+
+class AuditResult(BaseModel):
+    """Structured output accepted only from the bound independent execution."""
+
+    status: Literal["success"]
+    checked_out_sha: str = Field(pattern=r"^[0-9a-f]{40}$")
+    issue_revision: str
+    criteria: list[CriterionEvidence]
+    follow_ups: list[FollowUp] = Field(default_factory=list, max_length=20)

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -4466,6 +4466,16 @@ class FlowExecutionOrchestrator:
         try:
             if not self.flow or not self.execution_log:
                 return
+            try:
+                from preloop.services.issue_lifecycle_runtime import (
+                    lifecycle_execution_finished,
+                )
+
+                await lifecycle_execution_finished(
+                    self.db, self.execution_log, self.flow
+                )
+            except Exception:
+                logger.exception("Issue lifecycle completion needs reconciliation")
             notifications = getattr(self.flow, "notifications", None)
             if not notifications:
                 return

--- a/backend/preloop/services/flow_trigger_service.py
+++ b/backend/preloop/services/flow_trigger_service.py
@@ -688,6 +688,16 @@ class FlowTriggerService:
                 precreated_execution.id,
             )
             return precreated_execution
+
+        if precreated_execution is None:
+            from preloop.services.issue_lifecycle_runtime import lifecycle_flow_entry
+
+            handled, lifecycle_execution = await lifecycle_flow_entry(
+                self, flow, event_data, nats_client
+            )
+            if handled:
+                return lifecycle_execution
+
         if precreated_execution is not None:
             execution = precreated_execution
             execution_id = execution.id

--- a/backend/preloop/services/flow_trigger_service.py
+++ b/backend/preloop/services/flow_trigger_service.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
+import threading
 import uuid
 from typing import Any, Dict, List, Optional
 
+from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Session, sessionmaker
 
 from preloop.models.crud import crud_flow, crud_flow_execution
@@ -103,10 +105,31 @@ class FlowTriggerService:
 
     def __init__(self, db: Session, session_factory: sessionmaker | None = None):
         self.db = db
-        self.session_factory = session_factory or get_session_factory()
+        self._session_factory = session_factory
+        self._db_thread = threading.get_ident()
 
     def _create_orchestrator_session(self) -> Session:
-        return self.session_factory()
+        factory = self._session_factory or get_session_factory()
+        return factory()
+
+    def _flows_halted(self, account_id: Any) -> bool:
+        """Read the account halt flag on a Session owned by this thread.
+
+        Lifecycle workers may marshal ``_start_flow_execution`` onto the
+        application loop. SQLAlchemy sync Sessions are not safe there.
+        """
+        db = self.db
+        if (
+            isinstance(db, Session)
+            and threading.get_ident() != self._db_thread
+            and not isinstance(db.get_bind(), Connection)
+        ):
+            session = self._create_orchestrator_session()
+            try:
+                return flows_halted(session, account_id)
+            finally:
+                session.close()
+        return flows_halted(db, account_id)
 
     def _extract_resource_key(self, event_data: Dict[str, Any]) -> Optional[str]:
         """
@@ -673,7 +696,7 @@ class FlowTriggerService:
         from preloop.services.flow_execution_runner import run_existing_execution
         from preloop.services.flow_orchestrator import _make_json_serializable
 
-        if flows_halted(self.db, flow.account_id):
+        if self._flows_halted(flow.account_id):
             if precreated_execution is None:
                 raise FlowHaltActiveError(
                     f"Flow '{flow.name}' ({flow.id}) not started: the account "
@@ -691,12 +714,19 @@ class FlowTriggerService:
 
         if precreated_execution is None:
             from preloop.services.issue_lifecycle_runtime import lifecycle_flow_entry
+            from preloop.services.issue_lifecycle_worker import lifecycle_entry_decision
 
-            handled, lifecycle_execution = await lifecycle_flow_entry(
-                self, flow, event_data, nats_client
+            event = event_data if isinstance(event_data, dict) else {}
+            skip_entry = (
+                isinstance(self.db, Session)
+                and not lifecycle_entry_decision(self.db, flow, event).engaged
             )
-            if handled:
-                return lifecycle_execution
+            if not skip_entry:
+                handled, lifecycle_execution = await lifecycle_flow_entry(
+                    self, flow, event_data, nats_client
+                )
+                if handled:
+                    return lifecycle_execution
 
         if precreated_execution is not None:
             execution = precreated_execution

--- a/backend/preloop/services/issue_lifecycle.py
+++ b/backend/preloop/services/issue_lifecycle.py
@@ -1,0 +1,533 @@
+"""Readiness transitions and merge-linked independent completion auditing."""
+
+from collections.abc import Awaitable, Callable
+from hashlib import sha256
+from typing import Any, Protocol
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from preloop.config import settings
+from preloop.models import models
+from preloop.models.crud import crud_issue_lifecycle
+from preloop.schemas.issue_lifecycle import AuditResult, ReadinessContract
+from preloop.services.issue_lifecycle_provider import LifecycleProvider
+
+
+class EnvironmentCapabilities(Protocol):
+    """The environment service owns image approval and runnable command names."""
+
+    async def blockers(self, profile: str, commands: list[str]) -> list[str]: ...
+
+
+class IssueLifecycleService:
+    """A single controller shared by HTTP, tracker triggers and terminal hooks."""
+
+    def __init__(
+        self,
+        db: Session,
+        *,
+        account_id: UUID,
+        issue: models.Issue,
+        provider: LifecycleProvider,
+        capabilities: EnvironmentCapabilities,
+        policy: dict[str, Any],
+    ) -> None:
+        self.db, self.account_id, self.issue = db, account_id, issue
+        self.provider, self.capabilities, self.policy = provider, capabilities, policy
+        self.number = int(issue.key.rsplit("#", 1)[-1])
+
+    def _get(self, kind: str, revision: str) -> models.IssueLifecycle | None:
+        return crud_issue_lifecycle.get(
+            self.db,
+            account_id=self.account_id,
+            issue_id=self.issue.id,
+            kind=kind,
+            revision=revision,
+        )
+
+    def _put(
+        self, kind: str, revision: str, state: str, data: dict[str, Any]
+    ) -> models.IssueLifecycle:
+        return crud_issue_lifecycle.put(
+            self.db,
+            account_id=self.account_id,
+            issue_id=self.issue.id,
+            kind=kind,
+            revision=revision,
+            state=state,
+            data=data,
+        )
+
+    async def refine(self, contract: ReadinessContract) -> dict[str, Any]:
+        """Persist a reviewable proposal and explain material blockers."""
+        async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
+            current = await self.provider.issue(self.number)
+            blockers = await self._blockers(contract)
+            if current.revision != contract.issue_revision:
+                blockers.append("issue_scope_changed")
+            pickup = self._get("pickup", "once")
+            if pickup and pickup.data["issue_revision"] != current.revision:
+                blockers.append("implementation_scope_requires_reconciliation")
+                self._put("pickup", "once", "needs_reconciliation", pickup.data)
+            data = {
+                "contract": contract.model_dump(),
+                "blockers": blockers,
+                "issue_url": current.url,
+            }
+            self._put(
+                "readiness",
+                contract.issue_revision,
+                "blocked" if blockers else "reviewable",
+                data,
+            )
+            return data
+
+    async def _blockers(self, contract: ReadinessContract) -> list[str]:
+        missing = [
+            name
+            for name in (
+                "problem",
+                "user_outcome",
+                "criteria",
+                "code_entry_points",
+                "test_entry_points",
+                "environment_profile",
+                "test_commands",
+            )
+            if not getattr(contract, name)
+        ]
+        blockers = [f"missing_{name}" for name in missing]
+        blockers.extend(f"decision:{item}" for item in contract.blocking_decisions)
+        blockers.extend(f"conflict:{item}" for item in contract.conflicts)
+        ids = [criterion.id for criterion in contract.criteria]
+        if len(ids) != len(set(ids)):
+            blockers.append("duplicate_acceptance_id")
+        for number in contract.dependencies:
+            if number <= 0 or number == self.number:
+                blockers.append(f"invalid_dependency:{number}")
+            elif (await self.provider.issue(number)).state != "closed":
+                blockers.append(f"blocked_dependency:{number}")
+        if contract.environment_profile and contract.test_commands:
+            blockers.extend(
+                await self.capabilities.blockers(
+                    contract.environment_profile, contract.test_commands
+                )
+            )
+        return blockers
+
+    async def ready(self, revision: str) -> dict[str, Any]:
+        """Authorize exactly one additive label transition for an issue.
+
+        GitHub has no conditional-label-write API. The provider rereads scope
+        immediately before the effect and this controller checks again after it;
+        concurrent edits are recorded for reconciliation, never silently adopted.
+        """
+        if self.policy.get("ready_enabled") is not True:
+            raise ValueError("readiness_transition_not_authorized")
+        async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
+            existing = self._get("pickup", "once")
+            current = await self.provider.issue(self.number)
+            if existing:
+                if existing.data["issue_revision"] != current.revision:
+                    self._put("pickup", "once", "needs_reconciliation", existing.data)
+                if existing.state != "label_pending":
+                    return {"state": existing.state, **existing.data}
+            row = self._get("readiness", revision)
+            if row is None:
+                raise ValueError("readiness_contract_missing")
+            contract = ReadinessContract.model_validate(row.data["contract"])
+            blockers = await self._blockers(contract)
+            if current.revision != revision or current.state != "open":
+                blockers.append("issue_scope_changed")
+            if blockers:
+                return {"state": "blocked", "blockers": blockers}
+            label = self.policy.get("ready_label", "agent-ready")
+            if label != "agent-ready":
+                raise ValueError("unsupported_ready_label")
+            # The marker is stable even if provider success precedes rollback.
+            data = {
+                "issue_revision": revision,
+                "contract": contract.model_dump(),
+                "label": label,
+            }
+            self._put("pickup", "once", "label_pending", data)
+        # Persist intent before the provider effect. If its successful response
+        # is lost, the real label webhook can still resolve this authorization.
+        async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
+            pending = self._get("pickup", "once")
+            if pending.state != "label_pending":
+                return {"state": pending.state, **pending.data}
+            await self.provider.add_ready_label(self.number, label, revision)
+            after = await self.provider.issue(self.number)
+            state = "ready" if after.revision == revision else "needs_reconciliation"
+            self._put("pickup", "once", state, data)
+            return {"state": state, **data}
+
+    async def schedule_pickup(
+        self,
+        flow: models.Flow,
+        event: dict[str, Any],
+        dispatch: Callable[[models.FlowExecution], Awaitable[None]],
+    ) -> models.FlowExecution | None:
+        """Atomically bind the authorized pickup to one execution."""
+        async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
+            row = self._get("pickup", "once")
+            current = await self.provider.issue(self.number)
+            if row is None or row.data.get("issue_revision") != current.revision:
+                if row:
+                    self._put("pickup", "once", "needs_reconciliation", row.data)
+                return None
+            if str(flow.id) != str(self.policy.get("implementation_flow_id")):
+                return None
+            if row.state not in {"label_pending", "ready", "dispatched"}:
+                return None
+            if current.state != "open" or row.data["label"] not in current.labels:
+                return None
+            if await self._blockers(
+                ReadinessContract.model_validate(row.data["contract"])
+            ):
+                return None
+            event = {
+                **event,
+                "lifecycle_pickup": {"issue_id": str(self.issue.id), **row.data},
+            }
+            execution = crud_issue_lifecycle.create_execution(
+                self.db, row=row, flow_id=flow.id, event=event
+            )
+            self._put("pickup", "once", "dispatched", row.data)
+        if execution.status == "PENDING":
+            await dispatch(execution)
+        return execution
+
+    async def schedule_audit(
+        self,
+        flow: models.Flow,
+        dispatch: Callable[[models.FlowExecution], Awaitable[None]],
+    ) -> models.FlowExecution | None:
+        """Revalidate closure, create one independent run and dispatch durably."""
+        async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
+            current = await self.provider.issue(self.number)
+            links = await self.provider.merged_links(self.number)
+            if current.state != "closed" or not links:
+                return None
+            merge = links[-1]
+            if (
+                flow.account_id != self.account_id
+                or (flow.agent_config or {}).get("lifecycle_kind") != "merge_audit"
+            ):
+                raise ValueError("invalid_audit_flow")
+            git = flow.git_clone_config or {}
+            repos = git.get("repositories") or []
+            if (
+                not git.get("enabled")
+                or git.get("create_pull_request")
+                or len(repos) != 1
+                or str(repos[0].get("project_id")) != str(self.issue.project_id)
+            ):
+                raise ValueError(
+                    "audit_requires_exact_project_checkout_without_publication"
+                )
+            if flow.allowed_mcp_servers or flow.allowed_mcp_tools:
+                raise ValueError("audit_requires_independent_read_only_tool_scope")
+            row = self._get("merge_audit", merge.sha)
+            if row and row.state == "published":
+                return None
+            if row is None:
+                ready = self._get("readiness", current.revision)
+                contract = (
+                    ready.data["contract"]
+                    if ready
+                    else ReadinessContract(issue_revision=current.revision).model_dump()
+                )
+                pickup = self._get("pickup", "once")
+                data = {
+                    "issue_revision": current.revision,
+                    "pickup_revision": pickup.data.get("issue_revision")
+                    if pickup
+                    else None,
+                    "contract": contract,
+                    "issue_url": current.url,
+                    "issue_title": current.title,
+                    "issue_body": current.body,
+                    "merge_sha": merge.sha,
+                    "merges": [
+                        {"number": link.number, "sha": link.sha, "url": link.url}
+                        for link in links
+                    ],
+                }
+                row = self._put("merge_audit", merge.sha, "queued", data)
+            event = {
+                "source": str(self.issue.tracker_id),
+                "type": "issue_closed",
+                "project_id": str(self.issue.project_id),
+                "payload": {
+                    "sha": merge.sha,
+                    "repository": {"full_name": self.issue.key.rsplit("#", 1)[0]},
+                    "lifecycle": {"issue_id": str(self.issue.id), **row.data},
+                },
+            }
+            execution = crud_issue_lifecycle.create_execution(
+                self.db, row=row, flow_id=flow.id, event=event
+            )
+        # The durable PENDING execution is recoverable if dispatch fails. The
+        # normal worker's execution claim also tolerates repeated delivery.
+        if execution.status == "PENDING":
+            await dispatch(execution)
+        return execution
+
+    async def schedule_deployment_audit(
+        self,
+        *,
+        merge_sha: str,
+        target: str,
+        deployed_revision: str,
+        deployment_evidence: str,
+        flow: models.Flow,
+        dispatch: Callable[[models.FlowExecution], Awaitable[None]],
+    ) -> models.FlowExecution:
+        """Trigger separate verification only after an authorized deployment record.
+
+        Target and test scope come from project policy, never issue text. The
+        authenticated CD/operator caller records the actual deployed revision
+        and its deployment evidence; closing an issue cannot call this method.
+        """
+        target_policy = (self.policy.get("deployment_targets") or {}).get(target)
+        if (
+            not target_policy
+            or str(target_policy.get("flow_id")) != str(flow.id)
+            or not target_policy.get("approved_scope")
+        ):
+            raise ValueError("deployment_scope_not_authorized")
+        if (
+            flow.account_id != self.account_id
+            or not flow.is_enabled
+            or (flow.agent_config or {}).get("lifecycle_kind") != "deployment_audit"
+        ):
+            raise ValueError("invalid_deployment_audit_flow")
+        if (flow.git_clone_config or {}).get("create_pull_request"):
+            raise ValueError("deployment_audit_cannot_publish_code")
+        operation = sha256(
+            f"{merge_sha}:{target}:{deployed_revision}".encode()
+        ).hexdigest()
+        async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
+            merged = self._get("merge_audit", merge_sha)
+            if (
+                not merged
+                or merged.state != "published"
+                or not merged.data.get("deployment_verification")
+            ):
+                raise ValueError("merge_audit_not_waiting_for_deployment")
+            row = self._get("deployment_audit", operation)
+            if row is None:
+                contract = ReadinessContract.model_validate(merged.data["contract"])
+                contract.criteria = [
+                    item for item in contract.criteria if item.deployment_required
+                ]
+                data = {
+                    **merged.data,
+                    "contract": contract.model_dump(),
+                    "audit_kind": "deployment_audit",
+                    "operation_revision": operation,
+                    "deployed_revision": deployed_revision,
+                    "deployment_record": {
+                        "target": target,
+                        "evidence": deployment_evidence,
+                        "approved_scope": target_policy["approved_scope"],
+                    },
+                    "follow_ups": {},
+                    "deployment_verification": None,
+                }
+                row = self._put("deployment_audit", operation, "queued", data)
+            event = {
+                "source": "authorized_deployment",
+                "type": "deployment_verification",
+                "project_id": str(self.issue.project_id),
+                "payload": {
+                    "sha": deployed_revision,
+                    "lifecycle": {"issue_id": str(self.issue.id), **row.data},
+                },
+            }
+            execution = crud_issue_lifecycle.create_execution(
+                self.db, row=row, flow_id=flow.id, event=event
+            )
+        if execution.status == "PENDING":
+            await dispatch(execution)
+        return execution
+
+    async def finish_audit(self, execution: models.FlowExecution) -> dict[str, Any]:
+        """Publish one verdict and at most three confirmed, deduplicated gaps."""
+        envelope = (execution.trigger_event_details or {}).get("payload", {}).get(
+            "lifecycle"
+        ) or {}
+        sha = envelope.get("merge_sha", "")
+        async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
+            kind = envelope.get("audit_kind", "merge_audit")
+            operation = envelope.get("operation_revision", sha)
+            row = self._get(kind, operation)
+            if not row or row.execution_id != execution.id:
+                raise ValueError("audit_execution_not_bound")
+            if row.state == "published":
+                return row.data
+            if execution.status != "SUCCEEDED":
+                if execution.status not in {
+                    "FAILED",
+                    "CANCELLED",
+                    "TIMED_OUT",
+                    "ABORTED",
+                }:
+                    return {"state": "waiting_for_successful_audit"}
+                contract = ReadinessContract.model_validate(row.data["contract"])
+                data = {
+                    **row.data,
+                    "verdict": "unknown",
+                    "follow_ups": {},
+                    "deployment_verification": None,
+                    "evidence": {
+                        "status": "error",
+                        "checked_out_sha": None,
+                        "criteria": [
+                            {
+                                "criterion_id": item.id,
+                                "verdict": "unknown",
+                                "code": [],
+                                "tests": [],
+                                "observations": [],
+                                "reason": f"Independent audit execution ended with {execution.status}; acceptance is unverified.",
+                            }
+                            for item in contract.criteria
+                        ],
+                    },
+                }
+                marker = f"<!-- preloop-{kind}:{self.account_id}:{self.issue.id}:{operation} -->"
+                data["comment_url"] = await self.provider.upsert_comment(
+                    self.number, marker, self._audit_comment(data, execution.id)
+                )
+                self._put(kind, operation, "published", data)
+                return data
+            result = AuditResult.model_validate(execution.result)
+            if (
+                result.checked_out_sha != envelope.get("deployed_revision", sha)
+                or result.issue_revision != row.data["issue_revision"]
+            ):
+                raise ValueError("audit_revision_mismatch")
+            contract = ReadinessContract.model_validate(row.data["contract"])
+            criteria = {criterion.id: criterion for criterion in contract.criteria}
+            evidence = {item.criterion_id: item for item in result.criteria}
+            if len(evidence) != len(result.criteria) or set(evidence) != set(criteria):
+                raise ValueError("audit_acceptance_coverage_mismatch")
+            verdicts = []
+            for key, item in evidence.items():
+                verdict = item.verdict
+                if verdict == "complete" and (
+                    not item.code
+                    or not item.tests
+                    or not item.observations
+                    or (
+                        criteria[key].deployment_required and kind != "deployment_audit"
+                    )
+                ):
+                    verdict = "unknown"
+                if (
+                    verdict == "gap"
+                    and not item.code
+                    and not item.tests
+                    and not item.observations
+                ):
+                    verdict = "unknown"
+                item.verdict = verdict
+                verdicts.append(verdict)
+            verdict = (
+                "gap"
+                if "gap" in verdicts
+                else "unknown"
+                if not criteria or "unknown" in verdicts
+                else "complete"
+            )
+            current = await self.provider.issue(self.number)
+            if current.revision != row.data["issue_revision"]:
+                verdict = "unknown"
+            follow_ups = dict(row.data.get("follow_ups", {}))
+            if self.policy.get("create_follow_ups") is True:
+                for item in result.follow_ups:
+                    if (
+                        item.criterion_id not in evidence
+                        or evidence[item.criterion_id].verdict != "gap"
+                    ):
+                        continue
+                    if len(follow_ups) >= 3:
+                        break
+                    key = sha256(
+                        f"{self.account_id}:{self.issue.id}:{item.criterion_id}:{item.kind}".encode()
+                    ).hexdigest()
+                    if key in follow_ups:
+                        continue
+                    marker = f"<!-- preloop-follow-up:{key} -->"
+                    body = (
+                        f"{item.description}\n\nKind: {item.kind}\nSource: {row.data['issue_url']}\nMerge: {sha}\nAcceptance criterion: {item.criterion_id}\nEvidence:\n"
+                        + "\n".join(f"- {link}" for link in item.evidence)
+                    )
+                    body += "\n\nThis follow-up requires a separate readiness review before implementation."
+                    follow_ups[key] = await self.provider.ensure_follow_up(
+                        self.number, marker, item.title, body
+                    )
+            deployment = [
+                criterion.id
+                for criterion in criteria.values()
+                if criterion.deployment_required and kind != "deployment_audit"
+            ]
+            data = {
+                **row.data,
+                "verdict": verdict,
+                "evidence": result.model_dump(),
+                "follow_ups": follow_ups,
+                "deployment_verification": {
+                    "state": "requires_deployment_revision_and_scope_approval",
+                    "criteria": deployment,
+                    "merge_sha": sha,
+                }
+                if deployment
+                else None,
+            }
+            body = self._audit_comment(data, execution.id)
+            marker = (
+                f"<!-- preloop-{kind}:{self.account_id}:{self.issue.id}:{operation} -->"
+            )
+            data["comment_url"] = await self.provider.upsert_comment(
+                self.number, marker, body
+            )
+            self._put(kind, operation, "published", data)
+            return data
+
+    @staticmethod
+    def _audit_comment(data: dict[str, Any], execution_id: UUID) -> str:
+        rows = [
+            f"Completion audit: **{data['verdict']}**",
+            f"Merged revision: `{data['merge_sha']}`",
+            f"Issue revision: `{data['issue_revision']}`",
+            f"Independent execution: [{execution_id}]({settings.preloop_url.rstrip('/')}/console/flows/executions/{execution_id})",
+            "",
+        ]
+        rows.extend(
+            f"Merged PR: {merge['url']} (`{merge['sha']}`)" for merge in data["merges"]
+        )
+        if data.get("deployment_record"):
+            rows.append(f"Deployed revision: `{data['deployed_revision']}`")
+            rows.append(f"Deployment evidence: {data['deployment_record']['evidence']}")
+            rows.append(
+                f"Approved scope: {data['deployment_record']['approved_scope']}"
+            )
+        for item in data["evidence"]["criteria"]:
+            rows.append(
+                f"- {item['criterion_id']}: {item['verdict']} — {item['reason']}"
+            )
+            rows.extend(
+                f"  - {pointer}"
+                for pointer in item["code"] + item["tests"] + item["observations"]
+            )
+        rows.extend(f"Follow-up: {url}" for url in data["follow_ups"].values())
+        if data["deployment_verification"]:
+            rows.append(
+                "Deployment acceptance remains unknown. Separate verification requires a recorded deployed revision and approved test scope; no environment was probed automatically."
+            )
+        return "\n".join(rows)

--- a/backend/preloop/services/issue_lifecycle.py
+++ b/backend/preloop/services/issue_lifecycle.py
@@ -11,7 +11,10 @@ from preloop.config import settings
 from preloop.models import models
 from preloop.models.crud import crud_issue_lifecycle
 from preloop.schemas.issue_lifecycle import AuditResult, ReadinessContract
-from preloop.services.issue_lifecycle_provider import LifecycleProvider
+from preloop.services.issue_lifecycle_provider import (
+    LifecycleProvider,
+    publication_budget,
+)
 
 
 class EnvironmentCapabilities(Protocol):
@@ -131,7 +134,17 @@ class IssueLifecycleService:
             if existing:
                 if existing.data["issue_revision"] != current.revision:
                     self._put("pickup", "once", "needs_reconciliation", existing.data)
-                if existing.state != "label_pending":
+                if existing.state == "needs_reconciliation":
+                    if existing.execution_id is not None:
+                        return {
+                            "state": existing.state,
+                            **existing.data,
+                            "blockers": ["pickup_reconciliation_required"],
+                        }
+                    # This explicit /ready request can replace an authorization
+                    # that never launched. It still validates the current proposal
+                    # and scope below; an existing execution is never replaced.
+                elif existing.state != "label_pending":
                     return {"state": existing.state, **existing.data}
             row = self._get("readiness", revision)
             if row is None:
@@ -151,6 +164,13 @@ class IssueLifecycleService:
                 "contract": contract.model_dump(),
                 "label": label,
             }
+            if existing and existing.state == "needs_reconciliation":
+                self._put(
+                    "pickup",
+                    existing.data["issue_revision"],
+                    "superseded",
+                    dict(existing.data),
+                )
             self._put("pickup", "once", "label_pending", data)
         # Persist intent before the provider effect. If its successful response
         # is lost, the real label webhook can still resolve this authorization.
@@ -361,7 +381,10 @@ class IssueLifecycleService:
             "lifecycle"
         ) or {}
         sha = envelope.get("merge_sha", "")
-        async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
+        async with (
+            crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id),
+            publication_budget(),
+        ):
             kind = envelope.get("audit_kind", "merge_audit")
             operation = envelope.get("operation_revision", sha)
             row = self._get(kind, operation)

--- a/backend/preloop/services/issue_lifecycle.py
+++ b/backend/preloop/services/issue_lifecycle.py
@@ -169,6 +169,7 @@ class IssueLifecycleService:
                         "SUCCEEDED",
                         "FAILED",
                         "CANCELLED",
+                        "STOPPED",
                         "TIMED_OUT",
                         "ABORTED",
                     }:
@@ -243,6 +244,8 @@ class IssueLifecycleService:
         dispatch: Callable[[models.FlowExecution], Awaitable[None]],
     ) -> models.FlowExecution | None:
         """Atomically bind the authorized pickup to one execution."""
+        from preloop.services.flow_trigger_service import FlowDispatchError
+
         async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
             row = self._get("pickup", "once")
             current = await self.provider.issue(self.number)
@@ -252,7 +255,12 @@ class IssueLifecycleService:
                 return None
             if str(flow.id) != str(self.policy.get("implementation_flow_id")):
                 return None
-            if row.state not in {"label_pending", "ready", "dispatched"}:
+            if row.state not in {
+                "label_pending",
+                "ready",
+                "dispatch_pending",
+                "dispatched",
+            }:
                 return None
             if current.state != "open" or row.data["label"] not in current.labels:
                 return None
@@ -267,9 +275,26 @@ class IssueLifecycleService:
             execution = crud_issue_lifecycle.create_execution(
                 self.db, row=row, flow_id=flow.id, event=event
             )
-            self._put("pickup", "once", "dispatched", row.data)
+            state = (
+                "dispatch_pending" if execution.status == "PENDING" else "dispatched"
+            )
+            self._put("pickup", "once", state, row.data)
         if execution.status == "PENDING":
-            await dispatch(execution)
+            try:
+                await dispatch(execution)
+            except FlowDispatchError:
+                # The committed execution is recoverable; do not claim delivery
+                # or replace it when the broker did not acknowledge publication.
+                return execution
+            async with crud_issue_lifecycle.locked(
+                self.db, self.account_id, self.issue.id
+            ):
+                current = self._get("pickup", "once")
+                if (
+                    current.execution_id == execution.id
+                    and current.state == "dispatch_pending"
+                ):
+                    self._put("pickup", "once", "dispatched", current.data)
         return execution
 
     async def schedule_audit(

--- a/backend/preloop/services/issue_lifecycle.py
+++ b/backend/preloop/services/issue_lifecycle.py
@@ -303,7 +303,12 @@ class IssueLifecycleService:
         dispatch: Callable[[models.FlowExecution], Awaitable[None]],
     ) -> models.FlowExecution | None:
         """Revalidate closure, create one independent run and dispatch durably."""
-        async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
+        if str(flow.id) != str(self.policy.get("audit_flow_id")):
+            return None
+        async with (
+            crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id),
+            publication_budget(),
+        ):
             current = await self.provider.issue(self.number)
             links = await self.provider.merged_links(self.number)
             if current.state != "closed" or not links:

--- a/backend/preloop/services/issue_lifecycle.py
+++ b/backend/preloop/services/issue_lifecycle.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from hashlib import sha256
 from typing import Any, Protocol
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from sqlalchemy.orm import Session
 
@@ -119,7 +119,19 @@ class IssueLifecycleService:
             )
         return blockers
 
+    async def reconcile_pickup(
+        self, revision: str, previous_execution_id: UUID, reason: str
+    ) -> dict[str, Any]:
+        """Explicitly authorize changed scope only after the previous run ends."""
+        return await self._ready(revision, previous_execution_id, reason)
+
     async def ready(self, revision: str) -> dict[str, Any]:
+        """Authorize initial or unlaunched pickup, preserving existing executions."""
+        return await self._ready(revision)
+
+    async def _ready(
+        self, revision: str, previous_execution_id: UUID | None = None, reason: str = ""
+    ) -> dict[str, Any]:
         """Authorize exactly one additive label transition for an issue.
 
         GitHub has no conditional-label-write API. The provider rereads scope
@@ -131,11 +143,45 @@ class IssueLifecycleService:
         async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
             existing = self._get("pickup", "once")
             current = await self.provider.issue(self.number)
+            if current.revision != revision or current.state != "open":
+                return {"state": "blocked", "blockers": ["issue_scope_changed"]}
+            replacement = previous_execution_id is not None
+            if replacement:
+                if (
+                    existing
+                    and existing.data.get("replaces_execution_id")
+                    == str(previous_execution_id)
+                    and existing.data["issue_revision"] == revision
+                ):
+                    if existing.state != "label_pending":
+                        return {"state": existing.state, **existing.data}
+                    replacement = (
+                        False  # Retry a provider effect without resetting intent.
+                    )
+                else:
+                    if (
+                        existing is None
+                        or existing.execution_id != previous_execution_id
+                    ):
+                        raise ValueError("pickup_execution_mismatch")
+                    prior = crud_issue_lifecycle.pickup_execution(self.db, row=existing)
+                    if prior is None or prior.status not in {
+                        "SUCCEEDED",
+                        "FAILED",
+                        "CANCELLED",
+                        "TIMED_OUT",
+                        "ABORTED",
+                    }:
+                        raise ValueError("pickup_execution_not_terminal")
+                    if existing.data["issue_revision"] == revision:
+                        raise ValueError("pickup_scope_unchanged_use_execution_retry")
+                    if not reason.strip():
+                        raise ValueError("pickup_reconciliation_reason_required")
             if existing:
                 if existing.data["issue_revision"] != current.revision:
                     self._put("pickup", "once", "needs_reconciliation", existing.data)
                 if existing.state == "needs_reconciliation":
-                    if existing.execution_id is not None:
+                    if existing.execution_id is not None and not replacement:
                         return {
                             "state": existing.state,
                             **existing.data,
@@ -144,7 +190,7 @@ class IssueLifecycleService:
                     # This explicit /ready request can replace an authorization
                     # that never launched. It still validates the current proposal
                     # and scope below; an existing execution is never replaced.
-                elif existing.state != "label_pending":
+                elif existing.state != "label_pending" and not replacement:
                     return {"state": existing.state, **existing.data}
             row = self._get("readiness", revision)
             if row is None:
@@ -155,28 +201,34 @@ class IssueLifecycleService:
                 blockers.append("issue_scope_changed")
             if blockers:
                 return {"state": "blocked", "blockers": blockers}
-            label = self.policy.get("ready_label", "agent-ready")
-            if label != "agent-ready":
-                raise ValueError("unsupported_ready_label")
+            label = self.policy.get("ready_label")
+            if not isinstance(label, str) or not label.strip():
+                raise ValueError("ready_label_not_configured")
+            await self.provider.require_ready_label(label)
             # The marker is stable even if provider success precedes rollback.
             data = {
                 "issue_revision": revision,
                 "contract": contract.model_dump(),
                 "label": label,
             }
-            if existing and existing.state == "needs_reconciliation":
-                self._put(
-                    "pickup",
-                    existing.data["issue_revision"],
-                    "superseded",
-                    dict(existing.data),
+            if replacement:
+                data.update(
+                    {
+                        "authorization_id": str(uuid4()),
+                        "replaces_execution_id": str(previous_execution_id),
+                        "reconciliation_reason": reason,
+                    }
                 )
+            elif existing and existing.state == "label_pending":
+                data = dict(existing.data)
+            if existing and (replacement or existing.state == "needs_reconciliation"):
+                crud_issue_lifecycle.archive_pickup(self.db, row=existing)
             self._put("pickup", "once", "label_pending", data)
         # Persist intent before the provider effect. If its successful response
         # is lost, the real label webhook can still resolve this authorization.
         async with crud_issue_lifecycle.locked(self.db, self.account_id, self.issue.id):
             pending = self._get("pickup", "once")
-            if pending.state != "label_pending":
+            if pending.state != "label_pending" or pending.data != data:
                 return {"state": pending.state, **pending.data}
             await self.provider.add_ready_label(self.number, label, revision)
             after = await self.provider.issue(self.number)

--- a/backend/preloop/services/issue_lifecycle_provider.py
+++ b/backend/preloop/services/issue_lifecycle_provider.py
@@ -75,6 +75,7 @@ class LifecycleProvider(Protocol):
 
     async def issue(self, number: int) -> IssueSnapshot: ...
     async def merged_links(self, number: int) -> list[MergeLink]: ...
+    async def require_ready_label(self, label: str) -> None: ...
     async def add_ready_label(self, number: int, label: str, revision: str) -> None: ...
     async def upsert_comment(self, number: int, marker: str, body: str) -> str: ...
     async def ensure_follow_up(
@@ -207,8 +208,16 @@ class GitHubLifecycleProvider:
         # contributions in its evidence envelope.
         return sorted(links, key=lambda link: link.sha == closing_sha)
 
+    async def require_ready_label(self, label: str) -> None:
+        """Require an existing repository label; never create project vocabulary."""
+        async for row in self._rows(f"{self.root}/labels"):
+            if row.get("name") == label:
+                return
+        raise ValueError("ready_label_not_found")
+
     async def add_ready_label(self, number: int, label: str, revision: str) -> None:
         """Recheck immediately before an additive, naturally idempotent effect."""
+        await self.require_ready_label(label)
         current = await self.issue(number)
         if current.revision != revision or current.state != "open":
             raise ValueError("issue_scope_changed")

--- a/backend/preloop/services/issue_lifecycle_provider.py
+++ b/backend/preloop/services/issue_lifecycle_provider.py
@@ -1,0 +1,229 @@
+"""Live provider authority and idempotent external effects for issue lifecycles."""
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+import re
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class IssueSnapshot:
+    """A scope revision excludes labels/comments changed by automation."""
+
+    number: int
+    title: str
+    body: str
+    state: str
+    url: str
+    labels: tuple[str, ...]
+
+    @property
+    def revision(self) -> str:
+        """Fingerprint implementation scope, not mutable presentation metadata."""
+        return sha256(
+            json.dumps([self.title, self.body], ensure_ascii=False).encode()
+        ).hexdigest()
+
+
+@dataclass(frozen=True)
+class MergeLink:
+    """Provider-verified PR association and immutable merged commit."""
+
+    number: int
+    sha: str
+    url: str
+
+
+class LifecycleProvider(Protocol):
+    """Implementations must re-read authority and use additive label updates."""
+
+    async def issue(self, number: int) -> IssueSnapshot: ...
+    async def merged_links(self, number: int) -> list[MergeLink]: ...
+    async def add_ready_label(self, number: int, label: str, revision: str) -> None: ...
+    async def upsert_comment(self, number: int, marker: str, body: str) -> str: ...
+    async def ensure_follow_up(
+        self, number: int, marker: str, title: str, body: str
+    ) -> str: ...
+
+
+class GitHubRequests(Protocol):
+    """Existing tracker transport handles PAT, installation and OAuth auth."""
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        data: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any: ...
+
+
+class GitHubLifecycleProvider:
+    """GitHub adapter. Unknown/truncated authority fails closed."""
+
+    def __init__(self, client: GitHubRequests, repository: str) -> None:
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+            raise ValueError("invalid_lifecycle_repository")
+        self.client = client
+        self.repository = repository
+        self.root = f"/repos/{repository}"
+
+    async def _pages(
+        self, endpoint: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for page in range(1, 101):
+            batch = await self.client._request(
+                "GET",
+                endpoint,
+                params={**(params or {}), "per_page": 100, "page": page},
+            )
+            if not isinstance(batch, list):
+                raise ValueError("invalid_lifecycle_provider_response")
+            rows.extend(batch)
+            if len(batch) < 100:
+                return rows
+        raise ValueError("lifecycle_provider_results_truncated")
+
+    async def issue(self, number: int) -> IssueSnapshot:
+        """Read authoritative scope and preserve project-owned label names."""
+        raw = await self.client._request("GET", f"{self.root}/issues/{number}")
+        if raw.get("pull_request"):
+            raise ValueError("lifecycle_target_is_pull_request")
+        return IssueSnapshot(
+            number,
+            raw["title"],
+            raw.get("body") or "",
+            raw["state"],
+            raw["html_url"],
+            tuple(label["name"] for label in raw.get("labels", [])),
+        )
+
+    async def merged_links(self, number: int) -> list[MergeLink]:
+        """Require a closing commit tied to a provider-linked merged PR.
+
+        A completed/manual close with no closing commit never qualifies.
+        Linked PRs are reloaded rather than trusting webhook body text.
+        """
+        snapshot = await self.issue(number)
+        if snapshot.state != "closed":
+            return []
+        timeline = await self._pages(f"{self.root}/issues/{number}/timeline")
+        closes = [item for item in timeline if item.get("event") == "closed"]
+        if not closes or not closes[-1].get("commit_id"):
+            return []
+        closing_sha = closes[-1]["commit_id"]
+        numbers = set()
+        for item in timeline:
+            source = (item.get("source") or {}).get("issue") or {}
+            pull_request = source.get("pull_request") or {}
+            source_repo = source.get("repository", {}).get("full_name")
+            pr_path = urlparse(pull_request.get("url", "")).path
+            if pull_request and (
+                source_repo == self.repository
+                or pr_path == f"{self.root}/pulls/{source.get('number')}"
+            ):
+                numbers.add(source["number"])
+        # The closing commit's associated PRs also cover auto-close timelines
+        # where GitHub omitted a separate cross-reference event.
+        associated = await self._pages(f"{self.root}/commits/{closing_sha}/pulls")
+        numbers.update(
+            pr["number"]
+            for pr in associated
+            if pr.get("base", {}).get("repo", {}).get("full_name") == self.repository
+        )
+        links = []
+        for pr_number in sorted(numbers):
+            pr = await self.client._request("GET", f"{self.root}/pulls/{pr_number}")
+            sha = pr.get("merge_commit_sha") or ""
+            if (
+                pr.get("merged")
+                and re.fullmatch(r"[0-9a-f]{40}", sha)
+                and pr.get("base", {}).get("repo", {}).get("full_name")
+                == self.repository
+            ):
+                links.append(MergeLink(pr_number, sha, pr["html_url"]))
+        if not any(link.sha == closing_sha for link in links):
+            return []
+        # Audit the final closing revision once, retaining all linked merged
+        # contributions in its evidence envelope.
+        return sorted(links, key=lambda link: link.sha == closing_sha)
+
+    async def add_ready_label(self, number: int, label: str, revision: str) -> None:
+        """Recheck immediately before an additive, naturally idempotent effect."""
+        current = await self.issue(number)
+        if current.revision != revision or current.state != "open":
+            raise ValueError("issue_scope_changed")
+        if label not in current.labels:
+            await self.client._request(
+                "POST", f"{self.root}/issues/{number}/labels", {"labels": [label]}
+            )
+
+    async def upsert_comment(self, number: int, marker: str, body: str) -> str:
+        """Recover a previous provider-success/local-rollback by durable marker."""
+        comments = await self._pages(f"{self.root}/issues/{number}/comments")
+        existing = next(
+            (item for item in comments if marker in (item.get("body") or "")), None
+        )
+        payload = {"body": f"{body}\n\n{marker}"}
+        if existing:
+            result = await self.client._request(
+                "PATCH", f"{self.root}/issues/comments/{existing['id']}", payload
+            )
+        else:
+            result = await self.client._request(
+                "POST", f"{self.root}/issues/{number}/comments", payload
+            )
+        return result["html_url"]
+
+    async def ensure_follow_up(
+        self, number: int, marker: str, title: str, body: str
+    ) -> str:
+        """Search linked work before creating; omit all readiness labels.
+
+        List instead of search avoids GitHub search-index lag after a timeout.
+        Markers intentionally survive across subsequent merges of the issue.
+        """
+        issues = await self._pages(
+            f"{self.root}/issues",
+            {"state": "all", "sort": "created", "direction": "desc"},
+        )
+        for issue in issues:
+            existing_body = issue.get("body") or ""
+            # Human-created linked follow-ups need not know our marker. An
+            # exact criterion reference or matching title plus source link is
+            # sufficient to reuse them instead of filing parallel work.
+            source = next(
+                (
+                    line.removeprefix("Source: ")
+                    for line in body.splitlines()
+                    if line.startswith("Source: ")
+                ),
+                "",
+            )
+            criterion = next(
+                (
+                    line
+                    for line in body.splitlines()
+                    if line.startswith("Acceptance criterion: ")
+                ),
+                "",
+            )
+            linked = (
+                bool(source)
+                and source in existing_body
+                and (
+                    issue.get("title") == title
+                    or (criterion and criterion in existing_body.splitlines())
+                )
+            )
+            if not issue.get("pull_request") and (marker in existing_body or linked):
+                return issue["html_url"]
+        result = await self.client._request(
+            "POST",
+            f"{self.root}/issues",
+            {"title": title, "body": f"{body}\n\n{marker}", "labels": []},
+        )
+        return result["html_url"]

--- a/backend/preloop/services/issue_lifecycle_provider.py
+++ b/backend/preloop/services/issue_lifecycle_provider.py
@@ -1,11 +1,45 @@
 """Live provider authority and idempotent external effects for issue lifecycles."""
 
+import asyncio
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from hashlib import sha256
 import json
 import re
 from typing import Any, Protocol
 from urllib.parse import urlparse
+
+
+PUBLICATION_TIMEOUT_SECONDS = 8.0
+PUBLICATION_MAX_REQUESTS = 128
+
+
+@dataclass
+class _PublicationBudget:
+    remaining_requests: int
+
+
+_publication_budget: ContextVar[_PublicationBudget | None] = ContextVar(
+    "lifecycle_publication_budget", default=None
+)
+
+
+@asynccontextmanager
+async def publication_budget() -> AsyncIterator[None]:
+    """Bound provider work while retaining serialized, deduplicated effects."""
+    token = _publication_budget.set(_PublicationBudget(PUBLICATION_MAX_REQUESTS))
+    deadline = asyncio.timeout(PUBLICATION_TIMEOUT_SECONDS)
+    try:
+        async with deadline:
+            yield
+    except TimeoutError as exc:
+        if not deadline.expired():
+            raise
+        raise ValueError("lifecycle_publication_deadline_exceeded") from exc
+    finally:
+        _publication_budget.reset(token)
 
 
 @dataclass(frozen=True)
@@ -70,26 +104,48 @@ class GitHubLifecycleProvider:
         self.repository = repository
         self.root = f"/repos/{repository}"
 
-    async def _pages(
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        data: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        budget = _publication_budget.get()
+        if budget is not None:
+            if budget.remaining_requests <= 0:
+                raise ValueError("lifecycle_publication_request_budget_exhausted")
+            budget.remaining_requests -= 1
+        return await self.client._request(method, endpoint, data=data, params=params)
+
+    async def _rows(
         self, endpoint: str, params: dict[str, Any] | None = None
-    ) -> list[dict[str, Any]]:
-        rows: list[dict[str, Any]] = []
-        for page in range(1, 101):
-            batch = await self.client._request(
+    ) -> AsyncIterator[dict[str, Any]]:
+        # Page 101 is an exhaustion probe. Exactly 10,000 results are complete;
+        # anything beyond the bound fails closed before a new remote effect.
+        for page in range(1, 102):
+            batch = await self._request(
                 "GET",
                 endpoint,
                 params={**(params or {}), "per_page": 100, "page": page},
             )
             if not isinstance(batch, list):
                 raise ValueError("invalid_lifecycle_provider_response")
-            rows.extend(batch)
+            if page == 101 and batch:
+                raise ValueError("lifecycle_provider_results_truncated")
+            for row in batch:
+                yield row
             if len(batch) < 100:
-                return rows
-        raise ValueError("lifecycle_provider_results_truncated")
+                return
+
+    async def _pages(
+        self, endpoint: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        return [row async for row in self._rows(endpoint, params)]
 
     async def issue(self, number: int) -> IssueSnapshot:
         """Read authoritative scope and preserve project-owned label names."""
-        raw = await self.client._request("GET", f"{self.root}/issues/{number}")
+        raw = await self._request("GET", f"{self.root}/issues/{number}")
         if raw.get("pull_request"):
             raise ValueError("lifecycle_target_is_pull_request")
         return IssueSnapshot(
@@ -136,7 +192,7 @@ class GitHubLifecycleProvider:
         )
         links = []
         for pr_number in sorted(numbers):
-            pr = await self.client._request("GET", f"{self.root}/pulls/{pr_number}")
+            pr = await self._request("GET", f"{self.root}/pulls/{pr_number}")
             sha = pr.get("merge_commit_sha") or ""
             if (
                 pr.get("merged")
@@ -157,23 +213,24 @@ class GitHubLifecycleProvider:
         if current.revision != revision or current.state != "open":
             raise ValueError("issue_scope_changed")
         if label not in current.labels:
-            await self.client._request(
+            await self._request(
                 "POST", f"{self.root}/issues/{number}/labels", {"labels": [label]}
             )
 
     async def upsert_comment(self, number: int, marker: str, body: str) -> str:
         """Recover a previous provider-success/local-rollback by durable marker."""
-        comments = await self._pages(f"{self.root}/issues/{number}/comments")
-        existing = next(
-            (item for item in comments if marker in (item.get("body") or "")), None
-        )
+        existing = None
+        async for item in self._rows(f"{self.root}/issues/{number}/comments"):
+            if marker in (item.get("body") or ""):
+                existing = item
+                break
         payload = {"body": f"{body}\n\n{marker}"}
         if existing:
-            result = await self.client._request(
+            result = await self._request(
                 "PATCH", f"{self.root}/issues/comments/{existing['id']}", payload
             )
         else:
-            result = await self.client._request(
+            result = await self._request(
                 "POST", f"{self.root}/issues/{number}/comments", payload
             )
         return result["html_url"]
@@ -186,11 +243,10 @@ class GitHubLifecycleProvider:
         List instead of search avoids GitHub search-index lag after a timeout.
         Markers intentionally survive across subsequent merges of the issue.
         """
-        issues = await self._pages(
+        async for issue in self._rows(
             f"{self.root}/issues",
             {"state": "all", "sort": "created", "direction": "desc"},
-        )
-        for issue in issues:
+        ):
             existing_body = issue.get("body") or ""
             # Human-created linked follow-ups need not know our marker. An
             # exact criterion reference or matching title plus source link is
@@ -221,7 +277,7 @@ class GitHubLifecycleProvider:
             )
             if not issue.get("pull_request") and (marker in existing_body or linked):
                 return issue["html_url"]
-        result = await self.client._request(
+        result = await self._request(
             "POST",
             f"{self.root}/issues",
             {"title": title, "body": f"{body}\n\n{marker}", "labels": []},

--- a/backend/preloop/services/issue_lifecycle_provider.py
+++ b/backend/preloop/services/issue_lifecycle_provider.py
@@ -216,8 +216,11 @@ class GitHubLifecycleProvider:
         raise ValueError("ready_label_not_found")
 
     async def add_ready_label(self, number: int, label: str, revision: str) -> None:
-        """Recheck immediately before an additive, naturally idempotent effect."""
-        await self.require_ready_label(label)
+        """Apply the ready label after `_ready` already required it exists.
+
+        Scope is re-read here because the issue can change between the two
+        advisory locks; the repository label list is not enumerated again.
+        """
         current = await self.issue(number)
         if current.revision != revision or current.state != "open":
             raise ValueError("issue_scope_changed")

--- a/backend/preloop/services/issue_lifecycle_runtime.py
+++ b/backend/preloop/services/issue_lifecycle_runtime.py
@@ -1,0 +1,173 @@
+"""Production adapters and flow entry/terminal hooks for issue lifecycles."""
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from preloop.api.common import get_tracker_client
+from preloop.models import models
+from preloop.models.crud import crud_flow, crud_issue, crud_issue_lifecycle
+from preloop.schemas.issue_lifecycle import ReadinessContract
+from preloop.services.issue_lifecycle import IssueLifecycleService
+from preloop.services.issue_lifecycle_provider import GitHubLifecycleProvider
+
+logger = logging.getLogger(__name__)
+
+
+class FlowEnvironmentCapabilities:
+    """Resolve the selected implementation flow through environment service."""
+
+    def __init__(self, db: Session, account_id: UUID, policy: dict[str, Any]) -> None:
+        self.db, self.account_id, self.policy = db, account_id, policy
+
+    async def blockers(self, profile: str, commands: list[str]) -> list[str]:
+        """Reject missing harness/image/service command capabilities explicitly."""
+        flow_id = self.policy.get("implementation_flow_id")
+        if not flow_id:
+            return ["implementation_flow_not_configured"]
+        flow = crud_flow.get(self.db, id=UUID(flow_id), account_id=self.account_id)
+        if flow is None or not flow.is_enabled:
+            return ["implementation_flow_unavailable"]
+        if (flow.agent_config or {}).get("environment_profile") != profile:
+            return ["implementation_environment_profile_mismatch"]
+        from preloop.services.flow_environment import verification_profile_readiness
+        from preloop.services.runner_service import resolve_runner_pool
+
+        pool = resolve_runner_pool(flow, {}, db=self.db)
+        readiness = verification_profile_readiness(
+            flow.agent_config or {},
+            flow.git_clone_config or {},
+            agent_type=flow.agent_type,
+            runner="server" if pool is None else "private",
+            required_command_ids=commands,
+        )
+        return readiness["blockers"]
+
+
+async def build_lifecycle_service(
+    db: Session,
+    *,
+    issue_id: UUID,
+    account_id: UUID,
+    current_user: models.User | None = None,
+) -> IssueLifecycleService:
+    """Resolve tenant access and existing tracker include/exclude policy."""
+    issue = crud_issue_lifecycle.get_issue(db, issue_id=issue_id, account_id=account_id)
+    if issue is None:
+        raise ValueError("lifecycle_issue_not_found")
+    project = crud_issue_lifecycle.get_project(
+        db, project_id=issue.project_id, account_id=account_id
+    )
+    if project is None:
+        raise ValueError("lifecycle_project_not_found")
+    # A flow is already tenant-authorized by the trigger service; use the same
+    # scope resolver as HTTP callers, never bypass tracker exclusions.
+    actor = current_user or models.User(
+        account_id=account_id, username="lifecycle-worker"
+    )
+    client = await get_tracker_client(project.organization_id, project.id, db, actor)
+    if client.tracker_type != "github":
+        raise ValueError("lifecycle_provider_unsupported")
+    policy = (project.settings or {}).get("issue_lifecycle") or {}
+    provider = GitHubLifecycleProvider(client, issue.key.rsplit("#", 1)[0])
+    return IssueLifecycleService(
+        db,
+        account_id=account_id,
+        issue=issue,
+        provider=provider,
+        capabilities=FlowEnvironmentCapabilities(db, account_id, policy),
+        policy=policy,
+    )
+
+
+async def lifecycle_flow_entry(
+    trigger_service: Any, flow: models.Flow, event: dict[str, Any], nats_client: Any
+) -> tuple[bool, models.FlowExecution | None]:
+    """Intercept explicitly configured lifecycle flows before ordinary dispatch."""
+    kind = (flow.agent_config or {}).get("lifecycle_kind")
+    if kind not in {"merge_audit", "refinement"} and event.get("type") not in {
+        "issue_labeled",
+        "issue_updated",
+        "issue_created",
+    }:
+        return False, None
+    project_id = event.get("project_id")
+    if not project_id or not flow.account_id:
+        return False, None
+    project = crud_issue_lifecycle.get_project(
+        trigger_service.db, project_id=UUID(str(project_id)), account_id=flow.account_id
+    )
+    if not project:
+        return False, None
+    policy = (project.settings or {}).get("issue_lifecycle") or {}
+    pickup = (
+        policy.get("ready_enabled") is True
+        and str(policy.get("implementation_flow_id")) == str(flow.id)
+        and event.get("type") in {"issue_labeled", "issue_updated", "issue_created"}
+    )
+    if kind not in {"merge_audit", "refinement"} and not pickup:
+        return False, None
+    payload = event.get("payload") or {}
+    raw_issue = payload.get("issue") or payload.get("object_attributes") or {}
+    external_id = raw_issue.get("id")
+    issue = crud_issue.get_by_external_id(
+        trigger_service.db,
+        project_id=str(project.id),
+        external_id=str(external_id),
+        account_id=str(flow.account_id),
+    )
+    if issue is None:
+        raise ValueError("lifecycle_issue_not_synced")
+    service = await build_lifecycle_service(
+        trigger_service.db, issue_id=issue.id, account_id=flow.account_id
+    )
+
+    async def dispatch(execution: models.FlowExecution) -> None:
+        await trigger_service._start_flow_execution(
+            flow,
+            execution.trigger_event_details,
+            nats_client,
+            precreated_execution=execution,
+        )
+
+    if kind == "merge_audit":
+        return True, await service.schedule_audit(flow, dispatch)
+    if pickup:
+        return True, await service.schedule_pickup(flow, event, dispatch)
+    # Refinement runs normally, but receives a trusted source revision. Its
+    # result is a proposal and cannot itself add the ready label.
+    current = await service.provider.issue(service.number)
+    event["lifecycle_refinement"] = {
+        "issue_id": str(issue.id),
+        "issue_revision": current.revision,
+    }
+    return False, None
+
+
+async def lifecycle_execution_finished(
+    db: Session, execution: models.FlowExecution, flow: models.Flow
+) -> None:
+    """Consume persisted structured output; failures remain retryable by API."""
+    event = execution.trigger_event_details or {}
+    envelope = (event.get("payload") or {}).get("lifecycle") or event.get(
+        "lifecycle_refinement"
+    )
+    if not envelope or not flow.account_id:
+        return
+    service = await build_lifecycle_service(
+        db, issue_id=UUID(envelope["issue_id"]), account_id=flow.account_id
+    )
+    if (flow.agent_config or {}).get("lifecycle_kind") in {
+        "merge_audit",
+        "deployment_audit",
+    }:
+        await service.finish_audit(execution)
+    elif execution.status == "SUCCEEDED":
+        contract = ReadinessContract.model_validate(
+            (execution.result or {}).get("readiness_contract")
+        )
+        if contract.issue_revision != envelope["issue_revision"]:
+            raise ValueError("refinement_revision_mismatch")
+        await service.refine(contract)

--- a/backend/preloop/services/issue_lifecycle_runtime.py
+++ b/backend/preloop/services/issue_lifecycle_runtime.py
@@ -14,8 +14,9 @@ from preloop.schemas.issue_lifecycle import ReadinessContract
 from preloop.services.issue_lifecycle import IssueLifecycleService
 from preloop.services.issue_lifecycle_provider import GitHubLifecycleProvider
 from preloop.services.issue_lifecycle_worker import (
-    lifecycle_worker_hook,
     dispatch_lifecycle_execution,
+    lifecycle_worker_hook,
+    worker_owned_session,
 )
 
 logger = logging.getLogger(__name__)
@@ -92,6 +93,26 @@ async def lifecycle_flow_entry(
     trigger_service: Any, flow: models.Flow, event: dict[str, Any], nats_client: Any
 ) -> tuple[bool, models.FlowExecution | None]:
     """Intercept explicitly configured lifecycle flows before ordinary dispatch."""
+    db, owned = worker_owned_session(
+        trigger_service, getattr(trigger_service, "db", None)
+    )
+    try:
+        return await _lifecycle_flow_entry(
+            db, flow, event, nats_client, trigger_service
+        )
+    finally:
+        if owned:
+            db.close()
+
+
+async def _lifecycle_flow_entry(
+    db: Any,
+    flow: models.Flow,
+    event: dict[str, Any],
+    nats_client: Any,
+    trigger_service: Any,
+) -> tuple[bool, models.FlowExecution | None]:
+    """CRUD for ``lifecycle_flow_entry`` on the worker-owned session."""
     kind = (flow.agent_config or {}).get("lifecycle_kind")
     if kind not in {"merge_audit", "refinement"} and event.get("type") not in {
         "issue_labeled",
@@ -103,7 +124,7 @@ async def lifecycle_flow_entry(
     if not project_id or not flow.account_id:
         return False, None
     project = crud_issue_lifecycle.get_project(
-        trigger_service.db, project_id=UUID(str(project_id)), account_id=flow.account_id
+        db, project_id=UUID(str(project_id)), account_id=flow.account_id
     )
     if not project:
         return False, None
@@ -119,7 +140,7 @@ async def lifecycle_flow_entry(
     raw_issue = payload.get("issue") or payload.get("object_attributes") or {}
     external_id = raw_issue.get("id")
     issue = crud_issue.get_by_external_id(
-        trigger_service.db,
+        db,
         project_id=str(project.id),
         external_id=str(external_id),
         account_id=str(flow.account_id),
@@ -127,7 +148,7 @@ async def lifecycle_flow_entry(
     if issue is None:
         raise ValueError("lifecycle_issue_not_synced")
     service = await build_lifecycle_service(
-        trigger_service.db, issue_id=issue.id, account_id=flow.account_id
+        db, issue_id=issue.id, account_id=flow.account_id
     )
 
     async def dispatch(execution: models.FlowExecution) -> None:
@@ -163,24 +184,29 @@ async def lifecycle_execution_finished(
     db: Session, execution: models.FlowExecution, flow: models.Flow
 ) -> None:
     """Consume persisted structured output; failures remain retryable by API."""
-    event = execution.trigger_event_details or {}
-    envelope = (event.get("payload") or {}).get("lifecycle") or event.get(
-        "lifecycle_refinement"
-    )
-    if not envelope or not flow.account_id:
-        return
-    service = await build_lifecycle_service(
-        db, issue_id=UUID(envelope["issue_id"]), account_id=flow.account_id
-    )
-    if (flow.agent_config or {}).get("lifecycle_kind") in {
-        "merge_audit",
-        "deployment_audit",
-    }:
-        await service.finish_audit(execution)
-    elif execution.status == "SUCCEEDED":
-        contract = ReadinessContract.model_validate(
-            (execution.result or {}).get("readiness_contract")
+    worker_db, owned = worker_owned_session(fallback=db)
+    try:
+        event = execution.trigger_event_details or {}
+        envelope = (event.get("payload") or {}).get("lifecycle") or event.get(
+            "lifecycle_refinement"
         )
-        if contract.issue_revision != envelope["issue_revision"]:
-            raise ValueError("refinement_revision_mismatch")
-        await service.refine(contract)
+        if not envelope or not flow.account_id:
+            return
+        service = await build_lifecycle_service(
+            worker_db, issue_id=UUID(envelope["issue_id"]), account_id=flow.account_id
+        )
+        if (flow.agent_config or {}).get("lifecycle_kind") in {
+            "merge_audit",
+            "deployment_audit",
+        }:
+            await service.finish_audit(execution)
+        elif execution.status == "SUCCEEDED":
+            contract = ReadinessContract.model_validate(
+                (execution.result or {}).get("readiness_contract")
+            )
+            if contract.issue_revision != envelope["issue_revision"]:
+                raise ValueError("refinement_revision_mismatch")
+            await service.refine(contract)
+    finally:
+        if owned:
+            worker_db.close()

--- a/backend/preloop/services/issue_lifecycle_runtime.py
+++ b/backend/preloop/services/issue_lifecycle_runtime.py
@@ -15,8 +15,8 @@ from preloop.services.issue_lifecycle import IssueLifecycleService
 from preloop.services.issue_lifecycle_provider import GitHubLifecycleProvider
 from preloop.services.issue_lifecycle_worker import (
     dispatch_lifecycle_execution,
+    lifecycle_worker_db,
     lifecycle_worker_hook,
-    worker_owned_session,
 )
 
 logger = logging.getLogger(__name__)
@@ -93,16 +93,11 @@ async def lifecycle_flow_entry(
     trigger_service: Any, flow: models.Flow, event: dict[str, Any], nats_client: Any
 ) -> tuple[bool, models.FlowExecution | None]:
     """Intercept explicitly configured lifecycle flows before ordinary dispatch."""
-    db, owned = worker_owned_session(
-        trigger_service, getattr(trigger_service, "db", None)
-    )
-    try:
+    fallback = getattr(trigger_service, "db", None)
+    with lifecycle_worker_db(trigger_service, fallback) as db:
         return await _lifecycle_flow_entry(
             db, flow, event, nats_client, trigger_service
         )
-    finally:
-        if owned:
-            db.close()
 
 
 async def _lifecycle_flow_entry(
@@ -184,9 +179,8 @@ async def lifecycle_execution_finished(
     db: Session, execution: models.FlowExecution, flow: models.Flow
 ) -> None:
     """Consume persisted structured output; failures remain retryable by API."""
-    worker_db, owned = worker_owned_session(fallback=db)
-    try:
-        event = execution.trigger_event_details or {}
+    event = execution.trigger_event_details or {}
+    with lifecycle_worker_db(fallback=db) as worker_db:
         envelope = (event.get("payload") or {}).get("lifecycle") or event.get(
             "lifecycle_refinement"
         )
@@ -207,6 +201,3 @@ async def lifecycle_execution_finished(
             if contract.issue_revision != envelope["issue_revision"]:
                 raise ValueError("refinement_revision_mismatch")
             await service.refine(contract)
-    finally:
-        if owned:
-            worker_db.close()

--- a/backend/preloop/services/issue_lifecycle_runtime.py
+++ b/backend/preloop/services/issue_lifecycle_runtime.py
@@ -15,7 +15,7 @@ from preloop.services.issue_lifecycle import IssueLifecycleService
 from preloop.services.issue_lifecycle_provider import GitHubLifecycleProvider
 from preloop.services.issue_lifecycle_worker import (
     lifecycle_worker_hook,
-    on_application_loop,
+    dispatch_lifecycle_execution,
 )
 
 logger = logging.getLogger(__name__)
@@ -133,14 +133,15 @@ async def lifecycle_flow_entry(
     async def dispatch(execution: models.FlowExecution) -> None:
         # Resolve expired ORM attributes before crossing to the application loop.
         _ = flow.id, execution.id
-        await on_application_loop(
+        await dispatch_lifecycle_execution(
+            execution.id,
             partial(
                 trigger_service._start_flow_execution,
                 flow,
                 execution.trigger_event_details,
                 nats_client,
                 precreated_execution=execution,
-            )
+            ),
         )
 
     if kind == "merge_audit":

--- a/backend/preloop/services/issue_lifecycle_runtime.py
+++ b/backend/preloop/services/issue_lifecycle_runtime.py
@@ -1,6 +1,7 @@
 """Production adapters and flow entry/terminal hooks for issue lifecycles."""
 
 import logging
+from functools import partial
 from typing import Any
 from uuid import UUID
 
@@ -12,6 +13,10 @@ from preloop.models.crud import crud_flow, crud_issue, crud_issue_lifecycle
 from preloop.schemas.issue_lifecycle import ReadinessContract
 from preloop.services.issue_lifecycle import IssueLifecycleService
 from preloop.services.issue_lifecycle_provider import GitHubLifecycleProvider
+from preloop.services.issue_lifecycle_worker import (
+    lifecycle_worker_hook,
+    on_application_loop,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +87,7 @@ async def build_lifecycle_service(
     )
 
 
+@lifecycle_worker_hook
 async def lifecycle_flow_entry(
     trigger_service: Any, flow: models.Flow, event: dict[str, Any], nats_client: Any
 ) -> tuple[bool, models.FlowExecution | None]:
@@ -125,11 +131,16 @@ async def lifecycle_flow_entry(
     )
 
     async def dispatch(execution: models.FlowExecution) -> None:
-        await trigger_service._start_flow_execution(
-            flow,
-            execution.trigger_event_details,
-            nats_client,
-            precreated_execution=execution,
+        # Resolve expired ORM attributes before crossing to the application loop.
+        _ = flow.id, execution.id
+        await on_application_loop(
+            partial(
+                trigger_service._start_flow_execution,
+                flow,
+                execution.trigger_event_details,
+                nats_client,
+                precreated_execution=execution,
+            )
         )
 
     if kind == "merge_audit":
@@ -146,6 +157,7 @@ async def lifecycle_flow_entry(
     return False, None
 
 
+@lifecycle_worker_hook
 async def lifecycle_execution_finished(
     db: Session, execution: models.FlowExecution, flow: models.Flow
 ) -> None:

--- a/backend/preloop/services/issue_lifecycle_runtime.py
+++ b/backend/preloop/services/issue_lifecycle_runtime.py
@@ -15,6 +15,7 @@ from preloop.services.issue_lifecycle import IssueLifecycleService
 from preloop.services.issue_lifecycle_provider import GitHubLifecycleProvider
 from preloop.services.issue_lifecycle_worker import (
     dispatch_lifecycle_execution,
+    lifecycle_entry_decision,
     lifecycle_worker_db,
     lifecycle_worker_hook,
 )
@@ -108,29 +109,10 @@ async def _lifecycle_flow_entry(
     trigger_service: Any,
 ) -> tuple[bool, models.FlowExecution | None]:
     """CRUD for ``lifecycle_flow_entry`` on the worker-owned session."""
-    kind = (flow.agent_config or {}).get("lifecycle_kind")
-    if kind not in {"merge_audit", "refinement"} and event.get("type") not in {
-        "issue_labeled",
-        "issue_updated",
-        "issue_created",
-    }:
+    entry = lifecycle_entry_decision(db, flow, event)
+    if not entry.engaged:
         return False, None
-    project_id = event.get("project_id")
-    if not project_id or not flow.account_id:
-        return False, None
-    project = crud_issue_lifecycle.get_project(
-        db, project_id=UUID(str(project_id)), account_id=flow.account_id
-    )
-    if not project:
-        return False, None
-    policy = (project.settings or {}).get("issue_lifecycle") or {}
-    pickup = (
-        policy.get("ready_enabled") is True
-        and str(policy.get("implementation_flow_id")) == str(flow.id)
-        and event.get("type") in {"issue_labeled", "issue_updated", "issue_created"}
-    )
-    if kind not in {"merge_audit", "refinement"} and not pickup:
-        return False, None
+    project = entry.project
     payload = event.get("payload") or {}
     raw_issue = payload.get("issue") or payload.get("object_attributes") or {}
     external_id = raw_issue.get("id")
@@ -160,9 +142,9 @@ async def _lifecycle_flow_entry(
             ),
         )
 
-    if kind == "merge_audit":
+    if entry.kind == "merge_audit":
         return True, await service.schedule_audit(flow, dispatch)
-    if pickup:
+    if entry.pickup:
         return True, await service.schedule_pickup(flow, event, dispatch)
     # Refinement runs normally, but receives a trusted source revision. Its
     # result is a proposal and cannot itself add the ready label.

--- a/backend/preloop/services/issue_lifecycle_worker.py
+++ b/backend/preloop/services/issue_lifecycle_worker.py
@@ -1,0 +1,45 @@
+"""Keep complete lifecycle ORM transactions away from the application loop."""
+
+from collections.abc import Awaitable, Callable
+from functools import partial, wraps
+from typing import ParamSpec, TypeVar
+
+import anyio
+from anyio import from_thread
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def run_lifecycle_endpoint(operation: Callable[[], Awaitable[T]]) -> T:
+    """Run one HTTP operation inside its synchronous FastAPI worker handler.
+
+    The private loop handles provider I/O while all synchronous CRUD and lazy
+    ORM reads stay in the same worker. Detached flow tasks must be dispatched
+    through ``on_application_loop``, never started on this temporary loop.
+    """
+    return anyio.run(operation)
+
+
+def lifecycle_worker_hook(
+    operation: Callable[P, Awaitable[T]],
+) -> Callable[P, Awaitable[T]]:
+    """Offload a trigger or completion hook with its entire ORM transaction."""
+
+    @wraps(operation)
+    async def offload(*args: P.args, **kwargs: P.kwargs) -> T:
+        return await anyio.to_thread.run_sync(
+            partial(run_lifecycle_endpoint, partial(operation, *args, **kwargs))
+        )
+
+    return offload
+
+
+async def on_application_loop(operation: Callable[[], Awaitable[T]]) -> T:
+    """Dispatch on the originating application loop, preserving detached tasks.
+
+    Called only inside a lifecycle worker. The worker waits without using its
+    session concurrently; the originating AnyIO token selects the persistent
+    application loop, not the worker's temporary provider-I/O loop.
+    """
+    return from_thread.run(operation)

--- a/backend/preloop/services/issue_lifecycle_worker.py
+++ b/backend/preloop/services/issue_lifecycle_worker.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import partial, wraps
-from typing import Any, ParamSpec, TypeVar
+from typing import Any, NamedTuple, ParamSpec, TypeVar
 from uuid import UUID
 
 import anyio
@@ -96,6 +96,56 @@ def run_lifecycle_endpoint(operation: Callable[[], Awaitable[T]]) -> T:
     return anyio.run(operation)
 
 
+LIFECYCLE_ENTRY_EVENTS = frozenset({"issue_labeled", "issue_updated", "issue_created"})
+LIFECYCLE_ENTRY_KINDS = frozenset({"merge_audit", "refinement"})
+
+
+class LifecycleEntry(NamedTuple):
+    """One trigger decision: the flow kind, its tenant project and pickup."""
+
+    kind: str | None
+    project: Any | None
+    pickup: bool
+
+    @property
+    def engaged(self) -> bool:
+        """True when the entry hook reads or writes lifecycle state."""
+        return self.project is not None and (
+            self.kind in LIFECYCLE_ENTRY_KINDS or self.pickup
+        )
+
+
+def lifecycle_entry_decision(
+    db: Any, flow: Any, event: dict[str, Any]
+) -> LifecycleEntry:
+    """Decide once whether a trigger event belongs to a lifecycle flow.
+
+    The entry hook and the caller-commit gate both read this decision, so the
+    gate cannot silently under-commit when the entry conditions change.
+    """
+    kind = (flow.agent_config or {}).get("lifecycle_kind")
+    event_type = event.get("type")
+    if kind not in LIFECYCLE_ENTRY_KINDS and event_type not in LIFECYCLE_ENTRY_EVENTS:
+        return LifecycleEntry(kind, None, False)
+    project_id = event.get("project_id")
+    if not project_id or not flow.account_id:
+        return LifecycleEntry(kind, None, False)
+    from preloop.models.crud import crud_issue_lifecycle
+
+    project = crud_issue_lifecycle.get_project(
+        db, project_id=UUID(str(project_id)), account_id=flow.account_id
+    )
+    if project is None:
+        return LifecycleEntry(kind, None, False)
+    policy = (project.settings or {}).get("issue_lifecycle") or {}
+    pickup = (
+        event_type in LIFECYCLE_ENTRY_EVENTS
+        and policy.get("ready_enabled") is True
+        and str(policy.get("implementation_flow_id")) == str(flow.id)
+    )
+    return LifecycleEntry(kind, project, pickup)
+
+
 def _should_commit_lifecycle_caller(caller: Session, *args: Any, **kwargs: Any) -> bool:
     """Commit only after the event is a confirmed lifecycle operation."""
     flow = None
@@ -117,32 +167,9 @@ def _should_commit_lifecycle_caller(caller: Session, *args: Any, **kwargs: Any) 
             "lifecycle"
         ) or execution_event.get("lifecycle_refinement")
         return bool(envelope)
-    if flow is None:
+    if flow is None or event is None:
         return False
-    kind = (flow.agent_config or {}).get("lifecycle_kind")
-    if kind in {"merge_audit", "refinement", "deployment_audit"}:
-        return True
-    if not event or event.get("type") not in {
-        "issue_labeled",
-        "issue_updated",
-        "issue_created",
-    }:
-        return False
-    project_id = event.get("project_id")
-    account_id = flow.account_id
-    if not project_id or not account_id:
-        return False
-    from preloop.models.crud import crud_issue_lifecycle
-
-    project = crud_issue_lifecycle.get_project(
-        caller, project_id=UUID(str(project_id)), account_id=account_id
-    )
-    if project is None:
-        return False
-    policy = (project.settings or {}).get("issue_lifecycle") or {}
-    return policy.get("ready_enabled") is True and str(
-        policy.get("implementation_flow_id")
-    ) == str(flow.id)
+    return lifecycle_entry_decision(caller, flow, event).engaged
 
 
 def lifecycle_worker_hook(

--- a/backend/preloop/services/issue_lifecycle_worker.py
+++ b/backend/preloop/services/issue_lifecycle_worker.py
@@ -7,9 +7,25 @@ from uuid import UUID
 
 import anyio
 from anyio import from_thread
+from sqlalchemy.orm import Session
 
 P = ParamSpec("P")
 T = TypeVar("T")
+
+
+def worker_owned_session(owner: Any = None, fallback: Any = None) -> tuple[Any, bool]:
+    """Open a Session on this worker thread instead of borrowing the caller's.
+
+    Test doubles that are not SQLAlchemy sessions are returned unchanged.
+    """
+    create = getattr(owner, "_create_orchestrator_session", None)
+    if callable(create):
+        return create(), True
+    if isinstance(fallback, Session):
+        from preloop.models.db.session import get_session_factory
+
+        return get_session_factory()(), True
+    return fallback, False
 
 
 def run_lifecycle_endpoint(operation: Callable[[], Awaitable[T]]) -> T:

--- a/backend/preloop/services/issue_lifecycle_worker.py
+++ b/backend/preloop/services/issue_lifecycle_worker.py
@@ -2,7 +2,8 @@
 
 from collections.abc import Awaitable, Callable
 from functools import partial, wraps
-from typing import ParamSpec, TypeVar
+from typing import Any, ParamSpec, TypeVar
+from uuid import UUID
 
 import anyio
 from anyio import from_thread
@@ -43,3 +44,27 @@ async def on_application_loop(operation: Callable[[], Awaitable[T]]) -> T:
     application loop, not the worker's temporary provider-I/O loop.
     """
     return from_thread.run(operation)
+
+
+async def dispatch_lifecycle_execution(
+    execution_id: UUID, local_dispatch: Callable[[], Awaitable[Any]]
+) -> None:
+    """Require a worker publish acknowledgment or schedule on the persistent loop."""
+    from preloop.services.flow_execution_dispatcher import (
+        dispatch_execute,
+        flow_execution_worker_enabled,
+    )
+    from preloop.services.flow_trigger_service import FlowDispatchError
+
+    async def dispatch() -> None:
+        if flow_execution_worker_enabled():
+            if not await dispatch_execute(execution_id):
+                raise FlowDispatchError(
+                    str(execution_id),
+                    "PENDING",
+                    RuntimeError("worker_dispatch_not_acknowledged"),
+                )
+        else:
+            await local_dispatch()
+
+    await on_application_loop(dispatch)

--- a/backend/preloop/services/issue_lifecycle_worker.py
+++ b/backend/preloop/services/issue_lifecycle_worker.py
@@ -34,23 +34,29 @@ def _caller_session(*args: Any, **kwargs: Any) -> Session | None:
 def worker_owned_session(owner: Any = None, fallback: Any = None) -> tuple[Any, bool]:
     """Open a Session on this worker thread instead of borrowing the caller's.
 
-    The worker joins the caller's connection (captured on the application
-    thread) so uncommitted rows stay visible. Test doubles that are not
-    SQLAlchemy sessions are returned unchanged.
+    Engine-bound callers get a fresh factory Session whose commit is durable.
+    Connection-bound callers (pytest savepoints) join that connection so
+    uncommitted fixture rows stay visible. Test doubles are unchanged.
     """
-    bind = _lifecycle_bind.get()
+    join = _lifecycle_bind.get()
     session = fallback if isinstance(fallback, Session) else None
     if session is None:
         db = getattr(owner, "db", None)
         if isinstance(db, Session):
             session = db
-    if bind is None and session is not None:
-        bind = session.connection()
-    if bind is not None:
+    if join is None and session is not None:
+        raw = session.get_bind()
+        if isinstance(raw, Connection):
+            join = raw
+    if join is not None:
         return (
-            Session(bind=bind, join_transaction_mode="create_savepoint"),
+            Session(bind=join, join_transaction_mode="create_savepoint"),
             True,
         )
+    if session is not None:
+        from preloop.models.db.session import get_session_factory
+
+        return get_session_factory()(), True
     return fallback, False
 
 
@@ -89,7 +95,14 @@ def lifecycle_worker_hook(
     @wraps(operation)
     async def offload(*args: P.args, **kwargs: P.kwargs) -> T:
         caller = _caller_session(*args, **kwargs)
-        token = _lifecycle_bind.set(caller.connection() if caller is not None else None)
+        join = None
+        if caller is not None:
+            raw = caller.get_bind()
+            if isinstance(raw, Connection):
+                join = raw
+            else:
+                caller.commit()
+        token = _lifecycle_bind.set(join)
         try:
             return await anyio.to_thread.run_sync(
                 partial(run_lifecycle_endpoint, partial(operation, *args, **kwargs))

--- a/backend/preloop/services/issue_lifecycle_worker.py
+++ b/backend/preloop/services/issue_lifecycle_worker.py
@@ -187,6 +187,10 @@ def lifecycle_worker_hook(
                 join = raw
             elif _should_commit_lifecycle_caller(caller, *args, **kwargs):
                 caller.commit()
+            else:
+                # Ordinary triggers are not lifecycle work. Stay on the caller
+                # thread instead of opening a worker loop and Session.
+                return await operation(*args, **kwargs)
         token = _lifecycle_bind.set(join)
         try:
             return await anyio.to_thread.run_sync(

--- a/backend/preloop/services/issue_lifecycle_worker.py
+++ b/backend/preloop/services/issue_lifecycle_worker.py
@@ -50,7 +50,7 @@ def worker_owned_session(owner: Any = None, fallback: Any = None) -> tuple[Any, 
             join = raw
     if join is not None:
         return (
-            Session(bind=join, join_transaction_mode="create_savepoint"),
+            Session(bind=join, join_transaction_mode="rollback_only"),
             True,
         )
     if session is not None:
@@ -62,14 +62,23 @@ def worker_owned_session(owner: Any = None, fallback: Any = None) -> tuple[Any, 
 
 @contextmanager
 def lifecycle_worker_db(owner: Any = None, fallback: Any = None) -> Iterator[Any]:
-    """Open a worker-thread Session that joins the caller's transaction."""
+    """Open a worker-thread Session.
+
+    Engine-bound callers get a durable factory Session. Connection-bound
+    callers (pytest savepoints) join that connection so fixture rows stay
+    visible without stealing the caller's savepoint.
+    """
     db, owned = worker_owned_session(owner, fallback)
+    joined = owned and isinstance(db.get_bind(), Connection)
     try:
         yield db
         if owned:
-            db.commit()
+            if joined:
+                db.flush()
+            else:
+                db.commit()
     except Exception:
-        if owned:
+        if owned and not joined:
             db.rollback()
         raise
     finally:
@@ -87,6 +96,55 @@ def run_lifecycle_endpoint(operation: Callable[[], Awaitable[T]]) -> T:
     return anyio.run(operation)
 
 
+def _should_commit_lifecycle_caller(caller: Session, *args: Any, **kwargs: Any) -> bool:
+    """Commit only after the event is a confirmed lifecycle operation."""
+    flow = None
+    event: dict[str, Any] | None = None
+    execution_event: dict[str, Any] | None = None
+    for value in (*args, *kwargs.values()):
+        config = getattr(value, "agent_config", None)
+        if isinstance(config, dict) and getattr(value, "account_id", None) is not None:
+            flow = value
+        if isinstance(value, dict) and (
+            "type" in value or "project_id" in value or "payload" in value
+        ):
+            event = value
+        details = getattr(value, "trigger_event_details", None)
+        if isinstance(details, dict):
+            execution_event = details
+    if execution_event is not None:
+        envelope = (execution_event.get("payload") or {}).get(
+            "lifecycle"
+        ) or execution_event.get("lifecycle_refinement")
+        return bool(envelope)
+    if flow is None:
+        return False
+    kind = (flow.agent_config or {}).get("lifecycle_kind")
+    if kind in {"merge_audit", "refinement", "deployment_audit"}:
+        return True
+    if not event or event.get("type") not in {
+        "issue_labeled",
+        "issue_updated",
+        "issue_created",
+    }:
+        return False
+    project_id = event.get("project_id")
+    account_id = flow.account_id
+    if not project_id or not account_id:
+        return False
+    from preloop.models.crud import crud_issue_lifecycle
+
+    project = crud_issue_lifecycle.get_project(
+        caller, project_id=UUID(str(project_id)), account_id=account_id
+    )
+    if project is None:
+        return False
+    policy = (project.settings or {}).get("issue_lifecycle") or {}
+    return policy.get("ready_enabled") is True and str(
+        policy.get("implementation_flow_id")
+    ) == str(flow.id)
+
+
 def lifecycle_worker_hook(
     operation: Callable[P, Awaitable[T]],
 ) -> Callable[P, Awaitable[T]]:
@@ -100,7 +158,7 @@ def lifecycle_worker_hook(
             raw = caller.get_bind()
             if isinstance(raw, Connection):
                 join = raw
-            else:
+            elif _should_commit_lifecycle_caller(caller, *args, **kwargs):
                 caller.commit()
         token = _lifecycle_bind.set(join)
         try:

--- a/backend/preloop/services/issue_lifecycle_worker.py
+++ b/backend/preloop/services/issue_lifecycle_worker.py
@@ -1,31 +1,74 @@
 """Keep complete lifecycle ORM transactions away from the application loop."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from functools import partial, wraps
 from typing import Any, ParamSpec, TypeVar
 from uuid import UUID
 
 import anyio
 from anyio import from_thread
+from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Session
 
 P = ParamSpec("P")
 T = TypeVar("T")
 
+_lifecycle_bind: ContextVar[Connection | None] = ContextVar(
+    "lifecycle_bind", default=None
+)
+
+
+def _caller_session(*args: Any, **kwargs: Any) -> Session | None:
+    """Find the request/test Session without treating test doubles as ORM."""
+    for value in (*args, *kwargs.values()):
+        if isinstance(value, Session):
+            return value
+        db = getattr(value, "db", None)
+        if isinstance(db, Session):
+            return db
+    return None
+
 
 def worker_owned_session(owner: Any = None, fallback: Any = None) -> tuple[Any, bool]:
     """Open a Session on this worker thread instead of borrowing the caller's.
 
-    Test doubles that are not SQLAlchemy sessions are returned unchanged.
+    The worker joins the caller's connection (captured on the application
+    thread) so uncommitted rows stay visible. Test doubles that are not
+    SQLAlchemy sessions are returned unchanged.
     """
-    create = getattr(owner, "_create_orchestrator_session", None)
-    if callable(create):
-        return create(), True
-    if isinstance(fallback, Session):
-        from preloop.models.db.session import get_session_factory
-
-        return get_session_factory()(), True
+    bind = _lifecycle_bind.get()
+    session = fallback if isinstance(fallback, Session) else None
+    if session is None:
+        db = getattr(owner, "db", None)
+        if isinstance(db, Session):
+            session = db
+    if bind is None and session is not None:
+        bind = session.connection()
+    if bind is not None:
+        return (
+            Session(bind=bind, join_transaction_mode="create_savepoint"),
+            True,
+        )
     return fallback, False
+
+
+@contextmanager
+def lifecycle_worker_db(owner: Any = None, fallback: Any = None) -> Iterator[Any]:
+    """Open a worker-thread Session that joins the caller's transaction."""
+    db, owned = worker_owned_session(owner, fallback)
+    try:
+        yield db
+        if owned:
+            db.commit()
+    except Exception:
+        if owned:
+            db.rollback()
+        raise
+    finally:
+        if owned:
+            db.close()
 
 
 def run_lifecycle_endpoint(operation: Callable[[], Awaitable[T]]) -> T:
@@ -45,9 +88,16 @@ def lifecycle_worker_hook(
 
     @wraps(operation)
     async def offload(*args: P.args, **kwargs: P.kwargs) -> T:
-        return await anyio.to_thread.run_sync(
-            partial(run_lifecycle_endpoint, partial(operation, *args, **kwargs))
-        )
+        caller = _caller_session(*args, **kwargs)
+        token = _lifecycle_bind.set(caller.connection() if caller is not None else None)
+        try:
+            return await anyio.to_thread.run_sync(
+                partial(run_lifecycle_endpoint, partial(operation, *args, **kwargs))
+            )
+        finally:
+            _lifecycle_bind.reset(token)
+            if caller is not None:
+                caller.expire_all()
 
     return offload
 

--- a/backend/presets/012-issue-refinement-readiness.yaml
+++ b/backend/presets/012-issue-refinement-readiness.yaml
@@ -1,0 +1,34 @@
+slug: issue-refinement-readiness
+name: Issue Refinement and Readiness
+description: Produce a reviewable acceptance contract from triage; readiness authorization is separate.
+icon: clipboard-check
+trigger_event_source: null
+trigger_event_types:
+  - issue.opened
+prompt_template: |
+  Refine this issue after triage using repository instructions and issue templates.
+  Source issue: {{trigger_event.payload.issue}}
+  Trusted revision: {{trigger_event.lifecycle_refinement.issue_revision}}
+  Produce problem, user_outcome, constraints, non_goals, assumptions, blocking_decisions,
+  conflicts, criteria, code_entry_points, test_entry_points, dependencies,
+  environment_profile and test_commands. Ask only about materially blocking decisions.
+  Ordinary implementation choices belong in assumptions, not approval questions.
+  Each criterion has id, outcome, verification, deployment_required. Dependencies
+  are issue numbers in this repository. test_commands are named commands in the
+  selected operator-approved environment profile, not invented shell commands.
+  Missing environment or conflicting requirements block readiness; do not invent them.
+  Store /workspace/result.json with "status": "success" and readiness_contract containing
+  all those fields plus issue_revision set to the trusted revision above.
+  The result is a reviewable proposal. Do not add agent-ready, create follow-ups,
+  start implementation, or change project labels. A separate authorized transition
+  rechecks the live issue, dependencies and runner capabilities before pickup.
+agent_type: codex
+agent_config:
+  sandbox_type: exec
+  enable_auto_lint: false
+  lifecycle_kind: refinement
+allowed_mcp_servers: []
+allowed_mcp_tools: []
+git_clone_config: null
+trigger_config: null
+is_preset: true

--- a/backend/presets/012-issue-refinement-readiness.yaml
+++ b/backend/presets/012-issue-refinement-readiness.yaml
@@ -19,7 +19,7 @@ prompt_template: |
   Missing environment or conflicting requirements block readiness; do not invent them.
   Store /workspace/result.json with "status": "success" and readiness_contract containing
   all those fields plus issue_revision set to the trusted revision above.
-  The result is a reviewable proposal. Do not add agent-ready, create follow-ups,
+  The result is a reviewable proposal. Do not add readiness labels, create follow-ups,
   start implementation, or change project labels. A separate authorized transition
   rechecks the live issue, dependencies and runner capabilities before pickup.
 agent_type: codex

--- a/backend/presets/013-merged-issue-completion-audit.yaml
+++ b/backend/presets/013-merged-issue-completion-audit.yaml
@@ -1,0 +1,48 @@
+slug: merged-issue-completion-audit
+name: Merged Issue Completion Audit
+description: Independently check acceptance at the exact closing merge revision and propose bounded follow-ups.
+icon: clipboard-check
+trigger_event_source: null
+trigger_event_types:
+  - issue.closed
+prompt_template: |
+  Independently audit the merged implementation against this acceptance contract:
+  {{trigger_event.payload.lifecycle}}
+
+  The controller verified the provider's issue-to-merged-PR relation and pinned
+  checkout to payload.sha. Verify git rev-parse HEAD equals that exact merge_sha
+  before inspecting code or running tests. Do not reuse the implementer's conversation.
+  Read repository instructions and run only relevant approved test-profile commands.
+  Map every criterion to code, tests and observable evidence. Source inspection
+  alone is not a passing test, and issue closure never proves deployed acceptance.
+  Missing environment, skipped checks, ambiguous criteria or deployment evidence
+  must remain unknown. Write artifacts/logs under /workspace/evidence.
+
+  Write /workspace/result.json:
+  {"status": "success", "checked_out_sha":"<exact 40-hex merge SHA>",
+   "issue_revision":"<supplied issue revision>",
+   "criteria":[{"criterion_id":"<contract id>",
+     "verdict":"complete|gap|unknown", "code":["file:line"],
+     "tests":["command and artifact path with actual result"],
+     "observations":["observable evidence"], "reason":"<bounded conclusion>"}],
+   "follow_ups":[{"criterion_id":"<confirmed gap criterion>",
+     "kind":"defect|enhancement", "title":"<clear bounded title>",
+     "description":"<problem, expected outcome and acceptance>",
+     "evidence":["<evidence pointers>"]}]}
+
+  No criteria in the supplied contract means insufficient evidence; do not invent
+  a complete verdict. Propose at most three clear follow-ups. The controller searches
+  existing linked work, applies external-creation policy, and upserts one audit comment.
+  Do not directly create issues/comments, add agent-ready, reopen the original issue,
+  push, publish PRs, deploy, or probe production. Deployment requirements need a
+  separate approved verification with a recorded deployed revision and test scope.
+agent_type: codex
+agent_config:
+  sandbox_type: exec
+  enable_auto_lint: false
+  lifecycle_kind: merge_audit
+allowed_mcp_servers: []
+allowed_mcp_tools: []
+git_clone_config: null
+trigger_config: null
+is_preset: true

--- a/backend/presets/013-merged-issue-completion-audit.yaml
+++ b/backend/presets/013-merged-issue-completion-audit.yaml
@@ -33,7 +33,7 @@ prompt_template: |
   No criteria in the supplied contract means insufficient evidence; do not invent
   a complete verdict. Propose at most three clear follow-ups. The controller searches
   existing linked work, applies external-creation policy, and upserts one audit comment.
-  Do not directly create issues/comments, add agent-ready, reopen the original issue,
+  Do not directly create issues/comments, add readiness labels, reopen the original issue,
   push, publish PRs, deploy, or probe production. Deployment requirements need a
   separate approved verification with a recorded deployed revision and test scope.
 agent_type: codex

--- a/backend/presets/README.md
+++ b/backend/presets/README.md
@@ -94,3 +94,12 @@ later file wins and a warning is logged at startup.
 - The `is_preset` field defaults to `true` if not specified
 - Presets are loaded at application startup and cached
 - Invalid YAML files will cause a startup error
+
+## Issue readiness and completion auditing
+
+`012-issue-refinement-readiness.yaml` produces a structured, reviewable acceptance
+contract after triage. `013-merged-issue-completion-audit.yaml` independently audits
+the exact revision that closed an issue through a verified merged PR. Both use the
+public lifecycle controller; neither requires private presets or plugins. Configure
+project policy, scoped repository checkout and approved test environments as
+explained in [the lifecycle guide](../../docs/guide/flows/issue-lifecycle.md).

--- a/backend/tests/api/test_flow_artifact_loop_safety.py
+++ b/backend/tests/api/test_flow_artifact_loop_safety.py
@@ -51,3 +51,57 @@ async def test_artifact_authorization_pool_wait_does_not_block_ping(
         finally:
             result = await upload
         assert result.status_code == 503
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("oversized", [False, True])
+async def test_upload_consumes_stream_on_app_loop_before_worker_persistence(
+    monkeypatch: pytest.MonkeyPatch, oversized: bool
+) -> None:
+    """Read actual ASGI chunks; never persist an oversized or partial stream."""
+    from collections.abc import AsyncIterator
+    from preloop.models.schemas.flow_artifact import ArtifactReference
+
+    app = FastAPI()
+    app.include_router(flow_artifacts.router)
+    app.dependency_overrides[get_db_session] = lambda: object()
+    claims = {
+        "account_id": uuid4(),
+        "flow_id": uuid4(),
+        "thread_id": "test",
+        "kind": "workspace",
+    }
+    app.dependency_overrides[flow_artifacts.artifact_claims] = lambda: claims
+    monkeypatch.setattr(flow_artifacts, "authorize", lambda *args: None)
+    monkeypatch.setattr(
+        flow_artifacts.settings, "workspace_snapshot_max_bytes", 5 if oversized else 6
+    )
+    origin = threading.get_ident()
+    bodies: list[bytes] = []
+
+    def persist(db: Any, **kwargs: Any) -> ArtifactReference:
+        assert threading.get_ident() != origin
+        bodies.append(kwargs["archive"])
+        return ArtifactReference(
+            artifact_id=uuid4(),
+            execution_id=kwargs["execution_id"],
+            manifest_sha256="a" * 64,
+        )
+
+    monkeypatch.setattr(flow_artifacts, "put_artifact", persist)
+
+    async def chunks() -> AsyncIterator[bytes]:
+        assert threading.get_ident() == origin
+        yield b"abc"
+        await asyncio.sleep(0)
+        assert threading.get_ident() == origin
+        yield b"def"
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        result = await client.put(
+            f"/flows/executions/{uuid4()}/artifacts", content=chunks()
+        )
+    assert result.status_code == (413 if oversized else 200), result.text
+    assert bodies == ([] if oversized else [b"abcdef"])

--- a/backend/tests/api/test_flow_artifact_loop_safety.py
+++ b/backend/tests/api/test_flow_artifact_loop_safety.py
@@ -64,7 +64,7 @@ async def test_upload_consumes_stream_on_app_loop_before_worker_persistence(
 
     app = FastAPI()
     app.include_router(flow_artifacts.router)
-    app.dependency_overrides[get_db_session] = lambda: object()
+    app.dependency_overrides[get_db_session] = object
     claims = {
         "account_id": uuid4(),
         "flow_id": uuid4(),

--- a/backend/tests/api/test_issue_lifecycle_loop_safety.py
+++ b/backend/tests/api/test_issue_lifecycle_loop_safety.py
@@ -42,6 +42,14 @@ def lifecycle_app() -> FastAPI:
         ("/ready", {"issue_revision": "revision"}),
         ("/audit/reconcile", {}),
         (
+            "/pickup/reconcile",
+            {
+                "issue_revision": "revision",
+                "previous_execution_id": str(uuid4()),
+                "reason": "Approve changed scope",
+            },
+        ),
+        (
             "/deployment/verify",
             {
                 "merge_sha": "a" * 40,

--- a/backend/tests/api/test_issue_lifecycle_loop_safety.py
+++ b/backend/tests/api/test_issue_lifecycle_loop_safety.py
@@ -25,7 +25,7 @@ def lifecycle_app() -> FastAPI:
     app.include_router(issue_lifecycle.router)
     actor = models.User(id=uuid4(), account_id=uuid4(), username="loop-test")
     app.dependency_overrides[get_current_active_user] = lambda: actor
-    app.dependency_overrides[get_db_session] = lambda: object()
+    app.dependency_overrides[get_db_session] = object
 
     @app.get("/ping")
     async def ping() -> dict[str, bool]:

--- a/backend/tests/api/test_issue_lifecycle_loop_safety.py
+++ b/backend/tests/api/test_issue_lifecycle_loop_safety.py
@@ -1,0 +1,184 @@
+"""Lifecycle pool waits and dispatched background work use separate loops."""
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from preloop.api.auth import get_current_active_user
+from preloop.api.endpoints import issue_lifecycle
+from preloop.models import models
+from preloop.models.db.session import get_db_session
+from preloop.services.flow_trigger_service import FlowTriggerService
+
+
+def lifecycle_app() -> FastAPI:
+    """Mount the production routes with isolated authentication and DB fixtures."""
+    app = FastAPI()
+    app.include_router(issue_lifecycle.router)
+    actor = models.User(id=uuid4(), account_id=uuid4(), username="loop-test")
+    app.dependency_overrides[get_current_active_user] = lambda: actor
+    app.dependency_overrides[get_db_session] = lambda: object()
+
+    @app.get("/ping")
+    async def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    return app
+
+
+@pytest.mark.parametrize(
+    ("suffix", "body"),
+    [
+        ("", None),
+        ("/refine", {"issue_revision": "revision"}),
+        ("/ready", {"issue_revision": "revision"}),
+        ("/audit/reconcile", {}),
+        (
+            "/deployment/verify",
+            {
+                "merge_sha": "a" * 40,
+                "deployed_revision": "b" * 40,
+                "deployment_evidence": "https://ci.example.test/deployment/1",
+                "target": "test",
+            },
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_lifecycle_database_wait_keeps_ping_responsive(
+    monkeypatch: pytest.MonkeyPatch, suffix: str, body: dict[str, Any] | None
+) -> None:
+    """Every real route keeps a blocked scoped issue lookup off the app loop."""
+    started = threading.Event()
+
+    def blocked_lookup(*args: Any, **kwargs: Any) -> None:
+        started.set()
+        time.sleep(0.5)
+        return None
+
+    monkeypatch.setattr(
+        issue_lifecycle.crud_issue_lifecycle, "get_issue", blocked_lookup
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=lifecycle_app()), base_url="http://test"
+    ) as client:
+        url = f"/issues/{uuid4()}/lifecycle{suffix}"
+        request = asyncio.create_task(
+            client.get(url) if body is None else client.post(url, json=body)
+        )
+        try:
+            assert await asyncio.to_thread(started.wait, 2)
+            assert not request.done()
+            assert (await client.get("/ping")).status_code == 200
+            assert not request.done(), "lifecycle DB wait blocked the application loop"
+        finally:
+            response = await request
+        assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_reconcile_dispatch_survives_lifecycle_worker_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detached flow work runs on the persistent application loop after response."""
+    origin = asyncio.get_running_loop()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+    tasks: list[asyncio.Task[None]] = []
+    flow = SimpleNamespace(id=uuid4(), is_enabled=True)
+    execution = SimpleNamespace(id=uuid4(), status="PENDING", trigger_event_details={})
+
+    async def background() -> None:
+        await release.wait()
+        finished.set()
+
+    async def start(*args: Any, **kwargs: Any) -> Any:
+        assert asyncio.get_running_loop() is origin
+        tasks.append(asyncio.create_task(background()))
+        return execution
+
+    async def schedule(flow: Any, dispatch: Any) -> Any:
+        assert asyncio.get_running_loop() is not origin
+        await dispatch(execution)
+        return execution
+
+    service = SimpleNamespace(
+        policy={"audit_flow_id": str(flow.id)}, schedule_audit=schedule
+    )
+    monkeypatch.setattr(
+        issue_lifecycle, "build_lifecycle_service", AsyncMock(return_value=service)
+    )
+    monkeypatch.setattr(issue_lifecycle.crud_flow, "get", lambda *args, **kwargs: flow)
+    monkeypatch.setattr(FlowTriggerService, "_start_flow_execution", start)
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=lifecycle_app()), base_url="http://test"
+        ) as client:
+            response = await client.post(f"/issues/{uuid4()}/lifecycle/audit/reconcile")
+        assert response.status_code == 200, response.text
+        assert response.json()["execution_id"] == str(execution.id)
+        assert len(tasks) == 1 and not tasks[0].done()
+        release.set()
+        await asyncio.wait_for(finished.wait(), 2)
+    finally:
+        release.set()
+        await asyncio.gather(*tasks)
+
+
+@pytest.mark.parametrize("terminal", [False, True])
+@pytest.mark.asyncio
+async def test_lifecycle_hook_database_wait_stays_off_application_loop(
+    monkeypatch: pytest.MonkeyPatch, terminal: bool
+) -> None:
+    """Tracker and completion hooks retain the same whole-operation isolation."""
+    from preloop.services import issue_lifecycle_runtime
+
+    started = threading.Event()
+
+    def blocked_lookup(*args: Any, **kwargs: Any) -> None:
+        started.set()
+        time.sleep(0.5)
+        return None
+
+    monkeypatch.setattr(
+        issue_lifecycle_runtime.crud_issue_lifecycle,
+        "get_issue" if terminal else "get_project",
+        blocked_lookup,
+    )
+    flow = SimpleNamespace(
+        account_id=uuid4(), agent_config={"lifecycle_kind": "merge_audit"}
+    )
+    if terminal:
+        operation = issue_lifecycle_runtime.lifecycle_execution_finished(
+            object(),
+            SimpleNamespace(
+                trigger_event_details={
+                    "payload": {"lifecycle": {"issue_id": str(uuid4())}}
+                }
+            ),
+            flow,
+        )
+    else:
+        operation = issue_lifecycle_runtime.lifecycle_flow_entry(
+            SimpleNamespace(db=object()), flow, {"project_id": str(uuid4())}, None
+        )
+    task = asyncio.create_task(operation)
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        assert not task.done(), "hook blocked the application loop on database work"
+        await asyncio.sleep(0)
+        assert not task.done()
+    finally:
+        if terminal:
+            with pytest.raises(ValueError, match="lifecycle_issue_not_found"):
+                await task
+        else:
+            assert await task == (False, None)

--- a/backend/tests/api/test_issue_lifecycle_loop_safety.py
+++ b/backend/tests/api/test_issue_lifecycle_loop_safety.py
@@ -190,3 +190,44 @@ async def test_lifecycle_hook_database_wait_stays_off_application_loop(
                 await task
         else:
             assert await task == (False, None)
+
+
+@pytest.mark.asyncio
+async def test_strict_lifecycle_local_dispatch_survives_worker_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worker-disabled pickup keeps detached work on the persistent app loop."""
+    from preloop.services.issue_lifecycle_worker import (
+        dispatch_lifecycle_execution,
+        lifecycle_worker_hook,
+    )
+
+    origin = asyncio.get_running_loop()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+    tasks: list[asyncio.Task[None]] = []
+    monkeypatch.setattr(
+        "preloop.services.flow_execution_dispatcher.flow_execution_worker_enabled",
+        lambda: False,
+    )
+
+    async def background() -> None:
+        await release.wait()
+        finished.set()
+
+    async def local_dispatch() -> None:
+        assert asyncio.get_running_loop() is origin
+        tasks.append(asyncio.create_task(background()))
+
+    @lifecycle_worker_hook
+    async def operation() -> None:
+        await dispatch_lifecycle_execution(uuid4(), local_dispatch)
+
+    try:
+        await operation()
+        assert len(tasks) == 1 and not tasks[0].done()
+        release.set()
+        await asyncio.wait_for(finished.wait(), 2)
+    finally:
+        release.set()
+        await asyncio.gather(*tasks)

--- a/backend/tests/models/test_alembic_single_head.py
+++ b/backend/tests/models/test_alembic_single_head.py
@@ -144,4 +144,11 @@ def test_flow_runners_revision_chains_onto_approval_rule_context() -> None:
         "20260906_approval_api_key",
         "20260906_publication_caps",
     }
-    assert script.get_heads() == ["20260906_pub_caps_merge"]
+    lifecycle = script.get_revision("20260906_issue_lifecycle")
+    assert lifecycle.down_revision == "20260906_flow_artifacts"
+    lifecycle_joined = script.get_revision("20260906_lifecycle_key_merge")
+    assert set(lifecycle_joined.down_revision) == {
+        "20260906_pub_caps_merge",
+        "20260906_issue_lifecycle",
+    }
+    assert script.get_heads() == ["20260906_lifecycle_key_merge"]

--- a/backend/tests/services/test_flow_environment.py
+++ b/backend/tests/services/test_flow_environment.py
@@ -213,6 +213,73 @@ def test_readiness_checks_command_text_not_only_identifier(
     assert mismatch["blockers"] == ["environment_command_mismatch:component"]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "pool, commands, expected",
+    [
+        ("server", ["component"], []),
+        ("server", ["component", "backend"], ["environment_command_missing:backend"]),
+        (
+            "private-pool",
+            ["component"],
+            ["environment_protocol_unsupported_private_runner"],
+        ),
+    ],
+)
+async def test_lifecycle_uses_actual_environment_capability_registry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pool: str,
+    commands: list[str],
+    expected: list[str],
+) -> None:
+    from types import SimpleNamespace
+    from uuid import uuid4
+    from unittest.mock import Mock
+
+    from preloop.services.issue_lifecycle_runtime import FlowEnvironmentCapabilities
+    from preloop.models.crud import crud_flow
+
+    registry = tmp_path / "profiles.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "approved": {
+                    "image": IMAGE,
+                    "harness": "codex",
+                    "test_commands": {"component": ["npm test"]},
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(settings, "flow_environment_profiles_file", str(registry))
+    flow = SimpleNamespace(
+        agent_config={"environment_profile": "approved"},
+        agent_type="codex",
+        runner_pool=pool,
+        is_enabled=True,
+        git_clone_config={
+            "verification": {
+                "mode": "gate",
+                "profile": {
+                    "profile_id": "tests",
+                    "always": [
+                        {"id": key, "command": "npm test", "reason": "acceptance"}
+                        for key in commands
+                    ],
+                },
+            }
+        },
+    )
+    monkeypatch.setattr(crud_flow, "get", lambda *args, **kwargs: flow)
+    capabilities = FlowEnvironmentCapabilities(
+        Mock(),
+        uuid4(),
+        {"implementation_flow_id": str(uuid4())},
+    )
+    assert await capabilities.blockers("approved", commands) == expected
+
+
 @pytest.mark.parametrize(
     "policy, expected",
     [

--- a/backend/tests/services/test_issue_lifecycle.py
+++ b/backend/tests/services/test_issue_lifecycle.py
@@ -326,8 +326,9 @@ async def test_readiness_blocks_material_gaps(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("first_dispatch_ok", [True, False])
 async def test_ready_and_duplicate_webhook_create_one_authorized_pickup(
-    rig: tuple, monkeypatch: pytest.MonkeyPatch
+    rig: tuple, monkeypatch: pytest.MonkeyPatch, first_dispatch_ok: bool
 ) -> None:
     service, transport, flow, _ = rig
     contract = await contract_for(service)
@@ -370,7 +371,7 @@ async def test_ready_and_duplicate_webhook_create_one_authorized_pickup(
         "preloop.services.flow_execution_dispatcher.flow_execution_worker_enabled",
         lambda: True,
     )
-    dispatch = AsyncMock(return_value=True)
+    dispatch = AsyncMock(side_effect=[first_dispatch_ok, True])
     monkeypatch.setattr(
         "preloop.services.flow_execution_dispatcher.dispatch_execute", dispatch
     )
@@ -381,8 +382,12 @@ async def test_ready_and_duplicate_webhook_create_one_authorized_pickup(
     }
     trigger = FlowTriggerService(service.db)
     first = await trigger._start_flow_execution(flow, event, None)
+    assert service._get("pickup", "once").state == (
+        "dispatched" if first_dispatch_ok else "dispatch_pending"
+    )
     second = await trigger._start_flow_execution(flow, event, None)
     assert first.id == second.id
+    assert service._get("pickup", "once").state == "dispatched"
     assert len({str(call.args[0]) for call in dispatch.await_args_list}) == 1
     assert (
         first.trigger_event_details["lifecycle_pickup"]["issue_revision"]
@@ -1091,9 +1096,11 @@ async def test_explicit_replacement_preserves_terminal_history_and_reuses_author
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("first_dispatch_ok", [True, False])
 async def test_reconcile_http_dispatches_once_with_label_already_present(
     rig: tuple,
     monkeypatch: pytest.MonkeyPatch,
+    first_dispatch_ok: bool,
 ) -> None:
     import httpx
     from fastapi import FastAPI
@@ -1126,7 +1133,7 @@ async def test_reconcile_http_dispatches_once_with_label_already_present(
         "preloop.services.flow_execution_dispatcher.flow_execution_worker_enabled",
         lambda: True,
     )
-    dispatch = AsyncMock(return_value=True)
+    dispatch = AsyncMock(side_effect=[first_dispatch_ok, True])
     monkeypatch.setattr(
         "preloop.services.flow_execution_dispatcher.dispatch_execute", dispatch
     )
@@ -1148,8 +1155,18 @@ async def test_reconcile_http_dispatches_once_with_label_already_present(
         path = f"/issues/{service.issue.id}/lifecycle/pickup/reconcile"
         initial = await client.post(path, json=body)
         assert initial.status_code == 200, initial.text
+        assert initial.json()["state"] == (
+            "dispatched" if first_dispatch_ok else "dispatch_pending"
+        )
+        pending = service._get("pickup", "once")
+        assert pending.state == initial.json()["state"]
+        assert (
+            crud_issue_lifecycle.pickup_execution(service.db, row=pending).status
+            == "PENDING"
+        )
         replay = await client.post(path, json=body)
         assert replay.status_code == 200, replay.text
+        assert replay.json()["state"] == "dispatched"
         assert initial.json()["execution_id"] == replay.json()["execution_id"]
         assert initial.json()["execution_id"] != str(first.id)
         assert initial.json()["authorization_id"] == replay.json()["authorization_id"]
@@ -1224,3 +1241,48 @@ async def test_merge_fixture_checks_out_exact_revision_before_independent_audit(
     await service.finish_audit(execution)
     assert len(transport.comments) == 1 and len(transport.issues) == 2
     assert merged_sha in transport.comments[0]["body"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status",
+    [
+        "SUCCEEDED",
+        "FAILED",
+        "STOPPED",
+        "CANCELLED",
+        "TIMED_OUT",
+        "ABORTED",
+        "PENDING",
+        "RUNNING",
+        "PAUSED",
+        "UNKNOWN",
+    ],
+)
+async def test_pickup_replacement_requires_real_terminal_status(
+    rig: tuple, status: str
+) -> None:
+    service, transport, flow, _ = rig
+    original = await contract_for(service)
+    await service.refine(original)
+    await service.ready(original.issue_revision)
+    previous = await service.schedule_pickup(flow, {}, AsyncMock())
+    transport.issues[1]["body"] += " Approved replacement scope."
+    current = await contract_for(service)
+    await service.refine(current)
+    crud_flow_execution.update(
+        service.db, db_obj=previous, obj_in=FlowExecutionUpdate(status=status)
+    )
+    service.db.commit()
+    if status in {"PENDING", "RUNNING", "PAUSED", "UNKNOWN"}:
+        with pytest.raises(ValueError, match="pickup_execution_not_terminal"):
+            await service.reconcile_pickup(
+                current.issue_revision, previous.id, "Reviewed new scope"
+            )
+        assert service._get("pickup", "once").execution_id == previous.id
+    else:
+        result = await service.reconcile_pickup(
+            current.issue_revision, previous.id, "Reviewed new scope"
+        )
+        assert result["state"] == "ready"
+        assert result["replaces_execution_id"] == str(previous.id)

--- a/backend/tests/services/test_issue_lifecycle.py
+++ b/backend/tests/services/test_issue_lifecycle.py
@@ -895,3 +895,82 @@ async def test_lost_label_response_does_not_lose_authorized_pickup(rig: tuple) -
     )
     assert execution is not None
     assert (await service.ready(contract.issue_revision))["state"] == "dispatched"
+
+
+@pytest.mark.asyncio
+async def test_explicit_ready_reconciles_only_unlaunched_current_revision(
+    rig: tuple,
+) -> None:
+    service, transport, flow, _ = rig
+    old = await contract_for(service)
+    await service.refine(old)
+    await service.ready(old.issue_revision)
+    transport.issues[1]["body"] += " New scope."
+    current = await contract_for(service)
+    await service.refine(current)
+    stale = await service.ready(old.issue_revision)
+    assert stale["state"] == "blocked"
+    assert "issue_scope_changed" in stale["blockers"]
+    assert (await service.ready(current.issue_revision))["state"] == "ready"
+    prior = service._get("pickup", old.issue_revision)
+    assert prior.state == "superseded"
+    assert prior.data["contract"] == old.model_dump()
+    dispatch = AsyncMock()
+    first = await service.schedule_pickup(flow, {}, dispatch)
+    assert first is not None
+    assert (await service.ready(current.issue_revision))["state"] == "dispatched"
+    transport.issues[1]["body"] += " Yet another scope."
+    next_contract = await contract_for(service)
+    await service.refine(next_contract)
+    blocked = await service.ready(next_contract.issue_revision)
+    assert blocked["state"] == "needs_reconciliation"
+    assert "pickup_reconciliation_required" in blocked["blockers"]
+    assert service._get("pickup", "once").execution_id == first.id
+    assert await service.schedule_pickup(flow, {}, dispatch) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exhaustion", ["time", "requests"])
+async def test_audit_publication_budget_rolls_back_and_can_reconcile(
+    rig: tuple, monkeypatch: pytest.MonkeyPatch, exhaustion: str
+) -> None:
+    import asyncio
+    from preloop.services import issue_lifecycle_provider
+
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    transport.merge()
+    execution = await service.schedule_audit(flow, AsyncMock())
+    crud_flow_execution.update(
+        service.db,
+        db_obj=execution,
+        obj_in=FlowExecutionUpdate(
+            status="SUCCEEDED", result=audit_result(contract, "gap")
+        ),
+    )
+    service.db.commit()
+    original = transport._request
+
+    async def stalled(*args: Any, **kwargs: Any) -> Any:
+        await asyncio.sleep(1)
+        return await original(*args, **kwargs)
+
+    with monkeypatch.context() as patcher:
+        if exhaustion == "time":
+            patcher.setattr(
+                issue_lifecycle_provider, "PUBLICATION_TIMEOUT_SECONDS", 0.02
+            )
+            patcher.setattr(transport, "_request", stalled)
+            error = "publication_deadline_exceeded"
+        else:
+            patcher.setattr(issue_lifecycle_provider, "PUBLICATION_MAX_REQUESTS", 1)
+            error = "publication_request_budget_exhausted"
+        with pytest.raises(ValueError, match=error):
+            await service.finish_audit(execution)
+    assert service._get("merge_audit", SHA).state == "queued"
+    assert len(transport.issues) == 1
+    assert not transport.comments
+    result = await service.finish_audit(execution)
+    assert len(result["follow_ups"]) == 1
+    assert len(transport.issues) == 2

--- a/backend/tests/services/test_issue_lifecycle.py
+++ b/backend/tests/services/test_issue_lifecycle.py
@@ -487,6 +487,35 @@ async def test_manual_completed_close_is_not_merge_authority(rig: tuple) -> None
 
 
 @pytest.mark.asyncio
+async def test_schedule_audit_requires_configured_audit_flow(rig: tuple) -> None:
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    transport.merge()
+    other = CRUDBase(models.Flow).create(
+        service.db,
+        obj_in={
+            "name": "Draft audit",
+            "account_id": service.account_id,
+            "agent_type": "codex",
+            "agent_config": {"lifecycle_kind": "merge_audit"},
+            "prompt_template": "Audit",
+            "is_enabled": True,
+            "allowed_mcp_servers": [],
+            "allowed_mcp_tools": [],
+            "git_clone_config": flow.git_clone_config,
+        },
+    )
+    dispatch = AsyncMock()
+    assert await service.schedule_audit(other, dispatch) is None
+    dispatch.assert_not_awaited()
+    assert service._get("merge_audit", SHA) is None
+    execution = await service.schedule_audit(flow, dispatch)
+    assert execution is not None
+    dispatch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_provider_success_local_failure_recovers_existing_followup(
     rig: tuple,
 ) -> None:
@@ -960,6 +989,41 @@ async def test_explicit_ready_reconciles_only_unlaunched_current_revision(
     assert "pickup_reconciliation_required" in blocked["blockers"]
     assert service._get("pickup", "once").execution_id == first.id
     assert await service.schedule_pickup(flow, {}, dispatch) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exhaustion", ["time", "requests"])
+async def test_schedule_audit_discovery_uses_publication_budget(
+    rig: tuple, monkeypatch: pytest.MonkeyPatch, exhaustion: str
+) -> None:
+    import asyncio
+    from preloop.services import issue_lifecycle_provider
+
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    transport.merge()
+    original = transport._request
+
+    async def stalled(*args: Any, **kwargs: Any) -> Any:
+        await asyncio.sleep(1)
+        return await original(*args, **kwargs)
+
+    with monkeypatch.context() as patcher:
+        if exhaustion == "time":
+            patcher.setattr(
+                issue_lifecycle_provider, "PUBLICATION_TIMEOUT_SECONDS", 0.02
+            )
+            patcher.setattr(transport, "_request", stalled)
+            error = "publication_deadline_exceeded"
+        else:
+            patcher.setattr(issue_lifecycle_provider, "PUBLICATION_MAX_REQUESTS", 1)
+            error = "publication_request_budget_exhausted"
+        with pytest.raises(ValueError, match=error):
+            await service.schedule_audit(flow, AsyncMock())
+    assert service._get("merge_audit", SHA) is None
+    execution = await service.schedule_audit(flow, AsyncMock())
+    assert execution is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_issue_lifecycle.py
+++ b/backend/tests/services/test_issue_lifecycle.py
@@ -46,6 +46,7 @@ class FakeGitHub:
                 "labels": [{"name": "feature"}],
             }
         }
+        self.repository_labels = ["feature", "agent-ready"]
         self.comments: list[dict[str, Any]] = []
         self.timeline: list[dict[str, Any]] = []
         self.prs: dict[int, dict[str, Any]] = {}
@@ -98,6 +99,8 @@ class FakeGitHub:
     ) -> Any:
         self.calls.append((method, endpoint))
         root = f"/repos/{REPO}"
+        if endpoint == f"{root}/labels" and method == "GET":
+            return [{"name": name} for name in self.repository_labels]
         if endpoint == f"{root}/issues" and method == "GET":
             return deepcopy(list(self.issues.values()))
         if endpoint == f"{root}/issues" and method == "POST":
@@ -215,6 +218,7 @@ def rig(
     )
     policy = {
         "ready_enabled": True,
+        "ready_label": "agent-ready",
         "implementation_flow_id": str(implementer.id),
         "audit_flow_id": str(audit.id),
         "create_follow_ups": True,
@@ -327,7 +331,31 @@ async def test_ready_and_duplicate_webhook_create_one_authorized_pickup(
 ) -> None:
     service, transport, flow, _ = rig
     contract = await contract_for(service)
-    assert not (await service.refine(contract))["blockers"]
+    vague = ReadinessContract(issue_revision=contract.issue_revision)
+    assert "missing_criteria" in (await service.refine(vague))["blockers"]
+    assert (await service.ready(contract.issue_revision))["state"] == "blocked"
+    assert not any(method == "POST" for method, _ in transport.calls)
+    monkeypatch.setattr(
+        "preloop.services.issue_lifecycle_runtime.build_lifecycle_service",
+        AsyncMock(return_value=service),
+    )
+    refinement = models.Flow(
+        account_id=service.account_id,
+        agent_config={"lifecycle_kind": "refinement"},
+    )
+    proposal = models.FlowExecution(
+        status="SUCCEEDED",
+        trigger_event_details={
+            "lifecycle_refinement": {
+                "issue_id": str(service.issue.id),
+                "issue_revision": contract.issue_revision,
+            }
+        },
+        result={"status": "success", "readiness_contract": contract.model_dump()},
+    )
+    await lifecycle_execution_finished(service.db, proposal, refinement)
+    assert service._get("readiness", contract.issue_revision).state == "reviewable"
+    assert not any(method == "POST" for method, _ in transport.calls)
     assert (await service.ready(contract.issue_revision))["state"] == "ready"
     assert (await service.ready(contract.issue_revision))["state"] == "ready"
     assert transport.issues[1]["labels"] == [
@@ -974,3 +1002,225 @@ async def test_audit_publication_budget_rolls_back_and_can_reconcile(
     result = await service.finish_audit(execution)
     assert len(result["follow_ups"]) == 1
     assert len(transport.issues) == 2
+
+
+@pytest.mark.asyncio
+async def test_ready_uses_only_explicit_existing_project_label(rig: tuple) -> None:
+    service, transport, _, _ = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    service.policy.pop("ready_label", None)
+    with pytest.raises(ValueError, match="ready_label_not_configured"):
+        await service.ready(contract.issue_revision)
+    service.policy["ready_label"] = "ready for implementation"
+    transport.repository_labels = ["feature"]
+    with pytest.raises(ValueError, match="ready_label_not_found"):
+        await service.ready(contract.issue_revision)
+    assert not any(method == "POST" for method, _ in transport.calls)
+    transport.repository_labels.append("ready for implementation")
+    result = await service.ready(contract.issue_revision)
+    assert result["label"] == "ready for implementation"
+    assert transport.issues[1]["labels"] == [
+        {"name": "feature"},
+        {"name": "ready for implementation"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_explicit_replacement_preserves_terminal_history_and_reuses_authorization(
+    rig: tuple,
+) -> None:
+    service, transport, flow, _ = rig
+    old = await contract_for(service)
+    await service.refine(old)
+    await service.ready(old.issue_revision)
+    first = await service.schedule_pickup(flow, {}, AsyncMock())
+    transport.issues[1]["body"] += " New scope."
+    current = await contract_for(service)
+    await service.refine(current)
+    with pytest.raises(ValueError, match="pickup_execution_not_terminal"):
+        await service.reconcile_pickup(
+            current.issue_revision, first.id, "Approve revised scope"
+        )
+    assert service._get("pickup", "once").execution_id == first.id
+    crud_flow_execution.update(
+        service.db, db_obj=first, obj_in=FlowExecutionUpdate(status="CANCELLED")
+    )
+    service.db.commit()
+    with pytest.raises(ValueError, match="pickup_execution_mismatch"):
+        await service.reconcile_pickup(
+            current.issue_revision, uuid4(), "Wrong execution"
+        )
+    stale = await service.reconcile_pickup(old.issue_revision, first.id, "Stale scope")
+    assert stale["state"] == "blocked"
+    approved = await service.reconcile_pickup(
+        current.issue_revision, first.id, "Approve revised scope"
+    )
+    assert approved["state"] == "ready"
+    assert approved["replaces_execution_id"] == str(first.id)
+    history = crud_issue_lifecycle.list_for_issue(
+        service.db, account_id=service.account_id, issue_id=service.issue.id
+    )
+    prior = next(
+        row for row in history if row.kind == "pickup" and row.state == "superseded"
+    )
+    assert prior.execution_id == first.id
+    assert prior.data["contract"] == old.model_dump()
+    second = await service.schedule_pickup(flow, {}, AsyncMock())
+    assert second.id != first.id
+    assert second.retry_of_execution_id is None and second.cli_session is None
+    replay = await service.reconcile_pickup(
+        current.issue_revision, first.id, "Approve revised scope"
+    )
+    assert replay["authorization_id"] == approved["authorization_id"]
+    assert (await service.schedule_pickup(flow, {}, AsyncMock())).id == second.id
+    assert (
+        first.trigger_event_details["lifecycle_pickup"]["contract"] == old.model_dump()
+    )
+    assert (
+        second.trigger_event_details["lifecycle_pickup"]["contract"]
+        == current.model_dump()
+    )
+    assert (
+        sum(
+            method == "POST" and url.endswith("/labels")
+            for method, url in transport.calls
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_http_dispatches_once_with_label_already_present(
+    rig: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+    from fastapi import FastAPI
+    from preloop.api.auth import get_current_active_user
+    from preloop.api.endpoints.issue_lifecycle import router
+    from preloop.models.db.session import get_db_session
+
+    service, transport, flow, _ = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    await service.ready(contract.issue_revision)
+    first = await service.schedule_pickup(flow, {}, AsyncMock())
+    transport.issues[1]["body"] += " Revised requirement."
+    revised = await contract_for(service)
+    await service.refine(revised)
+    crud_flow_execution.update(
+        service.db, db_obj=first, obj_in=FlowExecutionUpdate(status="SUCCEEDED")
+    )
+    service.db.commit()
+    transport.tracker_type = "github"
+    monkeypatch.setattr(
+        "preloop.services.issue_lifecycle_runtime.get_tracker_client",
+        AsyncMock(return_value=transport),
+    )
+    monkeypatch.setattr(
+        "preloop.services.issue_lifecycle_runtime.FlowEnvironmentCapabilities.blockers",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        "preloop.services.flow_execution_dispatcher.flow_execution_worker_enabled",
+        lambda: True,
+    )
+    dispatch = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "preloop.services.flow_execution_dispatcher.dispatch_execute", dispatch
+    )
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db_session] = lambda: service.db
+    actor = models.User(
+        id=uuid4(), account_id=service.account_id, username="reviewer", is_active=True
+    )
+    app.dependency_overrides[get_current_active_user] = lambda: actor
+    body = {
+        "issue_revision": revised.issue_revision,
+        "previous_execution_id": str(first.id),
+        "reason": "Approve reviewed revised scope",
+    }
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        path = f"/issues/{service.issue.id}/lifecycle/pickup/reconcile"
+        initial = await client.post(path, json=body)
+        assert initial.status_code == 200, initial.text
+        replay = await client.post(path, json=body)
+        assert replay.status_code == 200, replay.text
+        assert initial.json()["execution_id"] == replay.json()["execution_id"]
+        assert initial.json()["execution_id"] != str(first.id)
+        assert initial.json()["authorization_id"] == replay.json()["authorization_id"]
+    assert len({str(call.args[0]) for call in dispatch.await_args_list}) == 1
+    assert (
+        sum(
+            method == "POST" and url.endswith("/labels")
+            for method, url in transport.calls
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_fixture_checks_out_exact_revision_before_independent_audit(
+    rig: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Run the production checkout script against a real disposable repository."""
+    import subprocess
+    import sys
+    from preloop.agents.codex import CodexAgent
+
+    def git(*args: str) -> str:
+        return subprocess.check_output(
+            ["git", "-C", str(tmp_path), *args], text=True
+        ).strip()
+
+    git("init", "-b", "main")
+    git("config", "user.name", "Local lifecycle fixture")
+    git("config", "user.email", "fixture@example.invalid")
+    (tmp_path / "preference.txt").write_text("accepted revision\n")
+    git("add", "preference.txt")
+    git("commit", "-m", "Merged acceptance fixture")
+    merged_sha = git("rev-parse", "HEAD")
+    (tmp_path / "preference.txt").write_text("later unrelated change\n")
+    git("commit", "-am", "Later main revision")
+    assert git("rev-parse", "HEAD") != merged_sha
+    monkeypatch.setattr(sys.modules[__name__], "SHA", merged_sha)
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    transport.merge()
+    execution = await service.schedule_audit(flow, AsyncMock())
+    agent = CodexAgent({})
+    event = execution.trigger_event_details
+    selected = agent._extract_commit_sha_from_trigger(event)
+    script = agent._build_git_branch_setup_shell(
+        full_path=str(tmp_path),
+        commit_sha=selected,
+        source_branch="main",
+        target_branch="independent-audit",
+        trigger_data=event,
+    )
+    # Only the final sandbox-directory reset is unnecessary on the local host.
+    script = script.removesuffix("cd /workspace")
+    subprocess.run(["bash", "-ec", script], check=True, capture_output=True, text=True)
+    assert git("rev-parse", "HEAD") == merged_sha
+    assert (tmp_path / "preference.txt").read_text() == "accepted revision\n"
+    assert execution.cli_session is None and execution.retry_of_execution_id is None
+    result = audit_result(contract, "gap")
+    result["checked_out_sha"] = git("rev-parse", "HEAD")
+    crud_flow_execution.update(
+        service.db,
+        db_obj=execution,
+        obj_in=FlowExecutionUpdate(status="SUCCEEDED", result=result),
+    )
+    summary = await service.finish_audit(execution)
+    assert summary["verdict"] == "gap"
+    assert len(transport.comments) == 1 and len(transport.issues) == 2
+    await service.finish_audit(execution)
+    assert len(transport.comments) == 1 and len(transport.issues) == 2
+    assert merged_sha in transport.comments[0]["body"]

--- a/backend/tests/services/test_issue_lifecycle.py
+++ b/backend/tests/services/test_issue_lifecycle.py
@@ -1,0 +1,897 @@
+"""Disposable-Postgres lifecycle integration through real provider/controller hooks."""
+
+from copy import deepcopy
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from preloop.models import models
+from preloop.models.crud.base import CRUDBase
+from preloop.models.schemas.flow_execution import FlowExecutionUpdate
+from preloop.models.crud import (
+    crud_account,
+    crud_flow_execution,
+    crud_issue,
+    crud_issue_lifecycle,
+    crud_organization,
+    crud_project,
+    crud_tracker,
+)
+from preloop.schemas.issue_lifecycle import Criterion, ReadinessContract
+from preloop.services.flow_trigger_service import FlowTriggerService
+from preloop.services.issue_lifecycle import IssueLifecycleService
+from preloop.services.issue_lifecycle_provider import GitHubLifecycleProvider
+from preloop.services.issue_lifecycle_runtime import lifecycle_execution_finished
+
+SHA = "a" * 40
+OTHER_SHA = "b" * 40
+REPO = "example/project"
+
+
+class FakeGitHub:
+    """Fake external transport; production provider pagination/effects stay real."""
+
+    def __init__(self) -> None:
+        self.issues = {
+            1: {
+                "id": 1001,
+                "number": 1,
+                "title": "Save preferences",
+                "body": "Persist user preferences across sessions.",
+                "state": "open",
+                "html_url": f"https://github.com/{REPO}/issues/1",
+                "labels": [{"name": "feature"}],
+            }
+        }
+        self.comments: list[dict[str, Any]] = []
+        self.timeline: list[dict[str, Any]] = []
+        self.prs: dict[int, dict[str, Any]] = {}
+        self.calls: list[tuple[str, str]] = []
+        self.fail_after_creation = False
+        self.change_before_label = False
+
+    def merge(self, *, manual: bool = False, multiple: bool = False) -> None:
+        self.issues[1]["state"] = "closed"
+        self.timeline = [{"event": "closed", "commit_id": None if manual else SHA}]
+        self.prs = {
+            7: {
+                "number": 7,
+                "merged": True,
+                "merge_commit_sha": SHA,
+                "html_url": f"https://github.com/{REPO}/pull/7",
+                "base": {"repo": {"full_name": REPO}},
+            }
+        }
+        if multiple:
+            self.prs[6] = {
+                **self.prs[7],
+                "number": 6,
+                "merge_commit_sha": OTHER_SHA,
+                "html_url": f"https://github.com/{REPO}/pull/6",
+            }
+            self.timeline.insert(
+                0,
+                {
+                    "event": "cross-referenced",
+                    "source": {
+                        "issue": {
+                            "number": 6,
+                            "pull_request": {},
+                            "repository": {"full_name": REPO},
+                        }
+                    },
+                },
+            )
+            self.timeline[0]["source"]["issue"]["pull_request"] = {
+                "url": "https://api.github.com/example"
+            }
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        data: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        self.calls.append((method, endpoint))
+        root = f"/repos/{REPO}"
+        if endpoint == f"{root}/issues" and method == "GET":
+            return deepcopy(list(self.issues.values()))
+        if endpoint == f"{root}/issues" and method == "POST":
+            number = max(self.issues) + 1
+            item = {
+                **data,
+                "number": number,
+                "state": "open",
+                "html_url": f"https://github.com/{REPO}/issues/{number}",
+            }
+            self.issues[number] = item
+            if self.fail_after_creation:
+                self.fail_after_creation = False
+                raise TimeoutError("provider effect succeeded but response was lost")
+            return deepcopy(item)
+        if endpoint == f"{root}/issues/1/timeline":
+            return deepcopy(self.timeline)
+        if endpoint == f"{root}/commits/{SHA}/pulls":
+            return deepcopy(list(self.prs.values()))
+        if "/pulls/" in endpoint:
+            return deepcopy(self.prs[int(endpoint.rsplit("/", 1)[-1])])
+        if endpoint == f"{root}/issues/1/comments":
+            if method == "GET":
+                return deepcopy(self.comments)
+            item = {
+                "id": len(self.comments) + 1,
+                "body": data["body"],
+                "html_url": "https://github.com/example/project/issues/1#issuecomment-1",
+            }
+            self.comments.append(item)
+            return deepcopy(item)
+        if "/issues/comments/" in endpoint:
+            self.comments[0]["body"] = data["body"]
+            return deepcopy(self.comments[0])
+        if endpoint.endswith("/labels"):
+            if self.change_before_label:
+                self.issues[1]["body"] += " New requirement."
+            self.issues[1]["labels"].extend({"name": name} for name in data["labels"])
+            return self.issues[1]["labels"]
+        return deepcopy(self.issues[int(endpoint.rsplit("/", 1)[-1])])
+
+
+class Capabilities:
+    """Substitute only operator environment runtime availability."""
+
+    async def blockers(self, profile: str, commands: list[str]) -> list[str]:
+        return (
+            []
+            if profile == "python-tests" and commands == ["unit"]
+            else ["environment_unavailable"]
+        )
+
+
+@pytest.fixture
+def rig(
+    db_session: Session,
+) -> tuple[IssueLifecycleService, FakeGitHub, models.Flow, models.Flow]:
+    account = crud_account.create(
+        db_session, obj_in={"organization_name": "Example", "is_active": True}
+    )
+    tracker = crud_tracker.create(
+        db_session,
+        obj_in={
+            "name": "Example tracker",
+            "tracker_type": "github",
+            "account_id": account.id,
+            "api_key": "fake-local-only",
+        },
+    )
+    org = crud_organization.create(
+        db_session,
+        obj_in={"name": "example", "identifier": "example", "tracker_id": tracker.id},
+    )
+    project = crud_project.create(
+        db_session,
+        obj_in={"name": "project", "identifier": REPO, "organization_id": org.id},
+    )
+    issue = crud_issue.create(
+        db_session,
+        obj_in={
+            "title": "Save preferences",
+            "description": "Persist user preferences across sessions.",
+            "status": "open",
+            "external_id": "1001",
+            "key": f"{REPO}#1",
+            "project_id": project.id,
+            "tracker_id": tracker.id,
+        },
+    )
+    config = {
+        "name": "Implementation",
+        "account_id": account.id,
+        "agent_type": "codex",
+        "agent_config": {},
+        "prompt_template": "Implement",
+        "is_enabled": True,
+        "allowed_mcp_servers": [],
+        "allowed_mcp_tools": [],
+    }
+    implementer = CRUDBase(models.Flow).create(db_session, obj_in=config)
+    audit = CRUDBase(models.Flow).create(
+        db_session,
+        obj_in={
+            **config,
+            "name": "Audit",
+            "agent_config": {"lifecycle_kind": "merge_audit"},
+            "git_clone_config": {
+                "enabled": True,
+                "create_pull_request": False,
+                "repositories": [
+                    {"project_id": str(project.id), "tracker_id": str(tracker.id)}
+                ],
+            },
+        },
+    )
+    policy = {
+        "ready_enabled": True,
+        "implementation_flow_id": str(implementer.id),
+        "audit_flow_id": str(audit.id),
+        "create_follow_ups": True,
+    }
+    crud_project.update(
+        db_session, db_obj=project, obj_in={"settings": {"issue_lifecycle": policy}}
+    )
+    transport = FakeGitHub()
+    service = IssueLifecycleService(
+        db_session,
+        account_id=account.id,
+        issue=issue,
+        provider=GitHubLifecycleProvider(transport, REPO),
+        capabilities=Capabilities(),
+        policy=policy,
+    )
+    return service, transport, implementer, audit
+
+
+async def contract_for(
+    service: IssueLifecycleService, count: int = 1
+) -> ReadinessContract:
+    snapshot = await service.provider.issue(1)
+    return ReadinessContract(
+        issue_revision=snapshot.revision,
+        problem="Preferences disappear",
+        user_outcome="Preferences persist",
+        constraints=["Use existing storage"],
+        non_goals=["Cross-device sync"],
+        criteria=[
+            Criterion(
+                id=f"C{i}",
+                outcome="Preference survives restart",
+                verification="Restart and assert persisted value",
+            )
+            for i in range(count)
+        ],
+        code_entry_points=["app/preferences.py"],
+        test_entry_points=["tests/test_preferences.py"],
+        environment_profile="python-tests",
+        test_commands=["unit"],
+    )
+
+
+def audit_result(
+    contract: ReadinessContract, verdict: str = "complete"
+) -> dict[str, Any]:
+    return {
+        "status": "success",
+        "checked_out_sha": SHA,
+        "issue_revision": contract.issue_revision,
+        "criteria": [
+            {
+                "criterion_id": item.id,
+                "verdict": verdict,
+                "code": ["app/preferences.py:20"],
+                "tests": ["pytest tests/test_preferences.py: passed"],
+                "observations": ["Stored preference survives process restart"],
+                "reason": "Verified persistence",
+            }
+            for item in contract.criteria
+        ],
+        "follow_ups": [
+            {
+                "criterion_id": item.id,
+                "kind": "defect",
+                "title": f"Fix {item.id}",
+                "description": "Persistence gap reproduced; retain value across process restart.",
+                "evidence": ["evidence/tests.txt"],
+            }
+            for item in contract.criteria
+        ]
+        if verdict == "gap"
+        else [],
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "variant,expected",
+    [
+        ("vague", "missing_problem"),
+        ("missing_environment", "environment_unavailable"),
+        ("dependency", "blocked_dependency:2"),
+        ("conflict", "conflict:two incompatible persistence requirements"),
+    ],
+)
+async def test_readiness_blocks_material_gaps(
+    rig: tuple, variant: str, expected: str
+) -> None:
+    service, transport, _, _ = rig
+    contract = await contract_for(service)
+    if variant == "vague":
+        contract = ReadinessContract(issue_revision=contract.issue_revision)
+    elif variant == "missing_environment":
+        contract.environment_profile = "missing"
+    elif variant == "dependency":
+        transport.issues[2] = {**transport.issues[1], "number": 2}
+        contract.dependencies = [2]
+    else:
+        contract.conflicts = ["two incompatible persistence requirements"]
+    assert expected in (await service.refine(contract))["blockers"]
+    assert (await service.ready(contract.issue_revision))["state"] == "blocked"
+    assert not any(method == "POST" for method, _ in transport.calls)
+
+
+@pytest.mark.asyncio
+async def test_ready_and_duplicate_webhook_create_one_authorized_pickup(
+    rig: tuple, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, transport, flow, _ = rig
+    contract = await contract_for(service)
+    assert not (await service.refine(contract))["blockers"]
+    assert (await service.ready(contract.issue_revision))["state"] == "ready"
+    assert (await service.ready(contract.issue_revision))["state"] == "ready"
+    assert transport.issues[1]["labels"] == [
+        {"name": "feature"},
+        {"name": "agent-ready"},
+    ]
+    monkeypatch.setattr(
+        "preloop.services.issue_lifecycle_runtime.build_lifecycle_service",
+        AsyncMock(return_value=service),
+    )
+    monkeypatch.setattr(
+        "preloop.services.flow_execution_dispatcher.flow_execution_worker_enabled",
+        lambda: True,
+    )
+    dispatch = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "preloop.services.flow_execution_dispatcher.dispatch_execute", dispatch
+    )
+    event = {
+        "type": "issue_labeled",
+        "project_id": str(service.issue.project_id),
+        "payload": {"issue": {"id": 1001}},
+    }
+    trigger = FlowTriggerService(service.db)
+    first = await trigger._start_flow_execution(flow, event, None)
+    second = await trigger._start_flow_execution(flow, event, None)
+    assert first.id == second.id
+    assert len({str(call.args[0]) for call in dispatch.await_args_list}) == 1
+    assert (
+        first.trigger_event_details["lifecycle_pickup"]["issue_revision"]
+        == contract.issue_revision
+    )
+    assert first.cli_session is None
+
+
+@pytest.mark.asyncio
+async def test_scope_change_cannot_dispatch_and_is_visible(rig: tuple) -> None:
+    service, transport, flow, _ = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    transport.change_before_label = True
+    assert (await service.ready(contract.issue_revision))[
+        "state"
+    ] == "needs_reconciliation"
+    dispatch = AsyncMock()
+    assert await service.schedule_pickup(flow, {}, dispatch) is None
+    dispatch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_readiness_never_writes_label(rig: tuple) -> None:
+    service, transport, _, _ = rig
+    service.policy["ready_enabled"] = False
+    with pytest.raises(ValueError, match="not_authorized"):
+        await service.ready("revision")
+    assert not transport.calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("verdict", ["complete", "gap", "unknown"])
+async def test_merge_to_terminal_hook_one_audit_and_deduplicated_followups(
+    rig: tuple, monkeypatch: pytest.MonkeyPatch, verdict: str
+) -> None:
+    service, transport, _, flow = rig
+    contract = await contract_for(service, 5)
+    await service.refine(contract)
+    transport.merge(multiple=True)
+    monkeypatch.setattr(
+        "preloop.services.issue_lifecycle_runtime.build_lifecycle_service",
+        AsyncMock(return_value=service),
+    )
+    monkeypatch.setattr(
+        "preloop.services.flow_execution_dispatcher.flow_execution_worker_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "preloop.services.flow_execution_dispatcher.dispatch_execute",
+        AsyncMock(return_value=True),
+    )
+    trigger = FlowTriggerService(service.db)
+    event = {
+        "type": "issue_closed",
+        "project_id": str(service.issue.project_id),
+        "payload": {"issue": {"id": 1001}},
+    }
+    execution = await trigger._start_flow_execution(flow, event, None)
+    assert execution.trigger_event_details["payload"]["sha"] == SHA
+    assert len(execution.trigger_event_details["payload"]["lifecycle"]["merges"]) == 2
+    assert execution.cli_session is None
+    assert execution.retry_of_execution_id is None
+    assert (await trigger._start_flow_execution(flow, event, None)).id == execution.id
+    execution = crud_flow_execution.update(
+        service.db,
+        db_obj=execution,
+        obj_in=FlowExecutionUpdate(
+            status="SUCCEEDED", result=audit_result(contract, verdict)
+        ),
+    )
+    await lifecycle_execution_finished(service.db, execution, flow)
+    await lifecycle_execution_finished(service.db, execution, flow)
+    row = crud_issue_lifecycle.get(
+        service.db,
+        account_id=service.account_id,
+        issue_id=service.issue.id,
+        kind="merge_audit",
+        revision=SHA,
+    )
+    assert row.state == "published" and row.data["verdict"] == verdict
+    assert len(transport.comments) == 1
+    assert len(transport.issues) == (4 if verdict == "gap" else 1)
+    for issue in list(transport.issues.values())[1:]:
+        assert issue["labels"] == []
+        assert SHA in issue["body"]
+    assert transport.issues[1]["state"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_manual_completed_close_is_not_merge_authority(rig: tuple) -> None:
+    service, transport, _, flow = rig
+    transport.merge(manual=True)
+    dispatch = AsyncMock()
+    assert await service.schedule_audit(flow, dispatch) is None
+    dispatch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_provider_success_local_failure_recovers_existing_followup(
+    rig: tuple,
+) -> None:
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    transport.merge()
+    execution = await service.schedule_audit(flow, AsyncMock())
+    crud_flow_execution.update(
+        service.db,
+        db_obj=execution,
+        obj_in=FlowExecutionUpdate(
+            status="SUCCEEDED", result=audit_result(contract, "gap")
+        ),
+    )
+    service.db.commit()  # The production terminal hook receives a durable result.
+    transport.fail_after_creation = True
+    with pytest.raises(TimeoutError):
+        await service.finish_audit(execution)
+    assert len(transport.issues) == 2
+    result = await service.finish_audit(execution)
+    assert len(result["follow_ups"]) == 1
+    assert len(transport.issues) == 2
+    assert len(transport.comments) == 1
+
+
+@pytest.mark.asyncio
+async def test_exact_sha_and_bound_execution_required(rig: tuple) -> None:
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    transport.merge()
+    execution = await service.schedule_audit(flow, AsyncMock())
+    result = {**audit_result(contract), "checked_out_sha": OTHER_SHA}
+    crud_flow_execution.update(
+        service.db,
+        db_obj=execution,
+        obj_in=FlowExecutionUpdate(status="SUCCEEDED", result=result),
+    )
+    with pytest.raises(ValueError, match="revision_mismatch"):
+        await service.finish_audit(execution)
+    assert not transport.comments
+    impostor = models.FlowExecution(
+        id=uuid4(),
+        trigger_event_details=execution.trigger_event_details,
+        status="SUCCEEDED",
+        result=result,
+    )
+    with pytest.raises(ValueError, match="not_bound"):
+        await service.finish_audit(impostor)
+
+
+@pytest.mark.asyncio
+async def test_deployment_acceptance_remains_unknown_without_probe(rig: tuple) -> None:
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    contract.criteria[0].deployment_required = True
+    await service.refine(contract)
+    transport.merge()
+    execution = await service.schedule_audit(flow, AsyncMock())
+    crud_flow_execution.update(
+        service.db,
+        db_obj=execution,
+        obj_in=FlowExecutionUpdate(status="SUCCEEDED", result=audit_result(contract)),
+    )
+    result = await service.finish_audit(execution)
+    assert result["verdict"] == "unknown"
+    assert result["deployment_verification"]["merge_sha"] == SHA
+    assert result["deployment_verification"]["criteria"] == ["C0"]
+    assert all(endpoint.startswith("/repos/") for _, endpoint in transport.calls)
+
+
+@pytest.mark.asyncio
+async def test_existing_human_followup_is_reused_and_policy_blocks_creation(
+    rig: tuple,
+) -> None:
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    transport.issues[2] = {
+        "number": 2,
+        "title": "Existing persistence defect",
+        "body": f"Source: https://github.com/{REPO}/issues/1\nAcceptance criterion: C0",
+        "state": "open",
+        "html_url": f"https://github.com/{REPO}/issues/2",
+        "labels": [{"name": "bug"}],
+    }
+    transport.merge()
+    execution = await service.schedule_audit(flow, AsyncMock())
+    crud_flow_execution.update(
+        service.db,
+        db_obj=execution,
+        obj_in=FlowExecutionUpdate(
+            status="SUCCEEDED", result=audit_result(contract, "gap")
+        ),
+    )
+    result = await service.finish_audit(execution)
+    assert list(result["follow_ups"].values()) == [transport.issues[2]["html_url"]]
+    assert len(transport.issues) == 2
+    assert transport.issues[2]["labels"] == [{"name": "bug"}]
+    assert not any(
+        method == "POST" and endpoint.endswith("/issues")
+        for method, endpoint in transport.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_evidence_cannot_claim_complete_or_file_unknown_gap(
+    rig: tuple,
+) -> None:
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    transport.merge()
+    execution = await service.schedule_audit(flow, AsyncMock())
+    result = audit_result(contract, "gap")
+    result["criteria"][0].update(code=[], tests=[], observations=[])
+    crud_flow_execution.update(
+        service.db,
+        db_obj=execution,
+        obj_in=FlowExecutionUpdate(status="SUCCEEDED", result=result),
+    )
+    summary = await service.finish_audit(execution)
+    assert summary["verdict"] == "unknown"
+    assert summary["evidence"]["criteria"][0]["verdict"] == "unknown"
+    assert len(transport.issues) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_followup_policy_leaves_gap_in_audit(rig: tuple) -> None:
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    transport.merge()
+    execution = await service.schedule_audit(flow, AsyncMock())
+    crud_flow_execution.update(
+        service.db,
+        db_obj=execution,
+        obj_in=FlowExecutionUpdate(
+            status="SUCCEEDED", result=audit_result(contract, "gap")
+        ),
+    )
+    service.policy["create_follow_ups"] = False
+    result = await service.finish_audit(execution)
+    assert result["verdict"] == "gap"
+    assert not result["follow_ups"]
+    assert len(transport.issues) == 1
+
+
+@pytest.mark.asyncio
+async def test_deployment_audit_is_separate_approved_and_pinned(rig: tuple) -> None:
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    contract.criteria[0].deployment_required = True
+    await service.refine(contract)
+    transport.merge()
+    execution = await service.schedule_audit(flow, AsyncMock())
+    crud_flow_execution.update(
+        service.db,
+        db_obj=execution,
+        obj_in=FlowExecutionUpdate(status="SUCCEEDED", result=audit_result(contract)),
+    )
+    await service.finish_audit(execution)
+    deploy_flow = CRUDBase(models.Flow).create(
+        service.db,
+        obj_in={
+            "name": "Staging verification",
+            "account_id": service.account_id,
+            "agent_type": "codex",
+            "agent_config": {"lifecycle_kind": "deployment_audit"},
+            "prompt_template": "Verify only the approved deployment scope",
+            "is_enabled": True,
+            "allowed_mcp_tools": [],
+            "allowed_mcp_servers": [],
+            "git_clone_config": flow.git_clone_config,
+        },
+    )
+    kwargs = {
+        "merge_sha": SHA,
+        "target": "staging",
+        "deployed_revision": OTHER_SHA,
+        "deployment_evidence": "https://ci.example.com/deployments/42",
+        "flow": deploy_flow,
+        "dispatch": AsyncMock(),
+    }
+    with pytest.raises(ValueError, match="not_authorized"):
+        await service.schedule_deployment_audit(**kwargs)
+    service.policy["deployment_targets"] = {
+        "staging": {
+            "flow_id": str(deploy_flow.id),
+            "approved_scope": [
+                "GET https://staging.example.com/preferences for synthetic test account"
+            ],
+        }
+    }
+    deployed = await service.schedule_deployment_audit(**kwargs)
+    assert deployed.id != execution.id
+    assert deployed.trigger_event_details["payload"]["sha"] == OTHER_SHA
+    assert (await service.schedule_deployment_audit(**kwargs)).id == deployed.id
+    result = {**audit_result(contract), "checked_out_sha": OTHER_SHA}
+    crud_flow_execution.update(
+        service.db,
+        db_obj=deployed,
+        obj_in=FlowExecutionUpdate(status="SUCCEEDED", result=result),
+    )
+    summary = await service.finish_audit(deployed)
+    assert summary["verdict"] == "complete"
+    assert summary["deployment_verification"] is None
+    assert len(transport.comments) == 2
+    assert "Deployed revision" in transport.comments[-1]["body"]
+
+
+def test_http_entrypoints_preserve_tenant_scope_and_authorization(
+    rig: tuple, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from preloop.api.auth import get_current_active_user
+    from preloop.api.endpoints.issue_lifecycle import router
+    from preloop.models.db.session import get_db_session
+
+    service, transport, _, _ = rig
+    transport.tracker_type = "github"
+    monkeypatch.setattr(
+        "preloop.services.issue_lifecycle_runtime.get_tracker_client",
+        AsyncMock(return_value=transport),
+    )
+    monkeypatch.setattr(
+        "preloop.services.issue_lifecycle_runtime.FlowEnvironmentCapabilities.blockers",
+        AsyncMock(return_value=[]),
+    )
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[get_db_session] = lambda: service.db
+    actor = models.User(
+        id=uuid4(),
+        account_id=service.account_id,
+        username="example-user",
+        is_active=True,
+    )
+    app.dependency_overrides[get_current_active_user] = lambda: actor
+    with TestClient(app) as client:
+        path = f"/api/v1/issues/{service.issue.id}/lifecycle"
+        response = client.get(path)
+        assert response.status_code == 200
+        revision = response.json()["issue_revision"]
+        contract = {
+            "issue_revision": revision,
+            "problem": "Preferences disappear",
+            "user_outcome": "Retain preferences",
+            "criteria": [
+                {
+                    "id": "C0",
+                    "outcome": "Retain value",
+                    "verification": "Restart and inspect persisted value",
+                }
+            ],
+            "code_entry_points": ["app/preferences.py"],
+            "test_entry_points": ["tests/test_preferences.py"],
+            "environment_profile": "python-tests",
+            "test_commands": ["unit"],
+        }
+        assert client.post(path + "/refine", json=contract).status_code == 200
+        assert (
+            client.post(path + "/ready", json={"issue_revision": revision}).json()[
+                "state"
+            ]
+            == "ready"
+        )
+        actor.account_id = uuid4()
+        response = client.get(path)
+        assert response.status_code == 409
+        assert response.json()["detail"] == "lifecycle_issue_not_found"
+        del app.dependency_overrides[get_current_active_user]
+        assert client.get(path).status_code in {401, 403}
+
+
+@pytest.mark.asyncio
+async def test_refinement_terminal_hook_stores_reviewable_contract_without_label(
+    rig: tuple, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    monkeypatch.setattr(
+        "preloop.services.issue_lifecycle_runtime.build_lifecycle_service",
+        AsyncMock(return_value=service),
+    )
+    flow.agent_config = {"lifecycle_kind": "refinement"}
+    execution = models.FlowExecution(
+        status="SUCCEEDED",
+        trigger_event_details={
+            "lifecycle_refinement": {
+                "issue_id": str(service.issue.id),
+                "issue_revision": contract.issue_revision,
+            }
+        },
+        result={"status": "success", "readiness_contract": contract.model_dump()},
+    )
+    await lifecycle_execution_finished(service.db, execution, flow)
+    row = crud_issue_lifecycle.get(
+        service.db,
+        account_id=service.account_id,
+        issue_id=service.issue.id,
+        kind="readiness",
+        revision=contract.issue_revision,
+    )
+    assert row.state == "reviewable"
+    assert not any(method == "POST" for method, _ in transport.calls)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ready_requests_serialize_without_blocking_event_loop(
+    db_engine: Any,
+) -> None:
+    import asyncio
+
+    # Separate committed connections exercise real PostgreSQL contention. This
+    # test database is disposable; regular db_session fixtures are savepoints
+    # on one connection and cannot exercise concurrent ownership correctly.
+    with Session(db_engine) as first_db, Session(db_engine) as second_db:
+        service, transport, _, _ = rig.__wrapped__(first_db)
+        contract = await contract_for(service)
+        await service.refine(contract)
+        issue = crud_issue_lifecycle.get_issue(
+            second_db, account_id=service.account_id, issue_id=service.issue.id
+        )
+        second = IssueLifecycleService(
+            second_db,
+            account_id=service.account_id,
+            issue=issue,
+            provider=service.provider,
+            capabilities=Capabilities(),
+            policy=service.policy,
+        )
+        original = transport._request
+        entered, release = asyncio.Event(), asyncio.Event()
+
+        async def delayed(
+            method: str,
+            endpoint: str,
+            data: dict[str, Any] | None = None,
+            params: dict[str, Any] | None = None,
+        ) -> Any:
+            if method == "POST" and endpoint.endswith("/labels"):
+                entered.set()
+                await release.wait()
+            return await original(method, endpoint, data, params)
+
+        transport._request = delayed
+        first_task = asyncio.create_task(service.ready(contract.issue_revision))
+        await asyncio.wait_for(entered.wait(), 2)
+        second_task = asyncio.create_task(second.ready(contract.issue_revision))
+        await asyncio.sleep(0.1)
+        release.set()
+        results = await asyncio.wait_for(asyncio.gather(first_task, second_task), 3)
+        assert all(result["state"] == "ready" for result in results)
+        assert (
+            sum(
+                method == "POST" and endpoint.endswith("/labels")
+                for method, endpoint in transport.calls
+            )
+            == 1
+        )
+
+
+@pytest.mark.asyncio
+async def test_failed_runner_publishes_unknown_without_inventing_checkout(
+    rig: tuple, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from preloop.services.flow_orchestrator import FlowExecutionOrchestrator
+
+    service, transport, _, flow = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    transport.merge()
+    execution = await service.schedule_audit(flow, AsyncMock())
+    crud_flow_execution.update(
+        service.db, db_obj=execution, obj_in=FlowExecutionUpdate(status="FAILED")
+    )
+    service.db.commit()
+    monkeypatch.setattr(
+        "preloop.services.issue_lifecycle_runtime.build_lifecycle_service",
+        AsyncMock(return_value=service),
+    )
+    # Exercise the universal terminal notification path, including startup
+    # failures where the main agent-result completion path never runs.
+    orchestrator = FlowExecutionOrchestrator.__new__(FlowExecutionOrchestrator)
+    orchestrator.db, orchestrator.flow, orchestrator.execution_log = (
+        service.db,
+        flow,
+        execution,
+    )
+    await orchestrator._notify_terminal("FAILED")
+    row = crud_issue_lifecycle.get(
+        service.db,
+        account_id=service.account_id,
+        issue_id=service.issue.id,
+        kind="merge_audit",
+        revision=SHA,
+    )
+    assert row.state == "published"
+    assert row.data["verdict"] == "unknown"
+    assert row.data["evidence"]["checked_out_sha"] is None
+    assert len(transport.issues) == 1 and len(transport.comments) == 1
+
+
+@pytest.mark.asyncio
+async def test_lost_label_response_does_not_lose_authorized_pickup(rig: tuple) -> None:
+    service, transport, flow, _ = rig
+    contract = await contract_for(service)
+    await service.refine(contract)
+    original = transport._request
+
+    async def lose_response(
+        method: str,
+        endpoint: str,
+        data: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        result = await original(method, endpoint, data, params)
+        if method == "POST" and endpoint.endswith("/labels"):
+            raise TimeoutError("label applied; acknowledgment lost")
+        return result
+
+    transport._request = lose_response
+    with pytest.raises(TimeoutError):
+        await service.ready(contract.issue_revision)
+    row = crud_issue_lifecycle.get(
+        service.db,
+        account_id=service.account_id,
+        issue_id=service.issue.id,
+        kind="pickup",
+        revision="once",
+    )
+    assert row.state == "label_pending"
+    execution = await service.schedule_pickup(
+        flow, {"type": "issue_labeled"}, AsyncMock()
+    )
+    assert execution is not None
+    assert (await service.ready(contract.issue_revision))["state"] == "dispatched"

--- a/backend/tests/services/test_issue_lifecycle_provider_limits.py
+++ b/backend/tests/services/test_issue_lifecycle_provider_limits.py
@@ -1,0 +1,58 @@
+"""Provider lookups stay bounded and stop after an idempotency marker matches."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from preloop.services.issue_lifecycle_provider import GitHubLifecycleProvider
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("overflow", [False, True])
+async def test_exact_scan_limit_checks_exhaustion(overflow: bool) -> None:
+    async def request(
+        method: str,
+        endpoint: str,
+        data: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        assert params is not None
+        page = params["page"]
+        return [{}] * 100 if page <= 100 else ([{}] if overflow else [])
+
+    client = SimpleNamespace(_request=AsyncMock(side_effect=request))
+    provider = GitHubLifecycleProvider(client, "example/project")
+    if overflow:
+        with pytest.raises(ValueError, match="results_truncated"):
+            await provider._pages("/rows")
+    else:
+        assert len(await provider._pages("/rows")) == 10000
+    assert client._request.await_count == 101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("follow_up", [False, True])
+async def test_marker_lookup_stops_on_first_page(follow_up: bool) -> None:
+    marker = "<!-- synthetic-marker -->"
+    existing = {"id": 1, "body": marker, "html_url": "https://example.test/issue/1"}
+    client = SimpleNamespace(
+        _request=AsyncMock(
+            side_effect=[
+                [existing] + [{"body": "unrelated"}] * 99,
+                existing,
+            ]
+        )
+    )
+    provider = GitHubLifecycleProvider(client, "example/project")
+    if follow_up:
+        assert (
+            await provider.ensure_follow_up(1, marker, "title", "body")
+            == existing["html_url"]
+        )
+        assert client._request.await_count == 1
+    else:
+        assert await provider.upsert_comment(1, marker, "body") == existing["html_url"]
+        assert client._request.await_count == 2
+        assert client._request.await_args_list[-1].args[0] == "PATCH"

--- a/backend/tests/services/test_issue_lifecycle_worker.py
+++ b/backend/tests/services/test_issue_lifecycle_worker.py
@@ -1,9 +1,11 @@
 """Worker sessions commit durably for engine-bound callers and join pytest connections."""
 
+import threading
 from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
 
+import anyio
 import pytest
 from sqlalchemy import select
 from sqlalchemy.engine import Connection, Engine
@@ -17,6 +19,7 @@ from preloop.models.crud import (
     crud_tracker,
 )
 from preloop.models.crud.base import CRUDBase
+from preloop.services.flow_trigger_service import FlowTriggerService
 from preloop.services.issue_lifecycle_runtime import _lifecycle_flow_entry
 from preloop.services.issue_lifecycle_worker import (
     _should_commit_lifecycle_caller,
@@ -347,3 +350,118 @@ async def test_commit_gate_never_disagrees_with_flow_entry(
             False,
             None,
         )
+
+
+@pytest.mark.asyncio
+async def test_unrelated_trigger_skips_lifecycle_worker_offload(
+    db_engine: Engine, monkeypatch
+) -> None:
+    """A push that is not lifecycle work must not hop to a worker thread."""
+    monkeypatch.setattr(
+        "preloop.models.db.session.get_session_factory",
+        lambda: sessionmaker(bind=db_engine, autocommit=False, autoflush=False),
+    )
+    hops: list[bool] = []
+    real_run_sync = anyio.to_thread.run_sync
+
+    async def spy(func: Any, *args: Any, **kwargs: Any) -> Any:
+        hops.append(True)
+        return await real_run_sync(func, *args, **kwargs)
+
+    monkeypatch.setattr(anyio.to_thread, "run_sync", spy)
+    caller = Session(bind=db_engine)
+    tenant = _lifecycle_tenant(caller)
+    rows = _tenant_rows(tenant)
+
+    @lifecycle_worker_hook
+    async def peek(service: object, flow: object, event: dict, _nats: object) -> str:
+        return "caller"
+
+    try:
+        result = await peek(
+            SimpleNamespace(db=caller),
+            tenant.flow,
+            {"type": "push", "project_id": str(tenant.project.id)},
+            None,
+        )
+        assert result == "caller"
+        assert hops == []
+    finally:
+        caller.close()
+        _drop(db_engine, rows)
+
+
+@pytest.mark.asyncio
+async def test_engaged_lifecycle_trigger_still_offloads_worker(
+    db_engine: Engine, monkeypatch
+) -> None:
+    """Pickup still isolates ORM work once the entry decision is engaged."""
+    monkeypatch.setattr(
+        "preloop.models.db.session.get_session_factory",
+        lambda: sessionmaker(bind=db_engine, autocommit=False, autoflush=False),
+    )
+    hops: list[bool] = []
+    real_run_sync = anyio.to_thread.run_sync
+
+    async def spy(func: Any, *args: Any, **kwargs: Any) -> Any:
+        hops.append(True)
+        return await real_run_sync(func, *args, **kwargs)
+
+    monkeypatch.setattr(anyio.to_thread, "run_sync", spy)
+    caller = Session(bind=db_engine)
+    tenant = _lifecycle_tenant(caller)
+    rows = _tenant_rows(tenant)
+
+    @lifecycle_worker_hook
+    async def peek(service: object, flow: object, event: dict, _nats: object) -> str:
+        return "worker"
+
+    try:
+        result = await peek(
+            SimpleNamespace(db=caller),
+            tenant.flow,
+            {"type": "issue_labeled", "project_id": str(tenant.project.id)},
+            None,
+        )
+        assert result == "worker"
+        assert hops == [True]
+    finally:
+        caller.close()
+        _drop(db_engine, rows)
+
+
+def test_cross_thread_halt_does_not_use_caller_session(
+    db_engine: Engine, monkeypatch
+) -> None:
+    """Application-loop halt reads must not borrow the request Session."""
+    seen: list[Session] = []
+
+    def spy(db: Session, account_id: Any) -> bool:
+        seen.append(db)
+        return False
+
+    monkeypatch.setattr("preloop.services.flow_trigger_service.flows_halted", spy)
+    caller = Session(bind=db_engine)
+    factory = sessionmaker(bind=db_engine, autocommit=False, autoflush=False)
+    service = FlowTriggerService(caller, session_factory=factory)
+    account_id = uuid4()
+    done = threading.Event()
+    error: list[Exception] = []
+
+    def other_thread() -> None:
+        try:
+            service._flows_halted(account_id)
+        except Exception as exc:
+            error.append(exc)
+        finally:
+            done.set()
+
+    try:
+        threading.Thread(target=other_thread).start()
+        assert done.wait(2)
+        assert error == []
+        assert seen and seen[0] is not caller
+    finally:
+        for session in seen:
+            session.close()
+        caller.close()

--- a/backend/tests/services/test_issue_lifecycle_worker.py
+++ b/backend/tests/services/test_issue_lifecycle_worker.py
@@ -1,6 +1,7 @@
 """Worker sessions commit durably for engine-bound callers and join pytest connections."""
 
 from types import SimpleNamespace
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -8,8 +9,17 @@ from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from preloop.models import models
-from preloop.models.crud import crud_account
+from preloop.models.crud import (
+    crud_account,
+    crud_organization,
+    crud_project,
+    crud_tracker,
+)
+from preloop.models.crud.base import CRUDBase
+from preloop.services.issue_lifecycle_runtime import _lifecycle_flow_entry
 from preloop.services.issue_lifecycle_worker import (
+    _should_commit_lifecycle_caller,
+    lifecycle_entry_decision,
     lifecycle_worker_db,
     lifecycle_worker_hook,
     worker_owned_session,
@@ -66,6 +76,100 @@ def _uncommitted_account(caller: Session) -> models.Account:
     return account
 
 
+def _flow(session: Session, account_id: Any, agent_config: dict[str, Any]) -> Any:
+    """Create an enabled flow the trigger service could dispatch."""
+    return CRUDBase(models.Flow).create(
+        session,
+        obj_in={
+            "name": f"lifecycle-flow-{uuid4()}",
+            "account_id": account_id,
+            "agent_type": "codex",
+            "agent_config": agent_config,
+            "prompt_template": "Implement",
+            "is_enabled": True,
+            "allowed_mcp_servers": [],
+            "allowed_mcp_tools": [],
+        },
+    )
+
+
+def _lifecycle_tenant(session: Session) -> SimpleNamespace:
+    """Create a tenant whose project selects one implementation flow for pickup.
+
+    This is durable configuration, like production: only the webhook's own
+    in-flight rows are left uncommitted for the commit gate to decide on.
+    """
+    suffix = uuid4()
+    account = crud_account.create(
+        session,
+        obj_in={"organization_name": f"lifecycle-tenant-{suffix}", "is_active": True},
+    )
+    tracker = crud_tracker.create(
+        session,
+        obj_in={
+            "name": f"tracker-{suffix}",
+            "tracker_type": "github",
+            "account_id": account.id,
+            "api_key": "fake-local-only",
+        },
+    )
+    organization = crud_organization.create(
+        session,
+        obj_in={
+            "name": f"org-{suffix}",
+            "identifier": f"org-{suffix}",
+            "tracker_id": tracker.id,
+        },
+    )
+    implementer = _flow(session, account.id, {})
+    project = crud_project.create(
+        session,
+        obj_in={
+            "name": f"project-{suffix}",
+            "identifier": f"example/{suffix}",
+            "organization_id": organization.id,
+            "settings": {
+                "issue_lifecycle": {
+                    "ready_enabled": True,
+                    "ready_label": "agent-ready",
+                    "implementation_flow_id": str(implementer.id),
+                }
+            },
+        },
+    )
+    return SimpleNamespace(
+        account=account,
+        tracker=tracker,
+        organization=organization,
+        project=project,
+        flow=implementer,
+    )
+
+
+def _tenant_rows(tenant: SimpleNamespace) -> list[tuple[type, Any]]:
+    """Deletion order for a tenant graph, child before parent."""
+    return [
+        (models.Project, tenant.project.id),
+        (models.Flow, tenant.flow.id),
+        (models.Organization, tenant.organization.id),
+        (models.Tracker, tenant.tracker.id),
+        (models.Account, tenant.account.id),
+    ]
+
+
+def _drop(engine: Engine, rows: list[tuple[type, Any]]) -> None:
+    """Remove durable rows a test committed."""
+    probe = Session(bind=engine)
+    try:
+        for model, ident in rows:
+            row = probe.get(model, ident)
+            if row is not None:
+                probe.delete(row)
+                probe.commit()
+    finally:
+        probe.close()
+
+
 @pytest.mark.asyncio
 async def test_hook_commits_engine_caller_before_lifecycle_worker(
     db_engine: Engine, monkeypatch
@@ -75,33 +179,33 @@ async def test_hook_commits_engine_caller_before_lifecycle_worker(
         lambda: sessionmaker(bind=db_engine, autocommit=False, autoflush=False),
     )
     caller = Session(bind=db_engine)
+    tenant = _lifecycle_tenant(caller)
     account = _uncommitted_account(caller)
     account_id = account.id
+    rows = [(models.Account, account_id), *_tenant_rows(tenant)]
 
     @lifecycle_worker_hook
     async def peek(service: object, flow: object, event: dict, _nats: object) -> bool:
         with lifecycle_worker_db(service, getattr(service, "db", None)) as db:
             return db.get(models.Account, account_id) is not None
 
-    seen = await peek(
-        SimpleNamespace(db=caller),
-        SimpleNamespace(
-            agent_config={"lifecycle_kind": "merge_audit"}, account_id=uuid4()
-        ),
-        {"type": "issue_closed"},
-        None,
-    )
-    assert seen is True
-    caller.close()
-    probe = Session(bind=db_engine)
     try:
-        assert probe.get(models.Account, account_id) is not None
+        seen = await peek(
+            SimpleNamespace(db=caller),
+            tenant.flow,
+            {"type": "issue_labeled", "project_id": str(tenant.project.id)},
+            None,
+        )
+        assert seen is True
+        caller.close()
+        probe = Session(bind=db_engine)
+        try:
+            assert probe.get(models.Account, account_id) is not None
+        finally:
+            probe.close()
     finally:
-        row = probe.get(models.Account, account_id)
-        if row is not None:
-            probe.delete(row)
-            probe.commit()
-        probe.close()
+        caller.close()
+        _drop(db_engine, rows)
 
 
 @pytest.mark.asyncio
@@ -113,24 +217,74 @@ async def test_hook_does_not_commit_unrelated_engine_caller(
         lambda: sessionmaker(bind=db_engine, autocommit=False, autoflush=False),
     )
     caller = Session(bind=db_engine)
+    tenant = _lifecycle_tenant(caller)
     account = _uncommitted_account(caller)
     account_id = account.id
+    rows = _tenant_rows(tenant)
+    event = {"type": "push", "project_id": str(tenant.project.id)}
 
     @lifecycle_worker_hook
     async def peek(service: object, flow: object, event: dict, _nats: object) -> bool:
         with lifecycle_worker_db(service, getattr(service, "db", None)) as db:
             return db.get(models.Account, account_id) is not None
 
-    seen = await peek(
-        SimpleNamespace(db=caller),
-        SimpleNamespace(agent_config={}, account_id=uuid4()),
-        {"type": "push"},
-        None,
-    )
-    assert seen is False
-    caller.close()
-    probe = Session(bind=db_engine)
     try:
-        assert probe.get(models.Account, account_id) is None
+        # The selected implementation flow, but a push: the entry hook declines
+        # it, so the caller's unrelated in-flight rows must not become durable.
+        seen = await peek(SimpleNamespace(db=caller), tenant.flow, event, None)
+        assert seen is False
+        caller.close()
+        probe = Session(bind=db_engine)
+        try:
+            assert probe.get(models.Account, account_id) is None
+        finally:
+            probe.close()
     finally:
-        probe.close()
+        caller.close()
+        _drop(db_engine, rows)
+
+
+@pytest.mark.parametrize(
+    "lifecycle_kind, selected, event_type, engaged",
+    [
+        (None, True, "push", False),
+        (None, True, "issue_labeled", True),
+        (None, False, "issue_labeled", False),
+        ("merge_audit", False, "issue_closed", True),
+        ("refinement", False, "issue_closed", True),
+        ("deployment_audit", False, "issue_closed", False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_commit_gate_never_disagrees_with_flow_entry(
+    db_session: Session,
+    lifecycle_kind: str | None,
+    selected: bool,
+    event_type: str,
+    engaged: bool,
+) -> None:
+    """One decision drives both the entry hook and the caller-commit gate."""
+    tenant = _lifecycle_tenant(db_session)
+    flow = (
+        tenant.flow
+        if selected
+        else _flow(
+            db_session,
+            tenant.account.id,
+            {"lifecycle_kind": lifecycle_kind} if lifecycle_kind else {},
+        )
+    )
+    event = {"type": event_type, "project_id": str(tenant.project.id), "payload": {}}
+
+    assert lifecycle_entry_decision(db_session, flow, event).engaged is engaged
+    assert _should_commit_lifecycle_caller(db_session, flow, event) is engaged
+    if engaged:
+        # Past the gate the entry hook needs a synced issue, which proves it
+        # did not short-circuit on the same conditions the gate just read.
+        with pytest.raises(ValueError, match="lifecycle_issue_not_synced"):
+            await _lifecycle_flow_entry(db_session, flow, event, None, None)
+    else:
+        assert await _lifecycle_flow_entry(db_session, flow, event, None, None) == (
+            False,
+            None,
+        )

--- a/backend/tests/services/test_issue_lifecycle_worker.py
+++ b/backend/tests/services/test_issue_lifecycle_worker.py
@@ -1,7 +1,9 @@
 """Worker sessions commit durably for engine-bound callers and join pytest connections."""
 
+from types import SimpleNamespace
 from uuid import uuid4
 
+import pytest
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -9,6 +11,7 @@ from preloop.models import models
 from preloop.models.crud import crud_account
 from preloop.services.issue_lifecycle_worker import (
     lifecycle_worker_db,
+    lifecycle_worker_hook,
     worker_owned_session,
 )
 
@@ -51,4 +54,83 @@ def test_engine_bound_worker_commit_survives_caller_close(
         if row is not None:
             probe.delete(row)
             probe.commit()
+        probe.close()
+
+
+def _uncommitted_account(caller: Session) -> models.Account:
+    account = models.Account(
+        organization_name=f"lifecycle-hook-{uuid4()}", is_active=True
+    )
+    caller.add(account)
+    caller.flush()
+    return account
+
+
+@pytest.mark.asyncio
+async def test_hook_commits_engine_caller_before_lifecycle_worker(
+    db_engine: Engine, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "preloop.models.db.session.get_session_factory",
+        lambda: sessionmaker(bind=db_engine, autocommit=False, autoflush=False),
+    )
+    caller = Session(bind=db_engine)
+    account = _uncommitted_account(caller)
+    account_id = account.id
+
+    @lifecycle_worker_hook
+    async def peek(service: object, flow: object, event: dict, _nats: object) -> bool:
+        with lifecycle_worker_db(service, getattr(service, "db", None)) as db:
+            return db.get(models.Account, account_id) is not None
+
+    seen = await peek(
+        SimpleNamespace(db=caller),
+        SimpleNamespace(
+            agent_config={"lifecycle_kind": "merge_audit"}, account_id=uuid4()
+        ),
+        {"type": "issue_closed"},
+        None,
+    )
+    assert seen is True
+    caller.close()
+    probe = Session(bind=db_engine)
+    try:
+        assert probe.get(models.Account, account_id) is not None
+    finally:
+        row = probe.get(models.Account, account_id)
+        if row is not None:
+            probe.delete(row)
+            probe.commit()
+        probe.close()
+
+
+@pytest.mark.asyncio
+async def test_hook_does_not_commit_unrelated_engine_caller(
+    db_engine: Engine, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "preloop.models.db.session.get_session_factory",
+        lambda: sessionmaker(bind=db_engine, autocommit=False, autoflush=False),
+    )
+    caller = Session(bind=db_engine)
+    account = _uncommitted_account(caller)
+    account_id = account.id
+
+    @lifecycle_worker_hook
+    async def peek(service: object, flow: object, event: dict, _nats: object) -> bool:
+        with lifecycle_worker_db(service, getattr(service, "db", None)) as db:
+            return db.get(models.Account, account_id) is not None
+
+    seen = await peek(
+        SimpleNamespace(db=caller),
+        SimpleNamespace(agent_config={}, account_id=uuid4()),
+        {"type": "push"},
+        None,
+    )
+    assert seen is False
+    caller.close()
+    probe = Session(bind=db_engine)
+    try:
+        assert probe.get(models.Account, account_id) is None
+    finally:
         probe.close()

--- a/backend/tests/services/test_issue_lifecycle_worker.py
+++ b/backend/tests/services/test_issue_lifecycle_worker.py
@@ -5,6 +5,7 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -32,8 +33,66 @@ def test_connection_bound_worker_session_joins_caller(db_session: Session) -> No
         assert owned
         assert db.get_bind() is db_session.get_bind()
         assert isinstance(db.get_bind(), Connection)
+        assert db.join_transaction_mode == "rollback_only"
     finally:
         db.close()
+
+
+@pytest.mark.asyncio
+async def test_connection_bound_hook_writes_into_caller_transaction(
+    db_session: Session,
+) -> None:
+    """A joined worker leaves its rows in the caller transaction, uncommitted."""
+    fixture = _uncommitted_account(db_session)
+    name = f"lifecycle-joined-{uuid4()}"
+
+    @lifecycle_worker_hook
+    async def write(service: object, flow: object, event: dict, _nats: object) -> bool:
+        with lifecycle_worker_db(service, getattr(service, "db", None)) as db:
+            assert db.get_bind() is db_session.get_bind()
+            crud_account.create(
+                db,
+                obj_in={"organization_name": name, "is_active": True},
+                commit=False,
+            )
+            return db.get(models.Account, fixture.id) is not None
+
+    seen = await write(
+        SimpleNamespace(db=db_session),
+        SimpleNamespace(agent_config={}, account_id=uuid4()),
+        {"type": "push"},
+        None,
+    )
+    assert seen is True
+    written = db_session.scalar(
+        select(models.Account).where(models.Account.organization_name == name)
+    )
+    assert written is not None
+    assert db_session.get(models.Account, fixture.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_connection_bound_hook_failure_keeps_caller_transaction(
+    db_session: Session,
+) -> None:
+    """The joined session must not roll back: rollback_only takes the caller with it."""
+    fixture = _uncommitted_account(db_session)
+
+    @lifecycle_worker_hook
+    async def boom(service: object, flow: object, event: dict, _nats: object) -> None:
+        with lifecycle_worker_db(service, getattr(service, "db", None)) as db:
+            db.execute(select(models.Account.id).limit(1))
+            raise ValueError("lifecycle_worker_failed")
+
+    with pytest.raises(ValueError, match="lifecycle_worker_failed"):
+        await boom(
+            SimpleNamespace(db=db_session),
+            SimpleNamespace(agent_config={}, account_id=uuid4()),
+            {"type": "push"},
+            None,
+        )
+    assert db_session.get(models.Account, fixture.id) is not None
+    assert db_session.scalar(select(models.Account.id).limit(1)) is not None
 
 
 def test_engine_bound_worker_commit_survives_caller_close(

--- a/backend/tests/services/test_issue_lifecycle_worker.py
+++ b/backend/tests/services/test_issue_lifecycle_worker.py
@@ -1,0 +1,54 @@
+"""Worker sessions commit durably for engine-bound callers and join pytest connections."""
+
+from uuid import uuid4
+
+from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from preloop.models import models
+from preloop.models.crud import crud_account
+from preloop.services.issue_lifecycle_worker import (
+    lifecycle_worker_db,
+    worker_owned_session,
+)
+
+
+def test_connection_bound_worker_session_joins_caller(db_session: Session) -> None:
+    db, owned = worker_owned_session(fallback=db_session)
+    try:
+        assert owned
+        assert db.get_bind() is db_session.get_bind()
+        assert isinstance(db.get_bind(), Connection)
+    finally:
+        db.close()
+
+
+def test_engine_bound_worker_commit_survives_caller_close(
+    db_engine: Engine, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "preloop.models.db.session.get_session_factory",
+        lambda: sessionmaker(bind=db_engine, autocommit=False, autoflush=False),
+    )
+    caller = Session(bind=db_engine)
+    account_id = None
+    with lifecycle_worker_db(fallback=caller) as db:
+        assert isinstance(db.get_bind(), Engine)
+        account = crud_account.create(
+            db,
+            obj_in={
+                "organization_name": f"lifecycle-durability-{uuid4()}",
+                "is_active": True,
+            },
+        )
+        account_id = account.id
+    caller.close()
+    probe = Session(bind=db_engine)
+    try:
+        assert probe.get(models.Account, account_id) is not None
+    finally:
+        row = probe.get(models.Account, account_id)
+        if row is not None:
+            probe.delete(row)
+            probe.commit()
+        probe.close()

--- a/backend/tests/test_flow_presets.py
+++ b/backend/tests/test_flow_presets.py
@@ -491,6 +491,8 @@ class TestRealPresetSlugs:
 # Maps preset file -> the exact status/verdict vocabulary line its prompt
 # documents (whitespace-normalized).
 PRESET_COMPLETION_MARKERS = {
+    "012-issue-refinement-readiness.yaml": '"status": "success"',
+    "013-merged-issue-completion-audit.yaml": '"status": "success"',
     "001-issue-triage-assistant.yaml": '"status": "success"',
     "002-pull-request-reviewer.yaml": '"status": "success"',
     "003-observe-eval.yaml": '"status": "pass" | "fail" | "error"',

--- a/docs/guide/flows/issue-lifecycle.md
+++ b/docs/guide/flows/issue-lifecycle.md
@@ -61,9 +61,15 @@ The scope fingerprint covers title and description, excluding automation's
 comments and labels. GitHub does not offer a conditional label-write API. The
 provider rereads scope immediately before labeling, then the controller checks
 again afterward and before dispatch. A racing scope edit is recorded as
-`needs_reconciliation`; it cannot silently start a new implementation. A major
-edit during an existing implementation similarly requires explicit reconciliation
-of that original pickup; resubmitting readiness does not launch another run.
+`needs_reconciliation`; it cannot silently start a new implementation. If no
+execution was created, refine the current revision and explicitly submit `/ready`
+again. The controller rechecks scope and blockers and archives the superseded
+authorization before replacing it. Stale revisions cannot authorize a pickup.
+
+Once an execution exists, `/ready` returns `pickup_reconciliation_required` and
+preserves that execution. Reconciliation of launched or completed implementation
+work is not provided by this draft; `/audit/reconcile` only recovers audits.
+Repeated labels or readiness requests cannot reset an existing execution.
 
 ## Audit the actual merge
 
@@ -130,3 +136,17 @@ pins checkout to the deployed revision and publishes a separate audit comment.
 Repeating the same target/revisions reuses that execution. The deployment record
 is an assertion by the authenticated CD/operator caller; it must come from the
 actual deployment system. The issue-close flow never probes production.
+
+
+### Bounded audit publication
+
+Audit effects remain serialized per issue because marker lookup followed by
+provider creation is not atomic. Marker scans stop as soon as a matching comment
+or follow-up is found. Complete scans accept up to 10,000 results, with one extra
+page used only to prove exhaustion. Larger responses fail closed before creation.
+Publication has an eight-second provider-work deadline and a shared 128-request
+budget, including lookups and mutations. Exhaustion rolls back the local operation
+and leaves its persisted result available through `/audit/reconcile`; a prior
+provider effect is recovered by marker on retry. The controller does not create a
+new ticket when it cannot finish the deduplication lookup. Large repositories may
+still require a later indexed or independently claimed publication path.

--- a/docs/guide/flows/issue-lifecycle.md
+++ b/docs/guide/flows/issue-lifecycle.md
@@ -1,0 +1,126 @@
+# Issue readiness and completion audits
+
+The lifecycle controller connects triage output, authorized implementation pickup,
+and an independent audit after a merged PR closes an issue. GitHub is the first
+provider adapter. Other providers fail explicitly until an authoritative merge
+linkage adapter is installed.
+
+## Configure a project
+
+Clone **Issue Refinement and Readiness** and **Merged Issue Completion Audit**
+from the preset catalog. Scope each flow to its tracker/project. The refinement
+flow can follow normal triage; its structured result is a proposal, not permission
+to implement. The audit flow subscribes to `issue.closed`.
+
+Configure `project.settings.issue_lifecycle` through the existing project settings
+API, using the account's actual flow IDs:
+
+```json
+{
+  "ready_enabled": true,
+  "implementation_flow_id": "<implementation-flow-uuid>",
+  "audit_flow_id": "<audit-flow-uuid>",
+  "create_follow_ups": false
+}
+```
+
+The implementation flow must select an operator-approved environment profile
+with named `test_commands`. Readiness consumes the environment capability
+service; it does not define image setup or replace the pre-push verification
+gate. Runtime setup still performs its own preflight before running an agent.
+Missing profiles, unsupported runner protocols and missing commands block pickup.
+
+The audit flow requires exactly one repository in `git_clone_config.repositories`,
+with the scoped `project_id`, cloning enabled and `create_pull_request: false`.
+Its MCP tool/server lists must be empty. It starts a fresh conversation, does not
+restore an implementation session, and the verified merge SHA is carried in
+`payload.sha` for the existing runner checkout path. Configure its environment
+profile with the relevant checks and dependency services for the application.
+
+## Refine and authorize
+
+All endpoints below require tenant authentication and existing issue/flow
+permissions. Paths are relative to `/api/v1/issues/{issue_uuid}/lifecycle`.
+
+1. `GET /` returns the live issue scope fingerprint and operation history.
+2. `POST /refine` stores a `ReadinessContract`, either submitted directly or
+   produced by the refinement flow. Include the live `issue_revision`, problem,
+   user outcome, constraints, non-goals, ordinary assumptions, materially blocking
+   decisions, conflicts, observable criteria with stable IDs, code/test entry
+   points, dependency issue numbers, environment profile and command names.
+3. Review blockers and the proposal. `POST /ready` with
+   `{"issue_revision":"<fingerprint>"}` rechecks the issue, dependencies and
+   environment and adds `agent-ready` once under project policy.
+
+Labels are added, not replaced: existing project labels retain their ownership.
+The normal label webhook triggers implementation. A durable pickup record binds
+that transition to one execution; repeated delivery reuses the same execution.
+Follow-up issues never inherit the readiness label or bypass this gate.
+
+The scope fingerprint covers title and description, excluding automation's
+comments and labels. GitHub does not offer a conditional label-write API. The
+provider rereads scope immediately before labeling, then the controller checks
+again afterward and before dispatch. A racing scope edit is recorded as
+`needs_reconciliation`; it cannot silently start a new implementation. A major
+edit during an existing implementation similarly requires explicit reconciliation
+of that original pickup; resubmitting readiness does not launch another run.
+
+## Audit the actual merge
+
+A completed issue state alone is insufficient. The provider loads the latest
+closure event, requires a closing commit, and verifies its association with a
+merged PR in the same repository. Manual closure without that evidence creates
+no audit. Multiple linked merged PRs remain in the evidence envelope; the final
+closing merge revision is the checkout and idempotency key.
+
+The independent result maps every stored acceptance criterion to code, test
+results and observations. The controller computes `complete`, `gap` or `unknown`.
+Missing evidence, unchecked deployment requirements and subsequent issue scope
+changes cannot produce a complete verdict. An issue with no stored acceptance
+contract remains unknown rather than inventing criteria.
+
+The controller upserts one marked audit comment, including issue and merge
+revisions, contributing PRs, evidence, and the execution link. With
+`create_follow_ups: true`, it searches existing issues and creates at most three
+bounded confirmed defects/enhancements. Existing marked issues, or human-created
+issues referencing the source issue and the same acceptance criterion, are reused.
+Unknown findings remain in the audit. The original issue is never reopened.
+
+Per-issue PostgreSQL transaction locks serialize decisions, and unique operation
+keys survive duplicate webhooks. Remote writes also use deterministic markers:
+a retry after provider success and local rollback finds the original issue or
+comment. `POST /audit/reconcile` retries pending dispatch or completed-result
+publication after transient failures. Results are persisted before the terminal
+hook runs, so reconciliation does not ask an agent to generate a second audit.
+
+## Verify deployment separately
+
+Closure cannot establish which revision runs in an environment. Deployment
+criteria therefore produce a pending verification requirement and remain unknown.
+An authenticated CD/operator caller can subsequently record the deployed revision
+and trigger a separate, explicitly approved verification flow:
+
+```json
+{
+  "deployment_targets": {
+    "staging": {
+      "flow_id": "<deployment-verification-flow-uuid>",
+      "approved_scope": ["Read preferences for the synthetic staging account"]
+    }
+  }
+}
+```
+
+Add this to the project lifecycle policy. Configure the dedicated flow with
+`agent_config.lifecycle_kind: deployment_audit`, an environment and exact project
+checkout, and a prompt that verifies only the supplied approved scope and emits
+the same audit-result contract as the merge preset. Its trigger types should be
+empty: the authorized endpoint is the trigger.
+
+Call `POST /deployment/verify` with `merge_sha`, configured `target`, exact
+`deployed_revision` and a `deployment_evidence` URL identifying the deployment
+record. The controller stores the record/scope, creates a separate conversation,
+pins checkout to the deployed revision and publishes a separate audit comment.
+Repeating the same target/revisions reuses that execution. The deployment record
+is an assertion by the authenticated CD/operator caller; it must come from the
+actual deployment system. The issue-close flow never probes production.

--- a/docs/guide/flows/issue-lifecycle.md
+++ b/docs/guide/flows/issue-lifecycle.md
@@ -82,7 +82,10 @@ a distinct authorization for the revised scope. It dispatches one fresh executio
 directly because the readiness label may already be present. It never removes
 and re-adds labels to manufacture another webhook. Repeating the same request or
 receiving duplicate issue events reuses the same authorization/execution, including
-a retry after dispatch failure. Old execution prompts and contracts remain intact.
+a retry after dispatch failure. A missing worker acknowledgment returns durable
+`dispatch_pending` plus the execution ID; retrying the same reconciliation request
+retries delivery without authorizing a second execution. Old execution prompts and
+contracts remain intact.
 Same-scope execution retries use the existing execution retry API. The
 `/audit/reconcile` endpoint separately recovers audits.
 

--- a/docs/guide/flows/issue-lifecycle.md
+++ b/docs/guide/flows/issue-lifecycle.md
@@ -86,6 +86,12 @@ bounded confirmed defects/enhancements. Existing marked issues, or human-created
 issues referencing the source issue and the same acceptance criterion, are reused.
 Unknown findings remain in the audit. The original issue is never reopened.
 
+HTTP handlers and lifecycle hooks run each complete operation in a worker,
+including synchronous CRUD calls and lazy ORM reads after commit. Provider I/O
+uses that worker's private loop. Flow dispatch returns to the persistent
+application loop, so locally dispatched background executions survive the
+request or hook finishing.
+
 Per-issue PostgreSQL transaction locks serialize decisions, and unique operation
 keys survive duplicate webhooks. Remote writes also use deterministic markers:
 a retry after provider success and local rollback finds the original issue or

--- a/docs/guide/flows/issue-lifecycle.md
+++ b/docs/guide/flows/issue-lifecycle.md
@@ -18,6 +18,7 @@ API, using the account's actual flow IDs:
 ```json
 {
   "ready_enabled": true,
+  "ready_label": "<existing-project-readiness-label>",
   "implementation_flow_id": "<implementation-flow-uuid>",
   "audit_flow_id": "<audit-flow-uuid>",
   "create_follow_ups": false
@@ -50,7 +51,8 @@ permissions. Paths are relative to `/api/v1/issues/{issue_uuid}/lifecycle`.
    points, dependency issue numbers, environment profile and command names.
 3. Review blockers and the proposal. `POST /ready` with
    `{"issue_revision":"<fingerprint>"}` rechecks the issue, dependencies and
-   environment and adds `agent-ready` once under project policy.
+   environment and adds the explicitly configured existing `ready_label` once
+   under project policy. No default label vocabulary is assumed.
 
 Labels are added, not replaced: existing project labels retain their ownership.
 The normal label webhook triggers implementation. A durable pickup record binds
@@ -67,9 +69,22 @@ again. The controller rechecks scope and blockers and archives the superseded
 authorization before replacing it. Stale revisions cannot authorize a pickup.
 
 Once an execution exists, `/ready` returns `pickup_reconciliation_required` and
-preserves that execution. Reconciliation of launched or completed implementation
-work is not provided by this draft; `/audit/reconcile` only recovers audits.
-Repeated labels or readiness requests cannot reset an existing execution.
+preserves that execution. Finish or cancel active work through the existing
+execution controls; scope edits never retarget a running conversation. Refine
+the revised scope, review the proposal, then explicitly call
+`POST /pickup/reconcile` with `issue_revision`, `previous_execution_id`, and a
+nonempty review `reason`. This requires both issue-edit and flow-execution
+permissions. The named previous execution must be terminal, the revision must
+be current and changed, and all readiness checks must pass again.
+
+The controller archives the old authorization with its execution link and creates
+a distinct authorization for the revised scope. It dispatches one fresh execution
+directly because the readiness label may already be present. It never removes
+and re-adds labels to manufacture another webhook. Repeating the same request or
+receiving duplicate issue events reuses the same authorization/execution, including
+a retry after dispatch failure. Old execution prompts and contracts remain intact.
+Same-scope execution retries use the existing execution retry API. The
+`/audit/reconcile` endpoint separately recovers audits.
 
 ## Audit the actual merge
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5590,6 +5590,190 @@ paths:
                 title: Response Get Issue Count Api V1 Issues Count Get
       security:
       - bearerAuth: []
+  /api/v1/issues/{issue_id}/lifecycle:
+    get:
+      tags:
+      - Issues
+      summary: Lifecycle Status
+      description: Read live scope plus durable readiness, pickup and audit history.
+      operationId: lifecycle_status_api_v1_issues__issue_id__lifecycle_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: issue_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Issue Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Lifecycle Status Api V1 Issues  Issue Id  Lifecycle
+                  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/issues/{issue_id}/lifecycle/refine:
+    post:
+      tags:
+      - Issues
+      summary: Refine Issue
+      description: Store a reviewable proposal; this operation cannot launch implementation.
+      operationId: refine_issue_api_v1_issues__issue_id__lifecycle_refine_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: issue_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Issue Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReadinessContract'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Refine Issue Api V1 Issues  Issue Id  Lifecycle Refine
+                  Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/issues/{issue_id}/lifecycle/ready:
+    post:
+      tags:
+      - Issues
+      summary: Ready Issue
+      description: Apply the configured readiness policy once to an approved scope.
+      operationId: ready_issue_api_v1_issues__issue_id__lifecycle_ready_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: issue_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Issue Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReadyRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Ready Issue Api V1 Issues  Issue Id  Lifecycle Ready
+                  Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/issues/{issue_id}/lifecycle/audit/reconcile:
+    post:
+      tags:
+      - Issues
+      summary: Reconcile Audit
+      description: Recover dispatch/publication after a transient provider or worker
+        failure.
+      operationId: reconcile_audit_api_v1_issues__issue_id__lifecycle_audit_reconcile_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: issue_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Issue Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Reconcile Audit Api V1 Issues  Issue Id  Lifecycle
+                  Audit Reconcile Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/issues/{issue_id}/lifecycle/deployment/verify:
+    post:
+      tags:
+      - Issues
+      summary: Verify Deployment
+      description: Trigger a separately approved target/scope after recording deployment.
+      operationId: verify_deployment_api_v1_issues__issue_id__lifecycle_deployment_verify_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: issue_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Issue Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeploymentVerificationRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Verify Deployment Api V1 Issues  Issue Id  Lifecycle
+                  Deployment Verify Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/issues/{issue_id}/comments:
     get:
       tags:
@@ -13928,6 +14112,34 @@ components:
       type: object
       title: CreateVersionRequest
       description: Request to create a new policy version.
+    Criterion:
+      properties:
+        id:
+          type: string
+          maxLength: 80
+          minLength: 1
+          title: Id
+        outcome:
+          type: string
+          maxLength: 2000
+          minLength: 1
+          title: Outcome
+        verification:
+          type: string
+          maxLength: 2000
+          minLength: 1
+          title: Verification
+        deployment_required:
+          type: boolean
+          title: Deployment Required
+          default: false
+      type: object
+      required:
+      - id
+      - outcome
+      - verification
+      title: Criterion
+      description: Observable acceptance, independently addressable by evidence.
     CronSchedule:
       properties:
         timezone:
@@ -14007,6 +14219,28 @@ components:
       type: object
       title: DashboardTelemetryResponse
       description: Aggregate high-level metrics for the global dashboard control plane.
+    DeploymentVerificationRequest:
+      properties:
+        merge_sha:
+          type: string
+          title: Merge Sha
+        target:
+          type: string
+          title: Target
+        deployed_revision:
+          type: string
+          title: Deployed Revision
+        deployment_evidence:
+          type: string
+          title: Deployment Evidence
+      type: object
+      required:
+      - merge_sha
+      - target
+      - deployed_revision
+      - deployment_evidence
+      title: DeploymentVerificationRequest
+      description: An authenticated deployment record, never inferred from issue closure.
     DetectorTimeoutFailMode:
       type: string
       enum:
@@ -19485,6 +19719,89 @@ components:
         per-row classification recorded at capture time; rows recorded before
 
         this feature carry no subtype and appear in neither count.'
+    ReadinessContract:
+      properties:
+        issue_revision:
+          type: string
+          title: Issue Revision
+        problem:
+          type: string
+          title: Problem
+          default: ''
+        user_outcome:
+          type: string
+          title: User Outcome
+          default: ''
+        constraints:
+          items:
+            type: string
+          type: array
+          title: Constraints
+        non_goals:
+          items:
+            type: string
+          type: array
+          title: Non Goals
+        assumptions:
+          items:
+            type: string
+          type: array
+          title: Assumptions
+        blocking_decisions:
+          items:
+            type: string
+          type: array
+          title: Blocking Decisions
+        conflicts:
+          items:
+            type: string
+          type: array
+          title: Conflicts
+        criteria:
+          items:
+            $ref: '#/components/schemas/Criterion'
+          type: array
+          title: Criteria
+        code_entry_points:
+          items:
+            type: string
+          type: array
+          title: Code Entry Points
+        test_entry_points:
+          items:
+            type: string
+          type: array
+          title: Test Entry Points
+        dependencies:
+          items:
+            type: integer
+          type: array
+          title: Dependencies
+        environment_profile:
+          type: string
+          title: Environment Profile
+          default: ''
+        test_commands:
+          items:
+            type: string
+          type: array
+          title: Test Commands
+      additionalProperties: false
+      type: object
+      required:
+      - issue_revision
+      title: ReadinessContract
+      description: A proposal can be incomplete; readiness explains each missing decision.
+    ReadyRequest:
+      properties:
+        issue_revision:
+          type: string
+          title: Issue Revision
+      type: object
+      required:
+      - issue_revision
+      title: ReadyRequest
+      description: The reviewer approves one exact issue revision.
     RefreshRequest:
       properties:
         refresh_token:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5701,6 +5701,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/issues/{issue_id}/lifecycle/pickup/reconcile:
+    post:
+      tags:
+      - Issues
+      summary: Reconcile Pickup
+      description: Authorize and durably dispatch changed scope after the prior run
+        ends.
+      operationId: reconcile_pickup_api_v1_issues__issue_id__lifecycle_pickup_reconcile_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: issue_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Issue Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PickupReconciliationRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Reconcile Pickup Api V1 Issues  Issue Id  Lifecycle
+                  Pickup Reconcile Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/issues/{issue_id}/lifecycle/audit/reconcile:
     post:
       tags:
@@ -18883,6 +18923,28 @@ components:
       - email
       title: PasswordResetRequest
       description: Model for password reset requests.
+    PickupReconciliationRequest:
+      properties:
+        issue_revision:
+          type: string
+          title: Issue Revision
+        previous_execution_id:
+          type: string
+          format: uuid
+          title: Previous Execution Id
+        reason:
+          type: string
+          maxLength: 2000
+          minLength: 1
+          title: Reason
+      type: object
+      required:
+      - issue_revision
+      - previous_execution_id
+      - reason
+      title: PickupReconciliationRequest
+      description: Approve a new revision while naming the exact implementation it
+        replaces.
     PolicyDiffItem:
       properties:
         path:


### PR DESCRIPTION
## Summary

Turn a refinement proposal into an explicitly authorized implementation, then independently audit the code that closed the issue. Readiness binds observable criteria, dependencies and verification capabilities to the current issue revision, using an explicitly configured existing project label. Duplicate events reuse one durable execution.

Scope changes preserve the existing execution and require review. `POST /pickup/reconcile` authorizes a changed revision only after the named previous execution is terminal, archives its contract/history and dispatches one fresh execution even when the readiness label is already present. A rejected worker handoff remains `dispatch_pending`; retry reuses the same execution instead of reporting delivery or creating duplicate work.

A verified merged-PR relation and exact merge SHA start a separate audit conversation. The audit maps criteria to complete/gap/unknown evidence and publishes a bounded, deduplicated comment and authorized follow-ups. Deployment verification requires separate authorization and a recorded deployed revision. Refs #433 and #434. Includes merged #446 environment/recovery ancestry.

## Testing

- [x] 327 broader backend integration tests passed; 163 focused checks passed after root review corrections, plus 3 final artifact ASGI checks.
- [x] Connected local readiness fixture: vague proposal, refinement output, explicit authorization and one implementation, including duplicate delivery and failed-then-successful worker handoff.
- [x] Actual HTTP reconciliation with an existing readiness label, terminal/active status cases, stale/mismatched requests, preserved execution history and idempotent retry.
- [x] Real local Git checkout uses the exact merged revision rather than later main, then runs the independent audit/deduplicated-follow-up fixture.
- [x] Existing provider pagination/deadline/request-budget and event-loop tests; disposable PostgreSQL migration; applicable hooks and generated OpenAPI passed.
- No live GitHub/model requests, production/staging tests or deployment. No new frontend components.

## Scope

GitHub is the initial provider. Project policy, implementation/audit flows and verification capabilities require explicit configuration; presets assume no readiness-label taxonomy. Follow-ups do not become ready automatically. Source inspection does not establish deployed acceptance. Trusted write-credential isolation is separate in #444.

## Checklist

- [x] Public guide, preset documentation, architecture and changelog updated.
- [x] Current issue scope and project label ownership preserved.
- [x] No secrets included.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> No security issues. All previously raised findings are resolved: ordinary triggers no longer hop to a lifecycle worker thread, and halt reads stay on the thread that owns the request Session. Audit discovery stays bounded by the shared publication timeout/request budget and `schedule_audit` pins to the configured `audit_flow_id`.
>
> **Overview**
> Adds policy-controlled issue readiness and an independent merge-audit on verified merged PRs (GitHub-only, tenant-scoped), stacked on the environment/recovery base. Well-tested and fails closed throughout; all previously raised findings are addressed.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit d357f410. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->