### PR TITLE
Settings and cost: models list and detail, cost range and budgets, settings polish (UX round 4, wave 2)

### DIFF
--- a/frontend/src/components/budget-health-card.test.ts
+++ b/frontend/src/components/budget-health-card.test.ts
@@ -135,6 +135,46 @@ describe('BudgetHealthCard', () => {
     ).to.contain('Hard limit exceeded');
   });
 
+  it('forecasts where the period lands and names rows as the Overview does', async () => {
+    // A month that is 60% gone with $120 spent lands at $200: over the soft
+    // limit, under the hard one, so the line reads as a warning.
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth(), 1);
+    const end = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    const forecastPolicies = [
+      {
+        ...policies[0],
+        period: 'monthly',
+        hard_limit_usd: 300,
+        soft_limit_usd: 100,
+        current_spend_usd: 120,
+        period_start: start.toISOString(),
+        period_end: end.toISOString(),
+      },
+    ] as unknown as BudgetPolicy[];
+
+    const element = (await fixture(html`
+      <budget-health-card
+        .summary=${summary}
+        .policies=${forecastPolicies}
+      ></budget-health-card>
+    `)) as BudgetHealthCard;
+    await element.updateComplete;
+
+    const forecast = element.shadowRoot?.querySelector('.budget-forecast');
+    expect(forecast, 'budget rows forecast the period end').to.exist;
+    expect(forecast?.textContent?.replace(/\s+/g, ' ')).to.contain(
+      'On track for $'
+    );
+
+    // One name per budget: "Monthly budget · Sep", not "Global spend · 30d".
+    const label = element.shadowRoot?.querySelector('.row-label');
+    const month = now.toLocaleDateString(undefined, { month: 'short' });
+    expect(label?.textContent?.replace(/\s+/g, ' ').trim()).to.equal(
+      `Monthly budget · ${month}`
+    );
+  });
+
   it('dispatches configure when limits button is clicked', async () => {
     const element = (await fixture(html`
       <budget-health-card

--- a/frontend/src/components/budget-health-card.ts
+++ b/frontend/src/components/budget-health-card.ts
@@ -6,6 +6,7 @@ import type {
   ManagedAgentSummary,
 } from '../types';
 import { budgetTrackStyles } from '../styles/budget-track';
+import { budgetForecast, forecastEndLabel } from '../utils/budget-forecast';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
@@ -127,6 +128,21 @@ export class BudgetHealthCard extends LitElement {
         color: var(--sl-color-danger-700);
       }
 
+      /* The forecast sentence, in the Overview's type and tones. */
+      .budget-forecast {
+        color: var(--sl-color-neutral-500);
+        font-size: var(--sl-font-size-x-small);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .budget-forecast.warning {
+        color: var(--sl-color-warning-700);
+      }
+
+      .budget-forecast.danger {
+        color: var(--sl-color-danger-700);
+      }
+
       .row-footer .limit-status {
         color: var(--sl-color-danger-700);
         font-weight: var(--sl-font-weight-semibold);
@@ -159,6 +175,34 @@ export class BudgetHealthCard extends LitElement {
     return period;
   }
 
+  /**
+   * Which window a budget row is about, in the Overview's words. "Global
+   * spend · 30d" was read as a rolling total; "Monthly budget · Sep" says the
+   * number resets, and says it the same way on both pages.
+   */
+  private periodWindow(period: string, now: Date = new Date()): string {
+    if (period === 'hourly') return 'this hour';
+    if (period === 'daily') return 'today';
+    if (period === 'weekly') return 'this week';
+    if (period === 'monthly' || period === 'month') {
+      return now.toLocaleDateString(undefined, { month: 'short' });
+    }
+    if (period === 'yearly' || period === 'year')
+      return String(now.getFullYear());
+    return '';
+  }
+
+  private budgetPeriodLabel(period: string, now: Date = new Date()): string {
+    const normalized =
+      period === 'month' ? 'monthly' : period === 'year' ? 'yearly' : period;
+    const base =
+      normalized === 'all_time'
+        ? 'All time budget'
+        : `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)} budget`;
+    const window = this.periodWindow(normalized, now);
+    return window ? `${base} · ${window}` : base;
+  }
+
   private periodForTimeRange(): BudgetPolicy['period'] {
     if (this.timeRange === 'day') return 'daily';
     if (this.timeRange === 'week') return 'weekly';
@@ -178,9 +222,11 @@ export class BudgetHealthCard extends LitElement {
   }
 
   private policyDisplayName(policy: BudgetPolicy): string {
-    const period = this.formatBudgetPeriod(policy.period);
+    const period =
+      this.periodWindow(policy.period) ||
+      this.formatBudgetPeriod(policy.period);
     if (policy.subject_type === 'global' || policy.subject_type === 'account') {
-      return `Global · ${period}`;
+      return this.budgetPeriodLabel(policy.period);
     }
     if (policy.subject_type === 'managed_agent') {
       const agentName =
@@ -344,12 +390,46 @@ export class BudgetHealthCard extends LitElement {
     return null;
   }
 
+  /**
+   * Straight-line projection for a budget row, the same sentence the Overview
+   * prints. "$12 of $300" on the 3rd reads as comfortable whether the account
+   * lands at $120 or $1,200; this says which.
+   */
+  private renderForecast(input: {
+    period: string;
+    spend: number;
+    softLimit: number;
+    hardLimit: number;
+    periodStart?: string | null;
+    periodEnd?: string | null;
+  }) {
+    const forecast = budgetForecast(input);
+    if (!forecast) return nothing;
+    const percent = Math.round(forecast.elapsedFraction * 100);
+    return html`
+      <div
+        class="budget-forecast ${forecast.tone}"
+        title=${`Straight line from ${this.formatCurrency(
+          input.spend
+        )} spent in the first ${percent}% of the period.`}
+      >
+        On track for ${this.formatCurrency(forecast.amount)} by
+        ${forecastEndLabel(input.period, forecast.end, forecast.endBasis)}
+      </div>
+    `;
+  }
+
   private renderBudgetLimitRow(
     label: string,
     icon: string,
     spend: number,
     softLimit: number,
-    hardLimit: number
+    hardLimit: number,
+    forecast: {
+      period: string;
+      periodStart?: string | null;
+      periodEnd?: string | null;
+    } | null = null
   ) {
     const maxLimit = hardLimit || softLimit;
     const fillPercent =
@@ -468,6 +548,18 @@ export class BudgetHealthCard extends LitElement {
               `
             : nothing
         }
+        ${
+          forecast
+            ? this.renderForecast({
+                period: forecast.period,
+                spend,
+                softLimit,
+                hardLimit,
+                periodStart: forecast.periodStart,
+                periodEnd: forecast.periodEnd,
+              })
+            : nothing
+        }
       </div>
     `;
   }
@@ -552,11 +644,16 @@ export class BudgetHealthCard extends LitElement {
         >
           <div class="rows">
             ${this.renderBudgetLimitRow(
-              `Global spend · ${this.formatBudgetPeriod(selectedPeriod)}`,
+              this.budgetPeriodLabel(selectedPeriod),
               'globe',
               globalSpend,
               globalSoftLimit,
-              globalHardLimit
+              globalHardLimit,
+              {
+                period: selectedPeriod,
+                periodStart: selectedGlobalUsage?.policy.period_start,
+                periodEnd: selectedGlobalUsage?.policy.period_end,
+              }
             )}
             ${
               additionalUsages.length
@@ -566,7 +663,12 @@ export class BudgetHealthCard extends LitElement {
                       this.policyIcon(usage.policy),
                       usage.spend,
                       usage.softLimit,
-                      usage.hardLimit
+                      usage.hardLimit,
+                      {
+                        period: usage.policy.period,
+                        periodStart: usage.policy.period_start,
+                        periodEnd: usage.policy.period_end,
+                      }
                     )
                   )
                 : html`<div class="empty">No additional budget policies.</div>`
@@ -586,7 +688,7 @@ export class BudgetHealthCard extends LitElement {
                       name="gear"
                       aria-hidden="true"
                     ></sl-icon>
-                    Configure Limits
+                    Configure limits
                   </sl-button>
                 `
               : nothing

--- a/frontend/src/components/budget-health-card.ts
+++ b/frontend/src/components/budget-health-card.ts
@@ -6,7 +6,12 @@ import type {
   ManagedAgentSummary,
 } from '../types';
 import { budgetTrackStyles } from '../styles/budget-track';
-import { budgetForecast, forecastEndLabel } from '../utils/budget-forecast';
+import {
+  budgetPeriodLabel,
+  budgetPeriodWindow,
+  budgetForecastStyles,
+  renderBudgetForecast,
+} from '../utils/budget-forecast';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
@@ -34,6 +39,7 @@ export class BudgetHealthCard extends LitElement {
 
   static styles = [
     budgetTrackStyles,
+    budgetForecastStyles,
     css`
       :host {
         display: block;
@@ -128,19 +134,10 @@ export class BudgetHealthCard extends LitElement {
         color: var(--sl-color-danger-700);
       }
 
-      /* The forecast sentence, in the Overview's type and tones. */
+      /* Cost runs one step smaller than the Overview; the sentence, its
+         tones and its tabular figures come from budgetForecastStyles. */
       .budget-forecast {
-        color: var(--sl-color-neutral-500);
         font-size: var(--sl-font-size-x-small);
-        font-variant-numeric: tabular-nums;
-      }
-
-      .budget-forecast.warning {
-        color: var(--sl-color-warning-700);
-      }
-
-      .budget-forecast.danger {
-        color: var(--sl-color-danger-700);
       }
 
       .row-footer .limit-status {
@@ -175,34 +172,6 @@ export class BudgetHealthCard extends LitElement {
     return period;
   }
 
-  /**
-   * Which window a budget row is about, in the Overview's words. "Global
-   * spend · 30d" was read as a rolling total; "Monthly budget · Sep" says the
-   * number resets, and says it the same way on both pages.
-   */
-  private periodWindow(period: string, now: Date = new Date()): string {
-    if (period === 'hourly') return 'this hour';
-    if (period === 'daily') return 'today';
-    if (period === 'weekly') return 'this week';
-    if (period === 'monthly' || period === 'month') {
-      return now.toLocaleDateString(undefined, { month: 'short' });
-    }
-    if (period === 'yearly' || period === 'year')
-      return String(now.getFullYear());
-    return '';
-  }
-
-  private budgetPeriodLabel(period: string, now: Date = new Date()): string {
-    const normalized =
-      period === 'month' ? 'monthly' : period === 'year' ? 'yearly' : period;
-    const base =
-      normalized === 'all_time'
-        ? 'All time budget'
-        : `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)} budget`;
-    const window = this.periodWindow(normalized, now);
-    return window ? `${base} · ${window}` : base;
-  }
-
   private periodForTimeRange(): BudgetPolicy['period'] {
     if (this.timeRange === 'day') return 'daily';
     if (this.timeRange === 'week') return 'weekly';
@@ -223,10 +192,10 @@ export class BudgetHealthCard extends LitElement {
 
   private policyDisplayName(policy: BudgetPolicy): string {
     const period =
-      this.periodWindow(policy.period) ||
+      budgetPeriodWindow(policy.period) ||
       this.formatBudgetPeriod(policy.period);
     if (policy.subject_type === 'global' || policy.subject_type === 'account') {
-      return this.budgetPeriodLabel(policy.period);
+      return budgetPeriodLabel(policy.period);
     }
     if (policy.subject_type === 'managed_agent') {
       const agentName =
@@ -390,35 +359,6 @@ export class BudgetHealthCard extends LitElement {
     return null;
   }
 
-  /**
-   * Straight-line projection for a budget row, the same sentence the Overview
-   * prints. "$12 of $300" on the 3rd reads as comfortable whether the account
-   * lands at $120 or $1,200; this says which.
-   */
-  private renderForecast(input: {
-    period: string;
-    spend: number;
-    softLimit: number;
-    hardLimit: number;
-    periodStart?: string | null;
-    periodEnd?: string | null;
-  }) {
-    const forecast = budgetForecast(input);
-    if (!forecast) return nothing;
-    const percent = Math.round(forecast.elapsedFraction * 100);
-    return html`
-      <div
-        class="budget-forecast ${forecast.tone}"
-        title=${`Straight line from ${this.formatCurrency(
-          input.spend
-        )} spent in the first ${percent}% of the period.`}
-      >
-        On track for ${this.formatCurrency(forecast.amount)} by
-        ${forecastEndLabel(input.period, forecast.end, forecast.endBasis)}
-      </div>
-    `;
-  }
-
   private renderBudgetLimitRow(
     label: string,
     icon: string,
@@ -550,14 +490,17 @@ export class BudgetHealthCard extends LitElement {
         }
         ${
           forecast
-            ? this.renderForecast({
-                period: forecast.period,
-                spend,
-                softLimit,
-                hardLimit,
-                periodStart: forecast.periodStart,
-                periodEnd: forecast.periodEnd,
-              })
+            ? renderBudgetForecast(
+                {
+                  period: forecast.period,
+                  spend,
+                  softLimit,
+                  hardLimit,
+                  periodStart: forecast.periodStart,
+                  periodEnd: forecast.periodEnd,
+                },
+                (value) => this.formatCurrency(value)
+              )
             : nothing
         }
       </div>
@@ -644,7 +587,7 @@ export class BudgetHealthCard extends LitElement {
         >
           <div class="rows">
             ${this.renderBudgetLimitRow(
-              this.budgetPeriodLabel(selectedPeriod),
+              budgetPeriodLabel(selectedPeriod),
               'globe',
               globalSpend,
               globalSoftLimit,

--- a/frontend/src/components/usage-card.ts
+++ b/frontend/src/components/usage-card.ts
@@ -15,7 +15,11 @@ import './time-range-select.ts';
 import type { BudgetPolicy } from '../api';
 import type { AccountGatewayUsageSummaryResponse } from '../types';
 import { budgetTrackStyles, renderBudgetTrack } from '../styles/budget-track';
-import { budgetForecast, forecastEndLabel } from '../utils/budget-forecast';
+import {
+  budgetPeriodLabel,
+  budgetForecastStyles,
+  renderBudgetForecast,
+} from '../utils/budget-forecast';
 
 export type UsageUnit = 'tokens' | 'dollars';
 
@@ -86,6 +90,7 @@ export class UsageCard extends LitElement {
 
   static styles = [
     budgetTrackStyles,
+    budgetForecastStyles,
     css`
       :host {
         display: block;
@@ -285,20 +290,6 @@ export class UsageCard extends LitElement {
       .muted {
         color: var(--sl-color-neutral-500);
         font-size: 0.8125rem;
-      }
-
-      .budget-forecast {
-        font-size: 0.8125rem;
-        color: var(--sl-color-neutral-500);
-        font-variant-numeric: tabular-nums;
-      }
-
-      .budget-forecast.warning {
-        color: var(--sl-color-warning-700);
-      }
-
-      .budget-forecast.danger {
-        color: var(--sl-color-danger-700);
       }
 
       .more-limits {
@@ -666,59 +657,6 @@ export class UsageCard extends LitElement {
     return this.summary?.budget?.monthly_limit_usd || 0;
   }
 
-  /**
-   * Which window a budget row is about. "Monthly budget: $12 / $50" was read
-   * as a running total; "Monthly budget - Sep" says the number resets.
-   */
-  private periodWindow(period: string, now: Date): string {
-    if (period === 'hourly') return 'this hour';
-    if (period === 'daily') return 'today';
-    if (period === 'weekly') return 'this week';
-    if (period === 'monthly') {
-      return now.toLocaleDateString(undefined, { month: 'short' });
-    }
-    if (period === 'yearly') return String(now.getFullYear());
-    return '';
-  }
-
-  private periodLabel(period: string, now: Date = new Date()): string {
-    const base =
-      period === 'all_time'
-        ? 'All time budget'
-        : `${period.charAt(0).toUpperCase()}${period.slice(1)} budget`;
-    const window = this.periodWindow(period, now);
-    return window ? `${base} · ${window}` : base;
-  }
-
-  /**
-   * Straight-line projection for a budget row, or nothing when the period is
-   * too young to project from. The tone follows the limit the forecast
-   * crosses, so a row that is calm today can still read as amber.
-   */
-  private renderForecast(policy: {
-    period: string;
-    spend: number;
-    softLimit: number;
-    hardLimit: number;
-    periodStart?: string | null;
-    periodEnd?: string | null;
-  }) {
-    const forecast = budgetForecast(policy);
-    if (!forecast) return nothing;
-    const percent = Math.round(forecast.elapsedFraction * 100);
-    return html`
-      <div
-        class="budget-forecast ${forecast.tone}"
-        title=${`Straight line from ${this.formatCurrency(
-          policy.spend
-        )} spent in the first ${percent}% of the period.`}
-      >
-        On track for ${this.formatCurrency(forecast.amount)} by
-        ${forecastEndLabel(policy.period, forecast.end, forecast.endBasis)}
-      </div>
-    `;
-  }
-
   private renderBudgetRow(
     label: string,
     period: string,
@@ -751,14 +689,17 @@ export class UsageCard extends LitElement {
               })
             : nothing
         }
-        ${this.renderForecast({
-          period,
-          spend,
-          softLimit,
-          hardLimit,
-          periodStart: bounds.start,
-          periodEnd: bounds.end,
-        })}
+        ${renderBudgetForecast(
+          {
+            period,
+            spend,
+            softLimit,
+            hardLimit,
+            periodStart: bounds.start,
+            periodEnd: bounds.end,
+          },
+          (value) => this.formatCurrency(value)
+        )}
       </div>
     `;
   }
@@ -777,7 +718,7 @@ export class UsageCard extends LitElement {
 
     const rows = globals.map((policy) =>
       this.renderBudgetRow(
-        this.periodLabel(policy.period),
+        budgetPeriodLabel(policy.period),
         policy.period,
         policy.current_spend_usd || 0,
         policy.soft_limit_usd || 0,
@@ -789,7 +730,7 @@ export class UsageCard extends LitElement {
     if (!hasGlobalMonthly && legacyLimit > 0) {
       rows.unshift(
         this.renderBudgetRow(
-          this.periodLabel('monthly'),
+          budgetPeriodLabel('monthly'),
           'monthly',
           this.summary?.budget?.current_spend_usd || 0,
           this.summary?.budget?.soft_limit_usd || 0,

--- a/frontend/src/utils/budget-forecast.test.ts
+++ b/frontend/src/utils/budget-forecast.test.ts
@@ -2,6 +2,8 @@ import { expect } from '@open-wc/testing';
 
 import {
   budgetForecast,
+  budgetPeriodLabel,
+  budgetPeriodWindow,
   forecastEndLabel,
   periodEndFor,
   periodStartFor,
@@ -163,5 +165,28 @@ describe('budget-forecast', () => {
             minute: '2-digit',
           });
     expect(forecastEndLabel('daily', utcDayEnd, 'utc')).to.equal(expected);
+  });
+
+  it('names a budget the same way whichever surface prints it', () => {
+    const now = at('2026-09-03T15:00:00');
+    const month = now.toLocaleDateString(undefined, { month: 'short' });
+    expect(budgetPeriodLabel('monthly', now)).to.equal(
+      `Monthly budget \u00b7 ${month}`
+    );
+    expect(budgetPeriodLabel('daily', now)).to.equal(
+      'Daily budget \u00b7 today'
+    );
+    expect(budgetPeriodLabel('all_time', now)).to.equal('All time budget');
+    // The legacy spellings are folded here, so Cost and the Overview cannot
+    // disagree about what the same budget is called.
+    expect(budgetPeriodLabel('month', now)).to.equal(
+      budgetPeriodLabel('monthly', now)
+    );
+    expect(budgetPeriodWindow('year', now)).to.equal(
+      budgetPeriodWindow('yearly', now)
+    );
+    expect(budgetPeriodWindow('year', now)).to.equal('2026');
+    // A legacy period also gets a forecast rather than silently losing one.
+    expect(periodStartFor('month', now)!.getDate()).to.equal(1);
   });
 });

--- a/frontend/src/utils/budget-forecast.ts
+++ b/frontend/src/utils/budget-forecast.ts
@@ -10,11 +10,29 @@
  * The projection is deliberately linear. Spend is bursty and this card is not
  * the place for a model with opinions; a straight line is the one rule an
  * operator can carry in their head and check by hand.
+ *
+ * The naming of a budget row lives here too (round 4). Cost and the Overview
+ * both print the same budget, and when each owned its own copy of the label
+ * they drifted within one branch.
  */
+import { css, html, nothing, type TemplateResult } from 'lit';
 
 /** Budget periods the forecast understands. `all_time` has no end to aim at. */
 export type ForecastPeriod =
   'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'all_time';
+
+/**
+ * Older policies were written with `month` and `year` where the current
+ * schema says `monthly` and `yearly`. Both spellings mean the same period, so
+ * they are folded here, once, rather than in each caller: when only one caller
+ * folded them the same budget was named "Monthly budget - Sep" on Cost and
+ * "Month budget" on the Overview.
+ */
+function normalizePeriod(period: string): string {
+  if (period === 'month') return 'monthly';
+  if (period === 'year') return 'yearly';
+  return period;
+}
 
 /**
  * Below this the sample is too short to project from: one expensive minute
@@ -62,7 +80,8 @@ export interface BudgetForecast {
  * (`get_period_start` in `models/crud/budget.py`): weeks start on Monday,
  * months on the 1st, years on 1 January.
  */
-export function periodStartFor(period: string, now: Date): Date | null {
+export function periodStartFor(rawPeriod: string, now: Date): Date | null {
+  const period = normalizePeriod(rawPeriod);
   const start = new Date(now.getTime());
   start.setMilliseconds(0);
   start.setSeconds(0);
@@ -91,7 +110,8 @@ export function periodStartFor(period: string, now: Date): Date | null {
 }
 
 /** Exclusive end of the period containing `now`. */
-export function periodEndFor(period: string, now: Date): Date | null {
+export function periodEndFor(rawPeriod: string, now: Date): Date | null {
+  const period = normalizePeriod(rawPeriod);
   const start = periodStartFor(period, now);
   if (!start) return null;
   const end = new Date(start.getTime());
@@ -195,4 +215,85 @@ export function forecastEndLabel(
     day: 'numeric',
     ...(basis === 'utc' ? { timeZone: 'UTC' } : {}),
   });
+}
+
+/**
+ * Which window a budget row is about, in words. "Global spend - 30d" was read
+ * as a rolling total; "Monthly budget - Sep" says the number resets, and says
+ * it the same way on Cost and on the Overview.
+ */
+export function budgetPeriodWindow(
+  rawPeriod: string,
+  now: Date = new Date()
+): string {
+  const period = normalizePeriod(rawPeriod);
+  if (period === 'hourly') return 'this hour';
+  if (period === 'daily') return 'today';
+  if (period === 'weekly') return 'this week';
+  if (period === 'monthly') {
+    return now.toLocaleDateString(undefined, { month: 'short' });
+  }
+  if (period === 'yearly') return String(now.getFullYear());
+  return '';
+}
+
+/**
+ * The full name of a global budget row, for example "Monthly budget - Sep".
+ * Both surfaces call this so a budget cannot be named two things.
+ */
+export function budgetPeriodLabel(
+  rawPeriod: string,
+  now: Date = new Date()
+): string {
+  const period = normalizePeriod(rawPeriod);
+  const base =
+    period === 'all_time'
+      ? 'All time budget'
+      : `${period.charAt(0).toUpperCase()}${period.slice(1)} budget`;
+  const window = budgetPeriodWindow(period, now);
+  return window ? `${base} · ${window}` : base;
+}
+
+/** The tone classes and type for the forecast sentence, shared by both cards. */
+export const budgetForecastStyles = css`
+  .budget-forecast {
+    color: var(--sl-color-neutral-500);
+    font-size: 0.8125rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .budget-forecast.warning {
+    color: var(--sl-color-warning-700);
+  }
+
+  .budget-forecast.danger {
+    color: var(--sl-color-danger-700);
+  }
+`;
+
+/**
+ * The forecast sentence, "On track for $X by Y", with the tone of the limit it
+ * crosses and the arithmetic behind it in the tooltip. Rendered here rather
+ * than in each card so the two surfaces cannot word the same projection
+ * differently. `formatCurrency` stays with the caller because the two cards
+ * round money on their own scales.
+ */
+export function renderBudgetForecast(
+  input: BudgetForecastInput,
+  formatCurrency: (value: number) => string
+): TemplateResult | typeof nothing {
+  const forecast = budgetForecast(input);
+  if (!forecast) return nothing;
+  const percent = Math.round(forecast.elapsedFraction * 100);
+  return html`
+    <div
+      class="budget-forecast ${forecast.tone}"
+      title=${`Straight line from ${formatCurrency(
+        Number(input.spend || 0)
+      )} spent in the first ${percent}% of the period.`}
+    >
+      On track for ${formatCurrency(forecast.amount)} by
+      ${forecastEndLabel(input.period, forecast.end, forecast.endBasis)}
+    </div>
+  `;
 }

--- a/frontend/src/views/authed/cost-view.test.ts
+++ b/frontend/src/views/authed/cost-view.test.ts
@@ -170,6 +170,101 @@ describe('CostView', () => {
     expect(agentTable?.querySelector('th[scope="col"]')).to.exist;
   });
 
+  it('carries the shared range control, restates the window and drops Refresh', async () => {
+    const element = (await fixture(html`<cost-view></cost-view>`)) as CostView;
+    await waitUntil(
+      () => (element as unknown as { loading: boolean }).loading === false
+    );
+    await element.updateComplete;
+
+    // One range vocabulary per page: the shared control, not a bare select.
+    const range = element.shadowRoot?.querySelector('time-range-select');
+    expect(range).to.exist;
+    expect(
+      element.shadowRoot?.querySelector('sl-select[label="Date range"]')
+    ).to.equal(null);
+
+    // The window the numbers cover is restated beside the control, and the
+    // page says how fresh it is instead of offering a manual poll.
+    const window = element.shadowRoot
+      ?.querySelector('.range-window')
+      ?.textContent?.replace(/\s+/g, ' ')
+      .trim();
+    expect(window).to.contain(' to ');
+    expect(window).to.contain('updated');
+
+    const buttons = Array.from(
+      element.shadowRoot?.querySelectorAll('sl-button') || []
+    ).map((button) => (button.textContent || '').trim());
+    expect(buttons).to.not.include('Refresh');
+  });
+
+  it('labels stats with the window and prints counts compact', async () => {
+    summaryPayload = {
+      ...summary,
+      total_requests: 32969,
+      successful_requests: 32519,
+      token_usage: {
+        prompt_tokens: 810_400_000,
+        completion_tokens: 13_700_000,
+        total_tokens: 824_100_000,
+      },
+    };
+    const element = (await fixture(html`<cost-view></cost-view>`)) as CostView;
+    await waitUntil(
+      () => (element as unknown as { loading: boolean }).loading === false
+    );
+    await element.updateComplete;
+
+    const metrics = element.shadowRoot
+      ?.querySelector('[aria-label="Cost summary metrics"]')
+      ?.textContent?.replace(/\s+/g, ' ');
+    expect(metrics).to.contain('$ est. · 30d');
+    expect(metrics).to.contain('Requests · 30d');
+    expect(metrics).to.contain('Tokens · 30d');
+    expect(metrics).to.contain('33K');
+    expect(metrics).to.contain('824.1M');
+    expect(metrics).to.not.contain('824,100,000');
+
+    // A delta is an arrow and a percentage, as on the Overview.
+    const delta = (
+      element as unknown as {
+        percentDelta: (current: number, previous: number) => string;
+      }
+    ).percentDelta(24, 10);
+    expect(delta).to.equal('▲ 140% vs prior 30d');
+  });
+
+  it('states the catalog age and offers the action that fixes a price', async () => {
+    summaryPayload = {
+      ...summary,
+      price_catalog: {
+        fetched_at: new Date(
+          Date.now() - 55 * 24 * 60 * 60 * 1000
+        ).toISOString(),
+        model_count: 868,
+      },
+    };
+    featuresPayload = { billing: true, model_price_overrides: true };
+    const element = (await fixture(html`<cost-view></cost-view>`)) as CostView;
+    await waitUntil(
+      () => (element as unknown as { loading: boolean }).loading === false
+    );
+    await element.updateComplete;
+
+    const line = Array.from(
+      element.shadowRoot?.querySelectorAll('.metric-detail') || []
+    )
+      .map((node) => (node.textContent || '').replace(/\s+/g, ' ').trim())
+      .find((text) => text.startsWith('Price catalog from'));
+    expect(line, 'catalog provenance line').to.exist;
+    expect(line).to.contain('(868 models), 55 days old.');
+    // "Update recommended" with nothing to click became something to click.
+    expect(line).to.not.contain('update recommended');
+    const action = element.shadowRoot?.querySelector('a.catalog-action');
+    expect(action?.textContent?.trim()).to.equal('Override a price');
+  });
+
   it('exposes loading status while analytics are fetched', async () => {
     const element = (await fixture(html`<cost-view></cost-view>`)) as CostView;
     await element.updateComplete;
@@ -506,7 +601,9 @@ describe('CostView', () => {
     await (header as LitElement).updateComplete;
 
     const h1 = header?.shadowRoot?.querySelector('h1');
-    expect(h1?.textContent).to.contain('Cost Analytics');
+    // One name for the page: the sidebar, the Overview link and the h1 all
+    // say Cost.
+    expect(h1?.textContent?.trim()).to.equal('Cost');
 
     const description = header?.shadowRoot?.querySelector('.description');
     expect(description?.textContent).to.contain(
@@ -601,7 +698,7 @@ describe('CostView', () => {
       expect(state.priceModelAlias).to.equal('openai-compatible/muse-spark');
 
       const dialog = element.shadowRoot?.querySelector(
-        'sl-dialog[label="Add Price Override"]'
+        'sl-dialog[label="Add price override"]'
       );
       expect(dialog).to.exist;
       expect((dialog as unknown as { open: boolean }).open).to.equal(true);

--- a/frontend/src/views/authed/cost-view.test.ts
+++ b/frontend/src/views/authed/cost-view.test.ts
@@ -191,7 +191,13 @@ describe('CostView', () => {
       ?.textContent?.replace(/\s+/g, ' ')
       .trim();
     expect(window).to.contain(' to ');
-    expect(window).to.contain('updated');
+    // The read time is a clock time, not "just now": the page neither polls
+    // nor subscribes, so a relative phrase painted once goes stale in place.
+    expect(window).to.match(/read \d/);
+    expect(window).to.not.contain('just now');
+    expect(
+      element.shadowRoot?.querySelector('.range-window')?.getAttribute('title')
+    ).to.contain('Loaded');
 
     const buttons = Array.from(
       element.shadowRoot?.querySelectorAll('sl-button') || []
@@ -261,8 +267,20 @@ describe('CostView', () => {
     expect(line).to.contain('(868 models), 55 days old.');
     // "Update recommended" with nothing to click became something to click.
     expect(line).to.not.contain('update recommended');
-    const action = element.shadowRoot?.querySelector('a.catalog-action');
+    // It opens a dialog, so it is a button: an anchor to "#panel-pricing"
+    // could never resolve inside a shadow root.
+    expect(element.shadowRoot?.querySelector('a.catalog-action')).to.equal(
+      null
+    );
+    const action = element.shadowRoot?.querySelector(
+      'button.catalog-action'
+    ) as HTMLButtonElement | null;
     expect(action?.textContent?.trim()).to.equal('Override a price');
+    action?.click();
+    await element.updateComplete;
+    expect(
+      (element as unknown as { priceDialogOpen: boolean }).priceDialogOpen
+    ).to.equal(true);
   });
 
   it('exposes loading status while analytics are fetched', async () => {

--- a/frontend/src/views/authed/cost-view.ts
+++ b/frontend/src/views/authed/cost-view.ts
@@ -1046,12 +1046,8 @@ export class CostView extends AuthedElement {
   }
 
   /**
-   * Which days the numbers cover, restated beside the range control. The
-   * server's own window is preferred over the client's presets: the four
-   * sibling pages disagree about "30 days", and this one prints what it was
-   * actually given.
+   * The short form of the selected range, for stat labels ("$ est. · 30d").
    */
-  /** The short form of the selected range, for stat labels ("$ est. · 30d"). */
   private rangeChipLabel(): string {
     const option = DATE_RANGE_OPTIONS.find(
       (item) => item.value === this.selectedRange
@@ -1059,6 +1055,12 @@ export class CostView extends AuthedElement {
     return (option?.label || '30d').toLowerCase();
   }
 
+  /**
+   * Which days the numbers cover, restated beside the range control. The
+   * server's own window is preferred over the client's presets: the four
+   * sibling pages disagree about "30 days", and this one prints what it was
+   * actually given.
+   */
   private rangeWindowLabel(): string {
     const params = this.getDateParams();
     const start = new Date(this.summary?.period_start || params.startDate);

--- a/frontend/src/views/authed/cost-view.ts
+++ b/frontend/src/views/authed/cost-view.ts
@@ -32,7 +32,6 @@ import type {
   ProviderBillingConnection,
 } from '../../types';
 import consoleStyles from '../../styles/console-styles.css?inline';
-import { formatRelativeTime } from '../../utils/date';
 import '../../components/view-header.ts';
 import '../../components/time-range-select.ts';
 import '../../components/budget-policy-editor.ts';
@@ -269,8 +268,21 @@ export class CostView extends AuthedElement {
         font-variant-numeric: tabular-nums;
       }
 
+      /* It opens a dialog, so it is a button. As an anchor it pointed at a
+         fragment that cannot resolve inside a shadow root, and told assistive
+         tech it was a link. */
       .catalog-action {
+        appearance: none;
+        background: none;
+        border: none;
+        padding: 0;
+        font: inherit;
         color: var(--sl-color-primary-600);
+        cursor: pointer;
+      }
+
+      .catalog-action:hover {
+        text-decoration: underline;
       }
 
       .metric-grid {
@@ -1055,9 +1067,23 @@ export class CostView extends AuthedElement {
     const day = (date: Date) =>
       date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
     const window = `${day(start)} to ${day(end)}`;
-    return this.loadedAt
-      ? `${window} · updated ${formatRelativeTime(this.loadedAt)}`
-      : window;
+    // Cost has no websocket subscription and no poll, so the numbers are as
+    // old as the last load. A relative "updated just now" painted once would
+    // still say "just now" an hour later; a clock time cannot go stale.
+    const loaded = this.loadedAt ? new Date(this.loadedAt) : null;
+    if (!loaded || Number.isNaN(loaded.getTime())) return window;
+    const read = loaded.toLocaleTimeString(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    return `${window} · read ${read}`;
+  }
+
+  /** The full timestamp behind "read 14:02", for the label's tooltip. */
+  private rangeWindowTitle(): string {
+    const loaded = this.loadedAt ? new Date(this.loadedAt) : null;
+    if (!loaded || Number.isNaN(loaded.getTime())) return '';
+    return `Loaded ${loaded.toLocaleString()}`;
   }
 
   /**
@@ -1429,15 +1455,15 @@ export class CostView extends AuthedElement {
         ${ageDays === 1 ? 'day' : 'days'} old.
         ${
           ageDays > 45
-            ? html`<a
+            ? html`<button
+                type="button"
                 class="catalog-action"
-                href="#panel-pricing"
-                @click=${(event: Event) => {
-                  event.preventDefault();
+                @click=${() => {
                   this.priceDialogOpen = true;
                 }}
-                >Override a price</a
-              >`
+              >
+                Override a price
+              </button>`
             : nothing
         }
       </div>
@@ -2811,7 +2837,9 @@ export class CostView extends AuthedElement {
             .options=${DATE_RANGE_OPTIONS}
             @range-change=${this.handleRangeChange}
           ></time-range-select>
-          <span class="range-window">${this.rangeWindowLabel()}</span>
+          <span class="range-window" title=${this.rangeWindowTitle()}
+            >${this.rangeWindowLabel()}</span
+          >
         </div>
 
         ${

--- a/frontend/src/views/authed/cost-view.ts
+++ b/frontend/src/views/authed/cost-view.ts
@@ -32,7 +32,9 @@ import type {
   ProviderBillingConnection,
 } from '../../types';
 import consoleStyles from '../../styles/console-styles.css?inline';
+import { formatRelativeTime } from '../../utils/date';
 import '../../components/view-header.ts';
+import '../../components/time-range-select.ts';
 import '../../components/budget-policy-editor.ts';
 import '../../components/budget-health-card.ts';
 import '../../components/tool-cost-flags-panel.ts';
@@ -117,6 +119,20 @@ const DATE_RANGE_PRESETS: DateRangePreset[] = [
   'last-90',
 ];
 
+// The page carries one range control, the shared `time-range-select`, so Cost
+// speaks the same range vocabulary as the Overview instead of a bare labelled
+// select. The calendar presets stay: "This month" and "Today" are what the
+// Month-to-date and Projected cards are computed from.
+const DATE_RANGE_OPTIONS: { value: DateRangePreset; label: string }[] = [
+  { value: 'today', label: 'Today' },
+  { value: 'this-week', label: 'This week' },
+  { value: 'this-month', label: 'This month' },
+  { value: 'last-month', label: 'Last month' },
+  { value: 'last-7', label: '7d' },
+  { value: 'last-30', label: '30d' },
+  { value: 'last-90', label: '90d' },
+];
+
 @customElement('cost-view')
 export class CostView extends AuthedElement {
   // Async reprice follow-up: check the summary every 5s for up to about a
@@ -127,6 +143,9 @@ export class CostView extends AuthedElement {
   @state() private summary: CostAnalyticsSummaryResponse | null = null;
   @state() private previousRangeSummary: CostAnalyticsSummaryResponse | null =
     null;
+  // When the numbers on screen were fetched. The page dropped its Refresh
+  // button, so it says how fresh it is instead of offering a manual poll.
+  @state() private loadedAt: string | null = null;
   @state() private budgetPolicies: BudgetPolicy[] = [];
   @state() private aiModels: AIModel[] = [];
   @state() private pricingOverrides: ModelPriceOverride[] = [];
@@ -232,8 +251,26 @@ export class CostView extends AuthedElement {
       .toolbar {
         display: flex;
         gap: var(--sl-spacing-medium);
-        align-items: end;
+        align-items: center;
         flex-wrap: wrap;
+      }
+
+      /* Wide enough for "Last month"; the shared control is 96px by default,
+         which is sized for 24h/7d/30d chips. */
+      .toolbar time-range-select {
+        --time-range-select-width: 140px;
+      }
+
+      /* The window the numbers cover, restated beside the control that chose
+         it, plus how fresh they are now that there is no Refresh button. */
+      .range-window {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .catalog-action {
+        color: var(--sl-color-primary-600);
       }
 
       .metric-grid {
@@ -701,7 +738,9 @@ export class CostView extends AuthedElement {
   // Clears previous-period comparison before reload so a stale delta from
   // another range is never shown (see C).
   private handleRangeChange = (event: Event) => {
-    const value = (event.target as HTMLSelectElement).value as DateRangePreset;
+    const detail = (event as CustomEvent<{ value?: string }>).detail;
+    const value = (detail?.value ??
+      (event.target as HTMLSelectElement).value) as DateRangePreset;
     if (!DATE_RANGE_PRESETS.includes(value) || value === this.selectedRange) {
       return;
     }
@@ -729,6 +768,7 @@ export class CostView extends AuthedElement {
         getFeatures().catch(() => ({ features: {} })),
       ]);
       this.summary = summary;
+      this.loadedAt = new Date().toISOString();
       this.featureFlags = features.features || {};
       await this.loadBudgetPolicies();
       this.aiModels = aiModels;
@@ -979,6 +1019,64 @@ export class CostView extends AuthedElement {
     return Number(value || 0).toLocaleString();
   }
 
+  /**
+   * Counts big enough to lose their shape are compact, as on the Overview
+   * ("836.5M"), with the exact figure kept in a title attribute for anyone
+   * who needs to read every digit.
+   */
+  private formatCompactNumber(value?: number | null): string {
+    const amount = Number(value || 0);
+    if (amount < 1000) return String(Math.round(amount));
+    return new Intl.NumberFormat(undefined, {
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(amount);
+  }
+
+  /**
+   * Which days the numbers cover, restated beside the range control. The
+   * server's own window is preferred over the client's presets: the four
+   * sibling pages disagree about "30 days", and this one prints what it was
+   * actually given.
+   */
+  /** The short form of the selected range, for stat labels ("$ est. · 30d"). */
+  private rangeChipLabel(): string {
+    const option = DATE_RANGE_OPTIONS.find(
+      (item) => item.value === this.selectedRange
+    );
+    return (option?.label || '30d').toLowerCase();
+  }
+
+  private rangeWindowLabel(): string {
+    const params = this.getDateParams();
+    const start = new Date(this.summary?.period_start || params.startDate);
+    const end = new Date(this.summary?.period_end || params.endDate);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return '';
+    const day = (date: Date) =>
+      date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    const window = `${day(start)} to ${day(end)}`;
+    return this.loadedAt
+      ? `${window} · updated ${formatRelativeTime(this.loadedAt)}`
+      : window;
+  }
+
+  /**
+   * A delta in the Overview's form: an arrow, a percentage, and the window it
+   * is measured against. A dollar difference alone ("+$14.30") says nothing
+   * about whether spend doubled or moved a percent.
+   */
+  private percentDelta(current: number, previous: number): string {
+    if (!previous || previous <= 0) {
+      return `No comparison for ${this.previousRangeLabel()}`;
+    }
+    const change = ((current - previous) / previous) * 100;
+    if (Math.abs(change) < 0.5) {
+      return `No change vs ${this.previousRangeLabel()}`;
+    }
+    const arrow = change > 0 ? '▲' : '▼';
+    return `${arrow} ${Math.abs(Math.round(change))}% vs ${this.previousRangeLabel()}`;
+  }
+
   private getProjectedPeriodCost(): number | null {
     if (!this.summary) return null;
     const now = new Date();
@@ -1010,10 +1108,10 @@ export class CostView extends AuthedElement {
 
   private projectedPeriodLabel(): string {
     return this.selectedRange === 'this-week'
-      ? 'Projected Week'
+      ? 'Projected week'
       : this.selectedRange === 'today'
-        ? 'Projected Today'
-        : 'Projected Month';
+        ? 'Projected today'
+        : 'Projected month';
   }
 
   private projectedPeriodComparisonDetail(projectedCost: number): string {
@@ -1021,22 +1119,19 @@ export class CostView extends AuthedElement {
     if (previousCost === null || previousCost === undefined) {
       return `Compared to ${this.previousRangeLabel()}`;
     }
-    return `${this.formatSignedCurrency(projectedCost - previousCost)} vs ${this.previousRangeLabel()}`;
+    return this.percentDelta(projectedCost, previousCost);
   }
 
-  private formatSignedCurrency(value: number): string {
-    const prefix = value > 0 ? '+' : '';
-    return `${prefix}${this.formatCurrency(value)}`;
-  }
-
+  // Named as on the Overview ("vs prior 30d"), not "previous 30 days": the
+  // same comparison should read the same on both pages.
   private previousRangeLabel(): string {
     if (this.selectedRange === 'today') return 'same time yesterday';
-    if (this.selectedRange === 'this-week') return 'previous week';
-    if (this.selectedRange === 'this-month') return 'previous month';
+    if (this.selectedRange === 'this-week') return 'prior week';
+    if (this.selectedRange === 'this-month') return 'prior month';
     if (this.selectedRange === 'last-month') return 'month before';
-    if (this.selectedRange === 'last-7') return 'previous 7 days';
-    if (this.selectedRange === 'last-90') return 'previous 90 days';
-    return 'previous 30 days';
+    if (this.selectedRange === 'last-7') return 'prior 7d';
+    if (this.selectedRange === 'last-90') return 'prior 90d';
+    return 'prior 30d';
   }
 
   private spendComparisonDetail(): string {
@@ -1044,9 +1139,7 @@ export class CostView extends AuthedElement {
     if (previousCost === null || previousCost === undefined) {
       return `Compared to ${this.previousRangeLabel()}`;
     }
-    const currentCost = this.summary?.estimated_cost || 0;
-    const delta = currentCost - previousCost;
-    return `${this.formatSignedCurrency(delta)} vs ${this.previousRangeLabel()}`;
+    return this.percentDelta(this.summary?.estimated_cost || 0, previousCost);
   }
 
   private renderSessionSubjects(row: GatewayUsageBySession) {
@@ -1181,8 +1274,8 @@ export class CostView extends AuthedElement {
           <div class="metric-label">
             ${
               this.selectedRange === 'this-month'
-                ? 'Month-to-date Spend'
-                : 'Estimated Spend'
+                ? 'Month to date'
+                : `$ est. · ${this.rangeChipLabel()}`
             }
           </div>
           <div class="metric-value">
@@ -1191,22 +1284,29 @@ export class CostView extends AuthedElement {
           <div class="metric-detail">${this.spendComparisonDetail()}</div>
         </div>
         <div class="metric-card">
-          <div class="metric-label">Gateway Requests</div>
-          <div class="metric-value">
-            ${this.formatNumber(summary?.total_requests)}
+          <div class="metric-label">Requests · ${this.rangeChipLabel()}</div>
+          <div
+            class="metric-value"
+            title=${this.formatNumber(summary?.total_requests)}
+          >
+            ${this.formatCompactNumber(summary?.total_requests)}
           </div>
           <div class="metric-detail">
-            ${this.formatNumber(summary?.successful_requests)} succeeded
+            ${this.formatCompactNumber(summary?.successful_requests)} succeeded
           </div>
         </div>
         <div class="metric-card">
-          <div class="metric-label">Tokens</div>
-          <div class="metric-value">
-            ${this.formatNumber(summary?.token_usage.total_tokens)}
+          <div class="metric-label">Tokens · ${this.rangeChipLabel()}</div>
+          <div
+            class="metric-value"
+            title=${this.formatNumber(summary?.token_usage.total_tokens)}
+          >
+            ${this.formatCompactNumber(summary?.token_usage.total_tokens)}
           </div>
           <div class="metric-detail">
-            ${this.formatNumber(summary?.token_usage.prompt_tokens)} prompt,
-            ${this.formatNumber(summary?.token_usage.completion_tokens)}
+            ${this.formatCompactNumber(summary?.token_usage.prompt_tokens)}
+            prompt ·
+            ${this.formatCompactNumber(summary?.token_usage.completion_tokens)}
             completion
           </div>
         </div>
@@ -1282,6 +1382,7 @@ export class CostView extends AuthedElement {
             ? html`<sl-button
                 size="small"
                 variant="warning"
+                outline
                 .loading=${this.repricing}
                 @click=${() => void this.handleReprice()}
                 >Reprice now</sl-button
@@ -1312,11 +1413,33 @@ export class CostView extends AuthedElement {
     const ageDays = Math.floor(
       (Date.now() - fetched.getTime()) / (24 * 60 * 60 * 1000)
     );
+    // The date is spelled out rather than left in US numeric form, the age is
+    // stated in days, and a stale catalog ends in something to click. There is
+    // no endpoint that re-downloads the catalog on demand, so the action is
+    // the one that actually fixes a wrong price: an override for this account.
     return html`
       <div class="metric-detail">
-        Prices as of ${fetched.toLocaleDateString()}
-        (${catalog.model_count ?? '?'}
-        models${ageDays > 45 ? ', update recommended' : ''})
+        Price catalog from
+        ${fetched.toLocaleDateString(undefined, {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        })}
+        (${catalog.model_count ?? '?'} models), ${ageDays}
+        ${ageDays === 1 ? 'day' : 'days'} old.
+        ${
+          ageDays > 45
+            ? html`<a
+                class="catalog-action"
+                href="#panel-pricing"
+                @click=${(event: Event) => {
+                  event.preventDefault();
+                  this.priceDialogOpen = true;
+                }}
+                >Override a price</a
+              >`
+            : nothing
+        }
       </div>
     `;
   }
@@ -2408,7 +2531,7 @@ export class CostView extends AuthedElement {
   private renderPriceOverrideDialog() {
     return html`
       <sl-dialog
-        label="Add Price Override"
+        label="Add price override"
         ?open=${this.priceDialogOpen}
         @sl-after-hide=${(event: Event) => {
           if (event.target === event.currentTarget) {
@@ -2633,7 +2756,7 @@ export class CostView extends AuthedElement {
         this.billingEnabled
           ? html`
               <sl-dialog
-                label="Configure Budget Limits"
+                label="Configure budget limits"
                 ?open=${this.budgetDialogOpen}
                 @sl-after-hide=${(event: Event) => {
                   if (event.target === event.currentTarget) {
@@ -2677,25 +2800,18 @@ export class CostView extends AuthedElement {
     return html`
       <div class="page">
         <view-header
-          headerText="Cost Analytics"
+          headerText="Cost"
           description="Understand gateway spend by agent, tool, session and user."
         ></view-header>
 
         <div class="toolbar">
-          <sl-select
-            label="Date range"
+          <time-range-select
+            ariaLabel="Cost date range"
             .value=${this.selectedRange}
-            @sl-change=${this.handleRangeChange}
-          >
-            <sl-option value="today">Today</sl-option>
-            <sl-option value="this-week">This week</sl-option>
-            <sl-option value="this-month">This month</sl-option>
-            <sl-option value="last-month">Last month</sl-option>
-            <sl-option value="last-7">Last 7 days</sl-option>
-            <sl-option value="last-30">Last 30 days</sl-option>
-            <sl-option value="last-90">Last 90 days</sl-option>
-          </sl-select>
-          <sl-button @click=${() => void this.load()}>Refresh</sl-button>
+            .options=${DATE_RANGE_OPTIONS}
+            @range-change=${this.handleRangeChange}
+          ></time-range-select>
+          <span class="range-window">${this.rangeWindowLabel()}</span>
         </div>
 
         ${

--- a/frontend/src/views/authed/notification-preferences-view.test.ts
+++ b/frontend/src/views/authed/notification-preferences-view.test.ts
@@ -53,9 +53,33 @@ describe('NotificationPreferencesView', () => {
     await tick();
     await el.updateComplete;
     expect((el as any).isLoading).to.be.false;
-    expect(el.shadowRoot?.textContent).to.contain('Notification Preferences');
+    // The page word is said once, in the title; the sections are named for
+    // what they hold.
+    expect(el.shadowRoot?.querySelector('h1')?.textContent).to.equal(
+      'Notifications'
+    );
+    const sections = Array.from(
+      el.shadowRoot?.querySelectorAll('.section-title') || []
+    ).map((node) => (node.textContent || '').trim());
+    expect(sections).to.include('Channels');
+    expect(sections).to.include('Devices');
+    expect(sections).to.not.include('Notification Channels');
     expect(el.shadowRoot?.querySelectorAll('sl-switch').length).to.equal(2);
     expect(el.shadowRoot?.querySelector('.device-item')).to.exist;
+
+    // Unregister is outline, and the store links are default buttons rather
+    // than two primary paints at the foot of a settings page.
+    const unregister = el.shadowRoot?.querySelector(
+      '.device-item sl-button[variant="danger"]'
+    );
+    expect(unregister?.hasAttribute('outline')).to.equal(true);
+    const store = Array.from(
+      el.shadowRoot?.querySelectorAll('.app-store-links sl-button') || []
+    );
+    expect(store).to.have.lengthOf(2);
+    store.forEach((button) => {
+      expect(button.getAttribute('variant')).to.equal('default');
+    });
   });
 
   it('shows the empty state when no devices are registered', async () => {

--- a/frontend/src/views/authed/notification-preferences-view.ts
+++ b/frontend/src/views/authed/notification-preferences-view.ts
@@ -155,13 +155,15 @@ export class NotificationPreferencesView extends AuthedElement {
         color: var(--sl-color-neutral-900);
       }
 
+      /* Hairline rows, not boxes: DESIGN.md depth limit two means nothing
+         inside a card gets its own border. */
       .preference-row {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding: var(--sl-spacing-medium);
-        border: 1px solid var(--sl-color-neutral-200);
-        border-radius: var(--sl-border-radius-medium);
+        gap: var(--sl-spacing-medium);
+        padding: var(--sl-spacing-medium) 0;
+        border-bottom: 1px solid var(--sl-color-neutral-200);
       }
 
       .preference-label {
@@ -190,10 +192,13 @@ export class NotificationPreferencesView extends AuthedElement {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding: var(--sl-spacing-medium);
-        border: 1px solid var(--sl-color-neutral-200);
-        border-radius: var(--sl-border-radius-medium);
-        background: var(--sl-color-neutral-50);
+        gap: var(--sl-spacing-medium);
+        padding: var(--sl-spacing-medium) 0;
+        border-bottom: 1px solid var(--sl-color-neutral-200);
+      }
+
+      .devices-list .device-item:last-of-type {
+        border-bottom: none;
       }
 
       .device-info {
@@ -266,32 +271,19 @@ export class NotificationPreferencesView extends AuthedElement {
       .app-store-links {
         display: flex;
         justify-content: center;
+        flex-wrap: wrap;
         gap: var(--sl-spacing-medium);
         margin-top: var(--sl-spacing-large);
       }
 
-      .app-store-button {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--sl-spacing-small);
-        padding: var(--sl-spacing-medium) var(--sl-spacing-large);
-        background: var(--sl-color-primary-600);
-        color: var(--sl-color-neutral-0);
-        text-decoration: none;
-        border-radius: var(--sl-border-radius-medium);
-        transition: all 0.2s ease;
-        font-weight: var(--sl-font-weight-semibold);
-        box-shadow: var(--sl-shadow-small);
-      }
-
-      .app-store-button:hover {
-        background: var(--sl-color-primary-700);
-        transform: translateY(-1px);
-        box-shadow: var(--sl-shadow-medium);
-      }
-
-      .app-store-button sl-icon {
-        font-size: 1.5rem;
+      /* Two links to an app store are not the primary action of this page:
+         they are default buttons under one sentence. */
+      .app-store-links .hint {
+        width: 100%;
+        text-align: center;
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        margin-bottom: var(--sl-spacing-small);
       }
 
       .loading {
@@ -814,7 +806,7 @@ export class NotificationPreferencesView extends AuthedElement {
 
     return html`
       <div class="header">
-        <h1>Notification Preferences</h1>
+        <h1>Notifications</h1>
         <p>Manage how you receive approval request notifications</p>
       </div>
 
@@ -841,7 +833,7 @@ export class NotificationPreferencesView extends AuthedElement {
 
       <div class="content">
         <sl-card>
-          <h2 class="section-title">Notification Channels</h2>
+          <h2 class="section-title">Channels</h2>
 
           <div class="preference-row">
             <div class="preference-label">
@@ -904,10 +896,10 @@ export class NotificationPreferencesView extends AuthedElement {
           <div
             style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--sl-spacing-medium);"
           >
-            <h2 class="section-title" style="margin: 0;">Mobile Devices</h2>
+            <h2 class="section-title" style="margin: 0;">Devices</h2>
             <sl-button size="small" @click=${this.handleShowQRCode}>
               <sl-icon slot="prefix" name="qr-code"></sl-icon>
-              Register New Device
+              Register device
             </sl-button>
           </div>
 
@@ -949,9 +941,13 @@ export class NotificationPreferencesView extends AuthedElement {
                               </div>
                             </div>
                           </div>
+                          <!-- Outline: removing one device is not the loudest
+                               thing on a settings page (DESIGN.md
+                               "Destructive actions"). -->
                           <sl-button
                             size="small"
                             variant="danger"
+                            outline
                             @click=${() =>
                               this.handleUnregisterDevice(device.token)}
                           >
@@ -981,31 +977,34 @@ export class NotificationPreferencesView extends AuthedElement {
         ${this.renderTestSendSection()}
 
         <div class="app-store-links">
-          <a
+          <div class="hint">
+            Get the mobile app to approve requests on the go.
+          </div>
+          <sl-button
+            class="app-store-button"
+            variant="default"
             href="https://apps.apple.com/app/preloop/id6757803021"
             target="_blank"
             rel="noopener noreferrer"
-            class="app-store-button"
-            title="Download on the App Store"
           >
-            <sl-icon name="apple"></sl-icon>
-            <span>App Store</span>
-          </a>
-          <a
+            <sl-icon slot="prefix" name="apple"></sl-icon>
+            App Store
+          </sl-button>
+          <sl-button
+            class="app-store-button"
+            variant="default"
             href="https://play.google.com/store/apps/details?id=ai.spacecode.preloop&pli=1"
             target="_blank"
             rel="noopener noreferrer"
-            class="app-store-button"
-            title="Get it on Google Play"
           >
-            <sl-icon name="google-play"></sl-icon>
-            <span>Google Play</span>
-          </a>
+            <sl-icon slot="prefix" name="google-play"></sl-icon>
+            Google Play
+          </sl-button>
         </div>
       </div>
 
       <sl-dialog
-        label="Register Mobile Device"
+        label="Register device"
         ?open=${this.showQRDialog}
         @sl-request-close=${this.handleCloseQRDialog}
         style="--width: 600px;"

--- a/frontend/src/views/authed/notification-preferences-view.ts
+++ b/frontend/src/views/authed/notification-preferences-view.ts
@@ -163,7 +163,12 @@ export class NotificationPreferencesView extends AuthedElement {
         align-items: center;
         gap: var(--sl-spacing-medium);
         padding: var(--sl-spacing-medium) 0;
-        border-bottom: 1px solid var(--sl-color-neutral-200);
+        border-bottom: 1px solid var(--console-hairline);
+      }
+
+      /* The card edge ends the list; a rule right above it is a second edge. */
+      .preference-row:last-of-type {
+        border-bottom: none;
       }
 
       .preference-label {
@@ -194,7 +199,7 @@ export class NotificationPreferencesView extends AuthedElement {
         align-items: center;
         gap: var(--sl-spacing-medium);
         padding: var(--sl-spacing-medium) 0;
-        border-bottom: 1px solid var(--sl-color-neutral-200);
+        border-bottom: 1px solid var(--console-hairline);
       }
 
       .devices-list .device-item:last-of-type {
@@ -981,7 +986,6 @@ export class NotificationPreferencesView extends AuthedElement {
             Get the mobile app to approve requests on the go.
           </div>
           <sl-button
-            class="app-store-button"
             variant="default"
             href="https://apps.apple.com/app/preloop/id6757803021"
             target="_blank"
@@ -991,7 +995,6 @@ export class NotificationPreferencesView extends AuthedElement {
             App Store
           </sl-button>
           <sl-button
-            class="app-store-button"
             variant="default"
             href="https://play.google.com/store/apps/details?id=ai.spacecode.preloop&pli=1"
             target="_blank"

--- a/frontend/src/views/authed/settings/account-view.ts
+++ b/frontend/src/views/authed/settings/account-view.ts
@@ -386,18 +386,21 @@ export class AccountView extends LitElement {
         color: var(--sl-color-danger-600);
       }
 
+      /* One hairline row, not five boxes inside a card: DESIGN.md depth
+         limit two. The rule between the numbers separates them; a border and
+         a fill around each one adds a third layer for no information. */
       .usage-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
         gap: 0.75rem;
         margin-top: 1rem;
+        padding-bottom: 0.875rem;
+        border-bottom: 1px solid var(--sl-color-neutral-200);
       }
 
-      .usage-metric {
-        padding: 0.875rem;
-        border-radius: 12px;
-        border: 1px solid var(--sl-color-neutral-200);
-        background: var(--sl-color-neutral-0);
+      .usage-metric + .usage-metric {
+        border-left: 1px solid var(--sl-color-neutral-200);
+        padding-left: 0.75rem;
       }
 
       .usage-label {

--- a/frontend/src/views/authed/settings/account-view.ts
+++ b/frontend/src/views/authed/settings/account-view.ts
@@ -395,12 +395,27 @@ export class AccountView extends LitElement {
         gap: 0.75rem;
         margin-top: 1rem;
         padding-bottom: 0.875rem;
-        border-bottom: 1px solid var(--sl-color-neutral-200);
+        border-bottom: 1px solid var(--console-hairline);
+        /* Clips the rule of whichever metric starts a row: see below. */
+        overflow: hidden;
       }
 
-      .usage-metric + .usage-metric {
-        border-left: 1px solid var(--sl-color-neutral-200);
-        padding-left: 0.75rem;
+      /* The separator is drawn in the gap to the metric's left rather than on
+         its own border, because a border follows DOM order and this grid
+         wraps: once it does, the first metric of the second row would carry a
+         rule with nothing beside it. Sitting in the gap, that rule falls
+         outside the grid's box and is clipped away. */
+      .usage-metric {
+        position: relative;
+      }
+
+      .usage-metric::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: -0.375rem;
+        border-left: 1px solid var(--console-hairline);
       }
 
       .usage-label {

--- a/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
@@ -16,8 +16,29 @@ describe('AIModelDetailView', () => {
   let overrideWrites: { url: string; method: string; body: any }[];
   let repriceCalls: any[];
   let repriceResponse: any;
+  let modelPayload: any;
 
   beforeEach(() => {
+    modelPayload = {
+      id: 'model-1',
+      name: 'Claude Sonnet Primary',
+      provider_name: 'Anthropic',
+      model_identifier: 'claude-sonnet-4',
+      has_api_key: true,
+      meta_data: {
+        gateway: {
+          enabled: true,
+          url: 'https://gateway.example/openai/v1',
+          model_alias: 'preloop/anthropic/claude-sonnet-4',
+        },
+        managed_agent_id: 'agent-1',
+        managed_agent_display_name: 'Mini Claw',
+        managed_agent_runtime_principal_id: 'mini-claw-123',
+      },
+      is_default: true,
+      created_at: '2026-03-01T10:00:00Z',
+      updated_at: '2026-03-09T18:30:00Z',
+    };
     featureFlags = {};
     overrideWrites = [];
     repriceCalls = [];
@@ -114,32 +135,10 @@ describe('AIModelDetailView', () => {
           !url.includes('/runtime-sessions') &&
           !url.includes('/interactions')
         ) {
-          return new Response(
-            JSON.stringify({
-              id: 'model-1',
-              name: 'Claude Sonnet Primary',
-              provider_name: 'Anthropic',
-              model_identifier: 'claude-sonnet-4',
-              has_api_key: true,
-              meta_data: {
-                gateway: {
-                  enabled: true,
-                  url: 'https://gateway.example/openai/v1',
-                  model_alias: 'preloop/anthropic/claude-sonnet-4',
-                },
-                managed_agent_id: 'agent-1',
-                managed_agent_display_name: 'Mini Claw',
-                managed_agent_runtime_principal_id: 'mini-claw-123',
-              },
-              is_default: true,
-              created_at: '2026-03-01T10:00:00Z',
-              updated_at: '2026-03-09T18:30:00Z',
-            }),
-            {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' },
-            }
-          );
+          return new Response(JSON.stringify(modelPayload), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
         }
 
         if (url.startsWith('/api/v1/ai-models/model-1/summary')) {
@@ -420,7 +419,9 @@ describe('AIModelDetailView', () => {
 
     const content = element.shadowRoot?.textContent || '';
     expect(content).to.contain('Claude Sonnet Primary');
-    expect(content).to.contain('Model Observability');
+    // The card is named for what it holds, not for a product feature.
+    expect(content).to.contain('Details');
+    expect(content).to.not.contain('Model Observability');
     expect(content).to.contain('Anthropic');
     expect(content).to.contain('claude-sonnet-4');
     expect(content).to.contain('preloop/anthropic/claude-sonnet-4');
@@ -613,8 +614,65 @@ describe('AIModelDetailView', () => {
     const dialog = element.shadowRoot?.querySelector('sl-dialog');
     expect(dialog).to.exist;
     expect(dialog?.getAttribute('label') || (dialog as any).label).to.contain(
-      'Delete Model'
+      'Delete model'
     );
+  });
+
+  it('sets the header Delete apart as an outline action', async () => {
+    const element = (await fixture(
+      html`<ai-model-detail-view .modelId=${'model-1'}></ai-model-detail-view>`
+    )) as AIModelDetailView;
+    await waitUntil(
+      () => !(element as any).loading,
+      'AI model detail view did not finish loading',
+      { timeout: 5000 }
+    );
+    await element.updateComplete;
+
+    const actions = element.shadowRoot?.querySelector('resource-actions');
+    const deleteAction = (
+      actions as unknown as {
+        actions: {
+          id: string;
+          variant?: string;
+          outline?: boolean;
+          separated?: boolean;
+        }[];
+      }
+    ).actions.find((action) => action.id === 'delete');
+    expect(deleteAction?.variant).to.equal('danger');
+    expect(deleteAction?.outline).to.equal(true);
+    expect(deleteAction?.separated).to.equal(true);
+  });
+
+  it('shows Never for a model that was never updated and a hairline usage strip', async () => {
+    modelPayload = {
+      ...modelPayload,
+      updated_at: null,
+    };
+
+    const element = (await fixture(
+      html`<ai-model-detail-view .modelId=${'model-1'}></ai-model-detail-view>`
+    )) as AIModelDetailView;
+    await waitUntil(
+      () => !(element as any).loading,
+      'AI model detail view did not finish loading',
+      { timeout: 5000 }
+    );
+    await element.updateComplete;
+
+    const content = (element.shadowRoot?.textContent || '').replace(
+      /\s+/g,
+      ' '
+    );
+    expect(content).to.contain('Updated: Never');
+
+    // The summary is a hairline row inside the card, not boxes inside a box.
+    expect(element.shadowRoot?.querySelector('.summary-strip')).to.exist;
+    expect(element.shadowRoot?.querySelector('.stat-card')).to.equal(null);
+    // The period is stated once, in the card header.
+    expect(content).to.contain('Usage summary');
+    expect(content).to.contain('30 days ·');
   });
   const mountModel = async (): Promise<AIModelDetailView> => {
     const element = (await fixture(

--- a/frontend/src/views/authed/settings/ai-model-detail-view.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.ts
@@ -357,17 +357,20 @@ export class AIModelDetailView extends LitElement {
         padding: var(--sl-spacing-medium);
       }
 
-      .summary-grid {
+      /* One hairline row of facts on the card surface. Nothing inside a card
+         gets a filled box of its own (DESIGN.md "Depth limit: two"); what
+         separates the facts is a hairline. */
+      .summary-strip {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
         gap: var(--sl-spacing-medium);
+        border-bottom: 1px solid var(--console-hairline);
+        padding-bottom: var(--sl-spacing-medium);
       }
 
-      .stat-card {
-        border: 1px solid var(--sl-color-neutral-200);
-        border-radius: var(--sl-border-radius-medium);
-        padding: var(--sl-spacing-medium);
-        background: var(--sl-color-neutral-0);
+      .stat-item + .stat-item {
+        border-left: 1px solid var(--console-hairline);
+        padding-left: var(--sl-spacing-medium);
       }
 
       .stat-label {
@@ -1278,14 +1281,35 @@ export class AIModelDetailView extends LitElement {
     }
   }
 
-  private renderStatCard(label: string, value: string, detail: string) {
+  private renderStat(label: string, value: string, detail: string) {
     return html`
-      <div class="stat-card">
+      <div class="stat-item">
         <div class="stat-label">${label}</div>
         <div class="stat-value">${value}</div>
         <div class="stat-detail">${detail}</div>
       </div>
     `;
+  }
+
+  /**
+   * The window the usage numbers cover, for the card header. "Sep 5, 2026,
+   * 11:59 PM" was rendered as a fourth big number labelled "Tracked Period";
+   * a period is context for the other three, not a stat of its own.
+   */
+  private get trackedPeriodLabel(): string | null {
+    if (!this.summary) {
+      return null;
+    }
+    const start = new Date(this.summary.period_start);
+    const end = new Date(this.summary.period_end);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      return null;
+    }
+    const days = Math.max(
+      1,
+      Math.round((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000))
+    );
+    return `${days} days · ${this.formatDate(this.summary.period_start)} to ${this.formatDate(this.summary.period_end)}`;
   }
 
   private renderDailyUsage(days: GatewayUsageByDay[]) {
@@ -1477,26 +1501,24 @@ export class AIModelDetailView extends LitElement {
 
     return html`
       <div class="stack">
-        <div class="summary-grid">
-          ${this.renderStatCard(
+        <!-- A hairline strip, not four filled boxes inside a card
+             (DESIGN.md "Depth limit: two"). The tracked period moved into the
+             card header: a date-time is not a stat. -->
+        <div class="summary-strip">
+          ${this.renderStat(
             'Requests',
             this.formatNumber(this.summary.total_requests),
             `${this.formatNumber(this.summary.successful_requests)} succeeded, ${this.formatNumber(this.summary.failed_requests)} failed`
           )}
-          ${this.renderStatCard(
-            'Estimated Cost',
+          ${this.renderStat(
+            '$ est.',
             this.formatCost(this.summary.estimated_cost),
             `${this.formatPercent(this.summary.successful_requests, this.summary.total_requests)} success rate`
           )}
-          ${this.renderStatCard(
-            'Total Tokens',
+          ${this.renderStat(
+            'Tokens',
             this.formatNumber(this.summary.token_usage.total_tokens),
             `${this.formatNumber(this.summary.token_usage.prompt_tokens)} prompt, ${this.formatNumber(this.summary.token_usage.completion_tokens)} completion`
-          )}
-          ${this.renderStatCard(
-            'Tracked Period',
-            this.formatDateTime(this.summary.period_end),
-            `${this.formatDateTime(this.summary.period_start)} to ${this.formatDateTime(this.summary.period_end)}`
           )}
         </div>
         <div>
@@ -1874,7 +1896,7 @@ export class AIModelDetailView extends LitElement {
             style="margin-left: -12px;"
           >
             <sl-icon slot="prefix" name="arrow-left"></sl-icon>
-            Back to AI Models
+            Back to models
           </sl-button>
         </div>
         <div slot="main-column" class="header-actions">
@@ -1887,11 +1909,16 @@ export class AIModelDetailView extends LitElement {
                 icon: 'pencil',
                 onClick: this.openEditModal,
               },
+              // Danger outline, last, after a gap: DESIGN.md "Destructive
+              // actions". Solid red next to Edit invited the click it should
+              // be hardest to make by accident.
               {
                 id: 'delete',
                 label: 'Delete',
                 icon: 'trash',
                 variant: 'danger',
+                outline: true,
+                separated: true,
                 onClick: this.openDeleteConfirm,
               },
             ]}
@@ -1903,12 +1930,15 @@ export class AIModelDetailView extends LitElement {
           <div class="page">
             <sl-card>
               <div slot="header" class="model-heading">
-                <div class="model-title">Model Observability</div>
+                <!-- This card holds a name, an identifier, an alias,
+                     credentials and a managed agent. That is "Details";
+                     "Observability" promised telemetry it never carried. -->
+                <div class="model-title">Details</div>
                 <div class="badge-row">
                   ${
                     this.model?.provider_name
                       ? html`
-                          <sl-badge variant="neutral">
+                          <sl-badge class="tag-chip" variant="neutral">
                             ${this.model.provider_name}
                           </sl-badge>
                         `
@@ -1916,13 +1946,15 @@ export class AIModelDetailView extends LitElement {
                   }
                   ${
                     this.model?.is_default
-                      ? html`<sl-badge variant="success">Default</sl-badge>`
+                      ? html`<sl-badge class="chip" variant="success" pill
+                          >Default</sl-badge
+                        >`
                       : ''
                   }
                   ${
                     this.model?.model_kind
                       ? html`
-                          <sl-badge variant="neutral">
+                          <sl-badge class="tag-chip" variant="neutral">
                             ${
                               this.model.model_kind === 'stt'
                                 ? 'Speech to text'
@@ -1948,7 +1980,13 @@ export class AIModelDetailView extends LitElement {
                           </span>
                           <span>
                             <strong>Updated:</strong>
-                            ${this.formatDateTime(this.model.updated_at)}
+                            ${
+                              // "Unknown" on a model that was never edited
+                              // reads as a lookup that failed.
+                              this.model.updated_at
+                                ? this.formatDateTime(this.model.updated_at)
+                                : 'Never'
+                            }
                           </span>
                         </div>
                         <div class="model-metadata">
@@ -2109,7 +2147,16 @@ export class AIModelDetailView extends LitElement {
                   `
                 : html`
                     <sl-card>
-                      <div slot="header" class="model-title">Usage Summary</div>
+                      <div slot="header" class="model-heading">
+                        <div class="model-title">Usage summary</div>
+                        ${
+                          this.trackedPeriodLabel
+                            ? html`<div class="meta-line">
+                                ${this.trackedPeriodLabel}
+                              </div>`
+                            : ''
+                        }
+                      </div>
                       ${this.renderSummarySection()}
                     </sl-card>
 
@@ -2145,7 +2192,7 @@ export class AIModelDetailView extends LitElement {
         @close-modal=${this.closeEditModal}
       ></add-ai-model-modal>
       <sl-dialog
-        label="Delete Model"
+        label="Delete model"
         .open=${this.isDeleteConfirmOpen}
         @sl-hide=${() => (this.isDeleteConfirmOpen = false)}
       >

--- a/frontend/src/views/authed/settings/ai-model-detail-view.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.ts
@@ -366,11 +366,26 @@ export class AIModelDetailView extends LitElement {
         gap: var(--sl-spacing-medium);
         border-bottom: 1px solid var(--console-hairline);
         padding-bottom: var(--sl-spacing-medium);
+        /* Clips the rule of whichever stat starts a row: see below. */
+        overflow: hidden;
       }
 
-      .stat-item + .stat-item {
+      /* The separator lives in the gap to the stat's left, not on its border:
+         a border follows DOM order, and once this grid wraps the first stat of
+         the second row would keep a rule with nothing beside it. A rule in the
+         gap falls outside the grid's box for a row's first stat and is
+         clipped. */
+      .stat-item {
+        position: relative;
+      }
+
+      .stat-item::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: calc(-1 * var(--sl-spacing-medium) / 2);
         border-left: 1px solid var(--console-hairline);
-        padding-left: var(--sl-spacing-medium);
       }
 
       .stat-label {

--- a/frontend/src/views/authed/settings/ai-models-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.test.ts
@@ -370,6 +370,42 @@ describe('AIModelsView', () => {
     expect(del.separated).to.equal(true);
   });
 
+  it('does not add a prior-window request to every realtime refresh', async () => {
+    const element = (await fixture(
+      html`<ai-models-view></ai-models-view>`
+    )) as AIModelsView;
+    await waitUntil(
+      () => !(element as any).isLoading,
+      'AI models view did not finish loading'
+    );
+    await element.updateComplete;
+    await waitUntil(
+      () => (element as any).priorFleetSpend !== null,
+      'prior window spend never loaded'
+    );
+
+    const overviewCalls = () =>
+      fetchStub
+        .getCalls()
+        .filter((call) =>
+          String(call.args[0]).startsWith('/api/v1/ai-models/overview')
+        ).length;
+    // Mount asks for this window and the one before it, once each.
+    expect(overviewCalls()).to.equal(2);
+
+    // A websocket refresh is one request, not two: the prior 30 day window
+    // moves once a day, and a burst of extra calls is what emptied the API
+    // connection pool on 2026-09-03.
+    await element.fetchModels({ preserveLoadingState: true });
+    expect(overviewCalls()).to.equal(3);
+
+    // Even a full reload reuses the loaded prior window while it is current.
+    await element.fetchModels();
+    await waitUntil(() => overviewCalls() >= 4, 'reload did not fetch');
+    expect(overviewCalls()).to.equal(4);
+    expect((element as any).priorFleetSpend).to.be.a('number');
+  });
+
   it('renders counts compact and sub-cent spend to four decimals', async () => {
     const element = (await fixture(
       html`<ai-models-view></ai-models-view>`

--- a/frontend/src/views/authed/settings/ai-models-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.test.ts
@@ -351,7 +351,9 @@ describe('AIModelsView', () => {
     // dash rather than fourteen invitations to change the default.
     const actions = (
       element as unknown as {
-        modelActions: (model: AIModel) => { id: string; outline?: boolean }[];
+        modelActions: (
+          model: AIModel
+        ) => { id: string; variant?: string; outline?: boolean }[];
       }
     ).modelActions({ id: 'model-1', is_default: false } as AIModel);
     expect(actions.map((action) => action.id)).to.deep.equal([
@@ -360,14 +362,29 @@ describe('AIModelsView', () => {
       'set-default',
       'delete',
     ]);
-    const del = actions[actions.length - 1] as {
-      variant?: string;
-      outline?: boolean;
-      separated?: boolean;
+    expect(actions[actions.length - 1].variant).to.equal('danger');
+
+    // What the row actually renders is the menu: in menu-only mode
+    // resource-actions sends every action into the dropdown and ignores the
+    // outline and separated flags, so the assertion that can fail is the
+    // order, with Delete last and its icon in danger red.
+    const kebab = kebabs?.[0] as HTMLElement & {
+      updateComplete?: Promise<unknown>;
     };
-    expect(del.variant).to.equal('danger');
-    expect(del.outline).to.equal(true);
-    expect(del.separated).to.equal(true);
+    await kebab.updateComplete;
+    const items = kebab.shadowRoot?.querySelectorAll('sl-menu-item') ?? [];
+    // The fixture model is already the default, so its menu holds three
+    // actions; Delete is last in either case.
+    expect([...items].map((item) => item.textContent?.trim())).to.deep.equal([
+      'View',
+      'Edit',
+      'Delete',
+    ]);
+    const last = items[items.length - 1];
+    expect(last.className).to.contain('danger-item');
+    expect(last.querySelector('sl-icon')?.getAttribute('style')).to.contain(
+      '--sl-color-danger-600'
+    );
   });
 
   it('does not add a prior-window request to every realtime refresh', async () => {

--- a/frontend/src/views/authed/settings/ai-models-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.test.ts
@@ -126,8 +126,11 @@ describe('AIModelsView', () => {
       ' '
     );
     expect(content).to.contain('Claude Sonnet Primary');
-    expect(content).to.contain('View');
-    expect(content).to.contain('Fleet spend');
+    // Honest stat labels: the window is in the label, not in a subtext that
+    // claims a configuration count is a 30-day metric.
+    expect(content).to.contain('$ est. · 30d');
+    expect(content).to.contain('Requests · 30d');
+    expect(content).to.contain('Need attention');
     expect(content).to.contain('$12.34');
     expect(content).to.contain('42 requests');
     expect(content).to.contain('3 active sessions');
@@ -146,12 +149,7 @@ describe('AIModelsView', () => {
     const nameLink = element.shadowRoot?.querySelector(
       'a.model-link[href="/console/ai-models/model-1"]'
     );
-    const viewButton = element.shadowRoot?.querySelector(
-      'sl-button[href="/console/ai-models/model-1"]'
-    );
-
     expect(nameLink).to.not.equal(null);
-    expect(viewButton).to.not.equal(null);
     expect(connectStub).to.have.been.calledOnce;
     expect(subscribeStub.callCount).to.equal(5);
 
@@ -318,6 +316,80 @@ describe('AIModelsView', () => {
     expect(element.shadowRoot?.querySelector('.model-card')).to.exist;
     expect(element.shadowRoot?.querySelector('.model-row')).to.equal(null);
     expect(element.shadowRoot?.textContent).to.contain('Default');
-    expect(element.shadowRoot?.textContent).to.contain('View');
+    // Cards carry the same one kebab as the rows, not a row of buttons.
+    expect(
+      element.shadowRoot?.querySelectorAll('.model-card resource-actions')
+    ).to.have.lengthOf(1);
+  });
+
+  it('gives each row one kebab holding View, Edit, Set default and Delete', async () => {
+    const element = (await fixture(
+      html`<ai-models-view></ai-models-view>`
+    )) as AIModelsView;
+    await waitUntil(
+      () => !(element as any).isLoading,
+      'AI models view did not finish loading'
+    );
+    await element.updateComplete;
+
+    const rows = element.shadowRoot?.querySelectorAll('.model-row') ?? [];
+    expect(rows).to.have.lengthOf(1);
+    const kebabs = element.shadowRoot?.querySelectorAll(
+      '.model-row resource-actions[menu-only]'
+    );
+    expect(kebabs).to.have.lengthOf(1);
+    // No solid danger button and no "Set as default" button in the row: the
+    // rare action and the destructive one both live in the kebab.
+    expect(
+      element.shadowRoot?.querySelector(
+        '.model-row sl-button[variant="danger"]'
+      )
+    ).to.equal(null);
+    expect(element.shadowRoot?.textContent).to.not.contain('Set as default');
+
+    // The default model is a chip, not a button; the rest of the column is a
+    // dash rather than fourteen invitations to change the default.
+    const actions = (
+      element as unknown as {
+        modelActions: (model: AIModel) => { id: string; outline?: boolean }[];
+      }
+    ).modelActions({ id: 'model-1', is_default: false } as AIModel);
+    expect(actions.map((action) => action.id)).to.deep.equal([
+      'view',
+      'edit',
+      'set-default',
+      'delete',
+    ]);
+    const del = actions[actions.length - 1] as {
+      variant?: string;
+      outline?: boolean;
+      separated?: boolean;
+    };
+    expect(del.variant).to.equal('danger');
+    expect(del.outline).to.equal(true);
+    expect(del.separated).to.equal(true);
+  });
+
+  it('renders counts compact and sub-cent spend to four decimals', async () => {
+    const element = (await fixture(
+      html`<ai-models-view></ai-models-view>`
+    )) as AIModelsView;
+    await waitUntil(
+      () => !(element as any).isLoading,
+      'AI models view did not finish loading'
+    );
+    await element.updateComplete;
+
+    const format = element as unknown as {
+      formatCompactNumber: (value: number) => string;
+      formatCurrency: (value: number) => string;
+    };
+    expect(format.formatCompactNumber(999)).to.equal('999');
+    expect(format.formatCompactNumber(18306)).to.equal('18.3K');
+    expect(format.formatCompactNumber(572180203)).to.equal('572.2M');
+    // A sub-cent estimate is four decimals, never a $0.00 that reads as free.
+    expect(format.formatCurrency(0.0042)).to.equal('$0.0042');
+    expect(format.formatCurrency(12.3)).to.equal('$12.30');
+    expect(format.formatCurrency(0)).to.equal('$0.00');
   });
 });

--- a/frontend/src/views/authed/settings/ai-models-view.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.ts
@@ -21,6 +21,8 @@ import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '../../../components/add-ai-model-modal';
 import '../../../components/list-toolbar';
+import '../../../components/resource-actions';
+import type { ResourceAction } from '../../../components/resource-actions';
 import { unifiedWebSocketManager } from '../../../services/unified-websocket-manager';
 import { formatRelativeTime } from '../../../utils/date';
 import {
@@ -102,6 +104,14 @@ export class AIModelsView extends LitElement {
 
   @state()
   private modelOverview = new Map<string, AIModelOverviewItem>();
+
+  /**
+   * Fleet spend in the window before this one. Loaded after first paint so a
+   * slower second call never holds up the numbers the page is for, and null
+   * while it is missing so the delta line simply does not render.
+   */
+  @state()
+  private priorFleetSpend: number | null = null;
 
   @state()
   private search = '';
@@ -269,6 +279,29 @@ export class AIModelsView extends LitElement {
         margin-top: var(--sl-spacing-2x-small);
         overflow-wrap: anywhere;
       }
+      /* The second line of the name cell: what the gateway answers to, in
+         mono so it reads as an identifier and not as prose. */
+      .model-identifier {
+        color: var(--console-meta-color);
+        font-family: var(--sl-font-mono);
+        font-size: var(--sl-font-size-small);
+        overflow-wrap: anywhere;
+      }
+      /* The kebab column is measured from the button it holds: one medium
+         sl-button is 48px at the default tokens, so 72px leaves room for the
+         padding without clipping (the same rule the agents table uses). */
+      .styled-table th.actions-cell,
+      .styled-table td.actions-cell {
+        width: 72px;
+        text-align: right;
+        padding-left: var(--sl-spacing-x-small);
+        padding-right: var(--sl-spacing-x-small);
+        overflow: visible;
+      }
+      .row-actions {
+        display: flex;
+        justify-content: flex-end;
+      }
       .badge-row {
         display: flex;
         flex-wrap: wrap;
@@ -403,6 +436,7 @@ export class AIModelsView extends LitElement {
       this.modelOverview = new Map(
         overview.models.map((item) => [item.ai_model_id, item])
       );
+      void this.loadPriorFleetSpend();
     } catch (error) {
       this.error =
         error instanceof Error ? error.message : 'Failed to fetch AI models';
@@ -413,20 +447,39 @@ export class AIModelsView extends LitElement {
     }
   }
 
-  private getOverviewParams() {
+  /**
+   * The fleet window, or the one before it when `periodsBack` is 1. The prior
+   * window is what the spend delta compares against.
+   */
+  private getOverviewParams(periodsBack = 0) {
+    const days = AIModelsView.FLEET_WINDOW_DAYS;
     const endDate = new Date();
+    endDate.setDate(endDate.getDate() - days * periodsBack);
     const startDate = new Date(endDate);
-    startDate.setDate(
-      startDate.getDate() - (AIModelsView.FLEET_WINDOW_DAYS - 1)
-    );
+    startDate.setDate(startDate.getDate() - (days - 1));
     return {
       startDate: startDate.toISOString(),
       endDate: endDate.toISOString(),
     };
   }
 
-  private get overviewWindowLabel(): string {
-    return `Last ${AIModelsView.FLEET_WINDOW_DAYS} days`;
+  private async loadPriorFleetSpend(): Promise<void> {
+    try {
+      const prior = await getAIModelsOverview(this.getOverviewParams(1));
+      this.priorFleetSpend = prior.models.reduce(
+        (total, item) => total + item.estimated_cost,
+        0
+      );
+    } catch {
+      // A missing comparison is not an error worth a banner: the delta line
+      // just does not render.
+      this.priorFleetSpend = null;
+    }
+  }
+
+  /** "30d", the suffix the Overview and Cost put after a windowed label. */
+  private get windowSuffix(): string {
+    return `${AIModelsView.FLEET_WINDOW_DAYS}d`;
   }
 
   private get fleetRequestCount(): number {
@@ -456,18 +509,67 @@ export class AIModelsView extends LitElement {
     ).length;
   }
 
+  /**
+   * A model needs a person when its calls fail or when the calls it did serve
+   * carry no price, which is the pair the stat card now names out loud
+   * instead of hiding a second fact under "models with traffic".
+   */
   private get modelsNeedingAttentionCount(): number {
     return [...this.modelOverview.values()].filter(
-      (item) => item.failed_requests > 0
+      (item) => item.failed_requests > 0 || item.unpriced_request_count > 0
     ).length;
   }
 
+  /**
+   * Money the way the rest of the console prints it: two decimals, except
+   * amounts under a cent, which keep four rather than collapsing into a
+   * `$0.00` that reads as "free" (DESIGN.md Numbers, the rule Cost and API
+   * usage already follow).
+   */
   private formatCurrency(value: number | null | undefined): string {
-    return `$${(value || 0).toFixed(2)}`;
+    const amount = Number(value || 0);
+    if (amount > 0 && amount < 0.01) {
+      return `$${amount.toFixed(4)}`;
+    }
+    return `$${amount.toFixed(2)}`;
   }
 
   private formatNumber(value: number | null | undefined): string {
     return Intl.NumberFormat().format(value || 0);
+  }
+
+  /**
+   * Counts under 1000 render whole, at or above they render compact, so this
+   * page says 18.3K where the Overview says 18.3K instead of 18,306.
+   */
+  private formatCompactNumber(value: number | null | undefined): string {
+    const amount = Number(value || 0);
+    if (amount < 1000) {
+      return String(Math.round(amount));
+    }
+    return new Intl.NumberFormat(undefined, {
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(amount);
+  }
+
+  /**
+   * Percent change against the window before this one, in the arrow form the
+   * Overview uses. Null when there is no prior period worth comparing to:
+   * "up 100% from nothing" is noise, not news.
+   */
+  private get fleetSpendDelta(): string | null {
+    const prior = this.priorFleetSpend;
+    if (prior === null || prior <= 0) {
+      return null;
+    }
+    const change = ((this.fleetSpend - prior) / prior) * 100;
+    const rounded = Math.round(change);
+    if (rounded === 0) {
+      return `No change vs prior ${AIModelsView.FLEET_WINDOW_DAYS}d`;
+    }
+    const arrow = rounded > 0 ? '▲' : '▼';
+    return `${arrow} ${Math.abs(rounded)}% vs prior ${AIModelsView.FLEET_WINDOW_DAYS}d`;
   }
 
   private getModelOverview(modelId: string) {
@@ -591,41 +693,52 @@ export class AIModelsView extends LitElement {
     this.statusFilter = value || '';
   }
 
+  /**
+   * Four cards, each with one fact and a label that says which window it is
+   * about. "Configured models / Last 30 days" claimed a configuration count
+   * was a 30-day metric, and "Models with traffic 6 / 5 need attention" put
+   * two different facts in one card.
+   */
   private renderFleetOverview() {
+    const delta = this.fleetSpendDelta;
     return html`
       <div class="summary-grid">
         <sl-card class="summary-card">
           <div class="metric-label">Configured models</div>
           <div class="metric-value">
-            ${this.formatNumber(this.models.length)}
-          </div>
-          <div class="metric-subtext">${this.overviewWindowLabel}</div>
-        </sl-card>
-        <sl-card class="summary-card">
-          <div class="metric-label">Models with traffic</div>
-          <div class="metric-value">
-            ${this.formatNumber(this.activeModelsCount)}
+            ${this.formatCompactNumber(this.models.length)}
           </div>
           <div class="metric-subtext">
-            ${this.formatNumber(this.modelsNeedingAttentionCount)} need
-            attention
+            ${this.formatCompactNumber(this.activeModelsCount)} with traffic in
+            ${this.windowSuffix}
           </div>
         </sl-card>
         <sl-card class="summary-card">
-          <div class="metric-label">Fleet requests</div>
+          <div class="metric-label">Need attention</div>
           <div class="metric-value">
-            ${this.formatNumber(this.fleetRequestCount)}
+            ${this.formatCompactNumber(this.modelsNeedingAttentionCount)}
+          </div>
+          <div class="metric-subtext">unpriced or failing</div>
+        </sl-card>
+        <sl-card class="summary-card">
+          <div class="metric-label">Requests · ${this.windowSuffix}</div>
+          <div
+            class="metric-value"
+            title=${this.formatNumber(this.fleetRequestCount)}
+          >
+            ${this.formatCompactNumber(this.fleetRequestCount)}
           </div>
           <div class="metric-subtext">
-            ${this.formatNumber(this.activeFleetSessions)} active sessions
+            ${this.formatCompactNumber(this.activeFleetSessions)} active
+            sessions
           </div>
         </sl-card>
         <sl-card class="summary-card">
-          <div class="metric-label">Fleet spend</div>
+          <div class="metric-label">$ est. · ${this.windowSuffix}</div>
           <div class="metric-value">
             ${this.formatCurrency(this.fleetSpend)}
           </div>
-          <div class="metric-subtext">${this.overviewWindowLabel}</div>
+          <div class="metric-subtext">${delta ?? `estimated, not billed`}</div>
         </sl-card>
       </div>
     `;
@@ -654,7 +767,7 @@ export class AIModelsView extends LitElement {
 
     return html`
       <view-header
-        headerText="AI Models"
+        headerText="Models"
         description="The AI models your agents reach through the gateway. Each model gets a gateway alias; every call through it is metered and attributed to an agent and session."
         width="narrow"
       >
@@ -663,7 +776,7 @@ export class AIModelsView extends LitElement {
             ? html`
                 <div slot="main-column">
                   <sl-button variant="primary" @click=${this.openAddModelModal}>
-                    <sl-icon slot="prefix" name="plus-lg"></sl-icon> Add Model
+                    <sl-icon slot="prefix" name="plus-lg"></sl-icon> Add model
                   </sl-button>
                 </div>
               `
@@ -761,7 +874,7 @@ export class AIModelsView extends LitElement {
                   @click=${this.openAddModelModal}
                 >
                   <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                  Add Model
+                  Add model
                 </sl-button>
               </div>
             </sl-card>
@@ -784,39 +897,67 @@ export class AIModelsView extends LitElement {
       : this.renderListView(models);
   }
 
+  /**
+   * The Default column states a fact, it does not carry a rare action:
+   * fourteen "Set as default" buttons in a column were fourteen invitations
+   * to a thing an operator does once. Setting the default lives in the kebab.
+   */
   private renderDefaultControl(model: AIModel) {
     return when(
       model.is_default,
-      () => html`<sl-badge variant="success" pill>Default</sl-badge>`,
-      () => html`
-        <sl-button size="small" @click=${() => this.handleSetDefault(model)}>
-          Set as default
-        </sl-button>
-      `
+      () =>
+        html`<sl-badge class="chip" variant="success" pill>Default</sl-badge>`,
+      () => html`<span class="cell-secondary">&mdash;</span>`
     );
+  }
+
+  private modelActions(model: AIModel): ResourceAction[] {
+    const actions: ResourceAction[] = [
+      {
+        id: 'view',
+        label: 'View',
+        icon: 'eye',
+        href: `/console/ai-models/${model.id}`,
+      },
+      {
+        id: 'edit',
+        label: 'Edit',
+        icon: 'pencil',
+        onClick: () => this.openEditModal(model),
+      },
+    ];
+    if (!model.is_default) {
+      actions.push({
+        id: 'set-default',
+        label: 'Set default',
+        icon: 'star',
+        onClick: () => void this.handleSetDefault(model),
+      });
+    }
+    // Danger outline, last, after a gap (DESIGN.md "Destructive actions"): a
+    // column of solid red circles read as a column of alarms.
+    actions.push({
+      id: 'delete',
+      label: 'Delete',
+      icon: 'trash',
+      variant: 'danger',
+      outline: true,
+      separated: true,
+      onClick: () => this.openDeleteConfirm(model),
+    });
+    return actions;
   }
 
   private renderModelActions(model: AIModel) {
     return html`
-      <div class="actions">
-        <sl-button size="small" href=${`/console/ai-models/${model.id}`}>
-          View
-        </sl-button>
-        <sl-button
-          size="small"
-          circle
-          @click=${() => this.openEditModal(model)}
-        >
-          <sl-icon name="pencil"></sl-icon>
-        </sl-button>
-        <sl-button
-          variant="danger"
-          size="small"
-          circle
-          @click=${() => this.openDeleteConfirm(model)}
-        >
-          <sl-icon name="trash"></sl-icon>
-        </sl-button>
+      <div
+        class="row-actions"
+        @click=${(event: Event) => event.stopPropagation()}
+      >
+        <resource-actions
+          .actions=${this.modelActions(model)}
+          menu-only
+        ></resource-actions>
       </div>
     `;
   }
@@ -832,7 +973,7 @@ export class AIModelsView extends LitElement {
               <th>Fleet health</th>
               <th>Usage</th>
               <th>Default</th>
-              <th>Actions</th>
+              <th class="actions-cell">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -847,102 +988,109 @@ export class AIModelsView extends LitElement {
     `;
   }
 
+  /**
+   * The name cell is two lines: the title, then the identifier the gateway
+   * answers to. The row used to print four lines here (title, identifier,
+   * "Gateway alias: ...", "Managed agent: ...") where the alias contains the
+   * identifier and the title usually contains both, which cost 160px a row.
+   * The managed agent moved next to the provider, which is the other fact
+   * about where the calls go.
+   */
+  private renderNameCell(model: AIModel) {
+    const alias = this.getGatewayAlias(model);
+    return html`
+      <div class="cell-stack">
+        <a class="model-link" href=${`/console/ai-models/${model.id}`}>
+          ${model.name}
+        </a>
+        <div class="model-identifier" title=${alias || model.model_identifier}>
+          ${alias || model.model_identifier}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderProviderCell(model: AIModel) {
+    const managedAgent = this.getManagedAgentDisplayName(model);
+    const secondary = [this.getPricingSourceLabel(model.id), managedAgent]
+      .filter(Boolean)
+      .join(' · ');
+    return html`
+      <div class="cell-stack">
+        <div class="cell-primary">${model.provider_name}</div>
+        <div class="cell-secondary">${secondary}</div>
+      </div>
+    `;
+  }
+
+  private renderHealthCell(model: AIModel) {
+    const overview = this.getModelOverview(model.id);
+    return html`
+      <div class="cell-stack">
+        <div class="badge-row">
+          <sl-badge
+            class="status-chip"
+            variant=${this.getHealthVariant(model.id)}
+            pill
+          >
+            ${this.getHealthLabel(model.id)}
+          </sl-badge>
+          ${
+            overview?.active_session_count
+              ? html`
+                  <sl-badge class="chip" variant="neutral" pill>
+                    ${this.formatCompactNumber(overview.active_session_count)}
+                    active sessions
+                  </sl-badge>
+                `
+              : null
+          }
+        </div>
+        <div class="cell-secondary">
+          ${this.formatCompactNumber(overview?.successful_requests)} successful
+          · ${this.formatCompactNumber(overview?.failed_requests)} failed
+        </div>
+      </div>
+    `;
+  }
+
+  private renderUsageCell(model: AIModel) {
+    const overview = this.getModelOverview(model.id);
+    return html`
+      <div class="cell-stack">
+        <div
+          class="cell-primary"
+          title=${this.formatNumber(overview?.total_requests)}
+        >
+          ${this.formatCompactNumber(overview?.total_requests)} requests
+        </div>
+        <div
+          class="cell-secondary"
+          title=${this.formatNumber(overview?.token_usage.total_tokens)}
+        >
+          ${this.formatCompactNumber(overview?.token_usage.total_tokens)} tokens
+          · ${this.formatCurrency(overview?.estimated_cost)} est.
+        </div>
+        ${
+          this.getLastRequestLabel(model.id)
+            ? html`<div class="cell-secondary">
+                ${this.getLastRequestLabel(model.id)}
+              </div>`
+            : null
+        }
+      </div>
+    `;
+  }
+
   private renderModelRow(model: AIModel) {
     return html`
       <tr class="model-row" data-model-id=${model.id}>
-        <td>
-          <a class="model-link" href=${`/console/ai-models/${model.id}`}>
-            ${model.name}
-          </a>
-          <div class="model-meta">${model.model_identifier}</div>
-          ${
-            this.getGatewayAlias(model)
-              ? html`
-                  <div class="model-meta">
-                    Gateway alias:
-                    <code>${this.getGatewayAlias(model)}</code>
-                  </div>
-                `
-              : null
-          }
-          ${
-            this.getManagedAgentDisplayName(model)
-              ? html`
-                  <div class="model-meta">
-                    Managed agent: ${this.getManagedAgentDisplayName(model)}
-                  </div>
-                `
-              : null
-          }
-        </td>
-        <td>
-          <div class="cell-stack">
-            <div class="cell-primary">${model.provider_name}</div>
-            <div class="cell-secondary">${this.getModelKindLabel(model)}</div>
-            <div class="cell-secondary">
-              ${this.getPricingSourceLabel(model.id)}
-            </div>
-          </div>
-        </td>
-        <td>
-          <div class="cell-stack">
-            <div class="badge-row">
-              <sl-badge variant=${this.getHealthVariant(model.id)} pill>
-                ${this.getHealthLabel(model.id)}
-              </sl-badge>
-              ${
-                this.getModelOverview(model.id)?.active_session_count
-                  ? html`
-                      <sl-badge variant="primary" pill>
-                        ${this.formatNumber(
-                          this.getModelOverview(model.id)?.active_session_count
-                        )}
-                        active sessions
-                      </sl-badge>
-                    `
-                  : null
-              }
-            </div>
-            <div class="cell-secondary">
-              ${this.formatNumber(
-                this.getModelOverview(model.id)?.successful_requests
-              )}
-              successful ·
-              ${this.formatNumber(
-                this.getModelOverview(model.id)?.failed_requests
-              )}
-              failed
-            </div>
-          </div>
-        </td>
-        <td>
-          <div class="cell-stack">
-            <div class="cell-primary">
-              ${this.formatNumber(
-                this.getModelOverview(model.id)?.total_requests
-              )}
-              requests
-            </div>
-            <div class="cell-secondary">
-              ${this.formatNumber(
-                this.getModelOverview(model.id)?.token_usage.total_tokens
-              )}
-              tokens ·
-              ${this.formatCurrency(
-                this.getModelOverview(model.id)?.estimated_cost
-              )}
-            </div>
-            ${
-              this.getLastRequestLabel(model.id)
-                ? html`<div class="cell-secondary">
-                    ${this.getLastRequestLabel(model.id)}
-                  </div>`
-                : null
-            }
-          </div>
-        </td>
+        <td>${this.renderNameCell(model)}</td>
+        <td>${this.renderProviderCell(model)}</td>
+        <td>${this.renderHealthCell(model)}</td>
+        <td>${this.renderUsageCell(model)}</td>
         <td>${this.renderDefaultControl(model)}</td>
-        <td>${this.renderModelActions(model)}</td>
+        <td class="actions-cell">${this.renderModelActions(model)}</td>
       </tr>
     `;
   }
@@ -969,27 +1117,41 @@ export class AIModelsView extends LitElement {
             </a>
             ${this.renderDefaultControl(model)}
           </div>
+          <div class="model-identifier">
+            ${this.getGatewayAlias(model) || model.model_identifier}
+          </div>
           <div class="cell-primary">${model.provider_name}</div>
-          <div class="cell-secondary">${this.getModelKindLabel(model)}</div>
           <div class="cell-secondary">
+            ${this.getModelKindLabel(model)} ·
             ${this.getPricingSourceLabel(model.id)}
           </div>
           <div class="badge-row">
-            <sl-badge variant=${this.getHealthVariant(model.id)} pill>
+            <sl-badge
+              class="status-chip"
+              variant=${this.getHealthVariant(model.id)}
+              pill
+            >
               ${this.getHealthLabel(model.id)}
             </sl-badge>
             ${
               isGatewayEnabled(model)
-                ? html`<sl-badge variant="neutral" pill>Enabled</sl-badge>`
-                : html`<sl-badge variant="neutral" pill>Disabled</sl-badge>`
+                ? html`<sl-badge class="chip" variant="neutral" pill
+                    >Enabled</sl-badge
+                  >`
+                : html`<sl-badge class="chip" variant="neutral" pill
+                    >Disabled</sl-badge
+                  >`
             }
           </div>
           <div class="cell-secondary">
-            ${this.formatNumber(this.getModelOverview(model.id)?.total_requests)}
+            ${this.formatCompactNumber(
+              this.getModelOverview(model.id)?.total_requests
+            )}
             requests ·
             ${this.formatCurrency(
               this.getModelOverview(model.id)?.estimated_cost
             )}
+            est.
           </div>
           <div class="model-card-actions">
             ${this.renderModelActions(model)}
@@ -1002,7 +1164,7 @@ export class AIModelsView extends LitElement {
   renderDeleteConfirm() {
     return html`
       <sl-dialog
-        label="Delete Model"
+        label="Delete model"
         .open=${this.isDeleteConfirmOpen}
         @sl-hide=${() => (this.isDeleteConfirmOpen = false)}
       >

--- a/frontend/src/views/authed/settings/ai-models-view.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.ts
@@ -113,6 +113,12 @@ export class AIModelsView extends LitElement {
   @state()
   private priorFleetSpend: number | null = null;
 
+  /**
+   * The prior window the loaded number belongs to, as a date key. The window
+   * moves once a day, so a realtime refresh has nothing new to ask for.
+   */
+  private priorFleetSpendWindow: string | null = null;
+
   @state()
   private search = '';
 
@@ -436,7 +442,12 @@ export class AIModelsView extends LitElement {
       this.modelOverview = new Map(
         overview.models.map((item) => [item.ai_model_id, item])
       );
-      void this.loadPriorFleetSpend();
+      // Not on realtime refreshes: five subscriptions feed this method, and
+      // the prior 30 day window changes at most once a day. A third request
+      // per socket message is how the pool emptied on 2026-09-03.
+      if (!options.preserveLoadingState) {
+        void this.loadPriorFleetSpend();
+      }
     } catch (error) {
       this.error =
         error instanceof Error ? error.message : 'Failed to fetch AI models';
@@ -464,15 +475,22 @@ export class AIModelsView extends LitElement {
   }
 
   private async loadPriorFleetSpend(): Promise<void> {
+    const params = this.getOverviewParams(1);
+    const window = params.startDate.slice(0, 10);
+    if (this.priorFleetSpendWindow === window) {
+      return;
+    }
     try {
-      const prior = await getAIModelsOverview(this.getOverviewParams(1));
+      const prior = await getAIModelsOverview(params);
+      this.priorFleetSpendWindow = window;
       this.priorFleetSpend = prior.models.reduce(
         (total, item) => total + item.estimated_cost,
         0
       );
     } catch {
       // A missing comparison is not an error worth a banner: the delta line
-      // just does not render.
+      // just does not render, and the next load may still get it.
+      this.priorFleetSpendWindow = null;
       this.priorFleetSpend = null;
     }
   }

--- a/frontend/src/views/authed/settings/ai-models-view.ts
+++ b/frontend/src/views/authed/settings/ai-models-view.ts
@@ -196,11 +196,6 @@ export class AIModelsView extends LitElement {
       .styled-table tr:last-child td {
         border-bottom: none;
       }
-      .actions {
-        display: flex;
-        gap: var(--sl-spacing-x-small);
-        justify-content: flex-end;
-      }
       .empty-state a {
         color: var(--sl-color-primary-600);
         text-decoration: none;
@@ -925,7 +920,10 @@ export class AIModelsView extends LitElement {
       model.is_default,
       () =>
         html`<sl-badge class="chip" variant="success" pill>Default</sl-badge>`,
-      () => html`<span class="cell-secondary">&mdash;</span>`
+      () =>
+        html`<span class="cell-secondary" aria-label="Not default"
+          >&ndash;</span
+        >`
     );
   }
 

--- a/frontend/src/views/authed/settings/invitation-management-view.test.ts
+++ b/frontend/src/views/authed/settings/invitation-management-view.test.ts
@@ -98,7 +98,10 @@ describe('InvitationManagementView', () => {
     await waitUntil(() => !(element as any).isLoading, 'still loading');
     await element.updateComplete;
 
-    expect(element.shadowRoot?.textContent).to.contain('Invitation Management');
+    // The page is called what the sidebar calls it.
+    expect(element.shadowRoot?.querySelector('h1')?.textContent).to.equal(
+      'Invitations'
+    );
     expect(element.shadowRoot?.textContent).to.contain('No invitations found');
   });
 
@@ -115,7 +118,11 @@ describe('InvitationManagementView', () => {
     await element.updateComplete;
 
     expect(element.shadowRoot?.textContent).to.contain('invitee@example.com');
-    expect(element.shadowRoot?.textContent).to.contain('pending');
+    // Status is a tint chip with a human label, not a raw enum value.
+    const chip = element.shadowRoot?.querySelector(
+      '.invitation-meta sl-badge.status-chip'
+    );
+    expect(chip?.textContent?.trim()).to.equal('Pending');
   });
 
   it('shows an error when invitation loading fails', async () => {

--- a/frontend/src/views/authed/settings/invitation-management-view.ts
+++ b/frontend/src/views/authed/settings/invitation-management-view.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, unsafeCSS } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import {
@@ -24,6 +24,7 @@ import '@shoelace-style/shoelace/dist/components/tab-panel/tab-panel.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '../../../components/preloop-invite-dialog';
+import consoleStyles from '../../../styles/console-styles.css?inline';
 
 @customElement('invitation-management-view')
 export class InvitationManagementView extends LitElement {
@@ -51,104 +52,120 @@ export class InvitationManagementView extends LitElement {
   @state()
   private isLoadingTeams = false;
 
-  static styles = css`
-    :host {
-      display: block;
-      padding: 2rem;
-    }
+  static styles = [
+    unsafeCSS(consoleStyles),
+    css`
+      :host {
+        display: block;
+        padding: 2rem;
+      }
 
-    .header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin-bottom: 2rem;
-    }
+      .header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 2rem;
+      }
 
-    h1 {
-      margin: 0;
-      font-size: 1.5rem;
-      font-weight: 600;
-    }
+      h1 {
+        margin: 0;
+        font-size: 1.5rem;
+        font-weight: 600;
+      }
 
-    .invitations-grid {
-      display: grid;
-      gap: 1rem;
-    }
+      .invitations-grid {
+        display: grid;
+        gap: 1rem;
+      }
 
-    sl-card {
-      width: 100%;
-    }
+      sl-card {
+        width: 100%;
+      }
 
-    .invitation-card-content {
-      display: grid;
-      grid-template-columns: auto 1fr auto;
-      gap: 1rem;
-      align-items: center;
-    }
+      .invitation-card-content {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        gap: 1rem;
+        align-items: center;
+      }
 
-    .invitation-icon {
-      font-size: 2rem;
-      width: 48px;
-      height: 48px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: var(--sl-color-primary-50);
-      border-radius: 50%;
-      color: var(--sl-color-primary-600);
-    }
+      .invitation-icon {
+        font-size: 2rem;
+        width: 48px;
+        height: 48px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--sl-color-primary-50);
+        border-radius: 50%;
+        color: var(--sl-color-primary-600);
+      }
 
-    .invitation-details {
-      flex: 1;
-    }
+      .invitation-details {
+        flex: 1;
+      }
 
-    .invitation-email {
-      font-weight: 600;
-      font-size: 1rem;
-      margin: 0 0 0.25rem 0;
-    }
+      .invitation-email {
+        font-weight: 600;
+        font-size: 1rem;
+        margin: 0 0 0.25rem 0;
+      }
 
-    .invitation-date {
-      color: var(--sl-color-neutral-600);
-      font-size: 0.875rem;
-      margin: 0 0 0.5rem 0;
-    }
+      .invitation-date {
+        color: var(--sl-color-neutral-600);
+        font-size: 0.875rem;
+        margin: 0 0 0.5rem 0;
+      }
 
-    .invitation-meta {
-      display: flex;
-      gap: 0.5rem;
-      flex-wrap: wrap;
-    }
+      .invitation-meta {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
 
-    .invitation-actions {
-      display: flex;
-      gap: 0.5rem;
-    }
+      .invitation-actions {
+        display: flex;
+        gap: 0.5rem;
+      }
 
-    .form-grid {
-      display: grid;
-      gap: 1rem;
-    }
+      .invitation-actions .danger-action {
+        margin-left: var(--sl-spacing-large);
+      }
 
-    .error {
-      color: var(--sl-color-danger-600);
-      background: var(--sl-color-danger-50);
-      padding: 1rem;
-      border-radius: 4px;
-      margin-bottom: 1rem;
-    }
+      .form-grid {
+        display: grid;
+        gap: 1rem;
+      }
 
-    .loading {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: 4rem;
-    }
+      .error {
+        color: var(--sl-color-danger-600);
+        background: var(--sl-color-danger-50);
+        padding: 1rem;
+        border-radius: 4px;
+        margin-bottom: 1rem;
+      }
 
-    sl-tab-group {
-      margin-bottom: 2rem;
-    }
-  `;
+      .loading {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 4rem;
+      }
+
+      sl-tab-group {
+        margin-bottom: 2rem;
+      }
+    `,
+  ];
+
+  /** Statuses are stored lower case; the chip says "Pending". */
+  static statusLabel(status: string | null | undefined): string {
+    const value = String(status || '').trim();
+    if (!value) return 'Unknown';
+    return value
+      .replace(/_/g, ' ')
+      .replace(/^\w/, (character) => character.toUpperCase());
+  }
 
   @state()
   private featureEnabled = true;
@@ -285,13 +302,13 @@ export class InvitationManagementView extends LitElement {
 
     return html`
       <div class="header">
-        <h1>Invitation Management</h1>
+        <h1>Invitations</h1>
         <sl-button
           variant="primary"
           @click=${() => (this.isCreateModalOpen = true)}
         >
           <sl-icon slot="prefix" name="envelope-plus"></sl-icon>
-          Send Invitation
+          Send invitation
         </sl-button>
       </div>
 
@@ -367,15 +384,16 @@ export class InvitationManagementView extends LitElement {
                   </p>
                   <div class="invitation-meta">
                     <sl-badge
+                      class="status-chip"
                       variant="${this.getStatusVariant(invitation.status)}"
                     >
-                      ${invitation.status}
+                      ${InvitationManagementView.statusLabel(invitation.status)}
                     </sl-badge>
                     ${
                       invitation.status === 'pending'
                         ? html`
-                            <sl-badge variant="neutral">
-                              Expires: ${this.formatDate(invitation.expires_at)}
+                            <sl-badge class="chip" variant="neutral">
+                              Expires ${this.formatDate(invitation.expires_at)}
                             </sl-badge>
                           `
                         : ''
@@ -383,8 +401,8 @@ export class InvitationManagementView extends LitElement {
                     ${
                       invitation.accepted_at
                         ? html`
-                            <sl-badge variant="success">
-                              Accepted:
+                            <sl-badge class="chip" variant="success">
+                              Accepted
                               ${this.formatDate(invitation.accepted_at)}
                             </sl-badge>
                           `
@@ -404,9 +422,13 @@ export class InvitationManagementView extends LitElement {
                           >
                             <sl-icon name="arrow-repeat"></sl-icon>
                           </sl-button>
+                          <!-- Outline, last, after a gap (DESIGN.md
+                               "Destructive actions"). -->
                           <sl-button
+                            class="danger-action"
                             size="small"
                             variant="danger"
+                            outline
                             @click=${() =>
                               this.handleCancelInvitation(invitation)}
                             title="Cancel invitation"

--- a/frontend/src/views/authed/settings/team-management-view.test.ts
+++ b/frontend/src/views/authed/settings/team-management-view.test.ts
@@ -106,7 +106,15 @@ describe('TeamManagementView', () => {
     );
     await element.updateComplete;
 
-    expect(element.shadowRoot?.textContent).to.contain('Team Management');
+    // The page is called what the sidebar calls it.
+    expect(element.shadowRoot?.querySelector('h1')?.textContent).to.equal(
+      'Teams'
+    );
+    // Delete is outline and last, after the gap.
+    const del = element.shadowRoot?.querySelector(
+      '.team-actions sl-button[variant="danger"]'
+    );
+    expect(del?.hasAttribute('outline')).to.equal(true);
     expect(element.shadowRoot?.textContent).to.contain('Platform');
     expect(element.shadowRoot?.textContent).to.contain(
       'Platform engineering team'

--- a/frontend/src/views/authed/settings/team-management-view.ts
+++ b/frontend/src/views/authed/settings/team-management-view.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, unsafeCSS } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import {
@@ -36,6 +36,7 @@ import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
+import consoleStyles from '../../../styles/console-styles.css?inline';
 import { consoleDialogStyles } from '../../../styles/console-dialog';
 
 @customElement('team-management-view')
@@ -85,7 +86,17 @@ export class TeamManagementView extends LitElement {
   @state()
   private teamRoles: Role[] = [];
 
+  /** Role names are stored lower case (`owner`); the chip says "Owner". */
+  static roleLabel(name: string | null | undefined): string {
+    const value = String(name || '').trim();
+    if (!value) return 'Role';
+    return value
+      .replace(/_/g, ' ')
+      .replace(/^\w/, (character) => character.toUpperCase());
+  }
+
   static styles = [
+    unsafeCSS(consoleStyles),
     consoleDialogStyles,
     css`
       :host {
@@ -166,6 +177,10 @@ export class TeamManagementView extends LitElement {
       .team-actions {
         display: flex;
         gap: 0.5rem;
+      }
+
+      .team-actions .danger-action {
+        margin-left: var(--sl-spacing-large);
       }
 
       .form-grid {
@@ -450,13 +465,13 @@ export class TeamManagementView extends LitElement {
 
     return html`
       <div class="header">
-        <h1>Team Management</h1>
+        <h1>Teams</h1>
         <sl-button
           variant="primary"
           @click=${() => (this.isCreateModalOpen = true)}
         >
           <sl-icon slot="prefix" name="people-fill"></sl-icon>
-          Create Team
+          Create team
         </sl-button>
       </div>
 
@@ -488,8 +503,10 @@ export class TeamManagementView extends LitElement {
                             <strong>Roles:</strong>
                             ${(team as any).roles.map(
                               (role: any) =>
-                                html`<sl-badge variant="primary"
-                                  >${role.name}</sl-badge
+                                html`<sl-badge class="chip" variant="neutral"
+                                  >${TeamManagementView.roleLabel(
+                                    role.name
+                                  )}</sl-badge
                                 >`
                             )}
                           </div>
@@ -516,9 +533,14 @@ export class TeamManagementView extends LitElement {
                   >
                     <sl-icon name="pencil"></sl-icon>
                   </sl-button>
+                  <!-- Outline, last, after a gap (DESIGN.md "Destructive
+                       actions"). -->
                   <sl-button
+                    class="danger-action"
                     size="small"
                     variant="danger"
+                    outline
+                    title="Delete team"
                     @click=${() => this.handleDeleteTeam(team)}
                   >
                     <sl-icon name="trash"></sl-icon>

--- a/frontend/src/views/authed/settings/user-management-view.test.ts
+++ b/frontend/src/views/authed/settings/user-management-view.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 
 import { invalidateApiCaches } from '../../../api';
 import './user-management-view';
-import type { UserManagementView } from './user-management-view';
+import { UserManagementView } from './user-management-view';
 
 describe('UserManagementView', () => {
   let fetchStub: sinon.SinonStub;
@@ -108,9 +108,66 @@ describe('UserManagementView', () => {
     );
     await element.updateComplete;
 
-    expect(element.shadowRoot?.textContent).to.contain('User Management');
+    // The page is called what the sidebar calls it.
+    expect(element.shadowRoot?.querySelector('h1')?.textContent).to.equal(
+      'Users'
+    );
     expect(element.shadowRoot?.textContent).to.contain('Alice Example');
     expect(element.shadowRoot?.textContent).to.contain('alice@example.com');
+  });
+
+  it('labels the sign-in source in words and keeps delete quiet', async () => {
+    fetchStub = createFetchStub({
+      users: [
+        { ...sampleUser, user_source: 'oauth_google', email_verified: false },
+      ],
+    });
+    const element = (await fixture(
+      html`<user-management-view></user-management-view>`
+    )) as UserManagementView;
+
+    await waitUntil(
+      () => (element as any).users?.length === 1,
+      'users did not load'
+    );
+    await element.updateComplete;
+
+    const chips = Array.from(
+      element.shadowRoot?.querySelectorAll('.user-meta sl-badge') || []
+    );
+    const labels = chips.map((chip) => (chip.textContent || '').trim());
+    // A raw enum value is not a label a reader can act on.
+    expect(labels).to.include('Google');
+    expect(labels).to.not.include('oauth_google');
+    // Chips are tints, and no chip is a solid paint.
+    chips.forEach((chip) => {
+      expect(chip.classList.contains('chip')).to.equal(true);
+      expect(chip.classList.contains('solid')).to.equal(false);
+    });
+
+    const del = element.shadowRoot?.querySelector(
+      '.user-actions sl-button[variant="danger"]'
+    );
+    expect(del?.hasAttribute('outline')).to.equal(true);
+    expect(del?.classList.contains('danger-action')).to.equal(true);
+    // Last in the row, after the gap.
+    const actions = Array.from(
+      element.shadowRoot?.querySelectorAll('.user-actions sl-button') || []
+    );
+    expect(actions[actions.length - 1]).to.equal(del);
+  });
+
+  it('names sign-in sources and roles without exposing the schema', () => {
+    expect(UserManagementView.userSourceLabel('local')).to.equal('Password');
+    expect(UserManagementView.userSourceLabel('oauth_google')).to.equal(
+      'Google'
+    );
+    expect(UserManagementView.userSourceLabel('oauth_github')).to.equal(
+      'GitHub'
+    );
+    expect(UserManagementView.userSourceLabel('')).to.equal('Unknown');
+    expect(UserManagementView.roleLabel('owner')).to.equal('Owner');
+    expect(UserManagementView.roleLabel('team_admin')).to.equal('Team admin');
   });
 
   it('renders an empty grid when there are no users', async () => {

--- a/frontend/src/views/authed/settings/user-management-view.ts
+++ b/frontend/src/views/authed/settings/user-management-view.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, unsafeCSS } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import {
@@ -25,6 +25,7 @@ import '@shoelace-style/shoelace/dist/components/dropdown/dropdown.js';
 import '@shoelace-style/shoelace/dist/components/menu/menu.js';
 import '@shoelace-style/shoelace/dist/components/menu-item/menu-item.js';
 import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
+import consoleStyles from '../../../styles/console-styles.css?inline';
 import { consoleDialogStyles } from '../../../styles/console-dialog';
 
 @customElement('user-management-view')
@@ -62,7 +63,39 @@ export class UserManagementView extends LitElement {
   @state()
   private editUser: Partial<UserUpdate> = {};
 
+  /**
+   * How the account was created, in words. The stored values are enum names
+   * (`local`, `oauth_google`); printing them verbatim asked the reader to
+   * know the schema to learn that someone signs in with Google.
+   */
+  static userSourceLabel(source: string | null | undefined): string {
+    const value = String(source || '').toLowerCase();
+    if (value === 'local' || value === 'password') return 'Password';
+    if (value === 'oauth_google' || value === 'google') return 'Google';
+    if (value === 'oauth_github' || value === 'github') return 'GitHub';
+    if (value === 'oauth_microsoft' || value === 'microsoft') {
+      return 'Microsoft';
+    }
+    if (value === 'saml' || value === 'sso') return 'SSO';
+    if (value === 'invitation') return 'Invitation';
+    if (!value) return 'Unknown';
+    return value
+      .replace(/^oauth_/, '')
+      .replace(/_/g, ' ')
+      .replace(/^\w/, (character) => character.toUpperCase());
+  }
+
+  /** Role names are stored lower case (`owner`); the chip says "Owner". */
+  static roleLabel(name: string | null | undefined): string {
+    const value = String(name || '').trim();
+    if (!value) return 'Role';
+    return value
+      .replace(/_/g, ' ')
+      .replace(/^\w/, (character) => character.toUpperCase());
+  }
+
   static styles = [
+    unsafeCSS(consoleStyles),
     consoleDialogStyles,
     css`
       :host {
@@ -149,6 +182,12 @@ export class UserManagementView extends LitElement {
       .user-actions {
         display: flex;
         gap: 0.5rem;
+      }
+
+      /* The gap DESIGN.md asks for between the ordinary actions and the
+         destructive one, so Deactivate is never hit on the way to Edit. */
+      .user-actions .danger-action {
+        margin-left: var(--sl-spacing-large);
       }
 
       .form-grid {
@@ -341,13 +380,13 @@ export class UserManagementView extends LitElement {
 
     return html`
       <div class="header">
-        <h1>User Management</h1>
+        <h1>Users</h1>
         <sl-button
           variant="primary"
           @click=${() => (this.isCreateModalOpen = true)}
         >
           <sl-icon slot="prefix" name="person-plus"></sl-icon>
-          Add User
+          Add user
         </sl-button>
       </div>
 
@@ -368,15 +407,22 @@ export class UserManagementView extends LitElement {
                   <p class="user-email">${user.email}</p>
                   <div class="user-meta">
                     <sl-badge
+                      class="chip"
                       variant="${user.is_active ? 'success' : 'neutral'}"
                     >
                       ${user.is_active ? 'Active' : 'Inactive'}
                     </sl-badge>
-                    <sl-badge variant="neutral">${user.user_source}</sl-badge>
+                    <sl-badge class="chip" variant="neutral"
+                      >${UserManagementView.userSourceLabel(
+                        user.user_source
+                      )}</sl-badge
+                    >
                     ${
                       user.email_verified
-                        ? html`<sl-badge variant="success">Verified</sl-badge>`
-                        : html`<sl-badge variant="warning"
+                        ? html`<sl-badge class="chip" variant="success"
+                            >Verified</sl-badge
+                          >`
+                        : html`<sl-badge class="chip" variant="warning"
                             >Unverified</sl-badge
                           >`
                     }
@@ -385,11 +431,13 @@ export class UserManagementView extends LitElement {
                     (user as any).roles && (user as any).roles.length > 0
                       ? html`
                           <div class="user-roles">
-                            <strong>Direct Roles:</strong>
+                            <strong>Roles:</strong>
                             ${(user as any).roles.map(
                               (role: any) =>
-                                html`<sl-badge variant="primary"
-                                  >${role.name}</sl-badge
+                                html`<sl-badge class="chip" variant="neutral"
+                                  >${UserManagementView.roleLabel(
+                                    role.name
+                                  )}</sl-badge
                                 >`
                             )}
                           </div>
@@ -401,13 +449,14 @@ export class UserManagementView extends LitElement {
                     (user as any).inherited_roles.length > 0
                       ? html`
                           <div class="user-roles">
-                            <strong>Inherited Roles:</strong>
+                            <strong>From teams:</strong>
                             ${(user as any).inherited_roles.map(
                               (role: any) =>
                                 html`<sl-badge
+                                  class="chip"
                                   variant="neutral"
                                   title="From team: ${role.team_name}"
-                                  >${role.name}
+                                  >${UserManagementView.roleLabel(role.name)}
                                   <span style="font-size: 0.7em;"
                                     >(${role.team_name})</span
                                   ></sl-badge
@@ -421,19 +470,26 @@ export class UserManagementView extends LitElement {
                 <div class="user-actions">
                   <sl-button
                     size="small"
+                    title="Manage roles"
                     @click=${() => this.openRoleModal(user)}
                   >
                     <sl-icon name="shield-check"></sl-icon>
                   </sl-button>
                   <sl-button
                     size="small"
+                    title="Edit user"
                     @click=${() => this.openEditModal(user)}
                   >
                     <sl-icon name="pencil"></sl-icon>
                   </sl-button>
+                  <!-- Destructive last, outline, after a gap (DESIGN.md
+                       "Destructive actions"): a solid red button beside two
+                       neutral ones is the loudest thing in the row. -->
                   <sl-button
+                    class="danger-action"
                     size="small"
                     variant="danger"
+                    outline
                     title="Deactivate user"
                     @click=${() => this.handleDeactivateUser(user)}
                   >


### PR DESCRIPTION
# Models, Cost and settings polish (UX round 4, wave 2: W2-9, W2-10, W2-11)

## Summary

Three console surfaces stop asking the reader to decode them. The models list becomes one scan (name over id, provider in its own column, tint chips, a single kebab) with stat labels that say what is measured and over what window. Cost gets the one range control the rest of the console uses, restates its window in dates, prints compact numbers with arrow deltas, and each budget row now forecasts where the period lands. The settings pages drop their solid badges and boxed rows for chips and hairlines, name their h1 as the sidebar names them, and put every destructive button last, outline, after a gap.

Frontend only. No API, schema or backend change.

## Changes

### W2-9. Models list and detail (D1, D4)

- `ai-models-view.ts`: two-line name cell (name over the provider model id), a provider column of its own (provider name over "priced from catalog · agent"), health and usage cells written in plain words, the default marker as a chip, and one kebab per row with View, Edit, Set default and Delete, where Delete is outline danger and separated.
- Fleet stats now read `Configured models`, `Need attention`, `Requests · 30d`, `$ est. · 30d`, compact at or above 1000, with a prior-window delta.
- `formatCurrency` gives four decimals below a cent, so a `$0.0042` model no longer rounds to `$0.00`.
- `ai-model-detail-view.ts`: header Delete set apart as an outline action, card titled "Details", "Updated: Never" when the model was never updated, and the usage summary rendered as a hairline strip with the period stated once in the card header.

### W2-10. Cost range and budgets (D2)

- `cost-view.ts`: the bare select and the Refresh button are replaced by the shared `time-range-select` plus a line restating the window and the read time, for example "Aug 7 to Sep 5 · read 3:21 PM" (an absolute time, because the page neither polls nor subscribes, with the full timestamp in the tooltip).
- Metric cards are compact with the exact figure in the tooltip, and deltas are arrows against the prior window ("▲ 91% vs prior 30d") instead of signed dollars.
- The price catalog age line names its age in days and offers "Override a price" once the catalog is over 45 days old.
- The soft-limit banner action is outline, and dialog and heading copy is sentence case. The h1 is "Cost".
- `budget-health-card.ts`: rows are named as the Overview names them ("Monthly budget · Sep", "Daily budget · today") and each carries the forecast line, "On track for $X by Y", toned neutral, warning or danger. The name and the sentence live in `utils/budget-forecast`, which both cards call, so the two surfaces cannot word the same budget differently.

### W2-11. Settings polish (D5, D6 remainder, D13 strip)

- Users, Teams and Invitations: tint chips with human labels ("Google", not `oauth_google`; "Owner", not `owner`; "Pending", not `pending`), h1 equal to the sidebar name, and Deactivate, Delete and Cancel as outline danger buttons placed last after a `--sl-spacing-large` gap.
- Notifications: preference and device rows are hairlines rather than boxes, sections are "Channels" and "Devices", Unregister is outline, and the App Store and Play links are default buttons under one hint sentence.
- Account: the usage stats are one hairline row with rule separators instead of five bordered boxes.

## Tests

- Full suite on the branch: **146 files, 1701 passed, 0 failed** (20.1s). On `main`: **1689 passed, 0 failed**. Net **+12** tests.
- `ai-models-view.test.ts` (8): one kebab per row rendering View, Edit and Delete in that order with Delete in danger red, the compact number format, the `$0.0042` case, and the request count per realtime refresh.
- `ai-model-detail-view.test.ts` (18): title "Details", "Updated: Never", the hairline usage strip, and the separated outline Delete.
- `cost-view.test.ts` (27): the shared range component is present with the window restated and no Refresh, compact stats with `percentDelta(24, 10) === '▲ 140% vs prior 30d'`, and the catalog age line with its override link.
- `budget-health-card.test.ts` (6): the forecast line renders and the row label reads "Monthly budget · <Mon>".
- `user-management-view.test.ts` (7): the label "Google" for `oauth_google`, no solid danger button.
- `notification-preferences-view.test.ts` (17): the new titles, the outline Unregister and the default store buttons.
- `budget-forecast.test.ts`: a budget is named the same way whichever surface prints it, including the legacy `month` and `year` spellings.
- `pre-commit run --files <changed files>` passes for every commit. `npx tsc --noEmit` reports 108 errors on the branch, the same 108 as on `main`, none in the changed hunks.

## Review follow-ups (V-J4)

The review approved with nits (0 blockers, 3 should-fix, 8 nits). All eleven are addressed in three further commits.

- **One budget name, one forecast sentence.** `budget-health-card` and `usage-card` each carried a copy of the period label and the forecast line, and had already drifted (only one folded the legacy `month`/`year` spellings). Both now call `utils/budget-forecast`, which already owned the math.
- **The models page is back to two requests per realtime refresh.** The prior 30 day window was reloaded inside every `fetchModels`, and five websocket subscriptions schedule that method. It is now loaded on mount and on explicit reloads only, memoised against the window's start date. A test counts the requests.
- **Nits.** The `&mdash;` entity in the Default column is an en dash labelled "Not default"; the Cost window line states a clock time rather than a "just now" that never updated; the catalog action is a button instead of an anchor to a fragment that cannot resolve in a shadow root; two dead rules and a dead class are gone; the last notification preference row no longer draws a rule against the card edge and both hairlines name `--console-hairline` rather than a neutral step; the account and model detail stat strips draw their separator in the grid gap so a wrapped row does not start with a dangling rule; and the models row test now asserts what the kebab renders instead of flags that `menu-only` ignores.
- **Two PR sentences were wrong about the code** and are corrected above: the provider cell is a plain name over "priced from catalog · agent" (no chip, no host), and the first fleet stat reads "Configured models".

## Founder calls

1. **The "Update catalog" link does not exist.** No route re-downloads the price catalog; the refresh lives inside the pricing job. The age line offers "Override a price" instead, which is real. If an admin-triggered catalog refresh is wanted, it needs a backend route and belongs in its own change.
2. **Cost keeps its seven calendar presets** (Today, This week, This month, Last month, 7d, 30d, 90d) inside the shared control rather than the after image's 24h/7d/30d/90d/1y, because "This month" and "Today" are what the "Month to date" and "Projected" cards are computed from.
3. **Budget rows are named by their period, not by the page range.** The after image kept "Global spend · 30d"; the section text asked for the Overview naming, and the Overview naming is the honest one, since the row tracks the policy period.
4. **h1s were renamed to the sidebar names** on Cost, Models, Users, Teams, Invitations and Notifications, extending the W2-11 rule to the two pages in the same diff that had the same mismatch.
5. **The App Store and Play badges are now plain default buttons.** They were the only custom solid buttons in settings, and they were louder than the primary action on the page.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **[Low Risk]**
> Frontend-only UX polish with no API, schema, or security-surface change, backed by 12 new tests. No blockers found.
>
> **Overview**
> Consolidates budget naming and forecasting into one `utils/budget-forecast` module shared by Cost and the Overview, switches the Cost page to the shared `time-range-select`, and normalizes destructive buttons across the models and settings surfaces to outline-danger-last.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit e9033e5. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->