### PR TITLE
Fix private runner leases, monitoring and marker consumption

### DIFF
--- a/backend/preloop/agents/remote_runner.py
+++ b/backend/preloop/agents/remote_runner.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 class RemoteRunnerExecutor(AgentExecutor):
     """Does not start a hosted container. Jobs wait for a matching runner."""
 
+    # Runner WebSocket handlers already persist and publish log lines.
+    streams_logs_externally = True
+
     def __init__(
         self,
         agent_type: str,
@@ -93,10 +96,23 @@ class RemoteRunnerExecutor(AgentExecutor):
 
     async def get_status(self, session_reference: str) -> AgentStatus:
         execution_id = _execution_id_from_ref(session_reference)
+        execution = crud_flow_execution.get(self.db, id=execution_id, refresh=True)
+        if execution and _map_status(execution.status) in (
+            AgentStatus.SUCCEEDED,
+            AgentStatus.FAILED,
+            AgentStatus.STOPPED,
+        ):
+            return _map_status(execution.status)
         if session_reference.startswith("runner:queued:"):
-            execution = (
-                crud_flow_execution.get(self.db, id=execution_id) or self.execution
-            )
+            execution = execution or self.execution
+            assigned_reference = getattr(execution, "agent_session_reference", None)
+            if (
+                isinstance(assigned_reference, str)
+                and assigned_reference.startswith("runner:")
+                and not assigned_reference.startswith("runner:queued:")
+                and _execution_id_from_ref(assigned_reference) == execution_id
+            ):
+                return await self.get_status(assigned_reference)
             started = (
                 execution.start_time
                 if execution and execution.start_time
@@ -163,7 +179,6 @@ class RemoteRunnerExecutor(AgentExecutor):
                 return AgentStatus.STOPPED
             if runner and runner.reported_status:
                 return _map_status(runner.reported_status)
-        execution = crud_flow_execution.get(self.db, id=execution_id)
         if execution:
             return _map_status(execution.status)
         return AgentStatus.PENDING

--- a/backend/preloop/models/crud/flow_execution.py
+++ b/backend/preloop/models/crud/flow_execution.py
@@ -102,13 +102,22 @@ class CRUDFlowExecution(CRUDBase[FlowExecution]):
         super().__init__(model=FlowExecution)
 
     def get(
-        self, db: Session, id: Any, *, account_id: Optional[str] = None
+        self,
+        db: Session,
+        id: Any,
+        *,
+        account_id: Optional[str] = None,
+        refresh: bool = False,
     ) -> Optional[FlowExecution]:
         """Get flow execution by ID.
 
         Overrides base get to properly filter by account_id through Flow relationship.
+        Set refresh for monitors that must replace cached attributes with updates
+        committed by another session, such as a runner WebSocket handler.
         """
         query = db.query(FlowExecution).filter(FlowExecution.id == id)
+        if refresh:
+            query = query.populate_existing()
         if account_id:
             query = query.join(Flow).filter(Flow.account_id == account_id)
         return query.first()

--- a/backend/preloop/models/crud/flow_execution_log.py
+++ b/backend/preloop/models/crud/flow_execution_log.py
@@ -1,7 +1,8 @@
 import uuid
+from datetime import datetime
 from typing import List, Optional
 
-from sqlalchemy import select
+from sqlalchemy import select, tuple_
 from sqlalchemy.orm import Session
 
 from preloop.models.models.flow_execution_log import FlowExecutionLog
@@ -46,6 +47,32 @@ class CRUDFlowExecutionLog(CRUDBase[FlowExecutionLog]):
             rows = list(reversed(rows))
 
         return list(rows)
+
+    def get_agent_log_page(
+        self,
+        db: Session,
+        execution_id: uuid.UUID,
+        *,
+        after: Optional[tuple[datetime, uuid.UUID]] = None,
+        limit: int = 500,
+    ) -> List[FlowExecutionLog]:
+        """Read one bounded raw-log page, using an execution-scoped keyset cursor.
+
+        Timestamp ties use row identity, so a page boundary cannot skip another
+        line with the same timestamp. Derived metrics/events are never replayed.
+        """
+        query = select(FlowExecutionLog).where(
+            FlowExecutionLog.execution_id == execution_id,
+            FlowExecutionLog.log_type == "agent_log_line",
+        )
+        if after is not None:
+            query = query.where(
+                tuple_(FlowExecutionLog.timestamp, FlowExecutionLog.id) > after
+            )
+        query = query.order_by(
+            FlowExecutionLog.timestamp.asc(), FlowExecutionLog.id.asc()
+        ).limit(max(1, min(limit, 1000)))
+        return list(db.execute(query).scalars().all())
 
     def get_event_by_id(
         self,

--- a/backend/preloop/models/crud/flow_runner.py
+++ b/backend/preloop/models/crud/flow_runner.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from sqlalchemy import func
+from sqlalchemy import JSON, func, or_
 from sqlalchemy.orm import Session
 
 from ..models.flow_runner import FlowRunner
@@ -92,7 +92,13 @@ class CRUDFlowRunner(CRUDBase[FlowRunner]):
             .filter(
                 FlowRunner.id == runner_id,
                 FlowRunner.status == "online",
-                FlowRunner.pending_job.is_(None),
+                # JSONB stores an assigned Python None as JSON null by default.
+                # Both representations mean there is no pending lease, including
+                # rows cleared by the runner completion/error handlers.
+                or_(
+                    FlowRunner.pending_job.is_(None),
+                    FlowRunner.pending_job == JSON.NULL,
+                ),
             )
             .with_for_update(skip_locked=True)
             .first()

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -18,6 +18,7 @@ from preloop.models.crud import (
     crud_api_key,
     crud_flow,
     crud_flow_execution,
+    crud_flow_execution_log,
     crud_runtime_session,
     crud_user,
 )
@@ -3034,6 +3035,64 @@ class FlowExecutionOrchestrator:
                 ):
                     self._note_agent_session(line)
 
+    def _replay_persisted_runner_logs(self) -> None:
+        """Fold WebSocket-persisted private-runner lines into marker parsing.
+
+        ``_stream_logs_to_nats`` returns early for these executors so lines
+        are not published twice. The runner ``logs`` handler only stores the
+        raw line, so PR-opened binding, CLI session, verification, nudge
+        markers, and MCP/token metrics would otherwise stay empty.
+        """
+        if self.execution_log is None:
+            return
+        ref = getattr(self.execution_log, "agent_session_reference", "") or ""
+        if not str(ref).startswith("runner:"):
+            return
+        if self.execution_logger.get_agent_output_lines():
+            return
+        rows = crud_flow_execution_log.get_by_execution_id(
+            self.db, self.execution_log.id
+        )
+        previous_line = ""
+        for row in rows:
+            if getattr(row, "log_type", None) not in {
+                None,
+                "log",
+                "agent_log_line",
+            }:
+                continue
+            line = row.message or ""
+            metadata = getattr(row, "metadata_", None)
+            if not line and isinstance(metadata, dict):
+                line = str(metadata.get("line") or "")
+            if not line:
+                continue
+            self.execution_logger.log_agent_output(line)
+            stripped = line.strip()
+            if PR_OPENED_MARKER in stripped:
+                self._note_opened_pr(stripped)
+            if any(
+                marker in stripped
+                for marker in (
+                    AGENT_SESSION_MARKER,
+                    "PRELOOP_NATIVE_SESSION_ARTIFACT ",
+                    "PRELOOP_NATIVE_RESUME ",
+                )
+            ):
+                self._note_agent_session(stripped)
+            if stripped.startswith(VERIFICATION_MARKER + " "):
+                self._note_verification_evidence(stripped)
+            if stripped == COMPLETION_NUDGE_MARKER:
+                self._note_inplace_nudge(source="post_exit_rescan")
+            elif stripped.startswith(COMPLETION_NUDGE_RESULT_MARKER):
+                self._note_inplace_nudge_result(stripped)
+            self.execution_logger.parse_agent_logs([line])
+            if "tokens used" in previous_line.lower():
+                token_match = re.search(r"(\d{1,3}(?:,\d{3})*)", stripped)
+                if token_match:
+                    self.total_tokens += int(token_match.group(1).replace(",", ""))
+            previous_line = line
+
     def _bind_opened_pr(self, output_summary: Optional[str]) -> None:
         """Persist the wrapper-opened PR on this execution's result.
 
@@ -4510,6 +4569,11 @@ class FlowExecutionOrchestrator:
             agent_result, session_reference = await self._run_agent_with_retries(
                 execution_context
             )
+
+            # Private runners persist lines on the WebSocket; the live stream
+            # skips them so they are not published twice. Fold them in before
+            # terminal PR/session/metrics binding.
+            self._replay_persisted_runner_logs()
 
             # Update execution log with final results including detailed logs
             final_status = agent_result.get("status", "FAILED")

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -18,6 +18,7 @@ from preloop.models.crud import (
     crud_api_key,
     crud_flow,
     crud_flow_execution,
+    crud_flow_execution_log,
     crud_runtime_session,
     crud_user,
 )
@@ -446,6 +447,10 @@ def _exception_message(exc: BaseException) -> str:
     return str(exc) or exc.__class__.__name__
 
 
+RUNNER_LOG_PAGE_SIZE = 500
+RUNNER_LOG_SUMMARY_LINES = 1000
+
+
 class FlowExecutionOrchestrator:
     """Manages the end-to-end lifecycle of a single Flow invocation."""
 
@@ -470,6 +475,9 @@ class FlowExecutionOrchestrator:
         self.execution_logger = FlowExecutionLogger()
         self.temporary_api_key_id: Optional[uuid.UUID] = None
         self._log_streaming_task: Optional[asyncio.Task] = None
+        self._runner_log_cursor: Optional[tuple[datetime, uuid.UUID]] = None
+        self._runner_log_previous_line = ""
+        self._runner_log_count = 0
         self._command_subscription: Optional[Any] = None
         self._stop_requested = asyncio.Event()
         self._success_sentinel_seen = asyncio.Event()
@@ -2243,7 +2251,7 @@ class FlowExecutionOrchestrator:
             session_reference: Container/Job reference
         """
         # Private runner WebSockets already persist and publish each line.
-        # They have no container stream, and replaying stored logs duplicates it.
+        # The main monitor consumes their stored markers with a keyset cursor.
         if getattr(agent_executor, "streams_logs_externally", False) is True:
             return
         logger.info(f"Starting log streaming for {session_reference}")
@@ -2257,154 +2265,11 @@ class FlowExecutionOrchestrator:
                 log_count += 1
                 logger.debug(f"Streamed log line #{log_count}: {log_line[:100]}")
 
-                # Store the log line for later summary
-                self.execution_logger.log_agent_output(log_line)
-
-                # Track the agent exec start marker — sentinel detection is
-                # suppressed until this marker is seen, preventing false
-                # positives from the prompt echo that contains the sentinel
-                # instruction text.
-                if (
-                    not self._agent_exec_started
-                    and log_line.strip() == AGENT_EXEC_START_MARKER
-                ):
-                    self._agent_exec_started = True
-                    logger.info(
-                        f"Agent exec start marker seen at log line #{log_count}"
-                    )
-
-                # Detect success sentinel — but ONLY after the agent exec
-                # start marker has been seen (to ignore prompt echo).
-                stripped_line = log_line.strip()
-                if stripped_line == FLOW_SUCCESS_SENTINEL:
-                    if not self._agent_exec_started:
-                        logger.warning(
-                            f"[Sentinel] Ignoring sentinel match at line #{log_count} "
-                            f"— agent exec start marker not yet seen (prompt echo?). "
-                            f"Previous line: {previous_line[:120]!r}"
-                        )
-                    elif self._success_sentinel_seen.is_set():
-                        logger.warning(
-                            f"[Sentinel] Duplicate sentinel match at line #{log_count} "
-                            f"— already triggered. Previous line: {previous_line[:120]!r}"
-                        )
-                    else:
-                        logger.info(
-                            f"[Sentinel] Success sentinel detected for {session_reference} "
-                            f"at line #{log_count}. "
-                            f"Previous line: {previous_line[:120]!r}"
-                        )
-                        self._success_sentinel_seen.set()
-
-                # PR/MR opened by the wrapper's post-execution curl. The
-                # response never reaches Python, so the line is the binding
-                # channel (MCP create_pull_request binds directly instead).
-                if PR_OPENED_MARKER in stripped_line:
-                    self._note_opened_pr(stripped_line)
-
-                # Native CLI session id reported by the agent script, so a
-                # later PR-comment resume can invoke the CLI resume flag.
-                if any(
-                    marker in stripped_line
-                    for marker in (
-                        AGENT_SESSION_MARKER,
-                        "PRELOOP_NATIVE_SESSION_ARTIFACT ",
-                        "PRELOOP_NATIVE_RESUME ",
-                    )
-                ):
-                    self._note_agent_session(stripped_line)
-
-                # Publication-gate verdict printed by the post-execution
-                # verifier. The gate always runs after the agent exits, so
-                # the last marker wins over anything the agent printed.
-                if stripped_line.startswith(VERIFICATION_MARKER + " "):
-                    self._note_verification_evidence(stripped_line)
-                elif stripped_line.startswith(VERIFICATION_DENIED_MARKER):
-                    logger.warning("Publication gate denied publication")
-
-                # In-place completion nudge markers printed by the agent
-                # script. Order matters: the result marker shares the start
-                # marker's prefix, so the exact match is tested first.
-                if stripped_line == COMPLETION_NUDGE_MARKER:
-                    self._note_inplace_nudge(source="live_stream")
-                elif stripped_line.startswith(COMPLETION_NUDGE_RESULT_MARKER):
-                    self._note_inplace_nudge_result(stripped_line)
-                elif stripped_line.startswith(COMPLETION_NUDGE_UNSUPPORTED_MARKER):
-                    self._inplace_nudge_unsupported = True
-                    logger.info(
-                        "Agent runtime could not resume its session in place "
-                        "for the completion contract: %s",
-                        stripped_line,
-                    )
-
-                previous_tool_calls_count = len(self.execution_logger.mcp_usage_logs)
-
-                # Parse log line for structured data (includes tool call detection)
-                self.execution_logger.parse_agent_logs([log_line])
-
-                # Check for token usage pattern: "tokens used" followed by number on next line
-                if "tokens used" in previous_line.lower():
-                    # Try to extract token count from current line
-                    # Pattern: number with optional commas (e.g., "1,234" or "1234")
-                    token_match = re.search(r"(\d{1,3}(?:,\d{3})*)", log_line.strip())
-                    if token_match:
-                        tokens = int(token_match.group(1).replace(",", ""))
-                        self.total_tokens += tokens
-
-                        logger.info(
-                            "Detected token usage: %s tokens (total: %s). "
-                            "Live cost remains unset until provider pricing is known.",
-                            tokens,
-                            self.total_tokens,
-                        )
-
-                        # Emit token usage update
-                        await self._publish_update(
-                            "token_usage_update",
-                            {
-                                "total_tokens": self.total_tokens,
-                                "pricing_available": False,
-                                "timestamp": datetime.now(timezone.utc).isoformat(),
-                            },
-                        )
-                        await self._persist_live_metrics()
-
-                # Check if this log line indicates a tool call was detected
-                updated_tool_calls_count = len(self.execution_logger.mcp_usage_logs)
-                if updated_tool_calls_count > self.tool_calls_count:
-                    new_tool_entries = self.execution_logger.mcp_usage_logs[
-                        previous_tool_calls_count:updated_tool_calls_count
-                    ]
-                    self.tool_calls_count = updated_tool_calls_count
-                    logger.info(f"Tool call detected (total: {self.tool_calls_count})")
-
-                    for tool_entry in new_tool_entries:
-                        await self._publish_update(
-                            "mcp_call",
-                            {
-                                **tool_entry,
-                                "timestamp": tool_entry.get("timestamp")
-                                or datetime.now(timezone.utc).isoformat(),
-                            },
-                        )
-
-                    # Emit tool call count update
-                    await self._publish_update(
-                        "tool_calls_update",
-                        {
-                            "tool_calls": self.tool_calls_count,
-                            "timestamp": datetime.now(timezone.utc).isoformat(),
-                        },
-                    )
-                    await self._persist_live_metrics()
-
-                # Publish log line to NATS
-                await self._publish_update(
-                    "agent_log_line",
-                    {
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
-                        "line": log_line,
-                    },
+                await self._process_agent_log_line(
+                    log_line,
+                    session_reference=session_reference,
+                    previous_line=previous_line,
+                    log_count=log_count,
                 )
 
                 # Update previous line for next iteration
@@ -2423,6 +2288,196 @@ class FlowExecutionOrchestrator:
             await self._publish_update(
                 "agent_log_error", {"error": f"Log streaming error: {str(e)}"}
             )
+
+    async def _process_agent_log_line(
+        self,
+        log_line: str,
+        *,
+        session_reference: str,
+        previous_line: str,
+        log_count: int,
+        publish_raw: bool = True,
+    ) -> None:
+        """Interpret one runtime line independently of raw-log transport ownership."""
+        # Store the log line for later summary
+        self.execution_logger.log_agent_output(log_line)
+
+        # Track the agent exec start marker — sentinel detection is
+        # suppressed until this marker is seen, preventing false
+        # positives from the prompt echo that contains the sentinel
+        # instruction text.
+        if not self._agent_exec_started and log_line.strip() == AGENT_EXEC_START_MARKER:
+            self._agent_exec_started = True
+            logger.info(f"Agent exec start marker seen at log line #{log_count}")
+
+        # Detect success sentinel — but ONLY after the agent exec
+        # start marker has been seen (to ignore prompt echo).
+        stripped_line = log_line.strip()
+        if stripped_line == FLOW_SUCCESS_SENTINEL:
+            if not self._agent_exec_started:
+                logger.warning(
+                    f"[Sentinel] Ignoring sentinel match at line #{log_count} "
+                    f"— agent exec start marker not yet seen (prompt echo?). "
+                    f"Previous line: {previous_line[:120]!r}"
+                )
+            elif self._success_sentinel_seen.is_set():
+                logger.warning(
+                    f"[Sentinel] Duplicate sentinel match at line #{log_count} "
+                    f"— already triggered. Previous line: {previous_line[:120]!r}"
+                )
+            else:
+                logger.info(
+                    f"[Sentinel] Success sentinel detected for {session_reference} "
+                    f"at line #{log_count}. "
+                    f"Previous line: {previous_line[:120]!r}"
+                )
+                self._success_sentinel_seen.set()
+
+        # PR/MR opened by the wrapper's post-execution curl. The
+        # response never reaches Python, so the line is the binding
+        # channel (MCP create_pull_request binds directly instead).
+        if PR_OPENED_MARKER in stripped_line:
+            self._note_opened_pr(stripped_line)
+
+        # Native CLI session id reported by the agent script, so a
+        # later PR-comment resume can invoke the CLI resume flag.
+        if any(
+            marker in stripped_line
+            for marker in (
+                AGENT_SESSION_MARKER,
+                "PRELOOP_NATIVE_SESSION_ARTIFACT ",
+                "PRELOOP_NATIVE_RESUME ",
+            )
+        ):
+            self._note_agent_session(stripped_line)
+
+        # Publication-gate verdict printed by the post-execution
+        # verifier. The gate always runs after the agent exits, so
+        # the last marker wins over anything the agent printed.
+        if stripped_line.startswith(VERIFICATION_MARKER + " "):
+            self._note_verification_evidence(stripped_line)
+        elif stripped_line.startswith(VERIFICATION_DENIED_MARKER):
+            logger.warning("Publication gate denied publication")
+
+        # In-place completion nudge markers printed by the agent
+        # script. Order matters: the result marker shares the start
+        # marker's prefix, so the exact match is tested first.
+        if stripped_line == COMPLETION_NUDGE_MARKER:
+            self._note_inplace_nudge(source="live_stream")
+        elif stripped_line.startswith(COMPLETION_NUDGE_RESULT_MARKER):
+            self._note_inplace_nudge_result(stripped_line)
+        elif stripped_line.startswith(COMPLETION_NUDGE_UNSUPPORTED_MARKER):
+            self._inplace_nudge_unsupported = True
+            logger.info(
+                "Agent runtime could not resume its session in place "
+                "for the completion contract: %s",
+                stripped_line,
+            )
+
+        previous_tool_calls_count = len(self.execution_logger.mcp_usage_logs)
+
+        # Parse log line for structured data (includes tool call detection)
+        self.execution_logger.parse_agent_logs([log_line])
+
+        # Check for token usage pattern: "tokens used" followed by number on next line
+        if "tokens used" in previous_line.lower():
+            # Try to extract token count from current line
+            # Pattern: number with optional commas (e.g., "1,234" or "1234")
+            token_match = re.search(r"(\d{1,3}(?:,\d{3})*)", log_line.strip())
+            if token_match:
+                tokens = int(token_match.group(1).replace(",", ""))
+                self.total_tokens += tokens
+
+                logger.info(
+                    "Detected token usage: %s tokens (total: %s). "
+                    "Live cost remains unset until provider pricing is known.",
+                    tokens,
+                    self.total_tokens,
+                )
+
+                # Emit token usage update
+                await self._publish_update(
+                    "token_usage_update",
+                    {
+                        "total_tokens": self.total_tokens,
+                        "pricing_available": False,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+                await self._persist_live_metrics()
+
+        # Check if this log line indicates a tool call was detected
+        updated_tool_calls_count = len(self.execution_logger.mcp_usage_logs)
+        if updated_tool_calls_count > self.tool_calls_count:
+            new_tool_entries = self.execution_logger.mcp_usage_logs[
+                previous_tool_calls_count:updated_tool_calls_count
+            ]
+            self.tool_calls_count = updated_tool_calls_count
+            logger.info(f"Tool call detected (total: {self.tool_calls_count})")
+
+            for tool_entry in new_tool_entries:
+                await self._publish_update(
+                    "mcp_call",
+                    {
+                        **tool_entry,
+                        "timestamp": tool_entry.get("timestamp")
+                        or datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+
+            # Emit tool call count update
+            await self._publish_update(
+                "tool_calls_update",
+                {
+                    "tool_calls": self.tool_calls_count,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+            await self._persist_live_metrics()
+
+        # Runner WebSockets already persisted and published this line.
+        if publish_raw:
+            await self._publish_update(
+                "agent_log_line",
+                {
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "line": log_line,
+                },
+            )
+
+    async def _consume_runner_log_page(self, session_reference: str) -> bool:
+        """Consume a bounded stored-log page; True when caught up with the runner.
+
+        The WebSocket owns persistence and raw log broadcast. This cursor only
+        reconstructs controller markers, summaries and derived metrics. Terminal
+        status is processed after all committed pages, because the runner flushes
+        its final lines before reporting completion.
+        """
+        rows = crud_flow_execution_log.get_agent_log_page(
+            self.db,
+            self.execution_log.id,
+            after=self._runner_log_cursor,
+            limit=RUNNER_LOG_PAGE_SIZE,
+        )
+        # The parser may commit metric/binding updates. Materialize scalar
+        # values first so an expired ORM page cannot cause a query per line.
+        events = [(row.timestamp, row.id, row.message) for row in rows]
+        for timestamp, event_id, message in events:
+            if message is not None:
+                self._runner_log_count += 1
+                await self._process_agent_log_line(
+                    message,
+                    session_reference=session_reference,
+                    previous_line=self._runner_log_previous_line,
+                    log_count=self._runner_log_count,
+                    publish_raw=False,
+                )
+                self._runner_log_previous_line = message
+                # Raw history remains in the log table; retain only the bounded
+                # tail used by summaries, completion checks and loop detection.
+                del self.execution_logger.agent_output_lines[:-RUNNER_LOG_SUMMARY_LINES]
+            self._runner_log_cursor = (timestamp, event_id)
+        return len(events) < RUNNER_LOG_PAGE_SIZE
 
     async def _persist_live_metrics(self):
         """Persist live execution counters so reloads can rehydrate them."""
@@ -3769,6 +3824,18 @@ class FlowExecutionOrchestrator:
                         # Continue polling for transient errors
                         await asyncio.sleep(poll_interval)
                         elapsed += poll_interval
+                        continue
+
+                if getattr(agent_executor, "streams_logs_externally", False) is True:
+                    caught_up = await self._consume_runner_log_page(session_reference)
+                    if not caught_up and status in (
+                        AgentStatus.SUCCEEDED,
+                        AgentStatus.FAILED,
+                        AgentStatus.STOPPED,
+                    ):
+                        # Drain the final backlog one bounded page at a time,
+                        # yielding between pages before deciding completion.
+                        await asyncio.sleep(0)
                         continue
 
                 # Publish status update (best effort - don't fail if NATS is down)

--- a/backend/preloop/services/flow_orchestrator.py
+++ b/backend/preloop/services/flow_orchestrator.py
@@ -2242,6 +2242,10 @@ class FlowExecutionOrchestrator:
             agent_executor: Agent executor instance
             session_reference: Container/Job reference
         """
+        # Private runner WebSockets already persist and publish each line.
+        # They have no container stream, and replaying stored logs duplicates it.
+        if getattr(agent_executor, "streams_logs_externally", False) is True:
+            return
         logger.info(f"Starting log streaming for {session_reference}")
         log_count = 0
 

--- a/backend/tests/agents/test_remote_runner.py
+++ b/backend/tests/agents/test_remote_runner.py
@@ -380,3 +380,71 @@ def test_factory_uses_account_default_pool() -> None:
     )
     assert isinstance(executor, RemoteRunnerExecutor)
     assert executor.pool == "office-mac"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("execution_status", ["RUNNING", "SUCCEEDED", "FAILED"])
+async def test_stale_queued_reference_follows_persisted_assignment(
+    monkeypatch: pytest.MonkeyPatch, execution_status: str
+) -> None:
+    """An old queue marker must neither lease twice nor overwrite completion."""
+    execution_id, runner_id = uuid4(), uuid4()
+    execution = SimpleNamespace(
+        id=execution_id,
+        status=execution_status,
+        start_time=datetime.now(timezone.utc) - timedelta(minutes=16),
+        agent_session_reference=f"runner:{runner_id}:{execution_id}",
+        runner_id=runner_id,
+        current_execution_id=None,
+        error_message=None,
+        end_time=None,
+    )
+    runner = SimpleNamespace(
+        id=runner_id,
+        halt_requested=False,
+        reported_status=execution_status,
+        current_execution_id=execution_id,
+    )
+    monkeypatch.setattr(
+        "preloop.agents.remote_runner.crud_flow_execution.get",
+        lambda *a, **k: execution,
+    )
+    monkeypatch.setattr(
+        "preloop.agents.remote_runner.crud_flow_runner.get", lambda *a, **k: runner
+    )
+    lease = MagicMock()
+    monkeypatch.setattr("preloop.agents.remote_runner.lease_job", lease)
+    executor = RemoteRunnerExecutor(
+        "codex", {}, db=MagicMock(), pool="auto", account_id=uuid4()
+    )
+    assert await executor.get_status(
+        f"runner:queued:auto:{execution_id}"
+    ) == AgentStatus(execution_status)
+    assert execution.status == execution_status
+    assert execution.error_message is None
+    lease.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_terminal_execution_ignores_reused_runner_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    execution_id, runner_id = uuid4(), uuid4()
+    execution = SimpleNamespace(id=execution_id, status="FAILED")
+    runner = SimpleNamespace(
+        halt_requested=False, reported_status="RUNNING", current_execution_id=uuid4()
+    )
+    monkeypatch.setattr(
+        "preloop.agents.remote_runner.crud_flow_execution.get",
+        lambda *a, **k: execution,
+    )
+    monkeypatch.setattr(
+        "preloop.agents.remote_runner.crud_flow_runner.get", lambda *a, **k: runner
+    )
+    executor = RemoteRunnerExecutor(
+        "codex", {}, db=MagicMock(), pool="auto", account_id=uuid4()
+    )
+    assert (
+        await executor.get_status(f"runner:{runner_id}:{execution_id}")
+        == AgentStatus.FAILED
+    )

--- a/backend/tests/models/test_flow_runner_claim.py
+++ b/backend/tests/models/test_flow_runner_claim.py
@@ -1,0 +1,174 @@
+"""Real PostgreSQL regression tests for idle runner lease eligibility."""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import JSON, null, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from preloop.models import models
+from preloop.models.crud import crud_account
+from preloop.models.crud.flow_runner import crud_flow_runner
+
+
+@pytest.mark.parametrize("pending_job", [None, JSON.NULL, null()])
+def test_claim_idle_accepts_both_null_representations(
+    db_session: Session, pending_job: object
+) -> None:
+    account = crud_account.create(
+        db_session,
+        obj_in={
+            "organization_name": "Runner lease test",
+            "is_active": True,
+        },
+    )
+    runner = crud_flow_runner.create(
+        db_session,
+        obj_in={
+            "account_id": account.id,
+            "name": f"runner-{uuid4()}",
+            "token_hash": "test-token-hash",
+            "status": "online",
+            "last_heartbeat": datetime.now(timezone.utc),
+            "pending_job": pending_job,
+        },
+    )
+    assert runner.pending_job is None
+    assert crud_flow_runner.find_matching(
+        db_session, account_id=account.id, pool="auto"
+    ) == [runner]
+    # Python None and JSON.NULL persist as JSON null under the existing model.
+    is_sql_null = db_session.scalar(
+        select(models.FlowRunner.pending_job.is_(None)).where(
+            models.FlowRunner.id == runner.id
+        )
+    )
+    assert is_sql_null is (not (pending_job is None or pending_job is JSON.NULL))
+    assert crud_flow_runner.claim_idle(db_session, runner_id=runner.id) is not None
+
+
+@pytest.mark.parametrize("pending_job", [{}, {"execution_id": "pending"}, [], False])
+def test_claim_idle_rejects_non_null_jobs(
+    db_session: Session, pending_job: object
+) -> None:
+    account = crud_account.create(
+        db_session, obj_in={"organization_name": "Busy runner test"}
+    )
+    runner = crud_flow_runner.create(
+        db_session,
+        obj_in={
+            "account_id": account.id,
+            "name": "occupied",
+            "token_hash": "test-token",
+            "status": "online",
+            "pending_job": pending_job,
+        },
+    )
+    assert crud_flow_runner.claim_idle(db_session, runner_id=runner.id) is None
+
+
+def test_cleared_runner_can_be_claimed_again(db_session: Session) -> None:
+    account = crud_account.create(
+        db_session, obj_in={"organization_name": "Completion test"}
+    )
+    runner = crud_flow_runner.create(
+        db_session,
+        obj_in={
+            "account_id": account.id,
+            "name": "completed",
+            "token_hash": "test-token",
+            "status": "busy",
+            "pending_job": {"execution_id": "previous"},
+        },
+    )
+    assert crud_flow_runner.claim_idle(db_session, runner_id=runner.id) is None
+    crud_flow_runner.update(
+        db_session, db_obj=runner, obj_in={"pending_job": None, "status": "online"}
+    )
+    assert crud_flow_runner.claim_idle(db_session, runner_id=runner.id) is not None
+
+
+def test_concurrent_claim_skips_locked_runner(db_engine: Engine) -> None:
+    """Two real transactions cannot claim the same JSON-null runner."""
+    with Session(db_engine) as setup:
+        account = crud_account.create(
+            setup, obj_in={"organization_name": "Concurrent lease test"}
+        )
+        account_id = account.id
+        runner = crud_flow_runner.create(
+            setup,
+            obj_in={
+                "account_id": account_id,
+                "name": "concurrent",
+                "token_hash": "test-token",
+                "status": "online",
+                "pending_job": None,
+            },
+        )
+        runner_id = runner.id
+    try:
+        with Session(db_engine) as first, Session(db_engine) as second:
+            claimed = crud_flow_runner.claim_idle(first, runner_id=runner_id)
+            assert claimed is not None
+            assert crud_flow_runner.claim_idle(second, runner_id=runner_id) is None
+            crud_flow_runner.update(
+                first,
+                db_obj=claimed,
+                obj_in={
+                    "status": "busy",
+                    "pending_job": {"execution_id": "winner"},
+                },
+            )
+            assert crud_flow_runner.claim_idle(second, runner_id=runner_id) is None
+    finally:
+        with Session(db_engine) as cleanup:
+            crud_flow_runner.delete(cleanup, id=runner_id)
+            crud_account.delete(cleanup, id=account_id)
+
+
+def test_monitor_refreshes_cached_execution(db_session: Session) -> None:
+    """Another session's completion must replace a cached queued state."""
+    from preloop.models.crud import crud_flow, crud_flow_execution
+    from preloop.models.schemas.flow import FlowCreate
+    from preloop.models.schemas.flow_execution import (
+        FlowExecutionCreate,
+        FlowExecutionUpdate,
+    )
+
+    account = crud_account.create(
+        db_session, obj_in={"organization_name": "Monitor refresh test"}
+    )
+    flow = crud_flow.create(
+        db_session,
+        account_id=account.id,
+        flow_in=FlowCreate(
+            name="Runner flow",
+            account_id=account.id,
+            agent_type="codex",
+            agent_config={},
+            prompt_template="Implement the issue",
+            trigger_event_source="github",
+            trigger_event_types=["issue_updated"],
+        ),
+    )
+    execution = crud_flow_execution.create(
+        db_session,
+        obj_in=FlowExecutionCreate(
+            flow_id=flow.id,
+            status="PENDING",
+        ),
+    )
+    with Session(
+        bind=db_session.connection(), join_transaction_mode="create_savepoint"
+    ) as writer:
+        other = crud_flow_execution.get(writer, id=execution.id)
+        crud_flow_execution.update(
+            writer, db_obj=other, obj_in=FlowExecutionUpdate(status="SUCCEEDED")
+        )
+        writer.commit()
+    assert execution.status == "PENDING"
+    current = crud_flow_execution.get(db_session, id=execution.id, refresh=True)
+    assert current is execution
+    assert current.status == "SUCCEEDED"

--- a/backend/tests/services/test_flow_orchestrator_streaming.py
+++ b/backend/tests/services/test_flow_orchestrator_streaming.py
@@ -778,3 +778,20 @@ class TestUserStopResult:
         assert "timed out" not in (result["error_message"] or "")
         assert "stopped by user request" in result["error_message"]
         mock_agent_executor.stop.assert_any_call("session-123")
+
+
+@pytest.mark.asyncio
+async def test_remote_runner_logs_are_not_streamed_twice(
+    orchestrator: FlowExecutionOrchestrator, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The runner WebSocket already persists and publishes its log lines."""
+    from uuid import uuid4
+    from preloop.agents.remote_runner import RemoteRunnerExecutor
+
+    executor = RemoteRunnerExecutor(
+        "codex", {}, db=MagicMock(), pool="auto", account_id=uuid4()
+    )
+    executor.get_logs = AsyncMock()
+    await orchestrator._stream_logs_to_nats(executor, f"runner:queued:auto:{uuid4()}")
+    assert not [record for record in caplog.records if record.levelname == "ERROR"]
+    executor.get_logs.assert_not_called()

--- a/backend/tests/services/test_flow_orchestrator_streaming.py
+++ b/backend/tests/services/test_flow_orchestrator_streaming.py
@@ -795,3 +795,29 @@ async def test_remote_runner_logs_are_not_streamed_twice(
     await orchestrator._stream_logs_to_nats(executor, f"runner:queued:auto:{uuid4()}")
     assert not [record for record in caplog.records if record.levelname == "ERROR"]
     executor.get_logs.assert_not_called()
+
+
+def test_replay_persisted_runner_logs_binds_opened_pr(
+    orchestrator: FlowExecutionOrchestrator,
+) -> None:
+    """Private-runner log rows still feed PR-opened binding after the skip."""
+    from unittest.mock import patch
+
+    orchestrator.execution_log.agent_session_reference = "runner:abc:exec"
+    orchestrator.execution_logger.agent_output_lines = []
+    row = MagicMock()
+    row.log_type = "agent_log_line"
+    row.message = (
+        'PRELOOP_PR_OPENED {"url": "https://example.com/mr/1", "branch": "fix"}'
+    )
+    row.metadata_ = None
+    with patch(
+        "preloop.services.flow_orchestrator.crud_flow_execution_log.get_by_execution_id",
+        return_value=[row],
+    ):
+        orchestrator._replay_persisted_runner_logs()
+    assert orchestrator.execution_logger.get_agent_output_lines() == [
+        'PRELOOP_PR_OPENED {"url": "https://example.com/mr/1", "branch": "fix"}'
+    ]
+    assert orchestrator._opened_pr is not None
+    assert orchestrator._opened_pr["url"] == "https://example.com/mr/1"

--- a/backend/tests/services/test_runner_log_markers.py
+++ b/backend/tests/services/test_runner_log_markers.py
@@ -1,0 +1,189 @@
+"""Consume runner-owned raw logs without duplicating their storage or broadcast."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from preloop.agents.base import AgentExecutionResult, AgentStatus
+from preloop.models import models
+from preloop.models.crud import (
+    crud_account,
+    crud_flow,
+    crud_flow_execution,
+    crud_flow_execution_log,
+)
+from preloop.models.schemas.flow import FlowCreate
+from preloop.models.schemas.flow_execution import FlowExecutionCreate
+from preloop.services.flow_orchestrator import FlowExecutionOrchestrator
+
+
+@pytest.fixture
+def execution(db_session: Session) -> models.FlowExecution:
+    account = crud_account.create(
+        db_session, obj_in={"organization_name": "Log cursor test"}
+    )
+    flow = crud_flow.create(
+        db_session,
+        account_id=account.id,
+        flow_in=FlowCreate(
+            name="Runner log flow",
+            account_id=account.id,
+            agent_type="codex",
+            agent_config={},
+            prompt_template="Implement issue",
+            trigger_event_source="github",
+            trigger_event_types=["issue_updated"],
+        ),
+    )
+    return crud_flow_execution.create(
+        db_session, obj_in=FlowExecutionCreate(flow_id=flow.id, status="RUNNING")
+    )
+
+
+def test_log_cursor_is_scoped_and_handles_timestamp_ties(
+    db_session: Session, execution: models.FlowExecution
+) -> None:
+    other = crud_flow_execution.create(
+        db_session, obj_in=FlowExecutionCreate(flow_id=execution.flow_id)
+    )
+    timestamp = datetime.now(timezone.utc)
+    for index, (target, kind) in enumerate(
+        [
+            (execution.id, "agent_log_line"),
+            (other.id, "agent_log_line"),
+            (execution.id, "mcp_call"),
+            (execution.id, "agent_log_line"),
+            (execution.id, "agent_log_line"),
+        ],
+        start=1,
+    ):
+        row = crud_flow_execution_log.append_log(
+            db_session, str(target), {"type": kind, "message": f"line-{index}"}
+        )
+        row.id = UUID(int=index)
+        row.timestamp = timestamp
+        db_session.flush()
+    first = crud_flow_execution_log.get_agent_log_page(
+        db_session, execution.id, limit=2
+    )
+    assert [row.message for row in first] == ["line-1", "line-4"]
+    second = crud_flow_execution_log.get_agent_log_page(
+        db_session,
+        execution.id,
+        after=(first[-1].timestamp, first[-1].id),
+        limit=2,
+    )
+    assert [row.message for row in second] == ["line-5"]
+    assert (
+        crud_flow_execution_log.get_agent_log_page(
+            db_session,
+            execution.id,
+            after=(second[-1].timestamp, second[-1].id),
+            limit=2,
+        )
+        == []
+    )
+
+
+def orchestrator() -> FlowExecutionOrchestrator:
+    instance = FlowExecutionOrchestrator(MagicMock(), uuid4(), {}, AsyncMock())
+    instance.execution_log = SimpleNamespace(id=uuid4())
+    instance._publish_update = AsyncMock()
+    instance._persist_live_metrics = AsyncMock()
+    instance._note_opened_pr = MagicMock()
+    instance._note_agent_session = MagicMock()
+    instance._note_verification_evidence = MagicMock()
+    return instance
+
+
+@pytest.mark.asyncio
+async def test_runner_log_pages_parse_markers_and_metrics_once() -> None:
+    instance = orchestrator()
+    lines = [
+        "PRELOOP_AGENT_EXEC_START",
+        "tokens used",
+        "1,234",
+        "Calling tool: github/get_issue",
+        'PRELOOP_PR_OPENED {"number":7}',
+        'PRELOOP_AGENT_SESSION {"agent_type":"codex","session_id":"native-session"}',
+        'PRELOOP_VERIFICATION {"status":"passed"}',
+        "FLOW_EXECUTION_SUCCESS",
+    ]
+    rows = [
+        SimpleNamespace(
+            id=UUID(int=i + 1), timestamp=datetime.now(timezone.utc), message=line
+        )
+        for i, line in enumerate(lines)
+    ]
+    cursors = []
+
+    def page(
+        _db: Session,
+        execution_id: UUID,
+        *,
+        after: tuple[datetime, UUID] | None,
+        limit: int,
+    ) -> list[SimpleNamespace]:
+        assert execution_id == instance.execution_log.id
+        cursors.append(after)
+        return [
+            row for row in rows if after is None or (row.timestamp, row.id) > after
+        ][:limit]
+
+    with (
+        patch("preloop.services.flow_orchestrator.RUNNER_LOG_PAGE_SIZE", 2),
+        patch("preloop.services.flow_orchestrator.RUNNER_LOG_SUMMARY_LINES", 3),
+        patch(
+            "preloop.services.flow_orchestrator.crud_flow_execution_log.get_agent_log_page",
+            side_effect=page,
+        ),
+    ):
+        # Process one bounded page per live poll, including a split token pair.
+        for _ in range(6):
+            await instance._consume_runner_log_page("runner:queued:auto:session")
+    assert instance.total_tokens == 1234
+    assert instance.tool_calls_count == 1
+    assert instance._agent_exec_started
+    assert instance._success_sentinel_seen.is_set()
+    instance._note_opened_pr.assert_called_once()
+    instance._note_agent_session.assert_called_once()
+    instance._note_verification_evidence.assert_called_once()
+    assert instance.execution_logger.get_agent_output_lines() == lines[-3:]
+    assert cursors[1] == (rows[1].timestamp, rows[1].id)
+    assert all(
+        call.args[0] != "agent_log_line"
+        for call in instance._publish_update.await_args_list
+    )
+    assert [call.args[0] for call in instance._publish_update.await_args_list].count(
+        "mcp_call"
+    ) == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_monitor_drains_runner_logs_before_result() -> None:
+    instance = orchestrator()
+    instance.flow = SimpleNamespace(
+        agent_type="codex", agent_config={}, timeout_seconds=60
+    )
+    instance._listen_for_commands = AsyncMock()
+    instance._cleanup_monitoring = AsyncMock()
+    instance._capture_result_artifact = AsyncMock(return_value={"status": "success"})
+    instance._sync_runtime_tool_activity_metrics = AsyncMock(return_value=None)
+    executor = AsyncMock()
+    executor.streams_logs_externally = True
+    executor.get_status.return_value = AgentStatus.SUCCEEDED
+    executor.get_result.return_value = AgentExecutionResult(
+        status=AgentStatus.SUCCEEDED,
+        session_reference="runner:test",
+        exit_code=0,
+    )
+    drains = AsyncMock(side_effect=[False, False, True])
+    with patch.object(instance, "_consume_runner_log_page", drains):
+        result = await instance._monitor_agent_execution("runner:test", executor)
+    assert drains.await_count == 3
+    executor.get_result.assert_awaited_once()
+    assert result["status"] == "SUCCEEDED"


### PR DESCRIPTION
## Summary

Private runners could remain unclaimable after completing a job, and monitors retaining a queued reference could miss the assignment. Their WebSocket logs also bypassed the controller parser, losing wrapper-opened PR bindings, native-session markers, verification evidence and metrics.

- Accept both JSON `null` and SQL `NULL` for idle runner leases under the existing locked query, including existing rows.
- Follow persisted assignments from stale queued references and refresh execution state written by the runner WebSocket. Preserve reported terminal status instead of leasing again or replacing it with a queue timeout.
- Share the hosted marker parser with private-runner monitoring. Consume execution-scoped raw logs in 500-row pages using a timestamp/UUID cursor, retain a 1,000-line summary tail, and drain remaining pages before terminal result binding. The WebSocket retains ownership of raw persistence and broadcast.
- Preserve concurrent terminal-recovery commit `50ba979` through a normal merge, adapting its PR-binding regression to the bounded shared cursor.

The cursor is in memory for each monitor; this does not guarantee transactional exactly-once derived metrics across controller crashes. Docker harness invocation and incremental CLI transport are in the separate launcher change. No deployment or live-run validation is included.

## Testing

- [x] Backend: original lease/monitor suite, 82 passed, including real PostgreSQL JSON-null/SQL-NULL, locking and cached-state cases.
- [x] Marker integration: 129 passed, including execution-scoped PostgreSQL timestamp-tie pagination, repeated polls, split token counts, MCP metrics, sentinel/session/verification/PR markers, bounded summary retention, terminal draining and actual PR binding.
- [x] All applicable changed-file pre-commit hooks, including OpenAPI generation with CI-pinned dependencies. OpenAPI unchanged. Shared-environment generator drift was independently reproduced on the untouched base before using the CI versions.
- [ ] Full private-runner application acceptance: requires the launcher change and separate authorized runtime validation.

## Checklist

- [x] Docs updated if needed: CRUD cursor and monitor behavior documented inline.
- [x] Changelog updated if needed: no separate entry required.
- [x] No secrets included.


<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Well-tested bug fixes (JSON-null lease eligibility, queued-reference follow-up, and shared marker consumption for private runners) with no active HIGH/CRITICAL issues.
>
> **Overview**
> Fixes private runners becoming unclaimable after completion, stale queued monitors missing persisted assignments, and the missing `stream_logs` error; also shares the hosted marker parser with private-runner monitoring via a bounded timestamp/UUID keyset cursor over persisted logs.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 9f78bf1f. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->