### PR TITLE
Skip OpenCode log-filter JS tests when node is missing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,6 +134,10 @@ frontend:unit-tests:
     DATABASE_URL: postgresql://test_user:test_password@postgres:5432/test_db
     SENTRY_DSN:
   before_script:
+    - |
+      if [ "$TEST_PATHS" = "backend/tests/agents" ]; then
+        apt-get update && apt-get install -y --no-install-recommends nodejs
+      fi
     - pip install -U pip
     - pip install pytest pytest-cov loguru
     - pip install -e ".[dev]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **OpenCode log-filter tests no longer crash without Node**:
+  `TestOpenCodeLogFilterJs` spawned `node` and raised `FileNotFoundError`
+  in the GitLab agents job (Python slim image) and any local env without
+  Node on `PATH`. Those cases skip; the agents unit job installs `nodejs`
+  so CI still parses and executes the embedded filter.
+
 - **Landing build fails on missing screenshots**: the brand Vite plugin
   now errors when a landing `hero.image` or feature `placeholderImg` is
   missing from `frontend/public`, so a 404 like the onboard-dialog still

--- a/backend/tests/agents/test_agent_opencode.py
+++ b/backend/tests/agents/test_agent_opencode.py
@@ -2,11 +2,18 @@
 
 import base64
 import os
+import shutil
 from unittest.mock import patch, AsyncMock
 
 import pytest
 
 from preloop.agents.opencode import OpenCodeAgent
+
+_HAS_NODE = shutil.which("node") is not None
+_SKIP_WITHOUT_NODE = pytest.mark.skipif(
+    not _HAS_NODE,
+    reason="node is required to parse the embedded OpenCode log filter",
+)
 
 
 class TestOpenCodeAgentInit:
@@ -823,6 +830,20 @@ class TestOpenCodeLogFilterJs:
         assert start > len(marker) and end > start, "filter heredoc not found"
         return script[start:end]
 
+    def test_filter_js_tracks_parent_session_id(self):
+        script = OpenCodeAgent({})._build_opencode_script(
+            {
+                "prompt": "test",
+                "opencode_model": "model-1",
+                "execution_id": "exec-1",
+                "flow_name": "test-flow",
+            }
+        )
+        js = self._extract_filter_js(script)
+        assert "parentSessionId" in js
+        assert "/tmp/preloop-cli-session-id" in js
+
+    @_SKIP_WITHOUT_NODE
     def test_filter_js_is_valid_javascript(self, tmp_path):
         import subprocess
 
@@ -846,6 +867,7 @@ class TestOpenCodeLogFilterJs:
         )
         assert result.returncode == 0, result.stderr
 
+    @_SKIP_WITHOUT_NODE
     def test_filter_js_detects_session_ids(self, tmp_path):
         """The filter writes the parent session.idle/created id, not nested ones."""
         import json

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15168,7 +15168,7 @@ components:
           description: Description for the Pull/Merge Request
         verification:
           anyOf:
-          - $ref: '#/components/schemas/VerificationPolicy'
+          - $ref: '#/components/schemas/VerificationPolicy-Input'
           - type: 'null'
           description: 'Publication gate policy: required checks a commit must pass
             before the flow pushes it or opens a pull request'
@@ -15245,7 +15245,7 @@ components:
           description: Description for the Pull/Merge Request
         verification:
           anyOf:
-          - $ref: '#/components/schemas/VerificationPolicy'
+          - $ref: '#/components/schemas/VerificationPolicy-Output'
           - type: 'null'
           description: 'Publication gate policy: required checks a commit must pass
             before the flow pushes it or opens a pull request'
@@ -21974,7 +21974,7 @@ components:
       - reason
       title: VerificationCommand
       description: 'One required check: a shell command plus why it exists.'
-    VerificationPolicy:
+    VerificationPolicy-Input:
       properties:
         mode:
           type: string
@@ -21984,7 +21984,7 @@ components:
           title: Mode
           default: gate
         profile:
-          $ref: '#/components/schemas/VerificationProfile'
+          $ref: '#/components/schemas/VerificationProfile-Input'
           description: Versioned trusted test profile driving required checks
         gate_budget_seconds:
           type: integer
@@ -22008,7 +22008,85 @@ components:
         leave the workspace. There is no draft-publication exception: unverified
 
         work stays unpushed.'
-    VerificationProfile:
+    VerificationPolicy-Output:
+      properties:
+        mode:
+          type: string
+          enum:
+          - 'off'
+          - gate
+          title: Mode
+          default: gate
+        profile:
+          $ref: '#/components/schemas/VerificationProfile-Output'
+          description: Versioned trusted test profile driving required checks
+        gate_budget_seconds:
+          type: integer
+          maximum: 14400.0
+          minimum: 30.0
+          title: Gate Budget Seconds
+          description: Wall-clock budget for the whole verification run; a check that
+            cannot start inside it is blocked, not failed
+          default: 3600
+      type: object
+      required:
+      - profile
+      title: VerificationPolicy
+      description: 'Publication gate policy inside ``git_clone_config`` (issue #428).
+
+
+        ``mode: "gate"`` requires the runner-controlled verifier to allow
+
+        publication (push / pull-request creation) before the agent''s commits
+
+        leave the workspace. There is no draft-publication exception: unverified
+
+        work stays unpushed.'
+    VerificationProfile-Input:
+      properties:
+        version:
+          type: string
+          const: v1
+          title: Version
+          default: v1
+        profile_id:
+          type: string
+          title: Profile Id
+          description: Stable profile name, e.g. 'default'
+        description:
+          type: string
+          title: Description
+          default: ''
+        always:
+          items:
+            $ref: '#/components/schemas/VerificationCommand'
+          type: array
+          title: Always
+        rules:
+          items:
+            $ref: '#/components/schemas/ProfileRule'
+          type: array
+          title: Rules
+        unknown_default:
+          items:
+            $ref: '#/components/schemas/VerificationCommand'
+          type: array
+          title: Unknown Default
+      type: object
+      required:
+      - profile_id
+      title: VerificationProfile
+      description: 'Versioned, trusted set of required checks for a repository.
+
+
+        Ships with the flow configuration, not inside the repository under test.
+
+        Inexpensive ``always`` hooks are required on every change; rules match
+
+        the changed-file diff; ``unknown_default`` covers unknown impact so a
+
+        diff never resolves to an empty required list.'
+    VerificationProfile-Output:
       properties:
         version:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15168,7 +15168,7 @@ components:
           description: Description for the Pull/Merge Request
         verification:
           anyOf:
-          - $ref: '#/components/schemas/VerificationPolicy-Input'
+          - $ref: '#/components/schemas/VerificationPolicy'
           - type: 'null'
           description: 'Publication gate policy: required checks a commit must pass
             before the flow pushes it or opens a pull request'
@@ -15245,7 +15245,7 @@ components:
           description: Description for the Pull/Merge Request
         verification:
           anyOf:
-          - $ref: '#/components/schemas/VerificationPolicy-Output'
+          - $ref: '#/components/schemas/VerificationPolicy'
           - type: 'null'
           description: 'Publication gate policy: required checks a commit must pass
             before the flow pushes it or opens a pull request'
@@ -21974,7 +21974,7 @@ components:
       - reason
       title: VerificationCommand
       description: 'One required check: a shell command plus why it exists.'
-    VerificationPolicy-Input:
+    VerificationPolicy:
       properties:
         mode:
           type: string
@@ -21984,7 +21984,7 @@ components:
           title: Mode
           default: gate
         profile:
-          $ref: '#/components/schemas/VerificationProfile-Input'
+          $ref: '#/components/schemas/VerificationProfile'
           description: Versioned trusted test profile driving required checks
         gate_budget_seconds:
           type: integer
@@ -22008,85 +22008,7 @@ components:
         leave the workspace. There is no draft-publication exception: unverified
 
         work stays unpushed.'
-    VerificationPolicy-Output:
-      properties:
-        mode:
-          type: string
-          enum:
-          - 'off'
-          - gate
-          title: Mode
-          default: gate
-        profile:
-          $ref: '#/components/schemas/VerificationProfile-Output'
-          description: Versioned trusted test profile driving required checks
-        gate_budget_seconds:
-          type: integer
-          maximum: 14400.0
-          minimum: 30.0
-          title: Gate Budget Seconds
-          description: Wall-clock budget for the whole verification run; a check that
-            cannot start inside it is blocked, not failed
-          default: 3600
-      type: object
-      required:
-      - profile
-      title: VerificationPolicy
-      description: 'Publication gate policy inside ``git_clone_config`` (issue #428).
-
-
-        ``mode: "gate"`` requires the runner-controlled verifier to allow
-
-        publication (push / pull-request creation) before the agent''s commits
-
-        leave the workspace. There is no draft-publication exception: unverified
-
-        work stays unpushed.'
-    VerificationProfile-Input:
-      properties:
-        version:
-          type: string
-          const: v1
-          title: Version
-          default: v1
-        profile_id:
-          type: string
-          title: Profile Id
-          description: Stable profile name, e.g. 'default'
-        description:
-          type: string
-          title: Description
-          default: ''
-        always:
-          items:
-            $ref: '#/components/schemas/VerificationCommand'
-          type: array
-          title: Always
-        rules:
-          items:
-            $ref: '#/components/schemas/ProfileRule'
-          type: array
-          title: Rules
-        unknown_default:
-          items:
-            $ref: '#/components/schemas/VerificationCommand'
-          type: array
-          title: Unknown Default
-      type: object
-      required:
-      - profile_id
-      title: VerificationProfile
-      description: 'Versioned, trusted set of required checks for a repository.
-
-
-        Ships with the flow configuration, not inside the repository under test.
-
-        Inexpensive ``always`` hooks are required on every change; rules match
-
-        the changed-file diff; ``unknown_default`` covers unknown impact so a
-
-        diff never resolves to an empty required list.'
-    VerificationProfile-Output:
+    VerificationProfile:
       properties:
         version:
           type: string


### PR DESCRIPTION
## Summary
- `TestOpenCodeLogFilterJs` spawned `node` and crashed with `FileNotFoundError` on the GitLab agents job (Python slim image) and any environment without Node on `PATH`.
- Skip those two tests when `node` is absent. The string-level session-id markers still run. The agents unit job installs `nodejs` so GitLab still parses and executes the embedded filter.
- `openapi.yaml` was regenerated by the pre-commit hook (Pydantic split `VerificationPolicy` into Input/Output). Required to land a Python change; not a behavior change in this PR.

## Test plan
- [ ] `PATH="\$VIRTUAL_ENV/bin:/usr/bin:/bin" pytest backend/tests/agents/test_agent_opencode.py::TestOpenCodeLogFilterJs` → 1 passed, 2 skipped
- [ ] With Node on `PATH`, the same file → 3 passed
- [ ] GitLab `test:unit:preloop-agents` installs `nodejs` and the two JS tests pass rather than skip

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change gating two Node-dependent tests behind a `skipif`; no production code paths touched.
>
> **Overview**
> Skips the OpenCode log-filter JS tests when `node` is absent from `PATH`, preserves string-level session-id assertions in a new non-skipped test, and installs `nodejs` in the agents CI job. The `openapi.yaml` regeneration is incidental to a prior Pydantic schema split.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 5af19d7d. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->