### PR TITLE
Approvals: bulk decide on the shared selection, bell carries approvals, diff view for file edits, copy fixes (round-4 report wave 3)

### DIFF
--- a/backend/preloop/api/endpoints/approval_requests.py
+++ b/backend/preloop/api/endpoints/approval_requests.py
@@ -52,6 +52,28 @@ async def _async_db_session() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
+@require_permission("decide_approvals")
+def _require_decide_approvals(
+    request: Request,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db_session),
+) -> None:
+    """Enforce ``decide_approvals`` for a handler that holds an async session.
+
+    The RBAC check behind ``@require_permission`` runs synchronous CRUD
+    (``crud_user_role.get_by_user``, ``db.query``) against whatever arrives as
+    ``db``, so a handler that declares an ``AsyncSession`` under that name
+    fails the check itself with a 500 on every request once RBAC is on.
+
+    Declaring the check as a plain ``def`` dependency gives it the sync
+    ``Session`` it needs and keeps the blocking pool checkout on FastAPI's
+    threadpool rather than on the event loop, which is the liveness risk the
+    ratchet in ``tests/api/test_event_loop_pool_wait.py`` exists to bound. The
+    handler keeps its own async session for the decisions.
+    """
+    _ = (request, current_user, db)  # Consumed by @require_permission.
+
+
 def _record_viewed_event(
     db: Session, approval_request: ApprovalRequest, actor_id: Union[uuid.UUID, None]
 ) -> None:
@@ -443,13 +465,18 @@ async def decide_request(
         )
 
 
-@router.post("/decide-batch", response_model=ApprovalBatchResponse)
-@require_permission("decide_approvals")
+@router.post(
+    "/decide-batch",
+    response_model=ApprovalBatchResponse,
+    # decide_approvals is enforced by a sync dependency instead of the
+    # handler decorator: the RBAC check needs a sync Session and must not run
+    # on the event loop. See _require_decide_approvals.
+    dependencies=[Depends(_require_decide_approvals)],
+)
 async def decide_requests_batch(
     decision: ApprovalBatchDecision,
     request: Request,
     current_user: User = Depends(get_current_active_user),
-    # Required by @require_permission (fail-closed checks kwargs["db"]).
     # Async session: a sync Session here would grow the event-loop pool-wait
     # surface (see test_async_sync_session_route_count_does_not_grow).
     db: AsyncSession = Depends(_async_db_session),
@@ -469,7 +496,7 @@ async def decide_requests_batch(
         decision: The ids to decide, the decision, and an optional comment
         request: HTTP request
         current_user: Current authenticated user
-        db: Async session used for the permission check and the decisions
+        db: Async session used for the decisions
 
     Returns:
         One result per requested id, in the order they were sent

--- a/backend/preloop/api/endpoints/approval_requests.py
+++ b/backend/preloop/api/endpoints/approval_requests.py
@@ -20,6 +20,9 @@ from preloop.models.db.session import get_async_db_session, get_db_session
 from preloop.models.models import ApprovalRequest
 from preloop.models.models.user import User
 from preloop.models.schemas.approval_request import (
+    ApprovalBatchDecision,
+    ApprovalBatchItemResult,
+    ApprovalBatchResponse,
     ApprovalRequestResponse,
     ApprovalDecision,
     ApprovalEventResponse,
@@ -427,3 +430,118 @@ async def decide_request(
         return ApprovalRequestResponse.model_validate(
             await attributed_async(async_db, updated)
         )
+
+
+@router.post("/decide-batch", response_model=ApprovalBatchResponse)
+@require_permission("decide_approvals")
+async def decide_requests_batch(
+    decision: ApprovalBatchDecision,
+    request: Request,
+    current_user: User = Depends(get_current_active_user),
+    # Required by @require_permission (fail-closed checks kwargs["db"]).
+    # Handler body uses get_async_db_session() for ApprovalService work.
+    db: Session = Depends(get_db_session),
+) -> ApprovalBatchResponse:
+    """Approve or decline several requests with one decision.
+
+    An operator clearing an inbox picks the rows first and decides once. Doing
+    that as N round trips means N approvals racing for the same expiry window
+    and N chances for the page to lose track of which ones landed, so the
+    console sends the whole selection here.
+
+    The batch never fails as a whole: each request is decided on its own and
+    reported on its own, so an id that expired while the operator was reading
+    costs that row and nothing else.
+
+    Args:
+        decision: The ids to decide, the decision, and an optional comment
+        request: HTTP request
+        current_user: Current authenticated user
+        db: Injected for the permission check
+
+    Returns:
+        One result per requested id, in the order they were sent
+    """
+    _ = db  # Injected for @require_permission; not used by handler body.
+    base_url = os.getenv("PRELOOP_URL", str(request.base_url).rstrip("/"))
+
+    results: list[ApprovalBatchItemResult] = []
+    async with get_async_db_session() as async_db:
+        approval_service = ApprovalService(async_db, base_url)
+
+        # Sequential on purpose. Each decision writes the request, appends
+        # timeline events and broadcasts, and several of those running at once
+        # against one session is how a batch turns into a deadlock.
+        for request_id in decision.unique_ids:
+            approval_request = await approval_service.get_approval_request(request_id)
+            if not approval_request:
+                results.append(
+                    ApprovalBatchItemResult(
+                        id=request_id, ok=False, error="Approval request not found"
+                    )
+                )
+                continue
+            if approval_request.account_id != current_user.account_id:
+                # Same message as "not found" on purpose: a caller must not be
+                # able to probe another account's request ids.
+                results.append(
+                    ApprovalBatchItemResult(
+                        id=request_id, ok=False, error="Approval request not found"
+                    )
+                )
+                continue
+            if approval_request.status != "pending":
+                results.append(
+                    ApprovalBatchItemResult(
+                        id=request_id,
+                        ok=False,
+                        status=approval_request.status,
+                        error=f"Request already {approval_request.status}",
+                    )
+                )
+                continue
+
+            try:
+                if decision.approved:
+                    updated = await approval_service.approve_request(
+                        request_id,
+                        decision.comment,
+                        user_id=current_user.id,
+                        channel=AUTHENTICATED_DECISION_CHANNEL,
+                    )
+                else:
+                    updated = await approval_service.decline_request(
+                        request_id,
+                        decision.comment,
+                        user_id=current_user.id,
+                        channel=AUTHENTICATED_DECISION_CHANNEL,
+                    )
+            except Exception as error:  # noqa: BLE001 - one bad id, not the batch
+                logger.warning(
+                    "Batch decision failed for approval %s: %s",
+                    request_id,
+                    error,
+                    exc_info=True,
+                )
+                results.append(
+                    ApprovalBatchItemResult(
+                        id=request_id, ok=False, error="Failed to process decision"
+                    )
+                )
+                continue
+
+            if not updated:
+                results.append(
+                    ApprovalBatchItemResult(
+                        id=request_id, ok=False, error="Failed to process decision"
+                    )
+                )
+                continue
+
+            results.append(
+                ApprovalBatchItemResult(
+                    id=request_id, ok=True, status=getattr(updated, "status", None)
+                )
+            )
+
+    return ApprovalBatchResponse(results=results)

--- a/backend/preloop/api/endpoints/approval_requests.py
+++ b/backend/preloop/api/endpoints/approval_requests.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import uuid
-from datetime import datetime
 from typing import AsyncGenerator, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -51,20 +50,6 @@ async def _async_db_session() -> AsyncGenerator[AsyncSession, None]:
     """
     async with get_async_db_session() as session:
         yield session
-
-
-def _pending_request_has_expired(approval_request: ApprovalRequest) -> bool:
-    """True when a still-pending row is past ``expires_at``.
-
-    Matches ``ApprovalService._reject_if_not_actionable``: naive UTC, so a
-    request the operator is staring at can expire without a status write.
-    """
-    expires_at = approval_request.expires_at
-    if expires_at is None:
-        return False
-    if getattr(expires_at, "tzinfo", None) is not None:
-        expires_at = expires_at.replace(tzinfo=None)
-    return datetime.utcnow() > expires_at
 
 
 def _record_viewed_event(
@@ -526,20 +511,11 @@ async def decide_requests_batch(
                 )
             )
             continue
-        if _pending_request_has_expired(approval_request):
-            # Still pending in the DB, but the window has closed. Do not
-            # call approve/decline: those would expire the row and this
-            # handler used to report that as ok=True.
-            results.append(
-                ApprovalBatchItemResult(
-                    id=request_id,
-                    ok=False,
-                    status="expired",
-                    error="Request already expired",
-                )
-            )
-            continue
-
+        # A past-deadline row is not pre-checked here. Expiry belongs to
+        # ApprovalService._reject_if_not_actionable, which holds the row lock,
+        # persists the expired transition, and honours the kill-switch freeze
+        # (#157) that keeps a frozen past-deadline request decidable. The
+        # post-check below reports whatever status the decision actually left.
         try:
             if decision.approved:
                 updated = await approval_service.approve_request(

--- a/backend/preloop/api/endpoints/approval_requests.py
+++ b/backend/preloop/api/endpoints/approval_requests.py
@@ -3,9 +3,11 @@
 import logging
 import os
 import uuid
-from typing import Optional, Union
+from datetime import datetime
+from typing import AsyncGenerator, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from preloop.api.auth import get_current_active_user
@@ -39,6 +41,30 @@ logger = logging.getLogger(__name__)
 #: Channel label recorded on the timeline for decisions made through the
 #: authenticated API (web console and mobile app sessions).
 AUTHENTICATED_DECISION_CHANNEL = "console"
+
+
+async def _async_db_session() -> AsyncGenerator[AsyncSession, None]:
+    """Yield an async session for handlers that must not block the event loop.
+
+    ``get_db_session`` on an ``async def`` route is a latent liveness risk:
+    the first sync query waits on the loop. Bulk decide uses this instead.
+    """
+    async with get_async_db_session() as session:
+        yield session
+
+
+def _pending_request_has_expired(approval_request: ApprovalRequest) -> bool:
+    """True when a still-pending row is past ``expires_at``.
+
+    Matches ``ApprovalService._reject_if_not_actionable``: naive UTC, so a
+    request the operator is staring at can expire without a status write.
+    """
+    expires_at = approval_request.expires_at
+    if expires_at is None:
+        return False
+    if getattr(expires_at, "tzinfo", None) is not None:
+        expires_at = expires_at.replace(tzinfo=None)
+    return datetime.utcnow() > expires_at
 
 
 def _record_viewed_event(
@@ -439,8 +465,9 @@ async def decide_requests_batch(
     request: Request,
     current_user: User = Depends(get_current_active_user),
     # Required by @require_permission (fail-closed checks kwargs["db"]).
-    # Handler body uses get_async_db_session() for ApprovalService work.
-    db: Session = Depends(get_db_session),
+    # Async session: a sync Session here would grow the event-loop pool-wait
+    # surface (see test_async_sync_session_route_count_does_not_grow).
+    db: AsyncSession = Depends(_async_db_session),
 ) -> ApprovalBatchResponse:
     """Approve or decline several requests with one decision.
 
@@ -457,91 +484,114 @@ async def decide_requests_batch(
         decision: The ids to decide, the decision, and an optional comment
         request: HTTP request
         current_user: Current authenticated user
-        db: Injected for the permission check
+        db: Async session used for the permission check and the decisions
 
     Returns:
         One result per requested id, in the order they were sent
     """
-    _ = db  # Injected for @require_permission; not used by handler body.
     base_url = os.getenv("PRELOOP_URL", str(request.base_url).rstrip("/"))
 
     results: list[ApprovalBatchItemResult] = []
-    async with get_async_db_session() as async_db:
-        approval_service = ApprovalService(async_db, base_url)
+    approval_service = ApprovalService(db, base_url)
+    expected_status = "approved" if decision.approved else "declined"
 
-        # Sequential on purpose. Each decision writes the request, appends
-        # timeline events and broadcasts, and several of those running at once
-        # against one session is how a batch turns into a deadlock.
-        for request_id in decision.unique_ids:
-            approval_request = await approval_service.get_approval_request(request_id)
-            if not approval_request:
-                results.append(
-                    ApprovalBatchItemResult(
-                        id=request_id, ok=False, error="Approval request not found"
-                    )
-                )
-                continue
-            if approval_request.account_id != current_user.account_id:
-                # Same message as "not found" on purpose: a caller must not be
-                # able to probe another account's request ids.
-                results.append(
-                    ApprovalBatchItemResult(
-                        id=request_id, ok=False, error="Approval request not found"
-                    )
-                )
-                continue
-            if approval_request.status != "pending":
-                results.append(
-                    ApprovalBatchItemResult(
-                        id=request_id,
-                        ok=False,
-                        status=approval_request.status,
-                        error=f"Request already {approval_request.status}",
-                    )
-                )
-                continue
-
-            try:
-                if decision.approved:
-                    updated = await approval_service.approve_request(
-                        request_id,
-                        decision.comment,
-                        user_id=current_user.id,
-                        channel=AUTHENTICATED_DECISION_CHANNEL,
-                    )
-                else:
-                    updated = await approval_service.decline_request(
-                        request_id,
-                        decision.comment,
-                        user_id=current_user.id,
-                        channel=AUTHENTICATED_DECISION_CHANNEL,
-                    )
-            except Exception as error:  # noqa: BLE001 - one bad id, not the batch
-                logger.warning(
-                    "Batch decision failed for approval %s: %s",
-                    request_id,
-                    error,
-                    exc_info=True,
-                )
-                results.append(
-                    ApprovalBatchItemResult(
-                        id=request_id, ok=False, error="Failed to process decision"
-                    )
-                )
-                continue
-
-            if not updated:
-                results.append(
-                    ApprovalBatchItemResult(
-                        id=request_id, ok=False, error="Failed to process decision"
-                    )
-                )
-                continue
-
+    # Sequential on purpose. Each decision writes the request, appends
+    # timeline events and broadcasts, and several of those running at once
+    # against one session is how a batch turns into a deadlock.
+    for request_id in decision.unique_ids:
+        approval_request = await approval_service.get_approval_request(request_id)
+        if not approval_request:
             results.append(
                 ApprovalBatchItemResult(
-                    id=request_id, ok=True, status=getattr(updated, "status", None)
+                    id=request_id, ok=False, error="Approval request not found"
                 )
             )
+            continue
+        if approval_request.account_id != current_user.account_id:
+            # Same message as "not found" on purpose: a caller must not be
+            # able to probe another account's request ids.
+            results.append(
+                ApprovalBatchItemResult(
+                    id=request_id, ok=False, error="Approval request not found"
+                )
+            )
+            continue
+        if approval_request.status != "pending":
+            results.append(
+                ApprovalBatchItemResult(
+                    id=request_id,
+                    ok=False,
+                    status=approval_request.status,
+                    error=f"Request already {approval_request.status}",
+                )
+            )
+            continue
+        if _pending_request_has_expired(approval_request):
+            # Still pending in the DB, but the window has closed. Do not
+            # call approve/decline: those would expire the row and this
+            # handler used to report that as ok=True.
+            results.append(
+                ApprovalBatchItemResult(
+                    id=request_id,
+                    ok=False,
+                    status="expired",
+                    error="Request already expired",
+                )
+            )
+            continue
+
+        try:
+            if decision.approved:
+                updated = await approval_service.approve_request(
+                    request_id,
+                    decision.comment,
+                    user_id=current_user.id,
+                    channel=AUTHENTICATED_DECISION_CHANNEL,
+                )
+            else:
+                updated = await approval_service.decline_request(
+                    request_id,
+                    decision.comment,
+                    user_id=current_user.id,
+                    channel=AUTHENTICATED_DECISION_CHANNEL,
+                )
+        except Exception as error:  # noqa: BLE001 - one bad id, not the batch
+            await db.rollback()
+            logger.warning(
+                "Batch decision failed for approval %s: %s",
+                request_id,
+                error,
+                exc_info=True,
+            )
+            results.append(
+                ApprovalBatchItemResult(
+                    id=request_id, ok=False, error="Failed to process decision"
+                )
+            )
+            continue
+
+        if not updated:
+            results.append(
+                ApprovalBatchItemResult(
+                    id=request_id, ok=False, error="Failed to process decision"
+                )
+            )
+            continue
+
+        updated_status = getattr(updated, "status", None)
+        if updated_status != expected_status:
+            results.append(
+                ApprovalBatchItemResult(
+                    id=request_id,
+                    ok=False,
+                    status=updated_status,
+                    error=f"Request {updated_status}",
+                )
+            )
+            continue
+
+        results.append(
+            ApprovalBatchItemResult(id=request_id, ok=True, status=updated_status)
+        )
 
     return ApprovalBatchResponse(results=results)

--- a/backend/preloop/models/schemas/approval_request.py
+++ b/backend/preloop/models/schemas/approval_request.py
@@ -415,3 +415,84 @@ class ApprovalDecision(BaseModel):
         the agent regardless of how they replied.
         """
         return self.answer_text or self.selected_option or self.comment
+
+
+#: Most requests one batch decision may carry. The console lists one page of
+#: 100 requests, so a batch can never need more than that; a larger body is a
+#: mistake or an abuse, and both are better refused than looped over.
+MAX_BATCH_DECISION_IDS = 100
+
+
+class ApprovalBatchDecision(BaseModel):
+    """One decision applied to several pending requests."""
+
+    ids: list[UUID] = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_BATCH_DECISION_IDS,
+        description="Approval request ids to decide, in the order they were picked",
+    )
+    approved: bool = Field(
+        ..., description="Whether every listed request is approved or declined"
+    )
+    comment: Optional[str] = Field(
+        None, description="Comment recorded on every request in the batch"
+    )
+
+    @property
+    def unique_ids(self) -> list[UUID]:
+        """The ids with duplicates removed, keeping the caller's order."""
+        seen: set[UUID] = set()
+        ordered: list[UUID] = []
+        for request_id in self.ids:
+            if request_id in seen:
+                continue
+            seen.add(request_id)
+            ordered.append(request_id)
+        return ordered
+
+
+class ApprovalBatchItemResult(BaseModel):
+    """What happened to one request in a batch decision."""
+
+    id: UUID = Field(..., description="The approval request this result is for")
+    ok: bool = Field(..., description="True when the decision was recorded")
+    status: Optional[str] = Field(
+        None, description="Status of the request after the decision, when known"
+    )
+    error: Optional[str] = Field(
+        None,
+        description=(
+            "Why this request was not decided: not found, not yours, or "
+            "already resolved. Null when ok is true."
+        ),
+    )
+
+    @field_serializer("id")
+    def serialize_id(self, value: UUID) -> str:
+        """Ids travel as strings, like every other approval id."""
+        return str(value)
+
+
+class ApprovalBatchResponse(BaseModel):
+    """Per-request results for a batch decision.
+
+    A batch never fails as a whole. One request that is already resolved (or
+    belongs to somebody else) must not cost the operator the other nineteen
+    decisions they just made, so every id gets its own result and the caller
+    reports the failures by name.
+    """
+
+    results: list[ApprovalBatchItemResult] = Field(
+        ..., description="One result per requested id, in request order"
+    )
+
+    @computed_field
+    def succeeded(self) -> int:
+        """How many requests took the decision."""
+        return sum(1 for result in self.results if result.ok)
+
+    @computed_field
+    def failed(self) -> int:
+        """How many requests did not."""
+        return sum(1 for result in self.results if not result.ok)

--- a/backend/tests/endpoints/test_approval_requests.py
+++ b/backend/tests/endpoints/test_approval_requests.py
@@ -624,6 +624,251 @@ class TestDecideRequest:
                 assert exc_info.value.status_code == 500
 
 
+class TestDecideRequestsBatch:
+    """Tests for the decide-batch endpoint (bulk approvals from the console)."""
+
+    @staticmethod
+    def _pending(account_id, status="pending"):
+        request = MagicMock()
+        request.id = uuid.uuid4()
+        request.account_id = account_id
+        request.status = status
+        return request
+
+    @staticmethod
+    def _service(requests_by_id, decided_status="approved"):
+        """An ApprovalService whose lookups answer from a dict of requests."""
+        service = AsyncMock()
+
+        async def _get(request_id):
+            return requests_by_id.get(request_id)
+
+        async def _decide(request_id, comment, user_id=None, channel=None):
+            decided = MagicMock()
+            decided.id = request_id
+            decided.status = decided_status
+            return decided
+
+        service.get_approval_request.side_effect = _get
+        service.approve_request.side_effect = _decide
+        service.decline_request.side_effect = _decide
+        return service
+
+    @pytest.mark.asyncio
+    async def test_batch_approves_every_pending_request(
+        self, mock_user, mock_db_session
+    ):
+        """Each id is approved once and reported once, in the order sent."""
+        from preloop.models.schemas.approval_request import ApprovalBatchDecision
+
+        first = self._pending(mock_user.account_id)
+        second = self._pending(mock_user.account_id)
+        service = self._service({first.id: first, second.id: second})
+
+        mock_http_request = MagicMock()
+        mock_http_request.base_url = "http://localhost"
+
+        with patch(
+            "preloop.api.endpoints.approval_requests.get_async_db_session"
+        ) as mock_get_session:
+            mock_get_session.return_value.__aenter__.return_value = AsyncMock()
+            with patch(
+                "preloop.api.endpoints.approval_requests.ApprovalService",
+                return_value=service,
+            ):
+                response = await approval_requests.decide_requests_batch(
+                    decision=ApprovalBatchDecision(
+                        ids=[first.id, second.id], approved=True, comment="ship it"
+                    ),
+                    request=mock_http_request,
+                    current_user=mock_user,
+                    db=mock_db_session,
+                )
+
+        assert [result.id for result in response.results] == [first.id, second.id]
+        assert all(result.ok for result in response.results)
+        assert response.succeeded == 2
+        assert response.failed == 0
+        assert service.approve_request.await_count == 2
+        service.decline_request.assert_not_awaited()
+        assert service.approve_request.await_args_list[0].kwargs["channel"] == (
+            approval_requests.AUTHENTICATED_DECISION_CHANNEL
+        )
+
+    @pytest.mark.asyncio
+    async def test_batch_declines_when_not_approved(self, mock_user, mock_db_session):
+        """approved=False routes every id to decline, never to approve."""
+        from preloop.models.schemas.approval_request import ApprovalBatchDecision
+
+        target = self._pending(mock_user.account_id)
+        service = self._service({target.id: target}, decided_status="declined")
+
+        mock_http_request = MagicMock()
+        mock_http_request.base_url = "http://localhost"
+
+        with patch(
+            "preloop.api.endpoints.approval_requests.get_async_db_session"
+        ) as mock_get_session:
+            mock_get_session.return_value.__aenter__.return_value = AsyncMock()
+            with patch(
+                "preloop.api.endpoints.approval_requests.ApprovalService",
+                return_value=service,
+            ):
+                response = await approval_requests.decide_requests_batch(
+                    decision=ApprovalBatchDecision(ids=[target.id], approved=False),
+                    request=mock_http_request,
+                    current_user=mock_user,
+                    db=mock_db_session,
+                )
+
+        assert response.results[0].ok is True
+        assert response.results[0].status == "declined"
+        service.approve_request.assert_not_awaited()
+        assert service.decline_request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_batch_reports_per_id_and_keeps_going(
+        self, mock_user, mock_db_session
+    ):
+        """A missing, foreign or resolved id costs that row and no other."""
+        from preloop.models.schemas.approval_request import ApprovalBatchDecision
+
+        good = self._pending(mock_user.account_id)
+        resolved = self._pending(mock_user.account_id, status="expired")
+        foreign = self._pending(str(uuid.uuid4()))
+        missing_id = uuid.uuid4()
+        service = self._service(
+            {good.id: good, resolved.id: resolved, foreign.id: foreign}
+        )
+
+        mock_http_request = MagicMock()
+        mock_http_request.base_url = "http://localhost"
+
+        with patch(
+            "preloop.api.endpoints.approval_requests.get_async_db_session"
+        ) as mock_get_session:
+            mock_get_session.return_value.__aenter__.return_value = AsyncMock()
+            with patch(
+                "preloop.api.endpoints.approval_requests.ApprovalService",
+                return_value=service,
+            ):
+                response = await approval_requests.decide_requests_batch(
+                    decision=ApprovalBatchDecision(
+                        ids=[missing_id, resolved.id, foreign.id, good.id],
+                        approved=True,
+                    ),
+                    request=mock_http_request,
+                    current_user=mock_user,
+                    db=mock_db_session,
+                )
+
+        by_id = {result.id: result for result in response.results}
+        assert by_id[missing_id].error == "Approval request not found"
+        assert by_id[resolved.id].error == "Request already expired"
+        # A request from another account is reported exactly like a missing one
+        # so ids cannot be probed across accounts.
+        assert by_id[foreign.id].error == "Approval request not found"
+        assert by_id[good.id].ok is True
+        assert response.succeeded == 1
+        assert response.failed == 3
+        # Only the one decidable request reached the service.
+        assert service.approve_request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_batch_decides_a_repeated_id_once(self, mock_user, mock_db_session):
+        """Duplicate ids in the body are collapsed before anything is decided."""
+        from preloop.models.schemas.approval_request import ApprovalBatchDecision
+
+        target = self._pending(mock_user.account_id)
+        service = self._service({target.id: target})
+
+        mock_http_request = MagicMock()
+        mock_http_request.base_url = "http://localhost"
+
+        with patch(
+            "preloop.api.endpoints.approval_requests.get_async_db_session"
+        ) as mock_get_session:
+            mock_get_session.return_value.__aenter__.return_value = AsyncMock()
+            with patch(
+                "preloop.api.endpoints.approval_requests.ApprovalService",
+                return_value=service,
+            ):
+                response = await approval_requests.decide_requests_batch(
+                    decision=ApprovalBatchDecision(
+                        ids=[target.id, target.id], approved=True
+                    ),
+                    request=mock_http_request,
+                    current_user=mock_user,
+                    db=mock_db_session,
+                )
+
+        assert len(response.results) == 1
+        assert service.approve_request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_batch_survives_one_failing_decision(
+        self, mock_user, mock_db_session
+    ):
+        """A raising decision is one failed result, not a failed batch."""
+        from preloop.models.schemas.approval_request import ApprovalBatchDecision
+
+        boom = self._pending(mock_user.account_id)
+        fine = self._pending(mock_user.account_id)
+        service = self._service({boom.id: boom, fine.id: fine})
+
+        async def _approve(request_id, comment, user_id=None, channel=None):
+            if request_id == boom.id:
+                raise RuntimeError("database is on fire")
+            decided = MagicMock()
+            decided.id = request_id
+            decided.status = "approved"
+            return decided
+
+        service.approve_request.side_effect = _approve
+
+        mock_http_request = MagicMock()
+        mock_http_request.base_url = "http://localhost"
+
+        with patch(
+            "preloop.api.endpoints.approval_requests.get_async_db_session"
+        ) as mock_get_session:
+            mock_get_session.return_value.__aenter__.return_value = AsyncMock()
+            with patch(
+                "preloop.api.endpoints.approval_requests.ApprovalService",
+                return_value=service,
+            ):
+                response = await approval_requests.decide_requests_batch(
+                    decision=ApprovalBatchDecision(
+                        ids=[boom.id, fine.id], approved=True
+                    ),
+                    request=mock_http_request,
+                    current_user=mock_user,
+                    db=mock_db_session,
+                )
+
+        by_id = {result.id: result for result in response.results}
+        assert by_id[boom.id].ok is False
+        assert by_id[boom.id].error == "Failed to process decision"
+        assert by_id[fine.id].ok is True
+
+    def test_batch_rejects_an_empty_or_oversized_body(self):
+        """The body carries at least one id and at most one page of them."""
+        import pydantic
+
+        from preloop.models.schemas.approval_request import (
+            MAX_BATCH_DECISION_IDS,
+            ApprovalBatchDecision,
+        )
+
+        with pytest.raises(pydantic.ValidationError):
+            ApprovalBatchDecision(ids=[], approved=True)
+        with pytest.raises(pydantic.ValidationError):
+            ApprovalBatchDecision(
+                ids=[uuid.uuid4() for _ in range(MAX_BATCH_DECISION_IDS + 1)],
+                approved=True,
+            )
+
+
 class TestGetApprovalRequestHistory:
     """Tests for the workflow-history timeline endpoint (issue #335)."""
 

--- a/backend/tests/endpoints/test_approval_requests.py
+++ b/backend/tests/endpoints/test_approval_requests.py
@@ -1,14 +1,20 @@
 """Tests for approval_requests API endpoints."""
 
+import os
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, UTC
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import NullPool
 
 from preloop.api.endpoints import approval_requests
 from preloop.models import models
+from preloop.models.crud import crud_account_halt
 from preloop.models.schemas.approval_request import ApprovalRequestResponse
 
 
@@ -873,6 +879,138 @@ class TestDecideRequestsBatch:
                 ids=[uuid.uuid4() for _ in range(MAX_BATCH_DECISION_IDS + 1)],
                 approved=True,
             )
+
+
+class TestDecideRequestsBatchAgainstPostgres:
+    """decide-batch on the real database, where expiry is an actual status write."""
+
+    @staticmethod
+    @asynccontextmanager
+    async def _session():
+        """An AsyncSession on the test database, like the route dependency."""
+        url = os.environ["DATABASE_URL"].replace(
+            "postgresql://", "postgresql+asyncpg://", 1
+        )
+        engine = create_async_engine(url, poolclass=NullPool)
+        try:
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                yield session
+        finally:
+            await engine.dispose()
+
+    @staticmethod
+    def _seed(db_engine, *, expires_at, halt_activated_at=None):
+        """Commit one pending request, optionally under a tools halt.
+
+        Committed rather than nested in the ``db_session`` transaction: the
+        route runs on its own asyncpg connection and would not see the rows.
+        """
+        account_id = uuid.uuid4()
+        with Session(db_engine) as db:
+            db.add(models.Account(id=account_id, organization_name="batch-expiry"))
+            db.flush()
+            workflow = models.ApprovalWorkflow(
+                account_id=account_id, name="batch expiry", workflow_type="simple"
+            )
+            tool = models.ToolConfiguration(
+                account_id=account_id,
+                tool_name="batch-expiry",
+                tool_source="builtin",
+            )
+            db.add_all([workflow, tool])
+            db.flush()
+            approval_request = models.ApprovalRequest(
+                account_id=account_id,
+                tool_configuration_id=tool.id,
+                approval_workflow_id=workflow.id,
+                tool_name="batch-expiry",
+                tool_args={},
+                requested_at=expires_at - timedelta(minutes=30),
+                expires_at=expires_at,
+                status="pending",
+            )
+            db.add(approval_request)
+            if halt_activated_at is not None:
+                crud_account_halt.set_scopes(
+                    db,
+                    account_id=account_id,
+                    scopes=["tools"],
+                    active=True,
+                    user_id=None,
+                    now=halt_activated_at.replace(tzinfo=UTC),
+                    commit=False,
+                )
+            db.commit()
+            return account_id, approval_request.id
+
+    @staticmethod
+    def _drop(db_engine, account_id):
+        """Remove the seeded account; every child row cascades with it."""
+        with Session(db_engine) as db:
+            db.query(models.Account).filter(models.Account.id == account_id).delete()
+            db.commit()
+
+    @staticmethod
+    def _status(db_engine, request_id):
+        with Session(db_engine) as db:
+            return db.get(models.ApprovalRequest, request_id).status
+
+    @classmethod
+    async def _decide(cls, account_id, request_id):
+        """Approve one id through the route with a real ApprovalService."""
+        from preloop.models.schemas.approval_request import ApprovalBatchDecision
+
+        user = MagicMock()
+        user.id = uuid.uuid4()
+        user.account_id = account_id
+        http_request = MagicMock()
+        http_request.base_url = "http://localhost"
+        async with cls._session() as session:
+            response = await approval_requests.decide_requests_batch(
+                decision=ApprovalBatchDecision(ids=[request_id], approved=True),
+                request=http_request,
+                current_user=user,
+                db=session,
+            )
+        return response.results[0]
+
+    @pytest.mark.asyncio
+    async def test_batch_decides_a_past_deadline_request_frozen_by_the_kill_switch(
+        self, db_engine
+    ):
+        """An incident freeze keeps a late request decidable (#157)."""
+        deadline = datetime.utcnow() - timedelta(minutes=1)
+        account_id, request_id = self._seed(
+            db_engine,
+            expires_at=deadline,
+            halt_activated_at=deadline - timedelta(minutes=10),
+        )
+        try:
+            result = await self._decide(account_id, request_id)
+
+            assert result.ok is True
+            assert result.status == "approved"
+            assert self._status(db_engine, request_id) == "approved"
+        finally:
+            self._drop(db_engine, account_id)
+
+    @pytest.mark.asyncio
+    async def test_batch_expires_a_past_deadline_request_when_nothing_is_frozen(
+        self, db_engine
+    ):
+        """Without a freeze the row is reported expired and written expired."""
+        account_id, request_id = self._seed(
+            db_engine, expires_at=datetime.utcnow() - timedelta(minutes=1)
+        )
+        try:
+            result = await self._decide(account_id, request_id)
+
+            assert result.ok is False
+            assert result.status == "expired"
+            # The old pre-check reported this without ever writing it.
+            assert self._status(db_engine, request_id) == "expired"
+        finally:
+            self._drop(db_engine, account_id)
 
 
 class TestGetApprovalRequestHistory:

--- a/backend/tests/endpoints/test_approval_requests.py
+++ b/backend/tests/endpoints/test_approval_requests.py
@@ -1,5 +1,9 @@
 """Tests for approval_requests API endpoints."""
 
+import asyncio
+import functools
+import importlib.util
+import inspect
 import os
 import uuid
 from contextlib import asynccontextmanager
@@ -7,14 +11,17 @@ from datetime import datetime, timedelta, UTC
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import NullPool
 
+from preloop.api.auth import get_current_active_user
 from preloop.api.endpoints import approval_requests
 from preloop.models import models
 from preloop.models.crud import crud_account_halt
+from preloop.models.db.session import get_db_session
 from preloop.models.schemas.approval_request import ApprovalRequestResponse
 
 
@@ -879,6 +886,141 @@ class TestDecideRequestsBatch:
                 ids=[uuid.uuid4() for _ in range(MAX_BATCH_DECISION_IDS + 1)],
                 approved=True,
             )
+
+
+class TestDecideRequestsBatchPermission:
+    """decide-batch must still enforce decide_approvals with RBAC switched on.
+
+    The handler holds an ``AsyncSession`` so its decisions stay off the event
+    loop, but the RBAC check is synchronous CRUD. Naming the async session
+    ``db`` handed it to that check and turned every RBAC-on request into a
+    500, so the check lives in its own synchronous dependency.
+    """
+
+    @staticmethod
+    def _rbac_plugin(seen):
+        """Build a plugin decorator shaped like ``plugins/rbac/permissions``.
+
+        The real plugin reads ``kwargs["db"]`` and immediately runs sync CRUD
+        against it, which is where an ``AsyncSession`` blows up.
+        """
+
+        def require_permission(permission_name: str):
+            def decorator(func):
+                def _enforce(kwargs) -> None:
+                    db = kwargs.get("db")
+                    seen["db"] = db
+                    seen["permission"] = permission_name
+                    if seen.get("deny"):
+                        raise HTTPException(
+                            status_code=403,
+                            detail=(
+                                f"Insufficient permissions. Required: {permission_name}"
+                            ),
+                        )
+                    db.query(models.UserRole).filter(
+                        models.UserRole.user_id == kwargs["current_user"].id
+                    )
+
+                if asyncio.iscoroutinefunction(func):
+
+                    @functools.wraps(func)
+                    async def async_wrapper(*args, **kwargs):
+                        _enforce(kwargs)
+                        return await func(*args, **kwargs)
+
+                    return async_wrapper
+
+                @functools.wraps(func)
+                def sync_wrapper(*args, **kwargs):
+                    _enforce(kwargs)
+                    return func(*args, **kwargs)
+
+                return sync_wrapper
+
+            return decorator
+
+        return require_permission
+
+    @classmethod
+    def _router_with_rbac(cls, monkeypatch, seen):
+        """Load a private copy of the endpoint module with RBAC enforcing.
+
+        ``require_permission`` binds the plugin when the module is imported,
+        and the installed build has no RBAC plugin, so the copy is executed
+        under a patched ``preloop.utils.permissions``. It is a separate module
+        object, so the shared import other tests use is left alone.
+        """
+        import preloop.utils.permissions as perms
+
+        monkeypatch.setattr(perms, "_plugin_require_permission", cls._rbac_plugin(seen))
+        monkeypatch.setattr(perms, "_rbac_checks_enabled", lambda: True)
+        spec = importlib.util.spec_from_file_location(
+            "approval_requests_rbac_probe", approval_requests.__file__
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @staticmethod
+    def _client(module, user):
+        """Serve the copied router with the session dependencies stubbed."""
+        app = FastAPI()
+        app.include_router(module.router, prefix="/api/v1")
+        app.dependency_overrides[get_current_active_user] = lambda: user
+        # Unbound, so the RBAC query builds without touching a database.
+        app.dependency_overrides[get_db_session] = lambda: Session()
+        app.dependency_overrides[module._async_db_session] = lambda: AsyncMock()
+        # Surface an unhandled error as the 500 a caller would actually see.
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_rbac_enabled_batch_decide_does_not_500(self, mock_user, monkeypatch):
+        """The permission check gets a sync session, so the route answers 200."""
+        seen: dict = {}
+        module = self._router_with_rbac(monkeypatch, seen)
+        service = AsyncMock()
+        service.get_approval_request.return_value = None
+
+        with patch.object(module, "ApprovalService", return_value=service):
+            with self._client(module, mock_user) as client:
+                response = client.post(
+                    "/api/v1/approval-requests/decide-batch",
+                    json={"ids": [str(uuid.uuid4())], "approved": True},
+                )
+
+        assert response.status_code == 200
+        assert seen["permission"] == "decide_approvals"
+        assert isinstance(seen["db"], Session)
+        assert not isinstance(seen["db"], AsyncSession)
+        # The batch itself still ran: the id simply does not exist.
+        assert response.json()["results"][0]["error"] == "Approval request not found"
+
+    def test_rbac_denial_blocks_the_batch(self, mock_user, monkeypatch):
+        """A missing permission is a 403 and no decision is attempted."""
+        seen: dict = {"deny": True}
+        module = self._router_with_rbac(monkeypatch, seen)
+        service = AsyncMock()
+
+        with patch.object(module, "ApprovalService", return_value=service):
+            with self._client(module, mock_user) as client:
+                response = client.post(
+                    "/api/v1/approval-requests/decide-batch",
+                    json={"ids": [str(uuid.uuid4())], "approved": True},
+                )
+
+        assert response.status_code == 403
+        service.get_approval_request.assert_not_awaited()
+
+    def test_permission_check_runs_off_the_event_loop(self):
+        """FastAPI dispatches a ``def`` dependency on its threadpool.
+
+        That is what keeps the RBAC pool checkout from stalling the loop, the
+        reason the async session is not simply renamed to ``db``.
+        """
+        guard = approval_requests._require_decide_approvals
+
+        assert not asyncio.iscoroutinefunction(guard)
+        assert inspect.signature(guard).parameters["db"].annotation is Session
 
 
 class TestDecideRequestsBatchAgainstPostgres:

--- a/backend/tests/endpoints/test_approval_requests.py
+++ b/backend/tests/endpoints/test_approval_requests.py
@@ -1,7 +1,7 @@
 """Tests for approval_requests API endpoints."""
 
 import uuid
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -628,11 +628,12 @@ class TestDecideRequestsBatch:
     """Tests for the decide-batch endpoint (bulk approvals from the console)."""
 
     @staticmethod
-    def _pending(account_id, status="pending"):
+    def _pending(account_id, status="pending", expires_at=None):
         request = MagicMock()
         request.id = uuid.uuid4()
         request.account_id = account_id
         request.status = status
+        request.expires_at = expires_at
         return request
 
     @staticmethod
@@ -654,36 +655,38 @@ class TestDecideRequestsBatch:
         service.decline_request.side_effect = _decide
         return service
 
-    @pytest.mark.asyncio
-    async def test_batch_approves_every_pending_request(
-        self, mock_user, mock_db_session
-    ):
-        """Each id is approved once and reported once, in the order sent."""
+    @staticmethod
+    async def _call(service, user, ids, *, approved=True, comment=None, session=None):
+        """Invoke the handler with a patched service and an async session."""
         from preloop.models.schemas.approval_request import ApprovalBatchDecision
 
+        mock_http_request = MagicMock()
+        mock_http_request.base_url = "http://localhost"
+        session = session or AsyncMock()
+        with patch(
+            "preloop.api.endpoints.approval_requests.ApprovalService",
+            return_value=service,
+        ):
+            response = await approval_requests.decide_requests_batch(
+                decision=ApprovalBatchDecision(
+                    ids=ids, approved=approved, comment=comment
+                ),
+                request=mock_http_request,
+                current_user=user,
+                db=session,
+            )
+        return response, session
+
+    @pytest.mark.asyncio
+    async def test_batch_approves_every_pending_request(self, mock_user):
+        """Each id is approved once and reported once, in the order sent."""
         first = self._pending(mock_user.account_id)
         second = self._pending(mock_user.account_id)
         service = self._service({first.id: first, second.id: second})
 
-        mock_http_request = MagicMock()
-        mock_http_request.base_url = "http://localhost"
-
-        with patch(
-            "preloop.api.endpoints.approval_requests.get_async_db_session"
-        ) as mock_get_session:
-            mock_get_session.return_value.__aenter__.return_value = AsyncMock()
-            with patch(
-                "preloop.api.endpoints.approval_requests.ApprovalService",
-                return_value=service,
-            ):
-                response = await approval_requests.decide_requests_batch(
-                    decision=ApprovalBatchDecision(
-                        ids=[first.id, second.id], approved=True, comment="ship it"
-                    ),
-                    request=mock_http_request,
-                    current_user=mock_user,
-                    db=mock_db_session,
-                )
+        response, _session = await self._call(
+            service, mock_user, [first.id, second.id], comment="ship it"
+        )
 
         assert [result.id for result in response.results] == [first.id, second.id]
         assert all(result.ok for result in response.results)
@@ -696,30 +699,14 @@ class TestDecideRequestsBatch:
         )
 
     @pytest.mark.asyncio
-    async def test_batch_declines_when_not_approved(self, mock_user, mock_db_session):
+    async def test_batch_declines_when_not_approved(self, mock_user):
         """approved=False routes every id to decline, never to approve."""
-        from preloop.models.schemas.approval_request import ApprovalBatchDecision
-
         target = self._pending(mock_user.account_id)
         service = self._service({target.id: target}, decided_status="declined")
 
-        mock_http_request = MagicMock()
-        mock_http_request.base_url = "http://localhost"
-
-        with patch(
-            "preloop.api.endpoints.approval_requests.get_async_db_session"
-        ) as mock_get_session:
-            mock_get_session.return_value.__aenter__.return_value = AsyncMock()
-            with patch(
-                "preloop.api.endpoints.approval_requests.ApprovalService",
-                return_value=service,
-            ):
-                response = await approval_requests.decide_requests_batch(
-                    decision=ApprovalBatchDecision(ids=[target.id], approved=False),
-                    request=mock_http_request,
-                    current_user=mock_user,
-                    db=mock_db_session,
-                )
+        response, _session = await self._call(
+            service, mock_user, [target.id], approved=False
+        )
 
         assert response.results[0].ok is True
         assert response.results[0].status == "declined"
@@ -727,12 +714,8 @@ class TestDecideRequestsBatch:
         assert service.decline_request.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_batch_reports_per_id_and_keeps_going(
-        self, mock_user, mock_db_session
-    ):
+    async def test_batch_reports_per_id_and_keeps_going(self, mock_user):
         """A missing, foreign or resolved id costs that row and no other."""
-        from preloop.models.schemas.approval_request import ApprovalBatchDecision
-
         good = self._pending(mock_user.account_id)
         resolved = self._pending(mock_user.account_id, status="expired")
         foreign = self._pending(str(uuid.uuid4()))
@@ -741,26 +724,9 @@ class TestDecideRequestsBatch:
             {good.id: good, resolved.id: resolved, foreign.id: foreign}
         )
 
-        mock_http_request = MagicMock()
-        mock_http_request.base_url = "http://localhost"
-
-        with patch(
-            "preloop.api.endpoints.approval_requests.get_async_db_session"
-        ) as mock_get_session:
-            mock_get_session.return_value.__aenter__.return_value = AsyncMock()
-            with patch(
-                "preloop.api.endpoints.approval_requests.ApprovalService",
-                return_value=service,
-            ):
-                response = await approval_requests.decide_requests_batch(
-                    decision=ApprovalBatchDecision(
-                        ids=[missing_id, resolved.id, foreign.id, good.id],
-                        approved=True,
-                    ),
-                    request=mock_http_request,
-                    current_user=mock_user,
-                    db=mock_db_session,
-                )
+        response, _session = await self._call(
+            service, mock_user, [missing_id, resolved.id, foreign.id, good.id]
+        )
 
         by_id = {result.id: result for result in response.results}
         assert by_id[missing_id].error == "Approval request not found"
@@ -775,43 +741,47 @@ class TestDecideRequestsBatch:
         assert service.approve_request.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_batch_decides_a_repeated_id_once(self, mock_user, mock_db_session):
-        """Duplicate ids in the body are collapsed before anything is decided."""
-        from preloop.models.schemas.approval_request import ApprovalBatchDecision
+    async def test_batch_skips_pending_rows_that_have_expired(self, mock_user):
+        """A still-pending row past expires_at is expired, not decided."""
+        stale = self._pending(
+            mock_user.account_id,
+            expires_at=datetime.utcnow() - timedelta(minutes=5),
+        )
+        fresh = self._pending(
+            mock_user.account_id,
+            expires_at=datetime.utcnow() + timedelta(minutes=5),
+        )
+        service = self._service({stale.id: stale, fresh.id: fresh})
 
+        response, _session = await self._call(service, mock_user, [stale.id, fresh.id])
+
+        by_id = {result.id: result for result in response.results}
+        assert by_id[stale.id].ok is False
+        assert by_id[stale.id].status == "expired"
+        assert by_id[stale.id].error == "Request already expired"
+        assert by_id[fresh.id].ok is True
+        assert by_id[fresh.id].status == "approved"
+        assert response.succeeded == 1
+        assert response.failed == 1
+        service.approve_request.assert_awaited_once()
+        assert service.approve_request.await_args.args[0] == fresh.id
+
+    @pytest.mark.asyncio
+    async def test_batch_decides_a_repeated_id_once(self, mock_user):
+        """Duplicate ids in the body are collapsed before anything is decided."""
         target = self._pending(mock_user.account_id)
         service = self._service({target.id: target})
 
-        mock_http_request = MagicMock()
-        mock_http_request.base_url = "http://localhost"
-
-        with patch(
-            "preloop.api.endpoints.approval_requests.get_async_db_session"
-        ) as mock_get_session:
-            mock_get_session.return_value.__aenter__.return_value = AsyncMock()
-            with patch(
-                "preloop.api.endpoints.approval_requests.ApprovalService",
-                return_value=service,
-            ):
-                response = await approval_requests.decide_requests_batch(
-                    decision=ApprovalBatchDecision(
-                        ids=[target.id, target.id], approved=True
-                    ),
-                    request=mock_http_request,
-                    current_user=mock_user,
-                    db=mock_db_session,
-                )
+        response, _session = await self._call(
+            service, mock_user, [target.id, target.id]
+        )
 
         assert len(response.results) == 1
         assert service.approve_request.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_batch_survives_one_failing_decision(
-        self, mock_user, mock_db_session
-    ):
+    async def test_batch_survives_one_failing_decision(self, mock_user):
         """A raising decision is one failed result, not a failed batch."""
-        from preloop.models.schemas.approval_request import ApprovalBatchDecision
-
         boom = self._pending(mock_user.account_id)
         fine = self._pending(mock_user.account_id)
         service = self._service({boom.id: boom, fine.id: fine})
@@ -826,30 +796,56 @@ class TestDecideRequestsBatch:
 
         service.approve_request.side_effect = _approve
 
-        mock_http_request = MagicMock()
-        mock_http_request.base_url = "http://localhost"
-
-        with patch(
-            "preloop.api.endpoints.approval_requests.get_async_db_session"
-        ) as mock_get_session:
-            mock_get_session.return_value.__aenter__.return_value = AsyncMock()
-            with patch(
-                "preloop.api.endpoints.approval_requests.ApprovalService",
-                return_value=service,
-            ):
-                response = await approval_requests.decide_requests_batch(
-                    decision=ApprovalBatchDecision(
-                        ids=[boom.id, fine.id], approved=True
-                    ),
-                    request=mock_http_request,
-                    current_user=mock_user,
-                    db=mock_db_session,
-                )
+        response, session = await self._call(service, mock_user, [boom.id, fine.id])
 
         by_id = {result.id: result for result in response.results}
         assert by_id[boom.id].ok is False
         assert by_id[boom.id].error == "Failed to process decision"
         assert by_id[fine.id].ok is True
+        session.rollback.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_batch_rolls_back_before_the_next_lookup(self, mock_user):
+        """A flush/commit failure must not poison the rest of the batch."""
+        boom = self._pending(mock_user.account_id)
+        fine = self._pending(mock_user.account_id)
+        requests_by_id = {boom.id: boom, fine.id: fine}
+        service = self._service(requests_by_id)
+        session = AsyncMock()
+        needs_rollback = False
+
+        async def _rollback() -> None:
+            nonlocal needs_rollback
+            needs_rollback = False
+
+        session.rollback.side_effect = _rollback
+
+        async def _get(request_id):
+            if needs_rollback:
+                raise RuntimeError("This session is in 'needs rollback' state")
+            return requests_by_id.get(request_id)
+
+        async def _approve(request_id, comment, user_id=None, channel=None):
+            nonlocal needs_rollback
+            if request_id == boom.id:
+                needs_rollback = True
+                raise RuntimeError("flush failed")
+            decided = MagicMock()
+            decided.id = request_id
+            decided.status = "approved"
+            return decided
+
+        service.get_approval_request.side_effect = _get
+        service.approve_request.side_effect = _approve
+
+        response, _session = await self._call(
+            service, mock_user, [boom.id, fine.id], session=session
+        )
+
+        by_id = {result.id: result for result in response.results}
+        assert by_id[boom.id].ok is False
+        assert by_id[fine.id].ok is True
+        session.rollback.assert_awaited()
 
     def test_batch_rejects_an_empty_or_oversized_body(self):
         """The body carries at least one id and at most one page of them."""

--- a/backend/tests/endpoints/test_approval_requests.py
+++ b/backend/tests/endpoints/test_approval_requests.py
@@ -741,8 +741,8 @@ class TestDecideRequestsBatch:
         assert service.approve_request.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_batch_skips_pending_rows_that_have_expired(self, mock_user):
-        """A still-pending row past expires_at is expired, not decided."""
+    async def test_batch_leaves_expiry_to_the_service(self, mock_user):
+        """A past-deadline row is still handed to the service, then reported."""
         stale = self._pending(
             mock_user.account_id,
             expires_at=datetime.utcnow() - timedelta(minutes=5),
@@ -753,18 +753,28 @@ class TestDecideRequestsBatch:
         )
         service = self._service({stale.id: stale, fresh.id: fresh})
 
+        async def _approve(request_id, comment, user_id=None, channel=None):
+            decided = MagicMock()
+            decided.id = request_id
+            # What _reject_if_not_actionable does to an unfrozen late row.
+            decided.status = "expired" if request_id == stale.id else "approved"
+            return decided
+
+        service.approve_request.side_effect = _approve
+
         response, _session = await self._call(service, mock_user, [stale.id, fresh.id])
 
         by_id = {result.id: result for result in response.results}
         assert by_id[stale.id].ok is False
         assert by_id[stale.id].status == "expired"
-        assert by_id[stale.id].error == "Request already expired"
+        assert by_id[stale.id].error == "Request expired"
         assert by_id[fresh.id].ok is True
         assert by_id[fresh.id].status == "approved"
         assert response.succeeded == 1
         assert response.failed == 1
-        service.approve_request.assert_awaited_once()
-        assert service.approve_request.await_args.args[0] == fresh.id
+        # No expiry pre-check here: the kill-switch freeze exception (#157)
+        # lives in the service, so every pending id has to reach it.
+        assert service.approve_request.await_count == 2
 
     @pytest.mark.asyncio
     async def test_batch_decides_a_repeated_id_once(self, mock_user):

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4536,6 +4536,49 @@ export async function declineRequest(
   return response.json();
 }
 
+/** What the batch endpoint reports back about one of the ids it was sent. */
+export interface ApprovalBatchItemResult {
+  id: string;
+  ok: boolean;
+  status?: string | null;
+  error?: string | null;
+}
+
+export interface ApprovalBatchResponse {
+  results: ApprovalBatchItemResult[];
+  succeeded: number;
+  failed: number;
+}
+
+/**
+ * Decide several approval requests with one call.
+ *
+ * The batch never fails as a whole: an id that expired while the operator was
+ * reading comes back as its own failed result, so the caller can name it and
+ * leave the rest alone.
+ */
+export async function decideApprovalsBatch(
+  ids: string[],
+  approved: boolean,
+  comment?: string
+): Promise<ApprovalBatchResponse> {
+  const response = await fetchWithAuth(
+    '/api/v1/approval-requests/decide-batch',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids, approved, comment: comment ?? null }),
+    }
+  );
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(
+      extractErrorMessage(errorData, 'Failed to record the decisions')
+    );
+  }
+  return response.json();
+}
+
 // ============================================================================
 // User Management API Functions
 // ============================================================================

--- a/frontend/src/components/approval-rule-context-block.test.ts
+++ b/frontend/src/components/approval-rule-context-block.test.ts
@@ -60,6 +60,19 @@ describe('ApprovalRuleContextBlock', () => {
     expect(expression?.textContent?.trim()).to.equal('args.amount >= 5000');
   });
 
+  it('prints the expression of an unnamed rule once, not twice', async () => {
+    // An unnamed rule is recorded with its expression as the name, so the
+    // heading and the mono block underneath were the same string.
+    const element = await mount({
+      ...boundaryRule,
+      rule_name: 'args.amount >= 5000',
+    });
+
+    const text = element.shadowRoot?.textContent || '';
+    expect(text.match(/args\.amount >= 5000/g)?.length).to.equal(1);
+    expect(has(element, '.rule-expression'), 'expression repeated').to.be.false;
+  });
+
   it('names the arguments the rule inspects and its priority', async () => {
     const element = await mount(boundaryRule);
 

--- a/frontend/src/components/approval-rule-context-block.ts
+++ b/frontend/src/components/approval-rule-context-block.ts
@@ -118,8 +118,19 @@ export class ApprovalRuleContextBlock extends LitElement {
   `;
 
   /** True when this context names a real rule with an expression. */
+  /**
+   * An expression worth printing under the name.
+   *
+   * Unnamed rules are recorded with their expression as the name, and
+   * printing "args.amount >= 100" as the heading and again in the mono block
+   * underneath reads as two facts when it is one. The compact variant
+   * already makes the same test against the rule id.
+   */
   private get hasExpression(): boolean {
-    return Boolean(this.ruleContext?.expression);
+    const context = this.ruleContext;
+    return Boolean(
+      context?.expression && context.expression !== context.rule_name
+    );
   }
 
   /** Tools page, narrowed to this tool when we know which one it is. */

--- a/frontend/src/components/approval-rule-context-block.ts
+++ b/frontend/src/components/approval-rule-context-block.ts
@@ -117,7 +117,6 @@ export class ApprovalRuleContextBlock extends LitElement {
     }
   `;
 
-  /** True when this context names a real rule with an expression. */
   /**
    * An expression worth printing under the name.
    *

--- a/frontend/src/components/args-diff.test.ts
+++ b/frontend/src/components/args-diff.test.ts
@@ -1,0 +1,138 @@
+/**
+ * The diff view for file-edit arguments.
+ *
+ * An approval for an edit used to print the whole call as JSON, so the
+ * decision rested on reading two escaped strings and spotting the difference
+ * by eye. These tests pin what the diff shows, that the exact payload stays
+ * one click away under Raw, and that calls with no before and after are left
+ * exactly as they were.
+ */
+import { expect, fixture, html } from '@open-wc/testing';
+import './args-diff.ts';
+import { fileEditsFromArgs, type ArgsDiff } from './args-diff';
+
+async function mount(
+  args: Record<string, unknown>,
+  raw = JSON.stringify(args, null, 2)
+): Promise<ArgsDiff> {
+  const el = await fixture<ArgsDiff>(
+    html`<args-diff .args=${args} .raw=${raw}></args-diff>`
+  );
+  await el.updateComplete;
+  return el;
+}
+
+function lines(el: ArgsDiff, type: 'added' | 'removed' | 'context'): string[] {
+  return Array.from(el.shadowRoot!.querySelectorAll(`.line.${type} .text`)).map(
+    (node) => node.textContent ?? ''
+  );
+}
+
+describe('args-diff', () => {
+  it('shows what leaves and what arrives for an old_string edit', async () => {
+    const el = await mount({
+      file_path: '/srv/app/config.py',
+      old_string: 'DEBUG = True\nPORT = 8000\n',
+      new_string: 'DEBUG = False\nPORT = 8000\n',
+    });
+
+    expect(lines(el, 'removed')).to.deep.equal(['DEBUG = True']);
+    expect(lines(el, 'added')).to.deep.equal(['DEBUG = False']);
+    // The unchanged line stays, so the change is read in its context.
+    expect(lines(el, 'context')).to.deep.equal(['PORT = 8000']);
+    expect(el.shadowRoot!.querySelector('.path')?.textContent).to.contain(
+      '/srv/app/config.py'
+    );
+  });
+
+  it('keeps the raw arguments one click away', async () => {
+    const raw = '{\n  "old_string": "a",\n  "new_string": "b"\n}';
+    const el = await mount({ old_string: 'a', new_string: 'b' }, raw);
+
+    expect(el.shadowRoot!.querySelector('[data-testid="args-diff"]')).to.exist;
+    expect(el.shadowRoot!.querySelector('[data-testid="args-raw"]')).to.not
+      .exist;
+
+    const toggle = el.shadowRoot!.querySelector<HTMLElement>(
+      '[data-testid="raw-toggle"]'
+    );
+    expect(toggle, 'raw toggle').to.exist;
+    expect(toggle!.textContent?.trim()).to.equal('Raw');
+
+    toggle!.click();
+    await el.updateComplete;
+
+    const rawBlock = el.shadowRoot!.querySelector('[data-testid="args-raw"]');
+    expect(rawBlock, 'raw block').to.exist;
+    expect(rawBlock!.textContent).to.contain('"new_string": "b"');
+    expect(el.shadowRoot!.querySelector('[data-testid="args-diff"]')).to.not
+      .exist;
+    // The toggle names where it goes next, so the way back is obvious.
+    expect(
+      el
+        .shadowRoot!.querySelector('[data-testid="raw-toggle"]')!
+        .textContent?.trim()
+    ).to.equal('Diff');
+
+    el.shadowRoot!.querySelector<HTMLElement>(
+      '[data-testid="raw-toggle"]'
+    )!.click();
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('[data-testid="args-diff"]')).to.exist;
+  });
+
+  it('numbers the edits of a multi-edit call', async () => {
+    const el = await mount({
+      file_path: 'app.ts',
+      edits: [
+        { old_string: 'one', new_string: 'uno' },
+        { old_string: 'two', new_string: 'dos' },
+      ],
+    });
+
+    expect(lines(el, 'removed')).to.deep.equal(['one', 'two']);
+    expect(lines(el, 'added')).to.deep.equal(['uno', 'dos']);
+    const labels = Array.from(
+      el.shadowRoot!.querySelectorAll('.edit-label')
+    ).map((node) => node.textContent?.replace(/\s+/g, ' ').trim());
+    expect(labels).to.deep.equal(['Edit 1 of 2', 'Edit 2 of 2']);
+  });
+
+  it('reads a whole-file write as a diff against nothing', async () => {
+    const el = await mount({ file_path: 'notes.md', content: 'hello\nworld' });
+
+    expect(lines(el, 'added')).to.deep.equal(['hello', 'world']);
+    expect(lines(el, 'removed')).to.deep.equal([]);
+  });
+
+  it('falls back to the raw arguments when there is no diff to show', async () => {
+    const raw = '{\n  "command": "ls -la"\n}';
+    const el = await mount({ command: 'ls -la' }, raw);
+
+    expect(el.shadowRoot!.querySelector('[data-testid="args-diff"]')).to.not
+      .exist;
+    expect(
+      el.shadowRoot!.querySelector('[data-testid="args-raw"]')!.textContent
+    ).to.contain('ls -la');
+    // Nothing to toggle between, so no toggle.
+    expect(el.shadowRoot!.querySelector('[data-testid="raw-toggle"]')).to.not
+      .exist;
+  });
+
+  it('reads the shapes agents actually send, and no others', () => {
+    expect(
+      fileEditsFromArgs({ old_string: 'a', new_string: 'b' })
+    ).to.have.lengthOf(1);
+    // MCP filesystem edits use camelCase for the same two fields.
+    expect(
+      fileEditsFromArgs({ edits: [{ oldText: 'a', newText: 'b' }] })
+    ).to.have.lengthOf(1);
+    // An edit that changes nothing is not a change.
+    expect(
+      fileEditsFromArgs({ old_string: 'a', new_string: 'a' })
+    ).to.deep.equal([]);
+    // Content without a file path could be any string argument at all.
+    expect(fileEditsFromArgs({ content: 'hello' })).to.deep.equal([]);
+    expect(fileEditsFromArgs(null)).to.deep.equal([]);
+  });
+});

--- a/frontend/src/components/args-diff.test.ts
+++ b/frontend/src/components/args-diff.test.ts
@@ -43,6 +43,13 @@ describe('args-diff', () => {
     expect(el.shadowRoot!.querySelector('.path')?.textContent).to.contain(
       '/srv/app/config.py'
     );
+    // Colour and a sign carry the state on screen; the word carries it to a
+    // screen reader, which would otherwise read "-" as "minus" or skip it.
+    expect(
+      Array.from(el.shadowRoot!.querySelectorAll('.line .state')).map((node) =>
+        node.textContent?.trim()
+      )
+    ).to.deep.equal(['Removed:', 'Added:']);
   });
 
   it('keeps the raw arguments one click away', async () => {
@@ -57,7 +64,7 @@ describe('args-diff', () => {
       '[data-testid="raw-toggle"]'
     );
     expect(toggle, 'raw toggle').to.exist;
-    expect(toggle!.textContent?.trim()).to.equal('Raw');
+    expect(toggle!.textContent?.trim()).to.equal('Show raw');
 
     toggle!.click();
     await el.updateComplete;
@@ -72,7 +79,7 @@ describe('args-diff', () => {
       el
         .shadowRoot!.querySelector('[data-testid="raw-toggle"]')!
         .textContent?.trim()
-    ).to.equal('Diff');
+    ).to.equal('Show diff');
 
     el.shadowRoot!.querySelector<HTMLElement>(
       '[data-testid="raw-toggle"]'

--- a/frontend/src/components/args-diff.ts
+++ b/frontend/src/components/args-diff.ts
@@ -1,0 +1,277 @@
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import { diffLines, toDiffLines, type DiffLine } from '../utils/line-diff';
+
+/** One before/after pair pulled out of a tool call's arguments. */
+export interface ArgsFileEdit {
+  /** File the edit applies to, when the call names one. */
+  path?: string;
+  before: string;
+  after: string;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function pathOf(args: Record<string, unknown>): string | undefined {
+  return (
+    asString(args.file_path) ??
+    asString(args.filePath) ??
+    asString(args.path) ??
+    asString(args.notebook_path)
+  );
+}
+
+function pairOf(entry: Record<string, unknown>): ArgsFileEdit | null {
+  const before = asString(entry.old_string) ?? asString(entry.oldText);
+  const after = asString(entry.new_string) ?? asString(entry.newText);
+  if (before === undefined || after === undefined) return null;
+  if (before === after) return null;
+  return { before, after };
+}
+
+/**
+ * Read the file edits out of a tool call's arguments.
+ *
+ * Covers the three shapes agents actually send: a single `old_string` /
+ * `new_string` replacement, a list of them under `edits`, and a whole-file
+ * `content` write, which is a diff against nothing. Anything else has no
+ * before and no after, so it has no diff and the caller shows the raw
+ * arguments instead.
+ */
+export function fileEditsFromArgs(
+  args: Record<string, unknown> | null | undefined
+): ArgsFileEdit[] {
+  if (!args || typeof args !== 'object') return [];
+  const path = pathOf(args);
+
+  const single = pairOf(args);
+  if (single) return [{ ...single, path }];
+
+  if (Array.isArray(args.edits)) {
+    const edits = args.edits
+      .filter(
+        (entry): entry is Record<string, unknown> =>
+          !!entry && typeof entry === 'object'
+      )
+      .map((entry) => pairOf(entry))
+      .filter((edit): edit is ArgsFileEdit => edit !== null)
+      .map((edit) => ({ ...edit, path }));
+    if (edits.length > 0) return edits;
+  }
+
+  const content = asString(args.content);
+  if (content !== undefined && path) {
+    return [{ path, before: '', after: content }];
+  }
+
+  return [];
+}
+
+/**
+ * The file edits in an approval, shown as a diff.
+ *
+ * An approval for an edit used to print the whole call as JSON, so deciding
+ * whether the change was safe meant reading two long escaped strings side by
+ * side and spotting the difference by eye. This shows what leaves and what
+ * arrives, and keeps the exact payload one click away under Raw, because the
+ * diff is a reading aid and the raw arguments are the thing being approved.
+ */
+@customElement('args-diff')
+export class ArgsDiff extends LitElement {
+  /** The tool call arguments, already stripped of approval metadata. */
+  @property({ attribute: false })
+  args: Record<string, unknown> | null = null;
+
+  /** The formatted arguments to show when there is no diff, or under Raw. */
+  @property({ type: String })
+  raw = '';
+
+  @state()
+  private showRaw = false;
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .raw,
+    .diff {
+      background: var(--console-page);
+      border-radius: 4px;
+      font-family: var(--sl-font-mono, monospace);
+      font-size: 0.875rem;
+    }
+
+    .raw {
+      padding: 1rem;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--sl-spacing-small);
+      margin-bottom: 0.5rem;
+    }
+
+    .path {
+      font-family: var(--sl-font-mono, monospace);
+      font-size: 0.8125rem;
+      color: var(--console-meta-color);
+      overflow-wrap: anywhere;
+    }
+
+    .diff {
+      padding: 0.5rem 0;
+      overflow: hidden;
+    }
+
+    .edit-label {
+      padding: 0.25rem 1rem 0.5rem;
+      font-family: var(--sl-font-sans);
+      font-size: 0.8125rem;
+      color: var(--console-meta-color);
+    }
+
+    .edit + .edit {
+      margin-top: 0.5rem;
+      border-top: 1px solid var(--console-hairline);
+      padding-top: 0.5rem;
+    }
+
+    .line {
+      display: flex;
+      gap: 0.5rem;
+      padding: 0 1rem;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+
+    .sign {
+      flex: 0 0 auto;
+      width: 0.75rem;
+      color: var(--console-meta-color);
+      user-select: none;
+    }
+
+    /* States are 16% tints with -800 ink, not solid paint (D27). */
+    .line.removed {
+      background: color-mix(
+        in srgb,
+        var(--sl-color-danger-500) 16%,
+        transparent
+      );
+      color: var(--sl-color-danger-800);
+    }
+
+    .line.removed .sign {
+      color: var(--sl-color-danger-800);
+    }
+
+    .line.added {
+      background: color-mix(
+        in srgb,
+        var(--sl-color-success-500) 16%,
+        transparent
+      );
+      color: var(--sl-color-success-800);
+    }
+
+    .line.added .sign {
+      color: var(--sl-color-success-800);
+    }
+
+    .empty {
+      padding: 0 1rem;
+      font-family: var(--sl-font-sans);
+      font-size: 0.8125rem;
+      color: var(--console-meta-color);
+    }
+  `;
+
+  /** The edits this call describes, if it describes any. */
+  get edits(): ArgsFileEdit[] {
+    return fileEditsFromArgs(this.args);
+  }
+
+  private toggleRaw() {
+    this.showRaw = !this.showRaw;
+  }
+
+  private renderLine(line: DiffLine) {
+    const sign =
+      line.type === 'added' ? '+' : line.type === 'removed' ? '-' : ' ';
+    return html`
+      <div class="line ${line.type}">
+        <span class="sign" aria-hidden="true">${sign}</span
+        ><span class="text">${line.text || ' '}</span>
+      </div>
+    `;
+  }
+
+  private renderEdit(edit: ArgsFileEdit, index: number, total: number) {
+    const lines = diffLines(
+      edit.before === '' ? [] : toDiffLines(edit.before),
+      edit.after === '' ? [] : toDiffLines(edit.after)
+    );
+    return html`
+      <div class="edit">
+        ${
+          total > 1
+            ? html`<div class="edit-label">Edit ${index + 1} of ${total}</div>`
+            : nothing
+        }
+        ${
+          lines.length === 0
+            ? html`<div class="empty">No text changes.</div>`
+            : lines.map((line) => this.renderLine(line))
+        }
+      </div>
+    `;
+  }
+
+  render() {
+    const edits = this.edits;
+    if (edits.length === 0) {
+      return html`<div class="raw" data-testid="args-raw">${this.raw}</div>`;
+    }
+
+    const path = edits.find((edit) => edit.path)?.path;
+    return html`
+      <div class="toolbar">
+        <span class="path">${path ?? ''}</span>
+        <sl-button
+          size="small"
+          variant="text"
+          data-testid="raw-toggle"
+          aria-pressed=${this.showRaw ? 'true' : 'false'}
+          @click=${this.toggleRaw}
+        >
+          ${this.showRaw ? 'Diff' : 'Raw'}
+        </sl-button>
+      </div>
+      ${
+        this.showRaw
+          ? html`<div class="raw" data-testid="args-raw">${this.raw}</div>`
+          : html`<div class="diff" data-testid="args-diff">
+              ${edits.map((edit, index) =>
+                this.renderEdit(edit, index, edits.length)
+              )}
+            </div>`
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'args-diff': ArgsDiff;
+  }
+}

--- a/frontend/src/components/args-diff.ts
+++ b/frontend/src/components/args-diff.ts
@@ -161,6 +161,25 @@ export class ArgsDiff extends LitElement {
       user-select: none;
     }
 
+    /*
+     * Added versus removed is a tint and a sign on screen, which is colour
+     * plus a glyph a screen reader reads as "plus". The word goes in the
+     * accessibility tree instead, and is left out of a selection so copying
+     * the diff still yields the file's own text.
+     */
+    .state {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      white-space: nowrap;
+      user-select: none;
+    }
+
     /* States are 16% tints with -800 ink, not solid paint (D27). */
     .line.removed {
       background: color-mix(
@@ -208,9 +227,18 @@ export class ArgsDiff extends LitElement {
   private renderLine(line: DiffLine) {
     const sign =
       line.type === 'added' ? '+' : line.type === 'removed' ? '-' : ' ';
+    const state =
+      line.type === 'added'
+        ? 'Added: '
+        : line.type === 'removed'
+          ? 'Removed: '
+          : '';
     return html`
       <div class="line ${line.type}">
-        <span class="sign" aria-hidden="true">${sign}</span
+        ${state ? html`<span class="state">${state}</span>` : nothing}<span
+          class="sign"
+          aria-hidden="true"
+          >${sign}</span
         ><span class="text">${line.text || ' '}</span>
       </div>
     `;
@@ -247,14 +275,19 @@ export class ArgsDiff extends LitElement {
     return html`
       <div class="toolbar">
         <span class="path">${path ?? ''}</span>
+        <!--
+          The label says what the next click does rather than carrying
+          aria-pressed: sl-button is a host with no button role of its own and
+          does not forward the attribute to the button in its shadow root, so
+          a pressed state set here would never reach a screen reader.
+        -->
         <sl-button
           size="small"
           variant="text"
           data-testid="raw-toggle"
-          aria-pressed=${this.showRaw ? 'true' : 'false'}
           @click=${this.toggleRaw}
         >
-          ${this.showRaw ? 'Diff' : 'Raw'}
+          ${this.showRaw ? 'Show diff' : 'Show raw'}
         </sl-button>
       </div>
       ${

--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -373,6 +373,37 @@ describe('console-header bell approvals', () => {
     expect(notificationItems(el).length, 'notification rows').to.equal(0);
   });
 
+  it('keeps a notification with no target reachable and marks it read', async () => {
+    const el = await header();
+    // The websocket also pushes notifications that carry no href (a budget
+    // alert, a role change). Clicking one still marks it read, so it is a
+    // control, and role="presentation" on a control tells a screen reader the
+    // opposite of what it does.
+    (el as unknown as { _userNotifications: unknown[] })._userNotifications = [
+      {
+        id: 'n-1',
+        type: 'system',
+        title: 'Budget threshold reached',
+        message: '',
+        created_at: new Date().toISOString(),
+        read: false,
+      },
+    ];
+    el.requestUpdate();
+    await el.updateComplete;
+
+    const item = notificationItems(el)[0];
+    expect(item.getAttribute('role')).to.equal('button');
+    expect(item.getAttribute('tabindex')).to.equal('0');
+
+    item.click();
+    await el.updateComplete;
+
+    expect(notificationItems(el)[0].classList.contains('unread')).to.be.false;
+    // Nothing to open, so nothing was opened.
+    expect(routes).to.deep.equal([]);
+  });
+
   it('drops an approval that expires while the tab stays open', async () => {
     const el = await header();
 

--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -10,6 +10,8 @@ import { expect, fixture, html, waitUntil } from '@open-wc/testing';
 import './console-header.ts';
 import type { ConsoleHeader } from './console-header.ts';
 import { publishAttentionSummary } from '../utils/attention-summary';
+import { unifiedWebSocketManager } from '../services/unified-websocket-manager';
+import { Router } from '@vaadin/router';
 
 const USER = {
   id: 'user-1',
@@ -198,5 +200,188 @@ describe('console-header bell empty state', () => {
     await el.updateComplete;
 
     expect(dropdownText(el)).to.contain('1 item needs attention: 1 approval');
+  });
+});
+
+/**
+ * The bell and approvals.
+ *
+ * The bell already lists pending approvals and opens them on click. What it
+ * did not do was say anything when one of those approvals stopped waiting:
+ * the row vanished mid-session with no trace, and the generic notification
+ * rows it does keep went nowhere when clicked. These tests pin the approval
+ * notification type, where its click lands, and the two cases that should
+ * stay quiet.
+ */
+describe('console-header bell approvals', () => {
+  const APPROVAL = {
+    id: 'ar-1',
+    tool_name: 'write_file',
+    tool_args: {},
+    status: 'pending',
+    requested_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + 600_000).toISOString(),
+    execution_id: 'exec-1',
+  };
+
+  let restoreFetch: () => void;
+  let restoreSubscribe: () => void;
+  let approvalListeners: ((message: any) => void)[];
+  let approvals: any[];
+  let routes: string[];
+  let restoreRouterGo: () => void;
+
+  /** Answer startup requests, including the pending approvals load. */
+  function stubApprovalFetch(): () => void {
+    const original = window.fetch;
+    window.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      let body: unknown = [];
+      if (url.includes('/users/me')) body = USER;
+      else if (url.includes('/approval-requests')) body = approvals;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof window.fetch;
+    return () => {
+      window.fetch = original;
+    };
+  }
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-token');
+    approvals = [APPROVAL];
+    approvalListeners = [];
+    routes = [];
+    restoreFetch = stubApprovalFetch();
+
+    const originalSubscribe = unifiedWebSocketManager.subscribe;
+    unifiedWebSocketManager.subscribe = ((
+      topic: string,
+      callback: (message: any) => void
+    ) => {
+      if (topic === 'approvals') approvalListeners.push(callback);
+      return () => {};
+    }) as typeof unifiedWebSocketManager.subscribe;
+    restoreSubscribe = () => {
+      unifiedWebSocketManager.subscribe = originalSubscribe;
+    };
+
+    const originalGo = Router.go;
+    (Router as unknown as { go: (path: string) => void }).go = (
+      path: string
+    ) => {
+      routes.push(path);
+    };
+    restoreRouterGo = () => {
+      (Router as unknown as { go: unknown }).go = originalGo;
+    };
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    restoreSubscribe();
+    restoreRouterGo();
+    localStorage.removeItem('accessToken');
+  });
+
+  async function header(): Promise<ConsoleHeader> {
+    const el = await fixture<ConsoleHeader>(
+      html`<console-header></console-header>`
+    );
+    await el.updateComplete;
+    await waitUntil(
+      () => el.shadowRoot!.textContent?.includes('write_file') ?? false,
+      'pending approval never rendered',
+      { timeout: 2000 }
+    ).catch(() => undefined);
+    return el;
+  }
+
+  function emit(message: Record<string, unknown>) {
+    approvalListeners.forEach((listener) => listener(message));
+  }
+
+  function notificationItems(el: ConsoleHeader): HTMLElement[] {
+    return Array.from(
+      el.shadowRoot!.querySelectorAll<HTMLElement>('.notification-item')
+    );
+  }
+
+  it('leaves an approval notification when one resolves elsewhere', async () => {
+    const el = await header();
+
+    emit({
+      type: 'approval_declined',
+      approval_request_id: 'ar-1',
+      tool_name: 'write_file',
+    });
+    await el.updateComplete;
+
+    const items = notificationItems(el);
+    expect(items.length, 'notification rows').to.equal(1);
+    expect(items[0].textContent).to.contain('Approval declined');
+    expect(items[0].textContent).to.contain('write_file');
+    expect(items[0].querySelector('sl-icon')?.getAttribute('name')).to.equal(
+      'shield-check'
+    );
+    // The pending row is gone, so the notification is the only trace left.
+    expect(el.shadowRoot!.querySelectorAll('.approval-item').length).to.equal(
+      0
+    );
+  });
+
+  it('opens the approval when its notification is clicked', async () => {
+    const el = await header();
+    emit({
+      type: 'approval_approved',
+      approval_request_id: 'ar-1',
+      tool_name: 'write_file',
+    });
+    await el.updateComplete;
+
+    const item = notificationItems(el)[0];
+    expect(item.getAttribute('data-href')).to.equal('/console/approval/ar-1');
+    item.click();
+    await el.updateComplete;
+
+    expect(routes).to.deep.equal(['/console/approval/ar-1']);
+    // Reading it also marks it read, so the badge stops counting it.
+    expect(item.classList.contains('unread')).to.be.false;
+  });
+
+  it('says nothing about a decision made in this bell', async () => {
+    const el = await header();
+    const approve = el.shadowRoot!.querySelector<HTMLElement>(
+      '.approval-actions sl-button[variant="success"]'
+    );
+    expect(approve, 'approve button').to.exist;
+    approve!.click();
+    await waitUntil(
+      () => el.shadowRoot!.querySelectorAll('.approval-item').length === 0,
+      'approval row never cleared'
+    );
+
+    emit({
+      type: 'approval_approved',
+      approval_request_id: 'ar-1',
+      tool_name: 'write_file',
+    });
+    await el.updateComplete;
+
+    expect(notificationItems(el).length, 'notification rows').to.equal(0);
+  });
+
+  it('does not count an approval that has already expired', async () => {
+    approvals = [
+      { ...APPROVAL, expires_at: new Date(Date.now() - 60_000).toISOString() },
+    ];
+    const el = await header();
+
+    expect(el.shadowRoot!.querySelectorAll('.approval-item').length).to.equal(
+      0
+    );
+    expect(el.shadowRoot!.querySelector('.notification-badge')).to.not.exist;
   });
 });

--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -373,11 +373,23 @@ describe('console-header bell approvals', () => {
     expect(notificationItems(el).length, 'notification rows').to.equal(0);
   });
 
-  it('does not count an approval that has already expired', async () => {
-    approvals = [
-      { ...APPROVAL, expires_at: new Date(Date.now() - 60_000).toISOString() },
-    ];
+  it('drops an approval that expires while the tab stays open', async () => {
     const el = await header();
+
+    // It loaded live, so the load-time filter is not what is under test here.
+    expect(el.shadowRoot!.querySelectorAll('.approval-item').length).to.equal(
+      1
+    );
+    expect(el.shadowRoot!.querySelector('.notification-badge')).to.exist;
+
+    // Nothing arrives when an approval times out, so the only thing between a
+    // dead request and the badge is the filter on read.
+    const loaded = (
+      el as unknown as { _pendingApprovals: Array<{ expires_at?: string }> }
+    )._pendingApprovals;
+    loaded[0].expires_at = new Date(Date.now() - 1_000).toISOString();
+    el.requestUpdate();
+    await el.updateComplete;
 
     expect(el.shadowRoot!.querySelectorAll('.approval-item').length).to.equal(
       0

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -1089,10 +1089,16 @@ export class ConsoleHeader extends LitElement {
         <div class="notification-list">
           ${this._userNotifications.slice(0, 5).map(
             (notification) => html`
+              <!--
+                A row without an href still does something when it is
+                clicked: it marks itself read. That is a button, not
+                presentation, and it stays focusable so the keyboard can
+                reach it too.
+              -->
               <div
                 class="notification-item ${notification.read ? '' : 'unread'}"
-                role=${notification.href ? 'link' : 'presentation'}
-                tabindex=${notification.href ? '0' : '-1'}
+                role=${notification.href ? 'link' : 'button'}
+                tabindex="0"
                 data-href=${notification.href ?? ''}
                 @click=${() => this.handleNotificationClick(notification)}
                 @keydown=${(event: KeyboardEvent) => {

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -59,6 +59,7 @@ interface ApprovalRequest {
 interface UserNotification {
   id: string;
   type:
+    | 'approval'
     | 'team_added'
     | 'team_removed'
     | 'policy_added'
@@ -69,8 +70,18 @@ interface UserNotification {
   message: string;
   created_at: string;
   read: boolean;
+  /** Console route this notification is about, when it is about something. */
+  href?: string;
   metadata?: Record<string, unknown>;
 }
+
+/** Bell headline for each way an approval can stop waiting. */
+const APPROVAL_RESOLUTION_TITLES: Record<string, string> = {
+  approval_approved: 'Approval approved',
+  approval_declined: 'Approval declined',
+  approval_expired: 'Approval expired',
+  approval_cancelled: 'Approval cancelled',
+};
 
 @customElement('console-header')
 export class ConsoleHeader extends LitElement {
@@ -108,6 +119,10 @@ export class ConsoleHeader extends LitElement {
   // Track notification IDs to prevent duplicates
   private shownExecutionNotifications: Set<string> = new Set();
   private shownApprovalNotifications: Set<string> = new Set();
+
+  // Approvals decided from this bell. The resolution broadcast comes back to
+  // this tab too, and telling the operator about their own click is noise.
+  private decidedHere: Set<string> = new Set();
 
   static styles = css`
     :host {
@@ -409,6 +424,7 @@ export class ConsoleHeader extends LitElement {
   private async handleApprove(approvalId: string, event: Event) {
     event.stopPropagation();
     this._processingApproval = approvalId;
+    this.decidedHere.add(approvalId);
     try {
       await api.approveRequest(approvalId);
       this._pendingApprovals = this._pendingApprovals.filter(
@@ -416,6 +432,8 @@ export class ConsoleHeader extends LitElement {
       );
     } catch (error) {
       console.error('Failed to approve request:', error);
+      // The decision never landed, so a later resolution is news again.
+      this.decidedHere.delete(approvalId);
     } finally {
       this._processingApproval = null;
     }
@@ -424,6 +442,7 @@ export class ConsoleHeader extends LitElement {
   private async handleDecline(approvalId: string, event: Event) {
     event.stopPropagation();
     this._processingApproval = approvalId;
+    this.decidedHere.add(approvalId);
     try {
       await api.declineRequest(approvalId);
       this._pendingApprovals = this._pendingApprovals.filter(
@@ -431,9 +450,54 @@ export class ConsoleHeader extends LitElement {
       );
     } catch (error) {
       console.error('Failed to decline request:', error);
+      // The decision never landed, so a later resolution is news again.
+      this.decidedHere.delete(approvalId);
     } finally {
       this._processingApproval = null;
     }
+  }
+
+  /**
+   * Turn an approval resolution into a bell notification.
+   *
+   * Only for requests this bell was carrying: an approval nobody here was
+   * waiting on is somebody else's news. Decisions made in this tab are
+   * skipped too, because the operator who clicked Approve does not need to
+   * be told that it was approved.
+   */
+  private recordApprovalResolution(message: {
+    type: string;
+    approval_request_id?: string;
+    tool_name?: string;
+    summary?: string;
+  }) {
+    const approvalId = message.approval_request_id;
+    if (!approvalId) return;
+    if (this.decidedHere.has(approvalId)) {
+      this.decidedHere.delete(approvalId);
+      return;
+    }
+    const pending = this._pendingApprovals.find(
+      (approval) => approval.id === approvalId
+    );
+    if (!pending) return;
+
+    const title = APPROVAL_RESOLUTION_TITLES[message.type];
+    if (!title) return;
+
+    const notification: UserNotification = {
+      id: `approval-${approvalId}-${message.type}`,
+      type: 'approval',
+      title,
+      message: message.summary || message.tool_name || pending.tool_name,
+      created_at: new Date().toISOString(),
+      read: false,
+      href: `/console/approval/${approvalId}`,
+    };
+    this._userNotifications = [
+      notification,
+      ...this._userNotifications.filter((n) => n.id !== notification.id),
+    ];
   }
 
   private markNotificationAsRead(notificationId: string) {
@@ -444,13 +508,37 @@ export class ConsoleHeader extends LitElement {
     // api.markNotificationRead(notificationId);
   }
 
+  /**
+   * Open what the notification is about, then mark it read. A bell item that
+   * names an approval and goes nowhere when clicked is a dead end.
+   */
+  private handleNotificationClick(notification: UserNotification) {
+    this.markNotificationAsRead(notification.id);
+    if (notification.href) {
+      Router.go(notification.href);
+    }
+  }
+
+  /**
+   * Pending approvals that can still be decided.
+   *
+   * The list is filtered when it loads, but a tab left open carries requests
+   * past their expiry, and a bell that counts a dead request sends the
+   * operator to a page where every button is disabled.
+   */
+  private get liveApprovals(): ApprovalRequest[] {
+    return this._pendingApprovals.filter((approval) =>
+      this.isUnexpiredPendingApproval(approval)
+    );
+  }
+
   private get totalNotificationCount(): number {
     const unreadNotifications = this._userNotifications.filter(
       (n) => !n.read
     ).length;
     return (
       this._runningExecutions.length +
-      this._pendingApprovals.length +
+      this.liveApprovals.length +
       unreadNotifications
     );
   }
@@ -576,6 +664,10 @@ export class ConsoleHeader extends LitElement {
             message.tool_name || 'Tool',
             message.type
           );
+          // Leave a trail in the bell before the row disappears: an approval
+          // that resolved elsewhere is the one bell item an operator most
+          // wants to reopen, and until now it vanished without a word.
+          this.recordApprovalResolution(message);
           // Remove from pending approvals
           this._pendingApprovals = this._pendingApprovals.filter(
             (approval) => approval.id !== message.approval_request_id
@@ -910,7 +1002,8 @@ export class ConsoleHeader extends LitElement {
   }
 
   private renderApprovalsSection() {
-    if (this._pendingApprovals.length === 0) return '';
+    const approvals = this.liveApprovals;
+    if (approvals.length === 0) return '';
 
     return html`
       <div class="notification-section">
@@ -918,9 +1011,7 @@ export class ConsoleHeader extends LitElement {
           <div class="section-title">
             <sl-icon name="shield-check"></sl-icon>
             Pending approvals
-            <span class="section-count"
-              >(${this._pendingApprovals.length})</span
-            >
+            <span class="section-count">(${approvals.length})</span>
           </div>
           <a
             class="section-link"
@@ -929,7 +1020,7 @@ export class ConsoleHeader extends LitElement {
           >
         </div>
         <div class="approval-list">
-          ${this._pendingApprovals.slice(0, 5).map(
+          ${approvals.slice(0, 5).map(
             (approval) => html`
               <div
                 class="approval-item"
@@ -1000,7 +1091,16 @@ export class ConsoleHeader extends LitElement {
             (notification) => html`
               <div
                 class="notification-item ${notification.read ? '' : 'unread'}"
-                @click=${() => this.markNotificationAsRead(notification.id)}
+                role=${notification.href ? 'link' : 'presentation'}
+                tabindex=${notification.href ? '0' : '-1'}
+                data-href=${notification.href ?? ''}
+                @click=${() => this.handleNotificationClick(notification)}
+                @keydown=${(event: KeyboardEvent) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    this.handleNotificationClick(notification);
+                  }
+                }}
               >
                 <div class="notification-title">
                   <sl-icon
@@ -1022,6 +1122,7 @@ export class ConsoleHeader extends LitElement {
 
   private getNotificationIcon(type: UserNotification['type']): string {
     const iconMap: Record<UserNotification['type'], string> = {
+      approval: 'shield-check',
       team_added: 'people',
       team_removed: 'people',
       policy_added: 'file-earmark-text',
@@ -1057,7 +1158,7 @@ export class ConsoleHeader extends LitElement {
   render() {
     const hasContent =
       this._runningExecutions.length > 0 ||
-      this._pendingApprovals.length > 0 ||
+      this.liveApprovals.length > 0 ||
       this._userNotifications.length > 0;
 
     return html`

--- a/frontend/src/components/governance-rule-set-editor.test.ts
+++ b/frontend/src/components/governance-rule-set-editor.test.ts
@@ -1,0 +1,27 @@
+/**
+ * The rule list under a tool. One label for one act: the policies page, this
+ * editor and the tool rule dialog all said something different ("Add rule",
+ * "Add Rule", "Add Access Rule - pay") for adding a rule.
+ */
+import { html, fixture, expect } from '@open-wc/testing';
+import './governance-rule-set-editor';
+import type { GovernanceRuleSetEditor } from './governance-rule-set-editor';
+
+describe('GovernanceRuleSetEditor', () => {
+  it('offers to add a rule in sentence case', async () => {
+    const el = (await fixture(html`
+      <governance-rule-set-editor
+        .toolName=${'pay'}
+        .rules=${[]}
+        .workflows=${[]}
+        .features=${{}}
+      ></governance-rule-set-editor>
+    `)) as GovernanceRuleSetEditor;
+    await el.updateComplete;
+
+    const label = Array.from(
+      el.shadowRoot!.querySelectorAll('.rules-footer sl-button')
+    ).map((button) => button.textContent?.trim());
+    expect(label).to.deep.equal(['Add rule']);
+  });
+});

--- a/frontend/src/components/governance-rule-set-editor.ts
+++ b/frontend/src/components/governance-rule-set-editor.ts
@@ -29,7 +29,9 @@ export class GovernanceRuleSetEditor extends LitElement {
   @property({ type: Object }) features: { [key: string]: boolean | string[] } =
     {};
   @property({ type: String }) emptyMessage = 'No scoped rules configured yet.';
-  @property({ type: String }) addButtonLabel = 'Add Rule';
+  // One label for the same act everywhere: the policies page, this editor
+  // and the tool rule dialog all say "Add rule", in sentence case.
+  @property({ type: String }) addButtonLabel = 'Add rule';
 
   @state() private _showRuleEditor = false;
   @state() private _editingRule: AccessRule | null = null;

--- a/frontend/src/components/inventory-card.test.ts
+++ b/frontend/src/components/inventory-card.test.ts
@@ -622,6 +622,26 @@ describe('inventory-card', () => {
     );
   });
 
+  it('labels every number the phone line prints, and leads the separators', async () => {
+    const el = await card();
+    const labels = Array.from(
+      el.shadowRoot!.querySelectorAll('tbody tr td.num')
+    ).map((cell) => cell.getAttribute('data-label'));
+    // Spend and last seen used to arrive as two bare numbers with no word
+    // saying what they were.
+    expect(labels).to.deep.equal(['Requests', 'Tokens', 'Spend', 'Seen']);
+
+    const css = Array.from(el.shadowRoot!.adoptedStyleSheets)
+      .flatMap((sheet) =>
+        Array.from(sheet.cssRules).map((rule) => rule.cssText)
+      )
+      .join('\n');
+    // The dot leads the value it belongs to. Trailing it left a dot alone at
+    // the end of a wrapped line, and left one behind when Tokens was hidden.
+    expect(css).to.contain("content: '· ' attr(data-label) ' '");
+    expect(css).to.not.contain("content: ' ·'");
+  });
+
   it('says what is missing, with the way to fix it', async () => {
     const el = await card({
       agentRows: [],

--- a/frontend/src/components/inventory-card.test.ts
+++ b/frontend/src/components/inventory-card.test.ts
@@ -631,6 +631,10 @@ describe('inventory-card', () => {
     // saying what they were.
     expect(labels).to.deep.equal(['Requests', 'Tokens', 'Spend', 'Seen']);
 
+    // Read from the stylesheet, not the DOM: the separator is a ::before on
+    // a media query, and a pseudo element has no node to query. The cost is
+    // that an equivalent rewrite of the rule breaks this assertion even
+    // though the behaviour holds.
     const css = Array.from(el.shadowRoot!.adoptedStyleSheets)
       .flatMap((sheet) =>
         Array.from(sheet.cssRules).map((rule) => rule.cssText)

--- a/frontend/src/components/inventory-card.ts
+++ b/frontend/src/components/inventory-card.ts
@@ -603,7 +603,9 @@ export class InventoryCard extends LitElement {
         .inventory-table tr {
           display: flex;
           flex-wrap: wrap;
-          gap: 2px var(--sl-spacing-small);
+          /* The separators below carry the rhythm now, so the gap only has
+             to keep the words apart. */
+          gap: 2px 4px;
           padding: var(--sl-spacing-x-small) var(--sl-spacing-medium);
         }
 
@@ -647,11 +649,15 @@ export class InventoryCard extends LitElement {
           content: attr(data-label) ' ';
         }
 
-        /* The second line is one sentence of numbers, so it is punctuated. */
-        .inventory-table td.num:not(:last-child)::after,
-        .inventory-table td.secondary:not(.wide-cell)::after {
-          color: var(--console-meta-color);
-          content: ' ·';
+        /* The second line is one sentence of numbers, so it is punctuated.
+           The separator leads each value instead of trailing the one before
+           it: a trailing dot wraps onto the next line on its own, and hiding
+           a cell (Tokens, below) used to leave its dot behind. Cells with no
+           label resolve attr(data-label) to nothing and print just the dot. */
+        .inventory-table
+          :is(td.num, td.secondary:not(.wide-cell))
+          ~ :is(td.num, td.secondary:not(.wide-cell))::before {
+          content: '· ' attr(data-label) ' ';
         }
 
         /* Tokens are the one number a phone can do without: the request
@@ -1071,10 +1077,14 @@ export class InventoryCard extends LitElement {
                             ></token-figures>`
                           )}
                         </td>
-                        <td class="num">
+                        <td class="num" data-label="Spend">
                           ${this.renderUsageCell(this.formatCurrency(row.cost))}
                         </td>
-                        <td class="num" title=${this.absolute(row.lastSeenAt)}>
+                        <td
+                          class="num"
+                          data-label="Seen"
+                          title=${this.absolute(row.lastSeenAt)}
+                        >
                           ${this.relative(row.lastSeenAt)}
                         </td>
                       </tr>
@@ -1215,7 +1225,7 @@ export class InventoryCard extends LitElement {
                             this.isFlowCostLoading()
                           )}
                         </td>
-                        <td class="num">
+                        <td class="num" data-label="Spend">
                           ${this.renderUsageCell(
                             this.formatCurrency(row.cost),
                             this.isFlowCostLoading()
@@ -1303,7 +1313,7 @@ export class InventoryCard extends LitElement {
                             this.isUsageLoading('models')
                           )}
                         </td>
-                        <td class="num">
+                        <td class="num" data-label="Spend">
                           ${this.renderUsageCell(
                             this.formatCurrency(row.cost),
                             this.isUsageLoading('models')
@@ -1388,7 +1398,7 @@ export class InventoryCard extends LitElement {
                             ></token-figures>`
                           )}
                         </td>
-                        <td class="num">
+                        <td class="num" data-label="Spend">
                           ${this.renderUsageCell(this.formatCurrency(row.cost))}
                         </td>
                       </tr>

--- a/frontend/src/components/list-selection.test.ts
+++ b/frontend/src/components/list-selection.test.ts
@@ -663,4 +663,57 @@ describe('ListSelectionController', () => {
     await element.updateComplete;
     expect(box.hasAttribute('disabled')).to.equal(false);
   });
+
+  it('runs one batch call and keeps only the refused rows selected', async () => {
+    const element = await host();
+    element.selection.toggleAll(true);
+    await element.updateComplete;
+
+    let sent: string[] = [];
+    const result = await element.selection.runBatch(
+      'approve',
+      element.selection.selectedItems,
+      async (items) => {
+        sent = items.map((item) => item.id);
+        return {
+          succeeded: items.filter((item) => item.id !== 'c'),
+          failed: items
+            .filter((item) => item.id === 'c')
+            .map((item) => ({ item, message: 'Already expired' })),
+        };
+      },
+      { verb: 'approve', verbPast: 'approved', noun: 'request' }
+    );
+
+    // One call, carrying the whole selection.
+    expect(sent).to.eql(['a', 'b', 'c', 'd']);
+    expect(result.succeeded.map((row) => row.id)).to.eql(['a', 'b', 'd']);
+    expect(element.selection.selectedIds).to.eql(['c']);
+    expect(element.selection.running).to.equal(null);
+  });
+
+  it('treats a batch call that throws as every row failing', async () => {
+    const element = await host();
+    element.selection.toggleAll(true);
+    await element.updateComplete;
+
+    const result = await element.selection.runBatch(
+      'approve',
+      element.selection.selectedItems,
+      async () => {
+        throw new Error('Service unavailable');
+      },
+      { verb: 'approve', verbPast: 'approved', noun: 'request' }
+    );
+
+    expect(result.succeeded).to.eql([]);
+    expect(result.failed.map((failure) => failure.message)).to.eql([
+      'Service unavailable',
+      'Service unavailable',
+      'Service unavailable',
+      'Service unavailable',
+    ]);
+    // Nothing was lost: the whole selection is still there to retry.
+    expect(element.selection.selectedIds).to.eql(['a', 'b', 'c', 'd']);
+  });
 });

--- a/frontend/src/components/list-selection.ts
+++ b/frontend/src/components/list-selection.ts
@@ -783,12 +783,7 @@ export class ListSelectionController<T> implements ReactiveController {
           this.host.requestUpdate();
         },
       });
-      reportBulkResult(result, report);
-      // Items that changed keep their selection only when they failed, so a
-      // retry is one click and a finished run leaves a quiet page.
-      this.selection = ListSelection.of(
-        result.failed.map((failure) => failure.item.id)
-      );
+      this.settle(result, report);
       return result;
     } finally {
       this.running = null;
@@ -796,6 +791,62 @@ export class ListSelectionController<T> implements ReactiveController {
       this.progressTotal = 0;
       this.host.requestUpdate();
     }
+  }
+
+  /**
+   * Runs one call that carries the whole selection, and reports the same way.
+   *
+   * Some collections have a real batch endpoint (approvals decide the picked
+   * ids in one POST). Those cannot report "3 of 7" because there is one
+   * request, but everything after it is identical: one toast, and only the
+   * failures stay selected. `action` returns the per item outcome the server
+   * sent back.
+   */
+  async runBatch<I extends BulkItem>(
+    actionId: string,
+    items: readonly I[],
+    action: (items: readonly I[]) => Promise<BulkResult<I>>,
+    report: BulkReport
+  ): Promise<BulkResult<I>> {
+    if (this.running !== null) {
+      return { succeeded: [], failed: [] };
+    }
+    this.running = actionId;
+    // No per item progress: one request settles all of them at once.
+    this.progressDone = 0;
+    this.progressTotal = 0;
+    this.host.requestUpdate();
+    try {
+      const result = await action(items);
+      this.settle(result, report);
+      return result;
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Request failed';
+      const failed = items.map((item) => ({ item, message }));
+      const result: BulkResult<I> = { succeeded: [], failed };
+      this.settle(result, report);
+      return result;
+    } finally {
+      this.running = null;
+      this.host.requestUpdate();
+    }
+  }
+
+  /**
+   * The end of every run: one toast, and only the failures stay selected so a
+   * retry is one click and a finished run leaves a quiet page.
+   */
+  private settle<I extends BulkItem>(
+    result: BulkResult<I>,
+    report: BulkReport
+  ): void {
+    reportBulkResult(result, report);
+    this.selection = ListSelection.of(
+      result.failed.map((failure) => failure.item.id)
+    );
   }
 
   private handleKeyDown = (event: KeyboardEvent): void => {

--- a/frontend/src/components/preloop-flow-preset-picker.test.ts
+++ b/frontend/src/components/preloop-flow-preset-picker.test.ts
@@ -129,6 +129,45 @@ describe('presetGroups', () => {
   });
 });
 
+describe('an account copy of a catalog preset', () => {
+  const COPY: FlowPresetRecord = {
+    id: 'preset-copy',
+    name: 'Pull Request Reviewer',
+    account_id: 'acct-1',
+    source_preset_id: 'preset-002',
+    description: 'Review a pull request when it opens.',
+    trigger_event_types: ['pull_request_opened'],
+  };
+
+  it('shows the copy once and leaves the catalog twin out', () => {
+    const groups = presetGroups([...CATALOG, COPY]);
+
+    expect(groups[0].presets.map((preset) => preset.id)).to.deep.equal([
+      'preset-copy',
+    ]);
+    // The catalog original is gone from Tracker automation: two rows with
+    // the same name is a choice nobody can make.
+    expect(groups[1].presets.map((preset) => preset.name)).to.deep.equal([
+      'Issue Triage Assistant',
+      'Automated Issue Implementation',
+    ]);
+  });
+
+  it('says which catalog preset the copy came from', async () => {
+    const element = (await fixture(html`
+      <preloop-flow-preset-picker
+        .presets=${[...CATALOG, COPY]}
+      ></preloop-flow-preset-picker>
+    `)) as PreloopFlowPresetPicker;
+    await element.updateComplete;
+
+    const origins = Array.from(
+      element.shadowRoot!.querySelectorAll('.row-origin')
+    ).map((node) => (node.textContent || '').replace(/\s+/g, ' ').trim());
+    expect(origins).to.deep.equal(['saved from Pull Request Reviewer']);
+  });
+});
+
 describe('presetChips', () => {
   it('lists chips for 001, 002, 011 and a tool-less preset', () => {
     expect(presetChips(CATALOG[0]).map((chip) => chip.label)).to.deep.equal([

--- a/frontend/src/components/preloop-flow-preset-picker.ts
+++ b/frontend/src/components/preloop-flow-preset-picker.ts
@@ -21,6 +21,8 @@ export const PRESET_GROUP_LABELS = {
 export interface FlowPresetRecord {
   id?: string;
   name?: string;
+  /** Catalog preset this one was cloned from, for account copies. */
+  source_preset_id?: string | null;
   description?: string;
   icon?: string;
   account_id?: string | null;
@@ -64,11 +66,43 @@ function isSecuritySlug(slug: string): boolean {
 }
 
 /**
+ * Catalog name each account copy was saved from, keyed by the copy's id.
+ *
+ * A cloned preset keeps the catalog name, so "Pull Request Reviewer" appeared
+ * twice with nothing to tell the two apart. The copy says where it came from
+ * and the catalog original steps aside.
+ */
+export function presetOrigins(
+  presets: FlowPresetRecord[]
+): Map<string, string> {
+  const catalogNames = new Map<string, string>();
+  for (const preset of presets) {
+    if (!preset.account_id && preset.id) {
+      catalogNames.set(preset.id, preset.name || 'a catalog preset');
+    }
+  }
+  const origins = new Map<string, string>();
+  for (const preset of presets) {
+    if (!preset.account_id || !preset.id || !preset.source_preset_id) continue;
+    const name = catalogNames.get(preset.source_preset_id);
+    if (name) origins.set(preset.id, name);
+  }
+  return origins;
+}
+
+/**
  * Group catalog presets client-side until YAML carries `category`.
  *
- * Account presets first. Catalog order is kept inside each group.
+ * Account presets first. Catalog order is kept inside each group. A catalog
+ * preset the account has already copied is left out: the copy is the one the
+ * operator will pick, and two identical names is a choice nobody can make.
  */
 export function presetGroups(presets: FlowPresetRecord[]): PresetGroup[] {
+  const copied = new Set(
+    presets
+      .filter((preset) => preset.account_id && preset.source_preset_id)
+      .map((preset) => preset.source_preset_id as string)
+  );
   const yours: FlowPresetRecord[] = [];
   const tracker: FlowPresetRecord[] = [];
   const scheduled: FlowPresetRecord[] = [];
@@ -77,6 +111,9 @@ export function presetGroups(presets: FlowPresetRecord[]): PresetGroup[] {
   for (const preset of presets) {
     if (preset.account_id) {
       yours.push(preset);
+      continue;
+    }
+    if (preset.id && copied.has(preset.id)) {
       continue;
     }
     const slug = presetSlug(preset);
@@ -197,7 +234,10 @@ export class PreloopFlowPresetPicker extends LitElement {
 
       .row {
         display: grid;
-        grid-template-columns: auto minmax(0, 1fr) auto auto;
+        /* The icon column is reserved rather than sized to its content, so
+           rows line up before the icons have loaded and when one is
+           missing. */
+        grid-template-columns: 1rem minmax(0, 1fr) auto auto;
         grid-template-rows: auto auto;
         column-gap: var(--sl-spacing-small);
         row-gap: 2px;
@@ -232,6 +272,14 @@ export class PreloopFlowPresetPicker extends LitElement {
         grid-row: 1 / span 2;
         color: var(--console-meta-color);
         font-size: 1rem;
+        width: 1rem;
+      }
+
+      .row-origin {
+        color: var(--console-meta-color);
+        font-size: var(--console-text-meta);
+        font-weight: 400;
+        margin-left: var(--sl-spacing-2x-small);
       }
 
       .row.selected .row-icon {
@@ -438,6 +486,7 @@ export class PreloopFlowPresetPicker extends LitElement {
     icon: string;
     name: string;
     description: string;
+    origin?: string;
     preset?: FlowPresetRecord;
   }) {
     const selected = this.selectedId === options.optionId;
@@ -452,7 +501,16 @@ export class PreloopFlowPresetPicker extends LitElement {
         @click=${() => this.emitSelect(options.optionId)}
       >
         <sl-icon class="row-icon" name=${options.icon}></sl-icon>
-        <div class="row-name">${options.name}</div>
+        <div class="row-name">
+          ${options.name}
+          ${
+            options.origin
+              ? html`<span class="row-origin"
+                  >saved from ${options.origin}</span
+                >`
+              : nothing
+          }
+        </div>
         ${options.preset ? this.renderChips(options.preset) : html`<div></div>`}
         ${
           selected
@@ -496,6 +554,7 @@ export class PreloopFlowPresetPicker extends LitElement {
 
   private renderList() {
     const groups = this.filteredGroups();
+    const origins = presetOrigins(this.presets);
     const activeId = this.visibleOptionIds().includes(this.activeId)
       ? this.activeId
       : BLANK_PRESET_ID;
@@ -543,6 +602,7 @@ export class PreloopFlowPresetPicker extends LitElement {
                 icon: preset.icon || 'gear',
                 name: preset.name || 'Untitled preset',
                 description: firstSentence(preset.description),
+                origin: origins.get(preset.id || ''),
                 preset,
               })
             )}

--- a/frontend/src/components/tool-rule-editor.test.ts
+++ b/frontend/src/components/tool-rule-editor.test.ts
@@ -24,6 +24,26 @@ describe('ToolRuleEditor', () => {
     expect(dialog?.hasAttribute('open') || (dialog as any).open).to.be.true;
   });
 
+  it('titles the dialog in sentence case, naming the tool it is for', async () => {
+    // Three entry points said "Add rule", "Add Rule" and
+    // "Add Access Rule - pay" for the same act.
+    const el = (await fixture(
+      html`<tool-rule-editor
+        .open=${true}
+        .workflows=${[]}
+        .features=${{}}
+        .toolName=${'pay'}
+      ></tool-rule-editor>`
+    )) as ToolRuleEditor;
+    await el.updateComplete;
+
+    expect(
+      el.shadowRoot?.querySelector('sl-dialog')?.getAttribute('label')
+    ).to.equal('Add rule for pay');
+    const save = el.shadowRoot?.querySelector('sl-button[variant="primary"]');
+    expect(save?.textContent?.trim()).to.equal('Add rule');
+  });
+
   it('renders action cards for deny, require_approval, and allow', async () => {
     const el = (await fixture(
       html`<tool-rule-editor
@@ -90,7 +110,7 @@ describe('ToolRuleEditor', () => {
     expect(closeFired).to.be.true;
   });
 
-  it('dispatches save-rule event when Add Rule is clicked', async () => {
+  it('dispatches save-rule event when Add rule is clicked', async () => {
     const el = (await fixture(
       html`<tool-rule-editor
         .open=${true}

--- a/frontend/src/components/tool-rule-editor.ts
+++ b/frontend/src/components/tool-rule-editor.ts
@@ -1240,8 +1240,8 @@ export class ToolRuleEditor extends LitElement {
   render() {
     return html`
       <sl-dialog
-        label="${this._isEditing ? 'Edit' : 'Add'} Access Rule${
-          this.toolName ? ` - ${this.toolName}` : ''
+        label="${this._isEditing ? 'Edit' : 'Add'} rule${
+          this.toolName ? ` for ${this.toolName}` : ''
         }"
         ?open=${this.open}
         @sl-request-close=${this._handleClose}
@@ -1387,7 +1387,7 @@ export class ToolRuleEditor extends LitElement {
             ?loading=${this._saving}
             @click=${this._handleSave}
           >
-            ${this._isEditing ? 'Update Rule' : 'Add Rule'}
+            ${this._isEditing ? 'Update rule' : 'Add rule'}
           </sl-button>
         </div>
       </sl-dialog>

--- a/frontend/src/utils/line-diff.ts
+++ b/frontend/src/utils/line-diff.ts
@@ -1,0 +1,87 @@
+/**
+ * Line-level diff, shared by everything in the console that shows a before
+ * and an after: the policy YAML preview and the file edits an agent asks
+ * permission to make. No third-party diff library.
+ */
+
+export type DiffLineType = 'context' | 'added' | 'removed';
+
+export interface DiffLine {
+  type: DiffLineType;
+  text: string;
+}
+
+/**
+ * Above this many lines on either side the LCS matrix costs more than the
+ * answer is worth, and a diff that big is read as "the file changed" anyway.
+ * Past it, the two texts are reported as a wholesale replacement.
+ */
+const LCS_LINE_LIMIT = 2000;
+
+function lcsMatrix(a: readonly string[], b: readonly string[]): number[][] {
+  const rows = a.length;
+  const cols = b.length;
+  const matrix: number[][] = Array.from({ length: rows + 1 }, () =>
+    Array(cols + 1).fill(0)
+  );
+  for (let i = rows - 1; i >= 0; i--) {
+    for (let j = cols - 1; j >= 0; j--) {
+      matrix[i][j] =
+        a[i] === b[j]
+          ? matrix[i + 1][j + 1] + 1
+          : Math.max(matrix[i + 1][j], matrix[i][j + 1]);
+    }
+  }
+  return matrix;
+}
+
+/** Split text into lines, dropping the empty line a trailing newline adds. */
+export function toDiffLines(text: string): string[] {
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
+  if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+/**
+ * Diff two line arrays into one ordered run of context, removed and added
+ * lines. Removals come before the additions that replace them, which is the
+ * order a reviewer reads them in.
+ */
+export function diffLines(
+  before: readonly string[],
+  after: readonly string[]
+): DiffLine[] {
+  if (before.length > LCS_LINE_LIMIT || after.length > LCS_LINE_LIMIT) {
+    return [
+      ...before.map((text): DiffLine => ({ type: 'removed', text })),
+      ...after.map((text): DiffLine => ({ type: 'added', text })),
+    ];
+  }
+
+  const matrix = lcsMatrix(before, after);
+  const result: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < before.length && j < after.length) {
+    if (before[i] === after[j]) {
+      result.push({ type: 'context', text: before[i] });
+      i += 1;
+      j += 1;
+    } else if (matrix[i + 1][j] >= matrix[i][j + 1]) {
+      result.push({ type: 'removed', text: before[i] });
+      i += 1;
+    } else {
+      result.push({ type: 'added', text: after[j] });
+      j += 1;
+    }
+  }
+  while (i < before.length) {
+    result.push({ type: 'removed', text: before[i] });
+    i += 1;
+  }
+  while (j < after.length) {
+    result.push({ type: 'added', text: after[j] });
+    j += 1;
+  }
+  return result;
+}

--- a/frontend/src/utils/yaml-unified-diff.ts
+++ b/frontend/src/utils/yaml-unified-diff.ts
@@ -1,6 +1,7 @@
 /**
- * Line-level unified diff for policy YAML. No third-party diff library.
+ * Unified-diff text for policy YAML, over the shared line diff.
  */
+import { diffLines } from './line-diff';
 
 export function normalizeYamlText(text: string): string {
   return text
@@ -11,23 +12,6 @@ export function normalizeYamlText(text: string): string {
 
 export function yamlDocumentsEqual(before: string, after: string): boolean {
   return normalizeYamlText(before) === normalizeYamlText(after);
-}
-
-function lcsMatrix(a: string[], b: string[]): number[][] {
-  const rows = a.length;
-  const cols = b.length;
-  const matrix: number[][] = Array.from({ length: rows + 1 }, () =>
-    Array(cols + 1).fill(0)
-  );
-  for (let i = rows - 1; i >= 0; i--) {
-    for (let j = cols - 1; j >= 0; j--) {
-      matrix[i][j] =
-        a[i] === b[j]
-          ? matrix[i + 1][j + 1] + 1
-          : Math.max(matrix[i + 1][j], matrix[i][j + 1]);
-    }
-  }
-  return matrix;
 }
 
 export function unifiedYamlDiff(
@@ -45,30 +29,10 @@ export function unifiedYamlDiff(
   ) {
     return '';
   }
-  const matrix = lcsMatrix(left, right);
-  const lines: string[] = [`--- a/${filename}`, `+++ b/${filename}`];
-  let i = 0;
-  let j = 0;
-  while (i < left.length && j < right.length) {
-    if (left[i] === right[j]) {
-      lines.push(` ${left[i]}`);
-      i += 1;
-      j += 1;
-    } else if (matrix[i + 1][j] >= matrix[i][j + 1]) {
-      lines.push(`-${left[i]}`);
-      i += 1;
-    } else {
-      lines.push(`+${right[j]}`);
-      j += 1;
-    }
-  }
-  while (i < left.length) {
-    lines.push(`-${left[i]}`);
-    i += 1;
-  }
-  while (j < right.length) {
-    lines.push(`+${right[j]}`);
-    j += 1;
-  }
-  return lines.join('\n');
+  const signs = { context: ' ', removed: '-', added: '+' } as const;
+  return [
+    `--- a/${filename}`,
+    `+++ b/${filename}`,
+    ...diffLines(left, right).map((line) => `${signs[line.type]}${line.text}`),
+  ].join('\n');
 }

--- a/frontend/src/views/authed/approval-view.ts
+++ b/frontend/src/views/authed/approval-view.ts
@@ -37,6 +37,8 @@ import {
 import '../../components/question-answer-panel';
 import '../../components/approval-rule-context-block';
 import '../../components/attribution-line';
+import '../../components/args-diff';
+import { fileEditsFromArgs } from '../../components/args-diff';
 import type { QuestionAnswerDetail } from '../../components/question-answer-panel';
 import consoleStyles from '../../styles/console-styles.css?inline';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
@@ -1117,7 +1119,13 @@ export class ApprovalView extends AuthedElement {
 
         <div class="content-section">
           <h2>${this.argsHeading(request)}</h2>
-          <div class="code-block">${toolArgs}</div>
+          <!-- A file edit is decided by reading what changes, not by
+               reading two escaped strings; args-diff falls back to the raw
+               arguments for every other kind of call. -->
+          <args-diff
+            .args=${withoutApprovalMetadata(request.tool_args)}
+            .raw=${toolArgs}
+          ></args-diff>
         </div>
 
         ${
@@ -1363,12 +1371,16 @@ export class ApprovalView extends AuthedElement {
     });
   }
 
-  /** Bash and friends carry a command; anything else carries arguments. */
+  /**
+   * Bash and friends carry a command, a file edit carries changes, anything
+   * else carries arguments. The heading names what is under it.
+   */
   private argsHeading(request: ApprovalRequest): string {
     const args = withoutApprovalMetadata(request.tool_args);
-    return typeof args.command === 'string' || typeof args.cmd === 'string'
-      ? 'Command'
-      : 'Arguments';
+    if (typeof args.command === 'string' || typeof args.cmd === 'string') {
+      return 'Command';
+    }
+    return fileEditsFromArgs(args).length > 0 ? 'Changes' : 'Arguments';
   }
 
   private async copyRequestId(id: string) {

--- a/frontend/src/views/authed/approvals-view.test.ts
+++ b/frontend/src/views/authed/approvals-view.test.ts
@@ -1043,4 +1043,26 @@ describe('ApprovalsView', () => {
       expect((element as any).selectedIds).to.deep.equal([]);
     });
   });
+
+  describe('configure approvals menu', () => {
+    it('sends each item to the tools tab it names', async () => {
+      const element = await renderList([baseRequest({ id: 'ar-1' })]);
+
+      const items = Array.from(
+        element.shadowRoot!.querySelectorAll('sl-menu-item')
+      ).map((item) => ({
+        text: (item.textContent || '').replace(/\s+/g, ' ').trim(),
+        href: item.getAttribute('data-href'),
+      }));
+
+      // Both tools items used to open /console/tools and land on whichever
+      // tab was open last, so one of them always looked broken.
+      expect(
+        items.find((item) => item.text.includes('MCP tool access'))?.href
+      ).to.equal('/console/tools?tab=mcp');
+      expect(
+        items.find((item) => item.text.includes('Native tool approvals'))?.href
+      ).to.equal('/console/tools?tab=native');
+    });
+  });
 });

--- a/frontend/src/views/authed/approvals-view.test.ts
+++ b/frontend/src/views/authed/approvals-view.test.ts
@@ -985,6 +985,34 @@ describe('ApprovalsView', () => {
       expect(toast?.textContent ?? '').to.contain('Request already expired');
     });
 
+    it('does not mark an expired pending result as approved', async () => {
+      const element = await renderList([
+        baseRequest({ id: 'ar-1', expires_at: inMinutes(10) }),
+      ]);
+      batchOutcomes = {
+        'ar-1': {
+          id: 'ar-1',
+          ok: true,
+          status: 'expired',
+          error: 'Request already expired',
+        },
+      };
+
+      await select(element, ['ar-1']);
+      barButton(element, 'approve').click();
+      await agree();
+      await waitUntil(() => !!batchCall(), 'no batch call');
+      await waitUntil(() => {
+        const toasts = Array.from(document.querySelectorAll('sl-alert'));
+        const toast = toasts[toasts.length - 1];
+        return (toast?.textContent ?? '').includes('Request already expired');
+      }, 'no expired toast');
+
+      expect((element as any).approvalRequests[0].status).to.not.equal(
+        'approved'
+      );
+    });
+
     it('drops a row from the selection when it leaves the page', async () => {
       const element = await renderList([
         baseRequest({

--- a/frontend/src/views/authed/approvals-view.test.ts
+++ b/frontend/src/views/authed/approvals-view.test.ts
@@ -9,6 +9,8 @@ import type { ApprovalsView } from './approvals-view';
 
 describe('ApprovalsView', () => {
   let fetchStub: sinon.SinonStub;
+  /** Per id results the stubbed batch endpoint should return, if any. */
+  let batchOutcomes: Record<string, unknown> = {};
 
   function createFetchStub(approvalRequests: unknown[] = []) {
     return sinon
@@ -34,6 +36,15 @@ describe('ApprovalsView', () => {
           return json({
             status: 'declined',
             resolved_at: new Date().toISOString(),
+          });
+        }
+
+        if (url.includes('/decide-batch') && method === 'POST') {
+          const ids = JSON.parse(String(init?.body)).ids as string[];
+          return json({
+            results: ids.map((id) => batchOutcomes[id] ?? { id, ok: true }),
+            succeeded: ids.length,
+            failed: 0,
           });
         }
 
@@ -96,6 +107,7 @@ describe('ApprovalsView', () => {
   }
 
   beforeEach(() => {
+    batchOutcomes = {};
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
   });
@@ -417,9 +429,24 @@ describe('ApprovalsView', () => {
   });
 
   describe('keyboard', () => {
-    function press(element: ApprovalsView, key: string) {
-      element.dispatchEvent(
-        new KeyboardEvent('keydown', { key, bubbles: true, composed: true })
+    function press(
+      element: ApprovalsView,
+      key: string,
+      options: { shiftKey?: boolean } = {}
+    ) {
+      // Keys go to the row the keyboard is on, exactly as they do in the
+      // browser: J and K put the focus on a row, so that row is the target.
+      const focused =
+        element.shadowRoot?.querySelector<HTMLElement>(
+          '.approval-item[tabindex="0"]'
+        ) ?? element;
+      focused.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key,
+          bubbles: true,
+          composed: true,
+          ...options,
+        })
       );
       return element.updateComplete;
     }
@@ -773,6 +800,247 @@ describe('ApprovalsView', () => {
         .exist;
       expect(element.shadowRoot?.querySelector('.approval-item')).to.exist;
       expect(element.shadowRoot?.textContent).to.contain('Details');
+    });
+  });
+  describe('bulk decisions', () => {
+    function rows(element: ApprovalsView) {
+      return Array.from(
+        element.shadowRoot?.querySelectorAll('.approval-item') ?? []
+      ) as HTMLElement[];
+    }
+
+    function checkboxes(element: ApprovalsView) {
+      return Array.from(
+        element.shadowRoot?.querySelectorAll('list-select-checkbox') ?? []
+      ) as HTMLElement[];
+    }
+
+    function bulkBar(element: ApprovalsView) {
+      return element.shadowRoot?.querySelector('list-bulk-bar') as HTMLElement;
+    }
+
+    function barButton(element: ApprovalsView, action: string) {
+      return bulkBar(element)?.shadowRoot?.querySelector(
+        `sl-button[data-action="${action}"]`
+      ) as HTMLElement;
+    }
+
+    async function select(element: ApprovalsView, ids: string[]) {
+      for (const id of ids) {
+        (element as any).selection.toggle(id);
+      }
+      await element.updateComplete;
+    }
+
+    function batchCall() {
+      return fetchStub
+        .getCalls()
+        .find((c) => String(c.args[0]).includes('/decide-batch'));
+    }
+
+    function confirmDialogElement() {
+      return document.querySelector('confirm-dialog');
+    }
+
+    async function agree() {
+      await waitUntil(() => !!confirmDialogElement(), 'no confirm dialog');
+      (
+        confirmDialogElement()!.shadowRoot?.querySelector(
+          '[data-testid="confirm-dialog-confirm"]'
+        ) as HTMLElement
+      ).click();
+    }
+
+    it('offers a checkbox on waiting rows only', async () => {
+      const element = await renderList([
+        baseRequest({ id: 'waiting', expires_at: inMinutes(10) }),
+        baseRequest({
+          id: 'done',
+          status: 'approved',
+          resolved_at: new Date().toISOString(),
+        }),
+        questionRequest({ id: 'question', expires_at: inMinutes(10) }),
+      ]);
+
+      const boxes = checkboxes(element);
+      expect(boxes.length, 'one checkbox, on the decidable row').to.equal(1);
+      expect(boxes[0].getAttribute('item-id')).to.equal('waiting');
+      expect(
+        rows(element).filter((row) => row.dataset.selectionId).length
+      ).to.equal(1);
+    });
+
+    it('shows the bar with a count only once something is selected', async () => {
+      const element = await renderList([
+        baseRequest({ id: 'ar-1', expires_at: inMinutes(10) }),
+        baseRequest({ id: 'ar-2', expires_at: inMinutes(20) }),
+      ]);
+
+      expect(bulkBar(element)?.shadowRoot?.querySelector('.bulk-bar')).to.not
+        .exist;
+
+      await select(element, ['ar-1', 'ar-2']);
+      expect(
+        bulkBar(element)
+          ?.shadowRoot?.querySelector('[data-testid="bulk-count"]')
+          ?.textContent?.trim()
+      ).to.equal('2 selected');
+    });
+
+    it('approves the selection with one call after naming the requests', async () => {
+      const element = await renderList([
+        baseRequest({
+          id: 'ar-1',
+          tool_name: 'write_file',
+          expires_at: inMinutes(10),
+        }),
+        baseRequest({
+          id: 'ar-2',
+          tool_name: 'run_tests',
+          expires_at: inMinutes(20),
+        }),
+      ]);
+
+      await select(element, ['ar-1', 'ar-2']);
+      barButton(element, 'approve').click();
+
+      await waitUntil(() => !!confirmDialogElement(), 'no confirm dialog');
+      const dialog = confirmDialogElement()!.shadowRoot!;
+      expect(dialog.querySelector('sl-dialog')?.getAttribute('label')).to.equal(
+        'Approve 2 requests?'
+      );
+      const dialogText = dialog.textContent ?? '';
+      expect(dialogText).to.contain('write_file');
+      expect(dialogText).to.contain('run_tests');
+      expect(batchCall(), 'decided before the operator agreed').to.be.undefined;
+
+      await agree();
+      await waitUntil(() => !!batchCall(), 'no batch call');
+
+      const body = bodyOf(batchCall()!);
+      expect(body.ids).to.deep.equal(['ar-1', 'ar-2']);
+      expect(body.approved).to.be.true;
+      expect(
+        fetchStub
+          .getCalls()
+          .filter((c) => String(c.args[0]).includes('/approve')).length,
+        'a batch must not also send per row calls'
+      ).to.equal(0);
+
+      await waitUntil(
+        () =>
+          (element as any).approvalRequests.every(
+            (r: any) => r.status === 'approved'
+          ),
+        'rows were not marked approved'
+      );
+      expect((element as any).selectedIds).to.deep.equal([]);
+    });
+
+    it('denies the selection with one call, confirming first', async () => {
+      const element = await renderList([
+        baseRequest({ id: 'ar-1', expires_at: inMinutes(10) }),
+      ]);
+
+      await select(element, ['ar-1']);
+      barButton(element, 'deny').click();
+
+      await waitUntil(() => !!confirmDialogElement(), 'no confirm dialog');
+      expect(
+        confirmDialogElement()!
+          .shadowRoot!.querySelector('sl-dialog')
+          ?.getAttribute('label')
+      ).to.equal('Deny 1 request?');
+      expect(batchCall(), 'denied without confirming').to.be.undefined;
+
+      await agree();
+      await waitUntil(() => !!batchCall(), 'no batch call');
+      expect(bodyOf(batchCall()!).approved).to.be.false;
+    });
+
+    it('keeps only the requests the server refused selected', async () => {
+      const element = await renderList([
+        baseRequest({ id: 'ar-1', expires_at: inMinutes(10) }),
+        baseRequest({ id: 'ar-2', expires_at: inMinutes(20) }),
+      ]);
+      batchOutcomes = {
+        'ar-2': { id: 'ar-2', ok: false, error: 'Request already expired' },
+      };
+
+      await select(element, ['ar-1', 'ar-2']);
+      barButton(element, 'approve').click();
+      await agree();
+      await waitUntil(() => !!batchCall(), 'no batch call');
+      await waitUntil(
+        () => (element as any).selectedIds.length === 1,
+        'the failure was not kept for a retry'
+      );
+
+      expect((element as any).selectedIds).to.deep.equal(['ar-2']);
+      const toast = document.querySelector('sl-alert[open]');
+      expect(toast?.textContent ?? '').to.contain('1 request approved');
+      expect(toast?.textContent ?? '').to.contain('Request already expired');
+    });
+
+    it('drops a row from the selection when it leaves the page', async () => {
+      const element = await renderList([
+        baseRequest({
+          id: 'ar-1',
+          tool_name: 'write_file',
+          expires_at: inMinutes(10),
+        }),
+        baseRequest({
+          id: 'ar-2',
+          tool_name: 'run_tests',
+          expires_at: inMinutes(20),
+        }),
+      ]);
+
+      await select(element, ['ar-1', 'ar-2']);
+      expect((element as any).selectedIds.length).to.equal(2);
+
+      (element as any).searchQuery = 'write_file';
+      (element as any).applyFilters();
+      await element.updateComplete;
+
+      expect((element as any).selectedIds).to.deep.equal(['ar-1']);
+    });
+
+    it('extends the selection with shift and X and clears it with Escape', async () => {
+      const element = await renderList([
+        baseRequest({ id: 'ar-1', expires_at: inMinutes(5) }),
+        baseRequest({ id: 'ar-2', expires_at: inMinutes(10) }),
+        baseRequest({ id: 'ar-3', expires_at: inMinutes(15) }),
+      ]);
+
+      const press = (key: string, shiftKey = false) => {
+        const focused = element.shadowRoot?.querySelector<HTMLElement>(
+          '.approval-item[tabindex="0"]'
+        ) as HTMLElement;
+        focused.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key,
+            shiftKey,
+            bubbles: true,
+            composed: true,
+          })
+        );
+        return element.updateComplete;
+      };
+
+      await press('j');
+      await press('x');
+      await press('j');
+      await press('j');
+      await press('X', true);
+      expect((element as any).selectedIds).to.deep.equal([
+        'ar-1',
+        'ar-2',
+        'ar-3',
+      ]);
+
+      await press('Escape');
+      expect((element as any).selectedIds).to.deep.equal([]);
     });
   });
 });

--- a/frontend/src/views/authed/approvals-view.test.ts
+++ b/frontend/src/views/authed/approvals-view.test.ts
@@ -1067,5 +1067,25 @@ describe('ApprovalsView', () => {
         items.find((item) => item.text.includes('Native tool approvals'))?.href
       ).to.equal('/console/tools?tab=native');
     });
+
+    it('navigates when an item is clicked', async () => {
+      const element = await renderList([baseRequest({ id: 'ar-1' })]);
+      const item = Array.from(
+        element.shadowRoot!.querySelectorAll('sl-menu-item')
+      ).find(
+        (candidate) =>
+          candidate.getAttribute('data-href') === '/console/tools?tab=mcp'
+      )!;
+
+      const go = sinon.stub(Router, 'go');
+      try {
+        // The attributes alone would still read correctly with the handler
+        // unwired, so the click is what proves the menu goes anywhere.
+        item.click();
+        expect(go.calledOnceWith('/console/tools?tab=mcp')).to.be.true;
+      } finally {
+        go.restore();
+      }
+    });
   });
 });

--- a/frontend/src/views/authed/approvals-view.test.ts
+++ b/frontend/src/views/authed/approvals-view.test.ts
@@ -115,7 +115,9 @@ describe('ApprovalsView', () => {
   afterEach(() => {
     fetchStub?.restore();
     resetConfirmDialogForTests();
-    document.querySelectorAll('sl-alert[open]').forEach((a) => a.remove());
+    // Any alert, not just [open]: a toast raised at the end of a test can set
+    // its open attribute after this hook runs and leak into the next test.
+    document.querySelectorAll('sl-alert').forEach((a) => a.remove());
     localStorage.clear();
   });
 
@@ -977,7 +979,8 @@ describe('ApprovalsView', () => {
       );
 
       expect((element as any).selectedIds).to.deep.equal(['ar-2']);
-      const toast = document.querySelector('sl-alert[open]');
+      const toasts = Array.from(document.querySelectorAll('sl-alert'));
+      const toast = toasts[toasts.length - 1];
       expect(toast?.textContent ?? '').to.contain('1 request approved');
       expect(toast?.textContent ?? '').to.contain('Request already expired');
     });

--- a/frontend/src/views/authed/approvals-view.ts
+++ b/frontend/src/views/authed/approvals-view.ts
@@ -1180,20 +1180,26 @@ export class ApprovalsView extends AuthedElement {
             Configure approvals
           </sl-button>
           <sl-menu>
+            <!-- The tools view honours ?tab=, so each item lands on the
+                 tab it names instead of on whichever one was open last.
+                 The destination lives on the item so it can be read. -->
             <sl-menu-item
-              @click=${() => (window.location.href = '/console/tools')}
+              data-href="/console/tools?tab=mcp"
+              @click=${this.openConfigLink}
             >
               <sl-icon slot="prefix" name="tools"></sl-icon>
               MCP tool access rules
             </sl-menu-item>
             <sl-menu-item
-              @click=${() => (window.location.href = '/console/tools')}
+              data-href="/console/tools?tab=native"
+              @click=${this.openConfigLink}
             >
               <sl-icon slot="prefix" name="shield-lock"></sl-icon>
               Native tool approvals (account default)
             </sl-menu-item>
             <sl-menu-item
-              @click=${() => (window.location.href = '/console/agents')}
+              data-href="/console/agents"
+              @click=${this.openConfigLink}
             >
               <sl-icon slot="prefix" name="robot"></sl-icon>
               Per-agent overrides
@@ -1389,6 +1395,12 @@ export class ApprovalsView extends AuthedElement {
    * rows. It renders nothing until something is selected, so a page with no
    * selection looks exactly as it did before.
    */
+  /** Follow the destination the configure menu item carries. */
+  private openConfigLink(event: Event) {
+    const href = (event.currentTarget as HTMLElement | null)?.dataset.href;
+    if (href) window.location.href = href;
+  }
+
   private renderBulkBar() {
     return html`
       <list-bulk-bar

--- a/frontend/src/views/authed/approvals-view.ts
+++ b/frontend/src/views/authed/approvals-view.ts
@@ -1391,16 +1391,22 @@ export class ApprovalsView extends AuthedElement {
   }
 
   /**
+   * Follow the destination the configure menu item carries.
+   *
+   * Through the router, not `window.location`: these are console pages, and a
+   * full page reload would throw away the websocket and reload the shell to
+   * reach a sibling view.
+   */
+  private openConfigLink(event: Event) {
+    const href = (event.currentTarget as HTMLElement | null)?.dataset.href;
+    if (href) Router.go(href);
+  }
+
+  /**
    * The shared bulk bar, on one hairline between the group heading and its
    * rows. It renders nothing until something is selected, so a page with no
    * selection looks exactly as it did before.
    */
-  /** Follow the destination the configure menu item carries. */
-  private openConfigLink(event: Event) {
-    const href = (event.currentTarget as HTMLElement | null)?.dataset.href;
-    if (href) window.location.href = href;
-  }
-
   private renderBulkBar() {
     return html`
       <list-bulk-bar

--- a/frontend/src/views/authed/approvals-view.ts
+++ b/frontend/src/views/authed/approvals-view.ts
@@ -1,7 +1,12 @@
-import { html, css, unsafeCSS } from 'lit';
+import { html, css, nothing, unsafeCSS } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { Router } from '@vaadin/router';
-import { AuthedElement, approveRequest, declineRequest } from '../../api';
+import {
+  AuthedElement,
+  approveRequest,
+  declineRequest,
+  decideApprovalsBatch,
+} from '../../api';
 import type { ApprovalRequest } from '../../types';
 import '../../components/question-answer-panel';
 import type { QuestionAnswerDetail } from '../../components/question-answer-panel';
@@ -20,6 +25,14 @@ import {
   partitionApprovalRequests,
 } from '../../utils/approvals';
 import { confirmDialog, showToast } from '../../components/confirm-dialog';
+import {
+  ListSelectionController,
+  confirmBulkAction,
+  type BulkAction,
+  type BulkItem,
+  type BulkResult,
+} from '../../components/list-selection';
+import '../../components/list-selection';
 import { unifiedWebSocketManager } from '../../services/unified-websocket-manager';
 import '../../components/approval-rule-context-block';
 import '../../components/attribution-line';
@@ -128,9 +141,20 @@ export class ApprovalsView extends AuthedElement {
   @state()
   private focusedIndex = -1;
 
-  /** Rows picked with X. Bulk actions land in a later slice (E6). */
-  @state()
-  private selectedIds: string[] = [];
+  /**
+   * The shared console selection: the same checkbox, keys and bulk bar every
+   * other collection uses (`components/list-selection.ts`). Only rows that
+   * can still be decided are handed to it, so the bar can never offer to
+   * approve something that has already expired.
+   */
+  private selection = new ListSelectionController<ApprovalRequest>(this, {
+    idOf: (request) => request.id,
+  });
+
+  /** Selected ids, in the order they were picked. Read by the tests. */
+  get selectedIds(): string[] {
+    return [...this.selection.selectedIds];
+  }
 
   /** Waiting rows the operator had not seen when the page loaded. */
   @state()
@@ -241,6 +265,13 @@ export class ApprovalsView extends AuthedElement {
         align-items: center;
         justify-content: space-between;
         gap: var(--sl-spacing-medium);
+      }
+
+      /* The select box sits in the same 40px column every console list uses,
+         so rows with and without one still line up. */
+      .row-select {
+        flex: 0 0 auto;
+        width: 24px;
       }
 
       .approval-item.question {
@@ -441,6 +472,18 @@ export class ApprovalsView extends AuthedElement {
     return [...this.waitingRequests, ...this.historyRequests];
   }
 
+  /**
+   * The rows a bulk decision can touch: waiting, not a question.
+   *
+   * A question is answered, not approved in bulk, and anything already
+   * resolved or timed out has nothing left to decide. Handing only these to
+   * the controller means a row that expires while the page is open drops out
+   * of the selection by itself.
+   */
+  private get selectableRequests(): ApprovalRequest[] {
+    return this.waitingRequests.filter((request) => !this.isQuestion(request));
+  }
+
   /** Ids of requests this browser has already shown, oldest dropped first. */
   private readSeenIds(): string[] {
     try {
@@ -482,6 +525,11 @@ export class ApprovalsView extends AuthedElement {
    * Keys are handled on the host so a focused row, the list, or the page
    * itself all reach the same handler. Typing in a filter, and keys that
    * already belong to a button or link, are left alone.
+   *
+   * X, shift+X and Escape are not here: selection keys belong to the shared
+   * `ListSelectionController`, which every other console collection installs,
+   * and which finds the row from the event path (J and K have already put the
+   * focus there).
    */
   private handleKeyDown(event: KeyboardEvent) {
     if (event.metaKey || event.ctrlKey || event.altKey) return;
@@ -527,11 +575,6 @@ export class ApprovalsView extends AuthedElement {
       Router.go(`/console/approval/${focused.id}`);
       return;
     }
-    if (key === 'x' || key === 'X') {
-      event.preventDefault();
-      this.toggleSelection(focused.id);
-      return;
-    }
     if (key === 'a' || key === 'A') {
       if (!this.canDecide(focused)) return;
       event.preventDefault();
@@ -562,10 +605,17 @@ export class ApprovalsView extends AuthedElement {
     this.pendingFocus = true;
   }
 
-  private toggleSelection(id: string) {
-    this.selectedIds = this.selectedIds.includes(id)
-      ? this.selectedIds.filter((selected) => selected !== id)
-      : [...this.selectedIds, id];
+  /**
+   * Hands the selection the rows the page is about to paint.
+   *
+   * In `willUpdate` and not in `applyFilters` so that every path that can take
+   * a row off the page (a filter change, a decision, the expiry tick, a
+   * websocket update) prunes before the bulk bar is built. The bar renders
+   * above the rows, so a count pruned later in the pass would paint over a
+   * page that no longer has those rows.
+   */
+  protected willUpdate() {
+    this.selection.setItems(this.selectableRequests);
   }
 
   protected updated() {
@@ -957,6 +1007,112 @@ export class ApprovalsView extends AuthedElement {
     }
   }
 
+  /**
+   * The bulk bar's two actions.
+   *
+   * The bar disables its own buttons while a run is in flight, so there is
+   * nothing per action to say here.
+   */
+  private get bulkActions(): BulkAction[] {
+    return [
+      { id: 'approve', label: 'Approve', icon: 'check-lg', variant: 'success' },
+      { id: 'deny', label: 'Deny', icon: 'x-lg', variant: 'danger' },
+    ];
+  }
+
+  /** Bulk items carry the tool name, which is what a confirm or toast says. */
+  private bulkItems(): Array<BulkItem & { request: ApprovalRequest }> {
+    return this.selection.selectedItems.map((request) => ({
+      id: request.id,
+      name: request.summary?.trim() || request.tool_name,
+      request,
+    }));
+  }
+
+  private handleBulkAction(event: CustomEvent<{ id: string }>) {
+    void this.decideSelection(event.detail.id === 'approve');
+  }
+
+  /**
+   * Decide every picked row with one call.
+   *
+   * Both directions confirm. The row buttons do not (approving one request
+   * you are looking at is not a leap), but a bulk decision is taken from a
+   * count, and the dialog listing the tools is the only place that count is
+   * checkable. The server decides each id on its own and reports per id, so a
+   * request that expired while the dialog was open costs that row alone and
+   * stays selected for a retry.
+   */
+  private async decideSelection(approved: boolean) {
+    const items = this.bulkItems();
+    if (items.length === 0) return;
+
+    const noun = items.length === 1 ? 'request' : 'requests';
+    this.confirming = true;
+    const confirmed = await confirmBulkAction({
+      title: approved
+        ? `Approve ${items.length} ${noun}?`
+        : `Deny ${items.length} ${noun}?`,
+      message: approved
+        ? 'These tool calls run as soon as you confirm.'
+        : 'These tool calls will not run.',
+      names: items.map((item) => item.name),
+      confirmLabel: approved ? 'Approve' : 'Deny',
+      variant: approved ? 'primary' : 'danger',
+    });
+    this.confirming = false;
+    if (!confirmed) return;
+
+    await this.selection.runBatch(
+      approved ? 'approve' : 'deny',
+      items,
+      async (picked) => this.sendBatchDecision(picked, approved),
+      {
+        verb: approved ? 'approve' : 'deny',
+        verbPast: approved ? 'approved' : 'denied',
+        noun: 'request',
+      }
+    );
+  }
+
+  /** One POST for the whole selection, mapped back to per row outcomes. */
+  private async sendBatchDecision<T extends BulkItem>(
+    items: readonly T[],
+    approved: boolean
+  ): Promise<BulkResult<T>> {
+    const response = await decideApprovalsBatch(
+      items.map((item) => item.id),
+      approved
+    );
+    const byId = new Map(
+      (response?.results ?? []).map((result) => [result.id, result])
+    );
+    const succeeded: T[] = [];
+    const failed: Array<{ item: T; message: string }> = [];
+    const resolvedAt = new Date().toISOString();
+    for (const item of items) {
+      const result = byId.get(item.id);
+      if (result?.ok) {
+        succeeded.push(item);
+        this.applyResolution(item.id, {
+          status: approved ? 'approved' : 'declined',
+          resolved_at: resolvedAt,
+        });
+        continue;
+      }
+      failed.push({
+        item,
+        message: result?.error || 'No result returned',
+      });
+    }
+    // Whatever the server said about the failures, the page may be out of
+    // date about them; a reload is cheaper than guessing.
+    if (failed.length > 0) {
+      void this.loadApprovalRequests();
+    }
+    return { succeeded, failed };
+  }
+
   /** An answered question is submitted as an approve carrying the answer. */
   private async handleQuestionAnswer(
     request: ApprovalRequest,
@@ -1213,6 +1369,7 @@ export class ApprovalsView extends AuthedElement {
               : ''
           }
         </div>
+        ${waiting ? this.renderBulkBar() : ''}
         <div
           class="approval-list"
           role="grid"
@@ -1227,13 +1384,32 @@ export class ApprovalsView extends AuthedElement {
     `;
   }
 
+  /**
+   * The shared bulk bar, on one hairline between the group heading and its
+   * rows. It renders nothing until something is selected, so a page with no
+   * selection looks exactly as it did before.
+   */
+  private renderBulkBar() {
+    return html`
+      <list-bulk-bar
+        label="Approval bulk actions"
+        .count=${this.selection.count}
+        .actions=${this.bulkActions}
+        .running=${this.selection.running}
+        @bulk-action=${this.handleBulkAction}
+        @selection-clear=${() => this.selection.clear()}
+      ></list-bulk-bar>
+    `;
+  }
+
   private renderRequest(
     request: ApprovalRequest,
     waiting: boolean,
     index: number
   ) {
     const focused = this.focusedIndex === index;
-    const selected = this.selectedIds.includes(request.id);
+    const selectable = waiting && !this.isQuestion(request);
+    const selected = this.selection.isSelected(request.id);
     const isNew = waiting && this.newIds.includes(request.id);
     return html`
       <div
@@ -1243,6 +1419,7 @@ export class ApprovalsView extends AuthedElement {
         role="row"
         data-index=${index}
         data-request-id=${request.id}
+        data-selection-id=${selectable ? request.id : nothing}
         aria-selected=${selected ? 'true' : 'false'}
         tabindex=${focused || (this.focusedIndex < 0 && index === 0) ? 0 : -1}
         @focus=${() => {
@@ -1250,6 +1427,18 @@ export class ApprovalsView extends AuthedElement {
         }}
       >
         <div class="approval-row" role="gridcell">
+          ${
+            selectable
+              ? html`<list-select-checkbox
+                  class="row-select"
+                  item-id=${request.id}
+                  label=${`Select ${request.summary?.trim() || request.tool_name}`}
+                  ?checked=${selected}
+                  ?disabled=${this.selection.busy}
+                  @selection-toggle=${this.selection.handleToggleEvent}
+                ></list-select-checkbox>`
+              : ''
+          }
           <div class="approval-info">
             <div class="approval-tool">
               ${

--- a/frontend/src/views/authed/approvals-view.ts
+++ b/frontend/src/views/authed/approvals-view.ts
@@ -1090,15 +1090,25 @@ export class ApprovalsView extends AuthedElement {
     const succeeded: T[] = [];
     const failed: Array<{ item: T; message: string }> = [];
     const resolvedAt = new Date().toISOString();
+    const expectedStatus = approved ? 'approved' : 'declined';
     for (const item of items) {
       const result = byId.get(item.id);
-      if (result?.ok) {
+      const decided =
+        result?.ok === true &&
+        (result.status == null || result.status === expectedStatus);
+      if (decided) {
         succeeded.push(item);
         this.applyResolution(item.id, {
-          status: approved ? 'approved' : 'declined',
+          status: expectedStatus,
           resolved_at: resolvedAt,
         });
         continue;
+      }
+      if (result?.status === 'expired') {
+        this.applyResolution(item.id, {
+          status: 'expired',
+          resolved_at: resolvedAt,
+        });
       }
       failed.push({
         item,

--- a/frontend/src/views/authed/audit-view.test.ts
+++ b/frontend/src/views/authed/audit-view.test.ts
@@ -348,6 +348,93 @@ describe('AuditView', () => {
     document.body.removeChild(element);
   });
 
+  it('shortens the ids in an expanded event and links the ones with a page', async () => {
+    const sessionId = '11111111-2222-4333-8444-555555555555';
+    const executionId = '99999999-8888-4777-8666-555555555555';
+    fetchStub.callsFake(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url === '/api/v1/users') {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.startsWith('/api/v1/audit-logs/grouped?')) {
+        return new Response(
+          JSON.stringify({
+            groups: [
+              {
+                correlation_id: null,
+                outcome: 'executed',
+                primary_event: {
+                  id: 'audit-id-1',
+                  account_id: 'account-1',
+                  user_id: null,
+                  action: 'tool_call',
+                  resource_type: 'tool',
+                  resource_id: 'search',
+                  status: 'executed',
+                  ip_address: null,
+                  user_agent: null,
+                  timestamp: '2026-03-10T10:00:00Z',
+                  details: {
+                    tool_name: 'search',
+                    runtime_session_id: sessionId,
+                    flow_execution_id: executionId,
+                  },
+                },
+                sub_events: [],
+              },
+            ],
+            total: 1,
+            skip: 0,
+            limit: 50,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      return new Response(JSON.stringify({ detail: url }), { status: 500 });
+    });
+
+    const element = document.createElement('audit-view') as AuditView;
+    document.body.appendChild(element);
+    await waitUntil(
+      () => !(element as any)._loading,
+      'Audit view did not finish loading'
+    );
+    await element.updateComplete;
+
+    const row = element.shadowRoot?.querySelector(
+      '.primary-row'
+    ) as HTMLElement;
+    row.click();
+    await element.updateComplete;
+
+    const ids = Array.from(
+      element.shadowRoot?.querySelectorAll('.id-value') || []
+    );
+    const texts = ids.map((node) => (node.textContent || '').trim());
+    // Eight characters is enough to tell two ids apart in one event; the
+    // whole thing is in the title and one click from the clipboard.
+    expect(texts).to.deep.equal(['11111111', '99999999']);
+    expect(
+      ids.map((node) =>
+        node.querySelector('sl-icon-button')?.getAttribute('label')
+      )
+    ).to.deep.equal(['Copy runtime session id', 'Copy flow execution id']);
+
+    const links = ids.map((node) => node.querySelector('a'));
+    expect(links[0]?.getAttribute('href')).to.equal(
+      `/console/runtime-sessions?sessionId=${sessionId}`
+    );
+    expect(links[0]?.getAttribute('title')).to.equal(sessionId);
+    expect(links[1]?.getAttribute('href')).to.equal(
+      `/console/flows/executions/${executionId}`
+    );
+
+    document.body.removeChild(element);
+  });
+
   describe('filter bar and rows (B-D1)', () => {
     async function mountLoaded() {
       const element = document.createElement('audit-view') as AuditView;

--- a/frontend/src/views/authed/audit-view.ts
+++ b/frontend/src/views/authed/audit-view.ts
@@ -17,6 +17,7 @@ import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import '@shoelace-style/shoelace/dist/components/icon-button/icon-button.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
@@ -609,6 +610,82 @@ export class AuditView extends AuthedElement {
     `;
   }
 
+  /** Console route for the ids the audit log records, where one exists. */
+  private _detailIdHref(key: string, id: string): string | null {
+    const value = encodeURIComponent(id);
+    switch (key) {
+      case 'runtime_session_id':
+        return `/console/runtime-sessions?sessionId=${value}`;
+      case 'flow_execution_id':
+      case 'execution_id':
+        return `/console/flows/executions/${value}`;
+      case 'flow_id':
+        return `/console/flows/${value}`;
+      case 'approval_id':
+        return `/console/approval/${value}`;
+      default:
+        return null;
+    }
+  }
+
+  private _isUuid(value: unknown): value is string {
+    return (
+      typeof value === 'string' &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        value
+      )
+    );
+  }
+
+  private async _copyDetailId(id: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(id);
+      showToast('Id copied', 'success');
+    } catch {
+      showToast('Could not copy the id', 'danger');
+    }
+  }
+
+  /**
+   * One id in the expanded event.
+   *
+   * The same UUID used to be printed four times at full length as plain
+   * text, which is 144 characters of noise and no way to reach the thing it
+   * names. It now shows its first 8 characters, links to the session,
+   * execution, flow or approval when the key says which, and copies in full
+   * on request; the full value stays in the title.
+   */
+  private _renderIdDetail(key: string, label: string, id: string) {
+    const href = this._detailIdHref(key, id);
+    const short = id.slice(0, 8);
+    return html`
+      <div class="detail-item">
+        <span class="detail-label">${label}</span>
+        <span class="detail-value id-value">
+          ${
+            href
+              ? html`<a href=${href} title=${id}>${short}</a>`
+              : html`<span title=${id}>${short}</span>`
+          }
+          <sl-icon-button
+            class="copy-id"
+            name="clipboard"
+            label="Copy ${label.toLowerCase()}"
+            @click=${() => this._copyDetailId(id)}
+          ></sl-icon-button>
+        </span>
+      </div>
+    `;
+  }
+
+  /** An id field gets the id treatment; everything else is printed. */
+  private _renderDetailField(key: string, value: unknown) {
+    const label = this._prettyDetailLabel(key);
+    return this._isUuid(value)
+      ? this._renderIdDetail(key, label, value)
+      : this._renderDetailItem(label, value);
+  }
+
   private _renderJsonDetail(label: string, value: unknown) {
     if (value == null) return nothing;
     let rendered = '';
@@ -692,10 +769,7 @@ export class AuditView extends AuthedElement {
       .filter((key) => details[key] != null && details[key] !== '')
       .map((key) => {
         renderedKeys.add(key);
-        return this._renderDetailItem(
-          this._prettyDetailLabel(key),
-          details[key]
-        );
+        return this._renderDetailField(key, details[key]);
       });
     const remainingItems = Object.entries(details)
       .filter(
@@ -705,9 +779,7 @@ export class AuditView extends AuthedElement {
           typeof value !== 'object' &&
           !['tool_name', 'decision', 'event'].includes(key)
       )
-      .map(([key, value]) =>
-        this._renderDetailItem(this._prettyDetailLabel(key), value)
-      );
+      .map(([key, value]) => this._renderDetailField(key, value));
 
     // Render recipient list as a small chip cluster when present.
     const recipientChips =
@@ -1848,6 +1920,25 @@ export class AuditView extends AuthedElement {
         font-size: 0.78rem;
         color: var(--sl-color-neutral-700);
         word-break: break-word;
+      }
+      .detail-value a {
+        color: var(--console-link-color);
+        text-decoration: none;
+      }
+      .detail-value a:hover,
+      .detail-value a:focus-visible {
+        text-decoration: underline;
+      }
+      .id-value {
+        align-items: center;
+        display: flex;
+        font-family: var(--sl-font-mono, monospace);
+        gap: 0.25rem;
+      }
+      .copy-id::part(base) {
+        padding: 0;
+        font-size: 0.78rem;
+        color: var(--sl-color-neutral-500);
       }
       .detail-json {
         margin: 0;

--- a/frontend/src/views/authed/console-shell.test.ts
+++ b/frontend/src/views/authed/console-shell.test.ts
@@ -433,6 +433,27 @@ describe('ConsoleShell', () => {
     expect(models).to.be.lessThan(tools);
   });
 
+  it('reaches the personal settings pages from the sidebar', async () => {
+    const el = (await fixture(
+      html`<console-shell></console-shell>`
+    )) as ConsoleShell;
+
+    await waitUntil(
+      () => el.shadowRoot?.querySelector('a[href="/console/tools"]') !== null,
+      'Sidebar did not render'
+    );
+
+    const hrefs = Array.from(
+      el.shadowRoot?.querySelectorAll('a.sidebar-link') ?? []
+    ).map((link) => link.getAttribute('href'));
+    // These four had routes and a place in the avatar menu, but no way in
+    // from the sidebar.
+    expect(hrefs).to.include('/console/settings/profile');
+    expect(hrefs).to.include('/console/settings/security');
+    expect(hrefs).to.include('/console/settings/appearance');
+    expect(hrefs).to.include('/console/settings/notification-preferences');
+  });
+
   describe('Policies preview gate', () => {
     /** Re-stub fetch with a chosen policies_console flag and superuser bit. */
     function stubShell(

--- a/frontend/src/views/authed/console-shell.ts
+++ b/frontend/src/views/authed/console-shell.ts
@@ -861,6 +861,26 @@ export class ConsoleShell extends LitElement {
                           '/console/settings/runners',
                           html`<sl-menu-item>Runners</sl-menu-item>`
                         )}
+                        <!-- The four personal pages had routes and a place in
+                             the avatar menu, but no way in from the sidebar,
+                             so Appearance in particular was unreachable for
+                             anyone who did not know the URL. -->
+                        ${this._renderNavLink(
+                          '/console/settings/profile',
+                          html`<sl-menu-item>Profile</sl-menu-item>`
+                        )}
+                        ${this._renderNavLink(
+                          '/console/settings/security',
+                          html`<sl-menu-item>Security</sl-menu-item>`
+                        )}
+                        ${this._renderNavLink(
+                          '/console/settings/appearance',
+                          html`<sl-menu-item>Appearance</sl-menu-item>`
+                        )}
+                        ${this._renderNavLink(
+                          '/console/settings/notification-preferences',
+                          html`<sl-menu-item>Notifications</sl-menu-item>`
+                        )}
                       </sl-menu>
                     </sl-details>
                   </sl-menu>

--- a/frontend/src/views/authed/tools-view.test.ts
+++ b/frontend/src/views/authed/tools-view.test.ts
@@ -1254,12 +1254,12 @@ describe('ToolsView – tabs and toolbar', () => {
 
     const addRule = [
       ...(ruleSet.shadowRoot?.querySelectorAll('sl-button') || []),
-    ].find((button) => button.textContent?.includes('Add Rule')) as
+    ].find((button) => button.textContent?.includes('Add rule')) as
       (HTMLElement & { click: () => void }) | undefined;
     expect(addRule).to.exist;
     await waitUntil(
       () => Boolean(addRule!.shadowRoot?.querySelector('button')),
-      'Add Rule button did not upgrade'
+      'Add rule button did not upgrade'
     );
     addRule!.click();
     await waitUntil(

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4202,8 +4202,8 @@ paths:
         \ while the operator was reading\ncosts that row and nothing else.\n\nArgs:\n\
         \    decision: The ids to decide, the decision, and an optional comment\n\
         \    request: HTTP request\n    current_user: Current authenticated user\n\
-        \    db: Async session used for the permission check and the decisions\n\n\
-        Returns:\n    One result per requested id, in the order they were sent"
+        \    db: Async session used for the decisions\n\nReturns:\n    One result\
+        \ per requested id, in the order they were sent"
       operationId: decide_requests_batch_api_v1_approval_requests_decide_batch_post
       requestBody:
         content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4187,6 +4187,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/approval-requests/decide-batch:
+    post:
+      tags:
+      - Approval Requests
+      - approval_requests
+      summary: Decide Requests Batch
+      description: "Approve or decline several requests with one decision.\n\nAn operator\
+        \ clearing an inbox picks the rows first and decides once. Doing\nthat as\
+        \ N round trips means N approvals racing for the same expiry window\nand N\
+        \ chances for the page to lose track of which ones landed, so the\nconsole\
+        \ sends the whole selection here.\n\nThe batch never fails as a whole: each\
+        \ request is decided on its own and\nreported on its own, so an id that expired\
+        \ while the operator was reading\ncosts that row and nothing else.\n\nArgs:\n\
+        \    decision: The ids to decide, the decision, and an optional comment\n\
+        \    request: HTTP request\n    current_user: Current authenticated user\n\
+        \    db: Injected for the permission check\n\nReturns:\n    One result per\
+        \ requested id, in the order they were sent"
+      operationId: decide_requests_batch_api_v1_approval_requests_decide_batch_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApprovalBatchDecision'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalBatchResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
   /api/v1/approval-bypasses/status:
     get:
       tags:
@@ -11435,6 +11474,96 @@ components:
       - name
       title: ApprovalApiKeySummary
       description: The API key the requesting caller authenticated with.
+    ApprovalBatchDecision:
+      properties:
+        ids:
+          items:
+            type: string
+            format: uuid
+          type: array
+          maxItems: 100
+          minItems: 1
+          title: Ids
+          description: Approval request ids to decide, in the order they were picked
+        approved:
+          type: boolean
+          title: Approved
+          description: Whether every listed request is approved or declined
+        comment:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Comment
+          description: Comment recorded on every request in the batch
+      type: object
+      required:
+      - ids
+      - approved
+      title: ApprovalBatchDecision
+      description: One decision applied to several pending requests.
+    ApprovalBatchItemResult:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: The approval request this result is for
+        ok:
+          type: boolean
+          title: Ok
+          description: True when the decision was recorded
+        status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Status
+          description: Status of the request after the decision, when known
+        error:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error
+          description: 'Why this request was not decided: not found, not yours, or
+            already resolved. Null when ok is true.'
+      type: object
+      required:
+      - id
+      - ok
+      title: ApprovalBatchItemResult
+      description: What happened to one request in a batch decision.
+    ApprovalBatchResponse:
+      properties:
+        results:
+          items:
+            $ref: '#/components/schemas/ApprovalBatchItemResult'
+          type: array
+          title: Results
+          description: One result per requested id, in request order
+        succeeded:
+          type: integer
+          title: Succeeded
+          description: How many requests took the decision.
+          readOnly: true
+        failed:
+          type: integer
+          title: Failed
+          description: How many requests did not.
+          readOnly: true
+      type: object
+      required:
+      - results
+      - succeeded
+      - failed
+      title: ApprovalBatchResponse
+      description: 'Per-request results for a batch decision.
+
+
+        A batch never fails as a whole. One request that is already resolved (or
+
+        belongs to somebody else) must not cost the operator the other nineteen
+
+        decisions they just made, so every id gets its own result and the caller
+
+        reports the failures by name.'
     ApprovalBypassCreate:
       properties:
         mode:
@@ -15634,7 +15763,7 @@ components:
           description: Description for the Pull/Merge Request
         verification:
           anyOf:
-          - $ref: '#/components/schemas/VerificationPolicy'
+          - $ref: '#/components/schemas/VerificationPolicy-Input'
           - type: 'null'
           description: 'Publication gate policy: required checks a commit must pass
             before the flow pushes it or opens a pull request'
@@ -15711,7 +15840,7 @@ components:
           description: Description for the Pull/Merge Request
         verification:
           anyOf:
-          - $ref: '#/components/schemas/VerificationPolicy'
+          - $ref: '#/components/schemas/VerificationPolicy-Output'
           - type: 'null'
           description: 'Publication gate policy: required checks a commit must pass
             before the flow pushes it or opens a pull request'
@@ -22641,7 +22770,7 @@ components:
       - reason
       title: VerificationCommand
       description: 'One required check: a shell command plus why it exists.'
-    VerificationPolicy:
+    VerificationPolicy-Input:
       properties:
         mode:
           type: string
@@ -22651,7 +22780,7 @@ components:
           title: Mode
           default: gate
         profile:
-          $ref: '#/components/schemas/VerificationProfile'
+          $ref: '#/components/schemas/VerificationProfile-Input'
           description: Versioned trusted test profile driving required checks
         gate_budget_seconds:
           type: integer
@@ -22675,7 +22804,85 @@ components:
         leave the workspace. There is no draft-publication exception: unverified
 
         work stays unpushed.'
-    VerificationProfile:
+    VerificationPolicy-Output:
+      properties:
+        mode:
+          type: string
+          enum:
+          - 'off'
+          - gate
+          title: Mode
+          default: gate
+        profile:
+          $ref: '#/components/schemas/VerificationProfile-Output'
+          description: Versioned trusted test profile driving required checks
+        gate_budget_seconds:
+          type: integer
+          maximum: 14400.0
+          minimum: 30.0
+          title: Gate Budget Seconds
+          description: Wall-clock budget for the whole verification run; a check that
+            cannot start inside it is blocked, not failed
+          default: 3600
+      type: object
+      required:
+      - profile
+      title: VerificationPolicy
+      description: 'Publication gate policy inside ``git_clone_config`` (issue #428).
+
+
+        ``mode: "gate"`` requires the runner-controlled verifier to allow
+
+        publication (push / pull-request creation) before the agent''s commits
+
+        leave the workspace. There is no draft-publication exception: unverified
+
+        work stays unpushed.'
+    VerificationProfile-Input:
+      properties:
+        version:
+          type: string
+          const: v1
+          title: Version
+          default: v1
+        profile_id:
+          type: string
+          title: Profile Id
+          description: Stable profile name, e.g. 'default'
+        description:
+          type: string
+          title: Description
+          default: ''
+        always:
+          items:
+            $ref: '#/components/schemas/VerificationCommand'
+          type: array
+          title: Always
+        rules:
+          items:
+            $ref: '#/components/schemas/ProfileRule'
+          type: array
+          title: Rules
+        unknown_default:
+          items:
+            $ref: '#/components/schemas/VerificationCommand'
+          type: array
+          title: Unknown Default
+      type: object
+      required:
+      - profile_id
+      title: VerificationProfile
+      description: 'Versioned, trusted set of required checks for a repository.
+
+
+        Ships with the flow configuration, not inside the repository under test.
+
+        Inexpensive ``always`` hooks are required on every change; rules match
+
+        the changed-file diff; ``unknown_default`` covers unknown impact so a
+
+        diff never resolves to an empty required list.'
+    VerificationProfile-Output:
       properties:
         version:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4202,8 +4202,8 @@ paths:
         \ while the operator was reading\ncosts that row and nothing else.\n\nArgs:\n\
         \    decision: The ids to decide, the decision, and an optional comment\n\
         \    request: HTTP request\n    current_user: Current authenticated user\n\
-        \    db: Injected for the permission check\n\nReturns:\n    One result per\
-        \ requested id, in the order they were sent"
+        \    db: Async session used for the permission check and the decisions\n\n\
+        Returns:\n    One result per requested id, in the order they were sent"
       operationId: decide_requests_batch_api_v1_approval_requests_decide_batch_post
       requestBody:
         content:
@@ -15763,7 +15763,7 @@ components:
           description: Description for the Pull/Merge Request
         verification:
           anyOf:
-          - $ref: '#/components/schemas/VerificationPolicy-Input'
+          - $ref: '#/components/schemas/VerificationPolicy'
           - type: 'null'
           description: 'Publication gate policy: required checks a commit must pass
             before the flow pushes it or opens a pull request'
@@ -15840,7 +15840,7 @@ components:
           description: Description for the Pull/Merge Request
         verification:
           anyOf:
-          - $ref: '#/components/schemas/VerificationPolicy-Output'
+          - $ref: '#/components/schemas/VerificationPolicy'
           - type: 'null'
           description: 'Publication gate policy: required checks a commit must pass
             before the flow pushes it or opens a pull request'
@@ -22770,7 +22770,7 @@ components:
       - reason
       title: VerificationCommand
       description: 'One required check: a shell command plus why it exists.'
-    VerificationPolicy-Input:
+    VerificationPolicy:
       properties:
         mode:
           type: string
@@ -22780,7 +22780,7 @@ components:
           title: Mode
           default: gate
         profile:
-          $ref: '#/components/schemas/VerificationProfile-Input'
+          $ref: '#/components/schemas/VerificationProfile'
           description: Versioned trusted test profile driving required checks
         gate_budget_seconds:
           type: integer
@@ -22804,85 +22804,7 @@ components:
         leave the workspace. There is no draft-publication exception: unverified
 
         work stays unpushed.'
-    VerificationPolicy-Output:
-      properties:
-        mode:
-          type: string
-          enum:
-          - 'off'
-          - gate
-          title: Mode
-          default: gate
-        profile:
-          $ref: '#/components/schemas/VerificationProfile-Output'
-          description: Versioned trusted test profile driving required checks
-        gate_budget_seconds:
-          type: integer
-          maximum: 14400.0
-          minimum: 30.0
-          title: Gate Budget Seconds
-          description: Wall-clock budget for the whole verification run; a check that
-            cannot start inside it is blocked, not failed
-          default: 3600
-      type: object
-      required:
-      - profile
-      title: VerificationPolicy
-      description: 'Publication gate policy inside ``git_clone_config`` (issue #428).
-
-
-        ``mode: "gate"`` requires the runner-controlled verifier to allow
-
-        publication (push / pull-request creation) before the agent''s commits
-
-        leave the workspace. There is no draft-publication exception: unverified
-
-        work stays unpushed.'
-    VerificationProfile-Input:
-      properties:
-        version:
-          type: string
-          const: v1
-          title: Version
-          default: v1
-        profile_id:
-          type: string
-          title: Profile Id
-          description: Stable profile name, e.g. 'default'
-        description:
-          type: string
-          title: Description
-          default: ''
-        always:
-          items:
-            $ref: '#/components/schemas/VerificationCommand'
-          type: array
-          title: Always
-        rules:
-          items:
-            $ref: '#/components/schemas/ProfileRule'
-          type: array
-          title: Rules
-        unknown_default:
-          items:
-            $ref: '#/components/schemas/VerificationCommand'
-          type: array
-          title: Unknown Default
-      type: object
-      required:
-      - profile_id
-      title: VerificationProfile
-      description: 'Versioned, trusted set of required checks for a repository.
-
-
-        Ships with the flow configuration, not inside the repository under test.
-
-        Inexpensive ``always`` hooks are required on every change; rules match
-
-        the changed-file diff; ``unknown_default`` covers unknown impact so a
-
-        diff never resolves to an empty required list.'
-    VerificationProfile-Output:
+    VerificationProfile:
       properties:
         version:
           type: string


### PR DESCRIPTION
Stacked on #465 (shared multi-select component); merge #465 first.

# Bulk approvals, approvals in the bell, a diff for file-edit args, and seven copy fixes

## Summary

Four console items from the 2026-09-05 UX review. An operator can now clear an
approvals inbox by selecting rows and deciding once, sees an approval that was
resolved elsewhere instead of watching it vanish from the bell, and reads a
file-edit approval as a diff instead of two escaped JSON strings. Plus seven
small copy and link faults across the console.

**Stacked on #465** (K4's `feat/list-selection-bulk-actions`), rebased onto its
current head `4f5565d5`. W3-1 reuses that branch's shared
`components/list-selection.ts` rather than adding a second selection model, so
this branch starts there: review and merge #465 first, or merge this one and
take both. My nine commits sit above `4f5565d5`: `76cce1c8`, `9febe4d9`,
`921cc06b`, `e0659267`, `06c1e744`, `a93b6e40`, then the three review
follow-ups `b4065086`, `59a87f2d`, `8461ad76`.

## Changes per item

### W3-1 Bulk approvals (B-L2 / E6)
- New `POST /approval-requests/decide-batch`
  (`backend/preloop/api/endpoints/approval_requests.py:408-520`,
  schemas in `models/schemas/approval_request.py`, `openapi.yaml` regenerated).
  Decisions run sequentially on one session and are reported per id, so a
  request that expired while the operator was reading costs that row and not
  the batch. A cross-account id gets the same message as a missing one.
- `views/authed/approvals-view.ts` drops the round 4 selection state and `x`
  key handler and installs K4's `ListSelectionController`,
  `<list-select-checkbox>` and `<list-bulk-bar>` (approve, deny). Deny confirms
  first, approve does not. Ids the server refused stay selected for a retry and
  the toast names the reason. `selectedIds` survives as a getter over the
  controller.

### W3-2 Bell carries approvals (B-O1 / E9)
The bell already listed pending approvals and navigated on click, so the
observation as written does not match current code. The real gaps, now fixed in
`components/console-header.ts`:
- an approval resolved elsewhere leaves a notification ("Approval approved",
  "declined", "expired", "cancelled") instead of disappearing, and decisions
  made in the bell itself stay quiet;
- notifications carry an `href` and clicking one navigates (approvals go to
  `/console/approval/<id>`), with Enter and Space bound too;
- approvals whose expiry has passed stop being counted in the badge.

No backend change: there is no notification store, and
`services/approval_service.py:507-575` already broadcasts everything the bell
needs.

### W3-3 Diff view for file-edit args (E14)
- `utils/line-diff.ts` (new) holds the LCS line diff that was welded into the
  policy YAML differ; `utils/yaml-unified-diff.ts` now sits on it.
- `components/args-diff.ts` (new) recognises `old_string`/`new_string`,
  `oldText`/`newText`, an `edits[]` array and `content` with a path, renders
  each edit as a diff with a "Raw" toggle, and falls back to raw JSON when the
  args are not a file edit.
- `views/authed/approval-view.ts` renders `<args-diff>`; the heading reads
  "Command", "Changes" or "Arguments".

### W3-7 Copy and link fixes
- A2 `components/inventory-card.ts`: collapsed numeric cells are labelled, so a
  narrow row reads `Requests 12 · Spend $0.42 · Seen 2h ago` (Tokens is the one
  number the phone layout drops).
- B-L4 `views/authed/approvals-view.ts`: the configure approvals menu items
  navigate.
- B-R2 `components/approval-rule-context-block.ts`: an unnamed rule prints its
  expression once, not twice.
- B-P3 `components/governance-rule-set-editor.ts`: "Add rule".
- B-D4 `components/tool-rule-editor.ts`: "Add rule for read_file" /
  "Edit rule for read_file", save button "Add rule" / "Update rule".
- C18 `components/preloop-flow-preset-picker.ts`: a saved copy shows
  "saved from <catalog preset>" and the catalog row it came from is not listed
  twice.
- D14 `views/authed/console-shell.ts`: profile, security, appearance and
  notification preferences in the sidebar Settings group.
- `views/authed/audit-view.ts`: ids in audit details link to the console page
  that owns them, shortened to 8 characters with a copy button and the full id
  in the tooltip.

## Review follow-ups

The V-W1 review approved with nits and no blockers. Applied here:

- Rebased onto K4's current head `4f5565d5` so the `list-selection.ts` conflict
  is resolved by the author, not at merge time. One conflict, in
  `list-selection.test.ts`, resolved by keeping K4's new test and both of mine.
  K4's component API is what survived: the approvals bulk actions dropped the
  removed `disabled` field, `setItems` moved into `willUpdate`, and the row
  checkboxes take K4's new `busy` getter.
- The expired-approval test passed on the code before the `liveApprovals`
  getter existed, because it seeded a row that was already expired at load. It
  now loads a live approval, pushes its expiry into the past on the loaded rows
  and asserts the badge and the row both drop it. Confirmed it fails with the
  filter removed.
- Three accessibility nits: the diff's `+` / `-` was `aria-hidden`, so added
  versus removed was colour alone (each changed line now carries a visually
  hidden "Added:" / "Removed:", excluded from selection so a copied diff is
  still the file's own text); `aria-pressed` on the raw toggle went nowhere
  because `sl-button` does not forward it, so the label says "Show raw" /
  "Show diff" instead; a bell notification with no target had
  `role="presentation"` on a div that marks itself read on click, and is now a
  focusable `role="button"`.
- The configure approvals menu navigates through `Router.go`, not
  `window.location.href` (no full page reload inside the console), and a test
  clicks an item with the router stubbed rather than only reading `data-href`.
- Comment tidying the review asked for: the bulk bar doc comment sat above an
  unrelated method, `hasExpression` carried two docstrings, and the inventory
  separator test now says why it matches CSS source.
- Not applied: the preset picker still hides a catalog original once an account
  copy exists (founder call 5 below). Two report inaccuracies the review caught
  are corrected here: the narrow inventory row example, and the list of new
  backend tests.

## Tests

- Frontend whole suite (Chromium): **1887 passed, 0 failed** across 157 files,
  20.3s. Branch base (K4 `4f5565d5`) 1857 passed / 155 files. So **+30 tests,
  +2 files**, no regressions. (Against the older K4 base `3d7003d8` it was
  1836 -> 1881, the +45 figure in the first draft.)
- Backend `backend/tests/endpoints/test_approval_requests.py`: **27 passed**,
  21 of them pre-existing. The 6 new ones are the happy path, mixed per id
  outcomes (cross-account and already-resolved are assertions inside it),
  duplicate ids, one decision raising, and body validation (empty or over 100
  ids). The permission decorator is shared verbatim with `/decide` and has no
  separate test.
- All three approval backend modules together
  (`test_approval_requests.py`, `test_async_approval.py`,
  `test_approval_link_routes.py`): **65 passed**.
- One pre-existing flake removed: the bulk failure test read whichever
  `sl-alert` was open in the document, sometimes the previous test's toast.
- `pre-commit run --files <changed files>` clean before every commit;
  `openapi.yaml` committed with the endpoint and unchanged by the hook after
  the rebase.

## Founder calls

1. B-O1 is wrong on current code: the bell has carried approvals since round 4.
   I fixed the three real gaps instead of building a feed. A durable, reload
   surviving notification list needs a backend table and its own brief.
2. Approvals selection was converged onto the shared component rather than kept
   alongside it, per the round 5 rule of one selection model.
3. `decide-batch` is partial by design: bad ids fail alone and stay selected.
4. Land after or together with #465. This branch is stacked on it.
5. C18 leftover: once an account copy of a catalog preset exists, the catalog
   row is dropped from the list, so a second clean copy cannot be started from
   the catalog. The "saved from <catalog preset>" label alone already fixes the
   ambiguity C18 reported. Keep hiding the original, or list both and rely on
   the label? Not changed pending an answer.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low risk**
> All previously reported issues are resolved. The final HIGH finding (`decide_requests_batch` passing an `AsyncSession` into `@require_permission`) is fixed by moving the `decide_approvals` check into a sync `def` dependency (`_require_decide_approvals`) that receives the sync `Session` it needs, leaving the handler's async session for the decisions. Covered by new RBAC-on router tests that exercise the route through FastAPI.
>
> **Overview**
> Adds `POST /approval-requests/decide-batch` for bulk approvals, makes the bell carry approval resolutions with working navigation, renders file-edit arguments as a diff, and applies seven copy/link fixes. Stacked on #465.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 257412bd. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->