### PR TITLE
Fix approval account locks blocking audit and gateway writes

### DIFF
--- a/backend/preloop/models/crud/account_halt.py
+++ b/backend/preloop/models/crud/account_halt.py
@@ -22,11 +22,16 @@ class CRUDAccountHalt(CRUDBase[models.AccountHalt]):
     """
 
     def lock_account(self, db: Session, *, account_id: Union[uuid.UUID, str]) -> None:
-        """Serialize halt transitions, approval expiry and runtime admission."""
+        """Serialize halt/approval admission without blocking child foreign keys.
+
+        The account identity is never changed here. PostgreSQL NO KEY UPDATE
+        remains exclusive against other admission/transition owners while
+        allowing KEY SHARE checks from concurrent audit and usage inserts.
+        """
         account = (
             db.query(models.Account.id)
             .filter(models.Account.id == account_id)
-            .with_for_update()
+            .with_for_update(key_share=True)
             .first()
         )
         if account is None:

--- a/backend/tests/models/test_account_halt_lock_compatibility.py
+++ b/backend/tests/models/test_account_halt_lock_compatibility.py
@@ -1,0 +1,67 @@
+"""Account halt locking must serialize admission without blocking audit FKs."""
+
+from collections.abc import Iterator
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import Engine, text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+from preloop.models import models
+from preloop.models.crud import crud_account_halt, crud_audit_log
+
+
+@pytest.fixture
+def committed_account(db_engine: Engine) -> Iterator[UUID]:
+    """Use a committed account visible to independent PostgreSQL sessions."""
+    account_id = uuid4()
+    with Session(db_engine) as db:
+        db.add(models.Account(id=account_id, organization_name="halt-lock-fixture"))
+        db.commit()
+    try:
+        yield account_id
+    finally:
+        with Session(db_engine) as db:
+            db.query(models.Account).filter(models.Account.id == account_id).delete()
+            db.commit()
+
+
+def test_halt_lock_allows_audit_foreign_key_insert(
+    db_engine: Engine, committed_account: UUID
+) -> None:
+    """An independent audit insert must finish while admission owns the mutex."""
+    with Session(db_engine) as admission, Session(db_engine) as audit:
+        crud_account_halt.lock_account(admission, account_id=committed_account)
+        audit.execute(text("SET LOCAL lock_timeout = '250ms'"))
+        event = crud_audit_log.log_action(
+            audit,
+            account_id=committed_account,
+            action="approval_created",
+            resource_type="approval_request",
+            status="success",
+        )
+        assert event.id is not None
+        assert admission.in_transaction()
+        admission.rollback()
+
+
+def test_halt_lock_still_serializes_competing_admission(
+    db_engine: Engine, committed_account: UUID
+) -> None:
+    """A second halt/admission owner waits until the first transaction releases."""
+    with Session(db_engine) as first, Session(db_engine) as second:
+        crud_account_halt.lock_account(first, account_id=committed_account)
+        second.execute(text("SET LOCAL lock_timeout = '250ms'"))
+        with pytest.raises(OperationalError, match="lock timeout"):
+            crud_account_halt.lock_account(second, account_id=committed_account)
+        second.rollback()
+        first.rollback()
+        second.execute(text("SET LOCAL lock_timeout = '250ms'"))
+        crud_account_halt.lock_account(second, account_id=committed_account)
+
+
+def test_halt_lock_rejects_missing_account(db_session: Session) -> None:
+    """An unknown account does not silently bypass serialized admission."""
+    with pytest.raises(ValueError, match="Account not found"):
+        crud_account_halt.lock_account(db_session, account_id=uuid4())


### PR DESCRIPTION
## Summary

- Fix production approval traffic blocking audit and gateway writes on the account row. Halt/admission previously used `FOR UPDATE`, which conflicts with the foreign-key `KEY SHARE` checks performed by child inserts. A synchronous audit write could then block the API event loop while an async admission transaction needed that loop to finish.
- Use PostgreSQL `FOR NO KEY UPDATE`: competing halt/admission transactions still serialize, while independent audit/usage foreign-key checks can proceed. This is the narrow lock correction; moving EE audit persistence off the event loop is a separate companion change.

## Testing

- [x] Backend tests: 26 passed, including real PostgreSQL independent audit insertion, competing admission exclusion/release, missing-account rejection, halt concurrency, audit rollback and deadline preservation.
- [ ] Frontend tests: not applicable.
- [x] Manual validation: production logs and bounded read-only lock metadata identified the conflict; local regression failed with the old lock and passed with the new lock. No production changes applied.
- [x] All changed-file pre-commit hooks and OpenAPI generation passed.

## Checklist

- [x] Docs updated if needed: lock semantics documented in the CRUD method.
- [x] Changelog updated if needed: no configuration or schema change.
- [x] No secrets included.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low**
> Narrow, well-tested PostgreSQL lock-mode correction with no security impact and clear regression coverage.
>
> **Overview**
> Switches account admission locking from `FOR UPDATE` to `FOR NO KEY UPDATE` so foreign-key `KEY SHARE` checks from audit/usage inserts no longer block the event loop, while competing halt/admission transactions still serialize. Includes three regression tests against real PostgreSQL.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 8af87f9. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->