### PR TITLE
Preserve approval results through session cleanup and handle overload safely

### DIFF
--- a/backend/preloop/api/app.py
+++ b/backend/preloop/api/app.py
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 from typing import AsyncGenerator, Any
 from urllib.parse import quote
 from uuid import UUID
-from fastapi import Depends, FastAPI, Request, HTTPException
+from fastapi import Depends, FastAPI, Request, HTTPException, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
@@ -23,6 +23,7 @@ from pyinstrument import Profiler
 from pyinstrument.renderers import SpeedscopeRenderer
 from sqlalchemy.exc import TimeoutError as SQLAlchemyPoolTimeout
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.websockets import WebSocketState
 
 from preloop import __version__
 from fastapi.encoders import jsonable_encoder
@@ -660,8 +661,8 @@ def create_app() -> FastAPI:
 
     @app.exception_handler(SQLAlchemyPoolTimeout)
     async def pool_timeout_exception_handler(
-        request: Request, exc: SQLAlchemyPoolTimeout
-    ) -> JSONResponse:
+        request: Request | WebSocket, exc: SQLAlchemyPoolTimeout
+    ) -> JSONResponse | None:
         """Turn a connection-pool timeout into a fast, honest 503.
 
         A saturated pool is a capacity problem, not a server bug. Reporting it
@@ -670,10 +671,16 @@ def create_app() -> FastAPI:
         """
         logger.warning(
             "Database pool exhausted serving %s %s: %s",
-            request.method,
+            request.scope.get("method", "WEBSOCKET"),
             request.url.path,
             exc,
         )
+        if isinstance(request, WebSocket):
+            if request.application_state != WebSocketState.DISCONNECTED:
+                await request.close(
+                    code=1013, reason="Database overloaded; retry shortly"
+                )
+            return None
         return JSONResponse(
             status_code=503,
             content={
@@ -684,13 +691,20 @@ def create_app() -> FastAPI:
 
     @app.exception_handler(Exception)
     async def global_exception_handler(
-        request: Request, exc: Exception
-    ) -> JSONResponse:
-        """Log all exceptions with full traceback."""
+        request: Request | WebSocket, exc: Exception
+    ) -> JSONResponse | None:
+        """Log the original exception without eagerly formatting ORM input."""
         logger.error(
-            f"Unhandled exception in {request.method} {request.url.path}: {exc}",
-            exc_info=True,
+            "Unhandled %s in %s %s",
+            type(exc).__name__,
+            request.scope.get("method", "WEBSOCKET"),
+            request.url.path,
+            exc_info=(type(exc), exc, exc.__traceback__),
         )
+        if isinstance(request, WebSocket):
+            if request.application_state != WebSocketState.DISCONNECTED:
+                await request.close(code=1011, reason="Internal server error")
+            return None
         # Re-raise HTTPException as-is
         if isinstance(exc, HTTPException):
             return JSONResponse(

--- a/backend/preloop/api/endpoints/approval_requests.py
+++ b/backend/preloop/api/endpoints/approval_requests.py
@@ -73,7 +73,7 @@ def get_approval_request(
     request_id: uuid.UUID,
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db_session),
-) -> ApprovalRequest:
+) -> ApprovalRequestResponse:
     """Get an approval request by ID.
 
     Args:
@@ -98,7 +98,7 @@ def get_approval_request(
     # Track who opened the request (one timeline entry per viewer).
     _record_viewed_event(db, approval_request, current_user.id)
 
-    return approval_request
+    return ApprovalRequestResponse.model_validate(approval_request)
 
 
 @router.get("/{request_id}/history", response_model=list[ApprovalEventResponse])
@@ -171,7 +171,7 @@ def list_approval_requests(
     skip: int = Query(0, description="Number of results to skip"),
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db_session),
-) -> list[ApprovalRequest]:
+) -> list[ApprovalRequestResponse]:
     """List approval requests for the current account.
 
     Args:
@@ -185,7 +185,7 @@ def list_approval_requests(
         List of approval requests
     """
     # Use CRUD layer to get approval requests with filters
-    return crud_approval_request.get_multi_by_account(
+    rows = crud_approval_request.get_multi_by_account(
         db,
         account_id=current_user.account_id,
         execution_id=execution_id,
@@ -193,6 +193,7 @@ def list_approval_requests(
         skip=skip,
         limit=limit,
     )
+    return [ApprovalRequestResponse.model_validate(row) for row in rows]
 
 
 @router.post("/{request_id}/approve", response_model=ApprovalRequestResponse)

--- a/backend/preloop/models/crud/approval_request.py
+++ b/backend/preloop/models/crud/approval_request.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Optional, Union
 from uuid import UUID
 from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from preloop.models import models
@@ -14,6 +15,13 @@ from .base import CRUDBase
 
 class CRUDApprovalRequest(CRUDBase[ApprovalRequest]):
     """CRUD operations for ApprovalRequest model."""
+
+    def detach_loaded_result(
+        self, db: Union[Session, AsyncSession], request: ApprovalRequest
+    ) -> ApprovalRequest:
+        """Preserve loaded scalar values before a read transaction rolls back."""
+        db.expunge(request)
+        return request
 
     def expire_stale_pending(
         self,

--- a/backend/preloop/models/models/approval_request.py
+++ b/backend/preloop/models/models/approval_request.py
@@ -5,7 +5,15 @@ import uuid
 from datetime import datetime
 from typing import Optional, TYPE_CHECKING
 
-from sqlalchemy import String, DateTime, Text, ForeignKey, Enum as SQLEnum, Index
+from sqlalchemy import (
+    String,
+    DateTime,
+    Text,
+    ForeignKey,
+    Enum as SQLEnum,
+    Index,
+    inspect,
+)
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -308,8 +316,13 @@ class ApprovalRequest(Base):
     )
 
     def __repr__(self) -> str:
-        """String representation."""
+        """Describe loaded state without lazy reads during exception formatting."""
+        state = inspect(self)
+        identity = state.dict.get("id")
+        if identity is None and state.identity:
+            identity = state.identity[0]
         return (
-            f"<ApprovalRequest(id={self.id}, tool_name={self.tool_name}, "
-            f"status={self.status}, requested_at={self.requested_at})>"
+            f"<ApprovalRequest(id={identity}, "
+            f"tool_name={state.dict.get('tool_name', '<unloaded>')}, "
+            f"status={state.dict.get('status', '<unloaded>')})>"
         )

--- a/backend/preloop/services/approval_service.py
+++ b/backend/preloop/services/approval_service.py
@@ -21,6 +21,7 @@ from preloop.models.schemas.approval_request import (
     ApprovalRequestUpdate,
 )
 from preloop.models.crud.approval_request import (
+    crud_approval_request,
     get_approval_request_async,
     get_approval_request_for_update_async,
 )
@@ -3175,7 +3176,11 @@ class ApprovalService:
 
                 # Check if resolved
                 if approval_request.status in ["approved", "declined", "cancelled"]:
-                    return approval_request
+                    # Rollback expires attached instances even when commits do
+                    # not. Detach the loaded result before poll cleanup runs.
+                    return crud_approval_request.detach_loaded_result(
+                        poll_db, approval_request
+                    )
 
                 if approval_request.status == "expired":
                     raise TimeoutError(f"Approval request {request_id} already expired")

--- a/backend/tests/endpoints/test_approval_requests.py
+++ b/backend/tests/endpoints/test_approval_requests.py
@@ -8,6 +8,8 @@ import pytest
 from fastapi import HTTPException
 
 from preloop.api.endpoints import approval_requests
+from preloop.models import models
+from preloop.models.schemas.approval_request import ApprovalRequestResponse
 
 
 @pytest.fixture
@@ -24,7 +26,7 @@ def mock_user():
 @pytest.fixture
 def mock_approval_request(mock_user):
     """Create a mock approval request."""
-    request = MagicMock()
+    request = models.ApprovalRequest(decided_by_ai=False)
     request.id = uuid.uuid4()
     request.account_id = mock_user.account_id
     request.tool_name = "test_tool"
@@ -67,7 +69,9 @@ class TestGetApprovalRequest:
                 db=mock_db_session,
             )
 
-            assert result == mock_approval_request
+            assert result == ApprovalRequestResponse.model_validate(
+                mock_approval_request
+            )
             mock_crud.get.assert_called_once_with(
                 mock_db_session,
                 id=str(mock_approval_request.id),
@@ -114,7 +118,9 @@ class TestListApprovalRequests:
             )
 
             assert len(result) == 1
-            assert result[0] == mock_approval_request
+            assert result[0] == ApprovalRequestResponse.model_validate(
+                mock_approval_request
+            )
             mock_crud.get_multi_by_account.assert_called_once_with(
                 mock_db_session,
                 account_id=mock_user.account_id,
@@ -791,4 +797,4 @@ class TestViewedEventRecording:
                 db=mock_db_session,
             )
 
-        assert result == mock_approval_request
+        assert result == ApprovalRequestResponse.model_validate(mock_approval_request)

--- a/backend/tests/test_approval_error_boundaries.py
+++ b/backend/tests/test_approval_error_boundaries.py
@@ -1,0 +1,181 @@
+"""Approval values and overload responses survive session/transport boundaries."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from fastapi import FastAPI, Request, WebSocket
+from fastapi.exceptions import ResponseValidationError
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import TimeoutError as PoolTimeout
+from sqlalchemy.orm import Session
+from starlette.websockets import WebSocketDisconnect
+
+from preloop.api.app import create_app
+from preloop.api.endpoints import approval_requests
+from preloop.models import models
+from preloop.models.schemas.approval_request import ApprovalRequestResponse
+from preloop.services.approval_service import ApprovalService
+
+
+@pytest.fixture
+def approval_row(db_session: Session, test_user: models.User) -> models.ApprovalRequest:
+    workflow = models.ApprovalWorkflow(account_id=test_user.account_id, name="boundary")
+    tool = models.ToolConfiguration(
+        account_id=test_user.account_id, tool_name="Read", tool_source="builtin"
+    )
+    db_session.add_all([workflow, tool])
+    db_session.flush()
+    row = models.ApprovalRequest(
+        account_id=test_user.account_id,
+        tool_configuration_id=tool.id,
+        approval_workflow_id=workflow.id,
+        tool_name="Read",
+        tool_args={"path": "example.txt"},
+        status="approved",
+        approver_comment="Approved safely",
+    )
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+def test_expired_detached_approval_repr_never_loads_attributes(
+    db_session: Session, approval_row: models.ApprovalRequest
+) -> None:
+    request_id = approval_row.id
+    db_session.expire(approval_row)
+    db_session.expunge(approval_row)
+    assert str(request_id) in repr(approval_row)
+    assert "ApprovalRequest" in repr(approval_row)
+
+
+@pytest.mark.parametrize("list_endpoint", [False, True])
+def test_approval_read_response_survives_session_cleanup(
+    db_session: Session,
+    test_user: models.User,
+    approval_row: models.ApprovalRequest,
+    list_endpoint: bool,
+) -> None:
+    request_id = approval_row.id
+    if list_endpoint:
+        result = approval_requests.list_approval_requests(
+            current_user=test_user,
+            db=db_session,
+            status=None,
+            execution_id=None,
+            limit=50,
+            skip=0,
+        )[0]
+    else:
+        with patch.object(approval_requests, "_record_viewed_event"):
+            result = approval_requests.get_approval_request(
+                request_id=request_id, current_user=test_user, db=db_session
+            )
+    db_session.expire(approval_row)
+    db_session.expunge(approval_row)
+    payload = ApprovalRequestResponse.model_validate(result).model_dump(mode="json")
+    assert payload["id"] == str(request_id)
+    assert payload["status"] == "approved"
+    assert payload["tool_args"] == {"path": "example.txt"}
+
+
+@pytest.mark.asyncio
+async def test_final_approval_survives_poll_rollback_and_detach(
+    db_session: Session, approval_row: models.ApprovalRequest
+) -> None:
+    request_id: UUID = approval_row.id
+
+    poll_db = Session(
+        bind=db_session.connection(), join_transaction_mode="create_savepoint"
+    )
+
+    @asynccontextmanager
+    async def poll_session():
+        try:
+            yield poll_db
+        finally:
+            poll_db.rollback()
+            poll_db.close()
+
+    service = ApprovalService(AsyncMock(), "https://fixture.invalid")
+    with (
+        patch("preloop.models.db.session.get_async_db_session", poll_session),
+        patch.object(
+            ApprovalService,
+            "get_approval_request_for_update",
+            new=AsyncMock(
+                side_effect=lambda _: poll_db.get(models.ApprovalRequest, request_id)
+            ),
+        ),
+    ):
+        result = await service.wait_for_approval(request_id)
+    assert result.id == request_id
+    assert result.status == "approved"
+    assert result.approver_comment == "Approved safely"
+
+
+@pytest.fixture
+def overload_app() -> FastAPI:
+    app = FastAPI()
+    app.add_exception_handler(PoolTimeout, create_app().exception_handlers[PoolTimeout])
+
+    @app.get("/overloaded")
+    async def overloaded() -> None:
+        raise PoolTimeout("pool exhausted")
+
+    @app.websocket("/socket")
+    async def overloaded_socket(websocket: WebSocket) -> None:
+        await websocket.accept()
+        raise PoolTimeout("pool exhausted")
+
+    return app
+
+
+def test_pool_exhaustion_http_remains_retryable(overload_app: FastAPI) -> None:
+    with TestClient(overload_app) as client:
+        response = client.get("/overloaded")
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "1"
+
+
+def test_pool_exhaustion_websocket_closes_with_retry_code(
+    overload_app: FastAPI,
+) -> None:
+    with TestClient(overload_app) as client:
+        with client.websocket_connect("/socket") as websocket:
+            with pytest.raises(WebSocketDisconnect) as exc:
+                websocket.receive_json()
+            assert exc.value.code == 1013
+
+
+@pytest.mark.asyncio
+async def test_response_validation_error_does_not_fail_while_logging(
+    db_session: Session, approval_row: models.ApprovalRequest
+) -> None:
+    error = ResponseValidationError(
+        [
+            {
+                "loc": ("response", "id"),
+                "type": "get_attribute_error",
+                "msg": "cannot load",
+                "input": approval_row,
+            }
+        ]
+    )
+    db_session.expire(approval_row)
+    db_session.expunge(approval_row)
+    handler = create_app().exception_handlers[Exception]
+    response = await handler(
+        Request(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": "/approval-requests",
+                "headers": [],
+            }
+        ),
+        error,
+    )
+    assert response.status_code == 500


### PR DESCRIPTION
## Summary

- Preserve resolved approval scalar values before the polling session rolls back; serialize approval GET/list responses while their session is open. This prevents detached-object failures after cleanup.
- Make approval object representations safe without database loads, so exception logging preserves the original validation error. Handle WebSocket pool exhaustion with retryable close code 1013 while retaining HTTP 503 and Retry-After.
- Complements #469. The production log showed a detached ApprovalRequest error masking a FastAPI validation exception and a WebSocket pool-timeout handler failing on a missing HTTP method. The original validation field/route is not established.

## Testing

- [x] Backend tests: seven new boundary regressions, 188 affected compatibility tests passed. Reproduced failures before fixing.
- [ ] Frontend tests: not applicable.
- [x] Manual validation: matched production stack paths; real database tests exercise rollback/detachment and HTTP/WebSocket tests exercise overload responses. No production changes.
- [x] Changed-file hooks and OpenAPI generation passed.

## Checklist

- [x] Docs updated if needed: scalar-result contract and safe representations documented in code.
- [x] Changelog updated if needed: no configuration/schema change.
- [x] No secrets included.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium risk**
> Well-tested hardening of approval result handling and overload responses; touches exception handlers and DB session lifecycle but adds no security or breaking changes.
>
> **Overview**
> Detaches approval results before poll-session rollback, serializes approval read responses while the session is open, makes `ApprovalRequest.__repr__` safe without DB loads, and adds WebSocket-aware overload handling (close 1013/1011) while retaining HTTP 503 + Retry-After. Covered by seven new regression tests.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 393eb22e. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->