### PR TITLE
Fix private runner startup with nonroot default images

### DIFF
--- a/cli/internal/cmd/runner_docker.go
+++ b/cli/internal/cmd/runner_docker.go
@@ -67,6 +67,12 @@ func dockerRunArgs(image string, env map[string]string, opts runnerDockerOpts) [
 	if opts.PersistWorkspace && opts.WorkspaceHostDir != "" {
 		args = append(args, "-v", opts.WorkspaceHostDir+":"+runnerWorkspaceMount)
 	}
+	if opts.Launch && !opts.hasWorkspaceMount() {
+		// Images may run as a nonroot user with no /workspace directory.
+		// Supply a writable, execution-local workspace without changing UID.
+		// exec is required for repository scripts and test binaries.
+		args = append(args, "--tmpfs", runnerWorkspaceMount+":rw,exec,mode=1777")
+	}
 	for _, mount := range opts.ExtraMounts {
 		args = append(args, "-v", mount)
 	}
@@ -86,6 +92,19 @@ func dockerRunArgs(image string, env map[string]string, opts runnerDockerOpts) [
 		args = append(args, "-c", runnerBootstrap)
 	}
 	return args
+}
+
+func (opts runnerDockerOpts) hasWorkspaceMount() bool {
+	if opts.PersistWorkspace && opts.WorkspaceHostDir != "" {
+		return true
+	}
+	for _, mount := range opts.ExtraMounts {
+		parts := strings.Split(mount, ":")
+		if len(parts) >= 2 && strings.TrimRight(parts[1], "/") == runnerWorkspaceMount {
+			return true
+		}
+	}
+	return false
 }
 
 func runnerDockerOptsFromJob(job map[string]any) (runnerDockerOpts, error) {

--- a/cli/internal/cmd/runner_docker.go
+++ b/cli/internal/cmd/runner_docker.go
@@ -68,9 +68,12 @@ func dockerRunArgs(image string, env map[string]string, opts runnerDockerOpts) [
 		args = append(args, "-v", opts.WorkspaceHostDir+":"+runnerWorkspaceMount)
 	}
 	if opts.Launch && !opts.hasWorkspaceMount() {
-		// Images may run as a nonroot user with no /workspace directory.
-		// Supply a writable, execution-local workspace without changing UID.
-		// exec is required for repository scripts and test binaries.
+		// Overlay /workspace for launch jobs with no configured mount.
+		// Nonroot default images need a writable, executable workspace
+		// without a UID change. Image inspect on every launch is skipped:
+		// it cannot tell shipped files from an empty dir without creating
+		// a container. The overlay masks image-shipped /workspace files;
+		// keep those via persist_workspace or an explicit extra_mount.
 		args = append(args, "--tmpfs", runnerWorkspaceMount+":rw,exec,mode=1777")
 	}
 	for _, mount := range opts.ExtraMounts {

--- a/cli/internal/cmd/runner_launch_test.go
+++ b/cli/internal/cmd/runner_launch_test.go
@@ -116,6 +116,58 @@ func TestRunnerBootstrapPassesNoSecretsInArgv(t *testing.T) {
 	}
 }
 
+func TestRunnerLaunchWorkspaceMount(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		opts      runnerDockerOpts
+		wantTmpfs bool
+	}{
+		{"default launch", runnerDockerOpts{Launch: true}, true},
+		{"persisted workspace", runnerDockerOpts{Launch: true, PersistWorkspace: true, WorkspaceHostDir: "/tmp/private-workspace"}, false},
+		{"explicit workspace", runnerDockerOpts{Launch: true, ExtraMounts: []string{"/tmp/custom:/workspace:rw"}}, false},
+		{"unrelated mount", runnerDockerOpts{Launch: true, ExtraMounts: []string{"/tmp/custom:/cache:rw"}}, true},
+		{"legacy image", runnerDockerOpts{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := dockerRunArgs("example/image", nil, tc.opts)
+			if got := containsPair(args, "--tmpfs", "/workspace:rw,exec,mode=1777"); got != tc.wantTmpfs {
+				t.Fatalf("workspace tmpfs=%v want %v: %v", got, tc.wantTmpfs, args)
+			}
+			if strings.Contains(strings.Join(args, " "), "--user") {
+				t.Fatal("launch must preserve the image user")
+			}
+		})
+	}
+}
+
+// Run against an already-local nonroot image; the script is deterministic,
+// uses no model credentials, and Docker networking is disabled.
+func TestRunnerNonrootWorkspaceDockerIntegration(t *testing.T) {
+	image := os.Getenv("PRELOOP_TEST_RUNNER_NONROOT_IMAGE")
+	if image == "" {
+		t.Skip("set PRELOOP_TEST_RUNNER_NONROOT_IMAGE to a local nonroot image")
+	}
+	env := map[string]string{"PRELOOP_RUNNER_SCRIPT": `set -eu
+test "$(id -u)" != 0
+test "$PWD" = /workspace
+mkdir -p nested
+printf '#!/bin/sh\nexit 0\n' > nested/check
+chmod +x nested/check
+./nested/check
+printf '{"status":"success","nonroot_workspace":true}\n' > /workspace/result.json
+`}
+	command := defaultNewRunnerJobCmd(image, env, runnerDockerOpts{Launch: true, Network: "none"})
+	var output bytes.Buffer
+	command.Stdout, command.Stderr = &output, &output
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	outcome := waitDockerJob(command, "nonroot-workspace", &output, nil)
+	if outcome.status != "SUCCEEDED" || outcome.result["nonroot_workspace"] != true {
+		t.Fatalf("outcome=%+v logs=%s", outcome, output.String())
+	}
+}
+
 // Optional real-Docker check. The fixture contains a generated hosted script
 // with fake credentials and fake CLIs. Network is disabled unconditionally.
 func TestRunnerDockerLaunchIntegration(t *testing.T) {

--- a/cli/internal/cmd/runner_launch_test.go
+++ b/cli/internal/cmd/runner_launch_test.go
@@ -140,6 +140,49 @@ func TestRunnerLaunchWorkspaceMount(t *testing.T) {
 	}
 }
 
+func TestLaunchWorkspaceTmpfsIgnoresImageIdentity(t *testing.T) {
+	// Documented: launch without a configured /workspace mount always overlays
+	// tmpfs. Image names are not inspected; custom image files in /workspace
+	// stay visible only with persist_workspace or an explicit extra_mount.
+	called := false
+	prev := dockerCLI
+	dockerCLI = func(args ...string) error {
+		called = true
+		t.Logf("unexpected docker CLI: %v", args)
+		return prev(args...)
+	}
+	t.Cleanup(func() { dockerCLI = prev })
+
+	for _, image := range []string{
+		"preloop/opencode:latest",
+		"example/custom-with-workspace:1",
+		"ghcr.io/openai/codex-universal:latest",
+	} {
+		args := dockerRunArgs(image, nil, runnerDockerOpts{Launch: true})
+		if !containsPair(args, "--tmpfs", "/workspace:rw,exec,mode=1777") {
+			t.Fatalf("image %s missing workspace tmpfs: %v", image, args)
+		}
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "inspect") {
+			t.Fatalf("launch args must not inspect the image: %v", args)
+		}
+		if strings.Contains(joined, "--user") {
+			t.Fatal("launch must preserve the image user")
+		}
+	}
+	if called {
+		t.Fatal("dockerRunArgs must not inspect the image")
+	}
+
+	seeded := dockerRunArgs("example/custom-with-workspace:1", nil, runnerDockerOpts{
+		Launch:      true,
+		ExtraMounts: []string{"/tmp/seeded:/workspace:rw"},
+	})
+	if containsPair(seeded, "--tmpfs", "/workspace:rw,exec,mode=1777") {
+		t.Fatalf("explicit /workspace mount must skip tmpfs: %v", seeded)
+	}
+}
+
 // Run against an already-local nonroot image; the script is deterministic,
 // uses no model credentials, and Docker networking is disabled.
 func TestRunnerNonrootWorkspaceDockerIntegration(t *testing.T) {

--- a/docs/guide/runners/quickstart-linux.md
+++ b/docs/guide/runners/quickstart-linux.md
@@ -125,6 +125,9 @@ memory and is discarded with the container. Repository scripts and test
 binaries can execute there. For larger or retained workspaces, configure
 `agent_config.runner.persist_workspace` or an explicit `/workspace` mount;
 the mounted directory must be writable by the image's configured user.
+The default tmpfs masks any files a custom image puts in `/workspace`. Package
+reusable tools and dependencies elsewhere (for example, `/opt`), and supply
+pre-populated working files through an explicit workspace mount.
 
 The control plane builds a versioned launch specification using the same
 Codex/OpenCode script and environment builders as hosted execution. The CLI

--- a/docs/guide/runners/quickstart-linux.md
+++ b/docs/guide/runners/quickstart-linux.md
@@ -118,6 +118,14 @@ control plane and CLI together: old or unknown launch protocol versions fail
 explicitly. Other harness types require a hosted executor until their private
 launch adapter is implemented.
 
+Launches without a configured workspace mount get a writable `/workspace`
+tmpfs, so nonroot images such as the default OpenCode image can start without
+creating directories under `/`. This temporary workspace uses Docker-host
+memory and is discarded with the container. Repository scripts and test
+binaries can execute there. For larger or retained workspaces, configure
+`agent_config.runner.persist_workspace` or an explicit `/workspace` mount;
+the mounted directory must be writable by the image's configured user.
+
 The control plane builds a versioned launch specification using the same
 Codex/OpenCode script and environment builders as hosted execution. The CLI
 runs a static Docker bootstrap that launches this script. Repository clone,


### PR DESCRIPTION
## Summary

- Fix private executions failing with `mkdir: Permission denied` immediately after leasing, before a model starts. The default OpenCode image runs as a nonroot user, while the launcher expects a writable `/workspace`.
- Supply an execution-local writable, executable `/workspace` tmpfs when no workspace mount is configured. Preserve the image UID and explicit/persistent workspace mounts.
- Requires updating the installed runner CLI. Backend-only deployment cannot change the Docker arguments of an older CLI. The default tmpfs is memory-backed and ephemeral; documented persistent/custom mounts remain available for larger or retained workspaces.

## Testing

- [x] Backend tests: runner/completion Go suites passed under race detection.
- [ ] Frontend tests: not applicable.
- [x] Manual validation: reproduced the exact error using the actual default nonroot image; real Docker bootstrap, executable repository fixture and result export pass after the fix, with networking disabled and no model credentials/calls.
- [x] Five mount-selection cases and required hooks passed.

## Checklist

- [x] Docs updated: private runner workspace behavior and update requirement.
- [x] Changelog updated if needed: no flow configuration migration.
- [x] No secrets included.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> A small, focused CLI fix to the private runner's Docker arguments; no security surface, well-tested, with only a minor documentation caveat flagged.
>
> **Overview**
> Adds a writable, executable `/workspace` tmpfs for launch runs without an explicit workspace mount so nonroot default images can start, while preserving persisted and explicit mounts. Docs and tests updated.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 832c8ac. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->