### PR TITLE
Console: agent detail summary strip, tracker tab panels as collection panes, API usage and model detail ranges (round-4 report wave 3)

### DIFF
--- a/frontend/src/components/list-toolbar.ts
+++ b/frontend/src/components/list-toolbar.ts
@@ -39,6 +39,12 @@ export class ListToolbar extends LitElement {
    * so the field is still announced as "Search sessions".
    */
   @property({ type: String }) searchLabel = '';
+  /**
+   * Collections that cannot be searched (the tracker's pull requests come
+   * from the host, unfiltered) still take the bar, without a field that
+   * would do nothing when typed into.
+   */
+  @property({ type: Boolean }) searchable = true;
   @property({ type: String }) view: ListViewMode = 'list';
   @property({ type: Array }) views: ListViewMode[] = ['list', 'cards'];
   @property({ type: String }) toggleLabel = 'View';
@@ -184,17 +190,23 @@ export class ListToolbar extends LitElement {
           class="filters"
           @submit=${(event: Event) => event.preventDefault()}
         >
-          <sl-input
-            class="search-input"
-            label=${this.searchLabel || this.searchPlaceholder}
-            placeholder=${this.searchPlaceholder}
-            clearable
-            .value=${this.search}
-            @sl-input=${this.handleSearchInput}
-            @sl-clear=${this.handleSearchClear}
-          >
-            <sl-icon name="search" slot="prefix"></sl-icon>
-          </sl-input>
+          ${
+            this.searchable
+              ? html`
+                  <sl-input
+                    class="search-input"
+                    label=${this.searchLabel || this.searchPlaceholder}
+                    placeholder=${this.searchPlaceholder}
+                    clearable
+                    .value=${this.search}
+                    @sl-input=${this.handleSearchInput}
+                    @sl-clear=${this.handleSearchClear}
+                  >
+                    <sl-icon name="search" slot="prefix"></sl-icon>
+                  </sl-input>
+                `
+              : nothing
+          }
           <slot></slot>
         </form>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1500,6 +1500,8 @@ export interface PullRequestListResponse {
   has_more: boolean;
   supported: boolean;
   fetched_at: string;
+  /** Present when the tracker reports how many open rows exist in total. */
+  total?: number | null;
 }
 
 export type VerdictStatus =

--- a/frontend/src/utils/time-range.test.ts
+++ b/frontend/src/utils/time-range.test.ts
@@ -1,0 +1,132 @@
+import { expect } from '@open-wc/testing';
+
+import {
+  formatTimeRangeWindow,
+  normalizeTimeRangeKey,
+  resolvePreviousTimeRange,
+  resolveTimeRange,
+  timeRangeShortLabel,
+} from './time-range';
+
+describe('time-range', () => {
+  // A fixed local instant, so the assertions below are about the math and not
+  // about the day the suite runs.
+  const now = new Date(2026, 8, 6, 14, 30, 0); // 6 Sep 2026, 14:30 local
+
+  it('reads every spelling the console grew for the same window', () => {
+    expect(normalizeTimeRangeKey('month')).to.equal('last-30');
+    expect(normalizeTimeRangeKey('30d')).to.equal('last-30');
+    expect(normalizeTimeRangeKey('last-30')).to.equal('last-30');
+    expect(normalizeTimeRangeKey('day')).to.equal('last-24h');
+    expect(normalizeTimeRangeKey('1y')).to.equal('last-365');
+    expect(normalizeTimeRangeKey('nonsense')).to.equal(null);
+    expect(normalizeTimeRangeKey('')).to.equal(null);
+  });
+
+  it('resolves the same window for every spelling of 30 days', () => {
+    const canonical = resolveTimeRange('last-30', now);
+    expect(resolveTimeRange('month', now)).to.deep.equal(canonical);
+    expect(resolveTimeRange('30d', now)).to.deep.equal(canonical);
+    expect(new Date(canonical.startDate as string).getTime()).to.equal(
+      new Date(2026, 7, 7, 14, 30, 0).getTime()
+    );
+    expect(new Date(canonical.endDate as string).getTime()).to.equal(
+      now.getTime()
+    );
+  });
+
+  it('measures rolling ranges in whole days back from now', () => {
+    const day = 24 * 60 * 60 * 1000;
+    for (const [key, days] of [
+      ['last-24h', 1],
+      ['last-7', 7],
+      ['last-90', 90],
+      ['last-365', 365],
+    ] as Array<[string, number]>) {
+      const window = resolveTimeRange(key, now);
+      const span =
+        new Date(window.endDate as string).getTime() -
+        new Date(window.startDate as string).getTime();
+      // Whole days back from the same instant; DST can move the clock by an
+      // hour, which is why this is a tolerance and not an equality.
+      expect(Math.abs(span - days * day)).to.be.at.most(day);
+    }
+  });
+
+  it('runs calendar ranges from the start of the period to now', () => {
+    const today = resolveTimeRange('today', now);
+    expect(new Date(today.startDate as string).getTime()).to.equal(
+      new Date(2026, 8, 6, 0, 0, 0, 0).getTime()
+    );
+
+    const thisMonth = resolveTimeRange('this-month', now);
+    expect(new Date(thisMonth.startDate as string).getTime()).to.equal(
+      new Date(2026, 8, 1, 0, 0, 0, 0).getTime()
+    );
+
+    // 6 Sep 2026 is a Sunday, so the week started on 31 Aug.
+    const thisWeek = resolveTimeRange('this-week', now);
+    expect(new Date(thisWeek.startDate as string).getTime()).to.equal(
+      new Date(2026, 7, 31, 0, 0, 0, 0).getTime()
+    );
+
+    const lastMonth = resolveTimeRange('last-month', now);
+    expect(new Date(lastMonth.startDate as string).getTime()).to.equal(
+      new Date(2026, 7, 1, 0, 0, 0, 0).getTime()
+    );
+    expect(new Date(lastMonth.endDate as string).getTime()).to.equal(
+      new Date(2026, 8, 1, 0, 0, 0, 0).getTime()
+    );
+  });
+
+  it('has no bounds for all time', () => {
+    expect(resolveTimeRange('all', now)).to.deep.equal({
+      startDate: null,
+      endDate: null,
+    });
+    expect(resolvePreviousTimeRange('all', now)).to.deep.equal({
+      startDate: null,
+      endDate: null,
+    });
+  });
+
+  it('puts the prior window immediately before the current one', () => {
+    const current = resolveTimeRange('last-30', now);
+    const previous = resolvePreviousTimeRange('last-30', now);
+    expect(previous.endDate).to.equal(current.startDate);
+    const currentSpan =
+      new Date(current.endDate as string).getTime() -
+      new Date(current.startDate as string).getTime();
+    const previousSpan =
+      new Date(previous.endDate as string).getTime() -
+      new Date(previous.startDate as string).getTime();
+    expect(previousSpan).to.equal(currentSpan);
+
+    // A calendar month steps back a whole month, not 30 days.
+    const previousMonth = resolvePreviousTimeRange('this-month', now);
+    expect(new Date(previousMonth.startDate as string).getTime()).to.equal(
+      new Date(2026, 7, 1, 0, 0, 0, 0).getTime()
+    );
+    expect(previousMonth.endDate).to.equal(
+      resolveTimeRange('this-month', now).startDate
+    );
+  });
+
+  it('labels a window in the register the stats use', () => {
+    expect(timeRangeShortLabel('month')).to.equal('30d');
+    expect(timeRangeShortLabel('this-month')).to.equal('this month');
+    expect(timeRangeShortLabel('nonsense')).to.equal('30d');
+    expect(formatTimeRangeWindow(resolveTimeRange('last-30', now))).to.equal(
+      `${new Date(2026, 7, 7).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+      })} to ${new Date(2026, 8, 6).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+      })}`
+    );
+    expect(formatTimeRangeWindow({ startDate: null, endDate: null })).to.equal(
+      ''
+    );
+  });
+});

--- a/frontend/src/utils/time-range.test.ts
+++ b/frontend/src/utils/time-range.test.ts
@@ -23,6 +23,26 @@ describe('time-range', () => {
     expect(normalizeTimeRangeKey('')).to.equal(null);
   });
 
+  it('defaults a missing or empty key to last-30', () => {
+    const canonical = resolveTimeRange('last-30', now);
+    const previous = resolvePreviousTimeRange('last-30', now);
+    expect(resolveTimeRange('', now)).to.deep.equal(canonical);
+    expect(resolveTimeRange('   ', now)).to.deep.equal(canonical);
+    expect(resolvePreviousTimeRange('', now)).to.deep.equal(previous);
+    expect(resolvePreviousTimeRange('   ', now)).to.deep.equal(previous);
+  });
+
+  it('rejects a key this module does not know', () => {
+    expect(() => resolveTimeRange('nonsense', now)).to.throw(
+      RangeError,
+      /Unrecognized time range key: nonsense/
+    );
+    expect(() => resolvePreviousTimeRange('nonsense', now)).to.throw(
+      RangeError,
+      /Unrecognized time range key: nonsense/
+    );
+  });
+
   it('resolves the same window for every spelling of 30 days', () => {
     const canonical = resolveTimeRange('last-30', now);
     expect(resolveTimeRange('month', now)).to.deep.equal(canonical);

--- a/frontend/src/utils/time-range.ts
+++ b/frontend/src/utils/time-range.ts
@@ -74,6 +74,9 @@ const KNOWN_KEYS: TimeRangeKey[] = [
   'all',
 ];
 
+/** Empty or missing keys resolve to this window. Unknown keys do not. */
+const DEFAULT_TIME_RANGE_KEY: TimeRangeKey = 'last-30';
+
 /** The short label a stat carries beside its name ("$ est. · 30d"). */
 const SHORT_LABELS: Record<TimeRangeKey, string> = {
   today: 'today',
@@ -102,12 +105,29 @@ export function normalizeTimeRangeKey(
   return KEY_ALIASES[key] ?? null;
 }
 
+/**
+ * Empty and missing keys keep the historical last-30 default. A key this
+ * module does not know is rejected so a typo cannot silently ask for 30 days.
+ */
+function coerceTimeRangeKey(
+  key: TimeRangeKey | string | null | undefined
+): TimeRangeKey {
+  if (key == null) return DEFAULT_TIME_RANGE_KEY;
+  const raw = String(key).trim();
+  if (!raw) return DEFAULT_TIME_RANGE_KEY;
+  const normalized = normalizeTimeRangeKey(raw);
+  if (!normalized) {
+    throw new RangeError(`Unrecognized time range key: ${raw}`);
+  }
+  return normalized;
+}
+
 /** The window a key covers, ending at `now`. */
 export function resolveTimeRange(
   key: TimeRangeKey | string,
   now: Date = new Date()
 ): TimeRangeWindow {
-  const normalized = normalizeTimeRangeKey(String(key)) ?? 'last-30';
+  const normalized = coerceTimeRangeKey(key);
   if (normalized === 'all') {
     return { startDate: null, endDate: null };
   }
@@ -153,7 +173,7 @@ export function resolvePreviousTimeRange(
   key: TimeRangeKey | string,
   now: Date = new Date()
 ): TimeRangeWindow {
-  const normalized = normalizeTimeRangeKey(String(key)) ?? 'last-30';
+  const normalized = coerceTimeRangeKey(key);
   if (normalized === 'all') {
     return { startDate: null, endDate: null };
   }

--- a/frontend/src/utils/time-range.ts
+++ b/frontend/src/utils/time-range.ts
@@ -1,0 +1,214 @@
+/**
+ * The one place the console works out what a range means.
+ *
+ * Four sibling pages used to compute their own "30 days" and disagreed about
+ * the answer: the Overview asked for one calendar month back, Cost for the
+ * last 30 x 24 hours, API usage and the model detail page for the 30 local
+ * calendar days ending tonight. The same account then read 18.9K, 18,306,
+ * 18,504 and 18,419 requests for the same nominal window, which is a bug in
+ * the arithmetic, not in the data. Every page now resolves its window here,
+ * so the same key asks the server the same question.
+ *
+ * A rolling key ("30d") is exactly N x 24 hours ending now. A calendar key
+ * ("This month") runs from the start of the period to now. `all` has no
+ * bounds at all.
+ */
+
+export type TimeRangeKey =
+  | 'today'
+  | 'this-week'
+  | 'this-month'
+  | 'last-month'
+  | 'last-24h'
+  | 'last-7'
+  | 'last-30'
+  | 'last-90'
+  | 'last-365'
+  | 'all';
+
+export interface TimeRangeWindow {
+  /** ISO 8601 start, or null when the range has no lower bound. */
+  startDate: string | null;
+  /** ISO 8601 end, or null when the range has no upper bound. */
+  endDate: string | null;
+}
+
+/** How many days each rolling key covers. */
+const ROLLING_DAYS: Partial<Record<TimeRangeKey, number>> = {
+  'last-24h': 1,
+  'last-7': 7,
+  'last-30': 30,
+  'last-90': 90,
+  'last-365': 365,
+};
+
+/**
+ * The spellings the console grew before the math was shared. The Overview and
+ * the agent detail strip say `day`/`week`/`month`/`year`; the chips say
+ * `24h`/`7d`/`30d`/`1y`; Cost says `last-30`.
+ */
+const KEY_ALIASES: Record<string, TimeRangeKey> = {
+  day: 'last-24h',
+  week: 'last-7',
+  month: 'last-30',
+  quarter: 'last-90',
+  year: 'last-365',
+  '24h': 'last-24h',
+  '7d': 'last-7',
+  '30d': 'last-30',
+  '90d': 'last-90',
+  '1y': 'last-365',
+  'last-1y': 'last-365',
+};
+
+const KNOWN_KEYS: TimeRangeKey[] = [
+  'today',
+  'this-week',
+  'this-month',
+  'last-month',
+  'last-24h',
+  'last-7',
+  'last-30',
+  'last-90',
+  'last-365',
+  'all',
+];
+
+/** The short label a stat carries beside its name ("$ est. · 30d"). */
+const SHORT_LABELS: Record<TimeRangeKey, string> = {
+  today: 'today',
+  'this-week': 'this week',
+  'this-month': 'this month',
+  'last-month': 'last month',
+  'last-24h': '24h',
+  'last-7': '7d',
+  'last-30': '30d',
+  'last-90': '90d',
+  'last-365': '1y',
+  all: 'all time',
+};
+
+/**
+ * Read a range key written in any of the console's spellings. Returns null
+ * for anything this module does not know, so a caller can fall back rather
+ * than silently resolve the wrong window.
+ */
+export function normalizeTimeRangeKey(
+  value: string | null | undefined
+): TimeRangeKey | null {
+  if (!value) return null;
+  const key = value.trim();
+  if ((KNOWN_KEYS as string[]).includes(key)) return key as TimeRangeKey;
+  return KEY_ALIASES[key] ?? null;
+}
+
+/** The window a key covers, ending at `now`. */
+export function resolveTimeRange(
+  key: TimeRangeKey | string,
+  now: Date = new Date()
+): TimeRangeWindow {
+  const normalized = normalizeTimeRangeKey(String(key)) ?? 'last-30';
+  if (normalized === 'all') {
+    return { startDate: null, endDate: null };
+  }
+
+  const start = new Date(now.getTime());
+  const end = new Date(now.getTime());
+
+  if (normalized === 'today') {
+    start.setHours(0, 0, 0, 0);
+  } else if (normalized === 'this-week') {
+    // Weeks start on Monday, the way the rest of the console counts them.
+    const daysSinceMonday = (start.getDay() + 6) % 7;
+    start.setDate(start.getDate() - daysSinceMonday);
+    start.setHours(0, 0, 0, 0);
+  } else if (normalized === 'this-month') {
+    start.setDate(1);
+    start.setHours(0, 0, 0, 0);
+  } else if (normalized === 'last-month') {
+    start.setMonth(start.getMonth() - 1, 1);
+    start.setHours(0, 0, 0, 0);
+    end.setDate(1);
+    end.setHours(0, 0, 0, 0);
+  } else {
+    start.setDate(start.getDate() - (ROLLING_DAYS[normalized] ?? 30));
+  }
+
+  return { startDate: start.toISOString(), endDate: end.toISOString() };
+}
+
+/**
+ * The window immediately before the one a key resolves to, for "vs prior 30d"
+ * deltas. A calendar key steps back a whole period; a rolling key steps back
+ * its own duration.
+ */
+export function resolvePreviousTimeRange(
+  key: TimeRangeKey | string,
+  now: Date = new Date()
+): TimeRangeWindow {
+  const normalized = normalizeTimeRangeKey(String(key)) ?? 'last-30';
+  if (normalized === 'all') {
+    return { startDate: null, endDate: null };
+  }
+
+  const current = resolveTimeRange(normalized, now);
+  const start = new Date(current.startDate as string);
+  const end = new Date(current.endDate as string);
+
+  if (normalized === 'today') {
+    const durationMs = end.getTime() - start.getTime();
+    const previousStart = new Date(start.getTime());
+    previousStart.setDate(previousStart.getDate() - 1);
+    return {
+      startDate: previousStart.toISOString(),
+      endDate: new Date(previousStart.getTime() + durationMs).toISOString(),
+    };
+  }
+
+  if (normalized === 'this-week') {
+    const previousStart = new Date(start.getTime());
+    previousStart.setDate(previousStart.getDate() - 7);
+    return {
+      startDate: previousStart.toISOString(),
+      endDate: start.toISOString(),
+    };
+  }
+
+  if (normalized === 'this-month' || normalized === 'last-month') {
+    const previousStart = new Date(start.getTime());
+    previousStart.setMonth(previousStart.getMonth() - 1, 1);
+    return {
+      startDate: previousStart.toISOString(),
+      endDate: start.toISOString(),
+    };
+  }
+
+  const durationMs = end.getTime() - start.getTime();
+  return {
+    startDate: new Date(start.getTime() - durationMs).toISOString(),
+    endDate: start.toISOString(),
+  };
+}
+
+/** "30d" for a stat label, "this month" for a calendar key. */
+export function timeRangeShortLabel(key: TimeRangeKey | string): string {
+  const normalized = normalizeTimeRangeKey(String(key));
+  return normalized ? SHORT_LABELS[normalized] : '30d';
+}
+
+/**
+ * Which days the numbers cover, for the line beside the range control:
+ * "Aug 7 to Sep 6". Empty when the window has no bounds to state.
+ */
+export function formatTimeRangeWindow(
+  window:
+    TimeRangeWindow | { startDate?: string | null; endDate?: string | null }
+): string {
+  const start = window.startDate ? new Date(window.startDate) : null;
+  const end = window.endDate ? new Date(window.endDate) : null;
+  if (!start || !end) return '';
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return '';
+  const day = (date: Date) =>
+    date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return `${day(start)} to ${day(end)}`;
+}

--- a/frontend/src/utils/time-range.ts
+++ b/frontend/src/utils/time-range.ts
@@ -141,6 +141,13 @@ export function resolveTimeRange(
  * The window immediately before the one a key resolves to, for "vs prior 30d"
  * deltas. A calendar key steps back a whole period; a rolling key steps back
  * its own duration.
+ *
+ * The two shapes are deliberately different and both are correct.
+ * `this-week`, `this-month` and `last-month` compare whole periods: the
+ * previous window ends exactly where the current one starts. `today` and the
+ * rolling keys compare equal durations: a window that is 9 hours old is
+ * measured against the same 9 hours of the day before, not against a whole
+ * day it would always lose to.
  */
 export function resolvePreviousTimeRange(
   key: TimeRangeKey | string,

--- a/frontend/src/views/authed/agent-detail-view.test.ts
+++ b/frontend/src/views/authed/agent-detail-view.test.ts
@@ -634,6 +634,22 @@ describe('AgentDetailView', () => {
     expect(stripText).to.contain('$0.57');
     expect(stripText).to.contain('4 requests');
 
+    // Volume leads the money on the strip as it does in the lists, so the
+    // card this replaced did not take the token split down with it.
+    const figures = strip?.querySelector(
+      '[data-testid="agent-token-figures"] token-figures'
+    ) as (HTMLElement & { updateComplete: Promise<unknown> }) | null;
+    expect(figures, 'the strip states the token split').to.exist;
+    await figures!.updateComplete;
+    const figuresText = (figures!.shadowRoot?.textContent || '').replace(
+      /\s+/g,
+      ' '
+    );
+    expect(figuresText).to.contain('300 in');
+    expect(figuresText).to.contain('120 out');
+    // This aggregate reported no cache fields, so no hit rate is claimed.
+    expect(figuresText).to.not.contain('hit');
+
     // One range control, the shared one, holding the selected window.
     const range = strip?.querySelector('time-range-select');
     expect(range, 'the strip carries the shared range control').to.exist;

--- a/frontend/src/views/authed/agent-detail-view.test.ts
+++ b/frontend/src/views/authed/agent-detail-view.test.ts
@@ -602,6 +602,45 @@ describe('AgentDetailView', () => {
     ).to.be.true;
   });
 
+  // Wave 3 (A5): the facts about the agent are one hairline row between the
+  // header and the tabs, not a 190px card holding one number.
+  it('states the agent facts and its spend on one summary strip', async () => {
+    const element = await fixture<AgentDetailView>(
+      html`<agent-detail-view agentId="agent-1"></agent-detail-view>`
+    );
+
+    await waitUntil(
+      () => !(element as any).loading && (element as any).agent !== null,
+      'Agent detail view did not finish loading'
+    );
+
+    const strip = element.shadowRoot?.querySelector('.summary-strip');
+    expect(strip, 'the summary strip is rendered').to.exist;
+    expect(element.shadowRoot?.querySelector('.agent-overview'), 'no card').to
+      .not.exist;
+
+    const stripText = getDeepText(strip).replace(/\s+/g, ' ').trim();
+    // Kind, the id the agent reports itself as, the reference it enrolled
+    // with, and its status, in that order.
+    expect(stripText).to.contain('Claude Code');
+    expect(stripText).to.contain('claude-code-agent-1');
+    expect(stripText).to.contain('claude-session-2');
+    expect(
+      strip?.querySelector('.badge-row sl-badge.status-chip')?.textContent
+    ).to.contain('Active now');
+
+    // The spend is stated with the window it covers and what it is based on.
+    expect(stripText).to.contain('Estimated spend · 30d');
+    expect(stripText).to.contain('$0.57');
+    expect(stripText).to.contain('4 requests');
+
+    // One range control, the shared one, holding the selected window.
+    const range = strip?.querySelector('time-range-select');
+    expect(range, 'the strip carries the shared range control').to.exist;
+    expect((range as unknown as { value: string }).value).to.equal('month');
+    expect(strip?.querySelector('select'), 'no bare select').to.not.exist;
+  });
+
   it('calls the session history panel Session History', async () => {
     const element = await fixture<AgentDetailView>(
       html`<agent-detail-view agentId="agent-1"></agent-detail-view>`

--- a/frontend/src/views/authed/agent-detail-view.test.ts
+++ b/frontend/src/views/authed/agent-detail-view.test.ts
@@ -641,6 +641,60 @@ describe('AgentDetailView', () => {
     expect(strip?.querySelector('select'), 'no bare select').to.not.exist;
   });
 
+  // DESIGN.md: the strip never wraps a UUID. Identifiers are shortened to
+  // eight characters, the whole value stays in the title and on the
+  // clipboard.
+  it('shortens the uuids on the strip and keeps the full value to copy', async () => {
+    const uuid = '2f1c8d9a-4b7e-4c21-9f3a-6d0e5b8c1a77';
+    fetchStub.callsFake(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (
+          url.startsWith('/api/v1/agents/agent-1') &&
+          !url.includes('/governance')
+        ) {
+          const response = await defaultFetch(input, init);
+          const payload = await response.json();
+          payload.agent.session_source_id = uuid;
+          payload.agent.session_reference = `agent-${uuid}`;
+          return new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return defaultFetch(input, init);
+      }
+    );
+
+    const element = await fixture<AgentDetailView>(
+      html`<agent-detail-view agentId="agent-1"></agent-detail-view>`
+    );
+    await waitUntil(
+      () => !(element as any).loading && (element as any).agent !== null,
+      'Agent detail view did not finish loading'
+    );
+
+    const strip = element.shadowRoot?.querySelector('.summary-strip');
+    const ids = Array.from(strip?.querySelectorAll('.strip-id') || []);
+    expect(ids.map((id) => id.textContent?.trim())).to.deep.equal([
+      '2f1c8d9a\u2026',
+      'agent-2f1c8d9a\u2026',
+    ]);
+    expect(ids.map((id) => id.getAttribute('title'))).to.deep.equal([
+      uuid,
+      `agent-${uuid}`,
+    ]);
+
+    // The full value goes to the clipboard, not to the screen.
+    const copyButtons = Array.from(
+      strip?.querySelectorAll('sl-copy-button') || []
+    );
+    expect(
+      copyButtons.map((button) => button.getAttribute('value'))
+    ).to.deep.equal([uuid, `agent-${uuid}`]);
+    expect(strip?.textContent).to.not.contain('4b7e-4c21');
+  });
+
   it('calls the session history panel Session History', async () => {
     const element = await fixture<AgentDetailView>(
       html`<agent-detail-view agentId="agent-1"></agent-detail-view>`

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -23,6 +23,7 @@ import '../../components/token-figures.ts';
 import '../../components/view-header.ts';
 import '../../components/resource-actions.ts';
 import '../../components/talk-button.ts';
+import '../../components/time-range-select.ts';
 import '../../components/confirm-dialog.ts';
 import { confirmDialog } from '../../components/confirm-dialog';
 import type { ResourceAction } from '../../components/resource-actions.ts';
@@ -89,6 +90,18 @@ type AllowedModelCandidate = {
   model_identifier?: string;
   meta_data?: Record<string, unknown> | null;
 };
+
+/**
+ * The spend window offered on the summary strip. Same vocabulary and same
+ * control as the Overview usage card, so "30d" means the same thing and looks
+ * the same wherever it is offered.
+ */
+const SPEND_RANGE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'day', label: '24h' },
+  { value: 'week', label: '7d' },
+  { value: 'month', label: '30d' },
+  { value: 'year', label: '1y' },
+];
 
 @customElement('agent-detail-view')
 export class AgentDetailView extends LitElement {
@@ -351,17 +364,73 @@ export class AgentDetailView extends LitElement {
         color: var(--sl-color-neutral-900);
       }
 
-      /* The identity block is a card: it sits on the page, so it takes the
-         card rung of the ladder rather than a named gray step. */
-      .agent-overview {
+      /* Facts about the agent live on one hairline row between the header and
+         the tabs (DESIGN "Strip, not cards"): kind, source id, config
+         reference and status on the left, the spend the page is scoped to on
+         the right. The card this replaced held two meta lines and one number
+         above 100px of nothing. */
+      .summary-strip {
         display: flex;
-        flex-direction: column;
-        gap: var(--sl-spacing-small);
-        padding: var(--sl-spacing-large);
-        border-radius: var(--console-card-radius);
-        background: var(--console-surface);
-        border: var(--console-card-border);
-        box-shadow: var(--console-card-shadow);
+        flex-wrap: wrap;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 8px var(--sl-spacing-medium);
+        padding: 12px 0;
+        border-top: 1px solid
+          var(--console-hairline, var(--sl-color-neutral-200));
+        border-bottom: 1px solid
+          var(--console-hairline, var(--sl-color-neutral-200));
+        color: var(--sl-color-neutral-900);
+        font-size: var(--console-text-body, var(--sl-font-size-small));
+        font-variant-numeric: tabular-nums;
+      }
+
+      .strip-facts {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+      }
+
+      .strip-facts .strip-id {
+        font-family: var(--sl-font-mono);
+        font-size: var(--sl-font-size-small);
+        color: var(--sl-color-neutral-700);
+        overflow-wrap: anywhere;
+      }
+
+      .strip-sep {
+        color: var(--console-meta-color, var(--sl-color-neutral-500));
+      }
+
+      .strip-spend {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--sl-spacing-x-small);
+        margin-left: auto;
+      }
+
+      .strip-spend .strip-label,
+      .strip-spend .strip-requests {
+        color: var(--console-meta-color, var(--sl-color-neutral-600));
+        font-size: var(--sl-font-size-small);
+      }
+
+      .strip-spend .strip-tokens {
+        display: inline-flex;
+        align-items: baseline;
+      }
+
+      .strip-spend .strip-value {
+        font-weight: var(--sl-font-weight-semibold);
+      }
+
+      /* The identity trail is rare (only a re-keyed agent has one) and does
+         not belong on the fact row, so it sits under it in the meta register. */
+      .strip-identity {
+        margin-top: var(--sl-spacing-x-small);
       }
 
       .section-header {
@@ -992,6 +1061,82 @@ export class AgentDetailView extends LitElement {
     return 'Live check pending';
   }
 
+  /** The label of the spend window currently selected ("30d"). */
+  private spendRangeLabel(): string {
+    return (
+      SPEND_RANGE_OPTIONS.find(
+        (option) => option.value === this.budgetTimeRange
+      )?.label || '30d'
+    );
+  }
+
+  /**
+   * One hairline row of facts between the header and the tabs: what kind of
+   * agent this is, the id it reports itself as, the config it was enrolled
+   * from, its status and its tags, then the spend for the selected window.
+   *
+   * DESIGN "Strip, not cards": these are facts about a thing, so they take a
+   * row, not a 190px box holding one number and 100px of empty space.
+   */
+  private renderSummaryStrip(
+    aggregate: ManagedAgentUsageAggregate | null
+  ): TemplateResult | typeof nothing {
+    if (!this.agent) return nothing;
+    const requests = aggregate?.total_requests ?? 0;
+    const reference = this.agent.session_reference;
+    return html`
+      <div class="summary-strip" role="region" aria-label="Agent summary">
+        <div class="strip-facts">
+          <span
+            >${this.getSourceLabel(
+              this.agent.agent_kind || this.agent.session_source_type
+            )}</span
+          >
+          <span class="strip-sep" aria-hidden="true">·</span>
+          <span class="strip-id">${this.agent.session_source_id}</span>
+          ${
+            reference
+              ? html`<span class="strip-sep" aria-hidden="true">·</span>
+                  <span class="strip-id" title=${reference}>${reference}</span>`
+              : nothing
+          }
+          <span class="badge-row">${this.renderHeaderChips()}</span>
+        </div>
+        <div class="strip-spend">
+          <span class="strip-label"
+            >Estimated spend · ${this.spendRangeLabel()}</span
+          >
+          <!-- Volume before money: the tokens are what the spend is made of,
+               split in and out with the cache share of the input. -->
+          <span class="strip-tokens" data-testid="agent-token-figures">
+            <token-figures
+              expanded
+              .usage=${aggregate?.token_usage ?? null}
+            ></token-figures>
+          </span>
+          <span class="strip-value"
+            >${this.formatMoney(aggregate?.estimated_cost)}</span
+          >
+          <span class="strip-requests"
+            >${requests} request${requests === 1 ? '' : 's'}</span
+          >
+          <time-range-select
+            ariaLabel="Estimated spend range"
+            .value=${this.budgetTimeRange}
+            .options=${SPEND_RANGE_OPTIONS}
+            @range-change=${(event: CustomEvent<{ value: string }>) => {
+              this.budgetTimeRange = event.detail
+                .value as typeof this.budgetTimeRange;
+              // The window is applied server-side through `start_date` on the
+              // agent detail call, so the numbers reload with the range.
+              void this.loadData();
+            }}
+          ></time-range-select>
+        </div>
+      </div>
+    `;
+  }
+
   /**
    * The chips under the agent name, in one deliberate order: what the agent is
    * doing right now, then anything that is switched off and costing you
@@ -1243,7 +1388,8 @@ export class AgentDetailView extends LitElement {
     if (ids.length === 0) return nothing;
     return html`
       <details
-        style="margin-top: var(--sl-spacing-x-small); font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-600);"
+        class="strip-identity"
+        style="font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-600);"
       >
         <summary style="cursor: pointer;">
           Identity history (${ids.length})
@@ -2743,77 +2889,7 @@ export class AgentDetailView extends LitElement {
         </div>
       </view-header>
       <div class="page" style="padding-top: 0;">
-        <div
-          class="agent-overview"
-          style="flex-direction: row; justify-content: space-between; align-items: stretch; flex-wrap: wrap;"
-        >
-          <div style="flex: 1; min-width: 300px;">
-            <div
-              style="color: var(--console-meta-color); font-size: 0.9rem; margin-top: 4px;"
-            >
-              ${this.getSourceLabel(
-                this.agent.agent_kind || this.agent.session_source_type
-              )}
-              · ${this.agent.session_source_id}
-              ${
-                this.agent.session_reference
-                  ? ` · ${this.agent.session_reference}`
-                  : ''
-              }
-            </div>
-
-            <div
-              style="display: flex; flex-direction: column; align-items: flex-start; gap: var(--sl-spacing-small); margin-top: var(--sl-spacing-small);"
-            >
-              <div class="badge-row">${this.renderHeaderChips()}</div>
-
-              ${this.renderIdentityHistory()}
-            </div>
-          </div>
-
-          <div
-            class="stat-card"
-            style="min-width: 200px; display: flex; flex-direction: column; justify-content: space-between; border-color: transparent;"
-          >
-            <div
-              style="display: flex; justify-content: space-between; align-items: center; width: 100%;"
-            >
-              ${this.renderStatLabel('Estimated spend')}
-              <select
-                style="background: transparent; border: none; font-size: var(--sl-font-size-small); color: var(--sl-color-neutral-600); cursor: pointer; outline: none;"
-                .value=${this.budgetTimeRange}
-                @change=${(e: Event) => {
-                  this.budgetTimeRange = (e.target as HTMLSelectElement)
-                    .value as any;
-                  // The API currently returns aggregate lifetime cost,
-                  // time window filtering requires a backend update for agent-specific spend
-                  this.loadData();
-                }}
-              >
-                <option value="day">24h</option>
-                <option value="week">7d</option>
-                <option value="month">30d</option>
-                <option value="year">1y</option>
-              </select>
-            </div>
-            <div>
-              <!-- Volume before money: the tokens are what the spend is made
-                   of, split in and out with the cache share of the input. -->
-              <div class="meta-line" data-testid="agent-token-figures">
-                <token-figures
-                  expanded
-                  .usage=${aggregate?.token_usage ?? null}
-                ></token-figures>
-              </div>
-              <div class="stat-value">
-                ${this.formatMoney(aggregate?.estimated_cost)}
-              </div>
-              <div class="meta-line">
-                Based on ${aggregate?.total_requests ?? 0} requests
-              </div>
-            </div>
-          </div>
-        </div>
+        ${this.renderSummaryStrip(aggregate)} ${this.renderIdentityHistory()}
 
         <!-- Sub-view Tab Navigation -->
         ${(() => {

--- a/frontend/src/views/authed/agent-detail-view.ts
+++ b/frontend/src/views/authed/agent-detail-view.ts
@@ -6,6 +6,7 @@ import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
+import '@shoelace-style/shoelace/dist/components/copy-button/copy-button.js';
 import '@shoelace-style/shoelace/dist/components/details/details.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
@@ -102,6 +103,14 @@ const SPEND_RANGE_OPTIONS: Array<{ value: string; label: string }> = [
   { value: 'month', label: '30d' },
   { value: 'year', label: '1y' },
 ];
+
+/**
+ * A uuid anywhere in an identifier, including a prefixed one
+ * ("agent-1f8c...", "flow-execution/1f8c..."), so the strip can shorten the
+ * uuid and keep the part that carries meaning.
+ */
+const UUID_IN_IDENTIFIER =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 
 @customElement('agent-detail-view')
 export class AgentDetailView extends LitElement {
@@ -338,11 +347,6 @@ export class AgentDetailView extends LitElement {
         gap: var(--sl-spacing-2x-small);
       }
 
-      .info-icon {
-        color: var(--console-meta-color);
-        font-size: 0.95rem;
-      }
-
       .stat-value {
         margin-top: var(--sl-spacing-2x-small);
         font-size: 1.35rem;
@@ -398,6 +402,10 @@ export class AgentDetailView extends LitElement {
         font-size: var(--sl-font-size-small);
         color: var(--sl-color-neutral-700);
         overflow-wrap: anywhere;
+      }
+
+      .strip-facts sl-copy-button::part(button) {
+        padding: 0 2px;
       }
 
       .strip-sep {
@@ -905,22 +913,6 @@ export class AgentDetailView extends LitElement {
     return 'This agent is not fully managed by Preloop yet.';
   }
 
-  private renderInfoTooltip(content: string): TemplateResult {
-    return html`
-      <sl-tooltip content=${content}>
-        <sl-icon class="info-icon" name="info-circle"></sl-icon>
-      </sl-tooltip>
-    `;
-  }
-
-  private renderStatLabel(label: string, explanation?: string): TemplateResult {
-    return html`
-      <div class="stat-label">
-        ${label}${explanation ? this.renderInfoTooltip(explanation) : null}
-      </div>
-    `;
-  }
-
   private getParsedModelBudgets(): Record<
     string,
     { monthly_usd_limit?: number }
@@ -1093,11 +1085,11 @@ export class AgentDetailView extends LitElement {
             )}</span
           >
           <span class="strip-sep" aria-hidden="true">·</span>
-          <span class="strip-id">${this.agent.session_source_id}</span>
+          ${this.renderStripId(this.agent.session_source_id, 'Copy source id')}
           ${
             reference
               ? html`<span class="strip-sep" aria-hidden="true">·</span>
-                  <span class="strip-id" title=${reference}>${reference}</span>`
+                  ${this.renderStripId(reference, 'Copy session reference')}`
               : nothing
           }
           <span class="badge-row">${this.renderHeaderChips()}</span>
@@ -1134,6 +1126,25 @@ export class AgentDetailView extends LitElement {
           ></time-range-select>
         </div>
       </div>
+    `;
+  }
+
+  /**
+   * An identifier on the strip, shortened. DESIGN "Strip, not cards": the
+   * strip never wraps a UUID, so a uuid (bare or prefixed, "agent-<uuid>")
+   * shows eight characters with the whole value in the title and a copy
+   * button that puts the full id on the clipboard. A short handle
+   * ("claude-code-agent-1") is left alone: truncating it would lose meaning.
+   */
+  private renderStripId(value: string, copyLabel: string): TemplateResult {
+    const match = value.match(UUID_IN_IDENTIFIER);
+    if (!match) {
+      return html`<span class="strip-id" title=${value}>${value}</span>`;
+    }
+    const shortened = `${value.slice(0, match.index)}${match[0].slice(0, 8)}\u2026`;
+    return html`
+      <span class="strip-id" title=${value}>${shortened}</span>
+      <sl-copy-button value=${value} copy-label=${copyLabel}></sl-copy-button>
     `;
   }
 

--- a/frontend/src/views/authed/api-usage-view.test.ts
+++ b/frontend/src/views/authed/api-usage-view.test.ts
@@ -295,7 +295,7 @@ describe('ApiUsageView', () => {
 
     const content = element.shadowRoot?.textContent || '';
 
-    expect(content).to.contain('Requests \u00b7 30d');
+    expect(content).to.contain('Requests · 30d');
     expect(content).to.contain('42');
     expect(content).to.contain('$3.46');
     expect(content).to.contain('16.5K');
@@ -435,10 +435,10 @@ describe('ApiUsageView', () => {
       element.shadowRoot?.querySelectorAll('.stat-label') || []
     ).map((node) => node.textContent?.trim());
     expect(labels).to.deep.equal([
-      'Requests \u00b7 30d',
-      '$ est. \u00b7 30d',
-      'Tokens \u00b7 30d',
-      'Success rate \u00b7 30d',
+      'Requests · 30d',
+      '$ est. · 30d',
+      'Tokens · 30d',
+      'Success rate · 30d',
     ]);
   });
 
@@ -472,5 +472,52 @@ describe('ApiUsageView', () => {
     expect(text).to.not.contain('Source:');
     expect(text).to.not.contain('Session reference:');
     expect(text).to.not.contain('session-def456');
+  });
+
+  // Only the captured interactions depend on the query, so a pause in typing
+  // costs one request, not the four the whole page costs.
+  it('spends one request on a search, not a whole page reload', async () => {
+    const element = (await fixture(
+      html`<api-usage-view></api-usage-view>`
+    )) as ApiUsageView;
+
+    await waitUntil(
+      () => !(element as any).loading && (element as any).summary !== null,
+      'API usage view did not finish loading'
+    );
+    await element.updateComplete;
+
+    // Icons are fetched too; only the API calls are counted here.
+    const apiCalls = () =>
+      fetchStub
+        .getCalls()
+        .map((call) => String(call.args[0]))
+        .filter((url) => url.startsWith('/api/'));
+    const callsAfterLoad = apiCalls().length;
+    const search = element.shadowRoot?.querySelector(
+      'sl-input.usage-search'
+    ) as HTMLInputElement;
+    search.value = 'rollback';
+    search.dispatchEvent(new CustomEvent('sl-input', { bubbles: true }));
+
+    await waitUntil(
+      () => apiCalls().length > callsAfterLoad,
+      'the debounced search never reached the server',
+      { timeout: 3000 }
+    );
+    await waitUntil(
+      () => !(element as any).searchLoading,
+      'the search never settled',
+      { timeout: 3000 }
+    );
+    await element.updateComplete;
+
+    const newCalls = apiCalls().slice(callsAfterLoad);
+    expect(newCalls).to.have.length(1);
+    expect(newCalls[0]).to.contain('/api/v1/account/gateway-usage/search');
+    expect(newCalls[0]).to.contain('query=rollback');
+
+    // The numbers the search did not touch are still on screen.
+    expect(element.shadowRoot?.textContent).to.contain('Requests · 30d');
   });
 });

--- a/frontend/src/views/authed/api-usage-view.test.ts
+++ b/frontend/src/views/authed/api-usage-view.test.ts
@@ -474,6 +474,63 @@ describe('ApiUsageView', () => {
     expect(text).to.not.contain('session-def456');
   });
 
+  // "All time" survived the Filters card: the shared util resolves it to a
+  // window with no bounds, so the page asks the server for everything.
+  it('offers All time and asks for it without date bounds', async () => {
+    const element = (await fixture(
+      html`<api-usage-view></api-usage-view>`
+    )) as ApiUsageView;
+
+    await waitUntil(
+      () => !(element as any).loading && (element as any).summary !== null,
+      'API usage view did not finish loading'
+    );
+    await element.updateComplete;
+
+    const range = element.shadowRoot?.querySelector('time-range-select');
+    expect(
+      ((range as any).options as { value: string; label: string }[]).map(
+        (option) => option.value
+      )
+    ).to.contain('all');
+
+    const before = fetchStub
+      .getCalls()
+      .map((call) => String(call.args[0]))
+      .filter((url) =>
+        url.startsWith('/api/v1/account/gateway-usage/summary')
+      ).length;
+    range?.dispatchEvent(
+      new CustomEvent('range-change', {
+        detail: { value: 'all' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await waitUntil(
+      () => !(element as any).loading,
+      'the All time reload never settled',
+      { timeout: 3000 }
+    );
+    await element.updateComplete;
+
+    const summaryCalls = fetchStub
+      .getCalls()
+      .map((call) => String(call.args[0]))
+      .filter((url) => url.startsWith('/api/v1/account/gateway-usage/summary'))
+      .slice(before);
+    expect(summaryCalls.length).to.be.greaterThan(0);
+    summaryCalls.forEach((url) => {
+      expect(url).to.not.contain('start_date=');
+      expect(url).to.not.contain('end_date=');
+    });
+    // No prior window exists, so no comparison request and no false delta.
+    expect(summaryCalls.length).to.equal(1);
+    expect(element.shadowRoot?.textContent).to.contain(
+      'All recorded gateway spend'
+    );
+  });
+
   // Only the captured interactions depend on the query, so a pause in typing
   // costs one request, not the four the whole page costs.
   it('spends one request on a search, not a whole page reload', async () => {

--- a/frontend/src/views/authed/api-usage-view.test.ts
+++ b/frontend/src/views/authed/api-usage-view.test.ts
@@ -4,15 +4,66 @@ import sinon from 'sinon';
 import './api-usage-view';
 import type { ApiUsageView } from './api-usage-view';
 
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function searchResponseWithExcerpt(excerpt: string) {
+  return {
+    period_start: '2026-02-08T00:00:00Z',
+    period_end: '2026-03-09T23:59:59Z',
+    query: 'rollback',
+    total: 1,
+    limit: 10,
+    offset: 0,
+    items: [
+      {
+        api_usage_id: 'usage-range-probe',
+        timestamp: '2026-03-09T19:15:00Z',
+        status_code: 200,
+        outcome: 'success',
+        endpoint: '/openai/v1/responses',
+        method: 'POST',
+        provider_name: 'OpenAI',
+        model_alias: 'openai/gpt-5',
+        flow_id: 'flow-1',
+        flow_name: 'Triage Assistant',
+        flow_execution_id: 'execution-1',
+        runtime_session_id: 'runtime-session-1',
+        session_source_type: 'flow_execution',
+        session_source_id: 'execution-1',
+        session_reference: 'session-abc123',
+        runtime_principal_type: 'flow_execution',
+        runtime_principal_id: 'execution-1',
+        runtime_principal_name: 'Triage Assistant',
+        estimated_cost: 0.27,
+        token_usage: {
+          prompt_tokens: 250,
+          completion_tokens: 80,
+          total_tokens: 330,
+        },
+        excerpt,
+        meta_data: {
+          source: 'gateway_interaction',
+          endpoint_kind: 'responses',
+        },
+      },
+    ],
+  };
+}
+
 describe('ApiUsageView', () => {
   let fetchStub: sinon.SinonStub;
+  let defaultUsageFetch: (input: RequestInfo | URL) => Promise<Response>;
 
   beforeEach(() => {
     localStorage.setItem('accessToken', 'test-access-token');
     localStorage.setItem('refreshToken', 'test-refresh-token');
 
-    fetchStub = sinon.stub(window, 'fetch');
-    fetchStub.callsFake(async (input: RequestInfo | URL) => {
+    defaultUsageFetch = async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
 
       if (url.startsWith('/api/v1/account/gateway-usage/summary')) {
@@ -274,7 +325,10 @@ describe('ApiUsageView', () => {
           headers: { 'Content-Type': 'application/json' },
         }
       );
-    });
+    };
+
+    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub.callsFake(defaultUsageFetch);
   });
 
   afterEach(() => {
@@ -576,5 +630,87 @@ describe('ApiUsageView', () => {
 
     // The numbers the search did not touch are still on screen.
     expect(element.shadowRoot?.textContent).to.contain('Requests · 30d');
+  });
+
+  // A search that left before the range changed must not land on top of the
+  // results the new window already painted.
+  it('does not let a stale in-flight search overwrite results after a range change', async () => {
+    const element = (await fixture(
+      html`<api-usage-view></api-usage-view>`
+    )) as ApiUsageView;
+
+    await waitUntil(
+      () => !(element as any).loading && (element as any).summary !== null,
+      'API usage view did not finish loading'
+    );
+    await element.updateComplete;
+
+    let resolveStaleSearch: ((response: Response) => void) | undefined;
+    let staleSearchStarted = false;
+
+    fetchStub.callsFake(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.startsWith('/api/v1/account/gateway-usage/search')) {
+        if (!staleSearchStarted) {
+          staleSearchStarted = true;
+          return new Promise<Response>((resolve) => {
+            resolveStaleSearch = resolve;
+          });
+        }
+        return jsonResponse(
+          searchResponseWithExcerpt('new-range captured interaction')
+        );
+      }
+      return defaultUsageFetch(input);
+    });
+
+    const search = element.shadowRoot?.querySelector(
+      'sl-input.usage-search'
+    ) as HTMLInputElement;
+    search.value = 'rollback';
+    search.dispatchEvent(new CustomEvent('sl-input', { bubbles: true }));
+
+    await waitUntil(
+      () => staleSearchStarted,
+      'the in-flight search never reached the server',
+      { timeout: 3000 }
+    );
+
+    const range = element.shadowRoot?.querySelector('time-range-select');
+    range?.dispatchEvent(
+      new CustomEvent('range-change', {
+        detail: { value: 'last-7' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await waitUntil(
+      () => !(element as any).loading && (element as any).summary !== null,
+      'the range reload never settled',
+      { timeout: 3000 }
+    );
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.textContent).to.contain(
+      'new-range captured interaction'
+    );
+    expect((element as any).searchLoading).to.equal(false);
+
+    resolveStaleSearch!(
+      jsonResponse(
+        searchResponseWithExcerpt('stale-range captured interaction')
+      )
+    );
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    await element.updateComplete;
+
+    const content = element.shadowRoot?.textContent || '';
+    expect(content).to.contain('new-range captured interaction');
+    expect(content).to.not.contain('stale-range captured interaction');
+    expect((element as any).searchResults.items[0].excerpt).to.equal(
+      'new-range captured interaction'
+    );
   });
 });

--- a/frontend/src/views/authed/api-usage-view.test.ts
+++ b/frontend/src/views/authed/api-usage-view.test.ts
@@ -151,6 +151,30 @@ describe('ApiUsageView', () => {
                 last_request_at: '2026-03-09T20:00:00Z',
                 ended_at: null,
               },
+              {
+                runtime_session_id: 'runtime-session-3',
+                runtime_session_name: 'Nightly Reviewer',
+                session_source_type: 'flow_execution',
+                session_source_id: '2f1c8d9a-4b7e-4c21-9f3a-6d0e5b8c1a77',
+                runtime_principal_type: 'flow_execution',
+                runtime_principal_id: '2f1c8d9a-4b7e-4c21-9f3a-6d0e5b8c1a77',
+                runtime_principal_name: 'Nightly Reviewer',
+                flow_execution_id: '2f1c8d9a-4b7e-4c21-9f3a-6d0e5b8c1a77',
+                flow_id: 'flow-2',
+                flow_name: 'PR Reviewer',
+                session_reference: 'session-def456',
+                model_alias: 'openai/gpt-5',
+                provider_name: 'OpenAI',
+                request_count: 9,
+                token_usage: {
+                  prompt_tokens: 3000,
+                  completion_tokens: 900,
+                  total_tokens: 3900,
+                },
+                estimated_cost: 0.41,
+                last_activity_at: '2026-03-09T21:00:00Z',
+                last_request_at: '2026-03-09T21:00:00Z',
+              },
             ],
           }),
           {
@@ -271,22 +295,20 @@ describe('ApiUsageView', () => {
 
     const content = element.shadowRoot?.textContent || '';
 
-    expect(content).to.contain('Gateway Usage Filters');
+    expect(content).to.contain('Requests \u00b7 30d');
     expect(content).to.contain('42');
     expect(content).to.contain('$3.46');
-    expect(content).to.contain('16,500');
+    expect(content).to.contain('16.5K');
     expect(content).to.contain('92.9%');
+    expect(content).to.contain('3 failed');
     expect(content).to.contain('openai/gpt-5');
     expect(content).to.contain('Triage Assistant');
-    expect(content).to.contain('Recent Runtime Sessions');
-    expect(content).to.contain('execution-1');
-    expect(content).to.contain('session-abc123');
+    expect(content).to.contain('Recent runtime sessions');
     expect(content).to.contain('Workspace Agent');
-    expect(content).to.contain('Source: Codex');
-    expect(content).to.contain('codex-run-1');
-    expect(content).to.contain('Budget Snapshot');
+    expect(content).to.contain('Codex');
+    expect(content).to.contain('Budget snapshot');
     expect(content).to.contain('$12.50');
-    expect(content).to.contain('Captured Interactions');
+    expect(content).to.contain('Captured interactions');
     expect(content).to.contain('production rollback checklist');
     expect(content).to.contain('provider timeout');
 
@@ -372,5 +394,83 @@ describe('ApiUsageView', () => {
     expect(
       (updated.shadowRoot?.textContent || '').replace(/\s+/g, ' ')
     ).to.contain('6K hit');
+  });
+
+  it('carries the shared range control and restates the window it resolved', async () => {
+    const element = (await fixture(
+      html`<api-usage-view></api-usage-view>`
+    )) as ApiUsageView;
+
+    await waitUntil(
+      () => !(element as any).loading && (element as any).summary !== null,
+      'API usage view did not finish loading'
+    );
+    await element.updateComplete;
+
+    // One range vocabulary per page: the shared control, not a select plus
+    // two date inputs plus Apply.
+    const range = element.shadowRoot?.querySelector('time-range-select');
+    expect(range).to.exist;
+    expect((range as any).value).to.equal('last-30');
+    expect(
+      element.shadowRoot?.querySelector('sl-select[label="Date range"]')
+    ).to.equal(null);
+    expect(element.shadowRoot?.querySelector('sl-input[type="date"]')).to.equal(
+      null
+    );
+
+    const content = element.shadowRoot?.textContent || '';
+    expect(content).to.not.contain('Gateway Usage Filters');
+    expect(content).to.not.contain('Apply');
+
+    // The window the numbers cover is restated beside the control that
+    // chose it, because the sibling pages used to disagree about "30 days".
+    const window = element.shadowRoot
+      ?.querySelector('.range-window')
+      ?.textContent?.trim();
+    expect(window).to.contain(' to ');
+
+    // Four stats, each labelled with the range they cover.
+    const labels = Array.from(
+      element.shadowRoot?.querySelectorAll('.stat-label') || []
+    ).map((node) => node.textContent?.trim());
+    expect(labels).to.deep.equal([
+      'Requests \u00b7 30d',
+      '$ est. \u00b7 30d',
+      'Tokens \u00b7 30d',
+      'Success rate \u00b7 30d',
+    ]);
+  });
+
+  it('reduces a session row to who ran, on what model, and a short run link', async () => {
+    const element = (await fixture(
+      html`<api-usage-view></api-usage-view>`
+    )) as ApiUsageView;
+
+    await waitUntil(
+      () => !(element as any).loading && (element as any).summary !== null,
+      'API usage view did not finish loading'
+    );
+    await element.updateComplete;
+
+    const uuid = '2f1c8d9a-4b7e-4c21-9f3a-6d0e5b8c1a77';
+    const link = element.shadowRoot?.querySelector(
+      `a[href="/console/flows/executions/${uuid}"]`
+    );
+    const row = link?.closest('.session-row');
+    const text = row?.textContent?.replace(/\s+/g, ' ').trim() || '';
+
+    expect(text).to.contain('Nightly Reviewer');
+    expect(text).to.contain('openai/gpt-5');
+
+    // The run is a short handle that links to the run, with the full id in
+    // the title: never a bare UUID where a link was available.
+    expect(link?.textContent?.trim()).to.equal('2f1c8d9a');
+    expect(link?.getAttribute('title')).to.equal(uuid);
+
+    // The lines that repeated the id in two other spellings are gone.
+    expect(text).to.not.contain('Source:');
+    expect(text).to.not.contain('Session reference:');
+    expect(text).to.not.contain('session-def456');
   });
 });

--- a/frontend/src/views/authed/api-usage-view.ts
+++ b/frontend/src/views/authed/api-usage-view.ts
@@ -98,6 +98,8 @@ export class ApiUsageView extends LitElement {
 
   private searchDebounce?: ReturnType<typeof setTimeout>;
 
+  private searchRequestId = 0;
+
   static styles = [
     unsafeCSS(consoleStyles),
     css`
@@ -459,11 +461,6 @@ export class ApiUsageView extends LitElement {
       }
 
       @media (max-width: 720px) {
-        .filters-actions {
-          margin-left: 0;
-          width: 100%;
-        }
-
         .daily-row {
           grid-template-columns: 1fr;
         }
@@ -600,17 +597,27 @@ export class ApiUsageView extends LitElement {
    * change one list.
    */
   private async loadSearchResults() {
+    // Two searches can be in flight at once, and the slower one must not
+    // overwrite the newer answer.
+    const request = ++this.searchRequestId;
     this.searchLoading = true;
 
     try {
-      this.searchResults = await getAccountGatewayUsageSearch({
+      const results = await getAccountGatewayUsageSearch({
         ...this.rangeParams(),
         query: this.searchQuery.trim() || undefined,
         limit: 10,
       });
+      if (request !== this.searchRequestId) {
+        return;
+      }
+      this.searchResults = results;
       this.searchError = null;
     } catch (error) {
       console.error('Failed to search captured gateway interactions:', error);
+      if (request !== this.searchRequestId) {
+        return;
+      }
       // A failed search says so where the results would be; the numbers above
       // it are still true and stay on screen.
       this.searchError =
@@ -619,7 +626,9 @@ export class ApiUsageView extends LitElement {
           : 'Failed to search captured interactions';
       this.searchResults = null;
     } finally {
-      this.searchLoading = false;
+      if (request === this.searchRequestId) {
+        this.searchLoading = false;
+      }
     }
   }
 

--- a/frontend/src/views/authed/api-usage-view.ts
+++ b/frontend/src/views/authed/api-usage-view.ts
@@ -53,6 +53,9 @@ const DATE_RANGE_OPTIONS: Array<{ value: TimeRangeKey; label: string }> = [
   { value: 'last-30', label: '30d' },
   { value: 'last-90', label: '90d' },
   { value: 'last-365', label: '1y' },
+  // The window with no bounds. The console lost it when the Filters card
+  // went; the shared util has always been able to resolve it.
+  { value: 'all', label: 'All time' },
 ];
 
 @customElement('api-usage-view')
@@ -551,11 +554,14 @@ export class ApiUsageView extends LitElement {
             return null;
           }),
           // The comparison window is a garnish on one stat: if it fails, the
-          // stat says it has no comparison rather than the page failing.
-          getAccountGatewayUsageSummary({
-            startDate: previousRange.startDate ?? undefined,
-            endDate: previousRange.endDate ?? undefined,
-          }).catch(() => null),
+          // stat says it has no comparison rather than the page failing. All
+          // time has nothing before it, so it costs no request.
+          previousRange.startDate
+            ? getAccountGatewayUsageSummary({
+                startDate: previousRange.startDate,
+                endDate: previousRange.endDate ?? undefined,
+              }).catch(() => null)
+            : Promise.resolve(null),
         ]);
       this.summary = summary;
       this.searchResults = searchResults;
@@ -656,6 +662,10 @@ export class ApiUsageView extends LitElement {
    * spend doubled or moved a percent.
    */
   private spendComparisonDetail(): string {
+    // "All time" has no window before it to compare against.
+    if (!resolvePreviousTimeRange(this.selectedRange).startDate) {
+      return 'All recorded gateway spend';
+    }
     const previousLabel = `prior ${this.rangeChipLabel()}`;
     const current = this.summary?.estimated_cost ?? 0;
     const previous = this.previousSummary?.estimated_cost ?? 0;

--- a/frontend/src/views/authed/api-usage-view.ts
+++ b/frontend/src/views/authed/api-usage-view.ts
@@ -587,6 +587,10 @@ export class ApiUsageView extends LitElement {
       return;
     }
     this.selectedRange = value;
+    // An in-flight search still carries the old window. Bump so its answer
+    // cannot overwrite the results this range is about to load.
+    this.searchRequestId++;
+    this.searchLoading = false;
     void this.loadSummary();
   }
 

--- a/frontend/src/views/authed/api-usage-view.ts
+++ b/frontend/src/views/authed/api-usage-view.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css, unsafeCSS } from 'lit';
+import { LitElement, html, css, nothing, unsafeCSS } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
@@ -13,6 +13,7 @@ import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '../../components/view-header.ts';
 import '../../components/token-figures.ts';
+import '../../components/time-range-select.ts';
 import {
   getAccountGatewayUsageSearch,
   getAccountGatewayUsageSummary,
@@ -33,13 +34,36 @@ import type {
   GatewayUsageBySession,
 } from '../../types';
 import consoleStyles from '../../styles/console-styles.css?inline';
+import { shortExecutionId } from '../../utils/execution-subject';
+import {
+  formatTimeRangeWindow,
+  resolvePreviousTimeRange,
+  resolveTimeRange,
+  timeRangeShortLabel,
+  type TimeRangeKey,
+} from '../../utils/time-range';
 
-type DateRangePreset = 'last-7' | 'last-30' | 'last-90' | 'all' | 'custom';
+// The page carries one range control, the shared `time-range-select`, with the
+// same vocabulary as the Overview and Cost. The window itself comes from
+// `utils/time-range`, so "30d" here is the same 30 days Cost and the model
+// detail page ask the server for.
+const DATE_RANGE_OPTIONS: Array<{ value: TimeRangeKey; label: string }> = [
+  { value: 'last-24h', label: '24h' },
+  { value: 'last-7', label: '7d' },
+  { value: 'last-30', label: '30d' },
+  { value: 'last-90', label: '90d' },
+  { value: 'last-365', label: '1y' },
+];
 
 @customElement('api-usage-view')
 export class ApiUsageView extends LitElement {
   @state()
   private summary: AccountGatewayUsageSummaryResponse | null = null;
+
+  // The window before the selected one, so spend can say "vs prior 30d"
+  // instead of a bare dollar figure.
+  @state()
+  private previousSummary: AccountGatewayUsageSummaryResponse | null = null;
 
   @state()
   private searchResults: AccountGatewayUsageSearchResponse | null = null;
@@ -54,18 +78,14 @@ export class ApiUsageView extends LitElement {
   private error: string | null = null;
 
   @state()
-  private selectedRange: DateRangePreset = 'last-30';
-
-  @state()
-  private startDate = '';
-
-  @state()
-  private endDate = '';
+  private selectedRange: TimeRangeKey = 'last-30';
 
   @state()
   private searchQuery = '';
 
   private initialized = false;
+
+  private searchDebounce?: ReturnType<typeof setTimeout>;
 
   static styles = [
     unsafeCSS(consoleStyles),
@@ -80,35 +100,63 @@ export class ApiUsageView extends LitElement {
         gap: var(--sl-spacing-large);
       }
 
-      .filters-card,
       .summary-card,
       .breakdown-card {
         overflow: hidden;
       }
 
-      .filters-grid {
+      /* One range control, then what it resolved to, then the search that
+         narrows the captured interactions. No Apply: the page answers as the
+         controls change. */
+      .toolbar {
         display: flex;
         gap: var(--sl-spacing-medium);
-        flex-wrap: wrap;
-        align-items: end;
-      }
-
-      .filters-grid sl-select,
-      .filters-grid sl-input {
-        min-width: 180px;
-      }
-
-      .filters-actions {
-        display: flex;
-        gap: var(--sl-spacing-small);
         align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .toolbar time-range-select {
+        --time-range-select-width: 110px;
+      }
+
+      /* The window the numbers cover, restated beside the control that chose
+         it, because the sibling pages used to disagree about "30 days". */
+      .range-window {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .usage-search {
+        flex: 1 1 260px;
+        min-width: 220px;
         margin-left: auto;
       }
 
-      .period-caption {
-        margin-top: var(--sl-spacing-small);
-        color: var(--sl-color-neutral-600);
-        font-size: var(--sl-font-size-small);
+      /* Names the search field for assistive tech without a visible label. */
+      .usage-search::part(form-control-label) {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      .results {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sl-spacing-large);
+      }
+
+      /* A range change never blanks answers the page already has: they stay
+         readable at 60% until the new ones arrive. */
+      .results.is-updating {
+        opacity: 0.6;
+        pointer-events: none;
       }
 
       .stats-grid {
@@ -436,51 +484,67 @@ export class ApiUsageView extends LitElement {
     super.connectedCallback();
 
     if (!this.initialized) {
-      if (this.selectedRange !== 'custom') {
-        this.applyPresetDates(this.selectedRange);
-      }
       this.initialized = true;
       void this.loadSummary();
     }
+  }
+
+  disconnectedCallback() {
+    if (this.searchDebounce) {
+      clearTimeout(this.searchDebounce);
+      this.searchDebounce = undefined;
+    }
+    super.disconnectedCallback();
   }
 
   private async loadSummary() {
     this.loading = true;
     this.error = null;
 
+    const range = resolveTimeRange(this.selectedRange);
+    const previousRange = resolvePreviousTimeRange(this.selectedRange);
+
     try {
       const params: GatewayUsageSummaryParams = {};
 
-      if (this.startDate) {
-        params.startDate = new Date(`${this.startDate}T00:00:00`).toISOString();
+      if (range.startDate) {
+        params.startDate = range.startDate;
       }
 
-      if (this.endDate) {
-        params.endDate = new Date(`${this.endDate}T23:59:59.999`).toISOString();
+      if (range.endDate) {
+        params.endDate = range.endDate;
       }
 
       const searchQuery = this.searchQuery.trim();
-      const [summary, searchResults, rateLimitReport] = await Promise.all([
-        getAccountGatewayUsageSummary({
-          ...params,
-          // This view renders model/flow/session/day breakdowns.
-          includeBreakdown: true,
-        }),
-        getAccountGatewayUsageSearch({
-          ...params,
-          query: searchQuery || undefined,
-          limit: 10,
-        }),
-        // Rate-limit telemetry is supplementary; a failure here must not
-        // blank the whole usage view.
-        getAccountRateLimitReport(params).catch((error: unknown) => {
-          console.error('Failed to load rate limit report:', error);
-          return null;
-        }),
-      ]);
+      const [summary, searchResults, rateLimitReport, previousSummary] =
+        await Promise.all([
+          getAccountGatewayUsageSummary({
+            ...params,
+            // This view renders model/flow/session/day breakdowns.
+            includeBreakdown: true,
+          }),
+          getAccountGatewayUsageSearch({
+            ...params,
+            query: searchQuery || undefined,
+            limit: 10,
+          }),
+          // Rate-limit telemetry is supplementary; a failure here must not
+          // blank the whole usage view.
+          getAccountRateLimitReport(params).catch((error: unknown) => {
+            console.error('Failed to load rate limit report:', error);
+            return null;
+          }),
+          // The comparison window is a garnish on one stat: if it fails, the
+          // stat says it has no comparison rather than the page failing.
+          getAccountGatewayUsageSummary({
+            startDate: previousRange.startDate ?? undefined,
+            endDate: previousRange.endDate ?? undefined,
+          }).catch(() => null),
+        ]);
       this.summary = summary;
       this.searchResults = searchResults;
       this.rateLimitReport = rateLimitReport;
+      this.previousSummary = previousSummary;
     } catch (error) {
       console.error('Failed to load account gateway usage summary:', error);
       this.error =
@@ -490,84 +554,91 @@ export class ApiUsageView extends LitElement {
       this.summary = null;
       this.searchResults = null;
       this.rateLimitReport = null;
+      this.previousSummary = null;
     } finally {
       this.loading = false;
     }
   }
 
-  private getLocalDateString(date: Date): string {
-    const year = date.getFullYear();
-    const month = `${date.getMonth() + 1}`.padStart(2, '0');
-    const day = `${date.getDate()}`.padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  }
-
-  private applyPresetDates(range: Exclude<DateRangePreset, 'custom'>) {
-    if (range === 'all') {
-      this.startDate = '';
-      this.endDate = '';
+  private handleRangeChange(event: Event) {
+    const value = (event as CustomEvent<{ value: string }>).detail
+      ?.value as TimeRangeKey;
+    if (!value || value === this.selectedRange) {
       return;
     }
-
-    const today = new Date();
-    const endDate = new Date(today);
-    const startDate = new Date(today);
-    const days = range === 'last-7' ? 7 : range === 'last-30' ? 30 : 90;
-
-    startDate.setDate(startDate.getDate() - (days - 1));
-
-    this.startDate = this.getLocalDateString(startDate);
-    this.endDate = this.getLocalDateString(endDate);
-  }
-
-  private handleRangeChange(event: Event) {
-    const value = (event.target as HTMLInputElement & { value: string })
-      .value as DateRangePreset;
-
     this.selectedRange = value;
-
-    if (value !== 'custom') {
-      this.applyPresetDates(value);
-      void this.loadSummary();
-    }
-  }
-
-  private handleStartDateChange(event: Event) {
-    this.startDate = (
-      event.target as HTMLInputElement & { value: string }
-    ).value;
-    this.selectedRange = 'custom';
-  }
-
-  private handleEndDateChange(event: Event) {
-    this.endDate = (event.target as HTMLInputElement & { value: string }).value;
-    this.selectedRange = 'custom';
+    void this.loadSummary();
   }
 
   private handleSearchQueryChange(event: Event) {
     this.searchQuery = (
       event.target as HTMLInputElement & { value: string }
     ).value;
-  }
-
-  private async applyCustomFilters() {
-    if (this.startDate && this.endDate && this.startDate > this.endDate) {
-      this.error = 'Start date must be earlier than end date.';
-      return;
+    // The search hits the server, so a keystroke is not a request: the page
+    // waits for a pause in typing.
+    if (this.searchDebounce) {
+      clearTimeout(this.searchDebounce);
     }
-
-    await this.loadSummary();
+    this.searchDebounce = setTimeout(() => {
+      this.searchDebounce = undefined;
+      void this.loadSummary();
+    }, 300);
   }
 
-  private async clearFilters() {
-    this.selectedRange = 'all';
-    this.startDate = '';
-    this.endDate = '';
-    await this.loadSummary();
+  /** The short form of the selected range, for stat labels ("$ est. · 30d"). */
+  private rangeChipLabel(): string {
+    return timeRangeShortLabel(this.selectedRange);
+  }
+
+  /**
+   * Which days the numbers cover, restated beside the control that chose
+   * them. The server's own window wins over the client's preset: what the
+   * page prints is what it was actually given.
+   */
+  private rangeWindowLabel(): string {
+    const requested = resolveTimeRange(this.selectedRange);
+    return formatTimeRangeWindow({
+      startDate: this.summary?.period_start ?? requested.startDate,
+      endDate: this.summary?.period_end ?? requested.endDate,
+    });
+  }
+
+  /**
+   * A delta in the Overview's form: an arrow, a percentage, and the window it
+   * is measured against. A dollar difference alone says nothing about whether
+   * spend doubled or moved a percent.
+   */
+  private spendComparisonDetail(): string {
+    const previousLabel = `prior ${this.rangeChipLabel()}`;
+    const current = this.summary?.estimated_cost ?? 0;
+    const previous = this.previousSummary?.estimated_cost ?? 0;
+    if (!previous || previous <= 0) {
+      return `No comparison for ${previousLabel}`;
+    }
+    const change = ((current - previous) / previous) * 100;
+    if (Math.abs(change) < 0.5) {
+      return `No change vs ${previousLabel}`;
+    }
+    const arrow = change > 0 ? '\u25b2' : '\u25bc';
+    return `${arrow} ${Math.abs(Math.round(change))}% vs ${previousLabel}`;
   }
 
   private formatNumber(value: number | null | undefined): string {
     return typeof value === 'number' ? value.toLocaleString() : '0';
+  }
+
+  /**
+   * Counts big enough to lose their shape are compact, as on the Overview and
+   * Cost ("821.3M"), with the exact figure kept in a title for anyone who
+   * needs every digit.
+   */
+  private formatCompactNumber(value: number | null | undefined): string {
+    const amount = Number(value || 0);
+    if (amount < 1000) return String(Math.round(amount));
+    return new Intl.NumberFormat(undefined, {
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(amount);
   }
 
   private formatPercent(value: number): string {
@@ -661,6 +732,19 @@ export class ApiUsageView extends LitElement {
     );
   }
 
+  /**
+   * A run id is a link, not a paragraph: a uuid shows its first 8 characters
+   * with the whole id in the title. An id that is already a short handle (a
+   * codex run key) is left alone, because truncating it would lose meaning.
+   */
+  private shortSourceId(id: string): string {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      id
+    )
+      ? shortExecutionId(id)
+      : id;
+  }
+
   private getRuntimeSessionHref(session: GatewayUsageBySession): string | null {
     return session.runtime_session_id
       ? `/console/runtime-sessions?sessionId=${session.runtime_session_id}`
@@ -692,7 +776,8 @@ export class ApiUsageView extends LitElement {
     label: string,
     value: string,
     detail: unknown,
-    icon: string
+    icon: string,
+    exact?: string
   ) {
     return html`
       <div class="stat-card">
@@ -700,7 +785,7 @@ export class ApiUsageView extends LitElement {
           <sl-icon name=${icon}></sl-icon>
           <span>${label}</span>
         </div>
-        <div class="stat-value">${value}</div>
+        <div class="stat-value" title=${exact ?? nothing}>${value}</div>
         <div class="stat-detail">${detail}</div>
       </div>
     `;
@@ -716,7 +801,7 @@ export class ApiUsageView extends LitElement {
         <div slot="header" class="section-header">
           <div class="section-title">
             <sl-icon name="cash-stack"></sl-icon>
-            <span>Budget Snapshot</span>
+            <span>Budget snapshot</span>
           </div>
           ${
             budget.hard_limit_exceeded
@@ -839,7 +924,7 @@ export class ApiUsageView extends LitElement {
         <div slot="header" class="section-header">
           <div class="section-title">
             <sl-icon name="speedometer2"></sl-icon>
-            <span>Rate Limits & Headroom</span>
+            <span>Rate limits and headroom</span>
           </div>
           ${
             hasHits
@@ -1099,44 +1184,34 @@ export class ApiUsageView extends LitElement {
     return html`
       <div class="session-list">
         <div class="session-header">
-          <div>Runtime Session</div>
+          <div>Runtime session</div>
           <div class="cell-numeric">Requests</div>
           <div class="cell-numeric">Tokens</div>
           <div class="cell-numeric">Cost</div>
-          <div>Last Activity</div>
+          <div>Last activity</div>
         </div>
         ${sortedSessions.map((session) => {
           const sourceType = this.getSessionSourceType(session);
           const sourceId = this.getSessionSourceId(session);
           const lastActivity = this.getSessionLastActivity(session);
           const flowBacked = this.isFlowBackedSession(session);
+          const sessionHref = this.getRuntimeSessionHref(session);
 
           return html`
             <div class="session-row">
               <div class="session-primary">
                 <div class="breakdown-name">
                   ${
-                    this.getRuntimeSessionHref(session)
-                      ? html`
-                          <a
-                            class="session-link"
-                            href=${this.getRuntimeSessionHref(session)!}
-                            >${this.getSessionDisplayName(session)}</a
-                          >
-                        `
+                    sessionHref
+                      ? html`<a class="session-link" href=${sessionHref}
+                          >${this.getSessionDisplayName(session)}</a
+                        >`
                       : this.getSessionDisplayName(session)
                   }
                 </div>
                 <div class="breakdown-secondary">
                   ${session.model_alias || 'Unknown model'}
-                  ${
-                    session.provider_name
-                      ? html`· ${session.provider_name}`
-                      : ''
-                  }
-                </div>
-                <div class="session-meta">
-                  Source: ${this.getSessionSourceLabel(sourceType)}
+                  ${session.provider_name ? `\u00b7 ${session.provider_name}` : ''}
                 </div>
                 ${
                   sourceId
@@ -1144,33 +1219,28 @@ export class ApiUsageView extends LitElement {
                         <div class="session-meta">
                           ${
                             flowBacked
-                              ? html`
-                                  Flow execution:
+                              ? html`Flow execution:
                                   <a
                                     class="session-link"
                                     href=${`/console/flows/executions/${sourceId}`}
-                                    >${sourceId}</a
-                                  >
-                                `
-                              : html` Source ID: <code>${sourceId}</code> `
+                                    title=${sourceId}
+                                    >${this.shortSourceId(sourceId)}</a
+                                  >`
+                              : html`${this.getSessionSourceLabel(sourceType)}
+                                  <code title=${sourceId}
+                                    >${this.shortSourceId(sourceId)}</code
+                                  >`
                           }
                         </div>
                       `
                     : ''
                 }
-                ${
-                  session.session_reference
-                    ? html`
-                        <div class="session-meta">
-                          Session reference:
-                          <code>${session.session_reference}</code>
-                        </div>
-                      `
-                    : ''
-                }
               </div>
-              <div class="cell-numeric">
-                ${this.formatNumber(session.request_count)}
+              <div
+                class="cell-numeric"
+                title=${this.formatNumber(session.request_count)}
+              >
+                ${this.formatCompactNumber(session.request_count)}
               </div>
               <div class="cell-numeric">
                 <token-figures
@@ -1263,31 +1333,34 @@ export class ApiUsageView extends LitElement {
   private renderSummary(summary: AccountGatewayUsageSummaryResponse) {
     const successRate = this.getSuccessRate(summary);
     const tokenUsage: GatewayTokenUsage = summary.token_usage;
+    const range = this.rangeChipLabel();
 
     return html`
-      <div class="stats-grid">
+      <div class="stats-grid" role="region" aria-label="Gateway usage totals">
         ${this.renderStatCard(
-          'Requests',
-          this.formatNumber(summary.total_requests),
+          `Requests \u00b7 ${range}`,
+          this.formatCompactNumber(summary.total_requests),
           `${this.formatNumber(summary.successful_requests)} succeeded, ${this.formatNumber(summary.failed_requests)} failed`,
-          'activity'
+          'activity',
+          this.formatNumber(summary.total_requests)
         )}
         ${this.renderStatCard(
-          'Estimated Cost',
+          `$ est. \u00b7 ${range}`,
           this.formatCost(summary.estimated_cost),
-          `${this.formatCost(summary.budget.current_spend_usd)} current spend`,
+          this.spendComparisonDetail(),
           'cash'
         )}
         ${this.renderStatCard(
-          'Total tokens',
-          this.formatNumber(tokenUsage.total_tokens),
+          `Tokens \u00b7 ${range}`,
+          this.formatCompactNumber(tokenUsage.total_tokens),
           html`<token-figures .usage=${tokenUsage} expanded></token-figures>`,
-          'cpu'
+          'cpu',
+          this.formatNumber(tokenUsage.total_tokens)
         )}
         ${this.renderStatCard(
-          'Success Rate',
+          `Success rate \u00b7 ${range}`,
           this.formatPercent(successRate),
-          `${this.formatDateTimeLabel(summary.period_start)} to ${this.formatDateTimeLabel(summary.period_end)}`,
+          `${this.formatNumber(summary.failed_requests)} failed`,
           'check2-circle'
         )}
       </div>
@@ -1296,77 +1369,30 @@ export class ApiUsageView extends LitElement {
 
   render() {
     return html`
-      <view-header headerText="API Usage" width="extra-wide"></view-header>
+      <view-header headerText="API usage" width="extra-wide"></view-header>
       <div class="column-layout dashboard extra-wide">
         <div class="main-column">
           <div class="page">
-            <sl-card class="filters-card">
-              <div slot="header" class="section-header">
-                <div class="section-title">
-                  <sl-icon name="funnel"></sl-icon>
-                  <span>Gateway Usage Filters</span>
-                </div>
-              </div>
-
-              <div class="filters-grid">
-                <sl-select
-                  label="Date range"
-                  value=${this.selectedRange}
-                  @sl-change=${this.handleRangeChange}
-                >
-                  <sl-option value="last-7">Last 7 days</sl-option>
-                  <sl-option value="last-30">Last 30 days</sl-option>
-                  <sl-option value="last-90">Last 90 days</sl-option>
-                  <sl-option value="all">All time</sl-option>
-                  <sl-option value="custom">Custom</sl-option>
-                </sl-select>
-
-                <sl-input
-                  type="date"
-                  label="Start date"
-                  .value=${this.startDate}
-                  @sl-change=${this.handleStartDateChange}
-                ></sl-input>
-
-                <sl-input
-                  type="date"
-                  label="End date"
-                  .value=${this.endDate}
-                  @sl-change=${this.handleEndDateChange}
-                ></sl-input>
-
-                <sl-input
-                  label="Conversation search"
-                  placeholder="Search captured prompts, outputs, or metadata"
-                  .value=${this.searchQuery}
-                  @sl-input=${this.handleSearchQueryChange}
-                ></sl-input>
-
-                <div class="filters-actions">
-                  <sl-button
-                    variant="primary"
-                    @click=${this.applyCustomFilters}
-                  >
-                    Apply
-                  </sl-button>
-                  <sl-button variant="default" @click=${this.clearFilters}>
-                    Reset
-                  </sl-button>
-                </div>
-              </div>
-
-              ${
-                this.summary
-                  ? html`
-                      <div class="period-caption">
-                        Showing gateway usage from
-                        ${this.formatDateTimeLabel(this.summary.period_start)}
-                        to ${this.formatDateTimeLabel(this.summary.period_end)}.
-                      </div>
-                    `
-                  : ''
-              }
-            </sl-card>
+            <div class="toolbar">
+              <time-range-select
+                ariaLabel="Gateway usage range"
+                .value=${this.selectedRange}
+                .options=${DATE_RANGE_OPTIONS}
+                @range-change=${this.handleRangeChange}
+              ></time-range-select>
+              <span class="range-window">${this.rangeWindowLabel()}</span>
+              <sl-input
+                class="usage-search"
+                label="Search captured interactions"
+                placeholder="Search prompts, outputs, or metadata"
+                clearable
+                .value=${this.searchQuery}
+                @sl-input=${this.handleSearchQueryChange}
+                @sl-clear=${this.handleSearchQueryChange}
+              >
+                <sl-icon name="search" slot="prefix"></sl-icon>
+              </sl-input>
+            </div>
 
             ${
               this.error
@@ -1382,10 +1408,15 @@ export class ApiUsageView extends LitElement {
                 : ''
             }
             ${
-              this.loading
+              this.loading && !this.summary
                 ? html`
                     <sl-card>
-                      <div class="loading-state">
+                      <div
+                        class="loading-state"
+                        role="status"
+                        aria-live="polite"
+                        aria-busy="true"
+                      >
                         <sl-spinner></sl-spinner>
                         <div>Loading gateway usage summary...</div>
                       </div>
@@ -1393,93 +1424,98 @@ export class ApiUsageView extends LitElement {
                   `
                 : this.summary
                   ? html`
-                      ${this.renderSummary(this.summary)}
+                      <div
+                        class="results ${this.loading ? 'is-updating' : ''}"
+                        aria-busy=${this.loading ? 'true' : 'false'}
+                      >
+                        ${this.renderSummary(this.summary)}
 
-                      <sl-card class="breakdown-card">
-                        <div slot="header" class="section-header">
-                          <div class="section-title">
-                            <sl-icon name="collection"></sl-icon>
-                            <span>Recent Runtime Sessions</span>
+                        <sl-card class="breakdown-card">
+                          <div slot="header" class="section-header">
+                            <div class="section-title">
+                              <sl-icon name="collection"></sl-icon>
+                              <span>Recent runtime sessions</span>
+                            </div>
+                            <span class="section-subtitle">
+                              Recent gateway activity grouped by runtime session
+                            </span>
                           </div>
-                          <span class="section-subtitle">
-                            Recent gateway activity grouped by runtime session
-                          </span>
-                        </div>
-                        ${this.renderSessionBreakdown(
-                          this.summary.usage_by_session
-                        )}
-                      </sl-card>
+                          ${this.renderSessionBreakdown(
+                            this.summary.usage_by_session
+                          )}
+                        </sl-card>
 
-                      <sl-card class="breakdown-card">
-                        <div slot="header" class="section-header">
-                          <div class="section-title">
-                            <sl-icon name="search"></sl-icon>
-                            <span>Captured Interactions</span>
+                        <sl-card class="breakdown-card">
+                          <div slot="header" class="section-header">
+                            <div class="section-title">
+                              <sl-icon name="search"></sl-icon>
+                              <span>Captured interactions</span>
+                            </div>
+                            <span class="section-subtitle">
+                              ${
+                                this.searchQuery.trim()
+                                  ? 'Search results from the indexed gateway corpus'
+                                  : 'Recent indexed gateway interactions'
+                              }
+                            </span>
                           </div>
-                          <span class="section-subtitle">
+                          ${this.renderSearchResults(this.searchResults)}
+                        </sl-card>
+
+                        <div class="content-grid">
+                          <div class="stack">
+                            <sl-card class="breakdown-card">
+                              <div slot="header" class="section-header">
+                                <div class="section-title">
+                                  <sl-icon name="bar-chart"></sl-icon>
+                                  <span>Daily activity</span>
+                                </div>
+                                <span class="section-subtitle">
+                                  Requests and spend over time
+                                </span>
+                              </div>
+                              ${this.renderDailyUsage(this.summary.requests_by_day)}
+                            </sl-card>
+
+                            <sl-card class="breakdown-card">
+                              <div slot="header" class="section-header">
+                                <div class="section-title">
+                                  <sl-icon name="cpu"></sl-icon>
+                                  <span>Usage by model</span>
+                                </div>
+                                <span class="section-subtitle">
+                                  Top models by cost and volume
+                                </span>
+                              </div>
+                              ${this.renderModelBreakdown(
+                                this.summary.usage_by_model
+                              )}
+                            </sl-card>
+                          </div>
+
+                          <div class="stack">
+                            ${this.renderBudgetCard(this.summary)}
                             ${
-                              this.searchQuery.trim()
-                                ? 'Search results from the indexed gateway corpus'
-                                : 'Recent indexed gateway interactions'
+                              this.rateLimitReport
+                                ? this.renderRateLimitCard(this.rateLimitReport)
+                                : ''
                             }
-                          </span>
-                        </div>
-                        ${this.renderSearchResults(this.searchResults)}
-                      </sl-card>
 
-                      <div class="content-grid">
-                        <div class="stack">
-                          <sl-card class="breakdown-card">
-                            <div slot="header" class="section-header">
-                              <div class="section-title">
-                                <sl-icon name="bar-chart"></sl-icon>
-                                <span>Daily Activity</span>
+                            <sl-card class="breakdown-card">
+                              <div slot="header" class="section-header">
+                                <div class="section-title">
+                                  <sl-icon name="diagram-3"></sl-icon>
+                                  <span>Usage by flow</span>
+                                </div>
+                                <span class="section-subtitle">
+                                  Flow-level gateway consumption
+                                </span>
                               </div>
-                              <span class="section-subtitle">
-                                Requests and spend over time
-                              </span>
-                            </div>
-                            ${this.renderDailyUsage(this.summary.requests_by_day)}
-                          </sl-card>
-
-                          <sl-card class="breakdown-card">
-                            <div slot="header" class="section-header">
-                              <div class="section-title">
-                                <sl-icon name="cpu"></sl-icon>
-                                <span>Usage By Model</span>
-                              </div>
-                              <span class="section-subtitle">
-                                Top models by cost and volume
-                              </span>
-                            </div>
-                            ${this.renderModelBreakdown(
-                              this.summary.usage_by_model
-                            )}
-                          </sl-card>
-                        </div>
-
-                        <div class="stack">
-                          ${this.renderBudgetCard(this.summary)}
-                          ${
-                            this.rateLimitReport
-                              ? this.renderRateLimitCard(this.rateLimitReport)
-                              : ''
-                          }
-
-                          <sl-card class="breakdown-card">
-                            <div slot="header" class="section-header">
-                              <div class="section-title">
-                                <sl-icon name="diagram-3"></sl-icon>
-                                <span>Usage By Flow</span>
-                              </div>
-                              <span class="section-subtitle">
-                                Flow-level gateway consumption
-                              </span>
-                            </div>
-                            ${this.renderFlowBreakdown(
-                              this.summary.usage_by_flow
-                            )}
-                          </sl-card>
+                              ${this.renderFlowBreakdown(
+                                this.summary.usage_by_flow
+                              )}
+                            </sl-card>
+                          </div>
                         </div>
                       </div>
                     `

--- a/frontend/src/views/authed/api-usage-view.ts
+++ b/frontend/src/views/authed/api-usage-view.ts
@@ -83,6 +83,14 @@ export class ApiUsageView extends LitElement {
   @state()
   private searchQuery = '';
 
+  // The search is its own request against its own card, so it has its own
+  // busy flag and its own error rather than blanking the page's numbers.
+  @state()
+  private searchLoading = false;
+
+  @state()
+  private searchError: string | null = null;
+
   private initialized = false;
 
   private searchDebounce?: ReturnType<typeof setTimeout>;
@@ -153,8 +161,10 @@ export class ApiUsageView extends LitElement {
       }
 
       /* A range change never blanks answers the page already has: they stay
-         readable at 60% until the new ones arrive. */
-      .results.is-updating {
+         readable at 60% until the new ones arrive. A search does the same to
+         the one card it changes. */
+      .results.is-updating,
+      .breakdown-card.is-updating {
         opacity: 0.6;
         pointer-events: none;
       }
@@ -497,24 +507,30 @@ export class ApiUsageView extends LitElement {
     super.disconnectedCallback();
   }
 
+  /** The selected window, in the shape the gateway endpoints take. */
+  private rangeParams(): GatewayUsageSummaryParams {
+    const range = resolveTimeRange(this.selectedRange);
+    const params: GatewayUsageSummaryParams = {};
+
+    if (range.startDate) {
+      params.startDate = range.startDate;
+    }
+
+    if (range.endDate) {
+      params.endDate = range.endDate;
+    }
+
+    return params;
+  }
+
   private async loadSummary() {
     this.loading = true;
     this.error = null;
 
-    const range = resolveTimeRange(this.selectedRange);
     const previousRange = resolvePreviousTimeRange(this.selectedRange);
 
     try {
-      const params: GatewayUsageSummaryParams = {};
-
-      if (range.startDate) {
-        params.startDate = range.startDate;
-      }
-
-      if (range.endDate) {
-        params.endDate = range.endDate;
-      }
-
+      const params = this.rangeParams();
       const searchQuery = this.searchQuery.trim();
       const [summary, searchResults, rateLimitReport, previousSummary] =
         await Promise.all([
@@ -543,6 +559,7 @@ export class ApiUsageView extends LitElement {
         ]);
       this.summary = summary;
       this.searchResults = searchResults;
+      this.searchError = null;
       this.rateLimitReport = rateLimitReport;
       this.previousSummary = previousSummary;
     } catch (error) {
@@ -570,6 +587,36 @@ export class ApiUsageView extends LitElement {
     void this.loadSummary();
   }
 
+  /**
+   * Only the captured interactions depend on the query, so a pause in typing
+   * is one request. Reloading the page would cost four (summary with
+   * breakdowns, search, the rate-limit report and the comparison window) to
+   * change one list.
+   */
+  private async loadSearchResults() {
+    this.searchLoading = true;
+
+    try {
+      this.searchResults = await getAccountGatewayUsageSearch({
+        ...this.rangeParams(),
+        query: this.searchQuery.trim() || undefined,
+        limit: 10,
+      });
+      this.searchError = null;
+    } catch (error) {
+      console.error('Failed to search captured gateway interactions:', error);
+      // A failed search says so where the results would be; the numbers above
+      // it are still true and stay on screen.
+      this.searchError =
+        error instanceof Error
+          ? error.message
+          : 'Failed to search captured interactions';
+      this.searchResults = null;
+    } finally {
+      this.searchLoading = false;
+    }
+  }
+
   private handleSearchQueryChange(event: Event) {
     this.searchQuery = (
       event.target as HTMLInputElement & { value: string }
@@ -581,7 +628,7 @@ export class ApiUsageView extends LitElement {
     }
     this.searchDebounce = setTimeout(() => {
       this.searchDebounce = undefined;
-      void this.loadSummary();
+      void this.loadSearchResults();
     }, 300);
   }
 
@@ -1268,6 +1315,15 @@ export class ApiUsageView extends LitElement {
   private renderSearchResults(
     results: AccountGatewayUsageSearchResponse | null
   ) {
+    if (this.searchError) {
+      return html`
+        <div class="empty-state" role="alert">
+          <sl-icon name="exclamation-triangle"></sl-icon>
+          <div>${this.searchError}</div>
+        </div>
+      `;
+    }
+
     if (!results || results.items.length === 0) {
       return html`
         <div class="empty-state">
@@ -1445,7 +1501,12 @@ export class ApiUsageView extends LitElement {
                           )}
                         </sl-card>
 
-                        <sl-card class="breakdown-card">
+                        <sl-card
+                          class="breakdown-card ${
+                            this.searchLoading ? 'is-updating' : ''
+                          }"
+                          aria-busy=${this.searchLoading ? 'true' : 'false'}
+                        >
                           <div slot="header" class="section-header">
                             <div class="section-title">
                               <sl-icon name="search"></sl-icon>

--- a/frontend/src/views/authed/cost-view.ts
+++ b/frontend/src/views/authed/cost-view.ts
@@ -33,6 +33,11 @@ import type {
   ProviderBillingConnection,
 } from '../../types';
 import consoleStyles from '../../styles/console-styles.css?inline';
+import {
+  resolvePreviousTimeRange,
+  resolveTimeRange,
+  timeRangeShortLabel,
+} from '../../utils/time-range';
 import '../../components/view-header.ts';
 import '../../components/time-range-select.ts';
 import '../../components/budget-policy-editor.ts';
@@ -587,75 +592,25 @@ export class CostView extends AuthedElement {
     window.localStorage.setItem(COST_DATE_RANGE_STORAGE_KEY, value);
   }
 
+  /**
+   * Cost asks the shared range math, so its "30d" is the same 30 days the
+   * Overview, API usage and the model detail page ask for.
+   */
   private getDateParams(
     range: DateRangePreset = this.selectedRange
   ): DateRangeParams {
-    const now = new Date();
-    const start = new Date(now);
-    const end = new Date(now);
-    if (range === 'today') {
-      start.setHours(0, 0, 0, 0);
-    } else if (range === 'this-week') {
-      const day = start.getDay();
-      const daysSinceMonday = (day + 6) % 7;
-      start.setDate(start.getDate() - daysSinceMonday);
-      start.setHours(0, 0, 0, 0);
-    } else if (range === 'this-month') {
-      start.setDate(1);
-      start.setHours(0, 0, 0, 0);
-    } else if (range === 'last-month') {
-      start.setMonth(now.getMonth() - 1, 1);
-      start.setHours(0, 0, 0, 0);
-      end.setDate(1);
-      end.setHours(0, 0, 0, 0);
-    } else {
-      const days = range === 'last-7' ? 7 : range === 'last-90' ? 90 : 30;
-      start.setDate(now.getDate() - days);
-    }
+    const window = resolveTimeRange(range);
     return {
-      startDate: start.toISOString(),
-      endDate: end.toISOString(),
+      startDate: window.startDate as string,
+      endDate: window.endDate as string,
     };
   }
 
   private getPreviousDateParams(range: DateRangePreset): DateRangeParams {
-    const current = this.getDateParams(range);
-    const start = new Date(current.startDate);
-    const end = new Date(current.endDate);
-    if (range === 'today') {
-      const durationMs = end.getTime() - start.getTime();
-      const previousStart = new Date(start);
-      previousStart.setDate(previousStart.getDate() - 1);
-      const previousEnd = new Date(previousStart.getTime() + durationMs);
-      return {
-        startDate: previousStart.toISOString(),
-        endDate: previousEnd.toISOString(),
-      };
-    }
-    if (range === 'this-week') {
-      const previousEnd = new Date(start);
-      const previousStart = new Date(start);
-      previousStart.setDate(previousStart.getDate() - 7);
-      return {
-        startDate: previousStart.toISOString(),
-        endDate: previousEnd.toISOString(),
-      };
-    }
-    if (range === 'this-month' || range === 'last-month') {
-      const previousStart = new Date(start);
-      previousStart.setMonth(previousStart.getMonth() - 1, 1);
-      const previousEnd = new Date(start);
-      return {
-        startDate: previousStart.toISOString(),
-        endDate: previousEnd.toISOString(),
-      };
-    }
-    const durationMs = end.getTime() - start.getTime();
-    const previousEnd = start;
-    const previousStart = new Date(previousEnd.getTime() - durationMs);
+    const window = resolvePreviousTimeRange(range);
     return {
-      startDate: previousStart.toISOString(),
-      endDate: previousEnd.toISOString(),
+      startDate: window.startDate as string,
+      endDate: window.endDate as string,
     };
   }
 
@@ -1056,10 +1011,7 @@ export class CostView extends AuthedElement {
    * The short form of the selected range, for stat labels ("$ est. · 30d").
    */
   private rangeChipLabel(): string {
-    const option = DATE_RANGE_OPTIONS.find(
-      (item) => item.value === this.selectedRange
-    );
-    return (option?.label || '30d').toLowerCase();
+    return timeRangeShortLabel(this.selectedRange);
   }
 
   /**

--- a/frontend/src/views/authed/dashboard-control-plane-view.ts
+++ b/frontend/src/views/authed/dashboard-control-plane-view.ts
@@ -95,6 +95,7 @@ import type {
   InventoryUserRow,
 } from '../../components/inventory-card';
 import consoleStyles from '../../styles/console-styles.css?inline';
+import { resolveTimeRange } from '../../utils/time-range';
 import { reducedMotionStyles } from '../../styles/reduced-motion';
 
 /**
@@ -1991,26 +1992,18 @@ export class DashboardView extends AuthedElement {
     this.scheduleCacheWrite();
   }
 
+  /**
+   * The lower bound of the window the Usage card is showing. The math is
+   * shared with Cost, API usage and the model detail page (`utils/time-range`)
+   * so the same nominal "30d" is the same 30 days everywhere: this page used
+   * to step back one calendar month, which is 28 to 31 days depending on the
+   * date, and its totals disagreed with its siblings.
+   */
   private getGatewayStartDate(): string {
-    const now = new Date();
-    if (this.gatewayTimeRange === 'day') {
-      const d = new Date(now);
-      d.setDate(d.getDate() - 1);
-      return d.toISOString();
-    }
-    if (this.gatewayTimeRange === 'week') {
-      const d = new Date(now);
-      d.setDate(d.getDate() - 7);
-      return d.toISOString();
-    }
-    if (this.gatewayTimeRange === 'year') {
-      const d = new Date(now);
-      d.setFullYear(d.getFullYear() - 1);
-      return d.toISOString();
-    }
-    const d = new Date(now);
-    d.setMonth(d.getMonth() - 1);
-    return d.toISOString();
+    return (
+      resolveTimeRange(this.gatewayTimeRange).startDate ??
+      new Date().toISOString()
+    );
   }
 
   /** The same boundary as `getGatewayStartDate()`, as epoch milliseconds. */

--- a/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
@@ -1082,6 +1082,54 @@ describe('AIModelDetailView', () => {
     ).to.be.false;
   });
 
+  // A range change that lands during the 250 ms realtime refresh used to be
+  // dropped, leaving the control naming a window nobody fetched.
+  it('runs a range change that arrives while a refresh is in flight', async () => {
+    const element = (await fixture(
+      html`<ai-model-detail-view .modelId=${'model-1'}></ai-model-detail-view>`
+    )) as AIModelDetailView;
+
+    await waitUntil(
+      () => !(element as any).loading,
+      'AI model detail view did not finish loading',
+      { timeout: 5000 }
+    );
+    await element.updateComplete;
+
+    const summaryCalls = () =>
+      fetchStub
+        .getCalls()
+        .map((call) => String(call.args[0]))
+        .filter((url) => url.startsWith('/api/v1/ai-models/model-1/summary'));
+    const before = summaryCalls().length;
+
+    // A background refresh takes the lock, then the operator picks 24h.
+    void (element as any).loadData({ preserveLoadingState: true });
+    (element as any).selectedRange = 'last-24h';
+    void (element as any).loadData({
+      preserveLoadingState: true,
+      markUpdating: true,
+    });
+
+    await waitUntil(
+      () => summaryCalls().length >= before + 2,
+      'the queued range change never ran',
+      { timeout: 5000 }
+    );
+    await waitUntil(
+      () => !(element as any).refreshInFlight,
+      'the reloads never settled',
+      { timeout: 5000 }
+    );
+
+    const last = summaryCalls()[summaryCalls().length - 1];
+    const query = new URLSearchParams(last.split('?')[1] || '');
+    const start = new Date(query.get('start_date') || '');
+    const end = new Date(query.get('end_date') || '');
+    const spanDays = (end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000);
+    expect(Math.abs(spanDays - 1)).to.be.below(0.01);
+  });
+
   // "All time" survived the Filters card here too.
   it('offers All time and asks for it without date bounds', async () => {
     const element = (await fixture(

--- a/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
@@ -985,4 +985,52 @@ describe('AIModelDetailView', () => {
       'Prices must be zero or more.'
     );
   });
+  it('carries the shared range control instead of a Filters card', async () => {
+    const element = (await fixture(
+      html`<ai-model-detail-view .modelId=${'model-1'}></ai-model-detail-view>`
+    )) as AIModelDetailView;
+
+    await waitUntil(
+      () => !(element as any).loading,
+      'AI model detail view did not finish loading',
+      { timeout: 5000 }
+    );
+    await element.updateComplete;
+
+    // One range vocabulary, shared with the Overview, Cost and API usage.
+    const range = element.shadowRoot?.querySelector('time-range-select');
+    expect(range).to.exist;
+    expect((range as any).value).to.equal('last-30');
+    expect(
+      element.shadowRoot?.querySelector('sl-select[label="Date range"]')
+    ).to.equal(null);
+    expect(element.shadowRoot?.querySelector('sl-input[type="date"]')).to.equal(
+      null
+    );
+
+    const content = element.shadowRoot?.textContent || '';
+    expect(content).to.not.contain('Filters');
+    expect(content).to.not.contain('Showing model-scoped activity from');
+
+    // The window is restated beside the control that chose it.
+    const window = element.shadowRoot
+      ?.querySelector('.range-window')
+      ?.textContent?.trim();
+    expect(window).to.contain(' to ');
+
+    // The window on the wire is the shared 30 days, not 30 local calendar
+    // days ending tonight.
+    const summaryCall = fetchStub
+      .getCalls()
+      .find((call) =>
+        String(call.args[0]).startsWith('/api/v1/ai-models/model-1/summary')
+      );
+    const query = new URLSearchParams(
+      String(summaryCall?.args[0]).split('?')[1] || ''
+    );
+    const start = new Date(query.get('start_date') || '');
+    const end = new Date(query.get('end_date') || '');
+    const spanDays = (end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000);
+    expect(Math.abs(spanDays - 30)).to.be.below(0.01);
+  });
 });

--- a/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
@@ -1082,6 +1082,51 @@ describe('AIModelDetailView', () => {
     ).to.be.false;
   });
 
+  // "All time" survived the Filters card here too.
+  it('offers All time and asks for it without date bounds', async () => {
+    const element = (await fixture(
+      html`<ai-model-detail-view .modelId=${'model-1'}></ai-model-detail-view>`
+    )) as AIModelDetailView;
+
+    await waitUntil(
+      () => !(element as any).loading,
+      'AI model detail view did not finish loading',
+      { timeout: 5000 }
+    );
+    await element.updateComplete;
+
+    const range = element.shadowRoot?.querySelector('time-range-select');
+    expect(
+      ((range as any).options as { value: string; label: string }[]).map(
+        (option) => option.value
+      )
+    ).to.contain('all');
+
+    const summaryCalls = () =>
+      fetchStub
+        .getCalls()
+        .map((call) => String(call.args[0]))
+        .filter((url) => url.startsWith('/api/v1/ai-models/model-1/summary'));
+    const before = summaryCalls().length;
+
+    range?.dispatchEvent(
+      new CustomEvent('range-change', {
+        detail: { value: 'all' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await waitUntil(
+      () => summaryCalls().length > before,
+      'the All time reload never reached the server',
+      { timeout: 3000 }
+    );
+
+    const url = summaryCalls().slice(before)[0];
+    expect(url).to.not.contain('start_date=');
+    expect(url).to.not.contain('end_date=');
+  });
+
   // Only the captured interactions depend on the query, so a pause in typing
   // costs one request, not the five the whole page costs.
   it('spends one request on an interaction search and shows the results', async () => {

--- a/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
@@ -1081,4 +1081,56 @@ describe('AIModelDetailView', () => {
         ?.classList.contains('is-updating')
     ).to.be.false;
   });
+
+  // Only the captured interactions depend on the query, so a pause in typing
+  // costs one request, not the five the whole page costs.
+  it('spends one request on an interaction search and shows the results', async () => {
+    const element = (await fixture(
+      html`<ai-model-detail-view .modelId=${'model-1'}></ai-model-detail-view>`
+    )) as AIModelDetailView;
+
+    await waitUntil(
+      () => !(element as any).loading,
+      'AI model detail view did not finish loading',
+      { timeout: 5000 }
+    );
+    await element.updateComplete;
+
+    // The search field promises a list, so the list is on the page.
+    expect(element.shadowRoot?.textContent).to.contain('Captured interactions');
+
+    // Icons are fetched too; only the API calls are counted here.
+    const apiCalls = () =>
+      fetchStub
+        .getCalls()
+        .map((call) => String(call.args[0]))
+        .filter((url) => url.startsWith('/api/'));
+    const callsAfterLoad = apiCalls().length;
+
+    const search = element.shadowRoot?.querySelector(
+      'sl-input.interaction-search'
+    ) as HTMLInputElement;
+    search.value = 'timeout';
+    search.dispatchEvent(new CustomEvent('sl-input', { bubbles: true }));
+
+    await waitUntil(
+      () => apiCalls().length > callsAfterLoad,
+      'the debounced search never reached the server',
+      { timeout: 3000 }
+    );
+    await waitUntil(
+      () => !(element as any).interactionsLoading,
+      'the search never settled',
+      { timeout: 3000 }
+    );
+    await element.updateComplete;
+
+    const newCalls = apiCalls().slice(callsAfterLoad);
+    expect(newCalls).to.have.length(1);
+    expect(newCalls[0]).to.contain('/api/v1/ai-models/model-1/interactions');
+    expect(newCalls[0]).to.contain('query=timeout');
+
+    // The summary the search did not touch is still on screen.
+    expect(element.shadowRoot?.textContent).to.contain('Usage summary');
+  });
 });

--- a/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.test.ts
@@ -1033,4 +1033,52 @@ describe('AIModelDetailView', () => {
     const spanDays = (end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000);
     expect(Math.abs(spanDays - 30)).to.be.below(0.01);
   });
+
+  // A range change is a refinement, not a new page: the answers it is
+  // replacing stay readable, the way API usage and Cost behave.
+  it('keeps the previous numbers on screen while a new range loads', async () => {
+    const element = (await fixture(
+      html`<ai-model-detail-view .modelId=${'model-1'}></ai-model-detail-view>`
+    )) as AIModelDetailView;
+
+    await waitUntil(
+      () => !(element as any).loading,
+      'AI model detail view did not finish loading',
+      { timeout: 5000 }
+    );
+    await element.updateComplete;
+
+    const range = element.shadowRoot?.querySelector('time-range-select');
+    range?.dispatchEvent(
+      new CustomEvent('range-change', {
+        detail: { value: 'last-7' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await element.updateComplete;
+
+    // No spinner card: the usage summary and the session observer are still
+    // there, dimmed and marked busy.
+    expect((element as any).updating, 'the reload is marked as an update').to.be
+      .true;
+    expect(element.shadowRoot?.querySelector('.loading-state')).to.equal(null);
+    const results = element.shadowRoot?.querySelector('.results');
+    expect(results, 'the answers stay mounted').to.exist;
+    expect(results?.classList.contains('is-updating')).to.be.true;
+    expect(results?.getAttribute('aria-busy')).to.equal('true');
+    expect(results?.textContent).to.contain('Usage summary');
+
+    await waitUntil(
+      () => !(element as any).updating,
+      'the range reload never settled',
+      { timeout: 5000 }
+    );
+    await element.updateComplete;
+    expect(
+      element.shadowRoot
+        ?.querySelector('.results')
+        ?.classList.contains('is-updating')
+    ).to.be.false;
+  });
 });

--- a/frontend/src/views/authed/settings/ai-model-detail-view.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.ts
@@ -118,6 +118,14 @@ export class AIModelDetailView extends LitElement {
   @state()
   private interactionQuery = '';
 
+  // The interaction search is one request against one card, so it carries its
+  // own busy flag and its own error instead of reloading the page.
+  @state()
+  private interactionsLoading = false;
+
+  @state()
+  private interactionsError: string | null = null;
+
   @state()
   private validationPrompt =
     'Welcome to Preloop. Reply with a short acknowledgement.';
@@ -223,8 +231,10 @@ export class AIModelDetailView extends LitElement {
 
       /* A range change never blanks answers the page already has: they stay
          readable at 60% until the new ones arrive, the way API usage and Cost
-         behave. Only the very first load shows a spinner. */
-      .results.is-updating {
+         behave. Only the very first load shows a spinner, and a search dims
+         only the card it changes. */
+      .results.is-updating,
+      sl-card.is-updating {
         opacity: 0.6;
         pointer-events: none;
       }
@@ -727,6 +737,7 @@ export class AIModelDetailView extends LitElement {
       this.summary = summary;
       this.sessions = sessions;
       this.interactions = interactions;
+      this.interactionsError = null;
     } catch (error) {
       this.error =
         error instanceof Error
@@ -786,8 +797,38 @@ export class AIModelDetailView extends LitElement {
     }
     this.interactionSearchDebounce = setTimeout(() => {
       this.interactionSearchDebounce = undefined;
-      void this.loadData({ preserveLoadingState: true, markUpdating: true });
+      void this.loadInteractions();
     }, 300);
+  }
+
+  /**
+   * Only the captured interactions depend on the query, so a pause in typing
+   * is one request. Reloading the page would cost five (the model, its price,
+   * the summary, the sessions and the search) to change one list.
+   */
+  private async loadInteractions() {
+    if (!this.modelId) {
+      return;
+    }
+    this.interactionsLoading = true;
+
+    try {
+      this.interactions = await getAIModelGatewayUsageSearch(this.modelId, {
+        ...this.buildSummaryParams(),
+        query: this.interactionQuery.trim() || undefined,
+        limit: 10,
+      });
+      this.interactionsError = null;
+    } catch (error) {
+      console.error('Failed to search captured model interactions:', error);
+      this.interactionsError =
+        error instanceof Error
+          ? error.message
+          : 'Failed to search captured interactions';
+      this.interactions = null;
+    } finally {
+      this.interactionsLoading = false;
+    }
   }
 
   /**
@@ -1526,6 +1567,15 @@ export class AIModelDetailView extends LitElement {
   }
 
   private renderInteractions() {
+    if (this.interactionsError) {
+      return html`
+        <div class="empty-state" role="alert">
+          <sl-icon name="exclamation-triangle"></sl-icon>
+          <div>${this.interactionsError}</div>
+        </div>
+      `;
+    }
+
     if (!this.interactions || this.interactions.items.length === 0) {
       return html`
         <div class="empty-state">
@@ -2214,6 +2264,19 @@ export class AIModelDetailView extends LitElement {
                             auditLinks: true,
                           }}
                         ></preloop-session-observer>
+                      </sl-card>
+
+                      <!-- The toolbar's search field narrows this list, so
+                           the list has to be on the page: before this it was
+                           fetched on every load and never rendered. -->
+                      <sl-card
+                        class="${this.interactionsLoading ? 'is-updating' : ''}"
+                        aria-busy=${this.interactionsLoading ? 'true' : 'false'}
+                      >
+                        <div slot="header" class="model-title">
+                          Captured interactions
+                        </div>
+                        ${this.renderInteractions()}
                       </sl-card>
                     </div>
                   `

--- a/frontend/src/views/authed/settings/ai-model-detail-view.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.ts
@@ -100,6 +100,15 @@ export class AIModelDetailView extends LitElement {
   @state()
   private loading = true;
 
+  /**
+   * A reload the operator asked for (a new range, a new search) dims the
+   * answers it is about to replace instead of blanking the page; the 250 ms
+   * realtime refresh does neither, because a page that dims itself twice a
+   * second is unreadable.
+   */
+  @state()
+  private updating = false;
+
   @state()
   private error: string | null = null;
 
@@ -198,6 +207,7 @@ export class AIModelDetailView extends LitElement {
 
       .page,
       .stack,
+      .results,
       .daily-list,
       .session-list,
       .interaction-list {
@@ -206,8 +216,17 @@ export class AIModelDetailView extends LitElement {
       }
 
       .page,
-      .stack {
+      .stack,
+      .results {
         gap: var(--sl-spacing-large);
+      }
+
+      /* A range change never blanks answers the page already has: they stay
+         readable at 60% until the new ones arrive, the way API usage and Cost
+         behave. Only the very first load shows a spinner. */
+      .results.is-updating {
+        opacity: 0.6;
+        pointer-events: none;
       }
 
       .price-grid {
@@ -652,7 +671,9 @@ export class AIModelDetailView extends LitElement {
     }, 250);
   }
 
-  private async loadData(options: { preserveLoadingState?: boolean } = {}) {
+  private async loadData(
+    options: { preserveLoadingState?: boolean; markUpdating?: boolean } = {}
+  ) {
     if (!this.modelId) {
       this.error = 'Missing AI model id.';
       this.loading = false;
@@ -666,6 +687,9 @@ export class AIModelDetailView extends LitElement {
     if (!options.preserveLoadingState) {
       this.loading = true;
     }
+    if (options.markUpdating) {
+      this.updating = true;
+    }
     this.error = null;
 
     try {
@@ -678,6 +702,8 @@ export class AIModelDetailView extends LitElement {
       this.sessions = null;
       this.interactions = null;
       this.loading = false;
+      this.updating = false;
+      this.refreshInFlight = false;
       return;
     }
 
@@ -711,6 +737,7 @@ export class AIModelDetailView extends LitElement {
       this.interactions = null;
     } finally {
       this.loading = false;
+      this.updating = false;
       this.refreshInFlight = false;
     }
   }
@@ -743,7 +770,9 @@ export class AIModelDetailView extends LitElement {
       return;
     }
     this.selectedRange = value;
-    void this.loadData();
+    // The numbers on screen stay readable while the new window loads; only a
+    // page that has nothing to show yet gets a spinner.
+    void this.loadData({ preserveLoadingState: true, markUpdating: true });
   }
 
   private handleInteractionQueryChange(event: Event) {
@@ -757,7 +786,7 @@ export class AIModelDetailView extends LitElement {
     }
     this.interactionSearchDebounce = setTimeout(() => {
       this.interactionSearchDebounce = undefined;
-      void this.loadData();
+      void this.loadData({ preserveLoadingState: true, markUpdating: true });
     }, 300);
   }
 
@@ -2133,50 +2162,60 @@ export class AIModelDetailView extends LitElement {
                 : ''
             }
             ${
-              this.loading
+              this.loading && !this.summary
                 ? html`
                     <sl-card>
-                      <div class="loading-state">
+                      <div
+                        class="loading-state"
+                        role="status"
+                        aria-live="polite"
+                        aria-busy="true"
+                      >
                         <sl-spinner></sl-spinner>
                         <div>Loading AI model observability...</div>
                       </div>
                     </sl-card>
                   `
                 : html`
-                    <sl-card>
-                      <div slot="header" class="model-heading">
-                        <div class="model-title">Usage summary</div>
-                        ${
-                          this.trackedPeriodLabel
-                            ? html`<div class="meta-line">
-                                ${this.trackedPeriodLabel}
-                              </div>`
-                            : ''
-                        }
-                      </div>
-                      ${this.renderSummarySection()}
-                    </sl-card>
+                    <div
+                      class="results ${this.updating ? 'is-updating' : ''}"
+                      aria-busy=${this.updating ? 'true' : 'false'}
+                    >
+                      <sl-card>
+                        <div slot="header" class="model-heading">
+                          <div class="model-title">Usage summary</div>
+                          ${
+                            this.trackedPeriodLabel
+                              ? html`<div class="meta-line">
+                                  ${this.trackedPeriodLabel}
+                                </div>`
+                              : ''
+                          }
+                        </div>
+                        ${this.renderSummarySection()}
+                      </sl-card>
 
-                    <sl-card>
-                      <div slot="header" class="model-title">
-                        Session Observer
-                      </div>
-                      <div class="meta-line" style="margin-bottom: 0.75rem;">
-                        Recent sessions, replay, cost breakdown, and
-                        optimization suggestions scoped to this model.
-                      </div>
-                      <preloop-session-observer
-                        scope="ai_model"
-                        .scopeId=${this.modelId}
-                        .sessions=${this.sessions?.items || []}
-                        layout="embedded"
-                        defaultReplayMode="timeline"
-                        .features=${{
-                          summaries: true,
-                          auditLinks: true,
-                        }}
-                      ></preloop-session-observer>
-                    </sl-card>
+                      <sl-card>
+                        <div slot="header" class="model-title">
+                          Session Observer
+                        </div>
+                        <div class="meta-line" style="margin-bottom: 0.75rem;">
+                          Recent sessions, replay, cost breakdown, and
+                          optimization suggestions scoped to this model.
+                        </div>
+                        <preloop-session-observer
+                          scope="ai_model"
+                          .scopeId=${this.modelId}
+                          .sessions=${this.sessions?.items || []}
+                          layout="embedded"
+                          defaultReplayMode="timeline"
+                          .features=${{
+                            summaries: true,
+                            auditLinks: true,
+                          }}
+                        ></preloop-session-observer>
+                      </sl-card>
+                    </div>
                   `
             }
           </div>

--- a/frontend/src/views/authed/settings/ai-model-detail-view.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.ts
@@ -14,6 +14,7 @@ import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
 import '../../../components/view-header.ts';
+import '../../../components/time-range-select.ts';
 import '../../../components/resource-actions.ts';
 import '../../../components/budget-policy-editor.ts';
 import '../../../components/preloop-session-observer.ts';
@@ -48,9 +49,22 @@ import type {
 } from '../../../types';
 import { unifiedWebSocketManager } from '../../../services/unified-websocket-manager';
 import consoleStyles from '../../../styles/console-styles.css?inline';
+import {
+  formatTimeRangeWindow,
+  resolveTimeRange,
+  type TimeRangeKey,
+} from '../../../utils/time-range';
 import { consoleDialogStyles } from '../../../styles/console-dialog';
 
-type DateRangePreset = 'last-7' | 'last-30' | 'last-90' | 'all' | 'custom';
+// The one range control, with the same vocabulary as the Overview, Cost and
+// API usage, and the window resolved by the same shared math so "30d" means
+// the same 30 days on all four pages.
+const DATE_RANGE_OPTIONS: Array<{ value: TimeRangeKey; label: string }> = [
+  { value: 'last-24h', label: '24h' },
+  { value: 'last-7', label: '7d' },
+  { value: 'last-30', label: '30d' },
+  { value: 'last-365', label: '1y' },
+];
 
 type PriceField =
   'input' | 'output' | 'cachedInput' | 'request' | 'effectiveFrom';
@@ -90,13 +104,7 @@ export class AIModelDetailView extends LitElement {
   private error: string | null = null;
 
   @state()
-  private selectedRange: DateRangePreset = 'last-30';
-
-  @state()
-  private startDate = '';
-
-  @state()
-  private endDate = '';
+  private selectedRange: TimeRangeKey = 'last-30';
 
   @state()
   private interactionQuery = '';
@@ -178,6 +186,7 @@ export class AIModelDetailView extends LitElement {
   private unsubscribeRealtime?: () => void;
   private refreshTimer: number | null = null;
   private refreshInFlight = false;
+  private interactionSearchDebounce?: ReturnType<typeof setTimeout>;
 
   static styles = [
     consoleDialogStyles,
@@ -273,7 +282,6 @@ export class AIModelDetailView extends LitElement {
         margin-top: var(--sl-spacing-small);
       }
 
-      .filters-grid,
       .interaction-toolbar {
         display: flex;
         gap: var(--sl-spacing-medium);
@@ -281,20 +289,49 @@ export class AIModelDetailView extends LitElement {
         align-items: end;
       }
 
-      .filters-grid sl-select,
-      .filters-grid sl-input,
-      .interaction-toolbar sl-input {
-        min-width: 180px;
-      }
-
       .interaction-toolbar sl-input {
         min-width: 280px;
       }
 
-      .filters-actions {
+      /* One range control, the window it resolved to, and the search that
+         narrows the captured interactions. No Apply: the page answers as the
+         controls change. */
+      .toolbar {
         display: flex;
-        gap: var(--sl-spacing-small);
+        gap: var(--sl-spacing-medium);
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .toolbar time-range-select {
+        --time-range-select-width: 110px;
+      }
+
+      /* The window the numbers cover, restated beside the control that chose
+         it, because the sibling usage pages used to disagree about "30 days". */
+      .range-window {
+        color: var(--sl-color-neutral-600);
+        font-size: var(--sl-font-size-small);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .interaction-search {
+        flex: 1 1 260px;
+        min-width: 220px;
         margin-left: auto;
+      }
+
+      /* Names the search field for assistive tech without a visible label. */
+      .interaction-search::part(form-control-label) {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+        border: 0;
       }
 
       .period-caption,
@@ -495,7 +532,7 @@ export class AIModelDetailView extends LitElement {
       }
 
       @media (max-width: 720px) {
-        .filters-actions {
+        .interaction-search {
           margin-left: 0;
           width: 100%;
         }
@@ -535,9 +572,6 @@ export class AIModelDetailView extends LitElement {
       new URLSearchParams(window.location.search).get('pricing') === 'edit';
 
     if (!this.initialized) {
-      if (this.selectedRange !== 'custom') {
-        this.applyPresetDates(this.selectedRange);
-      }
       this.initialized = true;
       if (this.modelId) {
         void this.loadData();
@@ -551,6 +585,10 @@ export class AIModelDetailView extends LitElement {
     if (this.refreshTimer !== null) {
       window.clearTimeout(this.refreshTimer);
       this.refreshTimer = null;
+    }
+    if (this.interactionSearchDebounce) {
+      clearTimeout(this.interactionSearchDebounce);
+      this.interactionSearchDebounce = undefined;
     }
   }
 
@@ -679,12 +717,13 @@ export class AIModelDetailView extends LitElement {
 
   private buildSummaryParams(): GatewayUsageSummaryParams {
     const params: GatewayUsageSummaryParams = {};
+    const range = resolveTimeRange(this.selectedRange);
 
-    if (this.startDate) {
-      params.startDate = new Date(`${this.startDate}T00:00:00`).toISOString();
+    if (range.startDate) {
+      params.startDate = range.startDate;
     }
-    if (this.endDate) {
-      params.endDate = new Date(`${this.endDate}T23:59:59.999`).toISOString();
+    if (range.endDate) {
+      params.endDate = range.endDate;
     }
 
     return params;
@@ -697,65 +736,41 @@ export class AIModelDetailView extends LitElement {
     return `${year}-${month}-${day}`;
   }
 
-  private applyPresetDates(range: Exclude<DateRangePreset, 'custom'>) {
-    if (range === 'all') {
-      this.startDate = '';
-      this.endDate = '';
+  private handleRangeChange(event: Event) {
+    const value = (event as CustomEvent<{ value: string }>).detail
+      ?.value as TimeRangeKey;
+    if (!value || value === this.selectedRange) {
       return;
     }
-
-    const today = new Date();
-    const startDate = new Date(today);
-    const days = range === 'last-7' ? 7 : range === 'last-30' ? 30 : 90;
-    startDate.setDate(startDate.getDate() - (days - 1));
-
-    this.startDate = this.getLocalDateString(startDate);
-    this.endDate = this.getLocalDateString(today);
-  }
-
-  private handleRangeChange(event: Event) {
-    const value = (event.target as HTMLInputElement & { value: string })
-      .value as DateRangePreset;
     this.selectedRange = value;
-
-    if (value !== 'custom') {
-      this.applyPresetDates(value);
-      void this.loadData();
-    }
-  }
-
-  private handleStartDateChange(event: Event) {
-    this.startDate = (
-      event.target as HTMLInputElement & { value: string }
-    ).value;
-    this.selectedRange = 'custom';
-  }
-
-  private handleEndDateChange(event: Event) {
-    this.endDate = (event.target as HTMLInputElement & { value: string }).value;
-    this.selectedRange = 'custom';
+    void this.loadData();
   }
 
   private handleInteractionQueryChange(event: Event) {
     this.interactionQuery = (
       event.target as HTMLInputElement & { value: string }
     ).value;
-  }
-
-  private async applyFilters() {
-    if (this.startDate && this.endDate && this.startDate > this.endDate) {
-      this.error = 'Start date must be earlier than end date.';
-      return;
+    // The search runs on the server, so a keystroke is not a request: the
+    // page waits for a pause in typing instead of an Apply button.
+    if (this.interactionSearchDebounce) {
+      clearTimeout(this.interactionSearchDebounce);
     }
-
-    await this.loadData();
+    this.interactionSearchDebounce = setTimeout(() => {
+      this.interactionSearchDebounce = undefined;
+      void this.loadData();
+    }, 300);
   }
 
-  private async clearFilters() {
-    this.selectedRange = 'last-30';
-    this.applyPresetDates('last-30');
-    this.interactionQuery = '';
-    await this.loadData();
+  /**
+   * Which days the numbers cover, restated under the control that chose them.
+   * The server's own window wins over the client's preset.
+   */
+  private rangeWindowLabel(): string {
+    const requested = resolveTimeRange(this.selectedRange);
+    return formatTimeRangeWindow({
+      startDate: this.summary?.period_start ?? requested.startDate,
+      endDate: this.summary?.period_end ?? requested.endDate,
+    });
   }
 
   private formatNumber(value: number | null | undefined): string {
@@ -2083,59 +2098,26 @@ export class AIModelDetailView extends LitElement {
 
             ${this.renderPricingCard()} ${this.renderGatewayValidation()}
 
-            <sl-card>
-              <div slot="header" class="model-title">Filters</div>
-              <div class="filters-grid">
-                <sl-select
-                  label="Date range"
-                  value=${this.selectedRange}
-                  @sl-change=${this.handleRangeChange}
-                >
-                  <sl-option value="last-7">Last 7 days</sl-option>
-                  <sl-option value="last-30">Last 30 days</sl-option>
-                  <sl-option value="last-90">Last 90 days</sl-option>
-                  <sl-option value="all">All time</sl-option>
-                  <sl-option value="custom">Custom</sl-option>
-                </sl-select>
-                <sl-input
-                  type="date"
-                  label="Start date"
-                  .value=${this.startDate}
-                  @sl-change=${this.handleStartDateChange}
-                ></sl-input>
-                <sl-input
-                  type="date"
-                  label="End date"
-                  .value=${this.endDate}
-                  @sl-change=${this.handleEndDateChange}
-                ></sl-input>
-                <sl-input
-                  label="Captured interaction search"
-                  placeholder="Search prompts, outputs, or metadata"
-                  .value=${this.interactionQuery}
-                  @sl-input=${this.handleInteractionQueryChange}
-                ></sl-input>
-                <div class="filters-actions">
-                  <sl-button variant="primary" @click=${this.applyFilters}>
-                    Apply
-                  </sl-button>
-                  <sl-button variant="default" @click=${this.clearFilters}>
-                    Reset
-                  </sl-button>
-                </div>
-              </div>
-              ${
-                this.summary
-                  ? html`
-                      <div class="period-caption">
-                        Showing model-scoped activity from
-                        ${this.formatDateTime(this.summary.period_start)} to
-                        ${this.formatDateTime(this.summary.period_end)}.
-                      </div>
-                    `
-                  : ''
-              }
-            </sl-card>
+            <div class="toolbar">
+              <time-range-select
+                ariaLabel="Model usage range"
+                .value=${this.selectedRange}
+                .options=${DATE_RANGE_OPTIONS}
+                @range-change=${this.handleRangeChange}
+              ></time-range-select>
+              <span class="range-window">${this.rangeWindowLabel()}</span>
+              <sl-input
+                class="interaction-search"
+                label="Search captured interactions"
+                placeholder="Search prompts, outputs, or metadata"
+                clearable
+                .value=${this.interactionQuery}
+                @sl-input=${this.handleInteractionQueryChange}
+                @sl-clear=${this.handleInteractionQueryChange}
+              >
+                <sl-icon name="search" slot="prefix"></sl-icon>
+              </sl-input>
+            </div>
 
             ${
               this.error

--- a/frontend/src/views/authed/settings/ai-model-detail-view.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.ts
@@ -206,7 +206,18 @@ export class AIModelDetailView extends LitElement {
   private unsubscribeRealtime?: () => void;
   private refreshTimer: number | null = null;
   private refreshInFlight = false;
+  /**
+   * A reload asked for while another is in flight is not dropped: the latest
+   * one is queued and runs when the in-flight call settles. Otherwise the
+   * range control could name a window whose data was never fetched, which the
+   * 250 ms realtime refresh made easy to hit.
+   */
+  private pendingReload: {
+    preserveLoadingState?: boolean;
+    markUpdating?: boolean;
+  } | null = null;
   private interactionSearchDebounce?: ReturnType<typeof setTimeout>;
+  private interactionsRequestId = 0;
 
   static styles = [
     consoleDialogStyles,
@@ -366,7 +377,6 @@ export class AIModelDetailView extends LitElement {
         border: 0;
       }
 
-      .period-caption,
       .meta-line,
       .session-meta,
       .interaction-meta,
@@ -375,10 +385,6 @@ export class AIModelDetailView extends LitElement {
         color: var(--sl-color-neutral-600);
         font-size: var(--sl-font-size-small);
         overflow-wrap: anywhere;
-      }
-
-      .period-caption {
-        margin-top: var(--sl-spacing-small);
       }
 
       .model-heading {
@@ -694,6 +700,18 @@ export class AIModelDetailView extends LitElement {
     }
 
     if (this.refreshInFlight) {
+      this.pendingReload = {
+        // The latest caller decides whether a spinner is wanted; a queued
+        // request for the dim treatment survives either way.
+        preserveLoadingState: options.preserveLoadingState,
+        markUpdating:
+          options.markUpdating || this.pendingReload?.markUpdating || false,
+      };
+      // The queued reload reads the range and the query as they are when it
+      // runs, so the last answer on screen is the last one asked for.
+      if (this.pendingReload.markUpdating) {
+        this.updating = true;
+      }
       return;
     }
     this.refreshInFlight = true;
@@ -717,6 +735,7 @@ export class AIModelDetailView extends LitElement {
       this.loading = false;
       this.updating = false;
       this.refreshInFlight = false;
+      this.runPendingReload();
       return;
     }
 
@@ -753,7 +772,18 @@ export class AIModelDetailView extends LitElement {
       this.loading = false;
       this.updating = false;
       this.refreshInFlight = false;
+      this.runPendingReload();
     }
+  }
+
+  /** Run the reload that arrived while the last one was still in flight. */
+  private runPendingReload(): void {
+    const pending = this.pendingReload;
+    if (!pending) {
+      return;
+    }
+    this.pendingReload = null;
+    void this.loadData(pending);
   }
 
   private buildSummaryParams(): GatewayUsageSummaryParams {
@@ -813,24 +843,36 @@ export class AIModelDetailView extends LitElement {
     if (!this.modelId) {
       return;
     }
+    // Two searches can be in flight at once, and the slower one must not
+    // overwrite the newer answer.
+    const request = ++this.interactionsRequestId;
     this.interactionsLoading = true;
 
     try {
-      this.interactions = await getAIModelGatewayUsageSearch(this.modelId, {
+      const results = await getAIModelGatewayUsageSearch(this.modelId, {
         ...this.buildSummaryParams(),
         query: this.interactionQuery.trim() || undefined,
         limit: 10,
       });
+      if (request !== this.interactionsRequestId) {
+        return;
+      }
+      this.interactions = results;
       this.interactionsError = null;
     } catch (error) {
       console.error('Failed to search captured model interactions:', error);
+      if (request !== this.interactionsRequestId) {
+        return;
+      }
       this.interactionsError =
         error instanceof Error
           ? error.message
           : 'Failed to search captured interactions';
       this.interactions = null;
     } finally {
-      this.interactionsLoading = false;
+      if (request === this.interactionsRequestId) {
+        this.interactionsLoading = false;
+      }
     }
   }
 

--- a/frontend/src/views/authed/settings/ai-model-detail-view.ts
+++ b/frontend/src/views/authed/settings/ai-model-detail-view.ts
@@ -64,6 +64,9 @@ const DATE_RANGE_OPTIONS: Array<{ value: TimeRangeKey; label: string }> = [
   { value: 'last-7', label: '7d' },
   { value: 'last-30', label: '30d' },
   { value: 'last-365', label: '1y' },
+  // The window with no bounds, kept from the Filters card this toolbar
+  // replaced: the shared util resolves it to no start and no end.
+  { value: 'all', label: 'All time' },
 ];
 
 type PriceField =

--- a/frontend/src/views/authed/tracker-detail-view.test.ts
+++ b/frontend/src/views/authed/tracker-detail-view.test.ts
@@ -365,6 +365,35 @@ describe('TrackerDetailView', () => {
     expect(empty!.getBoundingClientRect().height).to.be.at.least(72);
   });
 
+  // A dropdown reading "Alpha" names nothing: each filter says what it
+  // filters, on screen and to assistive tech.
+  it('names the Issues pane filters on screen, not only to a screen reader', async () => {
+    fetchStub = stubFetch({ issues: [], total: 0 });
+    const el = await mountView();
+    await el.updateComplete;
+
+    const selects = Array.from(
+      el.shadowRoot?.querySelectorAll(
+        'sl-tab-panel[name="issues"] .collection-pane sl-select'
+      ) || []
+    );
+    expect(selects.length).to.equal(2);
+    expect(
+      selects.map((select) =>
+        select.querySelector('[slot="prefix"]')?.textContent?.trim()
+      )
+    ).to.deep.equal(['Project', 'Status']);
+    // The accessible name survives too.
+    expect(selects.map((select) => select.getAttribute('label'))).to.deep.equal(
+      ['Project', 'Status']
+    );
+
+    const prList = el.shadowRoot?.querySelector(
+      'sl-tab-panel[name="pull-requests"] .collection-pane sl-select [slot="prefix"]'
+    );
+    expect(prList?.textContent?.trim()).to.equal('Project');
+  });
+
   it('search with no matches uses its own empty line', async () => {
     fetchStub = stubFetch({
       issues: [

--- a/frontend/src/views/authed/tracker-detail-view.test.ts
+++ b/frontend/src/views/authed/tracker-detail-view.test.ts
@@ -26,6 +26,7 @@ interface StubOpts {
   trackerType?: string;
   pullRequests?: unknown[];
   prHasMore?: boolean;
+  prTotal?: number;
   prSupported?: boolean;
   pullRequestHandler?: (url: string) => Response | null;
 }
@@ -38,6 +39,7 @@ function stubFetch(opts: StubOpts = {}) {
     trackerType = 'github',
     pullRequests = [],
     prHasMore = false,
+    prTotal,
     prSupported = true,
     pullRequestHandler,
   } = opts;
@@ -78,6 +80,7 @@ function stubFetch(opts: StubOpts = {}) {
           has_more: prHasMore,
           supported: prSupported,
           fetched_at: '2026-01-03T00:00:00Z',
+          ...(prTotal !== undefined ? { total: prTotal } : {}),
         });
       }
       if (url.includes('/api/v1/projects')) {
@@ -583,6 +586,77 @@ describe('TrackerDetailView', () => {
     expect(
       branches?.querySelector('.visually-hidden')?.textContent?.trim()
     ).to.equal('to');
+  });
+
+  it('does not report a paged PR list as the total', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      `/console/trackers/${trackerId}?tab=pull-requests&project=${projectA.id}`
+    );
+    fetchStub = stubFetch({
+      pullRequests: [
+        {
+          number: 12,
+          iid: 12,
+          title: 'Add login',
+          url: 'https://github.com/acme/widgets/pull/12',
+          author: 'janedoe',
+          source_branch: 'feature',
+          target_branch: 'main',
+          state: 'open',
+          draft: false,
+          updated_at: '2026-01-03T00:00:00Z',
+        },
+      ],
+      prHasMore: true,
+    });
+    const el = await mountView();
+    await (
+      el as unknown as { _loadPullRequests: (reset: boolean) => Promise<void> }
+    )._loadPullRequests(true);
+    await el.updateComplete;
+    const count = el.shadowRoot
+      ?.querySelector('sl-tab-panel[name="pull-requests"] [slot="count"]')
+      ?.textContent?.trim();
+    expect(count).to.equal('showing 1 pull request');
+    expect(count).to.not.contain('open pull request');
+  });
+
+  it('uses the API total when the PR list reports one', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      `/console/trackers/${trackerId}?tab=pull-requests&project=${projectA.id}`
+    );
+    fetchStub = stubFetch({
+      pullRequests: [
+        {
+          number: 12,
+          iid: 12,
+          title: 'Add login',
+          url: 'https://github.com/acme/widgets/pull/12',
+          author: 'janedoe',
+          source_branch: 'feature',
+          target_branch: 'main',
+          state: 'open',
+          draft: false,
+          updated_at: '2026-01-03T00:00:00Z',
+        },
+      ],
+      prHasMore: true,
+      prTotal: 40,
+    });
+    const el = await mountView();
+    await (
+      el as unknown as { _loadPullRequests: (reset: boolean) => Promise<void> }
+    )._loadPullRequests(true);
+    await el.updateComplete;
+    expect(
+      el.shadowRoot
+        ?.querySelector('sl-tab-panel[name="pull-requests"] [slot="count"]')
+        ?.textContent?.trim()
+    ).to.equal('1 of 40 open pull requests');
   });
 
   it('leaves the Branches cell empty when a branch is missing', async () => {

--- a/frontend/src/views/authed/tracker-detail-view.test.ts
+++ b/frontend/src/views/authed/tracker-detail-view.test.ts
@@ -321,6 +321,50 @@ describe('TrackerDetailView', () => {
     );
   });
 
+  // Wave 3 (C10): the Issues tab is a collection pane, not a card. It spans
+  // the page whether it has rows or not, the tab is its title, and the
+  // filters are the bar the Flows list established.
+  it('renders the Issues tab as a full-width pane when it is empty', async () => {
+    fetchStub = stubFetch({ issues: [], total: 0 });
+    const el = await mountView();
+    (el as unknown as { _selectedProjectId: string })._selectedProjectId =
+      projectA.id;
+    await (
+      el as unknown as { _loadIssues: (reset: boolean) => Promise<void> }
+    )._loadIssues(true);
+    await el.updateComplete;
+
+    const panel = el.shadowRoot?.querySelector(
+      'sl-tab-panel[name="issues"] .collection-pane'
+    ) as HTMLElement | null;
+    expect(panel, 'the issues tab renders a pane').to.exist;
+    expect(panel?.querySelector('sl-card'), 'no card around the collection').to
+      .not.exist;
+
+    // Spanning the page: the empty pane is as wide as its tab panel.
+    const panelWidth = panel!.getBoundingClientRect().width;
+    const hostWidth = el
+      .shadowRoot!.querySelector('sl-tab-panel[name="issues"]')!
+      .getBoundingClientRect().width;
+    expect(panelWidth).to.be.greaterThan(0);
+    expect(hostWidth - panelWidth).to.be.lessThan(2);
+
+    // The bar carries search, the project, the status and the count.
+    const toolbar = panel?.querySelector('list-toolbar');
+    expect(toolbar?.getAttribute('searchPlaceholder')).to.equal(
+      'Search key or title'
+    );
+    expect(panel?.querySelectorAll('sl-select').length).to.equal(2);
+    expect(
+      panel?.querySelector('[slot="count"]')?.textContent?.trim()
+    ).to.equal('0 issues');
+
+    // One line where the table would be, not a collapsed card.
+    const empty = panel?.querySelector('.issues-empty') as HTMLElement | null;
+    expect(empty?.textContent).to.contain('No open issues in Alpha');
+    expect(empty!.getBoundingClientRect().height).to.be.at.least(72);
+  });
+
   it('search with no matches uses its own empty line', async () => {
     fetchStub = stubFetch({
       issues: [
@@ -493,7 +537,10 @@ describe('TrackerDetailView', () => {
     await el.updateComplete;
     const text = el.shadowRoot?.textContent || '';
     expect(text).to.contain('Merge requests');
-    expect(text).to.contain('Open merge requests');
+    // The tab is the title, so the pane no longer repeats it as a card
+    // heading; the count on the bar says what is on screen.
+    expect(text).to.not.contain('Open merge requests');
+    expect(text).to.contain('1 open merge request');
     expect(text).to.contain('Live from GitLab, refreshed every minute.');
     expect(text).to.contain('Fix login');
     expect(text).to.contain('#7');

--- a/frontend/src/views/authed/tracker-detail-view.ts
+++ b/frontend/src/views/authed/tracker-detail-view.ts
@@ -138,6 +138,9 @@ export class TrackerDetailView extends LitElement {
   private _pullRequests: PullRequestListItem[] = [];
 
   @state()
+  private _prsTotal: number | null = null;
+
+  @state()
   private _prsPage = 1;
 
   @state()
@@ -784,10 +787,22 @@ export class TrackerDetailView extends LitElement {
   }
 
   private _pullRequestsCountLabel(): string {
-    const count = this._pullRequests.length;
+    const loaded = this._pullRequests.length;
     const noun = this._prNoun();
     const singular = noun.endsWith('s') ? noun.slice(0, -1) : noun;
-    return `${count} open ${count === 1 ? singular : noun}`;
+    const unit = loaded === 1 ? singular : noun;
+    const total = this._prsTotal;
+    if (total != null) {
+      if (total > loaded) {
+        const totalUnit = total === 1 ? singular : noun;
+        return `${loaded} of ${total.toLocaleString()} open ${totalUnit}`;
+      }
+      return `${total.toLocaleString()} open ${total === 1 ? singular : noun}`;
+    }
+    if (this._prsHasMore) {
+      return `showing ${loaded.toLocaleString()} ${unit}`;
+    }
+    return `${loaded} open ${unit}`;
   }
 
   /** Row actions live in the row's kebab, not as a button per row. */
@@ -891,11 +906,13 @@ export class TrackerDetailView extends LitElement {
     if (!this._selectedProjectId) {
       this._pullRequests = [];
       this._prsHasMore = false;
+      this._prsTotal = null;
       return;
     }
     if (reset) {
       this._prsPage = 1;
       this._pullRequests = [];
+      this._prsTotal = null;
     }
     this._prsLoading = true;
     this._prsError = null;
@@ -908,12 +925,18 @@ export class TrackerDetailView extends LitElement {
       if (!data.supported) {
         this._pullRequests = [];
         this._prsHasMore = false;
+        this._prsTotal = null;
         return;
       }
       this._pullRequests = reset
         ? data.items
         : [...this._pullRequests, ...data.items];
       this._prsHasMore = data.has_more;
+      if (typeof data.total === 'number' && Number.isFinite(data.total)) {
+        this._prsTotal = data.total;
+      } else if (reset) {
+        this._prsTotal = null;
+      }
     } catch (error) {
       this._prsError =
         error instanceof Error ? error.message : 'Could not reach tracker.';

--- a/frontend/src/views/authed/tracker-detail-view.ts
+++ b/frontend/src/views/authed/tracker-detail-view.ts
@@ -327,8 +327,14 @@ export class TrackerDetailView extends LitElement {
         min-width: 180px;
       }
 
-      /* The selects carry a label for assistive tech; the bar has no room to
-         print it, so the placeholder does the naming on screen. */
+      /* The bar has no room for a stacked label above every control, so each
+         select names itself inside its own combobox ("Project Alpha",
+         "Status Open") and the label is left for assistive tech. A dropdown
+         reading only "Alpha" names nothing. */
+      .collection-pane sl-select .select-name {
+        color: var(--console-meta-color, var(--sl-color-neutral-500));
+      }
+
       .collection-pane sl-select::part(form-control-label) {
         position: absolute;
         width: 1px;
@@ -1132,6 +1138,7 @@ export class TrackerDetailView extends LitElement {
             value=${this._selectedProjectId}
             @sl-change=${this._onProjectFilter}
           >
+            <span slot="prefix" class="select-name">Project</span>
             ${this._projects.map(
               (item) =>
                 html`<sl-option value=${item.id}>${item.name}</sl-option>`
@@ -1142,6 +1149,7 @@ export class TrackerDetailView extends LitElement {
             value=${this._issueStatus}
             @sl-change=${this._onStatusFilter}
           >
+            <span slot="prefix" class="select-name">Status</span>
             <sl-option value="open">Open</sl-option>
             <sl-option value="closed">Closed</sl-option>
             <sl-option value="all">All</sl-option>
@@ -1337,6 +1345,7 @@ export class TrackerDetailView extends LitElement {
             value=${this._selectedProjectId}
             @sl-change=${this._onProjectFilter}
           >
+            <span slot="prefix" class="select-name">Project</span>
             ${this._projects.map(
               (item) =>
                 html`<sl-option value=${item.id}>${item.name}</sl-option>`

--- a/frontend/src/views/authed/tracker-detail-view.ts
+++ b/frontend/src/views/authed/tracker-detail-view.ts
@@ -17,6 +17,8 @@ import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
 import '../../components/view-header.ts';
 import '../../components/resource-actions.ts';
+import '../../components/list-toolbar.ts';
+import type { ResourceAction } from '../../components/resource-actions.ts';
 import {
   fetchWithAuth,
   getFeatures,
@@ -307,27 +309,64 @@ export class TrackerDetailView extends LitElement {
         font-size: var(--console-text-body);
       }
 
-      .issues-controls {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--sl-spacing-small);
-        align-items: end;
+      /* Issues and pull requests are collections, so their tabs are panes
+         that span the page: a filter bar, then the table, with no card
+         around them and no title (the tab is the title). Flows is the
+         reference collection page and this is the same bar. */
+      .collection-pane {
+        display: block;
+        width: 100%;
+        padding-top: var(--sl-spacing-medium);
       }
 
-      .issues-controls sl-select,
-      .issues-controls sl-input {
-        min-width: 160px;
+      .collection-pane list-toolbar {
+        margin-bottom: var(--sl-spacing-small);
+      }
+
+      .collection-pane sl-select {
+        min-width: 180px;
+      }
+
+      /* The selects carry a label for assistive tech; the bar has no room to
+         print it, so the placeholder does the naming on screen. */
+      .collection-pane sl-select::part(form-control-label) {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      .collection-pane .styled-table {
+        width: 100%;
+      }
+
+      .actions-cell {
+        width: 56px;
+        text-align: right;
+        overflow: visible;
       }
 
       .select-col {
         width: 2.5rem;
       }
 
+      /* One line, the height of a table row, so an empty pane is the same
+         page as a full one rather than a collapsed card. */
       .issues-empty,
       .issues-error,
       .prs-empty,
       .prs-error {
-        padding: var(--sl-spacing-medium) 0;
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: var(--sl-spacing-x-small);
+        min-height: 72px;
+        border-top: 1px solid var(--console-hairline);
         color: var(--console-meta-color);
         font-size: var(--console-text-body);
       }
@@ -693,8 +732,17 @@ export class TrackerDetailView extends LitElement {
     void this._loadIssues(true);
   }
 
+  /**
+   * The bar reports a search as `search-change` with the text on `detail`;
+   * a bare input reports it on its target. Both are read here so the pane and
+   * the tests can drive the same handler.
+   */
   private _onIssueSearch(event: Event) {
-    this._issueSearch = (event.target as HTMLInputElement).value;
+    const detail = (event as CustomEvent<{ value?: string }>).detail;
+    this._issueSearch =
+      detail && typeof detail.value === 'string'
+        ? detail.value
+        : (event.target as HTMLInputElement).value;
     if (this._issueSearchTimer !== null) {
       window.clearTimeout(this._issueSearchTimer);
     }
@@ -712,6 +760,51 @@ export class TrackerDetailView extends LitElement {
   private _isGitTracker(): boolean {
     const type = this._tracker?.tracker_type?.toLowerCase() || '';
     return type.includes('github') || type.includes('gitlab');
+  }
+
+  /**
+   * How many rows the filters matched, in the place the reference collection
+   * page puts it (the right end of the bar). "N of M" while more are on the
+   * server, because the pane never claims to be showing what it is not.
+   */
+  private _issuesCountLabel(): string {
+    const loaded = this._issues.length;
+    const total = this._issuesTotal;
+    const noun = total === 1 ? 'issue' : 'issues';
+    if (total > loaded) {
+      return `${loaded} of ${total.toLocaleString()} ${noun}`;
+    }
+    return `${total.toLocaleString()} ${noun}`;
+  }
+
+  private _pullRequestsCountLabel(): string {
+    const count = this._pullRequests.length;
+    const noun = this._prNoun();
+    const singular = noun.endsWith('s') ? noun.slice(0, -1) : noun;
+    return `${count} open ${count === 1 ? singular : noun}`;
+  }
+
+  /** Row actions live in the row's kebab, not as a button per row. */
+  private _issueRowActions(issue: IssueListItem): ResourceAction[] {
+    return [
+      {
+        id: 'run-implementer',
+        label: 'Run implementer',
+        icon: 'play',
+        onClick: () => this._runImplementer(issue),
+      },
+    ];
+  }
+
+  private _pullRequestRowActions(pr: PullRequestListItem): ResourceAction[] {
+    return [
+      {
+        id: 'run-reviewer',
+        label: 'Run reviewer',
+        icon: 'play',
+        onClick: () => this._runReviewer(pr),
+      },
+    ];
   }
 
   private _runImplementer(issue: IssueListItem) {
@@ -1026,62 +1119,48 @@ export class TrackerDetailView extends LitElement {
     const canLoadMore = this._issues.length < this._issuesTotal;
 
     return html`
-      <sl-card>
-        <div slot="header" class="section-header">
-          <h2 class="section-title">
-            Issues
+      <div class="collection-pane">
+        <list-toolbar
+          .search=${this._issueSearch}
+          searchPlaceholder="Search key or title"
+          searchLabel="Search issues"
+          .views=${['list']}
+          @search-change=${this._onIssueSearch}
+        >
+          <sl-select
+            label="Project"
+            value=${this._selectedProjectId}
+            @sl-change=${this._onProjectFilter}
+          >
+            ${this._projects.map(
+              (item) =>
+                html`<sl-option value=${item.id}>${item.name}</sl-option>`
+            )}
+          </sl-select>
+          <sl-select
+            label="Status"
+            value=${this._issueStatus}
+            @sl-change=${this._onStatusFilter}
+          >
+            <sl-option value="open">Open</sl-option>
+            <sl-option value="closed">Closed</sl-option>
+            <sl-option value="all">All</sl-option>
+          </sl-select>
+          <sl-button
+            size="small"
+            ?disabled=${this._selectedIssueIds.length === 0}
+            data-testid="run-triage-selected"
+            @click=${() => this._runTriageOnSelected()}
+          >
+            Run triage on selected
             ${
-              this._issuesTotal
-                ? html`<sl-badge variant="neutral" pill class="solid"
-                    >${this._issuesTotal}</sl-badge
-                  >`
-                : ''
+              this._selectedIssueIds.length
+                ? html`(${this._selectedIssueIds.length})`
+                : nothing
             }
-          </h2>
-          <div class="issues-controls">
-            <sl-select
-              size="small"
-              label="Project"
-              value=${this._selectedProjectId}
-              @sl-change=${this._onProjectFilter}
-            >
-              ${this._projects.map(
-                (item) =>
-                  html`<sl-option value=${item.id}>${item.name}</sl-option>`
-              )}
-            </sl-select>
-            <sl-select
-              size="small"
-              label="Status"
-              value=${this._issueStatus}
-              @sl-change=${this._onStatusFilter}
-            >
-              <sl-option value="open">Open</sl-option>
-              <sl-option value="closed">Closed</sl-option>
-              <sl-option value="all">All</sl-option>
-            </sl-select>
-            <sl-input
-              size="small"
-              label="Search"
-              placeholder="Key or title"
-              value=${this._issueSearch}
-              @sl-input=${this._onIssueSearch}
-            ></sl-input>
-            <sl-button
-              size="small"
-              ?disabled=${this._selectedIssueIds.length === 0}
-              data-testid="run-triage-selected"
-              @click=${() => this._runTriageOnSelected()}
-            >
-              Run triage on selected
-              ${
-                this._selectedIssueIds.length
-                  ? html`(${this._selectedIssueIds.length})`
-                  : nothing
-              }
-            </sl-button>
-          </div>
-        </div>
+          </sl-button>
+          <span slot="count">${this._issuesCountLabel()}</span>
+        </list-toolbar>
         ${
           this._issuesError
             ? html`<div class="issues-error">
@@ -1201,16 +1280,16 @@ export class TrackerDetailView extends LitElement {
                               <td title=${issue.updated_at}>
                                 ${formatRelativeTime(issue.updated_at)}
                               </td>
-                              <td>
+                              <td class="actions-cell">
                                 ${
                                   this._isGitTracker()
                                     ? html`
-                                        <sl-button
-                                          size="small"
-                                          @click=${() =>
-                                            this._runImplementer(issue)}
-                                          >Run implementer</sl-button
-                                        >
+                                        <resource-actions
+                                          menu-only
+                                          .actions=${this._issueRowActions(
+                                            issue
+                                          )}
+                                        ></resource-actions>
                                       `
                                     : nothing
                                 }
@@ -1234,7 +1313,7 @@ export class TrackerDetailView extends LitElement {
                     }
                   `
         }
-      </sl-card>
+      </div>
     `;
   }
 
@@ -1247,30 +1326,24 @@ export class TrackerDetailView extends LitElement {
     }
 
     const project = this._selectedProject();
-    const heading = this._isGitlab()
-      ? 'Open merge requests'
-      : 'Open pull requests';
     const empty = `No open ${this._prNoun()} in ${project?.name || 'this project'}.`;
     const errorHost = this._prHost();
 
     return html`
-      <sl-card>
-        <div slot="header" class="section-header">
-          <h2 class="section-title">${heading}</h2>
-          <div class="issues-controls">
-            <sl-select
-              size="small"
-              label="Project"
-              value=${this._selectedProjectId}
-              @sl-change=${this._onProjectFilter}
-            >
-              ${this._projects.map(
-                (item) =>
-                  html`<sl-option value=${item.id}>${item.name}</sl-option>`
-              )}
-            </sl-select>
-          </div>
-        </div>
+      <div class="collection-pane">
+        <list-toolbar .views=${['list']} ?searchable=${false}>
+          <sl-select
+            label="Project"
+            value=${this._selectedProjectId}
+            @sl-change=${this._onProjectFilter}
+          >
+            ${this._projects.map(
+              (item) =>
+                html`<sl-option value=${item.id}>${item.name}</sl-option>`
+            )}
+          </sl-select>
+          <span slot="count">${this._pullRequestsCountLabel()}</span>
+        </list-toolbar>
         <p class="live-note">Live from ${errorHost}, refreshed every minute.</p>
         ${
           this._prsLoading && this._pullRequests.length === 0
@@ -1317,12 +1390,11 @@ export class TrackerDetailView extends LitElement {
                                   : ''
                               }
                             </td>
-                            <td>
-                              <sl-button
-                                size="small"
-                                @click=${() => this._runReviewer(pr)}
-                                >Run reviewer</sl-button
-                              >
+                            <td class="actions-cell">
+                              <resource-actions
+                                menu-only
+                                .actions=${this._pullRequestRowActions(pr)}
+                              ></resource-actions>
                             </td>
                           </tr>
                         `
@@ -1344,7 +1416,7 @@ export class TrackerDetailView extends LitElement {
                   ${this._prsError ? this._renderPrsError() : ''}
                 `
         }
-      </sl-card>
+      </div>
     `;
   }
 

--- a/frontend/src/views/authed/usage-range-agreement.test.ts
+++ b/frontend/src/views/authed/usage-range-agreement.test.ts
@@ -1,0 +1,249 @@
+import { fixture, html, expect, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
+
+import '../../setup-tests';
+import './cost-view.ts';
+import './api-usage-view.ts';
+import './settings/ai-model-detail-view.ts';
+import { invalidateApiCaches } from '../../api';
+
+/**
+ * Cost, API usage and the model detail page each report the same account's
+ * gateway usage. They used to compute "the last 30 days" three different ways
+ * (a rolling instant, 30 local calendar days ending tonight, a calendar month
+ * back), so the same data read 18,504 on one page and 18,419 on another. They
+ * now all resolve the window through `utils/time-range`: one fixture, one
+ * total, one window.
+ */
+describe('usage range agreement', () => {
+  let fetchStub: sinon.SinonStub;
+  let requestedWindows: Record<string, { start: string; end: string }>;
+
+  const TOTAL_REQUESTS = 18419;
+  const TOTAL_TOKENS = 821295121;
+
+  const tokenUsage = {
+    prompt_tokens: 807700000,
+    completion_tokens: 13595121,
+    total_tokens: TOTAL_TOKENS,
+  };
+
+  const usageSummary = {
+    period_start: '2026-08-07T00:00:00Z',
+    period_end: '2026-09-06T00:00:00Z',
+    total_requests: TOTAL_REQUESTS,
+    successful_requests: 18358,
+    failed_requests: 61,
+    token_usage: tokenUsage,
+    estimated_cost: 38.21,
+    budget: {
+      monthly_limit_usd: 100,
+      soft_limit_usd: 80,
+      current_spend_usd: 38.21,
+      soft_limit_exceeded: false,
+      hard_limit_exceeded: false,
+    },
+    requests_by_day: [],
+    usage_by_model: [],
+    usage_by_flow: [],
+    usage_by_session: [],
+  };
+
+  const modelSummary = {
+    ai_model_id: 'model-1',
+    model_name: 'Claude Sonnet Primary',
+    provider_name: 'Anthropic',
+    model_identifier: 'claude-sonnet-4',
+    period_start: usageSummary.period_start,
+    period_end: usageSummary.period_end,
+    total_requests: TOTAL_REQUESTS,
+    successful_requests: 18358,
+    failed_requests: 61,
+    token_usage: tokenUsage,
+    estimated_cost: 38.21,
+    requests_by_day: [],
+    usage_by_session: [],
+  };
+
+  const json = (payload: unknown) =>
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  const recordWindow = (page: string, url: string) => {
+    const query = new URLSearchParams(url.split('?')[1] || '');
+    const start = query.get('start_date');
+    const end = query.get('end_date');
+    if (start && end && !requestedWindows[page]) {
+      requestedWindows[page] = { start, end };
+    }
+  };
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-access-token');
+    localStorage.setItem('refreshToken', 'test-refresh-token');
+    requestedWindows = {};
+
+    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub.callsFake(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+
+      if (url.startsWith('/api/v1/cost/summary')) {
+        recordWindow('cost', url);
+        return json(usageSummary);
+      }
+      if (url.startsWith('/api/v1/account/gateway-usage/summary')) {
+        recordWindow('api-usage', url);
+        return json(usageSummary);
+      }
+      if (url.startsWith('/api/v1/ai-models/model-1/summary')) {
+        recordWindow('models', url);
+        return json(modelSummary);
+      }
+      if (url.startsWith('/api/v1/account/gateway-usage/search')) {
+        return json({ total: 0, limit: 10, offset: 0, items: [] });
+      }
+      if (url.startsWith('/api/v1/ai-models/model-1/interactions')) {
+        return json({ total: 0, limit: 10, offset: 0, items: [] });
+      }
+      if (url.startsWith('/api/v1/ai-models/model-1/runtime-sessions')) {
+        return json({ total: 0, limit: 10, offset: 0, items: [] });
+      }
+      if (url.startsWith('/api/v1/ai-models/model-1/pricing')) {
+        return json({
+          ai_model_id: 'model-1',
+          source: 'none',
+          price: null,
+          currency: 'USD',
+          fetch_supported: false,
+        });
+      }
+      if (url.startsWith('/api/v1/ai-models/model-1')) {
+        return json({
+          id: 'model-1',
+          name: 'Claude Sonnet Primary',
+          provider_name: 'Anthropic',
+          model_identifier: 'claude-sonnet-4',
+          has_api_key: true,
+          meta_data: {},
+          is_default: false,
+          created_at: '2026-03-01T10:00:00Z',
+          updated_at: '2026-03-09T18:30:00Z',
+        });
+      }
+      if (url.startsWith('/api/v1/account/gateway-usage/rate-limits')) {
+        // Rate-limit telemetry is not what this test is about, and the view
+        // treats a failure here as "no report".
+        return new Response(JSON.stringify({ detail: 'not available' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/v1/budget/policies')) {
+        return json([]);
+      }
+      if (url.includes('/api/v1/billing/cost/pricing-overrides')) {
+        return json([]);
+      }
+      if (url.includes('/api/v1/features')) {
+        return json({ features: { billing: true } });
+      }
+      if (url.includes('/api/v1/ai-models')) {
+        return json([]);
+      }
+      return json({});
+    });
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    localStorage.clear();
+    sessionStorage.clear();
+    invalidateApiCaches();
+  });
+
+  const untilLoaded = async (element: HTMLElement) => {
+    await waitUntil(
+      () => (element as unknown as { loading: boolean }).loading === false,
+      `${element.tagName} did not finish loading`
+    );
+    await (element as unknown as { updateComplete: Promise<unknown> })
+      .updateComplete;
+  };
+
+  it('asks for one window and prints one total on Cost, API usage and Models', async () => {
+    const cost = (await fixture(html`<cost-view></cost-view>`)) as HTMLElement;
+    await untilLoaded(cost);
+
+    const apiUsage = (await fixture(
+      html`<api-usage-view></api-usage-view>`
+    )) as HTMLElement;
+    await untilLoaded(apiUsage);
+
+    const models = (await fixture(
+      html`<ai-model-detail-view modelId="model-1"></ai-model-detail-view>`
+    )) as HTMLElement;
+    await untilLoaded(models);
+
+    // 1. The same nominal 30 days is the same 30 days on the wire. The three
+    // pages mount milliseconds apart, so the bound is a second, not equality.
+    const pages = ['cost', 'api-usage', 'models'];
+    for (const page of pages) {
+      expect(requestedWindows[page], `${page} sent no window`).to.not.equal(
+        undefined
+      );
+    }
+    const spanDays = (window: { start: string; end: string }) =>
+      (new Date(window.end).getTime() - new Date(window.start).getTime()) /
+      (24 * 60 * 60 * 1000);
+    for (const page of pages) {
+      const window = requestedWindows[page];
+      expect(Math.abs(spanDays(window) - 30), `${page} span`).to.be.below(0.01);
+      expect(
+        Math.abs(
+          new Date(window.start).getTime() -
+            new Date(requestedWindows.cost.start).getTime()
+        ),
+        `${page} start`
+      ).to.be.below(2000);
+      expect(
+        Math.abs(
+          new Date(window.end).getTime() -
+            new Date(requestedWindows.cost.end).getTime()
+        ),
+        `${page} end`
+      ).to.be.below(2000);
+    }
+
+    // 2. One fixture, one total. Cost and API usage print the count compact
+    // and keep the exact figure in a title; the model page prints it in full.
+    const exact = TOTAL_REQUESTS.toLocaleString();
+    const compact = new Intl.NumberFormat(undefined, {
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(TOTAL_REQUESTS);
+
+    const readsTotal = (element: HTMLElement) => {
+      const root = element.shadowRoot!;
+      const text = root.textContent || '';
+      const titles = Array.from(root.querySelectorAll('[title]'))
+        .map((node) => node.getAttribute('title') || '')
+        .join(' ');
+      return {
+        shown: text.includes(compact) || text.includes(exact),
+        exact: titles.includes(exact) || text.includes(exact),
+      };
+    };
+
+    for (const [name, element] of [
+      ['cost', cost],
+      ['api usage', apiUsage],
+      ['models', models],
+    ] as Array<[string, HTMLElement]>) {
+      const reading = readsTotal(element);
+      expect(reading.shown, `${name} does not show the total`).to.equal(true);
+      expect(reading.exact, `${name} hides the exact total`).to.equal(true);
+    }
+  });
+});


### PR DESCRIPTION
# Agent detail summary strip, tracker tabs as collection panes, one shared range

Round 5, wave 3 of the 2026-09-05 UX review: items W3-4 (A5), W3-5 (C10) and
W3-6 (D8, D9, finding 32).

## Summary

Three pages stop inventing their own version of a pattern the console already
has. The agent detail overview card becomes the hairline summary strip DESIGN.md
describes. The tracker's Issues and Pull requests tabs become collection panes
with the shared list toolbar instead of cards inside tabs. API usage and the
model detail page drop their Filters cards for the shared time range control,
and every page that reports gateway usage now resolves its window through one
module, so "30 days" means the same 30 days everywhere.

## Changes

**1. Agent detail summary strip (`0b60d4b6`)**
- `views/authed/agent-detail-view.ts`: the `.agent-overview` card is replaced by
  a `.summary-strip` hairline row that states kind, source id, session
  reference, the status chips, estimated spend and the request count, with the
  range control at the right.
- The last bare range `<select>` on the page becomes `time-range-select`
  (24h/7d/30d/1y).
- Test: the strip states the agent's facts and its spend, and the card is gone.

**2. Tracker tabs as collection panes (`63ec239d`)**
- `views/authed/tracker-detail-view.ts`: the Issues and Pull requests tabs lose
  their cards and their repeated titles. Each is a full-width pane with a
  `list-toolbar` (search, the project and status selects, the bulk triage
  action, a count in `slot="count"`), and empty states are hairline rows rather
  than centred cards in a box.
- Per-row buttons become `resource-actions menu-only` kebabs.
- `components/list-toolbar.ts` gains `searchable`, so a collection the host
  returns unfiltered (pull requests) can take the shared bar without a search
  field that would do nothing.
- Tests: the empty Issues tab renders as a full-width pane; the GitLab tab says
  "1 open merge request" and no longer repeats the tab's name.

**3. One range control and one shared answer for "30 days" (`cc512088`)**
- New `utils/time-range.ts`: reads every range spelling the console grew
  (`day`/`week`/`month`/`year`, `24h`/`7d`/`30d`/`1y`, `last-30`) and resolves
  it to one window, plus the prior window for deltas and the "Aug 7 to Sep 6"
  label.
- Cost, the Overview Usage card, API usage and the model detail page all use it.
  Before this, the same account read 18.9K, 18,306, 18,504 and 18,419 requests
  for the same nominal month.
- API usage and the model detail page replace the Filters card (select + two
  date inputs + Apply + Reset) with `time-range-select`, the resolved window
  restated beside it, and a search field that answers as you type.
- API usage adopts Cost's stat vocabulary: "Requests · 30d" with the
  succeeded/failed split, "$ est. · 30d" with an arrow delta against the prior
  window, "Tokens · 30d" compact, "Success rate · 30d" with the failure count.
  A range change keeps the previous numbers at 60% instead of blanking the page.
- A session row is reduced to name, model and one short link to the run, instead
  of printing the same id three ways. Section titles are sentence case.

## Review follow-ups (V-W2)

The review returned 4 "should" items and 5 nits, all applied in five further
commits.

- **A search pause is one request, not four.** Only the captured interactions
  depend on the query, so both usage pages now have a loader that refreshes
  that one card, with its own busy state and its own error line. Measured in
  the browser: API usage 1 API call per pause in typing (was 4), the model
  detail page 1 (was 5).
- **The model detail page dims instead of blanking.** A range change or a
  search used to swap the whole page for a spinner card. It now keeps the
  numbers at 60% with `aria-busy`, the way API usage and Cost behave, while
  the 250 ms realtime refresh stays silent. A reload that arrives during
  another one is queued rather than dropped, so the range control cannot name
  a window whose data was never fetched.
- **The model detail page renders the interaction list its search promised.**
  The results were fetched on every load and never shown, on this branch and
  on main.
- **The tracker pane filters name themselves on screen** ("Project Alpha",
  "Status Open") instead of showing two unnamed dropdowns reading "Alpha" and
  "Open".
- **"All time" is back on both range controls.** The shared util already
  resolved it to a window with no bounds; API usage skips the comparison
  request for it and says "All recorded gateway spend" rather than printing a
  delta against itself.
- Nits: the agent strip shortens uuids to eight characters with the full value
  in the title and on the clipboard (DESIGN.md line 312); the render helpers
  and CSS rules that died with the overview card and the Filters cards are
  deleted; `utils/time-range.ts` documents why calendar and rolling comparison
  windows have different shapes.

## Tests

`cd frontend && npm ci && npm test`: **156 files, 1839 passed, 0 failed**
(baseline on main: 154 files, 1818 passed). 21 new tests, including
`utils/time-range.test.ts` for the math and
`views/authed/usage-range-agreement.test.ts`, which mounts Cost, API usage and
Models against one fixture and asserts they ask for the same window and print
the same total, plus 8 from the review follow-ups (the dim on a range change,
the one-request search on both pages, the queued reload, the named tracker
filters, "All time" on both pages, and the shortened strip ids). No backend
change, so no pytest. `npx tsc --noEmit` adds no errors to the touched files
(three pre-existing ones remain).

## Founder calls

1. The tracker Issues tab keeps a single-project select: issues are fetched per
   project, so an "All projects" option would need a fan-out or a new endpoint.
2. API usage and the model detail page keep "All time" but still have no custom
   date window. A custom mode belongs inside `time-range-select`, where all
   five pages would gain it at once, rather than two pages keeping their own
   date inputs.
3. The canonical 30 days is a rolling instant window (Cost's shipped
   behaviour), so the Overview's totals shift slightly now that it no longer
   steps back a calendar month.
4. The API usage search now runs 300 ms after the last keystroke instead of on
   Apply, and costs one server request per pause.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low risk**
> UI-only consolidation onto shared console patterns; no backend, config, or API-surface changes, and the shared range math is heavily unit- and cross-page-tested. All previously flagged findings are now addressed.
>
> **Overview**
> Three pages stop inventing their own versions of existing patterns: the agent detail card becomes a summary strip, tracker tabs become collection panes with the shared list toolbar, and API usage / model detail adopt the shared `time-range-select` with one `utils/time-range.ts` resolving "30 days" identically everywhere. All three prior low findings (paginated PR count label, silent range-key fallback, and the search/range race) are now addressed.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 519025f9. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->