### PR TITLE
Remove expired approvals from the pending menu and badge

### DIFF
--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -488,8 +488,19 @@ describe('console-header approval deadlines', () => {
 
   async function mount(): Promise<void> {
     el = await fixture<ConsoleHeader>(html`<console-header></console-header>`);
-    await clock.tickAsync(0);
-    await el.updateComplete;
+    // Fetch + json() are native promises. Flush them without advancing
+    // expiry timers (those are at least 1ms).
+    for (let i = 0; i < 25; i++) {
+      await Promise.resolve();
+      await clock.tickAsync(0);
+      await el.updateComplete;
+      if (approvalReads >= 1) {
+        await Promise.resolve();
+        await clock.tickAsync(0);
+        await el.updateComplete;
+        break;
+      }
+    }
   }
 
   function names(): string[] {
@@ -523,6 +534,7 @@ describe('console-header approval deadlines', () => {
       type: 'approval_created',
       approval_request_id: 'stale',
     });
+    await clock.tickAsync(0);
     await el.updateComplete;
     expect(names()).to.deep.equal(['alive']);
     expect(badge()).to.equal('1');

--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -549,6 +549,27 @@ describe('console-header approval deadlines', () => {
     expect(approvalReads).to.equal(1);
   });
 
+  it('drops expired rows from updated() and converges without looping', async () => {
+    approvals = [approval('first', 1_000), approval('second', 5_000)];
+    await mount();
+    const header = el as ConsoleHeader & {
+      pruneAndScheduleApprovalExpiry: () => void;
+    };
+    const prune = sinon.spy(header, 'pruneAndScheduleApprovalExpiry');
+    await clock.tickAsync(1_000);
+    await el.updateComplete;
+    await el.updateComplete;
+    await clock.tickAsync(0);
+    await el.updateComplete;
+    expect(names()).to.deep.equal(['second']);
+    expect(badge()).to.equal('1');
+    // Timer callback prunes once; updated() prunes once more and the
+    // length-equality check stops further _pendingApprovals writes.
+    expect(prune.callCount).to.equal(2);
+    expect(clock.countTimers()).to.equal(1);
+    expect(approvalReads).to.equal(1);
+  });
+
   it('keeps requests without deadlines and handles deadlines beyond the browser timer limit', async () => {
     approvals = [approval('indefinite'), approval('distant', 3_000_000_000)];
     await mount();

--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -591,6 +591,8 @@ describe('console-header approval deadlines', () => {
     window.dispatchEvent(new Event('focus'));
     await clock.tickAsync(0);
     await el.updateComplete;
+    await clock.tickAsync(0);
+    await el.updateComplete;
     expect(names()).to.deep.equal(['new-request']);
     expect(badge()).to.equal('1');
     expect(approvalReads).to.equal(2);

--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -504,6 +504,30 @@ describe('console-header approval deadlines', () => {
       ?.textContent?.trim();
   }
 
+  it('omits already-expired requests from the pending menu and badge', async () => {
+    approvals = [approval('alive', 5_000), approval('already-expired', -1_000)];
+    await mount();
+    expect(names()).to.deep.equal(['alive']);
+    expect(badge()).to.equal('1');
+    expect(
+      el.shadowRoot!.querySelector('.section-count')!.textContent
+    ).to.contain('(1)');
+    expect(clock.countTimers()).to.equal(1);
+  });
+
+  it('ignores a websocket create whose deadline has already passed', async () => {
+    approvals = [approval('alive', 5_000)];
+    await mount();
+    receiveApproval({
+      ...approval('stale', -1_000),
+      type: 'approval_created',
+      approval_request_id: 'stale',
+    });
+    await el.updateComplete;
+    expect(names()).to.deep.equal(['alive']);
+    expect(badge()).to.equal('1');
+  });
+
   it('removes expired rows, decision buttons and badge at each deadline without a message', async () => {
     approvals = [approval('first', 1_000), approval('second', 3_000)];
     await mount();

--- a/frontend/src/components/console-header.test.ts
+++ b/frontend/src/components/console-header.test.ts
@@ -7,10 +7,14 @@
  * contract so a future restyle cannot silently drop keyboard access.
  */
 import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
+import {
+  ConnectionState,
+  unifiedWebSocketManager,
+} from '../services/unified-websocket-manager';
 import './console-header.ts';
 import type { ConsoleHeader } from './console-header.ts';
 import { publishAttentionSummary } from '../utils/attention-summary';
-import { unifiedWebSocketManager } from '../services/unified-websocket-manager';
 import { Router } from '@vaadin/router';
 
 const USER = {
@@ -22,11 +26,15 @@ const USER = {
 };
 
 /** Answer every console-header startup request so rendering is deterministic. */
-function stubFetch(): () => void {
+function stubFetch(approvals: () => unknown[] = () => []): () => void {
   const original = window.fetch;
   window.fetch = (async (input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input.toString();
-    const body = url.includes('/users/me') ? USER : [];
+    const body = url.includes('/users/me')
+      ? USER
+      : url.includes('/approval-requests')
+        ? approvals()
+        : [];
     return new Response(JSON.stringify(body), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -203,16 +211,6 @@ describe('console-header bell empty state', () => {
   });
 });
 
-/**
- * The bell and approvals.
- *
- * The bell already lists pending approvals and opens them on click. What it
- * did not do was say anything when one of those approvals stopped waiting:
- * the row vanished mid-session with no trace, and the generic notification
- * rows it does keep went nowhere when clicked. These tests pin the approval
- * notification type, where its click lands, and the two cases that should
- * stay quiet.
- */
 describe('console-header bell approvals', () => {
   const APPROVAL = {
     id: 'ar-1',
@@ -426,5 +424,200 @@ describe('console-header bell approvals', () => {
       0
     );
     expect(el.shadowRoot!.querySelector('.notification-badge')).to.not.exist;
+  });
+});
+
+describe('console-header approval deadlines', () => {
+  const NOW = Date.parse('2030-01-01T12:00:00Z');
+  let clock: sinon.SinonFakeTimers;
+  let restoreFetch: () => void;
+  let el: ConsoleHeader;
+  let approvals: Record<string, unknown>[];
+  let approvalReads: number;
+  let receiveApproval: Parameters<typeof unifiedWebSocketManager.subscribe>[1];
+  let changeState: Parameters<typeof unifiedWebSocketManager.onStateChange>[0];
+  let unsubscribeState: sinon.SinonSpy;
+
+  function approval(id: string, delay?: number): Record<string, unknown> {
+    return {
+      id,
+      tool_name: id,
+      status: 'pending',
+      requested_at: new Date(NOW).toISOString(),
+      // Backend timestamps without a timezone must still be read as UTC.
+      expires_at:
+        delay === undefined
+          ? null
+          : new Date(NOW + delay).toISOString().replace('Z', ''),
+    };
+  }
+
+  beforeEach(() => {
+    localStorage.setItem('accessToken', 'test-token');
+    clock = sinon.useFakeTimers({
+      now: NOW,
+      toFake: ['Date', 'setTimeout', 'clearTimeout'],
+    });
+    approvals = [];
+    approvalReads = 0;
+    restoreFetch = stubFetch(() => {
+      approvalReads++;
+      return approvals;
+    });
+    sinon.stub(unifiedWebSocketManager, 'subscribe').callsFake((topic, cb) => {
+      if (topic === 'approvals') receiveApproval = cb;
+      return () => {};
+    });
+    unsubscribeState = sinon.spy();
+    sinon.stub(unifiedWebSocketManager, 'onStateChange').callsFake((cb) => {
+      changeState = cb;
+      return unsubscribeState;
+    });
+    if ('Notification' in window) {
+      sinon.stub(Notification, 'requestPermission').resolves('denied');
+    }
+  });
+
+  afterEach(() => {
+    el?.remove();
+    clock.restore();
+    sinon.restore();
+    restoreFetch();
+    localStorage.removeItem('accessToken');
+  });
+
+  async function mount(): Promise<void> {
+    el = await fixture<ConsoleHeader>(html`<console-header></console-header>`);
+    await clock.tickAsync(0);
+    await el.updateComplete;
+  }
+
+  function names(): string[] {
+    return [...el.shadowRoot!.querySelectorAll('.approval-name')].map((row) =>
+      row.textContent!.trim()
+    );
+  }
+
+  function badge(): string | undefined {
+    return el
+      .shadowRoot!.querySelector('.notification-badge')
+      ?.textContent?.trim();
+  }
+
+  it('removes expired rows, decision buttons and badge at each deadline without a message', async () => {
+    approvals = [approval('first', 1_000), approval('second', 3_000)];
+    await mount();
+    expect(names()).to.deep.equal(['first', 'second']);
+    expect(badge()).to.equal('2');
+    expect(clock.countTimers()).to.equal(1);
+    await clock.tickAsync(1_000);
+    await el.updateComplete;
+    expect(names()).to.deep.equal(['second']);
+    expect(badge()).to.equal('1');
+    expect(
+      el.shadowRoot!.querySelector('.section-count')!.textContent
+    ).to.contain('(1)');
+    await clock.tickAsync(2_000);
+    await el.updateComplete;
+    expect(names()).to.deep.equal([]);
+    expect(el.shadowRoot!.querySelector('.approval-actions')).to.not.exist;
+    expect(badge()).to.equal(undefined);
+    expect(approvalReads).to.equal(1);
+  });
+
+  it('keeps requests without deadlines and handles deadlines beyond the browser timer limit', async () => {
+    approvals = [approval('indefinite'), approval('distant', 3_000_000_000)];
+    await mount();
+    await clock.tickAsync(2_147_483_647);
+    await el.updateComplete;
+    expect(names()).to.deep.equal(['indefinite', 'distant']);
+    await clock.tickAsync(3_000_000_000 - 2_147_483_647);
+    await el.updateComplete;
+    expect(names()).to.deep.equal(['indefinite']);
+    expect(badge()).to.equal('1');
+    expect(clock.countTimers()).to.equal(0);
+    expect(approvalReads).to.equal(1);
+  });
+
+  it('reschedules when a websocket request has an earlier deadline', async () => {
+    approvals = [approval('later', 5_000)];
+    await mount();
+    receiveApproval({
+      ...approval('earlier', 1_000),
+      type: 'approval_created',
+      approval_request_id: 'earlier',
+    });
+    await el.updateComplete;
+    await clock.tickAsync(1_000);
+    await el.updateComplete;
+    expect(names()).to.deep.equal(['later']);
+    expect(badge()).to.equal('1');
+    await clock.tickAsync(4_000);
+    await el.updateComplete;
+    expect(names()).to.deep.equal([]);
+  });
+
+  it('prunes on focus after sleep and refreshes requests missed while away', async () => {
+    approvals = [approval('expired-while-asleep', 1_000)];
+    await mount();
+    clock.setSystemTime(NOW + 2_000);
+    approvals = [approval('new-request', 10_000)];
+    window.dispatchEvent(new Event('focus'));
+    changeState(ConnectionState.CONNECTED);
+    window.dispatchEvent(new Event('focus'));
+    await clock.tickAsync(0);
+    await el.updateComplete;
+    expect(names()).to.deep.equal(['new-request']);
+    expect(badge()).to.equal('1');
+    expect(approvalReads).to.equal(2);
+  });
+
+  it('refreshes when a hidden tab becomes visible', async () => {
+    approvals = [approval('expires-hidden', 1_000)];
+    await mount();
+    const visibility = sinon.stub(document, 'visibilityState');
+    visibility.get(() => 'hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(approvalReads).to.equal(1);
+    clock.setSystemTime(NOW + 2_000);
+    approvals = [approval('visible-request', 10_000)];
+    visibility.get(() => 'visible');
+    document.dispatchEvent(new Event('visibilitychange'));
+    await clock.tickAsync(0);
+    await el.updateComplete;
+    expect(names()).to.deep.equal(['visible-request']);
+    expect(badge()).to.equal('1');
+    expect(approvalReads).to.equal(2);
+  });
+
+  it('refreshes on websocket reconnection and unregisters the state listener on removal', async () => {
+    approvals = [approval('resolved-offline', 5_000)];
+    await mount();
+    approvals = [];
+    changeState(ConnectionState.CONNECTED);
+    await clock.tickAsync(0);
+    await el.updateComplete;
+    expect(names()).to.deep.equal([]);
+    expect(badge()).to.equal(undefined);
+    expect(approvalReads).to.equal(2);
+    el.remove();
+    expect(unsubscribeState.calledOnce).to.equal(true);
+  });
+
+  it('cancels expiry work on removal and refreshes after the element reconnects', async () => {
+    approvals = [approval('expires-detached', 1_000)];
+    await mount();
+    el.remove();
+    const timersAfterRemoval = clock.countTimers();
+    expect(timersAfterRemoval).to.equal(0);
+    window.dispatchEvent(new Event('focus'));
+    await clock.tickAsync(2_000);
+    expect(approvalReads).to.equal(1);
+    document.body.append(el);
+    await clock.tickAsync(0);
+    await el.updateComplete;
+    expect(names()).to.deep.equal([]);
+    expect(badge()).to.equal(undefined);
+    expect(approvalReads).to.equal(2);
   });
 });

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -120,6 +120,7 @@ export class ConsoleHeader extends LitElement {
   private unsubscribeNotifications?: () => void;
   private unsubscribeConnectionState?: () => void;
   private approvalExpiryTimer?: ReturnType<typeof setTimeout>;
+  private pruningApprovalExpiry = false;
   private loadingPendingApprovals = false;
 
   private refreshPendingApprovals = (): void => {
@@ -404,10 +405,26 @@ export class ConsoleHeader extends LitElement {
     this.approvalExpiryTimer = undefined;
   }
 
-  protected willUpdate(changed: PropertyValues): void {
-    if (changed.has('_pendingApprovals')) {
-      this.pruneAndScheduleApprovalExpiry();
+  /**
+   * Drop expired rows and arm the next deadline after the current update.
+   * Mutating `_pendingApprovals` from willUpdate dirties the same cycle.
+   */
+  protected updated(changed: PropertyValues): void {
+    if (!changed.has('_pendingApprovals') || this.pruningApprovalExpiry) {
+      return;
     }
+    this.pruningApprovalExpiry = true;
+    try {
+      this.pruneAndScheduleApprovalExpiry();
+    } finally {
+      this.pruningApprovalExpiry = false;
+    }
+  }
+
+  private unexpiredPendingApprovals(): ApprovalRequest[] {
+    return this._pendingApprovals.filter((approval) =>
+      this.isUnexpiredPendingApproval(approval)
+    );
   }
 
   private pruneAndScheduleApprovalExpiry(): void {
@@ -415,9 +432,7 @@ export class ConsoleHeader extends LitElement {
     this.approvalExpiryTimer = undefined;
     if (!this.isConnected) return;
 
-    const pending = this._pendingApprovals.filter((approval) =>
-      this.isUnexpiredPendingApproval(approval)
-    );
+    const pending = this.unexpiredPendingApprovals();
     if (pending.length !== this._pendingApprovals.length) {
       this._pendingApprovals = pending;
     }
@@ -591,9 +606,7 @@ export class ConsoleHeader extends LitElement {
    * operator to a page where every button is disabled.
    */
   private get liveApprovals(): ApprovalRequest[] {
-    return this._pendingApprovals.filter((approval) =>
-      this.isUnexpiredPendingApproval(approval)
-    );
+    return this.unexpiredPendingApprovals();
   }
 
   private get totalNotificationCount(): number {
@@ -602,7 +615,7 @@ export class ConsoleHeader extends LitElement {
     ).length;
     return (
       this._runningExecutions.length +
-      this.liveApprovals.length +
+      this.unexpiredPendingApprovals().length +
       unreadNotifications
     );
   }
@@ -1070,8 +1083,8 @@ export class ConsoleHeader extends LitElement {
   }
 
   private renderApprovalsSection() {
-    const approvals = this.liveApprovals;
-    if (approvals.length === 0) return '';
+    const pending = this.unexpiredPendingApprovals();
+    if (pending.length === 0) return '';
 
     return html`
       <div class="notification-section">
@@ -1079,7 +1092,7 @@ export class ConsoleHeader extends LitElement {
           <div class="section-title">
             <sl-icon name="shield-check"></sl-icon>
             Pending approvals
-            <span class="section-count">(${approvals.length})</span>
+            <span class="section-count">(${pending.length})</span>
           </div>
           <a
             class="section-link"
@@ -1088,7 +1101,7 @@ export class ConsoleHeader extends LitElement {
           >
         </div>
         <div class="approval-list">
-          ${approvals.slice(0, 5).map(
+          ${pending.slice(0, 5).map(
             (approval) => html`
               <div
                 class="approval-item"
@@ -1232,7 +1245,7 @@ export class ConsoleHeader extends LitElement {
   render() {
     const hasContent =
       this._runningExecutions.length > 0 ||
-      this.liveApprovals.length > 0 ||
+      this.unexpiredPendingApprovals().length > 0 ||
       this._userNotifications.length > 0;
 
     return html`

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, type PropertyValues } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@shoelace-style/shoelace/dist/components/dropdown/dropdown.js';
 import '@shoelace-style/shoelace/dist/components/menu/menu.js';
@@ -14,7 +14,10 @@ import './theme-switcher.ts';
 import './user-avatar.ts';
 import * as api from '../api';
 import { Router } from '@vaadin/router';
-import { unifiedWebSocketManager } from '../services/unified-websocket-manager';
+import {
+  ConnectionState,
+  unifiedWebSocketManager,
+} from '../services/unified-websocket-manager';
 import {
   formatFutureRelativeTime,
   formatRelativeTime,
@@ -115,6 +118,20 @@ export class ConsoleHeader extends LitElement {
   private unsubscribeFlow?: () => void;
   private unsubscribeApprovals?: () => void;
   private unsubscribeNotifications?: () => void;
+  private unsubscribeConnectionState?: () => void;
+  private approvalExpiryTimer?: ReturnType<typeof setTimeout>;
+  private loadingPendingApprovals = false;
+
+  private refreshPendingApprovals = (): void => {
+    this.pruneAndScheduleApprovalExpiry();
+    void this.loadPendingApprovals();
+  };
+
+  private handleVisibilityChange = (): void => {
+    if (document.visibilityState === 'visible') {
+      this.refreshPendingApprovals();
+    }
+  };
 
   // Track notification IDs to prevent duplicates
   private shownExecutionNotifications: Set<string> = new Set();
@@ -353,6 +370,9 @@ export class ConsoleHeader extends LitElement {
       ATTENTION_SUMMARY_EVENT,
       this.handleAttentionSummary as EventListener
     );
+    window.addEventListener('focus', this.refreshPendingApprovals);
+    document.addEventListener('visibilitychange', this.handleVisibilityChange);
+    this.pruneAndScheduleApprovalExpiry();
     this.fetchUserDetails();
     this.connectToFlowUpdates();
     this.connectToApprovalUpdates();
@@ -374,6 +394,45 @@ export class ConsoleHeader extends LitElement {
     this.unsubscribeFlow?.();
     this.unsubscribeApprovals?.();
     this.unsubscribeNotifications?.();
+    this.unsubscribeConnectionState?.();
+    window.removeEventListener('focus', this.refreshPendingApprovals);
+    document.removeEventListener(
+      'visibilitychange',
+      this.handleVisibilityChange
+    );
+    clearTimeout(this.approvalExpiryTimer);
+    this.approvalExpiryTimer = undefined;
+  }
+
+  protected willUpdate(changed: PropertyValues): void {
+    if (changed.has('_pendingApprovals')) {
+      this.pruneAndScheduleApprovalExpiry();
+    }
+  }
+
+  private pruneAndScheduleApprovalExpiry(): void {
+    clearTimeout(this.approvalExpiryTimer);
+    this.approvalExpiryTimer = undefined;
+    if (!this.isConnected) return;
+
+    const pending = this._pendingApprovals.filter((approval) =>
+      this.isUnexpiredPendingApproval(approval)
+    );
+    if (pending.length !== this._pendingApprovals.length) {
+      this._pendingApprovals = pending;
+    }
+    const nextExpiry = pending.reduce((earliest, approval) => {
+      if (!approval.expires_at) return earliest;
+      return Math.min(earliest, parseUTCDate(approval.expires_at).getTime());
+    }, Infinity);
+    if (Number.isFinite(nextExpiry)) {
+      // One timer for the nearest deadline, capped to the browser's signed
+      // 32-bit delay limit. Long deadlines are rescheduled when it fires.
+      this.approvalExpiryTimer = setTimeout(
+        () => this.pruneAndScheduleApprovalExpiry(),
+        Math.min(Math.max(nextExpiry - Date.now(), 1), 2_147_483_647)
+      );
+    }
   }
 
   private async loadRunningExecutions() {
@@ -388,8 +447,11 @@ export class ConsoleHeader extends LitElement {
   }
 
   private async loadPendingApprovals() {
+    if (this.loadingPendingApprovals || !this.isConnected) return;
+    this.loadingPendingApprovals = true;
     try {
       const approvals = await api.listApprovalRequests({ status: 'pending' });
+      if (!this.isConnected) return;
       this._pendingApprovals = approvals
         .map((approval: any) => ({
           id: approval.id,
@@ -407,6 +469,8 @@ export class ConsoleHeader extends LitElement {
         );
     } catch (error) {
       console.error('Failed to load pending approvals:', error);
+    } finally {
+      this.loadingPendingApprovals = false;
     }
   }
 
@@ -615,9 +679,13 @@ export class ConsoleHeader extends LitElement {
     );
 
     // Track connection state
-    unifiedWebSocketManager.onStateChange((state) => {
-      console.log(`Console header WebSocket state: ${state}`);
-    });
+    this.unsubscribeConnectionState = unifiedWebSocketManager.onStateChange(
+      (state) => {
+        if (state === ConnectionState.CONNECTED) {
+          this.refreshPendingApprovals();
+        }
+      }
+    );
   }
 
   private connectToApprovalUpdates() {

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -120,13 +120,27 @@ export class ConsoleHeader extends LitElement {
   private unsubscribeNotifications?: () => void;
   private unsubscribeConnectionState?: () => void;
   private approvalExpiryTimer?: ReturnType<typeof setTimeout>;
+  private pendingApprovalsRefreshTimer?: ReturnType<typeof setTimeout>;
   private pruningApprovalExpiry = false;
   private loadingPendingApprovals = false;
+  private pendingApprovalsReload = false;
 
   private refreshPendingApprovals = (): void => {
     this.pruneAndScheduleApprovalExpiry();
-    void this.loadPendingApprovals();
+    this.schedulePendingApprovalsRefresh();
   };
+
+  /**
+   * Coalesce focus/visibility/reconnect into one follow-up fetch, and retry
+   * if that fetch was requested while a load was already in flight.
+   */
+  private schedulePendingApprovalsRefresh(): void {
+    if (this.pendingApprovalsRefreshTimer !== undefined) return;
+    this.pendingApprovalsRefreshTimer = setTimeout(() => {
+      this.pendingApprovalsRefreshTimer = undefined;
+      void this.loadPendingApprovals();
+    }, 0);
+  }
 
   private handleVisibilityChange = (): void => {
     if (document.visibilityState === 'visible') {
@@ -403,6 +417,8 @@ export class ConsoleHeader extends LitElement {
     );
     clearTimeout(this.approvalExpiryTimer);
     this.approvalExpiryTimer = undefined;
+    clearTimeout(this.pendingApprovalsRefreshTimer);
+    this.pendingApprovalsRefreshTimer = undefined;
   }
 
   /**
@@ -462,30 +478,42 @@ export class ConsoleHeader extends LitElement {
   }
 
   private async loadPendingApprovals() {
-    if (this.loadingPendingApprovals || !this.isConnected) return;
+    if (!this.isConnected) return;
+    if (this.loadingPendingApprovals) {
+      this.pendingApprovalsReload = true;
+      return;
+    }
     this.loadingPendingApprovals = true;
     try {
-      const approvals = await api.listApprovalRequests({ status: 'pending' });
-      if (!this.isConnected) return;
-      this._pendingApprovals = approvals
-        .map((approval: any) => ({
-          id: approval.id,
-          tool_name: approval.tool_name,
-          tool_args: approval.tool_args || {},
-          status: approval.status,
-          requested_at: approval.requested_at,
-          expires_at: approval.expires_at,
-          execution_id: approval.execution_id,
-          agent_reasoning: approval.agent_reasoning,
-          managed_agent_name: approval.managed_agent_name,
-        }))
-        .filter((approval: ApprovalRequest) =>
-          this.isUnexpiredPendingApproval(approval)
-        );
+      do {
+        this.pendingApprovalsReload = false;
+        const approvals = await api.listApprovalRequests({
+          status: 'pending',
+        });
+        if (!this.isConnected) return;
+        this._pendingApprovals = approvals
+          .map((approval: any) => ({
+            id: approval.id,
+            tool_name: approval.tool_name,
+            tool_args: approval.tool_args || {},
+            status: approval.status,
+            requested_at: approval.requested_at,
+            expires_at: approval.expires_at,
+            execution_id: approval.execution_id,
+            agent_reasoning: approval.agent_reasoning,
+            managed_agent_name: approval.managed_agent_name,
+          }))
+          .filter((approval: ApprovalRequest) =>
+            this.isUnexpiredPendingApproval(approval)
+          );
+      } while (this.pendingApprovalsReload && this.isConnected);
     } catch (error) {
       console.error('Failed to load pending approvals:', error);
     } finally {
       this.loadingPendingApprovals = false;
+      if (this.pendingApprovalsReload && this.isConnected) {
+        void this.loadPendingApprovals();
+      }
     }
   }
 

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -121,7 +121,6 @@ export class ConsoleHeader extends LitElement {
   private unsubscribeConnectionState?: () => void;
   private approvalExpiryTimer?: ReturnType<typeof setTimeout>;
   private pendingApprovalsRefreshTimer?: ReturnType<typeof setTimeout>;
-  private pruningApprovalExpiry = false;
   private loadingPendingApprovals = false;
   private pendingApprovalsReload = false;
 
@@ -426,15 +425,8 @@ export class ConsoleHeader extends LitElement {
    * Mutating `_pendingApprovals` from willUpdate dirties the same cycle.
    */
   protected updated(changed: PropertyValues): void {
-    if (!changed.has('_pendingApprovals') || this.pruningApprovalExpiry) {
-      return;
-    }
-    this.pruningApprovalExpiry = true;
-    try {
-      this.pruneAndScheduleApprovalExpiry();
-    } finally {
-      this.pruningApprovalExpiry = false;
-    }
+    if (!changed.has('_pendingApprovals')) return;
+    this.pruneAndScheduleApprovalExpiry();
   }
 
   private unexpiredPendingApprovals(): ApprovalRequest[] {

--- a/frontend/src/components/console-header.ts
+++ b/frontend/src/components/console-header.ts
@@ -422,7 +422,8 @@ export class ConsoleHeader extends LitElement {
 
   /**
    * Drop expired rows and arm the next deadline after the current update.
-   * Mutating `_pendingApprovals` from willUpdate dirties the same cycle.
+   * Pruning here (rather than in `willUpdate`) avoids mutating
+   * `_pendingApprovals` mid-cycle, which would dirty the same update pass.
    */
   protected updated(changed: PropertyValues): void {
     if (!changed.has('_pendingApprovals')) return;
@@ -616,17 +617,6 @@ export class ConsoleHeader extends LitElement {
     if (notification.href) {
       Router.go(notification.href);
     }
-  }
-
-  /**
-   * Pending approvals that can still be decided.
-   *
-   * The list is filtered when it loads, but a tab left open carries requests
-   * past their expiry, and a bell that counts a dead request sends the
-   * operator to a page where every button is disabled.
-   */
-  private get liveApprovals(): ApprovalRequest[] {
-    return this.unexpiredPendingApprovals();
   }
 
   private get totalNotificationCount(): number {


### PR DESCRIPTION
## Summary

- Remove expired approvals from the header menu, its actions and badge count as their deadlines pass. Previously the header filtered expiry only on initial load or a WebSocket event, so a quiet or disconnected tab could display expired requests with active approval buttons.
- Use one timer for the nearest deadline. Refresh on focus, visibility and WebSocket reconnection; coalesce overlapping requests and clean up timers/listeners on disconnect. Keep existing UTC parsing and pending/no-expiry semantics, with no backend mutation or expiry sweep.

## Testing

- [ ] Backend tests: not applicable.
- [x] Frontend tests: 46 focused Chromium checks passed, including seven new deadline/lifecycle regressions. Five initial regressions reproduced the problem before the fix.
- [x] Manual validation: matched the reported stale menu behavior in browser tests, including expiry without a server event.
- [x] Required changed-file hooks passed.

## Checklist

- [x] Docs updated if needed: internal timer lifecycle documented; no new user configuration.
- [x] Changelog updated if needed: small UI correction.
- [x] No secrets included.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Frontend-only bug fix with no security implications, no backend mutation, and comprehensive regression coverage (46 Chromium checks).

> **Overview**
> Removes expired approval requests from the header menu, its decision buttons and badge as deadlines pass. A single nearest-deadline timer drives the expiry, refreshed on focus/visibility/reconnection, with timers and listeners cleaned up on disconnect. Preserves existing UTC parsing and pending/no-expiry semantics.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 1c1e2df. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->