### PR TITLE
Prevent API stalls and fix transaction lock lifetimes

### DIFF
--- a/backend/preloop/services/runtime_session_explorer.py
+++ b/backend/preloop/services/runtime_session_explorer.py
@@ -54,6 +54,11 @@ MAX_TITLES_PER_LIST_REQUEST = 8
 # many requests since the title was last generated.
 TITLE_REFRESH_REQUEST_DELTA = 5
 
+# Per-attempt provider I/O bound for interaction summaries. Matches the
+# approval-summary attempt budget so a cancelled call does not sit on
+# litellm's 600s default while run_db_off_loop drains the worker.
+INTERACTION_SUMMARY_ATTEMPT_TIMEOUT_SECONDS = 5.0
+
 
 _TRANSCRIPT_ROLE_TITLES = {
     "user": "User message",
@@ -729,6 +734,11 @@ class RuntimeSessionExplorerService:
         kwargs = build_aux_kwargs(
             model, creds_kwargs, call_site_kwargs=call_site_kwargs
         )
+
+        # Cancellation drains a worker that still owns the caller's Session.
+        # Bound provider I/O as well as any coroutine deadline.
+        kwargs["timeout"] = INTERACTION_SUMMARY_ATTEMPT_TIMEOUT_SECONDS
+        kwargs["num_retries"] = 0
 
         response = litellm.completion(**kwargs)
         check_reasoning_model_empty_content(response)

--- a/backend/tests/services/test_runtime_session_explorer.py
+++ b/backend/tests/services/test_runtime_session_explorer.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 
 from preloop.services import runtime_session_explorer as rse_mod
 from preloop.services.runtime_session_explorer import (
+    INTERACTION_SUMMARY_ATTEMPT_TIMEOUT_SECONDS,
     MAX_TITLES_PER_LIST_REQUEST,
     TITLE_REFRESH_REQUEST_DELTA,
     RuntimeSessionExplorerService,
@@ -561,6 +562,22 @@ def test_call_interaction_summary_model_rejects_non_object(service):
             service._call_interaction_summary_model(
                 model, {"api_key": "sk-test"}, payload={}
             )
+
+
+def test_call_interaction_summary_model_bounds_provider_timeout(service):
+    model = _make_ai_model()
+    completion = MagicMock()
+    completion.choices = [MagicMock()]
+    completion.choices[0].message.content = '{"title": "T", "summary": "S"}'
+    with patch.object(
+        rse_mod.litellm, "completion", return_value=completion
+    ) as mock_completion:
+        service._call_interaction_summary_model(
+            model, {"api_key": "sk-test"}, payload={}
+        )
+    kwargs = mock_completion.call_args.kwargs
+    assert kwargs["timeout"] == INTERACTION_SUMMARY_ATTEMPT_TIMEOUT_SECONDS
+    assert kwargs["num_retries"] == 0
 
 
 # --- summarize_account_runtime_session_interaction -------------------------


### PR DESCRIPTION
Database waits in async authentication, approval summaries, and permission checks could stall the API event loop and cause liveness failures. This follow-up to #469 and #470 moves those operations into workers, preserves session ownership through cancellation, and releases permission-check authentication connections before waiting for a human.

The lock audit also found three independent concurrency hazards: artifact quota locks blocked account foreign-key inserts; OAuth refresh could reuse stale credentials or retain an unnecessary lock; and heartbeats acquired rows in the opposite order from decommissioning. This change corrects each while preserving the required exclusion.

Validation: **573 tests passed across 36 affected modules**, using a migrated PostgreSQL database with seeded system roles. Tests exercise independent-session lock compatibility, refresh contention, heartbeat ordering, event-loop responsiveness, and cancellation/session cleanup. All changed-file pre-commit hooks passed; OpenAPI is unchanged.

The EE audit/RBAC companion must use this backend revision. Long-lived gateway stream and agent-control WebSocket sessions remain separate follow-ups (#475 and #476); this PR does not claim to complete those lifecycle changes.

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Medium risk**
> Changes important concurrency and transaction-locking logic across authentication, approval, and secret-refresh paths, but is well-tested with targeted regression coverage for each hazard.

> **Overview**
> Moves blocking DB work off the API event loop (auth, approval summaries, permission checks), preserves session ownership through cancellation, and fixes three lock hazards: artifact quota `FOR NO KEY UPDATE`, OAuth refresh savepoint release, and heartbeat/operator lock-order alignment.

> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit ad98607340dd8224ae55d79fc3a075f5abe6ac09. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->